### PR TITLE
[codex] release 0.6.0 retrieval unavailable contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -448,7 +448,20 @@ pub(crate) fn ensure_index_ready(opened: &OpenedProject, subcommand: &str) -> Re
 }
 
 pub(crate) fn map_api_error(error: ApiError) -> anyhow::Error {
-    anyhow!("{}: {}", error.code, error.message)
+    let mut message = format!("{}: {}", error.code, error.message);
+    if let Some(next_commands) = api_error_next_commands(&error) {
+        message.push_str("\n\nNext commands:");
+        for command in next_commands {
+            message.push_str("\n  ");
+            message.push_str(&command);
+        }
+    }
+    anyhow!(message)
+}
+
+fn api_error_next_commands(error: &ApiError) -> Option<Vec<String>> {
+    let commands = &error.details.as_ref()?.next_commands;
+    (!commands.is_empty()).then_some(commands.clone())
 }
 
 pub(crate) fn search_hit_from_node(node: &NodeDetailsDto) -> SearchHit {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::{
     AgentAskRequest, AgentPacketRequestDto, AgentResponseModeDto, AgentRetrievalPresetDto,
-    AgentRetrievalProfileSelectionDto, GroundingBudgetDto, ListChildrenSymbolsRequest,
+    AgentRetrievalProfileSelectionDto, ApiError, GroundingBudgetDto, ListChildrenSymbolsRequest,
     ListRootSymbolsRequest, NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto,
     SearchRepoTextMode, SearchRequest, TrailDirection,
 };
@@ -494,7 +494,7 @@ fn handle_stdio_packet(
             latency_budget_ms,
         })
         .map(|packet| serde_json::json!({"result": packet}))
-        .unwrap_or_else(|error| serde_json::json!({"error": map_api_error(error).to_string()}));
+        .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}));
     if response.get("result").is_some() {
         state.packet_cache.insert(cache_key, response.clone());
     }
@@ -819,7 +819,7 @@ fn handle_stdio_search(
             hybrid_limits: None,
         })
         .map(|result| serde_json::json!({"result": enrich_stdio_search_result(result)}))
-        .unwrap_or_else(|error| serde_json::json!({"error": map_api_error(error).to_string()}));
+        .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}));
     if response.get("result").is_some() {
         state.search_cache.insert(cache_key, response.clone());
     }
@@ -1057,7 +1057,12 @@ fn handle_stdio_context(
             ));
             serde_json::json!({"result": context_packet_json(&result)})
         })
-        .unwrap_or_else(|error| serde_json::json!({"error": map_api_error(error).to_string()}))
+        .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}))
+}
+
+fn stdio_api_error_value(error: ApiError) -> serde_json::Value {
+    serde_json::to_value(error.clone())
+        .unwrap_or_else(|_| serde_json::json!({"message": map_api_error(error).to_string()}))
 }
 
 fn stdio_context_target(

--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -279,9 +279,18 @@ fn search_json_fails_closed_without_full_sidecars() {
     );
     let stderr = String::from_utf8_lossy(&search.stderr);
     assert!(
-        stderr.contains("sidecar retrieval primary is unavailable or degraded")
-            && stderr.contains("expected mode=full"),
+        stderr.contains(
+            "retrieval_unavailable: sidecar retrieval primary is unavailable or degraded"
+        ) && stderr.contains("expected mode=full"),
         "search should report mandatory sidecar full-mode boundary: {stderr}"
+    );
+    assert!(
+        stderr.contains("Next commands:")
+            && stderr.contains("codestory-cli index")
+            && stderr.contains("--refresh full")
+            && stderr.contains("codestory-cli retrieval bootstrap")
+            && stderr.contains("codestory-cli doctor"),
+        "search should include retrieval repair commands: {stderr}"
     );
 }
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1633,6 +1633,11 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
     );
 
     let error = assert_tool_error(&response, json!("search-requires-full-retrieval"));
+    assert_eq!(
+        error.pointer("/code").and_then(Value::as_str),
+        Some("retrieval_unavailable"),
+        "stdio search should preserve typed retrieval failure code: {response}"
+    );
     let message = error
         .pointer("/message")
         .and_then(Value::as_str)
@@ -1641,6 +1646,33 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
         message.contains("sidecar retrieval primary is unavailable or degraded")
             && message.contains("expected mode=full"),
         "stdio search should fail closed when the fixture has only a plain index: {response}"
+    );
+    let details = error
+        .pointer("/details")
+        .unwrap_or_else(|| panic!("stdio search error should include details: {response}"));
+    assert_eq!(details["failed_layer"], json!("retrieval_sidecar"));
+    let expected_project = fs::canonicalize(fixture.workspace.path()).expect("canonical project");
+    assert_eq!(
+        details["project"].as_str(),
+        Some(expected_project.to_str().expect("workspace path")),
+        "stdio search error should include the current project path: {response}"
+    );
+    let next_commands = details["next_commands"]
+        .as_array()
+        .unwrap_or_else(|| panic!("stdio search error should include next_commands: {response}"));
+    assert!(
+        next_commands
+            .iter()
+            .any(|command| command.as_str().is_some_and(|text| text
+                .contains("codestory-cli index")
+                && text.contains("--refresh full"))),
+        "stdio search error should include index repair command: {response}"
+    );
+    assert!(
+        next_commands.iter().any(|command| command
+            .as_str()
+            .is_some_and(|text| text.contains("codestory-cli retrieval bootstrap"))),
+        "stdio search error should include sidecar bootstrap repair command: {response}"
     );
 }
 

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -45,7 +45,7 @@ pub use dto::{
     UpdateBookmarkCategoryRequest, UpdateBookmarkRequest, WorkspaceMemberIndexDto,
     WriteFileDataUrlRequest, WriteFileResponse, WriteFileTextRequest,
 };
-pub use errors::ApiError;
+pub use errors::{ApiError, ApiErrorDetails};
 pub use events::{AppEventPayload, IndexingPhaseTimings};
 pub use ids::{EdgeId, NodeId};
 pub use types::{

--- a/crates/codestory-contracts/src/api/errors.rs
+++ b/crates/codestory-contracts/src/api/errors.rs
@@ -5,6 +5,28 @@ use specta::Type;
 pub struct ApiError {
     pub code: String,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<ApiErrorDetails>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ApiErrorDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_layer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_commands: Vec<String>,
+}
+
+impl ApiErrorDetails {
+    pub fn retrieval_unavailable(project: impl Into<String>, next_commands: Vec<String>) -> Self {
+        Self {
+            failed_layer: Some("retrieval_sidecar".to_string()),
+            project: Some(project.into()),
+            next_commands,
+        }
+    }
 }
 
 impl ApiError {
@@ -12,6 +34,19 @@ impl ApiError {
         Self {
             code: code.into(),
             message: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn with_details(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        details: ApiErrorDetails,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            details: Some(details),
         }
     }
 
@@ -25,5 +60,45 @@ impl ApiError {
 
     pub fn internal(message: impl Into<String>) -> Self {
         Self::new("internal", message)
+    }
+
+    pub fn retrieval_unavailable(
+        message: impl Into<String>,
+        project: impl Into<String>,
+        next_commands: Vec<String>,
+    ) -> Self {
+        Self::with_details(
+            "retrieval_unavailable",
+            message,
+            ApiErrorDetails::retrieval_unavailable(project, next_commands),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retrieval_unavailable_error_serializes_repair_details() {
+        let error = ApiError::retrieval_unavailable(
+            "sidecar retrieval primary is unavailable or degraded",
+            "C:/repo/example",
+            vec![
+                "codestory-cli index --project \"C:/repo/example\" --refresh full".to_string(),
+                "codestory-cli retrieval bootstrap --project \"C:/repo/example\" --format json"
+                    .to_string(),
+            ],
+        );
+
+        let value = serde_json::to_value(error).expect("serialize api error");
+
+        assert_eq!(value["code"], "retrieval_unavailable");
+        assert_eq!(value["details"]["failed_layer"], "retrieval_sidecar");
+        assert_eq!(value["details"]["project"], "C:/repo/example");
+        assert_eq!(
+            value["details"]["next_commands"][0],
+            "codestory-cli index --project \"C:/repo/example\" --refresh full"
+        );
     }
 }

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -24,7 +24,8 @@ use crate::agent::profiles::{ResolvedProfile, TrailPlan, resolve_profile};
 use crate::agent::retrieval_primary::{
     RETRIEVAL_VERSION_SIDECAR, SidecarPrimarySearchOutcome, maybe_log_rollback_after_packet,
     maybe_run_retrieval_shadow, sidecar_retrieval_blocks_nucleo_supplement,
-    sidecar_retrieval_primary_enabled, try_sidecar_primary_search,
+    sidecar_retrieval_primary_enabled, sidecar_retrieval_unavailable_error,
+    try_sidecar_primary_search,
 };
 use crate::agent::trace::{TraceRecorder, field};
 use crate::agent::trace_export;
@@ -4647,18 +4648,20 @@ fn execute_retrieval(
             trace.annotate(format!(
                 "retrieval_sidecar_primary rejected=true fail_closed=true reason={reason}"
             ));
-            return Err(ApiError::invalid_argument(format!(
-                "sidecar retrieval primary rejected query: {reason}"
-            )));
+            return Err(sidecar_retrieval_unavailable_error(
+                controller,
+                format!("sidecar retrieval primary rejected query: {reason}"),
+            ));
         }
         Some(SidecarPrimarySearchOutcome::Unavailable { reason }) => {
             trace.annotate(format!(
                 "retrieval_sidecar_primary unavailable=true fail_closed=true reason={reason}"
             ));
-            return Err(ApiError::invalid_argument(reason));
+            return Err(sidecar_retrieval_unavailable_error(controller, reason));
         }
         None => {
-            return Err(ApiError::invalid_argument(
+            return Err(sidecar_retrieval_unavailable_error(
+                controller,
                 "sidecar retrieval primary is mandatory; non-sidecar initial search is disabled",
             ));
         }

--- a/crates/codestory-runtime/src/agent/packet_search.rs
+++ b/crates/codestory-runtime/src/agent/packet_search.rs
@@ -2,7 +2,7 @@
 
 use crate::agent::retrieval_primary::{
     packet_batch_should_use_sidecar, search_sidecar_packet_batch,
-    sidecar_retrieval_unavailable_reason,
+    sidecar_retrieval_unavailable_error, sidecar_retrieval_unavailable_reason,
 };
 use crate::{AppController, HybridSearchScoredHit};
 use codestory_contracts::api::{
@@ -42,16 +42,20 @@ impl AppController {
                         "sidecar retrieval packet lexical batch unavailable; fail-closed: {}",
                         error.message
                     );
-                    return Err(ApiError::invalid_argument(format!(
-                        "sidecar retrieval packet lexical batch unavailable: {}; sidecar retrieval is mandatory",
-                        error.message
-                    )));
+                    return Err(sidecar_retrieval_unavailable_error(
+                        self,
+                        format!(
+                            "sidecar retrieval packet lexical batch unavailable: {}; sidecar retrieval is mandatory",
+                            error.message
+                        ),
+                    ));
                 }
             }
         } else if let Some(reason) = sidecar_retrieval_unavailable_reason(self) {
-            return Err(ApiError::invalid_argument(reason));
+            return Err(sidecar_retrieval_unavailable_error(self, reason));
         }
-        Err(ApiError::invalid_argument(
+        Err(sidecar_retrieval_unavailable_error(
+            self,
             "sidecar retrieval primary is mandatory for packet lexical batch",
         ))
     }
@@ -99,16 +103,20 @@ impl AppController {
                         "sidecar retrieval packet semantic batch unavailable; fail-closed: {}",
                         error.message
                     );
-                    return Err(ApiError::invalid_argument(format!(
-                        "sidecar retrieval packet semantic batch unavailable: {}; sidecar retrieval is mandatory",
-                        error.message
-                    )));
+                    return Err(sidecar_retrieval_unavailable_error(
+                        self,
+                        format!(
+                            "sidecar retrieval packet semantic batch unavailable: {}; sidecar retrieval is mandatory",
+                            error.message
+                        ),
+                    ));
                 }
             }
         } else if let Some(reason) = sidecar_retrieval_unavailable_reason(self) {
-            return Err(ApiError::invalid_argument(reason));
+            return Err(sidecar_retrieval_unavailable_error(self, reason));
         }
-        Err(ApiError::invalid_argument(
+        Err(sidecar_retrieval_unavailable_error(
+            self,
             "sidecar retrieval primary is mandatory for packet semantic batch",
         ))
     }
@@ -123,9 +131,10 @@ impl AppController {
         if packet_batch_should_use_sidecar(self) {
             return Ok(());
         } else if let Some(reason) = sidecar_retrieval_unavailable_reason(self) {
-            return Err(ApiError::invalid_argument(reason));
+            return Err(sidecar_retrieval_unavailable_error(self, reason));
         }
-        Err(ApiError::invalid_argument(
+        Err(sidecar_retrieval_unavailable_error(
+            self,
             "sidecar retrieval primary is mandatory for packet subquery warmup",
         ))
     }
@@ -149,6 +158,13 @@ mod tests {
                 .contains("sidecar retrieval primary requires an open project"),
             "warmup should report the mandatory sidecar gate, got: {}",
             error.message
+        );
+        assert_eq!(error.code, "retrieval_unavailable");
+        let details = error.details.expect("retrieval error details");
+        assert_eq!(details.failed_layer.as_deref(), Some("retrieval_sidecar"));
+        assert!(
+            !details.next_commands.is_empty(),
+            "warmup should include recovery commands"
         );
     }
 }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -161,6 +161,7 @@ fn sidecar_retrieval_recovery_commands(project: &str) -> Vec<String> {
     vec![
         format!("codestory-cli index --project {project} --refresh full"),
         format!("codestory-cli retrieval bootstrap --project {project} --format json"),
+        format!("codestory-cli retrieval index --project {project} --refresh full"),
         format!("codestory-cli doctor --project {project} --format markdown"),
     ]
 }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -140,6 +140,35 @@ pub(crate) fn sidecar_retrieval_unavailable_reason(controller: &AppController) -
     ))
 }
 
+pub(crate) fn sidecar_retrieval_unavailable_error(
+    controller: &AppController,
+    reason: impl Into<String>,
+) -> ApiError {
+    let project = controller
+        .require_project_root()
+        .ok()
+        .map(|path| path.to_string_lossy().to_string())
+        .unwrap_or_else(|| "<project>".to_string());
+    ApiError::retrieval_unavailable(
+        reason,
+        project.clone(),
+        sidecar_retrieval_recovery_commands(&project),
+    )
+}
+
+fn sidecar_retrieval_recovery_commands(project: &str) -> Vec<String> {
+    let project = quote_cli_arg(project);
+    vec![
+        format!("codestory-cli index --project {project} --refresh full"),
+        format!("codestory-cli retrieval bootstrap --project {project} --format json"),
+        format!("codestory-cli doctor --project {project} --format markdown"),
+    ]
+}
+
+fn quote_cli_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
 pub(crate) fn shadow_retrieval_enabled() -> bool {
     if let Some(env) = unsupported_deprecated_env() {
         tracing::error!(
@@ -398,7 +427,10 @@ fn search_sidecar_packet_batch_inner(
     for (query, max_results) in queries {
         let query_result = run_sidecar_query(controller, query, Some(per_query_budget as u32))
             .map_err(|error| {
-                ApiError::invalid_argument(format!("sidecar retrieval batch query failed: {error}"))
+                sidecar_retrieval_unavailable_error(
+                    controller,
+                    format!("sidecar retrieval batch query failed: {error}"),
+                )
             })?;
         let max_results = (*max_results).clamp(1, 50);
         let resolved_hits =
@@ -407,9 +439,12 @@ fn search_sidecar_packet_batch_inner(
         if let Some(reason) = sidecar_packet_batch_rejection_reason(&query_result, &resolved_hits) {
             let diagnostic =
                 sidecar_rejection_diagnostic(controller, &query_result, &resolved_hits, 5);
-            return Err(ApiError::invalid_argument(format!(
-                "sidecar retrieval rejected packet batch query `{query}`: {reason}; {diagnostic}"
-            )));
+            return Err(sidecar_retrieval_unavailable_error(
+                controller,
+                format!(
+                    "sidecar retrieval rejected packet batch query `{query}`: {reason}; {diagnostic}"
+                ),
+            ));
         }
         results.push((query.clone(), resolved_hits));
     }
@@ -1459,6 +1494,22 @@ mod tests {
         assert_eq!(sidecar_budget_ms(Some(400)), 400);
         assert_eq!(sidecar_budget_ms(Some(5_000)), DEFAULT_SIDECAR_BUDGET_MS);
         assert_eq!(sidecar_budget_ms(None), DEFAULT_SIDECAR_BUDGET_MS);
+    }
+
+    #[test]
+    fn recovery_commands_quote_powershell_sensitive_project_paths() {
+        let commands = sidecar_retrieval_recovery_commands(r"C:\tmp\cost$cache`tick's repo");
+
+        assert_eq!(
+            commands[0],
+            r"codestory-cli index --project 'C:\tmp\cost$cache`tick''s repo' --refresh full"
+        );
+        assert!(
+            commands
+                .iter()
+                .all(|command| command.contains(r"--project 'C:\tmp\cost$cache`tick''s repo'")),
+            "all recovery commands should quote the project path literally: {commands:?}"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -7561,13 +7561,18 @@ impl AppController {
                 .unwrap_or_else(|| {
                     "sidecar retrieval primary is mandatory; legacy search is disabled".to_string()
                 });
-            return Err(ApiError::invalid_argument(reason));
+            return Err(
+                agent::retrieval_primary::sidecar_retrieval_unavailable_error(self, reason),
+            );
         }
 
         let query = intent_query.effective_query.clone();
         let query_result = agent::retrieval_primary::run_sidecar_query(self, &query, None)
             .map_err(|error| {
-                ApiError::invalid_argument(format!("sidecar search failed: {error}"))
+                agent::retrieval_primary::sidecar_retrieval_unavailable_error(
+                    self,
+                    format!("sidecar search failed: {error}"),
+                )
             })?;
         let mut indexed_symbol_hits =
             agent::retrieval_primary::resolve_sidecar_candidates_to_search_hits(
@@ -7586,9 +7591,12 @@ impl AppController {
                 &indexed_symbol_hits,
                 5,
             );
-            return Err(ApiError::invalid_argument(format!(
-                "sidecar search rejected query: {reason}; {diagnostic}"
-            )));
+            return Err(
+                agent::retrieval_primary::sidecar_retrieval_unavailable_error(
+                    self,
+                    format!("sidecar search rejected query: {reason}; {diagnostic}"),
+                ),
+            );
         }
         let candidate_count = query_result.hits.len();
         let resolved_hit_count = indexed_symbol_hits.len();
@@ -9608,7 +9616,7 @@ mod tests {
     }
 
     fn assert_mandatory_sidecar_unavailable(error: &ApiError) {
-        assert_eq!(error.code, "invalid_argument");
+        assert_eq!(error.code, "retrieval_unavailable");
         assert!(
             error
                 .message
@@ -9617,6 +9625,12 @@ mod tests {
                     .message
                     .contains("sidecar retrieval primary is mandatory"),
             "expected mandatory sidecar failure, got {error:?}"
+        );
+        let details = error.details.as_ref().expect("retrieval error details");
+        assert_eq!(details.failed_layer.as_deref(), Some("retrieval_sidecar"));
+        assert!(
+            !details.next_commands.is_empty(),
+            "retrieval error should include repair commands: {error:?}"
         );
     }
 

--- a/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
+++ b/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
@@ -272,7 +272,7 @@ fn try_ask_browser_with_profile(
 }
 
 fn assert_mandatory_sidecar_unavailable(error: &ApiError) {
-    assert_eq!(error.code, "invalid_argument");
+    assert_eq!(error.code, "retrieval_unavailable");
     assert!(
         error
             .message
@@ -282,6 +282,31 @@ fn assert_mandatory_sidecar_unavailable(error: &ApiError) {
     assert!(
         error.message.contains("expected mode=full"),
         "error should name the full-mode requirement: {error:?}"
+    );
+    let details = error.details.as_ref().expect("retrieval error details");
+    assert_eq!(details.failed_layer.as_deref(), Some("retrieval_sidecar"));
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .any(|command| command.contains("codestory-cli index")
+                && command.contains("--refresh full")),
+        "retrieval error should include index recovery command: {error:?}"
+    );
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .any(|command| command.contains("codestory-cli retrieval bootstrap")),
+        "retrieval error should include bootstrap recovery command: {error:?}"
+    );
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .any(|command| command.contains("codestory-cli retrieval index")
+                && command.contains("--refresh full")),
+        "retrieval error should include sidecar index recovery command: {error:?}"
     );
 }
 

--- a/crates/codestory-runtime/tests/retrieval_eval.rs
+++ b/crates/codestory-runtime/tests/retrieval_eval.rs
@@ -158,7 +158,7 @@ fn retrieval_eval_search_fails_closed_without_full_retrieval_sidecars() {
         )
         .expect_err("plain indexing must not satisfy full sidecar retrieval search");
 
-    assert_eq!(error.code, "invalid_argument");
+    assert_eq!(error.code, "retrieval_unavailable");
     assert!(
         error
             .message
@@ -170,6 +170,31 @@ fn retrieval_eval_search_fails_closed_without_full_retrieval_sidecars() {
         error.message.contains("expected mode=full"),
         "{}",
         error.message
+    );
+    let details = error.details.as_ref().expect("retrieval error details");
+    assert_eq!(details.failed_layer.as_deref(), Some("retrieval_sidecar"));
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .any(|command| command.contains("codestory-cli index")
+                && command.contains("--refresh full")),
+        "retrieval error should include index recovery command: {error:?}"
+    );
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .any(|command| command.contains("codestory-cli retrieval bootstrap")),
+        "retrieval error should include bootstrap recovery command: {error:?}"
+    );
+    assert!(
+        details
+            .next_commands
+            .iter()
+            .any(|command| command.contains("codestory-cli retrieval index")
+                && command.contains("--refresh full")),
+        "retrieval error should include sidecar index recovery command: {error:?}"
     );
 }
 

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## What changed
- Add structured `retrieval_unavailable` API error details and recovery commands.
- Route sidecar-unavailable runtime, CLI, stdio, and search paths through the typed contract.
- Include the actual `codestory-cli retrieval index --project <repo> --refresh full` recovery step.
- Bump synchronized CodeStory workspace crate versions to `0.6.0`.

## Why it changed
This changes the public error contract so agents and automation can distinguish retrieval-sidecar setup failures from generic invalid arguments and recover deterministically. Because the error code/details are public API behavior, this is the minor-version PR in the stack.

## Verification
- `cargo check -p codestory-cli`
- `cargo test -p codestory-contracts retrieval_unavailable_error_serializes_repair_details -- --nocapture`
- `cargo test -p codestory-runtime --test retrieval_eval -- --nocapture`
- `cargo test -p codestory-runtime --test retrieval_browser_contracts -- --nocapture`
- `cargo test -p codestory-cli --test search_json_output search_json_fails_closed_without_full_sidecars -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts search_tool_fails_closed_without_full_retrieval_sidecars -- --nocapture`
- `git diff --check`

## Remaining risk or follow-up
- Live full-sidecar success contracts remain ignored unless a prepared sidecar environment is supplied.
