### PR TITLE
[codex] clarify agent interface contracts

### DIFF
--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -536,7 +536,7 @@ static SYMBOL_SUMMARY_SCHEMA: SchemaObject = SchemaObject::object(
 );
 
 static SEARCH_RESULTS_SCHEMA: SchemaObject = SchemaObject::object(
-    "CodeStory search results DTO.",
+    "CodeStory discovery results DTO. Treat broad structural questions as packet-first; search rows select candidates for proof-bearing graph/source follow-up.",
     &[
         SchemaProperty::string("query", "Search query."),
         SchemaProperty::object("retrieval", "Retrieval state DTO."),
@@ -751,7 +751,7 @@ static CONTEXT_PACKET_SCHEMA: SchemaObject = SchemaObject::object(
 );
 
 static AGENT_PACKET_SCHEMA: SchemaObject = SchemaObject::object(
-    "CodeStory broad task packet DTO.",
+    "CodeStory broad task packet DTO with graph/sidecar evidence, budget truncation, unsafe-to-claim gaps, and follow-up commands.",
     &[
         SchemaProperty::string("packet_id", "Stable packet id."),
         SchemaProperty::string("question", "Packet question."),
@@ -979,14 +979,14 @@ static PACKET_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
 static TOOLS: &[ToolSpec] = &[
     ToolSpec {
         name: "packet",
-        description: "Build a broad task packet with a sufficiency contract.",
+        description: "Answer broad structural questions with graph/sidecar evidence, sufficiency, truncation, and follow-up commands before source snippets.",
         input_schema: PACKET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(AGENT_PACKET_SCHEMA)),
         safety: SafetyMetadata::read_only(),
     },
     ToolSpec {
         name: "search",
-        description: "Search indexed symbols and repo text.",
+        description: "Discover candidate symbols and sidecar hits; for broad structural questions call packet before snippet/source reads.",
         input_schema: SEARCH_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(SEARCH_RESULTS_SCHEMA)),
         safety: SafetyMetadata::read_only(),
@@ -1056,14 +1056,14 @@ static TOOLS: &[ToolSpec] = &[
     },
     ToolSpec {
         name: "snippet",
-        description: "Return a focused source snippet for a symbol id or query.",
+        description: "Return a focused source snippet after packet, search, or graph evidence selects a concrete target.",
         input_schema: TARGET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(SNIPPET_CONTEXT_SCHEMA)),
         safety: SafetyMetadata::read_only(),
     },
     ToolSpec {
         name: "context",
-        description: "Build a deep evidence packet for one concrete retrieval target; not question answering.",
+        description: "Build proof-bearing source/graph evidence for one concrete target; not broad question answering.",
         input_schema: CONTEXT_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(CONTEXT_PACKET_SCHEMA)),
         safety: SafetyMetadata::read_only(),

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -273,6 +273,36 @@ fn stdio_packet_text(packet: &serde_json::Value) -> String {
             .pointer("/sufficiency/status")
             .and_then(|value| value.as_str()),
     );
+    append_packet_text_field(
+        &mut text,
+        "budget",
+        packet
+            .pointer("/budget/requested")
+            .and_then(|value| value.as_str()),
+    );
+    append_packet_bool_field(
+        &mut text,
+        "truncated",
+        packet
+            .pointer("/budget/truncated")
+            .and_then(|value| value.as_bool()),
+    );
+    if let Some(status) = packet
+        .pointer("/sufficiency/status")
+        .and_then(|value| value.as_str())
+    {
+        let unsafe_to_claim = if status == "sufficient" {
+            "false"
+        } else {
+            "true - resolve gaps, open_next, or follow_up_commands before proof claims"
+        };
+        append_packet_text_field(&mut text, "unsafe_to_claim", Some(unsafe_to_claim));
+    }
+    append_packet_text_field(
+        &mut text,
+        "pagination",
+        Some("structuredContent keeps full arrays; compact text lists first 8"),
+    );
 
     for section in packet
         .pointer("/answer/sections")
@@ -304,16 +334,29 @@ fn stdio_packet_text(packet: &serde_json::Value) -> String {
         }
     }
 
-    append_packet_string_array(&mut text, "gaps", packet.pointer("/sufficiency/gaps"));
+    append_packet_string_array(
+        &mut text,
+        "omitted_sections",
+        packet.pointer("/budget/omitted_sections"),
+        None,
+    );
+    append_packet_string_array(
+        &mut text,
+        "gaps",
+        packet.pointer("/sufficiency/gaps"),
+        Some("none"),
+    );
     append_packet_string_array(
         &mut text,
         "open_next",
         packet.pointer("/sufficiency/open_next"),
+        Some("none"),
     );
     append_packet_string_array(
         &mut text,
         "follow_up_commands",
         packet.pointer("/sufficiency/follow_up_commands"),
+        Some("none"),
     );
 
     if text.trim().is_empty() {
@@ -333,11 +376,30 @@ fn append_packet_text_field(text: &mut String, label: &str, value: Option<&str>)
     text.push('\n');
 }
 
-fn append_packet_string_array(text: &mut String, title: &str, value: Option<&serde_json::Value>) {
+fn append_packet_bool_field(text: &mut String, label: &str, value: Option<bool>) {
+    let Some(value) = value else {
+        return;
+    };
+    append_packet_text_field(text, label, Some(if value { "true" } else { "false" }));
+}
+
+fn append_packet_string_array(
+    text: &mut String,
+    title: &str,
+    value: Option<&serde_json::Value>,
+    empty_text: Option<&str>,
+) {
     let Some(items) = value.and_then(|value| value.as_array()) else {
         return;
     };
     if items.is_empty() {
+        if let Some(empty_text) = empty_text {
+            text.push('\n');
+            text.push_str(title);
+            text.push_str(": ");
+            text.push_str(empty_text);
+            text.push('\n');
+        }
         return;
     }
     text.push('\n');
@@ -1647,10 +1709,11 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
         ],
         "safety_notes": [
             "All stdio tools are read-only, non-destructive, idempotent, local-only, and closed-world.",
-            "Use packet for broad task questions; use context only after selecting one concrete target.",
+            "Use packet for broad task questions before snippet/source reads; use context only after selecting one concrete target.",
+            "Treat packet status other than sufficient as unsafe to claim until gaps, open_next, and follow_up_commands are resolved.",
             "Use continuation links from search or definition results before broadening retrieval.",
             "Keep search limits bounded; stdio search clamps limit to 1..50.",
-            "Treat repo-text hits as navigation clues until backed by resolvable sidecar or source evidence."
+            "Treat repo-text hits as navigation clues and search hits as discovery clues until backed by proof-bearing sidecar, graph, or source evidence."
         ]
     })
 }

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -736,6 +736,32 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
                 .any(|name| matches!(*name, "files" | "affected")),
         "stdio tool names should stay agent-facing and avoid shell/file mutation surfaces: {tool_names:?}"
     );
+    let packet_description = tool_by_name(&tools, "packet")["description"]
+        .as_str()
+        .expect("packet description");
+    assert!(
+        packet_description.contains("broad structural questions")
+            && packet_description.contains("graph/sidecar evidence")
+            && packet_description.contains("truncation")
+            && packet_description.contains("follow-up commands")
+            && packet_description.contains("before source snippets"),
+        "packet description should route broad questions to proof-bearing packet evidence first: {packet_description}"
+    );
+    let search_description = tool_by_name(&tools, "search")["description"]
+        .as_str()
+        .expect("search description");
+    assert!(
+        search_description.contains("Discover candidate")
+            && search_description.contains("packet before snippet/source reads"),
+        "search description should label discovery before source proof reads: {search_description}"
+    );
+    let snippet_description = tool_by_name(&tools, "snippet")["description"]
+        .as_str()
+        .expect("snippet description");
+    assert!(
+        snippet_description.contains("after packet, search, or graph evidence"),
+        "snippet description should not be the first stop for broad structural questions: {snippet_description}"
+    );
 
     for tool in tools["tools"].as_array().expect("tools array") {
         assert_read_only_tool_metadata(tool);
@@ -1526,6 +1552,15 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
         "agent guide should treat repo-text hits as navigation clues: {guide}"
     );
     assert!(
+        guide_text.contains("search hits as discovery clues")
+            && guide_text.contains("proof-bearing sidecar, graph, or source evidence"),
+        "agent guide should distinguish discovery clues from proof-bearing evidence: {guide}"
+    );
+    assert!(
+        guide_text.contains("unsafe to claim") && guide_text.contains("follow_up_commands"),
+        "agent guide should name unsafe-to-claim and follow-up states: {guide}"
+    );
+    assert!(
         !guide_text.contains("repo-text hits as evidence"),
         "agent guide should not present repo-text hits as evidence: {guide}"
     );
@@ -1851,6 +1886,20 @@ fn packet_tool_returns_budgeted_sufficiency_contract() {
         text.contains("packet_id:") && text.contains("sufficiency:"),
         "stdio packet text should summarize packet identity and sufficiency: {text}"
     );
+    for expected in [
+        "budget:",
+        "truncated:",
+        "unsafe_to_claim:",
+        "pagination:",
+        "gaps:",
+        "open_next:",
+        "follow_up_commands:",
+    ] {
+        assert!(
+            text.contains(expected),
+            "stdio packet text should name {expected}: {text}"
+        );
+    }
     assert!(
         !text.trim_start().starts_with('{'),
         "stdio packet text should be a digest, not duplicated JSON: {text}"


### PR DESCRIPTION
## What changed

- Updated stdio tool and output-schema descriptions so broad structural questions route through `packet` and graph/sidecar evidence before snippet/source reads.
- Updated stdio packet text summaries to name budget, truncation, unsafe-to-claim state, pagination, omitted sections, gaps, `open_next`, and `follow_up_commands`.
- Added stdio protocol contract assertions that distinguish discovery clues from proof-bearing sidecar/graph/source evidence.

## Why

Issue #47 needs the product-agent interface to be harder to misuse after the sidecar and profile contract work landed. This keeps the first slice to wording and contract tests, with no broad public DTO shape change.

Parent context: #38 tracks the larger saga.

Closes #47

## Verification

- `cargo fmt --check`
- `cargo check -p codestory-cli`
- `cargo test -p codestory-cli --test stdio_protocol_contracts tool_catalog_keeps_stable_read_only_browser_tool_names -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_agent_guide_describes_default_browser_loop_and_safety -- --nocapture`
- `git diff --check`

Earlier before this rebase, the ignored live packet contract also passed with explicit product embedding settings:

- `$env:CODESTORY_STDIO_FULL_RETRIEVAL_TESTS='1'; $env:CODESTORY_EMBED_BACKEND='llamacpp'; $env:CODESTORY_EMBED_RUNTIME_MODE='llamacpp'; cargo test -p codestory-cli --test stdio_protocol_contracts packet_tool_returns_budgeted_sufficiency_contract -- --ignored --nocapture`

I did not rerun the ignored sidecar packet test after the final rebase because the local project sidecar manifest is stale against the uncommitted/then committed branch diff unless the expensive retrieval refresh is repeated.

## Remaining risk

- This PR intentionally does not add or reshape public DTO fields. Any broader CLI/API/MCP contract fields should be approved as a separate slice.
- GitHub project attachment was not applied from CLI because querying project metadata hit GitHub's classic-project deprecation error.