### PR TITLE
Add retrieval sidecar crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,8 +302,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -462,6 +470,25 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+]
+
+[[package]]
+name = "codestory-retrieval"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "codestory-contracts",
+ "codestory-store",
+ "codestory-workspace",
+ "directories",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "ureq 2.12.1",
 ]
 
 [[package]]
@@ -898,6 +925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1012,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1053,15 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs4"
@@ -1246,6 +1303,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1395,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -1471,6 +1631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1727,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1829,7 +2005,7 @@ dependencies = [
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -1840,7 +2016,7 @@ checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -1959,6 +2135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2207,6 +2392,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,12 +2473,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2512,6 +2737,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,6 +2868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,6 +2882,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2884,6 +3132,16 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -3235,6 +3493,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,6 +3545,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-ranges"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3567,12 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3445,6 +3743,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,6 +3848,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3788,6 +4113,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,10 +4162,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/codestory-workspace",
     "crates/codestory-store",
     "crates/codestory-indexer",
+    "crates/codestory-retrieval",
     "crates/codestory-runtime",
     "crates/codestory-cli",
     "crates/codestory-bench",
@@ -16,6 +17,7 @@ codestory-contracts = { path = "crates/codestory-contracts" }
 codestory-workspace = { path = "crates/codestory-workspace" }
 codestory-store = { path = "crates/codestory-store" }
 codestory-indexer = { path = "crates/codestory-indexer" }
+codestory-retrieval = { path = "crates/codestory-retrieval" }
 codestory-runtime = { path = "crates/codestory-runtime" }
 codestory-bench = { path = "crates/codestory-bench" }
 
@@ -75,6 +77,7 @@ feature-probe = "0.1.1"
 tempfile = "3.10"
 toml = "0.8"
 sha2 = "0.10"
+ureq = "2.12"
 
 criterion = "0.8.2"
 proptest = "1.5"

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "codestory-retrieval"
+version = "0.4.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+codestory-contracts = { workspace = true }
+codestory-store = { workspace = true }
+codestory-workspace = { workspace = true }
+directories = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+ureq = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/codestory-retrieval/src/cache.rs
+++ b/crates/codestory-retrieval/src/cache.rs
@@ -1,0 +1,191 @@
+use codestory_store::RetrievalIndexManifest;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+
+/// Cache key ties results to a published retrieval manifest generation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RetrievalCacheKey {
+    pub project_id: String,
+    pub zoekt_version: String,
+    pub qdrant_collection: String,
+    pub scip_revision: Option<String>,
+    pub sidecar_generation: Option<String>,
+    pub sidecar_input_hash: Option<String>,
+    pub sidecar_schema_version: Option<i32>,
+    pub projection_count: Option<i64>,
+    pub query_fingerprint: String,
+}
+
+impl RetrievalCacheKey {
+    pub fn from_manifest(
+        manifest: &RetrievalIndexManifest,
+        query_fingerprint: impl Into<String>,
+    ) -> Self {
+        Self {
+            project_id: manifest.project_id.clone(),
+            zoekt_version: manifest.zoekt_version.clone(),
+            qdrant_collection: manifest.qdrant_collection.clone(),
+            scip_revision: manifest.scip_revision.clone(),
+            sidecar_generation: manifest.sidecar_generation.clone(),
+            sidecar_input_hash: manifest.sidecar_input_hash.clone(),
+            sidecar_schema_version: manifest.sidecar_schema_version,
+            projection_count: manifest.projection_count,
+            query_fingerprint: query_fingerprint.into(),
+        }
+    }
+}
+
+const DEFAULT_RETRIEVAL_CACHE_CAPACITY: usize = 128;
+
+/// In-memory version-keyed query result cache.
+#[derive(Debug)]
+pub struct RetrievalCache {
+    entries: HashMap<RetrievalCacheKey, Vec<super::CandidateHit>>,
+    order: VecDeque<RetrievalCacheKey>,
+    capacity: usize,
+}
+
+impl Default for RetrievalCache {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_RETRIEVAL_CACHE_CAPACITY)
+    }
+}
+
+impl RetrievalCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            capacity: capacity.max(1),
+        }
+    }
+
+    pub fn get(&self, key: &RetrievalCacheKey) -> Option<&[super::CandidateHit]> {
+        self.entries.get(key).map(Vec::as_slice)
+    }
+
+    pub fn insert(&mut self, key: RetrievalCacheKey, hits: Vec<super::CandidateHit>) {
+        if self.entries.contains_key(&key) {
+            self.order.retain(|existing| existing != &key);
+        }
+        self.order.push_back(key.clone());
+        self.entries.insert(key, hits);
+        while self.entries.len() > self.capacity {
+            let Some(evicted) = self.order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&evicted);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+        self.order.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_round_trip() {
+        let mut cache = RetrievalCache::new();
+        let key = RetrievalCacheKey {
+            project_id: "abc".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_abc".into(),
+            scip_revision: None,
+            sidecar_generation: Some("abc-hash".into()),
+            sidecar_input_hash: Some("hash".into()),
+            sidecar_schema_version: Some(1),
+            projection_count: Some(1),
+            query_fingerprint: "fp".into(),
+        };
+        cache.insert(
+            key.clone(),
+            vec![super::super::CandidateHit::lexical_stub("src/lib.rs", 1.0)],
+        );
+        assert_eq!(cache.get(&key).expect("hit").len(), 1);
+    }
+
+    #[test]
+    fn cache_evicts_oldest_entry_when_capacity_is_reached() {
+        let mut cache = RetrievalCache::with_capacity(1);
+        let first = RetrievalCacheKey {
+            project_id: "abc".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_abc".into(),
+            scip_revision: None,
+            sidecar_generation: Some("abc-hash".into()),
+            sidecar_input_hash: Some("hash".into()),
+            sidecar_schema_version: Some(1),
+            projection_count: Some(1),
+            query_fingerprint: "first".into(),
+        };
+        let second = RetrievalCacheKey {
+            query_fingerprint: "second".into(),
+            ..first.clone()
+        };
+        cache.insert(
+            first.clone(),
+            vec![super::super::CandidateHit::lexical_stub(
+                "src/first.rs",
+                1.0,
+            )],
+        );
+        cache.insert(
+            second.clone(),
+            vec![super::super::CandidateHit::lexical_stub(
+                "src/second.rs",
+                1.0,
+            )],
+        );
+
+        assert!(cache.get(&first).is_none());
+        assert_eq!(
+            cache.get(&second).expect("second entry should remain")[0].file_path,
+            "src/second.rs"
+        );
+    }
+
+    #[test]
+    fn cache_key_tracks_sidecar_generation_contract() {
+        let base = RetrievalIndexManifest {
+            project_id: "abc".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_abc_hash_a".into(),
+            scip_revision: Some("scip-a".into()),
+            built_at_epoch_ms: 0,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: Some("llamacpp:bge-base".into()),
+            embedding_dim: Some(768),
+            sidecar_schema_version: Some(1),
+            sidecar_input_hash: Some("hash-a".into()),
+            sidecar_generation: Some("abc-hash-a".into()),
+            projection_count: Some(10),
+        };
+        let mut changed = base.clone();
+        changed.qdrant_collection = "codestory_abc_hash_b".into();
+        changed.sidecar_input_hash = Some("hash-b".into());
+        changed.sidecar_generation = Some("abc-hash-b".into());
+
+        assert_ne!(
+            RetrievalCacheKey::from_manifest(&base, "query"),
+            RetrievalCacheKey::from_manifest(&changed, "query")
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/candidate.rs
+++ b/crates/codestory-retrieval/src/candidate.rs
@@ -1,0 +1,83 @@
+use codestory_store::FileRole;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RankFeatures {
+    pub lexical: f32,
+    pub semantic: f32,
+    pub scip_distance: f32,
+    pub file_role_prior: f32,
+    pub definition_quality: f32,
+    pub token_overlap: f32,
+}
+
+/// Unified retrieval candidate from any sidecar lane.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidateHit {
+    pub file_path: String,
+    pub symbol_name: Option<String>,
+    pub start_line: Option<u32>,
+    pub score: f32,
+    pub source: CandidateSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_role: Option<FileRole>,
+    /// SCIP graph hops from anchor (lower is better).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scip_hop_distance: Option<u32>,
+    /// Populated by the feature ranker after fusion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rank_features: Option<RankFeatures>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CandidateSource {
+    Zoekt,
+    Qdrant,
+    Scip,
+    Legacy,
+}
+
+/// Dev-only synthetic hit prefix (`zoekt:`, `semantic:`, `scip:`).
+pub fn is_phantom_sidecar_hit(hit: &CandidateHit) -> bool {
+    hit.file_path.starts_with("zoekt:")
+        || hit.file_path.starts_with("semantic:")
+        || hit.file_path.starts_with("scip:")
+}
+
+pub fn phantom_sidecar_candidates_only(candidates: &[CandidateHit]) -> bool {
+    !candidates.is_empty() && candidates.iter().all(is_phantom_sidecar_hit)
+}
+
+impl CandidateHit {
+    pub fn lexical_stub(file_path: impl Into<String>, score: f32) -> Self {
+        Self {
+            file_path: file_path.into(),
+            symbol_name: None,
+            start_line: None,
+            score,
+            source: CandidateSource::Zoekt,
+            file_role: None,
+            scip_hop_distance: None,
+            rank_features: None,
+        }
+    }
+
+    pub fn with_source(
+        file_path: impl Into<String>,
+        symbol_name: Option<String>,
+        score: f32,
+        source: CandidateSource,
+    ) -> Self {
+        Self {
+            file_path: file_path.into(),
+            symbol_name,
+            start_line: None,
+            score,
+            source,
+            file_role: None,
+            scip_hop_distance: None,
+            rank_features: None,
+        }
+    }
+}

--- a/crates/codestory-retrieval/src/capabilities.rs
+++ b/crates/codestory-retrieval/src/capabilities.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+/// Capability flags derived from probes (not just HTTP reachability).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct SidecarCapabilities {
+    pub lexical: bool,
+    pub semantic: bool,
+    pub graph: bool,
+}
+
+impl SidecarCapabilities {
+    pub const NONE: Self = Self {
+        lexical: false,
+        semantic: false,
+        graph: false,
+    };
+
+    pub fn production_stack() -> Self {
+        Self {
+            lexical: true,
+            semantic: true,
+            graph: true,
+        }
+    }
+}

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -1,0 +1,336 @@
+use crate::config::{SidecarLayout, retrieval_compose_profile};
+use crate::health::{InfrastructureHealth, probe_infrastructure_health};
+use crate::qdrant_storage::{
+    BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION, QdrantStorageRepairReport,
+    repair_qdrant_storage,
+};
+use crate::sidecar::{SidecarStateFile, sidecar_up};
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Relative path from repository root to the retrieval compose file.
+pub const DEFAULT_COMPOSE_REL_PATH: &str = "docker/retrieval-compose.yml";
+
+#[derive(Debug, Clone)]
+pub struct BootstrapReport {
+    pub state: SidecarStateFile,
+    pub infrastructure: InfrastructureHealth,
+    pub compose_started: bool,
+    pub compose_file: Option<PathBuf>,
+    pub storage_repair: QdrantStorageRepairReport,
+}
+
+/// Prepare cache dirs, optionally start Docker Compose, write sidecar state, wait for probes.
+pub fn bootstrap_sidecars(
+    repo_root: Option<&Path>,
+    storage_scope: &BootstrapStorageScope,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+) -> Result<BootstrapReport> {
+    let layout = SidecarLayout::from_env();
+    layout.ensure_data_dirs()?;
+    let storage_repair =
+        repair_qdrant_storage(&layout, storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?;
+
+    let resolved_compose = if skip_compose {
+        None
+    } else {
+        Some(resolve_compose_file(repo_root, compose_file)?)
+    };
+
+    let compose_started = if let Some(path) = resolved_compose.as_ref() {
+        docker_compose_up(path, repo_root, &layout)?;
+        true
+    } else {
+        false
+    };
+
+    let state = sidecar_up()?;
+    let infrastructure = if wait_timeout.is_zero() {
+        probe_infrastructure_health(&layout)
+    } else {
+        wait_for_infrastructure(&layout, wait_timeout)?
+    };
+
+    Ok(BootstrapReport {
+        state,
+        infrastructure,
+        compose_started,
+        compose_file: resolved_compose,
+        storage_repair,
+    })
+}
+
+/// Deprecated: pass [`BootstrapStorageScope::from_parts`] as the second argument to [`bootstrap_sidecars`].
+#[deprecated(
+    since = "0.4.0",
+    note = "use bootstrap_sidecars(repo_root, &BootstrapStorageScope::from_parts(repo_root, None, None), compose_file, skip_compose, wait_timeout)"
+)]
+pub fn bootstrap_sidecars_without_storage_scope(
+    repo_root: Option<&Path>,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+) -> Result<BootstrapReport> {
+    let storage_scope = BootstrapStorageScope::from_parts(repo_root, None, None);
+    bootstrap_sidecars(
+        repo_root,
+        &storage_scope,
+        compose_file,
+        skip_compose,
+        wait_timeout,
+    )
+}
+
+pub fn resolve_compose_file(
+    repo_root: Option<&Path>,
+    override_path: Option<&Path>,
+) -> Result<PathBuf> {
+    if let Some(path) = override_path {
+        let path = path.to_path_buf();
+        if path.is_file() {
+            return Ok(path);
+        }
+        bail!("compose file not found: {}", path.display());
+    }
+    if let Ok(path) = std::env::var("CODESTORY_RETRIEVAL_COMPOSE_FILE") {
+        let path = PathBuf::from(path);
+        if path.is_file() {
+            return Ok(path);
+        }
+        bail!(
+            "CODESTORY_RETRIEVAL_COMPOSE_FILE is set but not a file: {}",
+            path.display()
+        );
+    }
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Some(root) = repo_root {
+        roots.push(root.to_path_buf());
+    }
+    if let Ok(dir) = std::env::current_dir()
+        && !roots.iter().any(|existing| existing == &dir)
+    {
+        roots.push(dir);
+    }
+    for root in roots {
+        let candidate = root.join(DEFAULT_COMPOSE_REL_PATH);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    bail!(
+        "retrieval compose file not found (expected {DEFAULT_COMPOSE_REL_PATH} under repo root); \
+         set CODESTORY_RETRIEVAL_COMPOSE_FILE or pass --compose-file"
+    );
+}
+
+pub fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn docker_compose_up(
+    compose_file: &Path,
+    repo_root: Option<&Path>,
+    layout: &SidecarLayout,
+) -> Result<()> {
+    if !docker_available() {
+        bail!(
+            "docker is not available on PATH. Install Docker Desktop (Windows) or Docker Engine, \
+             then re-run bootstrap. Manual Qdrant: docker run -p 6333:6333 -p 6334:6334 \
+             -v \"{}:/qdrant/storage\" {}",
+            layout.qdrant_data_dir.display(),
+            crate::config::QDRANT_IMAGE_PIN
+        );
+    }
+
+    std::fs::create_dir_all(&layout.qdrant_data_dir).with_context(|| {
+        format!(
+            "create Qdrant data dir {}",
+            layout.qdrant_data_dir.display()
+        )
+    })?;
+    std::fs::create_dir_all(&layout.zoekt_data_dir)
+        .with_context(|| format!("create Zoekt data dir {}", layout.zoekt_data_dir.display()))?;
+
+    let workdir = repo_root
+        .or_else(|| compose_file.parent().and_then(|p| p.parent()))
+        .unwrap_or_else(|| Path::new("."));
+
+    let mut command = docker_compose_command()?;
+    let compose_profile = retrieval_compose_profile();
+    if !compose_profile.trim().eq_ignore_ascii_case("real") {
+        bail!(
+            "CODESTORY_RETRIEVAL_COMPOSE_PROFILE={compose_profile} is unsupported; real sidecars are mandatory"
+        );
+    }
+    remove_container_if_present("codestory-zoekt-stub")?;
+    command
+        .arg("compose")
+        .arg("-f")
+        .arg(compose_file)
+        .arg("up")
+        .arg("-d")
+        .current_dir(workdir)
+        .env(
+            "CODESTORY_QDRANT_DATA_DIR",
+            docker_bind_path(&layout.qdrant_data_dir),
+        )
+        .env(
+            "CODESTORY_QDRANT_HTTP_PORT",
+            layout.qdrant_http_port.to_string(),
+        )
+        .env(
+            "CODESTORY_QDRANT_GRPC_PORT",
+            layout.qdrant_grpc_port.to_string(),
+        )
+        .env("CODESTORY_ZOEKT_PORT", layout.zoekt_http_port.to_string())
+        .env(
+            "CODESTORY_ZOEKT_DATA_DIR",
+            docker_bind_path(&layout.zoekt_data_dir),
+        )
+        .env(
+            "CODESTORY_EMBED_MODEL_DIR",
+            docker_bind_path(&embed_model_dir(repo_root, layout)),
+        )
+        .env("COMPOSE_PROFILES", compose_profile);
+
+    let output = command.output().context("spawn docker compose")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "docker compose up failed (exit {:?}):\n{stdout}{stderr}",
+            output.status.code()
+        );
+    }
+    Ok(())
+}
+
+fn docker_compose_command() -> Result<Command> {
+    Ok(Command::new("docker"))
+}
+
+fn remove_container_if_present(name: &str) -> Result<()> {
+    let inspect = Command::new("docker")
+        .args(["container", "inspect", name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .with_context(|| format!("inspect docker container {name}"))?;
+    if !inspect.success() {
+        return Ok(());
+    }
+    let output = Command::new("docker")
+        .args(["rm", "-f", name])
+        .output()
+        .with_context(|| format!("remove stale docker container {name}"))?;
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "failed to remove stale docker container {name} (exit {:?}):\n{stdout}{stderr}",
+            output.status.code()
+        );
+    }
+    Ok(())
+}
+
+fn docker_bind_path(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    let without_verbatim = if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = raw.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        raw.to_string()
+    };
+    without_verbatim.replace('\\', "/")
+}
+
+fn embed_model_dir(repo_root: Option<&Path>, layout: &SidecarLayout) -> PathBuf {
+    if let Ok(path) = std::env::var("CODESTORY_EMBED_MODEL_DIR") {
+        let path = PathBuf::from(path);
+        if path.is_dir() {
+            return path;
+        }
+    }
+    let workdir = repo_root
+        .or_else(|| Some(Path::new(".")))
+        .unwrap_or(Path::new("."));
+    for candidate in [
+        workdir.join("target").join("retrieval-models"),
+        workdir.join("models").join("gguf").join("bge-base-en-v1.5"),
+    ] {
+        if candidate
+            .join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF)
+            .is_file()
+        {
+            return candidate;
+        }
+    }
+    layout
+        .qdrant_data_dir
+        .parent()
+        .map(|parent| parent.join("embed-models"))
+        .unwrap_or_else(|| layout.qdrant_data_dir.join("embed-models"))
+}
+
+fn wait_for_infrastructure(
+    layout: &SidecarLayout,
+    timeout: Duration,
+) -> Result<InfrastructureHealth> {
+    let started = Instant::now();
+    let poll = Duration::from_millis(500);
+    let mut last = probe_infrastructure_health(layout);
+    while started.elapsed() < timeout {
+        if last.zoekt_reachable && last.qdrant_reachable && last.embed_reachable {
+            return Ok(last);
+        }
+        thread::sleep(poll);
+        last = probe_infrastructure_health(layout);
+    }
+    Ok(last)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn embed_model_dir_discovers_repo_models_layout() {
+        let project = tempdir().expect("project");
+        let model_dir = project
+            .path()
+            .join("models")
+            .join("gguf")
+            .join("bge-base-en-v1.5");
+        std::fs::create_dir_all(&model_dir).expect("model dir");
+        std::fs::write(
+            model_dir.join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF),
+            b"model placeholder",
+        )
+        .expect("model file");
+        let layout = SidecarLayout::from_env();
+
+        assert_eq!(embed_model_dir(Some(project.path()), &layout), model_dir);
+    }
+
+    #[test]
+    fn docker_bind_path_removes_windows_verbatim_prefix() {
+        assert_eq!(
+            docker_bind_path(Path::new(r"\\?\C:\Users\alber\codestory\models")),
+            "C:/Users/alber/codestory/models"
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -1,0 +1,136 @@
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Phase 2 lexical shard pin (local index + optional Zoekt webserver).
+pub const ZOEKT_REAL_VERSION_PIN: &str = "zoekt-20250506123554";
+
+/// Zoekt webserver image for `COMPOSE_PROFILES=real`.
+pub const ZOEKT_WEBSERVER_IMAGE_PIN: &str =
+    "sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4";
+
+/// Qdrant container image pin for local dev and CI smoke.
+pub const QDRANT_IMAGE_PIN: &str = "qdrant/qdrant:v1.12.5";
+
+/// llama.cpp server image for `COMPOSE_PROFILES=real` embed service (see `docker/retrieval-compose.yml`).
+#[allow(dead_code)]
+pub const LLAMACPP_SERVER_IMAGE_PIN: &str = "ghcr.io/ggml-org/llama.cpp:server";
+
+pub const DEFAULT_ZOEKT_HTTP_PORT: u16 = 6070;
+pub const DEFAULT_QDRANT_HTTP_PORT: u16 = 6333;
+pub const DEFAULT_QDRANT_GRPC_PORT: u16 = 6334;
+
+pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
+pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Clone)]
+pub struct SidecarLayout {
+    pub zoekt_http_port: u16,
+    pub qdrant_http_port: u16,
+    pub qdrant_grpc_port: u16,
+    pub zoekt_data_dir: PathBuf,
+    pub qdrant_data_dir: PathBuf,
+    pub scip_artifacts_root: PathBuf,
+    pub state_file: PathBuf,
+}
+
+impl SidecarLayout {
+    pub fn from_env() -> Self {
+        let base = user_cache_root();
+        Self {
+            zoekt_http_port: env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT),
+            qdrant_http_port: env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT),
+            qdrant_grpc_port: env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT),
+            zoekt_data_dir: base.join("zoekt"),
+            qdrant_data_dir: base.join("qdrant"),
+            scip_artifacts_root: base.join("scip"),
+            state_file: base.join("retrieval-sidecars.json"),
+        }
+    }
+
+    pub fn zoekt_base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.zoekt_http_port)
+    }
+
+    pub fn qdrant_base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.qdrant_http_port)
+    }
+
+    pub fn scip_project_dir(&self, project_id: &str) -> PathBuf {
+        self.scip_artifacts_root.join(project_id)
+    }
+
+    pub fn ensure_data_dirs(&self) -> Result<()> {
+        for dir in [
+            &self.zoekt_data_dir,
+            &self.qdrant_data_dir,
+            &self.scip_artifacts_root,
+        ] {
+            std::fs::create_dir_all(dir)
+                .with_context(|| format!("create sidecar data dir {}", dir.display()))?;
+        }
+        Ok(())
+    }
+}
+
+pub fn user_cache_root() -> PathBuf {
+    ProjectDirs::from("dev", "codestory", "codestory")
+        .map(|dirs| dirs.cache_dir().to_path_buf())
+        .unwrap_or_else(|| std::env::temp_dir().join("codestory").join("cache"))
+}
+
+pub fn zoekt_enabled() -> bool {
+    env_flag("CODESTORY_ZOEKT_ENABLED", true)
+}
+
+pub fn qdrant_enabled() -> bool {
+    env_flag("CODESTORY_QDRANT_ENABLED", true)
+}
+
+/// Sidecar retrieval is mandatory; Qdrant uses 768-d semantic vectors by default.
+/// `CODESTORY_RETRIEVAL_REAL_EMBEDDINGS=0` is unsupported for product indexing.
+pub fn qdrant_semantic_vectors_enabled() -> bool {
+    env_flag("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", true)
+}
+
+/// Docker compose profile: `real` by default. Other profiles are rejected by product bootstrap.
+pub fn retrieval_compose_profile() -> String {
+    std::env::var("CODESTORY_RETRIEVAL_COMPOSE_PROFILE")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "real".to_string())
+}
+
+fn env_port(name: &str, default: u16) -> u16 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_flag(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(value) => matches!(
+            value.trim(),
+            "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+        ),
+        Err(_) => default,
+    }
+}
+
+pub fn dir_size_bytes(path: &Path) -> u64 {
+    let mut total = 0u64;
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            total = total.saturating_add(entry.metadata().map(|m| m.len()).unwrap_or(0));
+        } else if path.is_dir() {
+            total = total.saturating_add(dir_size_bytes(&path));
+        }
+    }
+    total
+}

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -1,0 +1,532 @@
+//! Query embeddings for Qdrant plus diagnostic document embedding helpers.
+//!
+//! Product Qdrant indexing copies stored local semantic-document vectors. The live sidecar still
+//! uses **BAAI/bge-base-en-v1.5** (768-dim) via llama.cpp `/v1/embeddings` for query vectors and
+//! semantic smoke checks.
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::thread;
+use std::time::Duration;
+
+/// bge-base-en-v1.5 vector width (must match Qdrant collection and llama.cpp model).
+pub const RETRIEVAL_EMBEDDING_DIM: usize = 768;
+
+/// GGUF filename under `CODESTORY_EMBED_MODEL_DIR` (see docker/retrieval-compose.yml).
+pub const BGE_BASE_EN_V1_5_GGUF: &str = "bge-base-en-v1.5.Q8_0.gguf";
+
+pub const BGE_QUERY_PREFIX_DEFAULT: &str =
+    "Represent this sentence for searching relevant passages: ";
+pub const PRODUCT_EMBEDDING_RUNTIME_ID: &str = "llamacpp:bge-base-en-v1.5";
+
+const LLAMACPP_URL_ENV: &str = "CODESTORY_EMBED_LLAMACPP_URL";
+const DEFAULT_LLAMACPP_URL: &str = "http://127.0.0.1:8080/v1/embeddings";
+const EMBEDDING_BACKEND_ENV: &str = "CODESTORY_EMBED_BACKEND";
+const QUERY_PREFIX_ENV: &str = "CODESTORY_EMBED_QUERY_PREFIX";
+const DOCUMENT_PREFIX_ENV: &str = "CODESTORY_EMBED_DOCUMENT_PREFIX";
+const LLAMACPP_BATCH_SIZE_ENV: &str = "CODESTORY_EMBED_LLAMACPP_BATCH_SIZE";
+const LLAMACPP_REQUEST_COUNT_ENV: &str = "CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT";
+const ALLOW_REMOTE_EMBEDDINGS_ENV: &str = "CODESTORY_ALLOW_REMOTE_EMBEDDINGS";
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(120);
+const HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_LLAMACPP_BATCH_SIZE: usize = 128;
+const DEFAULT_LLAMACPP_REQUEST_COUNT: usize = 6;
+
+#[derive(Debug, Clone)]
+pub struct EmbeddingRuntimeProbe {
+    pub reachable: bool,
+    pub detail: String,
+}
+
+/// Stable id stored on retrieval manifest rows (backend + model family).
+pub fn embedding_runtime_id() -> String {
+    if llamacpp_backend_selected() {
+        PRODUCT_EMBEDDING_RUNTIME_ID.into()
+    } else if super::config::qdrant_semantic_vectors_enabled() {
+        "hash-projection:768".into()
+    } else {
+        "hash-label:8".into()
+    }
+}
+
+pub fn manifest_embedding_backend_is_product(backend: Option<&str>) -> bool {
+    backend == Some(PRODUCT_EMBEDDING_RUNTIME_ID)
+}
+
+pub fn ensure_product_embedding_backend() -> Result<()> {
+    if !super::config::qdrant_semantic_vectors_enabled() {
+        bail!("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS=0 is unsupported for product sidecar indexing");
+    }
+    if !llamacpp_backend_selected() {
+        bail!(
+            "llama.cpp embedding sidecar is mandatory; set CODESTORY_EMBED_BACKEND=llamacpp and CODESTORY_EMBED_LLAMACPP_URL"
+        );
+    }
+    Ok(())
+}
+
+pub fn embed_query(text: &str) -> Result<Vec<f32>> {
+    let prefix = query_prefix();
+    embed_prepared(&format!("{prefix}{text}"))
+}
+
+/// Active embedding backend label for ops/status (`hash`, `llamacpp`).
+pub fn embedding_backend_label() -> &'static str {
+    if llamacpp_backend_selected() {
+        "llamacpp"
+    } else {
+        "hash"
+    }
+}
+
+pub fn embed_documents(texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    let prefix = std::env::var(DOCUMENT_PREFIX_ENV).unwrap_or_default();
+    let prepared = texts
+        .iter()
+        .map(|text| format!("{prefix}{text}"))
+        .collect::<Vec<_>>();
+    if prepared.iter().any(|text| text.trim().is_empty()) {
+        bail!("cannot embed empty text");
+    }
+    if llamacpp_backend_selected() {
+        llamacpp_embed_batched(&prepared)
+    } else {
+        Ok(prepared
+            .iter()
+            .map(|text| hash_projection_embed(text, RETRIEVAL_EMBEDDING_DIM))
+            .collect())
+    }
+}
+
+fn query_prefix() -> String {
+    if let Ok(value) = std::env::var(QUERY_PREFIX_ENV)
+        && (!value.is_empty() || !llamacpp_backend_selected())
+    {
+        return value;
+    }
+    if llamacpp_backend_selected() {
+        return BGE_QUERY_PREFIX_DEFAULT.to_string();
+    }
+    String::new()
+}
+
+fn embed_prepared(prepared: &str) -> Result<Vec<f32>> {
+    if prepared.trim().is_empty() {
+        bail!("cannot embed empty text");
+    }
+    if llamacpp_backend_selected() {
+        llamacpp_embed(&[prepared.to_string()])?
+            .pop()
+            .ok_or_else(|| anyhow!("llama.cpp returned no embedding vector"))
+    } else {
+        Ok(hash_projection_embed(prepared, RETRIEVAL_EMBEDDING_DIM))
+    }
+}
+
+fn llamacpp_backend_selected() -> bool {
+    match std::env::var(EMBEDDING_BACKEND_ENV) {
+        Ok(value) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            normalized == "llamacpp" || normalized == "llama_cpp"
+        }
+        Err(_) => {
+            super::config::qdrant_semantic_vectors_enabled()
+                || std::env::var(LLAMACPP_URL_ENV).is_ok()
+        }
+    }
+}
+
+fn llamacpp_embed(texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    let url = llamacpp_url()?;
+    llamacpp_embed_with_timeout(texts, &url, HTTP_TIMEOUT)
+}
+
+fn llamacpp_embed_batched(texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    let batch_size = env_usize(
+        LLAMACPP_BATCH_SIZE_ENV,
+        DEFAULT_LLAMACPP_BATCH_SIZE,
+        1,
+        1024,
+    );
+    let request_count = env_usize(
+        LLAMACPP_REQUEST_COUNT_ENV,
+        DEFAULT_LLAMACPP_REQUEST_COUNT,
+        1,
+        16,
+    );
+    if texts.len() <= batch_size {
+        return llamacpp_embed(texts);
+    }
+
+    let url = llamacpp_url()?;
+    let batches = texts
+        .chunks(batch_size)
+        .map(|chunk| chunk.to_vec())
+        .collect::<Vec<_>>();
+    let mut output = Vec::with_capacity(texts.len());
+    for (wave_index, wave) in batches.chunks(request_count).enumerate() {
+        let mut wave_results = thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(wave.len());
+            for (index, batch) in wave.iter().cloned().enumerate() {
+                let url = url.clone();
+                handles.push(scope.spawn(move || {
+                    llamacpp_embed_with_timeout(&batch, &url, HTTP_TIMEOUT)
+                        .map(|vectors| (index, vectors))
+                }));
+            }
+            let mut joined = Vec::with_capacity(handles.len());
+            for handle in handles {
+                joined.push(
+                    handle
+                        .join()
+                        .map_err(|_| anyhow!("llama.cpp embedding worker panicked"))??,
+                );
+            }
+            Ok::<_, anyhow::Error>(joined)
+        })
+        .with_context(|| format!("embed llama.cpp request wave {wave_index}"))?;
+        wave_results.sort_by_key(|(index, _)| *index);
+        for (_, vectors) in wave_results {
+            output.extend(vectors);
+        }
+    }
+    Ok(output)
+}
+
+fn env_usize(name: &str, default: usize, min: usize, max: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .map(|value| value.clamp(min, max))
+        .unwrap_or(default)
+}
+
+pub fn probe_product_embedding_runtime() -> EmbeddingRuntimeProbe {
+    let result = llamacpp_url().and_then(|url| {
+        llamacpp_embed_with_timeout(
+            &["codestory health probe".to_string()],
+            &url,
+            HEALTH_TIMEOUT,
+        )
+    });
+    match result {
+        Ok(vectors) => EmbeddingRuntimeProbe {
+            reachable: true,
+            detail: format!(
+                "llama.cpp embeddings reachable dim={}",
+                vectors.first().map(|vector| vector.len()).unwrap_or(0)
+            ),
+        },
+        Err(error) => EmbeddingRuntimeProbe {
+            reachable: false,
+            detail: format!("llama.cpp embeddings unavailable: {error}"),
+        },
+    }
+}
+
+fn llamacpp_url() -> Result<String> {
+    let url = std::env::var(LLAMACPP_URL_ENV).unwrap_or_else(|_| DEFAULT_LLAMACPP_URL.to_string());
+    ensure_llamacpp_url_allowed(&url)?;
+    Ok(url)
+}
+
+fn ensure_llamacpp_url_allowed(url: &str) -> Result<()> {
+    if !allow_remote_embeddings() && !is_loopback_embedding_url(url) {
+        bail!(
+            "remote embedding URL is disabled; use a loopback URL or set {ALLOW_REMOTE_EMBEDDINGS_ENV}=1"
+        );
+    }
+    Ok(())
+}
+
+fn allow_remote_embeddings() -> bool {
+    std::env::var(ALLOW_REMOTE_EMBEDDINGS_ENV)
+        .ok()
+        .is_some_and(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+}
+
+fn is_loopback_embedding_url(url: &str) -> bool {
+    let Some(host) = http_url_host(url) else {
+        return false;
+    };
+    matches!(
+        host.to_ascii_lowercase().as_str(),
+        "127.0.0.1" | "localhost" | "[::1]"
+    )
+}
+
+fn http_url_host(url: &str) -> Option<&str> {
+    let rest = url.trim().strip_prefix("http://")?;
+    let authority = rest.split('/').next()?;
+    let host_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if host_port.starts_with('[') {
+        let end = host_port.find(']')?;
+        return Some(&host_port[..=end]);
+    }
+    host_port.split(':').next().filter(|host| !host.is_empty())
+}
+
+fn llamacpp_embed_with_timeout(
+    texts: &[String],
+    url: &str,
+    timeout: Duration,
+) -> Result<Vec<Vec<f32>>> {
+    let body = serde_json::json!({
+        "input": texts,
+        "model": "bge-base-en-v1.5",
+    });
+    let payload = serde_json::to_string(&body).context("serialize embeddings request")?;
+    let response = ureq::post(url)
+        .timeout(timeout)
+        .set("Content-Type", "application/json")
+        .send_string(&payload)
+        .map_err(|error| anyhow!("llama.cpp embeddings request failed: {error}"))?;
+    let status = response.status();
+    if !(200..300).contains(&status) {
+        bail!("llama.cpp embeddings http {status}");
+    }
+    let response_body = response.into_string().unwrap_or_default();
+    parse_openai_embeddings(&response_body, true)
+}
+
+#[derive(Deserialize)]
+struct OpenAiEmbeddingsResponse {
+    data: Vec<OpenAiEmbeddingRow>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiEmbeddingRow {
+    embedding: Vec<f32>,
+}
+
+fn parse_openai_embeddings(body: &str, require_llamacpp_dim: bool) -> Result<Vec<Vec<f32>>> {
+    let parsed: OpenAiEmbeddingsResponse =
+        serde_json::from_str(body).context("parse llama.cpp embeddings json")?;
+    if parsed.data.is_empty() {
+        bail!("llama.cpp embeddings response had no data rows");
+    }
+    let mut vectors = Vec::with_capacity(parsed.data.len());
+    for row in parsed.data {
+        if require_llamacpp_dim && row.embedding.len() != RETRIEVAL_EMBEDDING_DIM {
+            bail!(
+                "llama.cpp embedding dim {} != expected {} (bge-base-en-v1.5); check model GGUF and CODESTORY_EMBED_BACKEND",
+                row.embedding.len(),
+                RETRIEVAL_EMBEDDING_DIM
+            );
+        }
+        vectors.push(row.embedding);
+    }
+    Ok(vectors)
+}
+
+/// Same algorithm as `codestory_runtime::search::engine::embed_text_with_hash_projection`.
+pub fn hash_projection_embed(text: &str, dim: usize) -> Vec<f32> {
+    let mut vector = vec![0.0_f32; dim];
+    for token in text.split_whitespace() {
+        let norm = token.trim().to_ascii_lowercase();
+        if norm.is_empty() {
+            continue;
+        }
+        let mut hasher = DefaultHasher::new();
+        norm.hash(&mut hasher);
+        let hash = hasher.finish();
+        let index = (hash as usize) % dim;
+        let sign = if ((hash >> 8) & 1) == 0 { 1.0 } else { -1.0 };
+        vector[index] += sign;
+        let index2 = ((hash >> 17) as usize) % dim;
+        vector[index2] += 0.5 * sign;
+    }
+    l2_normalize(&mut vector);
+    vector
+}
+
+fn l2_normalize(vector: &mut [f32]) {
+    let norm = vector
+        .iter()
+        .map(|value| f64::from(*value) * f64::from(*value))
+        .sum::<f64>()
+        .sqrt();
+    if norm <= f64::EPSILON {
+        return;
+    }
+    let scale = (1.0 / norm) as f32;
+    for value in vector.iter_mut() {
+        *value *= scale;
+    }
+}
+
+/// Stable 8-d hash vector used only for diagnostic downgraded vectors.
+pub fn label_to_vector(label: &str) -> Vec<f32> {
+    let digest = Sha256::digest(label.as_bytes());
+    (0..8).map(|index| digest[index] as f32 / 255.0).collect()
+}
+
+pub fn qdrant_vector_dim() -> usize {
+    if super::config::qdrant_semantic_vectors_enabled() {
+        RETRIEVAL_EMBEDDING_DIM
+    } else {
+        8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn hash_projection_dim_matches_retrieval_embedding_dim() {
+        let vector = hash_projection_embed("extension_service handler", RETRIEVAL_EMBEDDING_DIM);
+        assert_eq!(vector.len(), RETRIEVAL_EMBEDDING_DIM);
+        let norm: f32 = vector.iter().map(|v| v * v).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 0.01 || vector.iter().all(|v| *v == 0.0));
+    }
+
+    #[test]
+    fn embed_documents_preserves_count_for_hash_projection() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::set(EMBEDDING_BACKEND_ENV, "hash");
+        let docs = vec!["alpha".to_string(), "beta".to_string()];
+
+        let vectors = embed_documents(&docs).expect("embed docs");
+
+        assert_eq!(vectors.len(), docs.len());
+        assert!(
+            vectors
+                .iter()
+                .all(|vector| vector.len() == RETRIEVAL_EMBEDDING_DIM)
+        );
+    }
+
+    #[test]
+    fn label_to_vector_smoke_dim_is_eight() {
+        assert_eq!(label_to_vector("handler").len(), 8);
+    }
+
+    #[test]
+    fn default_qdrant_semantic_vectors_are_768() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::remove("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS");
+        let _guard2 = EnvGuard::remove(EMBEDDING_BACKEND_ENV);
+        assert_eq!(embedding_runtime_id(), PRODUCT_EMBEDDING_RUNTIME_ID);
+        assert_eq!(qdrant_vector_dim(), RETRIEVAL_EMBEDDING_DIM);
+    }
+
+    #[test]
+    fn embedding_runtime_id_llamacpp_when_backend_set() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::set(EMBEDDING_BACKEND_ENV, "llamacpp");
+        let _guard2 = EnvGuard::set("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
+        assert_eq!(embedding_runtime_id(), "llamacpp:bge-base-en-v1.5");
+    }
+
+    #[test]
+    fn explicit_onnx_backend_is_not_product_sidecar_runtime() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::set(EMBEDDING_BACKEND_ENV, "onnx");
+        let _guard2 = EnvGuard::set("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
+
+        assert_eq!(embedding_runtime_id(), "hash-projection:768");
+        assert!(!manifest_embedding_backend_is_product(Some(
+            embedding_runtime_id().as_str()
+        )));
+        let error = ensure_product_embedding_backend()
+            .expect_err("explicit ONNX should not satisfy product sidecar indexing");
+        assert!(
+            error
+                .to_string()
+                .contains("llama.cpp embedding sidecar is mandatory"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn loopback_embedding_urls_are_allowed() {
+        assert!(is_loopback_embedding_url(
+            "http://127.0.0.1:8080/v1/embeddings"
+        ));
+        assert!(is_loopback_embedding_url(
+            "http://localhost:8080/v1/embeddings"
+        ));
+        assert!(is_loopback_embedding_url("http://[::1]:8080/v1/embeddings"));
+    }
+
+    #[test]
+    fn remote_embedding_urls_are_not_loopback() {
+        assert!(!is_loopback_embedding_url(
+            "https://example.com/v1/embeddings"
+        ));
+        assert!(!is_loopback_embedding_url(
+            "http://192.168.1.10:8080/v1/embeddings"
+        ));
+        assert!(!is_loopback_embedding_url(
+            "http://localhost.example.com:8080/v1/embeddings"
+        ));
+    }
+
+    #[test]
+    fn remote_embedding_url_requires_explicit_opt_in() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::remove(ALLOW_REMOTE_EMBEDDINGS_ENV);
+        let error = ensure_llamacpp_url_allowed("http://192.168.1.10:8080/v1/embeddings")
+            .expect_err("remote URL should be rejected by default");
+        assert!(error.to_string().contains(ALLOW_REMOTE_EMBEDDINGS_ENV));
+
+        let _allow = EnvGuard::set(ALLOW_REMOTE_EMBEDDINGS_ENV, "1");
+        ensure_llamacpp_url_allowed("http://192.168.1.10:8080/v1/embeddings")
+            .expect("remote URL should be allowed when explicitly opted in");
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            // SAFETY: test-only single-threaded env mutation.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            // SAFETY: test-only env mutation guarded by ENV_LOCK.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: test-only single-threaded env mutation.
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+}

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -1,0 +1,822 @@
+use crate::cache::{RetrievalCache, RetrievalCacheKey};
+use crate::candidate::CandidateHit;
+use crate::health::probe_sidecar_health;
+use crate::index::query_fingerprint;
+use crate::mode::{RetrievalDegradedMode, derive_degraded_mode};
+use crate::planner::{PlannedStage, RetrievalStageKind};
+use crate::query_features::{QueryFeatures, classify_query};
+use crate::ranker::rank_candidates;
+use crate::sidecar_search::SidecarSearch;
+use anyhow::{Result, bail};
+use codestory_store::RetrievalIndexManifest;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StageTrace {
+    pub stage: RetrievalStageKind,
+    pub budget_ms: u64,
+    pub elapsed_ms: u64,
+    pub candidates_added: usize,
+    pub marginal_gain: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel_reason: Option<String>,
+    pub cache_hit: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub degraded: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stub_reason: Option<String>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryTrace {
+    pub retrieval_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub degraded_reason: Option<String>,
+    pub total_budget_ms: u64,
+    pub elapsed_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel_reason: Option<String>,
+    pub cache_hit: bool,
+    pub stages: Vec<StageTrace>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueryResult {
+    pub query: String,
+    pub features: QueryFeatures,
+    pub hits: Vec<CandidateHit>,
+    pub trace: QueryTrace,
+}
+
+pub struct QueryExecutor<'a> {
+    pub sidecars: &'a dyn SidecarSearch,
+    pub cache: &'a mut RetrievalCache,
+    pub manifest: Option<RetrievalIndexManifest>,
+    pub file_roles: HashMap<String, codestory_store::FileRole>,
+    pub cancelled: Arc<AtomicBool>,
+    /// When set (tests), skips live health probing.
+    pub mode_override: Option<RetrievalDegradedMode>,
+}
+
+impl<'a> QueryExecutor<'a> {
+    pub fn execute(&mut self, query: &str, total_budget_ms: Option<u64>) -> Result<QueryResult> {
+        let features = classify_query(query);
+        let fingerprint = query_fingerprint(&features.raw_query);
+
+        let (mode, degraded_reason) = self.resolve_mode();
+        if mode != RetrievalDegradedMode::Full {
+            bail!(
+                "retrieval sidecar is mandatory; project is not in full mode (mode={}, reason={})",
+                mode.as_str(),
+                degraded_reason.as_deref().unwrap_or("unknown")
+            );
+        }
+
+        if let Some(manifest) = self.manifest.as_ref() {
+            let key = RetrievalCacheKey::from_manifest(manifest, fingerprint.clone());
+            if let Some(cached) = self.cache.get(&key) {
+                return Ok(QueryResult {
+                    query: features.raw_query.clone(),
+                    features,
+                    hits: cached.to_vec(),
+                    trace: QueryTrace {
+                        retrieval_mode: mode.as_str().into(),
+                        degraded_reason: None,
+                        total_budget_ms: 0,
+                        elapsed_ms: 0,
+                        cancel_reason: None,
+                        cache_hit: true,
+                        stages: Vec::new(),
+                    },
+                });
+            }
+        }
+
+        let mut plan = crate::planner::plan_query(&features, mode);
+        if let Some(budget) = total_budget_ms {
+            plan.total_budget_ms = budget;
+        }
+
+        let started = Instant::now();
+        let deadline = started + Duration::from_millis(plan.total_budget_ms);
+        let mut candidates = Vec::new();
+        let mut stage_traces = Vec::new();
+
+        let cancel_reason = self.run_stage_sequence(
+            &features,
+            &plan.stages,
+            &mut candidates,
+            &mut stage_traces,
+            deadline,
+            StageSequenceOptions {
+                stop_marginal_gain_threshold: Some(plan.stop_marginal_gain_threshold),
+                stop_after_low_gain_streak: plan.stop_after_low_gain_streak,
+            },
+        )?;
+
+        enrich_candidates_with_file_roles(&mut candidates, &self.file_roles);
+        let ranked = rank_candidates(&features, candidates);
+        let hits = ranked;
+
+        if cancel_reason.is_none()
+            && let Some(manifest) = self.manifest.as_ref()
+        {
+            let key = RetrievalCacheKey::from_manifest(manifest, fingerprint);
+            self.cache.insert(key, hits.clone());
+        }
+
+        Ok(QueryResult {
+            query: features.raw_query.clone(),
+            features,
+            hits,
+            trace: QueryTrace {
+                retrieval_mode: mode.as_str().into(),
+                degraded_reason,
+                total_budget_ms: plan.total_budget_ms,
+                elapsed_ms: started.elapsed().as_millis() as u64,
+                cancel_reason,
+                cache_hit: false,
+                stages: stage_traces,
+            },
+        })
+    }
+
+    fn resolve_mode(&self) -> (RetrievalDegradedMode, Option<String>) {
+        if let Some(mode) = self.mode_override {
+            return (mode, None);
+        }
+        if let Some(manifest) = self.manifest.as_ref() {
+            let layout = crate::config::SidecarLayout::from_env();
+            let report =
+                probe_sidecar_health(&layout, &manifest.project_id, Some(manifest.clone()));
+            return derive_degraded_mode(&report.zoekt, &report.qdrant, &report.scip);
+        }
+        (
+            RetrievalDegradedMode::LexicalOnly,
+            Some("manifest_missing".into()),
+        )
+    }
+
+    fn run_stage(
+        &self,
+        stage: &PlannedStage,
+        features: &QueryFeatures,
+        anchors: &[CandidateHit],
+    ) -> Result<Vec<CandidateHit>> {
+        let query = &features.raw_query;
+        match stage.kind {
+            RetrievalStageKind::Stage0ScipAnchor => self.sidecars.scip_anchor(query, stage.top_k),
+            RetrievalStageKind::Stage1ZoektLexical => {
+                self.sidecars.zoekt_search(query, stage.top_k)
+            }
+            RetrievalStageKind::Stage1bQdrantSemantic => {
+                self.sidecars.qdrant_search(query, stage.top_k)
+            }
+            RetrievalStageKind::Stage2ScipExpand => self.sidecars.scip_expand(anchors, stage.top_k),
+            RetrievalStageKind::Stage3RepoTextFallback => {
+                bail!("repo-text diagnostic stage is unsupported in mandatory sidecar retrieval")
+            }
+        }
+    }
+
+    fn run_stage_sequence(
+        &self,
+        features: &QueryFeatures,
+        stages: &[PlannedStage],
+        candidates: &mut Vec<CandidateHit>,
+        stage_traces: &mut Vec<StageTrace>,
+        deadline: Instant,
+        options: StageSequenceOptions,
+    ) -> Result<Option<String>> {
+        let mut low_gain_streak = 0u32;
+        for stage in stages {
+            if self.cancelled.load(Ordering::Relaxed) {
+                return Ok(Some("cancelled".into()));
+            }
+            if Instant::now() >= deadline {
+                return Ok(Some("deadline".into()));
+            }
+
+            if should_skip_after_exact_symbol_anchor(stage, features, candidates) {
+                stage_traces.push(stage_trace(
+                    stage,
+                    0,
+                    0,
+                    0.0,
+                    Some("exact_symbol_anchor".into()),
+                    false,
+                    None,
+                ));
+                continue;
+            }
+
+            let stage_started = Instant::now();
+            let before_score = candidate_mass(candidates);
+            let stage_hits = self.run_stage(stage, features, candidates)?;
+            let (stub_reason, stage_degraded) = stage_stub_metadata(&stage_hits);
+            let added = merge_candidates(candidates, stage_hits);
+            let after_score = candidate_mass(candidates);
+            let marginal_gain = if before_score <= 0.0 {
+                after_score
+            } else {
+                ((after_score - before_score) / before_score).max(0.0)
+            };
+
+            stage_traces.push(stage_trace(
+                stage,
+                stage_started.elapsed().as_millis() as u64,
+                added,
+                marginal_gain,
+                None,
+                stage_degraded,
+                stub_reason,
+            ));
+
+            if let Some(threshold) = options.stop_marginal_gain_threshold {
+                if marginal_gain < threshold && !candidates.is_empty() {
+                    low_gain_streak += 1;
+                    if low_gain_streak >= options.stop_after_low_gain_streak {
+                        return Ok(Some("marginal_gain".into()));
+                    }
+                } else {
+                    low_gain_streak = 0;
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StageSequenceOptions {
+    stop_marginal_gain_threshold: Option<f32>,
+    stop_after_low_gain_streak: u32,
+}
+
+fn stage_trace(
+    stage: &PlannedStage,
+    elapsed_ms: u64,
+    candidates_added: usize,
+    marginal_gain: f32,
+    cancel_reason: Option<String>,
+    degraded: bool,
+    stub_reason: Option<String>,
+) -> StageTrace {
+    StageTrace {
+        stage: stage.kind,
+        budget_ms: stage.budget_ms,
+        elapsed_ms,
+        candidates_added,
+        marginal_gain,
+        cancel_reason,
+        cache_hit: false,
+        degraded,
+        stub_reason,
+    }
+}
+
+fn should_skip_after_exact_symbol_anchor(
+    stage: &PlannedStage,
+    features: &QueryFeatures,
+    candidates: &[CandidateHit],
+) -> bool {
+    if !matches!(
+        features.shape,
+        crate::query_features::QueryShape::SymbolLike
+    ) {
+        return false;
+    }
+    if !matches!(
+        stage.kind,
+        RetrievalStageKind::Stage1bQdrantSemantic | RetrievalStageKind::Stage2ScipExpand
+    ) {
+        return false;
+    }
+    candidates
+        .iter()
+        .any(|candidate| candidate_is_exact_symbol_anchor(&features.raw_query, candidate))
+}
+
+fn candidate_is_exact_symbol_anchor(query: &str, candidate: &CandidateHit) -> bool {
+    if matches!(
+        candidate.source,
+        crate::candidate::CandidateSource::Qdrant | crate::candidate::CandidateSource::Legacy
+    ) {
+        return false;
+    }
+    let Some(symbol) = candidate.symbol_name.as_deref() else {
+        return false;
+    };
+    let query_lower = query.trim().to_ascii_lowercase();
+    if query_lower.is_empty() {
+        return false;
+    }
+    let symbol_lower = symbol.trim().to_ascii_lowercase();
+    if symbol_lower == query_lower {
+        return true;
+    }
+    let symbol_tail = symbol_lower
+        .rsplit("::")
+        .next()
+        .unwrap_or(&symbol_lower)
+        .rsplit('.')
+        .next()
+        .unwrap_or(&symbol_lower);
+    query
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|token| token.len() >= 2)
+        .map(|token| token.to_ascii_lowercase())
+        .any(|token| token == symbol_tail)
+}
+
+fn candidate_mass(candidates: &[CandidateHit]) -> f32 {
+    candidates.iter().map(|hit| hit.score.max(0.01)).sum()
+}
+
+fn stage_stub_metadata(hits: &[CandidateHit]) -> (Option<String>, bool) {
+    if hits.is_empty() {
+        return (None, false);
+    }
+    if crate::candidate::phantom_sidecar_candidates_only(hits) {
+        return (Some("phantom_stub_hits".into()), true);
+    }
+    (None, false)
+}
+
+fn merge_candidates(acc: &mut Vec<CandidateHit>, incoming: Vec<CandidateHit>) -> usize {
+    let mut added = 0usize;
+    for hit in incoming {
+        let duplicate = acc.iter().any(|existing| {
+            existing.file_path == hit.file_path && existing.symbol_name == hit.symbol_name
+        });
+        if !duplicate {
+            acc.push(hit);
+            added += 1;
+        }
+    }
+    added
+}
+
+pub fn cancellation_flag() -> Arc<AtomicBool> {
+    Arc::new(AtomicBool::new(false))
+}
+
+fn enrich_candidates_with_file_roles(
+    candidates: &mut [CandidateHit],
+    file_roles: &HashMap<String, codestory_store::FileRole>,
+) {
+    for candidate in candidates {
+        if candidate.file_role.is_some() {
+            continue;
+        }
+        candidate.file_role = Some(
+            lookup_file_role(file_roles, &candidate.file_path).unwrap_or_else(|| {
+                codestory_store::FileRole::classify_path(Path::new(&candidate.file_path))
+            }),
+        );
+    }
+}
+
+fn lookup_file_role(
+    file_roles: &HashMap<String, codestory_store::FileRole>,
+    file_path: &str,
+) -> Option<codestory_store::FileRole> {
+    file_roles.get(file_path).copied().or_else(|| {
+        let normalized = file_path.replace('\\', "/");
+        file_roles.get(&normalized).copied()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::RetrievalCache;
+    use crate::candidate::{CandidateHit, CandidateSource};
+    use crate::sidecar_search::mock::MockSidecarSearch;
+    use codestory_store::RetrievalIndexManifest;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn sample_manifest() -> RetrievalIndexManifest {
+        RetrievalIndexManifest {
+            project_id: "testproj".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_testproj".into(),
+            scip_revision: Some("rev1".into()),
+            built_at_epoch_ms: 0,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: None,
+            embedding_dim: None,
+            sidecar_schema_version: None,
+            sidecar_input_hash: None,
+            sidecar_generation: None,
+            projection_count: None,
+        }
+    }
+
+    #[test]
+    fn executor_runs_stages_with_mock_sidecars() {
+        let mock = MockSidecarSearch {
+            zoekt: Mutex::new(HashMap::from([(
+                "ExtensionService".into(),
+                vec![CandidateHit::with_source(
+                    "src/service.rs",
+                    Some("ExtensionService".into()),
+                    0.9,
+                    CandidateSource::Zoekt,
+                )],
+            )])),
+            qdrant: Mutex::new(HashMap::from([(
+                "ExtensionService".into(),
+                vec![CandidateHit::with_source(
+                    "src/service_semantic.rs",
+                    Some("ExtensionService".into()),
+                    0.8,
+                    CandidateSource::Qdrant,
+                )],
+            )])),
+            scip_anchor: Mutex::new(HashMap::new()),
+            scip_expand: Mutex::new(Vec::new()),
+        };
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor
+            .execute("ExtensionService", Some(800))
+            .expect("query succeeds");
+        assert!(!result.hits.is_empty());
+        assert!(!result.trace.stages.is_empty());
+        assert!(!result.trace.cache_hit);
+    }
+
+    #[test]
+    fn executor_uses_cache_on_second_query() {
+        let mock = MockSidecarSearch::default();
+        let mut cache = RetrievalCache::new();
+        let manifest = sample_manifest();
+        let key = RetrievalCacheKey::from_manifest(&manifest, query_fingerprint("cached-query"));
+        cache.insert(key, vec![CandidateHit::lexical_stub("cached.rs", 1.0)]);
+
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(manifest),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor.execute("cached-query", None).expect("cache hit");
+        assert!(result.trace.cache_hit);
+        assert_eq!(result.hits[0].file_path, "cached.rs");
+    }
+
+    #[test]
+    fn executor_caches_only_complete_query_results() {
+        let mock = MockSidecarSearch {
+            zoekt: Mutex::new(HashMap::from([(
+                "startup".into(),
+                vec![CandidateHit::with_source(
+                    "src/startup.rs",
+                    Some("startup".into()),
+                    0.9,
+                    CandidateSource::Zoekt,
+                )],
+            )])),
+            ..Default::default()
+        };
+        let mut cache = RetrievalCache::new();
+        let manifest = sample_manifest();
+        {
+            let mut executor = QueryExecutor {
+                sidecars: &mock,
+                cache: &mut cache,
+                manifest: Some(manifest.clone()),
+                file_roles: HashMap::new(),
+                cancelled: cancellation_flag(),
+                mode_override: Some(RetrievalDegradedMode::Full),
+            };
+            let result = executor.execute("startup", Some(800)).expect("query");
+            assert_eq!(result.trace.cancel_reason, None);
+        }
+        let key = RetrievalCacheKey::from_manifest(&manifest, query_fingerprint("startup"));
+        assert!(cache.get(&key).is_some());
+
+        let mut cancelled_cache = RetrievalCache::new();
+        let cancelled = cancellation_flag();
+        cancelled.store(true, Ordering::Relaxed);
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cancelled_cache,
+            manifest: Some(manifest.clone()),
+            file_roles: HashMap::new(),
+            cancelled,
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor.execute("startup", Some(800)).expect("query");
+        assert_eq!(result.trace.cancel_reason.as_deref(), Some("cancelled"));
+        assert_eq!(cancelled_cache.len(), 0);
+    }
+
+    #[test]
+    fn executor_skips_semantic_and_expand_after_exact_symbol_anchor() {
+        let mock = MockSidecarSearch {
+            scip_anchor: Mutex::new(HashMap::from([(
+                "EventProcessor".into(),
+                vec![CandidateHit::with_source(
+                    "src/event_processor.rs",
+                    Some("EventProcessor".into()),
+                    0.95,
+                    CandidateSource::Scip,
+                )],
+            )])),
+            qdrant: Mutex::new(HashMap::from([(
+                "EventProcessor".into(),
+                vec![CandidateHit::with_source(
+                    "docs/event-output.md",
+                    Some("event output".into()),
+                    0.99,
+                    CandidateSource::Qdrant,
+                )],
+            )])),
+            scip_expand: Mutex::new(vec![CandidateHit::with_source(
+                "src/neighbor.rs",
+                Some("Neighbor".into()),
+                0.80,
+                CandidateSource::Scip,
+            )]),
+            ..Default::default()
+        };
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor
+            .execute("EventProcessor", Some(800))
+            .expect("query succeeds");
+        assert_eq!(
+            result.hits.first().map(|hit| hit.file_path.as_str()),
+            Some("src/event_processor.rs")
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .all(|hit| hit.file_path != "docs/event-output.md")
+        );
+        let skipped: Vec<_> = result
+            .trace
+            .stages
+            .iter()
+            .filter(|stage| stage.cancel_reason.as_deref() == Some("exact_symbol_anchor"))
+            .map(|stage| stage.stage)
+            .collect();
+        assert!(skipped.contains(&RetrievalStageKind::Stage1bQdrantSemantic));
+        assert!(skipped.contains(&RetrievalStageKind::Stage2ScipExpand));
+    }
+
+    #[test]
+    fn executor_rejects_non_full_modes() {
+        let mock = MockSidecarSearch::default();
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::NoSemantic),
+        };
+        let error = executor
+            .execute("ExtensionService", Some(800))
+            .expect_err("non-full modes must fail closed");
+        assert!(error.to_string().contains("retrieval sidecar is mandatory"));
+    }
+
+    #[test]
+    fn executor_rejects_cached_hits_when_mode_is_not_full() {
+        let mock = MockSidecarSearch::default();
+        let mut cache = RetrievalCache::new();
+        let manifest = sample_manifest();
+        let key = RetrievalCacheKey::from_manifest(&manifest, query_fingerprint("cached-query"));
+        cache.insert(key, vec![CandidateHit::lexical_stub("cached.rs", 1.0)]);
+
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(manifest),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::NoSemantic),
+        };
+        let error = executor
+            .execute("cached-query", None)
+            .expect_err("cache must not bypass mandatory full sidecar mode");
+        assert!(error.to_string().contains("retrieval sidecar is mandatory"));
+    }
+
+    #[test]
+    fn executor_reaches_semantic_stage_after_empty_lexical_stages() {
+        let mock = MockSidecarSearch {
+            qdrant: Mutex::new(HashMap::from([(
+                "how does startup sequence work".into(),
+                vec![CandidateHit::with_source(
+                    "src/semantic.rs",
+                    Some("SemanticAnchor".into()),
+                    0.8,
+                    CandidateSource::Qdrant,
+                )],
+            )])),
+            ..Default::default()
+        };
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor
+            .execute("how does startup sequence work", Some(800))
+            .expect("query");
+        assert!(
+            result
+                .trace
+                .stages
+                .iter()
+                .any(|stage| stage.stage == RetrievalStageKind::Stage1bQdrantSemantic),
+            "semantic stage should run after empty SCIP/Zoekt stages: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .any(|hit| hit.file_path == "src/semantic.rs"),
+            "expected semantic hit after empty lexical stages: {:?}",
+            result.hits
+        );
+    }
+
+    #[test]
+    fn executor_respects_cancellation() {
+        let mock = MockSidecarSearch::default();
+        let mut cache = RetrievalCache::new();
+        let cancelled = cancellation_flag();
+        cancelled.store(true, Ordering::Relaxed);
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled,
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor.execute("anything", Some(500)).expect("partial ok");
+        assert_eq!(result.trace.cancel_reason.as_deref(), Some("cancelled"));
+    }
+
+    #[test]
+    fn executor_enriches_file_role_before_ranking() {
+        let mock = MockSidecarSearch {
+            zoekt: Mutex::new(HashMap::from([(
+                "startup".into(),
+                vec![
+                    CandidateHit::with_source("src/main.rs", None, 0.55, CandidateSource::Zoekt),
+                    CandidateHit::with_source(
+                        "src\\boot_test.rs",
+                        None,
+                        0.80,
+                        CandidateSource::Zoekt,
+                    ),
+                ],
+            )])),
+            ..Default::default()
+        };
+        let mut cache = RetrievalCache::new();
+        let mut roles = HashMap::new();
+        roles.insert(
+            "src/main.rs".to_string(),
+            codestory_store::FileRole::Entrypoint,
+        );
+        roles.insert(
+            "src/boot_test.rs".to_string(),
+            codestory_store::FileRole::Test,
+        );
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: roles,
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor.execute("startup", Some(500)).expect("query");
+        let role_by_path = result
+            .hits
+            .iter()
+            .map(|hit| (hit.file_path.as_str(), hit.file_role))
+            .collect::<HashMap<_, _>>();
+        assert_eq!(
+            role_by_path.get("src/main.rs").copied().flatten(),
+            Some(codestory_store::FileRole::Entrypoint)
+        );
+        assert_eq!(
+            role_by_path.get("src\\boot_test.rs").copied().flatten(),
+            Some(codestory_store::FileRole::Test)
+        );
+    }
+
+    #[test]
+    fn executor_infers_file_role_when_storage_lookup_misses() {
+        let mock = MockSidecarSearch {
+            zoekt: Mutex::new(HashMap::from([(
+                "startup".into(),
+                vec![CandidateHit::with_source(
+                    "fixtures/generated/boot_test.rs",
+                    None,
+                    0.80,
+                    CandidateSource::Zoekt,
+                )],
+            )])),
+            ..Default::default()
+        };
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor.execute("startup", Some(500)).expect("query");
+        assert_eq!(
+            result.hits.first().and_then(|hit| hit.file_role),
+            Some(codestory_store::FileRole::Generated)
+        );
+    }
+
+    #[test]
+    fn executor_does_not_use_repo_text_diagnostic_for_natural_language_queries() {
+        let mock = MockSidecarSearch {
+            zoekt: Mutex::new(HashMap::from([(
+                "how does startup sequence work".into(),
+                vec![CandidateHit::with_source(
+                    "src/main.rs",
+                    None,
+                    0.7,
+                    CandidateSource::Zoekt,
+                )],
+            )])),
+            ..Default::default()
+        };
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: &mock,
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor
+            .execute("how does startup sequence work", Some(500))
+            .expect("query");
+        assert!(
+            result
+                .hits
+                .iter()
+                .all(|hit| hit.file_path != "docs/startup.md")
+        );
+        assert!(
+            result
+                .trace
+                .stages
+                .iter()
+                .all(|stage| stage.stage != RetrievalStageKind::Stage3RepoTextFallback)
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/generation.rs
+++ b/crates/codestory-retrieval/src/generation.rs
@@ -1,0 +1,444 @@
+use codestory_contracts::graph::NodeKind;
+use codestory_store::{LlmSymbolDoc, RetrievalIndexManifest, Store};
+
+pub const SIDECAR_SCHEMA_VERSION: i32 = 1;
+pub const SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED: &str =
+    "sidecar_semantic_doc_embedding_contract_changed";
+const STALENESS_DOC_BATCH_SIZE: usize = 1024;
+
+pub fn sidecar_generation_id(project_id: &str, sidecar_input_hash: &str) -> String {
+    let suffix = sidecar_input_hash.chars().take(16).collect::<String>();
+    format!("{project_id}-{suffix}")
+}
+
+pub fn sidecar_qdrant_collection(project_id: &str, sidecar_input_hash: &str) -> String {
+    let suffix = sidecar_input_hash.chars().take(16).collect::<String>();
+    format!("codestory_{project_id}_{suffix}")
+}
+
+pub fn manifest_has_current_sidecar_contract(
+    project_id: &str,
+    manifest: &RetrievalIndexManifest,
+) -> bool {
+    let Some(hash) = manifest.sidecar_input_hash.as_deref() else {
+        return false;
+    };
+    let expected_generation = sidecar_generation_id(project_id, hash);
+    let expected_collection = sidecar_qdrant_collection(project_id, hash);
+    !hash.trim().is_empty()
+        && manifest.sidecar_schema_version == Some(SIDECAR_SCHEMA_VERSION)
+        && manifest.sidecar_generation.as_deref() == Some(expected_generation.as_str())
+        && manifest.qdrant_collection == expected_collection
+        && manifest.projection_count.is_some_and(|count| count >= 0)
+}
+
+pub fn manifest_staleness_reason(
+    storage: &Store,
+    manifest: &RetrievalIndexManifest,
+) -> Option<String> {
+    let embedding_backend = crate::embeddings::embedding_runtime_id();
+    if manifest.embedding_backend.as_deref() != Some(embedding_backend.as_str()) {
+        return Some(format!(
+            "sidecar_embedding_backend_changed: manifest={} current={embedding_backend}",
+            manifest.embedding_backend.as_deref().unwrap_or("<missing>")
+        ));
+    }
+
+    let embedding_dim = i32::try_from(crate::embeddings::qdrant_vector_dim())
+        .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
+    if manifest.embedding_dim != Some(embedding_dim) {
+        return Some(format!(
+            "sidecar_embedding_dim_changed: manifest={} current={embedding_dim}",
+            manifest
+                .embedding_dim
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "<missing>".into())
+        ));
+    }
+
+    if let Some(expected_count) = manifest.projection_count {
+        match collect_sidecar_semantic_doc_stats(storage) {
+            Ok(stats) => {
+                if stats.doc_count == 0 {
+                    return Some(
+                        "sidecar_semantic_doc_count_unavailable: no sidecar-eligible stored docs"
+                            .into(),
+                    );
+                }
+                if stats.mixed_embedding_profiles
+                    || stats.mixed_embedding_models
+                    || stats.mixed_embedding_backends
+                    || stats.mixed_dimensions
+                    || stats.mixed_doc_shapes
+                    || stats.embedding_profile.as_deref() != Some("bge-base-en-v1.5")
+                    || stats.embedding_dim
+                        != Some(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32)
+                    || !stats
+                        .embedding_model
+                        .as_deref()
+                        .is_some_and(|model| model.contains("bge-base-en-v1.5"))
+                {
+                    return Some(SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED.into());
+                }
+                if i64::from(stats.doc_count) != expected_count {
+                    return Some(format!(
+                        "sidecar_semantic_doc_count_changed: manifest={expected_count} current={}",
+                        stats.doc_count
+                    ));
+                }
+            }
+            Err(error) => {
+                return Some(format!("sidecar_semantic_doc_count_unavailable: {error}"));
+            }
+        }
+    }
+
+    match storage.max_indexed_file_modification_time() {
+        Ok(Some(max_mtime)) if max_mtime > manifest.built_at_epoch_ms => Some(format!(
+            "indexed_file_newer_than_sidecar_manifest: file_mtime={max_mtime} manifest_built_at={}",
+            manifest.built_at_epoch_ms
+        )),
+        Err(error) => Some(format!("indexed_file_mtime_unavailable: {error}")),
+        _ => None,
+    }
+}
+
+pub fn manifest_unavailable_reason(
+    project_id: &str,
+    storage: &Store,
+    manifest: &RetrievalIndexManifest,
+) -> Option<String> {
+    if !manifest_has_current_sidecar_contract(project_id, manifest) {
+        return Some("sidecar_manifest_generation_contract_missing".into());
+    }
+    manifest_staleness_reason(storage, manifest)
+        .map(|reason| format!("sidecar_manifest_stale: {reason}"))
+}
+
+pub fn manifest_sidecar_generation(manifest: &RetrievalIndexManifest) -> &str {
+    manifest
+        .sidecar_generation
+        .as_deref()
+        .expect("validated sidecar manifest has a generation id")
+}
+
+pub(crate) fn sidecar_semantic_doc_is_product_eligible(doc: &LlmSymbolDoc) -> bool {
+    sidecar_semantic_node_kind(doc.kind) && sidecar_stored_embedding_is_product_compatible(doc)
+}
+
+pub(crate) fn sidecar_semantic_node_kind(kind: NodeKind) -> bool {
+    matches!(
+        kind,
+        NodeKind::STRUCT
+            | NodeKind::CLASS
+            | NodeKind::INTERFACE
+            | NodeKind::ANNOTATION
+            | NodeKind::UNION
+            | NodeKind::ENUM
+            | NodeKind::TYPEDEF
+            | NodeKind::FUNCTION
+            | NodeKind::METHOD
+            | NodeKind::MACRO
+            | NodeKind::GLOBAL_VARIABLE
+            | NodeKind::CONSTANT
+            | NodeKind::ENUM_CONSTANT
+    )
+}
+
+fn sidecar_stored_embedding_is_product_compatible(doc: &LlmSymbolDoc) -> bool {
+    if doc.embedding_dim as usize != crate::embeddings::RETRIEVAL_EMBEDDING_DIM
+        || doc.embedding.len() != crate::embeddings::RETRIEVAL_EMBEDDING_DIM
+        || doc.embedding.iter().any(|value| !value.is_finite())
+    {
+        return false;
+    }
+    if doc.embedding_profile.as_deref() != Some("bge-base-en-v1.5") {
+        return false;
+    }
+    if !doc.embedding_model.contains("bge-base-en-v1.5") {
+        return false;
+    }
+    matches!(
+        doc.embedding_backend
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("onnx" | "llamacpp" | "llama_cpp")
+    )
+}
+
+#[derive(Default)]
+struct SidecarSemanticDocStats {
+    doc_count: u32,
+    embedding_profile: Option<String>,
+    embedding_model: Option<String>,
+    embedding_backend: Option<String>,
+    embedding_dim: Option<u32>,
+    doc_shape: Option<String>,
+    mixed_embedding_profiles: bool,
+    mixed_embedding_models: bool,
+    mixed_embedding_backends: bool,
+    mixed_dimensions: bool,
+    mixed_doc_shapes: bool,
+}
+
+fn collect_sidecar_semantic_doc_stats(storage: &Store) -> Result<SidecarSemanticDocStats, String> {
+    let mut stats = SidecarSemanticDocStats::default();
+    let mut first_profile: Option<Option<String>> = None;
+    let mut first_model: Option<Option<String>> = None;
+    let mut first_backend: Option<Option<String>> = None;
+    let mut first_dim: Option<Option<u32>> = None;
+    let mut first_shape: Option<Option<String>> = None;
+    let mut after = None;
+
+    loop {
+        let docs = storage
+            .get_llm_symbol_docs_batch_after(after, STALENESS_DOC_BATCH_SIZE)
+            .map_err(|error| error.to_string())?;
+        if docs.is_empty() {
+            break;
+        }
+        after = docs.last().map(|doc| doc.node_id);
+        for doc in docs
+            .into_iter()
+            .filter(sidecar_semantic_doc_is_product_eligible)
+        {
+            stats.doc_count = stats.doc_count.saturating_add(1);
+            observe_optional_string(
+                &mut first_profile,
+                &mut stats.embedding_profile,
+                &mut stats.mixed_embedding_profiles,
+                doc.embedding_profile.as_deref(),
+            );
+            observe_optional_string(
+                &mut first_model,
+                &mut stats.embedding_model,
+                &mut stats.mixed_embedding_models,
+                Some(&doc.embedding_model),
+            );
+            observe_optional_string(
+                &mut first_backend,
+                &mut stats.embedding_backend,
+                &mut stats.mixed_embedding_backends,
+                doc.embedding_backend.as_deref(),
+            );
+            observe_optional_u32(
+                &mut first_dim,
+                &mut stats.embedding_dim,
+                &mut stats.mixed_dimensions,
+                Some(doc.embedding_dim),
+            );
+            observe_optional_string(
+                &mut first_shape,
+                &mut stats.doc_shape,
+                &mut stats.mixed_doc_shapes,
+                doc.doc_shape.as_deref(),
+            );
+        }
+    }
+
+    Ok(stats)
+}
+
+fn observe_optional_string(
+    first: &mut Option<Option<String>>,
+    value: &mut Option<String>,
+    mixed: &mut bool,
+    current: Option<&str>,
+) {
+    let current = current.map(str::to_string);
+    match first {
+        Some(first) if first != &current => *mixed = true,
+        Some(_) => {}
+        None => {
+            *value = current.clone();
+            *first = Some(current);
+        }
+    }
+}
+
+fn observe_optional_u32(
+    first: &mut Option<Option<u32>>,
+    value: &mut Option<u32>,
+    mixed: &mut bool,
+    current: Option<u32>,
+) {
+    match first {
+        Some(first) if first != &current => *mixed = true,
+        Some(_) => {}
+        None => {
+            *value = current;
+            *first = Some(current);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::graph::{Node, NodeId, NodeKind};
+    use tempfile::TempDir;
+
+    fn manifest(project_id: &str, hash: &str) -> RetrievalIndexManifest {
+        RetrievalIndexManifest {
+            project_id: project_id.into(),
+            zoekt_version: "zoekt-real-v1".into(),
+            qdrant_collection: sidecar_qdrant_collection(project_id, hash),
+            scip_revision: Some("graph-test".into()),
+            built_at_epoch_ms: 123,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+            embedding_dim: Some(768),
+            sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+            sidecar_input_hash: Some(hash.into()),
+            sidecar_generation: Some(sidecar_generation_id(project_id, hash)),
+            projection_count: Some(7),
+        }
+    }
+
+    #[test]
+    fn current_sidecar_contract_requires_derived_generation_and_collection() {
+        let project_id = "proj";
+        let hash = "deadbeefcafebabe1234";
+        let current = manifest(project_id, hash);
+        assert!(manifest_has_current_sidecar_contract(project_id, &current));
+
+        let mut stale_generation = current.clone();
+        stale_generation.sidecar_generation = Some("proj-old".into());
+        assert!(!manifest_has_current_sidecar_contract(
+            project_id,
+            &stale_generation
+        ));
+
+        let mut stale_collection = current.clone();
+        stale_collection.qdrant_collection = "codestory_proj_old".into();
+        assert!(!manifest_has_current_sidecar_contract(
+            project_id,
+            &stale_collection
+        ));
+
+        let mut legacy = current;
+        legacy.sidecar_schema_version = None;
+        assert!(!manifest_has_current_sidecar_contract(project_id, &legacy));
+    }
+
+    #[test]
+    fn manifest_staleness_rejects_embedding_contract_drift() {
+        let project = TempDir::new().expect("project");
+        let storage_path = project.path().join("codestory.db");
+        let storage = Store::open(&storage_path).expect("open store");
+        let mut manifest = manifest("proj", "deadbeefcafebabe1234");
+        manifest.embedding_backend = Some("other-backend:768".into());
+
+        let reason = manifest_staleness_reason(&storage, &manifest)
+            .expect("embedding backend drift should stale manifest");
+
+        assert!(reason.contains("sidecar_embedding_backend_changed"));
+    }
+
+    #[test]
+    fn manifest_staleness_rejects_mixed_semantic_doc_shapes() {
+        let project = TempDir::new().expect("project");
+        let storage_path = project.path().join("codestory.db");
+        let mut storage = Store::open(&storage_path).expect("open store");
+        storage
+            .insert_nodes_batch(&[
+                Node {
+                    id: NodeId(1),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "do_work_1".into(),
+                    ..Default::default()
+                },
+                Node {
+                    id: NodeId(2),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "do_work_2".into(),
+                    ..Default::default()
+                },
+            ])
+            .expect("nodes");
+        storage
+            .upsert_llm_symbol_docs_batch(&[
+                semantic_doc(1, "semantic_doc_version=4;scope=durable_symbols"),
+                semantic_doc(
+                    2,
+                    "semantic_doc_version=4;scope=durable_symbols;alias_mode=alias_variant",
+                ),
+            ])
+            .expect("docs");
+        let mut manifest = manifest("proj", "deadbeefcafebabe1234");
+        manifest.embedding_backend = Some(crate::embeddings::embedding_runtime_id());
+        manifest.embedding_dim = Some(crate::embeddings::qdrant_vector_dim() as i32);
+
+        let reason =
+            manifest_staleness_reason(&storage, &manifest).expect("mixed shapes should stale");
+
+        assert_eq!(reason, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED);
+    }
+
+    #[test]
+    fn manifest_staleness_counts_only_sidecar_eligible_semantic_docs() {
+        let project = TempDir::new().expect("project");
+        let storage_path = project.path().join("codestory.db");
+        let mut storage = Store::open(&storage_path).expect("open store");
+        storage
+            .insert_nodes_batch(&[
+                Node {
+                    id: NodeId(1),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "do_work".into(),
+                    ..Default::default()
+                },
+                Node {
+                    id: NodeId(2),
+                    kind: NodeKind::VARIABLE,
+                    serialized_name: "current".into(),
+                    ..Default::default()
+                },
+            ])
+            .expect("nodes");
+        storage
+            .upsert_llm_symbol_docs_batch(&[
+                semantic_doc(1, "semantic_doc_version=4;scope=durable_symbols"),
+                LlmSymbolDoc {
+                    kind: NodeKind::VARIABLE,
+                    doc_shape: Some(
+                        "semantic_doc_version=4;scope=local_symbol;variable=true".into(),
+                    ),
+                    ..semantic_doc(2, "semantic_doc_version=4;scope=local_symbol")
+                },
+            ])
+            .expect("docs");
+        let mut manifest = manifest("proj", "deadbeefcafebabe1234");
+        manifest.embedding_backend = Some(crate::embeddings::embedding_runtime_id());
+        manifest.embedding_dim = Some(crate::embeddings::qdrant_vector_dim() as i32);
+        manifest.projection_count = Some(1);
+
+        let reason = manifest_staleness_reason(&storage, &manifest);
+
+        assert_eq!(reason, None);
+    }
+
+    fn semantic_doc(node_id: i64, doc_shape: &str) -> LlmSymbolDoc {
+        LlmSymbolDoc {
+            node_id: NodeId(node_id),
+            file_node_id: None,
+            kind: NodeKind::FUNCTION,
+            display_name: format!("do_work_{node_id}"),
+            qualified_name: Some(format!("pkg::do_work_{node_id}")),
+            file_path: Some("src/lib.rs".into()),
+            start_line: Some(1),
+            doc_text: "semantic_doc_version: 4\nsymbol_kind: FUNCTION\nname: do_work".into(),
+            doc_version: 4,
+            doc_hash: format!("hash-{node_id}"),
+            embedding_profile: Some("bge-base-en-v1.5".into()),
+            embedding_model: "BAAI/bge-base-en-v1.5-local|backend=onnx".into(),
+            embedding_backend: Some("onnx".into()),
+            embedding_dim: crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            doc_shape: Some(doc_shape.into()),
+            embedding: vec![0.01; crate::embeddings::RETRIEVAL_EMBEDDING_DIM],
+            updated_at_epoch_ms: 123,
+        }
+    }
+}

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,0 +1,403 @@
+use crate::capabilities::SidecarCapabilities;
+use crate::config::{
+    QDRANT_HEALTH_BUDGET, SidecarLayout, ZOEKT_HEALTH_BUDGET, qdrant_semantic_vectors_enabled,
+};
+use crate::embeddings::manifest_embedding_backend_is_product;
+use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
+use crate::qdrant_client::QdrantClient;
+use crate::scip_client::{ScipAvailability, ScipClient};
+use crate::zoekt_client::ZoektClient;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComponentStatus {
+    Healthy,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentHealth {
+    pub name: String,
+    pub status: ComponentStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    pub detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub degraded_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "capabilities_are_empty")]
+    pub capabilities: SidecarCapabilities,
+}
+
+fn capabilities_are_empty(cap: &SidecarCapabilities) -> bool {
+    !cap.lexical && !cap.semantic && !cap.graph
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrievalStatusReport {
+    pub retrieval_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub degraded_reason: Option<String>,
+    pub zoekt: ComponentHealth,
+    pub qdrant: ComponentHealth,
+    pub scip: ComponentHealth,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<codestory_store::RetrievalIndexManifest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InfrastructureHealth {
+    pub zoekt_reachable: bool,
+    pub qdrant_reachable: bool,
+    pub embed_reachable: bool,
+    pub zoekt_detail: String,
+    pub qdrant_detail: String,
+    pub embed_detail: String,
+}
+
+fn unavailable_component(name: &str, reason: &str) -> ComponentHealth {
+    ComponentHealth {
+        name: name.into(),
+        status: ComponentStatus::Unavailable,
+        latency_ms: None,
+        detail: reason.into(),
+        degraded_reason: Some(reason.into()),
+        capabilities: SidecarCapabilities::NONE,
+    }
+}
+
+pub fn unavailable_status_report(
+    reason: impl Into<String>,
+    manifest: Option<codestory_store::RetrievalIndexManifest>,
+) -> RetrievalStatusReport {
+    let reason = reason.into();
+    RetrievalStatusReport {
+        retrieval_mode: "unavailable".into(),
+        degraded_reason: Some(reason.clone()),
+        zoekt: unavailable_component("zoekt", &reason),
+        qdrant: unavailable_component("qdrant", &reason),
+        scip: unavailable_component("scip", &reason),
+        manifest,
+    }
+}
+
+/// Zoekt + Qdrant + embedding reachability without a project collection (used during bootstrap).
+pub fn probe_infrastructure_health(layout: &SidecarLayout) -> InfrastructureHealth {
+    let zoekt_probe = ZoektClient::new(layout).health_probe();
+    let qdrant_client = QdrantClient::new(layout);
+    let qdrant_probe = qdrant_client.list_collections_probe();
+    let embed_probe = crate::embeddings::probe_product_embedding_runtime();
+    InfrastructureHealth {
+        zoekt_reachable: zoekt_probe.reachable,
+        qdrant_reachable: qdrant_probe.reachable,
+        embed_reachable: embed_probe.reachable,
+        zoekt_detail: zoekt_probe.detail,
+        qdrant_detail: qdrant_probe.detail,
+        embed_detail: embed_probe.detail,
+    }
+}
+
+fn zoekt_capabilities(
+    layout: &SidecarLayout,
+    sidecar_generation: &str,
+    reachable: bool,
+    _zoekt_client: &ZoektClient,
+) -> SidecarCapabilities {
+    let shard_dir = crate::zoekt_index::shard_dir_for(&layout.zoekt_data_dir, sidecar_generation);
+    if !crate::zoekt_index::shard_has_lexical_index(&shard_dir) {
+        return SidecarCapabilities::NONE;
+    }
+    let _ = reachable;
+    SidecarCapabilities {
+        lexical: true,
+        semantic: false,
+        graph: false,
+    }
+}
+
+fn qdrant_capabilities(
+    layout: &SidecarLayout,
+    collection: &str,
+    probe: &crate::qdrant_client::QdrantHealthProbe,
+    expected_points: Option<u64>,
+    product_embedding_backend: bool,
+    current_product_embedding_backend: bool,
+) -> SidecarCapabilities {
+    if !probe.reachable || !probe.collection_exists {
+        return SidecarCapabilities::NONE;
+    }
+    if qdrant_point_count_incomplete(probe, expected_points) {
+        return SidecarCapabilities::NONE;
+    }
+    let client = QdrantClient::new(layout);
+    let semantic = !QdrantClient::is_collection_stubbed(&layout.qdrant_data_dir, collection)
+        && qdrant_semantic_vectors_enabled()
+        && product_embedding_backend
+        && current_product_embedding_backend
+        && client.semantic_search_smoke(collection);
+    SidecarCapabilities {
+        lexical: false,
+        semantic,
+        graph: false,
+    }
+}
+
+fn qdrant_point_count_incomplete(
+    probe: &crate::qdrant_client::QdrantHealthProbe,
+    expected_points: Option<u64>,
+) -> bool {
+    matches!(
+        (probe.point_count, expected_points),
+        (Some(actual), Some(expected)) if actual < expected
+    )
+}
+
+fn scip_capabilities(availability: &ScipAvailability, project_dir: &Path) -> SidecarCapabilities {
+    match availability {
+        ScipAvailability::Ready { revision }
+            if revision != "stub-v1" && has_real_scip_artifact(project_dir) =>
+        {
+            SidecarCapabilities {
+                lexical: false,
+                semantic: false,
+                graph: true,
+            }
+        }
+        ScipAvailability::Ready { .. } => SidecarCapabilities::NONE,
+        ScipAvailability::Unavailable { .. } => SidecarCapabilities::NONE,
+    }
+}
+
+fn has_real_scip_artifact(project_dir: &Path) -> bool {
+    project_dir
+        .join(crate::scip_index::SCIP_SYMBOLS_FILE)
+        .is_file()
+        && project_dir
+            .join(crate::scip_index::SCIP_INDEX_FILE)
+            .is_file()
+        && project_dir.join("revision.txt").is_file()
+        && !project_dir.join("index.scip.stub").is_file()
+}
+
+pub fn probe_sidecar_health(
+    layout: &SidecarLayout,
+    project_id: &str,
+    manifest: Option<codestory_store::RetrievalIndexManifest>,
+) -> RetrievalStatusReport {
+    if let Some(manifest) = manifest.as_ref() {
+        if !manifest_has_current_sidecar_contract(project_id, manifest) {
+            return unavailable_status_report(
+                "sidecar_manifest_generation_contract_missing",
+                Some(manifest.clone()),
+            );
+        }
+    } else {
+        return unavailable_status_report("retrieval_manifest_missing", None);
+    }
+
+    let manifest = manifest.expect("manifest validation returned above");
+    let zoekt_client = ZoektClient::new(layout);
+    let zoekt_probe = zoekt_client.health_probe();
+    let sidecar_generation = manifest_sidecar_generation(&manifest);
+    let zoekt_capabilities = zoekt_capabilities(
+        layout,
+        sidecar_generation,
+        zoekt_probe.reachable,
+        &zoekt_client,
+    );
+    let zoekt_stub = zoekt_probe.reachable && !zoekt_capabilities.lexical;
+    let zoekt = ComponentHealth {
+        name: "zoekt".into(),
+        status: if !zoekt_probe.reachable {
+            ComponentStatus::Unavailable
+        } else if zoekt_stub {
+            ComponentStatus::Degraded
+        } else if zoekt_probe.latency_ms <= ZOEKT_HEALTH_BUDGET.as_millis() as u64 {
+            ComponentStatus::Healthy
+        } else {
+            ComponentStatus::Degraded
+        },
+        latency_ms: Some(zoekt_probe.latency_ms),
+        detail: zoekt_probe.detail,
+        degraded_reason: if !zoekt_probe.reachable {
+            Some("zoekt_unreachable".into())
+        } else if zoekt_stub {
+            Some("zoekt_stub".into())
+        } else {
+            None
+        },
+        capabilities: zoekt_capabilities,
+    };
+
+    let collection = manifest.qdrant_collection.clone();
+    let qdrant_probe = QdrantClient::new(layout).health_probe(&collection);
+    let expected_qdrant_points = manifest
+        .projection_count
+        .and_then(|count| u64::try_from(count).ok());
+    let qdrant_point_count_incomplete =
+        qdrant_point_count_incomplete(&qdrant_probe, expected_qdrant_points);
+    let product_embedding_backend =
+        manifest_embedding_backend_is_product(manifest.embedding_backend.as_deref());
+    let current_embedding_backend = crate::embeddings::embedding_runtime_id();
+    let current_product_embedding_backend =
+        manifest_embedding_backend_is_product(Some(current_embedding_backend.as_str()));
+    let qdrant_capabilities = qdrant_capabilities(
+        layout,
+        &collection,
+        &qdrant_probe,
+        expected_qdrant_points,
+        product_embedding_backend,
+        current_product_embedding_backend,
+    );
+    let qdrant_semantic_stub =
+        qdrant_probe.reachable && qdrant_probe.collection_exists && !qdrant_capabilities.semantic;
+    let qdrant = ComponentHealth {
+        name: "qdrant".into(),
+        status: if !qdrant_probe.reachable {
+            ComponentStatus::Unavailable
+        } else if !qdrant_probe.collection_exists || qdrant_semantic_stub {
+            ComponentStatus::Degraded
+        } else if qdrant_probe.latency_ms <= QDRANT_HEALTH_BUDGET.as_millis() as u64 {
+            ComponentStatus::Healthy
+        } else {
+            ComponentStatus::Degraded
+        },
+        latency_ms: Some(qdrant_probe.latency_ms),
+        detail: qdrant_probe.detail,
+        degraded_reason: if !qdrant_probe.reachable {
+            Some("qdrant_unreachable".into())
+        } else if !qdrant_probe.collection_exists {
+            Some("qdrant_collection_missing".into())
+        } else if qdrant_point_count_incomplete {
+            Some("qdrant_point_count_incomplete".into())
+        } else if !product_embedding_backend {
+            Some("qdrant_non_product_embedding_backend".into())
+        } else if !current_product_embedding_backend {
+            Some("qdrant_current_embedding_backend_not_product".into())
+        } else if qdrant_semantic_stub {
+            Some(if qdrant_semantic_vectors_enabled() {
+                "qdrant_semantic_smoke_failed".into()
+            } else {
+                "qdrant_hash_vectors_only".into()
+            })
+        } else {
+            None
+        },
+        capabilities: qdrant_capabilities,
+    };
+
+    let scip_project_dir = layout.scip_project_dir(sidecar_generation);
+    let scip_probe = ScipClient::health_probe(layout, sidecar_generation);
+    let scip_capabilities = scip_capabilities(&scip_probe.availability, &scip_project_dir);
+    let scip_stub = matches!(&scip_probe.availability, ScipAvailability::Ready { .. })
+        && !scip_capabilities.graph;
+    let (scip_status, scip_degraded) = match &scip_probe.availability {
+        ScipAvailability::Ready { .. } if scip_capabilities.graph => {
+            (ComponentStatus::Healthy, None)
+        }
+        ScipAvailability::Ready { .. } => (ComponentStatus::Degraded, Some("scip_stub".into())),
+        ScipAvailability::Unavailable { reason } => {
+            (ComponentStatus::Unavailable, Some(reason.clone()))
+        }
+    };
+    let scip = ComponentHealth {
+        name: "scip".into(),
+        status: scip_status,
+        latency_ms: None,
+        detail: scip_probe.detail,
+        degraded_reason: scip_degraded.or_else(|| scip_stub.then_some("scip_stub".into())),
+        capabilities: scip_capabilities,
+    };
+
+    let (mode, degraded_reason) = crate::mode::derive_degraded_mode(&zoekt, &qdrant, &scip);
+
+    RetrievalStatusReport {
+        retrieval_mode: mode.as_str().into(),
+        degraded_reason,
+        zoekt,
+        qdrant,
+        scip,
+        manifest: Some(manifest),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SidecarLayout;
+
+    #[test]
+    fn status_reports_unavailable_when_zoekt_down() {
+        let layout = SidecarLayout::from_env();
+        let report = probe_sidecar_health(&layout, "testproject", None);
+        assert_eq!(report.zoekt.name, "zoekt");
+        if report.zoekt.status == ComponentStatus::Unavailable {
+            assert_eq!(report.retrieval_mode, "unavailable");
+        }
+    }
+
+    #[test]
+    fn status_reports_unavailable_for_legacy_manifest_without_generation_contract() {
+        let layout = SidecarLayout::from_env();
+        let manifest = codestory_store::RetrievalIndexManifest {
+            project_id: "testproject".into(),
+            zoekt_version: "zoekt-real-v1".into(),
+            qdrant_collection: QdrantClient::collection_name("testproject"),
+            scip_revision: Some("graph-test".into()),
+            built_at_epoch_ms: 1,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: Some("hash-projection:768".into()),
+            embedding_dim: Some(768),
+            sidecar_schema_version: None,
+            sidecar_input_hash: None,
+            sidecar_generation: None,
+            projection_count: None,
+        };
+
+        let report = probe_sidecar_health(&layout, "testproject", Some(manifest));
+
+        assert_eq!(report.retrieval_mode, "unavailable");
+        assert_eq!(
+            report.degraded_reason.as_deref(),
+            Some("sidecar_manifest_generation_contract_missing")
+        );
+        assert_eq!(report.zoekt.capabilities, SidecarCapabilities::NONE);
+        assert_eq!(report.qdrant.capabilities, SidecarCapabilities::NONE);
+        assert_eq!(report.scip.capabilities, SidecarCapabilities::NONE);
+    }
+
+    #[test]
+    fn qdrant_point_count_gap_blocks_semantic_capability() {
+        let probe = crate::qdrant_client::QdrantHealthProbe {
+            reachable: true,
+            latency_ms: 1,
+            collection_exists: true,
+            point_count: Some(10),
+            detail: "http 200 points_count=10".into(),
+        };
+
+        assert!(qdrant_point_count_incomplete(&probe, Some(11)));
+        assert!(!qdrant_point_count_incomplete(&probe, Some(10)));
+        assert!(!qdrant_point_count_incomplete(&probe, None));
+    }
+
+    #[test]
+    fn qdrant_capability_requires_product_current_backend() {
+        let layout = SidecarLayout::from_env();
+        let probe = crate::qdrant_client::QdrantHealthProbe {
+            reachable: true,
+            latency_ms: 1,
+            collection_exists: true,
+            point_count: Some(10),
+            detail: "http 200 points_count=10".into(),
+        };
+
+        let capabilities =
+            qdrant_capabilities(&layout, "codestory_test", &probe, Some(10), true, false);
+
+        assert_eq!(capabilities, SidecarCapabilities::NONE);
+    }
+}

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1,0 +1,1105 @@
+use crate::config::{
+    SidecarLayout, ZOEKT_REAL_VERSION_PIN, dir_size_bytes, qdrant_enabled,
+    qdrant_semantic_vectors_enabled, zoekt_enabled,
+};
+use crate::generation::{
+    SIDECAR_SCHEMA_VERSION, manifest_has_current_sidecar_contract, manifest_unavailable_reason,
+    sidecar_generation_id,
+};
+use crate::health::probe_sidecar_health;
+use crate::qdrant_client::{QDRANT_INDEX_UPSERT_BATCH_SIZE, QdrantClient, QdrantUpsertPoint};
+use crate::scip_index::emit_scip_artifacts_from_store;
+use crate::zoekt_client::ZoektClient;
+use crate::zoekt_index::{build_zoekt_shard, lexical_input_fingerprint};
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use codestory_store::{FileRole, LlmSymbolDoc, RetrievalIndexManifest, Store};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::Path;
+use tracing::{info, warn};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FinalizeIndexOutcome {
+    pub project_id: String,
+    pub manifest: RetrievalIndexManifest,
+    pub degraded_modes: Vec<String>,
+    pub zoekt_stubbed: bool,
+    pub qdrant_stubbed: bool,
+    pub scip_stubbed: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProjectQdrantRepairOutcome {
+    pub project_id: String,
+    pub qdrant_collection: String,
+    pub collection_existed: bool,
+    pub repaired: bool,
+    pub points_upserted: usize,
+    pub skipped_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SidecarInputFingerprint {
+    hash: String,
+    projection_count: i64,
+    lexical_file_count: u32,
+    lexical_hash: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SidecarStubFlags {
+    zoekt_stubbed: bool,
+    qdrant_stubbed: bool,
+    scip_stubbed: bool,
+}
+
+const SIDECAR_INPUT_BATCH_SIZE: usize = QDRANT_INDEX_UPSERT_BATCH_SIZE * 8;
+
+pub fn project_id_for_root(project_root: &Path) -> String {
+    let canonical = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    fnv1a_hex(canonical.to_string_lossy().as_bytes())
+}
+
+pub fn repair_project_qdrant_collection(
+    project_root: &Path,
+    storage_path: &Path,
+) -> Result<Option<ProjectQdrantRepairOutcome>> {
+    if !storage_path.is_file() {
+        return Ok(None);
+    }
+
+    let project_id = project_id_for_root(project_root);
+    let storage = Store::open(storage_path).context("open storage for qdrant project repair")?;
+    let Some(manifest) = storage
+        .get_retrieval_index_manifest(&project_id)
+        .context("load retrieval manifest for qdrant project repair")?
+    else {
+        return Ok(None);
+    };
+    if let Some(reason) = manifest_unavailable_reason(&project_id, &storage, &manifest) {
+        return Ok(Some(ProjectQdrantRepairOutcome {
+            project_id,
+            qdrant_collection: manifest.qdrant_collection,
+            collection_existed: false,
+            repaired: false,
+            points_upserted: 0,
+            skipped_reason: Some(reason),
+        }));
+    }
+    drop(storage);
+
+    if !qdrant_enabled() {
+        return Ok(Some(ProjectQdrantRepairOutcome {
+            project_id,
+            qdrant_collection: manifest.qdrant_collection,
+            collection_existed: false,
+            repaired: false,
+            points_upserted: 0,
+            skipped_reason: Some("qdrant_disabled".into()),
+        }));
+    }
+
+    let layout = SidecarLayout::from_env();
+    layout.ensure_data_dirs()?;
+    let qdrant_client = QdrantClient::new(&layout);
+    let probe = qdrant_client.health_probe(&manifest.qdrant_collection);
+    if !probe.reachable {
+        return Ok(Some(ProjectQdrantRepairOutcome {
+            project_id,
+            qdrant_collection: manifest.qdrant_collection,
+            collection_existed: false,
+            repaired: false,
+            points_upserted: 0,
+            skipped_reason: Some(format!("qdrant_unreachable: {}", probe.detail)),
+        }));
+    }
+
+    let collection_existed = probe.collection_exists;
+    if collection_existed
+        && qdrant_client.semantic_search_smoke(&manifest.qdrant_collection)
+        && qdrant_ready_point_count(
+            &qdrant_client,
+            &manifest.qdrant_collection,
+            manifest.projection_count.unwrap_or(0),
+        )
+        .is_some()
+    {
+        return Ok(Some(ProjectQdrantRepairOutcome {
+            project_id,
+            qdrant_collection: manifest.qdrant_collection,
+            collection_existed,
+            repaired: false,
+            points_upserted: 0,
+            skipped_reason: Some("collection_healthy".into()),
+        }));
+    }
+
+    let points_upserted = upsert_qdrant_points_from_store(
+        storage_path,
+        project_root,
+        &qdrant_client,
+        &manifest.qdrant_collection,
+    )
+    .context("repair qdrant project collection from indexed symbol projection")?;
+    if points_upserted == 0 {
+        return Ok(Some(ProjectQdrantRepairOutcome {
+            project_id,
+            qdrant_collection: manifest.qdrant_collection,
+            collection_existed,
+            repaired: false,
+            points_upserted: 0,
+            skipped_reason: Some("no_indexed_symbol_points".into()),
+        }));
+    }
+
+    Ok(Some(ProjectQdrantRepairOutcome {
+        project_id,
+        qdrant_collection: manifest.qdrant_collection,
+        collection_existed,
+        repaired: true,
+        points_upserted,
+        skipped_reason: None,
+    }))
+}
+
+pub fn finalize_index(project_root: &Path, storage_path: &Path) -> Result<FinalizeIndexOutcome> {
+    let layout = SidecarLayout::from_env();
+    layout.ensure_data_dirs()?;
+
+    let project_id = project_id_for_root(project_root);
+    let degraded_modes = Vec::new();
+    let zoekt_stubbed = false;
+    let qdrant_stubbed = false;
+    let scip_stubbed = false;
+
+    let zoekt_client = ZoektClient::new(&layout);
+    let zoekt_probe = zoekt_client.health_probe();
+    if !zoekt_enabled() {
+        bail!("Zoekt sidecar is mandatory; CODESTORY_ZOEKT_ENABLED=false is unsupported");
+    }
+    if !zoekt_probe.reachable {
+        bail!(
+            "Zoekt sidecar is mandatory and must be reachable at {} before indexing {project_id}: {}",
+            layout.zoekt_base_url(),
+            zoekt_probe.detail
+        );
+    }
+
+    let qdrant_client = QdrantClient::new(&layout);
+    let embedding_backend = crate::embeddings::embedding_runtime_id();
+    let embedding_dim = i32::try_from(crate::embeddings::qdrant_vector_dim())
+        .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
+    if !qdrant_enabled() {
+        bail!("Qdrant sidecar is mandatory; CODESTORY_QDRANT_ENABLED=false is unsupported");
+    }
+    crate::embeddings::ensure_product_embedding_backend()?;
+
+    let mut storage =
+        Store::open(storage_path).context("open storage for retrieval sidecar input")?;
+    ensure_search_symbol_projection(&mut storage)?;
+    let sidecar_input = compute_sidecar_input_fingerprint(
+        &storage,
+        project_root,
+        &project_id,
+        &embedding_backend,
+        embedding_dim,
+    )?;
+    let previous_manifest = storage
+        .get_retrieval_index_manifest(&project_id)
+        .context("load previous retrieval_index_manifest")?;
+    let previous_manifest_unavailable_reason = previous_manifest
+        .as_ref()
+        .and_then(|manifest| manifest_unavailable_reason(&project_id, &storage, manifest));
+    drop(storage);
+
+    if let Some(previous) = previous_manifest.as_ref() {
+        if let Some(reason) = previous_manifest_unavailable_reason.as_ref() {
+            warn!(
+                project_id = %project_id,
+                reason = %reason,
+                "existing retrieval sidecar manifest is stale; rebuilding"
+            );
+        } else if manifest_matches_sidecar_input(
+            previous,
+            &sidecar_input,
+            &embedding_backend,
+            embedding_dim,
+        ) {
+            let status = probe_sidecar_health(&layout, &project_id, Some(previous.clone()));
+            let qdrant_point_count = qdrant_ready_point_count(
+                &qdrant_client,
+                &previous.qdrant_collection,
+                sidecar_input.projection_count,
+            );
+            if status.retrieval_mode == "full" && qdrant_point_count.is_some() {
+                info!(
+                    project_id = %project_id,
+                    sidecar_generation = ?previous.sidecar_generation,
+                    projection_count = sidecar_input.projection_count,
+                    qdrant_point_count = qdrant_point_count.unwrap_or_default(),
+                    lexical_file_count = sidecar_input.lexical_file_count,
+                    "retrieval sidecar generation unchanged; reused existing full sidecars"
+                );
+                return Ok(FinalizeIndexOutcome {
+                    project_id,
+                    manifest: previous.clone(),
+                    degraded_modes,
+                    zoekt_stubbed,
+                    qdrant_stubbed,
+                    scip_stubbed,
+                });
+            }
+            warn!(
+                project_id = %project_id,
+                retrieval_mode = %status.retrieval_mode,
+                degraded_reason = ?status.degraded_reason,
+                qdrant_point_count = ?qdrant_point_count,
+                "sidecar input unchanged but current generation is not healthy; rebuilding"
+            );
+        }
+    }
+
+    let generation = sidecar_generation_id(&project_id, &sidecar_input.hash);
+    let collection = QdrantClient::collection_name_for_generation(&project_id, &sidecar_input.hash);
+    let scip_dir = layout.scip_project_dir(&generation);
+    let mut manifest = retrieval_manifest_for_sidecar(
+        &project_id,
+        &generation,
+        &collection,
+        &embedding_backend,
+        embedding_dim,
+        &sidecar_input,
+    );
+    manifest.scip_revision = read_scip_revision(&scip_dir);
+
+    let existing_status = probe_sidecar_health(&layout, &project_id, Some(manifest.clone()));
+    let zoekt_ready = existing_status.zoekt.capabilities.lexical
+        && crate::zoekt_index::shard_matches_lexical_input(
+            &layout.zoekt_data_dir,
+            &generation,
+            sidecar_input.lexical_file_count,
+            &sidecar_input.lexical_hash,
+        );
+    let qdrant_ready_points = if existing_status.qdrant.capabilities.semantic {
+        qdrant_ready_point_count(&qdrant_client, &collection, sidecar_input.projection_count)
+    } else {
+        None
+    };
+    let scip_ready = existing_status.scip.capabilities.graph;
+
+    if zoekt_ready && qdrant_ready_points.is_some() && scip_ready {
+        manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
+        let status = probe_sidecar_health(&layout, &project_id, Some(manifest.clone()));
+        if status.retrieval_mode == "full" {
+            info!(
+                project_id = %project_id,
+                sidecar_generation = %generation,
+                qdrant_point_count = qdrant_ready_points.unwrap_or_default(),
+                "current generated sidecars already healthy; persisted manifest without rebuild"
+            );
+            return persist_finalized_manifest(
+                storage_path,
+                project_id,
+                manifest,
+                degraded_modes,
+                zoekt_stubbed,
+                qdrant_stubbed,
+                scip_stubbed,
+            );
+        }
+    }
+
+    let zoekt_version = ensure_zoekt_generation(
+        project_root,
+        &layout,
+        &project_id,
+        &generation,
+        zoekt_probe.reachable,
+        zoekt_ready,
+    )?;
+
+    let _qdrant_point_count = ensure_qdrant_collection(
+        storage_path,
+        project_root,
+        &qdrant_client,
+        &project_id,
+        &collection,
+        sidecar_input.projection_count,
+        qdrant_ready_points,
+    )?;
+
+    ensure_scip_artifacts(
+        storage_path,
+        &scip_dir,
+        &project_id,
+        &generation,
+        scip_ready,
+        &mut manifest,
+    )?;
+
+    manifest.zoekt_version = zoekt_version;
+    manifest.scip_revision = read_scip_revision(&scip_dir).or(manifest.scip_revision);
+    manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
+
+    finalize_manifest_after_health_check(
+        storage_path,
+        &layout,
+        &qdrant_client,
+        project_id,
+        &collection,
+        &sidecar_input,
+        manifest,
+        degraded_modes,
+        SidecarStubFlags {
+            zoekt_stubbed,
+            qdrant_stubbed,
+            scip_stubbed,
+        },
+    )
+}
+
+fn ensure_zoekt_generation(
+    project_root: &Path,
+    layout: &SidecarLayout,
+    project_id: &str,
+    generation: &str,
+    zoekt_probe_reachable: bool,
+    mut zoekt_ready: bool,
+) -> Result<String> {
+    if zoekt_ready {
+        info!(project_id = %project_id, sidecar_generation = %generation, "Zoekt lexical shard reused");
+    } else {
+        match build_zoekt_shard(
+            project_root,
+            &layout.zoekt_data_dir,
+            generation,
+            zoekt_probe_reachable,
+        ) {
+            Ok(true) => {
+                zoekt_ready = true;
+                info!(project_id = %project_id, sidecar_generation = %generation, "Zoekt lexical shard built");
+            }
+            Ok(false) => {
+                warn!(project_id = %project_id, "Zoekt shard build produced no files");
+            }
+            Err(error) => bail!("mandatory Zoekt shard build failed for {project_id}: {error}"),
+        }
+    }
+    let shard_dir = crate::zoekt_index::shard_dir_for(&layout.zoekt_data_dir, generation);
+    if !zoekt_ready || !crate::zoekt_index::shard_has_lexical_index(&shard_dir) {
+        bail!("mandatory Zoekt lexical shard is missing for {project_id}");
+    }
+    Ok(ZOEKT_REAL_VERSION_PIN.to_string())
+}
+
+fn ensure_qdrant_collection(
+    storage_path: &Path,
+    project_root: &Path,
+    qdrant_client: &QdrantClient,
+    project_id: &str,
+    collection: &str,
+    projection_count: i64,
+    mut qdrant_ready_points: Option<u64>,
+) -> Result<u64> {
+    let qdrant_probe = qdrant_client.health_probe(collection);
+    if !qdrant_probe.reachable {
+        bail!(
+            "qdrant sidecar is mandatory but unreachable while finalizing retrieval index for {project_id}: {}",
+            qdrant_probe.detail
+        );
+    }
+    if let Some(point_count) = qdrant_ready_points {
+        info!(
+            project_id = %project_id,
+            collection = %collection,
+            qdrant_point_count = point_count,
+            "Qdrant generated collection reused"
+        );
+    } else {
+        let count =
+            upsert_qdrant_points_from_store(storage_path, project_root, qdrant_client, collection)?;
+        if count == 0 {
+            bail!(
+                "mandatory Qdrant semantic collection has no indexed symbol points for {project_id}"
+            );
+        }
+        qdrant_ready_points = qdrant_ready_point_count(qdrant_client, collection, projection_count);
+        if qdrant_ready_points.is_none() {
+            let actual = qdrant_client
+                .count_points_exact(collection)
+                .unwrap_or_default();
+            bail!(
+                "mandatory Qdrant semantic collection incomplete for {project_id}: expected at least {} points, found {actual}",
+                projection_count
+            );
+        }
+        info!(
+            project_id = %project_id,
+            collection = %collection,
+            points = count,
+            qdrant_point_count = qdrant_ready_points.unwrap_or_default(),
+            real_embeddings = qdrant_semantic_vectors_enabled(),
+            "Qdrant collection ensured and populated"
+        );
+    }
+    if !qdrant_client.semantic_search_smoke(collection) {
+        bail!("mandatory Qdrant semantic smoke failed for {project_id} collection {collection}");
+    }
+    Ok(qdrant_ready_points.unwrap_or_default())
+}
+
+fn ensure_scip_artifacts(
+    storage_path: &Path,
+    scip_dir: &Path,
+    project_id: &str,
+    generation: &str,
+    scip_ready: bool,
+    manifest: &mut RetrievalIndexManifest,
+) -> Result<()> {
+    if scip_ready {
+        info!(project_id = %project_id, sidecar_generation = %generation, "SCIP graph artifacts reused");
+        return Ok(());
+    }
+    match emit_scip_artifacts_from_store(storage_path, scip_dir) {
+        Ok(Some(revision)) => {
+            manifest.scip_revision = Some(revision.clone());
+            info!(project_id = %project_id, sidecar_generation = %generation, %revision, "SCIP graph artifacts emitted from store");
+            Ok(())
+        }
+        Ok(None) => {
+            bail!("mandatory SCIP graph artifacts unavailable for {project_id}");
+        }
+        Err(error) => {
+            bail!("mandatory SCIP graph artifact emit failed for {project_id}: {error}");
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finalize_manifest_after_health_check(
+    storage_path: &Path,
+    layout: &SidecarLayout,
+    qdrant_client: &QdrantClient,
+    project_id: String,
+    collection: &str,
+    sidecar_input: &SidecarInputFingerprint,
+    manifest: RetrievalIndexManifest,
+    degraded_modes: Vec<String>,
+    stub_flags: SidecarStubFlags,
+) -> Result<FinalizeIndexOutcome> {
+    let status = probe_sidecar_health(layout, &project_id, Some(manifest.clone()));
+    if status.retrieval_mode != "full" {
+        bail!(
+            "mandatory sidecar generation did not reach full mode for {project_id}: {} {:?}",
+            status.retrieval_mode,
+            status.degraded_reason
+        );
+    }
+    if qdrant_ready_point_count(qdrant_client, collection, sidecar_input.projection_count).is_none()
+    {
+        bail!(
+            "mandatory Qdrant semantic collection incomplete for {project_id}: expected at least {} generated points",
+            sidecar_input.projection_count
+        );
+    }
+
+    persist_finalized_manifest(
+        storage_path,
+        project_id,
+        manifest,
+        degraded_modes,
+        stub_flags.zoekt_stubbed,
+        stub_flags.qdrant_stubbed,
+        stub_flags.scip_stubbed,
+    )
+}
+
+#[allow(dead_code)] // Phase 2 cache keys
+pub fn query_fingerprint(query: &str) -> String {
+    let digest = Sha256::digest(query.as_bytes());
+    format!("{:x}", digest)[..16].to_string()
+}
+
+fn ensure_search_symbol_projection(storage: &mut Store) -> Result<()> {
+    if storage.get_search_symbol_projection_count().unwrap_or(0) == 0 {
+        storage
+            .rebuild_search_symbol_projection_from_node_table()
+            .context("rebuild search_symbol_projection")?;
+    }
+    Ok(())
+}
+
+fn manifest_matches_sidecar_input(
+    manifest: &RetrievalIndexManifest,
+    sidecar_input: &SidecarInputFingerprint,
+    embedding_backend: &str,
+    embedding_dim: i32,
+) -> bool {
+    if !manifest_has_current_sidecar_contract(&manifest.project_id, manifest) {
+        return false;
+    }
+    manifest.sidecar_schema_version == Some(SIDECAR_SCHEMA_VERSION)
+        && manifest.sidecar_input_hash.as_deref() == Some(sidecar_input.hash.as_str())
+        && manifest.projection_count == Some(sidecar_input.projection_count)
+        && manifest.embedding_backend.as_deref() == Some(embedding_backend)
+        && manifest.embedding_dim == Some(embedding_dim)
+}
+
+fn retrieval_manifest_for_sidecar(
+    project_id: &str,
+    generation: &str,
+    collection: &str,
+    embedding_backend: &str,
+    embedding_dim: i32,
+    sidecar_input: &SidecarInputFingerprint,
+) -> RetrievalIndexManifest {
+    RetrievalIndexManifest {
+        project_id: project_id.to_string(),
+        zoekt_version: ZOEKT_REAL_VERSION_PIN.to_string(),
+        qdrant_collection: collection.to_string(),
+        scip_revision: None,
+        built_at_epoch_ms: Utc::now().timestamp_millis(),
+        disk_bytes: None,
+        degraded_modes_json: "[]".into(),
+        embedding_backend: Some(embedding_backend.to_string()),
+        embedding_dim: Some(embedding_dim),
+        sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+        sidecar_input_hash: Some(sidecar_input.hash.clone()),
+        sidecar_generation: Some(generation.to_string()),
+        projection_count: Some(sidecar_input.projection_count),
+    }
+}
+
+fn read_scip_revision(scip_dir: &Path) -> Option<String> {
+    std::fs::read_to_string(scip_dir.join("revision.txt"))
+        .ok()
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn sidecar_disk_bytes(layout: &SidecarLayout, scip_dir: &Path) -> Option<i64> {
+    Some(
+        dir_size_bytes(&layout.zoekt_data_dir)
+            .saturating_add(dir_size_bytes(&layout.qdrant_data_dir))
+            .saturating_add(dir_size_bytes(scip_dir)) as i64,
+    )
+}
+
+fn qdrant_ready_point_count(
+    qdrant_client: &QdrantClient,
+    collection: &str,
+    expected_points: i64,
+) -> Option<u64> {
+    let expected_points = u64::try_from(expected_points).ok()?;
+    if expected_points == 0 {
+        return None;
+    }
+    match qdrant_client.count_points_exact(collection) {
+        Ok(actual) if actual >= expected_points => Some(actual),
+        Ok(actual) => {
+            warn!(
+                collection = %collection,
+                expected_points,
+                actual_points = actual,
+                "Qdrant generated collection is incomplete"
+            );
+            None
+        }
+        Err(error) => {
+            warn!(
+                collection = %collection,
+                error = %error,
+                "Qdrant generated collection point count unavailable"
+            );
+            None
+        }
+    }
+}
+
+fn persist_finalized_manifest(
+    storage_path: &Path,
+    project_id: String,
+    mut manifest: RetrievalIndexManifest,
+    degraded_modes: Vec<String>,
+    zoekt_stubbed: bool,
+    qdrant_stubbed: bool,
+    scip_stubbed: bool,
+) -> Result<FinalizeIndexOutcome> {
+    manifest.built_at_epoch_ms = Utc::now().timestamp_millis();
+    manifest.degraded_modes_json =
+        serde_json::to_string(&degraded_modes).unwrap_or_else(|_| "[]".into());
+    let mut storage = Store::open(storage_path).context("open storage for retrieval manifest")?;
+    if let Some(reason) = manifest_unavailable_reason(&project_id, &storage, &manifest) {
+        bail!(
+            "mandatory retrieval sidecar manifest would be unavailable immediately for {project_id}: {reason}"
+        );
+    }
+    storage
+        .upsert_retrieval_index_manifest(&manifest)
+        .context("persist retrieval_index_manifest")?;
+
+    info!(
+        project_id = %project_id,
+        zoekt_version = %manifest.zoekt_version,
+        qdrant_collection = %manifest.qdrant_collection,
+        sidecar_generation = ?manifest.sidecar_generation,
+        degraded_modes = ?degraded_modes,
+        "retrieval index manifest persisted"
+    );
+
+    Ok(FinalizeIndexOutcome {
+        project_id,
+        manifest,
+        degraded_modes,
+        zoekt_stubbed,
+        qdrant_stubbed,
+        scip_stubbed,
+    })
+}
+
+fn compute_sidecar_input_fingerprint(
+    storage: &Store,
+    project_root: &Path,
+    project_id: &str,
+    embedding_backend: &str,
+    embedding_dim: i32,
+) -> Result<SidecarInputFingerprint> {
+    let lexical = lexical_input_fingerprint(project_root).context("hash lexical sidecar input")?;
+    let mut hasher = Sha256::new();
+    hash_part(&mut hasher, "codestory-sidecar-input-v4");
+    hash_part(&mut hasher, project_id);
+    hash_part(&mut hasher, &SIDECAR_SCHEMA_VERSION.to_string());
+    hash_part(&mut hasher, ZOEKT_REAL_VERSION_PIN);
+    hash_part(&mut hasher, &lexical.file_count.to_string());
+    hash_part(&mut hasher, &lexical.hash);
+    hash_part(&mut hasher, embedding_backend);
+    hash_part(&mut hasher, &embedding_dim.to_string());
+    hash_part(
+        &mut hasher,
+        std::env::var("CODESTORY_EMBED_QUERY_PREFIX")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    hash_part(
+        &mut hasher,
+        std::env::var("CODESTORY_EMBED_DOCUMENT_PREFIX")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    hash_part(
+        &mut hasher,
+        if qdrant_semantic_vectors_enabled() {
+            "qdrant-semantic-vectors"
+        } else {
+            "qdrant-hash-vectors"
+        },
+    );
+    hash_part(&mut hasher, "scip-symbols-json-v1");
+
+    let mut projection_count = 0_i64;
+    let mut after = None;
+    loop {
+        let batch = storage
+            .get_llm_symbol_docs_batch_after(after, SIDECAR_INPUT_BATCH_SIZE)
+            .context("load stored semantic docs for sidecar hash")?;
+        if batch.is_empty() {
+            break;
+        }
+        after = batch.last().map(|doc| doc.node_id);
+        let batch = batch
+            .into_iter()
+            .filter(qdrant_semantic_doc_row)
+            .collect::<Vec<_>>();
+        projection_count += i64::try_from(batch.len()).unwrap_or(i64::MAX);
+        for doc in batch {
+            hash_semantic_doc_detail(&mut hasher, project_root, &doc);
+        }
+    }
+
+    Ok(SidecarInputFingerprint {
+        hash: format!("{:x}", hasher.finalize()),
+        projection_count,
+        lexical_file_count: lexical.file_count,
+        lexical_hash: lexical.hash,
+    })
+}
+
+fn hash_semantic_doc_detail(hasher: &mut Sha256, project_root: &Path, doc: &LlmSymbolDoc) {
+    let file_path = doc
+        .file_path
+        .as_deref()
+        .and_then(|path| normalize_sidecar_file_path(path, project_root).ok())
+        .unwrap_or_default();
+    let file_role = if file_path.is_empty() {
+        ""
+    } else {
+        FileRole::classify_path(Path::new(&file_path)).as_str()
+    };
+    hash_part(hasher, &doc.node_id.0.to_string());
+    hash_part(hasher, &(doc.kind as i32).to_string());
+    hash_part(hasher, &doc.display_name);
+    hash_part(hasher, doc.qualified_name.as_deref().unwrap_or(""));
+    hash_part(hasher, &file_path);
+    hash_part(hasher, file_role);
+    hash_part(
+        hasher,
+        &doc.start_line
+            .map(|line| line.to_string())
+            .unwrap_or_default(),
+    );
+    hash_part(hasher, &doc.doc_version.to_string());
+    hash_part(hasher, &doc.doc_hash);
+    hash_part(hasher, doc.embedding_profile.as_deref().unwrap_or(""));
+    hash_part(hasher, &doc.embedding_model);
+    hash_part(hasher, doc.embedding_backend.as_deref().unwrap_or(""));
+    hash_part(hasher, &doc.embedding_dim.to_string());
+    hash_part(hasher, doc.doc_shape.as_deref().unwrap_or(""));
+    hash_part(hasher, &doc.embedding.len().to_string());
+    hash_embedding_vector(hasher, &doc.embedding);
+}
+
+#[cfg(test)]
+fn qdrant_semantic_projection_row(row: &codestory_store::SearchSymbolProjectionDetail) -> bool {
+    let Some(kind) = row
+        .node_kind
+        .and_then(|kind| i32::try_from(kind).ok())
+        .and_then(|kind| codestory_contracts::graph::NodeKind::try_from(kind).ok())
+    else {
+        return false;
+    };
+    crate::generation::sidecar_semantic_node_kind(kind)
+}
+
+fn qdrant_semantic_doc_row(doc: &LlmSymbolDoc) -> bool {
+    crate::generation::sidecar_semantic_doc_is_product_eligible(doc)
+}
+
+fn hash_part(hasher: &mut Sha256, value: &str) {
+    hasher.update(value.len().to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn hash_embedding_vector(hasher: &mut Sha256, embedding: &[f32]) {
+    hasher.update(embedding.len().to_le_bytes());
+    for value in embedding {
+        hasher.update(value.to_bits().to_le_bytes());
+    }
+}
+
+fn upsert_qdrant_points_from_store(
+    storage_path: &Path,
+    project_root: &Path,
+    qdrant_client: &QdrantClient,
+    collection: &str,
+) -> Result<usize> {
+    let mut storage = Store::open(storage_path).context("open storage for qdrant upsert")?;
+    ensure_search_symbol_projection(&mut storage)?;
+    let file_roles = storage
+        .get_files()
+        .map(|files| sidecar_file_role_map(files, project_root))
+        .unwrap_or_default();
+    let mut total = 0usize;
+    let mut after = None;
+    loop {
+        let batch = storage
+            .get_llm_symbol_docs_batch_after(after, SIDECAR_INPUT_BATCH_SIZE)
+            .context("load stored semantic docs for qdrant")?;
+        if batch.is_empty() {
+            break;
+        }
+        after = batch.last().map(|doc| doc.node_id);
+        let points = batch
+            .into_iter()
+            .filter(qdrant_semantic_doc_row)
+            .map(|doc| {
+                let id = qdrant_point_id_for_node_id(doc.node_id.0);
+                let display_name = doc.qualified_name.clone().unwrap_or(doc.display_name);
+                let file_path = doc
+                    .file_path
+                    .as_deref()
+                    .and_then(|path| normalize_sidecar_file_path(path, project_root).ok());
+                let file_role = file_path
+                    .as_deref()
+                    .and_then(|path| file_roles.get(path).copied())
+                    .or_else(|| {
+                        file_path
+                            .as_deref()
+                            .map(|path| FileRole::classify_path(Path::new(path)))
+                    });
+                QdrantUpsertPoint {
+                    id,
+                    display_name,
+                    node_id: doc.node_id.0.to_string(),
+                    file_path,
+                    file_role,
+                    vector: Some(doc.embedding),
+                }
+            })
+            .collect::<Vec<_>>();
+        if points.is_empty() {
+            continue;
+        }
+        total += qdrant_client
+            .upsert_points(collection, &points)
+            .context("qdrant collection upsert")?;
+    }
+    Ok(total)
+}
+
+fn sidecar_file_role_map(
+    files: Vec<codestory_store::FileInfo>,
+    project_root: &Path,
+) -> HashMap<String, FileRole> {
+    files
+        .into_iter()
+        .filter_map(|file| {
+            let path = file.path.to_string_lossy().to_string();
+            normalize_sidecar_file_path(&path, project_root)
+                .ok()
+                .map(|path| (path, file.file_role))
+        })
+        .collect()
+}
+
+fn qdrant_point_id_for_node_id(node_id: i64) -> u64 {
+    u64::from_le_bytes(node_id.to_le_bytes())
+}
+
+fn normalize_sidecar_file_path(path: &str, project_root: &Path) -> Result<String> {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        path.strip_prefix(project_root)
+            .with_context(|| format!("strip project root from {}", path.display()))
+            .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+    } else {
+        Ok(path.to_string_lossy().replace('\\', "/"))
+    }
+}
+
+fn fnv1a_hex(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::graph::{Node, NodeId, NodeKind};
+    use codestory_store::SearchSymbolProjectionDetail;
+    use tempfile::TempDir;
+
+    #[test]
+    fn qdrant_point_ids_preserve_negative_node_ids() {
+        assert_eq!(qdrant_point_id_for_node_id(42), 42);
+        assert_ne!(
+            qdrant_point_id_for_node_id(-1),
+            qdrant_point_id_for_node_id(0)
+        );
+        assert_ne!(
+            qdrant_point_id_for_node_id(-2),
+            qdrant_point_id_for_node_id(-1)
+        );
+    }
+
+    #[test]
+    fn finalize_index_fails_without_mandatory_sidecar_artifacts() {
+        let project = TempDir::new().expect("project dir");
+        let storage_dir = TempDir::new().expect("storage dir");
+        let storage_path = storage_dir.path().join("codestory.db");
+        {
+            let storage = Store::open(&storage_path).expect("open empty db");
+            drop(storage);
+        }
+        let error = finalize_index(project.path(), &storage_path)
+            .expect_err("empty stores cannot satisfy mandatory sidecar indexing");
+        assert!(
+            error.to_string().contains("mandatory"),
+            "expected mandatory-sidecar error, got {error:#}"
+        );
+    }
+
+    #[test]
+    fn project_qdrant_repair_noops_without_manifest() {
+        let project = TempDir::new().expect("project dir");
+        let storage_dir = TempDir::new().expect("storage dir");
+        let storage_path = storage_dir.path().join("codestory.db");
+        {
+            let storage = Store::open(&storage_path).expect("open empty db");
+            drop(storage);
+        }
+
+        let repair =
+            repair_project_qdrant_collection(project.path(), &storage_path).expect("repair");
+        assert!(repair.is_none());
+    }
+
+    #[test]
+    fn generated_manifest_helper_records_current_sidecar_contract() {
+        let project_id = "proj";
+        let input = SidecarInputFingerprint {
+            hash: "0123456789abcdef0123456789abcdef".into(),
+            projection_count: 42,
+            lexical_file_count: 3,
+            lexical_hash: "lexical".into(),
+        };
+        let generation = sidecar_generation_id(project_id, &input.hash);
+        let collection = QdrantClient::collection_name_for_generation(project_id, &input.hash);
+
+        let manifest = retrieval_manifest_for_sidecar(
+            project_id,
+            &generation,
+            &collection,
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            768,
+            &input,
+        );
+
+        assert!(manifest_has_current_sidecar_contract(project_id, &manifest));
+        assert_eq!(manifest.projection_count, Some(42));
+        assert_eq!(
+            manifest.sidecar_generation.as_deref(),
+            Some(generation.as_str())
+        );
+        assert_eq!(manifest.qdrant_collection, collection);
+    }
+
+    #[test]
+    fn qdrant_semantic_projection_excludes_low_value_local_symbols() {
+        let row = |kind: NodeKind| SearchSymbolProjectionDetail {
+            node_id: codestory_contracts::graph::NodeId(1),
+            display_name: "symbol".into(),
+            node_kind: Some(kind as i64),
+            file_path: Some("src/lib.rs".into()),
+            start_line: Some(1),
+            end_line: Some(1),
+        };
+
+        assert!(qdrant_semantic_projection_row(&row(NodeKind::FUNCTION)));
+        assert!(qdrant_semantic_projection_row(&row(
+            NodeKind::ENUM_CONSTANT
+        )));
+        assert!(!qdrant_semantic_projection_row(&row(NodeKind::VARIABLE)));
+        assert!(!qdrant_semantic_projection_row(&row(NodeKind::FIELD)));
+        assert!(!qdrant_semantic_projection_row(&row(NodeKind::UNKNOWN)));
+    }
+
+    #[test]
+    fn qdrant_semantic_doc_requires_product_stored_embedding() {
+        let doc = |kind: NodeKind, backend: Option<&str>, dim: u32| LlmSymbolDoc {
+            node_id: codestory_contracts::graph::NodeId(1),
+            file_node_id: None,
+            kind,
+            display_name: "do_work".into(),
+            qualified_name: Some("pkg::do_work".into()),
+            file_path: Some("src/lib.rs".into()),
+            start_line: Some(1),
+            doc_text: "semantic doc".into(),
+            doc_version: 4,
+            doc_hash: "hash".into(),
+            embedding_profile: Some("bge-base-en-v1.5".into()),
+            embedding_model: "BAAI/bge-base-en-v1.5-local|backend=onnx".into(),
+            embedding_backend: backend.map(str::to_string),
+            embedding_dim: dim,
+            doc_shape: Some("semantic_doc_version=4;scope=durable_symbols".into()),
+            embedding: vec![0.01; dim as usize],
+            updated_at_epoch_ms: 123,
+        };
+
+        assert!(qdrant_semantic_doc_row(&doc(
+            NodeKind::FUNCTION,
+            Some("onnx"),
+            768
+        )));
+        assert!(qdrant_semantic_doc_row(&doc(
+            NodeKind::METHOD,
+            Some("llamacpp"),
+            768
+        )));
+        assert!(!qdrant_semantic_doc_row(&doc(
+            NodeKind::VARIABLE,
+            Some("onnx"),
+            768
+        )));
+        assert!(!qdrant_semantic_doc_row(&doc(
+            NodeKind::FUNCTION,
+            Some("hash"),
+            768
+        )));
+        assert!(!qdrant_semantic_doc_row(&doc(
+            NodeKind::FUNCTION,
+            Some("onnx"),
+            384
+        )));
+    }
+
+    #[test]
+    fn sidecar_input_hash_changes_when_embedding_values_change() {
+        let project = TempDir::new().expect("project dir");
+        std::fs::write(project.path().join("lib.rs"), "pub fn do_work() {}\n")
+            .expect("project file");
+        let storage_dir = TempDir::new().expect("storage dir");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let mut storage = Store::open(&storage_path).expect("open store");
+        storage
+            .insert_nodes_batch(&[Node {
+                id: NodeId(1),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "do_work".into(),
+                ..Default::default()
+            }])
+            .expect("node");
+        let mut doc = LlmSymbolDoc {
+            node_id: NodeId(1),
+            file_node_id: None,
+            kind: NodeKind::FUNCTION,
+            display_name: "do_work".into(),
+            qualified_name: Some("pkg::do_work".into()),
+            file_path: Some("lib.rs".into()),
+            start_line: Some(1),
+            doc_text: "semantic doc".into(),
+            doc_version: 4,
+            doc_hash: "hash".into(),
+            embedding_profile: Some("bge-base-en-v1.5".into()),
+            embedding_model: "BAAI/bge-base-en-v1.5-local|backend=onnx".into(),
+            embedding_backend: Some("onnx".into()),
+            embedding_dim: crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+            doc_shape: Some("semantic_doc_version=4;scope=durable_symbols".into()),
+            embedding: vec![0.01; crate::embeddings::RETRIEVAL_EMBEDDING_DIM],
+            updated_at_epoch_ms: 123,
+        };
+        storage
+            .upsert_llm_symbol_docs_batch(&[doc.clone()])
+            .expect("first doc");
+        let first = compute_sidecar_input_fingerprint(
+            &storage,
+            project.path(),
+            "proj",
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+        )
+        .expect("first fingerprint");
+        doc.embedding[0] = 0.02;
+        storage
+            .upsert_llm_symbol_docs_batch(&[doc])
+            .expect("second doc");
+        let second = compute_sidecar_input_fingerprint(
+            &storage,
+            project.path(),
+            "proj",
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+        )
+        .expect("second fingerprint");
+
+        assert_eq!(first.projection_count, 1);
+        assert_eq!(second.projection_count, 1);
+        assert_ne!(first.hash, second.hash);
+    }
+}

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -1,0 +1,77 @@
+//! Retrieval v2 sidecar orchestration: health probes, local-dev clients, and index manifests.
+
+mod cache;
+mod candidate;
+mod capabilities;
+mod compose;
+mod config;
+mod embeddings;
+mod executor;
+mod generation;
+mod health;
+mod index;
+mod mode;
+mod planner;
+mod qdrant_client;
+mod qdrant_storage;
+mod query;
+mod query_features;
+mod ranker;
+mod scip_client;
+mod scip_index;
+mod sidecar;
+mod sidecar_search;
+mod zoekt_client;
+mod zoekt_index;
+
+pub use cache::{RetrievalCache, RetrievalCacheKey};
+pub use candidate::{CandidateHit, CandidateSource, RankFeatures};
+pub use candidate::{is_phantom_sidecar_hit, phantom_sidecar_candidates_only};
+pub use capabilities::SidecarCapabilities;
+#[allow(deprecated)]
+pub use compose::bootstrap_sidecars_without_storage_scope;
+pub use compose::{
+    BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, docker_available,
+    resolve_compose_file,
+};
+pub use config::{
+    DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN,
+    SidecarLayout, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
+};
+pub use config::{qdrant_enabled, qdrant_semantic_vectors_enabled};
+pub use embeddings::qdrant_vector_dim;
+pub use embeddings::{
+    BGE_BASE_EN_V1_5_GGUF, BGE_QUERY_PREFIX_DEFAULT, RETRIEVAL_EMBEDDING_DIM,
+    embedding_backend_label, embedding_runtime_id,
+};
+pub use executor::{QueryExecutor, QueryResult, QueryTrace, StageTrace, cancellation_flag};
+pub use generation::{SIDECAR_SCHEMA_VERSION, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED};
+pub use health::{
+    ComponentHealth, ComponentStatus, InfrastructureHealth, RetrievalStatusReport,
+    probe_infrastructure_health, probe_sidecar_health,
+};
+pub use index::{
+    FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, project_id_for_root,
+    repair_project_qdrant_collection,
+};
+pub use mode::RetrievalDegradedMode;
+pub use mode::derive_degraded_mode;
+pub use planner::{PlannedStage, RetrievalPlan, RetrievalStageKind, plan_query};
+pub use qdrant_client::{
+    QDRANT_INDEX_UPSERT_BATCH_SIZE, QDRANT_VECTOR_DIM, QdrantClient, QdrantUpsertPoint,
+};
+pub use qdrant_storage::{
+    BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION,
+    PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR, QdrantStorageRepairReport, repair_qdrant_storage,
+};
+pub use query::{QueryRequest, execute_retrieval_query, execute_retrieval_query_with_cache};
+pub use query_features::{QueryFeatures, QueryShape, classify_query};
+pub use ranker::rank_candidates;
+pub use scip_client::ScipClient;
+pub use sidecar::{
+    SidecarStateFile, sidecar_down, sidecar_status, sidecar_up, strict_sidecar_status,
+};
+pub use sidecar_search::{LiveSidecarSearch, SidecarSearch};
+pub use zoekt_client::ZoektClient;
+
+pub use codestory_store::RetrievalIndexManifest;

--- a/crates/codestory-retrieval/src/mode.rs
+++ b/crates/codestory-retrieval/src/mode.rs
@@ -1,0 +1,176 @@
+use crate::health::{ComponentHealth, ComponentStatus};
+
+/// v2 mandatory sidecar mode matrix row (design doc § Mandatory sidecar mode matrix).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalDegradedMode {
+    Full,
+    NoScip,
+    NoSemantic,
+    LexicalOnly,
+    Unavailable,
+}
+
+impl RetrievalDegradedMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::NoScip => "no_scip",
+            Self::NoSemantic => "no_semantic",
+            Self::LexicalOnly => "lexical_only",
+            Self::Unavailable => "unavailable",
+        }
+    }
+
+    pub fn promotion_eligible(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    pub fn runs_scip_stages(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    pub fn runs_qdrant_stage(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    pub fn runs_zoekt_stage(self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
+
+pub fn derive_degraded_mode(
+    zoekt: &ComponentHealth,
+    qdrant: &ComponentHealth,
+    scip: &ComponentHealth,
+) -> (RetrievalDegradedMode, Option<String>) {
+    if zoekt.status == ComponentStatus::Unavailable || !zoekt.capabilities.lexical {
+        return (
+            RetrievalDegradedMode::Unavailable,
+            zoekt
+                .degraded_reason
+                .clone()
+                .or_else(|| Some("mandatory_zoekt_unavailable".into())),
+        );
+    }
+    if qdrant.status == ComponentStatus::Unavailable || !qdrant.capabilities.semantic {
+        let mode = if scip.capabilities.graph {
+            RetrievalDegradedMode::NoSemantic
+        } else {
+            RetrievalDegradedMode::LexicalOnly
+        };
+        return (
+            mode,
+            qdrant
+                .degraded_reason
+                .clone()
+                .or_else(|| Some("mandatory_qdrant_unavailable".into())),
+        );
+    }
+    if scip.status != ComponentStatus::Healthy || !scip.capabilities.graph {
+        return (RetrievalDegradedMode::NoScip, scip.degraded_reason.clone());
+    }
+    (RetrievalDegradedMode::Full, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::SidecarCapabilities;
+
+    fn component(
+        name: &str,
+        status: ComponentStatus,
+        reason: Option<&str>,
+        capabilities: crate::capabilities::SidecarCapabilities,
+    ) -> ComponentHealth {
+        ComponentHealth {
+            name: name.into(),
+            status,
+            latency_ms: None,
+            detail: String::new(),
+            degraded_reason: reason.map(str::to_string),
+            capabilities,
+        }
+    }
+
+    #[test]
+    fn matrix_rows_match_design_doc() {
+        let production = crate::capabilities::SidecarCapabilities::production_stack();
+        let zoekt_up = component("zoekt", ComponentStatus::Healthy, None, production);
+        let qdrant_up = component("qdrant", ComponentStatus::Healthy, None, production);
+        let scip_up = component("scip", ComponentStatus::Healthy, None, production);
+        assert_eq!(
+            derive_degraded_mode(&zoekt_up, &qdrant_up, &scip_up).0,
+            RetrievalDegradedMode::Full
+        );
+
+        let scip_down = component(
+            "scip",
+            ComponentStatus::Unavailable,
+            Some("scip_unavailable"),
+            SidecarCapabilities::NONE,
+        );
+        assert_eq!(
+            derive_degraded_mode(&zoekt_up, &qdrant_up, &scip_down).0,
+            RetrievalDegradedMode::NoScip
+        );
+
+        let qdrant_down = component(
+            "qdrant",
+            ComponentStatus::Unavailable,
+            Some("qdrant_unreachable"),
+            SidecarCapabilities::NONE,
+        );
+        assert_eq!(
+            derive_degraded_mode(&zoekt_up, &qdrant_down, &scip_up).0,
+            RetrievalDegradedMode::NoSemantic
+        );
+        assert_eq!(
+            derive_degraded_mode(&zoekt_up, &qdrant_down, &scip_down).0,
+            RetrievalDegradedMode::LexicalOnly
+        );
+
+        let zoekt_down = component(
+            "zoekt",
+            ComponentStatus::Unavailable,
+            Some("zoekt_unreachable"),
+            SidecarCapabilities::NONE,
+        );
+        assert_eq!(
+            derive_degraded_mode(&zoekt_down, &qdrant_up, &scip_up).0,
+            RetrievalDegradedMode::Unavailable
+        );
+    }
+
+    #[test]
+    fn stub_stack_never_reports_full() {
+        let lexical_only = SidecarCapabilities {
+            lexical: true,
+            semantic: false,
+            graph: false,
+        };
+        let zoekt_stub = component(
+            "zoekt",
+            ComponentStatus::Degraded,
+            Some("zoekt_stub"),
+            lexical_only,
+        );
+        let qdrant_stub = component(
+            "qdrant",
+            ComponentStatus::Degraded,
+            Some("qdrant_hash_vectors_only"),
+            SidecarCapabilities::NONE,
+        );
+        let scip_stub = component(
+            "scip",
+            ComponentStatus::Degraded,
+            Some("scip_stub"),
+            SidecarCapabilities::NONE,
+        );
+        assert_ne!(
+            derive_degraded_mode(&zoekt_stub, &qdrant_stub, &scip_stub).0,
+            RetrievalDegradedMode::Full
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -1,0 +1,197 @@
+use crate::mode::RetrievalDegradedMode;
+use crate::query_features::{QueryFeatures, QueryShape};
+use serde::{Deserialize, Serialize};
+
+/// Staged retrieval lane (design doc staged retrieval).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalStageKind {
+    Stage0ScipAnchor,
+    Stage1ZoektLexical,
+    Stage1bQdrantSemantic,
+    Stage2ScipExpand,
+    Stage3RepoTextFallback,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlannedStage {
+    pub kind: RetrievalStageKind,
+    pub budget_ms: u64,
+    pub top_k: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrievalPlan {
+    pub stages: Vec<PlannedStage>,
+    pub total_budget_ms: u64,
+    pub stop_marginal_gain_threshold: f32,
+    pub stop_after_low_gain_streak: u32,
+}
+
+const DEFAULT_TOTAL_BUDGET_MS: u64 = 1_000;
+const MARGINAL_GAIN_THRESHOLD: f32 = 0.05;
+const LOW_GAIN_STREAK: u32 = 2;
+
+pub fn plan_query(features: &QueryFeatures, mode: RetrievalDegradedMode) -> RetrievalPlan {
+    if mode != RetrievalDegradedMode::Full {
+        return RetrievalPlan {
+            stages: Vec::new(),
+            total_budget_ms: 0,
+            stop_marginal_gain_threshold: MARGINAL_GAIN_THRESHOLD,
+            stop_after_low_gain_streak: LOW_GAIN_STREAK,
+        };
+    }
+
+    let mut stages = Vec::new();
+    let top_k = top_k_for_shape(features.shape);
+
+    if mode.runs_scip_stages()
+        && matches!(
+            features.shape,
+            QueryShape::SymbolLike | QueryShape::PathLike
+        )
+    {
+        stages.push(PlannedStage {
+            kind: RetrievalStageKind::Stage0ScipAnchor,
+            budget_ms: stage0_budget_ms(features.shape),
+            top_k: top_k.min(8),
+        });
+    }
+
+    if mode.runs_zoekt_stage() {
+        stages.push(PlannedStage {
+            kind: RetrievalStageKind::Stage1ZoektLexical,
+            budget_ms: stage1_budget_ms(features.shape),
+            top_k,
+        });
+    }
+
+    if mode.runs_qdrant_stage() && features.shape != QueryShape::PathLike {
+        let semantic_top_k = match features.shape {
+            QueryShape::NaturalLanguage | QueryShape::Mixed => top_k.saturating_mul(2).min(40),
+            _ => top_k,
+        };
+        stages.push(PlannedStage {
+            kind: RetrievalStageKind::Stage1bQdrantSemantic,
+            budget_ms: stage1b_budget_ms(features.shape),
+            top_k: semantic_top_k,
+        });
+    }
+
+    if mode.runs_scip_stages() {
+        let stage2_top_k = match features.shape {
+            QueryShape::NaturalLanguage => top_k.min(20),
+            _ => top_k.min(16),
+        };
+        stages.push(PlannedStage {
+            kind: RetrievalStageKind::Stage2ScipExpand,
+            budget_ms: stage2_budget_ms(features.shape),
+            top_k: stage2_top_k,
+        });
+    }
+
+    let total_budget_ms = stages
+        .iter()
+        .map(|stage| stage.budget_ms)
+        .sum::<u64>()
+        .min(DEFAULT_TOTAL_BUDGET_MS);
+
+    RetrievalPlan {
+        stages,
+        total_budget_ms,
+        stop_marginal_gain_threshold: MARGINAL_GAIN_THRESHOLD,
+        stop_after_low_gain_streak: LOW_GAIN_STREAK,
+    }
+}
+
+fn top_k_for_shape(shape: QueryShape) -> usize {
+    match shape {
+        QueryShape::SymbolLike => 12,
+        QueryShape::PathLike => 8,
+        QueryShape::NaturalLanguage => 48,
+        QueryShape::Mixed => 24,
+    }
+}
+
+fn stage0_budget_ms(shape: QueryShape) -> u64 {
+    match shape {
+        QueryShape::SymbolLike | QueryShape::PathLike => 40,
+        _ => 30,
+    }
+}
+
+fn stage1_budget_ms(shape: QueryShape) -> u64 {
+    match shape {
+        QueryShape::NaturalLanguage | QueryShape::Mixed => 120,
+        _ => 80,
+    }
+}
+
+fn stage1b_budget_ms(shape: QueryShape) -> u64 {
+    match shape {
+        QueryShape::NaturalLanguage | QueryShape::Mixed => 250,
+        QueryShape::SymbolLike => 120,
+        QueryShape::PathLike => 0,
+    }
+    .max(80)
+}
+
+fn stage2_budget_ms(shape: QueryShape) -> u64 {
+    match shape {
+        QueryShape::SymbolLike | QueryShape::Mixed => 180,
+        QueryShape::PathLike => 120,
+        QueryShape::NaturalLanguage => 90,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query_features::classify_query;
+
+    #[test]
+    fn full_mode_includes_all_stages_for_symbol_query() {
+        let features = classify_query("ExtensionService");
+        let plan = plan_query(&features, RetrievalDegradedMode::Full);
+        let kinds: Vec<_> = plan.stages.iter().map(|s| s.kind).collect();
+        assert!(kinds.contains(&RetrievalStageKind::Stage0ScipAnchor));
+        assert!(kinds.contains(&RetrievalStageKind::Stage1ZoektLexical));
+        assert!(kinds.contains(&RetrievalStageKind::Stage1bQdrantSemantic));
+        assert!(kinds.contains(&RetrievalStageKind::Stage2ScipExpand));
+    }
+
+    #[test]
+    fn non_full_modes_have_no_product_stages() {
+        let features = classify_query("ExtensionService");
+        for mode in [
+            RetrievalDegradedMode::NoScip,
+            RetrievalDegradedMode::NoSemantic,
+            RetrievalDegradedMode::LexicalOnly,
+            RetrievalDegradedMode::Unavailable,
+        ] {
+            let plan = plan_query(&features, mode);
+            assert!(plan.stages.is_empty(), "mode {mode:?} must fail closed");
+        }
+    }
+
+    #[test]
+    fn natural_language_plan_includes_scip_expand_stage() {
+        let features = classify_query("how does request dispatch flow through interceptors");
+        let plan = plan_query(&features, RetrievalDegradedMode::Full);
+        let kinds: Vec<_> = plan.stages.iter().map(|s| s.kind).collect();
+        assert!(!kinds.contains(&RetrievalStageKind::Stage0ScipAnchor));
+        assert!(kinds.contains(&RetrievalStageKind::Stage1bQdrantSemantic));
+        assert!(kinds.contains(&RetrievalStageKind::Stage2ScipExpand));
+    }
+
+    #[test]
+    fn mixed_prompt_plan_does_not_let_scip_anchor_starve_semantic_stage() {
+        let features = classify_query("Explain how FooBar flows through request handling");
+        let plan = plan_query(&features, RetrievalDegradedMode::Full);
+        let kinds: Vec<_> = plan.stages.iter().map(|s| s.kind).collect();
+        assert!(!kinds.contains(&RetrievalStageKind::Stage0ScipAnchor));
+        assert!(kinds.contains(&RetrievalStageKind::Stage1ZoektLexical));
+        assert!(kinds.contains(&RetrievalStageKind::Stage1bQdrantSemantic));
+        assert!(kinds.contains(&RetrievalStageKind::Stage2ScipExpand));
+    }
+}

--- a/crates/codestory-retrieval/src/qdrant_client.rs
+++ b/crates/codestory-retrieval/src/qdrant_client.rs
@@ -1,0 +1,661 @@
+use crate::config::{
+    QDRANT_HEALTH_BUDGET, SidecarLayout, qdrant_enabled, qdrant_semantic_vectors_enabled,
+};
+use crate::embeddings::{self, qdrant_vector_dim as active_vector_dim};
+use anyhow::{Context, Result, bail};
+use codestory_store::FileRole;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Back-compat smoke width when semantic vectors are explicitly downgraded.
+pub const QDRANT_VECTOR_DIM: usize = 8;
+
+/// Batch size for Qdrant point upserts. This is not a coverage cap.
+pub const QDRANT_INDEX_UPSERT_BATCH_SIZE: usize = 512;
+
+const QDRANT_MUTATION_BUDGET: Duration = Duration::from_secs(5);
+const QDRANT_UPSERT_BUDGET: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone)]
+pub struct QdrantUpsertPoint {
+    pub id: u64,
+    pub display_name: String,
+    pub node_id: String,
+    pub file_path: Option<String>,
+    pub file_role: Option<FileRole>,
+    pub vector: Option<Vec<f32>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QdrantHealthProbe {
+    pub reachable: bool,
+    pub latency_ms: u64,
+    pub collection_exists: bool,
+    pub point_count: Option<u64>,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct QdrantClient {
+    base_url: String,
+    timeout: Duration,
+}
+
+impl QdrantClient {
+    pub fn new(layout: &SidecarLayout) -> Self {
+        Self {
+            base_url: layout.qdrant_base_url(),
+            timeout: QDRANT_HEALTH_BUDGET,
+        }
+    }
+
+    pub fn collection_name(project_id: &str) -> String {
+        format!("codestory_{project_id}")
+    }
+
+    pub fn collection_name_for_generation(project_id: &str, sidecar_input_hash: &str) -> String {
+        crate::generation::sidecar_qdrant_collection(project_id, sidecar_input_hash)
+    }
+
+    /// List collection names from `GET /collections` (empty when unreachable or disabled).
+    pub fn list_collection_names(&self) -> Result<Vec<String>> {
+        if !qdrant_enabled() {
+            return Ok(Vec::new());
+        }
+        let url = format!("{}/collections", self.base_url);
+        let response = ureq::get(&url)
+            .timeout(self.timeout)
+            .call()
+            .context("list qdrant collections")?;
+        let status = response.status();
+        if !(200..300).contains(&status) {
+            bail!("list collections http {status}");
+        }
+        let body = response.into_string().unwrap_or_default();
+        parse_collection_names(&body)
+    }
+
+    /// Reachability probe that does not require a project collection.
+    pub fn list_collections_probe(&self) -> QdrantHealthProbe {
+        let started = Instant::now();
+        if !qdrant_enabled() {
+            return QdrantHealthProbe {
+                reachable: false,
+                latency_ms: 0,
+                collection_exists: false,
+                point_count: None,
+                detail: "disabled via CODESTORY_QDRANT_ENABLED=false".into(),
+            };
+        }
+        let url = format!("{}/collections", self.base_url);
+        match ureq::get(&url).timeout(self.timeout).call() {
+            Ok(response) => {
+                let status = response.status();
+                QdrantHealthProbe {
+                    reachable: (200..500).contains(&status),
+                    latency_ms: started.elapsed().as_millis() as u64,
+                    collection_exists: false,
+                    point_count: None,
+                    detail: format!("http {status}"),
+                }
+            }
+            Err(error) => QdrantHealthProbe {
+                reachable: false,
+                latency_ms: started.elapsed().as_millis() as u64,
+                collection_exists: false,
+                point_count: None,
+                detail: error.to_string(),
+            },
+        }
+    }
+
+    pub fn health_probe(&self, collection: &str) -> QdrantHealthProbe {
+        let started = Instant::now();
+        if !qdrant_enabled() {
+            return QdrantHealthProbe {
+                reachable: false,
+                latency_ms: 0,
+                collection_exists: false,
+                point_count: None,
+                detail: "disabled via CODESTORY_QDRANT_ENABLED=false".into(),
+            };
+        }
+        let url = format!("{}/collections/{collection}", self.base_url);
+        let latency_ms = || started.elapsed().as_millis() as u64;
+        match ureq::get(&url).timeout(self.timeout).call() {
+            Ok(response) => {
+                let status = response.status();
+                let body = response.into_string().unwrap_or_default();
+                let point_count = parse_collection_point_count(&body);
+                let detail = match point_count {
+                    Some(count) => format!("http {status} points_count={count}"),
+                    None => format!("http {status}"),
+                };
+                QdrantHealthProbe {
+                    reachable: true,
+                    latency_ms: latency_ms(),
+                    collection_exists: status == 200,
+                    point_count,
+                    detail,
+                }
+            }
+            Err(error) => match collection_probe_from_http_error(&error) {
+                Some((reachable, collection_exists, detail)) => QdrantHealthProbe {
+                    reachable,
+                    latency_ms: latency_ms(),
+                    collection_exists,
+                    point_count: None,
+                    detail,
+                },
+                None => QdrantHealthProbe {
+                    reachable: false,
+                    latency_ms: latency_ms(),
+                    collection_exists: false,
+                    point_count: None,
+                    detail: error.to_string(),
+                },
+            },
+        }
+    }
+
+    /// Exact count of indexed points in a generated collection.
+    pub fn count_points_exact(&self, collection: &str) -> Result<u64> {
+        if !qdrant_enabled() {
+            bail!("qdrant sidecar is mandatory; CODESTORY_QDRANT_ENABLED=false is unsupported");
+        }
+        let url = format!("{}/collections/{collection}/points/count", self.base_url);
+        let body = serde_json::json!({ "exact": true });
+        let payload = serde_json::to_string(&body).context("serialize qdrant count body")?;
+        match ureq::post(&url)
+            .timeout(self.timeout)
+            .set("Content-Type", "application/json")
+            .send_string(&payload)
+        {
+            Ok(response) => {
+                let status = response.status();
+                if !(200..300).contains(&status) {
+                    bail!("qdrant count http {status}");
+                }
+                let response_body = response.into_string().unwrap_or_default();
+                parse_count_points_response(&response_body)
+            }
+            Err(error) => Err(anyhow::anyhow!("qdrant count request failed: {error}")),
+        }
+    }
+
+    /// Semantic search against Qdrant's Query API (parses `result.points[]` on HTTP 2xx).
+    pub fn search(
+        &self,
+        collection: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<super::CandidateHit>> {
+        if !qdrant_enabled() {
+            bail!("qdrant sidecar is mandatory; CODESTORY_QDRANT_ENABLED=false is unsupported");
+        }
+        let url = format!("{}/collections/{collection}/points/query", self.base_url);
+        let vector = query_vector(query)?;
+        let body = serde_json::json!({
+            "query": vector,
+            "limit": limit,
+            "with_payload": true,
+        });
+        let payload = serde_json::to_string(&body).context("serialize qdrant search body")?;
+        match ureq::post(&url)
+            .timeout(self.timeout)
+            .set("Content-Type", "application/json")
+            .send_string(&payload)
+        {
+            Ok(response) => {
+                let status = response.status();
+                if (200..300).contains(&status) {
+                    let response_body = response.into_string().unwrap_or_default();
+                    return parse_search_response(&response_body, limit);
+                }
+                bail!("qdrant search http {status}")
+            }
+            Err(error) => Err(anyhow::anyhow!("qdrant search request failed: {error}")),
+        }
+    }
+
+    /// Drop collection when embedding backend/dim changes (idempotent).
+    pub fn delete_collection(&self, collection: &str) -> Result<()> {
+        if !qdrant_enabled() {
+            return Ok(());
+        }
+        let url = format!("{}/collections/{collection}", self.base_url);
+        match ureq::delete(&url).timeout(QDRANT_MUTATION_BUDGET).call() {
+            Ok(response) => {
+                let status = response.status();
+                if status == 200 || status == 404 {
+                    self.clear_collection_stub_marker(collection);
+                    return Ok(());
+                }
+                bail!("delete collection http {status}");
+            }
+            Err(error) => {
+                if matches!(error, ureq::Error::Status(404, _)) {
+                    self.clear_collection_stub_marker(collection);
+                    return Ok(());
+                }
+                bail!("delete collection request failed: {error}")
+            }
+        }
+    }
+
+    /// Create collection when missing (idempotent for 409 already exists).
+    pub fn ensure_collection(&self, collection: &str) -> Result<()> {
+        if !qdrant_enabled() {
+            bail!("qdrant disabled");
+        }
+        let probe = self.health_probe(collection);
+        if !probe.reachable {
+            bail!("qdrant unreachable: {}", probe.detail);
+        }
+        if probe.collection_exists {
+            return Ok(());
+        }
+        let url = format!("{}/collections/{collection}", self.base_url);
+        let body = serde_json::json!({
+            "vectors": {
+                "size": active_vector_dim(),
+                "distance": "Cosine"
+            }
+        });
+        let payload = serde_json::to_string(&body).context("serialize create collection body")?;
+        match ureq::put(&url)
+            .timeout(QDRANT_MUTATION_BUDGET)
+            .set("Content-Type", "application/json")
+            .send_string(&payload)
+        {
+            Ok(response) => {
+                let status = response.status();
+                if status == 200 || status == 201 {
+                    return Ok(());
+                }
+                if status == 409 {
+                    return Ok(());
+                }
+                bail!("create collection http {status}");
+            }
+            Err(error) => bail!("create collection request failed: {error}"),
+        }
+    }
+
+    /// Upsert semantic points (replaces same ids on conflict).
+    ///
+    /// Product indexing supplies stored local semantic-document vectors. If no vectors are supplied,
+    /// this method still supports embedding labels for focused diagnostics; mixed batches fail.
+    pub fn upsert_points(&self, collection: &str, points: &[QdrantUpsertPoint]) -> Result<usize> {
+        if !qdrant_enabled() {
+            bail!("qdrant sidecar is mandatory; CODESTORY_QDRANT_ENABLED=false is unsupported");
+        }
+        if points.is_empty() {
+            return Ok(0);
+        }
+        self.ensure_collection(collection)?;
+        let url = format!(
+            "{}/collections/{collection}/points?wait=true",
+            self.base_url
+        );
+        let mut written = 0usize;
+        for chunk in points.chunks(QDRANT_INDEX_UPSERT_BATCH_SIZE) {
+            let vectors = vectors_for_points(chunk)?;
+            if vectors.len() != chunk.len() {
+                bail!(
+                    "embedding batch returned {} vector(s) for {} qdrant point(s)",
+                    vectors.len(),
+                    chunk.len()
+                );
+            }
+            let mut qdrant_points = Vec::with_capacity(chunk.len());
+            for (point, vector) in chunk.iter().zip(vectors) {
+                if vector.len() != active_vector_dim() {
+                    bail!(
+                        "qdrant point vector dim {} != collection dim {} for node {}",
+                        vector.len(),
+                        active_vector_dim(),
+                        point.node_id
+                    );
+                }
+                qdrant_points.push(serde_json::json!({
+                        "id": point.id,
+                        "vector": vector,
+                        "payload": {
+                            "node_id": point.node_id,
+                            "display_name": point.display_name,
+                            "path": point.file_path,
+                            "file_role": point.file_role.map(FileRole::as_str),
+                            "symbol": point.display_name,
+                        }
+                }));
+            }
+            let body = serde_json::json!({ "points": qdrant_points });
+            let payload = serde_json::to_string(&body).context("serialize upsert body")?;
+            match ureq::put(&url)
+                .timeout(QDRANT_UPSERT_BUDGET)
+                .set("Content-Type", "application/json")
+                .send_string(&payload)
+            {
+                Ok(response) => {
+                    let status = response.status();
+                    if (200..300).contains(&status) {
+                        written += chunk.len();
+                    } else {
+                        let body = response.into_string().unwrap_or_default();
+                        bail!("upsert points http {status}: {}", truncate_http_body(&body));
+                    }
+                }
+                Err(ureq::Error::Status(status, response)) => {
+                    let body = response.into_string().unwrap_or_default();
+                    bail!("upsert points http {status}: {}", truncate_http_body(&body));
+                }
+                Err(error) => bail!("upsert points request failed: {error}"),
+            }
+        }
+        self.clear_collection_stub_marker(collection);
+        Ok(written)
+    }
+
+    /// Smoke semantic search used by health probes (requires indexed collection).
+    pub fn semantic_search_smoke(&self, collection: &str) -> bool {
+        if !qdrant_semantic_vectors_enabled() {
+            return false;
+        }
+        match self.search(collection, "function", 3) {
+            Ok(hits) => hits.iter().any(|hit| {
+                let path = hit.file_path.trim();
+                !path.is_empty()
+                    && !path.contains(':')
+                    && (path.contains('/') || path.contains('\\') || path.contains('.'))
+            }),
+            Err(_) => false,
+        }
+    }
+
+    pub fn clear_collection_stub_marker(&self, collection: &str) {
+        let layout = SidecarLayout::from_env();
+        Self::clear_stub_marker_files(&layout.qdrant_data_dir, collection);
+    }
+
+    pub fn clear_stub_marker_files(qdrant_data_dir: &Path, collection: &str) {
+        let marker = Self::stub_marker_path(qdrant_data_dir, collection);
+        if marker.is_file() {
+            let _ = std::fs::remove_file(marker);
+        }
+        let legacy = Self::legacy_stub_marker_path(qdrant_data_dir, collection);
+        if legacy.is_file() {
+            let _ = std::fs::remove_file(legacy);
+        }
+    }
+
+    pub fn stub_marker_path(qdrant_data_dir: &Path, collection: &str) -> std::path::PathBuf {
+        qdrant_data_dir
+            .join("codestory-stub-markers")
+            .join(format!("{collection}.qdrant-stub"))
+    }
+
+    pub fn legacy_stub_marker_path(qdrant_data_dir: &Path, collection: &str) -> std::path::PathBuf {
+        qdrant_data_dir
+            .join("collections")
+            .join(collection)
+            .join(".qdrant-stub")
+    }
+
+    pub fn is_collection_stubbed(qdrant_data_dir: &Path, collection: &str) -> bool {
+        Self::stub_marker_path(qdrant_data_dir, collection).is_file()
+            || Self::legacy_stub_marker_path(qdrant_data_dir, collection).is_file()
+    }
+}
+
+fn parse_collection_names(body: &str) -> Result<Vec<String>> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).context("parse qdrant collections response json")?;
+    let Some(collections) = parsed
+        .get("result")
+        .and_then(|value| value.get("collections"))
+        .and_then(|value| value.as_array())
+    else {
+        return Ok(Vec::new());
+    };
+    let mut names = Vec::new();
+    for entry in collections {
+        if let Some(name) = entry.get("name").and_then(|value| value.as_str()) {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
+}
+
+fn parse_collection_point_count(body: &str) -> Option<u64> {
+    let parsed: serde_json::Value = serde_json::from_str(body).ok()?;
+    parsed
+        .get("result")
+        .and_then(|value| value.get("points_count"))
+        .or_else(|| {
+            parsed
+                .get("result")
+                .and_then(|value| value.get("indexed_vectors_count"))
+        })
+        .and_then(|value| value.as_u64())
+}
+
+fn parse_count_points_response(body: &str) -> Result<u64> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).context("parse qdrant count response json")?;
+    parsed
+        .get("result")
+        .and_then(|value| value.get("count"))
+        .and_then(|value| value.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("qdrant count response missing result.count"))
+}
+
+/// ureq treats 4xx as `Error::Status`; map collection GET 404 to reachable + missing.
+fn collection_probe_from_http_error(error: &ureq::Error) -> Option<(bool, bool, String)> {
+    let ureq::Error::Status(code, _) = error else {
+        return None;
+    };
+    if *code == 404 {
+        return Some((true, false, "http 404".into()));
+    }
+    if *code < 500 {
+        return Some((true, false, format!("http {code}")));
+    }
+    None
+}
+
+/// Parse Qdrant Query API JSON (`result.points[]` with payload paths / symbols).
+pub fn parse_search_response(body: &str, limit: usize) -> Result<Vec<super::CandidateHit>> {
+    use super::candidate::{CandidateHit, CandidateSource};
+    let parsed: serde_json::Value =
+        serde_json::from_str(body).context("parse qdrant search response json")?;
+    let points = parsed
+        .get("result")
+        .and_then(|value| value.get("points"))
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| anyhow::anyhow!("qdrant query response missing result.points"))?;
+    let mut hits = Vec::new();
+    for point in points {
+        if hits.len() >= limit {
+            break;
+        }
+        let score = point
+            .get("score")
+            .and_then(|value| value.as_f64())
+            .map(|value| value as f32)
+            .unwrap_or(0.5);
+        let payload = point.get("payload").and_then(|value| value.as_object());
+        let file_path = payload
+            .and_then(|map| map.get("path"))
+            .or_else(|| payload.and_then(|map| map.get("file_path")))
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .or_else(|| {
+                payload
+                    .and_then(|map| map.get("display_name"))
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+            });
+        let Some(file_path) = file_path else {
+            continue;
+        };
+        let symbol_name = payload
+            .and_then(|map| map.get("symbol"))
+            .or_else(|| payload.and_then(|map| map.get("display_name")))
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        let file_role = payload
+            .and_then(|map| map.get("file_role"))
+            .and_then(|value| value.as_str())
+            .map(FileRole::from_db_value);
+        let mut hit =
+            CandidateHit::with_source(file_path, symbol_name, score, CandidateSource::Qdrant);
+        hit.file_role = file_role;
+        hits.push(hit);
+    }
+    Ok(hits)
+}
+
+#[allow(dead_code)]
+pub fn label_to_vector(label: &str) -> Vec<f32> {
+    embeddings::label_to_vector(label)
+}
+
+fn query_vector(query: &str) -> Result<Vec<f32>> {
+    if qdrant_semantic_vectors_enabled() {
+        embeddings::embed_query(query)
+    } else {
+        Ok(embeddings::label_to_vector(query))
+    }
+}
+
+fn document_vectors(labels: &[String]) -> Result<Vec<Vec<f32>>> {
+    if qdrant_semantic_vectors_enabled() {
+        embeddings::embed_documents(labels)
+    } else {
+        Ok(labels
+            .iter()
+            .map(|label| embeddings::label_to_vector(label))
+            .collect())
+    }
+}
+
+fn vectors_for_points(points: &[QdrantUpsertPoint]) -> Result<Vec<Vec<f32>>> {
+    let provided = points.iter().filter(|point| point.vector.is_some()).count();
+    if provided == points.len() {
+        return Ok(points
+            .iter()
+            .map(|point| point.vector.clone().expect("count verified vectors"))
+            .collect());
+    }
+    if provided != 0 {
+        bail!(
+            "qdrant upsert received mixed stored and generated vectors; this would hide embedding contract drift"
+        );
+    }
+
+    let labels = points
+        .iter()
+        .map(|point| point.display_name.clone())
+        .collect::<Vec<_>>();
+    document_vectors(&labels).with_context(|| {
+        format!(
+            "embed qdrant document batch size={} first={}",
+            labels.len(),
+            labels.first().map(String::as_str).unwrap_or("<empty>")
+        )
+    })
+}
+
+fn truncate_http_body(body: &str) -> String {
+    const MAX: usize = 512;
+    let trimmed = body.trim();
+    if trimmed.len() <= MAX {
+        return trimmed.to_string();
+    }
+    format!("{}...", &trimmed[..MAX])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::candidate::CandidateSource;
+
+    #[test]
+    fn label_to_vector_has_fixed_dim() {
+        let vector = label_to_vector("handler");
+        assert_eq!(vector.len(), QDRANT_VECTOR_DIM);
+        assert!(vector.iter().all(|value| (0.0..=1.0).contains(value)));
+    }
+
+    #[test]
+    fn parse_search_response_maps_query_points() {
+        let body = r#"{
+            "result": {
+                "points": [
+                    {
+                        "score": 0.91,
+                        "payload": {
+                            "path": "src/handler.rs",
+                            "symbol": "handle_request",
+                            "file_role": "source"
+                        }
+                    }
+                ]
+            }
+        }"#;
+        let hits = parse_search_response(body, 8).expect("parse");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].file_path, "src/handler.rs");
+        assert_eq!(hits[0].symbol_name.as_deref(), Some("handle_request"));
+        assert_eq!(hits[0].source, CandidateSource::Qdrant);
+        assert_eq!(hits[0].file_role, Some(FileRole::Source));
+    }
+
+    #[test]
+    fn parse_search_response_empty_result_is_empty() {
+        let hits = parse_search_response(r#"{ "result": { "points": [] } }"#, 8).expect("parse");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn parse_search_response_missing_result_points_is_error() {
+        let error = parse_search_response(r#"{ "status": "ok" }"#, 8)
+            .expect_err("query response must contain result.points");
+        assert!(error.to_string().contains("result.points"));
+    }
+
+    #[test]
+    fn parse_collection_names_reads_result_array() {
+        let body = r#"{
+            "result": {
+                "collections": [
+                    { "name": "codestory_a" },
+                    { "name": "other" }
+                ]
+            }
+        }"#;
+        let names = parse_collection_names(body).expect("parse");
+        assert_eq!(names, vec!["codestory_a", "other"]);
+    }
+
+    #[test]
+    fn parse_collection_point_count_reads_collection_info() {
+        let body = r#"{
+            "result": {
+                "status": "green",
+                "points_count": 42,
+                "indexed_vectors_count": 40
+            }
+        }"#;
+
+        assert_eq!(parse_collection_point_count(body), Some(42));
+    }
+
+    #[test]
+    fn parse_count_points_response_reads_exact_count() {
+        let body = r#"{ "result": { "count": 1234 }, "status": "ok" }"#;
+
+        assert_eq!(parse_count_points_response(body).expect("parse"), 1234);
+    }
+}

--- a/crates/codestory-retrieval/src/qdrant_storage.rs
+++ b/crates/codestory-retrieval/src/qdrant_storage.rs
@@ -1,0 +1,934 @@
+//! Qdrant on-disk storage repair before sidecar bootstrap (invalid dirs, retention, stub migration).
+
+use crate::config::{SidecarLayout, user_cache_root};
+use crate::qdrant_client::QdrantClient;
+use anyhow::{Context, Result};
+use codestory_store::Store;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::{debug, warn};
+
+/// Default cap for `codestory_*` collections; protected manifest collections are never pruned.
+pub const DEFAULT_QDRANT_COLLECTION_RETENTION: usize = 64;
+
+/// Machine-readable reason when retention deletes are skipped after protection-scan errors.
+pub const PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR: &str = "protection_scan_error";
+
+/// Inputs for manifest-aware Qdrant collection protection during bootstrap repair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BootstrapStorageScope {
+    pub repo_root: Option<PathBuf>,
+    pub active_storage_path: Option<PathBuf>,
+    pub active_cache_root: Option<PathBuf>,
+    pub global_cache_root: PathBuf,
+}
+
+impl BootstrapStorageScope {
+    pub fn from_parts(
+        repo_root: Option<&Path>,
+        active_storage_path: Option<&Path>,
+        active_cache_root: Option<&Path>,
+    ) -> Self {
+        Self {
+            repo_root: repo_root.map(Path::to_path_buf),
+            active_storage_path: active_storage_path.map(Path::to_path_buf),
+            active_cache_root: active_cache_root.map(Path::to_path_buf),
+            global_cache_root: user_cache_root(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct ProtectionScanResult {
+    protected: HashSet<String>,
+    recency_by_collection: HashMap<String, i64>,
+    scan_errors: Vec<String>,
+    sources_scanned: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct QdrantStorageRepairReport {
+    pub qdrant_reachable: bool,
+    pub removed_invalid_dirs: usize,
+    pub migrated_legacy_stub_markers: usize,
+    pub pruned_collections: usize,
+    pub protected_collections: usize,
+    pub collections_seen: usize,
+    pub prune_candidates: usize,
+    pub overflow_protected: bool,
+    pub scan_errors: Vec<String>,
+    pub sources_scanned: usize,
+    /// Set when retention deletes were skipped (e.g. `protection_scan_error`).
+    pub prune_suppressed_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RetentionPlan {
+    to_prune: Vec<String>,
+    overflow_protected: bool,
+}
+
+pub fn repair_qdrant_storage(
+    layout: &SidecarLayout,
+    scope: &BootstrapStorageScope,
+    max_keep: usize,
+) -> Result<QdrantStorageRepairReport> {
+    let mut scan = collect_protected_collections(scope)?;
+    let protected = scan.protected.clone();
+    let protected_count = protected.len();
+    let qdrant = QdrantClient::new(layout);
+    let probe = qdrant.list_collections_probe();
+
+    let (removed_invalid_dirs, migrated_legacy_stub_markers) =
+        if offline_disk_cleanup_when_unreachable(probe.reachable) {
+            run_offline_disk_cleanup(&layout.qdrant_data_dir)?
+        } else {
+            (0, 0)
+        };
+
+    let prune_suppressed_reason = prune_suppressed_reason(&scan.scan_errors);
+    let suppress_prune = prune_suppressed_reason.is_some();
+
+    let (pruned, collections_seen, prune_candidates, overflow_protected) = if suppress_prune {
+        measure_retention(
+            &qdrant,
+            layout,
+            probe.reachable,
+            &protected,
+            &scan.recency_by_collection,
+            max_keep,
+        )?
+    } else if probe.reachable {
+        execute_retention_via_http(
+            &qdrant,
+            layout,
+            &protected,
+            &scan.recency_by_collection,
+            max_keep,
+            &mut scan.scan_errors,
+        )?
+    } else {
+        execute_retention_on_disk(
+            &layout.qdrant_data_dir,
+            &protected,
+            &scan.recency_by_collection,
+            max_keep,
+        )?
+    };
+
+    debug!(
+        qdrant_reachable = probe.reachable,
+        protected_collections = protected_count,
+        removed_invalid_dirs,
+        migrated_legacy_stub_markers,
+        pruned_collections = pruned,
+        collections_seen,
+        prune_candidates,
+        overflow_protected,
+        scan_errors = scan.scan_errors.len(),
+        prune_suppressed = prune_suppressed_reason.is_some(),
+        "qdrant storage repair complete"
+    );
+
+    Ok(QdrantStorageRepairReport {
+        qdrant_reachable: probe.reachable,
+        removed_invalid_dirs,
+        migrated_legacy_stub_markers,
+        pruned_collections: pruned,
+        protected_collections: protected_count,
+        collections_seen,
+        prune_candidates,
+        overflow_protected,
+        scan_errors: scan.scan_errors,
+        sources_scanned: scan.sources_scanned,
+        prune_suppressed_reason,
+    })
+}
+
+fn prune_on_scan_error_override() -> bool {
+    std::env::var("CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR")
+        .ok()
+        .is_some_and(|value| {
+            matches!(
+                value.trim(),
+                "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
+            )
+        })
+}
+
+fn prune_suppressed_reason(scan_errors: &[String]) -> Option<String> {
+    if scan_errors.is_empty() || prune_on_scan_error_override() {
+        None
+    } else {
+        Some(PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR.to_string())
+    }
+}
+
+fn run_offline_disk_cleanup(qdrant_data_dir: &Path) -> Result<(usize, usize)> {
+    Ok((
+        remove_invalid_collection_dirs(qdrant_data_dir)?,
+        migrate_legacy_stub_markers(qdrant_data_dir)?,
+    ))
+}
+
+fn offline_disk_cleanup_when_unreachable(qdrant_reachable: bool) -> bool {
+    !qdrant_reachable
+}
+
+fn collect_protected_collections(scope: &BootstrapStorageScope) -> Result<ProtectionScanResult> {
+    let mut result = ProtectionScanResult::default();
+
+    let mut scanned_dbs = HashSet::new();
+    scan_cache_tree(&scope.global_cache_root, &mut scanned_dbs, &mut result)?;
+
+    if let Some(active_cache) = scope.active_cache_root.as_deref()
+        && active_cache != scope.global_cache_root.as_path()
+    {
+        scan_cache_tree(active_cache, &mut scanned_dbs, &mut result)?;
+    }
+
+    if let Some(storage_path) = scope.active_storage_path.as_deref()
+        && storage_path.is_file()
+    {
+        scan_manifest_db(storage_path, &mut scanned_dbs, &mut result)?;
+    }
+
+    Ok(result)
+}
+
+fn scan_cache_tree(
+    cache_root: &Path,
+    scanned_dbs: &mut HashSet<PathBuf>,
+    result: &mut ProtectionScanResult,
+) -> Result<()> {
+    let flat_db = cache_root.join("codestory.db");
+    if flat_db.is_file() {
+        scan_manifest_db(&flat_db, scanned_dbs, result)?;
+    }
+    if !cache_root.is_dir() {
+        return Ok(());
+    }
+    let entries = match std::fs::read_dir(cache_root) {
+        Ok(entries) => entries,
+        Err(err) => {
+            result
+                .scan_errors
+                .push(format!("read cache root {}: {err}", cache_root.display()));
+            return Ok(());
+        }
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                result.scan_errors.push(format!(
+                    "read cache entry under {}: {err}",
+                    cache_root.display()
+                ));
+                continue;
+            }
+        };
+        let db_path = entry.path().join("codestory.db");
+        if db_path.is_file() {
+            scan_manifest_db(&db_path, scanned_dbs, result)?;
+        }
+    }
+    Ok(())
+}
+
+fn scan_manifest_db(
+    db_path: &Path,
+    scanned_dbs: &mut HashSet<PathBuf>,
+    result: &mut ProtectionScanResult,
+) -> Result<()> {
+    let canonical = db_path
+        .canonicalize()
+        .unwrap_or_else(|_| db_path.to_path_buf());
+    if !scanned_dbs.insert(canonical) {
+        return Ok(());
+    }
+    result.sources_scanned += 1;
+    match Store::open(db_path) {
+        Ok(storage) => match storage.list_retrieval_qdrant_collections_with_recency() {
+            Ok(entries) => {
+                for (collection, recency_ms) in entries {
+                    result.protected.insert(collection.clone());
+                    result
+                        .recency_by_collection
+                        .entry(collection)
+                        .and_modify(|existing| *existing = (*existing).max(recency_ms))
+                        .or_insert(recency_ms);
+                }
+            }
+            Err(err) => result
+                .scan_errors
+                .push(format!("list manifests in {}: {err}", db_path.display())),
+        },
+        Err(err) => result
+            .scan_errors
+            .push(format!("open cache db {}: {err}", db_path.display())),
+    }
+    Ok(())
+}
+
+fn collection_has_config(collection_dir: &Path) -> bool {
+    collection_dir.join("config.json").is_file()
+        || collection_dir.join("config").join("params.json").is_file()
+}
+
+fn remove_invalid_collection_dirs(qdrant_data_dir: &Path) -> Result<usize> {
+    let collections_dir = qdrant_data_dir.join("collections");
+    let Ok(entries) = std::fs::read_dir(&collections_dir) else {
+        return Ok(0);
+    };
+    let mut removed = 0usize;
+    for entry in entries.flatten() {
+        let collection_dir = entry.path();
+        if !collection_dir.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("codestory_") {
+            continue;
+        }
+        if !collection_has_config(&collection_dir) {
+            std::fs::remove_dir_all(&collection_dir).with_context(|| {
+                format!(
+                    "remove invalid qdrant collection dir without config {}",
+                    collection_dir.display()
+                )
+            })?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+fn migrate_legacy_stub_markers(qdrant_data_dir: &Path) -> Result<usize> {
+    let collections_dir = qdrant_data_dir.join("collections");
+    let Ok(entries) = std::fs::read_dir(&collections_dir) else {
+        return Ok(0);
+    };
+    let mut migrated = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let legacy = QdrantClient::legacy_stub_marker_path(qdrant_data_dir, &name);
+        if !legacy.is_file() {
+            continue;
+        }
+        let new_path = QdrantClient::stub_marker_path(qdrant_data_dir, &name);
+        if !new_path.is_file() {
+            if let Some(parent) = new_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(&legacy, &new_path).with_context(|| {
+                format!(
+                    "migrate legacy qdrant stub marker {} -> {}",
+                    legacy.display(),
+                    new_path.display()
+                )
+            })?;
+            migrated += 1;
+        }
+        let _ = std::fs::remove_file(legacy);
+    }
+    Ok(migrated)
+}
+
+#[derive(Debug, Clone)]
+struct CollectionCandidate {
+    name: String,
+    rank_key: u128,
+}
+
+fn candidate_rank_key(recency_ms: Option<i64>, modified: SystemTime) -> u128 {
+    if let Some(ms) = recency_ms {
+        return ms.max(0) as u128;
+    }
+    modified
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn plan_retention(
+    all: &[CollectionCandidate],
+    protected: &HashSet<String>,
+    max_keep: usize,
+) -> RetentionPlan {
+    if all.len() <= max_keep {
+        return RetentionPlan {
+            to_prune: Vec::new(),
+            overflow_protected: false,
+        };
+    }
+    let mut unprotected: Vec<&CollectionCandidate> = all
+        .iter()
+        .filter(|candidate| !protected.contains(&candidate.name))
+        .collect();
+    if unprotected.is_empty() {
+        return RetentionPlan {
+            to_prune: Vec::new(),
+            overflow_protected: true,
+        };
+    }
+    let excess = all.len().saturating_sub(max_keep);
+    unprotected.sort_by_key(|candidate| candidate.rank_key);
+    RetentionPlan {
+        to_prune: unprotected
+            .into_iter()
+            .take(excess)
+            .map(|candidate| candidate.name.clone())
+            .collect(),
+        overflow_protected: false,
+    }
+}
+
+fn list_on_disk_codestory_collections(
+    qdrant_data_dir: &Path,
+    recency_by_collection: &HashMap<String, i64>,
+) -> Result<Vec<CollectionCandidate>> {
+    let collections_dir = qdrant_data_dir.join("collections");
+    let Ok(entries) = std::fs::read_dir(&collections_dir) else {
+        return Ok(Vec::new());
+    };
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        let collection_dir = entry.path();
+        if !collection_dir.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("codestory_") || !collection_has_config(&collection_dir) {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        let recency = recency_by_collection.get(&name).copied();
+        candidates.push(CollectionCandidate {
+            name,
+            rank_key: candidate_rank_key(recency, modified),
+        });
+    }
+    Ok(candidates)
+}
+
+fn measure_retention(
+    qdrant: &QdrantClient,
+    layout: &SidecarLayout,
+    qdrant_reachable: bool,
+    protected: &HashSet<String>,
+    recency_by_collection: &HashMap<String, i64>,
+    max_keep: usize,
+) -> Result<(usize, usize, usize, bool)> {
+    let all = if qdrant_reachable {
+        list_http_codestory_collections(qdrant, layout, recency_by_collection)?
+    } else {
+        list_on_disk_codestory_collections(&layout.qdrant_data_dir, recency_by_collection)?
+    };
+    let collections_seen = all.len();
+    let plan = plan_retention(&all, protected, max_keep);
+    Ok((
+        0,
+        collections_seen,
+        plan.to_prune.len(),
+        plan.overflow_protected,
+    ))
+}
+
+fn list_http_codestory_collections(
+    qdrant: &QdrantClient,
+    layout: &SidecarLayout,
+    recency_by_collection: &HashMap<String, i64>,
+) -> Result<Vec<CollectionCandidate>> {
+    let names = qdrant.list_collection_names().unwrap_or_default();
+    let mut all: Vec<CollectionCandidate> = names
+        .into_iter()
+        .filter(|name| name.starts_with("codestory_"))
+        .map(|name| {
+            let dir = layout.qdrant_data_dir.join("collections").join(&name);
+            let modified = std::fs::metadata(&dir)
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            let recency = recency_by_collection.get(&name).copied();
+            CollectionCandidate {
+                name,
+                rank_key: candidate_rank_key(recency, modified),
+            }
+        })
+        .collect();
+    if all.is_empty() {
+        all = list_on_disk_codestory_collections(&layout.qdrant_data_dir, recency_by_collection)?;
+    }
+    Ok(all)
+}
+
+fn execute_retention_on_disk(
+    qdrant_data_dir: &Path,
+    protected: &HashSet<String>,
+    recency_by_collection: &HashMap<String, i64>,
+    max_keep: usize,
+) -> Result<(usize, usize, usize, bool)> {
+    let all = list_on_disk_codestory_collections(qdrant_data_dir, recency_by_collection)?;
+    let collections_seen = all.len();
+    let plan = plan_retention(&all, protected, max_keep);
+    let prune_candidates = plan.to_prune.len();
+    let mut removed = 0usize;
+    for name in plan.to_prune {
+        let path = qdrant_data_dir.join("collections").join(&name);
+        if path.is_dir() {
+            std::fs::remove_dir_all(&path).with_context(|| {
+                format!(
+                    "remove stale qdrant collection dir beyond retention {}",
+                    path.display()
+                )
+            })?;
+            QdrantClient::clear_stub_marker_files(qdrant_data_dir, &name);
+            removed += 1;
+        }
+    }
+    Ok((
+        removed,
+        collections_seen,
+        prune_candidates,
+        plan.overflow_protected,
+    ))
+}
+
+fn execute_retention_via_http(
+    qdrant: &QdrantClient,
+    layout: &SidecarLayout,
+    protected: &HashSet<String>,
+    recency_by_collection: &HashMap<String, i64>,
+    max_keep: usize,
+    repair_errors: &mut Vec<String>,
+) -> Result<(usize, usize, usize, bool)> {
+    let all = list_http_codestory_collections(qdrant, layout, recency_by_collection)?;
+    let collections_seen = all.len();
+    let plan = plan_retention(&all, protected, max_keep);
+    let prune_candidates = plan.to_prune.len();
+    let mut removed = 0usize;
+    for name in plan.to_prune {
+        match qdrant.delete_collection(&name) {
+            Ok(()) => {
+                removed += 1;
+            }
+            Err(error) => {
+                warn!(
+                    collection = %name,
+                    %error,
+                    "failed to prune stale Qdrant collection; continuing bootstrap repair"
+                );
+                repair_errors.push(format!("delete stale qdrant collection {name}: {error}"));
+            }
+        }
+    }
+    Ok((
+        removed,
+        collections_seen,
+        prune_candidates,
+        plan.overflow_protected,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qdrant_client::QdrantClient;
+    use codestory_store::RetrievalIndexManifest;
+    use std::fs;
+    use std::sync::Mutex;
+    use std::thread;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    static PRUNE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_prune_env() -> std::sync::MutexGuard<'static, ()> {
+        PRUNE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn offline_test_layout(qdrant_data: &tempfile::TempDir) -> SidecarLayout {
+        SidecarLayout {
+            zoekt_http_port: 6070,
+            qdrant_http_port: 1,
+            qdrant_grpc_port: 1,
+            zoekt_data_dir: qdrant_data.path().join("zoekt"),
+            qdrant_data_dir: qdrant_data.path().to_path_buf(),
+            scip_artifacts_root: qdrant_data.path().join("scip"),
+            state_file: qdrant_data.path().join("state.json"),
+        }
+    }
+
+    fn touch_collection(collections_dir: &Path, name: &str, with_config: bool) {
+        let dir = collections_dir.join(name);
+        fs::create_dir_all(&dir).expect("create collection dir");
+        if with_config {
+            fs::write(dir.join("config.json"), "{}").expect("write config");
+        }
+    }
+
+    #[test]
+    fn remove_invalid_collection_dirs_drops_codestory_dirs_without_config() {
+        let root = tempdir().expect("tempdir");
+        let collections = root.path().join("collections");
+        touch_collection(&collections, "codestory_bad", false);
+        touch_collection(&collections, "codestory_good", true);
+        touch_collection(&collections, "other_bad", false);
+        let removed = remove_invalid_collection_dirs(root.path()).expect("cleanup");
+        assert_eq!(removed, 1);
+        assert!(!collections.join("codestory_bad").exists());
+        assert!(collections.join("codestory_good").exists());
+        assert!(collections.join("other_bad").exists());
+    }
+
+    #[test]
+    fn prune_on_disk_skips_protected_collections() {
+        let root = tempdir().expect("tempdir");
+        let collections = root.path().join("collections");
+        let mut protected = HashSet::new();
+        for index in 0..65 {
+            let name = format!("codestory_repo_{index:02}");
+            touch_collection(&collections, &name, true);
+            if index == 0 {
+                protected.insert(name);
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        let (pruned, seen, _, overflow) =
+            execute_retention_on_disk(root.path(), &protected, &HashMap::new(), 64).expect("prune");
+        assert!(pruned > 0);
+        assert_eq!(seen, 65);
+        assert!(!overflow);
+        assert!(collections.join("codestory_repo_00").exists());
+    }
+
+    #[test]
+    fn plan_retention_reports_overflow_when_all_protected() {
+        let candidates: Vec<CollectionCandidate> = (0..70)
+            .map(|index| CollectionCandidate {
+                name: format!("codestory_{index:02}"),
+                rank_key: index as u128,
+            })
+            .collect();
+        let protected: HashSet<String> = candidates
+            .iter()
+            .map(|candidate| candidate.name.clone())
+            .collect();
+        let plan = plan_retention(&candidates, &protected, 64);
+        assert!(plan.to_prune.is_empty());
+        assert!(plan.overflow_protected);
+    }
+
+    #[test]
+    fn collect_protected_includes_flat_custom_cache_root() {
+        let global_cache = tempdir().expect("global cache");
+        let custom_cache = tempdir().expect("custom cache");
+        fs::create_dir_all(custom_cache.path()).expect("mkdir custom");
+        let custom_db = custom_cache.path().join("codestory.db");
+        let mut storage = Store::open(&custom_db).expect("open custom db");
+        storage
+            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                project_id: "custom".into(),
+                zoekt_version: "v1".into(),
+                qdrant_collection: "codestory_custom_flat".into(),
+                scip_revision: None,
+                built_at_epoch_ms: 42,
+                disk_bytes: None,
+                degraded_modes_json: "[]".into(),
+                embedding_backend: None,
+                embedding_dim: None,
+                sidecar_schema_version: None,
+                sidecar_input_hash: None,
+                sidecar_generation: None,
+                projection_count: None,
+            })
+            .expect("upsert");
+
+        let scope = BootstrapStorageScope {
+            repo_root: None,
+            active_storage_path: Some(custom_db),
+            active_cache_root: Some(custom_cache.path().to_path_buf()),
+            global_cache_root: global_cache.path().to_path_buf(),
+        };
+        let scan = collect_protected_collections(&scope).expect("scan");
+        assert!(scan.protected.contains("codestory_custom_flat"));
+    }
+
+    #[test]
+    fn collect_protected_records_corrupt_cache_db_warning() {
+        let cache_root = tempdir().expect("cache");
+        let corrupt_db = cache_root.path().join("codestory.db");
+        fs::write(&corrupt_db, b"not sqlite").expect("write corrupt db");
+        let scope = BootstrapStorageScope {
+            repo_root: None,
+            active_storage_path: Some(corrupt_db.clone()),
+            active_cache_root: Some(cache_root.path().to_path_buf()),
+            global_cache_root: cache_root.path().to_path_buf(),
+        };
+        let scan = collect_protected_collections(&scope).expect("scan");
+        assert!(!scan.scan_errors.is_empty());
+        assert!(scan.scan_errors[0].contains("open cache db"));
+    }
+
+    #[test]
+    fn protected_scan_reads_hashed_manifest_databases() {
+        let cache_root = tempdir().expect("cache tempdir");
+        let project_cache_a = cache_root.path().join("aaaaaaaaaaaaaaaa");
+        let project_cache_b = cache_root.path().join("bbbbbbbbbbbbbbbb");
+        fs::create_dir_all(&project_cache_a).expect("cache a");
+        fs::create_dir_all(&project_cache_b).expect("cache b");
+
+        let mut storage_a = Store::open(project_cache_a.join("codestory.db")).expect("open a");
+        storage_a
+            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                project_id: "a".into(),
+                zoekt_version: "v1".into(),
+                qdrant_collection: "codestory_from_a".into(),
+                scip_revision: None,
+                built_at_epoch_ms: 1,
+                disk_bytes: None,
+                degraded_modes_json: "[]".into(),
+                embedding_backend: None,
+                embedding_dim: None,
+                sidecar_schema_version: None,
+                sidecar_input_hash: None,
+                sidecar_generation: None,
+                projection_count: None,
+            })
+            .expect("manifest a");
+
+        let mut storage_b = Store::open(project_cache_b.join("codestory.db")).expect("open b");
+        storage_b
+            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                project_id: "b".into(),
+                zoekt_version: "v1".into(),
+                qdrant_collection: "codestory_from_b".into(),
+                scip_revision: None,
+                built_at_epoch_ms: 1,
+                disk_bytes: None,
+                degraded_modes_json: "[]".into(),
+                embedding_backend: None,
+                embedding_dim: None,
+                sidecar_schema_version: None,
+                sidecar_input_hash: None,
+                sidecar_generation: None,
+                projection_count: None,
+            })
+            .expect("manifest b");
+
+        let scope = BootstrapStorageScope {
+            repo_root: None,
+            active_storage_path: None,
+            active_cache_root: None,
+            global_cache_root: cache_root.path().to_path_buf(),
+        };
+        let scan = collect_protected_collections(&scope).expect("scan manifests");
+        assert!(scan.protected.contains("codestory_from_a"));
+        assert!(scan.protected.contains("codestory_from_b"));
+    }
+
+    #[test]
+    fn migrate_legacy_stub_marker_creates_new_path() {
+        let root = tempdir().expect("tempdir");
+        let collection = "codestory_legacy";
+        let legacy = QdrantClient::legacy_stub_marker_path(root.path(), collection);
+        fs::create_dir_all(legacy.parent().expect("parent")).expect("mkdir");
+        fs::write(&legacy, "legacy").expect("write legacy");
+        let migrated = migrate_legacy_stub_markers(root.path()).expect("migrate");
+        assert_eq!(migrated, 1);
+        assert!(QdrantClient::stub_marker_path(root.path(), collection).is_file());
+        assert!(!legacy.is_file());
+    }
+
+    #[test]
+    fn is_collection_stubbed_checks_legacy_path() {
+        let root = tempdir().expect("tempdir");
+        let collection = "codestory_x";
+        let legacy = QdrantClient::legacy_stub_marker_path(root.path(), collection);
+        fs::create_dir_all(legacy.parent().expect("parent")).expect("mkdir");
+        fs::write(&legacy, "stub").expect("write");
+        assert!(QdrantClient::is_collection_stubbed(root.path(), collection));
+    }
+
+    #[test]
+    fn collect_protected_scans_flat_and_hashed_when_both_present() {
+        let cache_root = tempdir().expect("cache");
+        let flat_db = cache_root.path().join("codestory.db");
+        let mut flat_storage = Store::open(&flat_db).expect("open flat db");
+        flat_storage
+            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                project_id: "flat".into(),
+                zoekt_version: "v1".into(),
+                qdrant_collection: "codestory_flat_layout".into(),
+                scip_revision: None,
+                built_at_epoch_ms: 1,
+                disk_bytes: None,
+                degraded_modes_json: "[]".into(),
+                embedding_backend: None,
+                embedding_dim: None,
+                sidecar_schema_version: None,
+                sidecar_input_hash: None,
+                sidecar_generation: None,
+                projection_count: None,
+            })
+            .expect("flat manifest");
+
+        let hashed_dir = cache_root.path().join("bbbbbbbbbbbbbbbb");
+        fs::create_dir_all(&hashed_dir).expect("hashed dir");
+        let mut hashed_storage =
+            Store::open(hashed_dir.join("codestory.db")).expect("open hashed db");
+        hashed_storage
+            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                project_id: "hashed".into(),
+                zoekt_version: "v1".into(),
+                qdrant_collection: "codestory_hashed_layout".into(),
+                scip_revision: None,
+                built_at_epoch_ms: 1,
+                disk_bytes: None,
+                degraded_modes_json: "[]".into(),
+                embedding_backend: None,
+                embedding_dim: None,
+                sidecar_schema_version: None,
+                sidecar_input_hash: None,
+                sidecar_generation: None,
+                projection_count: None,
+            })
+            .expect("hashed manifest");
+
+        let scope = BootstrapStorageScope {
+            repo_root: None,
+            active_storage_path: None,
+            active_cache_root: None,
+            global_cache_root: cache_root.path().to_path_buf(),
+        };
+        let scan = collect_protected_collections(&scope).expect("scan both layouts");
+        assert!(scan.protected.contains("codestory_flat_layout"));
+        assert!(scan.protected.contains("codestory_hashed_layout"));
+    }
+
+    #[test]
+    fn scan_cache_tree_records_unreadable_cache_root_without_panic() {
+        let cache_root = tempdir().expect("cache");
+        let missing = cache_root.path().join("nested-missing");
+        let mut scanned = HashSet::new();
+        let mut result = ProtectionScanResult::default();
+        scan_cache_tree(&missing, &mut scanned, &mut result).expect("missing root is ok");
+        assert!(result.scan_errors.is_empty());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let unreadable = cache_root.path().join("unreadable");
+            fs::create_dir_all(&unreadable).expect("mkdir unreadable");
+            fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000))
+                .expect("chmod unreadable");
+            scan_cache_tree(&unreadable, &mut scanned, &mut result).expect("no panic");
+            assert!(
+                result
+                    .scan_errors
+                    .iter()
+                    .any(|error| error.contains("read cache root")),
+                "expected read cache root scan error, got {:?}",
+                result.scan_errors
+            );
+            fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o755))
+                .expect("restore permissions");
+        }
+    }
+
+    #[test]
+    fn repair_suppresses_prune_when_protection_scan_errors_present() {
+        let _guard = lock_prune_env();
+        // SAFETY: serialized env mutation for this test only.
+        unsafe {
+            std::env::remove_var("CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR");
+        }
+        let cache_root = tempdir().expect("cache");
+        let corrupt_db = cache_root.path().join("codestory.db");
+        fs::write(&corrupt_db, b"not sqlite").expect("write corrupt db");
+        let qdrant_data = tempdir().expect("qdrant data");
+        let collections = qdrant_data.path().join("collections");
+        fs::create_dir_all(&collections).expect("mkdir collections");
+        for index in 0..65 {
+            touch_collection(&collections, &format!("codestory_prune_{index:02}"), true);
+        }
+
+        let layout = offline_test_layout(&qdrant_data);
+        let scope = BootstrapStorageScope {
+            repo_root: None,
+            active_storage_path: Some(corrupt_db),
+            active_cache_root: Some(cache_root.path().to_path_buf()),
+            global_cache_root: cache_root.path().to_path_buf(),
+        };
+
+        let report = repair_qdrant_storage(&layout, &scope, 64).expect("repair");
+        assert!(!report.scan_errors.is_empty());
+        assert_eq!(
+            report.prune_suppressed_reason.as_deref(),
+            Some(PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR)
+        );
+        assert_eq!(report.pruned_collections, 0);
+        assert!(collections.join("codestory_prune_64").exists());
+    }
+
+    #[test]
+    fn prune_suppression_honors_env_override() {
+        let _guard = lock_prune_env();
+        // SAFETY: serialized env mutation for this test only.
+        unsafe {
+            std::env::set_var("CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR", "1");
+        }
+        let cache_root = tempdir().expect("cache");
+        let corrupt_db = cache_root.path().join("codestory.db");
+        fs::write(&corrupt_db, b"not sqlite").expect("write corrupt db");
+        let qdrant_data = tempdir().expect("qdrant data");
+        let collections = qdrant_data.path().join("collections");
+        fs::create_dir_all(&collections).expect("mkdir collections");
+        for index in 0..65 {
+            touch_collection(
+                &collections,
+                &format!("codestory_override_{index:02}"),
+                true,
+            );
+        }
+        let layout = offline_test_layout(&qdrant_data);
+        let scope = BootstrapStorageScope {
+            repo_root: None,
+            active_storage_path: Some(corrupt_db),
+            active_cache_root: Some(cache_root.path().to_path_buf()),
+            global_cache_root: cache_root.path().to_path_buf(),
+        };
+        let report = repair_qdrant_storage(&layout, &scope, 64).expect("repair with override");
+        assert!(report.prune_suppressed_reason.is_none());
+        assert!(report.pruned_collections > 0);
+        // SAFETY: test env cleanup.
+        unsafe {
+            std::env::remove_var("CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR");
+        }
+    }
+
+    #[test]
+    fn offline_disk_cleanup_runs_only_when_qdrant_unreachable() {
+        assert!(offline_disk_cleanup_when_unreachable(false));
+        assert!(!offline_disk_cleanup_when_unreachable(true));
+    }
+
+    #[test]
+    fn offline_disk_cleanup_removes_invalid_dirs_when_enabled() {
+        let root = tempdir().expect("tempdir");
+        let collections = root.path().join("collections");
+        touch_collection(&collections, "codestory_bad", false);
+        let (removed_invalid, migrated) = run_offline_disk_cleanup(root.path()).expect("cleanup");
+        assert_eq!(removed_invalid, 1);
+        assert_eq!(migrated, 0);
+        assert!(!collections.join("codestory_bad").exists());
+    }
+}

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -1,0 +1,410 @@
+use crate::cache::RetrievalCache;
+use crate::config::SidecarLayout;
+use crate::executor::{QueryExecutor, QueryResult, cancellation_flag};
+use crate::generation::manifest_unavailable_reason;
+use crate::index::project_id_for_root;
+use crate::sidecar::validate_strict_sidecar_readiness;
+use crate::sidecar_search::LiveSidecarSearch;
+use anyhow::{Context, Result, bail};
+use codestory_store::Store;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+#[derive(Debug, Clone)]
+pub struct QueryRequest<'a> {
+    pub project_root: &'a Path,
+    pub storage_path: &'a Path,
+    pub query: &'a str,
+    pub budget_ms: Option<u64>,
+    pub cancelled: Option<Arc<AtomicBool>>,
+}
+
+pub fn execute_retrieval_query(request: QueryRequest<'_>) -> Result<QueryResult> {
+    let mut cache = RetrievalCache::new();
+    execute_retrieval_query_with_cache(request, &mut cache)
+}
+
+pub fn execute_retrieval_query_with_cache(
+    request: QueryRequest<'_>,
+    cache: &mut RetrievalCache,
+) -> Result<QueryResult> {
+    let layout = SidecarLayout::from_env();
+    let project_id = project_id_for_root(request.project_root);
+    let (manifest, file_roles) = if request.storage_path.exists() {
+        let storage = Store::open(request.storage_path).context("open storage for query")?;
+        let manifest = storage
+            .get_retrieval_index_manifest(&project_id)
+            .context("load retrieval manifest")?;
+        if let Some(manifest) = manifest.as_ref() {
+            if let Err(error) = validate_strict_sidecar_readiness(request.project_root, &storage) {
+                bail!(
+                    "retrieval sidecar manifest is unavailable ({error}); run retrieval index for project {project_id}"
+                );
+            }
+            if let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest) {
+                bail!(
+                    "retrieval sidecar manifest is unavailable ({reason}); run retrieval index for project {project_id}"
+                );
+            }
+        } else {
+            bail!(
+                "retrieval sidecar manifest is missing; run retrieval index for project {project_id}"
+            );
+        }
+        let roles = storage
+            .get_files()
+            .map(|files| {
+                files
+                    .into_iter()
+                    .map(|file| (file.path.to_string_lossy().to_string(), file.file_role))
+                    .collect()
+            })
+            .unwrap_or_default();
+        (manifest, roles)
+    } else {
+        bail!("retrieval sidecar storage is missing; run retrieval index for project {project_id}");
+    };
+
+    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
+    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
+    let mut executor = QueryExecutor {
+        sidecars: &sidecars,
+        cache,
+        manifest,
+        file_roles,
+        cancelled,
+        mode_override: None,
+    };
+    executor.execute(request.query, request.budget_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generation::{
+        SIDECAR_SCHEMA_VERSION, sidecar_generation_id, sidecar_qdrant_collection,
+    };
+    use crate::index::finalize_index;
+    use crate::{QdrantClient, SidecarLayout, ZoektClient};
+    use codestory_contracts::graph::{Node, NodeId, NodeKind};
+    use codestory_store::{FileInfo, FileRole, LlmSymbolDoc, SearchSymbolProjection};
+    use tempfile::TempDir;
+
+    fn manifest_for(
+        project_id: &str,
+        hash: &str,
+        projection_count: i64,
+    ) -> codestory_store::RetrievalIndexManifest {
+        codestory_store::RetrievalIndexManifest {
+            project_id: project_id.into(),
+            zoekt_version: "zoekt-real-v1".into(),
+            qdrant_collection: sidecar_qdrant_collection(project_id, hash),
+            scip_revision: Some("graph-test".into()),
+            built_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+            embedding_dim: Some(768),
+            sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+            sidecar_input_hash: Some(hash.into()),
+            sidecar_generation: Some(sidecar_generation_id(project_id, hash)),
+            projection_count: Some(projection_count),
+        }
+    }
+
+    #[test]
+    fn integration_query_against_fixture_manifest() {
+        let layout = SidecarLayout::from_env();
+        if !QdrantClient::new(&layout)
+            .list_collections_probe()
+            .reachable
+            || !ZoektClient::new(&layout).health_probe().reachable
+        {
+            return;
+        }
+        if crate::embeddings::embed_query("function").is_err() {
+            return;
+        }
+
+        let project = TempDir::new().expect("project");
+        std::fs::write(
+            project.path().join("lib.rs"),
+            "pub fn extension_service() {}",
+        )
+        .expect("write");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            let file_id = 10_i64;
+            let source_path = project.path().join("lib.rs");
+            storage
+                .insert_file(&FileInfo {
+                    id: file_id,
+                    path: source_path.clone(),
+                    language: "rust".to_string(),
+                    modification_time: live_mtime_millis(&source_path),
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Entrypoint,
+                })
+                .expect("insert file");
+            storage
+                .insert_nodes_batch(&[
+                    Node {
+                        id: NodeId(file_id),
+                        kind: NodeKind::FILE,
+                        serialized_name: "lib.rs".to_string(),
+                        qualified_name: None,
+                        canonical_id: None,
+                        file_node_id: None,
+                        start_line: Some(1),
+                        start_col: Some(0),
+                        end_line: Some(1),
+                        end_col: Some(0),
+                    },
+                    Node {
+                        id: NodeId(11),
+                        kind: NodeKind::FUNCTION,
+                        serialized_name: "extension_service".to_string(),
+                        qualified_name: Some("extension_service".to_string()),
+                        canonical_id: None,
+                        file_node_id: Some(NodeId(file_id)),
+                        start_line: Some(1),
+                        start_col: Some(0),
+                        end_line: Some(1),
+                        end_col: Some(30),
+                    },
+                ])
+                .expect("insert nodes");
+            storage
+                .upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
+                    node_id: NodeId(11),
+                    display_name: "extension_service".to_string(),
+                }])
+                .expect("projection");
+            storage
+                .upsert_llm_symbol_docs_batch(&[LlmSymbolDoc {
+                    node_id: NodeId(11),
+                    file_node_id: Some(NodeId(file_id)),
+                    kind: NodeKind::FUNCTION,
+                    display_name: "extension_service".to_string(),
+                    qualified_name: Some("extension_service".to_string()),
+                    file_path: Some(project.path().join("lib.rs").display().to_string()),
+                    start_line: Some(1),
+                    doc_text:
+                        "semantic_doc_version: 4\nsymbol_kind: FUNCTION\nname: extension_service"
+                            .to_string(),
+                    doc_version: 4,
+                    doc_hash: "extension-service-doc".to_string(),
+                    embedding_profile: Some("bge-base-en-v1.5".to_string()),
+                    embedding_model: "BAAI/bge-base-en-v1.5-local|backend=onnx".to_string(),
+                    embedding_backend: Some("onnx".to_string()),
+                    embedding_dim: 768,
+                    doc_shape: Some("semantic_doc_version=4;scope=durable_symbols".to_string()),
+                    embedding: vec![0.01; 768],
+                    updated_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
+                }])
+                .expect("semantic doc");
+        }
+        finalize_index(project.path(), &storage_path).expect("index");
+
+        let result = execute_retrieval_query(QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "extension",
+            budget_ms: Some(500),
+            cancelled: None,
+        })
+        .expect("query");
+
+        assert_eq!(result.trace.retrieval_mode, "full");
+        assert!(!result.hits.is_empty() || !result.trace.stages.is_empty());
+    }
+
+    #[test]
+    fn query_rejects_legacy_manifest_before_sidecar_access() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let project_id = crate::index::project_id_for_root(project.path());
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
+                    project_id,
+                    zoekt_version: "zoekt-real-v1".into(),
+                    qdrant_collection: "codestory_legacy".into(),
+                    scip_revision: Some("graph-test".into()),
+                    built_at_epoch_ms: 1,
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: Some("hash-projection:768".into()),
+                    embedding_dim: Some(768),
+                    sidecar_schema_version: None,
+                    sidecar_input_hash: None,
+                    sidecar_generation: None,
+                    projection_count: None,
+                })
+                .expect("manifest");
+        }
+
+        let error = execute_retrieval_query(QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "ExtensionHostManager",
+            budget_ms: Some(100),
+            cancelled: None,
+        })
+        .expect_err("legacy manifests must fail closed");
+
+        assert!(error.to_string().contains("generation_contract_missing"));
+    }
+
+    #[test]
+    fn query_rejects_manifest_with_stale_projection_count() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let project_id = crate::index::project_id_for_root(project.path());
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .upsert_retrieval_index_manifest(&manifest_for(&project_id, "deadbeefcafebabe", 10))
+                .expect("manifest");
+        }
+
+        let error = execute_retrieval_query(QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "ExtensionHostManager",
+            budget_ms: Some(100),
+            cancelled: None,
+        })
+        .expect_err("stale manifests must fail closed");
+
+        assert!(error.to_string().contains("sidecar_manifest_stale"));
+    }
+
+    #[test]
+    fn query_rejects_manifest_when_indexed_file_changes_or_is_removed() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let source_path = project.path().join("src").join("lib.rs");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("create source parent");
+        std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let indexed_mtime = live_mtime_millis(&source_path);
+        let project_id = crate::index::project_id_for_root(project.path());
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .insert_file(&FileInfo {
+                    id: 1,
+                    path: source_path.clone(),
+                    language: "rust".into(),
+                    modification_time: indexed_mtime,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                })
+                .expect("insert indexed file");
+            storage
+                .upsert_retrieval_index_manifest(&manifest_for(
+                    &project_id,
+                    "changedfeedcafebeef",
+                    0,
+                ))
+                .expect("manifest");
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(&source_path, "pub fn indexed() -> usize { 1 }\n").expect("mutate source");
+        let changed_error = execute_retrieval_query(QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "indexed",
+            budget_ms: Some(100),
+            cancelled: None,
+        })
+        .expect_err("changed indexed file must fail closed");
+        assert!(changed_error.to_string().contains("sidecar_manifest_stale"));
+
+        std::fs::remove_file(&source_path).expect("remove source");
+        let removed_error = execute_retrieval_query(QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "indexed",
+            budget_ms: Some(100),
+            cancelled: None,
+        })
+        .expect_err("removed indexed file must fail closed");
+        assert!(removed_error.to_string().contains("sidecar_manifest_stale"));
+    }
+
+    #[test]
+    fn query_rejects_manifest_when_new_indexable_file_is_added() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let source_path = project.path().join("src").join("lib.rs");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("create source parent");
+        std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let indexed_mtime = live_mtime_millis(&source_path);
+        let project_id = crate::index::project_id_for_root(project.path());
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .insert_file(&FileInfo {
+                    id: 1,
+                    path: source_path.clone(),
+                    language: "rust".into(),
+                    modification_time: indexed_mtime,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                })
+                .expect("insert indexed file");
+            storage
+                .upsert_retrieval_index_manifest(&manifest_for(
+                    &project_id,
+                    "newfilefeedcafebeef",
+                    0,
+                ))
+                .expect("manifest");
+        }
+        std::fs::write(
+            project.path().join("src").join("new_module.rs"),
+            "pub fn newly_added() {}\n",
+        )
+        .expect("write new source");
+
+        let error = execute_retrieval_query(QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "newly_added",
+            budget_ms: Some(100),
+            cancelled: None,
+        })
+        .expect_err("new indexable file must fail closed");
+
+        assert!(error.to_string().contains("sidecar_manifest_stale"));
+    }
+
+    fn live_mtime_millis(path: &Path) -> i64 {
+        std::fs::metadata(path)
+            .expect("metadata")
+            .modified()
+            .expect("modified")
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("mtime since epoch")
+            .as_millis()
+            .min(i64::MAX as u128) as i64
+    }
+}

--- a/crates/codestory-retrieval/src/query_features.rs
+++ b/crates/codestory-retrieval/src/query_features.rs
@@ -1,0 +1,112 @@
+use serde::{Deserialize, Serialize};
+
+/// High-level query shape used by the planner (repo-agnostic).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryShape {
+    SymbolLike,
+    PathLike,
+    NaturalLanguage,
+    Mixed,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueryFeatures {
+    pub raw_query: String,
+    pub shape: QueryShape,
+    pub token_count: usize,
+    pub has_path_separators: bool,
+    pub has_camel_case_token: bool,
+    pub has_snake_case_token: bool,
+    pub looks_like_qualified_symbol: bool,
+}
+
+pub fn classify_query(query: &str) -> QueryFeatures {
+    let trimmed = query.trim();
+    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    let token_count = tokens.len().max(1);
+
+    let has_path_separators = trimmed.contains('/') || trimmed.contains('\\');
+    let has_camel_case_token = tokens.iter().any(|token| {
+        token.chars().any(char::is_uppercase) && token.chars().any(char::is_lowercase)
+    });
+    let has_snake_case_token = tokens.iter().any(|token| {
+        token.contains('_')
+            && token
+                .chars()
+                .filter(|c| c.is_ascii_alphabetic())
+                .all(|c| c.is_ascii_lowercase() || c == '_')
+    });
+    let looks_like_qualified_symbol = tokens
+        .iter()
+        .any(|token| token.contains('.') || token.contains("::"));
+
+    let path_like = has_path_separators
+        || (token_count == 1
+            && (trimmed.ends_with(".rs") || trimmed.ends_with(".ts") || trimmed.ends_with(".tsx")));
+    let symbol_like = looks_like_qualified_symbol
+        || has_camel_case_token
+        || has_snake_case_token
+        || (token_count == 1 && trimmed.chars().all(|c| c.is_alphanumeric() || c == '_'));
+
+    let nl_like = token_count >= 3
+        || trimmed.split_whitespace().any(|word| {
+            matches!(
+                word.to_ascii_lowercase().as_str(),
+                "how" | "what" | "where" | "why" | "when" | "explain" | "find"
+            )
+        });
+
+    let shape = if path_like {
+        if symbol_like && nl_like {
+            QueryShape::Mixed
+        } else {
+            QueryShape::PathLike
+        }
+    } else if symbol_like && !nl_like {
+        QueryShape::SymbolLike
+    } else if nl_like && !symbol_like {
+        QueryShape::NaturalLanguage
+    } else if nl_like {
+        QueryShape::Mixed
+    } else if symbol_like {
+        QueryShape::SymbolLike
+    } else {
+        QueryShape::NaturalLanguage
+    };
+
+    QueryFeatures {
+        raw_query: trimmed.to_string(),
+        shape,
+        token_count,
+        has_path_separators,
+        has_camel_case_token,
+        has_snake_case_token,
+        looks_like_qualified_symbol,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_symbol_like_queries() {
+        let features = classify_query("ExtensionService");
+        assert_eq!(features.shape, QueryShape::SymbolLike);
+        let features = classify_query("foo::Bar");
+        assert!(features.looks_like_qualified_symbol);
+    }
+
+    #[test]
+    fn classifies_path_like_queries() {
+        let features = classify_query("src/agent/orchestrator.rs");
+        assert_eq!(features.shape, QueryShape::PathLike);
+    }
+
+    #[test]
+    fn classifies_natural_language() {
+        let features = classify_query("how does packet retrieval work");
+        assert_eq!(features.shape, QueryShape::NaturalLanguage);
+    }
+}

--- a/crates/codestory-retrieval/src/ranker.rs
+++ b/crates/codestory-retrieval/src/ranker.rs
@@ -1,0 +1,704 @@
+use crate::candidate::{CandidateHit, CandidateSource, RankFeatures, is_phantom_sidecar_hit};
+use crate::query_features::{QueryFeatures, QueryShape};
+use codestory_store::FileRole;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy)]
+struct RankWeights {
+    lexical: f32,
+    semantic: f32,
+    scip_distance: f32,
+    file_role_prior: f32,
+    definition_quality: f32,
+    token_overlap: f32,
+}
+
+const STRUCTURAL_BASELINE_MULTIPLIER: f32 = 0.5;
+const STRUCTURAL_DYNAMIC_TOKEN_THRESHOLD: f32 = 0.35;
+const STRUCTURAL_DYNAMIC_SEMANTIC_THRESHOLD: f32 = 0.55;
+const STRUCTURAL_DYNAMIC_BOOST: f32 = 1.35;
+
+pub fn rank_candidates(
+    features: &QueryFeatures,
+    mut candidates: Vec<CandidateHit>,
+) -> Vec<CandidateHit> {
+    let weights = weights_for_shape(features.shape);
+    let query_tokens = tokenize(&features.raw_query);
+    candidates.retain(|candidate| !is_phantom_sidecar_hit(candidate));
+
+    let query_lower = features.raw_query.to_ascii_lowercase();
+    let code_intent = query_has_code_intent(&query_tokens);
+    let structural_intent = query_mentions_structural_role(&query_tokens);
+    let prefer_primary_code = prefers_primary_code_evidence(features.shape, &query_tokens);
+    for candidate in &mut candidates {
+        let file_role = effective_file_role(candidate);
+        candidate.file_role.get_or_insert(file_role);
+        let rank_features = build_rank_features(candidate, &query_tokens);
+        let mut fused = score_features(&rank_features, weights);
+        fused *= structural_fusion_multiplier(candidate, &rank_features);
+        fused *= primary_code_role_multiplier(file_role, prefer_primary_code);
+        candidate.score = fused;
+        if looks_like_repo_relative_path(&candidate.file_path) {
+            candidate.score += 0.08;
+        }
+        if matches!(features.shape, QueryShape::PathLike)
+            && query_lower.contains(&candidate.file_path.to_ascii_lowercase())
+        {
+            candidate.score += 0.25;
+        }
+        if matches!(features.shape, QueryShape::NaturalLanguage) {
+            let path_lower = candidate.file_path.to_ascii_lowercase();
+            let symbol_lower = candidate
+                .symbol_name
+                .as_deref()
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            let strong_token_hits = query_tokens
+                .iter()
+                .filter(|token| token.len() >= 4)
+                .filter(|token| {
+                    path_lower.contains(token.as_str()) || symbol_lower.contains(token.as_str())
+                })
+                .count();
+            candidate.score += (strong_token_hits as f32) * 0.06;
+        }
+        if prefer_primary_code && matches!(file_role, FileRole::Source | FileRole::Entrypoint) {
+            candidate.score += primary_source_path_bonus(&candidate.file_path, &query_tokens);
+        }
+        if prefer_primary_code && symbol_name_looks_test_like(candidate.symbol_name.as_deref()) {
+            candidate.score *= 0.55;
+        }
+        candidate.rank_features = Some(rank_features);
+    }
+
+    apply_exact_code_evidence_anchor(features, &query_tokens, &mut candidates);
+
+    let min_rank_score = min_rank_score(features.shape);
+    candidates.retain(|candidate| candidate.score >= min_rank_score);
+
+    if code_intent && !structural_intent {
+        apply_structural_code_intent_cap(&mut candidates);
+    }
+    if prefer_primary_code {
+        cap_non_primary_below_best_primary(&mut candidates);
+    }
+
+    candidates.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| file_role_sort_rank(left).cmp(&file_role_sort_rank(right)))
+            .then_with(|| source_sort_rank(left).cmp(&source_sort_rank(right)))
+            .then_with(|| left.file_path.cmp(&right.file_path))
+            .then_with(|| left.symbol_name.cmp(&right.symbol_name))
+    });
+    candidates
+}
+
+fn looks_like_repo_relative_path(file_path: &str) -> bool {
+    let trimmed = file_path.trim();
+    !trimmed.is_empty()
+        && !trimmed.contains(':')
+        && (trimmed.contains('/') || trimmed.contains('\\') || trimmed.contains(char::from(46)))
+}
+
+fn weights_for_shape(shape: QueryShape) -> RankWeights {
+    match shape {
+        QueryShape::SymbolLike => RankWeights {
+            lexical: 0.25,
+            semantic: 0.15,
+            scip_distance: 0.30,
+            file_role_prior: 0.10,
+            definition_quality: 0.15,
+            token_overlap: 0.05,
+        },
+        QueryShape::PathLike => RankWeights {
+            lexical: 0.45,
+            semantic: 0.05,
+            scip_distance: 0.15,
+            file_role_prior: 0.20,
+            definition_quality: 0.10,
+            token_overlap: 0.05,
+        },
+        QueryShape::NaturalLanguage => RankWeights {
+            lexical: 0.15,
+            semantic: 0.40,
+            scip_distance: 0.10,
+            file_role_prior: 0.10,
+            definition_quality: 0.10,
+            token_overlap: 0.15,
+        },
+        QueryShape::Mixed => RankWeights {
+            lexical: 0.25,
+            semantic: 0.25,
+            scip_distance: 0.20,
+            file_role_prior: 0.10,
+            definition_quality: 0.10,
+            token_overlap: 0.10,
+        },
+    }
+}
+
+fn min_rank_score(shape: QueryShape) -> f32 {
+    match shape {
+        QueryShape::NaturalLanguage => 0.04,
+        QueryShape::Mixed => 0.06,
+        QueryShape::SymbolLike | QueryShape::PathLike => 0.08,
+    }
+}
+
+fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> RankFeatures {
+    let path_lower = candidate.file_path.to_ascii_lowercase();
+    let symbol_lower = candidate
+        .symbol_name
+        .as_deref()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    let lexical = match candidate.source {
+        CandidateSource::Zoekt => candidate.score.max(0.35),
+        CandidateSource::Legacy => candidate.score * 0.5,
+        _ => candidate.score * 0.6,
+    };
+
+    let semantic = if candidate.source == CandidateSource::Qdrant {
+        candidate.score.max(0.4)
+    } else {
+        candidate.score * 0.25
+    };
+
+    let scip_distance = if candidate.source == CandidateSource::Scip {
+        1.0 / (1.0 + candidate.scip_hop_distance.unwrap_or(0) as f32)
+    } else {
+        0.2
+    };
+
+    let file_role_prior = file_role_prior(effective_file_role(candidate));
+    let definition_quality = if candidate.symbol_name.is_some() {
+        0.85
+    } else {
+        0.45
+    };
+    let token_overlap = token_overlap_score(query_tokens, &path_lower, &symbol_lower);
+
+    RankFeatures {
+        lexical,
+        semantic,
+        scip_distance,
+        file_role_prior,
+        definition_quality,
+        token_overlap,
+    }
+}
+
+fn score_features(features: &RankFeatures, weights: RankWeights) -> f32 {
+    weights.lexical * features.lexical
+        + weights.semantic * features.semantic
+        + weights.scip_distance * features.scip_distance
+        + weights.file_role_prior * features.file_role_prior
+        + weights.definition_quality * features.definition_quality
+        + weights.token_overlap * features.token_overlap
+}
+
+fn file_role_prior(file_role: FileRole) -> f32 {
+    match file_role {
+        FileRole::Entrypoint => 0.95,
+        FileRole::Source => 0.72,
+        FileRole::Test => 0.35,
+        FileRole::Docs => 0.30,
+        FileRole::Benchmark => 0.28,
+        FileRole::Generated => 0.22,
+        FileRole::Vendor => 0.18,
+    }
+}
+
+fn effective_file_role(candidate: &CandidateHit) -> FileRole {
+    candidate
+        .file_role
+        .unwrap_or_else(|| FileRole::classify_path(Path::new(&candidate.file_path)))
+}
+
+fn prefers_primary_code_evidence(shape: QueryShape, query_tokens: &[String]) -> bool {
+    matches!(shape, QueryShape::NaturalLanguage | QueryShape::Mixed)
+        && !query_mentions_non_primary_role(query_tokens)
+        && !query_mentions_structural_role(query_tokens)
+}
+
+fn query_mentions_non_primary_role(query_tokens: &[String]) -> bool {
+    const NON_PRIMARY_ROLE_TERMS: &[&str] = &[
+        "test",
+        "tests",
+        "spec",
+        "specs",
+        "fixture",
+        "fixtures",
+        "doc",
+        "docs",
+        "documentation",
+        "readme",
+        "benchmark",
+        "benchmarks",
+        "bench",
+        "generated",
+        "vendor",
+    ];
+    query_tokens
+        .iter()
+        .any(|token| NON_PRIMARY_ROLE_TERMS.contains(&token.as_str()))
+}
+
+fn query_mentions_structural_role(query_tokens: &[String]) -> bool {
+    const STRUCTURAL_ROLE_TERMS: &[&str] = &[
+        "css",
+        "html",
+        "layout",
+        "style",
+        "styles",
+        "stylesheet",
+        "sql",
+    ];
+    query_tokens
+        .iter()
+        .any(|token| STRUCTURAL_ROLE_TERMS.contains(&token.as_str()))
+}
+
+fn symbol_name_looks_test_like(symbol_name: Option<&str>) -> bool {
+    let Some(symbol_name) = symbol_name else {
+        return false;
+    };
+    let symbol = symbol_name.to_ascii_lowercase();
+    let local_name = symbol.rsplit("::").next().unwrap_or(symbol.as_str());
+    symbol.starts_with("tests::")
+        || symbol.contains("::tests::")
+        || local_name.starts_with("test_")
+        || local_name.ends_with("_test")
+        || local_name.ends_with("_tests")
+        || local_name.contains("_test_")
+        || local_name.contains("_tests_")
+}
+
+fn primary_code_role_multiplier(file_role: FileRole, prefer_primary_code: bool) -> f32 {
+    if !prefer_primary_code {
+        return 1.0;
+    }
+    match file_role {
+        FileRole::Entrypoint => 1.08,
+        FileRole::Source => 1.02,
+        FileRole::Test => 0.58,
+        FileRole::Docs => 0.68,
+        FileRole::Benchmark => 0.55,
+        FileRole::Generated => 0.42,
+        FileRole::Vendor => 0.35,
+    }
+}
+
+fn primary_source_path_bonus(file_path: &str, query_tokens: &[String]) -> f32 {
+    let path_lower = file_path.replace('\\', "/").to_ascii_lowercase();
+    let mut bonus = 0.0;
+    if path_lower.contains("/src/") || path_lower.starts_with("src/") {
+        bonus += 0.04;
+    }
+    if query_tokens
+        .iter()
+        .filter(|token| token.len() >= 4)
+        .any(|token| path_lower.contains(token.as_str()))
+    {
+        bonus += 0.03;
+    }
+    bonus
+}
+
+fn file_role_sort_rank(candidate: &CandidateHit) -> u8 {
+    match effective_file_role(candidate) {
+        FileRole::Entrypoint => 0,
+        FileRole::Source => 1,
+        FileRole::Test => 2,
+        FileRole::Docs => 3,
+        FileRole::Benchmark => 4,
+        FileRole::Generated => 5,
+        FileRole::Vendor => 6,
+    }
+}
+
+fn source_sort_rank(candidate: &CandidateHit) -> u8 {
+    match candidate.source {
+        CandidateSource::Zoekt => 0,
+        CandidateSource::Scip => 1,
+        CandidateSource::Qdrant => 2,
+        CandidateSource::Legacy => 3,
+    }
+}
+
+fn cap_non_primary_below_best_primary(candidates: &mut [CandidateHit]) {
+    let best_primary = candidates
+        .iter()
+        .filter(|candidate| {
+            matches!(
+                effective_file_role(candidate),
+                FileRole::Source | FileRole::Entrypoint
+            )
+        })
+        .map(|candidate| candidate.score)
+        .max_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let Some(best_primary) = best_primary else {
+        return;
+    };
+    for candidate in candidates {
+        if !matches!(
+            effective_file_role(candidate),
+            FileRole::Source | FileRole::Entrypoint
+        ) && candidate.score >= best_primary
+        {
+            candidate.score = (best_primary - 0.001).max(0.0);
+        }
+    }
+}
+
+fn token_overlap_score(query_tokens: &[String], path_lower: &str, symbol_lower: &str) -> f32 {
+    if query_tokens.is_empty() {
+        return 0.0;
+    }
+    let mut hits = 0usize;
+    for token in query_tokens {
+        if token.len() < 2 {
+            continue;
+        }
+        if path_lower.contains(token) || symbol_lower.contains(token) {
+            hits += 1;
+        }
+    }
+    hits as f32 / query_tokens.len() as f32
+}
+
+fn apply_exact_code_evidence_anchor(
+    features: &QueryFeatures,
+    query_tokens: &[String],
+    candidates: &mut [CandidateHit],
+) {
+    if !matches!(
+        features.shape,
+        QueryShape::SymbolLike | QueryShape::PathLike | QueryShape::Mixed
+    ) {
+        return;
+    }
+    let top_exact_code_score = candidates
+        .iter()
+        .filter(|candidate| is_exact_code_evidence(candidate, query_tokens))
+        .map(|candidate| candidate.score)
+        .max_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let Some(top_exact_code_score) = top_exact_code_score else {
+        return;
+    };
+    for candidate in candidates.iter_mut() {
+        if matches!(candidate.source, CandidateSource::Qdrant)
+            && !is_exact_code_evidence(candidate, query_tokens)
+            && candidate.score >= top_exact_code_score
+        {
+            candidate.score = (top_exact_code_score - 0.001).max(0.0);
+        }
+    }
+}
+
+fn is_exact_code_evidence(candidate: &CandidateHit, query_tokens: &[String]) -> bool {
+    if matches!(
+        candidate.source,
+        CandidateSource::Qdrant | CandidateSource::Legacy
+    ) {
+        return false;
+    }
+    let Some(symbol) = candidate.symbol_name.as_deref() else {
+        return exact_path_match(&candidate.file_path, query_tokens);
+    };
+    let symbol_tail = symbol
+        .rsplit("::")
+        .next()
+        .unwrap_or(symbol)
+        .rsplit('.')
+        .next()
+        .unwrap_or(symbol)
+        .to_ascii_lowercase();
+    query_tokens.iter().any(|token| token == &symbol_tail)
+        || exact_path_match(&candidate.file_path, query_tokens)
+}
+
+fn exact_path_match(file_path: &str, query_tokens: &[String]) -> bool {
+    let path = std::path::Path::new(file_path);
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+    let stem = stem.to_ascii_lowercase();
+    query_tokens.iter().any(|token| token == &stem)
+}
+
+fn structural_fusion_multiplier(candidate: &CandidateHit, features: &RankFeatures) -> f32 {
+    if !is_structural_candidate_path(&candidate.file_path) {
+        return 1.0;
+    }
+    let mut multiplier = STRUCTURAL_BASELINE_MULTIPLIER;
+    if features.token_overlap >= STRUCTURAL_DYNAMIC_TOKEN_THRESHOLD
+        || features.semantic >= STRUCTURAL_DYNAMIC_SEMANTIC_THRESHOLD
+    {
+        multiplier *= STRUCTURAL_DYNAMIC_BOOST;
+    }
+    multiplier.min(1.0)
+}
+
+fn is_structural_candidate_path(file_path: &str) -> bool {
+    let path = std::path::Path::new(file_path);
+    if let Some(ext) = path.extension() {
+        let ext_str = ext.to_string_lossy().to_ascii_lowercase();
+        matches!(ext_str.as_str(), "html" | "htm" | "css" | "sql")
+    } else {
+        false
+    }
+}
+
+fn query_has_code_intent(query_tokens: &[String]) -> bool {
+    const CODE_INTENT: &[&str] = &[
+        "function",
+        "func",
+        "method",
+        "class",
+        "struct",
+        "trait",
+        "interface",
+        "enum",
+        "impl",
+        "def",
+        "fn",
+        "type",
+        "module",
+        "namespace",
+    ];
+    query_tokens
+        .iter()
+        .any(|token| CODE_INTENT.contains(&token.as_str()))
+}
+
+fn apply_structural_code_intent_cap(candidates: &mut [CandidateHit]) {
+    let top_graph_score = candidates
+        .iter()
+        .filter(|candidate| !is_structural_candidate_path(&candidate.file_path))
+        .map(|candidate| candidate.score)
+        .max_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
+    let Some(top_graph_score) = top_graph_score else {
+        return;
+    };
+    for candidate in candidates.iter_mut() {
+        if is_structural_candidate_path(&candidate.file_path) && candidate.score > top_graph_score {
+            candidate.score = top_graph_score;
+        }
+    }
+}
+
+fn tokenize(query: &str) -> Vec<String> {
+    query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|token| token.len() >= 2)
+        .map(|token| token.to_ascii_lowercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::candidate::CandidateSource;
+    use crate::query_features::classify_query;
+    use codestory_store::FileRole;
+
+    #[test]
+    fn ranker_prefers_higher_lexical_for_path_query() {
+        let features = classify_query("src/lib.rs");
+        let candidates = vec![
+            CandidateHit::lexical_stub("src/lib.rs", 0.9),
+            CandidateHit::lexical_stub("docs/readme.md", 0.2),
+        ];
+        let ranked = rank_candidates(&features, candidates);
+        assert_eq!(ranked[0].file_path, "src/lib.rs");
+        assert!(ranked[0].score > ranked[1].score);
+    }
+
+    #[test]
+    fn ranker_does_not_use_repo_name_features() {
+        let features = classify_query("handler");
+        let mut hit = CandidateHit::lexical_stub("src/handler.rs", 0.8);
+        hit.source = CandidateSource::Zoekt;
+        hit.file_role = Some(FileRole::Source);
+        let ranked = rank_candidates(&features, vec![hit]);
+        let rf = ranked[0].rank_features.as_ref().expect("features");
+        assert!(rf.file_role_prior > 0.0);
+    }
+
+    #[test]
+    fn ranker_prefers_entrypoint_role_over_test_role() {
+        let features = classify_query("main startup entrypoint");
+        let mut test_hit = CandidateHit::lexical_stub("src/main_test.rs", 0.94);
+        test_hit.file_role = Some(FileRole::Test);
+        let mut entry_hit = CandidateHit::lexical_stub("src/main.rs", 0.72);
+        entry_hit.file_role = Some(FileRole::Entrypoint);
+        let ranked = rank_candidates(&features, vec![test_hit, entry_hit]);
+        assert_eq!(
+            ranked.first().map(|hit| hit.file_path.as_str()),
+            Some("src/main.rs")
+        );
+    }
+
+    #[test]
+    fn ranker_soft_prior_downweights_structural_by_default() {
+        let features = classify_query("layout styles for dashboard");
+        let mut structural = CandidateHit::lexical_stub("src/ui/layout.css", 0.9);
+        let mut graph = CandidateHit::lexical_stub("src/app/dashboard.rs", 0.55);
+        structural.source = CandidateSource::Zoekt;
+        graph.source = CandidateSource::Zoekt;
+        let ranked = rank_candidates(&features, vec![structural, graph]);
+        assert_eq!(ranked[0].file_path, "src/app/dashboard.rs");
+    }
+
+    #[test]
+    fn ranker_boosts_structural_on_strong_token_overlap() {
+        let features = classify_query("primary button layout css class");
+        let mut structural = CandidateHit::lexical_stub("src/ui/primary.css", 0.7);
+        structural.symbol_name = Some("primary".to_string());
+        structural.source = CandidateSource::Zoekt;
+        let mut graph = CandidateHit::lexical_stub("src/ui/components.rs", 0.72);
+        graph.source = CandidateSource::Zoekt;
+        let ranked = rank_candidates(&features, vec![structural, graph]);
+        assert_eq!(ranked[0].file_path, "src/ui/primary.css");
+    }
+
+    #[test]
+    fn ranker_caps_structural_on_code_intent_queries() {
+        let features = classify_query("UserService class method");
+        let mut structural = CandidateHit::lexical_stub("schema/users.sql", 0.99);
+        let mut graph = CandidateHit::lexical_stub("src/user_service.rs", 0.8);
+        structural.source = CandidateSource::Zoekt;
+        graph.source = CandidateSource::Zoekt;
+        let ranked = rank_candidates(&features, vec![structural, graph]);
+        assert_eq!(ranked[0].file_path, "src/user_service.rs");
+    }
+
+    #[test]
+    fn ranker_drops_phantom_hits_by_default() {
+        let features = classify_query("search pipeline");
+        let candidates = vec![
+            CandidateHit::with_source("zoekt:search", None, 0.9, CandidateSource::Zoekt),
+            CandidateHit::lexical_stub("crates/core/search.rs", 0.7),
+        ];
+        let ranked = rank_candidates(&features, candidates);
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].file_path, "crates/core/search.rs");
+    }
+
+    #[test]
+    fn ranker_keeps_exact_symbol_above_semantic_expansion() {
+        let features = classify_query("IndexManifest");
+        let mut exact = CandidateHit::with_source(
+            "crates/runtime/src/index.rs",
+            Some("codestory::IndexManifest".into()),
+            0.55,
+            CandidateSource::Zoekt,
+        );
+        exact.file_role = Some(FileRole::Source);
+        let mut semantic = CandidateHit::with_source(
+            "docs/retrieval.md",
+            Some("manifest overview".into()),
+            0.99,
+            CandidateSource::Qdrant,
+        );
+        semantic.file_role = Some(FileRole::Docs);
+
+        let ranked = rank_candidates(&features, vec![semantic, exact]);
+        assert_eq!(
+            ranked.first().map(|hit| hit.symbol_name.as_deref()),
+            Some(Some("codestory::IndexManifest"))
+        );
+    }
+
+    #[test]
+    fn ranker_infers_missing_roles_and_demotes_semantic_tests_for_prompts() {
+        let features = classify_query("explain request json output event processing");
+        let semantic_test = CandidateHit::with_source(
+            "workspace/app/tests/event_processor_with_json_output.rs",
+            Some("event processor json output".into()),
+            0.99,
+            CandidateSource::Qdrant,
+        );
+        let colocated_test = CandidateHit::with_source(
+            "workspace/app/src/event_processor_with_jsonl_output_tests.rs",
+            Some("jsonl event test output".into()),
+            0.98,
+            CandidateSource::Qdrant,
+        );
+        let source = CandidateHit::with_source(
+            "workspace/app/src/event_processor.rs",
+            Some("EventProcessor".into()),
+            0.72,
+            CandidateSource::Zoekt,
+        );
+
+        let ranked = rank_candidates(&features, vec![semantic_test, colocated_test, source]);
+
+        assert_eq!(
+            ranked.first().map(|hit| hit.file_path.as_str()),
+            Some("workspace/app/src/event_processor.rs")
+        );
+        assert_eq!(ranked[0].file_role, Some(FileRole::Source));
+        assert!(
+            ranked
+                .iter()
+                .filter(|hit| hit.file_role == Some(FileRole::Test))
+                .count()
+                >= 2
+        );
+    }
+
+    #[test]
+    fn ranker_demotes_test_named_source_helpers_for_production_prompts() {
+        let features = classify_query("explain runtime orchestration and search projection");
+        let test_helper = CandidateHit::with_source(
+            "crates/runtime/src/search/engine.rs",
+            Some("EmbeddingRuntime::test_runtime".into()),
+            0.99,
+            CandidateSource::Zoekt,
+        );
+        let production = CandidateHit::with_source(
+            "crates/runtime/src/services.rs",
+            Some("IndexService::run_indexing_blocking".into()),
+            0.72,
+            CandidateSource::Zoekt,
+        );
+
+        let ranked = rank_candidates(&features, vec![test_helper, production]);
+
+        assert_eq!(
+            ranked.first().and_then(|hit| hit.symbol_name.as_deref()),
+            Some("IndexService::run_indexing_blocking")
+        );
+    }
+
+    #[test]
+    fn ranker_does_not_demote_tests_when_prompt_asks_for_tests() {
+        let features = classify_query("event processor tests json output");
+        let semantic_test = CandidateHit::with_source(
+            "workspace/app/tests/event_processor_with_json_output.rs",
+            Some("event processor json output".into()),
+            0.99,
+            CandidateSource::Qdrant,
+        );
+        let source = CandidateHit::with_source(
+            "workspace/app/src/event_processor.rs",
+            Some("EventProcessor".into()),
+            0.72,
+            CandidateSource::Zoekt,
+        );
+
+        let ranked = rank_candidates(&features, vec![source, semantic_test]);
+
+        assert_eq!(
+            ranked.first().map(|hit| hit.file_path.as_str()),
+            Some("workspace/app/tests/event_processor_with_json_output.rs")
+        );
+        assert_eq!(ranked[0].file_role, Some(FileRole::Test));
+    }
+}

--- a/crates/codestory-retrieval/src/scip_client.rs
+++ b/crates/codestory-retrieval/src/scip_client.rs
@@ -1,0 +1,533 @@
+use crate::config::SidecarLayout;
+use crate::scip_index::{SCIP_SYMBOLS_FILE, ScipSymbolRecord, load_scip_symbols};
+use std::cmp::Ordering;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScipAvailability {
+    Ready { revision: String },
+    Unavailable { reason: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct ScipHealthProbe {
+    pub availability: ScipAvailability,
+    pub artifact_count: u32,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScipClient;
+
+impl ScipClient {
+    pub fn health_probe(layout: &SidecarLayout, project_id: &str) -> ScipHealthProbe {
+        let project_dir = layout.scip_project_dir(project_id);
+        if !project_dir.exists() {
+            return ScipHealthProbe {
+                availability: ScipAvailability::Unavailable {
+                    reason: "scip_unavailable".into(),
+                },
+                artifact_count: 0,
+                detail: format!("no artifacts at {}", project_dir.display()),
+            };
+        }
+        let artifacts = count_scip_artifacts(&project_dir);
+        if artifacts == 0 {
+            return ScipHealthProbe {
+                availability: ScipAvailability::Unavailable {
+                    reason: "scip_unavailable".into(),
+                },
+                artifact_count: 0,
+                detail: "scip project dir exists but empty (indexers not run)".into(),
+            };
+        }
+        if project_dir.join("index.scip.stub").is_file() {
+            return ScipHealthProbe {
+                availability: ScipAvailability::Unavailable {
+                    reason: "scip_stub".into(),
+                },
+                artifact_count: artifacts,
+                detail: "stub SCIP artifacts only (index.scip.stub present)".into(),
+            };
+        }
+        let revision = read_scip_revision(&project_dir).unwrap_or_else(|| "stub-v1".into());
+        let has_graph_index = has_real_scip_artifact(&project_dir);
+        let is_stub_revision = revision == "stub-v1" || !has_graph_index;
+        ScipHealthProbe {
+            availability: if is_stub_revision {
+                ScipAvailability::Unavailable {
+                    reason: "scip_stub".into(),
+                }
+            } else {
+                ScipAvailability::Ready {
+                    revision: revision.clone(),
+                }
+            },
+            artifact_count: artifacts,
+            detail: format!("{artifacts} artifact(s) under {}", project_dir.display()),
+        }
+    }
+
+    pub fn anchor_search(
+        layout: &SidecarLayout,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> anyhow::Result<Vec<super::CandidateHit>> {
+        let probe = Self::health_probe(layout, project_id);
+        let ScipAvailability::Ready { .. } = probe.availability else {
+            return Ok(Vec::new());
+        };
+        let project_dir = layout.scip_project_dir(project_id);
+        let Some(index) = load_scip_symbols(&project_dir)? else {
+            return Ok(Vec::new());
+        };
+        let profile = ScipQueryProfile::new(query);
+        let mut hits = Vec::new();
+        for symbol in index.symbols {
+            if symbol_matches_query(&symbol, &profile) {
+                let score = score_symbol_match(&symbol, &profile);
+                hits.push(symbol_to_hit(&symbol, score, 0));
+            }
+        }
+        hits.sort_by(|left, right| {
+            right
+                .score
+                .partial_cmp(&left.score)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| left.file_path.cmp(&right.file_path))
+                .then_with(|| left.symbol_name.cmp(&right.symbol_name))
+                .then_with(|| left.start_line.cmp(&right.start_line))
+        });
+        hits.truncate(limit);
+        Ok(hits)
+    }
+
+    pub fn expand_graph(
+        layout: &SidecarLayout,
+        project_id: &str,
+        anchors: &[super::CandidateHit],
+        limit: usize,
+    ) -> anyhow::Result<Vec<super::CandidateHit>> {
+        let probe = Self::health_probe(layout, project_id);
+        let ScipAvailability::Ready { .. } = probe.availability else {
+            return Ok(Vec::new());
+        };
+        let project_dir = layout.scip_project_dir(project_id);
+        let Some(index) = load_scip_symbols(&project_dir)? else {
+            return Ok(Vec::new());
+        };
+        let mut hits = Vec::new();
+        for anchor in anchors.iter().take(4) {
+            let anchor_symbol = anchor.symbol_name.as_deref().unwrap_or("");
+            for symbol in &index.symbols {
+                if hits.len() >= limit {
+                    break;
+                }
+                if symbol.path != anchor.file_path {
+                    continue;
+                }
+                if anchor_symbol.is_empty() || symbol.symbol == anchor_symbol {
+                    continue;
+                }
+                if symbol.symbol.contains(anchor_symbol) || anchor_symbol.contains(&symbol.symbol) {
+                    hits.push(symbol_to_hit(
+                        symbol,
+                        0.65,
+                        anchor.scip_hop_distance.unwrap_or(0) + 1,
+                    ));
+                }
+            }
+        }
+        hits.truncate(limit);
+        Ok(hits)
+    }
+}
+
+fn symbol_to_hit(symbol: &ScipSymbolRecord, score: f32, hop: u32) -> super::CandidateHit {
+    use super::candidate::{CandidateHit, CandidateSource};
+    CandidateHit {
+        file_path: symbol.path.clone(),
+        symbol_name: Some(symbol.symbol.clone()),
+        start_line: Some(symbol.start_line),
+        score,
+        source: CandidateSource::Scip,
+        file_role: None,
+        scip_hop_distance: Some(hop),
+        rank_features: None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ScipQueryProfile {
+    query_lower: String,
+    tokens: Vec<String>,
+    qualified: Option<QualifiedSymbolQuery>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QualifiedSymbolQuery {
+    prefix_lower: String,
+    terminal_lower: String,
+}
+
+impl ScipQueryProfile {
+    fn new(query: &str) -> Self {
+        let query_lower = query.to_ascii_lowercase();
+        let tokens = query_lower
+            .split_whitespace()
+            .filter(|token| !token.is_empty())
+            .map(str::to_string)
+            .collect();
+        Self {
+            query_lower,
+            tokens,
+            qualified: qualified_symbol_query(query),
+        }
+    }
+}
+
+fn qualified_symbol_query(query: &str) -> Option<QualifiedSymbolQuery> {
+    let trimmed = query.trim();
+    let index = trimmed.rfind("::")?;
+    let prefix = trimmed[..index].trim();
+    let terminal = trimmed[index + 2..].trim();
+    if prefix.is_empty()
+        || terminal.is_empty()
+        || terminal
+            .chars()
+            .any(|ch| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '$'))
+    {
+        return None;
+    }
+    Some(QualifiedSymbolQuery {
+        prefix_lower: prefix.to_ascii_lowercase(),
+        terminal_lower: terminal.to_ascii_lowercase(),
+    })
+}
+
+fn symbol_matches_query(symbol: &ScipSymbolRecord, profile: &ScipQueryProfile) -> bool {
+    let symbol_lower = symbol.symbol.to_ascii_lowercase();
+    let path_lower = symbol.path.to_ascii_lowercase();
+    if profile.tokens.is_empty() {
+        return symbol_lower.contains(&profile.query_lower)
+            || path_lower.contains(&profile.query_lower);
+    }
+    if profile
+        .tokens
+        .iter()
+        .all(|token| symbol_lower.contains(token) || path_lower.contains(token))
+    {
+        return true;
+    }
+    let Some(qualified) = profile.qualified.as_ref() else {
+        return false;
+    };
+    symbol_terminal(&symbol_lower) == qualified.terminal_lower
+        && qualified_prefix_path_score(&qualified.prefix_lower, &symbol.path) > 0
+}
+
+fn score_symbol_match(symbol: &ScipSymbolRecord, profile: &ScipQueryProfile) -> f32 {
+    let symbol_lower = symbol.symbol.to_ascii_lowercase();
+    let path_lower = symbol.path.to_ascii_lowercase();
+    let mut score = 0.70_f32;
+    if symbol_lower == profile.query_lower {
+        score += 0.22;
+    } else if symbol_lower.contains(&profile.query_lower) {
+        score += 0.14;
+    }
+    if path_lower == profile.query_lower {
+        score += 0.08;
+    } else if path_lower.contains(&profile.query_lower) {
+        score += 0.04;
+    }
+    for token in &profile.tokens {
+        if symbol_lower == *token {
+            score += 0.05;
+        } else if symbol_lower.contains(token) {
+            score += 0.03;
+        }
+        if path_lower.contains(token) {
+            score += 0.01;
+        }
+    }
+    if let Some(qualified) = profile.qualified.as_ref() {
+        let terminal = symbol_terminal(&symbol_lower);
+        let prefix_path_score = qualified_prefix_path_score(&qualified.prefix_lower, &symbol.path);
+        if terminal == qualified.terminal_lower {
+            score += 0.18;
+        }
+        score += match prefix_path_score {
+            3 => 0.12,
+            2 => 0.09,
+            1 => 0.05,
+            _ => 0.0,
+        };
+        if terminal == qualified.terminal_lower
+            && file_stem_lower(&symbol.path).as_deref() == Some(qualified.terminal_lower.as_str())
+        {
+            score += 0.16;
+        }
+        if symbol_lower == profile.query_lower
+            && file_stem_lower(&symbol.path).as_deref() != Some(qualified.terminal_lower.as_str())
+        {
+            score -= 0.12;
+        }
+    }
+    score.min(1.20)
+}
+
+fn symbol_terminal(symbol: &str) -> String {
+    symbol
+        .rsplit("::")
+        .next()
+        .unwrap_or(symbol)
+        .rsplit('.')
+        .next()
+        .unwrap_or(symbol)
+        .to_ascii_lowercase()
+}
+
+fn qualified_prefix_path_score(prefix_lower: &str, path: &str) -> u8 {
+    let normalized_path = path.replace('\\', "/").to_ascii_lowercase();
+    let segments = normalized_path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    if segments.is_empty() {
+        return 0;
+    }
+
+    let hyphenated_prefix = prefix_lower.replace('_', "-");
+    if !hyphenated_prefix.is_empty() && segments.iter().any(|segment| *segment == hyphenated_prefix)
+    {
+        return 3;
+    }
+
+    let trailing_prefix_segment = prefix_lower
+        .rsplit('_')
+        .next()
+        .unwrap_or(prefix_lower)
+        .replace('_', "-");
+    if trailing_prefix_segment.len() >= 3
+        && segments
+            .iter()
+            .any(|segment| *segment == trailing_prefix_segment)
+    {
+        return 2;
+    }
+
+    let compact_prefix = compact_alphanumeric(prefix_lower);
+    if compact_prefix.len() >= 3
+        && segments
+            .iter()
+            .any(|segment| compact_alphanumeric(segment) == compact_prefix)
+    {
+        return 1;
+    }
+
+    0
+}
+
+fn compact_alphanumeric(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn file_stem_lower(path: &str) -> Option<String> {
+    let file_name = path
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|file_name| !file_name.is_empty())?;
+    let stem = file_name
+        .rsplit_once('.')
+        .map_or(file_name, |(stem, _)| stem);
+    Some(stem.to_ascii_lowercase())
+}
+
+fn count_scip_artifacts(dir: &Path) -> u32 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_file())
+        .count() as u32
+}
+
+fn read_scip_revision(dir: &Path) -> Option<String> {
+    let revision_path = dir.join("revision.txt");
+    std::fs::read_to_string(revision_path)
+        .ok()
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn has_real_scip_artifact(project_dir: &Path) -> bool {
+    if !project_dir.join(SCIP_SYMBOLS_FILE).is_file()
+        || !project_dir
+            .join(crate::scip_index::SCIP_INDEX_FILE)
+            .is_file()
+        || !project_dir.join("revision.txt").is_file()
+        || project_dir.join("index.scip.stub").is_file()
+    {
+        return false;
+    }
+    load_scip_symbols(project_dir)
+        .ok()
+        .flatten()
+        .is_some_and(|index| !index.symbols.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scip_index::{SCIP_INDEX_FILE, ScipSymbolsIndex};
+    use tempfile::TempDir;
+
+    #[test]
+    fn anchor_search_scores_all_matches_before_truncating() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            zoekt_http_port: 1,
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            zoekt_data_dir: root.path().join("zoekt"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_id = "project";
+        let project_dir = layout.scip_project_dir(project_id);
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+
+        let mut symbols = Vec::new();
+        for index in 0..12 {
+            symbols.push(ScipSymbolRecord {
+                path: format!("src/needle/noise_{index}.ts"),
+                symbol: format!("noise_{index}"),
+                start_line: index + 1,
+                end_line: index + 1,
+            });
+        }
+        symbols.push(ScipSymbolRecord {
+            path: "src/needle/target.ts".to_string(),
+            symbol: "needle".to_string(),
+            start_line: 99,
+            end_line: 99,
+        });
+        let index = ScipSymbolsIndex {
+            revision: "graph-test".to_string(),
+            symbols,
+        };
+        std::fs::write(
+            project_dir.join(SCIP_SYMBOLS_FILE),
+            serde_json::to_string_pretty(&index).expect("serialize"),
+        )
+        .expect("write symbols");
+        std::fs::write(project_dir.join("revision.txt"), "graph-test\n").expect("revision");
+        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+
+        let hits = ScipClient::anchor_search(&layout, project_id, "needle", 8).expect("search");
+
+        assert!(
+            hits.iter()
+                .any(|hit| hit.file_path == "src/needle/target.ts"),
+            "exact SCIP symbol match should survive top-k truncation even when many earlier path-only matches exist"
+        );
+        assert_eq!(hits[0].file_path, "src/needle/target.ts");
+    }
+
+    #[test]
+    fn qualified_anchor_search_admits_crate_matching_terminal_definition() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            zoekt_http_port: 1,
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            zoekt_data_dir: root.path().join("zoekt"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_id = "project";
+        let project_dir = layout.scip_project_dir(project_id);
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+
+        let index = ScipSymbolsIndex {
+            revision: "graph-test".to_string(),
+            symbols: vec![
+                ScipSymbolRecord {
+                    path: "workspace/app/src/main.rs".to_string(),
+                    symbol: "workspace_app::Cli".to_string(),
+                    start_line: 15,
+                    end_line: 15,
+                },
+                ScipSymbolRecord {
+                    path: "workspace/tools/src/cli.rs".to_string(),
+                    symbol: "Cli".to_string(),
+                    start_line: 1,
+                    end_line: 1,
+                },
+                ScipSymbolRecord {
+                    path: "workspace/app/src/cli.rs".to_string(),
+                    symbol: "Cli".to_string(),
+                    start_line: 42,
+                    end_line: 42,
+                },
+            ],
+        };
+        std::fs::write(
+            project_dir.join(SCIP_SYMBOLS_FILE),
+            serde_json::to_string_pretty(&index).expect("serialize"),
+        )
+        .expect("write symbols");
+        std::fs::write(project_dir.join("revision.txt"), "graph-test\n").expect("revision");
+        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+
+        let hits = ScipClient::anchor_search(&layout, project_id, "workspace_app::Cli", 8)
+            .expect("search");
+
+        assert_eq!(
+            hits.first().map(|hit| hit.file_path.as_str()),
+            Some("workspace/app/src/cli.rs"),
+            "crate-qualified terminal definition should outrank import aliases and unrelated Cli definitions: {hits:#?}"
+        );
+        assert!(
+            hits.iter()
+                .all(|hit| hit.file_path != "workspace/tools/src/cli.rs"),
+            "qualified terminal expansion should require a matching prefix path: {hits:#?}"
+        );
+    }
+
+    #[test]
+    fn health_rejects_marker_without_symbol_index() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            zoekt_http_port: 1,
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            zoekt_data_dir: root.path().join("zoekt"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_id = "project";
+        let project_dir = layout.scip_project_dir(project_id);
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+        std::fs::write(project_dir.join("revision.txt"), "graph-test\n").expect("revision");
+        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+
+        let probe = ScipClient::health_probe(&layout, project_id);
+
+        assert_eq!(
+            probe.availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_stub".into()
+            }
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/scip_index.rs
+++ b/crates/codestory-retrieval/src/scip_index.rs
@@ -1,0 +1,201 @@
+//! Emit SCIP-shaped symbol artifacts from the CodeStory SQLite graph.
+
+use anyhow::{Context, Result};
+use codestory_store::Store;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+pub const SCIP_SYMBOLS_FILE: &str = "symbols.index.json";
+pub const SCIP_INDEX_FILE: &str = "index.scip";
+const STUB_MARKER: &str = "index.scip.stub";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScipSymbolRecord {
+    pub path: String,
+    pub symbol: String,
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScipSymbolsIndex {
+    pub revision: String,
+    pub symbols: Vec<ScipSymbolRecord>,
+}
+
+/// Write graph-backed SCIP artifacts; returns revision string on success.
+pub fn emit_scip_artifacts_from_store(
+    storage_path: &Path,
+    project_dir: &Path,
+) -> Result<Option<String>> {
+    std::fs::create_dir_all(project_dir)
+        .with_context(|| format!("create scip dir {}", project_dir.display()))?;
+    let mut storage = Store::open(storage_path).context("open storage for scip emit")?;
+    if storage.get_search_symbol_projection_count().unwrap_or(0) == 0 {
+        let _ = storage.rebuild_search_symbol_projection_from_node_table();
+    }
+
+    let mut symbols = Vec::new();
+    let mut after = None;
+    loop {
+        let batch = storage
+            .get_search_symbol_projection_detail_batch_after(after, 4096)
+            .context("load symbols for scip")?;
+        if batch.is_empty() {
+            break;
+        }
+        after = batch.last().map(|row| row.node_id);
+        for row in batch {
+            let Some(file_path) = row.file_path.as_deref().map(normalize_scip_path) else {
+                continue;
+            };
+            let start_line = row.start_line.unwrap_or(1);
+            let end_line = row.end_line.unwrap_or(start_line).max(start_line);
+            symbols.push(ScipSymbolRecord {
+                path: file_path,
+                symbol: row.display_name,
+                start_line,
+                end_line,
+            });
+        }
+    }
+
+    if symbols.is_empty() {
+        return Ok(None);
+    }
+
+    let revision = scip_revision_for_symbols(&symbols);
+    let index = ScipSymbolsIndex {
+        revision: revision.clone(),
+        symbols,
+    };
+    let json = serde_json::to_string_pretty(&index).context("serialize scip symbols index")?;
+    std::fs::write(project_dir.join(SCIP_SYMBOLS_FILE), json)
+        .context("write symbols.index.json")?;
+    std::fs::write(project_dir.join("revision.txt"), format!("{revision}\n"))
+        .context("write scip revision")?;
+    // Minimal marker so health treats graph lane as backed by a real artifact file.
+    std::fs::write(
+        project_dir.join(SCIP_INDEX_FILE),
+        format!("codestory-scip-v1\nrevision={revision}\n"),
+    )
+    .context("write index.scip marker")?;
+    let stub = project_dir.join(STUB_MARKER);
+    if stub.is_file() {
+        std::fs::remove_file(stub).context("remove scip stub marker")?;
+    }
+    Ok(Some(revision))
+}
+
+fn scip_revision_for_symbols(symbols: &[ScipSymbolRecord]) -> String {
+    let mut hasher = Sha256::new();
+    for symbol in symbols {
+        hasher.update(symbol.path.as_bytes());
+        hasher.update(symbol.symbol.as_bytes());
+        hasher.update(symbol.start_line.to_le_bytes());
+    }
+    format!("graph-{:x}", hasher.finalize())[..16].to_string()
+}
+
+fn normalize_scip_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+pub fn load_scip_symbols(project_dir: &Path) -> Result<Option<ScipSymbolsIndex>> {
+    let path = project_dir.join(SCIP_SYMBOLS_FILE);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let body = std::fs::read_to_string(&path).context("read scip symbols index")?;
+    let parsed: ScipSymbolsIndex =
+        serde_json::from_str(&body).context("parse scip symbols index json")?;
+    Ok(Some(parsed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::graph::{Node, NodeId, NodeKind};
+    use codestory_store::{FileInfo, FileRole, SearchSymbolProjection};
+    use tempfile::TempDir;
+
+    #[test]
+    fn scip_emit_does_not_stop_at_legacy_smoke_cap() {
+        let project = TempDir::new().expect("project");
+        let storage_path = project.path().join("codestory.db");
+        let mut storage = Store::open(&storage_path).expect("open store");
+        let file_node_id = NodeId(1);
+        storage
+            .insert_file(&FileInfo {
+                id: file_node_id.0,
+                path: project.path().join("src").join("large.ts"),
+                language: "typescript".to_string(),
+                modification_time: 1,
+                indexed: true,
+                complete: true,
+                line_count: 4_200,
+                file_role: FileRole::Source,
+            })
+            .expect("insert file");
+        storage
+            .insert_nodes_batch(&[Node {
+                id: file_node_id,
+                kind: NodeKind::FILE,
+                serialized_name: "src/large.ts".to_string(),
+                qualified_name: None,
+                canonical_id: None,
+                file_node_id: None,
+                start_line: Some(1),
+                start_col: Some(0),
+                end_line: Some(4_200),
+                end_col: Some(0),
+            }])
+            .expect("insert file node");
+
+        let mut nodes = Vec::new();
+        let mut projections = Vec::new();
+        for index in 0..4_100_i64 {
+            let id = NodeId(index + 2);
+            nodes.push(Node {
+                id,
+                kind: NodeKind::FUNCTION,
+                serialized_name: format!("symbol_{index:04}"),
+                qualified_name: Some(format!("symbol_{index:04}")),
+                canonical_id: None,
+                file_node_id: Some(file_node_id),
+                start_line: Some((index + 1) as u32),
+                start_col: Some(0),
+                end_line: Some((index + 1) as u32),
+                end_col: Some(10),
+            });
+            projections.push(SearchSymbolProjection {
+                node_id: id,
+                display_name: format!("symbol_{index:04}"),
+            });
+        }
+        storage.insert_nodes_batch(&nodes).expect("insert nodes");
+        storage
+            .upsert_search_symbol_projection_batch(&projections)
+            .expect("insert projections");
+        drop(storage);
+
+        let scip_dir = project.path().join("scip");
+        emit_scip_artifacts_from_store(&storage_path, &scip_dir).expect("emit scip");
+        let symbols = load_scip_symbols(&scip_dir)
+            .expect("load scip")
+            .expect("symbols");
+
+        assert!(
+            symbols.symbols.len() >= 4_100,
+            "SCIP emit should not truncate at the old 4096-symbol smoke cap"
+        );
+        assert!(
+            symbols
+                .symbols
+                .iter()
+                .any(|symbol| symbol.symbol == "symbol_4099"),
+            "SCIP emit should include symbols after the old cap"
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1,0 +1,416 @@
+use crate::config::SidecarLayout;
+use crate::generation::manifest_unavailable_reason;
+use crate::health::{RetrievalStatusReport, probe_sidecar_health};
+use crate::index::project_id_for_root;
+use anyhow::{Context, Result};
+use codestory_store::Store;
+use codestory_workspace::{RefreshInputs, StoredFileState, WorkspaceManifest};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SidecarStateFile {
+    pub zoekt_http_port: u16,
+    pub qdrant_http_port: u16,
+    pub qdrant_grpc_port: u16,
+    pub zoekt_data_dir: String,
+    pub qdrant_data_dir: String,
+    pub scip_artifacts_root: String,
+    pub started_at_epoch_ms: i64,
+}
+
+pub fn sidecar_up() -> Result<SidecarStateFile> {
+    let layout = SidecarLayout::from_env();
+    layout.ensure_data_dirs()?;
+    let state = SidecarStateFile {
+        zoekt_http_port: layout.zoekt_http_port,
+        qdrant_http_port: layout.qdrant_http_port,
+        qdrant_grpc_port: layout.qdrant_grpc_port,
+        zoekt_data_dir: layout.zoekt_data_dir.display().to_string(),
+        qdrant_data_dir: layout.qdrant_data_dir.display().to_string(),
+        scip_artifacts_root: layout.scip_artifacts_root.display().to_string(),
+        started_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
+    };
+    let json = serde_json::to_string_pretty(&state).context("serialize sidecar state")?;
+    std::fs::write(&layout.state_file, json).context("write retrieval-sidecars.json")?;
+    Ok(state)
+}
+
+pub fn sidecar_down() -> Result<()> {
+    let layout = SidecarLayout::from_env();
+    if layout.state_file.exists() {
+        std::fs::remove_file(&layout.state_file).context("remove retrieval-sidecars.json")?;
+    }
+    Ok(())
+}
+
+pub fn sidecar_status(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+) -> Result<RetrievalStatusReport> {
+    sidecar_status_inner(project_root, storage_path, false)
+}
+
+pub fn strict_sidecar_status(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+) -> Result<RetrievalStatusReport> {
+    sidecar_status_inner(project_root, storage_path, true)
+}
+
+fn sidecar_status_inner(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    strict: bool,
+) -> Result<RetrievalStatusReport> {
+    let layout = SidecarLayout::from_env();
+    let project_id = project_id_for_root(project_root);
+    let manifest = if let Some(path) = storage_path.filter(|path| path.exists()) {
+        let storage = Store::open(path).context("open storage for manifest")?;
+        let manifest = storage
+            .get_retrieval_index_manifest(&project_id)
+            .context("load retrieval manifest")?;
+        if strict
+            && let Some(manifest) = manifest.as_ref()
+            && let Some(reason) = strict_readiness_unavailable_reason(project_root, &storage)
+                .context("check strict sidecar readiness")?
+        {
+            return Ok(crate::health::unavailable_status_report(
+                format!("sidecar_manifest_stale: {reason}"),
+                Some(manifest.clone()),
+            ));
+        }
+        if let Some(manifest) = manifest.as_ref()
+            && let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest)
+        {
+            return Ok(crate::health::unavailable_status_report(
+                reason,
+                Some(manifest.clone()),
+            ));
+        }
+        manifest
+    } else {
+        None
+    };
+    Ok(probe_sidecar_health(&layout, &project_id, manifest))
+}
+
+pub(crate) fn validate_strict_sidecar_readiness(
+    project_root: &Path,
+    storage: &Store,
+) -> Result<()> {
+    if let Some(reason) = strict_readiness_unavailable_reason(project_root, storage)? {
+        anyhow::bail!("sidecar_manifest_stale: {reason}");
+    }
+    Ok(())
+}
+
+fn strict_readiness_unavailable_reason(
+    project_root: &Path,
+    storage: &Store,
+) -> Result<Option<String>> {
+    let workspace = WorkspaceManifest::open(project_root.to_path_buf())
+        .context("open workspace manifest for strict sidecar readiness")?;
+    let files = storage.files().get_files().context("load indexed files")?;
+    let refresh_inputs = RefreshInputs {
+        stored_files: files
+            .into_iter()
+            .map(|file| StoredFileState {
+                id: file.id,
+                path: file.path,
+                modification_time: file.modification_time,
+                indexed: file.indexed,
+            })
+            .collect(),
+        inventory: Default::default(),
+    };
+    let plan = workspace
+        .build_execution_plan(&refresh_inputs)
+        .context("build strict sidecar freshness plan")?;
+    if let Some(path) = plan.files_to_index.first() {
+        return Ok(Some(format!(
+            "indexable_file_added_or_changed_after_sidecar_manifest: {}",
+            path.display()
+        )));
+    }
+    if let Some(file_id) = plan.files_to_remove.first() {
+        return Ok(Some(format!(
+            "indexed_file_removed_after_sidecar_manifest: file_id={file_id}"
+        )));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generation::{
+        SIDECAR_SCHEMA_VERSION, sidecar_generation_id, sidecar_qdrant_collection,
+    };
+    use codestory_store::{FileInfo, FileRole};
+    use tempfile::TempDir;
+
+    #[test]
+    fn status_rejects_stale_manifest_before_component_probes() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let project_id = project_id_for_root(project.path());
+        let hash = "deadbeefcafebabe";
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
+                    project_id: project_id.clone(),
+                    zoekt_version: "zoekt-real-v1".into(),
+                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
+                    scip_revision: Some("graph-test".into()),
+                    built_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+                    embedding_dim: Some(768),
+                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+                    sidecar_input_hash: Some(hash.into()),
+                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
+                    projection_count: Some(10),
+                })
+                .expect("manifest");
+        }
+
+        let report = strict_sidecar_status(project.path(), Some(&storage_path))
+            .expect("sidecar status report");
+
+        assert_eq!(report.retrieval_mode, "unavailable");
+        assert!(
+            report
+                .degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("sidecar_manifest_stale")
+        );
+    }
+
+    #[test]
+    fn status_rejects_manifest_when_live_indexed_file_changes_or_is_removed() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let source_path = project.path().join("src").join("lib.rs");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("create source parent");
+        std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let indexed_mtime = live_mtime_millis(&source_path);
+        let project_id = project_id_for_root(project.path());
+        let hash = "feedfacecafebeef";
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .insert_file(&FileInfo {
+                    id: 1,
+                    path: source_path.clone(),
+                    language: "rust".into(),
+                    modification_time: indexed_mtime,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                })
+                .expect("insert indexed file");
+            storage
+                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
+                    project_id: project_id.clone(),
+                    zoekt_version: "zoekt-real-v1".into(),
+                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
+                    scip_revision: Some("graph-test".into()),
+                    built_at_epoch_ms: indexed_mtime,
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+                    embedding_dim: Some(768),
+                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+                    sidecar_input_hash: Some(hash.into()),
+                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
+                    projection_count: Some(0),
+                })
+                .expect("manifest");
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(&source_path, "pub fn indexed() -> usize { 1 }\n").expect("mutate source");
+        let changed = strict_sidecar_status(project.path(), Some(&storage_path))
+            .expect("changed sidecar status");
+        assert_eq!(changed.retrieval_mode, "unavailable");
+        assert!(
+            changed
+                .degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("indexable_file_added_or_changed_after_sidecar_manifest"),
+            "changed indexed file should make sidecar status fail closed: {changed:?}"
+        );
+
+        std::fs::remove_file(&source_path).expect("remove source");
+        let removed = strict_sidecar_status(project.path(), Some(&storage_path))
+            .expect("removed sidecar status");
+        assert_eq!(removed.retrieval_mode, "unavailable");
+        assert!(
+            removed
+                .degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("indexed_file_removed_after_sidecar_manifest"),
+            "removed indexed file should make sidecar status fail closed: {removed:?}"
+        );
+    }
+
+    #[test]
+    fn lightweight_status_does_not_scan_live_indexable_inventory() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let source_path = project.path().join("src").join("lib.rs");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("create source parent");
+        std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let indexed_mtime = live_mtime_millis(&source_path);
+        let project_id = project_id_for_root(project.path());
+        let hash = "1ead1e55cafebeef";
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .insert_file(&FileInfo {
+                    id: 1,
+                    path: source_path.clone(),
+                    language: "rust".into(),
+                    modification_time: indexed_mtime,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                })
+                .expect("insert indexed file");
+            storage
+                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
+                    project_id: project_id.clone(),
+                    zoekt_version: "zoekt-real-v1".into(),
+                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
+                    scip_revision: Some("graph-test".into()),
+                    built_at_epoch_ms: indexed_mtime,
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+                    embedding_dim: Some(768),
+                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+                    sidecar_input_hash: Some(hash.into()),
+                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
+                    projection_count: Some(0),
+                })
+                .expect("manifest");
+        }
+
+        std::fs::write(
+            project.path().join("src").join("new_module.rs"),
+            "pub fn newly_added() {}\n",
+        )
+        .expect("write new source");
+
+        let lightweight =
+            sidecar_status(project.path(), Some(&storage_path)).expect("lightweight status");
+        let strict =
+            strict_sidecar_status(project.path(), Some(&storage_path)).expect("strict status");
+
+        assert!(
+            !lightweight
+                .degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("indexable_file_added_or_changed_after_sidecar_manifest"),
+            "lightweight status should leave live inventory scans to strict callers: {lightweight:?}"
+        );
+        assert!(
+            strict
+                .degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("sidecar_manifest_stale"),
+            "strict status should fail closed on new indexable files: {strict:?}"
+        );
+    }
+
+    #[test]
+    fn strict_status_rejects_manifest_when_new_indexable_file_is_added() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let source_path = project.path().join("src").join("lib.rs");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("create source parent");
+        std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let indexed_mtime = live_mtime_millis(&source_path);
+        let project_id = project_id_for_root(project.path());
+        let hash = "ba5eba11cafebeef";
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .insert_file(&FileInfo {
+                    id: 1,
+                    path: source_path.clone(),
+                    language: "rust".into(),
+                    modification_time: indexed_mtime,
+                    indexed: true,
+                    complete: true,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                })
+                .expect("insert indexed file");
+            storage
+                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
+                    project_id: project_id.clone(),
+                    zoekt_version: "zoekt-real-v1".into(),
+                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
+                    scip_revision: Some("graph-test".into()),
+                    built_at_epoch_ms: indexed_mtime,
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+                    embedding_dim: Some(768),
+                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+                    sidecar_input_hash: Some(hash.into()),
+                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
+                    projection_count: Some(0),
+                })
+                .expect("manifest");
+        }
+
+        std::fs::write(
+            project.path().join("src").join("new_module.rs"),
+            "pub fn newly_added() {}\n",
+        )
+        .expect("write new source");
+
+        let report =
+            strict_sidecar_status(project.path(), Some(&storage_path)).expect("strict status");
+
+        assert_eq!(report.retrieval_mode, "unavailable");
+        assert!(
+            report
+                .degraded_reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("indexable_file_added_or_changed_after_sidecar_manifest"),
+            "new indexable file should make strict status fail closed: {report:?}"
+        );
+    }
+
+    fn live_mtime_millis(path: &Path) -> i64 {
+        std::fs::metadata(path)
+            .expect("metadata")
+            .modified()
+            .expect("modified")
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("mtime since epoch")
+            .as_millis()
+            .min(i64::MAX as u128) as i64
+    }
+}

--- a/crates/codestory-retrieval/src/sidecar_search.rs
+++ b/crates/codestory-retrieval/src/sidecar_search.rs
@@ -1,0 +1,163 @@
+use crate::candidate::CandidateHit;
+use crate::config::SidecarLayout;
+use crate::qdrant_client::QdrantClient;
+use crate::scip_client::ScipClient;
+use crate::zoekt_client::ZoektClient;
+use anyhow::Result;
+use codestory_store::RetrievalIndexManifest;
+/// Sidecar search surface used by the executor (mockable in unit tests).
+pub trait SidecarSearch: Send + Sync {
+    fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
+    fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
+    fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
+    fn scip_expand(&self, anchors: &[CandidateHit], limit: usize) -> Result<Vec<CandidateHit>>;
+}
+
+#[derive(Debug, Clone)]
+pub struct LiveSidecarSearch {
+    layout: SidecarLayout,
+    project_id: String,
+    sidecar_generation: String,
+    qdrant_collection: String,
+    zoekt: ZoektClient,
+    qdrant: QdrantClient,
+}
+
+impl LiveSidecarSearch {
+    pub fn new(
+        layout: SidecarLayout,
+        project_id: String,
+        manifest: Option<&RetrievalIndexManifest>,
+    ) -> Self {
+        let zoekt = ZoektClient::new(&layout);
+        let qdrant = QdrantClient::new(&layout);
+        let sidecar_generation = manifest
+            .and_then(|manifest| manifest.sidecar_generation.clone())
+            .unwrap_or_else(|| format!("{project_id}-missing-manifest"));
+        let qdrant_collection = manifest
+            .map(|manifest| manifest.qdrant_collection.clone())
+            .unwrap_or_else(|| format!("codestory_{project_id}_missing_manifest"));
+        Self {
+            layout,
+            project_id,
+            sidecar_generation,
+            qdrant_collection,
+            zoekt,
+            qdrant,
+        }
+    }
+
+    pub fn layout(&self) -> &SidecarLayout {
+        &self.layout
+    }
+
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+
+    pub fn sidecar_generation(&self) -> &str {
+        &self.sidecar_generation
+    }
+}
+
+impl SidecarSearch for LiveSidecarSearch {
+    fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
+        self.zoekt
+            .search(&self.layout, &self.sidecar_generation, query, limit)
+    }
+
+    fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
+        self.qdrant.search(&self.qdrant_collection, query, limit)
+    }
+
+    fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
+        ScipClient::anchor_search(&self.layout, &self.sidecar_generation, query, limit)
+    }
+
+    fn scip_expand(&self, anchors: &[CandidateHit], limit: usize) -> Result<Vec<CandidateHit>> {
+        ScipClient::expand_graph(&self.layout, &self.sidecar_generation, anchors, limit)
+    }
+}
+
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Debug, Default)]
+    pub struct MockSidecarSearch {
+        pub zoekt: Mutex<HashMap<String, Vec<CandidateHit>>>,
+        pub qdrant: Mutex<HashMap<String, Vec<CandidateHit>>>,
+        pub scip_anchor: Mutex<HashMap<String, Vec<CandidateHit>>>,
+        pub scip_expand: Mutex<Vec<CandidateHit>>,
+    }
+
+    impl MockSidecarSearch {
+        #[allow(dead_code)]
+        pub fn with_zoekt(query: &str, hits: Vec<CandidateHit>) -> Self {
+            let mut zoekt = HashMap::new();
+            zoekt.insert(query.to_string(), hits);
+            Self {
+                zoekt: Mutex::new(zoekt),
+                ..Default::default()
+            }
+        }
+    }
+
+    impl SidecarSearch for MockSidecarSearch {
+        fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(self
+                .zoekt
+                .lock()
+                .expect("zoekt lock")
+                .get(query)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .take(limit)
+                .collect())
+        }
+
+        fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(self
+                .qdrant
+                .lock()
+                .expect("qdrant lock")
+                .get(query)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .take(limit)
+                .collect())
+        }
+
+        fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(self
+                .scip_anchor
+                .lock()
+                .expect("scip anchor lock")
+                .get(query)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .take(limit)
+                .collect())
+        }
+
+        fn scip_expand(
+            &self,
+            _anchors: &[CandidateHit],
+            limit: usize,
+        ) -> Result<Vec<CandidateHit>> {
+            Ok(self
+                .scip_expand
+                .lock()
+                .expect("scip expand lock")
+                .clone()
+                .into_iter()
+                .take(limit)
+                .collect())
+        }
+    }
+}

--- a/crates/codestory-retrieval/src/zoekt_client.rs
+++ b/crates/codestory-retrieval/src/zoekt_client.rs
@@ -1,0 +1,135 @@
+use crate::config::{SidecarLayout, ZOEKT_HEALTH_BUDGET, zoekt_enabled};
+use crate::zoekt_index::{search_lexical_index, shard_dir_for, shard_has_lexical_index};
+use anyhow::Result;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct ZoektHealthProbe {
+    pub reachable: bool,
+    pub latency_ms: u64,
+    pub shard_count: u32,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ZoektClient {
+    base_url: String,
+    timeout: Duration,
+}
+
+impl ZoektClient {
+    pub fn new(layout: &SidecarLayout) -> Self {
+        Self {
+            base_url: layout.zoekt_base_url(),
+            timeout: ZOEKT_HEALTH_BUDGET,
+        }
+    }
+
+    pub fn health_probe(&self) -> ZoektHealthProbe {
+        let started = Instant::now();
+        if !zoekt_enabled() {
+            return ZoektHealthProbe {
+                reachable: false,
+                latency_ms: 0,
+                shard_count: 0,
+                detail: "disabled via CODESTORY_ZOEKT_ENABLED=false".into(),
+            };
+        }
+        let url = format!("{}/", self.base_url);
+        match ureq::get(&url).timeout(self.timeout).call() {
+            Ok(response) => {
+                let status = response.status();
+                ZoektHealthProbe {
+                    reachable: (200..500).contains(&status),
+                    latency_ms: started.elapsed().as_millis() as u64,
+                    shard_count: 0,
+                    detail: format!("http {status}"),
+                }
+            }
+            Err(error) => ZoektHealthProbe {
+                reachable: false,
+                latency_ms: started.elapsed().as_millis() as u64,
+                shard_count: 0,
+                detail: error.to_string(),
+            },
+        }
+    }
+
+    /// Lexical search: per-project shard only.
+    ///
+    /// The Zoekt HTTP `/search` API is intentionally not used for served hits until
+    /// the real sidecar path carries a project/repo filter. Health probing can still
+    /// prove the service is up, but primary retrieval must not leak global results.
+    pub fn search(
+        &self,
+        layout: &SidecarLayout,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<super::CandidateHit>> {
+        use super::candidate::{CandidateHit, CandidateSource};
+        let shard_dir = shard_dir_for(&layout.zoekt_data_dir, project_id);
+        if !shard_has_lexical_index(&shard_dir) {
+            return Ok(Vec::new());
+        }
+
+        let hits = search_lexical_index(&shard_dir, query, limit)?
+            .into_iter()
+            .map(|hit| CandidateHit::with_source(hit.path, None, hit.score, CandidateSource::Zoekt))
+            .collect::<Vec<_>>();
+        Ok(hits)
+    }
+
+    /// Probe search used by health to verify repo-relative hits exist.
+    pub fn probe_lexical_search(
+        &self,
+        layout: &SidecarLayout,
+        project_id: &str,
+    ) -> Result<Vec<String>> {
+        let hits = self.search(layout, project_id, "fn", 4)?;
+        Ok(hits.into_iter().map(|hit| hit.file_path).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zoekt_index::build_zoekt_shard;
+    use tempfile::TempDir;
+
+    #[test]
+    fn search_uses_project_local_shard_only() {
+        let project_a = TempDir::new().expect("project a");
+        let project_b = TempDir::new().expect("project b");
+        std::fs::create_dir_all(project_a.path().join("src")).expect("mkdir a");
+        std::fs::create_dir_all(project_b.path().join("src")).expect("mkdir b");
+        std::fs::write(
+            project_a.path().join("src").join("handler.rs"),
+            "pub fn project_a_handler() {}",
+        )
+        .expect("write a");
+        std::fs::write(
+            project_b.path().join("src").join("handler.rs"),
+            "pub fn project_b_handler() {}",
+        )
+        .expect("write b");
+
+        let zoekt_data = TempDir::new().expect("zoekt data");
+        build_zoekt_shard(project_a.path(), zoekt_data.path(), "project-a", false)
+            .expect("index a");
+        build_zoekt_shard(project_b.path(), zoekt_data.path(), "project-b", false)
+            .expect("index b");
+
+        let mut layout = SidecarLayout::from_env();
+        layout.zoekt_data_dir = zoekt_data.path().to_path_buf();
+        let client = ZoektClient::new(&layout);
+
+        let hits = client
+            .search(&layout, "project-a", "project_b_handler", 10)
+            .expect("search a");
+        assert!(
+            hits.is_empty(),
+            "project-a search must not return project-b shard hits: {hits:?}"
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/zoekt_index.rs
+++ b/crates/codestory-retrieval/src/zoekt_index.rs
@@ -1,0 +1,633 @@
+//! Build per-project Zoekt shard directories (lexical index + optional remote index).
+
+use crate::config::ZOEKT_REAL_VERSION_PIN;
+use anyhow::{Context, Result};
+use codestory_store::FileRole;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+const LEXICAL_INDEX_FILE: &str = "lexical-index.jsonl";
+const SHARD_META_FILE: &str = "shard-meta.json";
+const STUB_MARKER: &str = ".zoekt-stub";
+
+const MAX_FILE_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LexicalIndexEntry {
+    path: String,
+    content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ShardMeta {
+    version: String,
+    project_id: String,
+    file_count: u32,
+    lexical_hash: Option<String>,
+    indexed_at_epoch_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LexicalInputFingerprint {
+    pub file_count: u32,
+    pub hash: String,
+}
+
+/// Populate `shards/<project_id>/` with a searchable lexical index; remove stub marker on success.
+pub fn build_zoekt_shard(
+    project_root: &Path,
+    zoekt_data_dir: &Path,
+    project_id: &str,
+    zoekt_http_reachable: bool,
+) -> Result<bool> {
+    let shard_dir = zoekt_data_dir.join("shards").join(project_id);
+    std::fs::create_dir_all(&shard_dir)
+        .with_context(|| format!("create zoekt shard dir {}", shard_dir.display()))?;
+
+    let entries = collect_lexical_entries(project_root)?;
+    if entries.is_empty() {
+        return Ok(false);
+    }
+    let lexical_hash = lexical_entries_hash(&entries);
+
+    let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
+    let mut writer = std::fs::File::create(&index_path)
+        .with_context(|| format!("create {}", index_path.display()))?;
+    use std::io::Write;
+    for entry in &entries {
+        let line = serde_json::to_string(entry).context("serialize lexical index entry")?;
+        writeln!(writer, "{line}").context("write lexical index line")?;
+    }
+
+    let version = ZOEKT_REAL_VERSION_PIN.to_string();
+    let meta = ShardMeta {
+        version: version.clone(),
+        project_id: project_id.to_string(),
+        file_count: entries.len() as u32,
+        lexical_hash: Some(lexical_hash),
+        indexed_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
+    };
+    std::fs::write(
+        shard_dir.join(SHARD_META_FILE),
+        serde_json::to_string_pretty(&meta).context("serialize shard meta")?,
+    )
+    .context("write shard meta")?;
+
+    let stub = shard_dir.join(STUB_MARKER);
+    if stub.is_file() {
+        std::fs::remove_file(&stub).context("remove zoekt stub marker")?;
+    }
+
+    let _ = zoekt_http_reachable;
+    Ok(true)
+}
+
+pub fn shard_has_lexical_index(shard_dir: &Path) -> bool {
+    shard_dir.join(LEXICAL_INDEX_FILE).is_file() && !shard_dir.join(STUB_MARKER).is_file()
+}
+
+pub fn shard_matches_lexical_input(
+    zoekt_data_dir: &Path,
+    sidecar_generation: &str,
+    expected_file_count: u32,
+    expected_hash: &str,
+) -> bool {
+    let shard_dir = shard_dir_for(zoekt_data_dir, sidecar_generation);
+    if !shard_has_lexical_index(&shard_dir) {
+        return false;
+    }
+    let Ok(body) = std::fs::read_to_string(shard_dir.join(SHARD_META_FILE)) else {
+        return false;
+    };
+    let Ok(meta) = serde_json::from_str::<ShardMeta>(&body) else {
+        return false;
+    };
+    meta.version == ZOEKT_REAL_VERSION_PIN
+        && meta.project_id == sidecar_generation
+        && meta.file_count == expected_file_count
+        && meta.lexical_hash.as_deref() == Some(expected_hash)
+}
+
+pub fn lexical_input_fingerprint(project_root: &Path) -> Result<LexicalInputFingerprint> {
+    let entries = collect_lexical_entries(project_root)?;
+    Ok(LexicalInputFingerprint {
+        file_count: entries.len().min(u32::MAX as usize) as u32,
+        hash: lexical_entries_hash(&entries),
+    })
+}
+
+fn lexical_entries_hash(entries: &[LexicalIndexEntry]) -> String {
+    let mut hasher = sha2::Sha256::new();
+    use sha2::Digest;
+    hasher.update(b"codestory-zoekt-lexical-v1");
+    hasher.update(ZOEKT_REAL_VERSION_PIN.as_bytes());
+    for entry in entries {
+        hasher.update(entry.path.as_bytes());
+        hasher.update([0]);
+        hasher.update(entry.content.as_bytes());
+        hasher.update([0]);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+pub fn search_lexical_index(
+    shard_dir: &Path,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<LexicalHit>> {
+    let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
+    if !index_path.is_file() {
+        return Ok(Vec::new());
+    }
+    let tokens = lexical_query_tokens(query);
+    if tokens.is_empty() {
+        return Ok(Vec::new());
+    }
+    let command_tokens = command_query_tokens(query);
+    let content = std::fs::read_to_string(&index_path).context("read lexical index")?;
+    let entries = content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<LexicalIndexEntry>(line).ok())
+        .collect::<Vec<_>>();
+    let token_frequencies = token_document_frequencies(&entries, &tokens);
+    let token_weights = token_frequencies
+        .iter()
+        .zip(tokens.iter())
+        .map(|(frequency, token)| {
+            let mut weight = lexical_token_weight(*frequency, entries.len());
+            if command_tokens
+                .iter()
+                .any(|command_token| command_token == token)
+            {
+                weight *= 2.0;
+            }
+            weight
+        })
+        .collect::<Vec<_>>();
+    let total_weight = token_weights.iter().sum::<f32>();
+    let required_weight = required_lexical_match_weight(tokens.len(), total_weight);
+    let mut hits = Vec::new();
+    for entry in entries {
+        let path_lower = entry.path.to_ascii_lowercase();
+        let content_lower = entry.content.to_ascii_lowercase();
+        let token_match = lexical_token_match(&tokens, &token_weights, &path_lower, &content_lower);
+        if token_match.matched_weight >= required_weight
+            && broad_query_path_gate(tokens.len(), &token_match)
+        {
+            let score = score_lexical_match(&entry.path, &token_match);
+            hits.push(LexicalHit {
+                path: entry.path,
+                score,
+            });
+        }
+    }
+    hits.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    hits.truncate(limit);
+    Ok(hits)
+}
+
+fn lexical_query_tokens(query: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    for token in query
+        .split(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .filter(|token| token.len() >= 2)
+        .map(str::to_ascii_lowercase)
+        .filter(|token| !LEXICAL_STOP_WORDS.contains(&token.as_str()))
+    {
+        if !tokens.iter().any(|existing| existing == &token) {
+            tokens.push(token);
+        }
+    }
+    tokens
+}
+
+fn command_query_tokens(query: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut in_backticks = false;
+    let mut current = String::new();
+    for ch in query.chars() {
+        if ch == '`' {
+            if in_backticks {
+                push_command_tokens(&current, &mut tokens);
+                current.clear();
+            }
+            in_backticks = !in_backticks;
+            continue;
+        }
+        if in_backticks {
+            current.push(ch);
+        }
+    }
+    tokens
+}
+
+fn push_command_tokens(command: &str, tokens: &mut Vec<String>) {
+    for token in command
+        .split(|c: char| !(c.is_alphanumeric() || c == '_' || c == '-'))
+        .map(|token| token.trim_start_matches('-').to_ascii_lowercase())
+        .filter(|token| token.len() >= 2)
+        .filter(|token| token != "codex")
+    {
+        if !tokens.iter().any(|existing| existing == &token) {
+            tokens.push(token);
+        }
+    }
+}
+
+const LEXICAL_STOP_WORDS: &[&str] = &[
+    "about", "after", "and", "are", "cite", "does", "explain", "file", "files", "flow", "flows",
+    "for", "from", "how", "into", "level", "path", "source", "sources", "support", "that", "the",
+    "through", "top", "what", "where", "which", "with",
+];
+
+fn token_document_frequencies(entries: &[LexicalIndexEntry], tokens: &[String]) -> Vec<usize> {
+    tokens
+        .iter()
+        .map(|token| {
+            entries
+                .iter()
+                .filter(|entry| {
+                    let path_lower = entry.path.to_ascii_lowercase();
+                    let content_lower = entry.content.to_ascii_lowercase();
+                    path_lower.contains(token.as_str()) || content_lower.contains(token.as_str())
+                })
+                .count()
+        })
+        .collect()
+}
+
+fn lexical_token_weight(document_frequency: usize, document_count: usize) -> f32 {
+    let rarity = ((document_count as f32 + 1.0) / (document_frequency as f32 + 1.0)).ln();
+    (1.0 + rarity).clamp(0.25, 5.0)
+}
+
+fn required_lexical_match_weight(token_count: usize, total_weight: f32) -> f32 {
+    if token_count <= 3 {
+        return total_weight;
+    }
+    (total_weight * 0.28).max(2.5)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LexicalTokenMatch {
+    matched_weight: f32,
+    path_weight: f32,
+    content_weight: f32,
+    total_weight: f32,
+    meaningful_path_weight: f32,
+}
+
+fn lexical_token_match(
+    tokens: &[String],
+    token_weights: &[f32],
+    path_lower: &str,
+    content_lower: &str,
+) -> LexicalTokenMatch {
+    let mut matched_weight = 0.0;
+    let mut path_weight = 0.0;
+    let mut content_weight = 0.0;
+    let mut total_weight = 0.0;
+    let mut meaningful_path_weight = 0.0;
+    for (token, weight) in tokens.iter().zip(token_weights.iter().copied()) {
+        total_weight += weight;
+        let path_factor = path_match_factor(path_lower, token);
+        let path_match = path_factor > 0.0;
+        let content_match = content_lower.contains(token.as_str());
+        if path_match || content_match {
+            matched_weight += weight;
+        }
+        if path_match {
+            path_weight += weight * path_factor;
+            if path_factor >= 1.0 && weight >= 1.5 {
+                meaningful_path_weight += weight;
+            }
+        }
+        if content_match {
+            content_weight += weight;
+        }
+    }
+    LexicalTokenMatch {
+        matched_weight,
+        path_weight,
+        content_weight,
+        total_weight,
+        meaningful_path_weight,
+    }
+}
+
+fn broad_query_path_gate(token_count: usize, token_match: &LexicalTokenMatch) -> bool {
+    token_count < 8 || token_match.meaningful_path_weight > 0.0
+}
+
+fn path_match_factor(path_lower: &str, token: &str) -> f32 {
+    if path_lower.split('/').any(|segment| segment == token) {
+        return 1.8;
+    }
+    if path_lower
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .flat_map(|part| part.split('_'))
+        .any(|part| part == token)
+    {
+        return 1.0;
+    }
+    if path_lower.contains(token) {
+        return 0.35;
+    }
+    0.0
+}
+
+#[derive(Debug, Clone)]
+pub struct LexicalHit {
+    pub path: String,
+    pub score: f32,
+}
+
+fn score_lexical_match(path: &str, token_match: &LexicalTokenMatch) -> f32 {
+    let coverage = if token_match.total_weight <= 0.0 {
+        0.0
+    } else {
+        token_match.matched_weight / token_match.total_weight
+    };
+    let mut score = 0.20_f32
+        + coverage * 0.25
+        + token_match.path_weight * 0.09
+        + token_match.content_weight * 0.035;
+    let path_lower = path.replace('\\', "/").to_ascii_lowercase();
+    if path_lower.contains("/src/") || path_lower.starts_with("src/") {
+        score += 0.04;
+    }
+    score *= lexical_file_role_multiplier(FileRole::classify_path(Path::new(path)));
+    score.min(0.99)
+}
+
+fn lexical_file_role_multiplier(file_role: FileRole) -> f32 {
+    match file_role {
+        FileRole::Entrypoint => 1.08,
+        FileRole::Source => 1.0,
+        FileRole::Test => 0.68,
+        FileRole::Docs => 0.72,
+        FileRole::Benchmark => 0.64,
+        FileRole::Generated => 0.55,
+        FileRole::Vendor => 0.45,
+    }
+}
+
+fn collect_lexical_entries(project_root: &Path) -> Result<Vec<LexicalIndexEntry>> {
+    let mut entries = Vec::new();
+    collect_lexical_entries_inner(project_root, project_root, &mut entries)?;
+    Ok(entries)
+}
+
+fn collect_lexical_entries_inner(
+    project_root: &Path,
+    dir: &Path,
+    entries: &mut Vec<LexicalIndexEntry>,
+) -> Result<()> {
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(read_dir) => read_dir,
+        Err(_) => return Ok(()),
+    };
+    let mut dir_entries = read_dir.flatten().collect::<Vec<_>>();
+    dir_entries.sort_by_key(|entry| entry.path());
+
+    for entry in dir_entries {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            if should_skip_dir(&name) {
+                continue;
+            }
+            collect_lexical_entries_inner(project_root, &path, entries)?;
+            continue;
+        }
+        if !should_index_file(&name) {
+            continue;
+        }
+        let metadata = entry.metadata().ok();
+        if metadata
+            .as_ref()
+            .and_then(|meta| meta.len().try_into().ok())
+            .is_some_and(|len: usize| len > MAX_FILE_BYTES)
+        {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let rel = path
+            .strip_prefix(project_root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        entries.push(LexicalIndexEntry { path: rel, content });
+    }
+    Ok(())
+}
+
+fn should_skip_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git" | "target" | "node_modules" | "dist" | "build" | ".codestory" | "__pycache__"
+    )
+}
+
+fn should_index_file(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(lower.as_str(), "lib.rs" | "mod.rs" | "main.rs")
+        || lower.ends_with(".rs")
+        || lower.ends_with(".ts")
+        || lower.ends_with(".tsx")
+        || lower.ends_with(".js")
+        || lower.ends_with(".jsx")
+        || lower.ends_with(".py")
+        || lower.ends_with(".go")
+        || lower.ends_with(".java")
+        || lower.ends_with(".c")
+        || lower.ends_with(".cpp")
+        || lower.ends_with(".h")
+        || lower.ends_with(".hpp")
+        || lower.ends_with(".cs")
+        || lower.ends_with(".md")
+}
+
+pub fn shard_dir_for(zoekt_data_dir: &Path, project_id: &str) -> PathBuf {
+    zoekt_data_dir.join("shards").join(project_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn lexical_index_finds_repo_relative_paths() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(
+            project.path().join("lib.rs"),
+            "pub fn extension_service() {}",
+        )
+        .expect("write");
+        let zoekt_root = TempDir::new().expect("zoekt");
+        build_zoekt_shard(project.path(), zoekt_root.path(), "abc123", false).expect("build");
+        let shard = shard_dir_for(zoekt_root.path(), "abc123");
+        assert!(shard_has_lexical_index(&shard));
+        let hits = search_lexical_index(&shard, "extension", 8).expect("search");
+        assert!(hits.iter().any(|hit| hit.path == "lib.rs"));
+    }
+
+    #[test]
+    fn shard_match_requires_current_lexical_hash_metadata() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn alpha() {}").expect("write");
+        let zoekt_root = TempDir::new().expect("zoekt");
+        let fingerprint = lexical_input_fingerprint(project.path()).expect("fingerprint");
+        build_zoekt_shard(project.path(), zoekt_root.path(), "generation", false).expect("build");
+
+        assert!(shard_matches_lexical_input(
+            zoekt_root.path(),
+            "generation",
+            fingerprint.file_count,
+            &fingerprint.hash
+        ));
+        assert!(!shard_matches_lexical_input(
+            zoekt_root.path(),
+            "generation",
+            fingerprint.file_count,
+            "not-the-current-hash"
+        ));
+    }
+
+    #[test]
+    fn lexical_search_scores_all_matches_before_truncating() {
+        let zoekt_root = TempDir::new().expect("zoekt");
+        let shard = zoekt_root.path();
+        let weak = LexicalIndexEntry {
+            path: "src/a_weak.rs".into(),
+            content: "handler mentioned once".into(),
+        };
+        let strong = LexicalIndexEntry {
+            path: "src/z_strong_handler.rs".into(),
+            content: "handler handler handler".into(),
+        };
+        let lines = [weak, strong]
+            .into_iter()
+            .map(|entry| serde_json::to_string(&entry).expect("serialize"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(shard.join(LEXICAL_INDEX_FILE), lines).expect("write index");
+
+        let hits = search_lexical_index(shard, "handler", 1).expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].path, "src/z_strong_handler.rs");
+    }
+
+    #[test]
+    fn lexical_index_does_not_stop_at_legacy_smoke_cap() {
+        let project = TempDir::new().expect("project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(&src).expect("mkdir");
+        for index in 0..4_100 {
+            std::fs::write(
+                src.join(format!("file_{index:04}.ts")),
+                format!("export const symbol_{index:04} = {index};\n"),
+            )
+            .expect("write source file");
+        }
+
+        let zoekt_root = TempDir::new().expect("zoekt");
+        build_zoekt_shard(project.path(), zoekt_root.path(), "large", false).expect("build");
+        let shard = shard_dir_for(zoekt_root.path(), "large");
+        let hits = search_lexical_index(&shard, "symbol_4099", 4).expect("search");
+
+        assert!(
+            hits.iter().any(|hit| hit.path == "src/file_4099.ts"),
+            "large-repo lexical shard should include files after the old 4096-file cap"
+        );
+    }
+
+    #[test]
+    fn lexical_search_tie_breaks_by_path() {
+        let zoekt_root = TempDir::new().expect("zoekt");
+        let shard = zoekt_root.path();
+        let later = LexicalIndexEntry {
+            path: "src/b.rs".into(),
+            content: "handler".into(),
+        };
+        let earlier = LexicalIndexEntry {
+            path: "src/a.rs".into(),
+            content: "handler".into(),
+        };
+        let lines = [later, earlier]
+            .into_iter()
+            .map(|entry| serde_json::to_string(&entry).expect("serialize"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(shard.join(LEXICAL_INDEX_FILE), lines).expect("write index");
+
+        let hits = search_lexical_index(shard, "handler", 2).expect("search");
+        assert_eq!(
+            hits.iter().map(|hit| hit.path.as_str()).collect::<Vec<_>>(),
+            vec!["src/a.rs", "src/b.rs",]
+        );
+    }
+
+    #[test]
+    fn lexical_search_uses_partial_matching_for_broad_prompts() {
+        let zoekt_root = TempDir::new().expect("zoekt");
+        let shard = zoekt_root.path();
+        let source = LexicalIndexEntry {
+            path: "workspace/app/src/event_processor_with_jsonl_output.rs".into(),
+            content: "jsonl event output request runtime turn start".into(),
+        };
+        let test = LexicalIndexEntry {
+            path: "workspace/app/tests/event_processor_with_json_output.rs".into(),
+            content: "json event output test approval fixture".into(),
+        };
+        let unrelated = LexicalIndexEntry {
+            path: "workspace/core/src/session.rs".into(),
+            content: "session bookkeeping".into(),
+        };
+        let generic_agent_doc = LexicalIndexEntry {
+            path: ".agents/skills/review/SKILL.md".into(),
+            content: "request json cli runtime thread turn start event output".into(),
+        };
+        let generated_schema = LexicalIndexEntry {
+            path: "workspace/app-protocol/schema/typescript/v2/CommandRequestParams.ts".into(),
+            content: "app server command request turn start request".into(),
+        };
+        let lines = [test, unrelated, generic_agent_doc, generated_schema, source]
+            .into_iter()
+            .map(|entry| serde_json::to_string(&entry).expect("serialize"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(shard.join(LEXICAL_INDEX_FILE), lines).expect("write index");
+
+        let hits = search_lexical_index(
+            shard,
+            "Explain how `app request --json` flows from CLI into runtime thread turn start JSONL event output",
+            4,
+        )
+        .expect("search");
+
+        assert!(!hits.is_empty());
+        assert_eq!(
+            hits.first().map(|hit| hit.path.as_str()),
+            Some("workspace/app/src/event_processor_with_jsonl_output.rs")
+        );
+        assert!(
+            hits.iter()
+                .all(|hit| hit.path != "workspace/core/src/session.rs")
+        );
+        assert!(
+            hits.iter()
+                .all(|hit| hit.path != ".agents/skills/review/SKILL.md")
+        );
+    }
+}

--- a/crates/codestory-retrieval/tests/bootstrap_repair_contracts.rs
+++ b/crates/codestory-retrieval/tests/bootstrap_repair_contracts.rs
@@ -1,0 +1,125 @@
+//! Bootstrap Qdrant storage repair contracts (mixed cache layouts, prune suppression).
+
+use codestory_retrieval::{
+    BootstrapStorageScope, PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR, SidecarLayout,
+    repair_qdrant_storage,
+};
+use codestory_store::{RetrievalIndexManifest, Store};
+use std::fs;
+use tempfile::tempdir;
+
+fn touch_collection(collections_dir: &std::path::Path, name: &str) {
+    let dir = collections_dir.join(name);
+    fs::create_dir_all(&dir).expect("collection dir");
+    fs::write(dir.join("config.json"), "{}").expect("config");
+}
+
+fn test_layout(qdrant_data: &tempfile::TempDir) -> SidecarLayout {
+    SidecarLayout {
+        zoekt_http_port: 6070,
+        qdrant_http_port: 1,
+        qdrant_grpc_port: 1,
+        zoekt_data_dir: qdrant_data.path().join("zoekt"),
+        qdrant_data_dir: qdrant_data.path().to_path_buf(),
+        scip_artifacts_root: qdrant_data.path().join("scip"),
+        state_file: qdrant_data.path().join("state.json"),
+    }
+}
+
+#[test]
+fn mixed_flat_and_hashed_cache_protects_both_manifest_collections() {
+    let cache_root = tempdir().expect("cache");
+    let flat_db = cache_root.path().join("codestory.db");
+    let mut flat_storage = Store::open(&flat_db).expect("open flat");
+    flat_storage
+        .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+            project_id: "flat".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_contract_flat".into(),
+            scip_revision: None,
+            built_at_epoch_ms: 1,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: None,
+            embedding_dim: None,
+            sidecar_schema_version: None,
+            sidecar_input_hash: None,
+            sidecar_generation: None,
+            projection_count: None,
+        })
+        .expect("flat manifest");
+
+    let hashed_dir = cache_root.path().join("cccccccccccccccc");
+    fs::create_dir_all(&hashed_dir).expect("hashed dir");
+    let mut hashed_storage = Store::open(hashed_dir.join("codestory.db")).expect("open hashed");
+    hashed_storage
+        .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+            project_id: "hashed".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_contract_hashed".into(),
+            scip_revision: None,
+            built_at_epoch_ms: 1,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: None,
+            embedding_dim: None,
+            sidecar_schema_version: None,
+            sidecar_input_hash: None,
+            sidecar_generation: None,
+            projection_count: None,
+        })
+        .expect("hashed manifest");
+
+    let qdrant_data = tempdir().expect("qdrant");
+    let collections = qdrant_data.path().join("collections");
+    fs::create_dir_all(&collections).expect("collections dir");
+    touch_collection(&collections, "codestory_contract_flat");
+    touch_collection(&collections, "codestory_contract_hashed");
+    for index in 0..65 {
+        touch_collection(
+            &collections,
+            &format!("codestory_contract_extra_{index:02}"),
+        );
+    }
+
+    let scope = BootstrapStorageScope {
+        repo_root: None,
+        active_storage_path: None,
+        active_cache_root: None,
+        global_cache_root: cache_root.path().to_path_buf(),
+    };
+    let report = repair_qdrant_storage(&test_layout(&qdrant_data), &scope, 64).expect("repair");
+    assert!(report.prune_suppressed_reason.is_none());
+    assert!(report.pruned_collections > 0);
+    assert!(collections.join("codestory_contract_flat").exists());
+    assert!(collections.join("codestory_contract_hashed").exists());
+}
+
+#[test]
+fn corrupt_active_cache_suppresses_retention_deletes() {
+    let cache_root = tempdir().expect("cache");
+    let corrupt_db = cache_root.path().join("codestory.db");
+    fs::write(&corrupt_db, b"not sqlite").expect("corrupt db");
+
+    let qdrant_data = tempdir().expect("qdrant");
+    let collections = qdrant_data.path().join("collections");
+    fs::create_dir_all(&collections).expect("collections dir");
+    for index in 0..65 {
+        touch_collection(&collections, &format!("codestory_suppressed_{index:02}"));
+    }
+
+    let scope = BootstrapStorageScope {
+        repo_root: None,
+        active_storage_path: Some(corrupt_db),
+        active_cache_root: Some(cache_root.path().to_path_buf()),
+        global_cache_root: cache_root.path().to_path_buf(),
+    };
+    let report = repair_qdrant_storage(&test_layout(&qdrant_data), &scope, 64).expect("repair");
+    assert!(!report.scan_errors.is_empty());
+    assert_eq!(
+        report.prune_suppressed_reason.as_deref(),
+        Some(PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR)
+    );
+    assert_eq!(report.pruned_collections, 0);
+    assert_eq!(report.prune_candidates, 1);
+}

--- a/crates/codestory-retrieval/tests/degraded_modes.rs
+++ b/crates/codestory-retrieval/tests/degraded_modes.rs
@@ -1,0 +1,81 @@
+use codestory_retrieval::{
+    ComponentHealth, ComponentStatus, RetrievalDegradedMode, RetrievalStageKind, classify_query,
+    derive_degraded_mode, plan_query,
+};
+
+fn component(
+    name: &str,
+    status: ComponentStatus,
+    reason: Option<&str>,
+    capabilities: codestory_retrieval::SidecarCapabilities,
+) -> ComponentHealth {
+    ComponentHealth {
+        name: name.into(),
+        status,
+        latency_ms: None,
+        detail: String::new(),
+        degraded_reason: reason.map(str::to_string),
+        capabilities,
+    }
+}
+
+#[test]
+fn degraded_mode_planner_matrix() {
+    let production = codestory_retrieval::SidecarCapabilities::production_stack();
+    let zoekt_up = component("zoekt", ComponentStatus::Healthy, None, production);
+    let qdrant_up = component("qdrant", ComponentStatus::Healthy, None, production);
+    let scip_up = component("scip", ComponentStatus::Healthy, None, production);
+    let features = classify_query("handler");
+
+    let (full, _) = derive_degraded_mode(&zoekt_up, &qdrant_up, &scip_up);
+    assert_eq!(full, RetrievalDegradedMode::Full);
+    assert!(
+        plan_query(&features, full)
+            .stages
+            .iter()
+            .any(|s| s.kind == RetrievalStageKind::Stage1bQdrantSemantic)
+    );
+
+    let qdrant_down = component(
+        "qdrant",
+        ComponentStatus::Unavailable,
+        Some("qdrant_unreachable"),
+        codestory_retrieval::SidecarCapabilities::NONE,
+    );
+    let (no_semantic, _) = derive_degraded_mode(&zoekt_up, &qdrant_down, &scip_up);
+    assert_eq!(no_semantic, RetrievalDegradedMode::NoSemantic);
+    assert!(
+        !plan_query(&features, no_semantic)
+            .stages
+            .iter()
+            .any(|s| s.kind == RetrievalStageKind::Stage1bQdrantSemantic)
+    );
+
+    let scip_down = component(
+        "scip",
+        ComponentStatus::Unavailable,
+        Some("scip_unavailable"),
+        codestory_retrieval::SidecarCapabilities::NONE,
+    );
+    let (no_scip, _) = derive_degraded_mode(&zoekt_up, &qdrant_up, &scip_down);
+    assert_eq!(no_scip, RetrievalDegradedMode::NoScip);
+    assert!(
+        !plan_query(&features, no_scip)
+            .stages
+            .iter()
+            .any(|s| s.kind == RetrievalStageKind::Stage0ScipAnchor)
+    );
+
+    let (lexical_only, _) = derive_degraded_mode(&zoekt_up, &qdrant_down, &scip_down);
+    assert_eq!(lexical_only, RetrievalDegradedMode::LexicalOnly);
+
+    let zoekt_down = component(
+        "zoekt",
+        ComponentStatus::Unavailable,
+        Some("zoekt_unreachable"),
+        codestory_retrieval::SidecarCapabilities::NONE,
+    );
+    let (unavailable, _) = derive_degraded_mode(&zoekt_down, &qdrant_up, &scip_up);
+    assert_eq!(unavailable, RetrievalDegradedMode::Unavailable);
+    assert!(plan_query(&features, unavailable).stages.is_empty());
+}

--- a/crates/codestory-retrieval/tests/full_stack_integration.rs
+++ b/crates/codestory-retrieval/tests/full_stack_integration.rs
@@ -1,0 +1,157 @@
+//! Phase 2 exit: fixture index → `full` mode → SQLite-resolvable hits.
+
+use codestory_contracts::graph::{Node, NodeId, NodeKind};
+use codestory_retrieval::{
+    QdrantClient, QueryRequest, SidecarLayout, execute_retrieval_query, finalize_index,
+    probe_sidecar_health, project_id_for_root, qdrant_enabled,
+};
+use codestory_store::{FileInfo, FileRole, SearchSymbolProjection, Store};
+use std::path::Path;
+use tempfile::TempDir;
+
+fn seed_fixture_graph(
+    storage: &mut Store,
+    project_root: &Path,
+) -> codestory_contracts::graph::NodeId {
+    let file_path = project_root.join("lib.rs");
+    let file_node_id = 1_001_i64;
+    storage
+        .insert_file(&FileInfo {
+            id: file_node_id,
+            path: file_path.clone(),
+            language: "rust".to_string(),
+            modification_time: 1,
+            indexed: true,
+            complete: true,
+            line_count: 3,
+            file_role: FileRole::Entrypoint,
+        })
+        .expect("insert file");
+    let file_node = Node {
+        id: NodeId(file_node_id),
+        kind: NodeKind::FILE,
+        serialized_name: "lib.rs".to_string(),
+        qualified_name: None,
+        canonical_id: None,
+        file_node_id: None,
+        start_line: Some(1),
+        start_col: Some(0),
+        end_line: Some(3),
+        end_col: Some(0),
+    };
+    storage.insert_nodes_batch(&[file_node]).expect("file node");
+    let func_node = Node {
+        id: NodeId(2_001),
+        kind: NodeKind::FUNCTION,
+        serialized_name: "extension_service".to_string(),
+        qualified_name: Some("extension_service".to_string()),
+        canonical_id: None,
+        file_node_id: Some(NodeId(file_node_id)),
+        start_line: Some(1),
+        start_col: Some(0),
+        end_line: Some(1),
+        end_col: Some(30),
+    };
+    storage
+        .insert_nodes_batch(std::slice::from_ref(&func_node))
+        .expect("func node");
+    storage
+        .upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
+            node_id: func_node.id,
+            display_name: "extension_service".to_string(),
+        }])
+        .expect("projection");
+    func_node.id
+}
+
+#[test]
+#[ignore = "requires live mandatory retrieval sidecars"]
+fn full_mode_fixture_produces_resolvable_hits() {
+    // SAFETY: serialized env mutation for this test only.
+    unsafe {
+        std::env::set_var("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
+        std::env::set_var("CODESTORY_EMBED_BACKEND", "llamacpp");
+    }
+
+    let project = TempDir::new().expect("project");
+    std::fs::write(
+        project.path().join("lib.rs"),
+        "pub fn extension_service() {}\n",
+    )
+    .expect("write lib.rs");
+
+    let storage_dir = TempDir::new().expect("storage");
+    let storage_path = storage_dir.path().join("codestory.db");
+    {
+        let mut storage = Store::open(&storage_path).expect("open db");
+        seed_fixture_graph(&mut storage, project.path());
+    }
+
+    finalize_index(project.path(), &storage_path).expect("finalize index");
+
+    let layout = SidecarLayout::from_env();
+    let project_id = project_id_for_root(project.path());
+    if qdrant_enabled() {
+        let qdrant = QdrantClient::new(&layout);
+        if qdrant.list_collections_probe().reachable {
+            let collection = QdrantClient::collection_name(&project_id);
+            let _ = qdrant.ensure_collection(&collection);
+            let storage = Store::open(&storage_path).expect("reopen for qdrant");
+            if storage.get_search_symbol_projection_count().unwrap_or(0) > 0 {
+                let points = vec![codestory_retrieval::QdrantUpsertPoint {
+                    id: 2_001,
+                    display_name: "extension_service".to_string(),
+                    node_id: "2001".to_string(),
+                    file_path: Some("lib.rs".to_string()),
+                    file_role: Some(FileRole::Entrypoint),
+                    vector: None,
+                }];
+                if qdrant.upsert_points(&collection, &points).is_ok() {
+                    let stub = QdrantClient::stub_marker_path(&layout.qdrant_data_dir, &collection);
+                    if stub.is_file() {
+                        let _ = std::fs::remove_file(stub);
+                    }
+                }
+            }
+        }
+    }
+
+    let manifest = Store::open(&storage_path)
+        .expect("reopen")
+        .get_retrieval_index_manifest(&project_id)
+        .expect("load manifest")
+        .expect("manifest row");
+    let status = probe_sidecar_health(&layout, &project_id, Some(manifest));
+    assert_eq!(
+        status.retrieval_mode, "full",
+        "expected full mode, got {} ({:?})",
+        status.retrieval_mode, status.degraded_reason
+    );
+    assert!(status.zoekt.capabilities.lexical);
+    assert!(status.qdrant.capabilities.semantic);
+    assert!(status.scip.capabilities.graph);
+
+    let result = execute_retrieval_query(QueryRequest {
+        project_root: project.path(),
+        storage_path: &storage_path,
+        query: "extension_service",
+        budget_ms: Some(1_000),
+        cancelled: None,
+    })
+    .expect("query");
+    assert!(!result.hits.is_empty(), "expected sidecar hits");
+    assert!(
+        result
+            .hits
+            .iter()
+            .any(|hit| hit.file_path.contains("lib.rs") && !hit.file_path.starts_with("zoekt:")),
+        "expected repo-relative zoekt/scip hit, got {:?}",
+        result.hits
+    );
+
+    // SAFETY: test env cleanup.
+    unsafe {
+        std::env::remove_var("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS");
+        std::env::remove_var("CODESTORY_EMBED_BACKEND");
+    }
+}

--- a/crates/codestory-retrieval/tests/holdout_ranking.rs
+++ b/crates/codestory-retrieval/tests/holdout_ranking.rs
@@ -1,0 +1,92 @@
+//! Regression ranking checks for OSS holdout retrieval prompts.
+
+use codestory_retrieval::{CandidateHit, CandidateSource, classify_query, rank_candidates};
+
+fn holdout_candidates_ripgrep() -> Vec<CandidateHit> {
+    vec![
+        CandidateHit::with_source(
+            "crates/core/search.rs",
+            Some("SearchWorker".into()),
+            0.82,
+            CandidateSource::Zoekt,
+        ),
+        CandidateHit::with_source(
+            "crates/core/flags/mod.rs",
+            Some("parse".into()),
+            0.65,
+            CandidateSource::Zoekt,
+        ),
+        CandidateHit::with_source("zoekt:search pipeline", None, 0.95, CandidateSource::Zoekt),
+        CandidateHit::with_source("README.md", None, 0.2, CandidateSource::Zoekt),
+    ]
+}
+
+#[test]
+fn holdout_ripgrep_prompt_prefers_search_driver_files() {
+    let features = classify_query(
+        "Explain how ripgrep parses CLI flags, walks candidate files, and executes search through matcher, searcher, and printer components.",
+    );
+    let ranked = rank_candidates(&features, holdout_candidates_ripgrep());
+    assert!(!ranked.is_empty());
+    assert_eq!(ranked[0].file_path, "crates/core/search.rs");
+    assert!(
+        ranked
+            .iter()
+            .all(|hit| !hit.file_path.starts_with("zoekt:")),
+        "phantom hits must be dropped"
+    );
+}
+
+#[test]
+fn holdout_axios_prompt_prefers_dispatch_path() {
+    let features = classify_query(
+        "Explain how the default axios instance is created and how an HTTP request flows through interceptors, dispatchRequest, and the transport adapter.",
+    );
+    let candidates = vec![
+        CandidateHit::with_source(
+            "lib/core/dispatchRequest.js",
+            Some("dispatchRequest".into()),
+            0.8,
+            CandidateSource::Zoekt,
+        ),
+        CandidateHit::with_source("lib/defaults.js", None, 0.75, CandidateSource::Zoekt),
+        CandidateHit::with_source("semantic:axios", None, 0.95, CandidateSource::Qdrant),
+    ];
+    let ranked = rank_candidates(&features, candidates);
+    assert_eq!(ranked[0].file_path, "lib/core/dispatchRequest.js");
+}
+
+#[test]
+fn holdout_redis_prompt_prefers_server_event_loop_files() {
+    let features = classify_query(
+        "Explain how the Redis server starts its event loop, reads client commands from the network, and dispatches them through processCommand.",
+    );
+    let candidates = vec![
+        CandidateHit::with_source(
+            "src/server.c",
+            Some("main".into()),
+            0.82,
+            CandidateSource::Zoekt,
+        ),
+        CandidateHit::with_source(
+            "src/ae.c",
+            Some("aeMain".into()),
+            0.78,
+            CandidateSource::Zoekt,
+        ),
+        CandidateHit::with_source("README.md", None, 0.3, CandidateSource::Zoekt),
+    ];
+    let ranked = rank_candidates(&features, candidates);
+    assert_eq!(ranked[0].file_path, "src/server.c");
+}
+
+#[test]
+fn holdout_path_like_query_boosts_matching_file() {
+    let features = classify_query("crates/core/main.rs search");
+    let candidates = vec![
+        CandidateHit::lexical_stub("crates/core/main.rs", 0.85),
+        CandidateHit::lexical_stub("crates/ignore/walk.rs", 0.4),
+    ];
+    let ranked = rank_candidates(&features, candidates);
+    assert_eq!(ranked[0].file_path, "crates/core/main.rs");
+}

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -1,0 +1,64 @@
+# CodeStory retrieval sidecars (Qdrant + Zoekt).
+# Pins must match docs/ops/retrieval-sidecars.md and crates/codestory-retrieval/src/config.rs.
+#
+# Start via:
+#   node scripts/setup-retrieval-env.mjs
+# or:
+#   cargo run -p codestory-cli -- retrieval bootstrap
+
+name: codestory-retrieval
+
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.12.5
+    container_name: codestory-qdrant
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${CODESTORY_QDRANT_HTTP_PORT:-6333}:6333"
+      - "127.0.0.1:${CODESTORY_QDRANT_GRPC_PORT:-6334}:6334"
+    volumes:
+      - type: bind
+        source: ${CODESTORY_QDRANT_DATA_DIR:?set CODESTORY_QDRANT_DATA_DIR}
+        target: /qdrant/storage
+
+  # Zoekt webserver (mount index dir populated by `retrieval index`).
+  zoekt:
+    image: sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4
+    container_name: codestory-zoekt
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${CODESTORY_ZOEKT_PORT:-6070}:6070"
+    volumes:
+      - type: bind
+        source: ${CODESTORY_ZOEKT_DATA_DIR:?set CODESTORY_ZOEKT_DATA_DIR}
+        target: /data/index
+
+  # BAAI/bge-base-en-v1.5 embeddings via llama.cpp OpenAI-compatible API (768-dim).
+  # Model GGUF must exist under CODESTORY_EMBED_MODEL_DIR (see setup-retrieval-env.mjs).
+  embed:
+    image: ghcr.io/ggml-org/llama.cpp:server
+    container_name: codestory-embed
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${CODESTORY_EMBED_PORT:-8080}:8080"
+    volumes:
+      - type: bind
+        source: ${CODESTORY_EMBED_MODEL_DIR:?set CODESTORY_EMBED_MODEL_DIR}
+        target: /models
+        read_only: true
+    command:
+      - --embeddings
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "8080"
+      - -m
+      - /models/bge-base-en-v1.5.Q8_0.gguf
+      - -c
+      - "512"
+      - -b
+      - "1024"
+      - -ub
+      - "1024"
+      - -np
+      - "6"

--- a/docker/retrieval.env.example
+++ b/docker/retrieval.env.example
@@ -1,0 +1,37 @@
+# Copy to docker/.retrieval.env (gitignored) or export in your shell before compose.
+# No secrets in this file — localhost ports and cache paths only.
+
+# HTTP ports (must match CODESTORY_* env vars used by codestory retrieval status)
+CODESTORY_ZOEKT_PORT=6070
+CODESTORY_QDRANT_HTTP_PORT=6333
+CODESTORY_QDRANT_GRPC_PORT=6334
+CODESTORY_EMBED_PORT=8080
+
+# Bind-mount for Qdrant persistence (Windows example)
+# CODESTORY_QDRANT_DATA_DIR=C:\Users\you\AppData\Local\codestory\cache\qdrant
+
+# Zoekt index root (real profile webserver + lexical shards)
+# CODESTORY_ZOEKT_DATA_DIR=C:\Users\you\AppData\Local\codestory\cache\zoekt
+
+# bge-base-en-v1.5 GGUF for llama.cpp embed service (real profile)
+# CODESTORY_EMBED_MODEL_DIR=C:\Users\you\source\repos\codestory\target\retrieval-models
+# Fetch: node scripts/setup-retrieval-env.mjs --fetch-embed-model
+
+# Historical compose-profile overrides are rejected by product bootstrap/index paths.
+
+# Optional: override compose file location
+# CODESTORY_RETRIEVAL_COMPOSE_FILE=C:\path\to\codestory\docker\retrieval-compose.yml
+
+# Phase 2 — real Qdrant vectors (768-dim bge-base-en-v1.5)
+# CODESTORY_RETRIEVAL_REAL_EMBEDDINGS=1
+# CODESTORY_EMBED_BACKEND=llamacpp
+# CODESTORY_EMBED_LLAMACPP_URL=http://127.0.0.1:8080/v1/embeddings
+# CODESTORY_EMBED_QUERY_PREFIX=Represent this sentence for searching relevant passages:
+# CODESTORY_EMBED_DOCUMENT_PREFIX=
+# Smoke: curl -s $CODESTORY_EMBED_LLAMACPP_URL -d '{"input":["function"]}' | jq '.data[0].embedding|length'  # => 768
+# After index: `cargo run -p codestory-cli -- retrieval status` must show capabilities.semantic=true
+
+# Sidecar primary (promotion-gated default in retrieval_primary.rs)
+# CODESTORY_RETRIEVAL=1
+# CODESTORY_ZOEKT_ENABLED=1
+# CODESTORY_QDRANT_ENABLED=1


### PR DESCRIPTION
## Summary
- Adds the `codestory-retrieval` crate for mandatory sidecar planning, health, indexing, query, ranking, cache, Qdrant, SCIP, and Zoekt integration.
- Adds retrieval Docker compose/env assets and sidecar crate tests.

## Tests
- cargo check -p codestory-retrieval
- cargo test -p codestory-retrieval
- cargo fmt --check
- git diff --check

## Stack
Base: codex/accuracy-pass-01-indexer-coverage (#11)
Next: codex/accuracy-pass-03-runtime-retrieval