### PR TITLE
[codex] refresh benchmark ledger with June evidence

### DIFF
--- a/docs/testing/benchmark-ledger.md
+++ b/docs/testing/benchmark-ledger.md
@@ -1,218 +1,198 @@
 # CodeStory Benchmark Ledger
 
-Decision-grade scorecard and benchmark history - too dense for the README.
-Treat every row as machine-, cache-, runner-, and date-specific. Do not quote a
-row as a universal savings claim without checking harness tier and setup.
+This page is the current benchmark scorecard. It should answer a reader's first
+question quickly: did CodeStory help, hurt, or still need proof?
 
-Runs recorded before the 2026-05-24 harness tightening are historical unless
-they are reanalyzed or rerun with answer-level expected-file/symbol recall,
-immutable manifest refs, and CodeStory cache provenance. The harness now keeps
-transcript-observed anchors separate from anchors actually present in the final
-answer, so tool output alone cannot make a row quality-pass.
+Short answer: the June 13-14, 2026 evidence is promising, especially for
+TypeScript/React routing-style work, but it is not broad enough yet for a
+general public savings claim.
 
-## Current Scorecard
+## Plain English
 
-| Lane | Current status | Public claim status |
-| --- | --- | --- |
-| Agent A/B quick check | The 2026-05-23 CodeStory-only quick run passed both arms, but the CodeStory arm used more tokens, more wall time, and more tool starts. | No agent savings claim. |
-| Local-real Codex probe | On 2026-05-25, the narrowed `codex-exec-json-flow` live A/B repeated with a quality-passing CodeStory arm against a failing no-CodeStory arm. Latest corrected-wrapper repeat: `114,510` vs `2,209,856` tokens, `2` vs `39` observed tool calls, `117.37s` vs `262.39s`, and overhead ratio `0.183466`. | Strong exploratory evidence; no promotion claim from this task alone. |
-| Local-real Sourcetrail probe | On 2026-05-25, the `sourcetrail-indexing-to-storage` live A/B passed with CodeStory after source-group/indexing/storage packet fixes. CodeStory used `269,363` vs `5,697,852` tokens, `2` vs `105` observed tool calls, `138.92s` vs `532.68s`, `0` vs `87` source reads, and overhead ratio `0.10904`. | Strong second-repo exploratory evidence; still not promotion-grade because it is one repeat using a local existing cache. |
-| Local-real VS Code probe | On 2026-05-25, the `vscode-workbench-extension-host` packet holdout moved from partial coverage to a sufficient packet, then the live A/B passed with CodeStory after workbench/extension-host packet fixes. CodeStory used `1,070,153` vs `7,296,578` tokens, `2` vs `115` observed tool calls, `329.69s` vs `626.08s`, `0` vs `71` source reads, and overhead ratio `0.230215`. A follow-up release incremental refresh repaired the stale cache provenance, moving VS Code freshness from `74` new files to `0`. | Strong third-repo exploratory evidence; still not promotion-grade because it is one repeat and the no-CodeStory arm failed quality. |
-| Local-real drill-suite probe | On 2026-05-25, a four-repo `drill-suite` matrix exposed a real CodeStory cache-reuse blocker, stale Codex anchor selections, VS Code indexing-error blockage, and Sourcetrail source-truth-only bridges. After the CodeStory cache fix and Rust receiver/return-chain graph pass, this repo's one-case drill is still degraded but now resolves `11/11` anchors with `28/55` graph bridges, `27` partial bridges, and `0` unresolved bridges. | Diagnostic product evidence only; the remaining target is store/workspace execution-plan and snapshot/projection bridge coverage. |
-| Strict packet-first rows | Several with-CodeStory public-checkout rows passed quality, packet-first, and zero ordinary source reads after packet. | Behavior evidence only; paired savings still needs broader quality-passing baselines. |
-| Packet runtime | Public-core warm stdio and cold CLI packet rows passed repeated publishable quality gates. | Runtime evidence, not agent-token savings. |
-| Repo-scale cold index/read timing | The current timing source is the latest row in [codestory-e2e-stats-log.md](codestory-e2e-stats-log.md). | Current only after a fresh row is logged for the relevant change. |
-| Warm stdio smoke | The current warm-loop timing source is [codestory-stdio-warm-loop-stats.md](codestory-stdio-warm-loop-stats.md). | Smoke evidence for the persistent read surface. |
+| Term in raw artifacts | Reader meaning |
+| --- | --- |
+| Answer bundle | A CodeStory response with cited files, likely owners, and the explanation it can support. |
+| Quality pass | The answer covered the expected files and explanation points for that task. |
+| Files found | How many expected files CodeStory found or cited. |
+| Explanation points | How many expected claims were actually present in the answer. |
+| Follow-up needed | Extra commands CodeStory said a user should run because the answer bundle was incomplete. |
+| Comparison run | The same task run twice: once without CodeStory and once with CodeStory. |
+
+## Current Answer
+
+| Question | Answer |
+| --- | --- |
+| Is there benchmark data from this week? | Yes: one TypeScript/React comparison run and one 18-language answer-bundle run. |
+| Does the fresh data show CodeStory can be useful? | Yes. The TypeScript/React row shows a large win, and the 18-language run shows broad file-finding coverage. |
+| Can we claim general agent savings yet? | No. The strongest comparison row is one repeat, non-publishable, and reused one baseline run. |
+
+## Current Evidence At A Glance
+
+```mermaid
+flowchart LR
+    run["June 14 language run<br/>18 repo tasks"]
+    pass["12 quality pass"]
+    miss["6 quality miss"]
+    files["17/18 found all expected files"]
+    claims["11/18 found all expected explanation points"]
+    run --> pass
+    run --> miss
+    run --> files
+    run --> claims
+```
+
+| Lane | Fresh result | What it means | Claim status |
+| --- | --- | --- | --- |
+| TypeScript React library comparison | With CodeStory: `32,168` tokens, `42.67s` elapsed including setup check, `1` command, `0` source files opened, quality `1/1`. Without CodeStory: `535,632` tokens, `201.38s`, `35` commands, `30` source files opened, quality `0/1`. | CodeStory was clearly useful on this task. | Strong single-task evidence, not a general savings claim. |
+| 18-language answer-bundle run | `18/18` answer bundles completed; `12/18` passed full quality; `17/18` found all expected files; median elapsed time was `11.14s`. | CodeStory usually found the right files, but explanation quality is still uneven. | Broad runtime and coverage evidence, not a comparison-run savings claim. |
+
+## Performance By Language
+
+Source: `target/agent-benchmark/language-expansion-packet-runtime-current-after-claim-fixes/packet-runtime-summary.json`
+
+Generated: `2026-06-14T01:10:57.739Z`
+
+Sorted best to worst: quality pass first, then higher explanation coverage,
+higher file coverage, lower elapsed time, and fewer follow-up commands.
+
+| Language | Example project | Task kind | Result | Elapsed | Files found | Explanation points | Follow-up needed |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Bash | nvm | install dispatch | pass | `5.04s` | `100%` | `100%` | `0` |
+| SQL | Chinook | schema relations | pass | `5.12s` | `100%` | `100%` | `8` |
+| CSS | animate.css | animation base/keyframes | pass | `5.60s` | `100%` | `100%` | `8` |
+| Go | Gin | route dispatch | pass | `6.50s` | `100%` | `100%` | `0` |
+| JavaScript | Express | routing flow | pass | `7.71s` | `100%` | `100%` | `8` |
+| TypeScript | SWR | React data-fetching hook flow | pass | `7.78s` | `100%` | `100%` | `0` |
+| C++ | fmt | formatting flow | pass | `11.86s` | `100%` | `100%` | `0` |
+| Swift | Alamofire | request flow | pass | `12.89s` | `100%` | `100%` | `8` |
+| Rust | ripgrep | search pipeline | pass | `13.07s` | `100%` | `100%` | `3` |
+| Java | Commons Lang | string utility flow | pass | `33.03s` | `100%` | `100%` | `8` |
+| C | Redis | command loop | pass | `33.10s` | `75%` | `100%` | `8` |
+| Dart | http | HTTP client flow | pass | `18.63s` | `100%` | `75%` | `0` |
+| Ruby | Jekyll | site build | miss | `10.42s` | `100%` | `50%` | `0` |
+| Kotlin | Okio | buffer flow | miss | `22.30s` | `100%` | `50%` | `8` |
+| HTML | MDN forms | form validation | miss | `14.59s` | `100%` | `25%` | `0` |
+| PHP | Monolog | log record flow | miss | `5.19s` | `100%` | `0%` | `0` |
+| Python | requests | HTTP client flow | miss | `8.19s` | `100%` | `0%` | `0` |
+| C# | AutoMapper | mapping flow | miss | `12.01s` | `100%` | `0%` | `3` |
+
+What this says:
+
+- File discovery is mostly working: only Redis missed expected file coverage.
+- Explanation quality is the real gap: Python, Ruby, PHP, C#, Kotlin, and HTML
+  found the right files but failed or partially failed the expected claims.
+- Slow passing rows are Java and C at about `33s`.
+
+## Performance By Framework Or Domain Kind
+
+This groups the same 18 rows by the kind of code a user might recognize. It is
+more useful than a repo-name-only table when deciding where CodeStory is ready.
+
+Sorted best to worst: higher quality-pass rate first, then lower median elapsed
+time.
+
+| Framework / domain kind | Examples | Quality pass | Median elapsed | What it tells us |
+| --- | --- | ---: | ---: | --- |
+| Web routing and data fetching | Express, Gin, SWR | `3/3` | `7.71s` | Strong current lane: fast, complete file coverage, complete explanation coverage. |
+| Systems and data engines | ripgrep, Redis, Chinook SQL | `3/3` | `13.07s` | Quality passed; Redis still missed one expected file and was slow. |
+| Text and formatting utilities | Commons Lang, fmt | `2/2` | `22.45s` | Quality passed, but Java was one of the slow rows. |
+| HTTP client libraries | requests, Alamofire, Dart http | `2/3` | `12.89s` | Swift and Dart passed; Python found files but failed explanation points. |
+| Build, install, and site tooling | nvm, Jekyll | `1/2` | `7.73s` | Bash passed; Jekyll found files but only half the expected explanation points. |
+| Web documents and styling | MDN forms, animate.css | `1/2` | `10.09s` | CSS passed; HTML found files but missed explanation points. |
+| App support libraries | Monolog, AutoMapper, Okio | `0/3` | `12.01s` | Main weak lane: PHP, C#, and Kotlin need claim-quality work. |
+
+## TypeScript React Library Example
+
+Source: `target/agent-benchmark/segment9-current-ab-swr-generic-final/summary.json`
+
+Generated: `2026-06-13T11:15:27.190Z`
+
+SWR is Vercel's TypeScript/React data-fetching library. This row asks the same
+repository question with and without CodeStory.
+
+| Run | Quality | Tokens | Elapsed | Commands | Source files opened | Files found | Explanation points |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Without CodeStory | `0/1` | `535,632` | `201.38s` | `35` | `30` | `66.7%` | `25%` |
+| With CodeStory | `1/1` | `32,168` | `42.67s` | `1` | `0` | `100%` | `100%` |
+
+Why this matters:
+
+- It is a real example where CodeStory changed the work from a source-file crawl
+  into one cited answer bundle.
+- It is not enough for a broad savings claim. The raw run reports
+  `publishable: false`, `allow_failures: true`, and `reused_baseline_runs: 1`.
 
 ## What Is Solid
 
-- CodeStory can produce quality-passing packet-first answers on selected public
-  tasks while avoiding ordinary source reads after the answer packet.
-- Repeated packet-runtime rows show `packet` can fit inside an agent workflow
-  budget in both cold CLI and warm stdio modes.
-- The local-real harness now separates first-index setup cost from timed
-  cache-reuse agent work, blocks stale or semantic-empty caches from
-  publishable evidence, and records useful-context density for final-answer
-  context instead of raw packet volume alone.
-- The quality-passing local-real Codex live A/B has now repeated on the same
-  task with the corrected wrapper.
-- Sourcetrail now adds a second realistic repo where the CodeStory arm passed
-  quality and avoided source reads while the no-CodeStory arm failed quality
-  after broad exploration.
-- VS Code now adds a large TypeScript repo where the packet planner can find the
-  workbench startup, extension service, extension host manager, extension-host
-  activation, and command execution anchors without follow-up commands, and the
-  live CodeStory arm passed quality while using far fewer tools and source
-  reads than the no-CodeStory arm.
-- The VS Code cache freshness issue behind the first local-real row is now
-  understood and fixed: TypeScript/TSX factory-call superclass extraction no
-  longer crashes on `extends mock<T>()`, failed attempts are recorded as
-  incomplete files with attached errors, and `../vscode` now reports
-  `10,491/10,491` indexed files as fresh after incremental refresh.
-- CodeStory's own active cache can now recover from stale incremental
-  projection cleanup where cross-file callable state points at a deleted node;
-  release incremental refresh reports fresh inventory with `150/150` indexed
-  files, `0` errors, and `7,794` semantic docs.
-- The tightened CodeStory drill now exposes the CLI-to-runtime-to-indexer path
-  mostly as graph evidence: Rust receiver and return-chain resolution moved the
-  case from `3/55` graph bridges to `28/55`, while preserving explicit
-  source-truth-only status for the remaining unproven bridge pairs.
-- Repo-scale timing history is tracked in the stats log instead of copied into
-  prose that silently drifts.
+- CodeStory produced a much better agent run on one current holdout-language
+  task: the TypeScript React data-fetching row.
+- The current answer-bundle path runs through real sidecars, not stubbed or
+  disabled retrieval.
+- The 18-language run completed for every task.
+- File-level recall is strong in the fresh language run: `17/18` tasks found all
+  expected files.
 
 ## What Is Not Claimed
 
-This page does not claim that CodeStory generally reduces agent cost, token
-count, wall time, or tool calls. General savings claims require repeated
-controlled with/without-agent measurements from the benchmark harness, not one
-exploratory row or representative estimates.
+- No general "CodeStory saves tokens" claim yet.
+- No universal language-support claim yet.
+- No publishable paired benchmark claim from the June 13 TypeScript React row.
+- No claim that a complete-looking answer bundle always means answer quality
+  passes; the June 14 run has `4` sufficiency/quality gaps.
 
-The 2026-05-25 Codex, Sourcetrail, and VS Code local-real rows are explicitly
-non-promotional. They show a CodeStory advantage on three realistic tasks, but
-they are still single-run or same-task exploratory measurements using local
-cache state. The VS Code cache now has fresh provenance after the follow-up
-repair, but public savings language still needs repeated controlled rows, clean
-pinned checkout provenance, and at least one holdout that was not tuned during
-the implementation loop.
+## Next Runs Needed
 
-The 2026-05-25 `drill-suite` rows are also non-promotional. They are designed to
-find grounding failures before an agent A/B run, and the current CodeStory case
-still falls back to source-truth-only evidence for `27/55` bridge pairs.
+Run these before promoting the current story beyond "promising current
+evidence":
 
-## Proof Tier Ladder
+1. Repeat the TypeScript React comparison row with `--publishable`, no reused
+   baseline, and at least `3` repeats.
+2. Rerun the 18-language answer-bundle check after fixing the six
+   claim-quality misses.
+3. Add at least two more comparison rows from the language-expansion holdout
+   set.
 
-Use the highest tier actually reached when describing a row. Do not promote a
-lower tier into a broader claim just because the command exited successfully.
+## How To Rerun
 
-| Proof tier | Required evidence | Can claim | Cannot claim |
-| --- | --- | --- | --- |
-| Stats-only local regression signal | `codestory_repo_e2e_stats` completed with skip allowances or without prepared full sidecars. | Local timing, indexing, and cache-shape regression signal for the current checkout. | Full sidecar readiness, agent packet/search readiness, real-repo release coverage, or performance promotion. |
-| Full sidecar readiness proof | Zoekt, Qdrant, SCIP, and llama.cpp are running; `retrieval index --refresh full` succeeds; `retrieval status --format json` reports `retrieval_mode: "full"` and product backend fields. | Agent-facing packet/search readiness for the verified workspace and cache state. | General quality, cross-repo coverage, or benchmark savings. |
-| Real-repo drill proof | Prepared real-repo drill manifests run without skip allowances and produce expected evidence packets, source-truth checks, and verdicts. | The release path was exercised beyond the CodeStory checkout on the named drill cases. | Generalized agent savings or promotion-grade performance. |
-| Promotion-grade benchmark proof | Controlled baseline and candidate benchmark rows use pinned refs, comparable cache state, sidecar status, answer-level quality gates, and no-regression thresholds. | Cautious performance or retrieval-quality promotion for the measured scope. | Universal savings, untested repos, or environments outside the recorded setup. |
-
-## Promotion Rules
-
-- Use the same project, cache state, semantic backend, command flags, runner,
-  model, and sample shape when comparing before/after results.
-- Do not promote a speed win if expected anchors, answer-level quality, protocol
-  cleanliness, or semantic-doc reuse regress.
-- Treat small-fixture warm-loop numbers as smoke evidence, not repo-scale
-  product proof.
-- Append current repo-scale timing rows to
-  [codestory-e2e-stats-log.md](codestory-e2e-stats-log.md) when default
-  indexing, semantic persistence, embedding reuse, or cold-start behavior
-  changes.
-
-## Agent A/B History
-
-The 2026-05-23 quick CodeStory repo run used:
-
-```sh
-node ./scripts/codestory-agent-ab-benchmark.mjs --quick --repos codestory --repeats 3 --timeout-ms 900000 --sandbox danger-full-access --publishable --out-dir target/agent-benchmark/codestory-quick-2026-05-23-r3
-```
-
-It was a real baseline, not a savings claim. The without-CodeStory arm passed
-`3/3` with median `214.90s`, `1,605,030` total tokens, and `29` tool starts.
-The with-CodeStory arm passed `3/3` with median `306.24s`, `2,724,490` total
-tokens, and `43` tool starts. It showed no token, wall-time, or tool-count
-savings.
-
-The packet-first diagnostic series then tightened the harness around answer
-packets, `CODESTORY_CLI` injection, post-packet source-read budgets, final-answer
-quality scoring, and repository/cache provenance. The first strict
-with-CodeStory row for the CodeStory indexing-flow task was r20:
-
-| Arm | Quality | Answer packet first | Wall time | Total tokens | Tool starts | Direct source reads | Reads after packet |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| With CodeStory r20 | `3/3` | `3/3` | `71.92s` | `167,102` | `2` | `0` | `0` |
-
-Strict with-CodeStory public-checkout rows followed:
-
-| Repo | Task class | Quality | Answer packet first | Wall time | Total tokens | Tool starts | Direct source reads |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| vite | architecture_explanation | `3/3` | `3/3` | `66.78s` | `163,815` | `2` | `0` |
-| express | bug_localization | `3/3` | `3/3` | `67.39s` | `164,291` | `2` | `0` |
-| mux | architecture_explanation | `3/3` | `3/3` | `65.12s` | `163,935` | `2` | `0` |
-| express | symbol_ownership | `3/3` | `3/3` | `63.28s` | `165,715` | `2` | `0` |
-| mux | edit_planning | `3/3` | `3/3` | `59.08s` | `100,833` | `2` | `0` |
-| express | route_tracing | `3/3` | `3/3` | `62.80s` | `102,137` | `2` | `0` |
-
-Historical paired diagnostics remain useful for context, but rows produced
-before the 2026-05-24 answer-level quality and cache-provenance gates should be
-rerun or reanalyzed before promotion:
-
-| Task | Without CodeStory | With CodeStory | Historical note |
-| --- | --- | --- | --- |
-| express response send bug localization | `3/3`, `136.57s`, `635,793` tokens, `18` tool starts | `3/3`, `67.39s`, `164,291` tokens, `2` tool starts | Pre-gate scorer showed fewer tokens, wall time, and tool starts. |
-| mux router matching flow | `3/3`, `123.37s`, `321,908` tokens, `16` tool starts | `3/3`, `65.12s`, `163,935` tokens, `2` tool starts | Pre-gate scorer showed fewer tokens, wall time, and tool starts. |
-| express response symbol ownership | `3/3`, `125.10s`, `397,110` tokens, `15` tool starts | `3/3`, `63.28s`, `165,715` tokens, `2` tool starts | Covers `symbol_ownership`. |
-| mux CORS middleware edit plan | `3/3`, `115.12s`, `364,175` tokens, `14` tool starts | `3/3`, `59.08s`, `100,833` tokens, `2` tool starts | Covers edit planning without broad file reads. |
-| express application routing flow | `3/3`, `127.46s`, `334,231` tokens, `15` tool starts | `3/3`, `62.80s`, `102,137` tokens, `2` tool starts | Covers route tracing. |
-
-The public-core subset with CodeStory quality-passed for CodeStory and Vite, but
-strict reanalysis showed the answer packet was not the first repository-context
-command. Keep those rows diagnostic until rerun with the stricter prompt and
-publishable gate.
-
-## Packet Runtime History
-
-On 2026-05-23, the release CLI completed three-repeat packet runtime runs
-against the full public-core manifest suite in both warm stdio and cold CLI
-modes:
-
-```sh
-node ./scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite public-core --repeats 3 --packet-runtime-mode warm-stdio --codestory-cli ./target/release/codestory-cli --out-dir target/agent-benchmark/packet-runtime-public-core-warm-r8 --timeout-ms 120000 --publishable
-node ./scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite public-core --repeats 3 --packet-runtime-mode cold-cli --codestory-cli ./target/release/codestory-cli --out-dir target/agent-benchmark/packet-runtime-public-core-cold-r9 --timeout-ms 120000 --publishable
-```
-
-Across both modes, all `108` packet rows passed operationally and quality gates.
-Every row reported `sufficient` packet coverage with `0` sufficiency/quality
-mismatches. Warm stdio task medians ranged from `2.69s` to `3.60s`, with an
-aggregate task median of `3.13s`; cold CLI task medians ranged from `4.22s` to
-`5.76s`, with an aggregate task median of `4.86s`.
-
-## Harness Contract
-
-The agent A/B harness runs the same repository prompt in two arms:
-
-- `without_codestory`: avoid CodeStory and use normal repository exploration.
-- `with_codestory`: use CodeStory grounding first, run `packet` for broad
-  repository questions, then ordinary source reads only for named gaps.
-
-The harness writes raw stdout/stderr per run, a JSONL run log, transcript
-analysis, a machine summary, and a Markdown summary under
-`target/agent-benchmark/<timestamp>`. Compare medians across successful repeats
-for the same runner, repository set, prompt set, cache policy, semantic backend,
-and model.
-
-Use `--publishable` only when the selected runner reports token usage and every
-run succeeds. For agent A/B rows, `--publishable` also requires with-CodeStory
-runs to execute an answer packet with `--question` first and stay within the
-explicit post-packet ordinary source-read budget supplied through
-`--max-source-reads-after-packet <n>`. Use `0` for packet-only promotion
-evidence; use a larger number only when the row is intentionally CodeStory-first
-but not packet-only. Publishable rows must carry clean repository provenance
-pinned to a full 40-character Git commit SHA plus CodeStory cache provenance
-from `doctor --format json`. Tags are not accepted for publishable
-materialized-repo rows because they can be moved after the benchmark is
-published.
-
-Packet runtime runs compare cold CLI `packet` invocations with warm
-`serve --stdio` packet calls. They are runtime rows, not agent-token rows, and
-still use manifest quality gates before promotion.
-
-## Commands
+List available tasks:
 
 ```sh
 node ./scripts/codestory-agent-ab-benchmark.mjs --list
-node ./scripts/codestory-agent-ab-benchmark.mjs --quick --repos codestory --repeats 3 --timeout-ms 600000 --publishable --max-source-reads-after-packet 0
-node ./scripts/codestory-agent-ab-benchmark.mjs --task-suite public-core --list
-node ./scripts/codestory-agent-ab-benchmark.mjs --task-suite public-core --task-ids codestory-indexing-flow,vite-dev-server-architecture --arms with_codestory --repeats 3 --max-source-reads-after-packet 0 --allow-failures
-node ./scripts/codestory-agent-ab-benchmark.mjs --reanalyze-dir target/agent-benchmark/<run-dir>
-node ./scripts/codestory-agent-ab-benchmark.mjs --task-suite public-core --materialize-repos --list
-node ./scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite public-core --repeats 3
+node ./scripts/codestory-agent-ab-benchmark.mjs --task-suite language-expansion-holdout --list
 ```
+
+Language answer-bundle run:
+
+```sh
+node ./scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite language-expansion-holdout --repeats 1 --packet-runtime-mode cold-cli --codestory-cli ./target/release/codestory-cli --out-dir target/agent-benchmark/language-expansion-packet-runtime-current --timeout-ms 120000
+```
+
+Publishable TypeScript React comparison target:
+
+```sh
+node ./scripts/codestory-agent-ab-benchmark.mjs --task-suite language-expansion-holdout --task-ids typescript-swr-hook-flow --repeats 3 --publishable --max-source-reads-after-packet 0 --codestory-cli ./target/release/codestory-cli --out-dir target/agent-benchmark/swr-publishable-r3
+```
+
+## Harness Contract
+
+The agent benchmark harness runs the same repository prompt in two arms:
+
+- `without_codestory`: avoid CodeStory and use normal repository exploration.
+- `with_codestory`: use CodeStory grounding first, run an answer bundle for
+  broad repository questions, then ordinary source reads only for named gaps.
+
+The harness writes raw stdout/stderr per run, a JSONL run log, transcript
+analysis, a machine summary, and a Markdown summary under
+`target/agent-benchmark/<run-dir>`.
+
+Use `--publishable` only when:
+
+- both arms have token usage,
+- every required run succeeds,
+- repository provenance is pinned,
+- CodeStory cache provenance is recorded,
+- the with-CodeStory arm runs an answer bundle first, and
+- post-bundle source reads stay inside the explicit budget.
 
 Cold repo-scale timings are owned by
 [codestory-e2e-stats-log.md](codestory-e2e-stats-log.md). Warm stdio loop


### PR DESCRIPTION
## What changed

- Rewrote `docs/testing/benchmark-ledger.md` so it leads with current June 13/14 evidence and does not make readers parse stale historical runs.
- Removed the confusing ratio chart and replaced it with a plain outcome flow for the 18-language run.
- Added a plain-English glossary for artifact terms like answer bundle, quality pass, files found, explanation points, follow-up needed, and comparison run.
- Added the requested performance-by-language table, sorted best to worst by quality, explanation coverage, file coverage, elapsed time, and follow-up burden.
- Added the requested framework/domain-kind table, sorted best to worst by quality-pass rate and median elapsed time.

## Why it changed

The benchmark ledger needed to answer the reader's actual question: where does CodeStory perform well today, by language and by framework/domain kind? The previous version still foregrounded history and used chart choices that required too much decoding.

## How I verified it

- `git diff --check`
- Local Markdown link pass over `docs/testing/benchmark-ledger.md`
- Readback of the rewritten ledger
- Residue scan for stale-date/chart/jargon wording
- Extracted the language table values from `target/agent-benchmark/language-expansion-packet-runtime-current-after-claim-fixes/packet-runtime-summary.json`

## Remaining risk or follow-up

- The June 13 TypeScript React comparison row is favorable but still single-repeat and `publishable: false`; the ledger says this directly.
- The June 14 18-language answer-bundle run is broad runtime evidence, not paired agent-savings evidence.
- The language run still has only `12/18` full quality passes; the sorted tables make the remaining weak lanes visible.