### PR TITLE
[codex] reduce saga guard noise

### DIFF
--- a/.github/workflows/saga-issue-link-guard.yml
+++ b/.github/workflows/saga-issue-link-guard.yml
@@ -2,7 +2,7 @@ name: saga issue link guard
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, ready_for_review, synchronize, labeled, unlabeled]
+    types: [opened, edited, reopened, ready_for_review, synchronize, labeled]
 
 permissions:
   contents: read
@@ -11,6 +11,10 @@ permissions:
 jobs:
   require-closing-issue-link:
     name: require closing issue link
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'codex/') ||
+      startsWith(github.event.pull_request.title, '[codex]') ||
+      contains(github.event.pull_request.labels.*.name, 'saga:codestory-intelligence')
     runs-on: ubuntu-latest
     steps:
       - name: Check PR issue relationship


### PR DESCRIPTION
## What changed
- Added a job-level guard to `.github/workflows/saga-issue-link-guard.yml` so the issue-link check only runs for Codex branches, `[codex]` PRs, or PRs carrying the saga label.
- Removed the `unlabeled` trigger while keeping `labeled`, so late saga labeling can still invoke the guard.

## Why it changed
Dependabot PRs #63-#65 showed the guard producing successful checks on non-saga PRs, which adds noise while the saga orchestrator is trying to see real Codex/saga PRs quickly.

## How I verified
- `git diff --check`
- `node .github\scripts\check-workflow-policy.mjs`
- Read back `.github\workflows\saga-issue-link-guard.yml`

## Remaining risk or follow-up
- Non-saga PRs may still show a skipped workflow entry depending on GitHub UI behavior, but the Python check body will not run for them.
- If a non-Codex PR becomes saga-relevant only by title edit, the `edited` trigger still covers it; if it becomes saga-relevant by label, the `labeled` trigger still covers it.

Closes #67