### PR TITLE
[codex] add SCIP proof adapter contract

### DIFF
--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -330,6 +330,13 @@ fn scip_capabilities(availability: &ScipAvailability, project_dir: &Path) -> Sid
 }
 
 fn has_real_scip_artifact(project_dir: &Path) -> bool {
+    let Some(revision) = std::fs::read_to_string(project_dir.join("revision.txt"))
+        .ok()
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+    else {
+        return false;
+    };
     project_dir
         .join(crate::scip_index::SCIP_SYMBOLS_FILE)
         .is_file()
@@ -338,6 +345,10 @@ fn has_real_scip_artifact(project_dir: &Path) -> bool {
             .is_file()
         && project_dir.join("revision.txt").is_file()
         && !project_dir.join("index.scip.stub").is_file()
+        && crate::scip_index::load_fresh_scip_symbols(project_dir, &revision)
+            .ok()
+            .flatten()
+            .is_some_and(|index| !index.symbols.is_empty())
 }
 
 pub fn probe_sidecar_health(

--- a/crates/codestory-retrieval/src/scip_client.rs
+++ b/crates/codestory-retrieval/src/scip_client.rs
@@ -1,5 +1,8 @@
 use crate::config::SidecarLayout;
-use crate::scip_index::{SCIP_SYMBOLS_FILE, ScipSymbolRecord, load_scip_symbols};
+use crate::scip_index::{
+    SCIP_INDEX_FILE, SCIP_SYMBOLS_FILE, ScipSymbolRecord, load_fresh_scip_symbols,
+    load_scip_symbols,
+};
 use std::cmp::Ordering;
 use std::path::Path;
 
@@ -51,12 +54,16 @@ impl ScipClient {
             };
         }
         let revision = read_scip_revision(&project_dir).unwrap_or_else(|| "stub-v1".into());
-        let has_graph_index = has_real_scip_artifact(&project_dir);
-        let is_stub_revision = revision == "stub-v1" || !has_graph_index;
+        let artifact_status = scip_artifact_status(&project_dir, &revision);
+        let is_stub_revision = revision == "stub-v1" || artifact_status == "scip_stub";
         ScipHealthProbe {
             availability: if is_stub_revision {
                 ScipAvailability::Unavailable {
                     reason: "scip_stub".into(),
+                }
+            } else if artifact_status == "scip_stale" {
+                ScipAvailability::Unavailable {
+                    reason: "scip_stale".into(),
                 }
             } else {
                 ScipAvailability::Ready {
@@ -75,11 +82,14 @@ impl ScipClient {
         limit: usize,
     ) -> anyhow::Result<Vec<super::CandidateHit>> {
         let probe = Self::health_probe(layout, project_id);
-        let ScipAvailability::Ready { .. } = probe.availability else {
+        let ScipAvailability::Ready { revision } = probe.availability else {
             return Ok(Vec::new());
         };
         let project_dir = layout.scip_project_dir(project_id);
-        let Some(index) = load_scip_symbols(&project_dir)? else {
+        let Some(index) = load_fresh_scip_symbols(&project_dir, &revision)? else {
+            return Ok(Vec::new());
+        };
+        let Some(provenance) = index.contract.provenance_label() else {
             return Ok(Vec::new());
         };
         let profile = ScipQueryProfile::new(query);
@@ -87,7 +97,7 @@ impl ScipClient {
         for symbol in index.symbols {
             if symbol_matches_query(&symbol, &profile) {
                 let score = score_symbol_match(&symbol, &profile);
-                hits.push(symbol_to_hit(&symbol, score, 0));
+                hits.push(symbol_to_hit(&symbol, score, 0, provenance));
             }
         }
         hits.sort_by(|left, right| {
@@ -110,11 +120,14 @@ impl ScipClient {
         limit: usize,
     ) -> anyhow::Result<Vec<super::CandidateHit>> {
         let probe = Self::health_probe(layout, project_id);
-        let ScipAvailability::Ready { .. } = probe.availability else {
+        let ScipAvailability::Ready { revision } = probe.availability else {
             return Ok(Vec::new());
         };
         let project_dir = layout.scip_project_dir(project_id);
-        let Some(index) = load_scip_symbols(&project_dir)? else {
+        let Some(index) = load_fresh_scip_symbols(&project_dir, &revision)? else {
+            return Ok(Vec::new());
+        };
+        let Some(provenance) = index.contract.provenance_label() else {
             return Ok(Vec::new());
         };
         let mut hits = Vec::new();
@@ -135,6 +148,7 @@ impl ScipClient {
                         symbol,
                         0.65,
                         anchor.scip_hop_distance.unwrap_or(0) + 1,
+                        provenance,
                     ));
                 }
             }
@@ -144,7 +158,12 @@ impl ScipClient {
     }
 }
 
-fn symbol_to_hit(symbol: &ScipSymbolRecord, score: f32, hop: u32) -> super::CandidateHit {
+fn symbol_to_hit(
+    symbol: &ScipSymbolRecord,
+    score: f32,
+    hop: u32,
+    provenance: &str,
+) -> super::CandidateHit {
     use super::candidate::{CandidateHit, CandidateSource};
     CandidateHit {
         node_id: None,
@@ -153,7 +172,7 @@ fn symbol_to_hit(symbol: &ScipSymbolRecord, score: f32, hop: u32) -> super::Cand
         start_line: Some(symbol.start_line),
         score,
         source: CandidateSource::Scip,
-        provenance: Vec::new(),
+        provenance: vec![provenance.into()],
         file_role: None,
         scip_hop_distance: Some(hop),
         rank_features: None,
@@ -368,27 +387,110 @@ fn read_scip_revision(dir: &Path) -> Option<String> {
         .filter(|text| !text.is_empty())
 }
 
-fn has_real_scip_artifact(project_dir: &Path) -> bool {
+fn scip_artifact_status(project_dir: &Path, revision: &str) -> &'static str {
     if !project_dir.join(SCIP_SYMBOLS_FILE).is_file()
-        || !project_dir
-            .join(crate::scip_index::SCIP_INDEX_FILE)
-            .is_file()
+        || !project_dir.join(SCIP_INDEX_FILE).is_file()
         || !project_dir.join("revision.txt").is_file()
         || project_dir.join("index.scip.stub").is_file()
     {
-        return false;
+        return "scip_stub";
     }
     load_scip_symbols(project_dir)
         .ok()
         .flatten()
-        .is_some_and(|index| !index.symbols.is_empty())
+        .filter(|index| !index.symbols.is_empty())
+        .map_or("scip_stub", |index| {
+            if index.is_fresh_for(revision) {
+                "ready"
+            } else {
+                "scip_stale"
+            }
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::scip_index::{SCIP_INDEX_FILE, ScipSymbolsIndex};
+    use crate::scip_index::{
+        SCIP_IMPORTED_PROOF_PROVENANCE, ScipPackageIdentity, ScipProofAdapterContract,
+        ScipProofRecord, ScipSymbolsIndex,
+    };
     use tempfile::TempDir;
+
+    fn write_scip_index(
+        project_dir: &Path,
+        revision: &str,
+        contract: ScipProofAdapterContract,
+        symbols: Vec<ScipSymbolRecord>,
+        proofs: Vec<ScipProofRecord>,
+    ) {
+        let index = ScipSymbolsIndex {
+            revision: revision.to_string(),
+            contract,
+            symbols,
+            proofs,
+        };
+        std::fs::write(
+            project_dir.join(SCIP_SYMBOLS_FILE),
+            serde_json::to_string_pretty(&index).expect("serialize"),
+        )
+        .expect("write symbols");
+        std::fs::write(project_dir.join("revision.txt"), format!("{revision}\n"))
+            .expect("revision");
+        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+    }
+
+    fn imported_contract(revision: &str) -> ScipProofAdapterContract {
+        ScipProofAdapterContract {
+            evidence_source: SCIP_IMPORTED_PROOF_PROVENANCE.into(),
+            producer: "scip-fixture".into(),
+            producer_version: "0.1.0".into(),
+            producer_args: vec!["scip".into(), "index".into(), "--cwd=.".into()],
+            producer_config: "fixture-config-v1".into(),
+            revision: revision.into(),
+            package: ScipPackageIdentity {
+                manager: "cargo".into(),
+                name: "fixture_package".into(),
+                version: Some("1.2.3".into()),
+            },
+            position_encoding: "line_one_based_utf16_column_zero_based".into(),
+            freshness: "fresh".into(),
+        }
+    }
+
+    fn imported_symbol() -> ScipSymbolRecord {
+        ScipSymbolRecord {
+            path: "src/lib.rs".into(),
+            symbol: "fixture_package::run".into(),
+            start_line: 3,
+            end_line: 3,
+        }
+    }
+
+    fn valid_imported_proofs() -> Vec<ScipProofRecord> {
+        vec![
+            ScipProofRecord {
+                role: "definition".into(),
+                path: "src/lib.rs".into(),
+                symbol: "fixture_package::run".into(),
+                start_line: 3,
+                start_character_utf16: 4,
+                end_line: 3,
+                end_character_utf16: 7,
+                target_symbol: None,
+            },
+            ScipProofRecord {
+                role: "reference".into(),
+                path: "src/main.rs".into(),
+                symbol: "fixture_package::main".into(),
+                start_line: 8,
+                start_character_utf16: 9,
+                end_line: 8,
+                end_character_utf16: 12,
+                target_symbol: Some("fixture_package::run".into()),
+            },
+        ]
+    }
 
     #[test]
     fn anchor_search_scores_all_matches_before_truncating() {
@@ -421,17 +523,13 @@ mod tests {
             start_line: 99,
             end_line: 99,
         });
-        let index = ScipSymbolsIndex {
-            revision: "graph-test".to_string(),
+        write_scip_index(
+            &project_dir,
+            "graph-test",
+            ScipProofAdapterContract::graph_projection("graph-test"),
             symbols,
-        };
-        std::fs::write(
-            project_dir.join(SCIP_SYMBOLS_FILE),
-            serde_json::to_string_pretty(&index).expect("serialize"),
-        )
-        .expect("write symbols");
-        std::fs::write(project_dir.join("revision.txt"), "graph-test\n").expect("revision");
-        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+            Vec::new(),
+        );
 
         let hits = ScipClient::anchor_search(&layout, project_id, "needle", 8).expect("search");
 
@@ -459,9 +557,11 @@ mod tests {
         let project_dir = layout.scip_project_dir(project_id);
         std::fs::create_dir_all(&project_dir).expect("scip dir");
 
-        let index = ScipSymbolsIndex {
-            revision: "graph-test".to_string(),
-            symbols: vec![
+        write_scip_index(
+            &project_dir,
+            "graph-test",
+            ScipProofAdapterContract::graph_projection("graph-test"),
+            vec![
                 ScipSymbolRecord {
                     path: "workspace/app/src/main.rs".to_string(),
                     symbol: "workspace_app::Cli".to_string(),
@@ -481,14 +581,8 @@ mod tests {
                     end_line: 42,
                 },
             ],
-        };
-        std::fs::write(
-            project_dir.join(SCIP_SYMBOLS_FILE),
-            serde_json::to_string_pretty(&index).expect("serialize"),
-        )
-        .expect("write symbols");
-        std::fs::write(project_dir.join("revision.txt"), "graph-test\n").expect("revision");
-        std::fs::write(project_dir.join(SCIP_INDEX_FILE), "codestory-scip-v1\n").expect("index");
+            Vec::new(),
+        );
 
         let hits = ScipClient::anchor_search(&layout, project_id, "workspace_app::Cli", 8)
             .expect("search");
@@ -531,5 +625,166 @@ mod tests {
                 reason: "scip_stub".into()
             }
         );
+    }
+
+    #[test]
+    fn imported_proof_contract_labels_scip_candidates() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            zoekt_http_port: 1,
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            zoekt_data_dir: root.path().join("zoekt"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_id = "project";
+        let project_dir = layout.scip_project_dir(project_id);
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+        let revision = "imported-a";
+        write_scip_index(
+            &project_dir,
+            revision,
+            imported_contract(revision),
+            vec![imported_symbol()],
+            valid_imported_proofs(),
+        );
+
+        let loaded = load_scip_symbols(&project_dir)
+            .expect("load")
+            .expect("index");
+        assert_eq!(loaded.contract.producer, "scip-fixture");
+        assert_eq!(loaded.contract.producer_version, "0.1.0");
+        assert_eq!(loaded.contract.producer_args, ["scip", "index", "--cwd=."]);
+        assert_eq!(loaded.contract.producer_config, "fixture-config-v1");
+        assert_eq!(loaded.contract.revision, revision);
+        assert_eq!(loaded.contract.package.manager, "cargo");
+        assert_eq!(loaded.contract.package.name, "fixture_package");
+        assert_eq!(loaded.contract.package.version.as_deref(), Some("1.2.3"));
+        assert_eq!(
+            loaded.contract.position_encoding,
+            "line_one_based_utf16_column_zero_based"
+        );
+        assert_eq!(loaded.contract.freshness, "fresh");
+        assert_eq!(loaded.proofs.len(), 2);
+
+        let hits = ScipClient::anchor_search(&layout, project_id, "fixture_package::run", 4)
+            .expect("search");
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].source, crate::candidate::CandidateSource::Scip);
+        assert_eq!(hits[0].provenance, vec![SCIP_IMPORTED_PROOF_PROVENANCE]);
+    }
+
+    #[test]
+    fn imported_contract_without_proofs_fails_closed() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            zoekt_http_port: 1,
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            zoekt_data_dir: root.path().join("zoekt"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_id = "project";
+        let project_dir = layout.scip_project_dir(project_id);
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+        let revision = "imported-no-proofs";
+        write_scip_index(
+            &project_dir,
+            revision,
+            imported_contract(revision),
+            vec![imported_symbol()],
+            Vec::new(),
+        );
+
+        let probe = ScipClient::health_probe(&layout, project_id);
+        assert_eq!(
+            probe.availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_stale".into()
+            }
+        );
+        let hits = ScipClient::anchor_search(&layout, project_id, "fixture_package::run", 4)
+            .expect("search");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn unknown_evidence_source_fails_closed() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            zoekt_http_port: 1,
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            zoekt_data_dir: root.path().join("zoekt"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_id = "project";
+        let project_dir = layout.scip_project_dir(project_id);
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+        let revision = "imported-unknown-source";
+        let mut contract = imported_contract(revision);
+        contract.evidence_source = "imported-scip-proof".into();
+        write_scip_index(
+            &project_dir,
+            revision,
+            contract,
+            vec![imported_symbol()],
+            valid_imported_proofs(),
+        );
+
+        let probe = ScipClient::health_probe(&layout, project_id);
+        assert_eq!(
+            probe.availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_stale".into()
+            }
+        );
+        let hits = ScipClient::anchor_search(&layout, project_id, "fixture_package::run", 4)
+            .expect("search");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn stale_scip_import_fails_closed_without_candidates() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            zoekt_http_port: 1,
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            zoekt_data_dir: root.path().join("zoekt"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_id = "project";
+        let project_dir = layout.scip_project_dir(project_id);
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+        let mut contract = imported_contract("old-import");
+        contract.freshness = "stale".into();
+        write_scip_index(
+            &project_dir,
+            "current-import",
+            contract,
+            vec![imported_symbol()],
+            valid_imported_proofs(),
+        );
+
+        let probe = ScipClient::health_probe(&layout, project_id);
+        assert_eq!(
+            probe.availability,
+            ScipAvailability::Unavailable {
+                reason: "scip_stale".into()
+            }
+        );
+        let hits = ScipClient::anchor_search(&layout, project_id, "fixture_package::run", 4)
+            .expect("search");
+        assert!(hits.is_empty());
     }
 }

--- a/crates/codestory-retrieval/src/scip_index.rs
+++ b/crates/codestory-retrieval/src/scip_index.rs
@@ -8,6 +8,9 @@ use std::path::Path;
 
 pub const SCIP_SYMBOLS_FILE: &str = "symbols.index.json";
 pub const SCIP_INDEX_FILE: &str = "index.scip";
+pub const SCIP_IMPORTED_PROOF_PROVENANCE: &str = "imported_scip_proof";
+pub const SCIP_GRAPH_PROJECTION_PROVENANCE: &str = "scip_graph_projection";
+const SCIP_POSITION_ENCODING: &str = "line_one_based_utf16_column_zero_based";
 const STUB_MARKER: &str = "index.scip.stub";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,10 +21,163 @@ pub struct ScipSymbolRecord {
     pub end_line: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScipPackageIdentity {
+    pub manager: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScipProofAdapterContract {
+    pub evidence_source: String,
+    pub producer: String,
+    pub producer_version: String,
+    pub producer_args: Vec<String>,
+    pub producer_config: String,
+    pub revision: String,
+    pub package: ScipPackageIdentity,
+    pub position_encoding: String,
+    pub freshness: String,
+}
+
+impl ScipProofAdapterContract {
+    pub fn graph_projection(revision: &str) -> Self {
+        Self {
+            evidence_source: SCIP_GRAPH_PROJECTION_PROVENANCE.into(),
+            producer: "codestory-retrieval".into(),
+            producer_version: env!("CARGO_PKG_VERSION").into(),
+            producer_args: vec!["emit_scip_artifacts_from_store".into()],
+            producer_config: "search_symbol_projection".into(),
+            revision: revision.into(),
+            package: ScipPackageIdentity {
+                manager: "codestory".into(),
+                name: "local-workspace".into(),
+                version: None,
+            },
+            position_encoding: SCIP_POSITION_ENCODING.into(),
+            freshness: "fresh".into(),
+        }
+    }
+
+    pub(crate) fn evidence_source(&self) -> Option<ScipEvidenceSource> {
+        match self.evidence_source.as_str() {
+            SCIP_IMPORTED_PROOF_PROVENANCE => Some(ScipEvidenceSource::ImportedProof),
+            SCIP_GRAPH_PROJECTION_PROVENANCE => Some(ScipEvidenceSource::GraphProjection),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn provenance_label(&self) -> Option<&'static str> {
+        match self.evidence_source()? {
+            ScipEvidenceSource::ImportedProof => Some(SCIP_IMPORTED_PROOF_PROVENANCE),
+            ScipEvidenceSource::GraphProjection => Some(SCIP_GRAPH_PROJECTION_PROVENANCE),
+        }
+    }
+
+    pub(crate) fn is_fresh_for(&self, revision: &str) -> bool {
+        self.revision == revision
+            && self.freshness == "fresh"
+            && self.position_encoding == SCIP_POSITION_ENCODING
+            && self.evidence_source().is_some()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScipEvidenceSource {
+    ImportedProof,
+    GraphProjection,
+}
+
+impl Default for ScipProofAdapterContract {
+    fn default() -> Self {
+        let mut contract = Self::graph_projection("");
+        contract.freshness = "stale".into();
+        contract
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScipProofRecord {
+    pub role: String,
+    pub path: String,
+    pub symbol: String,
+    pub start_line: u32,
+    pub start_character_utf16: u32,
+    pub end_line: u32,
+    pub end_character_utf16: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_symbol: Option<String>,
+}
+
+impl ScipProofRecord {
+    fn definition(symbol: &ScipSymbolRecord) -> Self {
+        Self {
+            role: "definition".into(),
+            path: symbol.path.clone(),
+            symbol: symbol.symbol.clone(),
+            start_line: symbol.start_line,
+            start_character_utf16: 0,
+            end_line: symbol.end_line,
+            end_character_utf16: 0,
+            target_symbol: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScipSymbolsIndex {
     pub revision: String,
+    #[serde(default)]
+    pub contract: ScipProofAdapterContract,
     pub symbols: Vec<ScipSymbolRecord>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub proofs: Vec<ScipProofRecord>,
+}
+
+impl ScipSymbolsIndex {
+    pub(crate) fn is_fresh_for(&self, revision: &str) -> bool {
+        self.revision == revision
+            && self.contract.is_fresh_for(revision)
+            && self.has_required_proof_records()
+    }
+
+    fn has_required_proof_records(&self) -> bool {
+        match self.contract.evidence_source() {
+            Some(ScipEvidenceSource::GraphProjection) => true,
+            Some(ScipEvidenceSource::ImportedProof) => {
+                self.proofs.iter().any(|proof| self.proof_is_valid(proof))
+            }
+            None => false,
+        }
+    }
+
+    fn proof_is_valid(&self, proof: &ScipProofRecord) -> bool {
+        if proof.path.trim().is_empty()
+            || proof.symbol.trim().is_empty()
+            || proof.start_line == 0
+            || proof.end_line < proof.start_line
+            || (proof.end_line == proof.start_line
+                && proof.end_character_utf16 < proof.start_character_utf16)
+        {
+            return false;
+        }
+
+        match proof.role.as_str() {
+            "definition" => self.symbols.iter().any(|symbol| {
+                symbol.path == proof.path
+                    && symbol.symbol == proof.symbol
+                    && symbol.start_line <= proof.start_line
+                    && symbol.end_line >= proof.end_line
+            }),
+            "reference" => proof
+                .target_symbol
+                .as_deref()
+                .is_some_and(|target| self.symbols.iter().any(|symbol| symbol.symbol == target)),
+            _ => false,
+        }
+    }
 }
 
 /// Write graph-backed SCIP artifacts; returns revision string on success.
@@ -66,9 +222,12 @@ pub fn emit_scip_artifacts_from_store(
     }
 
     let revision = scip_revision_for_symbols(&symbols);
+    let proofs = symbols.iter().map(ScipProofRecord::definition).collect();
     let index = ScipSymbolsIndex {
         revision: revision.clone(),
+        contract: ScipProofAdapterContract::graph_projection(&revision),
         symbols,
+        proofs,
     };
     let json = serde_json::to_string_pretty(&index).context("serialize scip symbols index")?;
     std::fs::write(project_dir.join(SCIP_SYMBOLS_FILE), json)
@@ -94,6 +253,7 @@ fn scip_revision_for_symbols(symbols: &[ScipSymbolRecord]) -> String {
         hasher.update(symbol.path.as_bytes());
         hasher.update(symbol.symbol.as_bytes());
         hasher.update(symbol.start_line.to_le_bytes());
+        hasher.update(symbol.end_line.to_le_bytes());
     }
     format!("graph-{:x}", hasher.finalize())[..16].to_string()
 }
@@ -111,6 +271,16 @@ pub fn load_scip_symbols(project_dir: &Path) -> Result<Option<ScipSymbolsIndex>>
     let parsed: ScipSymbolsIndex =
         serde_json::from_str(&body).context("parse scip symbols index json")?;
     Ok(Some(parsed))
+}
+
+pub(crate) fn load_fresh_scip_symbols(
+    project_dir: &Path,
+    expected_revision: &str,
+) -> Result<Option<ScipSymbolsIndex>> {
+    let Some(index) = load_scip_symbols(project_dir)? else {
+        return Ok(None);
+    };
+    Ok(index.is_fresh_for(expected_revision).then_some(index))
 }
 
 #[cfg(test)]
@@ -186,6 +356,12 @@ mod tests {
             .expect("load scip")
             .expect("symbols");
 
+        assert_eq!(
+            symbols.contract.evidence_source,
+            SCIP_GRAPH_PROJECTION_PROVENANCE
+        );
+        assert_eq!(symbols.contract.freshness, "fresh");
+        assert_eq!(symbols.proofs.len(), symbols.symbols.len());
         assert!(
             symbols.symbols.len() >= 4_100,
             "SCIP emit should not truncate at the old 4096-symbol smoke cap"


### PR DESCRIPTION
## What changed

- Added a tiny SCIP proof-adapter contract to `symbols.index.json` with producer, version, args/config, revision, package identity, position encoding, and freshness fields.
- Added fixture-shaped definition/reference proof records without adding a storage table or full language integration.
- Labeled SCIP candidates with explicit provenance (`imported_scip_proof` or `scip_graph_projection`) so imported evidence is distinct from lexical, dense, and graph-neighbor evidence.
- Made stale SCIP contracts fail closed in health/search: stale imports report `scip_stale` and produce no candidates.

## Why it changed

Closes #60.

This establishes the smallest retrieval-side seam for imported SCIP proof records while preserving parser-backed and structural coverage outside the sidecar lane.

## How I verified it

- `./target/release/codestory-cli.exe index --project . --refresh full`
- `./target/release/codestory-cli.exe ground --project .`
- `cargo fmt --check`
- `cargo test -p codestory-retrieval scip -- --nocapture`
- `cargo test -p codestory-retrieval`

## Remaining risk or follow-up

- This is a fixture/contract adapter slice, not a full SCIP importer or language integration.
- Local `packet`/`search --why` failed closed because full sidecar retrieval was unavailable (`retrieval_manifest_missing`), so grounding used the local graph index lane instead of full agent packet/search sidecar proof.
- Rebased onto current `origin/main` after Dependabot PRs #63, #65, and #64; this branch has no `Cargo.lock` diff.
- No screenshot evidence; this is not UI-visible.