### PR TITLE
Pilot structural workflow source proof

### DIFF
--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -249,9 +249,19 @@ pub fn language_name_for_path(path: Option<&str>) -> Option<&'static str> {
 
 pub fn is_github_actions_workflow_path(path: &str) -> bool {
     let normalized = path.replace('\\', "/").to_ascii_lowercase();
-    let file_name = normalized.rsplit('/').next().unwrap_or(&normalized);
+    let mut parts = normalized.rsplit('/');
+    let Some(file_name) = parts.next().filter(|part| !part.is_empty()) else {
+        return false;
+    };
+    let Some(parent) = parts.next() else {
+        return false;
+    };
+    let Some(grandparent) = parts.next() else {
+        return false;
+    };
     (file_name.ends_with(".yml") || file_name.ends_with(".yaml"))
-        && normalized.contains(".github/workflows/")
+        && parent == "workflows"
+        && grandparent == ".github"
 }
 
 pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
@@ -403,6 +413,15 @@ mod tests {
             r"repo\.github\workflows\release.yaml"
         ));
         assert!(!is_github_actions_workflow_path("openapi.yaml"));
+        assert!(!is_github_actions_workflow_path(
+            "docs/not.github/workflows/ci.yml"
+        ));
+        assert!(!is_github_actions_workflow_path(
+            "repo/.github/workflows/nested/ci.yml"
+        ));
+        assert!(!is_github_actions_workflow_path(
+            "repo/.github/workflows/readme.md"
+        ));
         assert!(language_support_profile_for_ext("yaml").is_none());
     }
 }

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -1,3 +1,6 @@
+use crate::api::{PacketEvidenceResolutionDto, PacketEvidenceTierDto};
+use crate::graph::NodeKind;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageSupportMode {
     ParserBackedGraph,
@@ -33,6 +36,7 @@ pub enum LanguageClaimTier {
     FilenameRoute,
     GrammarParse,
     SourceGraphExtraction,
+    StructuralSourceProof,
     TypedSemanticEdges,
     PacketSufficientAnswerQuality,
 }
@@ -43,6 +47,7 @@ impl LanguageClaimTier {
             Self::FilenameRoute => "filename_route",
             Self::GrammarParse => "grammar_parse",
             Self::SourceGraphExtraction => "source_graph_extraction",
+            Self::StructuralSourceProof => "structural_source_proof",
             Self::TypedSemanticEdges => "typed_semantic_edges",
             Self::PacketSufficientAnswerQuality => "packet_sufficient_answer_quality",
         }
@@ -54,6 +59,7 @@ pub enum LanguageProofRole {
     ExtensionRouting,
     ParserSmoke,
     GraphFixture,
+    StructuralCollectorFixture,
     SemanticResolverFixture,
     PacketRuntimeArtifact,
 }
@@ -64,6 +70,7 @@ impl LanguageProofRole {
             Self::ExtensionRouting => "extension_routing",
             Self::ParserSmoke => "parser_smoke",
             Self::GraphFixture => "graph_fixture",
+            Self::StructuralCollectorFixture => "structural_collector_fixture",
             Self::SemanticResolverFixture => "semantic_resolver_fixture",
             Self::PacketRuntimeArtifact => "packet_runtime_artifact",
         }
@@ -94,6 +101,11 @@ pub const LANGUAGE_CLAIM_TIER_CONTRACTS: &[LanguageClaimTierContract] = &[
         provenance_expectations: &["fidelity or tictactoe graph fixture"],
     },
     LanguageClaimTierContract {
+        tier: LanguageClaimTier::StructuralSourceProof,
+        allowed_proof_roles: &[LanguageProofRole::StructuralCollectorFixture],
+        provenance_expectations: &["structural collector fixture with exact source spans"],
+    },
+    LanguageClaimTierContract {
         tier: LanguageClaimTier::TypedSemanticEdges,
         allowed_proof_roles: &[LanguageProofRole::SemanticResolverFixture],
         provenance_expectations: &["targeted resolver regression"],
@@ -102,6 +114,43 @@ pub const LANGUAGE_CLAIM_TIER_CONTRACTS: &[LanguageClaimTierContract] = &[
         tier: LanguageClaimTier::PacketSufficientAnswerQuality,
         allowed_proof_roles: &[LanguageProofRole::PacketRuntimeArtifact],
         provenance_expectations: &["publishable packet-runtime artifact"],
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StructuralSourceProofContract {
+    pub collector_name: &'static str,
+    pub path_pattern: &'static str,
+    pub emitted_node_kinds: &'static [NodeKind],
+    pub source_span: &'static str,
+    pub evidence_tier: PacketEvidenceTierDto,
+    pub resolution: PacketEvidenceResolutionDto,
+    pub confidence: f32,
+    pub unsupported_shape_notes: &'static [&'static str],
+    pub claim_boundary: &'static str,
+    pub semantic_proof_allowed: bool,
+}
+
+const GITHUB_ACTIONS_WORKFLOW_NODE_KINDS: &[NodeKind] =
+    &[NodeKind::MODULE, NodeKind::FUNCTION, NodeKind::ANNOTATION];
+const GITHUB_ACTIONS_WORKFLOW_UNSUPPORTED_SHAPES: &[&str] = &[
+    "YAML anchors, aliases, and merge keys are not interpreted.",
+    "Matrix expansion, expressions, reusable-workflow calls, and shell bodies are not semantically resolved.",
+    "The collector records exact source anchors; it does not validate GitHub Actions execution semantics.",
+];
+
+pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = &[
+    StructuralSourceProofContract {
+        collector_name: "github_actions_workflow",
+        path_pattern: ".github/workflows/*.{yml,yaml}",
+        emitted_node_kinds: GITHUB_ACTIONS_WORKFLOW_NODE_KINDS,
+        source_span: "1-based source line and column span for the matched workflow, job, or step anchor",
+        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
+        confidence: 1.0,
+        unsupported_shape_notes: GITHUB_ACTIONS_WORKFLOW_UNSUPPORTED_SHAPES,
+        claim_boundary: "structural exact-source proof only; not parser-backed graph parity, typed semantic resolution, or packet semantic-proof admission",
+        semantic_proof_allowed: false,
     },
 ];
 
@@ -123,7 +172,7 @@ const PARSER_BACKED_CLAIM_TIERS: &[LanguageClaimTier] = &[
 ];
 const STRUCTURAL_CLAIM_TIERS: &[LanguageClaimTier] = &[
     LanguageClaimTier::FilenameRoute,
-    LanguageClaimTier::SourceGraphExtraction,
+    LanguageClaimTier::StructuralSourceProof,
 ];
 
 pub const LANGUAGE_SUPPORT_PROFILES: &[LanguageSupportProfile] = &[
@@ -196,6 +245,13 @@ pub fn language_support_profile_for_language_name(
 pub fn language_name_for_path(path: Option<&str>) -> Option<&'static str> {
     let ext = path?.rsplit('.').next()?.trim_start_matches('.');
     language_support_profile_for_ext(ext).map(|profile| profile.language_name)
+}
+
+pub fn is_github_actions_workflow_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/").to_ascii_lowercase();
+    let file_name = normalized.rsplit('/').next().unwrap_or(&normalized);
+    (file_name.ends_with(".yml") || file_name.ends_with(".yaml"))
+        && normalized.contains(".github/workflows/")
 }
 
 pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
@@ -300,7 +356,8 @@ mod tests {
                 }
                 LanguageSupportMode::StructuralCollector => {
                     assert!(!tiers.contains(&LanguageClaimTier::GrammarParse));
-                    assert!(tiers.contains(&LanguageClaimTier::SourceGraphExtraction));
+                    assert!(tiers.contains(&LanguageClaimTier::StructuralSourceProof));
+                    assert!(!tiers.contains(&LanguageClaimTier::SourceGraphExtraction));
                 }
             }
 
@@ -315,5 +372,37 @@ mod tests {
                 profile.language_name
             );
         }
+    }
+
+    #[test]
+    fn structural_source_proof_contract_is_exact_source_not_semantic() {
+        let contract = STRUCTURAL_SOURCE_PROOF_CONTRACTS
+            .iter()
+            .find(|contract| contract.collector_name == "github_actions_workflow")
+            .expect("github actions structural contract");
+        assert_eq!(contract.path_pattern, ".github/workflows/*.{yml,yaml}");
+        assert!(contract.emitted_node_kinds.contains(&NodeKind::MODULE));
+        assert!(contract.emitted_node_kinds.contains(&NodeKind::FUNCTION));
+        assert_eq!(contract.evidence_tier, PacketEvidenceTierDto::ExactSource);
+        assert_eq!(
+            contract.resolution,
+            PacketEvidenceResolutionDto::SourceRangeOnly
+        );
+        assert_eq!(contract.confidence, 1.0);
+        assert!(!contract.unsupported_shape_notes.is_empty());
+        assert!(!contract.semantic_proof_allowed);
+        assert!(contract.claim_boundary.contains("not parser-backed"));
+    }
+
+    #[test]
+    fn github_actions_workflow_path_is_path_scoped_not_yaml_support() {
+        assert!(is_github_actions_workflow_path(
+            "repo/.github/workflows/ci.yml"
+        ));
+        assert!(is_github_actions_workflow_path(
+            r"repo\.github\workflows\release.yaml"
+        ));
+        assert!(!is_github_actions_workflow_path("openapi.yaml"));
+        assert!(language_support_profile_for_ext("yaml").is_none());
     }
 }

--- a/crates/codestory-indexer/src/structural/common.rs
+++ b/crates/codestory-indexer/src/structural/common.rs
@@ -3,9 +3,13 @@ use codestory_contracts::graph::{
     AccessKind, Edge, EdgeId, EdgeKind, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
     ResolutionCertainty, SourceLocation,
 };
+use codestory_contracts::language_support::is_github_actions_workflow_path;
 use std::path::Path;
 
 pub(crate) fn structural_language_name(path: &Path) -> &'static str {
+    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+        return "github_actions_workflow";
+    }
     match path
         .extension()
         .and_then(|ext| ext.to_str())
@@ -146,6 +150,8 @@ pub(crate) fn push_structural_node(
 ) -> NodeId {
     let node_id = NodeId(crate::generate_id(canonical_id));
     let label_len = name.len().max(1);
+    let start_col = col.max(1);
+    let end_col = start_col.saturating_add(label_len as u32).saturating_sub(1);
     storage.nodes.push(Node {
         id: node_id,
         kind,
@@ -154,9 +160,9 @@ pub(crate) fn push_structural_node(
         canonical_id: Some(canonical_id.to_string()),
         file_node_id: Some(file_id),
         start_line: Some(line),
-        start_col: Some(col.max(1)),
+        start_col: Some(start_col),
         end_line: Some(line),
-        end_col: Some(label_len as u32),
+        end_col: Some(end_col),
     });
     storage.component_access.push((node_id, AccessKind::Public));
     storage.occurrences.push(Occurrence {
@@ -165,9 +171,9 @@ pub(crate) fn push_structural_node(
         location: SourceLocation {
             file_node_id: file_id,
             start_line: line,
-            start_col: col.max(1),
+            start_col,
             end_line: line,
-            end_col: label_len as u32,
+            end_col,
         },
     });
     node_id

--- a/crates/codestory-indexer/src/structural/github_actions.rs
+++ b/crates/codestory-indexer/src/structural/github_actions.rs
@@ -119,15 +119,14 @@ fn collect_jobs_and_steps(
         }
         if in_steps
             && indent > steps_indent
-            && let Some((step_label, step_col)) = step_label(line_text)
+            && let Some((step_anchor, step_col)) = step_anchor(line_text)
         {
             step_index = step_index.saturating_add(1);
-            let name = format!("{job_name} step {step_index}: {step_label}");
             let step_id = push_structural_node(
                 storage,
                 file_id,
                 NodeKind::ANNOTATION,
-                &name,
+                &step_anchor,
                 &format!("github-actions:step:{path_key}:{job_name}:{step_index}"),
                 line,
                 step_col,
@@ -178,21 +177,15 @@ fn yaml_mapping_key(trimmed_line: &str) -> Option<String> {
     Some(key.to_string())
 }
 
-fn step_label(line: &str) -> Option<(String, u32)> {
+fn step_anchor(line: &str) -> Option<(String, u32)> {
     let indent = leading_spaces(line);
     let trimmed = line.trim_start();
-    let rest = trimmed.strip_prefix("- ")?;
+    trimmed.strip_prefix("- ")?;
     for key in ["name:", "uses:", "run:"] {
-        if let Some(value) = rest.trim_start().strip_prefix(key) {
-            let value = clean_yaml_scalar(value.trim());
-            let label = if value.is_empty() {
-                key.trim_end_matches(':').to_string()
-            } else {
-                value
-            };
+        if trimmed[2..].trim_start().starts_with(key) {
             return Some((
-                label,
-                indent.saturating_add(3).try_into().unwrap_or(u32::MAX),
+                trimmed.to_string(),
+                indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
             ));
         }
     }

--- a/crates/codestory-indexer/src/structural/github_actions.rs
+++ b/crates/codestory-indexer/src/structural/github_actions.rs
@@ -147,9 +147,12 @@ fn top_level_workflow_name(source: &str) -> Option<(String, u32, u32)> {
         if leading_spaces(line) == 0
             && let Some(rest) = trimmed.strip_prefix("name:")
         {
-            let value = clean_yaml_scalar(rest.trim());
+            let value_text = rest.trim_start();
+            let value = clean_yaml_scalar(value_text);
             if !value.is_empty() {
-                let col = line.find(&value).unwrap_or(0).saturating_add(1);
+                let value_offset = rest.len().saturating_sub(value_text.len())
+                    + value_text.find(&value).unwrap_or(0);
+                let col = "name:".len().saturating_add(value_offset).saturating_add(1);
                 return Some((
                     value,
                     line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX),

--- a/crates/codestory-indexer/src/structural/github_actions.rs
+++ b/crates/codestory-indexer/src/structural/github_actions.rs
@@ -11,8 +11,9 @@ pub(crate) fn collect_github_actions_workflow_entities(
     storage: &mut IntermediateStorage,
 ) {
     let path_key = path.to_string_lossy().replace('\\', "/");
-    let (workflow_name, workflow_line, workflow_col) =
-        workflow_name(source).unwrap_or_else(|| fallback_workflow_name(path));
+    let Some((workflow_name, workflow_line, workflow_col)) = workflow_anchor(source) else {
+        return;
+    };
     let workflow_id = push_structural_node(
         storage,
         file_id,
@@ -136,7 +137,11 @@ fn collect_jobs_and_steps(
     }
 }
 
-fn workflow_name(source: &str) -> Option<(String, u32, u32)> {
+fn workflow_anchor(source: &str) -> Option<(String, u32, u32)> {
+    top_level_workflow_name(source).or_else(|| top_level_jobs_anchor(source))
+}
+
+fn top_level_workflow_name(source: &str) -> Option<(String, u32, u32)> {
     for (line_idx, line) in source.lines().enumerate() {
         let trimmed = line.trim_start();
         if leading_spaces(line) == 0
@@ -156,16 +161,16 @@ fn workflow_name(source: &str) -> Option<(String, u32, u32)> {
     None
 }
 
-fn fallback_workflow_name(path: &Path) -> (String, u32, u32) {
-    (
-        path.file_stem()
-            .and_then(|value| value.to_str())
-            .filter(|value| !value.is_empty())
-            .unwrap_or("workflow")
-            .to_string(),
-        1,
-        1,
-    )
+fn top_level_jobs_anchor(source: &str) -> Option<(String, u32, u32)> {
+    source.lines().enumerate().find_map(|(line_idx, line)| {
+        (leading_spaces(line) == 0 && line.trim_start() == "jobs:").then(|| {
+            (
+                "jobs:".to_string(),
+                line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                line.find("jobs:").unwrap_or(0).saturating_add(1) as u32,
+            )
+        })
+    })
 }
 
 fn yaml_mapping_key(trimmed_line: &str) -> Option<String> {

--- a/crates/codestory-indexer/src/structural/github_actions.rs
+++ b/crates/codestory-indexer/src/structural/github_actions.rs
@@ -1,0 +1,217 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use std::path::Path;
+
+use super::common::{push_member_edge, push_structural_node};
+
+pub(crate) fn collect_github_actions_workflow_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) {
+    let path_key = path.to_string_lossy().replace('\\', "/");
+    let (workflow_name, workflow_line, workflow_col) =
+        workflow_name(source).unwrap_or_else(|| fallback_workflow_name(path));
+    let workflow_id = push_structural_node(
+        storage,
+        file_id,
+        NodeKind::MODULE,
+        &workflow_name,
+        &format!("github-actions:workflow:{path_key}"),
+        workflow_line,
+        workflow_col,
+    );
+    push_member_edge(storage, file_id, file_id, workflow_id, workflow_line);
+
+    collect_jobs_and_steps(&path_key, source, file_id, storage, workflow_id);
+}
+
+fn collect_jobs_and_steps(
+    path_key: &str,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    workflow_id: NodeId,
+) {
+    let mut in_jobs = false;
+    let mut job_indent = None;
+    let mut current_job: Option<(usize, NodeId, String)> = None;
+    let mut in_steps = false;
+    let mut steps_indent = 0usize;
+    let mut step_index = 0usize;
+
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line = line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX);
+        let trimmed = line_text.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line_text);
+
+        if indent == 0 && trimmed == "jobs:" {
+            in_jobs = true;
+            current_job = None;
+            in_steps = false;
+            continue;
+        }
+        if !in_jobs {
+            continue;
+        }
+        if indent == 0 {
+            break;
+        }
+
+        if let Some(expected_indent) = job_indent
+            && indent == expected_indent
+            && !trimmed.starts_with('-')
+            && let Some(job_name) = yaml_mapping_key(trimmed)
+        {
+            let job_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::FUNCTION,
+                &job_name,
+                &format!("github-actions:job:{path_key}:{job_name}"),
+                line,
+                indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+            );
+            push_member_edge(storage, file_id, workflow_id, job_id, line);
+            current_job = Some((indent, job_id, job_name));
+            in_steps = false;
+            step_index = 0;
+            continue;
+        }
+
+        if job_indent.is_none()
+            && indent > 0
+            && !trimmed.starts_with('-')
+            && let Some(job_name) = yaml_mapping_key(trimmed)
+        {
+            job_indent = Some(indent);
+            let job_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::FUNCTION,
+                &job_name,
+                &format!("github-actions:job:{path_key}:{job_name}"),
+                line,
+                indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+            );
+            push_member_edge(storage, file_id, workflow_id, job_id, line);
+            current_job = Some((indent, job_id, job_name));
+            step_index = 0;
+            continue;
+        }
+
+        let Some((current_job_indent, job_id, job_name)) = current_job.as_ref() else {
+            continue;
+        };
+        if indent <= *current_job_indent {
+            in_steps = false;
+            continue;
+        }
+        if trimmed == "steps:" {
+            in_steps = true;
+            steps_indent = indent;
+            step_index = 0;
+            continue;
+        }
+        if in_steps
+            && indent > steps_indent
+            && let Some((step_label, step_col)) = step_label(line_text)
+        {
+            step_index = step_index.saturating_add(1);
+            let name = format!("{job_name} step {step_index}: {step_label}");
+            let step_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::ANNOTATION,
+                &name,
+                &format!("github-actions:step:{path_key}:{job_name}:{step_index}"),
+                line,
+                step_col,
+            );
+            push_member_edge(storage, file_id, *job_id, step_id, line);
+        }
+    }
+}
+
+fn workflow_name(source: &str) -> Option<(String, u32, u32)> {
+    for (line_idx, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if leading_spaces(line) == 0
+            && let Some(rest) = trimmed.strip_prefix("name:")
+        {
+            let value = clean_yaml_scalar(rest.trim());
+            if !value.is_empty() {
+                let col = line.find(&value).unwrap_or(0).saturating_add(1);
+                return Some((
+                    value,
+                    line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                    col.try_into().unwrap_or(u32::MAX),
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn fallback_workflow_name(path: &Path) -> (String, u32, u32) {
+    (
+        path.file_stem()
+            .and_then(|value| value.to_str())
+            .filter(|value| !value.is_empty())
+            .unwrap_or("workflow")
+            .to_string(),
+        1,
+        1,
+    )
+}
+
+fn yaml_mapping_key(trimmed_line: &str) -> Option<String> {
+    let (key, _) = trimmed_line.split_once(':')?;
+    let key = key.trim();
+    if key.is_empty() || key.contains(' ') || !key.chars().all(github_actions_key_char) {
+        return None;
+    }
+    Some(key.to_string())
+}
+
+fn step_label(line: &str) -> Option<(String, u32)> {
+    let indent = leading_spaces(line);
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("- ")?;
+    for key in ["name:", "uses:", "run:"] {
+        if let Some(value) = rest.trim_start().strip_prefix(key) {
+            let value = clean_yaml_scalar(value.trim());
+            let label = if value.is_empty() {
+                key.trim_end_matches(':').to_string()
+            } else {
+                value
+            };
+            return Some((
+                label,
+                indent.saturating_add(3).try_into().unwrap_or(u32::MAX),
+            ));
+        }
+    }
+    None
+}
+
+fn clean_yaml_scalar(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.chars().take_while(|ch| *ch == ' ').count()
+}
+
+fn github_actions_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')
+}

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -139,6 +139,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Cargo test
         run: cargo test
+      - run: cargo fmt
 "#;
         std::fs::write(&path, yaml).expect("write workflow");
 
@@ -171,12 +172,9 @@ jobs:
         assert_eq!(build.start_line, Some(5));
         assert_eq!(build.start_col, Some(3));
         assert_eq!(build.end_col, Some(7));
-        assert!(
-            storage.nodes.iter().any(|node| {
-                node.kind == NodeKind::ANNOTATION && node.serialized_name.contains("Cargo test")
-            }),
-            "named workflow step should be collected"
-        );
+        assert_exact_step_span(&storage, "- uses: actions/checkout@v4", 8, 7);
+        assert_exact_step_span(&storage, "- name: Cargo test", 9, 7);
+        assert_exact_step_span(&storage, "- run: cargo fmt", 11, 7);
         assert!(
             storage
                 .edges
@@ -184,6 +182,26 @@ jobs:
                 .any(|edge| edge.kind == EdgeKind::MEMBER)
         );
         assert!(!is_structural_candidate_path(Path::new("openapi.yaml")));
+    }
+
+    fn assert_exact_step_span(
+        storage: &IntermediateStorage,
+        source_anchor: &str,
+        line: u32,
+        col: u32,
+    ) {
+        let node = storage
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::ANNOTATION && node.serialized_name == source_anchor)
+            .unwrap_or_else(|| panic!("missing exact step anchor {source_anchor}"));
+        assert_eq!(node.start_line, Some(line));
+        assert_eq!(node.start_col, Some(col));
+        assert_eq!(
+            node.end_col,
+            Some(col + source_anchor.len() as u32 - 1),
+            "step span must cover only source text"
+        );
     }
 
     #[test]

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -214,6 +214,54 @@ jobs:
         assert_eq!(workflow.end_col, Some(5));
     }
 
+    #[test]
+    fn github_actions_workflow_name_span_uses_scalar_value_not_key_text() {
+        assert_workflow_name_span(
+            r#"name: "name"
+on:
+  push:
+jobs:
+  test:
+    steps:
+      - run: cargo test
+"#,
+            "name",
+            8,
+            11,
+        );
+        assert_workflow_name_span(
+            r#"name: me
+on:
+  push:
+jobs:
+  test:
+    steps:
+      - run: cargo test
+"#,
+            "me",
+            7,
+            8,
+        );
+    }
+
+    fn assert_workflow_name_span(
+        source: &str,
+        expected_name: &str,
+        expected_start_col: u32,
+        expected_end_col: u32,
+    ) {
+        let storage = index_structural_source(Path::new(".github/workflows/name.yml"), source)
+            .expect("index workflow");
+        let workflow = storage
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::MODULE && node.serialized_name == expected_name)
+            .unwrap_or_else(|| panic!("missing workflow node {expected_name}"));
+        assert_eq!(workflow.start_line, Some(1));
+        assert_eq!(workflow.start_col, Some(expected_start_col));
+        assert_eq!(workflow.end_col, Some(expected_end_col));
+    }
+
     fn assert_exact_step_span(
         storage: &IntermediateStorage,
         source_anchor: &str,

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -3,6 +3,7 @@
 mod blanking;
 mod common;
 pub(crate) mod css;
+mod github_actions;
 mod html;
 mod sql;
 
@@ -17,9 +18,13 @@ pub fn structural_language_name(path: &Path) -> &'static str {
 use crate::intermediate_storage::IntermediateStorage;
 use anyhow::Result;
 use codestory_contracts::graph::NodeId;
+use codestory_contracts::language_support::is_github_actions_workflow_path;
 use std::path::Path;
 
 pub fn is_structural_candidate_path(path: &Path) -> bool {
+    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+        return true;
+    }
     matches!(
         structural_extension(path).as_deref(),
         Some("html" | "htm" | "css" | "sql")
@@ -56,11 +61,22 @@ pub fn index_structural_source(path: &Path, source: &str) -> Result<Intermediate
     });
     storage.nodes.push(file_node);
 
-    match structural_extension(path).as_deref() {
-        Some("html" | "htm") => html::collect_html_entities(path, source, file_id, &mut storage),
-        Some("css") => css::collect_css_entities(path, source, file_id, &mut storage, 1),
-        Some("sql") => sql::collect_sql_entities(path, source, file_id, &mut storage),
-        _ => {}
+    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+        github_actions::collect_github_actions_workflow_entities(
+            path,
+            source,
+            file_id,
+            &mut storage,
+        );
+    } else {
+        match structural_extension(path).as_deref() {
+            Some("html" | "htm") => {
+                html::collect_html_entities(path, source, file_id, &mut storage)
+            }
+            Some("css") => css::collect_css_entities(path, source, file_id, &mut storage, 1),
+            Some("sql") => sql::collect_sql_entities(path, source, file_id, &mut storage),
+            _ => {}
+        }
     }
 
     storage.callable_projection_states = crate::build_callable_projection_states(
@@ -105,6 +121,69 @@ mod tests {
         let storage = index_structural_file(&path).expect("index sql");
         assert!(storage.nodes.iter().any(|n| n.kind == NodeKind::CLASS));
         assert_eq!(storage.files[0].language, "sql");
+    }
+
+    #[test]
+    fn indexes_github_actions_workflow_as_structural_source_proof() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let workflow_dir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&workflow_dir).expect("workflow dir");
+        let path = workflow_dir.join("ci.yml");
+        let yaml = r#"name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cargo test
+        run: cargo test
+"#;
+        std::fs::write(&path, yaml).expect("write workflow");
+
+        let storage = index_structural_file(&path).expect("index workflow");
+
+        assert_eq!(storage.files[0].language, "github_actions_workflow");
+        assert!(
+            storage
+                .nodes
+                .iter()
+                .any(|node| node.kind == NodeKind::MODULE
+                    && node.serialized_name == "CI"
+                    && node.start_line == Some(1)
+                    && node.start_col == Some(7)
+                    && node.end_col == Some(8)),
+            "workflow name should be an exact source-span node"
+        );
+        let build = storage
+            .nodes
+            .iter()
+            .find(|node| {
+                node.kind == NodeKind::FUNCTION
+                    && node
+                        .canonical_id
+                        .as_deref()
+                        .is_some_and(|value| value.contains("github-actions:job:"))
+                    && node.serialized_name == "build"
+            })
+            .expect("build job node");
+        assert_eq!(build.start_line, Some(5));
+        assert_eq!(build.start_col, Some(3));
+        assert_eq!(build.end_col, Some(7));
+        assert!(
+            storage.nodes.iter().any(|node| {
+                node.kind == NodeKind::ANNOTATION && node.serialized_name.contains("Cargo test")
+            }),
+            "named workflow step should be collected"
+        );
+        assert!(
+            storage
+                .edges
+                .iter()
+                .any(|edge| edge.kind == EdgeKind::MEMBER)
+        );
+        assert!(!is_structural_candidate_path(Path::new("openapi.yaml")));
     }
 
     #[test]

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -184,6 +184,36 @@ jobs:
         assert!(!is_structural_candidate_path(Path::new("openapi.yaml")));
     }
 
+    #[test]
+    fn unnamed_github_actions_workflow_uses_jobs_source_anchor() {
+        let yaml = r#"on:
+  push:
+jobs:
+  test:
+    steps:
+      - run: cargo test
+"#;
+
+        let storage = index_structural_source(Path::new(".github/workflows/unnamed.yml"), yaml)
+            .expect("index workflow");
+
+        assert!(
+            !storage
+                .nodes
+                .iter()
+                .any(|node| node.kind == NodeKind::MODULE && node.serialized_name == "unnamed"),
+            "workflow module must not be derived from the filename"
+        );
+        let workflow = storage
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::MODULE && node.serialized_name == "jobs:")
+            .expect("jobs source anchor");
+        assert_eq!(workflow.start_line, Some(3));
+        assert_eq!(workflow.start_col, Some(1));
+        assert_eq!(workflow.end_col, Some(5));
+    }
+
     fn assert_exact_step_span(
         storage: &IntermediateStorage,
         source_anchor: &str,

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -4,6 +4,7 @@ use codestory_contracts::api::{
     AgentCitationDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto, SearchHit,
     SearchHitOrigin,
 };
+use codestory_contracts::language_support::is_github_actions_workflow_path;
 
 pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
 pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
@@ -36,16 +37,17 @@ pub(crate) fn evidence_candidate_from_hit(hit: &SearchHit) -> EvidenceCandidate 
 
 pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
     let candidate = evidence_candidate_from_hit(hit);
+    let structural_source_proof = hit_is_structural_source_proof(hit);
     hit.evidence_tier = Some(candidate.tier);
     hit.evidence_producer = Some(candidate.producer);
     hit.resolution_status = Some(candidate.resolution);
     if hit.loss_reason.is_none() {
         hit.loss_reason = candidate.loss_reason;
     }
-    hit.eligible_for_sufficiency = Some(evidence_is_sufficiency_eligible(
-        candidate.tier,
-        candidate.resolution,
-    ));
+    hit.eligible_for_sufficiency = Some(
+        !structural_source_proof
+            && evidence_is_sufficiency_eligible(candidate.tier, candidate.resolution),
+    );
 }
 
 pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &SearchHit) {
@@ -61,6 +63,14 @@ pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &
         .or_else(|| Some(evidence_resolution_for_hit(hit)));
     citation.loss_reason = hit.loss_reason.clone();
     citation.coverage_role = hit.coverage_role.clone();
+    if citation_is_structural_source_proof(citation) {
+        citation.evidence_tier = Some(PacketEvidenceTier::ExactSource);
+        citation.resolution_status = Some(evidence_resolution_for_citation(citation));
+        citation.evidence_producer =
+            Some("structural_github_actions_workflow_collector".to_string());
+        citation.eligible_for_sufficiency = Some(false);
+        return;
+    }
     citation.eligible_for_sufficiency = hit.eligible_for_sufficiency.or_else(|| {
         Some(evidence_is_sufficiency_eligible(
             citation
@@ -89,6 +99,9 @@ pub(crate) fn evidence_is_sufficiency_eligible(
 }
 
 pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool {
+    if citation_is_structural_source_proof(citation) {
+        return citation.eligible_for_sufficiency.unwrap_or(false);
+    }
     let tier = citation
         .evidence_tier
         .unwrap_or_else(|| evidence_tier_for_citation(citation));
@@ -101,6 +114,9 @@ pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool
 }
 
 pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
+    if hit_is_structural_source_proof(hit) {
+        return PacketEvidenceTier::ExactSource;
+    }
     if let Some(tier) = hit.evidence_tier {
         return tier;
     }
@@ -129,6 +145,13 @@ pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
 }
 
 pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceResolution {
+    if hit_is_structural_source_proof(hit) {
+        return if hit.file_path.is_some() && hit.line.is_some() {
+            PacketEvidenceResolution::SourceRangeOnly
+        } else {
+            PacketEvidenceResolution::Unresolved
+        };
+    }
     if let Some(resolution) = hit.resolution_status {
         return resolution;
     }
@@ -142,6 +165,9 @@ pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceReso
 }
 
 pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
+    if hit_is_structural_source_proof(hit) {
+        return "structural_github_actions_workflow_collector".to_string();
+    }
     if let Some(producer) = hit.evidence_producer.as_ref() {
         return producer.clone();
     }
@@ -157,6 +183,9 @@ pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
 }
 
 fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
+    if citation_is_structural_source_proof(citation) {
+        return PacketEvidenceTier::ExactSource;
+    }
     if let Some(breakdown) = citation.retrieval_score_breakdown.as_ref() {
         if breakdown.provenance.iter().any(|value| {
             value.contains("synthetic")
@@ -182,11 +211,86 @@ fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier
 }
 
 fn evidence_resolution_for_citation(citation: &AgentCitationDto) -> PacketEvidenceResolution {
+    if citation_is_structural_source_proof(citation) {
+        return if citation.file_path.is_some() && citation.line.is_some() {
+            PacketEvidenceResolution::SourceRangeOnly
+        } else {
+            PacketEvidenceResolution::Unresolved
+        };
+    }
     if citation.resolvable {
         PacketEvidenceResolution::Resolved
     } else if citation.file_path.is_some() && citation.line.is_some() {
         PacketEvidenceResolution::SourceRangeOnly
     } else {
         PacketEvidenceResolution::Unresolved
+    }
+}
+
+fn hit_is_structural_source_proof(hit: &SearchHit) -> bool {
+    hit.file_path
+        .as_deref()
+        .is_some_and(is_github_actions_workflow_path)
+}
+
+fn citation_is_structural_source_proof(citation: &AgentCitationDto) -> bool {
+    citation
+        .file_path
+        .as_deref()
+        .is_some_and(is_github_actions_workflow_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::api::{NodeId, NodeKind, RetrievalScoreBreakdownDto, SearchHitOrigin};
+
+    fn workflow_hit() -> SearchHit {
+        SearchHit {
+            node_id: NodeId("workflow-build".to_string()),
+            display_name: "build".to_string(),
+            kind: NodeKind::FUNCTION,
+            file_path: Some(".github/workflows/ci.yml".to_string()),
+            line: Some(5),
+            score: 1.0,
+            origin: SearchHitOrigin::IndexedSymbol,
+            match_quality: None,
+            resolvable: true,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: None,
+            score_breakdown: Some(RetrievalScoreBreakdownDto {
+                lexical: 0.0,
+                semantic: 0.0,
+                graph: 1.0,
+                total: 1.0,
+                tier_cap: None,
+                boosts: Vec::new(),
+                dampening: Vec::new(),
+                final_rank_reason: None,
+                provenance: Vec::new(),
+            }),
+        }
+    }
+
+    #[test]
+    fn github_actions_structural_hit_is_exact_source_diagnostic() {
+        let mut hit = workflow_hit();
+
+        decorate_search_hit_evidence(&mut hit);
+
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(
+            hit.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("structural_github_actions_workflow_collector")
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }
 }

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -2910,6 +2910,26 @@ mod tests {
     }
 
     #[test]
+    fn github_actions_exact_source_does_not_satisfy_semantic_packet_proof() {
+        let claim = cited_claim(
+            "The CI workflow build job runs the test command.",
+            Some("command dispatch"),
+            cited_anchor_with_tier(
+                "build",
+                ".github/workflows/ci.yml",
+                PacketEvidenceTierDto::ExactSource,
+                None,
+            ),
+            None,
+        );
+
+        assert!(
+            !packet_claim_can_satisfy_sufficiency(&claim),
+            "structural workflow exact-source evidence must not satisfy semantic packet proof roles"
+        );
+    }
+
+    #[test]
     fn covered_flow_roles_make_missing_probe_queries_follow_up_hints() {
         let question = "Explain how the form validation examples combine native HTML constraints with custom JavaScript validation.";
         let answer = answer_fixture(question);

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -15,7 +15,7 @@ profiles to parser and rule construction in `get_language_for_ext`.
 | Parser-backed graph | Extension routes to a parser and graph rules. | Full semantic navigation. |
 | Fidelity-gated | Core symbol/import/call/member shapes pass fixture suites. | Every language feature is covered. |
 | Semantic-resolution-backed | Targeted resolver tests prove the named behavior. | Broad cross-package or polymorphic dispatch. |
-| Structural collector | Dedicated extractor emits structural entities. | Parser-backed code navigation. |
+| Structural source-proof | Dedicated extractor emits exact source anchors for structural files. | Parser-backed graph extraction or semantic code navigation. |
 | Parser compatibility record | A parser crate/version was checked for future use. | Runtime support. |
 | Packet proof gate | A packet-runtime artifact proves the current packet citation and sufficiency contract for the measured tasks. | Public product-grade language quality. |
 | Publishable packet-runtime pass | Success, quality, sufficiency, and cold-SLA gates all pass in one coherent run. | A change to parser-backed or structural language coverage. |
@@ -26,7 +26,7 @@ profiles to parser and rule construction in `get_language_for_ext`.
 | Runtime claim | Languages | Evidence floor | Safe claim |
 | --- | --- | --- | --- |
 | Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | fidelity lab, tictactoe coverage, raw graph contracts, targeted rule/resolution suites, opt-in OSS corpus | daily graph navigation on typical code, with caveats |
-| Structural collector | HTML, CSS, SQL | structural collector tests | structural entity extraction |
+| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows | structural collector tests | exact-source structural anchors |
 
 Agent-facing packet/search quality is separate. The language-expansion A/B
 report is not blanket promotion proof for every parser-backed language.
@@ -36,13 +36,14 @@ report is not blanket promotion proof for every parser-backed language.
 The source-derived ladder in `language_support.rs` maps current profiles only to
 the tiers they prove. Parser-backed profiles currently claim filename routing,
 grammar parse, and source graph extraction. Structural collectors claim filename
-routing and source graph extraction only.
+routing and structural source-proof only.
 
 | Tier | Allowed proof role | Provenance expectation | Does not mean |
 | --- | --- | --- | --- |
 | `filename_route` | `extension_routing` | `LANGUAGE_SUPPORT_PROFILES` extension registry | Parser availability. |
 | `grammar_parse` | `parser_smoke` | Live tree-sitter parser config and parse smoke | Graph fidelity. |
 | `source_graph_extraction` | `graph_fixture` | Fidelity or tictactoe graph fixture | Typed semantic resolution. |
+| `structural_source_proof` | `structural_collector_fixture` | Structural collector fixture with exact source spans | Parser-backed graph extraction or semantic proof. |
 | `typed_semantic_edges` | `semantic_resolver_fixture` | Targeted resolver regression | Broad semantic parity. |
 | `packet_sufficient_answer_quality` | `packet_runtime_artifact` | Publishable packet-runtime artifact | Runtime language support. |
 
@@ -61,11 +62,21 @@ status. It is blocked:
 | Sufficiency | `107/108` sufficient, `1` partial | One packet is not proof-complete. |
 | Cold SLA | `8` misses | Cold latency still blocks publishable promotion. |
 
+GitHub Actions workflow support is path-scoped to `.github/workflows/*.{yml,yaml}`.
+The pilot emits workflow, job, and step anchors with `exact_source` /
+`source_range_only` evidence. Unsupported shapes stay explicit: YAML anchors and
+merge keys are not interpreted, matrix expansion and expressions are not
+resolved, reusable workflows and shell bodies are not semantically traced, and
+the collector does not validate GitHub Actions execution semantics. Packet
+evidence treats these anchors as diagnostic unless a future structural role
+explicitly admits them; they must not satisfy semantic proof roles.
+
 Safe wording: packet-runtime is implemented and completing the suite, but
 publishable agent-facing packet quality is not promoted until a coherent run has
 all quality, sufficiency, and cold-SLA gates green. This evidence is a
 development/proof-gate signal, not public product-grade proof for every
-parser-backed language. HTML, CSS, and SQL remain structural collectors.
+parser-backed language. HTML, CSS, SQL, and GitHub Actions workflows remain
+structural source-proof collectors.
 
 Older development comparison: the language-expansion comparison artifact built
 on 2026-06-17:
@@ -134,8 +145,9 @@ Workspace parser policy:
 - `tree-sitter-graph = "0.12"`
 
 Validation: each listed candidate passed an isolated `cargo check` probe with
-the policy pins; wired parser rows also passed a parse smoke. HTML, CSS, and SQL
-remain structural runtime paths, not parser-backed runtime claims.
+the policy pins; wired parser rows also passed a parse smoke. HTML, CSS, SQL,
+and GitHub Actions workflows remain structural runtime paths, not parser-backed
+runtime claims.
 
 | Language | Candidate crate | Version checked | Decision |
 | --- | --- | ---: | --- |


### PR DESCRIPTION
## What changed
- Added a structural source-proof contract tier and GitHub Actions workflow contract metadata for `.github/workflows/*.{yml,yaml}`.
- Added a path-scoped GitHub Actions structural collector that emits workflow, job, and step exact-source anchors.
- Fixed review blockers: workflow paths now require direct `.github/workflows/<file>.yml|yaml`; step nodes span exact `- name:`, `- uses:`, or `- run:` YAML source text; unnamed workflows use the real `jobs:` source anchor instead of a filename-derived node; workflow `name:` spans now anchor to the scalar value text rather than the YAML key.
- Forced workflow packet evidence to `exact_source` / `source_range_only` and diagnostic-only by default so it cannot satisfy semantic packet proof roles.
- Updated language-support docs to state the non-parser, non-semantic boundary.

## Why it changed
CodeStory needs useful workflow/config coverage without pretending YAML workflows have parser-backed graph or semantic-resolution parity. This is the smallest pilot for issue #62 and keeps the claim boundary explicit.

Closes #62
Refs #38

## How I verified
- `cargo fmt`
- `cargo test -p codestory-contracts --lib` (28 passed)
- `cargo test -p codestory-indexer github_actions --lib` (3 passed)
- `cargo test -p codestory-indexer structural --lib` (12 passed)
- `cargo test -p codestory-runtime github_actions --lib` (2 passed)
- `git diff --check`

Not used as success evidence: optional `cargo test -p codestory-runtime --lib` was interrupted after the runtime test binary stayed responsive but CPU-flat for a sustained interval. Treat that broad suite as unknown, not passed.

## Remaining risk or follow-up
- The GitHub Actions collector is intentionally line-oriented. YAML anchors/merge keys, expressions, matrix expansion, reusable workflow semantics, and shell bodies are recorded as unsupported rather than interpreted.
- Future structural packet admission should add explicit structural roles before these anchors can satisfy any sufficiency gate.