### PR TITLE
Expose compact packet provenance counts

### DIFF
--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1876,6 +1876,10 @@ pub struct PacketCoverageReportDto {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub covered: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provenance_labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub provenance_counts: std::collections::BTreeMap<String, u32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub missing: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ineligible: Vec<String>,

--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -725,6 +725,11 @@ mod tests {
         let mut packet = test_packet("Explain route dispatch gaps.", 4096);
         packet.sufficiency.coverage_report = Some(PacketCoverageReportDto {
             covered: vec!["request dispatch".to_string()],
+            provenance_labels: vec!["graph_neighbor".to_string()],
+            provenance_counts: std::collections::BTreeMap::from([(
+                "graph_neighbor".to_string(),
+                1,
+            )]),
             missing: vec!["route handling".to_string()],
             ineligible: vec!["claim=\"diagnostic\" reason=\"claim marked diagnostic\"".to_string()],
             unresolved: vec!["RouteDispatcher".to_string()],
@@ -740,6 +745,8 @@ mod tests {
             .as_ref()
             .expect("coverage report");
         assert_eq!(report.covered, vec!["request dispatch".to_string()]);
+        assert_eq!(report.provenance_labels, vec!["graph_neighbor".to_string()]);
+        assert_eq!(report.provenance_counts.get("graph_neighbor"), Some(&1));
         assert_eq!(report.missing, vec!["route handling".to_string()]);
         assert!(report.ineligible.is_empty());
         assert_eq!(report.unresolved, vec!["RouteDispatcher".to_string()]);

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -24,7 +24,7 @@ use codestory_contracts::api::{
     PacketBudgetModeDto, PacketClaimDto, PacketCoverageReportDto, PacketEvidenceResolutionDto,
     PacketEvidenceTierDto, PacketSufficiencyDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
 };
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::Path;
 
 pub(crate) const PACKET_MARKDOWN_TRUNCATION_SUFFIX: &str =
@@ -894,13 +894,44 @@ fn packet_coverage_report(
     let budget_omitted = has_sufficiency_blocking_budget_omission
         .then(|| budget.omitted_sections.clone())
         .unwrap_or_default();
+    let provenance_counts = packet_provenance_counts(supported_claims);
+    let provenance_labels = provenance_counts.keys().cloned().collect::<Vec<_>>();
     PacketCoverageReportDto {
         covered,
+        provenance_labels,
+        provenance_counts,
         missing,
         ineligible,
         unresolved: unresolved_sidecar_queries.to_vec(),
         budget_omitted,
     }
+}
+
+fn packet_provenance_counts(claims: &[PacketClaimDto]) -> BTreeMap<String, u32> {
+    let mut counts = BTreeMap::new();
+    for citation in claims.iter().flat_map(|claim| &claim.citations) {
+        let mut labels = citation
+            .retrieval_score_breakdown
+            .as_ref()
+            .map(|breakdown| {
+                breakdown
+                    .provenance
+                    .iter()
+                    .filter(|label| !label.is_empty())
+                    .cloned()
+                    .collect::<BTreeSet<_>>()
+            })
+            .unwrap_or_default();
+        if labels.is_empty()
+            && let Some(tier) = citation.evidence_tier
+        {
+            labels.insert(packet_evidence_provenance_label(tier).to_string());
+        }
+        for label in labels {
+            *counts.entry(label).or_insert(0) += 1;
+        }
+    }
+    counts
 }
 
 fn packet_claim_coverage_label(claim: &PacketClaimDto) -> Option<String> {
@@ -959,6 +990,19 @@ fn packet_evidence_tier_label(tier: PacketEvidenceTierDto) -> &'static str {
         PacketEvidenceTierDto::SymbolDoc => "symbol_doc",
         PacketEvidenceTierDto::ComponentReport => "component_report",
         PacketEvidenceTierDto::DenseSemantic => "dense_semantic",
+        PacketEvidenceTierDto::SyntheticSourceScan => "synthetic_source_scan",
+        PacketEvidenceTierDto::GeneratedSummary => "generated_summary",
+    }
+}
+
+fn packet_evidence_provenance_label(tier: PacketEvidenceTierDto) -> &'static str {
+    match tier {
+        PacketEvidenceTierDto::ExactSource => "exact",
+        PacketEvidenceTierDto::ResolvedGraph => "graph_neighbor",
+        PacketEvidenceTierDto::LexicalSource => "lexical_source",
+        PacketEvidenceTierDto::SymbolDoc => "symbol_doc",
+        PacketEvidenceTierDto::ComponentReport => "component_report",
+        PacketEvidenceTierDto::DenseSemantic => "dense_anchor",
         PacketEvidenceTierDto::SyntheticSourceScan => "synthetic_source_scan",
         PacketEvidenceTierDto::GeneratedSummary => "generated_summary",
     }
@@ -2089,7 +2133,7 @@ mod tests {
         AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, NodeId,
         NodeKind, PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetUsageDto,
         PacketEvidenceResolutionDto, PacketEvidenceTierDto, PacketSidecarQueryDiagnosticDto,
-        SearchHitOrigin,
+        RetrievalScoreBreakdownDto, SearchHitOrigin,
     };
     use std::path::Path;
 
@@ -3127,6 +3171,99 @@ mod tests {
         let report = sufficiency.coverage_report.as_ref().unwrap();
         assert!(report.missing.is_empty());
         assert!(report.budget_omitted.is_empty());
+    }
+
+    #[test]
+    fn compact_truncated_packet_retains_proof_provenance_counts() {
+        let question = "Explain compact packet provenance.";
+        let answer = answer_fixture(question);
+        let budget = compact_truncated_budget(question, vec!["citations", "markdown_blocks"]);
+        let tier_cases = [
+            ("exact", PacketEvidenceTierDto::ExactSource),
+            ("lexical_source", PacketEvidenceTierDto::LexicalSource),
+            ("symbol_doc", PacketEvidenceTierDto::SymbolDoc),
+            ("graph_neighbor", PacketEvidenceTierDto::ResolvedGraph),
+            ("component_report", PacketEvidenceTierDto::ComponentReport),
+            ("dense_anchor", PacketEvidenceTierDto::DenseSemantic),
+        ];
+        let mut claims = tier_cases
+            .iter()
+            .map(|(label, tier)| {
+                let text = format!("{label} proves provenance.");
+                let path = format!("src/{label}.rs");
+                cited_claim(
+                    &text,
+                    None,
+                    cited_anchor_with_tier(label, &path, *tier, Some(true)),
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut future_precise_import = cited_anchor_with_tier(
+            "precise_semantic_import",
+            "src/imports.rs",
+            PacketEvidenceTierDto::DenseSemantic,
+            Some(true),
+        );
+        future_precise_import.retrieval_score_breakdown = Some(RetrievalScoreBreakdownDto {
+            lexical: 0.0,
+            semantic: 1.0,
+            graph: 0.0,
+            total: 1.0,
+            tier_cap: None,
+            boosts: Vec::new(),
+            dampening: Vec::new(),
+            final_rank_reason: None,
+            provenance: vec!["precise_semantic_import".to_string()],
+        });
+        claims.push(cited_claim(
+            "Future precise semantic import provenance passes through.",
+            None,
+            future_precise_import,
+            None,
+        ));
+
+        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
+            project_root: Path::new("C:/workspace/project"),
+            question,
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            answer: &answer,
+            budget: &budget,
+            supported_claims: claims,
+            missing_required_probe_queries: Vec::new(),
+            targeted_follow_up_queries: Vec::new(),
+        });
+
+        assert_eq!(sufficiency.covered_claims.len(), 7);
+        assert!(!sufficiency.follow_up_commands.is_empty());
+        let report = sufficiency.coverage_report.as_ref().unwrap();
+        let expected_labels = [
+            "component_report",
+            "dense_anchor",
+            "exact",
+            "graph_neighbor",
+            "lexical_source",
+            "precise_semantic_import",
+            "symbol_doc",
+        ];
+        assert_eq!(
+            report.provenance_labels,
+            expected_labels
+                .iter()
+                .map(|label| (*label).to_string())
+                .collect::<Vec<_>>()
+        );
+        for label in expected_labels {
+            assert_eq!(report.provenance_counts.get(label), Some(&1));
+        }
+        assert!(
+            budget.truncated
+                && budget
+                    .omitted_sections
+                    .iter()
+                    .any(|item| item == "citations"),
+            "compact truncation state should remain visible beside provenance"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -910,28 +910,58 @@ fn packet_coverage_report(
 fn packet_provenance_counts(claims: &[PacketClaimDto]) -> BTreeMap<String, u32> {
     let mut counts = BTreeMap::new();
     for citation in claims.iter().flat_map(|claim| &claim.citations) {
-        let mut labels = citation
-            .retrieval_score_breakdown
-            .as_ref()
-            .map(|breakdown| {
-                breakdown
-                    .provenance
-                    .iter()
-                    .filter(|label| !label.is_empty())
-                    .cloned()
-                    .collect::<BTreeSet<_>>()
-            })
-            .unwrap_or_default();
-        if labels.is_empty()
-            && let Some(tier) = citation.evidence_tier
-        {
-            labels.insert(packet_evidence_provenance_label(tier).to_string());
-        }
+        let labels = packet_citation_provenance_labels(citation);
         for label in labels {
             *counts.entry(label).or_insert(0) += 1;
         }
     }
     counts
+}
+
+fn packet_citation_provenance_labels(citation: &AgentCitationDto) -> BTreeSet<String> {
+    let mut labels = citation
+        .retrieval_score_breakdown
+        .as_ref()
+        .map(|breakdown| {
+            breakdown
+                .provenance
+                .iter()
+                .filter(|label| packet_pass_through_provenance_label(label))
+                .cloned()
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    if let Some(tier) = citation.evidence_tier {
+        if labels.is_empty() {
+            labels.insert(packet_evidence_provenance_label(tier).to_string());
+        }
+    } else if let Some(breakdown) = citation.retrieval_score_breakdown.as_ref() {
+        labels.extend(
+            breakdown
+                .provenance
+                .iter()
+                .filter(|label| packet_public_provenance_label(label))
+                .cloned(),
+        );
+    }
+    labels
+}
+
+fn packet_pass_through_provenance_label(label: &str) -> bool {
+    matches!(label, "precise_semantic_import")
+}
+
+fn packet_public_provenance_label(label: &str) -> bool {
+    packet_pass_through_provenance_label(label)
+        || matches!(
+            label,
+            "exact"
+                | "lexical_source"
+                | "symbol_doc"
+                | "graph_neighbor"
+                | "component_report"
+                | "dense_anchor"
+        )
 }
 
 fn packet_claim_coverage_label(claim: &PacketClaimDto) -> Option<String> {
@@ -3178,6 +3208,17 @@ mod tests {
         let question = "Explain compact packet provenance.";
         let answer = answer_fixture(question);
         let budget = compact_truncated_budget(question, vec!["citations", "markdown_blocks"]);
+        let score_breakdown = |provenance: Vec<&str>| RetrievalScoreBreakdownDto {
+            lexical: 0.0,
+            semantic: 1.0,
+            graph: 0.0,
+            total: 1.0,
+            tier_cap: None,
+            boosts: Vec::new(),
+            dampening: Vec::new(),
+            final_rank_reason: None,
+            provenance: provenance.into_iter().map(str::to_string).collect(),
+        };
         let tier_cases = [
             ("exact", PacketEvidenceTierDto::ExactSource),
             ("lexical_source", PacketEvidenceTierDto::LexicalSource),
@@ -3191,12 +3232,13 @@ mod tests {
             .map(|(label, tier)| {
                 let text = format!("{label} proves provenance.");
                 let path = format!("src/{label}.rs");
-                cited_claim(
-                    &text,
-                    None,
-                    cited_anchor_with_tier(label, &path, *tier, Some(true)),
-                    None,
-                )
+                let mut citation = cited_anchor_with_tier(label, &path, *tier, Some(true));
+                if *label == "lexical_source" {
+                    citation.retrieval_score_breakdown = Some(score_breakdown(vec![
+                        "packet_required_file_scoped_source_probe",
+                    ]));
+                }
+                cited_claim(&text, None, citation, None)
             })
             .collect::<Vec<_>>();
         let mut future_precise_import = cited_anchor_with_tier(
@@ -3205,17 +3247,8 @@ mod tests {
             PacketEvidenceTierDto::DenseSemantic,
             Some(true),
         );
-        future_precise_import.retrieval_score_breakdown = Some(RetrievalScoreBreakdownDto {
-            lexical: 0.0,
-            semantic: 1.0,
-            graph: 0.0,
-            total: 1.0,
-            tier_cap: None,
-            boosts: Vec::new(),
-            dampening: Vec::new(),
-            final_rank_reason: None,
-            provenance: vec!["precise_semantic_import".to_string()],
-        });
+        future_precise_import.retrieval_score_breakdown =
+            Some(score_breakdown(vec!["precise_semantic_import"]));
         claims.push(cited_claim(
             "Future precise semantic import provenance passes through.",
             None,
@@ -3256,6 +3289,11 @@ mod tests {
         for label in expected_labels {
             assert_eq!(report.provenance_counts.get(label), Some(&1));
         }
+        assert!(
+            !report
+                .provenance_counts
+                .contains_key("packet_required_file_scoped_source_probe")
+        );
         assert!(
             budget.truncated
                 && budget


### PR DESCRIPTION
What changed
- Added provenance_labels and provenance_counts to PacketCoverageReportDto so compact packets retain source labels and counts without verbose evidence rows.
- Populate counts from citation score-breakdown provenance when present, otherwise from evidence tiers: exact, lexical_source, symbol_doc, graph_neighbor, component_report, dense_anchor, and pass-through precise_semantic_import.
- Kept packet-budget trimming from dropping those fields.

Why it changed
- Compact packet output trimmed verbose evidence but needed a durable proof ledger under issue 59.

Verification
- cargo fmt --check
- cargo test -p codestory-runtime compact_truncated_packet_retains_proof_provenance_counts --lib
- cargo test -p codestory-runtime sufficiency_verbose_trimming_preserves_missing_and_blocking_report_entries --lib
- cargo test -p codestory-contracts packet_sufficiency_serializes_status_as_snake_case
- Grounding packet attempted with --refresh incremental; failed fail-closed with retrieval_manifest_missing because local sidecars are not indexed/full.

Remaining risk or follow-up
- Did not run full benchmarks or sidecar repair by request. Existing docs already state retrieval_mode=full is infrastructure readiness, not answer-quality promotion.

Closes #59