### PR TITLE
[codex] add query-sliced embedding benchmark

### DIFF
--- a/docs/testing/embedding-backend-benchmarks.md
+++ b/docs/testing/embedding-backend-benchmarks.md
@@ -361,6 +361,10 @@ For bounded tuning, set `CODESTORY_EMBED_RESEARCH_CASES` to a comma-separated
 case-id list from the list command. The runner scopes selected case IDs to the
 requested stage before execution, which avoids mixing alias-stage and
 tuning-stage rows with identical settings.
+For quick autoresearch probes, also set `CODESTORY_EMBED_RESEARCH_QUERY_LIMIT`,
+`CODESTORY_EMBED_RESEARCH_QUERY_IDS`, or `CODESTORY_EMBED_RESEARCH_QUERY_BUCKETS`
+to keep a run inside a small wall-clock cap. Treat those rows as exploratory;
+promotion decisions still require the full query suite.
 
 ## Remaining Research Backlog
 

--- a/docs/testing/embedding-research-run-2.md
+++ b/docs/testing/embedding-research-run-2.md
@@ -52,6 +52,11 @@ it has metric columns.
 
 Use `CODESTORY_EMBED_RESEARCH_LIST=1` to list case IDs before running a stage.
 Use `CODESTORY_EMBED_RESEARCH_CASES=<case-id,...>` for bounded reruns.
+For short exploratory loops, set `CODESTORY_EMBED_RESEARCH_QUERY_LIMIT=<n>`,
+`CODESTORY_EMBED_RESEARCH_QUERY_IDS=<id,...>`, or
+`CODESTORY_EMBED_RESEARCH_QUERY_BUCKETS=<bucket,...>`. Query-sliced runs are
+useful for two-minute autoresearch probes, but the full query suite is still
+required before promoting a model, backend, or semantic-doc default.
 
 ## Scoring
 

--- a/scripts/embedding-gpu-fair-benchmark.mjs
+++ b/scripts/embedding-gpu-fair-benchmark.mjs
@@ -28,6 +28,19 @@ const selectedCaseIds = new Set(
     .map((id) => id.trim())
     .filter(Boolean),
 );
+const selectedQueryIds = new Set(
+  (process.env.CODESTORY_EMBED_RESEARCH_QUERY_IDS ?? "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean),
+);
+const selectedQueryBuckets = new Set(
+  (process.env.CODESTORY_EMBED_RESEARCH_QUERY_BUCKETS ?? "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean),
+);
+const queryLimit = parsePositiveIntEnv("CODESTORY_EMBED_RESEARCH_QUERY_LIMIT");
 const portBase = Number(process.env.CODESTORY_EMBED_RESEARCH_PORT_BASE ?? 8170);
 
 const blockedCandidates = [
@@ -521,6 +534,8 @@ const queries = [
   },
 ];
 
+const benchmarkQueries = selectQueries(queries);
+
 const modelPaths = {
   minilmOnnx: path.join(root, "models/all-minilm-l6-v2/model.onnx"),
   bgeSmallOnnx: path.join(root, "models/bge-small-en-v1.5/onnx/model.onnx"),
@@ -619,6 +634,35 @@ const baseProfiles = {
 
 function cloneCase(base, overrides = {}) {
   return { ...base, ...overrides };
+}
+
+function parsePositiveIntEnv(name) {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function selectQueries(allQueries) {
+  let out = allQueries;
+  if (selectedQueryIds.size > 0) {
+    out = out.filter((query) => selectedQueryIds.has(query.id));
+  }
+  if (selectedQueryBuckets.size > 0) {
+    out = out.filter((query) => selectedQueryBuckets.has(query.bucket));
+  }
+  if (queryLimit !== null) {
+    out = out.slice(0, queryLimit);
+  }
+  if (out.length === 0) {
+    throw new Error("query selection produced no benchmark queries");
+  }
+  return out;
 }
 
 function caseId(config) {
@@ -1501,7 +1545,7 @@ async function runCase(config) {
     const semanticSeconds = (indexJson.phase_timings?.semantic_embedding_ms ?? 0) / 1000;
     const searchResults = [];
     let searchElapsedMs = 0;
-    for (const q of queries) {
+    for (const q of benchmarkQueries) {
       const search = runCli(
         [
           "search",
@@ -1733,7 +1777,13 @@ function writeManifest(cases) {
     artifact_root: outDir,
     requested_stages: [...requestedStages],
     case_count: cases.length,
-    query_count: queries.length,
+    query_count: benchmarkQueries.length,
+    full_query_count: queries.length,
+    query_filter: {
+      ids: [...selectedQueryIds],
+      buckets: [...selectedQueryBuckets],
+      limit: queryLimit,
+    },
     scoring:
       "Decision ranking applies a quality gate, then 50% quality, 25% speed, 15% footprint, and 10% reliability.",
     source_references: researchSources,
@@ -1816,7 +1866,7 @@ function buildReportMarkdown(ranked, aliasRows, repeatRows, failed, cases) {
     `Artifact root: \`${outDir}\``,
     `Stages: \`${[...requestedStages].join(",")}\``,
     `Cases selected: \`${cases.length}\``,
-    `Queries: \`${queries.length}\``,
+    `Queries: \`${benchmarkQueries.length}\` of \`${queries.length}\``,
     "",
     "All decision-grade rows are GPU-only and must set `provider_verified=true`. ONNX rows require DirectML/CUDA fail-hard validation; llama.cpp rows require Vulkan0 and full model-layer offload.",
     "Source-led lanes are recorded in `manifest.json` and `sources.md`; skipped rows mean an artifact or implementation prerequisite is still missing.",
@@ -2077,7 +2127,7 @@ function writeReports(results, cases) {
 
   fs.writeFileSync(path.join(outDir, "results.json"), JSON.stringify(results, null, 2));
   fs.writeFileSync(path.join(outDir, "cases.json"), JSON.stringify(cases, null, 2));
-  fs.writeFileSync(path.join(outDir, "queries.json"), JSON.stringify(queries, null, 2));
+  fs.writeFileSync(path.join(outDir, "queries.json"), JSON.stringify(benchmarkQueries, null, 2));
 
   const failed = results.filter((result) => result.error);
   fs.writeFileSync(


### PR DESCRIPTION
## Summary

Adds query slicing to the embedding benchmark harness so bounded autoresearch probes can select a query limit, explicit query IDs, or query buckets.

## Why

The embedding benchmark can exceed short autoresearch caps when it runs the full query suite. Query slicing gives us a fast exploratory loop while keeping full-suite runs as the bar for promotion-grade model, backend, or semantic-doc decisions.

## Changes

- Add `CODESTORY_EMBED_RESEARCH_QUERY_LIMIT`, `CODESTORY_EMBED_RESEARCH_QUERY_IDS`, and `CODESTORY_EMBED_RESEARCH_QUERY_BUCKETS` handling to `scripts/embedding-gpu-fair-benchmark.mjs`.
- Record selected/full query counts and filters in benchmark manifests and reports.
- Write only the selected query set to `queries.json` for each bounded artifact.
- Update embedding research docs to state that query-sliced rows are exploratory and full-query evidence is still required before promotion.

## Autoresearch Evidence

Experiment: autoresearch run 3
Metric: `combined_score=0.3417` on a 12-query bounded probe
Evidence: the bounded run completed inside the two-minute cap and exposed the `scope=all + no_alias + b256` Hit@10 regression before spending time on full-suite promotion evidence.

## Validation

- `node --check scripts/embedding-gpu-fair-benchmark.mjs`
- `git diff --check main..HEAD`
- autoresearch finalize union verification passed
- autoresearch finalize session-artifact verification passed
