### PR TITLE
[codex] fix packet unresolved candidate diagnostics

### DIFF
--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1005,9 +1005,16 @@ fn shadow_from_query_result_with_counts_and_resolution_labels(
         .map(|hit| hit.file_path.clone())
         .collect();
 
-    let effective_candidate_count = candidate_count.max(result.hits.len());
-    let unresolved_candidate_count = effective_candidate_count.saturating_sub(resolved_hit_count);
     let candidate_resolution_counts = build_candidate_resolution_counts(resolution_labels);
+    let effective_candidate_count = candidate_count.max(result.hits.len());
+    let unresolved_candidate_count = if resolution_labels.is_empty() {
+        effective_candidate_count.saturating_sub(resolved_hit_count)
+    } else {
+        resolution_labels
+            .iter()
+            .filter(|label| label.as_str() != "resolved")
+            .count()
+    };
 
     RetrievalShadowDto {
         retrieval_mode: trace.retrieval_mode.clone(),
@@ -1700,6 +1707,10 @@ mod tests {
         assert_eq!(shadow.candidates[1].resolved_node_id.as_deref(), Some("3"));
         assert_eq!(shadow.candidates[1].search_hit_rank, Some(2));
         assert_eq!(shadow.candidates[1].final_rank, None);
+        assert_eq!(
+            shadow.unresolved_candidate_count, 0,
+            "resolved candidates rejected by the final result window are not unresolved sidecar candidates"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #75.
Parent: #38.
Blocked follow-ups: #78, #79, #74, #73.

## What changed

- Fixes packet retrieval shadow diagnostics so `unresolved_candidate_count` counts actual non-resolved sidecar candidate labels when resolution labels are available.
- Keeps the older subtraction fallback only for shadow payloads that do not carry resolution labels.
- Adds a focused regression assertion that candidates resolved by the sidecar but rejected only by the final result window do not inflate unresolved candidate diagnostics.

## Why it changed

The publishable #75 artifact showed every packet-runtime row failing on unresolved retrieval candidates even when the packet was sufficient. A concrete psf-requests row had `candidate_resolution_counts: resolved=40`, but `retrieval_shadow.unresolved_candidate_count=27` because the shadow code derived unresolved as `candidate_count - resolved_hit_count`. That counted resolved candidates outside the final result window as unresolved product diagnostics.

This keeps the publishable gate strict: actual non-resolved labels still report unresolved candidates, while result-window truncation no longer masquerades as sidecar resolution failure.

## How verified

- `cargo test -p codestory-runtime shadow_candidate_summaries_include_admission_diagnostics`
- `cargo build --release -p codestory-cli`
- `target\release\codestory-cli.exe retrieval status --project C:\Users\alber\source\repos\codestory\target\agent-benchmark\repos\psf-requests --format json`
  - confirmed `retrieval_mode=full` with healthy Zoekt, Qdrant, and SCIP before the live packet repro.
- Patched CLI live packet repro for the failed psf-requests question from the #75 artifact:
  - output: `target\issue-75-packet-repro\psf-requests.json`
  - sufficiency: `sufficient`, `gaps=0`, `follow_up_commands=0`
  - retrieval shadow: `candidate_count=40`, `resolved_hit_count=13`, `candidate_resolution_counts=[resolved=40]`, no serialized `unresolved_candidate_count` because it is zero.
- `cargo test -p codestory-runtime --test retrieval_generalization_guard`
  - `11 passed; 0 failed`
- `git diff --check`

## Not evidence / interrupted

- `cargo test -p codestory-runtime --lib` was started after the focused checks but was interrupted after several minutes in long semantic/indexing tests. It is not counted as passing evidence for this PR.

## Remaining risk / follow-up

- This PR targets the unresolved-candidate diagnostic inflation only.
- The original publishable run also had packet retrieval SLA misses (#78), the Okio repeat-2 quality failure, and the Alamofire repeat-2 quality/sufficiency failure (#79). Those are not solved by this one-file fix and still require clean or accepted-risk evidence before #74/#73 promotion work should proceed.
- No full publishable benchmark was started from this PR package.
