### PR TITLE
Redocument language support after full A/B run

### DIFF
--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -28,6 +28,28 @@ profiles to parser and rule construction in `get_language_for_ext`.
 Agent-facing packet/search quality is separate. The language-expansion A/B
 report is not blanket promotion proof for every parser-backed language.
 
+## Latest Agent-Facing Evidence
+
+The latest full language-expansion paired A/B run was completed on 2026-06-16:
+`target/agent-benchmark/language-expansion-holdout-20260616-0.8.0-retry/reanalyzed-summary.md`.
+
+That run is useful operational evidence, not a broad answer-quality promotion:
+
+| Measure | With CodeStory | Without CodeStory | Read |
+| --- | ---: | ---: | --- |
+| Runs attempted | `54` | `54` | Three repeats across 18 language tasks. |
+| Run success | `54/54` | `51/54` | All baseline failures were the Ruby/Jekyll row. |
+| Quality pass | `16/54` | `19/51` successful rows | Answer quality remains uneven. |
+| All-in wall time | `6,411,835 ms` | `7,523,716 ms` | CodeStory ratio `0.852`. |
+| Total tokens | `7,859,161` | `9,087,330` | CodeStory ratio `0.865`. |
+| Commands | `54` | `471` | CodeStory kept exploration bounded. |
+| Source reads | `0` | `417` | The CodeStory arm stayed packet-first. |
+
+Safe wording: CodeStory completed the full 18-language A/B arm with lower
+overall wall time, token use, command count, and direct source reads. Do not say
+the run proves first-class agent-facing quality across every language; the
+quality score is mixed and several rows still need better handoff semantics.
+
 ## Resolution Claims
 
 Receiver and import resolution are fixture-backed. If a behavior is not covered

--- a/docs/testing/benchmark-ledger.md
+++ b/docs/testing/benchmark-ledger.md
@@ -3,9 +3,10 @@
 This page is the current benchmark scorecard. It should answer a reader's first
 question quickly: did CodeStory help, hurt, or still need proof?
 
-Short answer: the June 13-14, 2026 evidence is promising, especially for
-TypeScript/React routing-style work, but it is not broad enough yet for a
-general public savings claim.
+Short answer: the June 16, 2026 full language A/B run is operationally
+positive, but it is still not a general public answer-quality claim. CodeStory
+completed every with-CodeStory row and reduced wall time, tokens, commands, and
+direct source reads. The quality score stayed mixed.
 
 ## Plain English
 
@@ -22,31 +23,61 @@ general public savings claim.
 
 | Question | Answer |
 | --- | --- |
-| Is there benchmark data from this week? | Yes: one TypeScript/React comparison run and one 18-language answer-bundle run. |
-| Does the fresh data show CodeStory can be useful? | Yes. The TypeScript/React row shows a large win, and the 18-language run shows broad file-finding coverage. |
-| Can we claim general agent savings yet? | No. The strongest comparison row is one repeat, non-publishable, and reused one baseline run. |
+| Is there benchmark data from this week? | Yes: a full 18-language paired A/B run with three repeats per language task, plus the earlier packet-runtime diagnostic. |
+| Does the fresh data show CodeStory can be useful? | Yes. In the full paired run, CodeStory succeeded on `54/54` rows, used `0.852x` all-in wall time, `0.865x` tokens, `54` commands instead of `471`, and `0` source reads instead of `417`. |
+| Can we claim general answer-quality superiority yet? | No. CodeStory quality passed `16/54` rows; the baseline passed `19/51` successful rows and failed all three Ruby/Jekyll repeats. |
 
 ## Current Evidence At A Glance
 
 ```mermaid
 flowchart LR
-    run["June 14 language run<br/>18 repo tasks"]
-    pass["12 quality pass"]
-    miss["6 quality miss"]
-    files["17/18 found all expected files"]
-    claims["11/18 found all expected explanation points"]
-    run --> pass
-    run --> miss
-    run --> files
-    run --> claims
+    run["June 16 full paired A/B<br/>18 tasks x 3 repeats"]
+    cs["with CodeStory<br/>54/54 success"]
+    base["without CodeStory<br/>51/54 success"]
+    ops["lower wall, tokens,<br/>commands, source reads"]
+    quality["quality still mixed<br/>16/54 vs 19/51"]
+    run --> cs
+    run --> base
+    cs --> ops
+    cs --> quality
 ```
 
 | Lane | Fresh result | What it means | Claim status |
 | --- | --- | --- | --- |
-| TypeScript React library comparison | With CodeStory: `32,168` tokens, `42.67s` elapsed including setup check, `1` command, `0` source files opened, quality `1/1`. Without CodeStory: `535,632` tokens, `201.38s`, `35` commands, `30` source files opened, quality `0/1`. | CodeStory was clearly useful on this task. | Strong single-task evidence, not a general savings claim. |
-| 18-language answer-bundle run | `18/18` answer bundles completed; `12/18` passed full quality; `17/18` found all expected files; median elapsed time was `11.14s`. | CodeStory usually found the right files, but explanation quality is still uneven. | Broad runtime and coverage evidence, not a comparison-run savings claim. |
+| Full 18-language paired A/B | With CodeStory: `54/54` success, `16/54` quality, `6,411,835 ms` all-in wall, `7,859,161` tokens, `54` commands, `0` source reads. Without CodeStory: `51/54` success, `19/51` quality over successful rows, `7,523,716 ms`, `9,087,330` tokens, `471` commands, `417` source reads. | CodeStory materially reduced operating cost and kept runs packet-first, but did not win broad quality. | Current full-suite evidence; operationally positive, quality-mixed. |
+| 18-language packet-runtime diagnostic | `18/18` answer bundles completed; `12/18` passed full quality; `17/18` found all expected files; median elapsed time was `11.14s`. | CodeStory usually found the right files, but explanation quality was uneven even before the paired run. | Runtime and coverage evidence, not a comparison-run savings claim. |
+| TypeScript React library comparison | With CodeStory: `32,168` tokens, `42.67s` elapsed including setup check, `1` command, `0` source files opened, quality `1/1`. Without CodeStory: `535,632` tokens, `201.38s`, `35` commands, `30` source files opened, quality `0/1`. | CodeStory was clearly useful on this task. | Strong historical single-task evidence, not a general savings claim. |
 
-## Performance By Language
+## Current Full A/B By Language
+
+Source: `target/agent-benchmark/language-expansion-holdout-20260616-0.8.0-retry/reanalyzed-summary.md`
+
+| Language | Example project | With CodeStory quality | Baseline quality | Read |
+| --- | --- | ---: | ---: | --- |
+| Python | requests | `1/3` | `3/3` | Anchor recall was high, explanation quality lagged. |
+| Java | Commons Lang | `0/3` | `0/3` | Both arms missed quality. |
+| Rust | ripgrep | `1/3` | `0/3` | Slight CodeStory quality lift, still incomplete. |
+| JavaScript | Express | `3/3` | `2/3` | Strong current row. |
+| TypeScript | SWR | `0/3` | `2/3` | Current paired run regressed versus older focused SWR evidence. |
+| C++ | fmt | `1/3` | `2/3` | Operationally cheaper, weaker quality. |
+| C | Redis | `0/3` | `1/3` | File anchors surfaced, handoff explanation missed. |
+| Go | Gin | `0/3` | `3/3` | Route explanation remains weak. |
+| Ruby | Jekyll | `0/3` | failed | Baseline failed all repeats. |
+| PHP | Monolog | `0/3` | `1/3` | Weak current row. |
+| C# | AutoMapper | `0/3` | `0/3` | Both arms missed quality. |
+| Kotlin | Okio | `0/3` | `1/3` | Weak current row. |
+| Swift | Alamofire | `1/3` | `1/3` | Strong recall, mixed explanation. |
+| Dart | http | `1/3` | `1/3` | Mixed quality. |
+| Bash | nvm | `3/3` | `2/3` | Strong current row. |
+| HTML | MDN forms | `0/3` | `0/3` | Structural row still weak. |
+| CSS | animate.css | `2/3` | `0/3` | Clear CodeStory lift, still mixed. |
+| SQL | Chinook | `3/3` | `0/3` | Strong current row. |
+
+## Packet Runtime Performance By Language
+
+This older packet-runtime diagnostic remains useful for packet composition and
+claim-quality work, but the June 16 full paired A/B is the current comparison
+source.
 
 Source: `target/agent-benchmark/language-expansion-packet-runtime-current-after-claim-fixes/packet-runtime-summary.json`
 
@@ -124,33 +155,36 @@ Why this matters:
 
 ## What Is Solid
 
-- CodeStory produced a much better agent run on one current holdout-language
-  task: the TypeScript React data-fetching row.
-- The current answer-bundle path runs through real sidecars, not stubbed or
-  disabled retrieval.
-- The 18-language run completed for every task.
-- File-level recall is strong in the fresh language run: `17/18` tasks found all
-  expected files.
+- The full 18-language with-CodeStory arm completed `54/54` attempted rows.
+- The current paired run lowered all-in wall time, total tokens, commands, and
+  direct source reads overall.
+- The current with-CodeStory arm stayed packet-first: `54` commands and `0`
+  direct source reads across the full suite.
+- JavaScript/Express, Bash/nvm, and SQL/Chinook are strong current quality rows;
+  CSS/animate.css is a positive but still mixed row.
 
 ## What Is Not Claimed
 
-- No general "CodeStory saves tokens" claim yet.
-- No universal language-support claim yet.
-- No publishable paired benchmark claim from the June 13 TypeScript React row.
+- No general public savings claim beyond the measured June 16 full-suite run.
+- No universal language-support or answer-quality claim yet.
+- No publishable public benchmark claim yet: the June 16 full suite is
+  quality-mixed, and the June 13 TypeScript row is a non-publishable single
+  task.
 - No claim that a complete-looking answer bundle always means answer quality
-  passes; the June 14 run has `4` sufficiency/quality gaps.
+  passes; the June 16 full A/B run has `16/54` CodeStory quality passes.
 
 ## Next Runs Needed
 
 Run these before promoting the current story beyond "promising current
 evidence":
 
-1. Repeat the TypeScript React comparison row with `--publishable`, no reused
-   baseline, and at least `3` repeats.
-2. Rerun the 18-language answer-bundle check after fixing the six
-   claim-quality misses.
-3. Add at least two more comparison rows from the language-expansion holdout
-   set.
+1. Improve answer semantics on the current `0/3` CodeStory quality rows:
+   Java, TypeScript/SWR, C/Redis, Go/Gin, Ruby/Jekyll, PHP, C#, Kotlin, and
+   HTML.
+2. Isolate the Ruby/Jekyll baseline failure so future paired runs keep both
+   arms comparable.
+3. Rerun the full 18-language paired A/B suite with `--publishable` once the
+   quality rows improve enough for a public claim.
 
 ## How To Rerun
 
@@ -165,6 +199,19 @@ Language answer-bundle run:
 
 ```sh
 node ./scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite language-expansion-holdout --repeats 1 --packet-runtime-mode cold-cli --codestory-cli ./target/release/codestory-cli --out-dir target/agent-benchmark/language-expansion-packet-runtime-current --timeout-ms 120000
+```
+
+Full paired language A/B run:
+
+```sh
+node ./scripts/codestory-agent-ab-benchmark.mjs \
+  --task-suite language-expansion-holdout \
+  --arms without_codestory,with_codestory \
+  --repeats 3 \
+  --materialize-repos \
+  --prepare-codestory-cache \
+  --out-dir target/agent-benchmark/language-expansion-holdout \
+  --timeout-ms 600000
 ```
 
 Publishable TypeScript React comparison target:

--- a/docs/testing/language-expansion-ab-report.md
+++ b/docs/testing/language-expansion-ab-report.md
@@ -1,6 +1,6 @@
 # Language Expansion A/B Report
 
-Date: 2026-06-14
+Date: 2026-06-16
 
 ## Verdict
 
@@ -19,16 +19,24 @@ The corrected frame is:
 - Parser-backed language support is not the same thing as first-class
   framework/domain support.
 
-Current evidence says CodeStory is better on the packet-eligible slice and the
-sidecar/packet path is improving, but the 18-language packet experience still
-needs iteration. The main remaining product gap is answer semantics: several
-packets cite the right anchors but still emit generic "supports/inspect" claims
-instead of explaining the actual handoff.
+Current evidence says CodeStory is operationally better on the latest full
+18-language paired A/B run, but answer quality is still mixed. The
+with-CodeStory arm completed all `54/54` attempted rows and used less all-in
+wall time, fewer tokens, fewer commands, and zero direct source reads. It did
+not beat the baseline quality score: CodeStory passed `16/54` quality rows,
+while the baseline passed `19/51` successful rows and failed all three
+Ruby/Jekyll repeats.
+
+The main remaining product gap is answer semantics. Several packets cite useful
+anchors but still miss the expected causal handoff or file coverage for the
+task.
 
 ## Evidence Ledger
 
 | Slice | Raw evidence | Result | Use it for |
 | --- | --- | --- | --- |
+| Current full 18-language paired A/B | `target/agent-benchmark/language-expansion-holdout-20260616-0.8.0-retry/reanalyzed-summary.json` and `.md` | CodeStory success `54/54` vs baseline `51/54`; CodeStory quality `16/54` vs baseline quality `19/51` successful rows. CodeStory used `6,411,835 ms` all-in wall vs `7,523,716 ms`, `7,859,161` tokens vs `9,087,330`, `54` commands vs `471`, and `0` source reads vs `417`. Baseline failed all Ruby/Jekyll repeats. | Current full-suite evidence. Use for operational efficiency and packet-first behavior, not broad answer-quality promotion. |
+| First 2026-06-16 full-suite attempt | `target/agent-benchmark/language-expansion-holdout-20260616-0.8.0` | Cache preparation failed on a transient `zoekt_unreachable` status for `BurntSushi-ripgrep`. A direct retrieval status check reported full mode afterward; `retrieval up` preceded the successful retry. | Sidecar startup-race context only; not a scored A/B result. |
 | Full 18-language paired A/B | `target/agent-benchmark/segment6-full-language-suite-r1-pathfix/reanalyzed-summary.json` and `.md` | CodeStory quality `9/18`; no-CodeStory quality `7/17` scored with one unsuccessful row. CodeStory used `13,060,265` tokens vs `8,191,771`, `4,014,646 ms` runner wall vs `3,094,988 ms`, and `4,796,792 ms` all-in wall vs `3,094,988 ms`. | Historical negative/diagnostic evidence. |
 | Packet-eligible paired A/B | `target/agent-benchmark/segment8-no-family-steering-current9-ab-java-css-generic-shapes/reanalyzed-summary.json` and `.md` | CodeStory quality `9/9` vs no-CodeStory `6/9`; CodeStory used `291,788` tokens vs `5,346,265`, `502,289 ms` all-in wall vs `1,881,683 ms`, `9` commands vs `282`, and zero source reads vs `228`. | Narrow positive evidence for rows that were packet-eligible in that run. |
 | Fresh 18-row packet runtime before sidecar fix | `target/agent-benchmark/language-expansion-packet-runtime-current-28717906/packet-runtime-summary.md`, `packet-composition.md`, and `quality-debug.json` | `13/18` rows produced scored packets, `7/13` scored rows passed manifest quality, `4/13` were partial, and `5/18` failed as hard `retrieval_unavailable` command failures. | Current diagnostic baseline before the sidecar unresolved-candidate fix. |
@@ -36,8 +44,10 @@ instead of explaining the actual handoff.
 | Two-row product-claim semantics fix slice | `target/agent-benchmark/language-expansion-packet-runtime-claim-semantics-fix/packet-runtime-summary.md` and `quality-debug.json` | Express and Swift/URLSession both passed manifest quality after source-derived product claims replaced generic "supports/inspect" wording. Both remain packet-partial. | Regression evidence for production framework/domain semantics without enabling eval-only probes. |
 | Current 18-row packet runtime after fixes | `target/agent-benchmark/language-expansion-packet-runtime-current-after-claim-fixes/packet-runtime-summary.json`, `.md`, `packet-composition.md`, and `quality-debug.json` | `18/18` command pass, `18/18` scored, `12/18` manifest-quality pass, `9/18` packet sufficient, `9/18` packet partial. Packet retrieval SLA misses remain on Java (`30,931 ms`), Redis (`30,313 ms`), and Okio (`20,799 ms`). | Canonical current packet-runtime evidence for this branch. |
 
-The current full packet-runtime artifact supersedes the stitched estimates from
-the smaller repair slices.
+The 2026-06-16 full paired A/B supersedes the older full A/B row for current
+full-suite comparison evidence. The current full packet-runtime artifact still
+supersedes the stitched estimates from the smaller repair slices for
+packet-runtime-only evidence.
 
 ## Product Semantics vs Benchmark Overfit
 
@@ -119,12 +129,64 @@ queries used to abort when a full-mode sidecar returned candidates from
 docs/tests/non-symbol files that could not resolve to indexed graph symbols.
 Those are now diagnostics and sufficiency gaps instead of command failures.
 
+## Current Full Paired A/B Read
+
+### What Improved
+
+- The with-CodeStory arm succeeded on every attempted row: `54/54` across 18
+  language tasks and three repeats.
+- CodeStory reduced all-in wall time from `7,523,716 ms` to `6,411,835 ms`
+  (`0.852` ratio).
+- CodeStory reduced total tokens from `9,087,330` to `7,859,161` (`0.865`
+  ratio).
+- CodeStory reduced shell commands from `471` to `54` and direct source reads
+  from `417` to `0`.
+- The strongest with-CodeStory quality rows were JavaScript/Express, Bash/nvm,
+  and SQL/Chinook at `3/3`; CSS passed `2/3`.
+
+### What Still Fails
+
+- CodeStory quality passed only `16/54` rows. The baseline passed `19/51`
+  successful rows, so this is not a broad answer-quality win.
+- Java, TypeScript/SWR, C/Redis, Go/Gin, Ruby/Jekyll, PHP/Monolog,
+  C#/AutoMapper, Kotlin/Okio, and HTML/MDN had `0/3` CodeStory quality passes.
+- The baseline Ruby/Jekyll row failed all three repeats, so baseline quality
+  should be read over successful rows only.
+- Some CodeStory rows had perfect file/citation recall but still missed the
+  expected explanation, which keeps answer semantics as the main gap.
+
+### Current Quality Snapshot
+
+Source:
+`target/agent-benchmark/language-expansion-holdout-20260616-0.8.0-retry/reanalyzed-summary.md`.
+
+| Language | Task | With CodeStory quality | Baseline quality | With CodeStory file/citation recall | Read |
+| --- | --- | ---: | ---: | ---: | --- |
+| Python | Requests session flow | `1/3` | `3/3` | `100%` | CodeStory found the anchors but under-explained the flow. |
+| Java | Commons Lang string utility flow | `0/3` | `0/3` | `100%` | Both arms missed quality; packet manifest was partial. |
+| Rust | ripgrep search pipeline | `1/3` | `0/3` | `80%` | CodeStory improved quality slightly but still missed expected coverage. |
+| JavaScript | Express routing flow | `3/3` | `2/3` | `100%` | Strong current CodeStory row. |
+| TypeScript | SWR hook flow | `0/3` | `2/3` | `50%` | Regression versus older focused SWR evidence; needs refreshed packet semantics. |
+| C++ | fmt formatting flow | `1/3` | `2/3` | `60%` | CodeStory was faster and cheaper but weaker on quality. |
+| C | Redis command loop | `0/3` | `1/3` | `100%` | Anchors present, handoff explanation missing. |
+| Go | Gin route dispatch | `0/3` | `3/3` | `100%` | Route anchors surfaced but quality scoring missed the expected explanation. |
+| Ruby | Jekyll site build | `0/3` | failed | `75%` | Baseline failed all repeats, so no baseline quality denominator. |
+| PHP | Monolog record flow | `0/3` | `1/3` | `50%` | File recall and explanation remain weak. |
+| C# | AutoMapper map flow | `0/3` | `0/3` | `50%` | Both arms missed quality; packet manifest was partial. |
+| Kotlin | Okio buffer flow | `0/3` | `1/3` | `33.3%` | Current weak row for file recall and explanation. |
+| Swift | Alamofire request flow | `1/3` | `1/3` | `100%` | File recall is strong; explanation still inconsistent. |
+| Dart | HTTP client flow | `1/3` | `1/3` | `71.4%` | Mixed but roughly tied quality. |
+| Bash | nvm install dispatch | `3/3` | `2/3` | `66.7%` | Strong quality despite partial manifest recall. |
+| HTML | MDN form validation | `0/3` | `0/3` | `0%` | Structural row still needs packet/search work. |
+| CSS | animate.css base/keyframes | `2/3` | `0/3` | `60%` | CodeStory improves quality but packet manifest remains partial. |
+| SQL | Chinook schema relations | `3/3` | `0/3` | `100%` | Strong current structural row. |
+
 ## Current Packet Runtime Read
 
 ### What Improved
 
 The five rows that previously failed before scoring now produce packet output
-and pass manifest quality in the current full run:
+and pass manifest quality in the current full packet-runtime run:
 
 - `java-commons-lang-string-utils`: quality pass, packet partial.
 - `javascript-express-routing-flow`: quality pass, packet partial.
@@ -144,8 +206,9 @@ The remaining quality failures are mostly answer-semantics gaps, not missing
 retrieval:
 
 - Python Requests, Jekyll, Monolog, AutoMapper, Okio, and MDN/HTML still fail
-  expected-claim recall in the current full run. Anchors are often present, but
-  the answer surface does not consistently state causal handoffs.
+  expected-claim recall in the current full packet-runtime run. Anchors are
+  often present, but the answer surface does not consistently state causal
+  handoffs.
 - Some partial rows are compact-budget artifacts. They retain enough citations
   to be useful but still need follow-up commands before the packet can claim to
   be self-contained.
@@ -156,6 +219,9 @@ retrieval:
 - The benchmark harness can compare strict no-CodeStory and CodeStory-first
   arms with wall time, token usage, command counts, direct source reads, web
   leakage, packet quality, and post-packet behavior.
+- CodeStory is operationally useful on the current full language A/B run: it
+  completed every CodeStory-arm row with lower all-in wall time, fewer tokens,
+  fewer commands, and zero direct source reads.
 - CodeStory is clearly useful on the current packet-eligible slice.
 - Parser-backed support exists for the languages listed in
   `crates/codestory-contracts/src/language_support.rs`, and HTML/CSS/SQL are
@@ -172,6 +238,8 @@ retrieval:
 ## What This Does Not Prove
 
 - It does not prove a broad 18-language A/B win.
+- It does not prove broad answer-quality superiority; the 2026-06-16
+  with-CodeStory quality score is lower than the successful-row baseline score.
 - It does not prove every public language-support profile has equal semantic
   resolution, graph depth, framework support, or packet sufficiency.
 - It does not prove React, LINQ, Rails, Django, ASP.NET, or any other framework
@@ -277,6 +345,19 @@ Remove-Item Env:CODESTORY_EVAL_PROBES
 
 Do not use eval-only rows as promotion evidence.
 
+Run the full paired language A/B suite:
+
+```powershell
+node scripts\codestory-agent-ab-benchmark.mjs `
+  --task-suite language-expansion-holdout `
+  --arms without_codestory,with_codestory `
+  --repeats 3 `
+  --materialize-repos `
+  --prepare-codestory-cache `
+  --out-dir target\agent-benchmark\language-expansion-holdout `
+  --timeout-ms 600000
+```
+
 ## Promotion Blockers
 
 - Raise packet answer semantics so cited anchors become concrete handoff
@@ -288,5 +369,5 @@ Do not use eval-only rows as promotion evidence.
 - Convert the current `9/18` packet-partial rows into self-contained packets or
   make their follow-up requirement more explicit in the product surface.
 - Fix packet retrieval latency misses on Java, Redis, and Okio.
-- Run a fresh full 18-language paired A/B suite only after packet sufficiency
-  and steering boundaries improve, then repeat before claiming promotion.
+- Rerun the full 18-language paired A/B suite after packet sufficiency and
+  steering boundaries improve, then repeat before claiming promotion.


### PR DESCRIPTION
## What changed
- Updated the language support contract with the June 16, 2026 full language A/B evidence.
- Refreshed the language expansion A/B report with the completed 18-language, 3-repeat paired run, including per-language quality outcomes.
- Refreshed the benchmark ledger headline, evidence table, current A/B by-language table, and rerun commands.

## Why it changed
- The full language A/B suite now has current evidence: CodeStory succeeded on 54/54 rows and reduced all-in wall time, tokens, commands, and source reads, but quality remained mixed.
- The docs needed to preserve the support boundary: parser-backed and structural language support are not the same as broad agent-facing answer-quality promotion.

## How verified
- Ran the full language A/B suite and reanalysis artifacts under `target/agent-benchmark/language-expansion-holdout-20260616-0.8.0-retry/`.
- `node scripts\codestory-language-holdout-integrity.mjs`
- `git diff --check`
- `cargo test -p codestory-cli --test architecture_contracts`

## Remaining risk or follow-up
- The full A/B command exited non-zero because the baseline Ruby/Jekyll row failed all three repeats; reanalysis still produced complete evidence for 108 attempted rows.
- CodeStory quality was 16/54 versus baseline 19/51 successful rows, so this is operational efficiency evidence, not answer-quality promotion evidence.
- The weak rows called out in the docs still need answer-semantics work before any public language-wide claim.