### PR TITLE
Add indexer coverage foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,11 +451,15 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-c",
+ "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-go",
  "tree-sitter-graph",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-php",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
 ]
@@ -3047,10 +3051,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c0f6d2209a3cd6d0bb9d2934715da15a15710d3c09c7c1ecd4c9804c3ecd10"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3099,10 +3123,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
+name = "tree-sitter-php"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-python"
 version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ tree-sitter-c = "0.23"
 tree-sitter-javascript = "0.23.1"
 tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23.4"
+tree-sitter-ruby = "0.23.1"
+tree-sitter-php = "0.23.11"
+tree-sitter-c-sharp = "=0.23.0"
 
 # Semantic Analysis
 tree-sitter-graph = "0.12"

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -31,3 +31,7 @@ tree-sitter-javascript = { workspace = true }
 tree-sitter-python = { workspace = true }
 tree-sitter-rust = { workspace = true }
 tree-sitter-typescript = { workspace = true }
+tree-sitter-go = { workspace = true }
+tree-sitter-ruby = { workspace = true }
+tree-sitter-php = { workspace = true }
+tree-sitter-c-sharp = { workspace = true }

--- a/crates/codestory-indexer/rules/csharp.scm
+++ b/crates/codestory-indexer/rules/csharp.scm
@@ -1,0 +1,141 @@
+(method_declaration
+  name: (identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "METHOD"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(class_declaration
+  name: (identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "CLASS"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(interface_declaration
+  name: (identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "INTERFACE"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(struct_declaration
+  name: (identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "STRUCT"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(namespace_declaration
+  name: (identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "NAMESPACE"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+;; Inheritance
+(class_declaration
+  name: (identifier) @class_name
+  (base_list (_) @parent_name))
+{
+  node @parent_name.node
+  attr (@parent_name.node) kind = "CLASS"
+  attr (@parent_name.node) name = (source-text @parent_name)
+  attr (@parent_name.node) start_row = (start-row @parent_name)
+  attr (@parent_name.node) start_col = (start-column @parent_name)
+  attr (@parent_name.node) end_row = (end-row @parent_name)
+  attr (@parent_name.node) end_col = (end-column @parent_name)
+
+  edge @class_name.node -> @parent_name.node
+  attr (@class_name.node -> @parent_name.node) kind = "INHERITANCE"
+}
+
+;; Calls
+(invocation_expression
+  function: (identifier) @callee_any) @call_any
+{
+  node @call_any.node
+  attr (@call_any.node) kind = "UNKNOWN"
+  attr (@call_any.node) name = (source-text @callee_any)
+  attr (@call_any.node) start_row = (start-row @callee_any)
+  attr (@call_any.node) start_col = (start-column @callee_any)
+  attr (@call_any.node) end_row = (end-row @callee_any)
+  attr (@call_any.node) end_col = (end-column @callee_any)
+
+  edge @call_any.node -> @call_any.node
+  attr (@call_any.node -> @call_any.node) kind = "CALL"
+  attr (@call_any.node -> @call_any.node) line = (start-row @call_any)
+}
+
+(invocation_expression
+  function: (member_access_expression
+    name: (identifier) @callee_any) @call_any)
+{
+  node @call_any.node
+  attr (@call_any.node) kind = "UNKNOWN"
+  attr (@call_any.node) name = (source-text @callee_any)
+  attr (@call_any.node) start_row = (start-row @callee_any)
+  attr (@call_any.node) start_col = (start-column @callee_any)
+  attr (@call_any.node) end_row = (end-row @callee_any)
+  attr (@call_any.node) end_col = (end-column @callee_any)
+
+  edge @call_any.node -> @call_any.node
+  attr (@call_any.node -> @call_any.node) kind = "CALL"
+  attr (@call_any.node -> @call_any.node) line = (start-row @call_any)
+}
+
+;; Using directives
+(using_directive
+  (identifier) @module)
+{
+  node @module.node
+  attr (@module.node) kind = "MODULE"
+  attr (@module.node) name = (source-text @module)
+  attr (@module.node) start_row = (start-row @module)
+  attr (@module.node) start_col = (start-column @module)
+  attr (@module.node) end_row = (end-row @module)
+  attr (@module.node) end_col = (end-column @module)
+
+  edge @module.node -> @module.node
+  attr (@module.node -> @module.node) kind = "IMPORT"
+}
+
+(using_directive
+  (qualified_name) @module)
+{
+  node @module.node
+  attr (@module.node) kind = "MODULE"
+  attr (@module.node) name = (source-text @module)
+  attr (@module.node) start_row = (start-row @module)
+  attr (@module.node) start_col = (start-column @module)
+  attr (@module.node) end_row = (end-row @module)
+  attr (@module.node) end_col = (end-column @module)
+
+  edge @module.node -> @module.node
+  attr (@module.node -> @module.node) kind = "IMPORT"
+}

--- a/crates/codestory-indexer/rules/go.scm
+++ b/crates/codestory-indexer/rules/go.scm
@@ -1,0 +1,115 @@
+(function_declaration
+  name: (identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "FUNCTION"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(method_declaration
+  name: (field_identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "METHOD"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(type_declaration
+  (type_spec
+    name: (type_identifier) @name)) @def
+{
+  node @name.node
+  attr (@name.node) kind = "STRUCT"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(package_clause
+  (package_identifier) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "MODULE"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+;; Calls (global fallback identifier)
+(call_expression
+  function: (identifier) @callee_any) @call_any
+{
+  node @call_any.node
+  attr (@call_any.node) kind = "UNKNOWN"
+  attr (@call_any.node) name = (source-text @callee_any)
+  attr (@call_any.node) start_row = (start-row @callee_any)
+  attr (@call_any.node) start_col = (start-column @callee_any)
+  attr (@call_any.node) end_row = (end-row @callee_any)
+  attr (@call_any.node) end_col = (end-column @callee_any)
+
+  edge @call_any.node -> @call_any.node
+  attr (@call_any.node -> @call_any.node) kind = "CALL"
+  attr (@call_any.node -> @call_any.node) line = (start-row @call_any)
+}
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @callee_any) @call_any)
+{
+  node @call_any.node
+  attr (@call_any.node) kind = "UNKNOWN"
+  attr (@call_any.node) name = (source-text @callee_any)
+  attr (@call_any.node) start_row = (start-row @callee_any)
+  attr (@call_any.node) start_col = (start-column @callee_any)
+  attr (@call_any.node) end_row = (end-row @callee_any)
+  attr (@call_any.node) end_col = (end-column @callee_any)
+
+  edge @call_any.node -> @call_any.node
+  attr (@call_any.node -> @call_any.node) kind = "CALL"
+  attr (@call_any.node -> @call_any.node) line = (start-row @call_any)
+}
+
+(import_declaration
+  (import_spec
+    path: (interpreted_string_literal) @module))
+{
+  node @module.node
+  attr (@module.node) kind = "MODULE"
+  attr (@module.node) name = (source-text @module)
+  attr (@module.node) start_row = (start-row @module)
+  attr (@module.node) start_col = (start-column @module)
+  attr (@module.node) end_row = (end-row @module)
+  attr (@module.node) end_col = (end-column @module)
+
+  edge @module.node -> @module.node
+  attr (@module.node -> @module.node) kind = "IMPORT"
+}
+
+(import_declaration
+  (import_spec_list
+    (import_spec
+      path: (interpreted_string_literal) @module)))
+{
+  node @module.node
+  attr (@module.node) kind = "MODULE"
+  attr (@module.node) name = (source-text @module)
+  attr (@module.node) start_row = (start-row @module)
+  attr (@module.node) start_col = (start-column @module)
+  attr (@module.node) end_row = (end-row @module)
+  attr (@module.node) end_col = (end-column @module)
+
+  edge @module.node -> @module.node
+  attr (@module.node -> @module.node) kind = "IMPORT"
+}

--- a/crates/codestory-indexer/rules/php.scm
+++ b/crates/codestory-indexer/rules/php.scm
@@ -1,0 +1,129 @@
+(function_definition
+  name: (name) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "FUNCTION"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(method_declaration
+  name: (name) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "METHOD"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(class_declaration
+  name: (name) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "CLASS"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(interface_declaration
+  name: (name) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "INTERFACE"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(namespace_definition
+  name: (namespace_name) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "NAMESPACE"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+;; Inheritance
+(class_declaration
+  name: (name) @class_name
+  (base_clause [(name) (qualified_name)] @parent_name))
+{
+  node @parent_name.node
+  attr (@parent_name.node) kind = "CLASS"
+  attr (@parent_name.node) name = (source-text @parent_name)
+  attr (@parent_name.node) start_row = (start-row @parent_name)
+  attr (@parent_name.node) start_col = (start-column @parent_name)
+  attr (@parent_name.node) end_row = (end-row @parent_name)
+  attr (@parent_name.node) end_col = (end-column @parent_name)
+
+  edge @class_name.node -> @parent_name.node
+  attr (@class_name.node -> @parent_name.node) kind = "INHERITANCE"
+}
+
+;; Calls
+(function_call_expression
+  function: [
+    (qualified_name (name) @callee_any)
+    (name) @callee_any
+  ]) @call_any
+{
+  node @call_any.node
+  attr (@call_any.node) kind = "UNKNOWN"
+  attr (@call_any.node) name = (source-text @callee_any)
+  attr (@call_any.node) start_row = (start-row @callee_any)
+  attr (@call_any.node) start_col = (start-column @callee_any)
+  attr (@call_any.node) end_row = (end-row @callee_any)
+  attr (@call_any.node) end_col = (end-column @callee_any)
+
+  edge @call_any.node -> @call_any.node
+  attr (@call_any.node -> @call_any.node) kind = "CALL"
+  attr (@call_any.node -> @call_any.node) line = (start-row @call_any)
+}
+
+(member_call_expression
+  name: (name) @callee_any) @call_any
+{
+  node @call_any.node
+  attr (@call_any.node) kind = "UNKNOWN"
+  attr (@call_any.node) name = (source-text @callee_any)
+  attr (@call_any.node) start_row = (start-row @callee_any)
+  attr (@call_any.node) start_col = (start-column @callee_any)
+  attr (@call_any.node) end_row = (end-row @callee_any)
+  attr (@call_any.node) end_col = (end-column @callee_any)
+
+  edge @call_any.node -> @call_any.node
+  attr (@call_any.node -> @call_any.node) kind = "CALL"
+  attr (@call_any.node -> @call_any.node) line = (start-row @call_any)
+}
+
+;; Use imports
+(namespace_use_declaration
+  (namespace_use_clause
+    (qualified_name) @module))
+{
+  node @module.node
+  attr (@module.node) kind = "MODULE"
+  attr (@module.node) name = (source-text @module)
+  attr (@module.node) start_row = (start-row @module)
+  attr (@module.node) start_col = (start-column @module)
+  attr (@module.node) end_row = (end-row @module)
+  attr (@module.node) end_col = (end-column @module)
+
+  edge @module.node -> @module.node
+  attr (@module.node -> @module.node) kind = "IMPORT"
+}

--- a/crates/codestory-indexer/rules/ruby.scm
+++ b/crates/codestory-indexer/rules/ruby.scm
@@ -1,0 +1,102 @@
+(method
+  name: (_) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "METHOD"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(singleton_method
+  name: (_) @name) @def
+{
+  node @name.node
+  attr (@name.node) kind = "METHOD"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(class
+  name: [
+    (constant) @name
+    (scope_resolution name: (_) @name)
+  ]) @def
+{
+  node @name.node
+  attr (@name.node) kind = "CLASS"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+(module
+  name: [
+    (constant) @name
+    (scope_resolution name: (_) @name)
+  ]) @def
+{
+  node @name.node
+  attr (@name.node) kind = "MODULE"
+  attr (@name.node) name = (source-text @name)
+  attr (@name.node) start_row = (start-row @def)
+  attr (@name.node) start_col = (start-column @def)
+  attr (@name.node) end_row = (end-row @def)
+  attr (@name.node) end_col = (end-column @def)
+}
+
+;; Inheritance
+(class
+  name: (constant) @class_name
+  (superclass (constant) @parent_name))
+{
+  node @parent_name.node
+  attr (@parent_name.node) kind = "CLASS"
+  attr (@parent_name.node) name = (source-text @parent_name)
+  attr (@parent_name.node) start_row = (start-row @parent_name)
+  attr (@parent_name.node) start_col = (start-column @parent_name)
+  attr (@parent_name.node) end_row = (end-row @parent_name)
+  attr (@parent_name.node) end_col = (end-column @parent_name)
+
+  edge @class_name.node -> @parent_name.node
+  attr (@class_name.node -> @parent_name.node) kind = "INHERITANCE"
+}
+
+;; Calls
+(call
+  method: (_) @callee_any) @call_any
+{
+  node @call_any.node
+  attr (@call_any.node) kind = "UNKNOWN"
+  attr (@call_any.node) name = (source-text @callee_any)
+  attr (@call_any.node) start_row = (start-row @callee_any)
+  attr (@call_any.node) start_col = (start-column @callee_any)
+  attr (@call_any.node) end_row = (end-row @callee_any)
+  attr (@call_any.node) end_col = (end-column @callee_any)
+
+  edge @call_any.node -> @call_any.node
+  attr (@call_any.node -> @call_any.node) kind = "CALL"
+  attr (@call_any.node -> @call_any.node) line = (start-row @call_any)
+}
+
+(call
+  arguments: (argument_list (string) @module))
+{
+  node @module.node
+  attr (@module.node) kind = "MODULE"
+  attr (@module.node) name = (source-text @module)
+  attr (@module.node) start_row = (start-row @module)
+  attr (@module.node) start_col = (start-column @module)
+  attr (@module.node) end_row = (end-row @module)
+  attr (@module.node) end_col = (end-column @module)
+
+  edge @module.node -> @module.node
+  attr (@module.node -> @module.node) kind = "IMPORT"
+}

--- a/crates/codestory-indexer/rules/rust.graph.scm
+++ b/crates/codestory-indexer/rules/rust.graph.scm
@@ -48,6 +48,25 @@
   attr (@name.node) end_col = (end-column @name)
 }
 
+(enum_item
+  name: (type_identifier) @enum_name
+  body: (enum_variant_list
+    (enum_variant
+      name: (identifier) @variant_name)))
+{
+  node @variant_name.node
+  attr (@variant_name.node) kind = "ENUM_CONSTANT"
+  attr (@variant_name.node) canonical_role = "declaration"
+  attr (@variant_name.node) name = (source-text @variant_name)
+  attr (@variant_name.node) start_row = (start-row @variant_name)
+  attr (@variant_name.node) start_col = (start-column @variant_name)
+  attr (@variant_name.node) end_row = (end-row @variant_name)
+  attr (@variant_name.node) end_col = (end-column @variant_name)
+
+  edge @enum_name.node -> @variant_name.node
+  attr (@enum_name.node -> @variant_name.node) kind = "MEMBER"
+}
+
 (union_item
   name: (type_identifier) @name)
 {
@@ -501,4 +520,3 @@
   edge @alias_name.node -> @module_path.node
   attr (@alias_name.node -> @module_path.node) kind = "IMPORT"
 }
-

--- a/crates/codestory-indexer/rules/rust.tags.scm
+++ b/crates/codestory-indexer/rules/rust.tags.scm
@@ -12,6 +12,11 @@
 (enum_item
   name: (type_identifier) @definition.enum)
 
+(enum_item
+  body: (enum_variant_list
+    (enum_variant
+      name: (identifier) @definition.enum_constant)))
+
 (union_item
   (visibility_modifier) @access
   name: (type_identifier) @definition.union)

--- a/crates/codestory-indexer/rules/tsx.graph.scm
+++ b/crates/codestory-indexer/rules/tsx.graph.scm
@@ -454,16 +454,16 @@
   (class_heritage
     (extends_clause value: (_) @parent_name)))
 {
-  node @parent_name.node
-  attr (@parent_name.node) kind = "CLASS"
-  attr (@parent_name.node) name = (source-text @parent_name)
-  attr (@parent_name.node) start_row = (start-row @parent_name)
-  attr (@parent_name.node) start_col = (start-column @parent_name)
-  attr (@parent_name.node) end_row = (end-row @parent_name)
-  attr (@parent_name.node) end_col = (end-column @parent_name)
+  node @parent_name.inheritance_node
+  attr (@parent_name.inheritance_node) kind = "CLASS"
+  attr (@parent_name.inheritance_node) name = (source-text @parent_name)
+  attr (@parent_name.inheritance_node) start_row = (start-row @parent_name)
+  attr (@parent_name.inheritance_node) start_col = (start-column @parent_name)
+  attr (@parent_name.inheritance_node) end_row = (end-row @parent_name)
+  attr (@parent_name.inheritance_node) end_col = (end-column @parent_name)
 
-  edge @class_name.node -> @parent_name.node
-  attr (@class_name.node -> @parent_name.node) kind = "INHERITANCE"
+  edge @class_name.node -> @parent_name.inheritance_node
+  attr (@class_name.node -> @parent_name.inheritance_node) kind = "INHERITANCE"
 }
 
 (class_declaration

--- a/crates/codestory-indexer/rules/typescript.graph.scm
+++ b/crates/codestory-indexer/rules/typescript.graph.scm
@@ -313,16 +313,16 @@
   (class_heritage
     (extends_clause value: (_) @parent_name)))
 {
-  node @parent_name.node
-  attr (@parent_name.node) kind = "CLASS"
-  attr (@parent_name.node) name = (source-text @parent_name)
-  attr (@parent_name.node) start_row = (start-row @parent_name)
-  attr (@parent_name.node) start_col = (start-column @parent_name)
-  attr (@parent_name.node) end_row = (end-row @parent_name)
-  attr (@parent_name.node) end_col = (end-column @parent_name)
+  node @parent_name.inheritance_node
+  attr (@parent_name.inheritance_node) kind = "CLASS"
+  attr (@parent_name.inheritance_node) name = (source-text @parent_name)
+  attr (@parent_name.inheritance_node) start_row = (start-row @parent_name)
+  attr (@parent_name.inheritance_node) start_col = (start-column @parent_name)
+  attr (@parent_name.inheritance_node) end_row = (end-row @parent_name)
+  attr (@parent_name.inheritance_node) end_col = (end-column @parent_name)
 
-  edge @class_name.node -> @parent_name.node
-  attr (@class_name.node -> @parent_name.node) kind = "INHERITANCE"
+  edge @class_name.node -> @parent_name.inheritance_node
+  attr (@class_name.node -> @parent_name.inheritance_node) kind = "INHERITANCE"
 }
 
 (class_declaration

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -25,7 +25,9 @@ pub mod compilation_database;
 pub mod intermediate_storage;
 pub mod resolution;
 pub mod semantic;
+pub mod structural;
 pub mod symbol_table;
+pub mod template_pipeline;
 use cache::{CachedIndexArtifact, build_index_artifact_cache_key};
 pub use cancellation::CancellationToken;
 use intermediate_storage::IntermediateStorage;
@@ -98,6 +100,10 @@ const TSX_GRAPH_QUERY: &str = include_str!("../rules/tsx.graph.scm");
 const TSX_TAGS_QUERY: &str = TYPESCRIPT_TAGS_QUERY;
 const CPP_GRAPH_QUERY: &str = include_str!("../rules/cpp.scm");
 const C_GRAPH_QUERY: &str = include_str!("../rules/c.scm");
+const GO_GRAPH_QUERY: &str = include_str!("../rules/go.scm");
+const RUBY_GRAPH_QUERY: &str = include_str!("../rules/ruby.scm");
+const PHP_GRAPH_QUERY: &str = include_str!("../rules/php.scm");
+const CSHARP_GRAPH_QUERY: &str = include_str!("../rules/csharp.scm");
 
 #[derive(Debug, Clone, Copy)]
 enum LanguageRuleset {
@@ -109,6 +115,10 @@ enum LanguageRuleset {
     Tsx,
     Cpp,
     C,
+    Go,
+    Ruby,
+    Php,
+    CSharp,
 }
 
 #[derive(Debug, Clone)]
@@ -243,6 +253,16 @@ impl LanguageRuleset {
                 compiled_rules_cache(language, CPP_GRAPH_QUERY, None, &CPP_RULES)
             }
             LanguageRuleset::C => compiled_rules_cache(language, C_GRAPH_QUERY, None, &C_RULES),
+            LanguageRuleset::Go => compiled_rules_cache(language, GO_GRAPH_QUERY, None, &GO_RULES),
+            LanguageRuleset::Ruby => {
+                compiled_rules_cache(language, RUBY_GRAPH_QUERY, None, &RUBY_RULES)
+            }
+            LanguageRuleset::Php => {
+                compiled_rules_cache(language, PHP_GRAPH_QUERY, None, &PHP_RULES)
+            }
+            LanguageRuleset::CSharp => {
+                compiled_rules_cache(language, CSHARP_GRAPH_QUERY, None, &CSHARP_RULES)
+            }
         }
     }
 }
@@ -281,6 +301,10 @@ static TYPESCRIPT_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceL
 static TSX_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static CPP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 static C_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+static GO_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+static RUBY_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+static PHP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
+static CSHARP_RULES: OnceLock<Result<CompiledLanguageRules, String>> = OnceLock::new();
 
 fn tag_definition_priority(definition: &TagDefinition) -> (u8, u8, u8) {
     let role_priority = canonical_role_priority(definition.canonical_role);
@@ -316,6 +340,7 @@ fn tag_definition_kind(kind: &str) -> Option<NodeKind> {
         "function" => Some(NodeKind::FUNCTION),
         "method" => Some(NodeKind::METHOD),
         "field" => Some(NodeKind::FIELD),
+        "enum_constant" => Some(NodeKind::ENUM_CONSTANT),
         "variable" => Some(NodeKind::VARIABLE),
         _ => None,
     }
@@ -925,8 +950,18 @@ impl WorkspaceIndexer {
                     || !batched_storage.nodes.is_empty()
                     || !batched_storage.edges.is_empty()
                     || !batched_storage.occurrences.is_empty();
+                let pipeline_flush =
+                    std::env::var("CODESTORY_PIPELINE_FLUSH")
+                        .ok()
+                        .is_some_and(|value| {
+                            matches!(
+                                value.trim().to_ascii_lowercase().as_str(),
+                                "1" | "true" | "yes" | "on"
+                            )
+                        });
                 if should_flush
-                    && (batched_storage.nodes.len() >= batch_config.node_batch_size
+                    && (pipeline_flush
+                        || batched_storage.nodes.len() >= batch_config.node_batch_size
                         || batched_storage.edges.len() >= batch_config.edge_batch_size
                         || batched_storage.occurrences.len() >= batch_config.occurrence_batch_size)
                 {
@@ -1244,22 +1279,75 @@ impl WorkspaceIndexer {
                 Ok(None) => {}
                 Err(err_storage) => return Err(err_storage),
             }
+            if let Some(template_kind) = template_pipeline::template_kind_for_path(&full_path) {
+                return match prepare_template_index_work(&full_path, template_kind) {
+                    Ok(local_storage) => Ok(PreparedIndexWork::Immediate(local_storage)),
+                    Err(error) => {
+                        let local_storage = incomplete_file_storage(
+                            &full_path,
+                            None,
+                            template_pipeline::template_surface_language(&full_path)
+                                .unwrap_or("template"),
+                            codestory_contracts::graph::ErrorInfo {
+                                message: format!(
+                                    "Failed to index template file {:?}: {}",
+                                    path, error
+                                ),
+                                file_id: None,
+                                line: None,
+                                column: None,
+                                is_fatal: false,
+                                index_step: codestory_contracts::graph::IndexStep::Indexing,
+                            },
+                        );
+                        Err(local_storage)
+                    }
+                };
+            }
+            if structural::is_structural_candidate_path(&full_path) {
+                return match structural::index_structural_file(&full_path) {
+                    Ok(local_storage) => Ok(PreparedIndexWork::Immediate(local_storage)),
+                    Err(error) => {
+                        let local_storage = incomplete_file_storage(
+                            &full_path,
+                            None,
+                            structural::structural_language_name(&full_path),
+                            codestory_contracts::graph::ErrorInfo {
+                                message: format!(
+                                    "Failed to index structural file {:?}: {}",
+                                    path, error
+                                ),
+                                file_id: None,
+                                line: None,
+                                column: None,
+                                is_fatal: false,
+                                index_step: codestory_contracts::graph::IndexStep::Indexing,
+                            },
+                        );
+                        Err(local_storage)
+                    }
+                };
+            }
             if is_text_only_candidate_path(&full_path) {
                 return match index_text_only_file(&full_path) {
                     Ok(local_storage) => Ok(PreparedIndexWork::Immediate(local_storage)),
                     Err(error) => {
-                        let mut local_storage = IntermediateStorage::default();
-                        local_storage.add_error(codestory_contracts::graph::ErrorInfo {
-                            message: format!(
-                                "Failed to index text-only file {:?}: {}",
-                                path, error
-                            ),
-                            file_id: None,
-                            line: None,
-                            column: None,
-                            is_fatal: false,
-                            index_step: codestory_contracts::graph::IndexStep::Indexing,
-                        });
+                        let local_storage = incomplete_file_storage(
+                            &full_path,
+                            None,
+                            text_only_language_name(&full_path),
+                            codestory_contracts::graph::ErrorInfo {
+                                message: format!(
+                                    "Failed to index text-only file {:?}: {}",
+                                    path, error
+                                ),
+                                file_id: None,
+                                line: None,
+                                column: None,
+                                is_fatal: false,
+                                index_step: codestory_contracts::graph::IndexStep::Indexing,
+                            },
+                        );
                         Err(local_storage)
                     }
                 };
@@ -1270,15 +1358,19 @@ impl WorkspaceIndexer {
         let bytes = match std::fs::read(&full_path) {
             Ok(bytes) => bytes,
             Err(e) => {
-                let mut local_storage = IntermediateStorage::default();
-                local_storage.add_error(codestory_contracts::graph::ErrorInfo {
-                    message: format!("Failed to read {:?}: {}", path, e),
-                    file_id: None,
-                    line: None,
-                    column: None,
-                    is_fatal: true,
-                    index_step: codestory_contracts::graph::IndexStep::Collection,
-                });
+                let local_storage = incomplete_file_storage(
+                    &full_path,
+                    None,
+                    language_config.language_name,
+                    codestory_contracts::graph::ErrorInfo {
+                        message: format!("Failed to read {:?}: {}", path, e),
+                        file_id: None,
+                        line: None,
+                        column: None,
+                        is_fatal: true,
+                        index_step: codestory_contracts::graph::IndexStep::Collection,
+                    },
+                );
                 return Err(local_storage);
             }
         };
@@ -1316,12 +1408,13 @@ impl WorkspaceIndexer {
                             && let Err(error) = storage.update_file_metadata(file_info)
                         {
                             let mut local_storage = IntermediateStorage::default();
+                            let file_id = NodeId(file_info.id);
                             local_storage.add_error(codestory_contracts::graph::ErrorInfo {
                                 message: format!(
                                     "Failed to refresh cached file metadata for {:?}: {:?}",
                                     full_path, error
                                 ),
-                                file_id: None,
+                                file_id: Some(file_id),
                                 line: None,
                                 column: None,
                                 is_fatal: false,
@@ -1382,29 +1475,36 @@ impl WorkspaceIndexer {
         let source = match std::fs::read_to_string(full_path) {
             Ok(source) => source,
             Err(error) => {
-                let mut local_storage = IntermediateStorage::default();
-                local_storage.add_error(codestory_contracts::graph::ErrorInfo {
-                    message: format!("Failed to read {:?}: {}", full_path, error),
-                    file_id: None,
-                    line: None,
-                    column: None,
-                    is_fatal: true,
-                    index_step: codestory_contracts::graph::IndexStep::Collection,
-                });
+                let local_storage = incomplete_file_storage(
+                    full_path,
+                    None,
+                    "openapi",
+                    codestory_contracts::graph::ErrorInfo {
+                        message: format!("Failed to read {:?}: {}", full_path, error),
+                        file_id: None,
+                        line: None,
+                        column: None,
+                        is_fatal: true,
+                        index_step: codestory_contracts::graph::IndexStep::Collection,
+                    },
+                );
                 return Err(local_storage);
             }
         };
         index_openapi_schema_file(full_path, &source).map_err(|error| {
-            let mut local_storage = IntermediateStorage::default();
-            local_storage.add_error(codestory_contracts::graph::ErrorInfo {
-                message: format!("Failed to index OpenAPI schema {:?}: {}", full_path, error),
-                file_id: None,
-                line: None,
-                column: None,
-                is_fatal: false,
-                index_step: codestory_contracts::graph::IndexStep::Indexing,
-            });
-            local_storage
+            incomplete_file_storage(
+                full_path,
+                Some(&source),
+                "openapi",
+                codestory_contracts::graph::ErrorInfo {
+                    message: format!("Failed to index OpenAPI schema {:?}: {}", full_path, error),
+                    file_id: None,
+                    line: None,
+                    column: None,
+                    is_fatal: false,
+                    index_step: codestory_contracts::graph::IndexStep::Indexing,
+                },
+            )
         })
     }
 
@@ -1413,7 +1513,6 @@ impl WorkspaceIndexer {
         prepared_input: &PreparedIndexInput,
         symbol_table: &Arc<SymbolTable>,
     ) -> PreparedIndexJobResult {
-        let mut local_storage = IntermediateStorage::default();
         match index_file(
             &prepared_input.full_path,
             &prepared_input.source,
@@ -1431,21 +1530,26 @@ impl WorkspaceIndexer {
                             cache_key: prepared_input.artifact_cache_key.clone(),
                             artifact_blob,
                         });
-                local_storage = artifact.into_intermediate_storage();
+                let local_storage = artifact.into_intermediate_storage();
                 PreparedIndexJobResult {
                     local_storage,
                     cache_write,
                 }
             }
             Err(e) => {
-                local_storage.add_error(codestory_contracts::graph::ErrorInfo {
-                    message: format!("Failed to index {:?}: {}", prepared_input.full_path, e),
-                    file_id: None,
-                    line: None,
-                    column: None,
-                    is_fatal: false,
-                    index_step: codestory_contracts::graph::IndexStep::Indexing,
-                });
+                let local_storage = incomplete_file_storage(
+                    &prepared_input.full_path,
+                    Some(&prepared_input.source),
+                    prepared_input.language_config.language_name,
+                    codestory_contracts::graph::ErrorInfo {
+                        message: format!("Failed to index {:?}: {}", prepared_input.full_path, e),
+                        file_id: None,
+                        line: None,
+                        column: None,
+                        is_fatal: false,
+                        index_step: codestory_contracts::graph::IndexStep::Indexing,
+                    },
+                );
                 PreparedIndexJobResult {
                     local_storage,
                     cache_write: None,
@@ -1508,7 +1612,7 @@ fn accumulate_flush_breakdown(
         .saturating_add(u64::from(breakdown.callable_projection_ms));
 }
 
-fn file_node_from_source(path: &Path, source: &str) -> (Node, String, NodeId) {
+pub(crate) fn file_node_from_source(path: &Path, source: &str) -> (Node, String, NodeId) {
     let file_name = path.to_string_lossy().to_string();
     let file_id = NodeId(WorkspaceIndexer::canonical_file_node_id_for_path(path));
     let line_count = source.lines().count() as u32;
@@ -1525,6 +1629,31 @@ fn file_node_from_source(path: &Path, source: &str) -> (Node, String, NodeId) {
     };
 
     (file_node, file_name, file_id)
+}
+
+fn incomplete_file_storage(
+    path: &Path,
+    source: Option<&str>,
+    language: impl Into<String>,
+    mut error: codestory_contracts::graph::ErrorInfo,
+) -> IntermediateStorage {
+    let source = source.unwrap_or("");
+    let (file_node, _file_name, file_id) = file_node_from_source(path, source);
+    let mut local_storage = IntermediateStorage::default();
+    local_storage.files.push(codestory_store::FileInfo {
+        id: file_id.0,
+        path: path.to_path_buf(),
+        language: language.into(),
+        modification_time: file_modification_time(path),
+        indexed: true,
+        complete: false,
+        line_count: source.lines().count() as u32,
+        file_role: codestory_store::FileRole::classify_path(path),
+    });
+    local_storage.nodes.push(file_node);
+    error.file_id = Some(file_id);
+    local_storage.add_error(error);
+    local_storage
 }
 
 fn node_kind_from_graph_kind(kind_str: &str) -> NodeKind {
@@ -2458,6 +2587,707 @@ fn collect_rust_generic_type_argument_edges(tree: &Tree, source: &str) -> Vec<Ma
         }
     });
     edges
+}
+
+#[derive(Debug, Clone)]
+struct RustReceiverCallHint {
+    method_name: String,
+    qualified_method_name: String,
+    start_line: u32,
+    start_col: u32,
+}
+
+type RustStructFieldTypes = HashMap<(String, String), String>;
+type RustMethodReturnTypes = HashMap<(String, String), String>;
+type RustTypeAliases = HashMap<String, String>;
+
+fn collect_rust_receiver_call_hints(tree: &Tree, source: &str) -> Vec<RustReceiverCallHint> {
+    let aliases = collect_rust_type_aliases(tree, source);
+    let field_types = collect_rust_struct_field_types(tree, source, &aliases);
+    let method_return_types = collect_rust_method_return_types(tree, source, &aliases);
+    let mut hints = Vec::new();
+
+    walk_tree_nodes(tree.root_node(), &mut |node| {
+        if node.kind() != "call_expression" {
+            return;
+        }
+        let Some(function_node) = node.child_by_field_name("function") else {
+            return;
+        };
+        if function_node.kind() != "field_expression" {
+            return;
+        }
+        let Some(method_node) = function_node.child_by_field_name("field") else {
+            return;
+        };
+        let Some(method_name) = node_source_text(method_node, source)
+            .map(|value| value.trim().to_string())
+            .filter(|value| is_rust_identifier_like(value))
+        else {
+            return;
+        };
+        let Some(receiver_node) = function_node.child_by_field_name("value") else {
+            return;
+        };
+        let impl_owner = rust_enclosing_impl_owner(node, source, &aliases);
+        let value_types = rust_enclosing_value_types(
+            node,
+            source,
+            &aliases,
+            &field_types,
+            &method_return_types,
+            impl_owner.as_deref(),
+        );
+        let Some(owner_name) = infer_rust_receiver_owner(
+            receiver_node,
+            source,
+            impl_owner.as_deref(),
+            &field_types,
+            &method_return_types,
+            &value_types,
+            &aliases,
+        )
+        .filter(|value| is_rust_type_like_name(value)) else {
+            return;
+        };
+        if rust_enclosing_generic_type_params(node, source).contains(&owner_name) {
+            return;
+        }
+        let position = method_node.start_position();
+        hints.push(RustReceiverCallHint {
+            method_name: method_name.clone(),
+            qualified_method_name: format!("{owner_name}::{method_name}"),
+            start_line: position.row as u32 + 1,
+            start_col: position.column as u32 + 1,
+        });
+    });
+
+    hints
+}
+
+fn apply_rust_receiver_call_hints(
+    tree: &Tree,
+    source: &str,
+    unique_nodes: &mut HashMap<NodeId, Node>,
+) {
+    let hints = collect_rust_receiver_call_hints(tree, source);
+    if hints.is_empty() {
+        return;
+    }
+
+    for hint in hints {
+        for node in unique_nodes.values_mut() {
+            if node.kind == NodeKind::UNKNOWN
+                && node.serialized_name == hint.method_name
+                && node.start_line == Some(hint.start_line)
+                && node.start_col == Some(hint.start_col)
+            {
+                node.serialized_name = hint.qualified_method_name.clone();
+                node.qualified_name = Some(hint.qualified_method_name.clone());
+            }
+        }
+    }
+}
+
+fn collect_rust_type_aliases(tree: &Tree, source: &str) -> RustTypeAliases {
+    let mut aliases = RustTypeAliases::new();
+    walk_tree_nodes(tree.root_node(), &mut |node| {
+        if node.kind() != "use_declaration" {
+            return;
+        }
+        let alias_surface = node
+            .child_by_field_name("argument")
+            .and_then(|argument| node_source_text(argument, source))
+            .or_else(|| node_source_text(node, source));
+        let Some(alias_surface) = alias_surface else {
+            return;
+        };
+        collect_rust_aliases_from_surface(&alias_surface, &mut aliases);
+    });
+    aliases
+}
+
+fn collect_rust_aliases_from_surface(surface: &str, aliases: &mut RustTypeAliases) {
+    for segment in surface.split(',') {
+        let segment = segment
+            .trim()
+            .trim_start_matches("use ")
+            .trim_end_matches(';')
+            .trim();
+        let Some((raw_target, raw_alias)) = segment.rsplit_once(" as ") else {
+            continue;
+        };
+        let Some(alias) = rust_tail_identifier(raw_alias) else {
+            continue;
+        };
+        let Some(target) = rust_tail_identifier(raw_target) else {
+            continue;
+        };
+        if is_rust_type_like_name(&alias) && is_rust_type_like_name(&target) {
+            aliases.insert(alias, target);
+        }
+    }
+}
+
+fn collect_rust_struct_field_types(
+    tree: &Tree,
+    source: &str,
+    aliases: &RustTypeAliases,
+) -> RustStructFieldTypes {
+    let mut fields = RustStructFieldTypes::new();
+    walk_tree_nodes(tree.root_node(), &mut |node| {
+        if node.kind() != "struct_item" {
+            return;
+        }
+        let Some(owner) = node
+            .child_by_field_name("name")
+            .and_then(|name| node_source_text(name, source))
+            .and_then(|name| normalize_rust_type_owner_name(&name, aliases))
+        else {
+            return;
+        };
+        walk_tree_nodes(node, &mut |field_node| {
+            if field_node.kind() != "field_declaration" {
+                return;
+            }
+            let Some(field_name) = field_node
+                .child_by_field_name("name")
+                .and_then(|name| node_source_text(name, source))
+                .map(|name| name.trim().to_string())
+                .filter(|name| is_rust_identifier_like(name))
+            else {
+                return;
+            };
+            let Some(field_type) = field_node
+                .child_by_field_name("type")
+                .and_then(|ty| node_source_text(ty, source))
+                .and_then(|ty| normalize_rust_type_owner_name(&ty, aliases))
+            else {
+                return;
+            };
+            fields.insert((owner.clone(), field_name), field_type);
+        });
+    });
+    fields
+}
+
+fn collect_rust_method_return_types(
+    tree: &Tree,
+    source: &str,
+    aliases: &RustTypeAliases,
+) -> RustMethodReturnTypes {
+    let mut return_types = RustMethodReturnTypes::new();
+    walk_tree_nodes(tree.root_node(), &mut |node| {
+        if node.kind() != "function_item" {
+            return;
+        }
+        let Some(owner) = rust_enclosing_impl_owner(node, source, aliases) else {
+            return;
+        };
+        let Some(method_name) = node
+            .child_by_field_name("name")
+            .and_then(|name| node_source_text(name, source))
+            .map(|name| name.trim().to_string())
+            .filter(|name| is_rust_identifier_like(name))
+        else {
+            return;
+        };
+        let Some(return_type) = rust_function_return_type_text(node, source)
+            .and_then(|ty| normalize_rust_return_owner_name(&ty, aliases, Some(&owner)))
+        else {
+            return;
+        };
+        return_types.insert((owner, method_name), return_type);
+    });
+    return_types
+}
+
+fn rust_function_return_type_text(function_node: TsNode<'_>, source: &str) -> Option<String> {
+    if let Some(return_node) = function_node
+        .child_by_field_name("return_type")
+        .or_else(|| {
+            let mut cursor = function_node.walk();
+            function_node
+                .named_children(&mut cursor)
+                .find(|child| child.kind() == "return_type")
+        })
+        && let Some(return_type) = node_source_text(return_node, source)
+    {
+        return Some(
+            return_type
+                .trim()
+                .trim_start_matches("->")
+                .trim()
+                .to_string(),
+        );
+    }
+
+    let surface = node_source_text(function_node, source)?;
+    let signature = surface.split('{').next().unwrap_or(&surface);
+    let (_, return_type) = signature.rsplit_once("->")?;
+    Some(return_type.trim().to_string())
+}
+
+fn rust_enclosing_impl_owner(
+    node: TsNode<'_>,
+    source: &str,
+    aliases: &RustTypeAliases,
+) -> Option<String> {
+    let mut cursor = Some(node);
+    while let Some(current) = cursor {
+        if current.kind() == "impl_item" {
+            return current
+                .child_by_field_name("type")
+                .and_then(|ty| node_source_text(ty, source))
+                .and_then(|ty| normalize_rust_type_owner_name(&ty, aliases));
+        }
+        cursor = current.parent();
+    }
+    None
+}
+
+fn rust_enclosing_value_types(
+    call_node: TsNode<'_>,
+    source: &str,
+    aliases: &RustTypeAliases,
+    field_types: &RustStructFieldTypes,
+    method_return_types: &RustMethodReturnTypes,
+    impl_owner: Option<&str>,
+) -> HashMap<String, String> {
+    let mut function_node = None;
+    let mut cursor = call_node.parent();
+    while let Some(current) = cursor {
+        if current.kind() == "function_item" {
+            function_node = Some(current);
+            break;
+        }
+        cursor = current.parent();
+    }
+
+    let Some(function_node) = function_node else {
+        return HashMap::new();
+    };
+
+    let mut value_types = HashMap::new();
+    let call_start_byte = call_node.start_byte();
+    walk_tree_nodes(function_node, &mut |node| {
+        if node.start_byte() > call_start_byte {
+            return;
+        }
+        if !matches!(node.kind(), "parameter" | "let_declaration") {
+            return;
+        }
+        let Some(pattern_node) = node.child_by_field_name("pattern") else {
+            return;
+        };
+        let Some(value_name) = rust_pattern_identifier(pattern_node, source) else {
+            return;
+        };
+        let type_name = node
+            .child_by_field_name("type")
+            .and_then(|ty| node_source_text(ty, source))
+            .and_then(|ty| normalize_rust_type_owner_name(&ty, aliases))
+            .or_else(|| {
+                if node.kind() != "let_declaration" {
+                    return None;
+                }
+                node.child_by_field_name("value").and_then(|value| {
+                    infer_rust_value_owner_from_expression(
+                        value,
+                        source,
+                        impl_owner,
+                        field_types,
+                        method_return_types,
+                        &value_types,
+                        aliases,
+                    )
+                })
+            });
+        let Some(type_name) = type_name else {
+            return;
+        };
+        value_types.insert(value_name, type_name);
+    });
+    value_types
+}
+
+fn infer_rust_receiver_owner(
+    receiver_node: TsNode<'_>,
+    source: &str,
+    impl_owner: Option<&str>,
+    field_types: &RustStructFieldTypes,
+    method_return_types: &RustMethodReturnTypes,
+    value_types: &HashMap<String, String>,
+    aliases: &RustTypeAliases,
+) -> Option<String> {
+    match receiver_node.kind() {
+        "self" => impl_owner.map(str::to_string),
+        "identifier" => node_source_text(receiver_node, source)
+            .map(|name| name.trim().to_string())
+            .and_then(|name| {
+                if name == "Self" {
+                    impl_owner.map(str::to_string)
+                } else {
+                    value_types.get(&name).cloned()
+                }
+            }),
+        "field_expression" => {
+            let field_name = receiver_node
+                .child_by_field_name("field")
+                .and_then(|field| node_source_text(field, source))
+                .map(|name| name.trim().to_string())
+                .filter(|name| is_rust_identifier_like(name))?;
+            let value_node = receiver_node.child_by_field_name("value")?;
+            let owner_name = infer_rust_receiver_owner(
+                value_node,
+                source,
+                impl_owner,
+                field_types,
+                method_return_types,
+                value_types,
+                aliases,
+            )?;
+            field_types.get(&(owner_name, field_name)).cloned()
+        }
+        "call_expression" | "try_expression" | "parenthesized_expression" => {
+            infer_rust_value_owner_from_expression(
+                receiver_node,
+                source,
+                impl_owner,
+                field_types,
+                method_return_types,
+                value_types,
+                aliases,
+            )
+        }
+        _ => None,
+    }
+}
+
+fn infer_rust_value_owner_from_expression(
+    expr_node: TsNode<'_>,
+    source: &str,
+    impl_owner: Option<&str>,
+    field_types: &RustStructFieldTypes,
+    method_return_types: &RustMethodReturnTypes,
+    value_types: &HashMap<String, String>,
+    aliases: &RustTypeAliases,
+) -> Option<String> {
+    match expr_node.kind() {
+        "call_expression" => infer_rust_call_return_owner(
+            expr_node,
+            source,
+            impl_owner,
+            field_types,
+            method_return_types,
+            value_types,
+            aliases,
+        ),
+        "try_expression" | "parenthesized_expression" | "await_expression" => {
+            let mut cursor = expr_node.walk();
+            expr_node.named_children(&mut cursor).find_map(|child| {
+                infer_rust_value_owner_from_expression(
+                    child,
+                    source,
+                    impl_owner,
+                    field_types,
+                    method_return_types,
+                    value_types,
+                    aliases,
+                )
+            })
+        }
+        "if_expression" => {
+            let mut inferred = HashSet::new();
+            walk_tree_nodes(expr_node, &mut |node| {
+                if node.kind() != "call_expression" {
+                    return;
+                }
+                if let Some(owner) = infer_rust_call_return_owner(
+                    node,
+                    source,
+                    impl_owner,
+                    field_types,
+                    method_return_types,
+                    value_types,
+                    aliases,
+                ) {
+                    inferred.insert(owner);
+                }
+            });
+            (inferred.len() == 1)
+                .then(|| inferred.into_iter().next())
+                .flatten()
+        }
+        "field_expression" | "identifier" | "self" => infer_rust_receiver_owner(
+            expr_node,
+            source,
+            impl_owner,
+            field_types,
+            method_return_types,
+            value_types,
+            aliases,
+        ),
+        _ => None,
+    }
+}
+
+fn infer_rust_call_return_owner(
+    call_node: TsNode<'_>,
+    source: &str,
+    impl_owner: Option<&str>,
+    field_types: &RustStructFieldTypes,
+    method_return_types: &RustMethodReturnTypes,
+    value_types: &HashMap<String, String>,
+    aliases: &RustTypeAliases,
+) -> Option<String> {
+    let function_node = call_node.child_by_field_name("function")?;
+    match function_node.kind() {
+        "field_expression" => {
+            let method_name = function_node
+                .child_by_field_name("field")
+                .and_then(|field| node_source_text(field, source))
+                .map(|name| name.trim().to_string())
+                .filter(|name| is_rust_identifier_like(name))?;
+            let value_node = function_node.child_by_field_name("value")?;
+            let receiver_owner = infer_rust_receiver_owner(
+                value_node,
+                source,
+                impl_owner,
+                field_types,
+                method_return_types,
+                value_types,
+                aliases,
+            )?;
+            method_return_types
+                .get(&(receiver_owner.clone(), method_name.clone()))
+                .cloned()
+                .or_else(|| {
+                    rust_type_preserving_adapter_method(&method_name).then_some(receiver_owner)
+                })
+        }
+        "scoped_identifier" => {
+            let (owner_name, method_name) =
+                rust_scoped_function_owner_and_name(function_node, source, aliases, impl_owner)?;
+            method_return_types
+                .get(&(owner_name.clone(), method_name.clone()))
+                .cloned()
+                .or_else(|| {
+                    rust_constructor_like_associated_method(&method_name).then_some(owner_name)
+                })
+        }
+        _ => None,
+    }
+}
+
+fn rust_scoped_function_owner_and_name(
+    function_node: TsNode<'_>,
+    source: &str,
+    aliases: &RustTypeAliases,
+    impl_owner: Option<&str>,
+) -> Option<(String, String)> {
+    let surface = node_source_text(function_node, source)?;
+    let (raw_owner, raw_method) = surface.rsplit_once("::")?;
+    let mut owner_name = normalize_rust_type_owner_name(raw_owner, aliases)?;
+    if owner_name == "Self" {
+        owner_name = impl_owner?.to_string();
+    }
+    let method_name = rust_tail_identifier(raw_method)?;
+    Some((owner_name, method_name))
+}
+
+fn rust_type_preserving_adapter_method(method_name: &str) -> bool {
+    matches!(
+        method_name,
+        "map_err" | "context" | "with_context" | "inspect" | "inspect_err"
+    )
+}
+
+fn rust_constructor_like_associated_method(method_name: &str) -> bool {
+    method_name == "new"
+        || method_name == "open"
+        || method_name == "default"
+        || method_name == "from"
+        || method_name.starts_with("new_")
+}
+
+fn rust_pattern_identifier(pattern_node: TsNode<'_>, source: &str) -> Option<String> {
+    if pattern_node.kind() == "identifier" {
+        return node_source_text(pattern_node, source)
+            .map(|name| name.trim().to_string())
+            .filter(|name| is_rust_identifier_like(name));
+    }
+
+    let mut found = None;
+    walk_tree_nodes(pattern_node, &mut |node| {
+        if found.is_none() && node.kind() == "identifier" {
+            found = node_source_text(node, source)
+                .map(|name| name.trim().to_string())
+                .filter(|name| is_rust_identifier_like(name));
+        }
+    });
+    found
+}
+
+fn rust_enclosing_generic_type_params(node: TsNode<'_>, source: &str) -> HashSet<String> {
+    let mut params = HashSet::new();
+    let mut cursor = Some(node);
+    while let Some(current) = cursor {
+        if matches!(
+            current.kind(),
+            "function_item" | "impl_item" | "struct_item" | "enum_item" | "trait_item"
+        ) {
+            collect_rust_generic_type_params(current, source, &mut params);
+        }
+        cursor = current.parent();
+    }
+    params
+}
+
+fn collect_rust_generic_type_params(node: TsNode<'_>, source: &str, params: &mut HashSet<String>) {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() != "type_parameters" {
+            continue;
+        }
+        let Some(raw_params) = node_source_text(child, source) else {
+            continue;
+        };
+        for part in split_top_level_type_arguments(&raw_params) {
+            if let Some(name) = rust_generic_param_name(&part) {
+                params.insert(name);
+            }
+        }
+    }
+}
+
+fn rust_generic_param_name(value: &str) -> Option<String> {
+    let raw = value.trim();
+    if raw.starts_with('\'') || raw.is_empty() {
+        return None;
+    }
+    let name = raw
+        .split(|ch: char| !(ch == '_' || ch.is_ascii_alphanumeric()))
+        .next()
+        .unwrap_or_default();
+    is_rust_identifier_like(name).then(|| name.to_string())
+}
+
+fn normalize_rust_return_owner_name(
+    raw_type: &str,
+    aliases: &RustTypeAliases,
+    impl_owner: Option<&str>,
+) -> Option<String> {
+    let mut value = raw_type
+        .trim()
+        .trim_start_matches("->")
+        .trim()
+        .trim_end_matches(';')
+        .trim();
+    if let Some((before_where, _)) = value.split_once(" where ") {
+        value = before_where.trim();
+    }
+    if let Some(rest) = value.strip_prefix("impl ") {
+        value = rest.trim();
+    }
+
+    let owner_surface = value
+        .find('<')
+        .and_then(|generic_start| {
+            let owner = rust_tail_identifier(&value[..generic_start])?;
+            matches!(
+                owner.as_str(),
+                "Result" | "Option" | "Box" | "Arc" | "Rc" | "Cow"
+            )
+            .then(|| split_top_level_type_arguments(value).into_iter().next())
+            .flatten()
+        })
+        .unwrap_or_else(|| value.to_string());
+
+    let mut owner = normalize_rust_type_owner_name(&owner_surface, aliases)?;
+    if owner == "Self" {
+        owner = impl_owner?.to_string();
+    }
+    Some(owner)
+}
+
+fn normalize_rust_type_owner_name(raw_type: &str, aliases: &RustTypeAliases) -> Option<String> {
+    let mut value = raw_type.trim();
+    loop {
+        let trimmed = value.trim_start();
+        if let Some(rest) = trimmed.strip_prefix('&') {
+            value = rest.trim_start();
+            if let Some(rest) = strip_rust_lifetime_prefix(value) {
+                value = rest;
+            }
+            if let Some(rest) = value.strip_prefix("mut ") {
+                value = rest.trim_start();
+            }
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("mut ") {
+            value = rest.trim_start();
+            continue;
+        }
+        value = trimmed;
+        break;
+    }
+
+    if let Some(rest) = value.strip_prefix("dyn ") {
+        value = rest.trim_start();
+    }
+    if value == "Self" {
+        return Some(value.to_string());
+    }
+
+    let generic_start = value.find('<').unwrap_or(value.len());
+    let owner_surface = value[..generic_start].trim();
+    let mut owner = rust_tail_identifier(owner_surface)?;
+    if let Some(alias_target) = aliases.get(&owner) {
+        owner = alias_target.clone();
+    }
+    is_rust_type_like_name(&owner).then_some(owner)
+}
+
+fn strip_rust_lifetime_prefix(value: &str) -> Option<&str> {
+    let value = value.trim_start();
+    let rest = value.strip_prefix('\'')?;
+    let end = rest
+        .char_indices()
+        .find_map(|(idx, ch)| (!(ch == '_' || ch.is_ascii_alphanumeric())).then_some(idx))
+        .unwrap_or(rest.len());
+    Some(rest[end..].trim_start())
+}
+
+fn rust_tail_identifier(surface: &str) -> Option<String> {
+    let trimmed = surface
+        .trim()
+        .trim_matches(|ch: char| matches!(ch, '{' | '}' | '(' | ')' | ';'));
+    let tail = trimmed
+        .rsplit(|ch: char| !(ch == '_' || ch == ':' || ch.is_ascii_alphanumeric()))
+        .find(|part| !part.is_empty())
+        .unwrap_or(trimmed)
+        .rsplit("::")
+        .next()
+        .unwrap_or(trimmed)
+        .trim();
+    is_rust_identifier_like(tail).then(|| tail.to_string())
+}
+
+fn is_rust_identifier_like(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn is_rust_type_like_name(value: &str) -> bool {
+    value
+        .chars()
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_uppercase())
 }
 
 fn collect_cpp_template_type_argument_edges(tree: &Tree, source: &str) -> Vec<ManualEdgeSpec> {
@@ -4370,6 +5200,7 @@ struct FrameworkRoute {
     line: u32,
     confidence: &'static str,
     source_convention: &'static str,
+    extraction_provenance: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4417,7 +5248,13 @@ impl FrameworkRoute {
             line,
             confidence,
             source_convention: confidence,
+            extraction_provenance: "line_scan",
         }
+    }
+
+    fn with_extraction_provenance(mut self, extraction_provenance: &'static str) -> Self {
+        self.extraction_provenance = extraction_provenance;
+        self
     }
 }
 
@@ -4436,10 +5273,7 @@ pub fn is_text_only_candidate_path(path: &Path) -> bool {
         .and_then(|value| value.to_str())
         .unwrap_or_default()
         .to_ascii_lowercase();
-    matches!(
-        extension.as_str(),
-        "svelte" | "vue" | "astro" | "go" | "rb" | "php" | "cs" | "cshtml"
-    )
+    matches!(extension.as_str(), "go" | "rb" | "php" | "cs" | "cshtml")
 }
 
 fn text_only_language_name(path: &Path) -> &'static str {
@@ -4461,6 +5295,79 @@ fn text_only_language_name(path: &Path) -> &'static str {
     }
 }
 
+fn prepare_template_index_work(
+    path: &Path,
+    template_kind: template_pipeline::TemplateKind,
+) -> Result<IntermediateStorage> {
+    let source = std::fs::read_to_string(path)?;
+    index_template_file(path, template_kind, &source)
+}
+
+fn index_template_file(
+    path: &Path,
+    template_kind: template_pipeline::TemplateKind,
+    source: &str,
+) -> Result<IntermediateStorage> {
+    let prepared = template_pipeline::prepare_template_source(template_kind, source);
+    let script_ext = match prepared.script_language {
+        "typescript" => "ts",
+        _ => "js",
+    };
+    let language_config = get_language_for_ext(script_ext)
+        .ok_or_else(|| anyhow!("missing tree-sitter config for template script language"))?;
+
+    let mut index_result = index_file(path, &prepared.blanked, &language_config, None, None)?;
+    let surface_language = template_pipeline::template_surface_language(path).unwrap_or("template");
+    if let Some(file_info) = index_result.files.first_mut() {
+        file_info.language = surface_language.to_string();
+    }
+
+    let file_id = index_result
+        .files
+        .first()
+        .map(|file| NodeId(file.id))
+        .unwrap_or_else(|| file_node_from_source(path, source).2);
+
+    let mut local_storage = IntermediateStorage::default();
+    local_storage.files.extend(index_result.files);
+    local_storage.nodes.extend(index_result.nodes);
+    local_storage.occurrences.extend(index_result.occurrences);
+    append_text_only_framework_routes(path, surface_language, source, file_id, &mut local_storage);
+    // Insert Tauri invoke edges before tree-sitter CALL edges so SQLite ON CONFLICT keeps
+    // the heuristic uncertain boundary evidence when identities collide.
+    append_text_only_tauri_invocations(surface_language, source, file_id, &mut local_storage);
+    local_storage.edges.extend(index_result.edges);
+    template_pipeline::delegate_template_style_blocks(
+        path,
+        &prepared.style_blocks,
+        file_id,
+        &mut local_storage,
+    );
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("template");
+    let flags = index_feature_flags();
+    let (final_nodes, id_remap) =
+        canonicalize_nodes(file_name, local_storage.nodes, &HashMap::new());
+    let new_file_id = id_remap.get(&file_id).copied().unwrap_or(file_id);
+    local_storage.nodes = final_nodes;
+    remap_file_affinity(&mut local_storage.nodes, new_file_id);
+    remap_edges(&mut local_storage.edges, new_file_id, &id_remap, flags);
+    remap_occurrences(&mut local_storage.occurrences, &id_remap);
+    if let Some(file_info) = local_storage.files.first_mut()
+        && let Some(remapped) = id_remap.get(&NodeId(file_info.id))
+    {
+        file_info.id = remapped.0;
+    }
+    local_storage.callable_projection_states = build_callable_projection_states(
+        &local_storage.nodes,
+        &local_storage.edges,
+        &local_storage.occurrences,
+    );
+    Ok(local_storage)
+}
+
 fn index_text_only_file(path: &Path) -> Result<IntermediateStorage> {
     let source = std::fs::read_to_string(path)?;
     let mut local_storage = IntermediateStorage::default();
@@ -4473,6 +5380,7 @@ fn index_text_only_file(path: &Path) -> Result<IntermediateStorage> {
         indexed: true,
         complete: true,
         line_count: source.lines().count() as u32,
+        file_role: codestory_store::FileRole::classify_path(path),
     });
     local_storage.nodes.push(file_node);
     if text_only_language_name(path) == "go" {
@@ -4679,6 +5587,7 @@ fn append_text_only_framework_routes(
     local_storage: &mut IntermediateStorage,
 ) {
     for route in collect_framework_routes(path, language_name, source) {
+        let route = route.with_extraction_provenance("text_only");
         let route_node = framework_route_node(file_id, &route);
         let route_node_id = route_node.id;
         local_storage.nodes.push(route_node);
@@ -4760,6 +5669,7 @@ fn index_openapi_schema_file(path: &Path, source: &str) -> Result<Option<Interme
         indexed: true,
         complete: true,
         line_count: source.lines().count() as u32,
+        file_role: codestory_store::FileRole::classify_path(path),
     });
     local_storage.nodes.push(file_node);
 
@@ -5005,6 +5915,10 @@ fn collect_framework_routes(path: &Path, language_name: &str, source: &str) -> V
     let has_koa_router =
         lower_code_source.contains("@koa/router") || lower_code_source.contains("koa-router");
     let has_hono = lower_code_source.contains("hono");
+    let has_ktor = lower_code_source.contains("ktor");
+    let has_vapor = lower_code_source.contains("vapor");
+    let has_shelf =
+        lower_code_source.contains("package:shelf") || lower_code_source.contains("shelf_router");
     let react_router_object_route_lines =
         react_router_object_route_lines(&code_lines, &code_source);
     for (index, line) in code_lines.iter().enumerate() {
@@ -5037,6 +5951,9 @@ fn collect_framework_routes(path: &Path, language_name: &str, source: &str) -> V
             "ruby" => collect_rails_route(trimmed, line_number, &mut routes),
             "php" => collect_laravel_route(trimmed, line_number, &mut routes),
             "csharp" => collect_aspnet_route(trimmed, line_number, &mut routes),
+            "kotlin" => collect_ktor_route(trimmed, line_number, &mut routes, has_ktor),
+            "swift" => collect_vapor_route(trimmed, line_number, &mut routes, has_vapor),
+            "dart" => collect_shelf_route(trimmed, line_number, &mut routes, has_shelf),
             "vue" => collect_vue_route(trimmed, line_number, &mut routes),
             "astro" => collect_astro_endpoint_route(path, trimmed, line_number, &mut routes),
             _ => {}
@@ -5079,7 +5996,17 @@ fn route_code_lines(language_name: &str, source: &str) -> Vec<String> {
 fn route_language_uses_c_style_comments(language_name: &str) -> bool {
     matches!(
         language_name,
-        "javascript" | "typescript" | "java" | "rust" | "go" | "php" | "csharp" | "vue" | "astro"
+        "javascript"
+            | "typescript"
+            | "java"
+            | "rust"
+            | "go"
+            | "php"
+            | "csharp"
+            | "kotlin"
+            | "dart"
+            | "vue"
+            | "astro"
     )
 }
 
@@ -5837,6 +6764,101 @@ fn collect_laravel_route(line: &str, line_number: u32, routes: &mut Vec<Framewor
     }
 }
 
+fn collect_ktor_route(
+    line: &str,
+    line_number: u32,
+    routes: &mut Vec<FrameworkRoute>,
+    has_ktor: bool,
+) {
+    if !has_ktor {
+        return;
+    }
+    for method in ["get", "post", "put", "patch", "delete", "head", "options"] {
+        let attr = format!("@{method}(");
+        if line.contains(&attr)
+            && let Some(path) = first_quoted_string(line)
+        {
+            routes.push(FrameworkRoute::new(
+                "ktor",
+                method.to_ascii_uppercase(),
+                path,
+                None,
+                line_number,
+                "annotation",
+            ));
+            continue;
+        }
+        for prefix in ["", "."] {
+            let needle = format!("{prefix}{method}(");
+            if line.contains(&needle)
+                && let Some(path) = first_quoted_string(line)
+            {
+                routes.push(FrameworkRoute::new(
+                    "ktor",
+                    method.to_ascii_uppercase(),
+                    path.clone(),
+                    route_handler_after_path(line, &path),
+                    line_number,
+                    "heuristic",
+                ));
+            }
+        }
+    }
+}
+
+fn collect_vapor_route(
+    line: &str,
+    line_number: u32,
+    routes: &mut Vec<FrameworkRoute>,
+    has_vapor: bool,
+) {
+    if !has_vapor && !line.contains("routes.") && !line.contains("app.") {
+        return;
+    }
+    for method in ["get", "post", "put", "patch", "delete"] {
+        let dotted = format!(".{method}(");
+        let bare = format!("{method}(");
+        if (line.contains(&dotted) || line.trim_start().starts_with(&bare))
+            && let Some(path) = first_quoted_string(line)
+        {
+            routes.push(FrameworkRoute::new(
+                "vapor",
+                method.to_ascii_uppercase(),
+                path.clone(),
+                value_after_key(line, "use"),
+                line_number,
+                "heuristic",
+            ));
+        }
+    }
+}
+
+fn collect_shelf_route(
+    line: &str,
+    line_number: u32,
+    routes: &mut Vec<FrameworkRoute>,
+    has_shelf: bool,
+) {
+    if !has_shelf && !line.contains("router.") && !line.contains("Router()") {
+        return;
+    }
+    for method in ["get", "post", "put", "patch", "delete", "head"] {
+        let needle = format!(".{method}(");
+        if line.contains(&needle)
+            && let Some(path) = first_quoted_string(line)
+        {
+            routes.push(FrameworkRoute::new(
+                "shelf",
+                method.to_ascii_uppercase(),
+                path.clone(),
+                route_handler_after_path(line, &path),
+                line_number,
+                "heuristic",
+            ));
+        }
+    }
+}
+
 fn collect_aspnet_route(line: &str, line_number: u32, routes: &mut Vec<FrameworkRoute>) {
     let attrs = [
         ("[HttpGet", "GET"),
@@ -6252,7 +7274,11 @@ fn framework_route_canonical_id(route: &FrameworkRoute) -> String {
             "params": route_params(&route.path),
             "confidence": route.confidence,
             "source_convention": route.source_convention,
-            "provenance": [format!("framework:{}", route.framework)],
+            "extraction_provenance": route.extraction_provenance,
+            "provenance": [
+                format!("framework:{}", route.framework),
+                format!("extraction:{}", route.extraction_provenance),
+            ],
         })
     )
 }
@@ -6486,6 +7512,7 @@ fn append_framework_routes(
     sinks: &mut FrameworkRouteSinks<'_>,
 ) {
     for route in collect_framework_routes(path, language_name, source) {
+        let route = route.with_extraction_provenance("ast_indexed");
         let route_node = framework_route_node(file_id, &route);
         let route_node_id = route_node.id;
         sinks
@@ -7691,6 +8718,7 @@ pub fn index_file(
         indexed: true,
         complete: !tree.root_node().has_error(),
         line_count: source.lines().count() as u32,
+        file_role: codestory_store::FileRole::classify_path(path),
     });
 
     // 1. First pass: Create nodes and a temporary mapping from GraphNodeId -> OurNodeId
@@ -8102,6 +9130,10 @@ pub fn index_file(
         },
     );
 
+    if language_config.language_name == "rust" {
+        apply_rust_receiver_call_hints(&tree, source, &mut unique_nodes);
+    }
+
     if !unique_nodes.is_empty() {
         result_nodes.extend(unique_nodes.values().cloned());
     }
@@ -8235,6 +9267,34 @@ pub fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
             C_GRAPH_QUERY,
             None,
             LanguageRuleset::C,
+        )),
+        "go" => Some(make_language_config(
+            tree_sitter_go::LANGUAGE.into(),
+            "go",
+            GO_GRAPH_QUERY,
+            None,
+            LanguageRuleset::Go,
+        )),
+        "rb" => Some(make_language_config(
+            tree_sitter_ruby::LANGUAGE.into(),
+            "ruby",
+            RUBY_GRAPH_QUERY,
+            None,
+            LanguageRuleset::Ruby,
+        )),
+        "php" => Some(make_language_config(
+            tree_sitter_php::LANGUAGE_PHP.into(),
+            "php",
+            PHP_GRAPH_QUERY,
+            None,
+            LanguageRuleset::Php,
+        )),
+        "cs" => Some(make_language_config(
+            tree_sitter_c_sharp::LANGUAGE.into(),
+            "csharp",
+            CSHARP_GRAPH_QUERY,
+            None,
+            LanguageRuleset::CSharp,
         )),
         _ => None,
     }
@@ -8389,7 +9449,7 @@ fn call_edge_still_has_unresolved_placeholder(edge: &Edge, callable_ids: &HashSe
     !callable_ids.contains(&edge.source) || edge.source == edge.target
 }
 
-fn build_callable_projection_states(
+pub(crate) fn build_callable_projection_states(
     nodes: &[Node],
     edges: &[Edge],
     occurrences: &[Occurrence],
@@ -10576,6 +11636,17 @@ function render() {
         assert!(storage.nodes.iter().any(|node| {
             node.serialized_name == "GET /users/:id (sveltekit route; confidence=file_convention)"
         }));
+        let route = storage
+            .nodes
+            .iter()
+            .find(|node| {
+                node.serialized_name
+                    == "GET /users/:id (sveltekit route; confidence=file_convention)"
+            })
+            .expect("sveltekit route node");
+        let canonical_id = route.canonical_id.as_deref().expect("route canonical id");
+        assert!(canonical_id.contains(r#""extraction_provenance":"text_only""#));
+        assert!(canonical_id.contains(r#""extraction:text_only""#));
         assert!(storage.edges.iter().any(|edge| {
             edge.kind == EdgeKind::MEMBER && edge.certainty == Some(ResolutionCertainty::Certain)
         }));
@@ -10615,6 +11686,157 @@ function render() {
         }));
         assert!(storage.occurrences.iter().any(|occurrence| {
             occurrence.element_id == command.id.0 && occurrence.kind == OccurrenceKind::REFERENCE
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_svelte_tauri_invoke_survives_projection_flush() -> Result<()> {
+        let source = r#"
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  export async function refresh() {
+    await invoke("get_snapshot");
+  }
+</script>
+"#;
+        let local = index_template_file(
+            Path::new("src/App.svelte"),
+            template_pipeline::TemplateKind::Svelte,
+            source,
+        )?;
+        let command = local
+            .nodes
+            .iter()
+            .find(|node| node.canonical_id.as_deref() == Some("tauri:command:get_snapshot"))
+            .expect("tauri command node");
+        assert!(local.edges.iter().any(|edge| {
+            edge.kind == EdgeKind::CALL
+                && edge.target == command.id
+                && edge.certainty == Some(ResolutionCertainty::Uncertain)
+        }));
+
+        let mut storage = Storage::new_in_memory()?;
+        storage
+            .projections()
+            .flush_projection_batch(codestory_store::ProjectionBatch {
+                files: &local.files,
+                nodes: &local.nodes,
+                edges: &local.edges,
+                occurrences: &local.occurrences,
+                component_access: &local.component_access,
+                callable_projection_states: &local.callable_projection_states,
+            })?;
+
+        let edges = storage.get_edges()?;
+        assert!(
+            edges.iter().any(|edge| {
+                edge.kind == EdgeKind::CALL
+                    && edge.target == command.id
+                    && edge.certainty == Some(ResolutionCertainty::Uncertain)
+            }),
+            "flush should preserve uncertain tauri invoke edge: {edges:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_workspace_svelte_tauri_invoke_indexes_uncertain_command_edge() -> Result<()> {
+        use codestory_contracts::events::EventBus;
+        use codestory_workspace::RefreshInfo;
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let root = dir.path();
+        let svelte = root.join("src/App.svelte");
+        fs::create_dir_all(svelte.parent().expect("parent"))?;
+        fs::write(
+            &svelte,
+            r#"
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  export async function refresh() {
+    await invoke("get_snapshot");
+  }
+</script>
+"#,
+        )?;
+        let rust = root.join("src-tauri/src/lib.rs");
+        fs::create_dir_all(rust.parent().expect("parent"))?;
+        fs::write(
+            &rust,
+            r#"
+#[tauri::command]
+fn get_snapshot() -> String {
+    String::new()
+}
+
+pub fn build() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![get_snapshot]);
+}
+"#,
+        )?;
+
+        let mut storage = Storage::new_in_memory()?;
+        let bus = EventBus::new();
+        let indexer = WorkspaceIndexer::new(root.to_path_buf());
+        let refresh_info = RefreshInfo {
+            mode: codestory_workspace::BuildMode::Incremental,
+            files_to_index: vec![svelte, rust],
+            files_to_remove: vec![],
+            existing_file_ids: std::collections::HashMap::new(),
+        };
+        indexer.run_incremental(&mut storage, &refresh_info, &bus, None)?;
+
+        let nodes = storage.get_nodes()?;
+        let edges = storage.get_edges()?;
+        let command = nodes
+            .iter()
+            .find(|node| node.canonical_id.as_deref() == Some("tauri:command:get_snapshot"))
+            .expect("tauri command node");
+        assert!(
+            edges.iter().any(|edge| {
+                edge.kind == EdgeKind::CALL
+                    && edge.target == command.id
+                    && edge.certainty == Some(ResolutionCertainty::Uncertain)
+            }),
+            "expected uncertain invoke edge to command {:?}, got {:?}",
+            command.id,
+            edges
+                .iter()
+                .filter(|edge| edge.target == command.id)
+                .collect::<Vec<_>>()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_svelte_tauri_invoke_indexes_uncertain_command_edge() -> Result<()> {
+        let source = r#"
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  export async function refresh() {
+    await invoke("get_snapshot");
+  }
+</script>
+"#;
+        let storage = index_template_file(
+            Path::new("src/App.svelte"),
+            template_pipeline::TemplateKind::Svelte,
+            source,
+        )?;
+        let command = storage
+            .nodes
+            .iter()
+            .find(|node| node.canonical_id.as_deref() == Some("tauri:command:get_snapshot"))
+            .expect("tauri command node");
+
+        assert!(storage.edges.iter().any(|edge| {
+            edge.kind == EdgeKind::CALL
+                && edge.target == command.id
+                && edge.certainty == Some(ResolutionCertainty::Uncertain)
         }));
         Ok(())
     }
@@ -10843,6 +12065,12 @@ export function Screen() {
             .iter()
             .find(|node| node.serialized_name == "GET /users (express route; confidence=heuristic)")
             .expect("express route node");
+        let express_canonical_id = express_route
+            .canonical_id
+            .as_deref()
+            .expect("express route canonical id");
+        assert!(express_canonical_id.contains(r#""extraction_provenance":"ast_indexed""#));
+        assert!(express_canonical_id.contains(r#""extraction:ast_indexed""#));
         let handler = result
             .nodes
             .iter()
@@ -11264,6 +12492,41 @@ web::resource("/actix").route(web::get().to(handler));
                 r#"{ path: "/vue", name: "VueHome" }"#,
                 vec!["vue-router"],
             ),
+            (
+                "kotlin",
+                Path::new("Routing.kt"),
+                r#"
+import io.ktor.server.routing.*
+fun Application.module() {
+  routing {
+    get("/ktor/users") { }
+    post("/ktor/users") { }
+  }
+}
+"#,
+                vec!["ktor"],
+            ),
+            (
+                "swift",
+                Path::new("routes.swift"),
+                r#"
+import Vapor
+func routes(_ app: Application) throws {
+  app.get("vapor/users", use: UserController.index)
+}
+"#,
+                vec!["vapor"],
+            ),
+            (
+                "dart",
+                Path::new("routes.dart"),
+                r#"
+import 'package:shelf_router/shelf_router.dart';
+final router = Router();
+router.get('/shelf/users', usersHandler);
+"#,
+                vec!["shelf"],
+            ),
         ];
 
         for (language, path, source, expected_frameworks) in cases {
@@ -11319,6 +12582,8 @@ func (r *Route) Get(name string) interface{} { return r.namedRoutes[name] }
         assert!(canonical_id.contains(r#""raw_path":"/api/users/[id]""#));
         assert!(canonical_id.contains(r#""params":["id"]"#));
         assert!(canonical_id.contains(r#""source_convention":"file_convention""#));
+        assert!(canonical_id.contains(r#""extraction_provenance":"line_scan""#));
+        assert!(canonical_id.contains(r#""extraction:line_scan""#));
     }
 
     #[test]

--- a/crates/codestory-indexer/src/resolution/candidate_selection.rs
+++ b/crates/codestory-indexer/src/resolution/candidate_selection.rs
@@ -9,6 +9,7 @@ pub(super) fn compute_call_resolution(
     let (edge_id, file_id, caller_qualified, _, target_name, _, callsite_identity) = row;
     let prepared_name = PreparedName::new(target_name.clone());
     let is_common_unqualified = is_common_unqualified_call_name(&prepared_name.original);
+    let is_owner_qualified = is_owner_qualified_call_name(&prepared_name.original);
     let mut selected: Option<(i64, f32, ResolutionStrategy)> = None;
     let mut semantic_fallback = UnambiguousBestCandidate::default();
     let mut candidate_ids = OrderedCandidateIds::with_capacity(8);
@@ -76,9 +77,27 @@ pub(super) fn compute_call_resolution(
         if pass.flags.store_candidates {
             candidate_ids.push(candidate);
         }
+        let confidence = if is_owner_qualified {
+            pass.policy.call_same_file
+        } else {
+            pass.policy.call_global_unique
+        };
+        selected = Some((candidate, confidence, ResolutionStrategy::CallGlobalUnique));
+    }
+
+    if selected.is_none()
+        && is_owner_qualified
+        && let Some(candidate) = candidate_index.find_global_unique_owner_alias_readonly(
+            &prepared_name.original,
+            &prepared_name.ascii_lower,
+        )
+    {
+        if pass.flags.store_candidates {
+            candidate_ids.push(candidate);
+        }
         selected = Some((
             candidate,
-            pass.policy.call_global_unique,
+            pass.policy.call_same_file,
             ResolutionStrategy::CallGlobalUnique,
         ));
     }
@@ -93,6 +112,7 @@ pub(super) fn compute_call_resolution(
     }
 
     if selected.is_none()
+        && !is_owner_qualified
         && let Some((candidate, confidence)) = semantic_fallback.selected()
     {
         selected = Some((
@@ -116,6 +136,10 @@ pub(super) fn compute_call_resolution(
     let selected_pair = selected.map(|(candidate, confidence, _)| (candidate, confidence));
     let update = build_resolved_edge_update(*edge_id, selected_pair, candidate_ids.as_slice())?;
     Ok(ComputedResolution { update, strategy })
+}
+
+fn is_owner_qualified_call_name(name: &str) -> bool {
+    name.contains("::") || name.contains('.')
 }
 
 pub(super) fn compute_import_resolution(

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -101,6 +101,7 @@ struct CandidateIndex {
     same_module_cache: RwLock<HashMap<SameModuleCacheKey, Option<i64>>>,
     global_unique_cache: RwLock<HashMap<NameCacheKey, Option<i64>>>,
     global_unique_exact_cache: RwLock<HashMap<NameCacheKey, Option<i64>>>,
+    global_owner_alias_cache: RwLock<HashMap<NameCacheKey, Option<i64>>>,
     fuzzy_cache: RwLock<HashMap<NameCacheKey, Option<i64>>>,
 }
 
@@ -111,6 +112,8 @@ struct ResolvedEdgeUpdate {
     confidence: Option<f32>,
     certainty: Option<&'static str>,
     candidate_payload: Option<String>,
+    /// When false, resolution had no match and indexer-provided confidence/certainty are kept.
+    touch_metadata: bool,
 }
 
 #[derive(Default, Debug)]
@@ -705,6 +708,7 @@ impl ResolutionPass {
             ));
         }
         query.push_str(" WHERE e.kind = ?1 AND e.resolved_target_node_id IS NULL");
+        sql::append_resolution_worklist_metadata_filter(&mut query, kind);
 
         let count: i64 = conn.query_row(&query, params![kind as i32], |row| row.get(0))?;
         Ok(count as usize)
@@ -935,23 +939,25 @@ fn build_resolved_edge_update(
     candidates: &[i64],
 ) -> Result<ResolvedEdgeUpdate> {
     let candidate_payload = candidate_json(candidates)?;
-    let (resolved_target_node_id, confidence, certainty) = if let Some((target_id, confidence)) =
-        selected
-    {
-        (
-            Some(target_id),
-            Some(confidence),
-            ResolutionCertainty::from_confidence(Some(confidence)).map(ResolutionCertainty::as_str),
-        )
-    } else {
-        (None, None, None)
-    };
+    let (touch_metadata, resolved_target_node_id, confidence, certainty) =
+        if let Some((target_id, confidence)) = selected {
+            (
+                true,
+                Some(target_id),
+                Some(confidence),
+                ResolutionCertainty::from_confidence(Some(confidence))
+                    .map(ResolutionCertainty::as_str),
+            )
+        } else {
+            (false, None, None, None)
+        };
     Ok(ResolvedEdgeUpdate {
         edge_id,
         resolved_target_node_id,
         confidence,
         certainty,
         candidate_payload,
+        touch_metadata,
     })
 }
 
@@ -972,6 +978,53 @@ fn collect_candidate_pool_from_index(
             }
         }
     }
+}
+
+fn split_owner_member_name(name: &str) -> Option<(&str, &str)> {
+    name.rsplit_once("::")
+        .or_else(|| name.rsplit_once('.'))
+        .filter(|(owner, member)| !owner.is_empty() && !member.is_empty())
+}
+
+fn owner_alias_compatible(requested_owner: &str, candidate_owner: &str) -> bool {
+    if requested_owner == candidate_owner {
+        return false;
+    }
+    let requested = owner_alias_token(requested_owner);
+    let candidate = owner_alias_token(candidate_owner);
+    if requested.is_empty() || candidate.is_empty() {
+        return false;
+    }
+    if requested == candidate {
+        return true;
+    }
+    owner_token_manifest_alias(requested, candidate)
+        || owner_token_manifest_alias(candidate, requested)
+        || owner_token_store_alias(requested, candidate)
+}
+
+fn owner_alias_token(owner: &str) -> &str {
+    owner
+        .rsplit([':', '.', '<', ' ', '&'])
+        .find(|part| !part.is_empty())
+        .unwrap_or(owner)
+        .trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+}
+
+fn owner_token_manifest_alias(shorter: &str, longer: &str) -> bool {
+    longer
+        .strip_prefix(shorter)
+        .is_some_and(|suffix| suffix == "Manifest")
+}
+
+fn owner_token_store_alias(left: &str, right: &str) -> bool {
+    matches!(
+        (
+            left.to_ascii_lowercase().as_str(),
+            right.to_ascii_lowercase().as_str()
+        ),
+        ("store", "storage") | ("storage", "store")
+    )
 }
 
 fn semantic_language_bucket(file_path: Option<&str>) -> Option<&'static str> {
@@ -1346,6 +1399,38 @@ impl CandidateIndex {
                 return Some(self.nodes[exact[0]].id);
             }
             None
+        })
+    }
+
+    fn find_global_unique_owner_alias_readonly(
+        &self,
+        name: &str,
+        name_ascii_lower: &str,
+    ) -> Option<i64> {
+        let key = (name.to_string(), name_ascii_lower.to_string());
+        self.cached_lookup(&self.global_owner_alias_cache, key, || {
+            let (requested_owner, requested_member) = split_owner_member_name(name)?;
+            let mut selected = None;
+            let mut ambiguous = false;
+            for node in &self.nodes {
+                let Some((candidate_owner, candidate_member)) =
+                    split_owner_member_name(&node.serialized_name)
+                else {
+                    continue;
+                };
+                if candidate_member != requested_member {
+                    continue;
+                }
+                if !owner_alias_compatible(requested_owner, candidate_owner) {
+                    continue;
+                }
+                if selected.is_some_and(|id| id != node.id) {
+                    ambiguous = true;
+                    break;
+                }
+                selected = Some(node.id);
+            }
+            (!ambiguous).then_some(selected).flatten()
         })
     }
 
@@ -1990,6 +2075,7 @@ mod tests {
                 kind INTEGER NOT NULL,
                 serialized_name TEXT NOT NULL,
                 qualified_name TEXT,
+                canonical_id TEXT,
                 file_node_id INTEGER,
                 start_line INTEGER
             );",
@@ -2321,6 +2407,7 @@ mod tests {
                 kind INTEGER NOT NULL,
                 serialized_name TEXT NOT NULL,
                 qualified_name TEXT,
+                canonical_id TEXT,
                 file_node_id INTEGER,
                 start_line INTEGER NOT NULL DEFAULT 0
             );
@@ -2330,6 +2417,8 @@ mod tests {
                 source_node_id INTEGER NOT NULL,
                 target_node_id INTEGER NOT NULL,
                 resolved_target_node_id INTEGER,
+                confidence REAL,
+                certainty TEXT,
                 callsite_identity TEXT
             );",
         )?;
@@ -2410,6 +2499,87 @@ mod tests {
     }
 
     #[test]
+    fn test_preclassified_call_edges_stay_out_of_resolution_worklist() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE node (
+                id INTEGER PRIMARY KEY,
+                kind INTEGER NOT NULL,
+                serialized_name TEXT NOT NULL,
+                qualified_name TEXT,
+                canonical_id TEXT,
+                file_node_id INTEGER,
+                start_line INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE edge (
+                id INTEGER PRIMARY KEY,
+                kind INTEGER NOT NULL,
+                source_node_id INTEGER NOT NULL,
+                target_node_id INTEGER NOT NULL,
+                resolved_target_node_id INTEGER,
+                confidence REAL,
+                certainty TEXT,
+                callsite_identity TEXT
+            );",
+        )?;
+
+        conn.execute(
+            "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+             VALUES (?1, ?2, ?3, NULL, NULL, 1)",
+            params![100_i64, NodeKind::FILE as i32, "/repo/src/routes.ts"],
+        )?;
+        conn.execute(
+            "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+            params![
+                1_i64,
+                NodeKind::FUNCTION as i32,
+                "route_handler",
+                "routes::route_handler",
+                100_i64
+            ],
+        )?;
+        conn.execute(
+            "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+            params![
+                10_i64,
+                NodeKind::FUNCTION as i32,
+                "handle",
+                "routes::handle",
+                100_i64
+            ],
+        )?;
+
+        conn.execute(
+            "INSERT INTO edge (id, kind, source_node_id, target_node_id, resolved_target_node_id, confidence, certainty, callsite_identity)
+             VALUES (?1, ?2, ?3, ?4, NULL, NULL, NULL, NULL)",
+            params![1000_i64, EdgeKind::CALL as i32, 1_i64, 10_i64],
+        )?;
+        conn.execute(
+            "INSERT INTO edge (id, kind, source_node_id, target_node_id, resolved_target_node_id, confidence, certainty, callsite_identity)
+             VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, NULL)",
+            params![
+                1001_i64,
+                EdgeKind::CALL as i32,
+                1_i64,
+                10_i64,
+                0.65_f64,
+                ResolutionCertainty::Probable.as_str()
+            ],
+        )?;
+
+        let context = ScopeCallerContext::prepare(&conn, None)?;
+        let rows = sql::unresolved_edges(&conn, EdgeKind::CALL, &context)?;
+        let count = ResolutionPass::count_unresolved_on_conn(&conn, EdgeKind::CALL, &context)?;
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, 1000_i64);
+        assert_eq!(count, 1);
+        Ok(())
+    }
+
+    #[test]
     fn test_exact_lookup_cache_reuses_same_file_key() -> Result<()> {
         let conn = Connection::open_in_memory()?;
         conn.execute_batch(
@@ -2417,6 +2587,7 @@ mod tests {
                 id INTEGER PRIMARY KEY,
                 kind INTEGER NOT NULL,
                 serialized_name TEXT NOT NULL,
+                canonical_id TEXT,
                 file_node_id INTEGER,
                 start_line INTEGER NOT NULL DEFAULT 0
             );",

--- a/crates/codestory-indexer/src/resolution/sql.rs
+++ b/crates/codestory-indexer/src/resolution/sql.rs
@@ -95,8 +95,15 @@ pub(super) fn unresolved_edges(
          JOIN node caller ON caller.id = e.source_node_id
          JOIN node target ON target.id = e.target_node_id
          LEFT JOIN node file_node ON file_node.id = caller.file_node_id
-         WHERE e.kind = ?1 AND e.resolved_target_node_id IS NULL",
+         WHERE e.kind = ?1 AND e.resolved_target_node_id IS NULL
+           AND (target.canonical_id IS NULL OR (
+             target.canonical_id NOT LIKE 'tauri:command:%'
+             AND target.canonical_id NOT LIKE 'openapi:endpoint:%'
+             AND target.canonical_id NOT LIKE 'route_endpoint:%'
+             AND target.canonical_id NOT LIKE 'payload:collection:%'
+           ))",
     );
+    append_resolution_worklist_metadata_filter(&mut query, kind);
     if scope_context.is_scoped() {
         query.push_str(&format!(
             " AND e.source_node_id IN (SELECT caller_id FROM {SCOPED_CALLER_TABLE})"
@@ -108,6 +115,12 @@ pub(super) fn unresolved_edges(
     let rows = stmt.query_map(params![kind as i32], map_unresolved_edge_row)?;
     let collected = rows.collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(collected)
+}
+
+pub(super) fn append_resolution_worklist_metadata_filter(query: &mut String, kind: EdgeKind) {
+    if kind == EdgeKind::CALL {
+        query.push_str(" AND e.confidence IS NULL AND e.certainty IS NULL");
+    }
 }
 
 pub(super) fn apply_resolution_updates(
@@ -124,7 +137,8 @@ pub(super) fn apply_resolution_updates(
             resolved_target_node_id INTEGER,
             confidence REAL,
             certainty TEXT,
-            candidate_target_node_ids TEXT
+            candidate_target_node_ids TEXT,
+            touch_metadata INTEGER NOT NULL DEFAULT 0
          );
          DELETE FROM resolution_edge_updates;",
     )?;
@@ -136,8 +150,9 @@ pub(super) fn apply_resolution_updates(
                 resolved_target_node_id,
                 confidence,
                 certainty,
-                candidate_target_node_ids
-             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                candidate_target_node_ids,
+                touch_metadata
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         )?;
         for update in updates {
             insert.execute(params![
@@ -146,16 +161,29 @@ pub(super) fn apply_resolution_updates(
                 update.confidence,
                 update.certainty,
                 update.candidate_payload.as_deref(),
+                i32::from(update.touch_metadata),
             ])?;
         }
     }
 
     conn.execute(
         "UPDATE edge
-         SET resolved_target_node_id = staged.resolved_target_node_id,
-             confidence = staged.confidence,
-             certainty = staged.certainty,
-             candidate_target_node_ids = staged.candidate_target_node_ids
+         SET resolved_target_node_id = CASE
+                 WHEN staged.touch_metadata = 1 THEN staged.resolved_target_node_id
+                 ELSE edge.resolved_target_node_id
+             END,
+             confidence = CASE
+                 WHEN staged.touch_metadata = 1 THEN staged.confidence
+                 ELSE edge.confidence
+             END,
+             certainty = CASE
+                 WHEN staged.touch_metadata = 1 THEN staged.certainty
+                 ELSE edge.certainty
+             END,
+             candidate_target_node_ids = COALESCE(
+                 staged.candidate_target_node_ids,
+                 edge.candidate_target_node_ids
+             )
          FROM resolution_edge_updates AS staged
          WHERE edge.id = staged.edge_id",
         [],

--- a/crates/codestory-indexer/src/semantic/csharp.rs
+++ b/crates/codestory-indexer/src/semantic/csharp.rs
@@ -1,0 +1,86 @@
+use super::{
+    SemanticCandidateIndex, SemanticResolutionCandidate, SemanticResolutionRequest,
+    SemanticResolver, call_target_name, namespace_tail, request_language, request_target,
+    resolve_call_candidates, resolve_import_candidates,
+};
+use anyhow::Result;
+use codestory_contracts::graph::{EdgeKind, NodeKind};
+
+pub struct CSharpSemanticResolver;
+
+impl SemanticResolver for CSharpSemanticResolver {
+    fn language(&self) -> &'static str {
+        "csharp"
+    }
+
+    fn resolve(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        match request.edge_kind {
+            EdgeKind::IMPORT => self.resolve_import(index, request),
+            EdgeKind::CALL => self.resolve_call(index, request),
+            _ => Ok(Vec::new()),
+        }
+    }
+}
+
+impl CSharpSemanticResolver {
+    fn resolve_import(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let Some(symbol) = namespace_tail(target, ".") else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [
+            NodeKind::NAMESPACE as i32,
+            NodeKind::MODULE as i32,
+            NodeKind::CLASS as i32,
+            NodeKind::INTERFACE as i32,
+            NodeKind::STRUCT as i32,
+            NodeKind::METHOD as i32,
+            NodeKind::FUNCTION as i32,
+        ];
+        resolve_import_candidates(
+            index,
+            &kinds,
+            symbol,
+            request.file_id,
+            request_language(request),
+            0.58,
+        )
+    }
+
+    fn resolve_call(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let Some(call_name) = call_target_name(target) else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [NodeKind::METHOD as i32, NodeKind::FUNCTION as i32];
+        resolve_call_candidates(
+            index,
+            &kinds,
+            call_name,
+            request.file_id,
+            request_language(request),
+            0.80,
+            0.70,
+        )
+    }
+}

--- a/crates/codestory-indexer/src/semantic/go.rs
+++ b/crates/codestory-indexer/src/semantic/go.rs
@@ -1,0 +1,86 @@
+use super::{
+    SemanticCandidateIndex, SemanticResolutionCandidate, SemanticResolutionRequest,
+    SemanticResolver, call_target_name, request_language, request_target, resolve_call_candidates,
+    resolve_import_candidates, tail_segment,
+};
+use anyhow::Result;
+use codestory_contracts::graph::{EdgeKind, NodeKind};
+
+pub struct GoSemanticResolver;
+
+impl SemanticResolver for GoSemanticResolver {
+    fn language(&self) -> &'static str {
+        "go"
+    }
+
+    fn resolve(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        match request.edge_kind {
+            EdgeKind::IMPORT => self.resolve_import(index, request),
+            EdgeKind::CALL => self.resolve_call(index, request),
+            _ => Ok(Vec::new()),
+        }
+    }
+}
+
+impl GoSemanticResolver {
+    fn resolve_import(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let symbol = tail_segment(target.trim_matches('"'), &['/', '.'])
+            .or_else(|| tail_segment(target, &['/', '.']));
+        let Some(symbol) = symbol else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [
+            NodeKind::MODULE as i32,
+            NodeKind::PACKAGE as i32,
+            NodeKind::FUNCTION as i32,
+            NodeKind::METHOD as i32,
+            NodeKind::STRUCT as i32,
+        ];
+        resolve_import_candidates(
+            index,
+            &kinds,
+            symbol,
+            request.file_id,
+            request_language(request),
+            0.58,
+        )
+    }
+
+    fn resolve_call(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let Some(call_name) = call_target_name(target) else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [NodeKind::METHOD as i32, NodeKind::FUNCTION as i32];
+        resolve_call_candidates(
+            index,
+            &kinds,
+            call_name,
+            request.file_id,
+            request_language(request),
+            0.80,
+            0.70,
+        )
+    }
+}

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -6,17 +6,25 @@ use std::collections::{HashMap, HashSet};
 
 mod c;
 mod cpp;
+mod csharp;
+mod go;
 mod java;
 mod javascript;
+mod php;
 mod python;
+mod ruby;
 mod rust;
 mod typescript;
 
 use c::CSemanticResolver;
 use cpp::CppSemanticResolver;
+use csharp::CSharpSemanticResolver;
+use go::GoSemanticResolver;
 use java::JavaSemanticResolver;
 use javascript::JavaScriptSemanticResolver;
+use php::PhpSemanticResolver;
 use python::PythonSemanticResolver;
+use ruby::RubySemanticResolver;
 use rust::RustSemanticResolver;
 use typescript::TypeScriptSemanticResolver;
 
@@ -285,6 +293,10 @@ pub struct SemanticResolverRegistry {
     rust: RustSemanticResolver,
     ts: TypeScriptSemanticResolver,
     java: JavaSemanticResolver,
+    go: GoSemanticResolver,
+    ruby: RubySemanticResolver,
+    php: PhpSemanticResolver,
+    csharp: CSharpSemanticResolver,
 }
 
 impl SemanticResolverRegistry {
@@ -298,6 +310,10 @@ impl SemanticResolverRegistry {
             rust: RustSemanticResolver,
             ts: TypeScriptSemanticResolver,
             java: JavaSemanticResolver,
+            go: GoSemanticResolver,
+            ruby: RubySemanticResolver,
+            php: PhpSemanticResolver,
+            csharp: CSharpSemanticResolver,
         }
     }
 
@@ -313,11 +329,17 @@ impl SemanticResolverRegistry {
         match detect_language(request.file_path.as_deref()) {
             Some("c") => self.c.resolve(index, request),
             Some("cpp") => self.cpp.resolve(index, request),
-            Some("javascript") => self.javascript.resolve(index, request),
+            Some("javascript") | Some("vue") | Some("svelte") | Some("astro") => {
+                self.javascript.resolve(index, request)
+            }
             Some("python") => self.python.resolve(index, request),
             Some("rust") => self.rust.resolve(index, request),
             Some("typescript") => self.ts.resolve(index, request),
             Some("java") => self.java.resolve(index, request),
+            Some("go") => self.go.resolve(index, request),
+            Some("ruby") => self.ruby.resolve(index, request),
+            Some("php") => self.php.resolve(index, request),
+            Some("csharp") => self.csharp.resolve(index, request),
             _ => Ok(Vec::new()),
         }
     }
@@ -338,6 +360,13 @@ pub(crate) fn detect_language(path: Option<&str>) -> Option<&'static str> {
         "py" | "pyi" => Some("python"),
         "rs" => Some("rust"),
         "ts" | "tsx" | "mts" | "cts" => Some("typescript"),
+        "vue" => Some("vue"),
+        "svelte" => Some("svelte"),
+        "astro" => Some("astro"),
+        "go" => Some("go"),
+        "rb" => Some("ruby"),
+        "php" => Some("php"),
+        "cs" => Some("csharp"),
         _ => None,
     }
 }
@@ -508,19 +537,24 @@ fn tail_component(value: &str) -> Option<&str> {
 fn language_family_bucket(language: &'static str) -> &'static str {
     match language {
         "c" | "cpp" => "native",
-        "javascript" | "typescript" => "webscript",
+        "javascript" | "typescript" | "vue" | "svelte" | "astro" => "webscript",
         "python" => "python",
         "rust" => "rust",
         "java" => "java",
+        "go" => "go",
+        "ruby" => "ruby",
+        "php" => "php",
+        "csharp" => "csharp",
+        "html" | "css" | "sql" => "structural",
         _ => language,
     }
 }
 
 fn compatible_language_families(
-    caller_language: Option<&str>,
-    candidate_language: Option<&str>,
+    caller_language_family: Option<&str>,
+    candidate_language_family: Option<&str>,
 ) -> bool {
-    match (caller_language, candidate_language) {
+    match (caller_language_family, candidate_language_family) {
         (Some(lhs), Some(rhs)) => lhs == rhs,
         _ => true,
     }
@@ -578,6 +612,9 @@ mod tests {
             ("a.tsx", Some("typescript")),
             ("a.mts", Some("typescript")),
             ("a.cts", Some("typescript")),
+            ("a.vue", Some("vue")),
+            ("a.svelte", Some("svelte")),
+            ("a.astro", Some("astro")),
             ("a.unknown", None),
         ];
         for (path, language) in expected {
@@ -699,6 +736,41 @@ mod tests {
             out.is_empty(),
             "unexpected cross-language fuzzy import candidates: {out:?}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_resolve_call_candidates_allow_webscript_cross_template_and_ts() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        create_node_table(&conn)?;
+        insert_file_node(&conn, 1, "App.vue")?;
+        insert_file_node(&conn, 2, "util.ts")?;
+        conn.execute(
+            "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                40_i64,
+                NodeKind::FUNCTION as i32,
+                "formatTitle",
+                "formatTitle",
+                2_i64,
+                3_i64
+            ],
+        )?;
+
+        let index = SemanticCandidateIndex::load(&conn, &[NodeKind::FUNCTION as i32])?;
+        let out = resolve_call_candidates(
+            &index,
+            &[NodeKind::FUNCTION as i32],
+            "formatTitle",
+            Some(1),
+            detect_language(Some("App.vue")),
+            0.82,
+            0.70,
+        )?;
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].target_node_id, 40);
         Ok(())
     }
 }

--- a/crates/codestory-indexer/src/semantic/php.rs
+++ b/crates/codestory-indexer/src/semantic/php.rs
@@ -1,0 +1,86 @@
+use super::{
+    SemanticCandidateIndex, SemanticResolutionCandidate, SemanticResolutionRequest,
+    SemanticResolver, call_target_name, namespace_tail, request_language, request_target,
+    resolve_call_candidates, resolve_import_candidates, tail_segment,
+};
+use anyhow::Result;
+use codestory_contracts::graph::{EdgeKind, NodeKind};
+
+pub struct PhpSemanticResolver;
+
+impl SemanticResolver for PhpSemanticResolver {
+    fn language(&self) -> &'static str {
+        "php"
+    }
+
+    fn resolve(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        match request.edge_kind {
+            EdgeKind::IMPORT => self.resolve_import(index, request),
+            EdgeKind::CALL => self.resolve_call(index, request),
+            _ => Ok(Vec::new()),
+        }
+    }
+}
+
+impl PhpSemanticResolver {
+    fn resolve_import(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let symbol = namespace_tail(target, "\\").or_else(|| tail_segment(target, &['\\', '/']));
+        let Some(symbol) = symbol else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [
+            NodeKind::NAMESPACE as i32,
+            NodeKind::MODULE as i32,
+            NodeKind::CLASS as i32,
+            NodeKind::INTERFACE as i32,
+            NodeKind::FUNCTION as i32,
+            NodeKind::METHOD as i32,
+        ];
+        resolve_import_candidates(
+            index,
+            &kinds,
+            symbol,
+            request.file_id,
+            request_language(request),
+            0.58,
+        )
+    }
+
+    fn resolve_call(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let Some(call_name) = call_target_name(target) else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [NodeKind::METHOD as i32, NodeKind::FUNCTION as i32];
+        resolve_call_candidates(
+            index,
+            &kinds,
+            call_name,
+            request.file_id,
+            request_language(request),
+            0.80,
+            0.70,
+        )
+    }
+}

--- a/crates/codestory-indexer/src/semantic/ruby.rs
+++ b/crates/codestory-indexer/src/semantic/ruby.rs
@@ -1,0 +1,85 @@
+use super::{
+    SemanticCandidateIndex, SemanticResolutionCandidate, SemanticResolutionRequest,
+    SemanticResolver, call_target_name, request_language, request_target, resolve_call_candidates,
+    resolve_import_candidates, tail_segment,
+};
+use anyhow::Result;
+use codestory_contracts::graph::{EdgeKind, NodeKind};
+
+pub struct RubySemanticResolver;
+
+impl SemanticResolver for RubySemanticResolver {
+    fn language(&self) -> &'static str {
+        "ruby"
+    }
+
+    fn resolve(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        match request.edge_kind {
+            EdgeKind::IMPORT => self.resolve_import(index, request),
+            EdgeKind::CALL => self.resolve_call(index, request),
+            _ => Ok(Vec::new()),
+        }
+    }
+}
+
+impl RubySemanticResolver {
+    fn resolve_import(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let symbol = tail_segment(target.trim_matches('"'), &['/', ':'])
+            .or_else(|| tail_segment(target, &['/', ':', '.']));
+        let Some(symbol) = symbol else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [
+            NodeKind::MODULE as i32,
+            NodeKind::CLASS as i32,
+            NodeKind::METHOD as i32,
+            NodeKind::FUNCTION as i32,
+        ];
+        resolve_import_candidates(
+            index,
+            &kinds,
+            symbol,
+            request.file_id,
+            request_language(request),
+            0.58,
+        )
+    }
+
+    fn resolve_call(
+        &self,
+        index: &SemanticCandidateIndex,
+        request: &SemanticResolutionRequest,
+    ) -> Result<Vec<SemanticResolutionCandidate>> {
+        let Some(target) = request_target(request) else {
+            return Ok(Vec::new());
+        };
+
+        let Some(call_name) = call_target_name(target) else {
+            return Ok(Vec::new());
+        };
+
+        let kinds = [NodeKind::METHOD as i32, NodeKind::FUNCTION as i32];
+        resolve_call_candidates(
+            index,
+            &kinds,
+            call_name,
+            request.file_id,
+            request_language(request),
+            0.80,
+            0.70,
+        )
+    }
+}

--- a/crates/codestory-indexer/src/structural/blanking.rs
+++ b/crates/codestory-indexer/src/structural/blanking.rs
@@ -1,0 +1,131 @@
+//! Whitespace-blanking for embedded `<script>` / `<style>` regions (byte-length preserving).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddedRegionKind {
+    Script,
+    Style,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedRegion {
+    pub kind: EmbeddedRegionKind,
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub start_line: u32,
+}
+
+/// Regions between paired tags (`<script>...</script>`, `<style>...</style>`), case-insensitive.
+pub fn extract_embedded_regions(source: &str) -> Vec<EmbeddedRegion> {
+    let lower = source.to_ascii_lowercase();
+    let mut regions = Vec::new();
+    for (open_tag, close_tag, kind) in [
+        ("<script", "</script>", EmbeddedRegionKind::Script),
+        ("<style", "</style>", EmbeddedRegionKind::Style),
+    ] {
+        let mut search_from = 0usize;
+        while let Some(open_rel) = lower[search_from..].find(open_tag) {
+            let open_start = search_from + open_rel;
+            let content_start = lower[open_start..]
+                .find('>')
+                .map(|idx| open_start + idx + 1)
+                .unwrap_or(open_start);
+            let close_rel = lower[content_start..].find(close_tag);
+            let Some(close_rel) = close_rel else {
+                break;
+            };
+            let content_end = content_start + close_rel;
+            let start_line =
+                1 + source[..open_start].bytes().filter(|b| *b == b'\n').count() as u32;
+            regions.push(EmbeddedRegion {
+                kind,
+                start_byte: content_start,
+                end_byte: content_end,
+                start_line,
+            });
+            search_from = content_end + close_tag.len();
+        }
+    }
+    regions.sort_by_key(|region| region.start_byte);
+    regions
+}
+
+/// Replace every byte outside `keep` regions with ASCII space; newlines and length are preserved.
+pub fn blank_outside_regions(source: &str, keep: &[EmbeddedRegion]) -> String {
+    if keep.is_empty() {
+        return " ".repeat(source.len());
+    }
+    let mut out = source.to_owned();
+    let mut cursor = 0usize;
+    for region in keep {
+        let keep_start = region.start_byte.min(out.len());
+        let keep_end = region.end_byte.min(out.len());
+        if cursor < keep_start {
+            blank_range(&mut out, cursor, keep_start);
+        }
+        cursor = keep_end;
+    }
+    let end = out.len();
+    if cursor < end {
+        blank_range(&mut out, cursor, end);
+    }
+    out
+}
+
+/// Keep only script bytes; blank everything else (for delegated JS/TS graph parse).
+pub fn blank_non_script_regions(source: &str) -> String {
+    let regions: Vec<_> = extract_embedded_regions(source)
+        .into_iter()
+        .filter(|region| region.kind == EmbeddedRegionKind::Script)
+        .collect();
+    blank_outside_regions(source, &regions)
+}
+
+/// Extract inner text for each `<style>` block.
+pub fn extract_style_block_sources(source: &str) -> Vec<(u32, String)> {
+    extract_embedded_regions(source)
+        .into_iter()
+        .filter(|region| region.kind == EmbeddedRegionKind::Style)
+        .map(|region| {
+            let slice = source
+                .get(region.start_byte..region.end_byte)
+                .unwrap_or_default();
+            (region.start_line, slice.to_string())
+        })
+        .collect()
+}
+
+fn blank_range(out: &mut str, start: usize, end: usize) {
+    // SAFETY: we only replace ASCII spaces/newlines in place; UTF-8 scalar boundaries stay valid.
+    let bytes = unsafe { out.as_bytes_mut() };
+    for byte in &mut bytes[start..end] {
+        if *byte != b'\n' && *byte != b'\r' {
+            *byte = b' ';
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blanking_preserves_length_and_newlines() {
+        let source = "<div>\n  <script>\nlet x = 1;\n</script>\n</div>";
+        let regions = extract_embedded_regions(source);
+        let blanked = blank_outside_regions(source, &regions);
+        assert_eq!(blanked.len(), source.len());
+        assert!(blanked.contains("let x = 1;"));
+        assert!(blanked.contains("let x = 1;"));
+        assert!(blanked.as_bytes()[0] == b' ');
+        assert!(blanked.as_bytes()[4] == b' ');
+    }
+
+    #[test]
+    fn extracts_script_and_style_regions() {
+        let source = "<style>.a{}</style><script>const a=1</script>";
+        let regions = extract_embedded_regions(source);
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[0].kind, EmbeddedRegionKind::Style);
+        assert_eq!(regions[1].kind, EmbeddedRegionKind::Script);
+    }
+}

--- a/crates/codestory-indexer/src/structural/common.rs
+++ b/crates/codestory-indexer/src/structural/common.rs
@@ -1,0 +1,188 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{
+    AccessKind, Edge, EdgeId, EdgeKind, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
+    ResolutionCertainty, SourceLocation,
+};
+use std::path::Path;
+
+pub(crate) fn structural_language_name(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "html" | "htm" => "html",
+        "css" => "css",
+        "sql" => "sql",
+        _ => "structural",
+    }
+}
+
+pub(crate) fn push_member_edge(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    parent_id: NodeId,
+    child_id: NodeId,
+    line: u32,
+) {
+    storage.edges.push(Edge {
+        id: EdgeId(structural_edge_id(
+            parent_id.0,
+            child_id.0,
+            EdgeKind::MEMBER,
+        )),
+        source: parent_id,
+        target: child_id,
+        kind: EdgeKind::MEMBER,
+        file_node_id: Some(file_id),
+        line: Some(line),
+        certainty: Some(ResolutionCertainty::Certain),
+        ..Default::default()
+    });
+}
+
+pub(crate) fn push_usage_edge(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    source_id: NodeId,
+    target_id: NodeId,
+    line: u32,
+) {
+    storage.edges.push(Edge {
+        id: EdgeId(structural_edge_id(
+            source_id.0,
+            target_id.0,
+            EdgeKind::USAGE,
+        )),
+        source: source_id,
+        target: target_id,
+        kind: EdgeKind::USAGE,
+        file_node_id: Some(file_id),
+        line: Some(line),
+        certainty: Some(ResolutionCertainty::Certain),
+        ..Default::default()
+    });
+}
+
+pub(crate) fn push_import_edge(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    source_id: NodeId,
+    target_id: NodeId,
+    line: u32,
+) {
+    storage.edges.push(Edge {
+        id: EdgeId(structural_edge_id(
+            source_id.0,
+            target_id.0,
+            EdgeKind::IMPORT,
+        )),
+        source: source_id,
+        target: target_id,
+        kind: EdgeKind::IMPORT,
+        file_node_id: Some(file_id),
+        line: Some(line),
+        certainty: Some(ResolutionCertainty::Certain),
+        ..Default::default()
+    });
+}
+
+pub(crate) fn push_type_usage_edge(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    source_id: NodeId,
+    target_id: NodeId,
+    line: u32,
+) {
+    storage.edges.push(Edge {
+        id: EdgeId(structural_edge_id(
+            source_id.0,
+            target_id.0,
+            EdgeKind::TYPE_USAGE,
+        )),
+        source: source_id,
+        target: target_id,
+        kind: EdgeKind::TYPE_USAGE,
+        file_node_id: Some(file_id),
+        line: Some(line),
+        certainty: Some(ResolutionCertainty::Certain),
+        ..Default::default()
+    });
+}
+
+pub(crate) fn push_annotation_usage_edge(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    source_id: NodeId,
+    target_id: NodeId,
+    line: u32,
+) {
+    storage.edges.push(Edge {
+        id: EdgeId(structural_edge_id(
+            source_id.0,
+            target_id.0,
+            EdgeKind::ANNOTATION_USAGE,
+        )),
+        source: source_id,
+        target: target_id,
+        kind: EdgeKind::ANNOTATION_USAGE,
+        file_node_id: Some(file_id),
+        line: Some(line),
+        certainty: Some(ResolutionCertainty::Certain),
+        ..Default::default()
+    });
+}
+
+pub(crate) fn push_structural_node(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    kind: NodeKind,
+    name: &str,
+    canonical_id: &str,
+    line: u32,
+    col: u32,
+) -> NodeId {
+    let node_id = NodeId(crate::generate_id(canonical_id));
+    let label_len = name.len().max(1);
+    storage.nodes.push(Node {
+        id: node_id,
+        kind,
+        serialized_name: name.to_string(),
+        qualified_name: Some(name.to_string()),
+        canonical_id: Some(canonical_id.to_string()),
+        file_node_id: Some(file_id),
+        start_line: Some(line),
+        start_col: Some(col.max(1)),
+        end_line: Some(line),
+        end_col: Some(label_len as u32),
+    });
+    storage.component_access.push((node_id, AccessKind::Public));
+    storage.occurrences.push(Occurrence {
+        element_id: node_id.0,
+        kind: OccurrenceKind::DEFINITION,
+        location: SourceLocation {
+            file_node_id: file_id,
+            start_line: line,
+            start_col: col.max(1),
+            end_line: line,
+            end_col: label_len as u32,
+        },
+    });
+    node_id
+}
+
+fn structural_edge_id(source: i64, target: i64, kind: EdgeKind) -> i64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    let mut update = |val: i64| {
+        for b in val.to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+    };
+    update(source);
+    update(target);
+    update(kind as i64);
+    h as i64
+}

--- a/crates/codestory-indexer/src/structural/css.rs
+++ b/crates/codestory-indexer/src/structural/css.rs
@@ -1,0 +1,211 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use std::collections::HashSet;
+use std::path::Path;
+
+use super::common::{push_member_edge, push_structural_node, push_usage_edge};
+
+pub(crate) fn collect_css_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    line_offset: u32,
+) {
+    let path_key = path.to_string_lossy();
+    let mut seen_classes = HashSet::new();
+    let mut seen_ids = HashSet::new();
+    let mut seen_vars = HashSet::new();
+
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line_number = line_idx as u32 + line_offset;
+        collect_css_tokens_on_line(
+            &path_key,
+            file_id,
+            storage,
+            line_number,
+            line_text,
+            &mut seen_classes,
+            &mut seen_ids,
+            &mut seen_vars,
+        );
+        collect_css_imports(path, file_id, storage, line_number, line_text);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_css_tokens_on_line(
+    path_key: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    line: u32,
+    text: &str,
+    seen_classes: &mut HashSet<String>,
+    seen_ids: &mut HashSet<String>,
+    seen_vars: &mut HashSet<String>,
+) {
+    let mut cursor = 0usize;
+    while let Some(rel) = text[cursor..].find('.') {
+        let start = cursor + rel + 1;
+        let name = take_css_ident(&text[start..]);
+        if name.is_empty() {
+            cursor = start;
+            continue;
+        }
+        if seen_classes.insert(name.to_string()) {
+            let canonical = format!("css:class:{name}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::CONSTANT,
+                name,
+                &canonical,
+                line,
+                start as u32,
+            );
+            push_member_edge(storage, file_id, file_id, node_id, line);
+        }
+        cursor = start + name.len();
+    }
+
+    cursor = 0;
+    while let Some(rel) = text[cursor..].find('#') {
+        let start = cursor + rel + 1;
+        let name = take_css_ident(&text[start..]);
+        if name.is_empty() {
+            cursor = start;
+            continue;
+        }
+        if seen_ids.insert(name.to_string()) {
+            let canonical = format!("css:id:{name}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::CONSTANT,
+                name,
+                &canonical,
+                line,
+                start as u32,
+            );
+            push_member_edge(storage, file_id, file_id, node_id, line);
+        }
+        cursor = start + name.len();
+    }
+
+    cursor = 0;
+    while let Some(rel) = text[cursor..].find("--") {
+        let start = cursor + rel;
+        let name = take_css_var_name(&text[start..]);
+        if name.is_empty() {
+            cursor = start + 2;
+            continue;
+        }
+        if seen_vars.insert(name.to_string()) {
+            let canonical = format!("css:var:{name}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::VARIABLE,
+                name,
+                &canonical,
+                line,
+                start as u32,
+            );
+            push_member_edge(storage, file_id, file_id, node_id, line);
+        }
+        cursor = start + name.len();
+    }
+
+    let _ = path_key;
+}
+
+fn collect_css_imports(
+    path: &Path,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    line: u32,
+    text: &str,
+) {
+    let lower = text.to_ascii_lowercase();
+    if !lower.contains("@import") {
+        return;
+    }
+    let import_path = extract_quoted_path(text).unwrap_or_default();
+    if import_path.is_empty() {
+        return;
+    }
+    let canonical = format!("file:{}", import_path);
+    let target_id = NodeId(crate::generate_id(&canonical));
+    storage.nodes.push(codestory_contracts::graph::Node {
+        id: target_id,
+        kind: NodeKind::FILE,
+        serialized_name: import_path.clone(),
+        qualified_name: Some(import_path.clone()),
+        canonical_id: Some(canonical),
+        file_node_id: None,
+        start_line: Some(line),
+        start_col: Some(1),
+        end_line: Some(line),
+        end_col: Some(import_path.len().max(1) as u32),
+    });
+    push_usage_edge(storage, file_id, file_id, target_id, line);
+    let _ = path;
+}
+
+fn take_css_ident(text: &str) -> &str {
+    let end = text
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_')
+        .unwrap_or(text.len());
+    &text[..end]
+}
+
+fn take_css_var_name(text: &str) -> &str {
+    if !text.starts_with("--") {
+        return "";
+    }
+    let rest = &text[2..];
+    let end = rest
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+        .unwrap_or(rest.len());
+    if end == 0 {
+        return "";
+    }
+    &text[..2 + end]
+}
+
+fn extract_quoted_path(text: &str) -> Option<String> {
+    for quote in ['"', '\''] {
+        if let Some(start) = text.find(quote) {
+            let rest = &text[start + 1..];
+            if let Some(end) = rest.find(quote) {
+                return Some(rest[..end].to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intermediate_storage::IntermediateStorage;
+    use codestory_contracts::graph::{EdgeKind, NodeKind};
+    use std::path::Path;
+
+    #[test]
+    fn collects_class_id_and_custom_property() {
+        let mut storage = IntermediateStorage::default();
+        let file_id = NodeId(42);
+        collect_css_entities(
+            Path::new("styles.css"),
+            ".btn { color: var(--primary); }\n#app { }",
+            file_id,
+            &mut storage,
+            1,
+        );
+        let kinds: Vec<_> = storage.nodes.iter().map(|n| n.kind).collect();
+        assert!(kinds.contains(&NodeKind::CONSTANT));
+        assert!(kinds.contains(&NodeKind::VARIABLE));
+        assert!(storage.edges.iter().any(|e| e.kind == EdgeKind::MEMBER));
+    }
+}

--- a/crates/codestory-indexer/src/structural/html.rs
+++ b/crates/codestory-indexer/src/structural/html.rs
@@ -1,0 +1,342 @@
+use crate::intermediate_storage::IntermediateStorage;
+use crate::structural::blanking::{
+    EmbeddedRegionKind, blank_non_script_regions, extract_embedded_regions,
+    extract_style_block_sources,
+};
+use crate::{get_language_for_ext, index_file};
+use codestory_contracts::graph::{NodeId, NodeKind};
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::common::{push_import_edge, push_member_edge, push_structural_node, push_usage_edge};
+use super::css::collect_css_entities;
+
+pub(crate) fn collect_html_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) {
+    let path_key = path.to_string_lossy();
+    let mut region_nodes: HashMap<u32, NodeId> = HashMap::new();
+    let mut id_nodes: HashMap<String, NodeId> = HashMap::new();
+
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line_number = line_idx as u32 + 1;
+        if let Some(region_id) =
+            maybe_region_node(&path_key, file_id, storage, line_number, line_text)
+        {
+            region_nodes.insert(line_number, region_id);
+        }
+        for id in extract_html_ids(line_text) {
+            if id_nodes.contains_key(&id) {
+                continue;
+            }
+            let canonical = format!("html:id:{id}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::CONSTANT,
+                &id,
+                &canonical,
+                line_number,
+                1,
+            );
+            id_nodes.insert(id.clone(), node_id);
+            if let Some(region_id) = region_nodes.values().last().copied() {
+                push_member_edge(storage, file_id, region_id, node_id, line_number);
+            } else {
+                push_member_edge(storage, file_id, file_id, node_id, line_number);
+            }
+        }
+        for class_name in extract_html_classes(line_text) {
+            let css_canonical = format!("css:class:{class_name}");
+            let css_id = NodeId(crate::generate_id(&css_canonical));
+            if !storage.nodes.iter().any(|node| node.id == css_id) {
+                storage.nodes.push(codestory_contracts::graph::Node {
+                    id: css_id,
+                    kind: NodeKind::CONSTANT,
+                    serialized_name: class_name.clone(),
+                    qualified_name: Some(class_name.clone()),
+                    canonical_id: Some(css_canonical),
+                    file_node_id: None,
+                    start_line: Some(line_number),
+                    start_col: Some(1),
+                    end_line: Some(line_number),
+                    end_col: Some(class_name.len().max(1) as u32),
+                });
+            }
+            let host_id = region_nodes
+                .get(&line_number)
+                .copied()
+                .or_else(|| id_nodes.values().copied().next())
+                .unwrap_or(file_id);
+            push_usage_edge(storage, file_id, host_id, css_id, line_number);
+        }
+    }
+
+    for (line, style_source) in extract_style_block_sources(source) {
+        collect_css_entities(path, &style_source, file_id, storage, line);
+    }
+
+    delegate_script_blocks(path, source, file_id, storage);
+}
+
+fn maybe_region_node(
+    path_key: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    line: u32,
+    text: &str,
+) -> Option<NodeId> {
+    let lower = text.to_ascii_lowercase();
+    if !lower.contains('<') {
+        return None;
+    }
+    let is_region_tag = [
+        "<main",
+        "<body",
+        "<section",
+        "<article",
+        "<template",
+        "<div",
+    ]
+    .iter()
+    .any(|tag| lower.contains(tag));
+    if !is_region_tag {
+        return None;
+    }
+    let canonical = format!("html:region:{path_key}:{line}");
+    Some(push_structural_node(
+        storage,
+        file_id,
+        NodeKind::MODULE,
+        &format!("region:{line}"),
+        &canonical,
+        line,
+        1,
+    ))
+}
+
+fn delegate_script_blocks(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) {
+    let script_regions: Vec<_> = extract_embedded_regions(source)
+        .into_iter()
+        .filter(|region| region.kind == EmbeddedRegionKind::Script)
+        .collect();
+    if script_regions.is_empty() {
+        return;
+    }
+
+    let blanked = blank_non_script_regions(source);
+    let lang = script_language_for_source(source);
+    let ext = if lang == "typescript" { "ts" } else { "js" };
+    let delegate_path = path.with_extension(ext);
+    let Some(language_config) = get_language_for_ext(ext) else {
+        for region in script_regions {
+            let canonical = format!(
+                "html:script:{}:{}",
+                path.to_string_lossy(),
+                region.start_line
+            );
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::MODULE,
+                &format!("script:{}", region.start_line),
+                &canonical,
+                region.start_line,
+                1,
+            );
+            push_import_edge(storage, file_id, file_id, node_id, region.start_line);
+        }
+        return;
+    };
+
+    if let Ok(index_result) = index_file(&delegate_path, &blanked, &language_config, None, None) {
+        merge_delegated_script_graph(storage, file_id, index_result, &script_regions);
+    }
+}
+
+fn script_language_for_source(source: &str) -> &'static str {
+    let lower = source.to_ascii_lowercase();
+    if lower.contains("lang=\"ts\"")
+        || lower.contains("lang='ts'")
+        || lower.contains("lang=\"typescript\"")
+    {
+        "typescript"
+    } else {
+        "javascript"
+    }
+}
+
+fn merge_delegated_script_graph(
+    storage: &mut IntermediateStorage,
+    host_file_id: NodeId,
+    index_result: crate::IndexResult,
+    script_regions: &[super::blanking::EmbeddedRegion],
+) {
+    let script_module = script_regions.first().map(|region| {
+        let canonical = format!("html:script-block:{}", region.start_line);
+        push_structural_node(
+            storage,
+            host_file_id,
+            NodeKind::MODULE,
+            "script",
+            &canonical,
+            region.start_line,
+            1,
+        )
+    });
+
+    for mut node in index_result.nodes {
+        if node.kind == NodeKind::FILE {
+            continue;
+        }
+        node.file_node_id = Some(host_file_id);
+        storage.nodes.push(node);
+    }
+
+    for mut edge in index_result.edges {
+        if edge.file_node_id.is_some() {
+            edge.file_node_id = Some(host_file_id);
+        }
+        storage.edges.push(edge);
+    }
+
+    storage
+        .occurrences
+        .extend(index_result.occurrences.into_iter().map(|mut occurrence| {
+            occurrence.location.file_node_id = host_file_id;
+            occurrence
+        }));
+    storage
+        .component_access
+        .extend(index_result.component_access);
+
+    if let (Some(module_id), Some(first_symbol)) = (
+        script_module,
+        storage
+            .nodes
+            .iter()
+            .find(|node| {
+                node.file_node_id == Some(host_file_id)
+                    && matches!(
+                        node.kind,
+                        NodeKind::FUNCTION | NodeKind::CLASS | NodeKind::METHOD
+                    )
+            })
+            .map(|node| node.id),
+    ) {
+        push_import_edge(
+            storage,
+            host_file_id,
+            module_id,
+            first_symbol,
+            script_regions[0].start_line,
+        );
+        push_member_edge(
+            storage,
+            host_file_id,
+            host_file_id,
+            module_id,
+            script_regions[0].start_line,
+        );
+    }
+}
+
+fn extract_html_ids(line: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    let lower = line.to_ascii_lowercase();
+    let mut search = 0usize;
+    while let Some(rel) = lower[search..]
+        .find("id=")
+        .or_else(|| lower[search..].find("id ="))
+    {
+        let idx = search + rel;
+        let rest = &line[idx..];
+        if let Some(value) = extract_attr_value(rest)
+            && !value.is_empty()
+        {
+            ids.push(value);
+        }
+        search = idx + 3;
+    }
+    ids
+}
+
+fn extract_html_classes(line: &str) -> Vec<String> {
+    let mut classes = Vec::new();
+    let lower = line.to_ascii_lowercase();
+    let mut search = 0usize;
+    while let Some(rel) = lower[search..]
+        .find("class=")
+        .or_else(|| lower[search..].find("class ="))
+    {
+        let idx = search + rel;
+        let rest = &line[idx..];
+        if let Some(value) = extract_attr_value(rest) {
+            for class_name in value.split_whitespace() {
+                let class_name = class_name.trim();
+                if !class_name.is_empty() {
+                    classes.push(class_name.to_string());
+                }
+            }
+        }
+        search = idx + 6;
+    }
+    classes
+}
+
+fn extract_attr_value(text: &str) -> Option<String> {
+    let after_eq = text.split('=').nth(1)?.trim();
+    if let Some(stripped) = after_eq.strip_prefix('"') {
+        let end = stripped.find('"')?;
+        return Some(stripped[..end].to_string());
+    }
+    if let Some(stripped) = after_eq.strip_prefix('\'') {
+        let end = stripped.find('\'')?;
+        return Some(stripped[..end].to_string());
+    }
+    let end = after_eq
+        .find(|c: char| c.is_whitespace() || c == '>')
+        .unwrap_or(after_eq.len());
+    Some(after_eq[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intermediate_storage::IntermediateStorage;
+    use codestory_contracts::graph::EdgeKind;
+    use std::path::Path;
+
+    #[test]
+    fn collects_ids_classes_and_style_blocks() {
+        let html = r#"<!doctype html>
+<main id="app" class="layout primary">
+  <style>.layout { }</style>
+  <script>function boot() { return 1; }</script>
+</main>"#;
+        let mut storage = IntermediateStorage::default();
+        let file_id = NodeId(99);
+        collect_html_entities(Path::new("index.html"), html, file_id, &mut storage);
+        assert!(
+            storage
+                .nodes
+                .iter()
+                .any(|n| n.canonical_id.as_deref() == Some("html:id:app"))
+        );
+        assert!(storage.edges.iter().any(|e| e.kind == EdgeKind::USAGE));
+        assert!(
+            storage
+                .nodes
+                .iter()
+                .any(|n| n.canonical_id.as_deref() == Some("css:class:layout"))
+        );
+    }
+}

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -1,0 +1,107 @@
+//! Structural-language entity collectors (HTML, CSS, SQL) with explicit node/edge mapping.
+
+mod blanking;
+mod common;
+pub(crate) mod css;
+mod html;
+mod sql;
+
+pub use blanking::{
+    EmbeddedRegion, EmbeddedRegionKind, blank_non_script_regions, blank_outside_regions,
+    extract_embedded_regions,
+};
+pub fn structural_language_name(path: &Path) -> &'static str {
+    common::structural_language_name(path)
+}
+
+use crate::intermediate_storage::IntermediateStorage;
+use anyhow::Result;
+use codestory_contracts::graph::NodeId;
+use std::path::Path;
+
+pub fn is_structural_candidate_path(path: &Path) -> bool {
+    matches!(
+        structural_extension(path).as_deref(),
+        Some("html" | "htm" | "css" | "sql")
+    )
+}
+
+pub fn index_structural_file(path: &Path) -> Result<IntermediateStorage> {
+    let source = std::fs::read_to_string(path)?;
+    index_structural_source(path, &source)
+}
+
+pub fn collect_embedded_style_css(
+    path: &Path,
+    style_source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    line_offset: u32,
+) {
+    css::collect_css_entities(path, style_source, file_id, storage, line_offset);
+}
+
+pub fn index_structural_source(path: &Path, source: &str) -> Result<IntermediateStorage> {
+    let mut storage = IntermediateStorage::default();
+    let (file_node, _file_name, file_id) = crate::file_node_from_source(path, source);
+    storage.files.push(codestory_store::FileInfo {
+        id: file_id.0,
+        path: path.to_path_buf(),
+        language: common::structural_language_name(path).to_string(),
+        modification_time: file_modification_time(path),
+        indexed: true,
+        complete: true,
+        line_count: source.lines().count() as u32,
+        file_role: codestory_store::FileRole::classify_path(path),
+    });
+    storage.nodes.push(file_node);
+
+    match structural_extension(path).as_deref() {
+        Some("html" | "htm") => html::collect_html_entities(path, source, file_id, &mut storage),
+        Some("css") => css::collect_css_entities(path, source, file_id, &mut storage, 1),
+        Some("sql") => sql::collect_sql_entities(path, source, file_id, &mut storage),
+        _ => {}
+    }
+
+    storage.callable_projection_states = crate::build_callable_projection_states(
+        &storage.nodes,
+        &storage.edges,
+        &storage.occurrences,
+    );
+    Ok(storage)
+}
+
+fn structural_extension(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+}
+
+fn file_modification_time(path: &Path) -> i64 {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .map(|time| {
+            time.duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::graph::NodeKind;
+
+    #[test]
+    fn indexes_dedicated_sql_file() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("schema.sql");
+        let sql =
+            "CREATE TABLE public.items (id INT);\nCREATE INDEX items_id_idx ON public.items (id);";
+        std::fs::write(&path, sql).expect("write sql");
+        let storage = index_structural_file(&path).expect("index sql");
+        assert!(storage.nodes.iter().any(|n| n.kind == NodeKind::CLASS));
+        assert_eq!(storage.files[0].language, "sql");
+    }
+}

--- a/crates/codestory-indexer/src/structural/sql.rs
+++ b/crates/codestory-indexer/src/structural/sql.rs
@@ -1,0 +1,374 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::common::{
+    push_annotation_usage_edge, push_member_edge, push_structural_node, push_type_usage_edge,
+    push_usage_edge,
+};
+
+pub(crate) fn collect_sql_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) {
+    let default_schema = infer_default_schema(source);
+    let schema_nodes = collect_schemas(source, file_id, storage, &default_schema);
+    let mut tables: HashMap<String, NodeId> = HashMap::new();
+    let mut views: HashMap<String, NodeId> = HashMap::new();
+
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line_number = line_idx as u32 + 1;
+        let upper = line_text.trim().to_ascii_uppercase();
+        if upper.starts_with("CREATE SCHEMA ") || upper.starts_with("CREATE DATABASE ") {
+            continue;
+        }
+        if let Some((schema, name)) = parse_qualified_name_after_keyword(line_text, "CREATE TABLE")
+        {
+            let schema_id = schema_nodes
+                .get(&schema)
+                .copied()
+                .unwrap_or_else(|| default_schema_node(file_id, storage, &schema));
+            let canonical = format!("sql:table:{schema}.{name}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::CLASS,
+                &format!("{schema}.{name}"),
+                &canonical,
+                line_number,
+                1,
+            );
+            push_member_edge(storage, file_id, schema_id, node_id, line_number);
+            tables.insert(format!("{schema}.{name}"), node_id);
+            collect_inline_columns(
+                line_text,
+                file_id,
+                storage,
+                &schema,
+                &name,
+                node_id,
+                line_number,
+            );
+        } else if let Some((schema, name)) =
+            parse_qualified_name_after_keyword(line_text, "CREATE VIEW")
+        {
+            let schema_id = schema_nodes
+                .get(&schema)
+                .copied()
+                .unwrap_or_else(|| default_schema_node(file_id, storage, &schema));
+            let canonical = format!("sql:view:{schema}.{name}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::CLASS,
+                &format!("{schema}.{name}"),
+                &canonical,
+                line_number,
+                1,
+            );
+            push_member_edge(storage, file_id, schema_id, node_id, line_number);
+            views.insert(format!("{schema}.{name}"), node_id);
+            if let Some(base) = parse_view_base_table(line_text)
+                && let Some(base_id) = tables.get(&base).copied()
+            {
+                push_type_usage_edge(storage, file_id, node_id, base_id, line_number);
+            }
+        } else if let Some((schema, table, index_name)) = parse_create_index(line_text) {
+            if let Some(table_id) = tables.get(&format!("{schema}.{table}")).copied() {
+                let canonical = format!("sql:index:{schema}.{table}.{index_name}");
+                let node_id = push_structural_node(
+                    storage,
+                    file_id,
+                    NodeKind::ANNOTATION,
+                    &index_name,
+                    &canonical,
+                    line_number,
+                    1,
+                );
+                push_annotation_usage_edge(storage, file_id, node_id, table_id, line_number);
+            }
+        } else if let Some((schema, name)) =
+            parse_qualified_name_after_keyword(line_text, "CREATE FUNCTION")
+                .or_else(|| parse_qualified_name_after_keyword(line_text, "CREATE PROCEDURE"))
+        {
+            let schema_id = schema_nodes
+                .get(&schema)
+                .copied()
+                .unwrap_or_else(|| default_schema_node(file_id, storage, &schema));
+            let canonical = format!("sql:func:{schema}.{name}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::FUNCTION,
+                &format!("{schema}.{name}"),
+                &canonical,
+                line_number,
+                1,
+            );
+            push_member_edge(storage, file_id, schema_id, node_id, line_number);
+            for table_key in referenced_tables(line_text, &schema) {
+                if let Some(table_id) = tables.get(&table_key).copied() {
+                    push_usage_edge(storage, file_id, node_id, table_id, line_number);
+                }
+            }
+        }
+    }
+
+    let _ = (path, views);
+}
+
+fn infer_default_schema(source: &str) -> String {
+    for line in source.lines() {
+        let upper = line.trim().to_ascii_uppercase();
+        if upper.starts_with("CREATE SCHEMA ")
+            && let Some(name) = next_ident(line)
+        {
+            return name;
+        }
+        if upper.starts_with("SET SEARCH_PATH ")
+            && let Some(name) = next_ident(line)
+        {
+            return name;
+        }
+    }
+    "public".to_string()
+}
+
+fn collect_schemas(
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    default_schema: &str,
+) -> HashMap<String, NodeId> {
+    let mut schemas = HashMap::new();
+    schemas.insert(
+        default_schema.to_string(),
+        default_schema_node(file_id, storage, default_schema),
+    );
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line_number = line_idx as u32 + 1;
+        let upper = line_text.trim().to_ascii_uppercase();
+        if upper.starts_with("CREATE SCHEMA ")
+            && let Some(name) = next_ident(line_text)
+        {
+            let canonical = format!("sql:schema:{name}");
+            let node_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::NAMESPACE,
+                &name,
+                &canonical,
+                line_number,
+                1,
+            );
+            push_member_edge(storage, file_id, file_id, node_id, line_number);
+            schemas.insert(name, node_id);
+        }
+    }
+    schemas
+}
+
+fn default_schema_node(file_id: NodeId, storage: &mut IntermediateStorage, schema: &str) -> NodeId {
+    let canonical = format!("sql:schema:{schema}");
+    push_structural_node(
+        storage,
+        file_id,
+        NodeKind::NAMESPACE,
+        schema,
+        &canonical,
+        1,
+        1,
+    )
+}
+
+fn parse_qualified_name_after_keyword(line: &str, keyword: &str) -> Option<(String, String)> {
+    let lower = line.to_ascii_lowercase();
+    let keyword_lower = keyword.to_ascii_lowercase();
+    let idx = lower.find(&keyword_lower)?;
+    let rest = line[idx + keyword.len()..].trim();
+    let rest = rest.trim_start_matches("IF NOT EXISTS").trim();
+    let (schema, name) = split_qualified_ident(rest)?;
+    Some((schema, name))
+}
+
+fn split_qualified_ident(text: &str) -> Option<(String, String)> {
+    let token = take_sql_ident(text)?;
+    if let Some((schema, name)) = token.split_once('.') {
+        Some((schema.to_string(), name.to_string()))
+    } else {
+        Some(("public".to_string(), token.to_string()))
+    }
+}
+
+fn take_sql_ident(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let first = trimmed.chars().next()?;
+    if first == '"' || first == '\'' || first == '`' {
+        let end = trimmed[1..].find(first)?;
+        let ident = &trimmed[1..1 + end];
+        return (!ident.is_empty()).then(|| ident.to_string());
+    }
+    let end = trimmed
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '.')
+        .unwrap_or(trimmed.len());
+    if end == 0 {
+        return None;
+    }
+    Some(trimmed[..end].to_string())
+}
+
+fn next_ident(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let upper = trimmed.to_ascii_uppercase();
+    if let Some(rest) = upper.strip_prefix("CREATE SCHEMA ") {
+        return take_sql_ident(trimmed[trimmed.len() - rest.len()..].trim());
+    }
+    if let Some(rest) = upper.strip_prefix("CREATE DATABASE ") {
+        return take_sql_ident(trimmed[trimmed.len() - rest.len()..].trim());
+    }
+    if let Some(rest) = upper.strip_prefix("SET SEARCH_PATH TO ") {
+        return take_sql_ident(trimmed[trimmed.len() - rest.len()..].trim());
+    }
+    if let Some(rest) = upper.strip_prefix("SET SEARCH_PATH ") {
+        return take_sql_ident(trimmed[trimmed.len() - rest.len()..].trim());
+    }
+    None
+}
+
+fn collect_inline_columns(
+    line: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    schema: &str,
+    table: &str,
+    table_id: NodeId,
+    line_no: u32,
+) {
+    if !line.contains('(') {
+        return;
+    }
+    let Some(start) = line.find('(') else {
+        return;
+    };
+    let Some(end) = line.rfind(')') else {
+        return;
+    };
+    let body = &line[start + 1..end];
+    for part in body.split(',') {
+        let part = part.trim();
+        if part.is_empty() || part.to_ascii_uppercase().starts_with("CONSTRAINT") {
+            continue;
+        }
+        let col = part
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .trim_matches('"');
+        if col.is_empty() {
+            continue;
+        }
+        let canonical = format!("sql:column:{schema}.{table}.{col}");
+        let node_id = push_structural_node(
+            storage,
+            file_id,
+            NodeKind::FIELD,
+            col,
+            &canonical,
+            line_no,
+            1,
+        );
+        push_member_edge(storage, file_id, table_id, node_id, line_no);
+    }
+}
+
+fn parse_create_index(line: &str) -> Option<(String, String, String)> {
+    let upper = line.trim().to_ascii_uppercase();
+    if !upper.starts_with("CREATE ") || !upper.contains(" INDEX ") {
+        return None;
+    }
+    let index_name = next_token_after(line, "INDEX")?;
+    let table_part = line.to_ascii_uppercase();
+    let on_idx = table_part.find(" ON ")?;
+    let table_ref = line[on_idx + 4..].trim();
+    let (schema, table) = split_qualified_ident(table_ref)?;
+    Some((schema, table, index_name))
+}
+
+fn next_token_after(line: &str, keyword: &str) -> Option<String> {
+    let upper = line.to_ascii_uppercase();
+    let idx = upper.find(&keyword.to_ascii_uppercase())?;
+    let rest = line[idx + keyword.len()..].trim();
+    take_sql_ident(rest)
+}
+
+fn parse_view_base_table(line: &str) -> Option<String> {
+    let upper = line.to_ascii_uppercase();
+    let idx = upper.find(" FROM ")?;
+    let rest = line[idx + 6..].trim();
+    let (schema, name) = split_qualified_ident(rest)?;
+    Some(format!("{schema}.{name}"))
+}
+
+fn referenced_tables(line: &str, default_schema: &str) -> Vec<String> {
+    let upper = line.to_ascii_uppercase();
+    let mut tables = Vec::new();
+    for keyword in [" FROM ", " JOIN ", " INTO ", " UPDATE "] {
+        let mut search = 0usize;
+        while let Some(rel) = upper[search..].find(keyword) {
+            let idx = search + rel + keyword.len();
+            let rest = line[idx..].trim();
+            if let Some((schema, name)) = split_qualified_ident(rest) {
+                let schema = if schema == "public" && !rest.contains('.') {
+                    default_schema.to_string()
+                } else {
+                    schema
+                };
+                tables.push(format!("{schema}.{name}"));
+            }
+            search = idx + 1;
+        }
+    }
+    tables
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intermediate_storage::IntermediateStorage;
+    use codestory_contracts::graph::{EdgeKind, NodeKind};
+    use std::path::Path;
+
+    #[test]
+    fn collects_schema_table_column_and_index() {
+        let sql = r#"
+CREATE SCHEMA app;
+CREATE TABLE app.users (id INT PRIMARY KEY, email TEXT);
+CREATE INDEX users_email_idx ON app.users (email);
+"#;
+        let mut storage = IntermediateStorage::default();
+        let file_id = NodeId(7);
+        collect_sql_entities(Path::new("schema.sql"), sql, file_id, &mut storage);
+        assert!(storage.nodes.iter().any(|n| n.kind == NodeKind::NAMESPACE
+            && n.canonical_id.as_deref() == Some("sql:schema:app")));
+        assert!(
+            storage
+                .nodes
+                .iter()
+                .any(|n| n.canonical_id.as_deref() == Some("sql:table:app.users"))
+        );
+        assert!(storage.nodes.iter().any(|n| n.kind == NodeKind::FIELD));
+        assert!(storage.edges.iter().any(|e| e.kind == EdgeKind::MEMBER));
+        assert!(
+            storage
+                .edges
+                .iter()
+                .any(|e| e.kind == EdgeKind::ANNOTATION_USAGE)
+        );
+    }
+}

--- a/crates/codestory-indexer/src/template_pipeline.rs
+++ b/crates/codestory-indexer/src/template_pipeline.rs
@@ -1,0 +1,464 @@
+//! Whitespace-blanking pipeline for Vue, Svelte, and Astro single-file components.
+//!
+//! Non-script regions are replaced with spaces (preserving newlines and byte length) so
+//! JavaScript/TypeScript tree-sitter graph rules can run on the full file while keeping
+//! absolute source positions aligned with the original template.
+
+use std::path::Path;
+
+/// Which template dialect applies to a file path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemplateKind {
+    Vue,
+    Svelte,
+    Astro,
+}
+
+/// Byte range in the original source (inclusive start, exclusive end).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ByteRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// A `<style>` block extracted for future CSS structural collection.
+#[derive(Debug, Clone)]
+pub struct StyleBlockRange {
+    pub range: ByteRange,
+    pub content: String,
+    pub start_line: u32,
+}
+
+/// Output of preparing a template file for JS/TS graph indexing.
+#[derive(Debug, Clone)]
+pub struct TemplatePrepareResult {
+    pub blanked: String,
+    /// `javascript` or `typescript` — selects tree-sitter ruleset.
+    pub script_language: &'static str,
+    pub style_blocks: Vec<StyleBlockRange>,
+}
+
+pub fn template_kind_for_path(path: &Path) -> Option<TemplateKind> {
+    let ext = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "vue" => Some(TemplateKind::Vue),
+        "svelte" => Some(TemplateKind::Svelte),
+        "astro" => Some(TemplateKind::Astro),
+        _ => None,
+    }
+}
+
+pub fn template_surface_language(path: &Path) -> Option<&'static str> {
+    template_kind_for_path(path).map(|kind| match kind {
+        TemplateKind::Vue => "vue",
+        TemplateKind::Svelte => "svelte",
+        TemplateKind::Astro => "astro",
+    })
+}
+
+pub fn prepare_template_source(kind: TemplateKind, source: &str) -> TemplatePrepareResult {
+    let mut keep_ranges = Vec::new();
+    let mut style_blocks = Vec::new();
+    let mut script_language = "javascript";
+
+    collect_script_blocks(source, &mut keep_ranges, &mut script_language);
+    collect_style_blocks(source, &mut style_blocks);
+
+    if matches!(kind, TemplateKind::Astro) {
+        collect_astro_frontmatter(source, &mut keep_ranges, &mut script_language);
+    }
+    if matches!(kind, TemplateKind::Svelte) {
+        let script_ranges = keep_ranges.clone();
+        collect_svelte_inline_expressions(source, &script_ranges, &mut keep_ranges);
+    }
+
+    keep_ranges.sort_by_key(|range| range.start);
+    keep_ranges = merge_ranges(keep_ranges);
+
+    let blanked = blank_source(source, &keep_ranges);
+
+    TemplatePrepareResult {
+        blanked,
+        script_language,
+        style_blocks,
+    }
+}
+
+/// Delegates embedded `<style>` blocks to the structural CSS entity collector.
+pub fn delegate_template_style_blocks(
+    path: &Path,
+    blocks: &[StyleBlockRange],
+    file_id: codestory_contracts::graph::NodeId,
+    storage: &mut crate::intermediate_storage::IntermediateStorage,
+) {
+    for block in blocks {
+        crate::structural::collect_embedded_style_css(
+            path,
+            &block.content,
+            file_id,
+            storage,
+            block.start_line,
+        );
+    }
+}
+
+fn collect_script_blocks(
+    source: &str,
+    keep_ranges: &mut Vec<ByteRange>,
+    script_language: &mut &'static str,
+) {
+    let bytes = source.as_bytes();
+    let lower = source.to_ascii_lowercase();
+    let mut search_from = 0usize;
+
+    while let Some(rel) = lower[search_from..].find("<script") {
+        let start = search_from + rel;
+        let Some(open_end) = lower[start..].find('>') else {
+            break;
+        };
+        let open_end = start + open_end + 1;
+        let Some(close_rel) = lower[open_end..].find("</script>") else {
+            break;
+        };
+        let close_start = open_end + close_rel;
+        let close_end = close_start + "</script>".len();
+        keep_ranges.push(ByteRange {
+            start: open_end,
+            end: close_start.min(bytes.len()),
+        });
+        if let Some(lang) = script_lang_from_opening_tag(&source[start..open_end]) {
+            *script_language = lang;
+        }
+        search_from = close_end;
+    }
+}
+
+fn collect_style_blocks(source: &str, style_blocks: &mut Vec<StyleBlockRange>) {
+    let lower = source.to_ascii_lowercase();
+    let mut search_from = 0usize;
+
+    while let Some(rel) = lower[search_from..].find("<style") {
+        let start = search_from + rel;
+        let Some(open_end) = lower[start..].find('>') else {
+            break;
+        };
+        let open_end = start + open_end + 1;
+        let Some(close_rel) = lower[open_end..].find("</style>") else {
+            break;
+        };
+        let close_start = open_end + close_rel;
+        let close_end = close_start + "</style>".len();
+        let end = close_end.min(source.len());
+        let start_line = 1 + source[..open_end].bytes().filter(|b| *b == b'\n').count() as u32;
+        style_blocks.push(StyleBlockRange {
+            range: ByteRange { start, end },
+            content: source[open_end..close_start].to_string(),
+            start_line,
+        });
+        search_from = close_end;
+    }
+}
+
+fn collect_astro_frontmatter(
+    source: &str,
+    keep_ranges: &mut Vec<ByteRange>,
+    script_language: &mut &'static str,
+) {
+    let trimmed = source.trim_start();
+    if !trimmed.starts_with("---") {
+        return;
+    }
+    let leading = source.len() - trimmed.len();
+    let after_open = leading + 3;
+    let Some(first_newline) = source[after_open..].find('\n') else {
+        return;
+    };
+    let content_start = after_open + first_newline + 1;
+    let Some(close_rel) = source[content_start..].find("\n---") else {
+        return;
+    };
+    let close_line_start = content_start + close_rel;
+    keep_ranges.push(ByteRange {
+        start: content_start,
+        end: close_line_start,
+    });
+    if source[content_start..close_line_start].contains("lang=\"ts\"")
+        || source[content_start..close_line_start].contains("lang='ts'")
+    {
+        *script_language = "typescript";
+    }
+}
+
+fn collect_svelte_inline_expressions(
+    source: &str,
+    script_ranges: &[ByteRange],
+    keep_ranges: &mut Vec<ByteRange>,
+) {
+    let bytes = source.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if in_any_range(index, script_ranges) {
+            index += 1;
+            continue;
+        }
+        if bytes[index] != b'{' {
+            index += 1;
+            continue;
+        }
+        if let Some(end) = find_brace_expression_end(source, index) {
+            keep_ranges.push(ByteRange { start: index, end });
+            index = end;
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn find_brace_expression_end(source: &str, open_index: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    if bytes.get(open_index) != Some(&b'{') {
+        return None;
+    }
+    let mut depth = 0i32;
+    let mut index = open_index;
+    let mut in_string: Option<u8> = None;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(quote) = in_string {
+            if byte == b'\\' {
+                index += 2;
+                continue;
+            }
+            if byte == quote {
+                in_string = None;
+            }
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'\'' | b'"' | b'`' => {
+                in_string = Some(byte);
+                index += 1;
+            }
+            b'{' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                index += 1;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+fn script_lang_from_opening_tag(opening_tag: &str) -> Option<&'static str> {
+    let lower = opening_tag.to_ascii_lowercase();
+    if lower.contains("lang=\"ts\"")
+        || lower.contains("lang='ts'")
+        || lower.contains("lang=ts")
+        || lower.contains("lang=\"typescript\"")
+        || lower.contains("lang='typescript'")
+        || lower.contains("lang=typescript")
+    {
+        Some("typescript")
+    } else {
+        None
+    }
+}
+
+fn blank_source(source: &str, keep_ranges: &[ByteRange]) -> String {
+    let bytes = source.as_bytes();
+    let mut out = vec![b' '; bytes.len()];
+    for (offset, byte) in bytes.iter().copied().enumerate() {
+        if byte == b'\n' || byte == b'\r' {
+            out[offset] = byte;
+        }
+    }
+    for range in keep_ranges {
+        let start = range.start.min(bytes.len());
+        let end = range.end.min(bytes.len());
+        out[start..end].copy_from_slice(&bytes[start..end]);
+    }
+    String::from_utf8(out).unwrap_or_else(|_| source.to_string())
+}
+
+fn merge_ranges(ranges: Vec<ByteRange>) -> Vec<ByteRange> {
+    if ranges.is_empty() {
+        return ranges;
+    }
+    let mut merged = Vec::new();
+    let mut current = ranges[0];
+    for next in ranges.into_iter().skip(1) {
+        if next.start <= current.end {
+            current.end = current.end.max(next.end);
+        } else {
+            merged.push(current);
+            current = next;
+        }
+    }
+    merged.push(current);
+    merged
+}
+
+fn in_any_range(index: usize, ranges: &[ByteRange]) -> bool {
+    ranges
+        .iter()
+        .any(|range| index >= range.start && index < range.end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{get_language_for_ext, index_file};
+    use std::path::Path;
+
+    fn symbol_line_col(result: &crate::IndexResult, name: &str) -> Option<(u32, u32)> {
+        result
+            .nodes
+            .iter()
+            .find(|node| node.serialized_name == name)
+            .and_then(|node| Some((node.start_line?, node.start_col?)))
+    }
+
+    fn assert_symbol_on_original_source_line(
+        source: &str,
+        result: &crate::IndexResult,
+        name: &str,
+    ) {
+        let (line, col) =
+            symbol_line_col(result, name).unwrap_or_else(|| panic!("missing symbol {name}"));
+        let line_text = source
+            .lines()
+            .nth(line as usize - 1)
+            .unwrap_or_else(|| panic!("line {line} out of range for {name}"));
+        assert!(
+            line_text.contains(name),
+            "expected {name} on original line {line} ({line_text:?}), got col {col}"
+        );
+        let name_start = line_text
+            .find(name)
+            .expect("name on line")
+            .saturating_add(1) as u32;
+        assert!(
+            col <= name_start,
+            "column for {name} should not be past identifier start (col {col}, name starts {name_start})"
+        );
+    }
+
+    #[test]
+    fn test_blank_preserves_byte_length_and_newlines() {
+        let source = "<template>\n  <p>x</p>\n</template>\n<script>\nconst a = 1\n</script>\n";
+        let prepared = prepare_template_source(TemplateKind::Vue, source);
+        assert_eq!(prepared.blanked.len(), source.len());
+        assert!(prepared.blanked.contains("const a = 1"));
+        assert!(prepared.blanked.starts_with(' '));
+        assert_eq!(
+            prepared.blanked.chars().filter(|c| *c == '\n').count(),
+            source.chars().filter(|c| *c == '\n').count()
+        );
+    }
+
+    #[test]
+    fn test_vue_script_symbols_match_original_line_columns() -> anyhow::Result<()> {
+        let source = r#"<template>
+  <p>{{ title }}</p>
+</template>
+<script setup lang="ts">
+export const title = 'Hello'
+export function greet(name: string) {
+  return name
+}
+</script>
+<style scoped>
+.title { color: red; }
+</style>
+"#;
+        let prepared = prepare_template_source(TemplateKind::Vue, source);
+        assert_eq!(prepared.script_language, "typescript");
+        assert_eq!(prepared.style_blocks.len(), 1);
+
+        let language_config = get_language_for_ext("ts").expect("typescript config");
+        let result = index_file(
+            Path::new("App.vue"),
+            &prepared.blanked,
+            &language_config,
+            None,
+            None,
+        )?;
+
+        assert_symbol_on_original_source_line(source, &result, "greet");
+        Ok(())
+    }
+
+    #[test]
+    fn test_svelte_script_and_inline_expression_positions() -> anyhow::Result<()> {
+        let source = r#"<script>
+  export let count = 0
+  export function bump() {
+    count += 1
+  }
+</script>
+
+<button on:click={bump}>{count}</button>
+
+<style>
+  button { font-weight: bold; }
+</style>
+"#;
+        let prepared = prepare_template_source(TemplateKind::Svelte, source);
+        let language_config = get_language_for_ext("js").expect("javascript config");
+        let result = index_file(
+            Path::new("Widget.svelte"),
+            &prepared.blanked,
+            &language_config,
+            None,
+            None,
+        )?;
+
+        assert_symbol_on_original_source_line(source, &result, "bump");
+        Ok(())
+    }
+
+    #[test]
+    fn test_astro_frontmatter_symbols_match_original_positions() -> anyhow::Result<()> {
+        let source = r#"---
+export function buildTitle(page: string) {
+  return `Page: ${page}`
+}
+const site = 'codestory'
+---
+<html>
+  <body>{site}</body>
+</html>
+"#;
+        let prepared = prepare_template_source(TemplateKind::Astro, source);
+        let language_config = get_language_for_ext("ts").expect("typescript config");
+        let result = index_file(
+            Path::new("src/pages/index.astro"),
+            &prepared.blanked,
+            &language_config,
+            None,
+            None,
+        )?;
+
+        assert_symbol_on_original_source_line(source, &result, "buildTitle");
+        Ok(())
+    }
+
+    #[test]
+    fn test_template_script_language_typescript_from_lang_attribute() {
+        let source = r#"<script lang="ts">export const x = 1</script>"#;
+        let prepared = prepare_template_source(TemplateKind::Vue, source);
+        assert_eq!(prepared.script_language, "typescript");
+    }
+}

--- a/crates/codestory-indexer/tests/call_resolution_common_methods.rs
+++ b/crates/codestory-indexer/tests/call_resolution_common_methods.rs
@@ -1,5 +1,5 @@
 use codestory_contracts::events::EventBus;
-use codestory_contracts::graph::{Edge, EdgeKind, Node};
+use codestory_contracts::graph::{Edge, EdgeKind, Node, ResolutionCertainty};
 use codestory_indexer::WorkspaceIndexer;
 use codestory_store::Store as Storage;
 use std::collections::{HashMap, HashSet};
@@ -544,6 +544,481 @@ impl WorkspaceIndexer {
         clone_edges_from_run >= 1,
         "expected at least one clone call edge from run_incremental"
     );
+    Ok(())
+}
+
+#[test]
+fn test_rust_self_field_receiver_calls_resolve_to_declared_field_owner() -> anyhow::Result<()> {
+    let source = r#"
+struct AppController;
+impl AppController {
+    fn run_indexing_blocking_without_runtime_refresh(&self) {}
+}
+
+struct ProjectService;
+impl ProjectService {
+    fn run_indexing_blocking_without_runtime_refresh(&self) {}
+}
+
+struct IndexService {
+    controller: AppController,
+}
+impl IndexService {
+    fn run_indexing_blocking_without_runtime_refresh(&self) {
+        self.controller.run_indexing_blocking_without_runtime_refresh();
+    }
+}
+
+struct RuntimeContext {
+    index: IndexService,
+}
+impl RuntimeContext {
+    fn ensure_open_from_summary(&self) {
+        self.index.run_indexing_blocking_without_runtime_refresh();
+    }
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+
+    assert_resolved_call_to_method_owner(
+        "rust self field receiver",
+        &nodes,
+        &edges,
+        "RuntimeContext::ensure_open_from_summary",
+        "IndexService",
+        "run_indexing_blocking_without_runtime_refresh",
+    );
+    assert_resolved_call_to_method_owner(
+        "rust self field receiver",
+        &nodes,
+        &edges,
+        "IndexService::run_indexing_blocking_without_runtime_refresh",
+        "AppController",
+        "run_indexing_blocking_without_runtime_refresh",
+    );
+
+    let node_by_id: HashMap<_, _> = nodes.iter().map(|node| (node.id, node)).collect();
+    let project_method_id = nodes
+        .iter()
+        .find(|node| {
+            is_matching_owned_method(
+                &node.serialized_name,
+                "ProjectService",
+                "run_indexing_blocking_without_runtime_refresh",
+            )
+        })
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("expected ProjectService method node"))?;
+    let index_service_ids = nodes
+        .iter()
+        .filter(|node| {
+            is_matching_owned_method(
+                &node.serialized_name,
+                "IndexService",
+                "run_indexing_blocking_without_runtime_refresh",
+            )
+        })
+        .map(|node| node.id)
+        .collect::<Vec<_>>();
+    assert!(
+        !index_service_ids.is_empty(),
+        "expected IndexService method node"
+    );
+
+    for edge in edges.iter().filter(|edge| edge.kind == EdgeKind::CALL) {
+        if !index_service_ids.contains(&edge.source) {
+            continue;
+        }
+        let Some(target_node) = node_by_id.get(&edge.target) else {
+            continue;
+        };
+        if !is_matching_name(
+            &target_node.serialized_name,
+            "run_indexing_blocking_without_runtime_refresh",
+        ) {
+            continue;
+        }
+        assert_ne!(
+            edge.resolved_target,
+            Some(project_method_id),
+            "self.controller call must not resolve to unrelated ProjectService method. Calls: {:?}",
+            describe_call_edges(&edges, &nodes)
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_parameter_receiver_call_resolves_to_declared_parameter_type() -> anyhow::Result<()> {
+    let source = r#"
+struct OtherStorage;
+impl OtherStorage {
+    fn projections(&mut self) {}
+}
+
+struct Storage;
+impl Storage {
+    fn projections(&mut self) {}
+}
+
+struct WorkspaceIndexer;
+impl WorkspaceIndexer {
+    fn flush_projection_batch(storage: &mut Storage) {
+        storage.projections();
+    }
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+    assert_resolved_call_to_method_owner(
+        "rust parameter receiver",
+        &nodes,
+        &edges,
+        "WorkspaceIndexer::flush_projection_batch",
+        "Storage",
+        "projections",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_constructor_inferred_receiver_call_resolves_to_owner_method() -> anyhow::Result<()> {
+    let source = r#"
+struct Error;
+
+struct RuntimeContext;
+impl RuntimeContext {
+    fn new() -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    fn new_inspect_only() -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    fn ensure_open(&self) {
+        self.ensure_open_from_summary();
+    }
+
+    fn ensure_open_from_summary(&self) {}
+}
+
+fn run(dry_run: bool) -> Result<(), Error> {
+    let runtime = if dry_run {
+        RuntimeContext::new_inspect_only()?
+    } else {
+        RuntimeContext::new()?
+    };
+    runtime.ensure_open();
+    Ok(())
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+    assert_resolved_call_to_method_owner(
+        "rust constructor-inferred receiver",
+        &nodes,
+        &edges,
+        "run",
+        "RuntimeContext",
+        "ensure_open",
+    );
+    assert_resolved_call_to_method_owner(
+        "rust constructor-inferred receiver",
+        &nodes,
+        &edges,
+        "RuntimeContext::ensure_open",
+        "RuntimeContext",
+        "ensure_open_from_summary",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_chained_receiver_call_uses_method_return_type() -> anyhow::Result<()> {
+    let source = r#"
+struct Storage;
+struct ProjectionStore;
+struct SnapshotStore;
+
+impl Storage {
+    fn projections(&mut self) -> ProjectionStore {
+        ProjectionStore
+    }
+
+    fn snapshots(&self) -> SnapshotStore {
+        SnapshotStore
+    }
+}
+
+impl ProjectionStore {
+    fn flush_projection_batch(&mut self) {}
+}
+
+impl SnapshotStore {
+    fn refresh_all_with_stats(&self) {}
+}
+
+struct WorkspaceIndexer;
+impl WorkspaceIndexer {
+    fn flush_projection_batch(storage: &mut Storage) {
+        storage.projections().flush_projection_batch();
+    }
+}
+
+fn refresh(storage: &Storage) {
+    storage.snapshots().refresh_all_with_stats();
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+    assert_resolved_call_to_method_owner(
+        "rust chained receiver return",
+        &nodes,
+        &edges,
+        "WorkspaceIndexer::flush_projection_batch",
+        "ProjectionStore",
+        "flush_projection_batch",
+    );
+    assert_resolved_call_to_method_owner(
+        "rust chained receiver return",
+        &nodes,
+        &edges,
+        "refresh",
+        "SnapshotStore",
+        "refresh_all_with_stats",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_owner_alias_receiver_call_resolves_to_manifest_owner() -> anyhow::Result<()> {
+    let source = r#"
+struct WorkspaceManifest;
+impl WorkspaceManifest {
+    fn build_execution_plan(&self) {}
+}
+
+type Workspace = WorkspaceManifest;
+
+fn run(workspace: &Workspace) {
+    workspace.build_execution_plan();
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+    assert_resolved_call_to_method_owner(
+        "rust owner alias receiver call",
+        &nodes,
+        &edges,
+        "run",
+        "WorkspaceManifest",
+        "build_execution_plan",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_owner_prefix_without_known_alias_stays_unresolved() -> anyhow::Result<()> {
+    let source = r#"
+struct WorkspaceRunner;
+impl WorkspaceRunner {
+    fn build_execution_plan(&self) {}
+}
+
+fn run(workspace: &Workspace) {
+    workspace.build_execution_plan();
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+    let node_by_id: HashMap<_, _> = nodes.iter().map(|n| (n.id, n)).collect();
+    let mut found = 0usize;
+    for edge in edges.iter().filter(|edge| edge.kind == EdgeKind::CALL) {
+        let Some(source) = node_by_id.get(&edge.source) else {
+            continue;
+        };
+        let Some(target) = node_by_id.get(&edge.target) else {
+            continue;
+        };
+        if is_matching_name(&source.serialized_name, "run")
+            && target.serialized_name.contains("build_execution_plan")
+        {
+            found += 1;
+            assert!(
+                edge.resolved_target.is_none(),
+                "unknown owner prefix should not resolve to unrelated owner. Calls: {:?}",
+                describe_call_edges(&edges, &nodes)
+            );
+        }
+    }
+    assert!(
+        found > 0,
+        "expected unresolved build_execution_plan call. Calls: {:?}",
+        describe_call_edges(&edges, &nodes)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_store_alias_receiver_call_resolves_to_storage_owner() -> anyhow::Result<()> {
+    let source = r#"
+struct Storage;
+impl Storage {
+    fn flush_projection_batch(&mut self) {}
+}
+
+type Store = Storage;
+
+struct ProjectionStore<'a> {
+    storage: &'a mut Store,
+}
+impl<'a> ProjectionStore<'a> {
+    fn flush_projection_batch(&mut self) {
+        self.storage.flush_projection_batch();
+    }
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+    assert_resolved_call_to_method_owner(
+        "rust store alias receiver call",
+        &nodes,
+        &edges,
+        "ProjectionStore::flush_projection_batch",
+        "Storage",
+        "flush_projection_batch",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_cross_file_receiver_call_is_certain_owner_qualified_path() -> anyhow::Result<()> {
+    let service_source = r#"
+pub struct IndexService;
+impl IndexService {
+    pub fn run_indexing_blocking_without_runtime_refresh(&self) {}
+}
+"#;
+    let runtime_source = r#"
+use crate::service::IndexService;
+
+struct RuntimeContext {
+    index: IndexService,
+}
+impl RuntimeContext {
+    fn ensure_open_from_summary(&self) {
+        self.index.run_indexing_blocking_without_runtime_refresh();
+    }
+}
+"#;
+
+    let (nodes, edges) = index_files(&[
+        ("service.rs", service_source),
+        ("runtime.rs", runtime_source),
+    ])?;
+    assert_resolved_call_to_method_owner(
+        "rust cross-file receiver",
+        &nodes,
+        &edges,
+        "RuntimeContext::ensure_open_from_summary",
+        "IndexService",
+        "run_indexing_blocking_without_runtime_refresh",
+    );
+
+    let node_by_id: HashMap<_, _> = nodes.iter().map(|node| (node.id, node)).collect();
+    let caller_ids = nodes
+        .iter()
+        .filter(|node| {
+            is_matching_owned_method(
+                &node.serialized_name,
+                "RuntimeContext",
+                "ensure_open_from_summary",
+            )
+        })
+        .map(|node| node.id)
+        .collect::<Vec<_>>();
+    let edge = edges
+        .iter()
+        .find(|edge| {
+            edge.kind == EdgeKind::CALL
+                && caller_ids.contains(&edge.source)
+                && edge
+                    .resolved_target
+                    .and_then(|target_id| node_by_id.get(&target_id))
+                    .is_some_and(|node| {
+                        is_matching_owned_method(
+                            &node.serialized_name,
+                            "IndexService",
+                            "run_indexing_blocking_without_runtime_refresh",
+                        )
+                    })
+        })
+        .ok_or_else(|| anyhow::anyhow!("expected cross-file receiver call edge"))?;
+    assert_eq!(
+        edge.certainty,
+        Some(ResolutionCertainty::Certain),
+        "cross-file owner-qualified receiver calls should survive hide-speculative trail filters"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_rust_untyped_common_receiver_call_remains_unresolved() -> anyhow::Result<()> {
+    let source = r#"
+struct NavigationHistory;
+impl NavigationHistory {
+    fn push(&mut self, _x: i32) {}
+}
+
+fn run() {
+    let mut items = Vec::new();
+    items.push(1);
+}
+"#;
+
+    let (nodes, edges) = index_single_file("main.rs", source)?;
+    let node_by_id: HashMap<_, _> = nodes.iter().map(|node| (node.id, node)).collect();
+    let navigation_push_id = nodes
+        .iter()
+        .find(|node| is_matching_owned_method(&node.serialized_name, "NavigationHistory", "push"))
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("expected NavigationHistory::push symbol"))?;
+    let run_ids = nodes
+        .iter()
+        .filter(|node| is_matching_name(&node.serialized_name, "run"))
+        .map(|node| node.id)
+        .collect::<Vec<_>>();
+
+    let mut push_edges = 0usize;
+    for edge in edges.iter().filter(|edge| edge.kind == EdgeKind::CALL) {
+        if !run_ids.contains(&edge.source) {
+            continue;
+        }
+        let Some(target_node) = node_by_id.get(&edge.target) else {
+            continue;
+        };
+        if !is_matching_name(&target_node.serialized_name, "push") {
+            continue;
+        }
+        push_edges += 1;
+        assert_ne!(
+            edge.resolved_target,
+            Some(navigation_push_id),
+            "untyped Vec::push receiver must not resolve to unrelated NavigationHistory::push"
+        );
+    }
+    assert!(push_edges >= 1, "expected a push call edge from run");
+
     Ok(())
 }
 

--- a/crates/codestory-indexer/tests/fidelity_regression.rs
+++ b/crates/codestory-indexer/tests/fidelity_regression.rs
@@ -810,6 +810,36 @@ fn test_rust_struct_enum_and_local_bindings_are_indexed() -> anyhow::Result<()> 
 }
 
 #[test]
+fn test_rust_enum_variants_are_indexed_as_owned_constants() -> anyhow::Result<()> {
+    let source = r#"
+enum Subcommand {
+    Exec(ExecCli),
+    Review(ReviewCommand),
+}
+"#;
+    let (nodes, edges) = index_single_file("subcommand.rs", source)?;
+
+    assert!(has_node_with_kind(
+        &nodes,
+        NodeKind::ENUM_CONSTANT,
+        "Subcommand::Exec"
+    ));
+    assert!(has_node_with_kind(
+        &nodes,
+        NodeKind::ENUM_CONSTANT,
+        "Subcommand::Review"
+    ));
+    assert!(has_edge_between_names(
+        &edges,
+        &nodes,
+        EdgeKind::MEMBER,
+        "Subcommand",
+        "Subcommand::Exec"
+    ));
+    Ok(())
+}
+
+#[test]
 fn test_python_module_constants_and_decorators_are_preserved() -> anyhow::Result<()> {
     let source = r#"
 MAX_RETRIES = 3

--- a/crates/codestory-indexer/tests/fixtures/tictactoe/csharp_tictactoe.cs
+++ b/crates/codestory-indexer/tests/fixtures/tictactoe/csharp_tictactoe.cs
@@ -1,0 +1,95 @@
+using System;
+
+namespace TicTacToe;
+
+static class Entry
+{
+    public static int numberIn() => 1;
+
+    public static void numberOut(int num) => Console.Write(num);
+
+    public static void stringOut(string value) => Console.Write(value);
+}
+
+class GameObject
+{
+    public void announce() { }
+}
+
+class Field : GameObject
+{
+    public int[,] grid = new int[3, 3];
+    public int left = 9;
+
+    public int opponent(int token)
+    {
+        if (token == 1) return 4;
+        if (token == 4) return 1;
+        return 0;
+    }
+
+    public int sameInRow(int token, int amount)
+    {
+        int total = token * amount;
+        int count = 0;
+        for (int i = 0; i < 3; i++)
+        {
+            if (grid[i, 0] + grid[i, 1] + grid[i, 2] == total) count++;
+        }
+        return count;
+    }
+
+    public bool makeMove(int row, int col, int token)
+    {
+        if (token == 0) return false;
+        grid[row, col] = token;
+        left--;
+        sameInRow(token, 3);
+        return true;
+    }
+}
+
+interface Player
+{
+    bool turn(Field field, int token);
+}
+
+class HumanPlayer : Player
+{
+    public bool turn(Field field, int token) => field.makeMove(0, 0, token);
+}
+
+class ArtificialPlayer : Player
+{
+    public int minMax(Field field, int token, int depth)
+    {
+        if (depth == 0) return 0;
+        return minMax(field, token, depth - 1);
+    }
+
+    public bool turn(Field field, int token)
+    {
+        minMax(field, token, 3);
+        return true;
+    }
+}
+
+class TicTacToe : GameObject
+{
+    public Field field = new();
+
+    public void run()
+    {
+        numberIn();
+        stringOut("start");
+        new Random().Next(3);
+    }
+}
+
+class Program
+{
+    static void Main()
+    {
+        new TicTacToe().run();
+    }
+}

--- a/crates/codestory-indexer/tests/fixtures/tictactoe/go_tictactoe.go
+++ b/crates/codestory-indexer/tests/fixtures/tictactoe/go_tictactoe.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func numberIn() int {
+	return 1
+}
+
+func numberOut(num int) {
+	fmt.Print(num)
+}
+
+func stringOut(value string) {
+	fmt.Print(value)
+}
+
+type GameObject struct{}
+
+func (GameObject) announce() {}
+
+type Field struct {
+	grid  [][]int
+	left  int
+}
+
+func (f *Field) opponent(token int) int {
+	if token == 1 {
+		return 4
+	}
+	if token == 4 {
+		return 1
+	}
+	return 0
+}
+
+func (f *Field) sameInRow(token int, amount int) int {
+	total := token * amount
+	count := 0
+	for i := 0; i < 3; i++ {
+		if f.grid[i][0]+f.grid[i][1]+f.grid[i][2] == total {
+			count++
+		}
+	}
+	return count
+}
+
+func (f *Field) makeMove(row int, col int, token int) bool {
+	if token == 0 {
+		return false
+	}
+	f.grid[row][col] = token
+	f.left--
+	f.sameInRow(token, 3)
+	return true
+}
+
+type Player interface {
+	turn(field *Field, token int) bool
+}
+
+type HumanPlayer struct{}
+
+func (HumanPlayer) turn(field *Field, token int) bool {
+	return field.makeMove(0, 0, token)
+}
+
+type ArtificialPlayer struct{}
+
+func (p ArtificialPlayer) minMax(field *Field, token int, depth int) int {
+	if depth == 0 {
+		return 0
+	}
+	return p.minMax(field, token, depth-1)
+}
+
+func (p ArtificialPlayer) turn(field *Field, token int) bool {
+	p.minMax(field, token, 3)
+	return true
+}
+
+type TicTacToe struct {
+	field *Field
+}
+
+func (t *TicTacToe) run() {
+	t.field = &Field{grid: make([][]int, 3), left: 9}
+	numberIn()
+	stringOut("start")
+	rand.Intn(3)
+}
+
+func main() {
+	game := &TicTacToe{}
+	game.run()
+}

--- a/crates/codestory-indexer/tests/fixtures/tictactoe/php_tictactoe.php
+++ b/crates/codestory-indexer/tests/fixtures/tictactoe/php_tictactoe.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace TicTacToe;
+
+use Random\Randomizer;
+
+function numberIn(): int
+{
+    return 1;
+}
+
+function numberOut(int $num): void
+{
+    echo $num;
+}
+
+function stringOut(string $value): void
+{
+    echo $value;
+}
+
+class GameObject
+{
+    public function announce(): void
+    {
+    }
+}
+
+class Field extends GameObject
+{
+    /** @var array<int, array<int, int>> */
+    public array $grid;
+    public int $left = 9;
+
+    public function __construct()
+    {
+        $this->grid = array_fill(0, 3, array_fill(0, 3, 0));
+    }
+
+    public function opponent(int $token): int
+    {
+        if ($token === 1) {
+            return 4;
+        }
+        if ($token === 4) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public function sameInRow(int $token, int $amount): int
+    {
+        $total = $token * $amount;
+        $count = 0;
+        for ($i = 0; $i < 3; $i++) {
+            if ($this->grid[$i][0] + $this->grid[$i][1] + $this->grid[$i][2] === $total) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    public function makeMove(int $row, int $col, int $token): bool
+    {
+        if ($token === 0) {
+            return false;
+        }
+        $this->grid[$row][$col] = $token;
+        $this->left--;
+        $this->sameInRow($token, 3);
+        return true;
+    }
+}
+
+interface Player
+{
+    public function turn(Field $field, int $token): bool;
+}
+
+class HumanPlayer implements Player
+{
+    public function turn(Field $field, int $token): bool
+    {
+        return $field->makeMove(0, 0, $token);
+    }
+}
+
+class ArtificialPlayer implements Player
+{
+    public function minMax(Field $field, int $token, int $depth): int
+    {
+        if ($depth === 0) {
+            return 0;
+        }
+        return $this->minMax($field, $token, $depth - 1);
+    }
+
+    public function turn(Field $field, int $token): bool
+    {
+        $this->minMax($field, $token, 3);
+        return true;
+    }
+}
+
+class TicTacToe extends GameObject
+{
+    public Field $field;
+
+    public function run(): void
+    {
+        $this->field = new Field();
+        numberIn();
+        stringOut("start");
+        (new Randomizer())->nextInt(0, 2);
+    }
+}
+
+(new TicTacToe())->run();

--- a/crates/codestory-indexer/tests/fixtures/tictactoe/ruby_tictactoe.rb
+++ b/crates/codestory-indexer/tests/fixtures/tictactoe/ruby_tictactoe.rb
@@ -1,0 +1,85 @@
+require "random"
+
+def numberIn
+  1
+end
+
+def numberOut(num)
+  print num
+end
+
+def stringOut(value)
+  print value
+end
+
+class GameObject
+  def announce
+  end
+end
+
+class Field < GameObject
+  def initialize
+    @grid = Array.new(3) { Array.new(3, 0) }
+    @left = 9
+  end
+
+  def opponent(token)
+    return 4 if token == 1
+    return 1 if token == 4
+    0
+  end
+
+  def sameInRow(token, amount)
+    total = token * amount
+    count = 0
+    3.times do |i|
+      count += 1 if @grid[i][0] + @grid[i][1] + @grid[i][2] == total
+    end
+    count
+  end
+
+  def makeMove(row, col, token)
+    return false if token == 0
+    @grid[row][col] = token
+    @left -= 1
+    sameInRow(token, 3)
+    true
+  end
+end
+
+class Player
+  def turn(field, token)
+    false
+  end
+end
+
+class HumanPlayer < Player
+  def turn(field, token)
+    field.makeMove(0, 0, token)
+  end
+end
+
+class ArtificialPlayer < Player
+  def minMax(field, token, depth)
+    return 0 if depth == 0
+    minMax(field, token, depth - 1)
+  end
+
+  def turn(field, token)
+    minMax(field, token, 3)
+    true
+  end
+end
+
+class TicTacToe < GameObject
+  def run
+    @field = Field.new
+    numberIn()
+    stringOut("start")
+    Random.rand(3)
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  TicTacToe.new.run
+end

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -1,6 +1,6 @@
 use codestory_contracts::events::EventBus;
 use codestory_contracts::graph::{
-    AccessKind, EdgeKind, NodeKind, OccurrenceKind, ResolutionCertainty,
+    AccessKind, EdgeKind, NodeId, NodeKind, OccurrenceKind, ResolutionCertainty,
 };
 use codestory_indexer::resolution::ResolutionPass;
 use codestory_indexer::{IncrementalIndexingStats, WorkspaceIndexer};
@@ -107,6 +107,43 @@ int main() {
     assert!(my_method.file_node_id.is_some());
     assert!(my_method.start_line.is_some());
     assert!(my_method.end_line.is_some());
+
+    Ok(())
+}
+
+#[test]
+fn test_failed_file_attempt_is_recorded_as_incomplete_with_attached_error() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("broken.ts");
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    let files = storage.get_files()?;
+    assert_eq!(
+        files.len(),
+        1,
+        "failed attempts should still record file inventory"
+    );
+    let file = &files[0];
+    assert_eq!(file.path, file_path);
+    assert!(file.indexed);
+    assert!(!file.complete);
+
+    let errors = storage.get_errors(None)?;
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].file_id, Some(NodeId(file.id)));
+
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    let errors = storage.get_errors(None)?;
+    assert_eq!(
+        errors.len(),
+        1,
+        "reindexing the same failed file should replace, not duplicate, its error"
+    );
+    assert_eq!(errors[0].file_id, Some(NodeId(file.id)));
 
     Ok(())
 }
@@ -377,8 +414,7 @@ fn keep() { fresh(); }
 }
 
 #[test]
-fn test_incremental_go_text_only_structural_change_removes_stale_projection() -> anyhow::Result<()>
-{
+fn test_incremental_go_structural_change_removes_stale_projection() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let root = dir.path();
     let file_path = root.join("mux.go");
@@ -402,8 +438,8 @@ func (r *Router) Handle(path string) {}
     assert!(
         before_nodes
             .iter()
-            .any(|node| node.serialized_name == "Router.StrictSlash"),
-        "expected initial Go text-only method projection"
+            .any(|node| node.serialized_name == "StrictSlash"),
+        "expected initial Go parser-backed method projection"
     );
     let file_id = before_nodes
         .iter()
@@ -414,8 +450,8 @@ func (r *Router) Handle(path string) {}
         storage
             .get_callable_projection_states_for_file(file_id.0)?
             .iter()
-            .any(|state| state.symbol_key.contains("Router.StrictSlash")),
-        "Go text-only indexing should persist callable projection state"
+            .any(|state| state.symbol_key.contains("StrictSlash")),
+        "Go parser-backed indexing should persist callable projection state"
     );
 
     fs::write(
@@ -435,15 +471,15 @@ func (r *Router) Handle(path string) {}
     assert!(
         !after_nodes
             .iter()
-            .any(|node| node.serialized_name == "Router.StrictSlash"),
-        "stale Go text-only method should be removed after structural refresh"
+            .any(|node| node.serialized_name == "StrictSlash"),
+        "stale Go method should be removed after structural refresh"
     );
     let states_after = storage.get_callable_projection_states_for_file(file_id.0)?;
     assert!(
         states_after
             .iter()
-            .all(|state| !state.symbol_key.contains("Router.StrictSlash")),
-        "stale Go text-only projection state should be removed"
+            .all(|state| !state.symbol_key.contains("StrictSlash")),
+        "stale Go projection state should be removed"
     );
 
     Ok(())

--- a/crates/codestory-indexer/tests/query_rule_regressions.rs
+++ b/crates/codestory-indexer/tests/query_rule_regressions.rs
@@ -265,6 +265,40 @@ class Example extends Base implements IFoo {
 }
 
 #[test]
+fn test_typescript_extends_factory_call_indexes_without_duplicate_variable() -> anyhow::Result<()> {
+    let (nodes, edges) = index_project(&[(
+        "main.ts",
+        r#"
+function mock<T>(): { new(): T } {
+  return class {} as any;
+}
+
+interface IGitService {}
+
+class TestGitService extends mock<IGitService>() {
+  getRecentRepositories() {
+    return [];
+  }
+}
+"#,
+    )])?;
+
+    assert!(has_node_kind(&nodes, "TestGitService", NodeKind::CLASS));
+    assert!(
+        edge_between_matching(
+            &nodes,
+            &edges,
+            EdgeKind::INHERITANCE,
+            |name| matches_name(name, "TestGitService"),
+            |name| name.contains("mock<IGitService>()")
+        ),
+        "expected TestGitService inheritance edge to the factory superclass expression"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_tsx_parenthesized_jsx_component_and_props_are_tracked() -> anyhow::Result<()> {
     let (nodes, edges) = index_project(&[(
         "App.tsx",

--- a/crates/codestory-indexer/tests/tictactoe_language_coverage.rs
+++ b/crates/codestory-indexer/tests/tictactoe_language_coverage.rs
@@ -10,6 +10,10 @@ const JAVASCRIPT_SOURCE: &str = include_str!("fixtures/tictactoe/javascript_tict
 const TYPESCRIPT_SOURCE: &str = include_str!("fixtures/tictactoe/typescript_tictactoe.ts");
 const CPP_SOURCE: &str = include_str!("fixtures/tictactoe/cpp_tictactoe.cpp");
 const C_SOURCE: &str = include_str!("fixtures/tictactoe/c_tictactoe.c");
+const GO_SOURCE: &str = include_str!("fixtures/tictactoe/go_tictactoe.go");
+const RUBY_SOURCE: &str = include_str!("fixtures/tictactoe/ruby_tictactoe.rb");
+const PHP_SOURCE: &str = include_str!("fixtures/tictactoe/php_tictactoe.php");
+const CSHARP_SOURCE: &str = include_str!("fixtures/tictactoe/csharp_tictactoe.cs");
 
 type NamePair = (&'static str, &'static str);
 
@@ -245,6 +249,97 @@ const TYPESCRIPT_INHERITANCE: &[NamePair] = &[
 const CPP_INHERITANCE: &[NamePair] = &[("TicTacToe", "GameObject")];
 const C_INHERITANCE: &[NamePair] = &[];
 
+const GO_SYMBOLS: &[(NodeKind, &str)] = &[
+    (NodeKind::STRUCT, "Field"),
+    (NodeKind::STRUCT, "GameObject"),
+    (NodeKind::STRUCT, "HumanPlayer"),
+    (NodeKind::STRUCT, "ArtificialPlayer"),
+    (NodeKind::STRUCT, "TicTacToe"),
+    (NodeKind::FUNCTION, "numberIn"),
+    (NodeKind::FUNCTION, "numberOut"),
+    (NodeKind::FUNCTION, "stringOut"),
+    (NodeKind::METHOD, "makeMove"),
+    (NodeKind::METHOD, "sameInRow"),
+    (NodeKind::METHOD, "turn"),
+    (NodeKind::METHOD, "minMax"),
+    (NodeKind::METHOD, "run"),
+    (NodeKind::FUNCTION, "main"),
+];
+const RUBY_SYMBOLS: &[(NodeKind, &str)] = &[
+    (NodeKind::CLASS, "GameObject"),
+    (NodeKind::CLASS, "Field"),
+    (NodeKind::CLASS, "Player"),
+    (NodeKind::CLASS, "HumanPlayer"),
+    (NodeKind::CLASS, "ArtificialPlayer"),
+    (NodeKind::CLASS, "TicTacToe"),
+    (NodeKind::FUNCTION, "numberIn"),
+    (NodeKind::FUNCTION, "numberOut"),
+    (NodeKind::FUNCTION, "stringOut"),
+    (NodeKind::METHOD, "makeMove"),
+    (NodeKind::METHOD, "sameInRow"),
+    (NodeKind::METHOD, "turn"),
+    (NodeKind::METHOD, "minMax"),
+    (NodeKind::METHOD, "run"),
+];
+const PHP_SYMBOLS: &[(NodeKind, &str)] = &[
+    (NodeKind::CLASS, "GameObject"),
+    (NodeKind::CLASS, "Field"),
+    (NodeKind::INTERFACE, "Player"),
+    (NodeKind::CLASS, "HumanPlayer"),
+    (NodeKind::CLASS, "ArtificialPlayer"),
+    (NodeKind::CLASS, "TicTacToe"),
+    (NodeKind::FUNCTION, "numberIn"),
+    (NodeKind::FUNCTION, "numberOut"),
+    (NodeKind::FUNCTION, "stringOut"),
+    (NodeKind::METHOD, "makeMove"),
+    (NodeKind::METHOD, "sameInRow"),
+    (NodeKind::METHOD, "turn"),
+    (NodeKind::METHOD, "minMax"),
+    (NodeKind::METHOD, "run"),
+];
+const CSHARP_SYMBOLS: &[(NodeKind, &str)] = &[
+    (NodeKind::CLASS, "GameObject"),
+    (NodeKind::CLASS, "Field"),
+    (NodeKind::INTERFACE, "Player"),
+    (NodeKind::CLASS, "HumanPlayer"),
+    (NodeKind::CLASS, "ArtificialPlayer"),
+    (NodeKind::CLASS, "TicTacToe"),
+    (NodeKind::METHOD, "numberIn"),
+    (NodeKind::METHOD, "numberOut"),
+    (NodeKind::METHOD, "stringOut"),
+    (NodeKind::METHOD, "makeMove"),
+    (NodeKind::METHOD, "sameInRow"),
+    (NodeKind::METHOD, "turn"),
+    (NodeKind::METHOD, "minMax"),
+    (NodeKind::METHOD, "run"),
+    (NodeKind::METHOD, "Main"),
+];
+
+const GO_IMPORTS: &[&str] = &["\"fmt\"", "\"math/rand\""];
+const RUBY_IMPORTS: &[&str] = &["\"random\""];
+const PHP_IMPORTS: &[&str] = &["Random\\Randomizer"];
+const CSHARP_IMPORTS: &[&str] = &["System"];
+
+const GO_CALLS: &[&str] = &["numberIn", "stringOut", "makeMove", "minMax"];
+const RUBY_CALLS: &[&str] = &["numberIn", "stringOut", "makeMove", "minMax"];
+const PHP_CALLS: &[&str] = &["numberIn", "stringOut", "makeMove", "minMax"];
+const CSHARP_CALLS: &[&str] = &["numberIn", "stringOut", "makeMove", "minMax"];
+
+const GO_MEMBERS: &[NamePair] = &[];
+const RUBY_MEMBERS: &[NamePair] = &[];
+const PHP_MEMBERS: &[NamePair] = &[];
+const CSHARP_MEMBERS: &[NamePair] = &[];
+
+const GO_INHERITANCE: &[NamePair] = &[];
+const RUBY_INHERITANCE: &[NamePair] = &[
+    ("Field", "GameObject"),
+    ("HumanPlayer", "Player"),
+    ("ArtificialPlayer", "Player"),
+    ("TicTacToe", "GameObject"),
+];
+const PHP_INHERITANCE: &[NamePair] = &[("Field", "GameObject"), ("TicTacToe", "GameObject")];
+const CSHARP_INHERITANCE: &[NamePair] = &[("Field", "GameObject"), ("TicTacToe", "GameObject")];
+
 #[derive(Clone, Copy)]
 struct FixtureCase {
     language: &'static str,
@@ -352,6 +447,58 @@ fn fixture_cases() -> Vec<FixtureCase> {
             required_call_targets: C_CALLS,
             required_member_pairs: C_MEMBERS,
             required_inheritance_pairs: C_INHERITANCE,
+        },
+        FixtureCase {
+            language: "go",
+            filename: "game.go",
+            extension: "go",
+            source: GO_SOURCE,
+            min_nodes: 12,
+            min_edges: 10,
+            required_symbols: GO_SYMBOLS,
+            required_import_targets: GO_IMPORTS,
+            required_call_targets: GO_CALLS,
+            required_member_pairs: GO_MEMBERS,
+            required_inheritance_pairs: GO_INHERITANCE,
+        },
+        FixtureCase {
+            language: "ruby",
+            filename: "game.rb",
+            extension: "rb",
+            source: RUBY_SOURCE,
+            min_nodes: 12,
+            min_edges: 10,
+            required_symbols: RUBY_SYMBOLS,
+            required_import_targets: RUBY_IMPORTS,
+            required_call_targets: RUBY_CALLS,
+            required_member_pairs: RUBY_MEMBERS,
+            required_inheritance_pairs: RUBY_INHERITANCE,
+        },
+        FixtureCase {
+            language: "php",
+            filename: "game.php",
+            extension: "php",
+            source: PHP_SOURCE,
+            min_nodes: 12,
+            min_edges: 10,
+            required_symbols: PHP_SYMBOLS,
+            required_import_targets: PHP_IMPORTS,
+            required_call_targets: PHP_CALLS,
+            required_member_pairs: PHP_MEMBERS,
+            required_inheritance_pairs: PHP_INHERITANCE,
+        },
+        FixtureCase {
+            language: "csharp",
+            filename: "game.cs",
+            extension: "cs",
+            source: CSHARP_SOURCE,
+            min_nodes: 12,
+            min_edges: 10,
+            required_symbols: CSHARP_SYMBOLS,
+            required_import_targets: CSHARP_IMPORTS,
+            required_call_targets: CSHARP_CALLS,
+            required_member_pairs: CSHARP_MEMBERS,
+            required_inheritance_pairs: CSHARP_INHERITANCE,
         },
     ]
 }
@@ -464,6 +611,10 @@ fn test_language_extension_coverage_and_names() {
         ("hpp", "cpp"),
         ("hxx", "cpp"),
         ("c", "c"),
+        ("go", "go"),
+        ("rb", "ruby"),
+        ("php", "php"),
+        ("cs", "csharp"),
     ];
 
     for (ext, expected_name) in expected {

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -14,10 +14,11 @@ pub use snapshot_store::{
     SnapshotRefreshStats, SnapshotStore, StagedSnapshot, StagedSnapshotFinalizeStats,
 };
 pub use storage_impl::{
-    CallerProjectionRemovalSummary, FileInfo, FileProjectionRemovalSummary, GroundingEdgeKindCount,
-    GroundingFileSummary, GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState,
-    LlmSymbolDoc, LlmSymbolDocReuseMetadata, LlmSymbolDocStats, ProjectionFlushBreakdown,
-    SearchSymbolProjection, Storage as Store, StorageError, StorageOpenMode, StorageStats,
+    CallerProjectionRemovalSummary, FileInfo, FileProjectionRemovalSummary, FileRole,
+    GroundingEdgeKindCount, GroundingFileSummary, GroundingNodeRecord, GroundingSnapshotMetadata,
+    GroundingSnapshotState, LlmSymbolDoc, LlmSymbolDocReuseMetadata, LlmSymbolDocStats,
+    ProjectionFlushBreakdown, RetrievalIndexManifest, SearchSymbolProjection,
+    SearchSymbolProjectionDetail, Storage as Store, StorageError, StorageOpenMode, StorageStats,
     SymbolSummaryRecord,
 };
 pub use trail_store::TrailStore;

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 
 mod bookmarks;
 mod helpers;
+mod retrieval_manifest;
 mod row_mapping;
 mod schema;
 mod trail;
@@ -25,7 +26,7 @@ use helpers::{
     numbered_placeholders, question_placeholders, serialize_candidate_targets,
 };
 
-const SCHEMA_VERSION: u32 = 13;
+const SCHEMA_VERSION: u32 = 17;
 const GROUNDING_SNAPSHOT_VERSION: i64 = 1;
 const GROUNDING_SNAPSHOT_STATE_DIRTY: i64 = 0;
 const GROUNDING_SNAPSHOT_STATE_BUILDING: i64 = 1;
@@ -38,6 +39,8 @@ const EDGE_SELECT_BASE: &str = "SELECT e.id, e.source_node_id, e.target_node_id,
                  JOIN node t ON t.id = e.target_node_id
                  LEFT JOIN node f ON f.id = e.file_node_id";
 const EDGE_NODE_LOOKUP_BATCH_SIZE: usize = 200;
+const NODE_LOOKUP_BATCH_SIZE: usize = 200;
+const OCCURRENCE_LOOKUP_BATCH_SIZE: usize = 200;
 
 fn clamp_i64_to_u32(value: i64) -> u32 {
     if value <= 0 {
@@ -316,6 +319,126 @@ pub struct FileInfo {
     pub indexed: bool,
     pub complete: bool,
     pub line_count: u32,
+    #[serde(default)]
+    pub file_role: FileRole,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FileRole {
+    #[default]
+    Source,
+    Entrypoint,
+    Test,
+    Docs,
+    Benchmark,
+    Generated,
+    Vendor,
+}
+
+impl FileRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Entrypoint => "entrypoint",
+            Self::Test => "test",
+            Self::Docs => "docs",
+            Self::Benchmark => "benchmark",
+            Self::Generated => "generated",
+            Self::Vendor => "vendor",
+        }
+    }
+
+    pub fn from_db_value(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "entrypoint" => Self::Entrypoint,
+            "test" => Self::Test,
+            "docs" => Self::Docs,
+            "benchmark" => Self::Benchmark,
+            "generated" => Self::Generated,
+            "vendor" => Self::Vendor,
+            _ => Self::Source,
+        }
+    }
+
+    pub fn classify_path(path: &Path) -> Self {
+        let normalized = path
+            .to_string_lossy()
+            .replace('\\', "/")
+            .to_ascii_lowercase();
+        let marked = format!("/{normalized}");
+        let file_name = normalized.rsplit('/').next().unwrap_or(normalized.as_str());
+
+        if marked.contains("/node_modules/")
+            || marked.contains("/vendor/")
+            || marked.contains("/third_party/")
+            || marked.contains("/third-party/")
+            || marked.contains("/external/")
+        {
+            return Self::Vendor;
+        }
+        if marked.contains("/target/")
+            || marked.contains("/dist/")
+            || marked.contains("/build/")
+            || marked.contains("/generated/")
+            || marked.contains("/schema/typescript/")
+            || marked.contains(".generated.")
+            || file_name.ends_with(".g.cs")
+            || file_name.contains("payload-types")
+        {
+            return Self::Generated;
+        }
+        if marked.contains("/tests/")
+            || marked.contains("/test/")
+            || marked.contains("/spec/")
+            || marked.contains("/fixtures/")
+            || marked.contains("/__tests__/")
+            || marked.contains("-test-client/")
+            || marked.contains("_test_client/")
+            || file_name.contains(".test.")
+            || file_name.contains(".spec.")
+            || file_name.ends_with("_test.rs")
+            || file_name.ends_with("_tests.rs")
+            || file_name.ends_with("_test.py")
+            || file_name.ends_with("_tests.py")
+            || file_name.ends_with("_test.ts")
+            || file_name.ends_with("_tests.ts")
+            || file_name.ends_with("_test.tsx")
+            || file_name.ends_with("_tests.tsx")
+        {
+            return Self::Test;
+        }
+        if marked.contains("/docs/")
+            || marked.contains("/doc/")
+            || matches!(file_name, "readme.md" | "changelog.md")
+        {
+            return Self::Docs;
+        }
+        if marked.contains("/benchmarks/")
+            || marked.contains("/benchmark/")
+            || marked.contains("/benches/")
+            || marked.contains("/bench/")
+        {
+            return Self::Benchmark;
+        }
+        if matches!(
+            file_name,
+            "main.rs"
+                | "lib.rs"
+                | "mod.rs"
+                | "main.ts"
+                | "main.tsx"
+                | "main.js"
+                | "main.jsx"
+                | "index.ts"
+                | "index.tsx"
+                | "index.js"
+                | "index.jsx"
+        ) {
+            return Self::Entrypoint;
+        }
+        Self::Source
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -550,6 +673,16 @@ pub struct CallerProjectionRemovalSummary {
 pub struct SearchSymbolProjection {
     pub node_id: NodeId,
     pub display_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchSymbolProjectionDetail {
+    pub node_id: NodeId,
+    pub display_name: String,
+    pub node_kind: Option<i64>,
+    pub file_path: Option<String>,
+    pub start_line: Option<u32>,
+    pub end_line: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -967,7 +1100,8 @@ impl Storage {
                  modification_time = ?4,
                  indexed = ?5,
                  complete = ?6,
-                 line_count = ?7
+                 line_count = ?7,
+                 file_role = ?8
              WHERE id = ?1",
             params![
                 info.id,
@@ -977,6 +1111,7 @@ impl Storage {
                 i32::from(info.indexed),
                 i32::from(info.complete),
                 info.line_count,
+                info.file_role.as_str(),
             ],
         )?;
         self.mark_grounding_snapshots_dirty()?;
@@ -1570,6 +1705,7 @@ impl Storage {
                 indexed: row.get::<_, i32>(4)? != 0,
                 complete: row.get::<_, i32>(5)? != 0,
                 line_count: row.get(6)?,
+                file_role: FileRole::Source,
             },
             symbol_count: clamp_i64_to_u32(row.get::<_, i64>(7)?),
             best_node_rank: row.get::<_, i64>(8)?.min(u8::MAX as i64) as u8,
@@ -2088,15 +2224,22 @@ impl Storage {
         let tx = self.conn.transaction()?;
 
         if !batch.files.is_empty() {
+            let placeholders = question_placeholders(batch.files.len());
+            tx.execute(
+                &format!("DELETE FROM error WHERE file_id IN ({placeholders})"),
+                params_from_iter(batch.files.iter().map(|file| file.id)),
+            )?;
+
             let started = std::time::Instant::now();
             let mut stmt = tx.prepare(
-                "INSERT INTO file (id, path, language, modification_time, indexed, complete, line_count)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                "INSERT INTO file (id, path, language, modification_time, indexed, complete, line_count, file_role)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                  ON CONFLICT(id) DO UPDATE SET
                     modification_time=excluded.modification_time,
                     indexed=excluded.indexed,
                     complete=excluded.complete,
-                    line_count=excluded.line_count",
+                    line_count=excluded.line_count,
+                    file_role=excluded.file_role",
             )?;
             for info in batch.files {
                 stmt.execute(params![
@@ -2107,6 +2250,7 @@ impl Storage {
                     i32::from(info.indexed),
                     i32::from(info.complete),
                     info.line_count,
+                    info.file_role.as_str(),
                 ])?;
             }
             breakdown.files_ms = clamp_i64_to_u32(started.elapsed().as_millis() as i64);
@@ -2423,6 +2567,43 @@ impl Storage {
         Ok(out)
     }
 
+    pub fn get_search_symbol_projection_detail_batch_after(
+        &self,
+        after_node_id: Option<NodeId>,
+        limit: usize,
+    ) -> Result<Vec<SearchSymbolProjectionDetail>, StorageError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT
+                projection.node_id,
+                projection.display_name,
+                node.kind,
+                file.serialized_name,
+                node.start_line,
+                node.end_line
+             FROM search_symbol_projection projection
+             LEFT JOIN node ON node.id = projection.node_id
+             LEFT JOIN node file ON file.id = node.file_node_id
+             WHERE (?1 IS NULL OR projection.node_id > ?1)
+             ORDER BY projection.node_id ASC
+             LIMIT ?2",
+        )?;
+        let after_node_id = after_node_id.map(|id| id.0);
+        let limit = limit.min(i64::MAX as usize) as i64;
+        let mut rows = stmt.query(params![after_node_id, limit])?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(SearchSymbolProjectionDetail {
+                node_id: NodeId(row.get(0)?),
+                display_name: row.get(1)?,
+                node_kind: row.get(2)?,
+                file_path: row.get(3)?,
+                start_line: row.get(4)?,
+                end_line: row.get(5)?,
+            });
+        }
+        Ok(out)
+    }
+
     pub fn get_search_symbol_projection_count(&self) -> Result<u32, StorageError> {
         let count =
             self.conn
@@ -2430,6 +2611,16 @@ impl Storage {
                     row.get::<_, i64>(0)
                 })?;
         Ok(clamp_i64_to_u32(count))
+    }
+
+    pub fn max_indexed_file_modification_time(&self) -> Result<Option<i64>, StorageError> {
+        self.conn
+            .query_row(
+                "SELECT MAX(modification_time) FROM file WHERE indexed = 1",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
     }
 
     pub fn clear_search_symbol_projection(&mut self) -> Result<usize, StorageError> {
@@ -2457,6 +2648,52 @@ impl Storage {
                 END
              FROM node",
             [],
+        )?;
+        tx.commit()?;
+        Ok(inserted.min(u32::MAX as usize) as u32)
+    }
+
+    pub fn rebuild_search_symbol_projection_for_file_scope(
+        &mut self,
+        file_node_ids: &HashSet<NodeId>,
+    ) -> Result<u32, StorageError> {
+        if file_node_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let mut file_ids: Vec<i64> = file_node_ids.iter().map(|id| id.0).collect();
+        file_ids.sort_unstable();
+        file_ids.dedup();
+        let placeholders = numbered_placeholders(1, file_ids.len());
+        let file_scope_predicate =
+            format!("id IN ({placeholders}) OR file_node_id IN ({placeholders})");
+
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            &format!(
+                "DELETE FROM search_symbol_projection
+                 WHERE node_id IN (
+                    SELECT id FROM node WHERE {file_scope_predicate}
+                 )"
+            ),
+            params_from_iter(file_ids.iter().copied()),
+        )?;
+        let inserted = tx.execute(
+            &format!(
+                "INSERT INTO search_symbol_projection (
+                    node_id,
+                    display_name
+                 )
+                 SELECT
+                    id,
+                    CASE
+                        WHEN qualified_name IS NOT NULL AND TRIM(qualified_name) != '' THEN qualified_name
+                        ELSE serialized_name
+                    END
+                 FROM node
+                 WHERE {file_scope_predicate}"
+            ),
+            params_from_iter(file_ids.iter().copied()),
         )?;
         tx.commit()?;
         Ok(inserted.min(u32::MAX as usize) as u32)
@@ -3176,6 +3413,87 @@ impl Storage {
         }
     }
 
+    pub fn get_nodes_by_ids(&self, ids: &[NodeId]) -> Result<HashMap<NodeId, Node>, StorageError> {
+        if ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut unique_ids = Vec::new();
+        let mut seen_ids = HashSet::new();
+        let mut nodes_by_id = HashMap::new();
+        for id in ids {
+            if !seen_ids.insert(*id) {
+                continue;
+            }
+            if let Some(node) = self.cache.nodes.read().get(id) {
+                nodes_by_id.insert(*id, node.clone());
+            } else {
+                unique_ids.push(*id);
+            }
+        }
+
+        for chunk in unique_ids.chunks(NODE_LOOKUP_BATCH_SIZE) {
+            let placeholders = numbered_placeholders(1, chunk.len());
+            let query = format!(
+                "SELECT id, kind, serialized_name, qualified_name, canonical_id, file_node_id, start_line, start_col, end_line, end_col FROM node WHERE id IN ({placeholders})"
+            );
+            let params = chunk.iter().map(|id| Value::from(id.0));
+            let mut stmt = self.conn.prepare(&query)?;
+            let mut rows = stmt.query(params_from_iter(params))?;
+            let mut cache = self.cache.nodes.write();
+            while let Some(row) = rows.next()? {
+                let node = Self::node_from_row(row)?;
+                cache.insert(node.id, node.clone());
+                nodes_by_id.insert(node.id, node);
+            }
+        }
+
+        Ok(nodes_by_id)
+    }
+
+    pub fn get_occurrences_for_node_ids(
+        &self,
+        node_ids: &[NodeId],
+    ) -> Result<HashMap<NodeId, Vec<Occurrence>>, StorageError> {
+        if node_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut unique_ids = Vec::new();
+        let mut seen_ids = HashSet::new();
+        for node_id in node_ids {
+            if seen_ids.insert(*node_id) {
+                unique_ids.push(*node_id);
+            }
+        }
+
+        let mut occurrences_by_node = unique_ids
+            .iter()
+            .copied()
+            .map(|node_id| (node_id, Vec::new()))
+            .collect::<HashMap<_, _>>();
+
+        for chunk in unique_ids.chunks(OCCURRENCE_LOOKUP_BATCH_SIZE) {
+            let placeholders = numbered_placeholders(1, chunk.len());
+            let query = format!(
+                "SELECT element_id, kind, file_node_id, start_line, start_col, end_line, end_col FROM occurrence WHERE element_id IN ({placeholders})"
+            );
+            let params = chunk.iter().map(|id| Value::from(id.0));
+            let mut stmt = self.conn.prepare(&query)?;
+            let mut rows = stmt.query(params_from_iter(params))?;
+            while let Some(row) = rows.next()? {
+                let occurrence = Self::occurrence_from_row(row)?;
+                if let Some(occurrences) =
+                    occurrences_by_node.get_mut(&NodeId(occurrence.element_id))
+                {
+                    occurrences.push(occurrence);
+                }
+            }
+        }
+
+        Ok(occurrences_by_node)
+    }
+
     pub fn get_occurrences_for_node(
         &self,
         node_id: codestory_contracts::graph::NodeId,
@@ -3210,15 +3528,16 @@ impl Storage {
 
     pub fn insert_file(&self, info: &FileInfo) -> Result<(), StorageError> {
         self.conn.execute(
-            "INSERT INTO file (id, path, language, modification_time, indexed, complete, line_count) 
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) 
-             ON CONFLICT(id) DO UPDATE SET 
-                path=excluded.path, 
-                language=excluded.language, 
-                modification_time=excluded.modification_time, 
-                indexed=excluded.indexed, 
-                complete=excluded.complete, 
-                line_count=excluded.line_count",
+            "INSERT INTO file (id, path, language, modification_time, indexed, complete, line_count, file_role)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(id) DO UPDATE SET
+                path=excluded.path,
+                language=excluded.language,
+                modification_time=excluded.modification_time,
+                indexed=excluded.indexed,
+                complete=excluded.complete,
+                line_count=excluded.line_count,
+                file_role=excluded.file_role",
             params![
                 info.id,
                 info.path.to_string_lossy(),
@@ -3227,6 +3546,7 @@ impl Storage {
                 i32::from(info.indexed),
                 i32::from(info.complete),
                 info.line_count,
+                info.file_role.as_str(),
             ],
         )?;
         self.invalidate_grounding_snapshots()?;
@@ -3240,15 +3560,16 @@ impl Storage {
         let tx = self.conn.transaction()?;
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO file (id, path, language, modification_time, indexed, complete, line_count) 
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) 
-                 ON CONFLICT(id) DO UPDATE SET 
-                    path=excluded.path, 
-                    language=excluded.language, 
-                    modification_time=excluded.modification_time, 
-                    indexed=excluded.indexed, 
-                    complete=excluded.complete, 
-                    line_count=excluded.line_count"
+                "INSERT INTO file (id, path, language, modification_time, indexed, complete, line_count, file_role)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(id) DO UPDATE SET
+                    path=excluded.path,
+                    language=excluded.language,
+                    modification_time=excluded.modification_time,
+                    indexed=excluded.indexed,
+                    complete=excluded.complete,
+                    line_count=excluded.line_count,
+                    file_role=excluded.file_role"
             )?;
             for info in files {
                 stmt.execute(params![
@@ -3259,6 +3580,7 @@ impl Storage {
                     i32::from(info.indexed),
                     i32::from(info.complete),
                     info.line_count,
+                    info.file_role.as_str(),
                 ])?;
             }
         }
@@ -3269,7 +3591,7 @@ impl Storage {
 
     pub fn get_files(&self) -> Result<Vec<FileInfo>, StorageError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, path, language, modification_time, indexed, complete, line_count FROM file",
+            "SELECT id, path, language, modification_time, indexed, complete, line_count, file_role FROM file",
         )?;
         let file_iter = stmt.query_map([], |row| {
             Ok(FileInfo {
@@ -3280,6 +3602,7 @@ impl Storage {
                 indexed: row.get::<_, i32>(4)? != 0,
                 complete: row.get::<_, i32>(5)? != 0,
                 line_count: row.get(6)?,
+                file_role: FileRole::from_db_value(&row.get::<_, String>(7)?),
             })
         })?;
 
@@ -3293,6 +3616,7 @@ impl Storage {
     pub fn get_files_ordered_limit(&self, limit: usize) -> Result<Vec<FileInfo>, StorageError> {
         let mut stmt = self.conn.prepare(
             "SELECT id, path, language, modification_time, indexed, complete, line_count
+             , file_role
              FROM file
              ORDER BY path ASC, id ASC
              LIMIT ?1",
@@ -3306,6 +3630,7 @@ impl Storage {
                 indexed: row.get::<_, i32>(4)? != 0,
                 complete: row.get::<_, i32>(5)? != 0,
                 line_count: row.get(6)?,
+                file_role: FileRole::from_db_value(&row.get::<_, String>(7)?),
             })
         })?;
 
@@ -3327,7 +3652,7 @@ impl Storage {
         for chunk in paths.chunks(500) {
             let placeholders = question_placeholders(chunk.len());
             let sql = format!(
-                "SELECT id, path, language, modification_time, indexed, complete, line_count
+                "SELECT id, path, language, modification_time, indexed, complete, line_count, file_role
                  FROM file
                  WHERE path IN ({placeholders})"
             );
@@ -3344,11 +3669,38 @@ impl Storage {
                     indexed: row.get::<_, i32>(4)? != 0,
                     complete: row.get::<_, i32>(5)? != 0,
                     line_count: row.get(6)?,
+                    file_role: FileRole::from_db_value(&row.get::<_, String>(7)?),
                 };
                 files.insert(file.path.clone(), file);
             }
         }
         Ok(files)
+    }
+
+    pub fn get_file_roles_by_paths(
+        &self,
+        paths: &[String],
+    ) -> Result<HashMap<String, FileRole>, StorageError> {
+        if paths.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut roles = HashMap::with_capacity(paths.len());
+        for chunk in paths.chunks(500) {
+            let placeholders = question_placeholders(chunk.len());
+            let sql = format!(
+                "SELECT path, file_role
+                 FROM file
+                 WHERE path IN ({placeholders})"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let mut rows = stmt.query(params_from_iter(chunk.iter().cloned()))?;
+            while let Some(row) = rows.next()? {
+                let path: String = row.get(0)?;
+                let role = FileRole::from_db_value(&row.get::<_, String>(1)?);
+                roles.insert(path, role);
+            }
+        }
+        Ok(roles)
     }
 
     pub fn get_file_node_count(&self) -> Result<i64, StorageError> {
@@ -3892,7 +4244,7 @@ impl Storage {
 
     pub fn get_file_by_path(&self, path: &Path) -> Result<Option<FileInfo>, StorageError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, path, language, modification_time, indexed, complete, line_count FROM file WHERE path = ?1",
+            "SELECT id, path, language, modification_time, indexed, complete, line_count, file_role FROM file WHERE path = ?1",
         )?;
         let mut rows = stmt.query(params![path.to_string_lossy()])?;
 
@@ -3905,6 +4257,7 @@ impl Storage {
                 indexed: row.get::<_, i32>(4)? != 0,
                 complete: row.get::<_, i32>(5)? != 0,
                 line_count: row.get(6)?,
+                file_role: FileRole::from_db_value(&row.get::<_, String>(7)?),
             }))
         } else {
             Ok(None)
@@ -4014,7 +4367,7 @@ impl Storage {
     /// Get symbols that have no parent (root namespaces, top-level classes, etc.)
     pub fn get_root_symbols(&self) -> Result<Vec<Node>, StorageError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, kind, serialized_name, qualified_name, canonical_id, file_node_id, start_line, start_col, end_line, end_col FROM node 
+            "SELECT id, kind, serialized_name, qualified_name, canonical_id, file_node_id, start_line, start_col, end_line, end_col FROM node
              WHERE id NOT IN (SELECT target_node_id FROM edge WHERE kind = ?1)
              AND kind != ?2", // Exclude files from symbol tree roots for now
         )?;
@@ -4172,7 +4525,11 @@ impl Storage {
         )?;
 
         let removed_callable_projection_state_count = tx.execute(
-            "DELETE FROM callable_projection_state WHERE file_id = ?1",
+            &format!(
+                "DELETE FROM callable_projection_state
+                 WHERE file_id = ?1
+                 OR node_id IN (SELECT node_id FROM {RELATED_NODE_IDS_TABLE})"
+            ),
             params![file_node_id],
         )?;
 
@@ -4192,6 +4549,13 @@ impl Storage {
         tx.execute(
             &format!(
                 "DELETE FROM search_symbol_projection
+                 WHERE node_id IN (SELECT node_id FROM {RELATED_NODE_IDS_TABLE})"
+            ),
+            [],
+        )?;
+        tx.execute(
+            &format!(
+                "DELETE FROM symbol_summary
                  WHERE node_id IN (SELECT node_id FROM {RELATED_NODE_IDS_TABLE})"
             ),
             [],
@@ -4397,6 +4761,24 @@ impl Storage {
     pub fn get_edges_for_node_id(&self, node_id: NodeId) -> Result<Vec<Edge>, StorageError> {
         trail::get_edges_for_node_id(self, node_id)
     }
+
+    /// Get direct incoming edges for a node using the same filters as trail traversal.
+    pub fn get_incoming_edges_for_node_id(
+        &self,
+        node_id: NodeId,
+        edge_filter: &[EdgeKind],
+        caller_scope: TrailCallerScope,
+        show_utility_calls: bool,
+    ) -> Result<Vec<Edge>, StorageError> {
+        trail::get_edges_for_node(
+            self,
+            node_id,
+            &TrailDirection::Incoming,
+            edge_filter,
+            caller_scope,
+            show_utility_calls,
+        )
+    }
 }
 
 fn neighbor_for_direction(
@@ -4581,6 +4963,7 @@ mod grounding_snapshot_fast_path_tests {
             indexed: true,
             complete: true,
             line_count: 32,
+            file_role: FileRole::classify_path(Path::new(path)),
         })?;
 
         let mut nodes = vec![Node {
@@ -4718,6 +5101,8 @@ mod grounding_snapshot_fast_path_tests {
         Ok(())
     }
 }
+
+pub use retrieval_manifest::RetrievalIndexManifest;
 
 #[cfg(test)]
 mod tests;

--- a/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
+++ b/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
@@ -1,0 +1,271 @@
+use super::{Storage, StorageError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetrievalIndexManifest {
+    pub project_id: String,
+    pub zoekt_version: String,
+    pub qdrant_collection: String,
+    pub scip_revision: Option<String>,
+    pub built_at_epoch_ms: i64,
+    pub disk_bytes: Option<i64>,
+    pub degraded_modes_json: String,
+    /// e.g. `llamacpp:bge-base-en-v1.5` or `hash-projection:768`.
+    pub embedding_backend: Option<String>,
+    pub embedding_dim: Option<i32>,
+    /// Version of the sidecar input hash/generation contract.
+    pub sidecar_schema_version: Option<i32>,
+    /// Stable hash of all local inputs used to build Zoekt, Qdrant, and SCIP sidecars.
+    pub sidecar_input_hash: Option<String>,
+    /// Artifact generation id used for Zoekt/SCIP directories.
+    pub sidecar_generation: Option<String>,
+    /// Number of symbol projection rows included in the sidecar input hash.
+    pub projection_count: Option<i64>,
+}
+
+impl Storage {
+    pub fn upsert_retrieval_index_manifest(
+        &mut self,
+        manifest: &RetrievalIndexManifest,
+    ) -> Result<(), StorageError> {
+        self.conn.execute(
+            "INSERT INTO retrieval_index_manifest (
+                project_id,
+                zoekt_version,
+                qdrant_collection,
+                scip_revision,
+                built_at_epoch_ms,
+                disk_bytes,
+                degraded_modes_json,
+                embedding_backend,
+                embedding_dim,
+                sidecar_schema_version,
+                sidecar_input_hash,
+                sidecar_generation,
+                projection_count
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            ON CONFLICT(project_id) DO UPDATE SET
+                zoekt_version = excluded.zoekt_version,
+                qdrant_collection = excluded.qdrant_collection,
+                scip_revision = excluded.scip_revision,
+                built_at_epoch_ms = excluded.built_at_epoch_ms,
+                disk_bytes = excluded.disk_bytes,
+                degraded_modes_json = excluded.degraded_modes_json,
+                embedding_backend = excluded.embedding_backend,
+                embedding_dim = excluded.embedding_dim,
+                sidecar_schema_version = excluded.sidecar_schema_version,
+                sidecar_input_hash = excluded.sidecar_input_hash,
+                sidecar_generation = excluded.sidecar_generation,
+                projection_count = excluded.projection_count",
+            rusqlite::params![
+                manifest.project_id,
+                manifest.zoekt_version,
+                manifest.qdrant_collection,
+                manifest.scip_revision,
+                manifest.built_at_epoch_ms,
+                manifest.disk_bytes,
+                manifest.degraded_modes_json,
+                manifest.embedding_backend,
+                manifest.embedding_dim,
+                manifest.sidecar_schema_version,
+                manifest.sidecar_input_hash,
+                manifest.sidecar_generation,
+                manifest.projection_count,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_retrieval_index_manifest(
+        &self,
+        project_id: &str,
+    ) -> Result<Option<RetrievalIndexManifest>, StorageError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT
+                project_id,
+                zoekt_version,
+                qdrant_collection,
+                scip_revision,
+                built_at_epoch_ms,
+                disk_bytes,
+                degraded_modes_json,
+                embedding_backend,
+                embedding_dim,
+                sidecar_schema_version,
+                sidecar_input_hash,
+                sidecar_generation,
+                projection_count
+             FROM retrieval_index_manifest
+             WHERE project_id = ?1",
+        )?;
+        let mut rows = stmt.query(rusqlite::params![project_id])?;
+        let Some(row) = rows.next()? else {
+            return Ok(None);
+        };
+        Ok(Some(RetrievalIndexManifest {
+            project_id: row.get(0)?,
+            zoekt_version: row.get(1)?,
+            qdrant_collection: row.get(2)?,
+            scip_revision: row.get(3)?,
+            built_at_epoch_ms: row.get(4)?,
+            disk_bytes: row.get(5)?,
+            degraded_modes_json: row.get(6)?,
+            embedding_backend: row.get(7)?,
+            embedding_dim: row.get(8)?,
+            sidecar_schema_version: row.get(9)?,
+            sidecar_input_hash: row.get(10)?,
+            sidecar_generation: row.get(11)?,
+            projection_count: row.get(12)?,
+        }))
+    }
+
+    pub fn list_retrieval_qdrant_collections(&self) -> Result<Vec<String>, StorageError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT qdrant_collection FROM retrieval_index_manifest")?;
+        let rows = stmt.query_map([], |row| row.get(0))?;
+        let mut collections = Vec::new();
+        for row in rows {
+            collections.push(row?);
+        }
+        Ok(collections)
+    }
+
+    /// Latest manifest `built_at_epoch_ms` per Qdrant collection (for retention ranking).
+    pub fn list_retrieval_qdrant_collections_with_recency(
+        &self,
+    ) -> Result<Vec<(String, i64)>, StorageError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT qdrant_collection, MAX(built_at_epoch_ms)
+             FROM retrieval_index_manifest
+             GROUP BY qdrant_collection",
+        )?;
+        let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        let mut collections = Vec::new();
+        for row in rows {
+            collections.push(row?);
+        }
+        Ok(collections)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Storage;
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn list_retrieval_qdrant_collections_with_recency_uses_latest_manifest() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("codestory.db");
+        let mut storage = Storage::open(&db_path).expect("open storage");
+        for (project_id, collection, built_at) in [
+            ("proj_a", "codestory_shared", 10_i64),
+            ("proj_b", "codestory_shared", 99_i64),
+            ("proj_c", "codestory_other", 5_i64),
+        ] {
+            storage
+                .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                    project_id: project_id.into(),
+                    zoekt_version: "v1".into(),
+                    qdrant_collection: collection.into(),
+                    scip_revision: None,
+                    built_at_epoch_ms: built_at,
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: None,
+                    embedding_dim: None,
+                    sidecar_schema_version: None,
+                    sidecar_input_hash: None,
+                    sidecar_generation: None,
+                    projection_count: None,
+                })
+                .expect("upsert manifest");
+        }
+        let mut recency = storage
+            .list_retrieval_qdrant_collections_with_recency()
+            .expect("list recency");
+        recency.sort_by(|left, right| left.0.cmp(&right.0));
+        assert_eq!(
+            recency,
+            vec![
+                ("codestory_other".to_string(), 5),
+                ("codestory_shared".to_string(), 99),
+            ]
+        );
+    }
+
+    #[test]
+    fn retrieval_manifest_round_trips_sidecar_generation_fields() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("codestory.db");
+        let mut storage = Storage::open(&db_path).expect("open storage");
+        let manifest = RetrievalIndexManifest {
+            project_id: "proj".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_proj_deadbeef".into(),
+            scip_revision: Some("graph-1234".into()),
+            built_at_epoch_ms: 123,
+            disk_bytes: Some(456),
+            degraded_modes_json: "[]".into(),
+            embedding_backend: Some("onnx:bge".into()),
+            embedding_dim: Some(768),
+            sidecar_schema_version: Some(1),
+            sidecar_input_hash: Some("deadbeefcafebabe".into()),
+            sidecar_generation: Some("proj-deadbeefcafebabe".into()),
+            projection_count: Some(99),
+        };
+        storage
+            .upsert_retrieval_index_manifest(&manifest)
+            .expect("upsert manifest");
+
+        let loaded = storage
+            .get_retrieval_index_manifest("proj")
+            .expect("load manifest")
+            .expect("manifest exists");
+
+        assert_eq!(loaded, manifest);
+    }
+
+    #[test]
+    fn list_retrieval_qdrant_collections_returns_distinct_names() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("codestory.db");
+        let mut storage = Storage::open(&db_path).expect("open storage");
+        for (project_id, collection) in [
+            ("proj_a", "codestory_proj_a"),
+            ("proj_b", "codestory_proj_b"),
+            ("proj_c", "codestory_proj_a"),
+        ] {
+            storage
+                .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                    project_id: project_id.into(),
+                    zoekt_version: "v1".into(),
+                    qdrant_collection: collection.into(),
+                    scip_revision: None,
+                    built_at_epoch_ms: 1,
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: None,
+                    embedding_dim: None,
+                    sidecar_schema_version: None,
+                    sidecar_input_hash: None,
+                    sidecar_generation: None,
+                    projection_count: None,
+                })
+                .expect("upsert manifest");
+        }
+        let mut collections = storage
+            .list_retrieval_qdrant_collections()
+            .expect("list collections");
+        collections.sort();
+        assert_eq!(
+            collections,
+            vec![
+                "codestory_proj_a".to_string(),
+                "codestory_proj_b".to_string()
+            ]
+        );
+    }
+}

--- a/crates/codestory-store/src/storage_impl/schema.rs
+++ b/crates/codestory-store/src/storage_impl/schema.rs
@@ -49,7 +49,8 @@ const TABLE_STATEMENTS: &[&str] = &[
         modification_time INTEGER,
         indexed INTEGER DEFAULT 0,
         complete INTEGER DEFAULT 0,
-        line_count INTEGER DEFAULT 0
+        line_count INTEGER DEFAULT 0,
+        file_role TEXT NOT NULL DEFAULT 'source'
     )",
     "CREATE TABLE IF NOT EXISTS local_symbol (
         id INTEGER PRIMARY KEY,
@@ -206,6 +207,21 @@ const TABLE_STATEMENTS: &[&str] = &[
         snapshot_blob,
         built_at_epoch_ms
     ) VALUES (1, 0, 0, NULL, NULL)",
+    "CREATE TABLE IF NOT EXISTS retrieval_index_manifest (
+        project_id TEXT PRIMARY KEY,
+        zoekt_version TEXT NOT NULL,
+        qdrant_collection TEXT NOT NULL,
+        scip_revision TEXT,
+        built_at_epoch_ms INTEGER NOT NULL,
+        disk_bytes INTEGER,
+        degraded_modes_json TEXT NOT NULL DEFAULT '[]',
+        embedding_backend TEXT,
+        embedding_dim INTEGER,
+        sidecar_schema_version INTEGER,
+        sidecar_input_hash TEXT,
+        sidecar_generation TEXT,
+        projection_count INTEGER
+    )",
 ];
 
 const LOAD_TIME_INDEX_STATEMENTS: &[&str] = &[
@@ -253,6 +269,8 @@ const SECONDARY_INDEX_STATEMENTS: &[&str] = &[
      ON grounding_node_snapshot(is_root, node_rank, sort_start_line, display_name, node_id)",
     "CREATE INDEX IF NOT EXISTS idx_index_artifact_cache_key
      ON index_artifact_cache(cache_key)",
+    "CREATE INDEX IF NOT EXISTS idx_retrieval_index_manifest_built_at
+     ON retrieval_index_manifest(built_at_epoch_ms)",
 ];
 
 pub(super) fn create_tables(conn: &Connection) -> Result<(), StorageError> {
@@ -353,6 +371,22 @@ pub(super) fn apply_schema_migrations(storage: &Storage) -> Result<(), StorageEr
     if stored_version < 13 {
         migrate_v13_llm_symbol_doc_embedding_contract(&storage.conn)?;
         storage.set_schema_version(13)?;
+    }
+    if stored_version < 14 {
+        migrate_v14_retrieval_index_manifest(&storage.conn)?;
+        storage.set_schema_version(14)?;
+    }
+    if stored_version < 15 {
+        migrate_v15_retrieval_manifest_embedding(&storage.conn)?;
+        storage.set_schema_version(15)?;
+    }
+    if stored_version < 16 {
+        migrate_v16_file_role(&storage.conn)?;
+        storage.set_schema_version(16)?;
+    }
+    if stored_version < 17 {
+        migrate_v17_retrieval_manifest_sidecar_generation(&storage.conn)?;
+        storage.set_schema_version(17)?;
     }
     create_llm_symbol_doc_reuse_index(&storage.conn)?;
     create_symbol_summary_indexes(&storage.conn)?;
@@ -455,6 +489,60 @@ pub(super) fn migrate_v13_llm_symbol_doc_embedding_contract(
     try_add_column(conn, "llm_symbol_doc", "embedding_profile TEXT")?;
     try_add_column(conn, "llm_symbol_doc", "embedding_backend TEXT")?;
     try_add_column(conn, "llm_symbol_doc", "doc_shape TEXT")?;
+    Ok(())
+}
+
+pub(super) fn migrate_v15_retrieval_manifest_embedding(
+    conn: &Connection,
+) -> Result<(), StorageError> {
+    try_add_column(conn, "retrieval_index_manifest", "embedding_backend TEXT")?;
+    try_add_column(conn, "retrieval_index_manifest", "embedding_dim INTEGER")?;
+    Ok(())
+}
+
+pub(super) fn migrate_v16_file_role(conn: &Connection) -> Result<(), StorageError> {
+    try_add_column(conn, "file", "file_role TEXT NOT NULL DEFAULT 'source'")?;
+    conn.execute(
+        "UPDATE file
+         SET file_role = 'source'
+         WHERE file_role IS NULL OR TRIM(file_role) = ''",
+        [],
+    )?;
+    Ok(())
+}
+
+pub(super) fn migrate_v17_retrieval_manifest_sidecar_generation(
+    conn: &Connection,
+) -> Result<(), StorageError> {
+    try_add_column(
+        conn,
+        "retrieval_index_manifest",
+        "sidecar_schema_version INTEGER",
+    )?;
+    try_add_column(conn, "retrieval_index_manifest", "sidecar_input_hash TEXT")?;
+    try_add_column(conn, "retrieval_index_manifest", "sidecar_generation TEXT")?;
+    try_add_column(conn, "retrieval_index_manifest", "projection_count INTEGER")?;
+    Ok(())
+}
+
+pub(super) fn migrate_v14_retrieval_index_manifest(conn: &Connection) -> Result<(), StorageError> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS retrieval_index_manifest (
+            project_id TEXT PRIMARY KEY,
+            zoekt_version TEXT NOT NULL,
+            qdrant_collection TEXT NOT NULL,
+            scip_revision TEXT,
+            built_at_epoch_ms INTEGER NOT NULL,
+            disk_bytes INTEGER,
+            degraded_modes_json TEXT NOT NULL DEFAULT '[]'
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_retrieval_index_manifest_built_at
+         ON retrieval_index_manifest(built_at_epoch_ms)",
+        [],
+    )?;
     Ok(())
 }
 

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use codestory_contracts::graph::{
-    AccessKind, Edge, EdgeId, EdgeKind, NodeId, NodeKind, ResolutionCertainty, SourceLocation,
-    TrailConfig, TrailDirection,
+    AccessKind, Edge, EdgeId, EdgeKind, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
+    ResolutionCertainty, SourceLocation, TrailConfig, TrailDirection,
 };
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -67,6 +67,7 @@ fn insert_file_row(storage: &Storage, id: i64, path: &str) -> Result<(), Storage
         indexed: true,
         complete: true,
         line_count: 1,
+        file_role: FileRole::Source,
     })
 }
 
@@ -351,6 +352,7 @@ fn test_update_file_metadata_preserves_resolution_support_snapshot() -> Result<(
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
     storage.put_resolution_support_snapshot(1, br#"{"hot":true}"#)?;
 
@@ -362,6 +364,7 @@ fn test_update_file_metadata_preserves_resolution_support_snapshot() -> Result<(
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
 
     assert!(storage.has_ready_resolution_support_snapshot(1)?);
@@ -732,16 +735,26 @@ fn test_search_symbol_projection_round_trip_and_backfill() -> Result<(), Storage
     let mut storage = Storage::new_in_memory()?;
     storage.insert_nodes_batch(&[
         Node {
+            id: NodeId(699),
+            kind: NodeKind::FILE,
+            serialized_name: "src/lib.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
             id: NodeId(700),
             kind: NodeKind::FUNCTION,
             serialized_name: "short_name".to_string(),
             qualified_name: Some("pkg::short_name".to_string()),
+            file_node_id: Some(NodeId(699)),
+            start_line: Some(10),
+            end_line: Some(12),
             ..Default::default()
         },
         Node {
             id: NodeId(701),
             kind: NodeKind::METHOD,
             serialized_name: "secondary".to_string(),
+            file_node_id: Some(NodeId(699)),
             ..Default::default()
         },
     ])?;
@@ -760,16 +773,99 @@ fn test_search_symbol_projection_round_trip_and_backfill() -> Result<(), Storage
     let projection = storage.get_search_symbol_projection_batch_after(None, 10)?;
     assert_eq!(projection.len(), 2);
     assert_eq!(projection[0].display_name, "pkg::short_name");
+    let details = storage.get_search_symbol_projection_detail_batch_after(None, 10)?;
+    assert_eq!(details.len(), 2);
+    assert_eq!(details[0].file_path.as_deref(), Some("src/lib.rs"));
+    assert_eq!(details[0].start_line, Some(10));
+    assert_eq!(details[0].end_line, Some(12));
 
     storage.clear_search_symbol_projection()?;
     assert_eq!(storage.get_search_symbol_projection_count()?, 0);
 
     let rebuilt = storage.rebuild_search_symbol_projection_from_node_table()?;
-    assert_eq!(rebuilt, 2);
+    assert_eq!(rebuilt, 3);
     let projection = storage.get_search_symbol_projection_batch_after(None, 10)?;
-    assert_eq!(projection.len(), 2);
-    assert_eq!(projection[0].display_name, "pkg::short_name");
-    assert_eq!(projection[1].display_name, "secondary");
+    assert_eq!(projection.len(), 3);
+    assert_eq!(projection[0].display_name, "src/lib.rs");
+    assert_eq!(projection[1].display_name, "pkg::short_name");
+    assert_eq!(projection[2].display_name, "secondary");
+    Ok(())
+}
+
+#[test]
+fn test_scoped_search_symbol_projection_rebuild() -> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(800),
+            kind: NodeKind::FILE,
+            serialized_name: "src/changed.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(801),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "old_name".to_string(),
+            qualified_name: Some("pkg::old_name".to_string()),
+            file_node_id: Some(NodeId(800)),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(810),
+            kind: NodeKind::FILE,
+            serialized_name: "src/untouched.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(811),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "untouched".to_string(),
+            qualified_name: Some("pkg::untouched".to_string()),
+            file_node_id: Some(NodeId(810)),
+            ..Default::default()
+        },
+    ])?;
+    assert_eq!(
+        storage.rebuild_search_symbol_projection_from_node_table()?,
+        4
+    );
+
+    storage.insert_nodes_batch(&[Node {
+        id: NodeId(801),
+        kind: NodeKind::FUNCTION,
+        serialized_name: "renamed".to_string(),
+        qualified_name: Some("pkg::renamed".to_string()),
+        file_node_id: Some(NodeId(800)),
+        ..Default::default()
+    }])?;
+    storage.upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
+        node_id: NodeId(811),
+        display_name: "stale_other_file".to_string(),
+    }])?;
+
+    let touched = HashSet::from([NodeId(800)]);
+    assert_eq!(
+        storage.rebuild_search_symbol_projection_for_file_scope(&touched)?,
+        2
+    );
+
+    let projection = storage.get_search_symbol_projection_batch_after(None, 10)?;
+    let names_by_id: HashMap<_, _> = projection
+        .into_iter()
+        .map(|entry| (entry.node_id, entry.display_name))
+        .collect();
+    assert_eq!(
+        names_by_id.get(&NodeId(800)).map(String::as_str),
+        Some("src/changed.rs")
+    );
+    assert_eq!(
+        names_by_id.get(&NodeId(801)).map(String::as_str),
+        Some("pkg::renamed")
+    );
+    assert_eq!(
+        names_by_id.get(&NodeId(811)).map(String::as_str),
+        Some("stale_other_file")
+    );
     Ok(())
 }
 
@@ -798,6 +894,7 @@ fn test_clear_removes_fk_dependents_and_cache() -> Result<(), StorageError> {
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
     storage.insert_nodes_batch(&[file_node.clone(), function_node.clone()])?;
     storage.insert_edges_batch(&[Edge {
@@ -889,6 +986,7 @@ fn test_callable_projection_state_round_trip() -> Result<(), StorageError> {
         indexed: true,
         complete: true,
         line_count: 40,
+        file_role: FileRole::Source,
     })?;
     storage.insert_nodes_batch(&[
         Node {
@@ -968,6 +1066,7 @@ fn test_delete_callable_projection_states_for_file() -> Result<(), StorageError>
         indexed: true,
         complete: true,
         line_count: 40,
+        file_role: FileRole::Source,
     })?;
     storage.insert_file(&FileInfo {
         id: 12,
@@ -977,6 +1076,7 @@ fn test_delete_callable_projection_states_for_file() -> Result<(), StorageError>
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
     storage.insert_nodes_batch(&[
         Node {
@@ -1090,6 +1190,7 @@ fn test_delete_projection_for_callers_removes_callable_scoped_data() -> Result<(
         indexed: true,
         complete: true,
         line_count: 50,
+        file_role: FileRole::Source,
     })?;
     storage.insert_nodes_batch(&[
         file_node.clone(),
@@ -1295,6 +1396,7 @@ fn test_promote_staged_snapshot_replaces_live_db_while_live_reader_is_open()
             indexed: true,
             complete: true,
             line_count: 10,
+            file_role: FileRole::Source,
         }])?;
 
         {
@@ -1307,6 +1409,7 @@ fn test_promote_staged_snapshot_replaces_live_db_while_live_reader_is_open()
                 indexed: true,
                 complete: true,
                 line_count: 20,
+                file_role: FileRole::Source,
             }])?;
             staged.finalize_staged_snapshot()?;
         }
@@ -1412,12 +1515,68 @@ fn test_file_storage() -> Result<(), StorageError> {
         indexed: true,
         complete: true,
         line_count: 100,
+        file_role: FileRole::Source,
     };
     storage.insert_file(&info)?;
     let files = storage.get_files()?;
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].path, PathBuf::from("src/main.rs"));
     assert_eq!(files[0].line_count, 100);
+    Ok(())
+}
+
+#[test]
+fn batched_nodes_and_occurrences_match_single_node_lookup() -> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FILE,
+            serialized_name: "src/main.rs".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(2),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "run".to_string(),
+            file_node_id: Some(NodeId(1)),
+            start_line: Some(10),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_occurrences_batch(&[Occurrence {
+        element_id: NodeId(2).0,
+        kind: OccurrenceKind::DEFINITION,
+        location: SourceLocation {
+            file_node_id: NodeId(1),
+            start_line: 10,
+            start_col: 0,
+            end_line: 10,
+            end_col: 4,
+        },
+    }])?;
+
+    let batched_nodes = storage.get_nodes_by_ids(&[NodeId(1), NodeId(2)])?;
+    assert_eq!(batched_nodes.len(), 2);
+    assert_eq!(
+        batched_nodes
+            .get(&NodeId(2))
+            .map(|node| node.serialized_name.as_str()),
+        Some("run")
+    );
+
+    let batched_occurrences = storage.get_occurrences_for_node_ids(&[NodeId(2)])?;
+    assert_eq!(
+        batched_occurrences.get(&NodeId(2)).map(|occs| occs.len()),
+        Some(1)
+    );
+    assert_eq!(
+        storage
+            .get_occurrences_for_node(NodeId(2))?
+            .first()
+            .map(|occ| occ.location.start_line),
+        Some(10)
+    );
     Ok(())
 }
 
@@ -1512,6 +1671,7 @@ fn test_error_storage() -> Result<(), StorageError> {
         indexed: true,
         complete: true,
         line_count: 100,
+        file_role: FileRole::Source,
     };
     storage.insert_file(&info)?;
     let error = codestory_contracts::graph::ErrorInfo {
@@ -1580,6 +1740,7 @@ fn test_delete_file_projection() -> Result<(), StorageError> {
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
     storage.insert_nodes_batch(&[file_node.clone(), func_node.clone()])?;
 
@@ -1631,6 +1792,13 @@ fn test_delete_file_projection() -> Result<(), StorageError> {
         embedding: vec![0.1_f32; 384],
         updated_at_epoch_ms: 1,
     }])?;
+    storage.upsert_symbol_summaries_batch(&[SymbolSummaryRecord {
+        node_id: func_node.id,
+        content_hash: "semantic-hash-foo".to_string(),
+        summary: "foo symbol summary".to_string(),
+        model: "test-model".to_string(),
+        updated_at_epoch_ms: 2,
+    }])?;
     storage.upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
         node_id: func_node.id,
         display_name: "foo".to_string(),
@@ -1662,6 +1830,11 @@ fn test_delete_file_projection() -> Result<(), StorageError> {
     assert!(storage.get_occurrences()?.is_empty());
     assert!(storage.get_all_llm_symbol_docs()?.is_empty());
     assert_eq!(storage.get_search_symbol_projection_count()?, 0);
+    let symbol_summary_count: i64 =
+        storage
+            .conn
+            .query_row("SELECT count(*) FROM symbol_summary", [], |row| row.get(0))?;
+    assert_eq!(symbol_summary_count, 0);
     assert!(
         storage
             .get_callable_projection_states_for_file(file_node_id)?
@@ -1692,6 +1865,7 @@ fn test_delete_file_projection_preserves_cross_file_edges_and_clears_resolution(
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
     storage.insert_file(&FileInfo {
         id: file_b_id,
@@ -1701,6 +1875,7 @@ fn test_delete_file_projection_preserves_cross_file_edges_and_clears_resolution(
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
 
     let file_a = Node {
@@ -1757,10 +1932,32 @@ fn test_delete_file_projection_preserves_cross_file_edges_and_clears_resolution(
         ..Default::default()
     }])?;
 
+    storage.upsert_callable_projection_states(&[
+        CallableProjectionState {
+            file_id: file_a_id,
+            symbol_key: "src/a.rs::caller:FUNCTION".to_string(),
+            node_id: caller_in_a.id,
+            signature_hash: 111,
+            body_hash: 211,
+            start_line: 1,
+            end_line: 2,
+        },
+        CallableProjectionState {
+            file_id: file_a_id,
+            symbol_key: "src/a.rs::stale-callee:FUNCTION".to_string(),
+            node_id: callee_in_b.id,
+            signature_hash: 112,
+            body_hash: 212,
+            start_line: 3,
+            end_line: 4,
+        },
+    ])?;
+
     let summary = storage.delete_file_projection(file_b_id)?;
     assert_eq!(summary.canonical_file_node_id, file_b_id);
     assert_eq!(summary.removed_node_count, 2);
     assert_eq!(summary.removed_edge_count, 0);
+    assert_eq!(summary.removed_callable_projection_state_count, 1);
 
     let edges = storage.get_edges()?;
     assert_eq!(edges.len(), 1);
@@ -1776,6 +1973,9 @@ fn test_delete_file_projection_preserves_cross_file_edges_and_clears_resolution(
     assert!(storage.get_node(file_b.id)?.is_none());
     assert!(storage.get_node(callee_in_b.id)?.is_none());
     assert!(storage.get_node(caller_in_a.id)?.is_some());
+    let remaining_states = storage.get_callable_projection_states_for_file(file_a_id)?;
+    assert_eq!(remaining_states.len(), 1);
+    assert_eq!(remaining_states[0].node_id, caller_in_a.id);
 
     Ok(())
 }
@@ -2060,6 +2260,161 @@ fn test_trail_to_target_symbol_simple_path() -> Result<(), StorageError> {
 }
 
 #[test]
+fn test_trail_to_target_symbol_prunes_unreachable_incoming_fanout() -> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+
+    let mut nodes = vec![
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "Root".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(2),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "Middle".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(3),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "Bridge".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(4),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "Target".to_string(),
+            ..Default::default()
+        },
+    ];
+    for id in 100..130 {
+        nodes.push(Node {
+            id: NodeId(id),
+            kind: NodeKind::FUNCTION,
+            serialized_name: format!("Noise{id}"),
+            ..Default::default()
+        });
+    }
+    storage.insert_nodes_batch(&nodes)?;
+
+    let mut edges = vec![
+        Edge {
+            id: EdgeId(1),
+            source: NodeId(1),
+            target: NodeId(2),
+            kind: EdgeKind::CALL,
+            ..Default::default()
+        },
+        Edge {
+            id: EdgeId(2),
+            source: NodeId(2),
+            target: NodeId(3),
+            kind: EdgeKind::CALL,
+            ..Default::default()
+        },
+        Edge {
+            id: EdgeId(3),
+            source: NodeId(3),
+            target: NodeId(4),
+            kind: EdgeKind::CALL,
+            ..Default::default()
+        },
+    ];
+    for id in 100..130 {
+        edges.push(Edge {
+            id: EdgeId(id),
+            source: NodeId(id),
+            target: NodeId(4),
+            kind: EdgeKind::CALL,
+            ..Default::default()
+        });
+    }
+    storage.insert_edges_batch(&edges)?;
+
+    let result = storage.get_trail(&TrailConfig {
+        root_id: NodeId(1),
+        mode: TrailMode::ToTargetSymbol,
+        target_id: Some(NodeId(4)),
+        depth: 3,
+        direction: TrailDirection::Outgoing,
+        caller_scope: TrailCallerScope::IncludeTestsAndBenches,
+        edge_filter: vec![],
+        show_utility_calls: true,
+        node_filter: Vec::new(),
+        max_nodes: 4,
+    })?;
+
+    assert_eq!(
+        result.nodes.iter().map(|node| node.id).collect::<Vec<_>>(),
+        vec![NodeId(1), NodeId(2), NodeId(3), NodeId(4)]
+    );
+    assert_eq!(
+        result.edges.iter().map(|edge| edge.id).collect::<Vec<_>>(),
+        vec![EdgeId(1), EdgeId(2), EdgeId(3)]
+    );
+    assert!(!result.truncated);
+
+    Ok(())
+}
+
+#[test]
+fn test_trail_to_target_symbol_no_path_returns_endpoints() -> Result<(), StorageError> {
+    let mut storage = Storage::new_in_memory()?;
+
+    storage.insert_nodes_batch(&[
+        Node {
+            id: NodeId(1),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "A".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(2),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "B".to_string(),
+            ..Default::default()
+        },
+        Node {
+            id: NodeId(3),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "C".to_string(),
+            ..Default::default()
+        },
+    ])?;
+    storage.insert_edges_batch(&[Edge {
+        id: EdgeId(1),
+        source: NodeId(1),
+        target: NodeId(2),
+        kind: EdgeKind::CALL,
+        ..Default::default()
+    }])?;
+
+    let result = storage.get_trail(&TrailConfig {
+        root_id: NodeId(1),
+        mode: TrailMode::ToTargetSymbol,
+        target_id: Some(NodeId(3)),
+        depth: 0,
+        direction: TrailDirection::Outgoing,
+        caller_scope: TrailCallerScope::IncludeTestsAndBenches,
+        edge_filter: vec![],
+        show_utility_calls: true,
+        node_filter: Vec::new(),
+        max_nodes: 100,
+    })?;
+
+    assert_eq!(
+        result.nodes.iter().map(|node| node.id).collect::<Vec<_>>(),
+        vec![NodeId(1), NodeId(3)]
+    );
+    assert!(result.edges.is_empty());
+    assert!(!result.truncated);
+
+    Ok(())
+}
+
+#[test]
 fn test_trail_ignores_ambiguous_call_resolutions() -> Result<(), StorageError> {
     let mut storage = Storage::new_in_memory()?;
 
@@ -2317,6 +2672,7 @@ fn test_grounding_queries_rank_symbols_and_roots() -> Result<(), StorageError> {
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
     storage.insert_file(&FileInfo {
         id: 200,
@@ -2326,6 +2682,7 @@ fn test_grounding_queries_rank_symbols_and_roots() -> Result<(), StorageError> {
         indexed: true,
         complete: true,
         line_count: 10,
+        file_role: FileRole::Source,
     })?;
     storage.insert_nodes_batch(&[
         codestory_contracts::graph::Node {

--- a/crates/codestory-store/src/storage_impl/trail.rs
+++ b/crates/codestory-store/src/storage_impl/trail.rs
@@ -134,12 +134,6 @@ pub(super) fn get_trail_to_target(
         TrailDirection::Outgoing,
         &traversal_options,
     )?;
-    let (dist_to_target, truncated_to_target) = bfs_distances(
-        storage,
-        target_id,
-        TrailDirection::Incoming,
-        &traversal_options,
-    )?;
 
     if !dist_from_root.contains_key(&target_id) {
         let mut result = TrailResult::default();
@@ -152,10 +146,17 @@ pub(super) fn get_trail_to_target(
         {
             result.nodes.push(node);
         }
-        result.truncated = truncated_from_root || truncated_to_target;
+        result.truncated = truncated_from_root;
         super::apply_trail_node_filter(&mut result, config);
         return Ok(result);
     }
+
+    let (dist_to_target, truncated_to_target) = bfs_distances_to_target_through_root_reachable(
+        storage,
+        target_id,
+        &dist_from_root,
+        &traversal_options,
+    )?;
 
     let mut included: HashSet<NodeId> = HashSet::new();
     for (id, d_root) in &dist_from_root {
@@ -353,6 +354,61 @@ fn bfs_distances(
             };
             if let std::collections::hash_map::Entry::Vacant(entry) = dist.entry(neighbor_id) {
                 let next_depth = depth.saturating_add(1);
+                entry.insert(next_depth);
+                queue.push_back((neighbor_id, next_depth));
+            }
+        }
+    }
+
+    Ok((dist, truncated))
+}
+
+fn bfs_distances_to_target_through_root_reachable(
+    storage: &Storage,
+    target_id: NodeId,
+    dist_from_root: &HashMap<NodeId, u32>,
+    options: &BfsTraversalOptions<'_>,
+) -> Result<(HashMap<NodeId, u32>, bool), StorageError> {
+    let mut dist: HashMap<NodeId, u32> = HashMap::new();
+    let mut queue: VecDeque<(NodeId, u32)> = VecDeque::new();
+    let mut truncated = false;
+
+    dist.insert(target_id, 0);
+    queue.push_back((target_id, 0));
+
+    while let Some((current_id, depth)) = queue.pop_front() {
+        if dist.len() >= options.max_nodes {
+            truncated = true;
+            break;
+        }
+        if depth >= options.max_depth {
+            continue;
+        }
+
+        let edges = get_edges_for_node(
+            storage,
+            current_id,
+            &TrailDirection::Incoming,
+            options.edge_filter,
+            options.caller_scope,
+            options.show_utility_calls,
+        )?;
+        for edge in edges {
+            let Some(neighbor_id) =
+                super::neighbor_for_direction(current_id, TrailDirection::Incoming, &edge)
+            else {
+                continue;
+            };
+            let Some(&dist_root) = dist_from_root.get(&neighbor_id) else {
+                continue;
+            };
+            let next_depth = depth.saturating_add(1);
+            if options.max_depth != u32::MAX
+                && dist_root as u64 + next_depth as u64 > options.max_depth as u64
+            {
+                continue;
+            }
+            if let std::collections::hash_map::Entry::Vacant(entry) = dist.entry(neighbor_id) {
                 entry.insert(next_depth);
                 queue.push_back((neighbor_id, next_depth));
             }


### PR DESCRIPTION
## Summary
- Adds cross-language indexer coverage for Go, Ruby, PHP, and C# rules, semantic handling, structural/template parsing, and tic-tac-toe fixtures.
- Adds store file-role/projection helpers needed by the richer indexer and later retrieval sidecar work.

## Tests
- cargo check -p codestory-indexer
- cargo test -p codestory-store
- cargo test -p codestory-indexer --test fidelity_regression
- cargo test -p codestory-indexer --test tictactoe_language_coverage
- cargo fmt --check
- git diff --check

## Stack
1. This PR
2. codex/accuracy-pass-02-retrieval-sidecar
3. codex/accuracy-pass-03-runtime-retrieval
4. codex/accuracy-pass-04-cli-retrieval
5. codex/accuracy-pass-05-benchmark-eval
6. codex/accuracy-pass-06-docs-ci