### PR TITLE
Cap compact packet probes

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -470,7 +470,7 @@ pub(crate) fn run_packet_anchor_expansion(
 pub(crate) fn packet_anchor_probe_limit(budget: PacketBudgetModeDto) -> usize {
     match budget {
         PacketBudgetModeDto::Tiny => 0,
-        PacketBudgetModeDto::Compact => 12,
+        PacketBudgetModeDto::Compact => 4,
         PacketBudgetModeDto::Standard => 40,
         PacketBudgetModeDto::Deep => 40,
     }
@@ -800,14 +800,14 @@ mod tests {
 
     #[test]
     fn compact_packet_anchor_probe_limit_stays_bounded() {
-        assert_eq!(packet_anchor_probe_limit(PacketBudgetModeDto::Compact), 12);
+        assert_eq!(packet_anchor_probe_limit(PacketBudgetModeDto::Compact), 4);
         assert_eq!(
             packet_anchor_probe_limit_for_budget(
                 PacketBudgetModeDto::Compact,
                 PacketLatencyBudget::new(None),
                 0,
             ),
-            12
+            4
         );
     }
 
@@ -816,11 +816,11 @@ mod tests {
         let latency = PacketLatencyBudget::new(Some(18_000));
         assert_eq!(
             packet_anchor_probe_limit_for_budget(PacketBudgetModeDto::Compact, latency, 9_000,),
-            6
+            2
         );
         assert_eq!(
             packet_anchor_probe_limit_for_budget(PacketBudgetModeDto::Compact, latency, 13_500,),
-            3
+            1
         );
     }
 


### PR DESCRIPTION
## What changed

- Reduced the compact packet anchor-probe cap from 12 to 4 in `crates/codestory-runtime/src/agent/packet_batch.rs`.
- Updated the compact-budget unit assertions for the new cap and proportional tapering.

Refs #78. This is partial #78 evidence only; the warm-mode acceptance gate still misses SLA.

## Why it changed

The residual #78 traces show compact packet runtime was spending the SLA budget on broad anchor-probe fan-out after sidecar readiness, not on process startup, indexing, or degraded sidecars. On current `main`, Apache and Redis both ran with `retrieval_mode=full`, quality intact, and sufficiency intact, but compact mode still executed 12 anchor probes plus 3 lexical subqueries.

This is a generic compact-budget product limit: compact packets should spend their small latency budget on the highest-priority symbol/flow anchors and then stop. The change is keyed only to `PacketBudgetModeDto::Compact`; it does not mention benchmark repos, task ids, expected files, expected symbols, scorer thresholds, or holdout shapes.

## Focused SLA evidence

Artifact paths:

- Before current-main cold slice: `C:\Users\alber\.codex\worktrees\83b1\codestory\target\agent-benchmark\issue-78-residual-main-cold`
- After cap-4 cold slice: `C:\Users\alber\.codex\worktrees\83b1\codestory\target\agent-benchmark\issue-78-residual-cap4-cold`
- After cap-4 warm slice: `C:\Users\alber\.codex\worktrees\83b1\codestory\target\agent-benchmark\issue-78-residual-cap4-warm`
- Previous failed branch evidence, read-only: `C:\Users\alber\.codex\worktrees\a026\codestory\target\agent-benchmark\issue-78-packet-sla-fanout-apache-redis-final`

Cold slice after cap 4:

| Row | Before retrieval | Before wall | Before SLA | After retrieval | After wall | After SLA | Quality | Sufficiency |
| --- | ---: | ---: | --- | ---: | ---: | --- | --- | --- |
| Apache Commons Lang cold | 23898 ms | 28101.502 ms | missed 1/1 | 15328 ms | 19472.378 ms | passed 0/1 missed | 1/1 | sufficient 1/1 |
| Redis cold | 23732 ms | 28727.333 ms | missed 1/1 | 14938 ms | 19960.443 ms | passed 0/1 missed | 1/1 | sufficient 1/1 |

Warm slice after cap 4:

| Row | Retrieval | Wall | SLA | Quality | Sufficiency | Cache hits |
| --- | ---: | ---: | --- | --- | --- | ---: |
| Apache Commons Lang warm | 26172 ms | 35821.504 ms | missed 1/1 | 1/1 | sufficient 1/1 | 0 |
| Redis warm | 19808 ms | 24930.333 ms | missed 1/1 | 1/1 | sufficient 1/1 | 0 |

Trace shape after the cap:

| Row | Anchor probes | Lexical subqueries | Search total | Step count |
| --- | ---: | ---: | ---: | ---: |
| Apache Commons Lang cold | 4 | 3 | 10364 ms | 20 |
| Redis cold | 4 | 3 | 9358 ms | 20 |

## Verification

Commands run, serialized with `RUSTC_WRAPPER` for Cargo:

```powershell
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime agent::packet_batch::tests

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo build --release -p codestory-cli

node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-78-residual-cap4-cold --out-dir target/agent-benchmark/issue-78-residual-cap4-cold --allow-failures

node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode warm-stdio --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-78-residual-cap4-warm --out-dir target/agent-benchmark/issue-78-residual-cap4-warm --allow-failures

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo fmt --check

git diff --check
```

Results:

- `cargo test -p codestory-runtime agent::packet_batch::tests`: passed, 7/7.
- `cargo build --release -p codestory-cli`: passed. Existing runtime dead-code warnings remained unchanged.
- Focused Apache+Redis cold slice: passed SLA for both rows with quality and sufficiency intact.
- Focused Apache+Redis warm slice: failed SLA for both rows, with quality and sufficiency still intact.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

## Remaining risk

This PR is not merge-ready for #78 acceptance because warm mode still misses the SLA. Per coordinator guardrail, no further cap values, scorer changes, harness changes, or threshold changes were attempted after the warm failure.