### PR TITLE
fix packet provenance sufficiency

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_capping.rs
+++ b/crates/codestory-runtime/src/agent/packet_capping.rs
@@ -703,10 +703,10 @@ fn packet_required_probe_multi_match_limit(query: &str) -> Option<usize> {
         "sessionrequestcreation"
         | "requestobjectcreation"
         | "requestresumedispatch"
-        | "datarequestvalidation"
         | "requestvalidationpipeline"
         | "delegatecallbackhandling"
         | "urlsessioncallbackboundary" => Some(2),
+        normalized if normalized.ends_with("requestvalidation") => Some(2),
         "serverbootstrap"
         | "commandserverentrypoint"
         | "eventloopsource"

--- a/crates/codestory-runtime/src/agent/packet_capping.rs
+++ b/crates/codestory-runtime/src/agent/packet_capping.rs
@@ -611,8 +611,17 @@ fn promote_distinct_required_probe_matches(
         .filter(|index| packet_citation_satisfies_required_probe(query, &answer.citations[**index]))
         .filter_map(|index| packet_citation_file_path_key(&answer.citations[*index]))
         .collect::<HashSet<_>>();
+    let prefer_shared_source_set = !packet_query_mentions_platform_source_set(query);
 
     while promoted_paths.len() < limit {
+        let promoted_source_set_score = promoted_indices
+            .iter()
+            .filter(|index| {
+                packet_citation_satisfies_required_probe(query, &answer.citations[**index])
+            })
+            .map(|index| packet_source_set_path_score(&answer.citations[*index]))
+            .max()
+            .unwrap_or_default();
         let mut best_match = None;
         for (index, citation) in answer.citations.iter().enumerate() {
             if promoted_indices.contains(&index) {
@@ -625,6 +634,12 @@ fn promote_distinct_required_probe_matches(
                 continue;
             }
             if !packet_required_probe_multi_match_candidate(query, citation) {
+                continue;
+            }
+            if prefer_shared_source_set
+                && promoted_source_set_score >= 2
+                && packet_source_set_path_score(citation) < promoted_source_set_score
+            {
                 continue;
             }
             let Some(match_rank) = packet_citation_probe_match_rank(query, citation) else {
@@ -665,6 +680,8 @@ fn packet_required_probe_multi_match_limit(query: &str) -> Option<usize> {
     match normalize_identifier(query).as_str() {
         "mapperpublicapi" | "mapperruntimeapi" | "mappingruntimeentrypoint" => Some(3),
         "sqlschemascripts" | "schemadialectscripts" => Some(3),
+        "bufferedsource" | "bufferedsink" | "bufferedwrapper" | "sourcebuffer" | "sinkbuffer"
+        | "sourcereadbuffer" | "sinkwritebuffer" => Some(2),
         "httptoplevelhelper"
         | "publicclientfacade"
         | "clientconveniencemethod"
@@ -686,6 +703,7 @@ fn packet_required_probe_multi_match_limit(query: &str) -> Option<usize> {
         "sessionrequestcreation"
         | "requestobjectcreation"
         | "requestresumedispatch"
+        | "datarequestvalidation"
         | "requestvalidationpipeline"
         | "delegatecallbackhandling"
         | "urlsessioncallbackboundary" => Some(2),
@@ -960,6 +978,11 @@ fn packet_prefer_required_probe_match(
         if candidate_test_like != existing_test_like {
             return !candidate_test_like;
         }
+        if let Some(prefer_candidate) =
+            packet_prefer_shared_source_set_citation(query, candidate, existing)
+        {
+            return prefer_candidate;
+        }
     }
     if candidate_rank != existing_rank {
         return candidate_rank > existing_rank;
@@ -986,6 +1009,68 @@ fn packet_prefer_required_probe_match(
     }
     packet_exact_definition_file_citation(candidate)
         && !packet_exact_definition_file_citation(existing)
+}
+
+fn packet_prefer_shared_source_set_citation(
+    query: &str,
+    candidate: &AgentCitationDto,
+    existing: &AgentCitationDto,
+) -> Option<bool> {
+    if packet_query_mentions_platform_source_set(query) {
+        return None;
+    }
+    let candidate_score = packet_source_set_path_score(candidate);
+    let existing_score = packet_source_set_path_score(existing);
+    (candidate_score != existing_score).then_some(candidate_score > existing_score)
+}
+
+fn packet_query_mentions_platform_source_set(query: &str) -> bool {
+    let normalized = normalize_identifier(query);
+    [
+        "jvm", "nonjvm", "android", "ios", "native", "linux", "windows", "darwin", "apple", "wasm",
+        "nodejs", "browser",
+    ]
+    .iter()
+    .any(|term| normalized.contains(term))
+}
+
+fn packet_source_set_path_score(citation: &AgentCitationDto) -> u8 {
+    let path = citation
+        .file_path
+        .as_deref()
+        .map(packet_display_path)
+        .unwrap_or_default()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    if path.is_empty() {
+        return 1;
+    }
+    // Path-name heuristic; replace with indexed source-set metadata if that exists.
+    if path.contains("/commonmain/")
+        || path.contains("/common/")
+        || path.contains("/shared/")
+        || path.contains("/src/main/")
+    {
+        return 2;
+    }
+    if path.contains("/jvmmain/")
+        || path.contains("/nonjvmmain/")
+        || path.contains("/androidmain/")
+        || path.contains("/iosmain/")
+        || path.contains("/nativemain/")
+        || path.contains("/linuxmain/")
+        || path.contains("/windowsmain/")
+        || path.contains("/darwinmain/")
+        || path.contains("/applemain/")
+        || path.contains("/wasmmain/")
+        || path.contains("/wasmwasimain/")
+        || path.contains("/nodejsmain/")
+        || path.contains("/jsmain/")
+        || path.contains("/browsermain/")
+    {
+        return 0;
+    }
+    1
 }
 
 fn packet_required_probe_prefers_implementation(query: &str) -> bool {
@@ -1205,6 +1290,11 @@ mod tests {
                 "Network command input",
                 "Network command input reader",
             ),
+            (
+                "source read buffer",
+                "RealBufferedSource.read",
+                "BufferedSource.readIntoBuffer",
+            ),
         ] {
             let mut answer = answer_fixture(vec![
                 citation(&format!("{query} guide"), "docs/flow-guide.md", 100.0),
@@ -1235,5 +1325,74 @@ mod tests {
                 Some("src/flow/secondary.rs")
             );
         }
+
+        let query = "data request validation";
+        let mut answer = answer_fixture(vec![
+            citation(&format!("{query} guide"), "docs/flow-guide.md", 100.0),
+            citation(&format!("{query} test"), "tests/flow_test.rs", 99.0),
+            citation("DataRequest.validate", "src/flow/primary.rs", 4.0),
+            citation(
+                "DataRequest.validationPipeline",
+                "src/flow/secondary.rs",
+                3.0,
+            ),
+        ]);
+
+        let protected = promote_required_probe_citations(&mut answer, &[query.to_string()]);
+        let protected_paths = answer
+            .citations
+            .iter()
+            .filter(|citation| protected.contains(&packet_citation_key(citation)))
+            .filter_map(|citation| citation.file_path.as_deref())
+            .collect::<HashSet<_>>();
+
+        assert_eq!(
+            protected_paths,
+            HashSet::from(["src/flow/primary.rs", "src/flow/secondary.rs"]),
+            "query `{query}` should protect both primary-source validation matches before docs/tests: {protected_paths:?}"
+        );
+    }
+
+    #[test]
+    fn required_probe_prefers_shared_source_set_over_platform_variant() {
+        let mut answer = answer_fixture(vec![
+            citation(
+                "RealBufferedSource.read",
+                "src/jvmMain/kotlin/io/RealBufferedSource.kt",
+                100.0,
+            ),
+            citation(
+                "RealBufferedSource.read",
+                "src/commonMain/kotlin/io/RealBufferedSource.kt",
+                1.0,
+            ),
+            citation(
+                "BufferedSource",
+                "src/commonMain/kotlin/io/BufferedSource.kt",
+                0.5,
+            ),
+        ]);
+
+        let protected = promote_required_probe_citations(
+            &mut answer,
+            &[
+                "source read buffer".to_string(),
+                "buffered source".to_string(),
+            ],
+        );
+        let protected_paths = answer
+            .citations
+            .iter()
+            .filter(|citation| protected.contains(&packet_citation_key(citation)))
+            .filter_map(|citation| citation.file_path.as_deref())
+            .collect::<Vec<_>>();
+
+        assert!(
+            protected_paths
+                .iter()
+                .take(2)
+                .all(|path| path.contains("commonMain")),
+            "generic source probes should protect shared source-set evidence before platform variants: {protected_paths:?}"
+        );
     }
 }

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -129,6 +129,7 @@ fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSuffi
     let has_sufficiency_blocking_budget_omission = packet_has_sufficiency_blocking_budget_omission(
         budget,
         &missing_required_flow_requirements,
+        &missing_required_probe_queries,
     );
     let unresolved_sidecar_queries = unresolved_sidecar_queries(answer);
     let blocking_unresolved_sidecar_queries = packet_blocking_unresolved_sidecar_queries(
@@ -3585,6 +3586,52 @@ mod tests {
     }
 
     #[test]
+    fn compact_budget_blocks_sufficiency_when_source_proof_probe_is_missing() {
+        let question = "Explain how buffered Source and Sink wrappers use Buffer state during reads and writes.";
+        let answer = answer_fixture(question);
+        let budget = compact_truncated_budget(question, vec!["citations", "trail_edges"]);
+        let claims = vec![
+            claim("Buffer is the in-memory byte store used by buffered reads and writes."),
+            claim("A buffered source wrapper reads from an upstream Source into a Buffer."),
+            claim("A buffered sink wrapper writes buffered bytes to an upstream Sink."),
+        ];
+
+        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
+            project_root: Path::new("C:/workspace/project"),
+            question,
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            answer: &answer,
+            budget: &budget,
+            supported_claims: claims,
+            missing_required_probe_queries: vec!["source read buffer".to_string()],
+            targeted_follow_up_queries: Vec::new(),
+        });
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains("answer-critical evidence")),
+            "compact packets missing source-proof probes should not report sufficient: {sufficiency:?}"
+        );
+        assert!(
+            sufficiency
+                .follow_up_commands
+                .iter()
+                .any(|command| command.contains("--query 'source read buffer'")),
+            "missing source-proof probe should remain the first repair path: {sufficiency:?}"
+        );
+        assert!(
+            sufficiency
+                .follow_up_commands
+                .iter()
+                .any(|command| command.contains("--budget standard")),
+            "compact source-proof omissions should recommend the standard packet: {sufficiency:?}"
+        );
+    }
+
+    #[test]
     fn route_tracing_site_build_prompts_use_lifecycle_flow_roles() {
         let claims = vec![
             claim("Build.process constructs or processes a site."),
@@ -4153,6 +4200,7 @@ mod tests {
 fn packet_has_sufficiency_blocking_budget_omission(
     budget: &PacketBudgetDto,
     missing_required_flow_requirements: &[FlowRequirement],
+    missing_required_probe_queries: &[String],
 ) -> bool {
     if !budget.truncated {
         return false;
@@ -4166,7 +4214,10 @@ fn packet_has_sufficiency_blocking_budget_omission(
         return true;
     }
 
-    if missing_required_flow_requirements.is_empty() {
+    let missing_proof_probe = missing_required_probe_queries
+        .iter()
+        .any(|query| packet_missing_probe_requires_compact_proof(query));
+    if missing_required_flow_requirements.is_empty() && !missing_proof_probe {
         return false;
     }
 
@@ -4177,6 +4228,19 @@ fn packet_has_sufficiency_blocking_budget_omission(
             "citations" | "markdown_blocks" | "trail_edges" | "output_bytes" => true,
             _ => false,
         })
+}
+
+fn packet_missing_probe_requires_compact_proof(query: &str) -> bool {
+    matches!(
+        normalize_identifier(query).as_str(),
+        "sourcereadbuffer"
+            | "sinkwritebuffer"
+            | "requestresumedispatch"
+            | "requestvalidationpipeline"
+            | "datarequestvalidation"
+            | "delegatecallbackhandling"
+            | "urlsessioncallbackboundary"
+    )
 }
 
 pub(crate) fn packet_budget_exceeded_hard_output_cap(budget: &PacketBudgetDto) -> bool {

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -4231,16 +4231,16 @@ fn packet_has_sufficiency_blocking_budget_omission(
 }
 
 fn packet_missing_probe_requires_compact_proof(query: &str) -> bool {
+    let normalized = normalize_identifier(query);
     matches!(
-        normalize_identifier(query).as_str(),
+        normalized.as_str(),
         "sourcereadbuffer"
             | "sinkwritebuffer"
             | "requestresumedispatch"
             | "requestvalidationpipeline"
-            | "datarequestvalidation"
             | "delegatecallbackhandling"
             | "urlsessioncallbackboundary"
-    )
+    ) || normalized.ends_with("requestvalidation")
 }
 
 pub(crate) fn packet_budget_exceeded_hard_output_cap(budget: &PacketBudgetDto) -> bool {


### PR DESCRIPTION
Closes #79

## What changed
- Prefer shared/common source-set citations over platform-source variants for generic required probes, while preserving platform-specific queries.
- Allow generic buffered-source/sink and request-validation probes to protect multiple primary source citations before docs/tests.
- Treat compact truncated packets that omit source-proof probes as partial, with targeted query and standard-budget follow-ups.
- Added focused unit coverage for wrong-platform source-variant sufficiency and compact omission behavior.

## Why it changed
The #72 packet-runtime artifacts showed an Okio provenance/sufficiency mismatch from generic buffered I/O probes picking or omitting the wrong source variants, and an Alamofire compact-budget evidence gap that should remain partial instead of being blessed as sufficient. This keeps the fix generic: no Okio or Alamofire literals, no new model, no broad scorer rewrite.

## How I verified
- `cargo fmt`
- `cargo test -p codestory-runtime packet_capping --lib`
- `cargo test -p codestory-runtime packet_sufficiency --lib`
- `cargo check -p codestory-runtime` (passes with existing dead-code warnings in packet_sufficiency)
- `git diff --check`
- `cargo build --release -p codestory-cli`
- Focused packet runtime slice: `node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite language-expansion-holdout --task-ids kotlin-okio-buffer-flow,swift-alamofire-request-flow --packet-runtime-mode cold-cli --repeats 1 --codestory-cli target\release\codestory-cli.exe --benchmark-run-id issue-79-focused-packet-quality-provenance --out-dir target\agent-benchmark\issue-79-focused-packet-quality-provenance --timeout-ms 300000 --jobs 1`

Focused packet-runtime result:
- Okio `kotlin-okio-buffer-flow`: quality pass 1/1, sufficiency `sufficient` 1/1, sufficient-quality mismatch 0, expected file recall 0.6667, citation coverage 0.6667, SLA missed 0.
- Alamofire `swift-alamofire-request-flow`: quality pass 1/1, sufficiency `partial` 1/1, sufficient-quality mismatch 0, expected file recall 1.0, citation coverage 1.0, 3 follow-up commands, SLA missed 0.

Artifacts: `target/agent-benchmark/issue-79-focused-packet-quality-provenance/packet-runtime-summary.json`, `quality-debug.json`, `packet-quality-deltas.json`.

## Remaining risk or follow-up
- The source-set preference is a path-name heuristic until source-set metadata is available in indexed citations.
- I intentionally did not run the full publishable benchmark or touch #78 SLA work.