### PR TITLE
[codex] consolidate semantic pressure autoresearch changes

### DIFF
--- a/crates/codestory-retrieval/src/generation.rs
+++ b/crates/codestory-retrieval/src/generation.rs
@@ -378,6 +378,51 @@ mod tests {
     }
 
     #[test]
+    fn manifest_staleness_rejects_staged_repair_dimension_drift() {
+        let project = TempDir::new().expect("project");
+        let storage_path = project.path().join("codestory.db");
+        let mut storage = Store::open(&storage_path).expect("open store");
+        storage
+            .insert_nodes_batch(&[
+                Node {
+                    id: NodeId(1),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "repaired_touched_file".into(),
+                    ..Default::default()
+                },
+                Node {
+                    id: NodeId(2),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "stale_untouched_file".into(),
+                    ..Default::default()
+                },
+            ])
+            .expect("nodes");
+        storage
+            .upsert_llm_symbol_docs_batch(&[
+                semantic_doc(1, "semantic_doc_version=4;scope=durable_symbols"),
+                LlmSymbolDoc {
+                    embedding_dim: 128,
+                    embedding: vec![0.0; 128],
+                    ..semantic_doc(2, "semantic_doc_version=4;scope=durable_symbols")
+                },
+            ])
+            .expect("docs");
+        let mut manifest = manifest("proj", "deadbeefcafebabe1234");
+        manifest.embedding_backend = Some(crate::embeddings::embedding_runtime_id());
+        manifest.embedding_dim = Some(crate::embeddings::qdrant_vector_dim() as i32);
+        manifest.projection_count = Some(2);
+
+        let reason = manifest_staleness_reason(&storage, &manifest)
+            .expect("staged dimension repair should stale");
+
+        assert_eq!(
+            reason,
+            "sidecar_semantic_doc_count_changed: manifest=2 current=1"
+        );
+    }
+
+    #[test]
     fn manifest_staleness_counts_only_sidecar_eligible_semantic_docs() {
         let project = TempDir::new().expect("project");
         let storage_path = project.path().join("codestory.db");

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -3776,6 +3776,7 @@ const SEMANTIC_DOC_SCOPE_ENV: &str = "CODESTORY_SEMANTIC_DOC_SCOPE";
 const SEMANTIC_DOC_ALIAS_MODE_ENV: &str = "CODESTORY_SEMANTIC_DOC_ALIAS_MODE";
 const SEMANTIC_DOC_MAX_TOKENS_ENV: &str = "CODESTORY_SEMANTIC_DOC_MAX_TOKENS";
 const SEMANTIC_DOC_DEFAULT_MAX_TOKENS: usize = 128;
+const SEMANTIC_DOC_FOREGROUND_LIMIT_ENV: &str = "CODESTORY_SEMANTIC_DOC_FOREGROUND_LIMIT";
 const SEMANTIC_STREAM_PENDING_DOCS_ENV: &str = "CODESTORY_SEMANTIC_STREAM_PENDING_DOCS";
 const SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV: &str =
     "CODESTORY_SEMANTIC_STREAM_SORT_WINDOW_BATCHES";
@@ -4172,6 +4173,20 @@ fn semantic_doc_max_tokens_from_env() -> usize {
         .filter(|value| *value > 0)
         .map(|value| value.clamp(16, 8_192))
         .unwrap_or(SEMANTIC_DOC_DEFAULT_MAX_TOKENS)
+}
+
+fn semantic_doc_foreground_limit_from_env() -> Option<usize> {
+    let value = std::env::var(SEMANTIC_DOC_FOREGROUND_LIMIT_ENV).ok()?;
+    let normalized = value.trim().to_ascii_lowercase();
+    if normalized.is_empty()
+        || matches!(
+            normalized.as_str(),
+            "all" | "full" | "none" | "off" | "unlimited"
+        )
+    {
+        return None;
+    }
+    normalized.parse::<usize>().ok()
 }
 
 fn stream_pending_llm_symbol_docs_from_env() -> bool {
@@ -4933,24 +4948,37 @@ fn sync_llm_symbol_projection(
         .map(|doc| (doc.node_id, doc))
         .collect::<HashMap<_, _>>();
 
-    let expand_semantic_scope_for_contract_repair = llm_refresh_file_scope.is_some()
-        && existing_docs.values().any(|existing_doc| {
-            !llm_symbol_doc_contract_matches(existing_doc, &embedding_contract)
-        });
-    if expand_semantic_scope_for_contract_repair {
+    let contract_stale_doc_count = existing_docs
+        .values()
+        .filter(|existing_doc| !llm_symbol_doc_contract_matches(existing_doc, &embedding_contract))
+        .count();
+    let scoped_contract_stale_docs = llm_refresh_file_scope
+        .map(|scope| {
+            existing_docs
+                .values()
+                .filter(|existing_doc| {
+                    !llm_symbol_doc_contract_matches(existing_doc, &embedding_contract)
+                        && existing_doc
+                            .file_node_id
+                            .map(|file_node_id| !scope.contains(&file_node_id))
+                            .unwrap_or(true)
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    if llm_refresh_file_scope.is_some() && contract_stale_doc_count > 0 {
         tracing::warn!(
-            "Stored semantic-doc contract differs from current embedding contract; expanding incremental semantic sync to rebuild all semantic docs"
+            contract_stale_doc_count,
+            scoped_contract_stale_docs,
+            "Stored semantic-doc contract differs from current embedding contract; repairing touched semantic docs only during incremental sync. Full refresh is required to repair untouched semantic docs."
         );
     }
-    let effective_llm_refresh_file_scope = if expand_semantic_scope_for_contract_repair {
-        None
-    } else {
-        llm_refresh_file_scope
-    };
+    let effective_llm_refresh_file_scope = llm_refresh_file_scope;
 
     if let Some(scope) = effective_llm_refresh_file_scope
         && scope.is_empty()
     {
+        stats.docs_stale = clamp_usize_to_u32(scoped_contract_stale_docs);
         if hydrate_semantic_docs {
             let reload_started = Instant::now();
             reload_llm_docs_from_storage(storage, engine, LLM_DOC_RELOAD_BATCH_SIZE)?;
@@ -4960,12 +4988,21 @@ fn sync_llm_symbol_projection(
     }
 
     let embed_batch_size = llm_doc_embed_batch_size();
+    let foreground_doc_limit = semantic_doc_foreground_limit_from_env();
     let stream_pending_docs = stream_pending_llm_symbol_docs_from_env();
     let stream_sort_window_batches = semantic_stream_sort_window_batches_from_env();
     let stream_sort_window_size = embed_batch_size.saturating_mul(stream_sort_window_batches);
     tracing::debug!(embed_batch_size, "Using semantic doc embedding batch size");
+    if let Some(foreground_doc_limit) = foreground_doc_limit {
+        tracing::debug!(
+            foreground_doc_limit,
+            "Using semantic doc foreground embedding limit"
+        );
+    }
     let mut pending_docs = Vec::<PendingLlmSymbolDoc>::new();
     let mut seen_node_ids = Vec::<codestory_contracts::graph::NodeId>::new();
+    let mut foreground_docs_selected = 0_usize;
+    let mut deferred_missing_docs = 0_usize;
     let mut doc_build_ns = 0_u128;
     let semantic_nodes = nodes
         .iter()
@@ -5028,13 +5065,21 @@ fn sync_llm_symbol_projection(
         doc_build_ns = doc_build_ns.saturating_add(doc_build_started.elapsed().as_nanos());
 
         for built_doc in built_docs {
-            seen_node_ids.push(built_doc.pending.node_id);
             if built_doc.reusable {
+                seen_node_ids.push(built_doc.pending.node_id);
                 stats.docs_reused = stats.docs_reused.saturating_add(1);
                 continue;
             }
 
             stats.docs_pending = stats.docs_pending.saturating_add(1);
+            if foreground_doc_limit.is_some_and(|limit| foreground_docs_selected >= limit) {
+                if !existing_docs.contains_key(&built_doc.pending.node_id) {
+                    deferred_missing_docs = deferred_missing_docs.saturating_add(1);
+                }
+                continue;
+            }
+            foreground_docs_selected = foreground_docs_selected.saturating_add(1);
+            seen_node_ids.push(built_doc.pending.node_id);
             pending_docs.push(built_doc.pending);
         }
 
@@ -5078,7 +5123,9 @@ fn sync_llm_symbol_projection(
             .map_err(|e| ApiError::internal(format!("Failed to prune stale LLM docs: {e}")))?
     };
     stats.prune_ms = clamp_u128_to_u32(prune_started.elapsed().as_millis());
-    stats.docs_stale = clamp_usize_to_u32(stale_docs);
+    stats.docs_stale = clamp_usize_to_u32(stale_docs)
+        .saturating_add(clamp_usize_to_u32(scoped_contract_stale_docs))
+        .saturating_add(clamp_usize_to_u32(deferred_missing_docs));
 
     if hydrate_semantic_docs {
         let reload_started = Instant::now();
@@ -9749,6 +9796,7 @@ mod tests {
                 EnvGuard::remove(SEMANTIC_DOC_SCOPE_ENV),
                 EnvGuard::remove(SEMANTIC_DOC_ALIAS_MODE_ENV),
                 EnvGuard::remove(SEMANTIC_DOC_MAX_TOKENS_ENV),
+                EnvGuard::remove(SEMANTIC_DOC_FOREGROUND_LIMIT_ENV),
                 EnvGuard::remove(SEMANTIC_STREAM_PENDING_DOCS_ENV),
                 EnvGuard::remove(SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV),
             ],
@@ -10067,6 +10115,24 @@ mod tests {
             SEMANTIC_DOC_DEFAULT_MAX_TOKENS
         );
         assert!(semantic_doc_shape_contract().contains("max_tokens=128"));
+    }
+
+    #[test]
+    fn semantic_doc_foreground_limit_defaults_to_unlimited_and_accepts_zero() {
+        let _lock = ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _env = EnvGuard::remove(SEMANTIC_DOC_FOREGROUND_LIMIT_ENV);
+        assert_eq!(semantic_doc_foreground_limit_from_env(), None);
+
+        let _env = EnvGuard::set(SEMANTIC_DOC_FOREGROUND_LIMIT_ENV, "2");
+        assert_eq!(semantic_doc_foreground_limit_from_env(), Some(2));
+
+        let _env = EnvGuard::set(SEMANTIC_DOC_FOREGROUND_LIMIT_ENV, "0");
+        assert_eq!(semantic_doc_foreground_limit_from_env(), Some(0));
+
+        let _env = EnvGuard::set(SEMANTIC_DOC_FOREGROUND_LIMIT_ENV, "unlimited");
+        assert_eq!(semantic_doc_foreground_limit_from_env(), None);
     }
 
     fn pending_semantic_doc_for_test(node_id: i64, doc_text: &str) -> PendingLlmSymbolDoc {
@@ -12813,6 +12879,99 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
+    fn semantic_foreground_limit_defers_unembedded_docs() {
+        let mut env = hybrid_test_env();
+        env.push(EnvGuard::set(SEMANTIC_DOC_FOREGROUND_LIMIT_ENV, "2"));
+        let mut storage = Storage::new_in_memory().expect("storage");
+        storage
+            .insert_nodes_batch(&[
+                Node {
+                    id: CoreNodeId(1),
+                    kind: NodeKind::FILE,
+                    serialized_name: "src/lib.rs".to_string(),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(10),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "alpha".to_string(),
+                    qualified_name: Some("pkg::alpha".to_string()),
+                    file_node_id: Some(CoreNodeId(1)),
+                    start_line: Some(1),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(11),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "beta".to_string(),
+                    qualified_name: Some("pkg::beta".to_string()),
+                    file_node_id: Some(CoreNodeId(1)),
+                    start_line: Some(5),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(12),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "gamma".to_string(),
+                    qualified_name: Some("pkg::gamma".to_string()),
+                    file_node_id: Some(CoreNodeId(1)),
+                    start_line: Some(9),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(13),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "delta".to_string(),
+                    qualified_name: Some("pkg::delta".to_string()),
+                    file_node_id: Some(CoreNodeId(1)),
+                    start_line: Some(13),
+                    ..Default::default()
+                },
+            ])
+            .expect("insert nodes");
+
+        let nodes = storage.get_nodes().expect("nodes");
+        let result = build_search_state(
+            &mut storage,
+            None,
+            nodes,
+            None,
+            SemanticProjectionMode::PersistBackedDocs,
+            false,
+        )
+        .expect("build capped semantic state");
+
+        let docs = storage
+            .get_all_llm_symbol_docs()
+            .expect("stored semantic docs");
+        println!(
+            "METRIC foreground_limit_pending_docs={}",
+            result.semantic_stats.docs_pending
+        );
+        println!(
+            "METRIC foreground_limit_embedded_docs={}",
+            result.semantic_stats.docs_embedded
+        );
+        println!(
+            "METRIC foreground_limit_stale_docs={}",
+            result.semantic_stats.docs_stale
+        );
+        println!("METRIC foreground_limit_stored_docs={}", docs.len());
+
+        assert_eq!(result.semantic_stats.docs_pending, 4);
+        assert_eq!(result.semantic_stats.docs_embedded, 2);
+        assert_eq!(result.semantic_stats.docs_stale, 2);
+        assert_eq!(docs.len(), 2);
+        assert!(
+            docs.iter().all(
+                |doc| doc.embedding_profile.as_deref() == Some("bge-small-en-v1.5")
+                    && doc.embedding_backend.as_deref() == Some("hash")
+            ),
+            "foreground docs should still use the current semantic contract"
+        );
+    }
+
+    #[test]
     fn full_refresh_repairs_reused_semantic_docs_missing_contract_metadata() {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
@@ -12977,7 +13136,7 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
-    fn incremental_refresh_rebuilds_all_semantic_docs_when_embedding_contract_changes() {
+    fn incremental_refresh_repairs_touched_file_semantic_docs_when_embedding_contract_changes() {
         let mut env = hybrid_test_env();
         env.push(EnvGuard::set(EMBEDDING_EXPECTED_DIM_ENV, "128"));
         let workspace = copy_tictactoe_workspace();
@@ -13018,21 +13177,58 @@ fn build_llm_symbol_doc_text() -> String {
         let incremental_timings = controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
             .expect("incremental index after contract drift");
-        assert!(
+        println!("METRIC contract_drift_before_docs={}", before_docs.len());
+        println!(
+            "METRIC contract_drift_embedded_docs={}",
             incremental_timings.semantic_docs_embedded.unwrap_or(0)
-                >= clamp_usize_to_u32(before_docs.len()),
-            "contract drift should expand incremental semantic sync beyond the touched file"
+        );
+        println!(
+            "METRIC contract_drift_stale_docs={}",
+            incremental_timings.semantic_docs_stale.unwrap_or(0)
+        );
+        assert!(
+            incremental_timings.semantic_docs_embedded.unwrap_or(0) > 0,
+            "changed-file docs should be embedded against the current contract"
+        );
+        assert!(
+            incremental_timings
+                .semantic_docs_embedded
+                .unwrap_or(u32::MAX)
+                < clamp_usize_to_u32(before_docs.len()),
+            "contract drift should not expand incremental semantic sync beyond the touched file"
+        );
+        assert!(
+            incremental_timings.semantic_docs_stale.unwrap_or(0) > 0,
+            "incremental repair should report untouched semantic docs that remain on the stale contract"
         );
 
         let repaired_docs = Storage::open(&storage_path)
             .expect("open storage after drift repair")
             .get_all_llm_symbol_docs()
             .expect("semantic docs after drift repair");
+        let rust_docs = repaired_docs
+            .iter()
+            .filter(|doc| {
+                doc.file_path
+                    .as_deref()
+                    .is_some_and(|path| path.contains("rust_tictactoe.rs"))
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            !rust_docs.is_empty(),
+            "fixture should have Rust semantic docs"
+        );
+        assert!(
+            rust_docs
+                .iter()
+                .all(|doc| doc.embedding_dim == 384 && doc.embedding.len() == 384),
+            "incremental repair should leave touched-file semantic docs on the current contract"
+        );
         assert!(
             repaired_docs
                 .iter()
-                .all(|doc| doc.embedding_dim == 384 && doc.embedding.len() == 384),
-            "incremental repair should leave all stored semantic docs on the current contract"
+                .any(|doc| doc.embedding_dim == 128 && doc.embedding.len() == 128),
+            "untouched semantic docs should remain staged for full-refresh contract repair"
         );
         assert!(
             repaired_docs.iter().any(|doc| doc

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -712,6 +712,7 @@ pub struct LlmSymbolDoc {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmSymbolDocReuseMetadata {
     pub node_id: NodeId,
+    pub file_node_id: Option<NodeId>,
     pub doc_version: u32,
     pub doc_hash: String,
     pub embedding_profile: Option<String>,
@@ -3053,6 +3054,7 @@ impl Storage {
         let mut stmt = self.conn.prepare(
             "SELECT
                 node_id,
+                file_node_id,
                 doc_version,
                 doc_hash,
                 embedding_profile,
@@ -3066,17 +3068,18 @@ impl Storage {
         let mut rows = stmt.query([])?;
         let mut docs = Vec::new();
         while let Some(row) = rows.next()? {
-            let doc_version: i64 = row.get(1)?;
-            let embedding_dim: i64 = row.get(6)?;
+            let doc_version: i64 = row.get(2)?;
+            let embedding_dim: i64 = row.get(7)?;
             docs.push(LlmSymbolDocReuseMetadata {
                 node_id: NodeId(row.get(0)?),
+                file_node_id: row.get::<_, Option<i64>>(1)?.map(NodeId),
                 doc_version: doc_version.max(0).min(u32::MAX as i64) as u32,
-                doc_hash: row.get(2)?,
-                embedding_profile: row.get(3)?,
-                embedding_model: row.get(4)?,
-                embedding_backend: row.get(5)?,
+                doc_hash: row.get(3)?,
+                embedding_profile: row.get(4)?,
+                embedding_model: row.get(5)?,
+                embedding_backend: row.get(6)?,
                 embedding_dim: embedding_dim.max(0).min(u32::MAX as i64) as u32,
-                doc_shape: row.get(7)?,
+                doc_shape: row.get(8)?,
             });
         }
         Ok(docs)

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -42,6 +42,7 @@ Important tuning surfaces:
 - `CODESTORY_SEMANTIC_DOC_SCOPE`: default durable symbols; use `all` for the older broad symbol set
 - `CODESTORY_SEMANTIC_DOC_ALIAS_MODE`: default `alias_variant`; use `no_alias` for baseline research rows or `current_alias` for the older full alias text
 - `CODESTORY_SEMANTIC_DOC_MAX_TOKENS`: generated semantic-doc token budget.
+- `CODESTORY_SEMANTIC_DOC_FOREGROUND_LIMIT`: optional foreground cap for newly embedded semantic docs. Reusable current docs still load; docs beyond the cap are left as semantic debt instead of being embedded during that index pass.
 - `CODESTORY_EMBED_BACKEND`: product sidecar indexing requires `llamacpp`.
 - `CODESTORY_EMBED_LLAMACPP_URL`: local OpenAI-compatible llama.cpp embedding endpoint for `CODESTORY_EMBED_BACKEND=llamacpp`.
 - `CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT`: local llama.cpp request concurrency, clamped from `1` to `16`.
@@ -60,6 +61,25 @@ then writes generation-bound sidecar artifacts and manifest metadata. Missing
 or non-product embedding state fails closed for agent-facing retrieval.
 
 Timing fields for this path are in `IndexingPhaseTimings`: `search_projection_rebuild_ms`, `search_symbol_index_ms`, `runtime_cache_publish_ms`, `semantic_doc_build_ms`, `semantic_embedding_ms`, `semantic_db_upsert_ms`, `semantic_reload_ms`, `semantic_prune_ms`, `semantic_docs_reused`, `semantic_docs_embedded`, `semantic_docs_pending`, and `semantic_docs_stale`.
+
+Embedding contract repair is intentionally asymmetric. Full refresh is the
+contract-repair path for the whole semantic corpus. Incremental refresh keeps
+semantic sync scoped to touched files even when the stored embedding contract
+differs from the current runtime contract; touched-file docs are rebuilt, while
+untouched docs remain stale and are reported through `semantic_docs_stale`.
+Mixed stored semantic-doc contracts keep sidecar manifests stale/fail-closed
+until a full refresh plus `retrieval index` repairs the corpus and writes fresh
+sidecar artifacts.
+
+Lazy foreground embedding is opt-in through
+`CODESTORY_SEMANTIC_DOC_FOREGROUND_LIMIT`. This mode keeps graph and lexical
+indexing complete, reuses current semantic docs when possible, embeds only the
+first capped set of missing or stale semantic docs, and reports the remaining
+debt through `semantic_docs_pending > semantic_docs_embedded` plus
+`semantic_docs_stale`. Deferred docs are not retained as stale vectors in the
+store, so sidecar manifests continue to fail closed on count or contract drift
+until a full uncapped repair and `retrieval index` rebuild the semantic
+artifacts.
 
 ## Failure Signatures
 

--- a/scripts/autoresearch-semantic-pressure.mjs
+++ b/scripts/autoresearch-semantic-pressure.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, resolve } from "node:path";
+
+const root = process.cwd();
+const args = new Set(process.argv.slice(2));
+const mode = optionValue("--mode") ?? process.env.CODESTORY_SEMANTIC_PRESSURE_MODE ?? "latest-log";
+
+if (args.has("--help") || args.has("-h")) {
+  console.log(`Usage: node scripts/autoresearch-semantic-pressure.mjs [--mode latest-log|full-sidecar|contract-drift-test|foreground-limit-test]
+
+Modes:
+  latest-log             Fast setup/lint mode. Reads docs/testing/codestory-e2e-stats-log.md.
+  full-sidecar           Runs the release build and ignored full-sidecar repo E2E stats test.
+  contract-drift-test    Runs the live incremental contract-drift regression test.
+  foreground-limit-test  Runs the live foreground semantic-doc limit regression test.
+
+The primary metric is lower-is-better:
+  latest-log/full-sidecar:  semantic_pressure_score = semantic_phase_seconds + index_seconds
+  contract-drift-test:      semantic_pressure_score = contract_drift_embedded_docs
+  foreground-limit-test:    semantic_pressure_score = foreground_limit_embedded_docs
+`);
+  process.exit(0);
+}
+
+if (mode === "latest-log") {
+  const stats = readLatestLoggedStats();
+  emitMetrics(stats, { liveMeasurement: 0, source: "latest-log" });
+  emitArtifact("stats_log", "docs/testing/codestory-e2e-stats-log.md");
+} else if (mode === "full-sidecar") {
+  run("cargo", ["build", "--release", "-p", "codestory-cli"]);
+  const output = run("cargo", [
+    "test",
+    "-p",
+    "codestory-cli",
+    "--test",
+    "codestory_repo_e2e_stats",
+    "--",
+    "--ignored",
+    "--nocapture",
+  ]);
+  const stats = parseStatsJson(output.stdout);
+  emitMetrics(stats, { liveMeasurement: 1, source: "full-sidecar" });
+} else if (mode === "contract-drift-test") {
+  const output = run("cargo", [
+    "test",
+    "-p",
+    "codestory-runtime",
+    "incremental_refresh_repairs_touched_file_semantic_docs_when_embedding_contract_changes",
+    "--",
+    "--nocapture",
+  ]);
+  const metrics = parseMetricLines(output.stdout);
+  const beforeDocs = requiredParsedMetric(metrics, "contract_drift_before_docs");
+  const embeddedDocs = requiredParsedMetric(metrics, "contract_drift_embedded_docs");
+  const staleDocs = requiredParsedMetric(metrics, "contract_drift_stale_docs");
+  console.log("semantic_pressure_source=contract-drift-test");
+  emitMetric("semantic_pressure_score", embeddedDocs);
+  emitMetric("contract_drift_before_docs", beforeDocs);
+  emitMetric("contract_drift_embedded_docs", embeddedDocs);
+  emitMetric("contract_drift_stale_docs", staleDocs);
+  emitMetric("contract_drift_embed_ratio", beforeDocs > 0 ? embeddedDocs / beforeDocs : 0);
+  emitMetric("live_measurement", 1);
+} else if (mode === "foreground-limit-test") {
+  const output = run("cargo", [
+    "test",
+    "-p",
+    "codestory-runtime",
+    "semantic_foreground_limit_defers_unembedded_docs",
+    "--",
+    "--nocapture",
+  ]);
+  const metrics = parseMetricLines(output.stdout);
+  const pendingDocs = requiredParsedMetric(metrics, "foreground_limit_pending_docs");
+  const embeddedDocs = requiredParsedMetric(metrics, "foreground_limit_embedded_docs");
+  const staleDocs = requiredParsedMetric(metrics, "foreground_limit_stale_docs");
+  const storedDocs = requiredParsedMetric(metrics, "foreground_limit_stored_docs");
+  console.log("semantic_pressure_source=foreground-limit-test");
+  emitMetric("semantic_pressure_score", embeddedDocs);
+  emitMetric("foreground_limit_pending_docs", pendingDocs);
+  emitMetric("foreground_limit_embedded_docs", embeddedDocs);
+  emitMetric("foreground_limit_stale_docs", staleDocs);
+  emitMetric("foreground_limit_stored_docs", storedDocs);
+  emitMetric("foreground_limit_deferred_docs", Math.max(0, pendingDocs - embeddedDocs));
+  emitMetric("live_measurement", 1);
+} else {
+  fail(
+    `unsupported --mode ${JSON.stringify(
+      mode,
+    )}; expected latest-log, full-sidecar, contract-drift-test, or foreground-limit-test`,
+  );
+}
+
+function optionValue(name) {
+  const values = process.argv.slice(2);
+  for (let index = 0; index < values.length; index += 1) {
+    if (values[index] === name) {
+      return values[index + 1];
+    }
+    if (values[index]?.startsWith(`${name}=`)) {
+      return values[index].slice(name.length + 1);
+    }
+  }
+  return null;
+}
+
+function readLatestLoggedStats() {
+  const logPath = join(root, "docs", "testing", "codestory-e2e-stats-log.md");
+  if (!existsSync(logPath)) {
+    fail(`missing stats log at ${logPath}`);
+  }
+  const lines = readFileSync(logPath, "utf8").split(/\r?\n/);
+  const phaseRows = lines
+    .filter((line) => line.startsWith("| 20") && !line.includes("| n/a |"))
+    .map(parseMarkdownRow)
+    .filter((cells) => cells.length >= 9 && Number.isFinite(Number(cells[3])) && Number.isFinite(Number(cells[5])));
+  const row = phaseRows.at(-1);
+  if (!row) {
+    fail("could not find a numeric phase-metrics row in docs/testing/codestory-e2e-stats-log.md");
+  }
+  return {
+    date: row[0],
+    commit: row[1],
+    scenario: row[2],
+    index_seconds: markdownNumber(row[3]),
+    graph_phase_seconds: markdownNumber(row[4]),
+    semantic_phase_seconds: markdownNumber(row[5]),
+    semantic_docs_reused: markdownNumber(row[6]),
+    semantic_docs_embedded: markdownNumber(row[7]),
+    semantic_docs_stale: markdownNumber(row[8]),
+    retrieval_index_seconds: extractScenarioNumber(row[2], "retrieval_index_seconds"),
+    proof_tier: row[2].includes("full_sidecar") || row[2].includes("retrieval_mode full") ? "full_sidecar" : "logged",
+  };
+}
+
+function parseMarkdownRow(line) {
+  return line
+    .split("|")
+    .slice(1, -1)
+    .map((cell) => cell.trim().replace(/^`|`$/g, ""));
+}
+
+function markdownNumber(value) {
+  return Number(String(value ?? "").replaceAll(",", ""));
+}
+
+function extractScenarioNumber(scenario, label) {
+  const pattern = new RegExp(`${label}\\s+([0-9]+(?:\\.[0-9]+)?)`);
+  const match = pattern.exec(scenario);
+  return match ? Number(match[1]) : 0;
+}
+
+function run(command, commandArgs) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: root,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+    maxBuffer: 1024 * 1024 * 64,
+  });
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  if (result.status !== 0) {
+    fail(`${command} ${commandArgs.join(" ")} exited with ${result.status}`);
+  }
+  return result;
+}
+
+function parseStatsJson(stdout) {
+  const start = stdout.indexOf("{\n  \"project_root\"");
+  if (start < 0) {
+    fail("could not find RepoE2eStats JSON in full-sidecar output");
+  }
+  for (let end = stdout.length; end > start; end = stdout.lastIndexOf("}", end - 1)) {
+    const candidate = stdout.slice(start, end + 1);
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // Keep searching for the matching final brace.
+    }
+  }
+  fail("could not parse RepoE2eStats JSON from full-sidecar output");
+}
+
+function parseMetricLines(stdout) {
+  const metrics = new Map();
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = /^METRIC\s+([A-Za-z0-9_.:-]+)=(-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)$/i.exec(
+      line.trim(),
+    );
+    if (match) {
+      metrics.set(match[1], Number(match[2]));
+    }
+  }
+  return metrics;
+}
+
+function requiredParsedMetric(metrics, name) {
+  const value = metrics.get(name);
+  if (!Number.isFinite(value)) {
+    fail(`benchmark output did not include METRIC ${name}=<number>`);
+  }
+  return value;
+}
+
+function emitMetrics(stats, { liveMeasurement, source }) {
+  const indexSeconds = requiredNumber(stats, "index_seconds");
+  const semanticSeconds = requiredNumber(stats, "semantic_phase_seconds");
+  const graphSeconds = optionalNumber(stats, "graph_phase_seconds");
+  const retrievalIndexSeconds = optionalNumber(stats, "retrieval_index_seconds");
+  const semanticDocsEmbedded = optionalNumber(stats, "semantic_docs_embedded");
+  const semanticDocsReused = optionalNumber(stats, "semantic_docs_reused");
+  const semanticDocsStale = optionalNumber(stats, "semantic_docs_stale");
+  const semanticPressureScore = semanticSeconds + indexSeconds;
+  const reuseRatio =
+    semanticDocsEmbedded + semanticDocsReused > 0
+      ? semanticDocsReused / (semanticDocsEmbedded + semanticDocsReused)
+      : 0;
+
+  console.log(`semantic_pressure_source=${source}`);
+  console.log(`semantic_pressure_date=${stats.date ?? ""}`);
+  console.log(`semantic_pressure_commit=${stats.commit ?? ""}`);
+  console.log(`semantic_pressure_proof_tier=${stats.proof_tier ?? ""}`);
+  emitMetric("semantic_pressure_score", semanticPressureScore);
+  emitMetric("index_seconds", indexSeconds);
+  emitMetric("semantic_phase_seconds", semanticSeconds);
+  emitMetric("graph_phase_seconds", graphSeconds);
+  emitMetric("retrieval_index_seconds", retrievalIndexSeconds);
+  emitMetric("semantic_docs_embedded", semanticDocsEmbedded);
+  emitMetric("semantic_docs_reused", semanticDocsReused);
+  emitMetric("semantic_docs_stale", semanticDocsStale);
+  emitMetric("semantic_reuse_ratio", reuseRatio);
+  emitMetric("live_measurement", liveMeasurement);
+}
+
+function requiredNumber(stats, key) {
+  const value = Number(stats[key]);
+  if (!Number.isFinite(value)) {
+    fail(`stats field ${key} is missing or not numeric`);
+  }
+  return value;
+}
+
+function optionalNumber(stats, key) {
+  const value = Number(stats[key] ?? 0);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function emitMetric(name, value) {
+  console.log(`METRIC ${name}=${round(value)}`);
+}
+
+function emitArtifact(name, path) {
+  console.log(`ARTIFACT ${name}=${resolve(root, path)}`);
+}
+
+function round(value) {
+  return Number(value).toFixed(6).replace(/\.?0+$/, "");
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}


### PR DESCRIPTION
## What changed

- Added scoped incremental semantic contract repair so embedding contract drift repairs touched-file docs only instead of foreground rebuilding the whole semantic corpus.
- Added sidecar manifest fail-closed coverage for staged semantic repair, including product-compatible semantic-doc count drift.
- Added opt-in lazy foreground semantic embedding via `CODESTORY_SEMANTIC_DOC_FOREGROUND_LIMIT`, with pending/stale debt reported when docs are deferred.
- Extended the semantic-pressure autoresearch benchmark wrapper with live contract-drift and foreground-limit modes, and documented the runtime behavior.

## Why it changed

Large CodeStory repos were spending most index time in semantic doc rebuild/embedding. This keeps graph and lexical indexing complete while making semantic repair staged, measurable, and fail-visible instead of silently doing all-repo foreground embedding work.

## Verification

- `cargo test -p codestory-runtime semantic_foreground_limit -- --nocapture`
- `cargo test -p codestory-runtime semantic_docs -- --nocapture`
- `cargo test -p codestory-retrieval manifest_staleness -- --nocapture`
- `cargo test -p codestory-store llm_symbol_doc -- --nocapture`
- `cargo check`

## Metrics

- Contract drift packet: embedded `53/359` docs and reported `307` stale-contract docs.
- Foreground limit packet: `4` pending docs, `2` embedded docs, `2` deferred/stale docs, repeat confirmed.

## Remaining risk / follow-up

- This is an opt-in cap, not a default large-repo policy change.
- Full sidecar repo e2e stats were not rerun live in this PR; focused live regression packets were used to avoid another heavy all-repo sidecar run.
- Query-triggered semantic backfill and any `turbovec` backend experiment remain separate follow-up lanes.