### PR TITLE
[codex] add enum dispatch resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "codestory-store",
  "codestory-workspace",
  "crossbeam-channel",
+ "enum_dispatch",
  "ignore",
  "parking_lot",
  "rayon",
@@ -960,6 +961,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -13,6 +13,7 @@ codestory-contracts = { workspace = true }
 codestory-store = { workspace = true }
 codestory-workspace = { workspace = true }
 crossbeam-channel = { workspace = true }
+enum_dispatch = "0.3.13"
 ignore = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use codestory_contracts::graph::EdgeKind;
+use enum_dispatch::enum_dispatch;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -277,6 +278,7 @@ impl SemanticCandidateIndex {
     }
 }
 
+#[enum_dispatch]
 pub trait SemanticResolver: Send + Sync {
     fn resolve(
         &self,
@@ -285,45 +287,29 @@ pub trait SemanticResolver: Send + Sync {
     ) -> Result<Vec<SemanticResolutionCandidate>>;
 }
 
+#[enum_dispatch(SemanticResolver)]
+enum SemanticResolverKind {
+    C(CSemanticResolver),
+    Cpp(CppSemanticResolver),
+    JavaScript(JavaScriptSemanticResolver),
+    Python(PythonSemanticResolver),
+    Rust(RustSemanticResolver),
+    TypeScript(TypeScriptSemanticResolver),
+    Java(JavaSemanticResolver),
+    Go(GoSemanticResolver),
+    Ruby(RubySemanticResolver),
+    Php(PhpSemanticResolver),
+    CSharp(CSharpSemanticResolver),
+    Generic(GenericSemanticResolver),
+}
+
 pub struct SemanticResolverRegistry {
     enabled: bool,
-    c: CSemanticResolver,
-    cpp: CppSemanticResolver,
-    javascript: JavaScriptSemanticResolver,
-    python: PythonSemanticResolver,
-    rust: RustSemanticResolver,
-    ts: TypeScriptSemanticResolver,
-    java: JavaSemanticResolver,
-    go: GoSemanticResolver,
-    ruby: RubySemanticResolver,
-    php: PhpSemanticResolver,
-    csharp: CSharpSemanticResolver,
-    kotlin: GenericSemanticResolver,
-    swift: GenericSemanticResolver,
-    dart: GenericSemanticResolver,
-    bash: GenericSemanticResolver,
 }
 
 impl SemanticResolverRegistry {
     pub fn new(enabled: bool) -> Self {
-        Self {
-            enabled,
-            c: CSemanticResolver,
-            cpp: CppSemanticResolver,
-            javascript: JavaScriptSemanticResolver,
-            python: PythonSemanticResolver,
-            rust: RustSemanticResolver,
-            ts: TypeScriptSemanticResolver,
-            java: JavaSemanticResolver,
-            go: GoSemanticResolver,
-            ruby: RubySemanticResolver,
-            php: PhpSemanticResolver,
-            csharp: CSharpSemanticResolver,
-            kotlin: GenericSemanticResolver::new("kotlin"),
-            swift: GenericSemanticResolver::new("swift"),
-            dart: GenericSemanticResolver::new("dart"),
-            bash: GenericSemanticResolver::new("bash"),
-        }
+        Self { enabled }
     }
 
     pub fn resolve(
@@ -335,26 +321,10 @@ impl SemanticResolverRegistry {
             return Ok(Vec::new());
         }
 
-        match detect_resolver_language(request.file_path.as_deref()) {
-            Some("c") => self.c.resolve(index, request),
-            Some("cpp") => self.cpp.resolve(index, request),
-            Some("javascript") | Some("vue") | Some("svelte") | Some("astro") => {
-                self.javascript.resolve(index, request)
-            }
-            Some("python") => self.python.resolve(index, request),
-            Some("rust") => self.rust.resolve(index, request),
-            Some("typescript") => self.ts.resolve(index, request),
-            Some("java") => self.java.resolve(index, request),
-            Some("go") => self.go.resolve(index, request),
-            Some("ruby") => self.ruby.resolve(index, request),
-            Some("php") => self.php.resolve(index, request),
-            Some("csharp") => self.csharp.resolve(index, request),
-            Some("kotlin") => self.kotlin.resolve(index, request),
-            Some("swift") => self.swift.resolve(index, request),
-            Some("dart") => self.dart.resolve(index, request),
-            Some("bash") => self.bash.resolve(index, request),
-            _ => Ok(Vec::new()),
-        }
+        let Some(resolver) = semantic_resolver_for_path(request.file_path.as_deref()) else {
+            return Ok(Vec::new());
+        };
+        resolver.resolve(index, request)
     }
 }
 
@@ -396,6 +366,27 @@ pub(crate) fn detect_resolver_language(path: Option<&str>) -> Option<&'static st
     match detect_language(path)? {
         "html" | "css" | "sql" => None,
         language => Some(language),
+    }
+}
+
+fn semantic_resolver_for_path(path: Option<&str>) -> Option<SemanticResolverKind> {
+    match detect_resolver_language(path)? {
+        "c" => Some(CSemanticResolver.into()),
+        "cpp" => Some(CppSemanticResolver.into()),
+        "javascript" | "vue" | "svelte" | "astro" => Some(JavaScriptSemanticResolver.into()),
+        "python" => Some(PythonSemanticResolver.into()),
+        "rust" => Some(RustSemanticResolver.into()),
+        "typescript" => Some(TypeScriptSemanticResolver.into()),
+        "java" => Some(JavaSemanticResolver.into()),
+        "go" => Some(GoSemanticResolver.into()),
+        "ruby" => Some(RubySemanticResolver.into()),
+        "php" => Some(PhpSemanticResolver.into()),
+        "csharp" => Some(CSharpSemanticResolver.into()),
+        "kotlin" => Some(GenericSemanticResolver::new("kotlin").into()),
+        "swift" => Some(GenericSemanticResolver::new("swift").into()),
+        "dart" => Some(GenericSemanticResolver::new("dart").into()),
+        "bash" => Some(GenericSemanticResolver::new("bash").into()),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## What changed

- Added `enum_dispatch` to `codestory-indexer` only.
- Replaced the stored per-language `SemanticResolverRegistry` fields with `SemanticResolverKind`, an enum-dispatched wrapper over the existing resolver implementations.
- Kept path/language selection behavior equivalent, including JavaScript handling for `vue`, `svelte`, and `astro`, and structural collector skip behavior for `html`, `css`, and `sql`.

## Why it changed

Closes #91. The reopened issue direction explicitly accepts a small dependency when it removes hand-written dispatch/boilerplate without expected performance cost. `enum_dispatch` lets the resolver call itself be generated by a standard crate while retaining the existing explicit language routing.

## Code reduction

- `crates/codestory-indexer/src/semantic/mod.rs`: 44 insertions, 53 deletions, net -9 lines.
- The manifest/lockfile additions are limited to `enum_dispatch v0.3.13` for `codestory-indexer`.

## Risk

- Risk tag: `S2/R2`, approved by the reopened issue policy.
- Main behavior risk is resolver routing equivalence. The public-ish `detect_resolver_language` behavior is unchanged; the new enum-dispatched resolver selection is covered by the existing semantic registry test.
- Remaining risk: this does not attempt broader enum/trait dispatch surfaces like `LanguageRuleset`, `EmbeddingBackend`, or `SidecarSearch`.

## Verification

- `cargo check -p codestory-indexer`
- `cargo test -p codestory-indexer semantic`
- `cargo fmt --check`
- `cargo run -p codestory-cli -- affected --project . --format markdown`
- `git diff --check`

## Skills used

- `codestory-grounding`
- `code-simplifier`
- `best-practices`
- `superpowers:receiving-code-review`
- `superpowers:verification-before-completion`
- `github:github`
- `github:yeet`

