### PR TITLE
[codex] release 0.6.1 cli recovery polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -37,25 +37,45 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum Command {
+    #[command(about = "Build or refresh the repository index.")]
     Index(IndexCommand),
+    #[command(about = "Summarize indexed repository context.")]
     Ground(GroundCommand),
+    #[command(about = "Gather evidence for one concrete target.")]
     Context(ContextCommand),
+    #[command(about = "Answer a broad repository question with evidence.")]
     Packet(PacketCommand),
+    #[command(about = "Check cache, index, and retrieval health.")]
     Doctor(DoctorCommand),
+    #[command(about = "Install or check local setup assets.")]
     Setup(SetupCommand),
+    #[command(about = "Find symbols and repo text evidence.")]
     Search(SearchCommand),
+    #[command(about = "Run a repeatable grounding quality check.")]
     Drill(DrillCommand),
+    #[command(about = "Run a drill manifest across repositories.")]
     DrillSuite(DrillSuiteCommand),
+    #[command(about = "Inspect a symbol by query or id.")]
     Symbol(SymbolCommand),
+    #[command(about = "Trace calls, refs, and related symbols.")]
     Trail(TrailCommand),
+    #[command(about = "Show source around a symbol.")]
     Snippet(SnippetCommand),
+    #[command(about = "Run structured graph queries.")]
     Query(QueryCommand),
+    #[command(about = "Explore a target without the TUI.")]
     Explore(ExploreCommand),
+    #[command(about = "List indexed files and coverage.")]
     Files(FilesCommand),
+    #[command(about = "Explain impact from changed files.")]
     Affected(AffectedCommand),
+    #[command(about = "Save and reuse investigation targets.")]
     Bookmark(BookmarkCommand),
+    #[command(about = "Start the local integration surface.")]
     Serve(ServeCommand),
+    #[command(about = "Generate shell completions.")]
     GenerateCompletions(GenerateCompletionsCommand),
+    #[command(about = "Manage retrieval sidecar data.")]
     Retrieval(RetrievalCommand),
 }
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -383,7 +383,12 @@ fn run_index_once(cmd: &IndexCommand) -> Result<()> {
         retrieval,
         phase_timings: opened.phase_timings.as_ref(),
         summary_generation: summary_generation.as_ref(),
-        next_commands: index_next_commands(&opened.summary.root, Some(retrieval), sidecar_is_full),
+        next_commands: index_next_commands(
+            &opened.summary.root,
+            Some(retrieval),
+            opened.summary.freshness.as_ref(),
+            sidecar_is_full,
+        ),
     };
 
     let markdown = render_index_markdown(&output);
@@ -7929,7 +7934,12 @@ fn build_doctor_output(
         retrieval,
         freshness: summary.freshness.clone(),
         checks,
-        next_commands: index_next_commands(&project, summary.retrieval.as_ref(), sidecar_is_full),
+        next_commands: index_next_commands(
+            &project,
+            summary.retrieval.as_ref(),
+            summary.freshness.as_ref(),
+            sidecar_is_full,
+        ),
         environment,
     }
 }
@@ -8258,10 +8268,34 @@ fn doctor_sidecar_check(sidecar: &DoctorSidecarStatusOutput) -> DoctorCheckOutpu
 fn index_next_commands(
     project: &str,
     retrieval: Option<&codestory_contracts::api::RetrievalStateDto>,
+    freshness: Option<&IndexFreshnessDto>,
     sidecar_is_full: bool,
 ) -> Vec<String> {
     let project = quote_command_path(std::path::Path::new(project));
     let mut commands = Vec::new();
+    if let Some(freshness) = freshness {
+        match freshness.status {
+            IndexFreshnessStatusDto::Stale => {
+                commands.push(format!(
+                    "codestory-cli index --project {project} --refresh incremental"
+                ));
+                commands.push(format!(
+                    "codestory-cli doctor --project {project} --format markdown"
+                ));
+                return commands;
+            }
+            IndexFreshnessStatusDto::NotChecked => {
+                commands.push(format!(
+                    "codestory-cli index --project {project} --refresh full"
+                ));
+                commands.push(format!(
+                    "codestory-cli doctor --project {project} --format markdown"
+                ));
+                return commands;
+            }
+            IndexFreshnessStatusDto::Fresh => {}
+        }
+    }
     if !sidecar_is_full {
         commands.push(format!(
             "codestory-cli retrieval status --project {project}"
@@ -8272,6 +8306,7 @@ fn index_next_commands(
         commands.push(format!(
             "codestory-cli doctor --project {project} --format markdown"
         ));
+        return commands;
     }
     if let Some(retrieval) = retrieval.filter(|state| !state.semantic_ready)
         && retrieval.fallback_reason == Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime)
@@ -9383,6 +9418,38 @@ mod tests {
             packet_task_class_label(PacketTaskClassDto::BugLocalization),
             "bug_localization"
         );
+    }
+
+    #[test]
+    fn index_next_commands_stop_at_check_index_when_freshness_not_checked() {
+        let freshness = IndexFreshnessDto {
+            status: IndexFreshnessStatusDto::NotChecked,
+            changed_file_count: 0,
+            new_file_count: 0,
+            removed_file_count: 0,
+            checked_file_count: 0,
+            indexed_file_count: 1,
+            duration_ms: 0,
+            reason: Some("bounded inventory overflow".to_string()),
+            samples: Vec::new(),
+        };
+
+        let commands = index_next_commands("C:/repo", None, Some(&freshness), true);
+        let joined = commands.join("\n");
+
+        assert!(
+            joined.contains("codestory-cli index")
+                && joined.contains("--refresh full")
+                && joined.contains("codestory-cli doctor")
+                && joined.contains("--format markdown"),
+            "not-checked freshness should recommend index verification before proof commands: {joined}"
+        );
+        for blocked in ["ground", "search", "context"] {
+            assert!(
+                !joined.contains(&format!("codestory-cli {blocked} ")),
+                "not-checked freshness should stop before `{blocked}` proof/navigation commands: {joined}"
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -250,6 +250,14 @@ fn quote_command_value(value: &str) -> String {
     quote_powershell_single_quoted_value(value)
 }
 
+fn quote_command_argument_value(value: &str) -> String {
+    if command_value_needs_single_quotes(value) {
+        quote_command_value(value)
+    } else {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    }
+}
+
 fn command_value_needs_single_quotes(value: &str) -> bool {
     value.chars().any(|ch| matches!(ch, '$' | '`' | '\'' | '"'))
 }
@@ -7682,6 +7690,8 @@ struct CliErrorBody {
     next_commands: Vec<String>,
 }
 
+const CLI_ERROR_MARKDOWN_ALTERNATIVE_LIMIT: usize = 10;
+
 fn resolve_target_or_emit_ambiguity(
     runtime: &RuntimeContext,
     target: args::TargetSelection,
@@ -7713,17 +7723,36 @@ fn render_cli_error_markdown(output: &CliErrorOutput) -> String {
     let _ = writeln!(markdown, "# Command Error");
     let _ = writeln!(markdown, "code: {}", output.error.code);
     let _ = writeln!(markdown, "failed_layer: {}", output.error.failed_layer);
-    let _ = writeln!(markdown, "message: {}", output.error.message);
+    let _ = writeln!(markdown, "message: {}", cli_error_markdown_message(output));
     let _ = writeln!(markdown, "query: `{}`", output.error.query);
     if let Some(file_filter) = output.error.file_filter.as_deref() {
         let _ = writeln!(markdown, "file_filter: `{file_filter}`");
+    }
+    if !output.error.next_commands.is_empty() {
+        let _ = writeln!(markdown, "next_commands:");
+        for command in &output.error.next_commands {
+            let _ = writeln!(markdown, "- `{command}`");
+        }
     }
     let _ = writeln!(
         markdown,
         "alternatives: {}",
         output.error.alternatives.len()
     );
-    for alternative in &output.error.alternatives {
+    if output.error.alternatives.len() > CLI_ERROR_MARKDOWN_ALTERNATIVE_LIMIT {
+        let _ = writeln!(
+            markdown,
+            "showing: {} of {}; use `--format json` or `search` to inspect all alternatives",
+            CLI_ERROR_MARKDOWN_ALTERNATIVE_LIMIT,
+            output.error.alternatives.len()
+        );
+    }
+    for alternative in output
+        .error
+        .alternatives
+        .iter()
+        .take(CLI_ERROR_MARKDOWN_ALTERNATIVE_LIMIT)
+    {
         let location = alternative
             .file_path
             .as_deref()
@@ -7758,13 +7787,20 @@ fn render_cli_error_markdown(output: &CliErrorOutput) -> String {
             let _ = writeln!(markdown, "- {note}");
         }
     }
-    if !output.error.next_commands.is_empty() {
-        let _ = writeln!(markdown, "next_commands:");
-        for command in &output.error.next_commands {
-            let _ = writeln!(markdown, "- `{command}`");
-        }
-    }
     markdown
+}
+
+fn cli_error_markdown_message(output: &CliErrorOutput) -> &str {
+    if output.error.code == "ambiguous_target" {
+        output
+            .error
+            .message
+            .lines()
+            .next()
+            .unwrap_or(&output.error.message)
+    } else {
+        &output.error.message
+    }
 }
 
 fn build_ambiguous_target_error_output(
@@ -7779,16 +7815,16 @@ fn build_ambiguous_target_error_output(
             build_numbered_search_hit_output(project_root, hit, Some(&ambiguous.query), index + 1)
         })
         .collect::<Vec<_>>();
-    let quoted_query = ambiguous.query.replace('"', "\\\"");
     let project = quote_command_path(project_root);
     let file_clause = ambiguous
         .file_filter
         .as_deref()
-        .map(|file_filter| format!(" --file \"{}\"", file_filter.replace('"', "\\\"")))
+        .map(|file_filter| format!(" --file {}", quote_command_argument_value(file_filter)))
         .unwrap_or_default();
     let mut next_commands = vec![format!(
-        "codestory-cli symbol --project {project} --query \"{}\"{} --choose 1",
-        quoted_query, file_clause
+        "codestory-cli symbol --project {project} --query {}{} --choose 1",
+        quote_command_argument_value(&ambiguous.query),
+        file_clause
     )];
     if let Some(first) = ambiguous.alternatives.first() {
         next_commands.push(format!(
@@ -7797,9 +7833,9 @@ fn build_ambiguous_target_error_output(
         ));
         if let Some(path) = first.file_path.as_deref() {
             next_commands.push(format!(
-                "codestory-cli symbol --project {project} --query \"{}\" --file {}",
-                quoted_query,
-                quote_command_value(&crate::display::relative_path(project_root, path))
+                "codestory-cli symbol --project {project} --query {} --file {}",
+                quote_command_argument_value(&ambiguous.query),
+                quote_command_argument_value(&crate::display::relative_path(project_root, path))
             ));
         }
     }
@@ -7821,7 +7857,8 @@ fn build_ambiguous_target_error_output(
                     ambiguous.query
                 ),
                 format!(
-                    "search: inspect alternatives with `codestory-cli search --project {project} --query`, then rerun this command with --choose, --id, or --file"
+                    "search: inspect alternatives with `codestory-cli search --project {project} --query {}`, then rerun this command with --choose, --id, or --file",
+                    quote_command_argument_value(&ambiguous.query)
                 ),
             ],
             next_commands,

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -567,8 +567,8 @@ pub(crate) fn render_search_markdown(project_root: &Path, output: &SearchOutput)
         append_search_plan(&mut markdown, project_root, plan);
     }
     if output.explain {
-        append_search_sidecar_diagnostics(&mut markdown, output);
         append_search_evidence_packet(&mut markdown, project_root, output);
+        append_search_sidecar_diagnostics(&mut markdown, output);
     }
     if !output.suggestions.is_empty() {
         let _ = writeln!(markdown, "did_you_mean:");
@@ -3415,8 +3415,8 @@ mod tests {
         GroundingCoverageDto, GroundingFileDigestDto, GroundingSnapshotDto,
         GroundingSymbolDigestDto, IndexFreshnessDto, NodeDetailsDto, NodeId, NodeKind,
         RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalScoreBreakdownDto,
-        RetrievalStateDto, SearchHitOrigin, SearchPlanNextActionDto, SemanticModeDto,
-        StorageStatsDto, TrailContextDto, TrailStoryDto, TrailStoryStepDto,
+        RetrievalShadowDto, RetrievalStateDto, SearchHitOrigin, SearchPlanNextActionDto,
+        SemanticModeDto, StorageStatsDto, TrailContextDto, TrailStoryDto, TrailStoryStepDto,
     };
     use serde_json::json;
     use std::path::Path;
@@ -3997,6 +3997,56 @@ mod tests {
             !markdown.contains("why:"),
             "search --why should not duplicate packet evidence as legacy per-hit why lines:\n{markdown}"
         );
+    }
+
+    #[test]
+    fn search_why_markdown_puts_evidence_before_diagnostics() {
+        let output = crate::args::SearchOutput {
+            query: "packet output".to_string(),
+            retrieval: sample_retrieval(),
+            retrieval_shadow: Some(RetrievalShadowDto {
+                retrieval_mode: "full".to_string(),
+                degraded_reason: None,
+                retrieval_total_ms: 12,
+                total_budget_ms: Some(500),
+                cancel_reason: None,
+                cache_hit: true,
+                stage_timings: Vec::new(),
+                candidates: Vec::new(),
+                would_rank: Vec::new(),
+                error: None,
+                candidate_count: 1,
+                resolved_hit_count: 1,
+                unresolved_candidate_count: 0,
+                candidate_resolution_counts: Vec::new(),
+            }),
+            freshness: None,
+            limit_per_source: 1,
+            repo_text_mode: crate::args::RepoTextMode::Auto,
+            repo_text_enabled: true,
+            query_assessment: Some(codestory_contracts::api::SearchQueryAssessmentDto {
+                exact_symbol_hit_count: 1,
+                weak_top_hit: false,
+                stale_or_missing_anchor: false,
+                repo_text_fallback_reason: None,
+                recommended_next_action: Some(
+                    "Open the exact indexed hit with symbol, trail, and snippet before answering."
+                        .to_string(),
+                ),
+            }),
+            search_plan: None,
+            explain: true,
+            query_hints: Vec::new(),
+            suggestions: Vec::new(),
+            indexed_symbol_hits: vec![sample_search_hit()],
+            repo_text_hits: Vec::new(),
+            repo_text_stats: None,
+        };
+
+        let markdown = render_search_markdown(Path::new("C:/repo"), &output);
+
+        assert_order(&markdown, "short_finding:", "Sidecar diagnostics:");
+        assert_order(&markdown, "citations:", "Sidecar diagnostics:");
     }
 
     #[test]

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3,11 +3,12 @@ use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentResponseBlockDto, AgentRetrievalPolicyModeDto,
     AgentRetrievalPresetDto, AgentRetrievalStepDto, AgentRetrievalStepKindDto,
     AgentRetrievalStepStatusDto, ClaimReadinessDto, EvidenceTypeDto, GraphArtifactDto,
-    GroundingSnapshotDto, IndexingPhaseTimings, NodeDetailsDto, RepoTextScanStatsDto,
-    RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalStateDto, SearchHit, SearchHitOrigin,
-    SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto,
-    SearchPlanBridgeStatusDto, SearchPlanChannelDto, SearchPlanDto, SearchPlanPromotionStatusDto,
-    SnippetContextDto, SymbolContextDto, TrailContextDto, TrailStoryDto,
+    GroundingSnapshotDto, IndexFreshnessStatusDto, IndexingPhaseTimings, NodeDetailsDto,
+    RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalStateDto,
+    SearchHit, SearchHitOrigin, SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto,
+    SearchPlanBridgeEvidenceKindDto, SearchPlanBridgeStatusDto, SearchPlanChannelDto,
+    SearchPlanDto, SearchPlanPromotionStatusDto, SnippetContextDto, SymbolContextDto,
+    TrailContextDto, TrailStoryDto,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -1960,6 +1961,12 @@ pub(crate) fn render_doctor_markdown(output: &DoctorOutput) -> String {
         output.retrieval_mode,
         output.degraded_reason.as_deref().unwrap_or("none")
     );
+    let _ = writeln!(
+        markdown,
+        "readiness: local_navigation={} agent_packet_search={}",
+        doctor_local_navigation_readiness(output),
+        doctor_agent_packet_search_readiness(output)
+    );
     if let Some(retrieval) = output.retrieval.as_ref() {
         let _ = writeln!(
             markdown,
@@ -2005,6 +2012,33 @@ pub(crate) fn render_doctor_markdown(output: &DoctorOutput) -> String {
         }
     }
     markdown
+}
+
+fn doctor_local_navigation_readiness(output: &DoctorOutput) -> &'static str {
+    if !output.indexed
+        || output
+            .freshness
+            .as_ref()
+            .is_some_and(|freshness| freshness.status == IndexFreshnessStatusDto::Stale)
+    {
+        return "repair_index";
+    }
+    "ready"
+}
+
+fn doctor_agent_packet_search_readiness(output: &DoctorOutput) -> &'static str {
+    if !output.indexed {
+        return "repair_index";
+    }
+    match output.freshness.as_ref().map(|freshness| freshness.status) {
+        Some(IndexFreshnessStatusDto::Stale) => return "repair_index",
+        Some(IndexFreshnessStatusDto::NotChecked) => return "check_index",
+        Some(IndexFreshnessStatusDto::Fresh) | None => {}
+    }
+    if output.retrieval_mode != "full" {
+        return "repair_retrieval";
+    }
+    "ready"
 }
 
 pub(crate) fn render_drill_markdown(output: &DrillOutput) -> String {
@@ -3379,10 +3413,10 @@ mod tests {
         AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto, AgentRetrievalTraceDto, EdgeId,
         EdgeKind, GraphEdgeDto, GraphNodeDto, GraphResponse, GroundingBudgetDto,
         GroundingCoverageDto, GroundingFileDigestDto, GroundingSnapshotDto,
-        GroundingSymbolDigestDto, NodeDetailsDto, NodeId, NodeKind, RetrievalFallbackReasonDto,
-        RetrievalModeDto, RetrievalScoreBreakdownDto, RetrievalStateDto, SearchHitOrigin,
-        SearchPlanNextActionDto, SemanticModeDto, StorageStatsDto, TrailContextDto, TrailStoryDto,
-        TrailStoryStepDto,
+        GroundingSymbolDigestDto, IndexFreshnessDto, NodeDetailsDto, NodeId, NodeKind,
+        RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalScoreBreakdownDto,
+        RetrievalStateDto, SearchHitOrigin, SearchPlanNextActionDto, SemanticModeDto,
+        StorageStatsDto, TrailContextDto, TrailStoryDto, TrailStoryStepDto,
     };
     use serde_json::json;
     use std::path::Path;
@@ -3450,6 +3484,28 @@ mod tests {
         }
     }
 
+    fn sample_doctor_output() -> DoctorOutput {
+        DoctorOutput {
+            project: "C:/repo".to_string(),
+            storage_path: "C:/cache/codestory.db".to_string(),
+            indexed: true,
+            stats: sample_storage_stats(),
+            retrieval_mode: "full".to_string(),
+            degraded_reason: None,
+            sidecar_retrieval: crate::args::DoctorSidecarStatusOutput {
+                retrieval_mode: "full".to_string(),
+                degraded_reason: None,
+                manifest_generation: None,
+                manifest_input_hash: None,
+            },
+            retrieval: None,
+            freshness: None,
+            checks: Vec::new(),
+            next_commands: Vec::new(),
+            environment: Vec::new(),
+        }
+    }
+
     fn sample_node_details(id: &str, display_name: &str) -> NodeDetailsDto {
         NodeDetailsDto {
             id: NodeId(id.to_string()),
@@ -3466,6 +3522,29 @@ mod tests {
             member_access: None,
             route_endpoint: None,
         }
+    }
+
+    #[test]
+    fn doctor_markdown_marks_agent_readiness_check_index_when_freshness_not_checked() {
+        let mut output = sample_doctor_output();
+        output.freshness = Some(IndexFreshnessDto {
+            status: IndexFreshnessStatusDto::NotChecked,
+            changed_file_count: 0,
+            new_file_count: 0,
+            removed_file_count: 0,
+            checked_file_count: 0,
+            indexed_file_count: 1,
+            duration_ms: 0,
+            reason: Some("bounded inventory overflow".to_string()),
+            samples: Vec::new(),
+        });
+
+        let markdown = render_doctor_markdown(&output);
+
+        assert!(
+            markdown.contains("readiness: local_navigation=ready agent_packet_search=check_index"),
+            "doctor markdown must not report agent packet/search ready when freshness was not checked:\n{markdown}"
+        );
     }
 
     fn sample_graph_node(id: &str, label: &str) -> GraphNodeDto {

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -17,6 +17,8 @@ use crate::query_resolution::{
     resolution_rank_with_project_root, search_hit_matches_file_filter,
 };
 
+const HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT: usize = 10;
+
 #[derive(Debug)]
 pub(crate) struct OpenedProject {
     pub(crate) summary: ProjectSummary,
@@ -544,24 +546,8 @@ fn ambiguous_query_error(
         .map(|value| format!(" even after applying `--file {}`", clean_path_string(value)))
         .unwrap_or_default();
     message.push_str(&format!(
-        "Query `{query}` is ambiguous{scope}. Top equally ranked matches:\n"
+        "Query `{query}` is ambiguous{scope}; choose a match or pass a stable id.\n"
     ));
-    for (index, hit) in alternatives.iter().enumerate() {
-        let number = index + 1;
-        message.push_str("  ");
-        message.push_str(&number.to_string());
-        message.push_str(". ");
-        message.push_str(&format_search_hit_target(project_root, hit));
-        message.push_str(" id=`");
-        message.push_str(&hit.node_id.0);
-        message.push('`');
-        if let Some(node_ref) = node_ref(project_root, hit) {
-            message.push_str(" ref=`");
-            message.push_str(&node_ref);
-            message.push('`');
-        }
-        message.push('\n');
-    }
     message.push_str("\nNext commands:\n");
     message.push_str(&format!(
         "  codestory-cli symbol --project {} --query {}{} --choose 1\n",
@@ -595,6 +581,31 @@ fn ambiguous_query_error(
             "\nPass a more qualified symbol name, add `--file <path-fragment>`, or resolve the exact `--id` from `search` output.",
         );
     }
+    let displayed = alternatives.len().min(HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT);
+    message.push_str(&format!(
+        "\n\nTop equally ranked matches (showing {displayed} of {}):\n",
+        alternatives.len()
+    ));
+    for (index, hit) in alternatives
+        .iter()
+        .take(HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT)
+        .enumerate()
+    {
+        let number = index + 1;
+        message.push_str("  ");
+        message.push_str(&number.to_string());
+        message.push_str(". ");
+        message.push_str(&format_search_hit_target(project_root, hit));
+        message.push_str(" id=`");
+        message.push_str(&hit.node_id.0);
+        message.push('`');
+        if let Some(node_ref) = node_ref(project_root, hit) {
+            message.push_str(" ref=`");
+            message.push_str(&node_ref);
+            message.push('`');
+        }
+        message.push('\n');
+    }
     message
 }
 
@@ -613,7 +624,19 @@ fn quote_cli_path(path: &Path) -> String {
 }
 
 fn quote_cli_value(value: &str) -> String {
-    format!("\"{}\"", value.replace('"', "\\\""))
+    if cli_value_needs_single_quotes(value) {
+        quote_cli_single_quoted_value(value)
+    } else {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    }
+}
+
+fn cli_value_needs_single_quotes(value: &str) -> bool {
+    value.chars().any(|ch| matches!(ch, '$' | '`' | '\'' | '"'))
+}
+
+fn quote_cli_single_quoted_value(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 #[cfg(test)]

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -45,6 +45,47 @@ pub mod beta;
     .expect("write beta.rs");
 }
 
+fn write_many_ambiguous_rust_workspace(root: &Path, count: usize) {
+    fs::create_dir_all(root.join("src")).expect("create src dir");
+    let mut lib = String::new();
+    for index in 1..=count {
+        lib.push_str(&format!("pub mod candidate_{index};\n"));
+        fs::write(
+            root.join("src").join(format!("candidate_{index}.rs")),
+            format!(
+                r#"pub fn configure() -> usize {{
+    {index}
+}}
+"#
+            ),
+        )
+        .expect("write candidate module");
+    }
+    fs::write(root.join("src").join("lib.rs"), lib).expect("write lib.rs");
+}
+
+fn write_many_ambiguous_rust_workspace_under_dir(root: &Path, dir: &str, count: usize) {
+    let source_dir = root.join("src").join(dir);
+    fs::create_dir_all(&source_dir).expect("create nested source dir");
+    let mut lib = String::new();
+    for index in 1..=count {
+        lib.push_str(&format!(
+            "#[path = \"{dir}/candidate_{index}.rs\"]\npub mod candidate_{index};\n"
+        ));
+        fs::write(
+            source_dir.join(format!("candidate_{index}.rs")),
+            format!(
+                r#"pub fn configure() -> usize {{
+    {index}
+}}
+"#
+            ),
+        )
+        .expect("write nested candidate module");
+    }
+    fs::write(root.join("src").join("lib.rs"), lib).expect("write lib.rs");
+}
+
 fn write_drill_friction_workspace(root: &Path) {
     fs::create_dir_all(root.join("src").join("collections")).expect("create collections dir");
     fs::create_dir_all(root.join("src").join("components")).expect("create components dir");
@@ -210,6 +251,35 @@ fn ambiguous_error_alternatives(json: &Value) -> &Vec<Value> {
     json.pointer("/error/alternatives")
         .and_then(Value::as_array)
         .unwrap_or_else(|| panic!("ambiguous JSON should expose /error/alternatives: {json:#}"))
+}
+
+#[test]
+fn top_level_help_names_command_purposes() {
+    let help = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+        .arg("--help")
+        .output()
+        .expect("run top-level help");
+    assert_success(&help, "codestory-cli --help failed");
+    let help_text = String::from_utf8_lossy(&help.stdout);
+
+    for (command, purpose) in [
+        ("index", "Build or refresh the repository index."),
+        ("search", "Find symbols and repo text evidence."),
+        (
+            "packet",
+            "Answer a broad repository question with evidence.",
+        ),
+        ("doctor", "Check cache, index, and retrieval health."),
+        ("setup", "Install or check local setup assets."),
+        ("symbol", "Inspect a symbol by query or id."),
+    ] {
+        assert!(
+            help_text
+                .lines()
+                .any(|line| line.trim_start().starts_with(command) && line.contains(purpose)),
+            "top-level help should show {command:?} purpose {purpose:?}, not only command names:\n{help_text}"
+        );
+    }
 }
 
 #[test]
@@ -582,6 +652,161 @@ fn ambiguous_query_lists_ranked_alternatives_and_next_steps() {
 }
 
 #[test]
+fn ambiguous_query_prioritizes_next_commands_and_caps_human_alternatives() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_many_ambiguous_rust_workspace(workspace.path(), 12);
+
+    index_workspace(workspace.path(), cache_dir.path());
+
+    let output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &["symbol", "--query", "configure", "--refresh", "none"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "ambiguous query must fail before a target is selected\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let next_commands = combined
+        .find("Next commands:")
+        .unwrap_or_else(|| panic!("missing Next commands in:\n{combined}"));
+    let alternatives = combined
+        .find("Top equally ranked matches")
+        .unwrap_or_else(|| panic!("missing alternatives heading in:\n{combined}"));
+    assert!(
+        next_commands < alternatives,
+        "Next commands should precede alternatives in the human diagnostic:\n{combined}"
+    );
+    assert!(
+        combined.contains("Top equally ranked matches (showing 10 of 12):"),
+        "human diagnostic should explain the displayed cap:\n{combined}"
+    );
+    let displayed_alternatives = combined
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            trimmed.contains(" id=`")
+                && trimmed
+                    .split_once('.')
+                    .is_some_and(|(number, _)| number.chars().all(|ch| ch.is_ascii_digit()))
+        })
+        .count();
+    assert_eq!(
+        displayed_alternatives, 10,
+        "human diagnostic should display at most 10 alternatives:\n{combined}"
+    );
+
+    let json_output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "symbol",
+            "--query",
+            "configure",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        !json_output.status.success(),
+        "ambiguous JSON query should fail without selecting a target"
+    );
+    let json = parse_stdout_json(&json_output);
+    assert_eq!(
+        ambiguous_error_alternatives(&json).len(),
+        12,
+        "structured ambiguity JSON should keep every tied alternative: {json:#}"
+    );
+}
+
+#[test]
+fn ambiguous_query_quotes_shell_sensitive_file_filters_in_next_commands() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_many_ambiguous_rust_workspace_under_dir(workspace.path(), "$hidden path", 2);
+    index_workspace(workspace.path(), cache_dir.path());
+
+    let output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "symbol",
+            "--query",
+            "configure",
+            "--file",
+            "$hidden path",
+            "--refresh",
+            "none",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "filtered ambiguous query should fail before selecting a target\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("--file '$hidden path'"),
+        "human diagnostic should single-quote shell-sensitive file filters:\n{combined}"
+    );
+    assert!(
+        !combined.contains("--file \"$hidden path\""),
+        "human diagnostic should not double-quote shell-sensitive file filters:\n{combined}"
+    );
+
+    let json_output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "symbol",
+            "--query",
+            "configure",
+            "--file",
+            "$hidden path",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        !json_output.status.success(),
+        "filtered ambiguous JSON query should fail before selecting a target"
+    );
+    let json = parse_stdout_json(&json_output);
+    assert_eq!(
+        ambiguous_error_alternatives(&json).len(),
+        2,
+        "filtered ambiguity JSON should keep every tied alternative: {json:#}"
+    );
+    assert!(
+        json.pointer("/error/next_commands")
+            .and_then(Value::as_array)
+            .is_some_and(|commands| commands.iter().any(|command| command
+                .as_str()
+                .is_some_and(|value| value.contains("--file '$hidden path'")))),
+        "structured next commands should single-quote shell-sensitive file filters: {json:#}"
+    );
+}
+
+#[test]
 fn ambiguous_symbol_json_includes_numbered_alternatives_with_stable_refs() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");
@@ -634,6 +859,14 @@ fn ambiguous_symbol_json_includes_numbered_alternatives_with_stable_refs() {
                 .iter()
                 .all(|note| !note.as_str().unwrap_or_default().contains("search --file"))),
         "ambiguous JSON should not imply `search --file` exists: {json:#}"
+    );
+    assert!(
+        json.pointer("/error/layer_notes")
+            .and_then(Value::as_array)
+            .is_some_and(|notes| notes.iter().any(|note| note
+                .as_str()
+                .is_some_and(|note| note.contains("--query \"configure\"")))),
+        "ambiguous JSON layer note should include the searched query when it names search: {json:#}"
     );
     assert!(
         json.pointer("/resolution/resolved").is_none(),
@@ -722,7 +955,7 @@ fn ambiguous_symbol_json_includes_numbered_alternatives_with_stable_refs() {
 fn ambiguous_query_writes_output_file_even_on_failure() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");
-    write_ambiguous_rust_workspace(workspace.path());
+    write_many_ambiguous_rust_workspace(workspace.path(), 12);
     index_workspace(workspace.path(), cache_dir.path());
     let output_file = cache_dir.path().join("ambiguous-snippet.md");
 
@@ -750,7 +983,68 @@ fn ambiguous_query_writes_output_file_even_on_failure() {
         diagnostic.contains("code: ambiguous_target"),
         "{diagnostic}"
     );
-    assert!(diagnostic.contains("alternatives:"), "{diagnostic}");
+    assert!(diagnostic.contains("alternatives: 12"), "{diagnostic}");
+    assert!(
+        diagnostic.contains(
+            "showing: 10 of 12; use `--format json` or `search` to inspect all alternatives"
+        ),
+        "{diagnostic}"
+    );
+    assert!(
+        !diagnostic.contains("Top equally ranked matches"),
+        "markdown output-file diagnostics should not duplicate the embedded human alternatives from the message:\n{diagnostic}"
+    );
+    let next_commands = diagnostic
+        .find("next_commands:")
+        .unwrap_or_else(|| panic!("missing next_commands in:\n{diagnostic}"));
+    let alternatives = diagnostic
+        .find("alternatives: 12")
+        .unwrap_or_else(|| panic!("missing alternatives heading in:\n{diagnostic}"));
+    assert!(
+        next_commands < alternatives,
+        "markdown output-file diagnostics should put next commands before alternatives:\n{diagnostic}"
+    );
+    let visible_alternative_rows = diagnostic
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            let numbered_runtime_row = trimmed.contains(" id=`")
+                && trimmed
+                    .split_once('.')
+                    .is_some_and(|(number, _)| number.chars().all(|ch| ch.is_ascii_digit()));
+            let structured_markdown_row =
+                trimmed.starts_with("- [") && trimmed.contains("configure");
+            numbered_runtime_row || structured_markdown_row
+        })
+        .count();
+    assert_eq!(
+        visible_alternative_rows, 10,
+        "markdown output-file diagnostics should render exactly one capped alternatives section:\n{diagnostic}"
+    );
+
+    let json_output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "snippet",
+            "--query",
+            "configure",
+            "--refresh",
+            "none",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        !json_output.status.success(),
+        "ambiguous JSON snippet should fail without selecting a target"
+    );
+    let json = parse_stdout_json(&json_output);
+    assert_eq!(
+        ambiguous_error_alternatives(&json).len(),
+        12,
+        "structured ambiguity JSON should keep every tied alternative: {json:#}"
+    );
 }
 
 #[test]

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -174,6 +174,25 @@ fn check_with_name<'a>(doctor: &'a Value, name: &str) -> &'a Value {
         .unwrap_or_else(|| panic!("doctor check `{name}` missing: {doctor:#}"))
 }
 
+fn doctor_next_commands(doctor: &Value) -> Vec<&str> {
+    doctor["next_commands"]
+        .as_array()
+        .expect("doctor next commands")
+        .iter()
+        .map(|command| command.as_str().expect("next command string"))
+        .collect()
+}
+
+fn assert_no_agent_proof_commands(commands: &[&str], context: &str) {
+    let joined = commands.join("\n");
+    for blocked in ["packet", "ground", "search", "context"] {
+        assert!(
+            !joined.contains(&format!("codestory-cli {blocked} ")),
+            "{context} should stop before `{blocked}` proof/navigation commands: {joined}"
+        );
+    }
+}
+
 fn clean_test_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
@@ -578,6 +597,140 @@ fn new_openapi_with_late_paths_marks_freshness_stale() {
         ),
         Some(1),
         "new OpenAPI schema with late paths should be counted as new: {freshness:#}"
+    );
+}
+
+#[test]
+fn doctor_next_commands_stop_at_index_repair_when_inventory_is_stale() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+
+    fs::write(
+        workspace.path().join("late-openapi.yaml"),
+        "openapi: 3.1.0\ninfo:\n  title: Late Paths\n  version: 1.0.0\npaths:\n  /api/late:\n    get:\n      operationId: getLate\n",
+    )
+    .expect("write late OpenAPI fixture");
+
+    let doctor = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["doctor", "--format", "json"],
+    );
+    let freshness = find_index_freshness(&doctor)
+        .unwrap_or_else(|| panic!("doctor should include index freshness: {doctor:#}"));
+    assert_eq!(
+        freshness["status"], "stale",
+        "doctor should report stale freshness before recommending repair: {doctor:#}"
+    );
+
+    let next_commands = doctor_next_commands(&doctor);
+    let joined = next_commands.join("\n");
+    assert!(
+        joined.contains("codestory-cli index")
+            && joined.contains("--refresh incremental")
+            && joined.contains("codestory-cli doctor")
+            && joined.contains("--format markdown"),
+        "stale doctor should recommend index repair then doctor recheck: {doctor:#}"
+    );
+    assert!(
+        !joined.contains("retrieval status") && !joined.contains("retrieval index"),
+        "stale doctor should stop before retrieval repair commands: {doctor:#}"
+    );
+    assert_no_agent_proof_commands(&next_commands, "stale doctor");
+
+    let markdown = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &["doctor", "--format", "markdown"],
+    );
+    assert!(
+        markdown.status.success(),
+        "doctor markdown failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&markdown.stdout),
+        String::from_utf8_lossy(&markdown.stderr)
+    );
+    let markdown = String::from_utf8_lossy(&markdown.stdout);
+    assert!(
+        markdown
+            .contains("readiness: local_navigation=repair_index agent_packet_search=repair_index"),
+        "doctor markdown should show split readiness with index repair first:\n{markdown}"
+    );
+}
+
+#[test]
+fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    let index = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+    let index_next_commands = doctor_next_commands(&index);
+    let index_next_commands_joined = index_next_commands.join("\n");
+    assert!(
+        index_next_commands_joined.contains("codestory-cli retrieval status")
+            && index_next_commands_joined.contains("codestory-cli retrieval index"),
+        "index output should recommend sidecar repair when sidecar retrieval is not full: {index:#}"
+    );
+    assert_no_agent_proof_commands(&index_next_commands, "index output");
+
+    let doctor = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["doctor", "--format", "json"],
+    );
+    let freshness = find_index_freshness(&doctor)
+        .unwrap_or_else(|| panic!("doctor should include index freshness: {doctor:#}"));
+    assert_ne!(
+        freshness["status"], "stale",
+        "sidecar repair test needs fresh enough inventory: {doctor:#}"
+    );
+    assert_ne!(
+        doctor["retrieval_mode"], "full",
+        "sidecar repair test needs mandatory sidecar retrieval to be not full: {doctor:#}"
+    );
+
+    let next_commands = doctor_next_commands(&doctor);
+    let joined = next_commands.join("\n");
+    assert!(
+        joined.contains("codestory-cli retrieval status")
+            && joined.contains("codestory-cli retrieval index")
+            && joined.contains("--refresh full")
+            && joined.contains("codestory-cli doctor")
+            && joined.contains("--format markdown"),
+        "doctor should recommend retrieval repair before packet/search: {doctor:#}"
+    );
+    assert!(
+        !joined.contains("codestory-cli index "),
+        "fresh doctor should not send users back to index repair: {doctor:#}"
+    );
+    assert_no_agent_proof_commands(&next_commands, "sidecar doctor");
+
+    let markdown = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &["doctor", "--format", "markdown"],
+    );
+    assert!(
+        markdown.status.success(),
+        "doctor markdown failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&markdown.stdout),
+        String::from_utf8_lossy(&markdown.stderr)
+    );
+    let markdown = String::from_utf8_lossy(&markdown.stdout);
+    assert!(
+        markdown.contains("readiness: local_navigation=ready agent_packet_search=repair_retrieval"),
+        "doctor markdown should show split readiness with retrieval repair for agent use:\n{markdown}"
     );
 }
 

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## What changed
- Make `doctor` readiness output recovery-first for stale indexes and non-full sidecars.
- Put evidence before diagnostics in search Markdown and improve ambiguous-query recovery guidance.
- Tighten shell-sensitive command quoting and output-file error rendering.
- Bump synchronized CodeStory workspace crate versions to `0.6.1`.

## Why it changed
The CLI should tell operators the next safe recovery command before offering broader diagnostics. This is backwards-compatible operator polish, so it is a patch PR after the `0.6.0` contract change.

## Verification
- `cargo check -p codestory-cli`
- `cargo test -p codestory-cli doctor_next_commands -- --nocapture`
- `cargo test -p codestory-cli --test cli_error_contracts -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

## Remaining risk or follow-up
- This PR focuses on CLI rendering/contracts and does not rerun the full release e2e gate.
