### PR TITLE
[codex] split publishable blocker buckets

### DIFF
--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -1273,6 +1273,17 @@ function packetPreludeManifestComplete(publicPrelude) {
   if (!quality?.pass) {
     return false;
   }
+  const sufficiency = publicPrelude?.packet_sufficiency;
+  const followUps = presentFiniteNumber(
+    sufficiency?.follow_up_commands_count ?? sufficiency?.follow_up_commands?.length,
+  );
+  if (
+    !sufficiency ||
+    sufficiency.status !== "sufficient" ||
+    followUps !== 0
+  ) {
+    return false;
+  }
   const composition = publicPrelude?.packet_composition;
   return (
     !composition ||
@@ -3886,20 +3897,48 @@ function packetRetrievalShadow(packet) {
   );
 }
 
-function packetCoverageUnresolvedCount(packet) {
+function packetDiagnosticIsDiagnosticOnly(value) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const classification = String(
+    value.classification ?? value.kind ?? value.tier ?? value.status ?? "",
+  ).toLowerCase();
+  return (
+    value.diagnostic_only === true ||
+    value.diagnosticOnly === true ||
+    classification === "diagnostic_only" ||
+    classification === "diagnostic-only"
+  );
+}
+
+function packetCoverageUnresolvedCounts(packet) {
   const unresolved =
     packet?.coverage_report?.unresolved ??
     packet?.answer?.coverage_report?.unresolved ??
     packet?.sufficiency?.coverage_report?.unresolved ??
     null;
   if (Array.isArray(unresolved)) {
-    return unresolved.length;
+    return {
+      total: unresolved.length,
+      blocking: unresolved.filter((entry) => !packetDiagnosticIsDiagnosticOnly(entry)).length,
+    };
   }
   const number = finiteNumber(unresolved);
   if (number != null) {
-    return number;
+    return { total: number, blocking: number };
   }
-  return unresolved && typeof unresolved === "object" ? Object.keys(unresolved).length : null;
+  if (unresolved && typeof unresolved === "object") {
+    if (packetDiagnosticIsDiagnosticOnly(unresolved)) {
+      return { total: 1, blocking: 0 };
+    }
+    const values = Object.values(unresolved);
+    return {
+      total: values.length,
+      blocking: values.filter((entry) => !packetDiagnosticIsDiagnosticOnly(entry)).length,
+    };
+  }
+  return { total: null, blocking: null };
 }
 
 function packetShape(packet) {
@@ -3929,6 +3968,7 @@ function packetSufficiencyTelemetry(packet, quality) {
   const openNext = cappedStringArray(packet.sufficiency?.open_next, 6);
   const followUpCommands = cappedStringArray(packet.sufficiency?.follow_up_commands, 6);
   const retrievalShadow = packetRetrievalShadow(packet);
+  const unresolvedCoverage = packetCoverageUnresolvedCounts(packet);
   return {
     status,
     covered_claims_count: packet.sufficiency?.covered_claims?.length ?? 0,
@@ -3942,7 +3982,9 @@ function packetSufficiencyTelemetry(packet, quality) {
     retrieval_mode: retrievalShadow?.retrieval_mode ?? null,
     degraded_reason: retrievalShadow?.degraded_reason ?? null,
     unresolved_candidate_count: finiteNumber(retrievalShadow?.unresolved_candidate_count),
-    coverage_unresolved_count: packetCoverageUnresolvedCount(packet),
+    unresolved_candidate_diagnostic_only: packetDiagnosticIsDiagnosticOnly(retrievalShadow),
+    coverage_unresolved_count: unresolvedCoverage.total,
+    coverage_unresolved_blocking_count: unresolvedCoverage.blocking,
     sufficient_quality_mismatch: status === "sufficient" && qualityPass === false,
   };
 }
@@ -4692,12 +4734,14 @@ function addPacketSufficiencyPublishableReasons(sufficiency, productReasons, har
     productReasons.push(`${label} sufficiency gaps=${gaps}; expected 0`);
   }
   const unresolvedCandidates = presentFiniteNumber(sufficiency.unresolved_candidate_count);
-  if (unresolvedCandidates > 0) {
-    harnessReasons.push(`${label} unresolved retrieval candidates=${unresolvedCandidates}; expected 0`);
+  if (unresolvedCandidates > 0 && sufficiency.unresolved_candidate_diagnostic_only !== true) {
+    productReasons.push(`${label} unresolved retrieval candidates=${unresolvedCandidates}; expected 0`);
   }
-  const unresolvedCoverage = presentFiniteNumber(sufficiency.coverage_unresolved_count);
+  const unresolvedCoverage = presentFiniteNumber(
+    sufficiency.coverage_unresolved_blocking_count ?? sufficiency.coverage_unresolved_count,
+  );
   if (unresolvedCoverage > 0) {
-    harnessReasons.push(`${label} unresolved coverage diagnostics=${unresolvedCoverage}; expected 0`);
+    productReasons.push(`${label} unresolved coverage diagnostics=${unresolvedCoverage}; expected 0`);
   }
 }
 
@@ -5444,7 +5488,7 @@ function agentPublishableBlockers(results, opts = {}) {
             prelude.packet_latency?.retrieval_shadow?.unresolved_candidate_count,
           );
           if (unresolvedCandidates > 0) {
-            harnessReasons.push(
+            productReasons.push(
               `${label} prelude packet unresolved retrieval candidates=${unresolvedCandidates}; expected 0`,
             );
           }
@@ -5758,6 +5802,7 @@ function runSelfTest() {
   assert.equal(weakPacketTelemetry.follow_up_commands_count, 1);
   assert.equal(weakPacketTelemetry.unresolved_candidate_count, 2);
   assert.equal(weakPacketTelemetry.coverage_unresolved_count, 1);
+  assert.equal(weakPacketTelemetry.coverage_unresolved_blocking_count, 1);
   assert.deepEqual(
     packetRuntimePublishableBlockers([
       { status: "pass", quality: { pass: true } },
@@ -5794,7 +5839,7 @@ function runSelfTest() {
       ],
       { enforcePacketRuntimeTelemetry: true },
     ).map((blocker) => blocker.category),
-    ["product", "harness-contract"],
+    ["product"],
   );
   assert.deepEqual(
     agentPublishableBlockers([

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -859,7 +859,10 @@ test("counts modern Codex JSONL tool categories including web search", () => {
     {
       status: "pass",
       arm: "without_codestory",
+      wall_ms: 1,
       usage: { total_tokens: 1 },
+      tool_calls_observed: 1,
+      quality: { pass: true },
       transcript_analysis: analysis,
     },
   ]);
@@ -1411,8 +1414,25 @@ test("packet manifest completion is gated by packet quality evidence", () => {
     packetPreludeManifestComplete({
       packet_manifest_quality: quality,
       packet_composition: packetComposition(packet, task),
+      packet_sufficiency: { status: "sufficient", follow_up_commands_count: 0 },
     }),
     true,
+  );
+  assert.equal(
+    packetPreludeManifestComplete({
+      packet_manifest_quality: quality,
+      packet_composition: packetComposition(packet, task),
+      packet_sufficiency: { status: "sufficient", follow_up_commands_count: 1 },
+    }),
+    false,
+  );
+  assert.equal(
+    packetPreludeManifestComplete({
+      packet_manifest_quality: quality,
+      packet_composition: packetComposition(packet, task),
+      packet_sufficiency: { status: "partial", follow_up_commands_count: 0 },
+    }),
+    false,
   );
 
   const incompleteQuality = packetManifestQualitySummary(
@@ -1734,20 +1754,12 @@ function publishablePacketRuntimeResult(overrides = {}) {
 test("publishable gate blocks avoidable source reads after packet", () => {
   const blockers = agentPublishableBlockers(
     [
-      {
-        repo: "codestory",
-        task_id: "codestory-indexing-flow",
-        arm: "with_codestory",
-        repeat: 1,
-        status: "pass",
-        usage: { total_tokens: 100 },
-        packet_first_required: true,
-        packet_first_pass: true,
-        quality: { pass: true },
+      publishableWithCodeStoryResult({
         transcript_analysis: {
+          command_count: 1,
           ordinary_source_reads_after_first_packet: 1,
         },
-      },
+      }),
     ],
     { maxSourceReadsAfterPacket: 0 },
   );
@@ -1779,6 +1791,39 @@ test("publishable gate requires explicit post-packet source-read budget", () => 
   assert.match(blockers[0].reasons.join("\n"), /missing explicit post-packet source-read budget/);
 });
 
+test("publishable gate treats baseline prelude warnings as harness-contract blockers", () => {
+  const blockers = agentPublishableBlockers(
+    [
+      {
+        repo: "codestory",
+        task_id: "codestory-indexing-flow",
+        arm: "without_codestory",
+        repeat: 1,
+        status: "pass",
+        wall_ms: 10,
+        usage: { total_tokens: 100 },
+        tool_calls_observed: 1,
+        packet_first_required: false,
+        packet_first_pass: true,
+        quality: { pass: true },
+        transcript_analysis: {
+          command_count: 1,
+          external_context_tool_calls: 0,
+        },
+        baseline_harness_prelude: {
+          status: "pass_with_warnings",
+        },
+        repo_provenance: pinnedRepoProvenance(),
+      },
+    ],
+    { publishable: true, maxSourceReadsAfterPacket: 0 },
+  );
+
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0].category, "harness-contract");
+  assert.match(blockers[0].reasons.join("\n"), /baseline prelude status=pass_with_warnings; expected pass/);
+});
+
 test("publishable gate rejects diagnostic packet probes", () => {
   const blockers = agentPublishableBlockers(
     [
@@ -1799,20 +1844,15 @@ test("publishable gate rejects diagnostic packet probes", () => {
 test("publishable gate requires packet before ordinary context exploration", () => {
   const blockers = agentPublishableBlockers(
     [
-      {
+      publishableWithCodeStoryResult({
         repo: "vite",
         task_id: "vite-dev-server-architecture",
-        arm: "with_codestory",
-        repeat: 1,
-        status: "pass",
-        usage: { total_tokens: 100 },
-        packet_first_required: true,
         packet_first_pass: false,
-        quality: { pass: true },
         transcript_analysis: {
+          command_count: 1,
           ordinary_source_reads_after_first_packet: 0,
         },
-      },
+      }),
     ],
     { maxSourceReadsAfterPacket: 0 },
   );
@@ -2047,11 +2087,14 @@ test("publishable provenance requires full-SHA clean manifest checkout", () => {
         arm: "with_codestory",
         repeat: 1,
         status: "pass",
+        wall_ms: 10,
         usage: { total_tokens: 100 },
+        tool_calls_observed: 1,
         packet_first_required: true,
         packet_first_pass: true,
         quality: { pass: true },
         transcript_analysis: {
+          command_count: 1,
           ordinary_source_reads_after_first_packet: 0,
         },
         repo_provenance: {
@@ -2205,24 +2248,68 @@ test("packet runtime publishable gate rejects diagnostic packet probes", () => {
   assert.match(blockers[0].reasons.join("\n"), /diagnostic packet extra probes used/);
 });
 
-test("packet runtime publishable gate separates product and harness blockers", () => {
+test("packet runtime publishable gate blocks unresolved packet diagnostics as product blockers", () => {
   const blockers = packetRuntimePublishableBlockers(
     [
       publishablePacketRuntimeResult({
-        quality: { pass: false },
-        codestory_cache_provenance: localCacheProvenance({
-          cache_policy: "unprepared-cache-blocked",
-          retrieval_mode: "full",
-        }),
+        sufficiency: {
+          status: "sufficient",
+          follow_up_commands_count: 0,
+          unresolved_candidate_count: 2,
+          coverage_unresolved_count: 1,
+          coverage_unresolved_blocking_count: 1,
+        },
       }),
     ],
     { publishable: true },
   );
 
-  assert.equal(blockers.length, 2);
-  assert.deepEqual(blockers.map((blocker) => blocker.category), ["product", "harness-contract"]);
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0].category, "product");
+  assert.match(blockers[0].reasons.join("\n"), /packet unresolved retrieval candidates=2; expected 0/);
+  assert.match(blockers[0].reasons.join("\n"), /packet unresolved coverage diagnostics=1; expected 0/);
+});
+
+test("packet runtime publishable gate allows explicitly diagnostic-only unresolved diagnostics", () => {
+  const blockers = packetRuntimePublishableBlockers(
+    [
+      publishablePacketRuntimeResult({
+        sufficiency: {
+          status: "sufficient",
+          follow_up_commands_count: 0,
+          unresolved_candidate_count: 2,
+          unresolved_candidate_diagnostic_only: true,
+          coverage_unresolved_count: 2,
+          coverage_unresolved_blocking_count: 0,
+        },
+      }),
+    ],
+    { publishable: true },
+  );
+
+  assert.deepEqual(blockers, []);
+});
+
+test("packet runtime publishable gate separates product, harness, and environment blockers", () => {
+  const blockers = packetRuntimePublishableBlockers(
+    [
+      publishablePacketRuntimeResult({
+        quality: { pass: false },
+        packet_extra_probe_strategy: "diagnostic_manifest_expected_anchors",
+        packet_latency: {
+          sla_missed: false,
+          retrieval_shadow: { retrieval_mode: "degraded" },
+        },
+      }),
+    ],
+    { publishable: true },
+  );
+
+  assert.equal(blockers.length, 3);
+  assert.deepEqual(blockers.map((blocker) => blocker.category), ["product", "harness-contract", "environment"]);
   assert.match(blockers[0].reasons.join("\n"), /manifest quality failed/);
-  assert.match(blockers[1].reasons.join("\n"), /CodeStory sidecar cache was not prepared/);
+  assert.match(blockers[1].reasons.join("\n"), /diagnostic packet extra probes used/);
+  assert.match(blockers[2].reasons.join("\n"), /packet retrieval shadow mode=degraded; expected full/);
 });
 
 test("holdout packet runtime requires quality gate unless failures are allowed", () => {


### PR DESCRIPTION
# What changed

- Split publishable benchmark blockers into product, harness-contract, and environment buckets for packet-runtime and agent A/B gates.
- Treat unresolved sidecar diagnostics and packet coverage_report.unresolved as publishable product blockers unless explicitly diagnostic-only.
- Require packet preludes to be sufficient with zero follow-ups before manifest-complete packet evidence can stop nested A/B exploration.
- Added focused harness tests for blocker buckets, unresolved diagnostics, baseline prelude warnings, and packet-prelude completion.

# Why it changed

Issue #61 needs publishable runs to fail with useful blocker buckets before the next full benchmark rerun. A sufficient-looking packet with unresolved sidecar diagnostics should not promote, and baseline pass_with_warnings must remain a harness contract blocker in publishable mode.

Closes #61

# How verified

- node --check scripts\\codestory-agent-ab-benchmark.mjs
- node --test scripts\\tests\\codestory-agent-ab-analyzer.test.mjs
- node scripts\\codestory-agent-ab-benchmark.mjs --self-test
- git diff --check origin/main...HEAD

# Remaining risk

- No full benchmark rerun was performed by design; this PR only verifies the harness classification slice with targeted tests.
