### PR TITLE
Profile packet batch overhead

### DIFF
--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -68,7 +68,10 @@ pub use qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION,
     PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR, QdrantStorageRepairReport, repair_qdrant_storage,
 };
-pub use query::{QueryRequest, execute_retrieval_query, execute_retrieval_query_with_cache};
+pub use query::{
+    QueryBatchItem, QueryBatchRequest, QueryRequest, execute_retrieval_query,
+    execute_retrieval_query_with_cache, execute_strict_retrieval_query_batch_with_cache,
+};
 pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
 pub use scip_client::ScipClient;

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -2,11 +2,14 @@ use crate::cache::RetrievalCache;
 use crate::config::SidecarLayout;
 use crate::executor::{QueryExecutor, QueryResult, cancellation_flag};
 use crate::generation::manifest_unavailable_reason;
+use crate::health::probe_sidecar_health;
 use crate::index::sidecar_project_id_for_root;
+use crate::mode::{RetrievalDegradedMode, derive_degraded_mode};
 use crate::sidecar::validate_strict_sidecar_readiness;
 use crate::sidecar_search::LiveSidecarSearch;
 use anyhow::{Context, Result, bail};
-use codestory_store::Store;
+use codestory_store::{FileRole, RetrievalIndexManifest, Store};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -20,6 +23,20 @@ pub struct QueryRequest<'a> {
     pub cancelled: Option<Arc<AtomicBool>>,
 }
 
+#[derive(Debug, Clone)]
+pub struct QueryBatchItem<'a> {
+    pub query: &'a str,
+    pub budget_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueryBatchRequest<'a> {
+    pub project_root: &'a Path,
+    pub storage_path: &'a Path,
+    pub queries: &'a [QueryBatchItem<'a>],
+    pub cancelled: Option<Arc<AtomicBool>>,
+}
+
 pub fn execute_retrieval_query(request: QueryRequest<'_>) -> Result<QueryResult> {
     let mut cache = RetrievalCache::new();
     execute_retrieval_query_with_cache(request, &mut cache)
@@ -29,19 +46,86 @@ pub fn execute_retrieval_query_with_cache(
     request: QueryRequest<'_>,
     cache: &mut RetrievalCache,
 ) -> Result<QueryResult> {
+    let QueryContext {
+        layout,
+        project_id,
+        manifest,
+        file_roles,
+    } = load_query_context(request.project_root, request.storage_path)?;
+    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
+    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
+    let mut executor = QueryExecutor {
+        sidecars: &sidecars,
+        cache,
+        manifest,
+        file_roles,
+        cancelled,
+        mode_override: single_query_mode_override(),
+    };
+    executor.execute(request.query, request.budget_ms)
+}
+
+pub fn execute_strict_retrieval_query_batch_with_cache(
+    request: QueryBatchRequest<'_>,
+    cache: &mut RetrievalCache,
+) -> Result<Vec<QueryResult>> {
+    if request.queries.is_empty() {
+        return Ok(Vec::new());
+    }
+    let QueryContext {
+        layout,
+        project_id,
+        manifest,
+        file_roles,
+    } = load_query_context(request.project_root, request.storage_path)?;
+    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
+    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
+    let (mode, degraded_reason) = resolve_batch_mode(&sidecars, manifest.as_ref());
+    if mode != RetrievalDegradedMode::Full {
+        bail!(
+            "retrieval sidecar is mandatory; project is not in full mode (mode={}, reason={})",
+            mode.as_str(),
+            degraded_reason.as_deref().unwrap_or("unknown")
+        );
+    }
+    let mut executor = QueryExecutor {
+        sidecars: &sidecars,
+        cache,
+        manifest,
+        file_roles,
+        cancelled,
+        mode_override: Some(mode),
+    };
+    request
+        .queries
+        .iter()
+        .map(|query| executor.execute(query.query, query.budget_ms))
+        .collect()
+}
+
+fn single_query_mode_override() -> Option<RetrievalDegradedMode> {
+    None
+}
+
+struct QueryContext {
+    layout: SidecarLayout,
+    project_id: String,
+    manifest: Option<RetrievalIndexManifest>,
+    file_roles: HashMap<String, FileRole>,
+}
+
+fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryContext> {
     let layout = SidecarLayout::from_env();
-    let project_id = sidecar_project_id_for_root(request.project_root);
-    let (manifest, file_roles) = if request.storage_path.exists() {
-        let storage = Store::open(request.storage_path).context("open storage for query")?;
+    let project_id = sidecar_project_id_for_root(project_root);
+    let (manifest, file_roles) = if storage_path.exists() {
+        let storage = Store::open(storage_path).context("open storage for query")?;
         let manifest = storage
             .get_retrieval_index_manifest(&project_id)
             .context("load retrieval manifest")?;
         if let Some(manifest) = manifest.as_ref() {
-            if let Err(error) = validate_strict_sidecar_readiness(
-                request.project_root,
-                request.storage_path,
-                &storage,
-            ) {
+            if let Err(error) =
+                validate_strict_sidecar_readiness(project_root, storage_path, &storage)
+            {
                 bail!(
                     "retrieval sidecar manifest is unavailable ({error}); run retrieval index for project {project_id}"
                 );
@@ -70,17 +154,30 @@ pub fn execute_retrieval_query_with_cache(
         bail!("retrieval sidecar storage is missing; run retrieval index for project {project_id}");
     };
 
-    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
-    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
-    let mut executor = QueryExecutor {
-        sidecars: &sidecars,
-        cache,
+    Ok(QueryContext {
+        layout,
+        project_id,
         manifest,
         file_roles,
-        cancelled,
-        mode_override: None,
-    };
-    executor.execute(request.query, request.budget_ms)
+    })
+}
+
+fn resolve_batch_mode(
+    sidecars: &LiveSidecarSearch,
+    manifest: Option<&RetrievalIndexManifest>,
+) -> (RetrievalDegradedMode, Option<String>) {
+    if let Some(manifest) = manifest {
+        let report = probe_sidecar_health(
+            sidecars.layout(),
+            &manifest.project_id,
+            Some(manifest.clone()),
+        );
+        return derive_degraded_mode(&report.zoekt, &report.qdrant, &report.scip);
+    }
+    (
+        RetrievalDegradedMode::LexicalOnly,
+        Some("manifest_missing".into()),
+    )
 }
 
 #[cfg(test)]
@@ -104,6 +201,32 @@ mod tests {
         manifest.dense_projection_count = Some(projection_count);
         manifest.dense_reason_counts_json = Some(format!("{{\"public_api\":{projection_count}}}"));
         manifest
+    }
+
+    #[test]
+    fn single_query_mode_override_is_not_forced_by_packet_batch_strictness() {
+        assert_eq!(single_query_mode_override(), None);
+    }
+
+    #[test]
+    fn empty_batch_query_does_not_require_storage() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("missing").join("codestory.db");
+        let mut cache = RetrievalCache::new();
+
+        let results = execute_strict_retrieval_query_batch_with_cache(
+            QueryBatchRequest {
+                project_root: project.path(),
+                storage_path: &storage_path,
+                queries: &[],
+                cancelled: None,
+            },
+            &mut cache,
+        )
+        .expect("empty batch should short-circuit before storage setup");
+
+        assert!(results.is_empty());
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -12,9 +12,10 @@ use codestory_contracts::api::{
 };
 use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
 use codestory_retrieval::{
-    CandidateHit, CandidateSource, QueryRequest, QueryResult, QueryTrace,
-    execute_retrieval_query_with_cache, is_phantom_sidecar_hit, sidecar_project_id_for_root,
-    strict_sidecar_status,
+    CandidateHit, CandidateSource, QueryBatchItem, QueryBatchRequest, QueryRequest, QueryResult,
+    QueryTrace, execute_retrieval_query_with_cache,
+    execute_strict_retrieval_query_batch_with_cache, is_phantom_sidecar_hit,
+    sidecar_project_id_for_root, strict_sidecar_status,
 };
 use codestory_store::Store;
 use std::collections::{BTreeMap, HashMap};
@@ -338,6 +339,35 @@ pub(crate) fn run_sidecar_query(
     )
 }
 
+pub(crate) fn run_sidecar_query_batch(
+    controller: &AppController,
+    queries: &[(String, u64)],
+) -> Result<Vec<QueryResult>, AnyhowError> {
+    let project_root = controller
+        .require_project_root()
+        .map_err(|error| anyhow::anyhow!("project root required: {}", error.message))?;
+    let storage_path = controller
+        .require_storage_path()
+        .map_err(|error| anyhow::anyhow!("storage path required: {}", error.message))?;
+    let batch_items = queries
+        .iter()
+        .map(|(query, budget_ms)| QueryBatchItem {
+            query,
+            budget_ms: Some(*budget_ms),
+        })
+        .collect::<Vec<_>>();
+    let mut cache = controller.sidecar_query_cache.lock();
+    execute_strict_retrieval_query_batch_with_cache(
+        QueryBatchRequest {
+            project_root: &project_root,
+            storage_path: &storage_path,
+            queries: &batch_items,
+            cancelled: None,
+        },
+        &mut cache,
+    )
+}
+
 pub(crate) fn maybe_run_retrieval_shadow(
     controller: &AppController,
     question: &str,
@@ -540,36 +570,60 @@ fn search_sidecar_packet_batch_inner(
     queries: &[(String, usize)],
     latency_budget_ms: Option<u32>,
 ) -> Result<SidecarPacketBatchOutcome, ApiError> {
-    search_sidecar_packet_batch_inner_with_query(
+    search_sidecar_packet_batch_inner_with_query_batch(
         controller,
         queries,
         latency_budget_ms,
-        run_sidecar_query,
+        run_sidecar_query_batch,
     )
 }
 
-fn search_sidecar_packet_batch_inner_with_query(
+fn search_sidecar_packet_batch_inner_with_query_batch(
     controller: &AppController,
     queries: &[(String, usize)],
     latency_budget_ms: Option<u32>,
-    mut run_query: impl FnMut(&AppController, &str, Option<u32>) -> Result<QueryResult, AnyhowError>,
+    mut run_query_batch: impl FnMut(
+        &AppController,
+        &[(String, u64)],
+    ) -> Result<Vec<QueryResult>, AnyhowError>,
 ) -> Result<SidecarPacketBatchOutcome, ApiError> {
     let per_query_budget = sidecar_packet_batch_budget_ms(latency_budget_ms)
         .checked_div(queries.len().max(1) as u64)
         .unwrap_or(100)
         .max(100);
+    let batch_queries = queries
+        .iter()
+        .map(|(query, _)| (query.clone(), per_query_budget))
+        .collect::<Vec<_>>();
+    let query_results = run_query_batch(controller, &batch_queries).map_err(|error| {
+        sidecar_retrieval_unavailable_error(
+            controller,
+            format!("sidecar retrieval batch query failed: {error}"),
+        )
+    })?;
+    if query_results.len() != queries.len() {
+        return Err(sidecar_retrieval_unavailable_error(
+            controller,
+            format!(
+                "sidecar retrieval batch returned {} results for {} queries",
+                query_results.len(),
+                queries.len()
+            ),
+        ));
+    }
     let mut results = Vec::with_capacity(queries.len());
     let mut diagnostics = Vec::with_capacity(queries.len());
-    for (query, max_results) in queries {
-        let query_started_at = Instant::now();
-        let query_result =
-            run_query(controller, query, Some(per_query_budget as u32)).map_err(|error| {
-                sidecar_retrieval_unavailable_error(
-                    controller,
-                    format!("sidecar retrieval batch query failed: {error}"),
-                )
-            })?;
-        let sidecar_query_ms = clamp_elapsed_ms(query_started_at);
+    for ((query, max_results), query_result) in queries.iter().zip(query_results) {
+        if query_result.query != *query {
+            return Err(sidecar_retrieval_unavailable_error(
+                controller,
+                format!(
+                    "sidecar retrieval batch query mismatch expected `{}` got `{}`",
+                    query, query_result.query
+                ),
+            ));
+        }
+        let sidecar_query_ms = u32::try_from(query_result.trace.elapsed_ms).unwrap_or(u32::MAX);
         let max_results = (*max_results).clamp(1, 50);
         let resolution_started_at = Instant::now();
         let resolution =
@@ -2227,12 +2281,13 @@ mod tests {
             .expect("open project");
 
         let queries = vec![("helpers".to_string(), 5)];
-        let outcome = search_sidecar_packet_batch_inner_with_query(
+        let outcome = search_sidecar_packet_batch_inner_with_query_batch(
             &controller,
             &queries,
             Some(500),
-            |_, _, _| {
-                Ok(QueryResult {
+            |_, batch| {
+                assert_eq!(batch, &[("helpers".to_string(), 500)]);
+                Ok(vec![QueryResult {
                     query: "helpers".into(),
                     features: classify_query("helpers"),
                     hits: vec![CandidateHit::with_source(
@@ -2250,7 +2305,7 @@ mod tests {
                         cache_hit: false,
                         stages: Vec::new(),
                     },
-                })
+                }])
             },
         )
         .expect("full-mode unresolved candidates should not reject packet batch");
@@ -2297,35 +2352,38 @@ mod tests {
             ("search projection".to_string(), 5),
         ];
         let mut observed_budgets = Vec::new();
-        let outcome = search_sidecar_packet_batch_inner_with_query(
+        let mut batch_call_count = 0;
+        let outcome = search_sidecar_packet_batch_inner_with_query_batch(
             &controller,
             &queries,
             Some(18_000),
-            |_, query, budget| {
-                observed_budgets.push(budget);
-                Ok(QueryResult {
-                    query: query.to_string(),
-                    features: classify_query(query),
-                    hits: Vec::new(),
-                    trace: QueryTrace {
-                        retrieval_mode: "full".into(),
-                        degraded_reason: None,
-                        total_budget_ms: u64::from(budget.unwrap_or_default()),
-                        elapsed_ms: 1,
-                        cancel_reason: None,
-                        cache_hit: false,
-                        stages: Vec::new(),
-                    },
-                })
+            |_, batch| {
+                batch_call_count += 1;
+                observed_budgets.extend(batch.iter().map(|(_, budget)| *budget));
+                Ok(batch
+                    .iter()
+                    .map(|(query, budget)| QueryResult {
+                        query: query.to_string(),
+                        features: classify_query(query),
+                        hits: Vec::new(),
+                        trace: QueryTrace {
+                            retrieval_mode: "full".into(),
+                            degraded_reason: None,
+                            total_budget_ms: *budget,
+                            elapsed_ms: 1,
+                            cancel_reason: None,
+                            cache_hit: false,
+                            stages: Vec::new(),
+                        },
+                    })
+                    .collect())
             },
         )
         .expect("empty full-mode packet query results should not reject");
 
         assert_eq!(outcome.results.len(), queries.len());
-        assert_eq!(
-            observed_budgets,
-            vec![Some(4_500), Some(4_500), Some(4_500), Some(4_500)]
-        );
+        assert_eq!(batch_call_count, 1);
+        assert_eq!(observed_budgets, vec![4_500, 4_500, 4_500, 4_500]);
     }
 
     #[test]
@@ -2342,12 +2400,13 @@ mod tests {
             .expect("remove storage parent");
 
         let queries = vec![("handler".to_string(), 5)];
-        let result = search_sidecar_packet_batch_inner_with_query(
+        let result = search_sidecar_packet_batch_inner_with_query_batch(
             &controller,
             &queries,
             Some(500),
-            |_, _, _| {
-                Ok(QueryResult {
+            |_, batch| {
+                assert_eq!(batch, &[("handler".to_string(), 500)]);
+                Ok(vec![QueryResult {
                     query: "handler".into(),
                     features: classify_query("handler"),
                     hits: vec![CandidateHit::with_source(
@@ -2365,7 +2424,7 @@ mod tests {
                         cache_hit: false,
                         stages: Vec::new(),
                     },
-                })
+                }])
             },
         );
 

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -4053,6 +4053,27 @@ function packetSearchPhaseTotal(searchSteps, mode) {
   return Number.isFinite(total) ? total : null;
 }
 
+function packetBatchTimings(annotations) {
+  if (!Array.isArray(annotations)) {
+    return [];
+  }
+  const pattern = /^(packet_[a-z_]+_batch) total_ms=(\d+) attributed_query_ms=(\d+) overhead_ms=(\d+) queries=(\d+)$/;
+  return annotations
+    .map((annotation) => pattern.exec(String(annotation ?? "")))
+    .filter(Boolean)
+    .map((match) => ({
+      label: match[1],
+      total_ms: Number(match[2]),
+      attributed_query_ms: Number(match[3]),
+      overhead_ms: Number(match[4]),
+      queries: Number(match[5]),
+    }));
+}
+
+function packetBatchTiming(timings, label, key) {
+  return finiteNumber(timings.find((timing) => timing.label === label)?.[key]);
+}
+
 function topPacketSearchQueries(searchSteps, limit = 8) {
   return [...searchSteps]
     .sort((left, right) => {
@@ -4075,18 +4096,25 @@ function packetLatencyTelemetry(packet, wallMs) {
   const steps = Array.isArray(retrievalTrace?.steps) ? retrievalTrace.steps : [];
   const topStep = [...steps].sort((left, right) => (right.duration_ms ?? 0) - (left.duration_ms ?? 0))[0] ?? null;
   const searchSteps = packetSearchStepTelemetry(steps);
+  const batchTimings = packetBatchTimings(retrievalTrace?.annotations);
   const retrievalTotalMs = finiteNumber(retrievalTrace?.total_latency_ms);
   const freshnessMs = finiteNumber(freshness?.duration_ms);
+  const accountedTraceMs =
+    Number.isFinite(retrievalTotalMs) && Number.isFinite(freshnessMs)
+      ? retrievalTotalMs + freshnessMs
+      : null;
   const unaccountedMs =
-    Number.isFinite(wallMs) && Number.isFinite(retrievalTotalMs) && Number.isFinite(freshnessMs)
-      ? Math.max(0, wallMs - retrievalTotalMs - freshnessMs)
+    Number.isFinite(wallMs) && Number.isFinite(accountedTraceMs)
+      ? Math.max(0, wallMs - accountedTraceMs)
       : null;
   return {
     freshness_ms: Number.isFinite(freshnessMs) ? freshnessMs : null,
     retrieval_total_ms: Number.isFinite(retrievalTotalMs) ? retrievalTotalMs : null,
+    accounted_trace_ms: Number.isFinite(accountedTraceMs) ? accountedTraceMs : null,
     sla_target_ms: finiteNumber(retrievalTrace?.sla_target_ms),
     sla_missed: retrievalTrace?.sla_missed ?? null,
     unaccounted_ms: unaccountedMs,
+    non_trace_wall_ms: unaccountedMs,
     top_step_kind: topStep?.kind ?? null,
     top_step_status: topStep?.status ?? null,
     top_step_duration_ms: finiteNumber(topStep?.duration_ms),
@@ -4098,6 +4126,18 @@ function packetLatencyTelemetry(packet, wallMs) {
     packet_lexical_subquery_search_total_ms: packetSearchPhaseTotal(searchSteps, "packet_lexical_batch"),
     packet_semantic_subquery_search_total_ms: packetSearchPhaseTotal(searchSteps, "packet_semantic_batch"),
     packet_search_queries: topPacketSearchQueries(searchSteps),
+    packet_batch_timings: batchTimings,
+    packet_batch_total_ms: batchTimings.reduce((sum, timing) => sum + timing.total_ms, 0),
+    packet_batch_attributed_query_ms: batchTimings.reduce((sum, timing) => sum + timing.attributed_query_ms, 0),
+    packet_batch_overhead_ms: batchTimings.reduce((sum, timing) => sum + timing.overhead_ms, 0),
+    packet_anchor_probe_batch_total_ms: packetBatchTiming(batchTimings, "packet_anchor_probe_batch", "total_ms"),
+    packet_anchor_probe_batch_attributed_query_ms: packetBatchTiming(batchTimings, "packet_anchor_probe_batch", "attributed_query_ms"),
+    packet_anchor_probe_batch_overhead_ms: packetBatchTiming(batchTimings, "packet_anchor_probe_batch", "overhead_ms"),
+    packet_anchor_probe_batch_queries: packetBatchTiming(batchTimings, "packet_anchor_probe_batch", "queries"),
+    packet_lexical_subquery_batch_total_ms: packetBatchTiming(batchTimings, "packet_lexical_subquery_batch", "total_ms"),
+    packet_lexical_subquery_batch_attributed_query_ms: packetBatchTiming(batchTimings, "packet_lexical_subquery_batch", "attributed_query_ms"),
+    packet_lexical_subquery_batch_overhead_ms: packetBatchTiming(batchTimings, "packet_lexical_subquery_batch", "overhead_ms"),
+    packet_lexical_subquery_batch_queries: packetBatchTiming(batchTimings, "packet_lexical_subquery_batch", "queries"),
     retrieval_shadow: retrievalShadow,
   };
 }
@@ -4394,7 +4434,13 @@ function summarizePacketRuntimeRuns(results) {
       median_budget_used_output_bytes: median(shapeRows.map((row) => row.packet_shape?.budget_used_output_bytes)),
       median_packet_freshness_ms: median(latencyRows.map((row) => row.packet_latency?.freshness_ms)),
       median_packet_retrieval_total_ms: median(latencyRows.map((row) => row.packet_latency?.retrieval_total_ms)),
+      median_packet_accounted_trace_ms: median(latencyRows.map((row) => row.packet_latency?.accounted_trace_ms)),
       median_packet_unaccounted_ms: median(latencyRows.map((row) => row.packet_latency?.unaccounted_ms)),
+      median_packet_batch_total_ms: median(latencyRows.map((row) => row.packet_latency?.packet_batch_total_ms)),
+      median_packet_batch_attributed_query_ms: median(latencyRows.map((row) => row.packet_latency?.packet_batch_attributed_query_ms)),
+      median_packet_batch_overhead_ms: median(latencyRows.map((row) => row.packet_latency?.packet_batch_overhead_ms)),
+      median_packet_anchor_probe_batch_overhead_ms: median(latencyRows.map((row) => row.packet_latency?.packet_anchor_probe_batch_overhead_ms)),
+      median_packet_lexical_subquery_batch_overhead_ms: median(latencyRows.map((row) => row.packet_latency?.packet_lexical_subquery_batch_overhead_ms)),
       packet_sla_missed_runs: latencyRows.filter((row) => row.packet_latency?.sla_missed === true).length,
       warm_stdio_packet_cache_hit_runs: successful.filter((row) => row.warm_stdio_packet_cache_hit === true).length,
       retrieval_shadow_cache_hit_runs: shadowRows.filter((shadow) => shadow.cache_hit === true).length,
@@ -4419,8 +4465,8 @@ function packetRuntimeMarkdown(summary) {
   const lines = [
     "# Packet Runtime Benchmark",
     "",
-    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Unaccounted ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const row of summary) {
     lines.push(packetRuntimeMarkdownRow(row));
@@ -4445,6 +4491,11 @@ function packetRuntimeMarkdownRow(row) {
     formatValue(row.median_packet_retrieval_total_ms),
     formatValue(row.median_packet_freshness_ms),
     formatValue(row.median_packet_unaccounted_ms),
+    formatValue(row.median_packet_batch_total_ms),
+    formatValue(row.median_packet_batch_attributed_query_ms),
+    formatValue(row.median_packet_batch_overhead_ms),
+    formatValue(row.median_packet_anchor_probe_batch_overhead_ms),
+    formatValue(row.median_packet_lexical_subquery_batch_overhead_ms),
     row.packet_top_latency_step_kind ?? "",
     formatValue(row.median_packet_top_step_ms),
     formatValue(row.packet_sla_missed_runs),
@@ -5822,7 +5873,15 @@ function runSelfTest() {
     answer: {
       citations: [{ display_name: "run_index" }],
       graphs: [{ id: "g", edges: [{ id: "e1" }] }],
-      retrieval_trace: { steps: [] },
+      freshness: { duration_ms: 10 },
+      retrieval_trace: {
+        total_latency_ms: 100,
+        annotations: [
+          "packet_anchor_probe_batch total_ms=25 attributed_query_ms=20 overhead_ms=5 queries=2",
+          "packet_lexical_subquery_batch total_ms=40 attributed_query_ms=31 overhead_ms=9 queries=3",
+        ],
+        steps: [],
+      },
       sections: [{ blocks: [{ markdown: "answer" }] }],
     },
   };
@@ -5832,6 +5891,14 @@ function runSelfTest() {
     packetSufficiencyTelemetry(packetFixture, { pass: false }).sufficient_quality_mismatch,
     true,
   );
+  const packetLatency = packetLatencyTelemetry(packetFixture, 150);
+  assert.equal(packetLatency.accounted_trace_ms, 110);
+  assert.equal(packetLatency.non_trace_wall_ms, 40);
+  assert.equal(packetLatency.packet_batch_total_ms, 65);
+  assert.equal(packetLatency.packet_batch_attributed_query_ms, 51);
+  assert.equal(packetLatency.packet_batch_overhead_ms, 14);
+  assert.equal(packetLatency.packet_anchor_probe_batch_overhead_ms, 5);
+  assert.equal(packetLatency.packet_lexical_subquery_batch_overhead_ms, 9);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }), true);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }, { publishable: true }), false);
   const weakPacketTelemetry = packetSufficiencyTelemetry(


### PR DESCRIPTION
Summary: Add diagnostic packet batch telemetry so the #89/#78 packet-runtime residual can be split without changing product retrieval behavior or relaxing gates.

Links: Closes #122. Parents and follow-ups #89, #95, #98, #87, and #78 remain open.

---

## Context

#89 needed the Apache warm residual split without changing SLA thresholds, quality checks, sufficiency checks, scorer behavior, or sidecar behavior. The runtime already emitted batch timing annotations, but the benchmark summary did not carry those numbers forward.

## What Changed

- Stacked on draft PR #88 and promoted existing packet batch timing annotations into packet-runtime telemetry.
- Added machine-readable batch totals, attributed query time, and overhead for anchor and lexical packet batches.
- Added packet-runtime markdown columns for non-trace wall time and batch overhead.
- Added a self-test for the annotation parser.

## Focused Evidence

Before values are from the residual #88 artifact rows. After values are from this branch's focused Apache+Redis packet-runtime slices. Current rows did not clear the SLA; they isolate the residual more precisely.

| Row | Before wall | After wall | After retrieval | After freshness | After non-trace wall | After batch total | After batch attributed | After batch overhead | After anchor overhead | After lexical overhead | SLA | Quality | Sufficiency |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
| Apache cold | 18523.601 ms | 25791.866 ms | 21203 ms | 533 ms | 4055.866 ms | 7203 ms | 3395 ms | 3808 ms | 2480 ms | 1328 ms | missed | 1/1 | sufficient |
| Redis cold | 19110.951 ms | 47750.176 ms | 31021 ms | 964 ms | 15765.176 ms | 25830 ms | 17269 ms | 8561 ms | 1845 ms | 6716 ms | missed | 1/1 | sufficient |
| Apache warm | 21622.945 ms | 29850.173 ms | 25050 ms | 497 ms | 4303.173 ms | 17451 ms | 11701 ms | 5750 ms | 1824 ms | 3926 ms | missed | 1/1 | sufficient |
| Redis warm | 20225.884 ms | 23835.001 ms | 18284 ms | 981 ms | 4570.001 ms | 11862 ms | 8915 ms | 2947 ms | 1652 ms | 1295 ms | missed | 1/1 | sufficient |

Interpretation: the common warm non-trace wall remains about 4.3-4.6s, so the residual still includes stdio/output/non-trace work. Apache warm's additional miss is now visible in packet batch overhead, especially lexical batch overhead at 3926 ms versus Redis at 1295 ms.

## Evidence Note

The focused evidence table above is the durable reviewer surface for this diagnostic slice. The original local benchmark directories were in an ephemeral worktree and are not required for landing #122.

## Verification

Commands run:

```powershell
node --check scripts\codestory-agent-ab-benchmark.mjs
node scripts\codestory-agent-ab-benchmark.mjs --self-test
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo build --release -p codestory-cli
node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-89-batch-telemetry-cold --out-dir target/agent-benchmark/issue-89-batch-telemetry-cold --codestory-cli target\release\codestory-cli.exe --allow-failures
node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode warm-stdio --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --materialize-repos --repeats 1 --jobs 1 --benchmark-run-id issue-89-batch-telemetry-warm --out-dir target/agent-benchmark/issue-89-batch-telemetry-warm --codestory-cli target\release\codestory-cli.exe --allow-failures
cargo fmt --check
git diff --check
```

Results:

- `node --check`: passed.
- `node ... --self-test`: passed.
- `cargo build --release -p codestory-cli`: passed in 3m03s; existing runtime dead-code warnings remained.
- Cold focused slice: completed; both rows quality 1/1 and sufficient; both SLA missed in this worktree run.
- Warm focused slice: completed; both rows quality 1/1 and sufficient; both SLA missed in this worktree run.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.

## Risk

This PR does not clear #89, #87, or #78. It isolates the residual enough to split the next work:

- Common warm non-trace wall: about 4.3-4.6s, likely stdio/tool response construction/output path or other packet work outside `retrieval_trace.total_latency_ms`.
- Apache-specific warm overhead: lexical packet batch overhead is 3926 ms, versus Redis 1295 ms, making Apache lexical batch materialization the next smaller blocker.
- The fresh worktree benchmark rows were slower than #88 residual artifacts, so compare deltas by field shape, not as a performance improvement claim.

## Skills Used

- Repo-local `codestory-grounding` for proof routing; a local search attempt after build hung during index refresh and was stopped without being used as success evidence.
- `performance` for latency decomposition, medians, and before/after benchmark rows.
- `best-practices` for harness-only scope and gate discipline.
- `superpowers:verification-before-completion` before build, benchmark, and PR claims.
- `github:github` and `github:yeet` for live issue/PR state checks and the stacked draft PR publish flow.
