### PR TITLE
[codex] tighten retrieval rollout proofing

### DIFF
--- a/.agents/skills/codestory-grounding/SKILL.md
+++ b/.agents/skills/codestory-grounding/SKILL.md
@@ -18,17 +18,20 @@ checkout is only the tool artifact unless the user is editing CodeStory itself.
 3. Use `doctor` when cache, freshness, or retrieval health matters; use
    `index --refresh full` for first runs or historical indexing failures, and
    incremental refreshes during normal edit loops.
-4. Start broad repo, product, architecture, review, and planning questions with
+4. For retrieval rollout, sidecar, runtime, CLI, benchmark, or smoke-CI work,
+   choose the proof layer from `references/retrieval-rollout.md` before running
+   broad or expensive verification.
+5. Start broad repo, product, architecture, review, and planning questions with
    `packet`. Start exact target discovery with `search --why`.
-5. Use `context` only after selecting one concrete target by id, query, or
+6. Use `context` only after selecting one concrete target by id, query, or
    bookmark. Do not pass broad natural-language questions directly to `context`.
-6. Use `symbol`, `trail --story --hide-speculative`, `snippet`, and `explore`
+7. Use `symbol`, `trail --story --hide-speculative`, `snippet`, and `explore`
    for source-backed detail around a selected target.
-7. Use `files` before claiming language/path coverage, and `affected` before
+8. Use `files` before claiming language/path coverage, and `affected` before
    choosing regression tests from changed files.
-8. Use `drill` or `drill-suite` for repeatable answer-quality checks that need
+9. Use `drill` or `drill-suite` for repeatable answer-quality checks that need
    source-truth verification artifacts.
-9. Keep ordinary grounding CLI-first. Use `serve --stdio` only for warm
+10. Keep ordinary grounding CLI-first. Use `serve --stdio` only for warm
    transport, protocol, or stdio integration work.
 
 ## Evidence Rules
@@ -95,4 +98,5 @@ Detailed argument tables, output examples, and usage patterns for each command:
 - [affected](references/affected.md) - Changed-file impact analysis
 - [bookmark](references/bookmark.md) - Save reusable investigation focus nodes
 - [setup](references/setup.md) - Managed embedding setup
+- [retrieval-rollout](references/retrieval-rollout.md) - Proof table for retrieval rollout layers, sidecar repair, benchmark gates, and CI smoke triage
 - [serve](references/serve.md) - Local integration surface outside the normal CLI-navigation docs/spec workflow

--- a/.agents/skills/codestory-grounding/references/retrieval-rollout.md
+++ b/.agents/skills/codestory-grounding/references/retrieval-rollout.md
@@ -1,0 +1,62 @@
+# Retrieval Rollout Verification
+
+Use this when a change touches retrieval coverage, sidecars, runtime integration,
+CLI retrieval/search output, benchmarks, or the `retrieval-sidecar-smoke` CI
+workflow. The goal is to choose the proof that establishes each layer is
+trustworthy; running retrieval alone is not enough.
+
+## Decision Table
+
+| Rollout layer | Trustworthy proof | Run when | Does not prove |
+| --- | --- | --- | --- |
+| Indexer coverage | `cargo test -p codestory-indexer --test fidelity_regression`; `cargo test -p codestory-indexer --test tictactoe_language_coverage`; targeted `files` or `affected` checks for changed paths | Parser, tree-sitter, semantic-resolution, symbol, edge, file-role, or coverage changes | Sidecar readiness, runtime packet behavior, or CLI search contract |
+| Retrieval sidecar crate | `cargo test -p codestory-retrieval`; then live `retrieval bootstrap`, `retrieval index --project <repo> --refresh full`, and `retrieval status --project <repo> --format json` reporting `retrieval_mode="full"` | Zoekt, Qdrant, SCIP, manifest generation, sidecar status, embedding backend/dim, or Qdrant client changes | Runtime admission, stdio cache invalidation, or full CLI output shape |
+| Runtime integration | `cargo test -p codestory-runtime --lib`; `cargo test -p codestory-runtime --test retrieval_generalization_guard`; `cargo test -p codestory-runtime --test retrieval_eval`; set `CODESTORY_RETRIEVAL_EVAL_FULL_TESTS=1` only after real sidecars are prepared | Packet/search orchestration, fail-closed modes, retrieval shadow traces, rollback-warning logic, or runtime use of sidecar results | CLI argument/output behavior or GitHub smoke workflow behavior |
+| CLI surface | `cargo test -p codestory-cli --test retrieval_bootstrap_contracts`; `cargo test -p codestory-cli --test stdio_protocol_contracts`; `cargo test -p codestory-cli --test search_json_output`; with real sidecars, run the ignored full-mode search JSON test explicitly | `retrieval bootstrap/status/index` contracts, stdio protocol/cache fingerprints, fail-closed search JSON, or user-facing command shape | Full product readiness unless `retrieval status` is `full` after live sidecar indexing |
+| Benchmark harness | `cargo check -p codestory-bench --benches`; the relevant Criterion bench only when it isolates the hot path; release e2e stats for real-repo timing | New benchmark code, latency/timing claims, rollback baseline updates, or performance-sensitive retrieval/index changes | Promotion by itself; synthetic or narrow benches are scouts until real-repo evidence exists |
+| Smoke CI | `.github/workflows/retrieval-sidecar-smoke.yml` plus `docs/contributors/retrieval-sidecar-smoke-ci.md` pass criteria | PRs touching retrieval crate, runtime/stdio/search wiring, indexer retrieval hooks, retrieval docs, scripts, Docker sidecar config, or the workflow | Full sidecar readiness. CI smoke uses `--skip-compose --wait-secs 0` and proves manifest-missing fail-closed shape only |
+
+## CI Smoke Triage
+
+The Windows `retrieval-sidecar-smoke` workflow is intentionally reduced. It
+should fail if the manifest-missing status shape, production-path lint,
+runtime/stdio/search contracts, or retrieval crate contracts drift. It should
+not be "fixed" to pretend that full retrieval is available on the runner.
+
+| Failure | First triage step | Expected boundary |
+| --- | --- | --- |
+| Generalization lint fails | Check `scripts/lint-retrieval-generalization.mjs` and production retrieval paths for hard-coded fixture or repo-specific assumptions | Fix source/docs drift before changing tests |
+| `retrieval_bootstrap_contracts` fails | Inspect the clean pre-index status JSON; it should report `degraded_reason="retrieval_manifest_missing"` and non-`full` mode | Passing smoke still means no real sidecars, no GGUF fetch, and no manifest |
+| Runtime or stdio tests fail | Localize to runtime admission, rollback warning, stdio cache fingerprint, or search JSON fail-closed behavior | Do not use repo-text fallback as success evidence |
+| A reviewer asks for full-mode proof | Prepare real sidecars, fetch the GGUF model, run `retrieval index`, then require `retrieval status` to report `retrieval_mode="full"` | The CI smoke job is not the full-mode proof |
+
+## Qdrant And Indexing Symptoms
+
+Treat non-`full` retrieval modes as diagnostic only. Product packet/search
+evidence is trustworthy only after live sidecars are indexed and status is full.
+
+| Symptom | Likely layer | Action |
+| --- | --- | --- |
+| `retrieval_manifest_missing` | Bootstrap/state exists but no project manifest was finalized | In CI smoke this is expected. For product proof, run live `retrieval index --refresh full` and recheck status |
+| `sidecar_manifest_stale`, input-hash drift, or embedding-backend drift | Source, SQLite projection, semantic docs, backend, dimension, or schema changed after the manifest | Rerun `retrieval index --refresh full`; `--refresh auto` may repair stale stored semantic-doc contracts once, but explicit failures still fail closed |
+| `no_semantic`, `lexical_only`, or `unavailable` with Qdrant errors | Qdrant, embedding endpoint, or semantic smoke failed | Run bootstrap, confirm ports `6333`/`6334` and the embedding endpoint, then rebuild sidecar indexes |
+| Qdrant collection exists but point count is below the semantic-doc projection count, is one-point, or has a stub marker | Partial or obsolete collection | Rerun `retrieval index`; do not bless semantic smoke alone as full readiness |
+| Qdrant response lacks `result.points[]` | Qdrant client/API contract drift or wrong image | Verify the pinned Qdrant image and update the client/test contract deliberately |
+| `storage_repair.scan_errors` appears during bootstrap | Cache protection scan was incomplete | Resolve unreadable cache roots or DBs before relying on retention pruning; do not treat suppressed pruning as readiness proof |
+
+## Repo-Scale E2E Stats Log
+
+Before committing in this repo, run the release CLI e2e stats lane and append
+the emitted headline metrics to `docs/testing/codestory-e2e-stats-log.md`:
+
+```powershell
+cargo build --release -p codestory-cli
+cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture
+```
+
+This log is especially mandatory for retrieval rollout changes that affect
+default indexing, semantic-doc persistence or reuse, sidecar indexing/status,
+packet/search behavior, runtime grounding surfaces, CLI command shape, or any
+performance/timing claim. A stats-only row with
+`CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1` can record local timing, but it
+is not real-drill release evidence.

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -40,11 +40,11 @@ pub struct ProjectQdrantRepairOutcome {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct SidecarInputFingerprint {
-    hash: String,
-    projection_count: i64,
-    lexical_file_count: u32,
-    lexical_hash: String,
+pub(crate) struct SidecarInputFingerprint {
+    pub(crate) hash: String,
+    pub(crate) projection_count: i64,
+    pub(crate) lexical_file_count: u32,
+    pub(crate) lexical_hash: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -660,7 +660,7 @@ fn persist_finalized_manifest(
     })
 }
 
-fn compute_sidecar_input_fingerprint(
+pub(crate) fn compute_sidecar_input_fingerprint(
     storage: &Store,
     project_root: &Path,
     project_id: &str,

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1,7 +1,10 @@
 use crate::config::SidecarLayout;
-use crate::generation::manifest_unavailable_reason;
+use crate::generation::{
+    SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
+    manifest_staleness_reason, manifest_unavailable_reason,
+};
 use crate::health::{RetrievalStatusReport, probe_sidecar_health};
-use crate::index::project_id_for_root;
+use crate::index::{compute_sidecar_input_fingerprint, project_id_for_root};
 use anyhow::{Context, Result};
 use codestory_store::Store;
 use codestory_workspace::{RefreshInputs, StoredFileState, WorkspaceManifest};
@@ -72,8 +75,9 @@ fn sidecar_status_inner(
             .context("load retrieval manifest")?;
         if strict
             && let Some(manifest) = manifest.as_ref()
-            && let Some(reason) = strict_readiness_unavailable_reason(project_root, &storage)
-                .context("check strict sidecar readiness")?
+            && let Some(reason) =
+                strict_readiness_unavailable_reason(project_root, &storage, &project_id, manifest)
+                    .context("check strict sidecar readiness")?
         {
             return Ok(crate::health::unavailable_status_report(
                 format!("sidecar_manifest_stale: {reason}"),
@@ -99,7 +103,16 @@ pub(crate) fn validate_strict_sidecar_readiness(
     project_root: &Path,
     storage: &Store,
 ) -> Result<()> {
-    if let Some(reason) = strict_readiness_unavailable_reason(project_root, storage)? {
+    let project_id = project_id_for_root(project_root);
+    let Some(manifest) = storage
+        .get_retrieval_index_manifest(&project_id)
+        .context("load retrieval manifest for strict readiness")?
+    else {
+        return Ok(());
+    };
+    if let Some(reason) =
+        strict_readiness_unavailable_reason(project_root, storage, &project_id, &manifest)?
+    {
         anyhow::bail!("sidecar_manifest_stale: {reason}");
     }
     Ok(())
@@ -108,7 +121,35 @@ pub(crate) fn validate_strict_sidecar_readiness(
 fn strict_readiness_unavailable_reason(
     project_root: &Path,
     storage: &Store,
+    project_id: &str,
+    manifest: &codestory_store::RetrievalIndexManifest,
 ) -> Result<Option<String>> {
+    if !manifest_has_current_sidecar_contract(project_id, manifest) {
+        return Ok(None);
+    }
+    if let Some(reason) = manifest_staleness_reason(storage, manifest)
+        && manifest_contract_drift_should_win(&reason)
+    {
+        return Ok(None);
+    }
+
+    let embedding_backend = crate::embeddings::embedding_runtime_id();
+    let embedding_dim = i32::try_from(crate::embeddings::qdrant_vector_dim())
+        .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
+    let current_input = compute_sidecar_input_fingerprint(
+        storage,
+        project_root,
+        project_id,
+        &embedding_backend,
+        embedding_dim,
+    )
+    .context("compute strict sidecar input fingerprint")?;
+    if manifest.sidecar_input_hash.as_deref() == Some(current_input.hash.as_str())
+        && manifest.projection_count == Some(current_input.projection_count)
+    {
+        return Ok(None);
+    }
+
     let workspace = WorkspaceManifest::open(project_root.to_path_buf())
         .context("open workspace manifest for strict sidecar readiness")?;
     let files = storage.files().get_files().context("load indexed files")?;
@@ -127,7 +168,11 @@ fn strict_readiness_unavailable_reason(
     let plan = workspace
         .build_execution_plan(&refresh_inputs)
         .context("build strict sidecar freshness plan")?;
-    if let Some(path) = plan.files_to_index.first() {
+    if let Some(path) = plan
+        .files_to_index
+        .iter()
+        .find(|path| graph_indexed_source_path(path))
+    {
         return Ok(Some(format!(
             "indexable_file_added_or_changed_after_sidecar_manifest: {}",
             path.display()
@@ -138,7 +183,63 @@ fn strict_readiness_unavailable_reason(
             "indexed_file_removed_after_sidecar_manifest: file_id={file_id}"
         )));
     }
-    Ok(None)
+    Ok(Some(format!(
+        "sidecar_input_hash_changed: manifest={} current={}; projection_count manifest={} current={}",
+        manifest
+            .sidecar_input_hash
+            .as_deref()
+            .unwrap_or("<missing>"),
+        current_input.hash,
+        manifest
+            .projection_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "<missing>".into()),
+        current_input.projection_count
+    )))
+}
+
+fn graph_indexed_source_path(path: &Path) -> bool {
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase());
+    matches!(
+        extension.as_deref(),
+        Some(
+            "rs" | "py"
+                | "pyi"
+                | "java"
+                | "js"
+                | "jsx"
+                | "mjs"
+                | "cjs"
+                | "svelte"
+                | "vue"
+                | "astro"
+                | "ts"
+                | "tsx"
+                | "mts"
+                | "cts"
+                | "c"
+                | "cc"
+                | "cpp"
+                | "cxx"
+                | "h"
+                | "hh"
+                | "hpp"
+                | "hxx"
+                | "go"
+                | "rb"
+                | "php"
+                | "cs"
+        )
+    )
+}
+
+fn manifest_contract_drift_should_win(reason: &str) -> bool {
+    reason.contains("sidecar_embedding_backend_changed")
+        || reason.contains("sidecar_embedding_dim_changed")
+        || reason == SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED
 }
 
 #[cfg(test)]
@@ -147,6 +248,7 @@ mod tests {
     use crate::generation::{
         SIDECAR_SCHEMA_VERSION, sidecar_generation_id, sidecar_qdrant_collection,
     };
+    use crate::index::compute_sidecar_input_fingerprint;
     use codestory_store::{FileInfo, FileRole};
     use tempfile::TempDir;
 
@@ -400,6 +502,71 @@ mod tests {
                 .unwrap_or_default()
                 .contains("indexable_file_added_or_changed_after_sidecar_manifest"),
             "new indexable file should make strict status fail closed: {report:?}"
+        );
+    }
+
+    #[test]
+    fn strict_readiness_accepts_markdown_covered_by_sidecar_fingerprint() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let source_path = project.path().join("src").join("lib.rs");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("create source parent");
+        std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        std::fs::write(project.path().join("AGENTS.md"), "# Agent guidance\n")
+            .expect("write markdown");
+        let indexed_mtime = live_mtime_millis(&source_path);
+        let project_id = project_id_for_root(project.path());
+
+        let mut storage = Store::open(&storage_path).expect("open db");
+        storage
+            .insert_file(&FileInfo {
+                id: 1,
+                path: source_path.clone(),
+                language: "rust".into(),
+                modification_time: indexed_mtime,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: FileRole::Source,
+            })
+            .expect("insert indexed file");
+        let input = compute_sidecar_input_fingerprint(
+            &storage,
+            project.path(),
+            &project_id,
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+        )
+        .expect("sidecar input");
+        storage
+            .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
+                project_id: project_id.clone(),
+                zoekt_version: "zoekt-real-v1".into(),
+                qdrant_collection: sidecar_qdrant_collection(&project_id, &input.hash),
+                scip_revision: Some("graph-test".into()),
+                built_at_epoch_ms: indexed_mtime,
+                disk_bytes: None,
+                degraded_modes_json: "[]".into(),
+                embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+                embedding_dim: Some(768),
+                sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
+                sidecar_input_hash: Some(input.hash.clone()),
+                sidecar_generation: Some(sidecar_generation_id(&project_id, &input.hash)),
+                projection_count: Some(input.projection_count),
+            })
+            .expect("manifest");
+
+        validate_strict_sidecar_readiness(project.path(), &storage)
+            .expect("markdown already covered by sidecar input should not look stale");
+
+        std::fs::write(project.path().join("README.md"), "# New docs\n").expect("write new docs");
+        let stale = validate_strict_sidecar_readiness(project.path(), &storage)
+            .expect_err("new sidecar-only docs should stale the manifest");
+        assert!(
+            stale.to_string().contains("sidecar_input_hash_changed"),
+            "docs-only sidecar drift should report input-hash drift, got: {stale:?}"
         );
     }
 

--- a/docs/testing/codestory-e2e-stats-log.md
+++ b/docs/testing/codestory-e2e-stats-log.md
@@ -52,6 +52,7 @@ Keep the full emitted JSON in the test output when reviewing locally, and add th
 | 2026-06-02 | 4c616548+wt | blocked, round 7 release e2e index phase did not complete; stopped child after 1075.05s with no stdout/stderr; failed command `index --refresh full --format json`; retrieval_index_seconds n/a; retrieval_mode n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a |
 | 2026-06-02 | 25751a39+wt | fail, round 8 release e2e stats ok; real drill manifest env missing fail-closed; retrieval_index_seconds 17.73; retrieval_status_seconds 0.46; retrieval_mode full | 720.80 | 0.31 | 1.54 | 0.52 | 0.26 | 0.26 | 78,478 | 66,235 | 217 | 0 | 10,839 | true |
 | 2026-06-02 | a23770f+wt | pass, round 9 stats-only release e2e; real drill intentionally skipped with CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1; not real-drill release evidence; retrieval_index_seconds 18.35; retrieval_status_seconds 0.56; retrieval_mode full | 711.31 | 0.32 | 1.77 | 0.59 | 0.32 | 0.27 | 78,582 | 66,332 | 217 | 0 | 10,847 | true |
+| 2026-06-05 | 42089cc5+wt | pass, stats-only retrieval rollout proof guidance plus strict sidecar markdown freshness fix; real drill intentionally skipped with CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1; retrieval_index_seconds 21.57; retrieval_status_seconds 0.96; retrieval_mode full | 981.56 | 0.50 | 2.94 | 0.54 | 0.34 | 0.26 | 79,028 | 66,731 | 217 | 0 | 10,881 | true |
 
 ## Phase Metrics
 
@@ -99,3 +100,4 @@ Keep the full emitted JSON in the test output when reviewing locally, and add th
 | 2026-06-02 | 4c616548+wt | round 7 blocked before phase metrics; release index child stopped after 1075.05s with no stdout/stderr; retrieval_index_seconds n/a; retrieval_mode n/a | n/a | n/a | n/a | n/a | n/a | n/a |
 | 2026-06-02 | 25751a39+wt | round 8 release e2e stats ok; real drill manifest env missing fail-closed; retrieval_index_seconds 17.73; retrieval_status_seconds 0.46; retrieval_mode full | 720.80 | 10.27 | 702.18 | 0 | 10,839 | 0 |
 | 2026-06-02 | a23770f+wt | round 9 stats-only release e2e; real drill intentionally skipped with CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1; not real-drill release evidence; retrieval_index_seconds 18.35; retrieval_mode full | 711.31 | 11.08 | 691.07 | 0 | 10,847 | 0 |
+| 2026-06-05 | 42089cc5+wt | stats-only retrieval rollout proof guidance plus strict sidecar markdown freshness fix; real drill intentionally skipped with CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1; retrieval_index_seconds 21.57; retrieval_mode full | 981.56 | 9.67 | 963.51 | 0 | 10,881 | 0 |


### PR DESCRIPTION
## Summary

- Add a `codestory-grounding` retrieval rollout proof table for indexer coverage, sidecar crate, runtime, CLI, benchmarks, and smoke CI.
- Fix strict retrieval sidecar freshness so Markdown/text files already covered by the sidecar input fingerprint do not keep strict status stale forever, while new source or sidecar input drift still fails closed.
- Append the 2026-06-05 repo-scale e2e stats-only row.

## Validation

- `cargo fmt --check`
- `cargo test -p codestory-retrieval`
- `cargo build --release -p codestory-cli`
- `target\release\codestory-cli.exe retrieval status --project . --format json` with product llama.cpp env after sidecar reindex: `retrieval_mode=full`
- `CODESTORY_EMBED_BACKEND=llamacpp CODESTORY_EMBED_LLAMACPP_URL=http://127.0.0.1:8080/v1/embeddings CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1 cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture`: pass, 2/2; stats row logged

## Notes

The first exact ignored e2e run failed locally because `CODESTORY_REAL_REPO_DRILL_CASES` was unset and strict sidecar status was stale. The documented stats-only rerun used `CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1`, so it is not real-drill release evidence.
