### PR TITLE
Profile warm packet search timings

### DIFF
--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1638,6 +1638,16 @@ pub struct RetrievalShadowDto {
 pub struct PacketSidecarQueryDiagnosticDto {
     pub query: String,
     pub retrieval_mode: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sidecar_query_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate_resolution_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_elapsed_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub sidecar_stage_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sidecar_stage_total_ms: Option<u32>,
     pub candidate_count: u32,
     pub resolved_hit_count: u32,
     pub unresolved_candidate_count: u32,
@@ -2013,6 +2023,35 @@ mod packet_tests {
         assert_eq!(parsed.retrieval_mode, "full");
         assert_eq!(parsed.would_rank, vec!["src/lib.rs".to_string()]);
         assert_eq!(parsed.unresolved_candidate_count, 1);
+    }
+
+    #[test]
+    fn packet_sidecar_query_diagnostic_serializes_timing_fields() {
+        let diagnostic = PacketSidecarQueryDiagnosticDto {
+            query: "StringUtils".to_string(),
+            retrieval_mode: "full".to_string(),
+            sidecar_query_ms: Some(17),
+            candidate_resolution_ms: Some(3),
+            total_elapsed_ms: Some(20),
+            sidecar_stage_count: 2,
+            sidecar_stage_total_ms: Some(16),
+            candidate_count: 5,
+            resolved_hit_count: 4,
+            unresolved_candidate_count: 1,
+            diagnostic: Some("sidecar candidates did not all resolve".to_string()),
+        };
+
+        let value = serde_json::to_value(&diagnostic).expect("serialize");
+        assert_eq!(value["sidecar_query_ms"], 17);
+        assert_eq!(value["candidate_resolution_ms"], 3);
+        assert_eq!(value["total_elapsed_ms"], 20);
+        assert_eq!(value["sidecar_stage_count"], 2);
+        assert_eq!(value["sidecar_stage_total_ms"], 16);
+
+        let parsed: PacketSidecarQueryDiagnosticDto =
+            serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed.total_elapsed_ms, Some(20));
+        assert_eq!(parsed.sidecar_stage_total_ms, Some(16));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -3127,7 +3127,7 @@ fn execute_retrieval(
                     field("retrieval_path", "sidecar"),
                 ],
             );
-            trace.finish_ok(
+            trace.finish_ok_with_duration_ms(
                 search_step,
                 vec![
                     field("hits", hits.len().to_string()),
@@ -3139,7 +3139,10 @@ fn execute_retrieval(
                     field("accepted_hits", hits.len().to_string()),
                     field("max_results", max_results.to_string()),
                     field("repo_text", "off_initial"),
+                    field("mode", "packet_initial_sidecar_query"),
+                    field("sidecar_query_ms", shadow.retrieval_total_ms.to_string()),
                 ],
+                shadow.retrieval_total_ms,
             );
             let semantic_query_step = trace.start_step(
                 AgentRetrievalStepKindDto::SemanticQueryEmbedding,
@@ -5414,6 +5417,11 @@ mod tests {
             .push(PacketSidecarQueryDiagnosticDto {
                 query: "sidecar batch".to_string(),
                 retrieval_mode: "full".to_string(),
+                sidecar_query_ms: None,
+                candidate_resolution_ms: None,
+                total_elapsed_ms: None,
+                sidecar_stage_count: 0,
+                sidecar_stage_total_ms: None,
                 candidate_count: 1,
                 resolved_hit_count: 0,
                 unresolved_candidate_count: 1,
@@ -5427,6 +5435,11 @@ mod tests {
             .push(PacketSidecarQueryDiagnosticDto {
                 query: "sidecar batch".to_string(),
                 retrieval_mode: "full".to_string(),
+                sidecar_query_ms: None,
+                candidate_resolution_ms: None,
+                total_elapsed_ms: None,
+                sidecar_stage_count: 0,
+                sidecar_stage_total_ms: None,
                 candidate_count: 1,
                 resolved_hit_count: 0,
                 unresolved_candidate_count: 1,

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -8,7 +8,8 @@ use super::packet_scoring::{
     packet_subquery_hit_limit,
 };
 use super::packet_trace::{
-    merge_packet_lexical_subquery_batch, merge_packet_semantic_subquery_batch,
+    append_packet_query_timing_fields, merge_packet_lexical_subquery_batch,
+    merge_packet_semantic_subquery_batch, packet_query_diagnostic, packet_query_duration_ms,
 };
 use super::planning::packet_subquery_hybrid_weights;
 use super::trace::field;
@@ -16,8 +17,8 @@ use crate::{AppController, clamp_u128_to_u32, query_has_symbol_or_literal_signal
 use codestory_contracts::api::{
     AgentAnswerDto, AgentHybridWeightsDto, AgentRetrievalStepDto, AgentRetrievalStepKindDto,
     AgentRetrievalStepStatusDto, ApiError, NodeKind, PacketBudgetLimitsDto, PacketBudgetModeDto,
-    PacketPlanDto, PacketPlanQueryDto, SearchHit, SearchHitOrigin, SearchMatchQualityDto,
-    SemanticFallbackRecordDto,
+    PacketPlanDto, PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, SearchHit, SearchHitOrigin,
+    SearchMatchQualityDto, SemanticFallbackRecordDto,
 };
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -151,13 +152,21 @@ pub(crate) fn run_packet_planned_subqueries(
                 answer
                     .retrieval_trace
                     .packet_sidecar_diagnostics
-                    .extend(outcome.sidecar_diagnostics);
+                    .extend(outcome.sidecar_diagnostics.clone());
                 let results = outcome.results;
+                let diagnostics = outcome.sidecar_diagnostics;
+                annotate_packet_batch_timing(
+                    answer,
+                    "packet_lexical_subquery_batch",
+                    duration_ms,
+                    &diagnostics,
+                );
                 merge_packet_lexical_subquery_batch(
                     answer,
                     &lexical_pending,
                     &results,
                     duration_ms,
+                    &diagnostics,
                     include_evidence,
                     rank_terms,
                     stage_carry_limit,
@@ -201,13 +210,21 @@ pub(crate) fn run_packet_planned_subqueries(
                             answer
                                 .retrieval_trace
                                 .packet_sidecar_diagnostics
-                                .extend(outcome.sidecar_diagnostics);
+                                .extend(outcome.sidecar_diagnostics.clone());
+                            let diagnostics = outcome.sidecar_diagnostics;
                             record_semantic_fallbacks(answer, &outcome.fallbacks);
+                            annotate_packet_batch_timing(
+                                answer,
+                                "packet_lexical_subquery_hybrid_retry_batch",
+                                retry_duration_ms,
+                                &diagnostics,
+                            );
                             merge_packet_semantic_subquery_batch(
                                 answer,
                                 &hybrid_retry_pending,
                                 &outcome.results,
                                 retry_duration_ms,
+                                &diagnostics,
                                 include_evidence,
                                 rank_terms,
                                 budget,
@@ -263,13 +280,21 @@ pub(crate) fn run_packet_planned_subqueries(
                     answer
                         .retrieval_trace
                         .packet_sidecar_diagnostics
-                        .extend(outcome.sidecar_diagnostics);
+                        .extend(outcome.sidecar_diagnostics.clone());
+                    let diagnostics = outcome.sidecar_diagnostics;
                     record_semantic_fallbacks(answer, &outcome.fallbacks);
+                    annotate_packet_batch_timing(
+                        answer,
+                        "packet_semantic_subquery_batch",
+                        duration_ms,
+                        &diagnostics,
+                    );
                     merge_packet_semantic_subquery_batch(
                         answer,
                         &semantic_pending,
                         &outcome.results,
                         duration_ms,
+                        &diagnostics,
                         include_evidence,
                         rank_terms,
                         budget,
@@ -316,6 +341,44 @@ pub(crate) fn record_semantic_fallbacks(
             "semantic_fallback_summary count={} degraded_runtime=true",
             fallbacks.len()
         ));
+    }
+}
+
+fn annotate_packet_batch_timing(
+    answer: &mut AgentAnswerDto,
+    label: &str,
+    duration_ms: u32,
+    diagnostics: &[PacketSidecarQueryDiagnosticDto],
+) {
+    let attributed_ms = diagnostics
+        .iter()
+        .filter_map(|diagnostic| diagnostic.total_elapsed_ms.or(diagnostic.sidecar_query_ms))
+        .fold(0_u32, u32::saturating_add);
+    let overhead_ms = duration_ms.saturating_sub(attributed_ms);
+    answer.retrieval_trace.annotations.push(format!(
+        "{label} total_ms={} attributed_query_ms={} overhead_ms={} queries={}",
+        duration_ms,
+        attributed_ms,
+        overhead_ms,
+        diagnostics.len()
+    ));
+}
+
+fn packet_anchor_timing_annotation(diagnostic: Option<&PacketSidecarQueryDiagnosticDto>) -> String {
+    let Some(diagnostic) = diagnostic else {
+        return String::new();
+    };
+    match (
+        diagnostic.sidecar_query_ms,
+        diagnostic.candidate_resolution_ms,
+        diagnostic.total_elapsed_ms,
+    ) {
+        (Some(query_ms), Some(resolution_ms), Some(total_ms)) => format!(
+            " sidecar_query_ms={} candidate_resolution_ms={} total_elapsed_ms={}",
+            query_ms, resolution_ms, total_ms
+        ),
+        (_, _, Some(total_ms)) => format!(" total_elapsed_ms={total_ms}"),
+        _ => String::new(),
     }
 }
 
@@ -401,10 +464,20 @@ pub(crate) fn run_packet_anchor_expansion(
             answer
                 .retrieval_trace
                 .packet_sidecar_diagnostics
-                .extend(outcome.sidecar_diagnostics);
+                .extend(outcome.sidecar_diagnostics.clone());
+            let diagnostics = outcome.sidecar_diagnostics;
+            annotate_packet_batch_timing(
+                answer,
+                "packet_anchor_probe_batch",
+                duration_ms,
+                &diagnostics,
+            );
             let results = outcome.results;
             let per_step_duration = duration_ms / results.len().max(1) as u32;
-            for (query, hits) in results {
+            for (diagnostic_index, (query, hits)) in results.into_iter().enumerate() {
+                let diagnostic = packet_query_diagnostic(&diagnostics, diagnostic_index, &query);
+                let step_duration =
+                    packet_query_duration_ms(diagnostic).unwrap_or(per_step_duration);
                 let mut added = 0usize;
                 let mut citations = hits
                     .iter()
@@ -422,24 +495,28 @@ pub(crate) fn run_packet_anchor_expansion(
                         added = added.saturating_add(1);
                     }
                 }
+                let mut output = vec![
+                    field("hits", hits.len().to_string()),
+                    field("accepted_hits", added.to_string()),
+                    field("stage_carry_limit", stage_carry_limit.to_string()),
+                    field("mode", "symbolic_packet_anchor_probe"),
+                ];
+                append_packet_query_timing_fields(&mut output, diagnostic);
                 answer.retrieval_trace.steps.push(AgentRetrievalStepDto {
                     kind: AgentRetrievalStepKindDto::Search,
                     status: AgentRetrievalStepStatusDto::Ok,
-                    duration_ms: per_step_duration,
+                    duration_ms: step_duration,
                     input: vec![field("query", query.clone())],
-                    output: vec![
-                        field("hits", hits.len().to_string()),
-                        field("accepted_hits", added.to_string()),
-                        field("stage_carry_limit", stage_carry_limit.to_string()),
-                        field("mode", "symbolic_packet_anchor_probe"),
-                    ],
+                    output,
                     message: Some("Packet symbol probe expanded broad task wording.".to_string()),
                 });
+                let timing_note = packet_anchor_timing_annotation(diagnostic);
                 answer.retrieval_trace.annotations.push(format!(
-                    "packet_anchor_probe query=`{}` hits={} added={}",
+                    "packet_anchor_probe query=`{}` hits={} added={}{}",
                     query.replace('`', "'"),
                     hits.len(),
-                    added
+                    added,
+                    timing_note
                 ));
             }
         }

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -2273,6 +2273,11 @@ mod tests {
         PacketSidecarQueryDiagnosticDto {
             query: query.to_string(),
             retrieval_mode: "full".to_string(),
+            sidecar_query_ms: None,
+            candidate_resolution_ms: None,
+            total_elapsed_ms: None,
+            sidecar_stage_count: 0,
+            sidecar_stage_total_ms: None,
             candidate_count: 1,
             resolved_hit_count: 0,
             unresolved_candidate_count: 1,

--- a/crates/codestory-runtime/src/agent/packet_trace.rs
+++ b/crates/codestory-runtime/src/agent/packet_trace.rs
@@ -9,8 +9,8 @@ use super::trace::field;
 use crate::HybridSearchScoredHit;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentResponseBlockDto, AgentResponseSectionDto, AgentRetrievalStepDto,
-    AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto, PacketBudgetModeDto,
-    PacketPlanQueryDto, SearchHit,
+    AgentRetrievalStepKindDto, AgentRetrievalStepStatusDto, AgentRetrievalSummaryFieldDto,
+    PacketBudgetModeDto, PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto, SearchHit,
 };
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -36,6 +36,7 @@ pub(crate) fn merge_packet_lexical_subquery_batch(
     pending: &[(usize, &PacketPlanQueryDto)],
     results: &[(String, Vec<SearchHit>)],
     duration_ms: u32,
+    diagnostics: &[PacketSidecarQueryDiagnosticDto],
     include_evidence: bool,
     rank_terms: &[String],
     stage_carry_limit: usize,
@@ -45,10 +46,14 @@ pub(crate) fn merge_packet_lexical_subquery_batch(
         .iter()
         .map(packet_citation_key)
         .collect::<HashSet<_>>();
-    let per_step_duration = duration_ms / pending.len().max(1) as u32;
 
-    for ((plan_index, query), (result_query, hits)) in pending.iter().zip(results.iter()) {
+    for (diagnostic_index, ((plan_index, query), (result_query, hits))) in
+        pending.iter().zip(results.iter()).enumerate()
+    {
         debug_assert_eq!(query.query, *result_query);
+        let diagnostic = packet_query_diagnostic(diagnostics, diagnostic_index, result_query);
+        let step_duration = packet_query_duration_ms(diagnostic)
+            .unwrap_or(duration_ms / pending.len().max(1) as u32);
         let mut added = 0usize;
         let mut citations = hits
             .iter()
@@ -65,25 +70,29 @@ pub(crate) fn merge_packet_lexical_subquery_batch(
                 added = added.saturating_add(1);
             }
         }
+        let mut output = vec![
+            field("hits", hits.len().to_string()),
+            field("citations_added", added.to_string()),
+            field("mode", "packet_lexical_batch".to_string()),
+        ];
+        append_packet_query_timing_fields(&mut output, diagnostic);
         answer.retrieval_trace.steps.push(AgentRetrievalStepDto {
             kind: AgentRetrievalStepKindDto::Search,
             status: AgentRetrievalStepStatusDto::Ok,
-            duration_ms: per_step_duration,
+            duration_ms: step_duration,
             input: vec![field("query", query.query.clone())],
-            output: vec![
-                field("hits", hits.len().to_string()),
-                field("citations_added", added.to_string()),
-                field("mode", "packet_lexical_batch".to_string()),
-            ],
+            output,
             message: Some(format!("packet subquery `{}`", query.purpose)),
         });
+        let timing_note = packet_query_timing_annotation(diagnostic);
         answer.retrieval_trace.annotations.push(format!(
-            "packet_lexical_subquery index={} query=`{}` purpose=`{}` hits={} citations_added={}",
+            "packet_lexical_subquery index={} query=`{}` purpose=`{}` hits={} citations_added={}{}",
             plan_index,
             query.query.replace('`', "'"),
             query.purpose.replace('`', "'"),
             hits.len(),
-            added
+            added,
+            timing_note
         ));
         answer.sections.push(AgentResponseSectionDto {
             id: format!("packet-subquery-{}", sanitize_section_id(&query.query)),
@@ -105,6 +114,7 @@ pub(crate) fn merge_packet_semantic_subquery_batch(
     pending: &[(usize, &PacketPlanQueryDto)],
     results: &[(String, Vec<HybridSearchScoredHit>)],
     duration_ms: u32,
+    diagnostics: &[PacketSidecarQueryDiagnosticDto],
     include_evidence: bool,
     rank_terms: &[String],
     budget: PacketBudgetModeDto,
@@ -115,10 +125,14 @@ pub(crate) fn merge_packet_semantic_subquery_batch(
         .iter()
         .map(packet_citation_key)
         .collect::<HashSet<_>>();
-    let per_step_duration = duration_ms / pending.len().max(1) as u32;
 
-    for ((plan_index, query), (result_query, scored_hits)) in pending.iter().zip(results.iter()) {
+    for (diagnostic_index, ((plan_index, query), (result_query, scored_hits))) in
+        pending.iter().zip(results.iter()).enumerate()
+    {
         debug_assert_eq!(query.query, *result_query);
+        let diagnostic = packet_query_diagnostic(diagnostics, diagnostic_index, result_query);
+        let step_duration = packet_query_duration_ms(diagnostic)
+            .unwrap_or(duration_ms / pending.len().max(1) as u32);
         let mut added = 0usize;
         let mut citations = scored_hits
             .iter()
@@ -135,24 +149,28 @@ pub(crate) fn merge_packet_semantic_subquery_batch(
                 added = added.saturating_add(1);
             }
         }
+        let mut output = vec![
+            field("hits", scored_hits.len().to_string()),
+            field("citations_added", added.to_string()),
+            field("mode", "packet_semantic_batch".to_string()),
+        ];
+        append_packet_query_timing_fields(&mut output, diagnostic);
         answer.retrieval_trace.steps.push(AgentRetrievalStepDto {
             kind: AgentRetrievalStepKindDto::Search,
             status: AgentRetrievalStepStatusDto::Ok,
-            duration_ms: per_step_duration,
+            duration_ms: step_duration,
             input: vec![field("query", query.query.clone())],
-            output: vec![
-                field("hits", scored_hits.len().to_string()),
-                field("citations_added", added.to_string()),
-                field("mode", "packet_semantic_batch".to_string()),
-            ],
+            output,
             message: Some(format!("packet semantic subquery `{}`", query.purpose)),
         });
+        let timing_note = packet_query_timing_annotation(diagnostic);
         answer.retrieval_trace.annotations.push(format!(
-            "packet_semantic_subquery index={} query=`{}` hits={} citations_added={}",
+            "packet_semantic_subquery index={} query=`{}` hits={} citations_added={}{}",
             plan_index,
             query.query.replace('`', "'"),
             scored_hits.len(),
-            added
+            added,
+            timing_note
         ));
         let hybrid_weights = packet_subquery_hybrid_weights(budget, query);
         let semantic_note = hybrid_weights
@@ -170,6 +188,70 @@ pub(crate) fn merge_packet_semantic_subquery_batch(
                 ),
             }],
         });
+    }
+}
+
+pub(crate) fn packet_query_diagnostic<'a>(
+    diagnostics: &'a [PacketSidecarQueryDiagnosticDto],
+    index: usize,
+    query: &str,
+) -> Option<&'a PacketSidecarQueryDiagnosticDto> {
+    diagnostics
+        .get(index)
+        .filter(|diagnostic| diagnostic.query == query)
+        .or_else(|| {
+            diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.query == query)
+        })
+}
+
+pub(crate) fn packet_query_duration_ms(
+    diagnostic: Option<&PacketSidecarQueryDiagnosticDto>,
+) -> Option<u32> {
+    diagnostic.and_then(|diagnostic| diagnostic.total_elapsed_ms.or(diagnostic.sidecar_query_ms))
+}
+
+pub(crate) fn append_packet_query_timing_fields(
+    output: &mut Vec<AgentRetrievalSummaryFieldDto>,
+    diagnostic: Option<&PacketSidecarQueryDiagnosticDto>,
+) {
+    let Some(diagnostic) = diagnostic else {
+        return;
+    };
+    if let Some(value) = diagnostic.sidecar_query_ms {
+        output.push(field("sidecar_query_ms", value.to_string()));
+    }
+    if let Some(value) = diagnostic.candidate_resolution_ms {
+        output.push(field("candidate_resolution_ms", value.to_string()));
+    }
+    if let Some(value) = diagnostic.total_elapsed_ms {
+        output.push(field("sidecar_total_ms", value.to_string()));
+    }
+    output.push(field(
+        "sidecar_stage_count",
+        diagnostic.sidecar_stage_count.to_string(),
+    ));
+    if let Some(value) = diagnostic.sidecar_stage_total_ms {
+        output.push(field("sidecar_stage_total_ms", value.to_string()));
+    }
+}
+
+fn packet_query_timing_annotation(diagnostic: Option<&PacketSidecarQueryDiagnosticDto>) -> String {
+    let Some(diagnostic) = diagnostic else {
+        return String::new();
+    };
+    match (
+        diagnostic.sidecar_query_ms,
+        diagnostic.candidate_resolution_ms,
+        diagnostic.total_elapsed_ms,
+    ) {
+        (Some(query_ms), Some(resolution_ms), Some(total_ms)) => format!(
+            " sidecar_query_ms={} candidate_resolution_ms={} total_elapsed_ms={}",
+            query_ms, resolution_ms, total_ms
+        ),
+        (_, _, Some(total_ms)) => format!(" total_elapsed_ms={total_ms}"),
+        _ => String::new(),
     }
 }
 
@@ -208,6 +290,19 @@ mod golden_tests {
             score_breakdown: None,
         };
         let results = vec![("exec_events".to_string(), vec![hit])];
+        let diagnostics = vec![PacketSidecarQueryDiagnosticDto {
+            query: "exec_events".to_string(),
+            retrieval_mode: "full".to_string(),
+            sidecar_query_ms: Some(9),
+            candidate_resolution_ms: Some(3),
+            total_elapsed_ms: Some(12),
+            sidecar_stage_count: 0,
+            sidecar_stage_total_ms: None,
+            candidate_count: 1,
+            resolved_hit_count: 1,
+            unresolved_candidate_count: 0,
+            diagnostic: None,
+        }];
         let rank_terms = vec!["exec".to_string(), "events".to_string()];
         let mut answer = AgentAnswerDto {
             answer_id: "golden".to_string(),
@@ -240,6 +335,7 @@ mod golden_tests {
             &pending,
             &results,
             12,
+            &diagnostics,
             false,
             &rank_terms,
             6,
@@ -254,6 +350,15 @@ mod golden_tests {
                 .find(|field| field.key == "mode")
                 .map(|field| field.value.as_str()),
             Some("packet_lexical_batch")
+        );
+        assert_eq!(answer.retrieval_trace.steps[0].duration_ms, 12);
+        assert_eq!(
+            answer.retrieval_trace.steps[0]
+                .output
+                .iter()
+                .find(|field| field.key == "sidecar_query_ms")
+                .map(|field| field.value.as_str()),
+            Some("9")
         );
         let citation = to_citation_from_hit(&results[0].1[0], None, None, false);
         assert_eq!(answer.citations[0].display_name, citation.display_name);

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -12,13 +12,14 @@ use codestory_contracts::api::{
 };
 use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
 use codestory_retrieval::{
-    CandidateHit, CandidateSource, QueryRequest, QueryResult, RetrievalStageKind,
+    CandidateHit, CandidateSource, QueryRequest, QueryResult, QueryTrace, RetrievalStageKind,
     execute_retrieval_query_with_cache, is_phantom_sidecar_hit, project_id_for_root,
     strict_sidecar_status,
 };
 use codestory_store::Store;
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 const DEFAULT_SIDECAR_BUDGET_MS: u64 = 1_000;
 const DEFAULT_PACKET_BATCH_BUDGET_MS: u64 = 18_000;
@@ -508,10 +509,23 @@ struct SidecarCandidateResolutionOutcome {
 fn packet_sidecar_query_diagnostic(
     query_result: &QueryResult,
     resolution: &SidecarCandidateResolutionOutcome,
+    sidecar_query_ms: u32,
+    candidate_resolution_ms: u32,
 ) -> PacketSidecarQueryDiagnosticDto {
+    let total_elapsed_ms = sidecar_query_ms.saturating_add(candidate_resolution_ms);
+    let stage_timings = retrieval_stage_timings(&query_result.trace);
+    let sidecar_stage_total_ms = stage_timings
+        .iter()
+        .map(|stage| stage.elapsed_ms)
+        .fold(0_u32, u32::saturating_add);
     PacketSidecarQueryDiagnosticDto {
         query: query_result.query.clone(),
         retrieval_mode: query_result.trace.retrieval_mode.clone(),
+        sidecar_query_ms: Some(sidecar_query_ms),
+        candidate_resolution_ms: Some(candidate_resolution_ms),
+        total_elapsed_ms: Some(total_elapsed_ms),
+        sidecar_stage_count: u32::try_from(stage_timings.len()).unwrap_or(u32::MAX),
+        sidecar_stage_total_ms: Some(sidecar_stage_total_ms),
         candidate_count: u32::try_from(resolution.attempted_candidate_count).unwrap_or(u32::MAX),
         resolved_hit_count: u32::try_from(resolution.resolved_hits.len()).unwrap_or(u32::MAX),
         unresolved_candidate_count: u32::try_from(resolution.unresolved_candidate_count)
@@ -547,6 +561,7 @@ fn search_sidecar_packet_batch_inner_with_query(
     let mut results = Vec::with_capacity(queries.len());
     let mut diagnostics = Vec::with_capacity(queries.len());
     for (query, max_results) in queries {
+        let query_started_at = Instant::now();
         let query_result =
             run_query(controller, query, Some(per_query_budget as u32)).map_err(|error| {
                 sidecar_retrieval_unavailable_error(
@@ -554,7 +569,9 @@ fn search_sidecar_packet_batch_inner_with_query(
                     format!("sidecar retrieval batch query failed: {error}"),
                 )
             })?;
+        let sidecar_query_ms = clamp_elapsed_ms(query_started_at);
         let max_results = (*max_results).clamp(1, 50);
+        let resolution_started_at = Instant::now();
         let resolution =
             resolve_sidecar_candidates_with_stats(controller, &query_result.hits, max_results)
                 .map_err(|error| {
@@ -566,7 +583,13 @@ fn search_sidecar_packet_batch_inner_with_query(
                         ),
                     )
                 })?;
-        diagnostics.push(packet_sidecar_query_diagnostic(&query_result, &resolution));
+        let candidate_resolution_ms = clamp_elapsed_ms(resolution_started_at);
+        diagnostics.push(packet_sidecar_query_diagnostic(
+            &query_result,
+            &resolution,
+            sidecar_query_ms,
+            candidate_resolution_ms,
+        ));
         let resolved_hits = resolution.resolved_hits;
         if let Some(reason) = sidecar_packet_batch_rejection_reason(&query_result, &resolved_hits) {
             let diagnostic =
@@ -584,6 +607,10 @@ fn search_sidecar_packet_batch_inner_with_query(
         results,
         diagnostics,
     })
+}
+
+fn clamp_elapsed_ms(started_at: Instant) -> u32 {
+    started_at.elapsed().as_millis().min(u32::MAX as u128) as u32
 }
 
 fn sidecar_packet_batch_rejection_reason(
@@ -950,22 +977,7 @@ fn shadow_from_query_result_with_counts_and_resolution_labels(
     admission_labels: &[SidecarCandidateAdmissionLabel],
 ) -> RetrievalShadowDto {
     let trace = &result.trace;
-    let stage_timings = trace
-        .stages
-        .iter()
-        .map(|stage| RetrievalStageTimingDto {
-            stage: stage_kind_label(stage.stage),
-            deadline_ms: u32::try_from(stage.budget_ms).ok(),
-            elapsed_ms: u32::try_from(stage.elapsed_ms).unwrap_or(u32::MAX),
-            candidates_added: u32::try_from(stage.candidates_added).unwrap_or(u32::MAX),
-            marginal_gain: stage.marginal_gain,
-            cancel_reason: stage.cancel_reason.clone(),
-            cache_hit: stage.cache_hit,
-            sidecar_latency_ms: sidecar_stage_latency_ms(stage.stage, stage.elapsed_ms),
-            degraded: stage.degraded,
-            stub_reason: stage.stub_reason.clone(),
-        })
-        .collect();
+    let stage_timings = retrieval_stage_timings(trace);
 
     let candidates = result
         .hits
@@ -1032,6 +1044,25 @@ fn shadow_from_query_result_with_counts_and_resolution_labels(
         unresolved_candidate_count: u32::try_from(unresolved_candidate_count).unwrap_or(u32::MAX),
         candidate_resolution_counts,
     }
+}
+
+fn retrieval_stage_timings(trace: &QueryTrace) -> Vec<RetrievalStageTimingDto> {
+    trace
+        .stages
+        .iter()
+        .map(|stage| RetrievalStageTimingDto {
+            stage: stage_kind_label(stage.stage),
+            deadline_ms: u32::try_from(stage.budget_ms).ok(),
+            elapsed_ms: u32::try_from(stage.elapsed_ms).unwrap_or(u32::MAX),
+            candidates_added: u32::try_from(stage.candidates_added).unwrap_or(u32::MAX),
+            marginal_gain: stage.marginal_gain,
+            cancel_reason: stage.cancel_reason.clone(),
+            cache_hit: stage.cache_hit,
+            sidecar_latency_ms: sidecar_stage_latency_ms(stage.stage, stage.elapsed_ms),
+            degraded: stage.degraded,
+            stub_reason: stage.stub_reason.clone(),
+        })
+        .collect()
 }
 
 fn stage_kind_label(kind: RetrievalStageKind) -> String {
@@ -1509,11 +1540,12 @@ mod tests {
             unresolved_candidate_count: 1,
         };
 
-        let diagnostic = packet_sidecar_query_diagnostic(&result, &resolution);
+        let diagnostic = packet_sidecar_query_diagnostic(&result, &resolution, 2, 1);
 
         assert_eq!(diagnostic.candidate_count, 1);
         assert_eq!(diagnostic.resolved_hit_count, 0);
         assert_eq!(diagnostic.unresolved_candidate_count, 1);
+        assert_eq!(diagnostic.total_elapsed_ms, Some(3));
         assert!(diagnostic.diagnostic.is_some());
     }
 
@@ -1918,7 +1950,8 @@ mod tests {
             attempted_candidate_count: 0,
             unresolved_candidate_count: 0,
         };
-        let empty_diagnostic = packet_sidecar_query_diagnostic(&empty_full, &empty_resolution);
+        let empty_diagnostic =
+            packet_sidecar_query_diagnostic(&empty_full, &empty_resolution, 1, 0);
         assert_eq!(empty_diagnostic.candidate_count, 0);
         assert_eq!(empty_diagnostic.resolved_hit_count, 0);
         assert_eq!(empty_diagnostic.unresolved_candidate_count, 0);
@@ -1949,7 +1982,7 @@ mod tests {
             unresolved_candidate_count: 1,
         };
         let unresolved_diagnostic =
-            packet_sidecar_query_diagnostic(&unresolved, &unresolved_resolution);
+            packet_sidecar_query_diagnostic(&unresolved, &unresolved_resolution, 1, 0);
         assert_eq!(unresolved_diagnostic.candidate_count, 1);
         assert_eq!(unresolved_diagnostic.resolved_hit_count, 0);
         assert_eq!(unresolved_diagnostic.unresolved_candidate_count, 1);
@@ -2051,7 +2084,7 @@ mod tests {
         assert_eq!(resolution.resolved_hits.len(), 1);
         assert_eq!(resolution.unresolved_candidate_count, 0);
 
-        let diagnostic = packet_sidecar_query_diagnostic(&query_result, &resolution);
+        let diagnostic = packet_sidecar_query_diagnostic(&query_result, &resolution, 1, 0);
         assert_eq!(diagnostic.candidate_count, 1);
         assert_eq!(diagnostic.resolved_hit_count, 1);
         assert_eq!(diagnostic.unresolved_candidate_count, 0);

--- a/crates/codestory-runtime/src/agent/trace.rs
+++ b/crates/codestory-runtime/src/agent/trace.rs
@@ -64,6 +64,21 @@ impl TraceRecorder {
         self.finish_with_status(token, AgentRetrievalStepStatusDto::Ok, output, None);
     }
 
+    pub(crate) fn finish_ok_with_duration_ms(
+        &mut self,
+        token: StepToken,
+        output: Vec<AgentRetrievalSummaryFieldDto>,
+        duration_ms: u32,
+    ) {
+        self.finish_with_status_and_duration(
+            token,
+            AgentRetrievalStepStatusDto::Ok,
+            output,
+            None,
+            Some(duration_ms),
+        );
+    }
+
     pub(crate) fn finish_skipped(
         &mut self,
         token: StepToken,
@@ -140,10 +155,23 @@ impl TraceRecorder {
         output: Vec<AgentRetrievalSummaryFieldDto>,
         message: Option<String>,
     ) {
+        self.finish_with_status_and_duration(token, status, output, message, None);
+    }
+
+    fn finish_with_status_and_duration(
+        &mut self,
+        token: StepToken,
+        status: AgentRetrievalStepStatusDto,
+        output: Vec<AgentRetrievalSummaryFieldDto>,
+        message: Option<String>,
+        explicit_duration_ms: Option<u32>,
+    ) {
         let duration_ms = if status == AgentRetrievalStepStatusDto::Skipped {
             0
         } else {
-            token.started_at.elapsed().as_millis().min(u32::MAX as u128) as u32
+            explicit_duration_ms.unwrap_or_else(|| {
+                token.started_at.elapsed().as_millis().min(u32::MAX as u128) as u32
+            })
         };
         self.steps.push(AgentRetrievalStepDto {
             kind: token.kind,

--- a/crates/codestory-runtime/src/agent/trace_export.rs
+++ b/crates/codestory-runtime/src/agent/trace_export.rs
@@ -16,6 +16,9 @@ pub(crate) struct PacketStepTraceRow {
     pub query: Option<String>,
     pub hits: Option<u32>,
     pub mode: Option<String>,
+    pub sidecar_query_ms: Option<u32>,
+    pub candidate_resolution_ms: Option<u32>,
+    pub sidecar_total_ms: Option<u32>,
     pub message: Option<String>,
 }
 
@@ -35,16 +38,8 @@ fn packet_step_row(index: usize, step: &AgentRetrievalStepDto) -> PacketStepTrac
         .iter()
         .find(|field| field.key == "query")
         .map(|field| field.value.clone());
-    let hits = step
-        .output
-        .iter()
-        .find(|field| field.key == "hits")
-        .and_then(|field| field.value.parse::<u32>().ok());
-    let mode = step
-        .output
-        .iter()
-        .find(|field| field.key == "mode")
-        .map(|field| field.value.clone());
+    let hits = step_output_u32(step, "hits");
+    let mode = step_output_string(step, "mode");
     PacketStepTraceRow {
         step_index: index,
         kind: format!("{:?}", step.kind),
@@ -53,8 +48,22 @@ fn packet_step_row(index: usize, step: &AgentRetrievalStepDto) -> PacketStepTrac
         query,
         hits,
         mode,
+        sidecar_query_ms: step_output_u32(step, "sidecar_query_ms"),
+        candidate_resolution_ms: step_output_u32(step, "candidate_resolution_ms"),
+        sidecar_total_ms: step_output_u32(step, "sidecar_total_ms"),
         message: step.message.clone(),
     }
+}
+
+fn step_output_string(step: &AgentRetrievalStepDto, key: &str) -> Option<String> {
+    step.output
+        .iter()
+        .find(|field| field.key == key)
+        .map(|field| field.value.clone())
+}
+
+fn step_output_u32(step: &AgentRetrievalStepDto, key: &str) -> Option<u32> {
+    step_output_string(step, key).and_then(|value| value.parse::<u32>().ok())
 }
 
 pub fn packet_step_trace_json(answer: &AgentAnswerDto) -> Value {
@@ -65,6 +74,7 @@ pub fn packet_step_trace_json(answer: &AgentAnswerDto) -> Value {
     let mut payload = json!({
         "total_latency_ms": answer.retrieval_trace.total_latency_ms,
         "attributed_step_duration_ms": attributable_step_duration_ms(&rows),
+        "unattributed_trace_ms": unattributed_trace_ms(answer, &rows),
         "sla_target_ms": answer.retrieval_trace.sla_target_ms,
         "sla_missed": answer.retrieval_trace.sla_missed,
         "semantic_fallback_count": semantic_fallback_count,
@@ -73,10 +83,16 @@ pub fn packet_step_trace_json(answer: &AgentAnswerDto) -> Value {
         "attributed_step_count": attributable_rows.len(),
         "steps": rows,
         "by_kind_ms": by_kind,
+        "search_phase_summary": search_phase_summary(&attributable_rows),
         "top_cost_buckets": top_cost_buckets(&by_kind, 3),
     });
     if let Some(shadow) = &answer.retrieval_trace.retrieval_shadow {
         payload["retrieval_shadow"] = serde_json::to_value(shadow).unwrap_or(Value::Null);
+    }
+    if !answer.retrieval_trace.packet_sidecar_diagnostics.is_empty() {
+        payload["packet_sidecar_diagnostics"] =
+            serde_json::to_value(&answer.retrieval_trace.packet_sidecar_diagnostics)
+                .unwrap_or(Value::Null);
     }
     payload
 }
@@ -154,6 +170,13 @@ fn attributable_step_duration_ms(rows: &[PacketStepTraceRow]) -> u32 {
         .sum()
 }
 
+fn unattributed_trace_ms(answer: &AgentAnswerDto, rows: &[PacketStepTraceRow]) -> u32 {
+    answer
+        .retrieval_trace
+        .total_latency_ms
+        .saturating_sub(attributable_step_duration_ms(rows))
+}
+
 fn aggregate_by_kind(rows: &[&PacketStepTraceRow]) -> serde_json::Map<String, Value> {
     let mut totals: std::collections::HashMap<String, u64> = std::collections::HashMap::new();
     for row in rows {
@@ -177,6 +200,49 @@ fn top_cost_buckets(by_kind: &serde_json::Map<String, Value>, limit: usize) -> V
         .take(limit)
         .map(|(kind, ms)| json!({ "kind": kind, "duration_ms": ms }))
         .collect()
+}
+
+fn search_phase_summary(rows: &[&PacketStepTraceRow]) -> Vec<Value> {
+    let mut phases: std::collections::HashMap<String, Vec<&PacketStepTraceRow>> =
+        std::collections::HashMap::new();
+    for row in rows {
+        if row.kind != format!("{:?}", AgentRetrievalStepKindDto::Search) {
+            continue;
+        }
+        let phase = row
+            .mode
+            .clone()
+            .unwrap_or_else(|| "unclassified_search".to_string());
+        phases.entry(phase).or_default().push(*row);
+    }
+    let mut summaries = phases
+        .into_iter()
+        .map(|(phase, rows)| {
+            let total_duration_ms = rows
+                .iter()
+                .map(|row| u64::from(row.duration_ms))
+                .sum::<u64>();
+            let top = rows.iter().max_by(|left, right| {
+                left.duration_ms
+                    .cmp(&right.duration_ms)
+                    .then_with(|| left.query.cmp(&right.query))
+            });
+            json!({
+                "phase": phase,
+                "step_count": rows.len(),
+                "total_duration_ms": total_duration_ms,
+                "max_duration_ms": top.map(|row| row.duration_ms),
+                "top_query": top.and_then(|row| row.query.clone()),
+            })
+        })
+        .collect::<Vec<_>>();
+    summaries.sort_by(|left, right| {
+        right["total_duration_ms"]
+            .as_u64()
+            .cmp(&left["total_duration_ms"].as_u64())
+            .then_with(|| left["phase"].as_str().cmp(&right["phase"].as_str()))
+    });
+    summaries
 }
 
 #[cfg(test)]

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -4014,6 +4014,57 @@ function packetRetrievalShadowTelemetry(shadow) {
   };
 }
 
+function packetTraceField(fields, key) {
+  if (!Array.isArray(fields)) {
+    return null;
+  }
+  const found = fields.find((field) => field?.key === key);
+  return found ? found.value : null;
+}
+
+function packetTraceNumber(fields, key) {
+  return finiteNumber(packetTraceField(fields, key));
+}
+
+function packetSearchStepTelemetry(steps) {
+  return steps
+    .map((step, index) => ({ step, index }))
+    .filter(({ step }) => String(step?.kind ?? "").toLowerCase() === "search")
+    .filter(({ step }) => String(step?.status ?? "").toLowerCase() !== "skipped")
+    .map(({ step, index }) => ({
+      step_index: index,
+      query: packetTraceField(step.input, "query"),
+      mode: packetTraceField(step.output, "mode") ?? "unclassified_search",
+      duration_ms: finiteNumber(step.duration_ms),
+      hits: packetTraceNumber(step.output, "hits"),
+      sidecar_query_ms: packetTraceNumber(step.output, "sidecar_query_ms"),
+      candidate_resolution_ms: packetTraceNumber(step.output, "candidate_resolution_ms"),
+      sidecar_total_ms: packetTraceNumber(step.output, "sidecar_total_ms"),
+      sidecar_stage_count: packetTraceNumber(step.output, "sidecar_stage_count"),
+      sidecar_stage_total_ms: packetTraceNumber(step.output, "sidecar_stage_total_ms"),
+      message: step.message ?? null,
+    }));
+}
+
+function packetSearchPhaseTotal(searchSteps, mode) {
+  const total = searchSteps
+    .filter((step) => step.mode === mode)
+    .reduce((sum, step) => sum + (finiteNumber(step.duration_ms) ?? 0), 0);
+  return Number.isFinite(total) ? total : null;
+}
+
+function topPacketSearchQueries(searchSteps, limit = 8) {
+  return [...searchSteps]
+    .sort((left, right) => {
+      const duration = (right.duration_ms ?? -1) - (left.duration_ms ?? -1);
+      if (duration !== 0) {
+        return duration;
+      }
+      return String(left.query ?? "").localeCompare(String(right.query ?? ""));
+    })
+    .slice(0, limit);
+}
+
 function packetLatencyTelemetry(packet, wallMs) {
   if (!packet || typeof packet !== "object") {
     return null;
@@ -4023,6 +4074,7 @@ function packetLatencyTelemetry(packet, wallMs) {
   const freshness = packet.answer?.freshness ?? null;
   const steps = Array.isArray(retrievalTrace?.steps) ? retrievalTrace.steps : [];
   const topStep = [...steps].sort((left, right) => (right.duration_ms ?? 0) - (left.duration_ms ?? 0))[0] ?? null;
+  const searchSteps = packetSearchStepTelemetry(steps);
   const retrievalTotalMs = finiteNumber(retrievalTrace?.total_latency_ms);
   const freshnessMs = finiteNumber(freshness?.duration_ms);
   const unaccountedMs =
@@ -4040,6 +4092,12 @@ function packetLatencyTelemetry(packet, wallMs) {
     top_step_duration_ms: finiteNumber(topStep?.duration_ms),
     top_step_message: topStep?.message ?? null,
     retrieval_step_count: steps.length,
+    packet_search_total_ms: searchSteps.reduce((sum, step) => sum + (finiteNumber(step.duration_ms) ?? 0), 0),
+    packet_initial_sidecar_query_ms: packetSearchPhaseTotal(searchSteps, "packet_initial_sidecar_query"),
+    packet_anchor_probe_search_total_ms: packetSearchPhaseTotal(searchSteps, "symbolic_packet_anchor_probe"),
+    packet_lexical_subquery_search_total_ms: packetSearchPhaseTotal(searchSteps, "packet_lexical_batch"),
+    packet_semantic_subquery_search_total_ms: packetSearchPhaseTotal(searchSteps, "packet_semantic_batch"),
+    packet_search_queries: topPacketSearchQueries(searchSteps),
     retrieval_shadow: retrievalShadow,
   };
 }


### PR DESCRIPTION
## What changed

- Added optional per-query timing fields to `PacketSidecarQueryDiagnosticDto`: `sidecar_query_ms`, `candidate_resolution_ms`, `total_elapsed_ms`, `sidecar_stage_count`, and `sidecar_stage_total_ms`.
- Recorded the initial packet sidecar search step with `mode=packet_initial_sidecar_query` and its actual sidecar query duration instead of a `0ms` trace row.
- Changed packet anchor/subquery trace rows to use per-query sidecar diagnostics when available, rather than evenly dividing batch duration across every query.
- Added batch timing annotations for anchor, lexical subquery, and semantic subquery batches: `total_ms`, `attributed_query_ms`, `overhead_ms`, and query count.
- Extended `scripts/codestory-agent-ab-benchmark.mjs` packet latency telemetry with search phase totals and top per-query rows.

Closes #85.

## Why it changed

Issue #85 needs first-request warm packet search evidence that can distinguish initial sidecar query cost, anchor batch cost, lexical subquery batch cost, per-query timing, and wall/output overhead. The previous trace divided batch duration evenly across queries, which hid whether the miss came from a few slow queries, candidate resolution, batch overhead, or repeated sidecar query work.

This PR is telemetry only. It does not change scorer thresholds, SLA thresholds, harness pass/fail behavior, compact cap values, or packet quality/sufficiency logic. PR #83 remains a separate draft partial-evidence branch and was not touched.

## Verification

Commands run, serialized for Cargo with `RUSTC_WRAPPER=$env:USERPROFILE\.cargo\bin\sccache.exe`:

```powershell
node --check scripts\codestory-agent-ab-benchmark.mjs

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime agent::packet_trace::golden_tests

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime agent::trace_export::tests

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime agent::retrieval_primary::tests

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime agent::packet_batch::tests

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-contracts packet_sidecar_query_diagnostic_serializes_timing_fields

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo build --release -p codestory-cli

node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-85-warm-search-telemetry-cold --out-dir target/agent-benchmark/issue-85-warm-search-telemetry-cold --codestory-cli target\release\codestory-cli.exe --allow-failures

node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode warm-stdio --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-85-warm-search-telemetry-warm --out-dir target/agent-benchmark/issue-85-warm-search-telemetry-warm --codestory-cli target\release\codestory-cli.exe --allow-failures

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo fmt --check

git diff --check
```

Results:

- `node --check scripts\codestory-agent-ab-benchmark.mjs`: passed.
- `cargo test -p codestory-runtime agent::packet_trace::golden_tests`: passed, 1/1.
- `cargo test -p codestory-runtime agent::trace_export::tests`: passed, 5/5.
- `cargo test -p codestory-runtime agent::retrieval_primary::tests`: passed, 25/25.
- `cargo test -p codestory-runtime agent::packet_batch::tests`: passed, 7/7.
- `cargo test -p codestory-contracts packet_sidecar_query_diagnostic_serializes_timing_fields`: passed, 1/1.
- `cargo build --release -p codestory-cli`: passed. Existing runtime dead-code warnings remained.
- Focused Apache+Redis current-main telemetry slices completed with `--allow-failures`; quality and sufficiency stayed intact while SLA still missed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

## Focused Evidence

Existing PR #83 / cap-4 evidence before this telemetry PR:

| Row | Mode | Retrieval | Wall | SLA | Quality | Sufficiency |
| --- | --- | ---: | ---: | --- | --- | --- |
| Apache Commons Lang | cold cap-4 | 15328 ms | 19472.378 ms | passed | 1/1 | sufficient |
| Redis | cold cap-4 | 14938 ms | 19960.443 ms | passed | 1/1 | sufficient |
| Apache Commons Lang | warm first request cap-4 | 26172 ms | 35821.504 ms | missed | 1/1 | sufficient |
| Redis | warm first request cap-4 | 19808 ms | 24930.333 ms | missed | 1/1 | sufficient |

This branch's focused telemetry run was from current `main` and does not include PR #83's cap-4 change, so it is not an acceptance comparison against cap-4. It proves the new trace fields on the same Apache+Redis task slice:

| Row | Mode | Wall | Retrieval | SLA | Quality | Sufficiency | Initial sidecar | Anchor probes | Lexical subqueries | Search total | Unaccounted wall |
| --- | --- | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| Apache Commons Lang | cold current-main | 24282.889 ms | 20942 ms | missed | 1/1 | sufficient | 583 ms | 13579 ms | 2897 ms | 17059 ms | 2992.889 ms |
| Redis | cold current-main | 29169.558 ms | 24373 ms | missed | 1/1 | sufficient | 498 ms | 16039 ms | 3337 ms | 19874 ms | 4000.558 ms |
| Apache Commons Lang | warm first request | 27424.388 ms | 23843 ms | missed | 1/1 | sufficient | 621 ms | 14351 ms | 2997 ms | 17969 ms | 3183.388 ms |
| Redis | warm first request | 29741.893 ms | 25136 ms | missed | 1/1 | sufficient | 493 ms | 13895 ms | 3026 ms | 17414 ms | 3750.893 ms |

Artifact paths:

- Existing main cold baseline: `C:\Users\alber\.codex\worktrees\83b1\codestory\target\agent-benchmark\issue-78-residual-main-cold`
- Existing cap-4 cold: `C:\Users\alber\.codex\worktrees\83b1\codestory\target\agent-benchmark\issue-78-residual-cap4-cold`
- Existing cap-4 warm: `C:\Users\alber\.codex\worktrees\83b1\codestory\target\agent-benchmark\issue-78-residual-cap4-warm`
- New telemetry cold: `C:\Users\alber\.codex\worktrees\c38c\codestory\target\agent-benchmark\issue-85-warm-search-telemetry-cold`
- New telemetry warm: `C:\Users\alber\.codex\worktrees\c38c\codestory\target\agent-benchmark\issue-85-warm-search-telemetry-warm`

Warm trace detail from the new telemetry:

| Row | Anchor batch | Lexical batch | Top query evidence |
| --- | --- | --- | --- |
| Apache Commons Lang warm | `total_ms=14994`, `attributed_query_ms=14351`, `overhead_ms=643`, `queries=12` | `total_ms=3604`, `attributed_query_ms=2997`, `overhead_ms=607`, `queries=3` | `StringUtils.java regionMatches` 1566 ms, `is_blank` 1416 ms, `is_case_sensitive` 1396 ms, `is_empty` 1341 ms |
| Redis warm | `total_ms=14633`, `attributed_query_ms=13895`, `overhead_ms=738`, `queries=12` | `total_ms=3756`, `attributed_query_ms=3026`, `overhead_ms=730`, `queries=3` | `client command input` 1487 ms, `event loop` 1318 ms, `server bootstrap` 1192 ms, `command server entrypoint` 1180 ms |

Candidate resolution was not the dominant cost. In the warm rows, candidate resolution was usually tens of milliseconds per query; repeated sidecar query calls were roughly 0.9-1.5s each, with about 0.6-0.7s of overhead per packet batch and several seconds of wall overhead outside retrieval trace.

## Remaining Risk

This PR closes the telemetry/profiling slice in #85 by recording exact residual evidence and filing #87 for the product latency fix. Issue #78 remains open, and this PR does not implement the latency product fix.

Smallest follow-up: add a product-safe packet sidecar batch executor that reduces repeated first-request sidecar query work, likely by bounded parallel sidecar batch execution or a real multi-query sidecar path that shares health/status/open-index work. Then rerun Apache+Redis cold+warm on the cap-4 branch or after PR #83 integration with quality and sufficiency intact.


