### PR TITLE
Remove unused semantic resolver language hook

### DIFF
--- a/crates/codestory-indexer/src/semantic/c.rs
+++ b/crates/codestory-indexer/src/semantic/c.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct CSemanticResolver;
 
 impl SemanticResolver for CSemanticResolver {
-    fn language(&self) -> &'static str {
-        "c"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/cpp.rs
+++ b/crates/codestory-indexer/src/semantic/cpp.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct CppSemanticResolver;
 
 impl SemanticResolver for CppSemanticResolver {
-    fn language(&self) -> &'static str {
-        "cpp"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/csharp.rs
+++ b/crates/codestory-indexer/src/semantic/csharp.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct CSharpSemanticResolver;
 
 impl SemanticResolver for CSharpSemanticResolver {
-    fn language(&self) -> &'static str {
-        "csharp"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/generic.rs
+++ b/crates/codestory-indexer/src/semantic/generic.rs
@@ -9,13 +9,11 @@ use codestory_contracts::{
     language_support::supported_extensions,
 };
 
-pub struct GenericSemanticResolver {
-    language: &'static str,
-}
+pub struct GenericSemanticResolver;
 
 impl GenericSemanticResolver {
-    pub const fn new(language: &'static str) -> Self {
-        Self { language }
+    pub const fn new(_language: &'static str) -> Self {
+        Self
     }
 
     fn resolve_import(
@@ -78,10 +76,6 @@ impl GenericSemanticResolver {
 }
 
 impl SemanticResolver for GenericSemanticResolver {
-    fn language(&self) -> &'static str {
-        self.language
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/go.rs
+++ b/crates/codestory-indexer/src/semantic/go.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct GoSemanticResolver;
 
 impl SemanticResolver for GoSemanticResolver {
-    fn language(&self) -> &'static str {
-        "go"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/java.rs
+++ b/crates/codestory-indexer/src/semantic/java.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct JavaSemanticResolver;
 
 impl SemanticResolver for JavaSemanticResolver {
-    fn language(&self) -> &'static str {
-        "java"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/javascript.rs
+++ b/crates/codestory-indexer/src/semantic/javascript.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct JavaScriptSemanticResolver;
 
 impl SemanticResolver for JavaScriptSemanticResolver {
-    fn language(&self) -> &'static str {
-        "javascript"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -278,7 +278,6 @@ impl SemanticCandidateIndex {
 }
 
 pub trait SemanticResolver: Send + Sync {
-    fn language(&self) -> &'static str;
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/php.rs
+++ b/crates/codestory-indexer/src/semantic/php.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct PhpSemanticResolver;
 
 impl SemanticResolver for PhpSemanticResolver {
-    fn language(&self) -> &'static str {
-        "php"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/python.rs
+++ b/crates/codestory-indexer/src/semantic/python.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct PythonSemanticResolver;
 
 impl SemanticResolver for PythonSemanticResolver {
-    fn language(&self) -> &'static str {
-        "python"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/ruby.rs
+++ b/crates/codestory-indexer/src/semantic/ruby.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct RubySemanticResolver;
 
 impl SemanticResolver for RubySemanticResolver {
-    fn language(&self) -> &'static str {
-        "ruby"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/rust.rs
+++ b/crates/codestory-indexer/src/semantic/rust.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct RustSemanticResolver;
 
 impl SemanticResolver for RustSemanticResolver {
-    fn language(&self) -> &'static str {
-        "rust"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/semantic/typescript.rs
+++ b/crates/codestory-indexer/src/semantic/typescript.rs
@@ -9,10 +9,6 @@ use codestory_contracts::graph::{EdgeKind, NodeKind};
 pub struct TypeScriptSemanticResolver;
 
 impl SemanticResolver for TypeScriptSemanticResolver {
-    fn language(&self) -> &'static str {
-        "typescript"
-    }
-
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,


### PR DESCRIPTION
## What changed
- Removed the unused `SemanticResolver::language()` trait hook.
- Deleted repeated resolver identity implementations across semantic resolver modules.
- Kept the explicit resolver dispatch table and did not add `enum_dispatch`.

## Why it changed
Issue #51 asked whether `enum_dispatch` could reduce real boilerplate. The highest-payoff candidate was the semantic resolver family, but the actual removable boilerplate was a dead trait method rather than repeated behavior dispatch. Deleting it removes code with no new dependency or proc-macro cost.

Closes #51.

## How I verified it
- `cargo fmt --check` (child thread)
- `cargo check -p codestory-indexer`
- `cargo test -p codestory-indexer semantic` (child thread, 37 semantic-related tests)
- `git diff --check`

## Remaining risk or follow-up
- No `enum_dispatch` dependency was added. Revisit only if one enum-backed trait family grows multiple repeated dispatch call sites where a macro removes more code than it hides.
