### PR TITLE
[codex] freeze profile migration decision

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_claim_profiles.rs
+++ b/crates/codestory-runtime/src/agent/packet_claim_profiles.rs
@@ -2544,6 +2544,48 @@ mod tests {
     }
 
     #[test]
+    fn non_high_risk_product_profiles_stay_pending_until_risk_evidence() {
+        let pending = [
+            SourceClaimProfile::ServerRoute,
+            SourceClaimProfile::ServerRequestDispatch,
+            SourceClaimProfile::HookCache,
+            SourceClaimProfile::ClientSend,
+            SourceClaimProfile::UrlSessionRequest,
+            SourceClaimProfile::StringPredicate,
+            SourceClaimProfile::StylesheetAnimation,
+            SourceClaimProfile::HtmlCssTemplateStructure,
+            SourceClaimProfile::SqlSchema,
+            SourceClaimProfile::RuntimeFormatting,
+            SourceClaimProfile::LoggerHandlerFlow,
+            SourceClaimProfile::SiteBuildPhase,
+            SourceClaimProfile::FormValidation,
+            SourceClaimProfile::EventLoopCommand,
+            SourceClaimProfile::SearchExecution,
+            SourceClaimProfile::BufferedIo,
+        ];
+
+        let actual_pending: Vec<_> = GENERIC_PRODUCT_CLAIM_PROFILES
+            .iter()
+            .filter_map(|entry| match entry.contract {
+                SourceClaimProfileContractStatus::PendingMigration => Some(entry.profile),
+                SourceClaimProfileContractStatus::Contracted(_) => None,
+            })
+            .collect();
+
+        assert_eq!(actual_pending.len(), pending.len());
+        for profile in pending {
+            assert!(
+                actual_pending.contains(&profile),
+                "expected {profile:?} to remain pending migration"
+            );
+            assert!(
+                contracted_product_profile(profile).is_none(),
+                "{profile:?} needs concrete overfit-risk evidence before contract migration"
+            );
+        }
+    }
+
+    #[test]
     fn contracted_product_profile_fixtures_execute_positive_and_negative_paths() {
         let _env = EnvVarGuard::cleared(EVAL_PROBES_ENV);
 

--- a/docs/testing/language-expansion-ab-report.md
+++ b/docs/testing/language-expansion-ab-report.md
@@ -90,6 +90,9 @@ named runtime profile modules:
   High-risk product profiles that resemble benchmark holdout families carry
   source-claim contract metadata for domain, proof roles, evidence tier, and
   positive/negative fixtures before they can leave the pending-migration state.
+  Non-high-risk product profiles remain pending by design; migrate one only
+  when a concrete overfit-risk signal justifies a PR-sized contract and
+  positive/false-positive fixture pair.
 - `packet_command_profiles.rs` owns command-span probes and command-flow claim
   templates.
 - `packet_evidence_roles.rs` owns typed citation role classification; labels


### PR DESCRIPTION
## What changed
- Added a focused contract test that keeps the non-high-risk product source-claim profiles in the pending-migration boundary.
- Documented the #42 remainder decision: high-risk profiles are contracted; non-high-risk profiles migrate only when concrete overfit-risk evidence justifies a PR-sized contract plus positive/false-positive fixtures.

## Why it changed
#42 was intentionally left open after PR #44 for the non-high-risk migration decision. This closes that remainder without sweeping the whole catalog or inventing contract metadata for profiles that do not currently have a concrete overfit signal.

Parent context: #38 tracks the larger saga.

Closes #42

## How I verified it
- `cargo fmt --check`
- `cargo test -p codestory-runtime product_profile --lib`
- `node scripts/lint-retrieval-generalization.mjs`
- `git diff --check`

## Remaining risk or follow-up
- Future profile migrations should be child PR-sized issues only when a specific pending profile shows benchmark-shaped or domain-specific overfit risk.
- I did not run the full repo-scale ignored E2E because this slice only adds a unit contract and documentation note.