### PR TITLE
Add retrieval benchmark harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benchmarks/tasks/README.md
+++ b/benchmarks/tasks/README.md
@@ -13,7 +13,13 @@ Each manifest should include:
 - `repo`: public repository metadata and optional setup notes.
 - `prompt`: the task text to run.
 - `expected_files`: repository-relative files that should be cited or used.
+- `expected_verification_files`: optional test, benchmark, or verification
+  files that are useful secondary evidence but should not count against primary
+  source recall unless the prompt asks for verification.
 - `expected_symbols`: stable symbols that should be found when applicable.
+  Symbol entries may include an optional `query` when the canonical symbol name
+  is intentionally ambiguous without task context; scoring still checks the
+  `name` and `path`.
 - `expected_claims`: claims a correct answer should make.
 - `forbidden_claims`: claims that should fail quality scoring when present.
 - `quality_thresholds`: pass/fail thresholds for files, symbols, claims,
@@ -56,3 +62,85 @@ the harness does not run arbitrary setup commands.
 Direct packet runtime rows are available with `--packet-runtime`. They compare
 cold CLI packet calls with warm `serve --stdio` packet calls while reusing the
 same expected-anchor quality gates.
+
+## Local Real-Repo Corpus
+
+The `local-real` suite targets sibling checkouts under the parent directory of
+this CodeStory repo. It is meant for exploratory A/B runs against the user's
+real local workspaces before promotion-grade public rows exist.
+
+Current slots:
+
+- `codestory`: this repo.
+- `sourcetrail`: `../Sourcetrail`.
+- `codex`: `../codex`.
+- `vscode`: `../vscode`; currently verified against pinned commit
+  `20ed2bc21d4d73a029b52d3ee6db382ee85c3cca` when that checkout is present.
+
+Local-real rows are not public savings claims by themselves. They must be
+repeated, quality-gated, tied to clean pinned checkouts, and compared against
+the no-CodeStory arm before they support promotion language.
+
+For CodeStory-assisted rows, use `--prepare-codestory-cache` unless the intent is
+explicitly to measure degraded cache behavior. This refreshes stale or
+semantic-empty local caches before the timed agent run and records the index
+cost as setup evidence, so cache-reuse savings are not confused with indexing
+cost.
+
+## Holdout retrieval
+
+The `holdout-retrieval` suite measures **generalization** on pinned public OSS
+libraries. It is required for sidecar retrieval promotion (pass at least 2/3 repos)
+and must **not** be used to tune planner or ranker heuristics.
+
+| Repo key | Upstream | Pin |
+|----------|----------|-----|
+| `ripgrep` | [BurntSushi/ripgrep](https://github.com/BurntSushi/ripgrep) | `14.1.0` |
+| `axios` | [axios/axios](https://github.com/axios/axios) | `v1.6.8` |
+| `redis` | [redis/redis](https://github.com/redis/redis) | `7.2.4` |
+
+Manifests live under `benchmarks/tasks/holdout-retrieval/`. Each task uses
+`task_class: architecture_explanation` and records immutable `repo.ref` values.
+
+### Materializing repos
+
+Holdout repos are cloned only under `target/agent-benchmark/repos/` (under
+`target/`, so they stay out of version control). No sibling checkout is required.
+
+Prefetch all three holdout checkouts:
+
+```powershell
+node scripts/fetch-holdout-repos.mjs
+```
+
+Or use the benchmark harness directly:
+
+```powershell
+node scripts/codestory-agent-ab-benchmark.mjs `
+  --list --task-suite holdout-retrieval --materialize-repos
+```
+
+Optional `--repo-cache-dir <path>` overrides the default cache directory on both
+commands.
+
+### Smoke run (packet runtime)
+
+```powershell
+node scripts/codestory-agent-ab-benchmark.mjs `
+  --packet-runtime --packet-runtime-mode cold-cli `
+  --task-suite holdout-retrieval --materialize-repos `
+  --repeats 1 --out-dir target/agent-benchmark/holdout-retrieval-smoke `
+  --codestory-cli target/release/codestory-cli.exe --timeout-ms 180000
+```
+
+Build `codestory-cli` in release mode before the smoke run. `redis` is L-tier and
+may exceed the default timeout on cold index; increase `--timeout-ms` when needed.
+
+### Forbidden tuning policy
+
+- Do **not** add repo-name, path, or display-name literals for `ripgrep`, `axios`,
+  or `redis` in v2 planner or ranker code.
+- Do **not** iterate KPI fixes against holdout manifests; use `local-real` for
+  in-scope tuning and treat holdout rows as promotion-only evidence.
+- Legacy sibling apps (`freelancer`, `traderotate`) are removed from default
+  benchmark repos; use this suite instead for generalization gates.

--- a/benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json
+++ b/benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "axios-request-dispatch",
+  "version": 1,
+  "suite": "holdout-retrieval",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "axios",
+    "url": "https://github.com/axios/axios.git",
+    "ref": "v1.6.8",
+    "workspace_root": ".",
+    "languages": [
+      "JavaScript",
+      "TypeScript"
+    ],
+    "setup": [
+      "npm install"
+    ]
+  },
+  "prompt": "Explain how the default axios instance is created and how an HTTP request flows through interceptors, dispatchRequest, and the transport adapter. Cite the source files that support the path.",
+  "expected_files": [
+    "lib/axios.js",
+    "lib/core/Axios.js",
+    "lib/core/dispatchRequest.js",
+    "lib/core/InterceptorManager.js",
+    "lib/adapters/adapters.js"
+  ],
+  "expected_symbols": [
+    {
+      "name": "createInstance",
+      "path": "lib/axios.js",
+      "kind": "function",
+      "why": "Factory that binds Axios methods onto the callable instance."
+    },
+    {
+      "name": "Axios",
+      "path": "lib/core/Axios.js",
+      "kind": "class",
+      "why": "Owns defaults and request/response interceptor managers."
+    },
+    {
+      "name": "Axios.prototype.request",
+      "path": "lib/core/Axios.js",
+      "kind": "method",
+      "why": "Merges config and runs the interceptor chain ending in dispatchRequest."
+    },
+    {
+      "name": "dispatchRequest",
+      "path": "lib/core/dispatchRequest.js",
+      "kind": "function",
+      "why": "Transforms data, selects an adapter, and settles the response."
+    },
+    {
+      "name": "InterceptorManager",
+      "path": "lib/core/InterceptorManager.js",
+      "kind": "class",
+      "why": "Registers fulfilled/rejected handlers for request and response chains."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "createInstance wraps an Axios context and exposes verb helpers bound to request."
+    },
+    {
+      "text": "Axios.request merges defaults, runs request interceptors, then calls dispatchRequest."
+    },
+    {
+      "text": "dispatchRequest transforms the body/headers and invokes the configured adapter."
+    },
+    {
+      "text": "InterceptorManager stores interceptor pairs used by the promise chain in request."
+    },
+    {
+      "text": "adapters.js selects xhr or http transport based on environment capabilities."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "axios sends HTTP requests directly from createInstance without an Axios request chain.",
+      "severity": "critical"
+    },
+    {
+      "text": "Interceptors run only after the transport adapter returns a response.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.7,
+    "min_expected_file_recall": 0.7,
+    "min_expected_symbol_recall": 0.65,
+    "min_expected_claim_recall": 0.75,
+    "min_citation_coverage": 0.7,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "holdout",
+    "javascript",
+    "http",
+    "generalization"
+  ],
+  "notes": [
+    "Generalization holdout for sidecar retrieval. Do not tune planner or ranker heuristics against this manifest."
+  ]
+}

--- a/benchmarks/tasks/holdout-retrieval/redis-server-event-loop.task.json
+++ b/benchmarks/tasks/holdout-retrieval/redis-server-event-loop.task.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "redis-server-event-loop",
+  "version": 1,
+  "suite": "holdout-retrieval",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "redis",
+    "url": "https://github.com/redis/redis.git",
+    "ref": "7.2.4",
+    "workspace_root": ".",
+    "languages": [
+      "C"
+    ],
+    "setup": [
+      "No dependency setup is required for read-only benchmark inspection."
+    ]
+  },
+  "prompt": "Explain how the Redis server starts its event loop, reads client commands from the network, and dispatches them through processCommand and call. Cite the source files that support the path.",
+  "expected_files": [
+    "src/server.c",
+    "src/ae.c",
+    "src/networking.c",
+    "src/server.h"
+  ],
+  "expected_symbols": [
+    {
+      "name": "main",
+      "path": "src/server.c",
+      "kind": "function",
+      "why": "Server bootstrap and event loop startup."
+    },
+    {
+      "name": "aeMain",
+      "path": "src/ae.c",
+      "kind": "function",
+      "why": "Runs the file and time event loop until stop is set."
+    },
+    {
+      "name": "readQueryFromClient",
+      "path": "src/networking.c",
+      "kind": "function",
+      "why": "Reads bytes from a client connection into the query buffer."
+    },
+    {
+      "name": "processCommand",
+      "path": "src/server.c",
+      "kind": "function",
+      "why": "Parses and validates an executed client command."
+    },
+    {
+      "name": "call",
+      "path": "src/server.c",
+      "kind": "function",
+      "why": "Invokes the command implementation and propagates flags."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "main initializes the server and enters aeMain on the shared event loop."
+    },
+    {
+      "text": "aeProcessEvents polls readable/writable fds and invokes registered file event handlers."
+    },
+    {
+      "text": "readQueryFromClient appends socket input and drives processInputBuffer when a full command is available."
+    },
+    {
+      "text": "processCommand resolves the command table entry and enforces ACL, arity, and cluster checks."
+    },
+    {
+      "text": "call executes the command proc and handles propagation, monitoring, and slowlog accounting."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "Redis executes commands synchronously in main without the ae event loop.",
+      "severity": "critical"
+    },
+    {
+      "text": "Client queries are parsed entirely inside call before processCommand runs.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.7,
+    "min_expected_file_recall": 0.65,
+    "min_expected_symbol_recall": 0.65,
+    "min_expected_claim_recall": 0.75,
+    "min_citation_coverage": 0.65,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "holdout",
+    "c",
+    "server",
+    "generalization"
+  ],
+  "notes": [
+    "Generalization holdout for sidecar retrieval (L-tier). Do not tune planner or ranker heuristics against this manifest."
+  ]
+}

--- a/benchmarks/tasks/holdout-retrieval/ripgrep-search-pipeline.task.json
+++ b/benchmarks/tasks/holdout-retrieval/ripgrep-search-pipeline.task.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "ripgrep-search-pipeline",
+  "version": 1,
+  "suite": "holdout-retrieval",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "ripgrep",
+    "url": "https://github.com/BurntSushi/ripgrep.git",
+    "ref": "14.1.0",
+    "workspace_root": ".",
+    "languages": [
+      "Rust"
+    ],
+    "setup": [
+      "No dependency setup is required for read-only benchmark inspection."
+    ]
+  },
+  "prompt": "Explain how ripgrep parses CLI flags, walks candidate files, and executes a search over each haystack through matcher, searcher, and printer components. Cite the source files that support the path.",
+  "expected_files": [
+    "crates/core/main.rs",
+    "crates/core/flags/mod.rs",
+    "crates/core/flags/hiargs.rs",
+    "crates/core/haystack.rs",
+    "crates/core/search.rs"
+  ],
+  "expected_symbols": [
+    {
+      "name": "main",
+      "path": "crates/core/main.rs",
+      "kind": "function",
+      "why": "CLI entry point that delegates into the search driver."
+    },
+    {
+      "name": "run",
+      "path": "crates/core/main.rs",
+      "kind": "function",
+      "why": "Selects search, files, types, or generate modes after flag parsing."
+    },
+    {
+      "name": "search",
+      "path": "crates/core/main.rs",
+      "kind": "function",
+      "why": "Single-threaded directory walk and per-file search loop."
+    },
+    {
+      "name": "SearchWorker",
+      "path": "crates/core/search.rs",
+      "kind": "struct",
+      "why": "Coordinates matcher, searcher, and printer for each haystack."
+    },
+    {
+      "name": "SearchWorker::search",
+      "path": "crates/core/search.rs",
+      "kind": "method",
+      "why": "Executes one haystack search including preprocessors and decompression."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "main calls run after flags::parse and routes into search or parallel search modes."
+    },
+    {
+      "text": "HiArgs builds walkers, matchers, searchers, and printers used by the search driver."
+    },
+    {
+      "text": "search walks haystacks from the ignore crate and invokes SearchWorker per file."
+    },
+    {
+      "text": "SearchWorker connects a PatternMatcher, grep searcher, and Printer for each haystack."
+    },
+    {
+      "text": "search_parallel uses walk_builder().build_parallel() to search files concurrently."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "ripgrep searches files without building haystacks from the directory walker.",
+      "severity": "critical"
+    },
+    {
+      "text": "Flag parsing happens inside SearchWorker instead of before run selects a mode.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.7,
+    "min_expected_file_recall": 0.7,
+    "min_expected_symbol_recall": 0.65,
+    "min_expected_claim_recall": 0.75,
+    "min_citation_coverage": 0.7,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "holdout",
+    "rust",
+    "search",
+    "generalization"
+  ],
+  "notes": [
+    "Generalization holdout for sidecar retrieval. Do not tune planner or ranker heuristics against this manifest."
+  ]
+}

--- a/benchmarks/tasks/local-real/codex-exec-json-flow.task.json
+++ b/benchmarks/tasks/local-real/codex-exec-json-flow.task.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "codex-exec-json-flow",
+  "version": 1,
+  "suite": "local-real",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "codex",
+    "url": "https://github.com/openai/codex.git",
+    "ref": "9f42c89c0112771dc29100a6f3fc904049b2655f",
+    "workspace_root": ".",
+    "languages": [
+      "Rust",
+      "TypeScript"
+    ],
+    "setup": [
+      "No dependency setup is required for read-only benchmark inspection."
+    ]
+  },
+  "prompt": "Explain how `codex exec --json` flows from the top-level CLI into the exec runtime, app-server thread and turn start requests, and JSONL event output. Cite the source files that support the path.",
+  "expected_files": [
+    "codex-rs/cli/src/main.rs",
+    "codex-rs/exec/src/main.rs",
+    "codex-rs/exec/src/cli.rs",
+    "codex-rs/exec/src/lib.rs",
+    "codex-rs/exec/src/event_processor.rs",
+    "codex-rs/exec/src/event_processor_with_jsonl_output.rs",
+    "codex-rs/exec/src/exec_events.rs"
+  ],
+  "expected_verification_files": [
+    "codex-rs/exec/tests/event_processor_with_json_output.rs"
+  ],
+  "expected_symbols": [
+    {
+      "name": "Subcommand::Exec",
+      "path": "codex-rs/cli/src/main.rs",
+      "kind": "enum variant",
+      "why": "Top-level CLI subcommand that routes non-interactive execution."
+    },
+    {
+      "name": "codex_exec::Cli",
+      "path": "codex-rs/exec/src/cli.rs",
+      "kind": "struct",
+      "why": "Defines exec-specific flags such as --json, --ephemeral, prompt, and resume/review subcommands."
+    },
+    {
+      "name": "run_main",
+      "query": "codex_exec::run_main",
+      "path": "codex-rs/exec/src/lib.rs",
+      "kind": "function",
+      "why": "Main exec runtime entry point after CLI parsing."
+    },
+    {
+      "name": "run_exec_session",
+      "path": "codex-rs/exec/src/lib.rs",
+      "kind": "function",
+      "why": "Creates the event processor, starts the app-server client, and sends thread/turn requests."
+    },
+    {
+      "name": "ThreadStartParams",
+      "path": "codex-rs/exec/src/lib.rs",
+      "kind": "type",
+      "why": "Carries model, cwd, permissions, sandbox, and thread metadata into the app-server thread start."
+    },
+    {
+      "name": "TurnStartParams",
+      "path": "codex-rs/exec/src/lib.rs",
+      "kind": "type",
+      "why": "Carries the user prompt and turn settings into the app-server turn start."
+    },
+    {
+      "name": "EventProcessor",
+      "path": "codex-rs/exec/src/event_processor.rs",
+      "kind": "trait",
+      "why": "Abstracts human and JSON event output handling."
+    },
+    {
+      "name": "EventProcessorWithJsonOutput",
+      "path": "codex-rs/exec/src/event_processor_with_jsonl_output.rs",
+      "kind": "struct",
+      "why": "Maps app-server notifications into JSONL thread events."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "The top-level Codex CLI has an Exec subcommand that delegates non-interactive execution into the codex_exec crate."
+    },
+    {
+      "text": "The codex-exec binary parses exec-specific CLI options and calls codex_exec::run_main."
+    },
+    {
+      "text": "The exec CLI defines --json as the switch that chooses JSONL stdout output."
+    },
+    {
+      "text": "run_main loads config, resolves sandbox and approval settings, and builds the in-process app-server start arguments."
+    },
+    {
+      "text": "run_exec_session chooses EventProcessorWithJsonOutput in JSON mode and EventProcessorWithHumanOutput otherwise."
+    },
+    {
+      "text": "run_exec_session starts or resumes an app-server thread, then sends TurnStartParams with the prompt input."
+    },
+    {
+      "text": "EventProcessorWithJsonOutput serializes typed thread events as JSON lines on stdout."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "codex exec bypasses the app-server path and talks directly to the model provider.",
+      "severity": "critical"
+    },
+    {
+      "text": "--json is handled by printing human output and converting it after the run completes.",
+      "severity": "major"
+    },
+    {
+      "text": "ThreadStartParams and TurnStartParams are only used by the interactive TUI, not by codex exec.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.75,
+    "min_expected_file_recall": 0.75,
+    "min_expected_symbol_recall": 0.7,
+    "min_expected_claim_recall": 0.8,
+    "min_citation_coverage": 0.75,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "local",
+    "rust",
+    "cli",
+    "exec",
+    "jsonl"
+  ],
+  "notes": [
+    "Local-real task for the user-requested sibling checkout. This is not public promotion evidence unless rerun against a pinned clean checkout with repeated paired rows."
+  ]
+}

--- a/benchmarks/tasks/local-real/rootandruntime-public-content-flow.task.json
+++ b/benchmarks/tasks/local-real/rootandruntime-public-content-flow.task.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "rootandruntime-public-content-flow",
+  "version": 1,
+  "suite": "local-real",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "rootandruntime",
+    "url": "file:///C:/Users/alber/source/repos/rootandruntime",
+    "ref": "44d46071a8783db0b44e4b7d7e1521b0dbb9fe65",
+    "workspace_root": ".",
+    "languages": [
+      "TypeScript",
+      "React"
+    ],
+    "setup": [
+      "No dependency setup is required for read-only benchmark inspection."
+    ]
+  },
+  "prompt": "Explain how Root & Runtime public writing and social surfaces connect through Payload collections, post rendering, comment auth/submission, RSS, and the Elsewhere feed. Cite the source files that support the path.",
+  "expected_files": [
+    "src/payload.config.ts",
+    "src/collections/Posts.ts",
+    "src/collections/Comments.ts",
+    "src/collections/SocialEntries.ts",
+    "src/app/(frontend)/posts/[slug]/page.tsx",
+    "src/app/(frontend)/posts/[slug]/comments/route.ts",
+    "src/app/feed.xml/route.ts",
+    "src/lib/payload.ts",
+    "src/lib/comment-auth.ts",
+    "src/lib/comment-submission-guard.ts",
+    "src/lib/content-data/post-content.ts",
+    "src/lib/content-data/comment-content.ts",
+    "src/lib/content-data/social-entry-content.ts"
+  ],
+  "expected_symbols": [
+    {
+      "name": "buildConfig",
+      "path": "src/payload.config.ts",
+      "kind": "function call",
+      "why": "Registers the Payload collections, globals, editor, database adapter, and storage plugin."
+    },
+    {
+      "name": "Posts",
+      "path": "src/collections/Posts.ts",
+      "kind": "collection config",
+      "why": "Defines the posts collection, publishing metadata, categories, authors, drafts, and revalidation hooks."
+    },
+    {
+      "name": "Comments",
+      "path": "src/collections/Comments.ts",
+      "kind": "collection config",
+      "why": "Defines moderated comment storage, post relationship, author fields, commenter auth metadata, and editorial access."
+    },
+    {
+      "name": "SocialEntries",
+      "path": "src/collections/SocialEntries.ts",
+      "kind": "collection config",
+      "why": "Defines stored Reddit/Instagram entries, hidden/pinned moderation, overrides, and social-entry revalidation hooks."
+    },
+    {
+      "name": "PostPage",
+      "path": "src/app/(frontend)/posts/[slug]/page.tsx",
+      "kind": "React server component",
+      "why": "Renders a published post with related posts, approved comments, structured data, and comment UI."
+    },
+    {
+      "name": "POST",
+      "path": "src/app/(frontend)/posts/[slug]/comments/route.ts",
+      "kind": "route handler",
+      "why": "Validates and persists public comment submissions through Payload."
+    },
+    {
+      "name": "getCommentAuthContextFromHeaders",
+      "path": "src/lib/comment-auth.ts",
+      "kind": "function",
+      "why": "Resolves optional Better Auth session context for authenticated commenters."
+    },
+    {
+      "name": "getLatestSocialEntries",
+      "path": "src/lib/content-data/social-entry-content.ts",
+      "kind": "function",
+      "why": "Reads stored social entries from Payload and returns public Elsewhere feed items."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "Payload is configured in src/payload.config.ts with Users, Media, Categories, Posts, Pages, Comments, and SocialEntries collections."
+    },
+    {
+      "text": "The Posts collection owns published writing metadata such as slugs, excerpts, authors, categories, hero media, drafts, and publishedAt."
+    },
+    {
+      "text": "The post page loads a post by slug, approved comments, related posts, and site settings before rendering RichTextRenderer and PostComments."
+    },
+    {
+      "text": "The comment POST route validates origin, honeypot, draft validity, timing, and rate limits before creating a pending comment in Payload."
+    },
+    {
+      "text": "Comment auth is optional: getCommentAuthContextFromHeaders returns a Better Auth session when configured, and guest comments still work when it is absent."
+    },
+    {
+      "text": "The feed.xml route reads published posts and site settings, then renders RSS item XML for each post."
+    },
+    {
+      "text": "SocialEntries stores moderated Reddit and Instagram entries with hidden/pinned flags, overrides, media payloads, and source metadata."
+    },
+    {
+      "text": "getLatestSocialEntries reads social-entries from Payload, merges pinned and recent entries, filters hidden entries, and maps them into Elsewhere feed items."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "The public homepage fetches Reddit and Instagram live during render instead of reading stored Payload social entries.",
+      "severity": "major"
+    },
+    {
+      "text": "Public comments are immediately approved and bypass moderation.",
+      "severity": "critical"
+    },
+    {
+      "text": "Comment auth is required for all readers before guest comments can be submitted.",
+      "severity": "major"
+    },
+    {
+      "text": "RSS output is generated from SocialEntries instead of published posts.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.75,
+    "min_expected_file_recall": 0.75,
+    "min_expected_symbol_recall": 0.7,
+    "min_expected_claim_recall": 0.8,
+    "min_citation_coverage": 0.75,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "local",
+    "typescript",
+    "nextjs",
+    "payload",
+    "holdout"
+  ],
+  "notes": [
+    "Local-real holdout task added after the Codex, Sourcetrail, and VS Code loops. Treat as promotion scaffolding until packet-runtime and live A/B rows are repeated against clean pinned checkout/cache provenance."
+  ]
+}

--- a/benchmarks/tasks/local-real/sourcetrail-indexing-to-storage.task.json
+++ b/benchmarks/tasks/local-real/sourcetrail-indexing-to-storage.task.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "sourcetrail-indexing-to-storage",
+  "version": 1,
+  "suite": "local-real",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "sourcetrail",
+    "url": "https://github.com/CoatiSoftware/Sourcetrail.git",
+    "ref": "4b1b0e4fd19c4af235fef12b0564c05348f5f6d3",
+    "workspace_root": ".",
+    "languages": [
+      "C++",
+      "Java"
+    ],
+    "setup": [
+      "No dependency setup is required for read-only benchmark inspection."
+    ]
+  },
+  "prompt": "Explain how Sourcetrail turns project/source-group configuration into indexing work, then how indexed data is accessed by the application. Cite the source files that support the path.",
+  "expected_files": [
+    "src/lib/project/Project.cpp",
+    "src/lib_cxx/project/SourceGroupCxxCdb.cpp",
+    "src/lib_cxx/project/SourceGroupCxxCdb.h",
+    "src/lib_cxx/data/indexer/IndexerCommandCxx.h",
+    "src/lib_java/data/indexer/IndexerJava.cpp",
+    "src/lib/data/storage/StorageAccess.h",
+    "src/lib/data/storage/StorageAccessProxy.cpp",
+    "src/lib/data/storage/PersistentStorage.cpp",
+    "src/lib/data/storage/PersistentStorage.h"
+  ],
+  "expected_symbols": [
+    {
+      "name": "Project::buildIndex",
+      "path": "src/lib/project/Project.cpp",
+      "kind": "method",
+      "why": "Builds the indexing task pipeline for project source groups."
+    },
+    {
+      "name": "TaskFillIndexerCommandsQueue",
+      "path": "src/lib/data/indexer/TaskFillIndexerCommandQueue.h",
+      "kind": "class",
+      "why": "Defines the task that queues indexer commands during the project build-index task flow; Project::buildIndex covers the callsite."
+    },
+    {
+      "name": "SourceGroupCxxCdb",
+      "path": "src/lib_cxx/project/SourceGroupCxxCdb.cpp",
+      "kind": "class",
+      "why": "Loads compile database input and creates C/C++ indexer commands."
+    },
+    {
+      "name": "IndexerCommandCxx",
+      "path": "src/lib_cxx/data/indexer/IndexerCommandCxx.h",
+      "kind": "class",
+      "why": "Represents C/C++ indexer command work emitted by C++ source groups."
+    },
+    {
+      "name": "IndexerJava",
+      "path": "src/lib_java/data/indexer/IndexerJava.cpp",
+      "kind": "class",
+      "why": "Executes Java indexing through the Java parser."
+    },
+    {
+      "name": "StorageAccess",
+      "path": "src/lib/data/storage/StorageAccess.h",
+      "kind": "interface",
+      "why": "Application-facing storage access contract."
+    },
+    {
+      "name": "StorageAccessProxy",
+      "path": "src/lib/data/storage/StorageAccessProxy.cpp",
+      "kind": "class",
+      "why": "Delegates storage calls to the active storage subject."
+    },
+    {
+      "name": "PersistentStorage",
+      "path": "src/lib/data/storage/PersistentStorage.cpp",
+      "kind": "class",
+      "why": "Concrete persistent implementation of storage access."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "Project::buildIndex builds a per-source-group indexing task pipeline before merge and injection work."
+    },
+    {
+      "text": "SourceGroupCxxCdb reads compile database input and emits IndexerCommandCxx work for C and C++ files."
+    },
+    {
+      "text": "IndexerJava delegates Java command execution into JavaParser build-index behavior."
+    },
+    {
+      "text": "StorageAccess is the application-facing storage contract and PersistentStorage implements it."
+    },
+    {
+      "text": "StorageAccessProxy forwards storage calls to the active storage subject rather than owning persistence itself."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "Sourcetrail only indexes Java and does not have a C/C++ compile database source-group path.",
+      "severity": "critical"
+    },
+    {
+      "text": "StorageAccessProxy is the persistent SQLite storage implementation.",
+      "severity": "major"
+    },
+    {
+      "text": "Project::buildIndex directly parses source files instead of building indexing tasks.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.75,
+    "min_expected_file_recall": 0.7,
+    "min_expected_symbol_recall": 0.7,
+    "min_expected_claim_recall": 0.8,
+    "min_citation_coverage": 0.7,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "local",
+    "cxx",
+    "java",
+    "indexing",
+    "storage"
+  ],
+  "notes": [
+    "Local-real task for the user-requested sibling checkout. This is not public promotion evidence unless rerun against a pinned clean checkout with repeated paired rows."
+  ]
+}

--- a/benchmarks/tasks/local-real/vscode-workbench-extension-host.task.json
+++ b/benchmarks/tasks/local-real/vscode-workbench-extension-host.task.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "vscode-workbench-extension-host",
+  "version": 1,
+  "suite": "local-real",
+  "task_class": "architecture_explanation",
+  "repo": {
+    "name": "vscode",
+    "url": "https://github.com/microsoft/vscode.git",
+    "ref": "20ed2bc21d4d73a029b52d3ee6db382ee85c3cca",
+    "workspace_root": ".",
+    "languages": [
+      "TypeScript"
+    ],
+    "setup": [
+      "No dependency setup is required for read-only benchmark inspection."
+    ]
+  },
+  "prompt": "Explain how VS Code workbench startup reaches extension host activation and command execution. Cite the source files that support the path.",
+  "expected_files": [
+    "src/vs/workbench/browser/workbench.ts",
+    "src/vs/workbench/services/extensions/browser/extensionService.ts",
+    "src/vs/workbench/services/extensions/common/extensionHostManager.ts",
+    "src/vs/workbench/api/common/extHostExtensionService.ts",
+    "src/vs/workbench/api/common/extHostCommands.ts"
+  ],
+  "expected_symbols": [
+    {
+      "name": "Workbench",
+      "path": "src/vs/workbench/browser/workbench.ts",
+      "kind": "class",
+      "why": "Workbench startup owner."
+    },
+    {
+      "name": "ExtensionService",
+      "path": "src/vs/workbench/services/extensions/browser/extensionService.ts",
+      "kind": "class",
+      "why": "Coordinates extension scanning, activation, and host management."
+    },
+    {
+      "name": "ExtensionHostManager",
+      "path": "src/vs/workbench/services/extensions/common/extensionHostManager.ts",
+      "kind": "class",
+      "why": "Manages extension host lifecycle."
+    },
+    {
+      "name": "AbstractExtHostExtensionService",
+      "path": "src/vs/workbench/api/common/extHostExtensionService.ts",
+      "kind": "class",
+      "why": "Extension-host-side activation service."
+    },
+    {
+      "name": "ExtHostCommands",
+      "path": "src/vs/workbench/api/common/extHostCommands.ts",
+      "kind": "class",
+      "why": "Extension-host-side command registration and execution surface."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "Workbench startup creates and initializes services before extensions can activate."
+    },
+    {
+      "text": "ExtensionService coordinates extension lifecycle and communicates with extension host managers."
+    },
+    {
+      "text": "ExtensionHostManager owns extension host lifecycle and messaging boundaries."
+    },
+    {
+      "text": "AbstractExtHostExtensionService handles extension activation inside the extension host."
+    },
+    {
+      "text": "ExtHostCommands owns extension-host command registration and execution behavior."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "The renderer directly executes extension code without an extension host boundary.",
+      "severity": "critical"
+    },
+    {
+      "text": "VS Code command execution is unrelated to extension activation.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 0.75,
+    "min_expected_file_recall": 0.75,
+    "min_expected_symbol_recall": 0.7,
+    "min_expected_claim_recall": 0.8,
+    "min_citation_coverage": 0.75,
+    "max_forbidden_claims": 0
+  },
+  "tags": [
+    "local",
+    "typescript",
+    "workbench",
+    "extension-host",
+    "holdout"
+  ],
+  "notes": [
+    "Local-real holdout manifest for the cloned ../vscode checkout at 20ed2bc21d4d73a029b52d3ee6db382ee85c3cca. Keep rows exploratory unless repeated with clean pinned provenance."
+  ]
+}

--- a/benchmarks/tasks/manifest.schema.json
+++ b/benchmarks/tasks/manifest.schema.json
@@ -102,6 +102,15 @@
       },
       "uniqueItems": true
     },
+    "expected_verification_files": {
+      "description": "Optional test, benchmark, or verification files that are useful secondary evidence but should not count against primary source recall unless the prompt asks for verification.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
     "expected_symbols": {
       "type": "array",
       "minItems": 1,
@@ -186,6 +195,11 @@
       ],
       "properties": {
         "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "query": {
+          "description": "Optional contextual search query to use for this expected symbol when the canonical symbol name is ambiguous on its own.",
           "type": "string",
           "minLength": 1
         },

--- a/crates/codestory-bench/benches/incremental_cleanup.rs
+++ b/crates/codestory-bench/benches/incremental_cleanup.rs
@@ -2,7 +2,7 @@ use codestory_contracts::graph::{
     AccessKind, CallableProjectionState, Edge, EdgeId, EdgeKind, Node, NodeId, NodeKind,
     Occurrence, OccurrenceKind, SourceLocation,
 };
-use codestory_store::{FileInfo, Store as Storage};
+use codestory_store::{FileInfo, FileRole, Store as Storage};
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -70,6 +70,7 @@ fn build_cleanup_storage() -> anyhow::Result<CleanupFixture> {
             id: file_id,
             path: PathBuf::from(format!("/bench/file_{file_idx}.rs")),
             language: "rust".to_string(),
+            file_role: FileRole::Source,
             modification_time: file_idx as i64,
             indexed: true,
             complete: true,

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -8,6 +8,18 @@ import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 
+import {
+  buildPacketQualityDeltas,
+  discoverPreviousPacketSummary,
+} from "./codestory-agent-value-score.mjs";
+import {
+  benchmarkChildEnv,
+  retrievalContractSummary,
+  retrievalEnv as benchmarkRetrievalEnv,
+  shouldPrepareRetrievalIndex,
+  unsupportedSidecarContractRequests,
+} from "./codestory-benchmark-contract.mjs";
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const siblingRoot = path.resolve(repoRoot, "..");
@@ -38,20 +50,34 @@ const PUBLIC_REPOS = {
 };
 
 const LOCAL_REPOS = {
-  freelancer: {
-    path: path.join(siblingRoot, "freelancer"),
+  sourcetrail: {
+    path: path.join(siblingRoot, "Sourcetrail"),
+    url: "https://github.com/CoatiSoftware/Sourcetrail.git",
+    ref: "4b1b0e4fd19c4af235fef12b0564c05348f5f6d3",
+    languages: ["C++", "Java"],
     prompt:
-      "Explain how lead, client, and project persistence flows through commands, repositories, and domain types.",
+      "Explain how project/source-group configuration becomes indexing work, then how indexed data is accessed by the application.",
+  },
+  codex: {
+    path: path.join(siblingRoot, "codex"),
+    url: "https://github.com/openai/codex.git",
+    ref: "9f42c89c0112771dc29100a6f3fc904049b2655f",
+    languages: ["Rust", "TypeScript"],
+    prompt:
+      "Explain how `codex exec` flows from the top-level CLI into the exec runtime, app-server turn start, and JSONL event output.",
+  },
+  vscode: {
+    path: path.join(siblingRoot, "vscode"),
+    url: "https://github.com/microsoft/vscode.git",
+    ref: "local",
+    languages: ["TypeScript"],
+    prompt:
+      "Explain how VS Code workbench startup reaches extension host activation and command execution.",
   },
   rootandruntime: {
     path: path.join(siblingRoot, "rootandruntime"),
     prompt:
       "Explain how public writing and social surfaces connect to Payload collections, comment auth, and the elsewhere feed.",
-  },
-  traderotate: {
-    path: path.join(siblingRoot, "traderotate"),
-    prompt:
-      "Explain how runtime config, wallet context, executor setup, and the hunt loop connect.",
   },
 };
 
@@ -61,7 +87,7 @@ const ARMS = {
   without_codestory:
     "Do not use CodeStory, codestory-cli, or codestory-grounding. Use normal repository exploration only.",
   with_codestory:
-    "Use CodeStory grounding first if available. If CODESTORY_CLI is set, use that executable; otherwise try codestory-cli on PATH. For broad repository questions, run packet first and read its sufficiency contract before ordinary source reads. If packet status is sufficient and follow_up_commands is empty, answer from the packet; budget truncation alone is not a gap. Preserve the packet's supported-claim wording in your final answer. Include a compact 'Support files' list containing every relevant path from the packet's answer.citations and sufficiency.avoid_opening, not only the paths mentioned in your prose. Use search, context, trail, or snippet only for named gaps. Run index only if the cache is missing and writes are allowed. If CodeStory is unavailable, say so explicitly and continue.",
+    "Use CodeStory grounding first. If CODESTORY_CLI is set, use that executable; otherwise use codestory-cli on PATH. For broad repository questions, run packet first and read its sufficiency contract before ordinary source reads. Read follow-up commands from sufficiency.follow_up_commands, not a top-level field. If sufficiency.status is partial, run only the listed follow_up_commands in order and prefer targeted `search --why` commands before escalating packet budget. If a later packet becomes sufficient, stop exploration and answer. If packet status is sufficient and sufficiency.follow_up_commands is empty, answer from the packet; do not verify citations with ordinary source reads, rg, grep, or git show. Budget truncation alone is not a gap. Preserve the packet's supported-claim wording in your final answer. Include a compact 'Support files' list containing every relevant path from the packet's answer.citations and sufficiency.avoid_opening, not only the paths mentioned in your prose. Use search, context, trail, or snippet only for named gaps. The prepared full sidecar cache is mandatory; if CodeStory or its sidecars are unavailable, fail the run instead of continuing with ordinary exploration.",
 };
 
 function usage() {
@@ -69,8 +95,8 @@ function usage() {
   node scripts/codestory-agent-ab-benchmark.mjs --list
   node scripts/codestory-agent-ab-benchmark.mjs --self-test
   node scripts/codestory-agent-ab-benchmark.mjs --reanalyze-dir target/agent-benchmark/<run-dir>
-  node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite public-core [--materialize-repos] [--repeats n]
-  node scripts/codestory-agent-ab-benchmark.mjs [--quick] [--repos names] [--arms names] [--task-suite name] [--task-ids ids] [--task-manifest path] [--include-local-repos] [--repeats n] [--runner codex] [--model model] [--sandbox mode] [--out-dir path] [--timeout-ms ms] [--allow-failures] [--publishable]
+  node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite <suite> [--materialize-repos] [--repeats n]
+  node scripts/codestory-agent-ab-benchmark.mjs [--quick] [--repos names] [--arms names] [--task-suite name] [--task-ids ids] [--task-manifest path] [--include-local-repos] [--repeats n] [--runner codex] [--model model] [--sandbox mode] [--out-dir path] [--timeout-ms ms] [--prepare-codestory-cache] [--allow-failures] [--publishable]
 
 Options:
   --list          Print configured benchmark repositories or selected manifest tasks and exit.
@@ -79,7 +105,7 @@ Options:
   --quick         Default to repo=codestory and repeats=1 unless explicitly set.
   --repos         Comma-separated repo names. Public: ${Object.keys(PUBLIC_REPOS).join(", ")}. Local optional: ${Object.keys(LOCAL_REPOS).join(", ")}
   --arms          Comma-separated A/B arms. Default: ${Object.keys(ARMS).join(", ")}.
-  --task-suite    Task suite folder under benchmarks/tasks, such as public-core.
+  --task-suite    Task suite folder under benchmarks/tasks, such as public-core or holdout-retrieval.
   --task-ids      Comma-separated manifest task ids to include after suite/path loading.
   --task-manifest Task manifest JSON file or directory. When set, tasks drive repos and prompts.
   --materialize-repos
@@ -91,6 +117,8 @@ Options:
   --packet-runtime-mode
                   cold-cli, warm-stdio, or both. Default: both.
   --codestory-cli Path to codestory-cli for packet runtime mode. Default: CODESTORY_CLI, release binary, then PATH.
+  --benchmark-run-id
+                  Coherent benchmark run id to stamp packet-runtime artifacts.
   --include-local-repos
                   Include local sibling repos in the default non-quick run.
   --repeats       Repeats per repo/arm. Default: 3, or 1 with --quick.
@@ -99,10 +127,22 @@ Options:
   --sandbox       Codex sandbox mode. Default: workspace-write.
   --out-dir       Output directory. Default: target/agent-benchmark/<timestamp>.
   --timeout-ms    Timeout per runner invocation. Default: 600000.
+  --prepare-codestory-cache
+                  Before timed with-CodeStory runs, refresh stale or semantic-empty local caches and record indexing cost separately.
+                  Packet-runtime mode enables this by default because sidecar-primary packets require prepared local indexes.
+  --no-prepare-codestory-cache
+                  Unsupported; sidecar preparation is mandatory.
+  --prepare-codestory-timeout-ms
+                  Timeout for each pre-run CodeStory index refresh. Default: 1800000.
   --max-source-reads-after-packet
                   Publishable with-CodeStory runs fail above this post-packet ordinary source-read count. Default: 0.
   --allow-failures Exit 0 even when a run fails. Intended only for exploratory dry runs.
   --publishable   Fail unless every run succeeds and reports token usage.
+
+Environment (parity / promotion — see docs/testing/retrieval-architecture.md):
+  CODESTORY_RETRIEVAL unset|1 Sidecar-primary packet retrieval (benchmark default)
+  CODESTORY_RETRIEVAL=0       Unsupported; sidecar retrieval is mandatory
+  CODESTORY_EVAL_PROBES=1        Explicit diagnostic only; product benchmark runs do not inject it
 `);
 }
 
@@ -126,6 +166,7 @@ function parseArgs(argv) {
     packetRuntime: false,
     packetRuntimeMode: "both",
     codestoryCli: process.env.CODESTORY_CLI || null,
+    benchmarkRunId: null,
     includeLocalRepos: false,
     repeats: null,
     runner: "codex",
@@ -133,6 +174,9 @@ function parseArgs(argv) {
     sandbox: "workspace-write",
     outDir: null,
     timeoutMs: 600000,
+    prepareCodestoryCache: null,
+    prepareCodestoryTimeoutMs: 1_800_000,
+    cachePreparationByRepo: null,
     maxSourceReadsAfterPacket: 0,
     allowFailures: false,
     publishable: false,
@@ -232,8 +276,24 @@ function parseArgs(argv) {
       opts.outDir = argv[++i];
       continue;
     }
+    if (arg === "--benchmark-run-id") {
+      opts.benchmarkRunId = argv[++i];
+      continue;
+    }
     if (arg === "--timeout-ms") {
       opts.timeoutMs = Number.parseInt(argv[++i], 10);
+      continue;
+    }
+    if (arg === "--prepare-codestory-cache") {
+      opts.prepareCodestoryCache = true;
+      continue;
+    }
+    if (arg === "--no-prepare-codestory-cache") {
+      throw new Error("--no-prepare-codestory-cache is unsupported; sidecar preparation is mandatory");
+      continue;
+    }
+    if (arg === "--prepare-codestory-timeout-ms") {
+      opts.prepareCodestoryTimeoutMs = Number.parseInt(argv[++i], 10);
       continue;
     }
     if (arg === "--max-source-reads-after-packet") {
@@ -267,17 +327,26 @@ function parseArgs(argv) {
   if (!opts.repeats) {
     opts.repeats = opts.quick ? 1 : 3;
   }
+  if (opts.prepareCodestoryCache == null) {
+    opts.prepareCodestoryCache = opts.packetRuntime || opts.arms.includes("with_codestory");
+  }
   if (!Number.isInteger(opts.repeats) || opts.repeats < 1) {
     throw new Error("--repeats must be a positive integer");
   }
   if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs < 1000) {
     throw new Error("--timeout-ms must be an integer >= 1000");
   }
+  if (!Number.isInteger(opts.prepareCodestoryTimeoutMs) || opts.prepareCodestoryTimeoutMs < 1000) {
+    throw new Error("--prepare-codestory-timeout-ms must be an integer >= 1000");
+  }
   if (!["read-only", "workspace-write", "danger-full-access"].includes(opts.sandbox)) {
     throw new Error("--sandbox must be one of: read-only, workspace-write, danger-full-access");
   }
   if (!["cold-cli", "warm-stdio", "both"].includes(opts.packetRuntimeMode)) {
     throw new Error("--packet-runtime-mode must be one of: cold-cli, warm-stdio, both");
+  }
+  if (opts.benchmarkRunId != null) {
+    opts.benchmarkRunId = sanitizeBenchmarkRunId(opts.benchmarkRunId);
   }
   if (!Number.isInteger(opts.maxSourceReadsAfterPacket) || opts.maxSourceReadsAfterPacket < 0) {
     throw new Error("--max-source-reads-after-packet must be a non-negative integer");
@@ -291,6 +360,21 @@ function parseArgs(argv) {
     }
   }
   return opts;
+}
+
+function sanitizeBenchmarkRunId(value) {
+  const cleaned = String(value ?? "")
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!cleaned) {
+    throw new Error("--benchmark-run-id must contain at least one filesystem-safe character");
+  }
+  return cleaned;
+}
+
+function retrievalEnv() {
+  return benchmarkRetrievalEnv(benchmarkChildEnv(process.env));
 }
 
 function runnerCommand(opts, repoPath, prompt) {
@@ -509,6 +593,9 @@ function normalizeManifestTask(filePath, raw, opts = {}) {
     throw new Error(`Task manifest is missing prompt: ${filePath}`);
   }
   const expectedFiles = textAnchorList(raw.expected_files ?? raw.expectedFiles);
+  const expectedVerificationFiles = textAnchorList(
+    raw.expected_verification_files ?? raw.expectedVerificationFiles,
+  );
   const expectedSymbols = textAnchorList(raw.expected_symbols ?? raw.expectedSymbols);
   const expectedClaims = textAnchorList(raw.expected_claims ?? raw.expectedClaims);
   const qualityThresholds = raw.quality_thresholds ?? raw.qualityThresholds;
@@ -534,6 +621,7 @@ function normalizeManifestTask(filePath, raw, opts = {}) {
     task_class: taskClass,
     prompt,
     expected_files: expectedFiles,
+    expected_verification_files: expectedVerificationFiles,
     expected_symbols: expectedSymbols,
     expected_claims: expectedClaims,
     forbidden_claims: textAnchorList(raw.forbidden_claims ?? raw.forbiddenClaims),
@@ -556,6 +644,7 @@ function taskSnapshotForResult(task) {
       task_class: task.task_class,
       prompt: task.prompt,
       expected_files: task.expected_files ?? [],
+      expected_verification_files: task.expected_verification_files ?? [],
       expected_symbols: task.expected_symbols ?? [],
       expected_claims: task.expected_claims ?? [],
       forbidden_claims: task.forbidden_claims ?? [],
@@ -695,6 +784,7 @@ function validatePublishableShape(opts, tasks) {
       blockers.push(`public-core needs at least 3 tasks per class; underfilled: ${audit.underfilled_classes.join(", ")}`);
     }
   }
+  blockers.push(...unsupportedSidecarContractRequests(process.env));
   if (blockers.length) {
     throw new Error(`Publishable benchmark shape is incomplete:\n- ${blockers.join("\n- ")}`);
   }
@@ -866,6 +956,11 @@ ${packetFirstCommand}
 
 Run that answer packet before any repository search, direct source read, git command, CodeStory primitive, or help/probe command. The benchmark treats help/probe commands such as \`--help\` as not packet-first.`
     : "";
+  const stopContractBlock =
+    armName === "with_codestory"
+      ? `
+If the packet reports \`sufficiency.status: "sufficient"\` with no \`sufficiency.follow_up_commands\`, do not run ordinary source reads, \`rg\`, \`grep\`, \`git show\`, or file-open commands afterward. Those commands count as benchmark overhead unless the packet names a concrete unresolved gap.`
+      : "";
   return `You are running a controlled CodeStory benchmark.
 
 Repository: ${repoName}
@@ -875,6 +970,7 @@ Task: ${taskPrompt}
 Arm: ${armName}
 Instruction: ${ARMS[armName]}
 ${packetFirstBlock}
+${stopContractBlock}
 
 Return a concise answer with the files, symbols, and commands that support your explanation.
 Do not edit source files. Use read-only inspection commands only, except CodeStory may write its cache if needed.`;
@@ -1026,7 +1122,14 @@ function normalizePathLike(value) {
     .replace(/^['"]|['"]$/g, "")
     .replace(/\\/g, "/")
     .replace(/\/+/g, "/")
+    .replace(/^\?\/(?=[A-Za-z]:\/)/, "")
     .replace(/^\.?\//, "");
+}
+
+function pathMatchesLike(actual, expected) {
+  const left = normalizePathLike(actual).toLowerCase();
+  const right = normalizePathLike(expected).toLowerCase();
+  return left === right || left.endsWith(`/${right}`);
 }
 
 function isLikelySourcePath(value) {
@@ -1345,12 +1448,45 @@ function claimMatched(haystack, claim) {
   return matched >= Math.min(4, expectedTokens.length) && ratio >= 0.65;
 }
 
-function scoreClaimSet(claims, haystack) {
+const FORBIDDEN_POLARITY_TERMS = new Set([
+  "after",
+  "bypass",
+  "bypasses",
+  "bypassed",
+  "converting",
+  "direct",
+  "directly",
+  "instead",
+  "never",
+  "not",
+  "only",
+  "without",
+]);
+
+function claimPolarityTokens(claim) {
+  return claimTokens(claim).filter((token) => FORBIDDEN_POLARITY_TERMS.has(token));
+}
+
+function forbiddenClaimMatched(haystack, claim) {
+  if (!claimMatched(haystack, claim)) {
+    return false;
+  }
+  const polarityTokens = claimPolarityTokens(claim);
+  if (!polarityTokens.length) {
+    const haystackTokens = new Set(claimTokens(haystack));
+    return claimTokens(claim).every((token) => claimTokenMatched(token, haystackTokens));
+  }
+  const haystackTokens = new Set(claimTokens(haystack));
+  return polarityTokens.every((token) => claimTokenMatched(token, haystackTokens));
+}
+
+function scoreClaimSet(claims, haystack, opts = {}) {
   const expected = [...new Set((claims ?? []).map(String).map((value) => value.trim()).filter(Boolean))];
   const found = [];
   const missed = [];
   for (const claim of expected) {
-    if (claimMatched(haystack, claim)) {
+    const matched = opts.forbidden ? forbiddenClaimMatched(haystack, claim) : claimMatched(haystack, claim);
+    if (matched) {
       found.push(claim);
     } else {
       missed.push(claim);
@@ -1421,7 +1557,8 @@ function scoreQualityFromText(finalAnswer, transcript, task) {
   const symbols = scoreAnchorSet(task.expected_symbols, finalAnswer);
   const claims = scoreClaimSet(task.expected_claims, finalAnswer);
   const citations = scoreAnchorSet(task.expected_files, finalAnswer);
-  const forbidden = scoreClaimSet(task.forbidden_claims, finalAnswer);
+  const verificationFiles = scoreAnchorSet(task.expected_verification_files ?? [], finalAnswer);
+  const forbidden = scoreClaimSet(task.forbidden_claims, finalAnswer, { forbidden: true });
   const allAnchors = aggregateQualityAnchors(files, symbols, claims);
   const observedAnchors = aggregateQualityAnchors(observedFiles, observedSymbols, claims);
   const thresholds = task.quality_thresholds ?? {};
@@ -1454,6 +1591,7 @@ function scoreQualityFromText(finalAnswer, transcript, task) {
     },
     expected_anchors: allAnchors,
     expected_files: files,
+    expected_verification_files: verificationFiles,
     expected_symbols: symbols,
     observed_anchors: observedAnchors,
     observed_files: observedFiles,
@@ -1472,6 +1610,7 @@ function scoreQualityFromText(finalAnswer, transcript, task) {
     },
     missed_anchors: {
       files: files.missed_anchors,
+      verification_files: verificationFiles.missed_anchors,
       symbols: symbols.missed_anchors,
       claims: claims.missed_anchors,
     },
@@ -1595,7 +1734,7 @@ async function runOne(opts, run, outDir) {
   const repoConfig = ALL_REPOS[run.repo];
   const prompt = composePrompt(run.repo, repoConfig, run.arm, run.task);
   const { command, args, stdin, killProcessTree } = runnerCommand(opts, repoConfig.path, prompt);
-  const env = { ...process.env };
+  const env = run.arm === "with_codestory" ? benchmarkChildEnv(process.env) : { ...process.env };
   if (run.arm === "with_codestory") {
     env.CODESTORY_CLI = path.resolve(resolveCodeStoryCli(opts));
   }
@@ -1635,6 +1774,8 @@ async function runOne(opts, run, outDir) {
     ? await codestoryCacheProvenance(opts, repoConfig, {
         codestory_index_commands_observed: analysis.codestory_index_commands_observed,
         indexing_in_timed_run: analysis.codestory_index_commands_observed > 0,
+        cache_prepared: opts.cachePreparationByRepo?.has(run.repo) ?? false,
+        cache_preparation: opts.cachePreparationByRepo?.get(run.repo) ?? null,
         transport_mode: "agent_runner",
       })
     : null;
@@ -1714,6 +1855,223 @@ async function repoProvenance(config) {
   };
 }
 
+function trimTail(text, maxChars = 4000) {
+  const value = String(text ?? "");
+  return value.length <= maxChars ? value : value.slice(value.length - maxChars);
+}
+
+function doctorSnapshotFromOutput(result, output, parseError, wallMs) {
+  const retrieval = output?.retrieval ?? null;
+  const locality = semanticRuntimeLocality(output);
+  return {
+    status: result.status === "pass" && !parseError ? "pass" : result.status,
+    exit_code: result.exitCode,
+    timed_out: Boolean(result.timedOut),
+    error: result.error ?? parseError ?? null,
+    wall_ms: wallMs,
+    project: output?.project ?? null,
+    storage_path: output?.storage_path ?? null,
+    indexed: output?.indexed ?? null,
+    freshness_status: output?.freshness?.status ?? null,
+    changed_file_count: output?.freshness?.changed_file_count ?? null,
+    new_file_count: output?.freshness?.new_file_count ?? null,
+    removed_file_count: output?.freshness?.removed_file_count ?? null,
+    semantic_ready: retrieval?.semantic_ready ?? null,
+    semantic_backend: semanticBackendName(retrieval),
+    semantic_doc_count: retrieval?.semantic_doc_count ?? null,
+    embedding_model: retrieval?.embedding_model ?? retrieval?.current_embedding?.model_id ?? null,
+    local_only: locality.local_only,
+    locality_kind: locality.locality_kind,
+    locality_evidence: locality.locality_evidence,
+    stats: output?.stats ?? null,
+    stdout_tail: result.status === "pass" ? null : trimTail(result.stdout),
+    stderr_tail: result.status === "pass" ? null : trimTail(result.stderr),
+  };
+}
+
+function retrievalStatusSnapshotFromOutput(result, output, parseError, wallMs) {
+  return {
+    status: result.status === "pass" && !parseError ? "pass" : result.status,
+    exit_code: result.exitCode,
+    timed_out: Boolean(result.timedOut),
+    error: result.error ?? parseError ?? null,
+    wall_ms: wallMs,
+    retrieval_mode: output?.retrieval_mode ?? null,
+    degraded_reason: output?.degraded_reason ?? null,
+    manifest_embedding_backend: output?.manifest?.embedding_backend ?? null,
+    manifest_embedding_dim: output?.manifest?.embedding_dim ?? null,
+    sidecar_generation: output?.manifest?.sidecar_generation ?? null,
+    qdrant_collection: output?.manifest?.qdrant_collection ?? null,
+    zoekt_capabilities: output?.zoekt?.capabilities ?? null,
+    qdrant_capabilities: output?.qdrant?.capabilities ?? null,
+    scip_capabilities: output?.scip?.capabilities ?? null,
+    stdout_tail: result.status === "pass" ? null : trimTail(result.stdout),
+    stderr_tail: result.status === "pass" ? null : trimTail(result.stderr),
+  };
+}
+
+async function codestoryDoctorSnapshot(codestoryCli, project, timeoutMs) {
+  const started = performance.now();
+  const result = await runProcess(
+    codestoryCli,
+    ["doctor", "--project", project, "--format", "json"],
+    { timeoutMs, env: benchmarkChildEnv(process.env) },
+  );
+  const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
+  let output = null;
+  let parseError = null;
+  if (result.status === "pass") {
+    try {
+      output = JSON.parse(result.stdout);
+    } catch (error) {
+      parseError = error.message;
+    }
+  }
+  return doctorSnapshotFromOutput(result, output, parseError, wallMs);
+}
+
+async function codestoryRetrievalStatusSnapshot(codestoryCli, project, timeoutMs) {
+  const started = performance.now();
+  const result = await runProcess(
+    codestoryCli,
+    ["retrieval", "status", "--project", project, "--format", "json"],
+    { timeoutMs, env: benchmarkChildEnv(process.env) },
+  );
+  const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
+  let output = null;
+  let parseError = null;
+  if (result.status === "pass") {
+    try {
+      output = JSON.parse(result.stdout);
+    } catch (error) {
+      parseError = error.message;
+    }
+  }
+  return retrievalStatusSnapshotFromOutput(result, output, parseError, wallMs);
+}
+
+function cacheNeedsPreparation(snapshot) {
+  if (snapshot.status !== "pass") {
+    return true;
+  }
+  if (snapshot.indexed !== true) {
+    return true;
+  }
+  if (snapshot.freshness_status !== "fresh") {
+    return true;
+  }
+  return snapshot.semantic_ready !== true;
+}
+
+function cachePreparationAction(snapshot) {
+  return cacheNeedsPreparation(snapshot) ? "retrieval-index-auto" : "already-ready";
+}
+
+function compactCachePreparation(preparation) {
+  if (!preparation) {
+    return null;
+  }
+  return {
+    repo: preparation.repo,
+    action: preparation.action,
+    index_status: preparation.index_status ?? null,
+    index_exit_code: preparation.index_exit_code ?? null,
+    index_wall_ms: preparation.index_wall_ms ?? null,
+    retrieval_contract: preparation.retrieval_contract ?? null,
+    retrieval_index_status: preparation.retrieval_index_status ?? null,
+    retrieval_index_exit_code: preparation.retrieval_index_exit_code ?? null,
+    retrieval_index_wall_ms: preparation.retrieval_index_wall_ms ?? null,
+    retrieval_mode: preparation.retrieval_status?.retrieval_mode ?? null,
+    retrieval_degraded_reason: preparation.retrieval_status?.degraded_reason ?? null,
+    sidecar_generation: preparation.retrieval_status?.sidecar_generation ?? null,
+    manifest_embedding_backend: preparation.retrieval_status?.manifest_embedding_backend ?? null,
+    before_freshness_status: preparation.before?.freshness_status ?? null,
+    after_freshness_status: preparation.after?.freshness_status ?? null,
+    before_semantic_ready: preparation.before?.semantic_ready ?? null,
+    after_semantic_ready: preparation.after?.semantic_ready ?? null,
+    before_semantic_doc_count: preparation.before?.semantic_doc_count ?? null,
+    after_semantic_doc_count: preparation.after?.semantic_doc_count ?? null,
+  };
+}
+
+async function prepareCodeStoryCaches(opts, tasks) {
+  if (!opts.arms.includes("with_codestory")) {
+    return [];
+  }
+  const repoNames = [...new Set(tasks.map((task) => task.repo))];
+  const codestoryCli = resolveCodeStoryCli(opts);
+  const preparations = [];
+  for (const repo of repoNames) {
+    const config = ALL_REPOS[repo];
+    if (!config || !existsSync(config.path)) {
+      preparations.push({
+        repo,
+        project: config?.path ?? null,
+        action: "skipped-missing-repo",
+      });
+      continue;
+    }
+
+    console.log(`preparing CodeStory cache for ${repo}`);
+    const before = await codestoryDoctorSnapshot(codestoryCli, config.path, 60_000);
+    const preparation = {
+      repo,
+      project: config.path,
+      codestory_cli: path.resolve(codestoryCli),
+      action: cachePreparationAction(before),
+      before,
+      index_status: null,
+      index_exit_code: null,
+      index_wall_ms: 0,
+      index_stdout_tail: null,
+      index_stderr_tail: null,
+      retrieval_status: null,
+      retrieval_index_stdout_tail: null,
+      retrieval_index_stderr_tail: null,
+      after: before,
+    };
+
+    preparation.retrieval_contract = retrievalContractSummary(benchmarkChildEnv(process.env));
+    if (shouldPrepareRetrievalIndex(process.env)) {
+      const retrievalStarted = performance.now();
+      const retrievalIndex = await runProcess(
+        codestoryCli,
+        ["retrieval", "index", "--project", config.path, "--refresh", "auto"],
+        {
+          env: benchmarkChildEnv(process.env),
+          timeoutMs: opts.prepareCodestoryTimeoutMs,
+          timeoutMessage: `retrieval index timed out after ${opts.prepareCodestoryTimeoutMs}ms.`,
+        },
+      );
+      preparation.retrieval_index_status = retrievalIndex.status;
+      preparation.retrieval_index_exit_code = retrievalIndex.exitCode;
+      preparation.retrieval_index_wall_ms =
+        Math.round((performance.now() - retrievalStarted) * 1000) / 1000;
+      preparation.retrieval_index_stdout_tail = trimTail(retrievalIndex.stdout);
+      preparation.retrieval_index_stderr_tail = trimTail(retrievalIndex.stderr);
+      if (retrievalIndex.status !== "pass") {
+        throw new Error(
+          `mandatory retrieval index failed for ${repo}: ${trimTail(retrievalIndex.stderr || retrievalIndex.stdout)}`,
+        );
+      }
+      preparation.after = await codestoryDoctorSnapshot(codestoryCli, config.path, 60_000);
+      preparation.retrieval_status = await codestoryRetrievalStatusSnapshot(
+        codestoryCli,
+        config.path,
+        60_000,
+      );
+      if (preparation.retrieval_status.retrieval_mode !== "full") {
+        throw new Error(
+          `mandatory retrieval index for ${repo} did not reach full mode: ${preparation.retrieval_status.retrieval_mode ?? "unknown"} ${preparation.retrieval_status.degraded_reason ?? ""}`.trim(),
+        );
+      }
+    }
+
+    preparations.push(preparation);
+  }
+  return preparations;
+}
+
 function semanticBackendName(retrieval) {
   if (!retrieval || typeof retrieval !== "object") {
     return "unknown";
@@ -1725,10 +2083,82 @@ function semanticBackendName(retrieval) {
   );
 }
 
+function doctorEnvironmentValue(output, name) {
+  const row = (output?.environment ?? []).find((item) => item?.name === name);
+  if (!row || row.status !== "ok") {
+    return null;
+  }
+  const match = String(row.message ?? "").match(/`([^`]*)`/);
+  return match ? match[1] : null;
+}
+
+function isLoopbackUrl(value) {
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname.endsWith(".localhost")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function semanticRuntimeLocality(output) {
+  const retrieval = output?.retrieval ?? {};
+  const backend = semanticBackendName(retrieval);
+  if (backend === "symbolic-only") {
+    return {
+      local_only: true,
+      locality_kind: "no_semantic_runtime",
+      locality_evidence: "semantic retrieval unavailable; no embedding runtime was used",
+    };
+  }
+  if (backend === "onnx") {
+    return {
+      local_only: true,
+      locality_kind: "local_model_files",
+      locality_evidence: "semantic backend is onnx",
+    };
+  }
+  if (backend === "llamacpp") {
+    const endpoint = doctorEnvironmentValue(output, "CODESTORY_EMBED_LLAMACPP_URL");
+    if (!endpoint) {
+      return {
+        local_only: null,
+        locality_kind: "unknown_llamacpp_endpoint",
+        locality_evidence: "llama.cpp backend did not expose a configured endpoint",
+      };
+    }
+    const loopback = isLoopbackUrl(endpoint);
+    return {
+      local_only: loopback,
+      locality_kind: loopback ? "loopback_endpoint" : "remote_endpoint",
+      locality_evidence: "semantic backend is llama.cpp",
+    };
+  }
+  if (backend === "hash" || backend === "lexical") {
+    return {
+      local_only: true,
+      locality_kind: "local_deterministic_backend",
+      locality_evidence: `semantic backend is ${backend}`,
+    };
+  }
+  return {
+    local_only: null,
+    locality_kind: "unknown_backend",
+    locality_evidence: `semantic backend is ${backend}`,
+  };
+}
+
 function cachePolicyForRun(observations = {}) {
-  return observations.indexing_in_timed_run
-    ? "timed-run-indexed-cache"
-    : "existing-cache-read-only";
+  if (observations.indexing_in_timed_run) {
+    return "timed-run-indexed-cache";
+  }
+  return observations.cache_prepared ? "prepared-sidecar-cache-read-only" : "unprepared-cache-blocked";
 }
 
 async function codestoryCacheProvenance(opts, config, observations = {}) {
@@ -1747,38 +2177,42 @@ async function codestoryCacheProvenance(opts, config, observations = {}) {
     };
   }
 
-  const doctor = await runProcess(
+  const doctor = await codestoryDoctorSnapshot(
     codestoryCli,
-    ["doctor", "--project", config.path, "--format", "json"],
-    { timeoutMs: Math.min(opts.timeoutMs ?? 600_000, 60_000) },
+    config.path,
+    Math.min(opts.timeoutMs ?? 600_000, 60_000),
   );
-  let output = null;
-  let parseError = null;
-  if (doctor.status === "pass") {
-    try {
-      output = JSON.parse(doctor.stdout);
-    } catch (error) {
-      parseError = error.message;
-    }
-  }
-  const retrieval = output?.retrieval ?? null;
+  const retrievalStatus = observations.cache_preparation?.retrieval_status ??
+    await codestoryRetrievalStatusSnapshot(
+      codestoryCli,
+      config.path,
+      Math.min(opts.timeoutMs ?? 600_000, 60_000),
+    );
   return {
     codestory_cli: path.resolve(codestoryCli),
-    project: output?.project ?? config.path,
-    storage_path: output?.storage_path ?? null,
-    indexed: output?.indexed ?? null,
-    freshness_status: output?.freshness?.status ?? null,
-    semantic_ready: retrieval?.semantic_ready ?? null,
-    semantic_backend: semanticBackendName(retrieval),
-    semantic_doc_count: retrieval?.semantic_doc_count ?? null,
-    embedding_model: retrieval?.embedding_model ?? retrieval?.current_embedding?.model_id ?? null,
+    project: doctor.project ?? config.path,
+    storage_path: doctor.storage_path ?? null,
+    indexed: doctor.indexed ?? null,
+    freshness_status: doctor.freshness_status ?? null,
+    semantic_ready: doctor.semantic_ready ?? null,
+    semantic_backend: doctor.semantic_backend ?? null,
+    semantic_doc_count: doctor.semantic_doc_count ?? null,
+    embedding_model: doctor.embedding_model ?? null,
+    local_only: doctor.local_only ?? null,
+    locality_kind: doctor.locality_kind ?? null,
+    locality_evidence: doctor.locality_evidence ?? null,
     cache_policy: cachePolicyForRun(observations),
     indexing_in_timed_run: observations.indexing_in_timed_run ?? null,
     codestory_index_commands_observed: observations.codestory_index_commands_observed ?? null,
+    cache_preparation: compactCachePreparation(observations.cache_preparation),
     transport_mode: observations.transport_mode ?? null,
-    doctor_status: doctor.status === "pass" && !parseError ? "pass" : "fail",
-    doctor_exit_code: doctor.exitCode,
-    doctor_error: doctor.error ?? parseError,
+    retrieval_status: retrievalStatus,
+    retrieval_mode: retrievalStatus.retrieval_mode ?? null,
+    sidecar_generation: retrievalStatus.sidecar_generation ?? null,
+    manifest_embedding_backend: retrievalStatus.manifest_embedding_backend ?? null,
+    doctor_status: doctor.status,
+    doctor_exit_code: doctor.exit_code,
+    doctor_error: doctor.error,
   };
 }
 
@@ -1834,6 +2268,8 @@ async function recomputeRunAnalysis(result, opts, runDir, taskCache) {
       ? await codestoryCacheProvenance(opts, repoConfig, {
           codestory_index_commands_observed: analysis.codestory_index_commands_observed,
           indexing_in_timed_run: analysis.codestory_index_commands_observed > 0,
+          cache_prepared: opts.cachePreparationByRepo?.has(result.repo) ?? false,
+          cache_preparation: opts.cachePreparationByRepo?.get(result.repo) ?? null,
           transport_mode: "agent_runner",
         })
       : null
@@ -1938,7 +2374,33 @@ function packetPayloadText(packet) {
   if (!packet || typeof packet !== "object") {
     return String(packet ?? "");
   }
-  const chunks = [JSON.stringify(packet)];
+  const chunks = [];
+  chunks.push(packetAnswerText(packet));
+  for (const citation of packet.answer?.citations ?? []) {
+    chunks.push(
+      [
+        citation.display_name,
+        citation.file_path,
+        citation.line == null ? null : String(citation.line),
+      ]
+        .filter(Boolean)
+        .join(" "),
+    );
+  }
+  for (const claim of packet.sufficiency?.covered_claims ?? []) {
+    chunks.push(claim.claim);
+  }
+  for (const path of packet.sufficiency?.avoid_opening ?? []) {
+    chunks.push(path);
+  }
+  return chunks.filter(Boolean).join("\n");
+}
+
+function packetAnswerText(packet) {
+  if (!packet || typeof packet !== "object") {
+    return String(packet ?? "");
+  }
+  const chunks = [];
   if (packet.answer?.summary) {
     chunks.push(packet.answer.summary);
   }
@@ -1955,8 +2417,223 @@ function packetPayloadText(packet) {
   return chunks.join("\n");
 }
 
+function packetComposition(packet, task) {
+  if (!packet || typeof packet !== "object" || !task) {
+    return null;
+  }
+  const expectedFiles = [
+    ...new Set((task.expected_files ?? []).map(String).map((value) => value.trim()).filter(Boolean)),
+  ];
+  const expectedVerificationFiles = [
+    ...new Set(
+      (task.expected_verification_files ?? []).map(String).map((value) => value.trim()).filter(Boolean),
+    ),
+  ];
+  const citationPaths = (packet.answer?.citations ?? [])
+    .map((citation, index) => ({
+      source: "answer.citations",
+      path: citation.file_path,
+      rank: index + 1,
+      display_name: citation.display_name ?? null,
+      line: citation.line ?? null,
+    }))
+    .filter((entry) => entry.path);
+  const avoidOpeningPaths = (packet.sufficiency?.avoid_opening ?? [])
+    .map((pathValue, index) => ({
+      source: "sufficiency.avoid_opening",
+      path: pathValue,
+      rank: index + 1,
+      display_name: null,
+      line: null,
+    }))
+    .filter((entry) => entry.path);
+  const answerText = packetAnswerText(packet);
+  const structuredJson = JSON.stringify(packet);
+  const files = expectedFiles.map((expectedFile) => {
+    const citationSurfaces = pathSurfacesForExpected(citationPaths, expectedFile);
+    const avoidOpeningSurfaces = pathSurfacesForExpected(avoidOpeningPaths, expectedFile);
+    const answerTextMentioned = anchorMatched(answerText, expectedFile);
+    const structuredJsonMentioned = anchorMatched(structuredJson, expectedFile);
+    const citationBackedFound =
+      citationSurfaces.length > 0 || avoidOpeningSurfaces.length > 0;
+    const answerSurfaceFound = citationBackedFound || answerTextMentioned;
+    const structuredFound = answerSurfaceFound || structuredJsonMentioned;
+    return {
+      expected_file: expectedFile,
+      packet_boundary: packetLossBoundary({
+        cited: citationSurfaces.length > 0,
+        avoidOpening: avoidOpeningSurfaces.length > 0,
+        answerTextMentioned,
+        structuredJsonMentioned,
+      }),
+      citation_backed_found: citationBackedFound,
+      answer_surface_found: answerSurfaceFound,
+      structured_found: structuredFound,
+      cited: citationSurfaces.length > 0,
+      avoid_opening: avoidOpeningSurfaces.length > 0,
+      answer_text_mentioned: answerTextMentioned,
+      structured_json_mentioned: structuredJsonMentioned,
+      surfaces: [
+        ...citationSurfaces,
+        ...avoidOpeningSurfaces,
+        ...(answerTextMentioned
+          ? [{ source: "answer.text", path: expectedFile, rank: null, display_name: null, line: null }]
+          : []),
+        ...(structuredJsonMentioned && !answerSurfaceFound
+          ? [{ source: "packet.structured_json", path: expectedFile, rank: null, display_name: null, line: null }]
+          : []),
+      ],
+    };
+  });
+  const summary = summarizePacketComposition(files);
+  const verificationFiles = expectedVerificationFiles.map((expectedFile) =>
+    packetFileComposition(packet, expectedFile, {
+      citationPaths,
+      avoidOpeningPaths,
+      answerText,
+      structuredJson,
+    }),
+  );
+  const verificationSummary = summarizePacketComposition(verificationFiles);
+  return {
+    expected_file_count: expectedFiles.length,
+    ...summary,
+    files,
+    expected_verification_file_count: expectedVerificationFiles.length,
+    verification_summary: verificationSummary,
+    verification_files: verificationFiles,
+  };
+}
+
+function packetFileComposition(
+  packet,
+  expectedFile,
+  { citationPaths, avoidOpeningPaths, answerText, structuredJson },
+) {
+  const citationSurfaces = pathSurfacesForExpected(citationPaths, expectedFile);
+  const avoidOpeningSurfaces = pathSurfacesForExpected(avoidOpeningPaths, expectedFile);
+  const answerTextMentioned = anchorMatched(answerText, expectedFile);
+  const structuredJsonMentioned = anchorMatched(structuredJson, expectedFile);
+  const citationBackedFound =
+    citationSurfaces.length > 0 || avoidOpeningSurfaces.length > 0;
+  const answerSurfaceFound = citationBackedFound || answerTextMentioned;
+  const structuredFound = answerSurfaceFound || structuredJsonMentioned;
+  return {
+    expected_file: expectedFile,
+    packet_boundary: packetLossBoundary({
+      cited: citationSurfaces.length > 0,
+      avoidOpening: avoidOpeningSurfaces.length > 0,
+      answerTextMentioned,
+      structuredJsonMentioned,
+    }),
+    citation_backed_found: citationBackedFound,
+    answer_surface_found: answerSurfaceFound,
+    structured_found: structuredFound,
+    cited: citationSurfaces.length > 0,
+    avoid_opening: avoidOpeningSurfaces.length > 0,
+    answer_text_mentioned: answerTextMentioned,
+    structured_json_mentioned: structuredJsonMentioned,
+    surfaces: [
+      ...citationSurfaces,
+      ...avoidOpeningSurfaces,
+      ...(answerTextMentioned
+        ? [{ source: "answer.text", path: expectedFile, rank: null, display_name: null, line: null }]
+        : []),
+      ...(structuredJsonMentioned && !answerSurfaceFound
+        ? [{ source: "packet.structured_json", path: expectedFile, rank: null, display_name: null, line: null }]
+        : []),
+    ],
+  };
+}
+
+function pathSurfacesForExpected(paths, expectedFile) {
+  return paths
+    .filter((entry) => pathMatchesLike(entry.path, expectedFile))
+    .map((entry) => ({
+      source: entry.source,
+      path: normalizePathLike(entry.path),
+      rank: entry.rank,
+      display_name: entry.display_name,
+      line: entry.line,
+    }));
+}
+
+function packetLossBoundary({ cited, avoidOpening, answerTextMentioned, structuredJsonMentioned }) {
+  if (cited) {
+    return "cited_in_answer";
+  }
+  if (avoidOpening) {
+    return "listed_in_avoid_opening";
+  }
+  if (answerTextMentioned) {
+    return "mentioned_in_answer_text";
+  }
+  if (structuredJsonMentioned) {
+    return "present_only_in_structured_json";
+  }
+  return "absent_from_packet";
+}
+
+const PACKET_COMPOSITION_WEIGHTS = {
+  cited: 1,
+  avoid_opening: 0.9,
+  answer_text_only: 0.25,
+};
+
+function packetCompositionFileScore(file) {
+  if (file.cited) {
+    return PACKET_COMPOSITION_WEIGHTS.cited;
+  }
+  if (file.avoid_opening) {
+    return PACKET_COMPOSITION_WEIGHTS.avoid_opening;
+  }
+  if (file.answer_text_mentioned && !file.citation_backed_found) {
+    return PACKET_COMPOSITION_WEIGHTS.answer_text_only;
+  }
+  return 0;
+}
+
+function summarizePacketComposition(files) {
+  const expected = files.length;
+  const cited = files.filter((file) => file.cited).length;
+  const avoidOpening = files.filter((file) => file.avoid_opening).length;
+  const answerText = files.filter(
+    (file) => file.answer_text_mentioned && !file.citation_backed_found,
+  ).length;
+  const citationBacked = files.filter((file) => file.citation_backed_found).length;
+  const answerSurface = files.filter((file) => file.answer_surface_found).length;
+  const structured = files.filter((file) => file.structured_found).length;
+  const compositionScore = expected
+    ? files.reduce((sum, file) => sum + packetCompositionFileScore(file), 0) / expected
+    : null;
+  const boundaryCounts = {};
+  for (const file of files) {
+    boundaryCounts[file.packet_boundary] = (boundaryCounts[file.packet_boundary] ?? 0) + 1;
+  }
+  return {
+    cited_file_count: cited,
+    avoid_opening_file_count: avoidOpening,
+    answer_text_file_count: answerText,
+    citation_backed_file_count: citationBacked,
+    answer_surface_file_count: answerSurface,
+    structured_file_count: structured,
+    absent_file_count: expected - structured,
+    citation_recall: expected ? cited / expected : null,
+    citation_backed_recall: expected ? citationBacked / expected : null,
+    answer_surface_recall: expected ? answerSurface / expected : null,
+    structured_file_recall: expected ? structured / expected : null,
+    composition_score: compositionScore,
+    boundary_counts: boundaryCounts,
+  };
+}
+
 function jsonByteLength(value) {
   return Buffer.byteLength(JSON.stringify(value ?? null), "utf8");
+}
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
 }
 
 function packetShape(packet) {
@@ -1993,6 +2670,64 @@ function packetSufficiencyTelemetry(packet, quality) {
   };
 }
 
+function packetRetrievalShadowTelemetry(shadow) {
+  if (!shadow || typeof shadow !== "object") {
+    return null;
+  }
+  const stages = Array.isArray(shadow.stage_timings) ? shadow.stage_timings : [];
+  const cacheHitStages = stages.filter((stage) => stage?.cache_hit === true);
+  return {
+    retrieval_mode: shadow.retrieval_mode ?? null,
+    degraded_reason: shadow.degraded_reason ?? null,
+    retrieval_total_ms: finiteNumber(shadow.retrieval_total_ms),
+    total_budget_ms: finiteNumber(shadow.total_budget_ms),
+    cancel_reason: shadow.cancel_reason ?? null,
+    cache_hit: shadow.cache_hit === true,
+    stage_count: stages.length,
+    cache_hit_stage_count: cacheHitStages.length,
+    cache_hit_stages: cacheHitStages
+      .map((stage) => String(stage?.stage ?? "").trim())
+      .filter(Boolean),
+    candidate_count: finiteNumber(shadow.candidate_count),
+    resolved_hit_count: finiteNumber(shadow.resolved_hit_count),
+    unresolved_candidate_count: finiteNumber(shadow.unresolved_candidate_count),
+    error: shadow.error ?? null,
+  };
+}
+
+function packetLatencyTelemetry(packet, wallMs) {
+  if (!packet || typeof packet !== "object") {
+    return null;
+  }
+  const retrievalTrace = packet.answer?.retrieval_trace ?? null;
+  const benchmarkRetrievalTrace = packet.benchmark_trace?.retrieval_trace ?? null;
+  const retrievalShadow = packetRetrievalShadowTelemetry(
+    benchmarkRetrievalTrace?.retrieval_shadow ?? retrievalTrace?.retrieval_shadow ?? null,
+  );
+  const freshness = packet.answer?.freshness ?? null;
+  const steps = Array.isArray(retrievalTrace?.steps) ? retrievalTrace.steps : [];
+  const topStep = [...steps].sort((left, right) => (right.duration_ms ?? 0) - (left.duration_ms ?? 0))[0] ?? null;
+  const retrievalTotalMs = finiteNumber(retrievalTrace?.total_latency_ms);
+  const freshnessMs = finiteNumber(freshness?.duration_ms);
+  const unaccountedMs =
+    Number.isFinite(wallMs) && Number.isFinite(retrievalTotalMs) && Number.isFinite(freshnessMs)
+      ? Math.max(0, wallMs - retrievalTotalMs - freshnessMs)
+      : null;
+  return {
+    freshness_ms: Number.isFinite(freshnessMs) ? freshnessMs : null,
+    retrieval_total_ms: Number.isFinite(retrievalTotalMs) ? retrievalTotalMs : null,
+    sla_target_ms: finiteNumber(retrievalTrace?.sla_target_ms),
+    sla_missed: retrievalTrace?.sla_missed ?? null,
+    unaccounted_ms: unaccountedMs,
+    top_step_kind: topStep?.kind ?? null,
+    top_step_status: topStep?.status ?? null,
+    top_step_duration_ms: finiteNumber(topStep?.duration_ms),
+    top_step_message: topStep?.message ?? null,
+    retrieval_step_count: steps.length,
+    retrieval_shadow: retrievalShadow,
+  };
+}
+
 async function runColdPacketRuntime(opts, task, repeat, outDir) {
   const repoConfig = ALL_REPOS[task.repo];
   const codestoryCli = resolveCodeStoryCli(opts);
@@ -2017,7 +2752,10 @@ async function runColdPacketRuntime(opts, task, repeat, outDir) {
     args.push("--task-class", task.task_class.replace(/_/g, "-"));
   }
   const started = performance.now();
-  const result = await runProcess(codestoryCli, args, { timeoutMs: opts.timeoutMs });
+  const result = await runProcess(codestoryCli, args, {
+    env: benchmarkChildEnv(process.env),
+    timeoutMs: opts.timeoutMs,
+  });
   const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
   let packet = null;
   let parseError = null;
@@ -2033,6 +2771,8 @@ async function runColdPacketRuntime(opts, task, repeat, outDir) {
     : null;
   const shape = packetShape(packet);
   const sufficiency = packetSufficiencyTelemetry(packet, quality);
+  const latency = packetLatencyTelemetry(packet, wallMs);
+  const composition = packetComposition(packet, task);
   const runId = benchmarkRunId([task.repo, task.id, "cold-cli-packet", String(repeat).padStart(2, "0")]);
   await writeFile(path.join(outDir, `${runId}.stdout.json`), result.stdout, "utf8");
   await writeFile(path.join(outDir, `${runId}.stderr.txt`), result.stderr, "utf8");
@@ -2052,6 +2792,8 @@ async function runColdPacketRuntime(opts, task, repeat, outDir) {
     wall_ms: wallMs,
     response_bytes: Buffer.byteLength(result.stdout, "utf8"),
     packet_shape: shape,
+    packet_latency: latency,
+    packet_composition: composition,
     sufficiency,
     quality,
   };
@@ -2059,7 +2801,7 @@ async function runColdPacketRuntime(opts, task, repeat, outDir) {
 
 function createStdioClient(command, args, opts) {
   const child = spawn(command, args, {
-    env: process.env,
+    env: benchmarkChildEnv(process.env),
     shell: false,
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
@@ -2159,6 +2901,7 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
     opts,
   );
   const rows = [];
+  const previousPacketByTask = new Map();
   try {
     await client.request({
       jsonrpc: "2.0",
@@ -2186,11 +2929,24 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
         const response = JSON.parse(responseLine);
         const packet = response.result?.structuredContent ?? null;
         const isError = response.result?.isError === true || response.error;
+        const packetFingerprint = packet && !isError ? JSON.stringify(packet) : null;
+        const previousPacket = packetFingerprint ? previousPacketByTask.get(task.id) : null;
+        const warmStdioPacketCacheHit =
+          packetFingerprint != null && previousPacket?.fingerprint === packetFingerprint;
+        if (packetFingerprint) {
+          previousPacketByTask.set(task.id, {
+            fingerprint: packetFingerprint,
+            repeat,
+            wallMs,
+          });
+        }
         const quality = packet && !isError
           ? scoreQualityFromText(packetPayloadText(packet), JSON.stringify(packet), task)
           : null;
         const shape = packetShape(packet);
         const sufficiency = packetSufficiencyTelemetry(packet, quality);
+        const latency = packetLatencyTelemetry(packet, wallMs);
+        const composition = packetComposition(packet, task);
         const runId = benchmarkRunId([task.repo, task.id, "warm-stdio-packet", String(repeat).padStart(2, "0")]);
         await writeFile(path.join(outDir, `${runId}.response.json`), `${JSON.stringify(response, null, 2)}\n`, "utf8");
         rows.push({
@@ -2208,7 +2964,12 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
           error: response.error?.message ?? (isError ? response.result?.content?.[0]?.text : null),
           wall_ms: wallMs,
           response_bytes: Buffer.byteLength(responseLine, "utf8"),
+          warm_stdio_packet_cache_hit: warmStdioPacketCacheHit,
+          warm_stdio_packet_cache_reference_repeat: warmStdioPacketCacheHit ? previousPacket.repeat : null,
+          warm_stdio_packet_cache_reference_wall_ms: warmStdioPacketCacheHit ? previousPacket.wallMs : null,
           packet_shape: shape,
+          packet_latency: latency,
+          packet_composition: composition,
           sufficiency,
           quality,
         });
@@ -2238,6 +2999,16 @@ function summarizePacketRuntimeRuns(results) {
     const qualityRows = successful.filter((row) => row.quality);
     const sufficiencyRows = successful.filter((row) => row.sufficiency);
     const shapeRows = successful.filter((row) => row.packet_shape);
+    const latencyRows = successful.filter((row) => row.packet_latency);
+    const shadowRows = latencyRows
+      .map((row) => row.packet_latency?.retrieval_shadow)
+      .filter((shadow) => shadow && typeof shadow === "object");
+    const compositionRows = successful.filter((row) => row.packet_composition);
+    const topLatencyRow = latencyRows
+      .filter((row) => Number.isFinite(Number(row.packet_latency?.top_step_duration_ms)))
+      .sort((left, right) =>
+        Number(right.packet_latency.top_step_duration_ms) - Number(left.packet_latency.top_step_duration_ms)
+      )[0];
     const sufficiencyStatusCounts = {};
     for (const row of sufficiencyRows) {
       const status = row.sufficiency.status ?? "unknown";
@@ -2257,10 +3028,25 @@ function summarizePacketRuntimeRuns(results) {
       median_packet_bytes: median(shapeRows.map((row) => row.packet_shape?.packet_bytes)),
       median_packet_graph_bytes: median(shapeRows.map((row) => row.packet_shape?.graph_bytes)),
       median_budget_used_output_bytes: median(shapeRows.map((row) => row.packet_shape?.budget_used_output_bytes)),
+      median_packet_freshness_ms: median(latencyRows.map((row) => row.packet_latency?.freshness_ms)),
+      median_packet_retrieval_total_ms: median(latencyRows.map((row) => row.packet_latency?.retrieval_total_ms)),
+      median_packet_unaccounted_ms: median(latencyRows.map((row) => row.packet_latency?.unaccounted_ms)),
+      packet_sla_missed_runs: latencyRows.filter((row) => row.packet_latency?.sla_missed === true).length,
+      warm_stdio_packet_cache_hit_runs: successful.filter((row) => row.warm_stdio_packet_cache_hit === true).length,
+      retrieval_shadow_cache_hit_runs: shadowRows.filter((shadow) => shadow.cache_hit === true).length,
+      retrieval_shadow_stage_cache_hit_runs: shadowRows.filter((shadow) => Number(shadow.cache_hit_stage_count) > 0).length,
+      median_retrieval_shadow_cache_hit_stage_count: median(shadowRows.map((shadow) => shadow.cache_hit_stage_count)),
+      packet_top_latency_step_kind: topLatencyRow?.packet_latency?.top_step_kind ?? null,
+      packet_top_latency_step_status: topLatencyRow?.packet_latency?.top_step_status ?? null,
+      median_packet_top_step_ms: median(latencyRows.map((row) => row.packet_latency?.top_step_duration_ms)),
       median_avoid_opening_count: median(sufficiencyRows.map((row) => row.sufficiency?.avoid_opening_count)),
       median_follow_up_commands_count: median(sufficiencyRows.map((row) => row.sufficiency?.follow_up_commands_count)),
       median_expected_file_recall: median(qualityRows.map((row) => row.quality?.expected_files?.recall)),
+      median_expected_claim_recall: median(qualityRows.map((row) => row.quality?.expected_claims?.recall)),
       median_citation_coverage: median(qualityRows.map((row) => row.quality?.citation_coverage?.recall)),
+      median_packet_citation_recall: median(compositionRows.map((row) => row.packet_composition?.citation_recall)),
+      median_packet_answer_surface_recall: median(compositionRows.map((row) => row.packet_composition?.answer_surface_recall)),
+      median_packet_structured_file_recall: median(compositionRows.map((row) => row.packet_composition?.structured_file_recall)),
     };
   });
 }
@@ -2269,8 +3055,8 @@ function packetRuntimeMarkdown(summary) {
   const lines = [
     "# Packet Runtime Benchmark",
     "",
-    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Unaccounted ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const row of summary) {
     lines.push(packetRuntimeMarkdownRow(row));
@@ -2292,6 +3078,15 @@ function packetRuntimeMarkdownRow(row) {
     sufficiency,
     formatValue(row.sufficient_quality_mismatch_runs),
     formatValue(row.median_wall_ms),
+    formatValue(row.median_packet_retrieval_total_ms),
+    formatValue(row.median_packet_freshness_ms),
+    formatValue(row.median_packet_unaccounted_ms),
+    row.packet_top_latency_step_kind ?? "",
+    formatValue(row.median_packet_top_step_ms),
+    formatValue(row.packet_sla_missed_runs),
+    formatValue(row.warm_stdio_packet_cache_hit_runs),
+    formatValue(row.retrieval_shadow_cache_hit_runs),
+    formatValue(row.retrieval_shadow_stage_cache_hit_runs),
     formatValue(row.median_response_bytes),
     formatValue(row.median_packet_bytes),
     formatValue(row.median_packet_graph_bytes),
@@ -2299,6 +3094,9 @@ function packetRuntimeMarkdownRow(row) {
     formatValue(row.median_follow_up_commands_count),
     formatPercent(row.median_expected_file_recall),
     formatPercent(row.median_citation_coverage),
+    formatPercent(row.median_packet_citation_recall),
+    formatPercent(row.median_packet_answer_surface_recall),
+    formatPercent(row.median_packet_structured_file_recall),
   ];
   return `| ${cells.join(" | ")} |`;
 }
@@ -2361,8 +3159,34 @@ function cacheProvenanceBlockers(result) {
   if (!provenance.cache_policy) {
     reasons.push("missing CodeStory cache policy");
   }
+  if (provenance.cache_policy === "unprepared-cache-blocked") {
+    reasons.push("CodeStory sidecar cache was not prepared");
+  }
+  if (provenance.retrieval_mode !== "full") {
+    reasons.push(`CodeStory retrieval mode=${provenance.retrieval_mode ?? "unknown"}; expected full`);
+  }
+  if (!provenance.sidecar_generation) {
+    reasons.push("missing CodeStory sidecar generation");
+  }
+  if (provenance.manifest_embedding_backend !== "llamacpp:bge-base-en-v1.5") {
+    reasons.push(
+      `CodeStory sidecar embedding backend=${provenance.manifest_embedding_backend ?? "unknown"}; expected llamacpp:bge-base-en-v1.5`,
+    );
+  }
   if (provenance.semantic_backend == null) {
     reasons.push("missing CodeStory semantic backend");
+  }
+  if (provenance.local_only !== true) {
+    reasons.push(`CodeStory local-only guarantee is not proven (${provenance.locality_kind ?? "unknown"})`);
+  }
+  if (provenance.indexed !== true) {
+    reasons.push("CodeStory cache is not indexed");
+  }
+  if (provenance.freshness_status !== "fresh") {
+    reasons.push(`CodeStory cache freshness=${provenance.freshness_status ?? "unknown"}`);
+  }
+  if (provenance.semantic_ready !== true) {
+    reasons.push("CodeStory semantic docs are not ready");
   }
   if (provenance.indexing_in_timed_run == null) {
     reasons.push("missing timed-run indexing provenance");
@@ -2370,8 +3194,121 @@ function cacheProvenanceBlockers(result) {
   return reasons;
 }
 
+function qualityFailureReasons(quality) {
+  if (!quality) {
+    return ["missing_quality_score"];
+  }
+  if (quality.pass) {
+    return [];
+  }
+  const reasons = [];
+  const thresholds = quality.thresholds ?? {};
+  const files = quality.expected_files ?? {};
+  const symbols = quality.expected_symbols ?? {};
+  const claims = quality.expected_claims ?? {};
+  const citations = quality.citation_coverage ?? {};
+  const anchors = quality.expected_anchors ?? {};
+  const forbidden = quality.forbidden_claims ?? {};
+
+  if (!thresholdPass(anchors.recall, thresholdValue(thresholds, "expected_anchor_recall", 0.8))) {
+    reasons.push("expected_anchor_recall_low");
+  }
+  if (!thresholdPass(files.recall, thresholdValue(thresholds, "expected_file_recall", 0.8))) {
+    reasons.push("expected_file_recall_low");
+  }
+  if (!thresholdPass(symbols.recall, thresholdValue(thresholds, "expected_symbol_recall", 0.7))) {
+    reasons.push("expected_symbol_recall_low");
+  }
+  if (!thresholdPass(claims.recall, thresholdValue(thresholds, "expected_claim_recall", 0.8))) {
+    reasons.push("expected_claim_recall_low");
+  }
+  if (!thresholdPass(citations.recall, thresholdValue(thresholds, "citation_coverage", 0.6))) {
+    reasons.push("citation_coverage_low");
+  }
+  if ((forbidden.found ?? 0) > thresholdValue(thresholds, "max_forbidden_claims", 0)) {
+    reasons.push("forbidden_claim_present");
+  }
+  if (!reasons.length) {
+    reasons.push("quality_gate_failed");
+  }
+  return reasons;
+}
+
+function extractRetrievalDiagnostics(row) {
+  const shadow = row.packet_composition?.retrieval_shadow ?? row.packet_latency?.retrieval_shadow ?? null;
+  const composition = row.packet_composition ?? null;
+  if (!shadow && !composition) {
+    return null;
+  }
+  return {
+    retrieval_mode: shadow?.retrieval_mode ?? null,
+    degraded_reason: shadow?.degraded_reason ?? null,
+    cache_hit: shadow?.cache_hit ?? null,
+    cache_hit_stage_count: shadow?.cache_hit_stage_count ?? null,
+    cache_hit_stages: shadow?.cache_hit_stages ?? null,
+    candidate_count: shadow?.candidate_count ?? null,
+    resolved_hit_count: shadow?.resolved_hit_count ?? null,
+    unavailable_mode: shadow?.retrieval_mode === "unavailable",
+    citation_recall: composition?.citation_recall ?? null,
+    answer_surface_recall: composition?.answer_surface_recall ?? null,
+    structured_file_recall: composition?.structured_file_recall ?? null,
+  };
+}
+
+function buildQualityDebugPayload(results, meta = {}) {
+  const rows = results.map((row) => {
+    const quality = row.quality ?? null;
+    const failureReasons = qualityFailureReasons(quality);
+    return {
+      repo: row.repo,
+      task_id: row.task_id,
+      mode: row.mode,
+      repeat: row.repeat ?? null,
+      status: row.status,
+      warm_stdio_packet_cache_hit: row.warm_stdio_packet_cache_hit ?? null,
+      quality_pass: quality?.pass ?? null,
+      failure_reasons: failureReasons,
+      quality_metrics: quality
+        ? {
+            expected_file_recall: quality.expected_files?.recall ?? null,
+            expected_symbol_recall: quality.expected_symbols?.recall ?? null,
+            expected_claim_recall: quality.expected_claims?.recall ?? null,
+            citation_coverage: quality.citation_coverage?.recall ?? null,
+            expected_anchor_recall: quality.expected_anchors?.recall ?? null,
+            forbidden_claims_found: quality.forbidden_claims?.found ?? null,
+          }
+        : null,
+      missed_anchors: quality?.missed_anchors ?? null,
+      retrieval: extractRetrievalDiagnostics(row),
+      sufficiency_status: row.sufficiency?.status ?? null,
+      sufficient_quality_mismatch: row.sufficiency?.sufficient_quality_mismatch ?? null,
+    };
+  });
+  const failing = rows.filter((row) => row.quality_pass === false);
+  const reasonCounts = {};
+  for (const row of failing) {
+    for (const reason of row.failure_reasons) {
+      reasonCounts[reason] = (reasonCounts[reason] ?? 0) + 1;
+    }
+  }
+  return {
+    generated_at: new Date().toISOString(),
+    scope: "packet_runtime_quality_debug",
+    ...meta,
+    rows,
+    summary: {
+      runs: rows.length,
+      quality_scored_runs: rows.filter((row) => row.quality_pass != null).length,
+      quality_pass_runs: rows.filter((row) => row.quality_pass === true).length,
+      quality_fail_runs: failing.length,
+      failure_reason_counts: reasonCounts,
+    },
+  };
+}
+
 function packetRuntimePublishableBlockers(results, opts = {}) {
   const enforceRepoProvenance = Boolean(opts.publishable || opts.enforceRepoProvenance);
+  const enforcePacketRuntimeTelemetry = Boolean(opts.publishable || opts.enforcePacketRuntimeTelemetry);
   return results
     .map((row) => {
       const reasons = [];
@@ -2385,6 +3322,27 @@ function packetRuntimePublishableBlockers(results, opts = {}) {
       }
       if (row.sufficiency?.sufficient_quality_mismatch) {
         reasons.push("packet sufficiency says sufficient but manifest quality failed");
+      }
+      if (enforcePacketRuntimeTelemetry) {
+        if (!row.sufficiency) {
+          reasons.push("missing packet sufficiency telemetry");
+        } else if (row.sufficiency.status !== "sufficient") {
+          reasons.push(`packet sufficiency status=${row.sufficiency.status ?? "unknown"}; expected sufficient`);
+        }
+        const latency = row.packet_latency;
+        if (!latency) {
+          reasons.push("missing packet latency telemetry");
+        } else {
+          if (latency.sla_missed !== false) {
+            reasons.push(`packet retrieval SLA missed=${latency.sla_missed ?? "unknown"}; expected false`);
+          }
+          const shadow = latency.retrieval_shadow;
+          if (!shadow) {
+            reasons.push("missing retrieval shadow telemetry");
+          } else if (shadow.retrieval_mode !== "full") {
+            reasons.push(`packet retrieval shadow mode=${shadow.retrieval_mode ?? "unknown"}; expected full`);
+          }
+        }
       }
       if (enforceRepoProvenance) {
         reasons.push(...repoProvenanceBlockers(row));
@@ -2406,13 +3364,118 @@ function groupTasksByRepo(tasks) {
   return byRepo;
 }
 
+function packetCompositionPayload(results) {
+  return {
+    generated_at: new Date().toISOString(),
+    scope: "packet_runtime_composition",
+    rows: results
+      .filter((row) => row.packet_composition)
+      .map((row) => ({
+        repo: row.repo,
+        task_id: row.task_id,
+        mode: row.mode,
+        repeat: row.repeat,
+        status: row.status,
+        sufficiency_status: row.sufficiency?.status ?? null,
+        composition_summary: {
+          expected_file_count: row.packet_composition.expected_file_count,
+          cited_file_count: row.packet_composition.cited_file_count,
+          avoid_opening_file_count: row.packet_composition.avoid_opening_file_count,
+          answer_text_file_count: row.packet_composition.answer_text_file_count,
+          answer_surface_file_count: row.packet_composition.answer_surface_file_count,
+          structured_file_count: row.packet_composition.structured_file_count,
+          absent_file_count: row.packet_composition.absent_file_count,
+          citation_recall: row.packet_composition.citation_recall,
+          answer_surface_recall: row.packet_composition.answer_surface_recall,
+          structured_file_recall: row.packet_composition.structured_file_recall,
+          boundary_counts: row.packet_composition.boundary_counts,
+          expected_verification_file_count: row.packet_composition.expected_verification_file_count,
+          verification_summary: row.packet_composition.verification_summary,
+        },
+        expected_files: row.packet_composition.files,
+        expected_verification_files: row.packet_composition.verification_files,
+      })),
+  };
+}
+
+function packetCompositionMarkdown(payload) {
+  const lines = [
+    "# Packet Runtime Composition",
+    "",
+    "| Repo | Task | Mode | Repeat | Status | Sufficiency | Citation recall | Answer-surface recall | Structured recall | Boundary counts |",
+    "| --- | --- | --- | ---: | --- | --- | ---: | ---: | ---: | --- |",
+  ];
+  for (const row of payload.rows) {
+    const summary = row.composition_summary ?? {};
+    const boundaryCounts = Object.entries(summary.boundary_counts ?? {})
+      .map(([boundary, count]) => `${boundary}:${count}`)
+      .join(", ");
+    lines.push(
+      `| ${row.repo} | ${row.task_id} | ${row.mode} | ${row.repeat} | ${row.status} | ${row.sufficiency_status ?? ""} | ${formatPercent(summary.citation_recall)} | ${formatPercent(summary.answer_surface_recall)} | ${formatPercent(summary.structured_file_recall)} | ${boundaryCounts} |`,
+    );
+  }
+  for (const row of payload.rows) {
+    lines.push("");
+    lines.push(`## ${row.repo} / ${row.task_id} / ${row.mode} / repeat ${row.repeat}`);
+    lines.push("");
+    lines.push("| Expected file | Boundary | Surfaces |");
+    lines.push("| --- | --- | --- |");
+    for (const file of row.expected_files ?? []) {
+      const surfaces = (file.surfaces ?? [])
+        .map((surface) =>
+          [
+            surface.source,
+            surface.rank == null ? null : `rank=${surface.rank}`,
+            surface.line == null ? null : `line=${surface.line}`,
+          ]
+            .filter(Boolean)
+            .join(" "),
+        )
+        .join("<br>");
+      lines.push(`| ${file.expected_file} | ${file.packet_boundary} | ${surfaces || ""} |`);
+    }
+    if ((row.expected_verification_files ?? []).length) {
+      lines.push("");
+      lines.push("| Expected verification file | Boundary | Surfaces |");
+      lines.push("| --- | --- | --- |");
+      for (const file of row.expected_verification_files ?? []) {
+        const surfaces = (file.surfaces ?? [])
+          .map((surface) =>
+            [
+              surface.source,
+              surface.rank == null ? null : `rank=${surface.rank}`,
+              surface.line == null ? null : `line=${surface.line}`,
+            ]
+              .filter(Boolean)
+              .join(" "),
+          )
+          .join("<br>");
+        lines.push(`| ${file.expected_file} | ${file.packet_boundary} | ${surfaces || ""} |`);
+      }
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
 async function runPacketRuntimeBenchmark(opts, tasks) {
   if (!tasks.length) {
     throw new Error("--packet-runtime requires --task-suite or --task-manifest");
   }
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const outDir = path.resolve(opts.outDir ?? path.join(repoRoot, "target", "agent-benchmark", `packet-runtime-${timestamp}`));
+  const benchmarkId = opts.benchmarkRunId ?? path.basename(outDir);
   await mkdir(outDir, { recursive: true });
+  const cachePreparation = opts.prepareCodestoryCache
+    ? await prepareCodeStoryCaches(opts, tasks)
+    : [];
+  opts.cachePreparationByRepo = new Map(cachePreparation.map((row) => [row.repo, row]));
+  if (cachePreparation.length) {
+    await writeFile(
+      path.join(outDir, "codestory-cache-preparation.json"),
+      `${JSON.stringify(cachePreparation, null, 2)}\n`,
+      "utf8",
+    );
+  }
   const modes =
     opts.packetRuntimeMode === "both"
       ? ["cold-cli", "warm-stdio"]
@@ -2436,14 +3499,56 @@ async function runPacketRuntimeBenchmark(opts, tasks) {
   const summary = summarizePacketRuntimeRuns(results);
   const payload = {
     generated_at: new Date().toISOString(),
+    benchmark_run_id: benchmarkId,
     codestory_cli: resolveCodeStoryCli(opts),
     modes,
     repeats: opts.repeats,
     output_dir: outDir,
+    retrieval_env: retrievalEnv(),
+    retrieval_contract: retrievalContractSummary(benchmarkChildEnv(process.env)),
     summary,
   };
-  await writeFile(path.join(outDir, "packet-runtime-summary.json"), `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  const packetRuntimeSummaryPath = path.join(outDir, "packet-runtime-summary.json");
+  await writeFile(packetRuntimeSummaryPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
   await writeFile(path.join(outDir, "packet-runtime-summary.md"), packetRuntimeMarkdown(summary), "utf8");
+  const baselinePacketSummaryPath = discoverPreviousPacketSummary(packetRuntimeSummaryPath, repoRoot);
+  const baselinePacketSummary = baselinePacketSummaryPath
+    ? JSON.parse(await readFile(baselinePacketSummaryPath, "utf8"))
+    : null;
+  const packetQualityDeltas = buildPacketQualityDeltas(
+    summary,
+    Array.isArray(baselinePacketSummary?.summary) ? baselinePacketSummary.summary : [],
+    {
+      currentPath: packetRuntimeSummaryPath,
+      baselinePath: baselinePacketSummaryPath,
+    },
+  );
+  const packetQualityDeltasPath = path.join(outDir, "packet-quality-deltas.json");
+  await writeFile(packetQualityDeltasPath, `${JSON.stringify(packetQualityDeltas, null, 2)}\n`, "utf8");
+  console.log(`ARTIFACT packet_quality_deltas=${packetQualityDeltasPath}`);
+  const qualityDebug = buildQualityDebugPayload(results, {
+    output_dir: outDir,
+    benchmark_run_id: benchmarkId,
+    codestory_cli: resolveCodeStoryCli(opts),
+    modes,
+    repeats: opts.repeats,
+  });
+  const qualityDebugPath = path.join(outDir, "quality-debug.json");
+  await writeFile(qualityDebugPath, `${JSON.stringify(qualityDebug, null, 2)}\n`, "utf8");
+  console.log(`ARTIFACT quality_debug=${qualityDebugPath}`);
+  const compositionPayload = packetCompositionPayload(results);
+  if (compositionPayload.rows.length) {
+    await writeFile(
+      path.join(outDir, "packet-composition.json"),
+      `${JSON.stringify(compositionPayload, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(outDir, "packet-composition.md"),
+      packetCompositionMarkdown(compositionPayload),
+      "utf8",
+    );
+  }
 
   const blockers = packetRuntimePublishableBlockers(results, opts);
   if (opts.publishable && blockers.length) {
@@ -2534,10 +3639,35 @@ function summarizeRuns(results) {
       median_citation_coverage: median(
         qualityRows.map((row) => row.quality?.citation_coverage?.recall),
       ),
+      median_repository_context_output_chars: median(
+        successful.map((row) => repositoryContextOutputChars(row.transcript_analysis)),
+      ),
+      median_useful_anchor_hits_per_10k_context_chars: median(
+        qualityRows.map((row) => usefulAnchorHitsPer10kContextChars(row)),
+      ),
       median_command_categories: categoryMedians,
     });
   }
   return summaries;
+}
+
+function repositoryContextOutputChars(analysis) {
+  const byCategory = analysis?.output_chars_by_category ?? {};
+  return (
+    (byCategory.codestory_cli ?? 0) +
+    (byCategory.shell_search ?? 0) +
+    (byCategory.direct_file_read ?? 0) +
+    (byCategory.git ?? 0)
+  );
+}
+
+function usefulAnchorHitsPer10kContextChars(row) {
+  const hits = row.quality?.expected_anchors?.found;
+  if (hits == null) {
+    return null;
+  }
+  const contextChars = repositoryContextOutputChars(row.transcript_analysis);
+  return hits / Math.max(1, contextChars / 10_000);
 }
 
 function agentPublishableBlockers(results, opts = {}) {
@@ -2589,8 +3719,8 @@ function markdownSummary(summary, opts) {
     `Sandbox: \`${opts.sandbox}\``,
     `Host: \`${os.hostname()}\``,
     "",
-    "| Repo | Task | Arm | Runs | Success | Packet first | Quality pass | Median wall ms | Median tokens | Median cost USD | Median tool calls | Source reads | After CodeStory | After Packet | File recall | Citation coverage |",
-    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Repo | Task | Arm | Runs | Success | Packet first | Quality pass | Median wall ms | Median tokens | Median cost USD | Median tool calls | Source reads | After CodeStory | After Packet | File recall | Citation coverage | Context chars | Useful anchors / 10k context chars |",
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const row of summary) {
     lines.push(markdownSummaryRow(row));
@@ -2622,6 +3752,8 @@ function markdownSummaryRow(row) {
     formatValue(row.median_source_reads_after_packet),
     formatPercent(row.median_expected_file_recall),
     formatPercent(row.median_citation_coverage),
+    formatValue(row.median_repository_context_output_chars),
+    formatValue(row.median_useful_anchor_hits_per_10k_context_chars),
   ];
   return `| ${cells.join(" | ")} |`;
 }
@@ -2771,6 +3903,24 @@ function runSelfTest() {
     }),
     [null, false, true, "fail"],
   );
+  assert.equal(
+    cachePreparationAction({
+      status: "pass",
+      indexed: true,
+      freshness_status: "stale",
+      semantic_ready: false,
+    }),
+    "retrieval-index-auto",
+  );
+  assert.equal(
+    cachePreparationAction({
+      status: "pass",
+      indexed: true,
+      freshness_status: "fresh",
+      semantic_ready: true,
+    }),
+    "already-ready",
+  );
 
   console.log("self-test passed");
 }
@@ -2845,11 +3995,22 @@ async function main() {
     }
   }
 
+  const plannedRuns = planAgentRuns(opts, tasks);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const outDir = path.resolve(opts.outDir ?? path.join(repoRoot, "target", "agent-benchmark", timestamp));
   await mkdir(outDir, { recursive: true });
+  const cachePreparation = opts.prepareCodestoryCache
+    ? await prepareCodeStoryCaches(opts, tasks)
+    : [];
+  opts.cachePreparationByRepo = new Map(cachePreparation.map((row) => [row.repo, row]));
+  if (cachePreparation.length) {
+    await writeFile(
+      path.join(outDir, "codestory-cache-preparation.json"),
+      `${JSON.stringify(cachePreparation, null, 2)}\n`,
+      "utf8",
+    );
+  }
 
-  const plannedRuns = planAgentRuns(opts, tasks);
   const results = [];
   for (const run of plannedRuns) {
     console.log(`running ${run.repo} ${run.arm} repeat ${run.repeat}/${opts.repeats}`);
@@ -2868,6 +4029,8 @@ async function main() {
     task_suite: opts.taskSuite,
     task_ids: opts.taskIds,
     task_manifest: opts.taskManifest,
+    prepare_codestory_cache: opts.prepareCodestoryCache,
+    cache_preparation: cachePreparation,
     tasks: tasks.map((task) => ({
       id: task.id,
       repo: task.repo,
@@ -2881,6 +4044,8 @@ async function main() {
     timeout_ms: opts.timeoutMs,
     sandbox: opts.sandbox,
     output_dir: outDir,
+    retrieval_env: retrievalEnv(),
+    retrieval_contract: retrievalContractSummary(benchmarkChildEnv(process.env)),
     summary,
   };
   await writeFile(path.join(outDir, "summary.json"), `${JSON.stringify(summaryPayload, null, 2)}\n`, "utf8");
@@ -2918,18 +4083,29 @@ export {
   agentPublishableBlockers,
   assertSafeWindowsCmdArgs,
   benchmarkRunId,
+  buildPacketQualityDeltas,
+  buildQualityDebugPayload,
+  qualityFailureReasons,
   commandCategory,
   extractCommandExecutions,
   isPathInside,
   loadTaskForResult,
   loadTasks,
+  materializeRepos,
+  parseArgs,
   parseJsonLines,
+  packetComposition,
+  packetLatencyTelemetry,
+  packetRuntimePublishableBlockers,
+  PACKET_COMPOSITION_WEIGHTS,
+  packetCompositionFileScore,
   packetFirstCommandForPrompt,
   publicCoreCorpusAudit,
   repoProvenanceBlockers,
   repoConfigFromManifest,
   resolveCodeStoryCli,
   scoreQuality,
+  summarizePacketRuntimeRuns,
   taskSnapshotForResult,
 };
 

--- a/scripts/codestory-agent-value-score.mjs
+++ b/scripts/codestory-agent-value-score.mjs
@@ -1,0 +1,997 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_OUTPUT_DIR = path.join("target", "agent-value-score");
+
+const PACKET_QUALITY_WEIGHTS = {
+  expected_file_recall: 0.3,
+  expected_claim_recall: 0.3,
+  citation_coverage: 0.25,
+  follow_up: 0.15,
+};
+
+const PACKET_QUALITY_DELTA_FIELDS = [
+  "median_expected_file_recall",
+  "median_expected_claim_recall",
+  "median_citation_coverage",
+  "median_packet_citation_recall",
+  "median_follow_up_commands_count",
+  "quality_pass_runs",
+];
+
+function parseArgs(argv) {
+  const opts = {
+    cwd: process.cwd(),
+    promptSummaries: [],
+    symbolSummary: null,
+    packetSummary: null,
+    abDoc: "autoresearch.md",
+    includeAbDoc: true,
+    explicitPromptSummaries: false,
+    explicitSymbolSummary: false,
+    explicitPacketSummary: false,
+    outputDir: DEFAULT_OUTPUT_DIR,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--cwd") {
+      opts.cwd = requireValue(argv, ++index, arg);
+    } else if (arg === "--prompt-summary") {
+      opts.promptSummaries.push(requireValue(argv, ++index, arg));
+      opts.explicitPromptSummaries = true;
+    } else if (arg === "--symbol-summary") {
+      opts.symbolSummary = requireValue(argv, ++index, arg);
+      opts.explicitSymbolSummary = true;
+    } else if (arg === "--packet-summary") {
+      opts.packetSummary = requireValue(argv, ++index, arg);
+      opts.explicitPacketSummary = true;
+    } else if (arg === "--ab-doc") {
+      opts.abDoc = requireValue(argv, ++index, arg);
+      opts.includeAbDoc = true;
+    } else if (arg === "--no-ab-doc") {
+      opts.abDoc = null;
+      opts.includeAbDoc = false;
+    } else if (arg === "--output-dir") {
+      opts.outputDir = requireValue(argv, ++index, arg);
+    } else if (arg === "--from-existing") {
+      throw new Error("--from-existing is unsupported; provide fresh coherent mandatory-sidecar artifact paths");
+    } else if (arg === "--allow-mixed-run-inputs") {
+      throw new Error("--allow-mixed-run-inputs is unsupported; mandatory-sidecar scoring requires one coherent artifact run");
+    } else if (arg === "--help" || arg === "-h") {
+      opts.help = true;
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+
+  opts.cwd = path.resolve(opts.cwd);
+  opts.outputDir = path.resolve(opts.cwd, opts.outputDir);
+  opts.promptSummaries = opts.promptSummaries.map((entry) => resolveUnder(opts.cwd, entry));
+  opts.symbolSummary = opts.symbolSummary ? resolveUnder(opts.cwd, opts.symbolSummary) : null;
+  opts.packetSummary = opts.packetSummary ? resolveUnder(opts.cwd, opts.packetSummary) : null;
+  opts.abDoc = opts.abDoc && opts.includeAbDoc ? resolveUnder(opts.cwd, opts.abDoc) : null;
+  return opts;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function resolveUnder(cwd, entry) {
+  return path.isAbsolute(entry) ? entry : path.resolve(cwd, entry);
+}
+
+function discoverInputs(opts) {
+  const retrievalRoot = path.join(opts.cwd, "target", "retrieval-golden");
+  const packetRoot = path.join(opts.cwd, "target", "agent-benchmark");
+  const hasExplicitInput =
+    opts.explicitPromptSummaries || opts.explicitSymbolSummary || opts.explicitPacketSummary;
+  const sixLanePromptSummaries = [
+    newestSummary(retrievalRoot, /rootandruntime.*six-lane-bundle/u),
+    newestSummary(retrievalRoot, /prompt-guard.*six-lane-bundle/u),
+  ].filter(Boolean);
+  const defaultPromptSummaries = sixLanePromptSummaries;
+  const sixLaneSymbol = newestSummary(retrievalRoot, /symbol-slice.*six-lane-bundle/u);
+  return {
+    promptSummaries:
+      hasExplicitInput
+        ? opts.promptSummaries
+        : defaultPromptSummaries,
+    symbolSummary: hasExplicitInput ? opts.symbolSummary : sixLaneSymbol,
+    packetSummary:
+      hasExplicitInput
+        ? opts.packetSummary
+        : newestNestedFile(
+            packetRoot,
+            /packet-runtime-local-real.*six-lane/u,
+            "packet-runtime-summary.json",
+          ),
+    abDoc: opts.abDoc && opts.includeAbDoc && fs.existsSync(opts.abDoc) ? opts.abDoc : null,
+  };
+}
+
+function newestSummary(root, dirPattern) {
+  if (!fs.existsSync(root)) {
+    return null;
+  }
+  const candidates = fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && dirPattern.test(entry.name))
+    .map((entry) => path.join(root, entry.name, "summary.json"))
+    .filter((entryPath) => fs.existsSync(entryPath))
+    .map((entryPath) => ({ path: entryPath, mtimeMs: fs.statSync(entryPath).mtimeMs }))
+    .sort((left, right) => right.mtimeMs - left.mtimeMs || left.path.localeCompare(right.path));
+  return candidates[0]?.path ?? null;
+}
+
+function newestNestedFile(root, dirPattern, fileName) {
+  if (!fs.existsSync(root)) {
+    return null;
+  }
+  const candidates = fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && dirPattern.test(entry.name))
+    .map((entry) => path.join(root, entry.name, fileName))
+    .filter((entryPath) => fs.existsSync(entryPath))
+    .map((entryPath) => ({ path: entryPath, mtimeMs: fs.statSync(entryPath).mtimeMs }))
+    .sort((left, right) => right.mtimeMs - left.mtimeMs || left.path.localeCompare(right.path));
+  return candidates[0]?.path ?? null;
+}
+
+function computeAgentValueScore(inputPaths, opts = {}) {
+  const runCoherency = assertRunCoherency(inputPaths);
+  const promptSummaryEntries = inputPaths.promptSummaries.map((entryPath) => ({
+    path: entryPath,
+    summary: readJson(entryPath),
+  }));
+  const promptSummaries = promptSummaryEntries.map((entry) => entry.summary);
+  const symbolSummary = inputPaths.symbolSummary ? readJson(inputPaths.symbolSummary) : null;
+  const packetSummary = inputPaths.packetSummary ? readJson(inputPaths.packetSummary) : null;
+  const abRatios = inputPaths.abDoc ? parseAgentAbRatios(fs.readFileSync(inputPaths.abDoc, "utf8")) : [];
+  const sidecarDiagnostics = aggregateSidecarDiagnostics([
+    ...promptSummaryEntries.map((entry) => ({ path: entry.path, summary: entry.summary })),
+    ...(inputPaths.symbolSummary && symbolSummary
+      ? [{ path: inputPaths.symbolSummary, summary: symbolSummary }]
+      : []),
+  ]);
+
+  const promptRecalls = promptSummaries
+    .map((summary) => finiteNumber(summary.summary?.prompt_file_recall))
+    .filter(Number.isFinite);
+  const promptScore = mean(promptRecalls);
+
+  const symbolScore = finiteNumber(symbolSummary?.summary?.symbol_path_hit_at_k);
+  const packetRows = Array.isArray(packetSummary?.summary) ? packetSummary.summary : [];
+  const packetSufficiencyRate = packetRows.length
+    ? packetRows.filter((row) => rowEffectiveSufficiency(row)).length / packetRows.length
+    : NaN;
+  const packetFileRecall = mean(
+    packetRows.map((row) => finiteNumber(row.median_expected_file_recall)).filter(Number.isFinite),
+  );
+  const packetClaimRecall = mean(
+    packetRows.map((row) => finiteNumber(row.median_expected_claim_recall)).filter(Number.isFinite),
+  );
+  const packetCitationCoverage = mean(
+    packetRows.map((row) => finiteNumber(row.median_citation_coverage)).filter(Number.isFinite),
+  );
+  const packetFollowUpMean = mean(
+    packetRows.map((row) => finiteNumber(row.median_follow_up_commands_count)).filter(Number.isFinite),
+  );
+  const packetFollowUpScore = followUpBurdenScore(packetFollowUpMean);
+  const packetScore = aggregatePacketQualityScore(packetRows);
+  const baselinePacketSummaryPath = inputPaths.packetSummary
+    ? discoverPreviousPacketSummary(inputPaths.packetSummary, opts.cwd ?? process.cwd())
+    : null;
+  const baselinePacketSummary = baselinePacketSummaryPath ? readJson(baselinePacketSummaryPath) : null;
+  const baselinePacketRows = Array.isArray(baselinePacketSummary?.summary)
+    ? baselinePacketSummary.summary
+    : [];
+  const packetQualityDeltas = packetRows.length
+    ? buildPacketQualityDeltas(packetRows, baselinePacketRows, {
+        currentPath: inputPaths.packetSummary,
+        baselinePath: baselinePacketSummaryPath,
+      })
+    : null;
+
+  const packetWallValues = packetRows
+    .map((row) => finiteNumber(row.median_wall_ms))
+    .filter(Number.isFinite)
+    .sort((left, right) => left - right);
+  const packetP95WallMs = percentile(packetWallValues, 0.95);
+  const latencyScore = Number.isFinite(packetP95WallMs)
+    ? 1 / (1 + packetP95WallMs / 20_000)
+    : NaN;
+
+  const abOverheadRatioMean = mean(abRatios);
+  const abSavingsScore = Number.isFinite(abOverheadRatioMean)
+    ? 1 - clamp01(abOverheadRatioMean)
+    : NaN;
+
+  const agentValueScore = weightedMean([
+    [promptScore, 0.3],
+    [symbolScore, 0.15],
+    [packetScore, 0.25],
+    [latencyScore, 0.2],
+    [abSavingsScore, 0.1],
+  ]);
+  const agentValueGap = 1 - agentValueScore;
+  const triage = buildTriage([
+    { component: "prompt_file_recall", score: promptScore, weight: 0.3 },
+    { component: "exact_symbol_path_hit", score: symbolScore, weight: 0.15 },
+    { component: "packet_quality", score: packetScore, weight: 0.25 },
+    { component: "packet_latency", score: latencyScore, weight: 0.2 },
+    { component: "recorded_live_ab_savings", score: abSavingsScore, weight: 0.1 },
+  ]);
+  const contributors = buildContributors({
+    inputPaths,
+    cwd: opts.cwd ?? process.cwd(),
+    promptSummaryEntries,
+    promptRecalls,
+    symbolScore,
+    packetRows,
+    packetScore,
+    latencyScore,
+    abRatios,
+    abSavingsScore,
+  });
+
+  return {
+    generated_at: new Date().toISOString(),
+    metric:
+      "agent_value_gap = 1 - weighted agent_value_score; combines prompt recall, exact-symbol hit rate, packet claim/file/citation/follow-up rubric, packet latency, and recorded live A/B overhead savings",
+    score_weights: {
+      prompt_file_recall: 0.3,
+      exact_symbol_path_hit: 0.15,
+      packet_quality: 0.25,
+      packet_latency: 0.2,
+      recorded_live_ab_savings: 0.1,
+      packet_quality_rubric: PACKET_QUALITY_WEIGHTS,
+    },
+    run_coherency: runCoherency,
+    inputs: relativizeInputs(inputPaths, opts.cwd ?? process.cwd()),
+    metrics: {
+      agent_value_score: round(agentValueScore, 9),
+      agent_value_gap: round(agentValueGap, 9),
+      prompt_file_recall_mean: round(promptScore, 9),
+      prompt_summary_count: promptRecalls.length,
+      exact_symbol_path_hit_at_k: round(symbolScore, 9),
+      packet_score: round(packetScore, 9),
+      packet_sufficiency_rate: round(packetSufficiencyRate, 9),
+      packet_expected_file_recall_mean: round(packetFileRecall, 9),
+      packet_expected_claim_recall_mean: round(packetClaimRecall, 9),
+      packet_citation_coverage_mean: round(packetCitationCoverage, 9),
+      packet_follow_up_mean: round(packetFollowUpMean, 9),
+      packet_follow_up_score: round(packetFollowUpScore, 9),
+      packet_p95_wall_ms: round(packetP95WallMs, 3),
+      packet_latency_score: round(latencyScore, 9),
+      live_ab_overhead_ratio_mean: round(abOverheadRatioMean, 9),
+      live_ab_savings_score: round(abSavingsScore, 9),
+      live_ab_ratio_count: abRatios.length,
+      sidecar_expected_files_present_missing_from_search_count:
+        sidecarDiagnostics.expected_files_present_missing_from_search_count,
+      sidecar_expected_symbols_present_missing_from_search_count:
+        sidecarDiagnostics.expected_symbols_present_missing_from_search_count,
+      sidecar_query_trace_with_candidates_count:
+        sidecarDiagnostics.query_trace_with_candidates_count,
+      sidecar_query_trace_no_candidates_count:
+        sidecarDiagnostics.query_trace_no_candidates_count,
+      sidecar_prepare_count: sidecarDiagnostics.sidecar_prepare_count,
+      sidecar_prepare_failed_count: sidecarDiagnostics.sidecar_prepare_failed_count,
+      sidecar_prepare_max_latency_ms: sidecarDiagnostics.sidecar_prepare_max_latency_ms,
+      sidecar_candidate_count: sidecarDiagnostics.candidate_count,
+      sidecar_resolved_hit_count: sidecarDiagnostics.resolved_hit_count,
+      sidecar_unresolved_candidate_count:
+        sidecarDiagnostics.unresolved_candidate_count,
+      sidecar_candidate_resolution_rate:
+        sidecarDiagnostics.candidate_count > 0
+          ? round(sidecarDiagnostics.resolved_hit_count / sidecarDiagnostics.candidate_count, 9)
+          : null,
+    },
+    packet_quality_deltas: packetQualityDeltas,
+    triage,
+    contributors: {
+      ...contributors,
+      sidecar_diagnostics: sidecarDiagnostics,
+    },
+  };
+}
+
+function aggregateSidecarDiagnostics(summaryEntries) {
+  const seen = new Set();
+  const aggregate = {
+    summary_count: 0,
+    expected_files_present_missing_from_search_count: 0,
+    expected_symbols_present_missing_from_search_count: 0,
+    query_trace_with_candidates_count: 0,
+    query_trace_no_candidates_count: 0,
+    sidecar_prepare_count: 0,
+    sidecar_prepare_failed_count: 0,
+    sidecar_prepare_max_latency_ms: 0,
+    candidate_count: 0,
+    resolved_hit_count: 0,
+    unresolved_candidate_count: 0,
+    resolution_counts: [],
+  };
+  const resolutionCounts = new Map();
+  for (const entry of summaryEntries) {
+    if (!entry?.path || seen.has(entry.path)) {
+      continue;
+    }
+    seen.add(entry.path);
+    const payload = entry.summary;
+    const summary = payload?.summary ?? {};
+    aggregate.summary_count += 1;
+    aggregate.expected_files_present_missing_from_search_count += numericCount(
+      summary.sidecar_expected_files_present_missing_from_search_count,
+    );
+    aggregate.expected_symbols_present_missing_from_search_count += numericCount(
+      summary.sidecar_expected_symbols_present_missing_from_search_count,
+    );
+    aggregate.query_trace_with_candidates_count += numericCount(
+      summary.sidecar_query_trace_with_candidates_count,
+    );
+    aggregate.query_trace_no_candidates_count += numericCount(
+      summary.sidecar_query_trace_no_candidates_count,
+    );
+    aggregate.sidecar_prepare_count += numericCount(summary.sidecar_prepare_count);
+    aggregate.sidecar_prepare_failed_count += numericCount(summary.sidecar_prepare_failed_count);
+    aggregate.sidecar_prepare_max_latency_ms = Math.max(
+      aggregate.sidecar_prepare_max_latency_ms,
+      finiteNumber(summary.sidecar_prepare_max_latency_ms) || 0,
+    );
+
+    const summaryHasShadowCounts =
+      Number.isFinite(Number(summary.sidecar_shadow_candidate_count)) ||
+      Number.isFinite(Number(summary.sidecar_shadow_resolved_hit_count)) ||
+      Number.isFinite(Number(summary.sidecar_shadow_unresolved_candidate_count));
+    if (summaryHasShadowCounts) {
+      aggregate.candidate_count += numericCount(summary.sidecar_shadow_candidate_count);
+      aggregate.resolved_hit_count += numericCount(summary.sidecar_shadow_resolved_hit_count);
+      aggregate.unresolved_candidate_count += numericCount(
+        summary.sidecar_shadow_unresolved_candidate_count,
+      );
+      mergeResolutionCounts(resolutionCounts, summary.sidecar_shadow_resolution_counts);
+    } else {
+      aggregateShadowRows(aggregate, resolutionCounts, payload?.rows ?? []);
+    }
+  }
+  aggregate.resolution_counts = [...resolutionCounts.entries()]
+    .map(([resolution, count]) => ({ resolution, count }))
+    .sort((left, right) => left.resolution.localeCompare(right.resolution));
+  return aggregate;
+}
+
+function aggregateShadowRows(aggregate, resolutionCounts, rows) {
+  if (!Array.isArray(rows)) {
+    return;
+  }
+  for (const row of rows) {
+    const shadow = row?.retrieval_shadow;
+    if (!shadow || typeof shadow !== "object") {
+      continue;
+    }
+    aggregate.candidate_count += numericCount(shadow.candidate_count);
+    aggregate.resolved_hit_count += numericCount(shadow.resolved_hit_count);
+    aggregate.unresolved_candidate_count += numericCount(shadow.unresolved_candidate_count);
+    if (Array.isArray(shadow.candidate_resolution_counts)) {
+      mergeResolutionCounts(resolutionCounts, shadow.candidate_resolution_counts);
+    } else {
+      for (const candidate of shadow.candidates ?? []) {
+        const resolution = String(candidate?.resolution ?? "").trim();
+        if (resolution) {
+          resolutionCounts.set(resolution, (resolutionCounts.get(resolution) ?? 0) + 1);
+        }
+      }
+    }
+  }
+}
+
+function mergeResolutionCounts(counts, entries) {
+  if (!Array.isArray(entries)) {
+    return;
+  }
+  for (const entry of entries) {
+    const resolution = String(entry?.resolution ?? "").trim();
+    const count = numericCount(entry?.count);
+    if (resolution && count > 0) {
+      counts.set(resolution, (counts.get(resolution) ?? 0) + count);
+    }
+  }
+}
+
+function numericCount(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+function buildTriage(components) {
+  const componentGaps = componentGapRows(components);
+  const largest = componentGaps[0] ?? null;
+  return {
+    largest_gap_component: largest?.component ?? null,
+    recommended_next_lane: largest ? laneForComponent(largest.component) : null,
+    component_gaps: componentGaps,
+  };
+}
+
+function componentGapRows(components) {
+  const finite = components.filter((entry) => Number.isFinite(entry.score) && entry.weight > 0);
+  const weightTotal = finite.reduce((sum, entry) => sum + entry.weight, 0);
+  return finite
+    .map((entry) => {
+      const gap = 1 - clamp01(entry.score);
+      const effectiveWeight = entry.weight / weightTotal;
+      return {
+        component: entry.component,
+        score: round(entry.score, 9),
+        gap: round(gap, 9),
+        effective_weight: round(effectiveWeight, 9),
+        weighted_gap: round(gap * effectiveWeight, 9),
+        recommended_next_lane: laneForComponent(entry.component),
+      };
+    })
+    .sort((left, right) => {
+      const weightedGapDelta = Number(right.weighted_gap) - Number(left.weighted_gap);
+      return weightedGapDelta || left.component.localeCompare(right.component);
+    });
+}
+
+function laneForComponent(component) {
+  return (
+    {
+      prompt_file_recall: "prompt-recall",
+      exact_symbol_path_hit: "symbol-search",
+      packet_quality: "packet-quality",
+      packet_latency: "packet-latency",
+      recorded_live_ab_savings: "live-ab-overhead",
+    }[component] ?? null
+  );
+}
+
+function buildContributors({
+  inputPaths,
+  cwd,
+  promptSummaryEntries,
+  promptRecalls,
+  symbolScore,
+  packetRows,
+  packetScore,
+  latencyScore,
+  abRatios,
+  abSavingsScore,
+}) {
+  const relative = (entry) => (entry ? path.relative(cwd, entry).replaceAll(path.sep, "/") : null);
+  const inputs = [
+    ...promptSummaryEntries.map((entry) => {
+      const score = finiteNumber(entry.summary?.summary?.prompt_file_recall);
+      return contributorInputRow({
+        kind: "prompt_summary",
+        path: relative(entry.path),
+        component: "prompt_file_recall",
+        score,
+      });
+    }),
+    contributorInputRow({
+      kind: "symbol_summary",
+      path: relative(inputPaths.symbolSummary),
+      component: "exact_symbol_path_hit",
+      score: symbolScore,
+    }),
+    contributorInputRow({
+      kind: "packet_summary",
+      path: relative(inputPaths.packetSummary),
+      component: "packet_quality",
+      score: packetScore,
+    }),
+    contributorInputRow({
+      kind: "packet_summary",
+      path: relative(inputPaths.packetSummary),
+      component: "packet_latency",
+      score: latencyScore,
+    }),
+    contributorInputRow({
+      kind: "ab_doc",
+      path: relative(inputPaths.abDoc),
+      component: "recorded_live_ab_savings",
+      score: abSavingsScore,
+      count: abRatios.length,
+    }),
+  ].filter((entry) => entry.path && entry.score !== null);
+
+  return {
+    inputs,
+    packet_rows: packetRows.map(packetContributorRow).filter(Boolean),
+    counts: {
+      prompt_summary_rows: promptRecalls.length,
+      packet_rows: packetRows.length,
+      live_ab_ratios: abRatios.length,
+    },
+  };
+}
+
+function contributorInputRow({ kind, path: inputPath, component, score, count = null }) {
+  return {
+    kind,
+    path: inputPath,
+    component,
+    score: round(score, 9),
+    gap: round(1 - clamp01(score), 9),
+    recommended_next_lane: laneForComponent(component),
+    count,
+  };
+}
+
+function packetContributorRow(row) {
+  const packetQualityScore = packetRowQualityScore(row);
+  const packetLatencyScore = packetRowLatencyScore(row);
+  const triage = buildTriage([
+    { component: "packet_quality", score: packetQualityScore, weight: 0.25 },
+    { component: "packet_latency", score: packetLatencyScore, weight: 0.2 },
+  ]);
+  if (!triage.component_gaps.length) {
+    return null;
+  }
+  return {
+    repo: row.repo ?? null,
+    task_id: row.task_id ?? null,
+    mode: row.mode ?? null,
+    quality_pass_runs: Number.isFinite(Number(row.quality_pass_runs)) ? Number(row.quality_pass_runs) : null,
+    sufficiency_rate: round(rowSufficiencyRate(row), 9),
+    median_expected_file_recall: round(finiteNumber(row.median_expected_file_recall), 9),
+    median_expected_claim_recall: round(finiteNumber(row.median_expected_claim_recall), 9),
+    median_citation_coverage: round(finiteNumber(row.median_citation_coverage), 9),
+    packet_quality_score: round(packetQualityScore, 9),
+    packet_latency_score: round(packetLatencyScore, 9),
+    median_wall_ms: round(finiteNumber(row.median_wall_ms), 3),
+    median_retrieval_total_ms: round(finiteNumber(row.median_packet_retrieval_total_ms), 3),
+    median_freshness_ms: round(finiteNumber(row.median_packet_freshness_ms), 3),
+    median_unaccounted_ms: round(finiteNumber(row.median_packet_unaccounted_ms), 3),
+    top_latency_step: row.packet_top_latency_step_kind ?? null,
+    median_top_step_ms: round(finiteNumber(row.median_packet_top_step_ms), 3),
+    sla_missed_runs: Number.isFinite(Number(row.packet_sla_missed_runs)) ? Number(row.packet_sla_missed_runs) : null,
+    largest_gap_component: triage.largest_gap_component,
+    recommended_next_lane: triage.recommended_next_lane,
+  };
+}
+
+function packetRowQualityScore(row) {
+  const base = weightedMean([
+    [finiteNumber(row.median_expected_file_recall), PACKET_QUALITY_WEIGHTS.expected_file_recall],
+    [finiteNumber(row.median_expected_claim_recall), PACKET_QUALITY_WEIGHTS.expected_claim_recall],
+    [finiteNumber(row.median_citation_coverage), PACKET_QUALITY_WEIGHTS.citation_coverage],
+    [followUpBurdenScore(row.median_follow_up_commands_count), PACKET_QUALITY_WEIGHTS.follow_up],
+  ]);
+  if (!Number.isFinite(base)) {
+    return NaN;
+  }
+  const mismatchRuns = Number(row.sufficient_quality_mismatch_runs ?? 0);
+  if (mismatchRuns > 0) {
+    return base * 0.5;
+  }
+  return base;
+}
+
+function aggregatePacketQualityScore(packetRows) {
+  return mean(packetRows.map((row) => packetRowQualityScore(row)).filter(Number.isFinite));
+}
+
+function rowSufficiencyRate(row) {
+  const counts = row.sufficiency_status_counts ?? {};
+  const sufficient = Number(counts.sufficient ?? 0);
+  const total = Object.values(counts).reduce((sum, value) => sum + Number(value), 0);
+  return total > 0 ? sufficient / total : 0;
+}
+
+function rowEffectiveSufficiency(row) {
+  if (rowSufficiencyRate(row) <= 0) {
+    return false;
+  }
+  return Number(row.sufficient_quality_mismatch_runs ?? 0) <= 0;
+}
+
+function followUpBurdenScore(followUpMean) {
+  const value = finiteNumber(followUpMean);
+  return Number.isFinite(value) ? 1 - clamp01(value / 4) : NaN;
+}
+
+function extractRunStamp(filePath) {
+  if (!filePath) {
+    return null;
+  }
+  const normalized = String(filePath).replace(/\\/g, "/");
+  const patterns = [
+    /packet-runtime-local-real-six-lane-([^/]+)/u,
+    /six-lane(?:-bundle)?-([^/]+)/u,
+    /packet-runtime-post-([0-9a-f]{7,40})/iu,
+    /(?:^|\/)packet-runtime-([^/]+)/u,
+  ];
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern);
+    if (match?.[1]) {
+      return match[1].toLowerCase();
+    }
+  }
+  return null;
+}
+
+function metadataRunStamp(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return null;
+  }
+  let payload;
+  try {
+    payload = readJson(filePath);
+  } catch {
+    return null;
+  }
+  const stamp =
+    payload?.benchmark_run_id ??
+    payload?.run_id ??
+    payload?.metadata?.benchmark_run_id ??
+    payload?.metadata?.run_id ??
+    null;
+  return normalizeRunStamp(stamp);
+}
+
+function artifactRunStamp(filePath) {
+  return metadataRunStamp(filePath) ?? extractRunStamp(filePath);
+}
+
+function normalizeRunStamp(value) {
+  const stamp = String(value ?? "").trim();
+  return stamp ? stamp.toLowerCase() : null;
+}
+
+function extractArtifactLabel(filePath) {
+  if (!filePath) {
+    return null;
+  }
+  const stamp = extractRunStamp(filePath);
+  if (stamp) {
+    return stamp;
+  }
+  return path.basename(path.dirname(filePath));
+}
+
+function assertRunCoherency(inputPaths) {
+  const entries = [
+    ...inputPaths.promptSummaries.map((entryPath) => ({ kind: "prompt_summary", path: entryPath })),
+    ...(inputPaths.symbolSummary
+      ? [{ kind: "symbol_summary", path: inputPaths.symbolSummary }]
+      : []),
+    ...(inputPaths.packetSummary ? [{ kind: "packet_summary", path: inputPaths.packetSummary }] : []),
+  ];
+  const stamped = entries.map((entry) => ({
+    ...entry,
+    stamp: artifactRunStamp(entry.path),
+  }));
+  const presentStamps = stamped.map((entry) => entry.stamp).filter(Boolean);
+  const uniqueStamps = [...new Set(presentStamps)];
+  const unstamped = stamped.filter((entry) => !entry.stamp);
+  if (uniqueStamps.length > 1) {
+    const detail = stamped
+      .filter((entry) => entry.stamp)
+      .map((entry) => `${entry.kind}=${entry.stamp}`)
+      .join(", ");
+    throw new Error(
+      `mixed run stamps in scoring inputs (${detail}); provide one coherent fresh artifact run`,
+    );
+  }
+  if (presentStamps.length > 0 && unstamped.length > 0) {
+    const detail = unstamped.map((entry) => entry.kind).join(", ");
+    throw new Error(
+      `missing run stamp on ${detail}; provide one coherent fresh artifact run`,
+    );
+  }
+  return {
+    enforced: presentStamps.length > 0,
+    run_stamp: uniqueStamps[0] ?? null,
+    input_stamps: Object.fromEntries(
+      stamped.filter((entry) => entry.stamp).map((entry) => [entry.kind, entry.stamp]),
+    ),
+  };
+}
+
+function packetTaskKey(row) {
+  return `${row.repo}\t${row.task_id}\t${row.mode}`;
+}
+
+function pickPacketQualityMetrics(row) {
+  return Object.fromEntries(
+    PACKET_QUALITY_DELTA_FIELDS.map((field) => [field, round(finiteNumber(row[field]), 9)]).filter(
+      ([, value]) => value != null,
+    ),
+  );
+}
+
+function buildPacketQualityDeltas(currentRows, baselineRows, opts = {}) {
+  const baselineByKey = new Map(baselineRows.map((row) => [packetTaskKey(row), row]));
+  const tasks = currentRows.map((row) => {
+    const baseline = baselineByKey.get(packetTaskKey(row));
+    const currentMetrics = pickPacketQualityMetrics(row);
+    currentMetrics.sufficiency_rate = round(rowSufficiencyRate(row), 9);
+    if (!baseline) {
+      return {
+        repo: row.repo ?? null,
+        task_id: row.task_id ?? null,
+        mode: row.mode ?? null,
+        baseline: null,
+        current: currentMetrics,
+        deltas: null,
+      };
+    }
+    const baselineMetrics = pickPacketQualityMetrics(baseline);
+    baselineMetrics.sufficiency_rate = round(rowSufficiencyRate(baseline), 9);
+    const deltas = {};
+    for (const field of [...PACKET_QUALITY_DELTA_FIELDS, "sufficiency_rate"]) {
+      const currentValue = finiteNumber(
+        field === "sufficiency_rate" ? rowSufficiencyRate(row) : row[field],
+      );
+      const baselineValue = finiteNumber(
+        field === "sufficiency_rate" ? rowSufficiencyRate(baseline) : baseline[field],
+      );
+      if (Number.isFinite(currentValue) && Number.isFinite(baselineValue)) {
+        deltas[field] = {
+          baseline: round(baselineValue, 9),
+          current: round(currentValue, 9),
+          delta: round(currentValue - baselineValue, 9),
+        };
+      }
+    }
+    return {
+      repo: row.repo ?? null,
+      task_id: row.task_id ?? null,
+      mode: row.mode ?? null,
+      baseline: baselineMetrics,
+      current: currentMetrics,
+      deltas,
+    };
+  });
+  return {
+    baseline_summary: opts.baselinePath ?? null,
+    baseline_label: extractArtifactLabel(opts.baselinePath),
+    current_summary: opts.currentPath ?? null,
+    current_label: extractArtifactLabel(opts.currentPath),
+    tasks,
+  };
+}
+
+function discoverPreviousPacketSummary(packetSummaryPath, cwd) {
+  const packetRoot = path.join(cwd, "target", "agent-benchmark");
+  const resolvedCurrent = path.resolve(packetSummaryPath);
+  if (!fs.existsSync(packetRoot)) {
+    return null;
+  }
+  const candidates = fs
+    .readdirSync(packetRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /packet-runtime/u.test(entry.name))
+    .map((entry) => path.join(packetRoot, entry.name, "packet-runtime-summary.json"))
+    .filter(
+      (entryPath) => fs.existsSync(entryPath) && path.resolve(entryPath) !== resolvedCurrent,
+    )
+    .map((entryPath) => ({ path: entryPath, mtimeMs: fs.statSync(entryPath).mtimeMs }))
+    .sort((left, right) => right.mtimeMs - left.mtimeMs || left.path.localeCompare(right.path));
+  return candidates[0]?.path ?? null;
+}
+
+function packetRowLatencyScore(row) {
+  const wallMs = finiteNumber(row.median_wall_ms);
+  return Number.isFinite(wallMs) ? 1 / (1 + wallMs / 20_000) : NaN;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function parseAgentAbRatios(markdown) {
+  return [...markdown.matchAll(/agent_ab_overhead_ratio=([0-9]+(?:\.[0-9]+)?)/gu)]
+    .map((match) => Number(match[1]))
+    .filter(Number.isFinite);
+}
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : NaN;
+}
+
+function mean(values) {
+  const finite = values.filter(Number.isFinite);
+  if (!finite.length) {
+    return NaN;
+  }
+  return finite.reduce((sum, value) => sum + value, 0) / finite.length;
+}
+
+function weightedMean(entries) {
+  const finite = entries.filter(([value, weight]) => Number.isFinite(value) && weight > 0);
+  if (!finite.length) {
+    return NaN;
+  }
+  const weightTotal = finite.reduce((sum, [, weight]) => sum + weight, 0);
+  return finite.reduce((sum, [value, weight]) => sum + value * weight, 0) / weightTotal;
+}
+
+function percentile(sortedValues, percentileValue) {
+  if (!sortedValues.length) {
+    return NaN;
+  }
+  const index = Math.ceil(sortedValues.length * percentileValue) - 1;
+  return sortedValues[Math.min(sortedValues.length - 1, Math.max(0, index))];
+}
+
+function clamp01(value) {
+  return Math.min(1, Math.max(0, value));
+}
+
+function round(value, digits = 6) {
+  if (!Number.isFinite(Number(value))) {
+    return null;
+  }
+  const scale = 10 ** digits;
+  return Math.round(Number(value) * scale) / scale;
+}
+
+function relativizeInputs(inputPaths, cwd) {
+  const relative = (entry) => (entry ? path.relative(cwd, entry).replaceAll(path.sep, "/") : null);
+  return {
+    prompt_summaries: inputPaths.promptSummaries.map(relative),
+    symbol_summary: relative(inputPaths.symbolSummary),
+    packet_summary: relative(inputPaths.packetSummary),
+    ab_doc: relative(inputPaths.abDoc),
+  };
+}
+
+function writeSummary(summary, outputDir) {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const jsonPath = path.join(outputDir, "summary.json");
+  const mdPath = path.join(outputDir, "summary.md");
+  fs.writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`);
+  fs.writeFileSync(mdPath, renderMarkdown(summary));
+  return { jsonPath, mdPath };
+}
+
+function renderMarkdown(summary) {
+  const metricLines = Object.entries(summary.metrics).map(
+    ([name, value]) => `- ${name}: \`${value ?? "n/a"}\``,
+  );
+  const componentGapLines = (summary.triage?.component_gaps ?? []).map(
+    (row) =>
+      `- ${row.component}: gap \`${row.gap ?? "n/a"}\`, weighted \`${row.weighted_gap ?? "n/a"}\`, lane \`${row.recommended_next_lane ?? "n/a"}\``,
+  );
+  const packetContributorLines = (summary.contributors?.packet_rows ?? []).map(
+    (row) =>
+      `- ${row.repo ?? "unknown"} / ${row.task_id ?? "unknown"} / ${row.mode ?? "unknown"}: lane \`${row.recommended_next_lane ?? "n/a"}\`, quality \`${row.packet_quality_score ?? "n/a"}\`, latency \`${row.packet_latency_score ?? "n/a"}\`, top step \`${row.top_latency_step ?? "n/a"}\` \`${row.median_top_step_ms ?? "n/a"}ms\``,
+  );
+  const sidecarDiagnostics = summary.contributors?.sidecar_diagnostics ?? {};
+  const sidecarResolutionLines = (sidecarDiagnostics.resolution_counts ?? []).map(
+    (entry) => `- ${entry.resolution}: \`${entry.count}\``,
+  );
+  const deltaLines = (summary.packet_quality_deltas?.tasks ?? [])
+    .filter((row) => row.deltas)
+    .map((row) => {
+      const fileDelta = row.deltas.median_expected_file_recall?.delta ?? "n/a";
+      const claimDelta = row.deltas.median_expected_claim_recall?.delta ?? "n/a";
+      const citationDelta = row.deltas.median_citation_coverage?.delta ?? "n/a";
+      return `- ${row.repo ?? "unknown"} / ${row.task_id ?? "unknown"} / ${row.mode ?? "unknown"}: file \`${fileDelta}\`, claim \`${claimDelta}\`, citation \`${citationDelta}\``;
+    });
+  return [
+    "# CodeStory Agent Value Score",
+    "",
+    summary.metric,
+    "",
+    "This is a cheap steering metric from existing local artifacts. It is not promotion evidence by itself.",
+    "",
+    "## Inputs",
+    "",
+    ...summary.inputs.prompt_summaries.map((entry) => `- prompt: \`${entry}\``),
+    `- symbols: \`${summary.inputs.symbol_summary ?? "missing"}\``,
+    `- packet: \`${summary.inputs.packet_summary ?? "missing"}\``,
+    `- A/B notes: \`${summary.inputs.ab_doc ?? "missing"}\``,
+    "",
+    "## Metrics",
+    "",
+    ...metricLines,
+    "",
+    "## Triage",
+    "",
+    `- largest gap component: \`${summary.triage?.largest_gap_component ?? "n/a"}\``,
+    `- recommended next lane: \`${summary.triage?.recommended_next_lane ?? "n/a"}\``,
+    ...componentGapLines,
+    "",
+    "## Packet Contributors",
+    "",
+    ...(packetContributorLines.length ? packetContributorLines : ["- n/a"]),
+    "",
+    "## Sidecar Diagnostics",
+    "",
+    `- summaries: \`${sidecarDiagnostics.summary_count ?? 0}\``,
+    `- expected files present in sidecars but missing from search: \`${sidecarDiagnostics.expected_files_present_missing_from_search_count ?? 0}\``,
+    `- expected symbols present in sidecars but missing from search: \`${sidecarDiagnostics.expected_symbols_present_missing_from_search_count ?? 0}\``,
+    `- sidecar prepare rows: \`${sidecarDiagnostics.sidecar_prepare_count ?? 0}\``,
+    `- sidecar prepare failures: \`${sidecarDiagnostics.sidecar_prepare_failed_count ?? 0}\``,
+    `- sidecar prepare max latency ms: \`${sidecarDiagnostics.sidecar_prepare_max_latency_ms ?? 0}\``,
+    `- sidecar candidates: \`${sidecarDiagnostics.candidate_count ?? 0}\``,
+    `- resolved hits: \`${sidecarDiagnostics.resolved_hit_count ?? 0}\``,
+    `- unresolved candidates: \`${sidecarDiagnostics.unresolved_candidate_count ?? 0}\``,
+    ...(sidecarResolutionLines.length ? sidecarResolutionLines : ["- resolution counts: `n/a`"]),
+    "",
+    "## Packet Quality Deltas",
+    "",
+    `- baseline: \`${summary.packet_quality_deltas?.baseline_label ?? "n/a"}\``,
+    `- current: \`${summary.packet_quality_deltas?.current_label ?? "n/a"}\``,
+    ...(deltaLines.length ? deltaLines : ["- n/a"]),
+    "",
+  ].join("\n");
+}
+
+function emitMetrics(summary, artifactPaths) {
+  console.log(`summary: ${artifactPaths.mdPath}`);
+  console.log(`ARTIFACT agent_value_summary=${artifactPaths.jsonPath}`);
+  for (const [name, value] of metricEntries(summary)) {
+    console.log(`METRIC ${name}=${value}`);
+  }
+}
+
+function metricEntries(summary) {
+  return Object.entries(summary.metrics).filter(
+    ([, value]) => typeof value === "number" && Number.isFinite(value),
+  );
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/codestory-agent-value-score.mjs --prompt-summary <path> --symbol-summary <path> --packet-summary <path> [--ab-doc <path>|--no-ab-doc]
+
+Reads one coherent local benchmark artifact set and emits METRIC agent_value_gap=<n> plus supporting metrics.`);
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printHelp();
+    return;
+  }
+  const inputs = discoverInputs(opts);
+  if (!inputs.promptSummaries.length && !inputs.symbolSummary && !inputs.packetSummary) {
+    throw new Error("no existing agent-value inputs found");
+  }
+  const summary = computeAgentValueScore(inputs, {
+    cwd: opts.cwd,
+  });
+  if (!Number.isFinite(Number(summary.metrics.agent_value_gap))) {
+    throw new Error("agent_value_gap could not be computed from available inputs");
+  }
+  const artifacts = writeSummary(summary, opts.outputDir);
+  emitMetrics(summary, artifacts);
+}
+
+export {
+  assertRunCoherency,
+  artifactRunStamp,
+  buildPacketQualityDeltas,
+  computeAgentValueScore,
+  discoverInputs,
+  discoverPreviousPacketSummary,
+  extractRunStamp,
+  metricEntries,
+  parseAgentAbRatios,
+  parseArgs,
+  packetRowQualityScore,
+  percentile,
+  rowEffectiveSufficiency,
+  rowSufficiencyRate,
+};
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(error?.stack ?? String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/codestory-benchmark-contract.mjs
+++ b/scripts/codestory-benchmark-contract.mjs
@@ -1,0 +1,131 @@
+const RETRIEVAL_ENV_KEYS = [
+  "CODESTORY_RETRIEVAL",
+  "CODESTORY_RETRIEVAL_SHADOW",
+  "CODESTORY_RETRIEVAL_V2",
+  "CODESTORY_RETRIEVAL_V2_SHADOW",
+  "CODESTORY_QDRANT_ENABLED",
+  "CODESTORY_ZOEKT_ENABLED",
+  "CODESTORY_RETRIEVAL_REAL_EMBEDDINGS",
+  "CODESTORY_RETRIEVAL_COMPOSE_PROFILE",
+  "CODESTORY_EMBED_BACKEND",
+  "CODESTORY_EMBED_LLAMACPP_URL",
+  "CODESTORY_EVAL_PROBES",
+];
+
+const DEFAULT_LLAMACPP_EMBED_URL = "http://127.0.0.1:8080/v1/embeddings";
+
+function retrievalEnv(env = process.env) {
+  return Object.fromEntries(RETRIEVAL_ENV_KEYS.map((key) => [key, env[key] ?? null]));
+}
+
+function unsupportedSidecarDisabledRequest(env = process.env) {
+  return env.CODESTORY_RETRIEVAL === "0";
+}
+
+function unsupportedSidecarContractRequests(env = process.env) {
+  const blockers = [];
+  if (unsupportedSidecarDisabledRequest(env)) {
+    blockers.push("CODESTORY_RETRIEVAL=0 is unsupported; sidecar retrieval is mandatory");
+  }
+  if (env.CODESTORY_RETRIEVAL_V2 != null || env.CODESTORY_RETRIEVAL_V2_SHADOW != null) {
+    blockers.push("deprecated CODESTORY_RETRIEVAL_V2 aliases are unsupported; sidecar retrieval is mandatory");
+  }
+  const shadow = String(env.CODESTORY_RETRIEVAL_SHADOW ?? "").trim().toLowerCase();
+  if (shadow && !["0", "false", "no", "off"].includes(shadow)) {
+    blockers.push("CODESTORY_RETRIEVAL_SHADOW is unsupported in product benchmarks; sidecar retrieval is primary");
+  }
+  if (env.CODESTORY_QDRANT_ENABLED === "0" || env.CODESTORY_QDRANT_ENABLED === "false") {
+    blockers.push("CODESTORY_QDRANT_ENABLED=0 is unsupported; Qdrant sidecar is mandatory");
+  }
+  if (env.CODESTORY_ZOEKT_ENABLED === "0" || env.CODESTORY_ZOEKT_ENABLED === "false") {
+    blockers.push("CODESTORY_ZOEKT_ENABLED=0 is unsupported; Zoekt sidecar is mandatory");
+  }
+  if (
+    env.CODESTORY_RETRIEVAL_REAL_EMBEDDINGS === "0" ||
+    env.CODESTORY_RETRIEVAL_REAL_EMBEDDINGS === "false"
+  ) {
+    blockers.push(
+      "CODESTORY_RETRIEVAL_REAL_EMBEDDINGS=0 is unsupported; llama.cpp embedding sidecar is mandatory",
+    );
+  }
+  const composeProfile = String(env.CODESTORY_RETRIEVAL_COMPOSE_PROFILE ?? "").trim().toLowerCase();
+  if (composeProfile && composeProfile !== "real") {
+    blockers.push(
+      `CODESTORY_RETRIEVAL_COMPOSE_PROFILE=${composeProfile} is unsupported; profile real is mandatory`,
+    );
+  }
+  const embeddingBackend = String(env.CODESTORY_EMBED_BACKEND ?? "").trim().toLowerCase();
+  if (embeddingBackend && !["llamacpp", "llama_cpp"].includes(embeddingBackend)) {
+    blockers.push(
+      `CODESTORY_EMBED_BACKEND=${embeddingBackend} is unsupported; llama.cpp embedding sidecar is mandatory`,
+    );
+  }
+  return blockers;
+}
+
+function assertSidecarMandatoryEnv(env = process.env) {
+  const blockers = unsupportedSidecarContractRequests(env);
+  if (blockers.length) {
+    throw new Error(blockers.join("; "));
+  }
+}
+
+function retrievalContractSummary(env = process.env) {
+  const raw = env.CODESTORY_RETRIEVAL ?? null;
+  if (unsupportedSidecarDisabledRequest(env)) {
+    return {
+      retrieval_contract: "unsupported_sidecar_disabled",
+      sidecar_primary: false,
+      unsupported_sidecar_disabled_request: true,
+      code_story_retrieval: raw,
+    };
+  }
+  return {
+    retrieval_contract: raw === "1" ? "sidecar_primary_forced" : "sidecar_primary_default",
+    sidecar_primary: true,
+    unsupported_sidecar_disabled_request: false,
+    code_story_retrieval: raw,
+    embedding_backend: env.CODESTORY_EMBED_BACKEND ?? null,
+    compose_profile: env.CODESTORY_RETRIEVAL_COMPOSE_PROFILE ?? null,
+  };
+}
+
+function benchmarkChildEnv(baseEnv = process.env, additions = {}) {
+  const env = { ...baseEnv, ...additions };
+  if (env.CODESTORY_RETRIEVAL == null || env.CODESTORY_RETRIEVAL === "") {
+    env.CODESTORY_RETRIEVAL = "1";
+  }
+  if (
+    env.CODESTORY_RETRIEVAL_REAL_EMBEDDINGS == null ||
+    env.CODESTORY_RETRIEVAL_REAL_EMBEDDINGS === ""
+  ) {
+    env.CODESTORY_RETRIEVAL_REAL_EMBEDDINGS = "1";
+  }
+  if (env.CODESTORY_RETRIEVAL_COMPOSE_PROFILE == null || env.CODESTORY_RETRIEVAL_COMPOSE_PROFILE === "") {
+    env.CODESTORY_RETRIEVAL_COMPOSE_PROFILE = "real";
+  }
+  if (env.CODESTORY_EMBED_BACKEND == null || env.CODESTORY_EMBED_BACKEND === "") {
+    env.CODESTORY_EMBED_BACKEND = "llamacpp";
+  }
+  if (env.CODESTORY_EMBED_LLAMACPP_URL == null || env.CODESTORY_EMBED_LLAMACPP_URL === "") {
+    env.CODESTORY_EMBED_LLAMACPP_URL = DEFAULT_LLAMACPP_EMBED_URL;
+  }
+  assertSidecarMandatoryEnv(env);
+  return env;
+}
+
+function shouldPrepareRetrievalIndex(env = process.env) {
+  assertSidecarMandatoryEnv(env);
+  return true;
+}
+
+export {
+  RETRIEVAL_ENV_KEYS,
+  assertSidecarMandatoryEnv,
+  benchmarkChildEnv,
+  retrievalContractSummary,
+  retrievalEnv,
+  shouldPrepareRetrievalIndex,
+  unsupportedSidecarDisabledRequest,
+  unsupportedSidecarContractRequests,
+};

--- a/scripts/codestory-manual-friction-check.mjs
+++ b/scripts/codestory-manual-friction-check.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { benchmarkChildEnv } from "./codestory-benchmark-contract.mjs";
 
 const repoRoot = resolve(process.cwd());
 const artifactDir = join(repoRoot, "target", "autoresearch");
@@ -16,9 +17,9 @@ if (args.has("--help") || args.has("-h")) {
 
 Runs the CodeStory skill-first manual-friction harness across ../Sourcetrail,
 ../rootandruntime, and this repo. The gap list is seeded from the three manual
-subagent tracks: first-class repo explanation, semantic health, broad-search
+subagent tracks: packet-first repo explanation, semantic health, broad-search
 drift, grounding recommendation quality, object/config trails, snippet context,
-format validation, and skill-only guidance. Emits METRIC quality_gap=<count>
+format validation, and current skill guidance. Emits METRIC quality_gap=<count>
 and writes a JSON report under target/autoresearch/.`);
   process.exit(0);
 }
@@ -69,10 +70,7 @@ function runCli(commandArgs, options = {}) {
   const result = spawnSync(cliPath, commandArgs, {
     cwd: repoRoot,
     encoding: "utf8",
-    env: {
-      ...process.env,
-      NO_COLOR: "1",
-    },
+    env: benchmarkChildEnv(process.env, { NO_COLOR: "1" }),
     timeout: options.timeoutMs ?? 180_000,
   });
   return {
@@ -206,28 +204,45 @@ function checkBroadSearch(repoName, searchJson) {
   }
 }
 
-function checkExplain(repoName, explainJson) {
-  if (!Array.isArray(explainJson?.workflow) || !explainJson.workflow.includes("anchor_search")) {
-    addGap(repoName, "explain_workflow_missing", 1, "explain output does not report the guided workflow");
+function checkPacket(repoName, packetJson) {
+  const sufficiency = packetJson?.sufficiency ?? {};
+  const status = sufficiency.status ?? null;
+  if (!["sufficient", "partial"].includes(status)) {
+    addGap(repoName, "packet_status_unusable", 1, "packet output is neither sufficient nor partial", {
+      status,
+    });
   }
-  if (!Array.isArray(explainJson?.anchors) || explainJson.anchors.length === 0) {
-    addGap(repoName, "explain_missing_anchors", 1, "explain output has no architecture anchors");
+  const citations = packetJson?.answer?.citations ?? [];
+  const avoidOpening = sufficiency.avoid_opening ?? [];
+  if (!Array.isArray(citations) || citations.length === 0) {
+    addGap(repoName, "packet_missing_citations", 1, "packet answer has no structured citations");
+  }
+  if (
+    status === "sufficient" &&
+    Array.isArray(sufficiency.follow_up_commands) &&
+    sufficiency.follow_up_commands.length > 0
+  ) {
+    addGap(repoName, "packet_sufficient_with_followups", 2, "sufficient packet still asks for follow-up commands", {
+      follow_up_commands: sufficiency.follow_up_commands,
+    });
+  }
+  if (!Array.isArray(avoidOpening)) {
+    addGap(repoName, "packet_avoid_opening_malformed", 2, "packet sufficiency avoid_opening is not a list");
+  }
+  const retrievalTrace = packetJson?.answer?.retrieval_trace;
+  if (!retrievalTrace || typeof retrievalTrace !== "object") {
+    addGap(repoName, "packet_missing_retrieval_trace", 2, "packet answer does not expose retrieval trace telemetry");
   }
   const text = fieldText({
-    anchors: explainJson?.anchors ?? [],
-    answer: {
-      summary: explainJson?.answer?.summary,
-      citations: explainJson?.answer?.citations ?? [],
-      sections: explainJson?.answer?.sections ?? [],
-      annotations: explanationAnnotations(explainJson?.answer?.retrieval_trace?.annotations),
-    },
+    citations,
+    sufficiency,
+    sections: packetJson?.answer?.sections ?? [],
+    supported_claims: packetJson?.answer?.supported_claims ?? [],
+    annotations: explanationAnnotations(retrievalTrace?.annotations),
   });
-  if (!text.includes("repo_explain_db_first_no_local_agent") && !text.includes("repo_explain_local_agent")) {
-    addGap(repoName, "explain_mode_unlabeled", 2, "explain output does not label repo-explain DB-first/local-agent mode");
-  }
   for (const term of repoBadTerms(repoName)) {
     if (text.includes(term)) {
-      addGap(repoName, "explain_drift", 1, `explain output drifted into ${term}`);
+      addGap(repoName, "packet_drift", 1, `packet output drifted into ${term}`);
     }
   }
 }
@@ -262,11 +277,14 @@ function checkSkillGuidance(repoName) {
     return;
   }
   const skillText = String(report.skill_text ?? "").toLowerCase();
-  if (!skillText.includes("explain --project")) {
-    addGap(repoName, "skill_missing_explain_flow", 1, "skill does not route broad repo explanations through explain");
+  if (!skillText.includes("start broad repo") || !skillText.includes("`packet`")) {
+    addGap(repoName, "skill_missing_packet_flow", 1, "skill does not route broad repo explanations through packet");
   }
-  if (!skillText.includes("do not run `git status`")) {
-    addGap(repoName, "skill_only_constraint_gap", 2, "skill-only manual tests do not explicitly forbid git status");
+  if (!skillText.includes("sufficiency.follow_up_commands")) {
+    addGap(repoName, "skill_missing_followup_contract", 2, "skill does not name the packet follow-up contract");
+  }
+  if (!skillText.includes("do not pass broad natural-language questions directly to `context`")) {
+    addGap(repoName, "skill_missing_context_boundary", 2, "skill does not preserve packet-before-context boundary");
   }
 }
 
@@ -423,53 +441,22 @@ if (!existsSync(cliPath)) {
       checkBroadSearch(repoName, broadSearch.json);
     }
 
-    const explain = runJson(repoName, [
-      "explain",
+    const packet = runJson(repoName, [
+      "packet",
       "--project",
       repoPath,
+      "--question",
+      "How does this repo fit together?",
+      "--budget",
+      "compact",
       "--refresh",
       "none",
       "--format",
       "json",
     ], 240_000);
-    repoReport.commands.push(compactTranscript(explain.result));
-    if (explain.json) {
-      checkExplain(repoName, explain.json);
-    }
-
-    const ask = runJson(repoName, [
-      "ask",
-      "--project",
-      repoPath,
-      "--investigate",
-      "--format",
-      "json",
-      "How does this repo fit together?",
-    ], 240_000);
-    repoReport.commands.push(compactTranscript(ask.result));
-    if (ask.json) {
-      const answerText = fieldText(ask.json);
-      const driftText = fieldText({
-        answer: ask.json.answer,
-        hits: ask.json.hits,
-        citations: ask.json.citations,
-        sections: ask.json.sections,
-        retrieval_trace: {
-          annotations: explanationAnnotations(ask.json.retrieval_trace?.annotations),
-          steps: ask.json.retrieval_trace?.steps,
-        },
-      });
-      if (answerText.includes("low confidence")) {
-        addGap(repoName, "ask_low_confidence", 2, "broad explanation ask still reports low confidence");
-      }
-      for (const term of repoBadTerms(repoName)) {
-        if (driftText.includes(term)) {
-          addGap(repoName, "ask_drift", 1, `broad explanation drifted into ${term}`);
-        }
-      }
-      if (!answerText.includes("db-first retrieval packet") && !answerText.includes("mode=db_first_no_local_agent")) {
-        addGap(repoName, "ask_mode_unlabeled", 2, "ask output does not clearly label DB-first/no-local-agent mode");
-      }
+    repoReport.commands.push(compactTranscript(packet.result));
+    if (packet.json) {
+      checkPacket(repoName, packet.json);
     }
 
     if (repoName === "rootandruntime") {

--- a/scripts/cross-repo-promotion-benchmark.mjs
+++ b/scripts/cross-repo-promotion-benchmark.mjs
@@ -21,7 +21,10 @@ const outDir =
 const listOnly = process.argv.includes("--list") || process.env.CODESTORY_CROSS_REPO_LIST === "1";
 const skipIndex = process.argv.includes("--skip-index") || process.env.CODESTORY_CROSS_REPO_SKIP_INDEX === "1";
 const allowFail = process.env.CODESTORY_CROSS_REPO_ALLOW_FAIL === "1";
-const requiredProjects = Number(process.env.CODESTORY_CROSS_REPO_REQUIRED_PROJECTS ?? 4);
+const includeDeprecated =
+  process.argv.includes("--include-deprecated") ||
+  process.env.CODESTORY_CROSS_REPO_INCLUDE_DEPRECATED === "1";
+const requiredProjects = Number(process.env.CODESTORY_CROSS_REPO_REQUIRED_PROJECTS ?? 2);
 const minAggregateHit10 = Number(process.env.CODESTORY_CROSS_REPO_MIN_HIT10 ?? 0.85);
 const minAggregateMrr10 = Number(process.env.CODESTORY_CROSS_REPO_MIN_MRR10 ?? 0.7);
 const minProjectHit10 = Number(process.env.CODESTORY_CROSS_REPO_MIN_PROJECT_HIT10 ?? 0.75);
@@ -42,6 +45,7 @@ const suites = [
   {
     id: "freelancer",
     name: "freelancer",
+    deprecated: true,
     language_mix: "Rust/Tauri + TypeScript/React desktop app",
     pathCandidates: [String.raw`C:\Users\alber\source\repos\freelancer`],
     queries: [
@@ -183,6 +187,7 @@ const suites = [
   {
     id: "traderotate",
     name: "traderotate",
+    deprecated: true,
     language_mix: "JavaScript Hardhat/Remix arbitrage runners",
     pathCandidates: [String.raw`C:\Users\alber\source\repos\traderotate`],
     queries: [
@@ -476,7 +481,9 @@ const suites = [
 ];
 
 const activeSuites = suites.filter(
-  (suite) => selectedProjectIds.size === 0 || selectedProjectIds.has(suite.id.toLowerCase()),
+  (suite) =>
+    (includeDeprecated || !suite.deprecated) &&
+    (selectedProjectIds.size === 0 || selectedProjectIds.has(suite.id.toLowerCase())),
 );
 
 const resolvedSuites = activeSuites.map((suite) => ({
@@ -1121,7 +1128,7 @@ function configureProfile(name, env) {
   env.CODESTORY_EMBED_LLAMACPP_URL = url;
   env.CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT = llamaRequestCount;
   env.CODESTORY_SEMANTIC_DOC_MAX_TOKENS =
-    process.env.CODESTORY_CROSS_REPO_SEMANTIC_DOC_MAX_TOKENS ?? "384";
+    process.env.CODESTORY_CROSS_REPO_SEMANTIC_DOC_MAX_TOKENS ?? "128";
   delete env.CODESTORY_EMBED_MAX_TOKENS;
   delete env.CODESTORY_EMBED_QUERY_PREFIX;
   delete env.CODESTORY_EMBED_DOCUMENT_PREFIX;

--- a/scripts/embedding-gpu-fair-benchmark.mjs
+++ b/scripts/embedding-gpu-fair-benchmark.mjs
@@ -569,14 +569,15 @@ const queries = [
   },
   {
     id: "holdout-stdio-tool-router",
-    query: "dispatch JSON stdio tool calls to search symbol trail snippet and ask handlers",
+    query: "dispatch JSON stdio tool calls to packet search symbol trail snippet and context handlers",
     expect: [
       "handle_stdio_tool_call",
+      "handle_stdio_packet",
       "handle_stdio_search",
       "handle_stdio_symbol",
       "handle_stdio_trail",
       "handle_stdio_snippet",
-      "handle_stdio_ask",
+      "handle_stdio_context",
     ],
     bucket: "holdout-adversarial",
   },
@@ -605,14 +606,14 @@ const queries = [
   },
   {
     id: "holdout-agent-term-planner",
-    query: "ask a local agent to suggest extra search terms when retrieval needs a planner",
-    expect: ["build_term_planner_prompt", "should_use_agent_term_planner"],
+    query: "build packet search plans and concrete symbol probe queries from a broad task prompt",
+    expect: ["build_packet_plan", "packet_symbol_probe_queries", "infer_packet_task_class"],
     bucket: "holdout-adversarial",
   },
   {
     id: "holdout-agent-prompt-builder",
-    query: "build the constrained prompt sent to a local code assistant using indexed context only",
-    expect: ["build_local_agent_prompt"],
+    query: "augment a packet retrieval prompt with planned CodeStory queries for compact broad task grounding",
+    expect: ["packet_retrieval_prompt", "packet_compact_retrieval_prompt_lines"],
     bucket: "holdout-adversarial",
   },
   {
@@ -764,9 +765,9 @@ const queries = [
     bucket: "holdout-adversarial",
   },
   {
-    id: "holdout-ask-artifact-bundle",
-    query: "write agent ask bundle artifacts with a sanitized filename",
-    expect: ["write_ask_bundle", "sanitize_artifact_name"],
+    id: "holdout-context-artifact-bundle",
+    query: "write context bundle artifacts and sanitize generated artifact filenames",
+    expect: ["write_context_bundle", "sanitize_artifact_name"],
     bucket: "holdout-adversarial",
   },
   {

--- a/scripts/fetch-holdout-repos.mjs
+++ b/scripts/fetch-holdout-repos.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadTasks, materializeRepos } from "./codestory-agent-ab-benchmark.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const defaultRepoCacheRoot = path.join(repoRoot, "target", "agent-benchmark", "repos");
+
+function usage() {
+  console.log(`Usage:
+  node scripts/fetch-holdout-repos.mjs [--repo-cache-dir path] [--timeout-ms ms]
+
+Clones or updates pinned OSS repos for the holdout-retrieval suite into
+target/agent-benchmark/repos (gitignored). Same materialization path as
+codestory-agent-ab-benchmark.mjs --materialize-repos.
+`);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    repoCacheDir: defaultRepoCacheRoot,
+    timeoutMs: 1_800_000,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    }
+    if (arg === "--repo-cache-dir") {
+      opts.repoCacheDir = path.resolve(argv[++i]);
+      continue;
+    }
+    if (arg === "--timeout-ms") {
+      opts.timeoutMs = Number.parseInt(argv[++i], 10);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs < 1000) {
+    throw new Error("--timeout-ms must be an integer >= 1000");
+  }
+  return opts;
+}
+
+async function main() {
+  const cliOpts = parseArgs(process.argv.slice(2));
+  const opts = {
+    taskSuite: "holdout-retrieval",
+    taskManifest: null,
+    taskIds: null,
+    materializeRepos: true,
+    repoCacheDir: cliOpts.repoCacheDir,
+    timeoutMs: cliOpts.timeoutMs,
+  };
+  const tasks = await loadTasks(opts);
+  await materializeRepos(tasks, opts);
+  const repos = [...new Set(tasks.map((task) => task.repo))].sort();
+  console.log(
+    `materialized holdout-retrieval repos (${repos.join(", ")}) under ${opts.repoCacheDir}`,
+  );
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -13,12 +13,19 @@ import {
   isPathInside,
   loadTaskForResult,
   loadTasks,
+  parseArgs as parseBenchmarkArgs,
   parseJsonLines,
+  packetComposition,
+  packetLatencyTelemetry,
   packetFirstCommandForPrompt,
+  packetRuntimePublishableBlockers,
   publicCoreCorpusAudit,
   repoProvenanceBlockers,
   resolveCodeStoryCli,
   scoreQuality,
+  summarizePacketRuntimeRuns,
+  buildQualityDebugPayload,
+  qualityFailureReasons,
   taskSnapshotForResult,
 } from "../codestory-agent-ab-benchmark.mjs";
 
@@ -26,6 +33,94 @@ const RUNTIME_SERVICE_FILE = "crates/codestory-runtime/src/services.rs";
 const RUN_INDEX_SYMBOL = "IndexService::run_indexing_blocking";
 const RUNTIME_REFRESH_CLAIM =
   "The runtime opens the workspace and store, chooses full or incremental indexing, and coordinates later refresh phases.";
+
+test("parses packet-runtime benchmark run id", () => {
+  const opts = parseBenchmarkArgs([
+    "--packet-runtime",
+    "--task-suite",
+    "local-real",
+    "--benchmark-run-id",
+    "segment 43/v2",
+  ]);
+
+  assert.equal(opts.packetRuntime, true);
+  assert.equal(opts.benchmarkRunId, "segment-43-v2");
+  assert.equal(opts.prepareCodestoryCache, true);
+  assert.throws(
+    () =>
+      parseBenchmarkArgs([
+        "--packet-runtime",
+        "--task-suite",
+        "local-real",
+        "--no-prepare-codestory-cache",
+      ]),
+    /sidecar preparation is mandatory/,
+  );
+});
+
+test("packet latency telemetry preserves retrieval shadow cache diagnostics", () => {
+  const packet = {
+    answer: {
+      freshness: { duration_ms: 12 },
+      retrieval_trace: {
+        total_latency_ms: 40,
+        sla_target_ms: 500,
+        sla_missed: false,
+        steps: [{ kind: "search", status: "success", duration_ms: 25, message: "ok" }],
+      },
+    },
+    benchmark_trace: {
+      retrieval_trace: {
+        retrieval_shadow: {
+          retrieval_mode: "full",
+          retrieval_total_ms: 7,
+          cache_hit: true,
+          stage_timings: [
+            { stage: "stage1_zoekt_lexical", elapsed_ms: 2, cache_hit: false },
+            { stage: "stage2_semantic_vector", elapsed_ms: 1, cache_hit: true },
+          ],
+          candidate_count: 4,
+          resolved_hit_count: 3,
+          unresolved_candidate_count: 1,
+        },
+      },
+    },
+  };
+
+  const telemetry = packetLatencyTelemetry(packet, 80);
+  assert.equal(telemetry.retrieval_shadow.cache_hit, true);
+  assert.equal(telemetry.retrieval_shadow.cache_hit_stage_count, 1);
+  assert.deepEqual(telemetry.retrieval_shadow.cache_hit_stages, ["stage2_semantic_vector"]);
+
+  const summary = summarizePacketRuntimeRuns([
+    {
+      repo: "fixture",
+      task_id: "cache",
+      mode: "warm_stdio_packet",
+      status: "pass",
+      wall_ms: 80,
+      warm_stdio_packet_cache_hit: true,
+      packet_latency: telemetry,
+    },
+  ]);
+  assert.equal(summary[0].warm_stdio_packet_cache_hit_runs, 1);
+  assert.equal(summary[0].retrieval_shadow_cache_hit_runs, 1);
+  assert.equal(summary[0].retrieval_shadow_stage_cache_hit_runs, 1);
+
+  const debug = buildQualityDebugPayload([
+    {
+      repo: "fixture",
+      task_id: "cache",
+      mode: "warm_stdio_packet",
+      status: "pass",
+      warm_stdio_packet_cache_hit: true,
+      packet_latency: telemetry,
+    },
+  ]);
+  assert.equal(debug.rows[0].warm_stdio_packet_cache_hit, true);
+  assert.equal(debug.rows[0].retrieval.cache_hit, true);
+  assert.equal(debug.rows[0].retrieval.cache_hit_stage_count, 1);
+});
 
 function commandEvent(id, type, command, aggregatedOutput = "", exitCode = 0) {
   return {
@@ -203,6 +298,29 @@ test("Windows Codex runner args reject cmd metacharacters", () => {
   );
 });
 
+test("holdout-retrieval suite loads three OSS manifests", async () => {
+  const tasks = await loadTasks({
+    taskSuite: "holdout-retrieval",
+    taskManifest: null,
+    taskIds: null,
+    materializeRepos: true,
+    repoCacheDir: path.join("target", "agent-benchmark", "repos"),
+  });
+
+  assert.equal(tasks.length, 3);
+  assert.deepEqual(
+    tasks.map((task) => task.id).sort(),
+    ["axios-request-dispatch", "redis-server-event-loop", "ripgrep-search-pipeline"],
+  );
+  for (const task of tasks) {
+    assert.equal(task.suite, "holdout-retrieval");
+    assert.equal(task.task_class, "architecture_explanation");
+    assert.ok(task.repo_metadata?.url);
+    assert.ok(task.repo_metadata?.ref);
+    assert.notEqual(task.repo_metadata.ref, "local");
+  }
+});
+
 test("public-core corpus keeps publishable coverage locked", async () => {
   const tasks = await loadTasks({
     taskSuite: "public-core",
@@ -275,6 +393,7 @@ test("analyzes transcript command friction and scores manifest anchors", () => {
     id: "fixture",
     task_class: "architecture_explanation",
     expected_files: ["crates/codestory-cli/src/main.rs"],
+    expected_verification_files: ["crates/codestory-cli/tests/onboarding_contracts.rs"],
     expected_symbols: ["RuntimeContext::ensure_open", "MissingSymbol"],
     expected_claims: ["Full indexing starts"],
     forbidden_claims: ["remote service is required"],
@@ -292,6 +411,10 @@ test("analyzes transcript command friction and scores manifest anchors", () => {
   assert.equal(quality.expected_files.recall, 1);
   assert.equal(quality.expected_symbols.recall, 0.5);
   assert.deepEqual(quality.missed_anchors.symbols, ["MissingSymbol"]);
+  assert.equal(quality.expected_verification_files.recall, 0);
+  assert.deepEqual(quality.missed_anchors.verification_files, [
+    "crates/codestory-cli/tests/onboarding_contracts.rs",
+  ]);
   assert.equal(quality.citation_coverage.recall, 1);
 });
 
@@ -451,6 +574,136 @@ test("quality scoring does not promote transcript-only expected anchors", () => 
   assert.equal(quality.expected_symbols.recall, 0);
 });
 
+test("packet composition separates citations, answer surfaces, and structured-only paths", () => {
+  const composition = packetComposition(
+    {
+      answer: {
+        summary: "The storage flow also mentions src/lib/data/storage/StorageAccessProxy.cpp.",
+        sections: [
+          {
+            title: "Indexing",
+            blocks: [
+              {
+                markdown: "Project::buildIndex creates indexing work.",
+              },
+            ],
+          },
+        ],
+        citations: [
+          {
+            display_name: "Project::buildIndex",
+            file_path: "src/lib/project/Project.cpp",
+            line: 42,
+          },
+        ],
+      },
+      sufficiency: {
+        avoid_opening: ["src/lib/data/storage/PersistentStorage.cpp"],
+        covered_claims: [
+          {
+            claim: "Hidden trace source mentions src/lib_cxx/project/SourceGroupCxxCdb.cpp.",
+          },
+        ],
+      },
+    },
+    {
+      expected_files: [
+        "src/lib/project/Project.cpp",
+        "src/lib/data/storage/PersistentStorage.cpp",
+        "src/lib/data/storage/StorageAccessProxy.cpp",
+        "src/lib_cxx/project/SourceGroupCxxCdb.cpp",
+        "src/lib_java/data/indexer/IndexerJava.cpp",
+      ],
+      expected_verification_files: ["test/lib/project/ProjectTest.cpp"],
+    },
+  );
+
+  assert.equal(composition.expected_file_count, 5);
+  assert.equal(composition.expected_verification_file_count, 1);
+  assert.equal(composition.cited_file_count, 1);
+  assert.equal(composition.citation_backed_file_count, 2);
+  assert.equal(composition.answer_surface_file_count, 3);
+  assert.equal(composition.structured_file_count, 4);
+  assert.equal(composition.citation_recall, 1 / 5);
+  assert.equal(composition.citation_backed_recall, 2 / 5);
+  assert.equal(composition.answer_surface_recall, 3 / 5);
+  assert.equal(composition.structured_file_recall, 4 / 5);
+  assert.ok(Math.abs(composition.composition_score - (1 + 0.9 + 0.25) / 5) < 1e-9);
+  assert.deepEqual(
+    composition.files.map((file) => [file.expected_file, file.packet_boundary]),
+    [
+      ["src/lib/project/Project.cpp", "cited_in_answer"],
+      ["src/lib/data/storage/PersistentStorage.cpp", "listed_in_avoid_opening"],
+      ["src/lib/data/storage/StorageAccessProxy.cpp", "mentioned_in_answer_text"],
+      ["src/lib_cxx/project/SourceGroupCxxCdb.cpp", "present_only_in_structured_json"],
+      ["src/lib_java/data/indexer/IndexerJava.cpp", "absent_from_packet"],
+    ],
+  );
+  assert.deepEqual(
+    composition.verification_files.map((file) => [file.expected_file, file.packet_boundary]),
+    [["test/lib/project/ProjectTest.cpp", "absent_from_packet"]],
+  );
+  assert.equal(composition.verification_summary.structured_file_recall, 0);
+});
+
+const LOCAL_REAL_COMPACT_BUDGET_TASKS = [
+  {
+    repo: "vscode",
+    task_id: "vscode-workbench-extension-host",
+    expected_files: [
+      "src/vs/workbench/browser/workbench.ts",
+      "src/vs/workbench/services/extensions/browser/extensionService.ts",
+      "src/vs/workbench/services/extensions/common/extensionHostManager.ts",
+      "src/vs/workbench/api/common/extHostExtensionService.ts",
+      "src/vs/workbench/api/common/extHostCommands.ts",
+    ],
+  },
+  {
+    repo: "codex",
+    task_id: "codex-exec-json-flow",
+    expected_files: [
+      "codex-rs/cli/src/main.rs",
+      "codex-rs/exec/src/lib.rs",
+      "codex-rs/exec/src/event_processor.rs",
+      "codex-rs/exec/src/event_processor_with_jsonl_output.rs",
+      "codex-rs/exec/src/exec_events.rs",
+    ],
+  },
+  {
+    repo: "sourcetrail",
+    task_id: "sourcetrail-indexing-to-storage",
+    expected_files: [
+      "src/lib/project/Project.cpp",
+      "src/lib_cxx/project/SourceGroupCxxCdb.cpp",
+      "src/lib_cxx/project/SourceGroupCxxCdb.h",
+      "src/lib/data/storage/StorageAccess.h",
+      "src/lib/data/storage/PersistentStorage.cpp",
+    ],
+  },
+];
+
+for (const task of LOCAL_REAL_COMPACT_BUDGET_TASKS) {
+  test(`compact-budget packet composition rewards citation-backed recall for ${task.repo}/${task.task_id}`, () => {
+    const citedPath = task.expected_files[0];
+    const composition = packetComposition(
+      {
+        answer: {
+          summary: `Cited ${citedPath} and mentioned another path only in prose.`,
+          citations: [{ display_name: "Anchor", file_path: citedPath, line: 1 }],
+        },
+        sufficiency: { avoid_opening: [], covered_claims: [] },
+      },
+      { expected_files: task.expected_files },
+    );
+
+    assert.equal(composition.cited_file_count, 1);
+    assert.equal(composition.citation_backed_file_count, 1);
+    assert.equal(composition.answer_text_file_count, 0);
+    assert.equal(composition.citation_backed_recall, composition.citation_recall);
+    assert.ok(composition.composition_score >= composition.citation_recall);
+  });
+}
+
 test("scores forbidden claims with the same fuzzy matcher as expected claims", () => {
   const task = runtimeQualityTask("forbidden-claim-fixture", {
     min_expected_file_recall: 0,
@@ -470,6 +723,129 @@ test("scores forbidden claims with the same fuzzy matcher as expected claims", (
   assert.equal(quality.forbidden_claims.found, 1);
   assert.equal(quality.pass, false);
 });
+
+test("forbidden claim scoring requires negative polarity terms", () => {
+  const task = runtimeQualityTask("forbidden-negation-fixture", {
+    min_expected_file_recall: 0,
+    min_expected_symbol_recall: 0,
+    min_expected_claim_recall: 0,
+    min_citation_coverage: 0,
+    min_expected_anchor_recall: 0,
+    max_forbidden_claims: 0,
+  });
+  task.forbidden_claims = [
+    "ThreadStartParams and TurnStartParams are only used by the interactive TUI, not by codex exec.",
+  ];
+
+  const quality = scoreQuality(
+    [
+      agentMessageEvent(
+        "codex exec sends ThreadStartParams and TurnStartParams through thread/start and turn/start, while the TUI has a separate helper.",
+      ),
+    ],
+    task,
+  );
+
+  assert.equal(quality.forbidden_claims.found, 0);
+  assert.equal(quality.pass, true);
+});
+
+test("forbidden claim scoring does not combine unrelated storage sentences", () => {
+  const task = runtimeQualityTask("forbidden-storage-fixture", {
+    min_expected_file_recall: 0,
+    min_expected_symbol_recall: 0,
+    min_expected_claim_recall: 0,
+    min_citation_coverage: 0,
+    min_expected_anchor_recall: 0,
+    max_forbidden_claims: 0,
+  });
+  task.forbidden_claims = ["StorageAccessProxy is the persistent SQLite storage implementation."];
+
+  const quality = scoreQuality(
+    [
+      agentMessageEvent(
+        "StorageAccessProxy forwards storage calls to the active storage subject. PersistentStorage is the concrete persistent implementation behind the storage access contract.",
+      ),
+    ],
+    task,
+  );
+
+  assert.equal(quality.forbidden_claims.found, 0);
+  assert.equal(quality.pass, true);
+});
+
+function pinnedRepoProvenance() {
+  return {
+    manifest_overridden_by_builtin: false,
+    configured: { ref: "9fdfd4650427eb050a11fd9ebd7a4e13dd4b57d7" },
+    manifest: { ref: "9fdfd4650427eb050a11fd9ebd7a4e13dd4b57d7" },
+    git_head: "9fdfd4650427eb050a11fd9ebd7a4e13dd4b57d7",
+    git_dirty: false,
+  };
+}
+
+function localCacheProvenance(overrides = {}) {
+  return {
+    doctor_status: "pass",
+    storage_path: "C:/Users/alber/AppData/Local/codestory/cache/codestory.db",
+    cache_policy: "prepared-sidecar-cache-read-only",
+    retrieval_mode: "full",
+    sidecar_generation: "proj-current",
+    manifest_embedding_backend: "llamacpp:bge-base-en-v1.5",
+    semantic_backend: "onnx",
+    local_only: true,
+    locality_kind: "local_model_files",
+    indexed: true,
+    freshness_status: "fresh",
+    semantic_ready: true,
+    indexing_in_timed_run: false,
+    ...overrides,
+  };
+}
+
+function publishableWithCodeStoryResult(overrides = {}) {
+  return {
+    repo: "codestory",
+    task_id: "codestory-indexing-flow",
+    arm: "with_codestory",
+    repeat: 1,
+    status: "pass",
+    usage: { total_tokens: 100 },
+    packet_first_required: true,
+    packet_first_pass: true,
+    quality: { pass: true },
+    transcript_analysis: {
+      ordinary_source_reads_after_first_packet: 0,
+    },
+    repo_provenance: pinnedRepoProvenance(),
+    codestory_cache_provenance: localCacheProvenance(),
+    ...overrides,
+  };
+}
+
+function publishablePacketRuntimeResult(overrides = {}) {
+  return {
+    repo: "codestory",
+    task_id: "codestory-indexing-flow",
+    mode: "cold",
+    repeat: 1,
+    status: "pass",
+    quality: { pass: true },
+    sufficiency: {
+      status: "sufficient",
+      sufficient_quality_mismatch: false,
+    },
+    packet_latency: {
+      sla_missed: false,
+      retrieval_shadow: {
+        retrieval_mode: "full",
+      },
+    },
+    repo_provenance: pinnedRepoProvenance(),
+    codestory_cache_provenance: localCacheProvenance(),
+    ...overrides,
+  };
+}
 
 test("publishable gate blocks avoidable source reads after packet", () => {
   const blockers = agentPublishableBlockers(
@@ -581,33 +957,95 @@ test("publishable provenance requires pinned clean manifest checkout", () => {
 test("publishable gate requires CodeStory cache provenance for CodeStory arm", () => {
   const blockers = agentPublishableBlockers(
     [
-      {
-        repo: "codestory",
-        task_id: "codestory-indexing-flow",
-        arm: "with_codestory",
-        repeat: 1,
-        status: "pass",
-        usage: { total_tokens: 100 },
-        packet_first_required: true,
-        packet_first_pass: true,
-        quality: { pass: true },
-        transcript_analysis: {
-          ordinary_source_reads_after_first_packet: 0,
-        },
-        repo_provenance: {
-          manifest_overridden_by_builtin: false,
-          configured: { ref: "9fdfd4650427eb050a11fd9ebd7a4e13dd4b57d7" },
-          manifest: { ref: "9fdfd4650427eb050a11fd9ebd7a4e13dd4b57d7" },
-          git_head: "9fdfd4650427eb050a11fd9ebd7a4e13dd4b57d7",
-          git_dirty: false,
-        },
-      },
+      publishableWithCodeStoryResult({
+        codestory_cache_provenance: null,
+      }),
     ],
     { publishable: true },
   );
 
   assert.equal(blockers.length, 1);
   assert.match(blockers[0].reasons.join("\n"), /missing CodeStory cache provenance/);
+});
+
+test("publishable gate accepts local-only CodeStory cache provenance", () => {
+  const blockers = agentPublishableBlockers(
+    [publishableWithCodeStoryResult()],
+    { publishable: true },
+  );
+
+  assert.deepEqual(blockers, []);
+});
+
+test("publishable gate requires CodeStory local-only provenance", () => {
+  const blockers = agentPublishableBlockers(
+    [
+      publishableWithCodeStoryResult({
+        codestory_cache_provenance: localCacheProvenance({
+          local_only: false,
+          locality_kind: "remote_endpoint",
+        }),
+      }),
+    ],
+    { publishable: true },
+  );
+
+  assert.equal(blockers.length, 1);
+  assert.match(blockers[0].reasons.join("\n"), /local-only guarantee is not proven/);
+});
+
+test("packet runtime publishable gate requires sufficient packets and telemetry", () => {
+  assert.deepEqual(
+    packetRuntimePublishableBlockers([publishablePacketRuntimeResult()], { publishable: true }),
+    [],
+  );
+
+  const blockers = packetRuntimePublishableBlockers(
+    [
+      publishablePacketRuntimeResult({ sufficiency: null }),
+      publishablePacketRuntimeResult({
+        sufficiency: { status: "partial", sufficient_quality_mismatch: false },
+      }),
+      publishablePacketRuntimeResult({ packet_latency: null }),
+    ],
+    { publishable: true },
+  );
+
+  assert.equal(blockers.length, 3);
+  assert.match(blockers[0].reasons.join("\n"), /missing packet sufficiency telemetry/);
+  assert.match(blockers[1].reasons.join("\n"), /packet sufficiency status=partial; expected sufficient/);
+  assert.match(blockers[2].reasons.join("\n"), /missing packet latency telemetry/);
+});
+
+test("packet runtime publishable gate requires SLA pass and full retrieval shadow", () => {
+  const blockers = packetRuntimePublishableBlockers(
+    [
+      publishablePacketRuntimeResult({
+        packet_latency: {
+          sla_missed: true,
+          retrieval_shadow: { retrieval_mode: "full" },
+        },
+      }),
+      publishablePacketRuntimeResult({
+        packet_latency: {
+          sla_missed: false,
+          retrieval_shadow: null,
+        },
+      }),
+      publishablePacketRuntimeResult({
+        packet_latency: {
+          sla_missed: false,
+          retrieval_shadow: { retrieval_mode: "degraded" },
+        },
+      }),
+    ],
+    { publishable: true },
+  );
+
+  assert.equal(blockers.length, 3);
+  assert.match(blockers[0].reasons.join("\n"), /packet retrieval SLA missed=true; expected false/);
+  assert.match(blockers[1].reasons.join("\n"), /missing retrieval shadow telemetry/);
+  assert.match(blockers[2].reasons.join("\n"), /packet retrieval shadow mode=degraded; expected full/);
 });
 
 test("reanalysis uses the run-time task snapshot before current manifest contents", async () => {
@@ -645,4 +1083,41 @@ test("reanalysis uses the run-time task snapshot before current manifest content
       assert.deepEqual(loaded.expected_claims, ["The snapshot claim is immutable."]);
     },
   );
+});
+
+test("qualityFailureReasons lists recall misses", () => {
+  const reasons = qualityFailureReasons({
+    pass: false,
+    thresholds: { expected_file_recall: 0.8 },
+    expected_anchors: { recall: 1 },
+    expected_files: { recall: 0.2 },
+    expected_symbols: { recall: 1 },
+    expected_claims: { recall: 1 },
+    citation_coverage: { recall: 1 },
+    forbidden_claims: { found: 0 },
+  });
+  assert.ok(reasons.includes("expected_file_recall_low"));
+});
+
+test("buildQualityDebugPayload aggregates failure counts", () => {
+  const payload = buildQualityDebugPayload([
+    {
+      repo: "ripgrep",
+      task_id: "ripgrep-search-pipeline",
+      mode: "cold-cli",
+      status: "pass",
+      quality: {
+        pass: false,
+        thresholds: {},
+        expected_anchors: { recall: 0.5 },
+        expected_files: { recall: 0.5 },
+        expected_symbols: { recall: 0.5 },
+        expected_claims: { recall: 0.5 },
+        citation_coverage: { recall: 0.5 },
+        forbidden_claims: { found: 0 },
+      },
+    },
+  ]);
+  assert.equal(payload.summary.quality_fail_runs, 1);
+  assert.ok(Object.keys(payload.summary.failure_reason_counts).length > 0);
 });

--- a/scripts/tests/codestory-agent-value-score.test.mjs
+++ b/scripts/tests/codestory-agent-value-score.test.mjs
@@ -1,0 +1,629 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  artifactRunStamp,
+  buildPacketQualityDeltas,
+  computeAgentValueScore,
+  discoverInputs,
+  extractRunStamp,
+  metricEntries,
+  parseAgentAbRatios,
+  parseArgs,
+  packetRowQualityScore,
+  percentile,
+  rowEffectiveSufficiency,
+  rowSufficiencyRate,
+} from "../codestory-agent-value-score.mjs";
+
+test("parses explicit inputs and rejects from-existing scoring", () => {
+  const opts = parseArgs([
+    "--cwd",
+    "C:/repo",
+    "--prompt-summary",
+    "target/retrieval-golden/prompt/summary.json",
+    "--symbol-summary",
+    "target/retrieval-golden/symbol/summary.json",
+    "--packet-summary",
+    "target/agent-benchmark/packet/packet-runtime-summary.json",
+    "--ab-doc",
+    "autoresearch.md",
+  ]);
+
+  assert.equal(opts.fromExisting, undefined);
+  assert.equal(opts.includeAbDoc, true);
+  assert.equal(opts.explicitPromptSummaries, true);
+  assert.equal(opts.explicitSymbolSummary, true);
+  assert.equal(opts.explicitPacketSummary, true);
+  assert.equal(opts.promptSummaries.length, 1);
+  assert.match(opts.promptSummaries[0], /target[\\/]retrieval-golden[\\/]prompt[\\/]summary\.json$/u);
+  assert.match(opts.symbolSummary, /target[\\/]retrieval-golden[\\/]symbol[\\/]summary\.json$/u);
+  assert.match(opts.packetSummary, /target[\\/]agent-benchmark[\\/]packet[\\/]packet-runtime-summary\.json$/u);
+  assert.match(opts.abDoc, /autoresearch\.md$/u);
+  assert.equal(parseArgs(["--no-ab-doc"]).abDoc, null);
+  assert.equal(parseArgs(["--no-ab-doc"]).includeAbDoc, false);
+  assert.throws(() => parseArgs(["--from-existing"]), /from-existing is unsupported/);
+  assert.throws(() => parseArgs(["--allow-mixed-run-inputs"]), /allow-mixed-run-inputs is unsupported/);
+});
+
+test("parses recorded live A/B ratios from markdown", () => {
+  assert.deepEqual(
+    parseAgentAbRatios([
+      "Codex `agent_ab_overhead_ratio=0.183466`.",
+      "Sourcetrail `agent_ab_overhead_ratio=0.10904`.",
+      "No metric here.",
+    ].join("\n")),
+    [0.183466, 0.10904],
+  );
+});
+
+test("percentile uses nearest-rank behavior for packet p95", () => {
+  assert.equal(percentile([10, 20, 30, 40], 0.95), 40);
+  assert.equal(percentile([10], 0.95), 10);
+});
+
+test("computes stable agent value gap from local artifact summaries", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-"));
+  const promptA = writeJson(root, "prompt-a.json", {
+    summary: { prompt_file_recall: 0.5 },
+  });
+  const promptB = writeJson(root, "prompt-b.json", {
+    summary: { prompt_file_recall: 1 },
+  });
+  const symbol = writeJson(root, "symbol.json", {
+    summary: { symbol_path_hit_at_k: 1 },
+  });
+  const packet = writeJson(root, "packet.json", {
+    summary: [
+      {
+        repo: "codex",
+        task_id: "event-output",
+        mode: "cold-cli",
+        quality_pass_runs: 1,
+        sufficiency_status_counts: { sufficient: 1 },
+        median_expected_file_recall: 1,
+        median_expected_claim_recall: 1,
+        median_citation_coverage: 0.8,
+        median_follow_up_commands_count: 0,
+        median_wall_ms: 10_000,
+      },
+      {
+        repo: "vscode",
+        task_id: "extension-flow",
+        mode: "cold-cli",
+        quality_pass_runs: 1,
+        sufficiency_status_counts: { sufficient: 1 },
+        median_expected_file_recall: 1,
+        median_expected_claim_recall: 0.8,
+        median_citation_coverage: 1,
+        median_follow_up_commands_count: 2,
+        median_wall_ms: 30_000,
+      },
+    ],
+  });
+  const abDoc = path.join(root, "autoresearch.md");
+  fs.writeFileSync(
+    abDoc,
+    "agent_ab_overhead_ratio=0.2\nagent_ab_overhead_ratio=0.4\n",
+  );
+
+  const summary = computeAgentValueScore(
+    {
+      promptSummaries: [promptA, promptB],
+      symbolSummary: symbol,
+      packetSummary: packet,
+      abDoc,
+    },
+    { cwd: root },
+  );
+
+  assert.equal(summary.metrics.prompt_file_recall_mean, 0.75);
+  assert.equal(summary.metrics.exact_symbol_path_hit_at_k, 1);
+  assert.equal(summary.metrics.packet_p95_wall_ms, 30000);
+  assert.equal(summary.metrics.live_ab_overhead_ratio_mean, 0.3);
+  assert.equal(summary.metrics.live_ab_ratio_count, 2);
+  assert.equal(summary.metrics.packet_sufficiency_rate, 1);
+  assert.equal(summary.metrics.packet_expected_file_recall_mean, 1);
+  assert.equal(summary.metrics.packet_expected_claim_recall_mean, 0.9);
+  assert.equal(summary.metrics.packet_citation_coverage_mean, 0.9);
+  assert.equal(summary.metrics.agent_value_score, 0.751875);
+  assert.equal(summary.metrics.agent_value_gap, 0.248125);
+});
+
+test("counts packet sufficiency without quality_pass_runs", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-sufficiency-"));
+  const packet = writeJson(root, "packet.json", {
+    summary: [
+      {
+        repo: "vscode",
+        task_id: "extension-flow",
+        mode: "cold-cli",
+        quality_pass_runs: 0,
+        sufficiency_status_counts: { sufficient: 1, partial: 1 },
+        median_expected_file_recall: 0.6,
+        median_expected_claim_recall: 0.5,
+        median_citation_coverage: 0.7,
+        median_follow_up_commands_count: 0,
+      },
+    ],
+  });
+
+  const summary = computeAgentValueScore(
+    {
+      promptSummaries: [],
+      symbolSummary: null,
+      packetSummary: packet,
+      abDoc: null,
+    },
+    { cwd: root },
+  );
+
+  const row = {
+    quality_pass_runs: 0,
+    sufficiency_status_counts: { sufficient: 1, partial: 1 },
+    median_expected_file_recall: 0.6,
+    median_expected_claim_recall: 0.5,
+    median_citation_coverage: 0.7,
+    median_follow_up_commands_count: 0,
+  };
+
+  assert.equal(summary.metrics.packet_sufficiency_rate, 1);
+  assert.equal(rowSufficiencyRate(row), 0.5);
+  assert.ok(Math.abs(packetRowQualityScore(row) - 0.655) < 1e-9);
+});
+
+test("penalizes sufficient_quality_mismatch in sufficiency rate and packet score", () => {
+  const row = {
+    sufficiency_status_counts: { sufficient: 1 },
+    sufficient_quality_mismatch_runs: 1,
+    median_expected_file_recall: 0.8,
+    median_expected_claim_recall: 0.8,
+    median_citation_coverage: 0.8,
+    median_follow_up_commands_count: 0,
+  };
+  assert.equal(rowEffectiveSufficiency(row), false);
+  assert.ok(packetRowQualityScore(row) < packetRowQualityScore({ ...row, sufficient_quality_mismatch_runs: 0 }));
+});
+
+test("rejects mixed run stamps", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-coherency-"));
+  const prompt = writeJson(
+    root,
+    "target/retrieval-golden/rootandruntime-prompt-six-lane-bundle-2026-05-25/summary.json",
+    { summary: { prompt_file_recall: 1 } },
+  );
+  const symbol = writeJson(
+    root,
+    "target/retrieval-golden/symbol-slice-six-lane-bundle-2026-05-26/summary.json",
+    { summary: { symbol_path_hit_at_k: 1 } },
+  );
+  const packet = writeJson(
+    root,
+    "target/agent-benchmark/packet-runtime-local-real-six-lane-2026-05-26/packet-runtime-summary.json",
+    { summary: [] },
+  );
+
+  assert.throws(
+    () =>
+      computeAgentValueScore(
+        {
+          promptSummaries: [prompt],
+          symbolSummary: symbol,
+          packetSummary: packet,
+          abDoc: null,
+        },
+        { cwd: root },
+      ),
+    /mixed run stamps/i,
+  );
+  assert.equal(extractRunStamp(prompt), "2026-05-25");
+  assert.equal(extractRunStamp(symbol), "2026-05-26");
+  assert.equal(extractRunStamp(packet), "2026-05-26");
+});
+
+test("uses benchmark_run_id metadata for coherent mandatory-sidecar artifact scoring", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-sidecar-coherency-"));
+  const prompt = writeJson(root, "prompt/summary.json", {
+    benchmark_run_id: "segment43-sidecar",
+    summary: { prompt_file_recall: 1 },
+  });
+  const symbol = writeJson(root, "symbol/summary.json", {
+    benchmark_run_id: "segment43-sidecar",
+    summary: { symbol_path_hit_at_k: 1 },
+  });
+  const packet = writeJson(root, "packet/packet-runtime-summary.json", {
+    benchmark_run_id: "segment43-sidecar",
+    summary: [],
+  });
+
+  const summary = computeAgentValueScore(
+    {
+      promptSummaries: [prompt],
+      symbolSummary: symbol,
+      packetSummary: packet,
+      abDoc: null,
+    },
+    { cwd: root },
+  );
+
+  assert.equal(artifactRunStamp(prompt), "segment43-sidecar");
+  assert.equal(summary.run_coherency.enforced, true);
+  assert.equal(summary.run_coherency.run_stamp, "segment43-sidecar");
+
+  const mismatchedPacket = writeJson(root, "packet-mismatch/packet-runtime-summary.json", {
+    benchmark_run_id: "segment43-other",
+    summary: [],
+  });
+  assert.throws(
+    () =>
+      computeAgentValueScore(
+        {
+          promptSummaries: [prompt],
+          symbolSummary: symbol,
+          packetSummary: mismatchedPacket,
+          abDoc: null,
+        },
+        { cwd: root },
+      ),
+    /mixed run stamps/i,
+  );
+});
+
+test("builds per-task commit-to-commit packet quality deltas", () => {
+  const baselineRows = [
+    {
+      repo: "codex",
+      task_id: "event-output",
+      mode: "cold-cli",
+      quality_pass_runs: 0,
+      sufficiency_status_counts: { partial: 1 },
+      median_expected_file_recall: 0.625,
+      median_expected_claim_recall: 0.5,
+      median_citation_coverage: 0.625,
+      median_follow_up_commands_count: 2,
+    },
+  ];
+  const currentRows = [
+    {
+      repo: "codex",
+      task_id: "event-output",
+      mode: "cold-cli",
+      quality_pass_runs: 1,
+      sufficiency_status_counts: { sufficient: 1 },
+      median_expected_file_recall: 0.75,
+      median_expected_claim_recall: 0.75,
+      median_citation_coverage: 0.75,
+      median_follow_up_commands_count: 0,
+    },
+  ];
+
+  const deltas = buildPacketQualityDeltas(currentRows, baselineRows, {
+    baselinePath: "target/agent-benchmark/packet-runtime-post-aaaaaaa/packet-runtime-summary.json",
+    currentPath: "target/agent-benchmark/packet-runtime-post-bbbbbbb/packet-runtime-summary.json",
+  });
+
+  assert.equal(deltas.baseline_label, "aaaaaaa");
+  assert.equal(deltas.current_label, "bbbbbbb");
+  assert.equal(deltas.tasks.length, 1);
+  assert.equal(deltas.tasks[0].deltas.median_expected_file_recall.delta, 0.125);
+  assert.equal(deltas.tasks[0].deltas.quality_pass_runs.delta, 1);
+  assert.equal(deltas.tasks[0].deltas.sufficiency_rate.delta, 1);
+});
+
+test("summarizes largest gap component and recommended next lane", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-lane-"));
+  const prompt = writeJson(root, "prompt.json", {
+    summary: { prompt_file_recall: 0.95 },
+  });
+  const symbol = writeJson(root, "symbol.json", {
+    summary: { symbol_path_hit_at_k: 0.9 },
+  });
+  const packet = writeJson(root, "packet.json", {
+    summary: [
+      {
+        repo: "codex",
+        task_id: "event-output",
+        mode: "cold-cli",
+        quality_pass_runs: 1,
+        sufficiency_status_counts: { sufficient: 1 },
+        median_expected_file_recall: 0.8,
+        median_expected_claim_recall: 0.7,
+        median_citation_coverage: 0.7,
+        median_follow_up_commands_count: 1,
+        median_wall_ms: 90_000,
+        median_packet_retrieval_total_ms: 70_000,
+        median_packet_freshness_ms: 10_000,
+        median_packet_unaccounted_ms: 10_000,
+        packet_top_latency_step_kind: "search",
+        median_packet_top_step_ms: 55_000,
+        packet_sla_missed_runs: 1,
+      },
+      {
+        repo: "vscode",
+        task_id: "extension-flow",
+        mode: "warm-stdio",
+        quality_pass_runs: 1,
+        sufficiency_status_counts: { sufficient: 1 },
+        median_expected_file_recall: 1,
+        median_expected_claim_recall: 1,
+        median_citation_coverage: 1,
+        median_follow_up_commands_count: 0,
+        median_wall_ms: 15_000,
+      },
+    ],
+  });
+
+  const summary = computeAgentValueScore(
+    {
+      promptSummaries: [prompt],
+      symbolSummary: symbol,
+      packetSummary: packet,
+      abDoc: null,
+    },
+    { cwd: root },
+  );
+
+  assert.equal(summary.triage.largest_gap_component, "packet_latency");
+  assert.equal(summary.triage.recommended_next_lane, "packet-latency");
+  assert.ok(summary.triage.component_gaps.some((row) => row.component === "packet_latency"));
+  assert.equal(summary.contributors.inputs[0].kind, "prompt_summary");
+  assert.equal(summary.contributors.packet_rows.length, 2);
+  assert.equal(summary.contributors.packet_rows[0].top_latency_step, "search");
+  assert.equal(summary.contributors.packet_rows[0].median_top_step_ms, 55_000);
+  assert.equal(summary.contributors.packet_rows[0].sla_missed_runs, 1);
+  assert.deepEqual(
+    summary.contributors.packet_rows.map((row) => [
+      row.repo,
+      row.task_id,
+      row.mode,
+      row.largest_gap_component,
+      row.recommended_next_lane,
+    ]),
+    [
+      ["codex", "event-output", "cold-cli", "packet_latency", "packet-latency"],
+      ["vscode", "extension-flow", "warm-stdio", "packet_latency", "packet-latency"],
+    ],
+  );
+});
+
+test("discovers newest default artifact inputs by known prefixes", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-discover-"));
+  writeJson(root, "target/retrieval-golden/rootandruntime-prompt-old/summary.json", {
+    summary: { prompt_file_recall: 0.2 },
+  });
+  const rootPrompt = writeJson(
+    root,
+    "target/retrieval-golden/rootandruntime-prompt-six-lane-bundle-new/summary.json",
+    { summary: { prompt_file_recall: 0.4 } },
+  );
+  const guardPrompt = writeJson(root, "target/retrieval-golden/prompt-guard-six-lane-bundle-new/summary.json", {
+    summary: { prompt_file_recall: 1 },
+  });
+  const symbol = writeJson(root, "target/retrieval-golden/symbol-slice-six-lane-bundle-new/summary.json", {
+    summary: { symbol_path_hit_at_k: 1 },
+  });
+  const packet = writeJson(
+    root,
+    "target/agent-benchmark/packet-runtime-local-real-six-lane-new/packet-runtime-summary.json",
+    { summary: [] },
+  );
+  fs.writeFileSync(path.join(root, "autoresearch.md"), "agent_ab_overhead_ratio=0.25\n");
+
+  const inputs = discoverInputs({
+    cwd: root,
+    promptSummaries: [],
+    symbolSummary: null,
+    packetSummary: null,
+    abDoc: path.join(root, "autoresearch.md"),
+  });
+
+  assert.deepEqual(inputs.promptSummaries.sort(), [guardPrompt, rootPrompt].sort());
+  assert.equal(inputs.symbolSummary, symbol);
+  assert.equal(inputs.packetSummary, packet);
+});
+
+test("explicit score inputs do not backfill mixed-vintage default artifacts", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-explicit-"));
+  const prompt = writeJson(root, "target/retrieval-golden/scout/summary.json", {
+    benchmark_run_id: "fresh-scout",
+    summary: { prompt_file_recall: 0.5, symbol_path_hit_at_k: 1 },
+  });
+  writeJson(root, "target/agent-benchmark/packet-runtime-local-real-six-lane-old/packet-runtime-summary.json", {
+    benchmark_run_id: "old-packet",
+    summary: [],
+  });
+
+  const opts = parseArgs([
+    "--cwd",
+    root,
+    "--prompt-summary",
+    prompt,
+    "--symbol-summary",
+    prompt,
+    "--no-ab-doc",
+  ]);
+  const inputs = discoverInputs(opts);
+
+  assert.deepEqual(inputs.promptSummaries, [prompt]);
+  assert.equal(inputs.symbolSummary, prompt);
+  assert.equal(inputs.packetSummary, null);
+  assert.equal(inputs.abDoc, null);
+});
+
+test("aggregates sidecar diagnostics once for shared prompt and symbol scout summary", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-agent-value-sidecar-loss-"));
+  const searchSummary = writeJson(root, "target/retrieval-golden/scout/summary.json", {
+    benchmark_run_id: "segment58-loss-scout",
+    summary: {
+      prompt_file_recall: 0.5,
+      symbol_path_hit_at_k: 1,
+      sidecar_expected_files_present_missing_from_search_count: 2,
+      sidecar_expected_symbols_present_missing_from_search_count: 1,
+      sidecar_query_trace_with_candidates_count: 1,
+      sidecar_query_trace_no_candidates_count: 0,
+      sidecar_prepare_count: 1,
+      sidecar_prepare_failed_count: 1,
+      sidecar_prepare_max_latency_ms: 90_070.026,
+      sidecar_shadow_candidate_count: 5,
+      sidecar_shadow_resolved_hit_count: 3,
+      sidecar_shadow_unresolved_candidate_count: 2,
+      sidecar_shadow_resolution_counts: [
+        { resolution: "node_unresolved", count: 2 },
+        { resolution: "resolved", count: 3 },
+      ],
+    },
+    rows: [
+      {
+        retrieval_shadow: {
+          candidate_count: 99,
+          resolved_hit_count: 99,
+          unresolved_candidate_count: 99,
+        },
+      },
+    ],
+  });
+
+  const summary = computeAgentValueScore(
+    {
+      promptSummaries: [searchSummary],
+      symbolSummary: searchSummary,
+      packetSummary: null,
+      abDoc: null,
+    },
+    { cwd: root },
+  );
+
+  assert.equal(summary.metrics.sidecar_expected_files_present_missing_from_search_count, 2);
+  assert.equal(summary.metrics.sidecar_expected_symbols_present_missing_from_search_count, 1);
+  assert.equal(summary.metrics.sidecar_query_trace_with_candidates_count, 1);
+  assert.equal(summary.metrics.sidecar_prepare_count, 1);
+  assert.equal(summary.metrics.sidecar_prepare_failed_count, 1);
+  assert.equal(summary.metrics.sidecar_prepare_max_latency_ms, 90_070.026);
+  assert.equal(summary.metrics.sidecar_candidate_count, 5);
+  assert.equal(summary.metrics.sidecar_resolved_hit_count, 3);
+  assert.equal(summary.metrics.sidecar_unresolved_candidate_count, 2);
+  assert.equal(summary.metrics.sidecar_candidate_resolution_rate, 0.6);
+  assert.deepEqual(summary.contributors.sidecar_diagnostics.resolution_counts, [
+    { resolution: "node_unresolved", count: 2 },
+    { resolution: "resolved", count: 3 },
+  ]);
+  assert.ok(
+    metricEntries(summary).some(
+      ([name, value]) => name === "sidecar_unresolved_candidate_count" && value === 2,
+    ),
+  );
+});
+
+test("metric emission excludes null component scores", () => {
+  const entries = metricEntries({
+    metrics: {
+      agent_value_gap: 0.5,
+      packet_score: null,
+      live_ab_overhead_ratio_mean: null,
+      live_ab_ratio_count: 0,
+    },
+  });
+
+  assert.deepEqual(entries, [
+    ["agent_value_gap", 0.5],
+    ["live_ab_ratio_count", 0],
+  ]);
+});
+
+test("packet composition scoring favors citation-backed recall over answer-text-only mentions", async () => {
+  const { packetComposition, packetCompositionFileScore, PACKET_COMPOSITION_WEIGHTS } = await import(
+    "../codestory-agent-ab-benchmark.mjs"
+  );
+
+  const expectedFiles = [
+    "src/lib/project/Project.cpp",
+    "src/lib/data/storage/StorageAccessProxy.cpp",
+  ];
+  const citedOnly = packetComposition(
+    {
+      answer: {
+        citations: expectedFiles.map((file_path, index) => ({
+          display_name: `Anchor${index}`,
+          file_path,
+          line: 1,
+        })),
+      },
+      sufficiency: { avoid_opening: [] },
+    },
+    { expected_files: expectedFiles },
+  );
+  const textOnly = packetComposition(
+    {
+      answer: {
+        summary: "Mentions src/lib/data/storage/StorageAccessProxy.cpp only in prose.",
+        citations: [{ display_name: "Anchor", file_path: "src/lib/project/Project.cpp", line: 1 }],
+      },
+      sufficiency: { avoid_opening: [] },
+    },
+    { expected_files: expectedFiles },
+  );
+
+  assert.equal(citedOnly.composition_score, 1);
+  assert.ok(textOnly.composition_score < citedOnly.composition_score);
+  assert.equal(textOnly.answer_text_file_count, 1);
+  assert.equal(PACKET_COMPOSITION_WEIGHTS.cited, 1);
+  assert.equal(packetCompositionFileScore({ cited: true, avoid_opening: false, answer_text_mentioned: false, citation_backed_found: true }), 1);
+});
+
+test("local-real compact-budget packet rows keep distinct repo task coverage", () => {
+  const packet = {
+    summary: [
+      {
+        repo: "vscode",
+        task_id: "vscode-workbench-extension-host",
+        mode: "cold-cli",
+        quality_pass_runs: 1,
+        sufficiency_status_counts: { sufficient: 1 },
+        median_expected_file_recall: 0.8,
+        median_expected_claim_recall: 0.8,
+        median_citation_coverage: 0.8,
+        median_follow_up_commands_count: 0,
+        median_wall_ms: 25_000,
+      },
+      {
+        repo: "codex",
+        task_id: "codex-exec-json-flow",
+        mode: "cold-cli",
+        quality_pass_runs: 1,
+        sufficiency_status_counts: { sufficient: 1 },
+        median_expected_file_recall: 0.85,
+        median_expected_claim_recall: 0.85,
+        median_citation_coverage: 0.75,
+        median_follow_up_commands_count: 1,
+        median_wall_ms: 12_000,
+      },
+      {
+        repo: "sourcetrail",
+        task_id: "sourcetrail-indexing-to-storage",
+        mode: "cold-cli",
+        quality_pass_runs: 1,
+        sufficiency_status_counts: { partial: 1 },
+        median_expected_file_recall: 0.7,
+        median_expected_claim_recall: 0.7,
+        median_citation_coverage: 0.65,
+        median_follow_up_commands_count: 2,
+        median_wall_ms: 18_000,
+      },
+    ],
+  };
+
+  for (const row of packet.summary) {
+    assert.ok(packetRowQualityScore(row) > 0.5, `${row.repo}/${row.task_id} should stay above quality floor`);
+    assert.ok(row.median_wall_ms <= 30_000, `${row.repo}/${row.task_id} should stay within compact budget SLA`);
+  }
+});
+
+function writeJson(root, relativePath, payload) {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+  return filePath;
+}

--- a/scripts/tests/codestory-benchmark-contract.test.mjs
+++ b/scripts/tests/codestory-benchmark-contract.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assertSidecarMandatoryEnv,
+  benchmarkChildEnv,
+  retrievalContractSummary,
+  retrievalEnv,
+  shouldPrepareRetrievalIndex,
+  unsupportedSidecarContractRequests,
+  unsupportedSidecarDisabledRequest,
+} from "../codestory-benchmark-contract.mjs";
+
+test("benchmark child env makes sidecar-primary explicit by default", () => {
+  const env = benchmarkChildEnv({});
+
+  assert.equal(env.CODESTORY_RETRIEVAL, "1");
+  assert.equal(env.CODESTORY_RETRIEVAL_REAL_EMBEDDINGS, "1");
+  assert.equal(env.CODESTORY_RETRIEVAL_COMPOSE_PROFILE, "real");
+  assert.equal(env.CODESTORY_EMBED_BACKEND, "llamacpp");
+  assert.equal(env.CODESTORY_EMBED_LLAMACPP_URL, "http://127.0.0.1:8080/v1/embeddings");
+  assert.equal(env.CODESTORY_EVAL_PROBES, undefined);
+  assert.equal(shouldPrepareRetrievalIndex(env), true);
+  assert.deepEqual(retrievalContractSummary(env), {
+    retrieval_contract: "sidecar_primary_forced",
+    sidecar_primary: true,
+    unsupported_sidecar_disabled_request: false,
+    code_story_retrieval: "1",
+    embedding_backend: "llamacpp",
+    compose_profile: "real",
+  });
+});
+
+test("benchmark child env preserves explicit eval probe diagnostics without injecting them", () => {
+  const env = benchmarkChildEnv({ CODESTORY_EVAL_PROBES: "1" });
+
+  assert.equal(env.CODESTORY_RETRIEVAL, "1");
+  assert.equal(env.CODESTORY_EVAL_PROBES, "1");
+});
+
+test("explicit sidecar disable is rejected by the benchmark contract", () => {
+  const env = { CODESTORY_RETRIEVAL: "0", CODESTORY_EVAL_PROBES: "0" };
+
+  assert.throws(
+    () => benchmarkChildEnv(env),
+    /CODESTORY_RETRIEVAL=0 is unsupported; sidecar retrieval is mandatory/,
+  );
+  assert.throws(
+    () => shouldPrepareRetrievalIndex(env),
+    /CODESTORY_RETRIEVAL=0 is unsupported; sidecar retrieval is mandatory/,
+  );
+  assert.throws(
+    () => assertSidecarMandatoryEnv(env),
+    /CODESTORY_RETRIEVAL=0 is unsupported; sidecar retrieval is mandatory/,
+  );
+  assert.equal(unsupportedSidecarDisabledRequest(env), true);
+  assert.deepEqual(retrievalContractSummary(env), {
+    retrieval_contract: "unsupported_sidecar_disabled",
+    sidecar_primary: false,
+    unsupported_sidecar_disabled_request: true,
+    code_story_retrieval: "0",
+  });
+});
+
+test("benchmark contract rejects diagnostic sidecar downgrades", () => {
+  const env = {
+    CODESTORY_RETRIEVAL: "1",
+    CODESTORY_RETRIEVAL_SHADOW: "1",
+    CODESTORY_RETRIEVAL_V2: "1",
+    CODESTORY_QDRANT_ENABLED: "0",
+    CODESTORY_ZOEKT_ENABLED: "false",
+    CODESTORY_RETRIEVAL_REAL_EMBEDDINGS: "0",
+    CODESTORY_RETRIEVAL_COMPOSE_PROFILE: "stub",
+    CODESTORY_EMBED_BACKEND: "hash",
+  };
+
+  const blockers = unsupportedSidecarContractRequests(env);
+  assert.equal(blockers.length, 7);
+  assert.throws(() => benchmarkChildEnv(env), /Qdrant sidecar is mandatory/);
+});
+
+test("retrieval env captures sidecar variables", () => {
+  const env = retrievalEnv({
+    CODESTORY_RETRIEVAL: "1",
+  });
+
+  assert.equal(env.CODESTORY_RETRIEVAL, "1");
+  assert.equal(env.CODESTORY_RETRIEVAL_SHADOW, null);
+  assert.equal(env.CODESTORY_RETRIEVAL_V2, null);
+  assert.equal(env.CODESTORY_RETRIEVAL_V2_SHADOW, null);
+});


### PR DESCRIPTION
## Summary
- Adds holdout/local-real benchmark task manifests and expands the task schema/readme.
- Updates the agent A/B benchmark for mandatory sidecar provenance, packet runtime scoring, and cache preparation.
- Adds value scoring and benchmark-contract scripts with tests, plus a small bench compile fix.

## Tests
- cargo check -p codestory-bench --benches
- node --check scripts/codestory-agent-ab-benchmark.mjs
- node --check scripts/codestory-agent-value-score.mjs
- node --check scripts/codestory-benchmark-contract.mjs
- node --check scripts/fetch-holdout-repos.mjs
- node --test scripts/tests/codestory-agent-ab-analyzer.test.mjs scripts/tests/codestory-agent-value-score.test.mjs scripts/tests/codestory-benchmark-contract.test.mjs
- cargo fmt --check
- git diff --check

## Stack
Base: codex/accuracy-pass-04-cli-retrieval (#14)
Next: codex/accuracy-pass-06-docs-ci