### PR TITLE
Share packet sidecar batch setup

### DIFF
--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -68,7 +68,10 @@ pub use qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION,
     PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR, QdrantStorageRepairReport, repair_qdrant_storage,
 };
-pub use query::{QueryRequest, execute_retrieval_query, execute_retrieval_query_with_cache};
+pub use query::{
+    QueryBatchItem, QueryBatchRequest, QueryRequest, execute_retrieval_query,
+    execute_retrieval_query_with_cache, execute_strict_retrieval_query_batch_with_cache,
+};
 pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
 pub use scip_client::ScipClient;

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -2,11 +2,14 @@ use crate::cache::RetrievalCache;
 use crate::config::SidecarLayout;
 use crate::executor::{QueryExecutor, QueryResult, cancellation_flag};
 use crate::generation::manifest_unavailable_reason;
+use crate::health::probe_sidecar_health;
 use crate::index::sidecar_project_id_for_root;
+use crate::mode::{RetrievalDegradedMode, derive_degraded_mode};
 use crate::sidecar::validate_strict_sidecar_readiness;
 use crate::sidecar_search::LiveSidecarSearch;
 use anyhow::{Context, Result, bail};
-use codestory_store::Store;
+use codestory_store::{FileRole, RetrievalIndexManifest, Store};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -20,6 +23,20 @@ pub struct QueryRequest<'a> {
     pub cancelled: Option<Arc<AtomicBool>>,
 }
 
+#[derive(Debug, Clone)]
+pub struct QueryBatchItem<'a> {
+    pub query: &'a str,
+    pub budget_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryBatchRequest<'a> {
+    pub project_root: &'a Path,
+    pub storage_path: &'a Path,
+    pub queries: &'a [QueryBatchItem<'a>],
+    pub cancelled: Option<Arc<AtomicBool>>,
+}
+
 pub fn execute_retrieval_query(request: QueryRequest<'_>) -> Result<QueryResult> {
     let mut cache = RetrievalCache::new();
     execute_retrieval_query_with_cache(request, &mut cache)
@@ -29,19 +46,86 @@ pub fn execute_retrieval_query_with_cache(
     request: QueryRequest<'_>,
     cache: &mut RetrievalCache,
 ) -> Result<QueryResult> {
+    let QueryContext {
+        layout,
+        project_id,
+        manifest,
+        file_roles,
+    } = load_query_context(request.project_root, request.storage_path)?;
+    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
+    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
+    let mut executor = QueryExecutor {
+        sidecars: &sidecars,
+        cache,
+        manifest,
+        file_roles,
+        cancelled,
+        mode_override: single_query_mode_override(),
+    };
+    executor.execute(request.query, request.budget_ms)
+}
+
+pub fn execute_strict_retrieval_query_batch_with_cache(
+    request: QueryBatchRequest<'_>,
+    cache: &mut RetrievalCache,
+) -> Result<Vec<QueryResult>> {
+    if request.queries.is_empty() {
+        return Ok(Vec::new());
+    }
+    let QueryContext {
+        layout,
+        project_id,
+        manifest,
+        file_roles,
+    } = load_query_context(request.project_root, request.storage_path)?;
+    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
+    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
+    let (mode, degraded_reason) = resolve_batch_mode(&sidecars, manifest.as_ref());
+    if mode != RetrievalDegradedMode::Full {
+        bail!(
+            "retrieval sidecar is mandatory; project is not in full mode (mode={}, reason={})",
+            mode.as_str(),
+            degraded_reason.as_deref().unwrap_or("unknown")
+        );
+    }
+    let mut executor = QueryExecutor {
+        sidecars: &sidecars,
+        cache,
+        manifest,
+        file_roles,
+        cancelled,
+        mode_override: Some(mode),
+    };
+    request
+        .queries
+        .iter()
+        .map(|query| executor.execute(query.query, query.budget_ms))
+        .collect()
+}
+
+fn single_query_mode_override() -> Option<RetrievalDegradedMode> {
+    None
+}
+
+struct QueryContext {
+    layout: SidecarLayout,
+    project_id: String,
+    manifest: Option<RetrievalIndexManifest>,
+    file_roles: HashMap<String, FileRole>,
+}
+
+fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryContext> {
     let layout = SidecarLayout::from_env();
-    let project_id = sidecar_project_id_for_root(request.project_root);
-    let (manifest, file_roles) = if request.storage_path.exists() {
-        let storage = Store::open(request.storage_path).context("open storage for query")?;
+    let project_id = sidecar_project_id_for_root(project_root);
+    let (manifest, file_roles) = if storage_path.exists() {
+        let storage = Store::open(storage_path).context("open storage for query")?;
         let manifest = storage
             .get_retrieval_index_manifest(&project_id)
             .context("load retrieval manifest")?;
         if let Some(manifest) = manifest.as_ref() {
-            if let Err(error) = validate_strict_sidecar_readiness(
-                request.project_root,
-                request.storage_path,
-                &storage,
-            ) {
+            if let Err(error) =
+                validate_strict_sidecar_readiness(project_root, storage_path, &storage)
+            {
                 bail!(
                     "retrieval sidecar manifest is unavailable ({error}); run retrieval index for project {project_id}"
                 );
@@ -70,17 +154,30 @@ pub fn execute_retrieval_query_with_cache(
         bail!("retrieval sidecar storage is missing; run retrieval index for project {project_id}");
     };
 
-    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
-    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
-    let mut executor = QueryExecutor {
-        sidecars: &sidecars,
-        cache,
+    Ok(QueryContext {
+        layout,
+        project_id,
         manifest,
         file_roles,
-        cancelled,
-        mode_override: None,
-    };
-    executor.execute(request.query, request.budget_ms)
+    })
+}
+
+fn resolve_batch_mode(
+    sidecars: &LiveSidecarSearch,
+    manifest: Option<&RetrievalIndexManifest>,
+) -> (RetrievalDegradedMode, Option<String>) {
+    if let Some(manifest) = manifest {
+        let report = probe_sidecar_health(
+            sidecars.layout(),
+            &manifest.project_id,
+            Some(manifest.clone()),
+        );
+        return derive_degraded_mode(&report.zoekt, &report.qdrant, &report.scip);
+    }
+    (
+        RetrievalDegradedMode::LexicalOnly,
+        Some("manifest_missing".into()),
+    )
 }
 
 #[cfg(test)]
@@ -104,6 +201,32 @@ mod tests {
         manifest.dense_projection_count = Some(projection_count);
         manifest.dense_reason_counts_json = Some(format!("{{\"public_api\":{projection_count}}}"));
         manifest
+    }
+
+    #[test]
+    fn single_query_mode_override_is_not_forced_by_packet_batch_strictness() {
+        assert_eq!(single_query_mode_override(), None);
+    }
+
+    #[test]
+    fn empty_batch_query_does_not_require_storage() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("missing").join("codestory.db");
+        let mut cache = RetrievalCache::new();
+
+        let results = execute_strict_retrieval_query_batch_with_cache(
+            QueryBatchRequest {
+                project_root: project.path(),
+                storage_path: &storage_path,
+                queries: &[],
+                cancelled: None,
+            },
+            &mut cache,
+        )
+        .expect("empty batch should short-circuit before storage setup");
+
+        assert!(results.is_empty());
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -12,9 +12,10 @@ use codestory_contracts::api::{
 };
 use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
 use codestory_retrieval::{
-    CandidateHit, CandidateSource, QueryRequest, QueryResult, QueryTrace,
-    execute_retrieval_query_with_cache, is_phantom_sidecar_hit, sidecar_project_id_for_root,
-    strict_sidecar_status,
+    CandidateHit, CandidateSource, QueryBatchItem, QueryBatchRequest, QueryRequest, QueryResult,
+    QueryTrace, execute_retrieval_query_with_cache,
+    execute_strict_retrieval_query_batch_with_cache, is_phantom_sidecar_hit,
+    sidecar_project_id_for_root, strict_sidecar_status,
 };
 use codestory_store::Store;
 use std::collections::{BTreeMap, HashMap};
@@ -338,6 +339,35 @@ pub(crate) fn run_sidecar_query(
     )
 }
 
+pub(crate) fn run_sidecar_query_batch(
+    controller: &AppController,
+    queries: &[(String, u64)],
+) -> Result<Vec<QueryResult>, AnyhowError> {
+    let project_root = controller
+        .require_project_root()
+        .map_err(|error| anyhow::anyhow!("project root required: {}", error.message))?;
+    let storage_path = controller
+        .require_storage_path()
+        .map_err(|error| anyhow::anyhow!("storage path required: {}", error.message))?;
+    let batch_items = queries
+        .iter()
+        .map(|(query, budget_ms)| QueryBatchItem {
+            query,
+            budget_ms: Some(*budget_ms),
+        })
+        .collect::<Vec<_>>();
+    let mut cache = controller.sidecar_query_cache.lock();
+    execute_strict_retrieval_query_batch_with_cache(
+        QueryBatchRequest {
+            project_root: &project_root,
+            storage_path: &storage_path,
+            queries: &batch_items,
+            cancelled: None,
+        },
+        &mut cache,
+    )
+}
+
 pub(crate) fn maybe_run_retrieval_shadow(
     controller: &AppController,
     question: &str,
@@ -540,36 +570,60 @@ fn search_sidecar_packet_batch_inner(
     queries: &[(String, usize)],
     latency_budget_ms: Option<u32>,
 ) -> Result<SidecarPacketBatchOutcome, ApiError> {
-    search_sidecar_packet_batch_inner_with_query(
+    search_sidecar_packet_batch_inner_with_query_batch(
         controller,
         queries,
         latency_budget_ms,
-        run_sidecar_query,
+        run_sidecar_query_batch,
     )
 }
 
-fn search_sidecar_packet_batch_inner_with_query(
+fn search_sidecar_packet_batch_inner_with_query_batch(
     controller: &AppController,
     queries: &[(String, usize)],
     latency_budget_ms: Option<u32>,
-    mut run_query: impl FnMut(&AppController, &str, Option<u32>) -> Result<QueryResult, AnyhowError>,
+    mut run_query_batch: impl FnMut(
+        &AppController,
+        &[(String, u64)],
+    ) -> Result<Vec<QueryResult>, AnyhowError>,
 ) -> Result<SidecarPacketBatchOutcome, ApiError> {
     let per_query_budget = sidecar_packet_batch_budget_ms(latency_budget_ms)
         .checked_div(queries.len().max(1) as u64)
         .unwrap_or(100)
         .max(100);
+    let batch_queries = queries
+        .iter()
+        .map(|(query, _)| (query.clone(), per_query_budget))
+        .collect::<Vec<_>>();
+    let query_results = run_query_batch(controller, &batch_queries).map_err(|error| {
+        sidecar_retrieval_unavailable_error(
+            controller,
+            format!("sidecar retrieval batch query failed: {error}"),
+        )
+    })?;
+    if query_results.len() != queries.len() {
+        return Err(sidecar_retrieval_unavailable_error(
+            controller,
+            format!(
+                "sidecar retrieval batch returned {} results for {} queries",
+                query_results.len(),
+                queries.len()
+            ),
+        ));
+    }
     let mut results = Vec::with_capacity(queries.len());
     let mut diagnostics = Vec::with_capacity(queries.len());
-    for (query, max_results) in queries {
-        let query_started_at = Instant::now();
-        let query_result =
-            run_query(controller, query, Some(per_query_budget as u32)).map_err(|error| {
-                sidecar_retrieval_unavailable_error(
-                    controller,
-                    format!("sidecar retrieval batch query failed: {error}"),
-                )
-            })?;
-        let sidecar_query_ms = clamp_elapsed_ms(query_started_at);
+    for ((query, max_results), query_result) in queries.iter().zip(query_results) {
+        if query_result.query != *query {
+            return Err(sidecar_retrieval_unavailable_error(
+                controller,
+                format!(
+                    "sidecar retrieval batch query mismatch expected `{}` got `{}`",
+                    query, query_result.query
+                ),
+            ));
+        }
+        let sidecar_query_ms = u32::try_from(query_result.trace.elapsed_ms).unwrap_or(u32::MAX);
         let max_results = (*max_results).clamp(1, 50);
         let resolution_started_at = Instant::now();
         let resolution =
@@ -2227,12 +2281,13 @@ mod tests {
             .expect("open project");
 
         let queries = vec![("helpers".to_string(), 5)];
-        let outcome = search_sidecar_packet_batch_inner_with_query(
+        let outcome = search_sidecar_packet_batch_inner_with_query_batch(
             &controller,
             &queries,
             Some(500),
-            |_, _, _| {
-                Ok(QueryResult {
+            |_, batch| {
+                assert_eq!(batch, &[("helpers".to_string(), 500)]);
+                Ok(vec![QueryResult {
                     query: "helpers".into(),
                     features: classify_query("helpers"),
                     hits: vec![CandidateHit::with_source(
@@ -2250,7 +2305,7 @@ mod tests {
                         cache_hit: false,
                         stages: Vec::new(),
                     },
-                })
+                }])
             },
         )
         .expect("full-mode unresolved candidates should not reject packet batch");
@@ -2297,35 +2352,38 @@ mod tests {
             ("search projection".to_string(), 5),
         ];
         let mut observed_budgets = Vec::new();
-        let outcome = search_sidecar_packet_batch_inner_with_query(
+        let mut batch_call_count = 0;
+        let outcome = search_sidecar_packet_batch_inner_with_query_batch(
             &controller,
             &queries,
             Some(18_000),
-            |_, query, budget| {
-                observed_budgets.push(budget);
-                Ok(QueryResult {
-                    query: query.to_string(),
-                    features: classify_query(query),
-                    hits: Vec::new(),
-                    trace: QueryTrace {
-                        retrieval_mode: "full".into(),
-                        degraded_reason: None,
-                        total_budget_ms: u64::from(budget.unwrap_or_default()),
-                        elapsed_ms: 1,
-                        cancel_reason: None,
-                        cache_hit: false,
-                        stages: Vec::new(),
-                    },
-                })
+            |_, batch| {
+                batch_call_count += 1;
+                observed_budgets.extend(batch.iter().map(|(_, budget)| *budget));
+                Ok(batch
+                    .iter()
+                    .map(|(query, budget)| QueryResult {
+                        query: query.to_string(),
+                        features: classify_query(query),
+                        hits: Vec::new(),
+                        trace: QueryTrace {
+                            retrieval_mode: "full".into(),
+                            degraded_reason: None,
+                            total_budget_ms: *budget,
+                            elapsed_ms: 1,
+                            cancel_reason: None,
+                            cache_hit: false,
+                            stages: Vec::new(),
+                        },
+                    })
+                    .collect())
             },
         )
         .expect("empty full-mode packet query results should not reject");
 
         assert_eq!(outcome.results.len(), queries.len());
-        assert_eq!(
-            observed_budgets,
-            vec![Some(4_500), Some(4_500), Some(4_500), Some(4_500)]
-        );
+        assert_eq!(batch_call_count, 1);
+        assert_eq!(observed_budgets, vec![4_500, 4_500, 4_500, 4_500]);
     }
 
     #[test]
@@ -2342,12 +2400,13 @@ mod tests {
             .expect("remove storage parent");
 
         let queries = vec![("handler".to_string(), 5)];
-        let result = search_sidecar_packet_batch_inner_with_query(
+        let result = search_sidecar_packet_batch_inner_with_query_batch(
             &controller,
             &queries,
             Some(500),
-            |_, _, _| {
-                Ok(QueryResult {
+            |_, batch| {
+                assert_eq!(batch, &[("handler".to_string(), 500)]);
+                Ok(vec![QueryResult {
                     query: "handler".into(),
                     features: classify_query("handler"),
                     hits: vec![CandidateHit::with_source(
@@ -2365,7 +2424,7 @@ mod tests {
                         cache_hit: false,
                         stages: Vec::new(),
                     },
-                })
+                }])
             },
         );
 


### PR DESCRIPTION
## What changed

- Added a packet-specific strict sidecar batch query API that shares sidecar query setup across all queries in one packet batch.
- Routed packet sidecar batches through that strict batch API while preserving existing single-query `execute_retrieval_query_with_cache` behavior (`mode_override: None`).
- Kept packet batch failures visible: batch query failures, result-count mismatches, query-order mismatches, non-full sidecar mode, and candidate-resolution errors still fail closed.
- Added narrow tests for the strict packet batch boundary and for the single-query/packet-batch semantic split.

Closes #120. Parent #87/#78 remain open.

## Why it changed

#86 telemetry showed first-request packet latency was dominated by repeated sidecar query work in packet batches, not candidate resolution. The smallest scoped change was to share sidecar setup/status/open-index work inside packet batches without changing scorer thresholds, SLA thresholds, quality gates, compact-probe caps, or single-query degraded-mode semantics.

This PR does not claim #87 or #78 clearance. It improves the focused rows, but Apache warm still misses the packet SLA by wall-clock accounting.

## Focused evidence

Before values are from #86 current-main telemetry. After values are from this branch's focused Apache+Redis packet-runtime slices.

| Row | Mode | Before wall | After wall | Before retrieval | After retrieval | After SLA | Quality | Sufficiency |
| --- | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
| Apache Commons Lang | cold CLI | 24282.889 ms | 18523.601 ms | 20942 ms | 14217 ms | clear | 1/1 | sufficient |
| Redis | cold CLI | 29169.558 ms | 19110.951 ms | 24373 ms | 14086 ms | clear | 1/1 | sufficient |
| Apache Commons Lang | warm stdio first request | 27424.388 ms | 21622.945 ms | 23843 ms | 16930 ms | blocked | 1/1 | sufficient |
| Redis | warm stdio first request | 29741.893 ms | 20225.884 ms | 25136 ms | 15129 ms | clear | 1/1 | sufficient |

Important SLA note: Apache warm has `retrieval_total_ms=16930`, below the 18000 ms target, but the packet trace still has `sla_missed=true` because `PacketLatencyBudget::apply_to_trace` also marks a miss when wall-clock elapsed time exhausts the latency budget. The warm artifact reports `wall=21622.945 ms` and `unaccounted=4296.945 ms`, so this is still a real SLA miss, not a summary inconsistency.

## Batch and phase timings after this PR

| Row | Search total | Initial | Anchor attributed | Anchor batch total / overhead | Lexical attributed | Lexical batch total / overhead | Top query timings |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Apache cold | 8892 ms | 574 ms | 6219 ms | 7460 ms / 1241 ms | 2099 ms | 3362 ms / 1263 ms | Commons 881 ms; StringUtils 807 ms; is_blank 806 ms |
| Redis cold | 8047 ms | 542 ms | 5512 ms | 6873 ms / 1361 ms | 1993 ms | 3377 ms / 1384 ms | Trace 718 ms; initializes 708 ms; event loop source 591 ms |
| Apache warm | 9663 ms | 711 ms | 6764 ms | 8119 ms / 1355 ms | 2188 ms | 3570 ms / 1382 ms | Commons 935 ms; is_blank 835 ms; StringUtils.java regionMatches 816 ms |
| Redis warm | 7497 ms | 590 ms | 5020 ms | 6334 ms / 1314 ms | 1887 ms | 3082 ms / 1195 ms | initializes 753 ms; Trace 661 ms; initial sidecar query 590 ms |

The win is supported by packet phase totals and focused cold/warm rows, not by lower per-query `sidecar_query_ms` alone. Shared setup and remaining wall/output costs are reflected in batch `overhead_ms` and summary `unaccounted` fields.

## Artifact paths

- Cold focused slice: `C:\Users\alber\.codex\worktrees\b467\codestory\target\agent-benchmark\issue-87-sidecar-batch-after-cold`
- Warm focused slice: `C:\Users\alber\.codex\worktrees\b467\codestory\target\agent-benchmark\issue-87-sidecar-batch-after-warm`
- Cold summary: `target\agent-benchmark\issue-87-sidecar-batch-after-cold\packet-runtime-summary.json`
- Warm summary: `target\agent-benchmark\issue-87-sidecar-batch-after-warm\packet-runtime-summary.json`

## Verification

Commands run with serialized Cargo and `RUSTC_WRAPPER=$env:USERPROFILE\.cargo\bin\sccache.exe` where applicable:

```powershell
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-retrieval query::tests -- --nocapture

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime agent::retrieval_primary::tests::packet_batch -- --nocapture

$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo build --release -p codestory-cli

node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-87-sidecar-batch-after-cold --out-dir target/agent-benchmark/issue-87-sidecar-batch-after-cold --codestory-cli target\release\codestory-cli.exe --allow-failures

node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode warm-stdio --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-87-sidecar-batch-after-warm --out-dir target/agent-benchmark/issue-87-sidecar-batch-after-warm --codestory-cli target\release\codestory-cli.exe --allow-failures

cargo fmt --check
git diff --check
```

Results:

- `cargo test -p codestory-retrieval query::tests -- --nocapture`: passed, 6 passed, 1 ignored live sidecar integration test.
- `cargo test -p codestory-runtime agent::retrieval_primary::tests::packet_batch -- --nocapture`: passed, 5 passed.
- `cargo build --release -p codestory-cli`: passed in 2m29s; existing runtime dead-code warnings remained.
- Focused cold Apache+Redis packet-runtime slice completed; both rows quality 1/1 and sufficient, SLA clear.
- Focused warm Apache+Redis packet-runtime slice completed; both rows quality 1/1 and sufficient, Redis SLA clear, Apache SLA still missed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

A redundant local `git apply --check` attempt against a piped partial diff failed as a check artifact before staging; it did not modify the tree and is not used as verification evidence.

## Skills used

- repo-local `codestory-grounding`: read `.agents/skills/codestory-grounding/SKILL.md` and `references/retrieval-rollout.md`; it kept the proof lane scoped to runtime integration and focused packet-runtime slices.
- `performance`: read; it shaped the before/after measurement around phase totals, batch overhead, and top query timings instead of treating telemetry as clearance.
- `best-practices`: read; it drove the single-query semantic boundary review and fail-closed error visibility.
- `superpowers:verification-before-completion`: read; it enforced fresh test/build/benchmark evidence before status claims.
- `github:github`: read; it guided live issue/PR state checks, rebasing after #86 merged, and draft PR publication with `Refs #87`.

## Remaining risk and next issue

Apache warm still blocks focused acceptance: `wall=21622.945 ms`, `retrieval_total=16930 ms`, `unaccounted=4296.945 ms`, `search_total=9663 ms`, and `sla_missed=true`.

Recommended next smallest issue: reduce Apache warm residual wall overhead and packet search overhead after shared sidecar setup. The first evidence target should separate packet trace overhead, stdio serialization/output materialization, and any remaining sidecar batch overhead without relaxing SLA or quality gates.

