### PR TITLE
[codex] stabilize retrieval readiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "tempfile",
  "tokenizers",
  "tracing",
+ "ureq 2.12.1",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -34,18 +34,36 @@ cargo build --release -p codestory-cli
 $CodeStoryCli = ".\target\release\codestory-cli.exe"
 $TargetWorkspace = "C:\path\to\repo"
 
-cargo retrieval-setup
 & $CodeStoryCli doctor --project $TargetWorkspace
 & $CodeStoryCli setup embeddings --project $TargetWorkspace --dry-run --format json
 & $CodeStoryCli index --project $TargetWorkspace --refresh full
-& $CodeStoryCli retrieval index --project $TargetWorkspace --refresh auto
 & $CodeStoryCli ground --project $TargetWorkspace --why
 ```
 
-Current packet/search evidence requires the local Zoekt, Qdrant, SCIP, and
-llama.cpp embedding sidecars to reach `retrieval_mode=full`; missing assets,
-stale manifests, disabled sidecars, or diagnostic embedding modes are setup
-failures to fix before trusting agent context.
+That basic path builds the local SQLite index and is enough for health, file,
+symbol, trail, snippet, and orientation checks. The managed embedding dry-run is
+a local semantic setup check; it does not prove sidecar readiness.
+
+Agent-facing `packet` and `search` evidence has one extra readiness contract:
+local Zoekt, Qdrant, SCIP, and llama.cpp embedding sidecars must report
+`retrieval_mode=full`.
+
+```powershell
+node scripts/setup-retrieval-env.mjs --fetch-embed-model
+$env:CODESTORY_EMBED_MODEL_DIR = (Resolve-Path .\target\retrieval-models).Path
+$env:CODESTORY_EMBED_BACKEND = "llamacpp"
+$env:CODESTORY_EMBED_LLAMACPP_URL = "http://127.0.0.1:8080/v1/embeddings"
+
+cargo retrieval-setup
+& $CodeStoryCli index --project $TargetWorkspace --refresh full
+& $CodeStoryCli retrieval index --project $TargetWorkspace --refresh full
+& $CodeStoryCli retrieval status --project $TargetWorkspace --format json
+& $CodeStoryCli doctor --project $TargetWorkspace
+```
+
+Missing sidecars, stale manifests, disabled sidecars, mixed stored-doc vector
+contracts, or diagnostic embedding modes are setup failures to fix before
+trusting packet/search context.
 
 After that first index, use narrower commands instead of asking the agent to
 start over:

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -18,9 +18,18 @@ refresh an existing cache in place, or `full` after a cache reset, schema change
 failure.";
 const DRILL_REFRESH_HELP: &str = "Drill defaults to `full` so each report is mechanically fresh. Use `none` only after a \
 fresh index, or `incremental` to refresh an existing cache in place.";
+const CLI_LONG_ABOUT: &str = "\
+CodeStory turns a local repository into auditable grounding evidence.
+
+Common lanes:
+  New repo:      codestory-cli index --project <repo> --refresh full
+  Broad question: codestory-cli packet --project <repo> \"How does this system work?\"
+  Exact target:  codestory-cli context --project <repo> --query <symbol-or-file>
+
+For agent-facing packet/search evidence, first run retrieval bootstrap + retrieval index and require retrieval status to report retrieval_mode=full.";
 
 #[derive(Parser, Debug)]
-#[command(author, version, about = "Skill-first repo grounding runtime", long_about = None)]
+#[command(author, version, about = "Skill-first repo grounding runtime", long_about = CLI_LONG_ABOUT)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) command: Command,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -519,7 +519,7 @@ fn run_context(cmd: ContextCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "context")?;
     preflight_output_file(cmd.output_file.as_deref())?;
     ensure_no_context_hybrid_overrides(&cmd)?;
-    let runtime = RuntimeContext::new(&cmd.project)?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "context")?;
 
@@ -566,7 +566,7 @@ fn run_context(cmd: ContextCommand) -> Result<()> {
 fn run_packet(cmd: PacketCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "packet")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = RuntimeContext::new(&cmd.project)?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "packet")?;
 
@@ -1044,7 +1044,7 @@ fn run_search(cmd: SearchCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "search")?;
     preflight_output_file(cmd.output_file.as_deref())?;
     ensure_no_search_hybrid_overrides(&cmd)?;
-    let runtime = RuntimeContext::new(&cmd.project)?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "search")?;
     let search_results = runtime

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -94,7 +94,7 @@ fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
 
 fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
-    let runtime = RuntimeContext::new(&cmd.project)?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let summary = runtime.open_project_summary()?;
     let refresh_mode = resolve_refresh_request(cmd.refresh, &summary);
     run_retrieval_index_refresh(&runtime, cmd.refresh, refresh_mode)?;
@@ -326,23 +326,24 @@ fn emit_retrieval_status(
     report: &RetrievalStatusReport,
     output_file: Option<&std::path::Path>,
 ) -> Result<()> {
-    let embedding_backend = codestory_retrieval::embedding_backend_label();
-    let manifest_embedding = report
-        .manifest
-        .as_ref()
-        .map(|manifest| {
-            format!(
-                "embedding_backend={:?} embedding_dim={:?}",
-                manifest.embedding_backend, manifest.embedding_dim
-            )
-        })
-        .unwrap_or_else(|| "manifest=none".into());
+    let manifest_vector_backend = report
+        .manifest_vector_embedding_backend
+        .as_deref()
+        .unwrap_or("<none>");
+    let stored_doc_backend = report
+        .stored_doc_vector_producer_backend
+        .as_deref()
+        .unwrap_or("<none>");
     let markdown = format!(
-        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- active_embedding_backend: `{}`\n- manifest: {}\n- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
+        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
         report.retrieval_mode,
         report.degraded_reason,
-        embedding_backend,
-        manifest_embedding,
+        report.query_embedding_backend,
+        manifest_vector_backend,
+        report.manifest_vector_embedding_dim,
+        stored_doc_backend,
+        report.stored_doc_vector_dim,
+        report.stored_doc_vector_mixed_backends,
         report.zoekt.status,
         report.zoekt.detail,
         report.zoekt.capabilities.lexical,

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -83,14 +83,16 @@ impl RuntimeContext {
         Self::new_with_startup(args, ManagedEmbeddingStartup::InspectOnly)
     }
 
-    fn new_with_startup(args: &ProjectArgs, _startup: ManagedEmbeddingStartup) -> Result<Self> {
+    fn new_with_startup(args: &ProjectArgs, startup: ManagedEmbeddingStartup) -> Result<Self> {
         let project_root = canonicalize_project_root(&args.project)?;
         let config = crate::config::load_config(&project_root)?;
         let cache_override = args.cache_dir.as_deref().or(config.cache_dir.as_deref());
         let cache_root = cache_root_for_project(&project_root, cache_override)?;
         let managed_embeddings_root =
             crate::managed_embeddings::runtime_managed_root(args.cache_dir.as_deref())?;
-        crate::managed_embeddings::prepare_runtime_if_installed(&managed_embeddings_root);
+        if startup == ManagedEmbeddingStartup::AutostartIfInstalled {
+            crate::managed_embeddings::prepare_runtime_if_installed(&managed_embeddings_root);
+        }
         let storage_path = cache_root.join("codestory.db");
         let runtime = Runtime::new();
         let events = runtime.events();
@@ -604,8 +606,73 @@ fn quote_cli_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::env;
     use std::fs;
     use tempfile::tempdir;
+
+    const MANAGED_ENV_VARS: &[&str] = &[
+        "CODESTORY_EMBED_RUNTIME_MODE",
+        "CODESTORY_EMBED_BACKEND",
+        "CODESTORY_EMBED_LLAMACPP_URL",
+        "CODESTORY_EMBED_ONNX_MODEL",
+        "CODESTORY_EMBED_ONNX_TOKENIZER",
+        "CODESTORY_EMBED_ONNX_PROVIDER",
+        "CODESTORY_EMBED_ONNX_BATCH_TOKENS",
+        "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE",
+        "CODESTORY_SEMANTIC_DOC_MAX_TOKENS",
+        "CODESTORY_STORED_VECTOR_ENCODING",
+        "CODESTORY_HYBRID_RETRIEVAL_ENABLED",
+    ];
+
+    struct EnvSnapshot {
+        values: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn clear(names: &'static [&'static str]) -> Self {
+            let values = names
+                .iter()
+                .map(|name| (*name, env::var(name).ok()))
+                .collect::<Vec<_>>();
+            unsafe {
+                for name in names {
+                    env::remove_var(name);
+                }
+            }
+            Self { values }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            unsafe {
+                for (name, value) in &self.values {
+                    if let Some(value) = value {
+                        env::set_var(name, value);
+                    } else {
+                        env::remove_var(name);
+                    }
+                }
+            }
+        }
+    }
+
+    fn write_fake_managed_onnx_assets(root: &Path) {
+        let model = root.join("assets").join("model.onnx");
+        let tokenizer = root.join("assets").join("tokenizer.json");
+        fs::create_dir_all(model.parent().expect("model parent")).expect("create model dir");
+        fs::write(&model, b"model").expect("write model");
+        fs::write(&tokenizer, b"tokenizer").expect("write tokenizer");
+        fs::write(
+            root.join("manifest.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "onnx_model_path": model.to_string_lossy().replace('\\', "/"),
+                "onnx_tokenizer_path": tokenizer.to_string_lossy().replace('\\', "/"),
+            }))
+            .expect("manifest json"),
+        )
+        .expect("write manifest");
+    }
 
     #[test]
     fn project_config_cache_dir_does_not_select_managed_executable_root() {
@@ -637,5 +704,54 @@ mod tests {
             config_cache.join("managed-embeddings"),
             "repo-controlled config cache_dir must not choose executable managed asset root"
         );
+    }
+
+    #[test]
+    fn inspect_only_runtime_does_not_mutate_embedding_env_when_managed_assets_exist() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let _env_snapshot = EnvSnapshot::clear(MANAGED_ENV_VARS);
+        let temp = tempdir().expect("temp dir");
+        let project = temp.path().join("repo");
+        let cache = temp.path().join("cache");
+        fs::create_dir_all(&project).expect("create project");
+        write_fake_managed_onnx_assets(&cache.join("managed-embeddings"));
+
+        RuntimeContext::new_inspect_only(&ProjectArgs {
+            project,
+            cache_dir: Some(cache),
+        })
+        .expect("runtime context");
+
+        for name in MANAGED_ENV_VARS {
+            assert_eq!(
+                env::var(name).ok(),
+                None,
+                "inspect-only runtime must not set {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn autostart_runtime_sets_managed_onnx_defaults_when_assets_exist() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let _env_snapshot = EnvSnapshot::clear(MANAGED_ENV_VARS);
+        let temp = tempdir().expect("temp dir");
+        let project = temp.path().join("repo");
+        let cache = temp.path().join("cache");
+        fs::create_dir_all(&project).expect("create project");
+        write_fake_managed_onnx_assets(&cache.join("managed-embeddings"));
+
+        RuntimeContext::new(&ProjectArgs {
+            project,
+            cache_dir: Some(cache),
+        })
+        .expect("runtime context");
+
+        assert_eq!(
+            env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
+            Some("onnx")
+        );
+        assert!(env::var("CODESTORY_EMBED_ONNX_MODEL").is_ok());
+        assert!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").is_ok());
     }
 }

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -40,6 +40,17 @@ pub struct RetrievalStatusReport {
     pub retrieval_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,
+    pub query_embedding_backend: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_vector_embedding_backend: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_vector_embedding_dim: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stored_doc_vector_producer_backend: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stored_doc_vector_dim: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stored_doc_vector_mixed_backends: Option<bool>,
     pub zoekt: ComponentHealth,
     pub qdrant: ComponentHealth,
     pub scip: ComponentHealth,
@@ -73,9 +84,21 @@ pub fn unavailable_status_report(
     manifest: Option<codestory_store::RetrievalIndexManifest>,
 ) -> RetrievalStatusReport {
     let reason = reason.into();
+    let manifest_vector_embedding_backend = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.embedding_backend.clone());
+    let manifest_vector_embedding_dim = manifest
+        .as_ref()
+        .and_then(|manifest| manifest.embedding_dim);
     RetrievalStatusReport {
         retrieval_mode: "unavailable".into(),
         degraded_reason: Some(reason.clone()),
+        query_embedding_backend: crate::embeddings::embedding_runtime_id(),
+        manifest_vector_embedding_backend,
+        manifest_vector_embedding_dim,
+        stored_doc_vector_producer_backend: None,
+        stored_doc_vector_dim: None,
+        stored_doc_vector_mixed_backends: None,
         zoekt: unavailable_component("zoekt", &reason),
         qdrant: unavailable_component("qdrant", &reason),
         scip: unavailable_component("scip", &reason),
@@ -316,6 +339,12 @@ pub fn probe_sidecar_health(
     RetrievalStatusReport {
         retrieval_mode: mode.as_str().into(),
         degraded_reason,
+        query_embedding_backend: current_embedding_backend,
+        manifest_vector_embedding_backend: manifest.embedding_backend.clone(),
+        manifest_vector_embedding_dim: manifest.embedding_dim,
+        stored_doc_vector_producer_backend: None,
+        stored_doc_vector_dim: None,
+        stored_doc_vector_mixed_backends: None,
         zoekt,
         qdrant,
         scip,

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -79,24 +79,40 @@ fn sidecar_status_inner(
                 strict_readiness_unavailable_reason(project_root, &storage, &project_id, manifest)
                     .context("check strict sidecar readiness")?
         {
-            return Ok(crate::health::unavailable_status_report(
-                format!("sidecar_manifest_stale: {reason}"),
-                Some(manifest.clone()),
+            return Ok(enrich_status_with_semantic_doc_stats(
+                crate::health::unavailable_status_report(
+                    format!("sidecar_manifest_stale: {reason}"),
+                    Some(manifest.clone()),
+                ),
+                &storage,
             ));
         }
         if let Some(manifest) = manifest.as_ref()
             && let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest)
         {
-            return Ok(crate::health::unavailable_status_report(
-                reason,
-                Some(manifest.clone()),
+            return Ok(enrich_status_with_semantic_doc_stats(
+                crate::health::unavailable_status_report(reason, Some(manifest.clone())),
+                &storage,
             ));
         }
-        manifest
+        let report = probe_sidecar_health(&layout, &project_id, manifest);
+        return Ok(enrich_status_with_semantic_doc_stats(report, &storage));
     } else {
         None
     };
     Ok(probe_sidecar_health(&layout, &project_id, manifest))
+}
+
+fn enrich_status_with_semantic_doc_stats(
+    mut report: RetrievalStatusReport,
+    storage: &Store,
+) -> RetrievalStatusReport {
+    if let Ok(stats) = storage.get_llm_symbol_doc_stats() {
+        report.stored_doc_vector_producer_backend = stats.embedding_backend;
+        report.stored_doc_vector_dim = stats.embedding_dim;
+        report.stored_doc_vector_mixed_backends = Some(stats.mixed_embedding_backends);
+    }
+    report
 }
 
 pub(crate) fn validate_strict_sidecar_readiness(

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = { workspace = true }
 tantivy = { workspace = true }
 tokenizers = { workspace = true }
 tracing = { workspace = true }
+ureq = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -3683,34 +3683,20 @@ fn summarize_symbol_doc(
 
     let body = serde_json::to_string(&request)
         .map_err(|e| ApiError::internal(format!("Failed to build summary request: {e}")))?;
-    let mut command = std::process::Command::new("curl");
-    command
-        .arg("-sS")
-        .arg("-X")
-        .arg("POST")
-        .arg(endpoint)
-        .arg("-H")
-        .arg("Content-Type: application/json");
+    let mut request = ureq::post(endpoint)
+        .timeout(summary_endpoint_timeout())
+        .set("Content-Type", "application/json");
     if let Ok(api_key) = std::env::var("CODESTORY_SUMMARY_API_KEY")
         && !api_key.trim().is_empty()
     {
-        command
-            .arg("-H")
-            .arg(format!("Authorization: Bearer {}", api_key.trim()));
+        request = request.set("Authorization", &format!("Bearer {}", api_key.trim()));
     }
-    let output = command.arg("-d").arg(body).output().map_err(|e| {
-        ApiError::internal(format!(
-            "Failed to invoke curl for CODESTORY_SUMMARY_ENDPOINT: {e}"
-        ))
-    })?;
-    if !output.status.success() {
-        return Err(ApiError::internal(format!(
-            "Summary endpoint failed with status {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        )));
-    }
-    let response: serde_json::Value = serde_json::from_slice(&output.stdout)
+    let response_body = request
+        .send_string(&body)
+        .map_err(summary_endpoint_http_error)?
+        .into_string()
+        .map_err(|e| ApiError::internal(format!("Summary endpoint response failed: {e}")))?;
+    let response: serde_json::Value = serde_json::from_str(&response_body)
         .map_err(|e| ApiError::internal(format!("Summary endpoint returned invalid JSON: {e}")))?;
     let summary = response
         .pointer("/choices/0/message/content")
@@ -3728,6 +3714,41 @@ fn summarize_symbol_doc(
             )
         })?;
     Ok(summary.lines().next().unwrap_or(summary).trim().to_string())
+}
+
+fn summary_endpoint_timeout() -> Duration {
+    let seconds = std::env::var("CODESTORY_SUMMARY_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|seconds| (1..=300).contains(seconds))
+        .unwrap_or(30);
+    Duration::from_secs(seconds)
+}
+
+fn summary_endpoint_http_error(error: ureq::Error) -> ApiError {
+    match error {
+        ureq::Error::Status(status, response) => {
+            let body = response
+                .into_string()
+                .unwrap_or_else(|read_error| format!("failed to read error body: {read_error}"));
+            ApiError::internal(format!(
+                "Summary endpoint failed with status {status}: {}",
+                truncate_error_body(&body)
+            ))
+        }
+        ureq::Error::Transport(error) => {
+            ApiError::internal(format!("Summary endpoint request failed: {error}"))
+        }
+    }
+}
+
+fn truncate_error_body(body: &str) -> String {
+    const MAX_ERROR_BODY_CHARS: usize = 2_048;
+    let mut truncated = body.chars().take(MAX_ERROR_BODY_CHARS).collect::<String>();
+    if body.chars().count() > MAX_ERROR_BODY_CHARS {
+        truncated.push_str("...");
+    }
+    truncated
 }
 
 fn local_symbol_summary(doc: &LlmSymbolDoc) -> String {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -10,7 +10,9 @@ flowchart LR
     Repo["repository"] --> Workspace["discover files and refresh plan"]
     Workspace --> Indexer["parse and extract graph"]
     Indexer --> Store["persist SQLite graph and read models"]
+    Store --> Retrieval["build and validate sidecar retrieval artifacts"]
     Store --> Runtime["assemble search, grounding, trails, and context"]
+    Retrieval --> Runtime
     Runtime --> CLI["render CLI, HTTP, and stdio reads"]
 ```
 
@@ -21,12 +23,12 @@ User-visible guarantees come from those boundaries:
 - CLI rendering stays thin; orchestration belongs to runtime.
 - Full refreshes can publish a staged store; incremental refreshes update the
   live store and refresh derived views.
-- Search and context output should be traceable back to files, symbols, or
-  explicit gaps.
+- Search, packet, and context output should be traceable back to files,
+  symbols, sidecar readiness, or explicit gaps.
 
 ## Layers
 
-The workspace has seven crates: six owning layers plus one support crate for
+The workspace has eight crates: seven owning layers plus one support crate for
 benchmarks and perf validation.
 
 ```mermaid
@@ -35,6 +37,7 @@ flowchart LR
     Workspace["codestory-workspace"]
     Store["codestory-store"]
     Indexer["codestory-indexer"]
+    Retrieval["codestory-retrieval"]
     Runtime["codestory-runtime"]
     CLI["codestory-cli"]
     Bench["codestory-bench"]
@@ -47,30 +50,36 @@ flowchart LR
     Store --> Runtime
     Store --> Indexer
     Indexer --> Runtime
+    Store --> Retrieval
+    Retrieval --> Runtime
+    Retrieval --> CLI
     Runtime --> CLI
     Runtime -. bench inputs .-> Bench
     Indexer -. bench inputs .-> Bench
     Store -. bench inputs .-> Bench
+    Retrieval -. bench inputs .-> Bench
 ```
 
 - `codestory-contracts` defines the shared graph model, DTOs, grounding/trail types, and shared events.
 - `codestory-workspace` discovers files, loads `codestory_project.json`, and computes full or incremental refresh plans.
 - `codestory-store` owns SQLite schema, graph persistence, snapshot lifecycle, trail queries, bookmark rows, and stored search documents.
 - `codestory-indexer` parses files, extracts symbols and edges, flushes batches to the store, and runs semantic resolution.
+- `codestory-retrieval` owns mandatory sidecar retrieval contracts: Zoekt/Qdrant/SCIP health, sidecar manifests, product embedding backend checks, and fail-closed query execution.
 - `codestory-runtime` orchestrates indexing, search, grounding, trail building, project summaries, and agent flows.
-- `codestory-cli` is the thin command adapter that parses args, calls runtime services, and renders text or JSON.
+- `codestory-cli` is the thin command adapter that parses args, calls runtime or retrieval services, and renders text or JSON.
 - `codestory-bench` measures indexing, grounding, resolution, and cleanup-sensitive paths without owning product behavior.
 
 ## Dependency Direction
 
 The intended dependency flow is:
 
-`contracts -> workspace / store / indexer -> runtime -> cli`
+`contracts -> workspace / store / indexer / retrieval -> runtime -> cli`
 
 Important rules:
 
 - `workspace` does not depend on the store or runtime.
 - `indexer` depends on `store`, not the reverse.
+- `retrieval` depends on `store` and owns sidecar artifacts; runtime and CLI call it instead of reimplementing sidecar rules.
 - `runtime` is the only orchestration layer.
 - `cli` does not import indexing or storage crates directly.
 - `bench` can depend on runtime-facing crates for measurement, but it does not define product contracts.

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -96,6 +96,19 @@ evidence.
 
 Append the emitted headline metrics to `docs/testing/codestory-e2e-stats-log.md`. Include graph seconds, semantic seconds, semantic docs reused, semantic docs embedded, total index seconds, `retrieval_index_seconds`, `retrieval_status_seconds`, and whether `sidecar_status_after_retrieval_index` plus `search.sidecar_shadow_retrieval_mode` were `full`.
 
+Release-readiness evidence is tiered:
+
+| Evidence tier | Required proof | Release meaning |
+| --- | --- | --- |
+| Stats-only | `codestory_repo_e2e_stats` completed with `CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1` or without prepared full sidecars | Useful local regression signal only; not release proof for packet/search readiness. |
+| Full sidecar | Local Zoekt, Qdrant, SCIP, and llama.cpp are running; `retrieval index --refresh full` succeeds; `retrieval status --format json` reports `retrieval_mode: "full"` plus product backend fields | Required before claiming agent-facing packet/search readiness on the current workspace. |
+| Real-repo drill | `CODESTORY_REAL_REPO_DRILL_CASES` points at prepared manifests and the drill cases run without skip allowances | Required before claiming the release was exercised beyond the CodeStory checkout. |
+| Promotion-grade benchmark | Baseline and candidate benchmark rows are captured with sidecar status, search shadow mode, and no-regression threshold | Required for performance or retrieval-quality promotion claims. |
+
+When logging release evidence, state the highest tier reached and the exact
+skip env vars used. A stats-only row must not be described as full sidecar or
+real-repo drill evidence.
+
 For the current repo-scale baseline, use the latest row in
 [`codestory-e2e-stats-log.md`](../testing/codestory-e2e-stats-log.md). Older
 rows, including the 2026-04-18 durable-scope measurements, are historical

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -33,6 +33,24 @@ SCIP sidecar artifacts, then use `codestory-cli retrieval status --project
 <repo> --format json` to verify `retrieval_mode: "full"` before using
 agent-facing packet/search evidence.
 
+First-run evidence path:
+
+```powershell
+node scripts/setup-retrieval-env.mjs --fetch-embed-model
+$env:CODESTORY_EMBED_MODEL_DIR = (Resolve-Path .\target\retrieval-models).Path
+$env:CODESTORY_EMBED_BACKEND = "llamacpp"
+$env:CODESTORY_EMBED_LLAMACPP_URL = "http://127.0.0.1:8080/v1/embeddings"
+cargo retrieval-setup
+.\target\release\codestory-cli.exe index --project <repo> --refresh full
+.\target\release\codestory-cli.exe retrieval index --project <repo> --refresh full
+.\target\release\codestory-cli.exe retrieval status --project <repo> --format json
+```
+
+`retrieval status` must show `retrieval_mode: "full"`. Its JSON backend fields
+distinguish the active query backend (`query_embedding_backend`), manifest
+vector contract (`manifest_vector_embedding_backend`), and stored semantic-doc
+producer (`stored_doc_vector_producer_backend`).
+
 Status after bootstrap:
 
 ```sh
@@ -212,15 +230,17 @@ semantic state, and SCIP graph artifacts. `CODESTORY_RETRIEVAL=0` is unsupported
 
 ### Real embeddings (bge-base-en-v1.5 + llama.cpp)
 
-Promotion uses **768-d** vectors. Qdrant document vectors come from stored semantic docs produced by
-the managed local embedding runtime. Query vectors still come from the local llama.cpp sidecar so
-retrieval remains sidecar-backed and can smoke-test the live collection. Hash projection is
-diagnostic only and never produces `retrieval_mode=full`.
+Promotion uses **768-d** vectors. Qdrant document vectors come from stored
+semantic docs with product-compatible vector metadata. Query vectors come from
+the local llama.cpp sidecar so retrieval remains sidecar-backed and can
+smoke-test the live collection. With real vectors enabled, an unset retrieval
+backend means this product llama.cpp contract; explicit ONNX or hash modes are
+diagnostic only and never produce `retrieval_mode=full`.
 
 1. Download GGUF (once): `node scripts/setup-retrieval-env.mjs --fetch-embed-model`
 2. Export (see [`docker/retrieval.env.example`](../../docker/retrieval.env.example)):
    - `CODESTORY_EMBED_MODEL_DIR=<repo>/target/retrieval-models`
-   - `CODESTORY_EMBED_BACKEND=llamacpp`
+   - `CODESTORY_EMBED_BACKEND=llamacpp` (recommended explicit product mode; unset is also product mode for retrieval commands)
    - `CODESTORY_EMBED_LLAMACPP_URL=http://127.0.0.1:8080/v1/embeddings`
 3. `cargo retrieval-setup` (starts Qdrant, Zoekt webserver, `codestory-embed` on `:8080`)
 4. Dim smoke: `curl -s http://127.0.0.1:8080/v1/embeddings -H "Content-Type: application/json" -d "{\"input\":[\"function\"]}"` → embedding length **768**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -186,24 +186,39 @@ project is usable only when the local Zoekt, Qdrant, and SCIP sidecars report
 `retrieval_mode=full`; missing sidecars, stale manifests, or embedding-contract
 drift fail closed instead of falling back to an older local search path.
 
-Product sidecar setup:
+Basic local index:
 
 ```powershell
-codestory-cli retrieval bootstrap --project <target-workspace>
+codestory-cli doctor --project <target-workspace>
+codestory-cli index --project <target-workspace> --refresh full
+codestory-cli ground --project <target-workspace> --why
+```
+
+That lane builds and reads the local SQLite cache. It does not start sidecars,
+write the retrieval manifest, or prove packet/search readiness.
+
+Product sidecar setup for agent-facing packet/search:
+
+```powershell
+node scripts/setup-retrieval-env.mjs --fetch-embed-model
+$env:CODESTORY_EMBED_MODEL_DIR = (Resolve-Path .\target\retrieval-models).Path
 $env:CODESTORY_EMBED_BACKEND = "llamacpp"
 $env:CODESTORY_EMBED_LLAMACPP_URL = "http://127.0.0.1:8080/v1/embeddings"
+cargo retrieval-setup
+
 codestory-cli index --project <target-workspace> --refresh full
 codestory-cli retrieval index --project <target-workspace> --refresh full
 codestory-cli retrieval status --project <target-workspace> --format json
 codestory-cli doctor --project <target-workspace>
 ```
 
-Plain `codestory-cli index` builds the core SQLite code index. It does not
-generate or prove sidecar readiness. Run `codestory-cli retrieval index` only
-after the local sidecar services, llama.cpp embedding endpoint, and
-`bge-base-en-v1.5` model configuration are ready, then require `retrieval
-status --format json` to report `retrieval_mode: "full"` before trusting
-agent-facing packet/search evidence.
+Run `codestory-cli retrieval index` only after the local sidecar services,
+llama.cpp embedding endpoint, and `bge-base-en-v1.5` model configuration are
+ready, then require `retrieval status --format json` to report
+`retrieval_mode: "full"` before trusting agent-facing packet/search evidence.
+The status JSON also reports `query_embedding_backend`,
+`manifest_vector_embedding_backend`, and `stored_doc_vector_producer_backend`
+so backend drift is visible.
 
 Legacy managed embedding setup is local semantic/diagnostic only:
 
@@ -213,7 +228,9 @@ codestory-cli setup embeddings --project <target-workspace>
 ```
 
 Those commands install managed ONNX assets. They do not start llama.cpp, create
-the retrieval manifest, or prove product sidecar readiness.
+the retrieval manifest, or prove product sidecar readiness. Retrieval sidecar
+commands do not silently switch to ONNX mode just because managed assets are
+installed; unset retrieval backend means the product llama.cpp sidecar contract.
 
 Useful environment knobs:
 


### PR DESCRIPTION
## What changed

- Made `RuntimeContext::new_with_startup` honor `ManagedEmbeddingStartup`, so inspect-only callers do not silently install managed ONNX env defaults.
- Moved product sidecar evidence commands (`retrieval index`, `search`, `context`, `packet`) onto the inspect-only runtime path.
- Added retrieval status backend contract fields for query backend, manifest vector backend/dim, and stored semantic-doc vector producer metadata.
- Replaced runtime summary `curl` execution with bounded `ureq` HTTP to avoid PATH/tool injection and command-line credential exposure.
- Updated CLI help, README, usage docs, sidecar ops docs, release evidence tiers, and architecture docs for the deterministic product retrieval path.

## Why

Installed managed ONNX assets could mutate default env during read/status paths, causing a valid llama.cpp sidecar manifest to appear stale under ONNX assumptions. Product retrieval should be deterministic: unset retrieval backend means the llama.cpp sidecar contract unless the operator explicitly chooses another mode.

## Verification

- `cargo test -p codestory-cli runtime::tests`
- `cargo test -p codestory-retrieval`
- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts`
- `cargo test -p codestory-cli --test search_json_output`
- `cargo test -p codestory-cli --test cli_golden_path tiny_workspace_browser_loop_works_from_existing_cache`
- `cargo test -p codestory-runtime sidecar_primary_modes_fail_closed_for_partial_sidecars`
- `cargo test -p codestory-cli --test onboarding_contracts`
- `cargo build --release -p codestory-cli`
- Final live sidecar proof: `.\target\release\codestory-cli.exe retrieval index --project . --refresh full --format json` produced `embedding_backend=llamacpp:bge-base-en-v1.5`, `embedding_dim=768`, no degraded modes, and all sidecars non-stubbed.
- Final release status proof: `.\target\release\codestory-cli.exe retrieval status --project . --format json` reported `retrieval_mode=full` with `query_embedding_backend=llamacpp:bge-base-en-v1.5`.
- Final release doctor proof: `.\target\release\codestory-cli.exe doctor --project . --format json` reported `retrieval_mode=full` and fresh index state under default env with managed ONNX installed.

## Remaining risk / follow-up

- This PR includes current-workspace full sidecar proof, but not a separate real-repo drill or promotion-grade benchmark run. The docs now distinguish those evidence tiers explicitly.
