### PR TITLE
Split warm packet non-trace wall

### DIFF
--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -39,8 +39,19 @@ pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
             continue;
         }
         if let Some(response) = handle_stdio_message(&runtime, &mut state, &line) {
-            writeln!(stdout, "{}", serde_json::to_string(&response)?)?;
+            let response_id = stdio_response_id_label(&response);
+            let serialize_started = Instant::now();
+            serde_json::to_writer(&mut stdout, &response)?;
+            let serialization_ms = stdio_elapsed_ms(serialize_started);
+            let newline_started = Instant::now();
+            stdout.write_all(b"\n")?;
+            let newline_write_ms = stdio_elapsed_ms(newline_started);
+            let flush_started = Instant::now();
             stdout.flush()?;
+            let flush_ms = stdio_elapsed_ms(flush_started);
+            report_stdio_server_phase(&response_id, "response_serialization", serialization_ms);
+            report_stdio_server_phase(&response_id, "newline_write", newline_write_ms);
+            report_stdio_server_phase(&response_id, "flush", flush_ms);
         }
     }
     Ok(())
@@ -286,6 +297,19 @@ fn append_stdio_packet_phase(packet: &mut serde_json::Value, label: &str, durati
 
 fn stdio_elapsed_ms(started_at: Instant) -> u32 {
     started_at.elapsed().as_millis().min(u128::from(u32::MAX)) as u32
+}
+
+fn stdio_response_id_label(response: &serde_json::Value) -> String {
+    response
+        .get("id")
+        .map(stdio_json_text)
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn report_stdio_server_phase(request_id: &str, label: &str, duration_ms: u32) {
+    eprintln!(
+        "packet_stdio_server_phase request_id={request_id} label={label} duration_ms={duration_ms}"
+    );
 }
 
 fn stdio_packet_text(packet: &serde_json::Value) -> String {
@@ -1884,6 +1908,35 @@ mod tests {
             storage_fingerprint: storage_fingerprint.to_string(),
             ..base_packet_cache_key_input(question)
         })
+    }
+
+    #[test]
+    fn stdio_tool_call_success_times_packet_materialization() {
+        let response = stdio_tool_call_success(json!({
+            "packet_id": "packet-1",
+            "answer": {
+                "retrieval_trace": {
+                    "annotations": []
+                }
+            }
+        }));
+        let annotations = response
+            .pointer("/structuredContent/answer/retrieval_trace/annotations")
+            .and_then(|value| value.as_array())
+            .expect("packet annotations");
+
+        assert!(annotations.iter().any(|annotation| {
+            annotation.as_str().is_some_and(|value| {
+                value.starts_with("packet_stdio_phase label=text_materialization duration_ms=")
+            })
+        }));
+        assert!(annotations.iter().any(|annotation| {
+            annotation.as_str().is_some_and(|value| {
+                value.starts_with(
+                    "packet_stdio_phase label=tool_response_materialization duration_ms=",
+                )
+            })
+        }));
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -25,6 +25,7 @@ use crate::stdio_catalog::{
 use crate::{
     build_ambiguous_target_error_output, build_query_resolution_output, build_search_hit_output,
 };
+use std::time::Instant;
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 
@@ -229,9 +230,20 @@ fn stdio_jsonrpc_tool_call_from_legacy(
     stdio_jsonrpc_success(id, stdio_tool_call_success(response))
 }
 
-fn stdio_tool_call_success(structured_content: serde_json::Value) -> serde_json::Value {
+fn stdio_tool_call_success(mut structured_content: serde_json::Value) -> serde_json::Value {
+    let is_packet = stdio_is_packet(&structured_content);
+    let text_started = Instant::now();
     let text = stdio_tool_text(&structured_content);
-    serde_json::json!({
+    if is_packet {
+        append_stdio_packet_phase(
+            &mut structured_content,
+            "text_materialization",
+            stdio_elapsed_ms(text_started),
+        );
+    }
+
+    let response_started = Instant::now();
+    let mut response = serde_json::json!({
         "content": [
             {
                 "type": "text",
@@ -239,14 +251,41 @@ fn stdio_tool_call_success(structured_content: serde_json::Value) -> serde_json:
             }
         ],
         "structuredContent": structured_content
-    })
+    });
+    if is_packet && let Some(structured_content) = response.get_mut("structuredContent") {
+        append_stdio_packet_phase(
+            structured_content,
+            "tool_response_materialization",
+            stdio_elapsed_ms(response_started),
+        );
+    }
+    response
 }
 
 fn stdio_tool_text(value: &serde_json::Value) -> String {
-    if value.get("packet_id").is_some() && value.get("answer").is_some() {
+    if stdio_is_packet(value) {
         return stdio_packet_text(value);
     }
     stdio_json_text(value)
+}
+
+fn stdio_is_packet(value: &serde_json::Value) -> bool {
+    value.get("packet_id").is_some() && value.get("answer").is_some()
+}
+
+fn append_stdio_packet_phase(packet: &mut serde_json::Value, label: &str, duration_ms: u32) {
+    if let Some(annotations) = packet
+        .pointer_mut("/answer/retrieval_trace/annotations")
+        .and_then(|value| value.as_array_mut())
+    {
+        annotations.push(serde_json::Value::String(format!(
+            "packet_stdio_phase label={label} duration_ms={duration_ms}"
+        )));
+    }
+}
+
+fn stdio_elapsed_ms(started_at: Instant) -> u32 {
+    started_at.elapsed().as_millis().min(u128::from(u32::MAX)) as u32
 }
 
 fn stdio_packet_text(packet: &serde_json::Value) -> String {

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -431,6 +431,7 @@ pub(crate) fn agent_packet(
         &rank_terms,
         &mut answer,
     )?;
+    let phase_started = Instant::now();
     maybe_append_sql_schema_file_citations(&project_root, &question, &mut answer);
     maybe_append_generic_source_shape_citations(&project_root, &question, &mut answer);
     let file_scoped_source_probes =
@@ -442,7 +443,10 @@ pub(crate) fn agent_packet(
         &file_scoped_source_probes,
         &mut answer,
     );
+    append_packet_non_trace_phase(&mut answer, "pre_rank_citations", phase_started);
+    let phase_started = Instant::now();
     packet_latency.apply_to_trace(&mut answer);
+    append_packet_non_trace_phase(&mut answer, "trace_apply", phase_started);
 
     let phase_started = Instant::now();
     rank_packet_evidence(&question, &mut answer);
@@ -496,6 +500,7 @@ pub(crate) fn agent_packet(
     let retrieval_trace_summary = trace_export::packet_retrieval_trace_summary(&answer);
     append_packet_non_trace_phase(&mut answer, "trace_summary", phase_started);
 
+    let phase_started = Instant::now();
     let mut packet = AgentPacketDto {
         packet_id: answer.answer_id.clone(),
         question,
@@ -506,10 +511,21 @@ pub(crate) fn agent_packet(
         sufficiency,
         retrieval_trace_summary,
     };
+    append_packet_non_trace_phase(&mut packet.answer, "packet_dto", phase_started);
+    let phase_started = Instant::now();
+    enforce_packet_output_budget(&project_root, &mut packet);
+    append_packet_non_trace_phase(&mut packet.answer, "output_budget", phase_started);
     enforce_packet_output_budget(&project_root, &mut packet);
 
     if let Some(diagnostic) = trace_export::write_packet_step_trace_from_env(&packet.answer) {
         packet.answer.retrieval_trace.annotations.push(diagnostic);
+        let phase_started = Instant::now();
+        enforce_packet_output_budget(&project_root, &mut packet);
+        append_packet_non_trace_phase(
+            &mut packet.answer,
+            "trace_artifact_output_budget",
+            phase_started,
+        );
         enforce_packet_output_budget(&project_root, &mut packet);
     }
 
@@ -9231,6 +9247,14 @@ mod tests {
             packet_non_trace_phase_annotation("budget", 42),
             "packet_non_trace_phase label=budget duration_ms=42"
         );
+        assert_eq!(
+            packet_non_trace_phase_annotation("pre_rank_citations", 7),
+            "packet_non_trace_phase label=pre_rank_citations duration_ms=7"
+        );
+        assert_eq!(
+            packet_non_trace_phase_annotation("trace_apply", 3),
+            "packet_non_trace_phase label=trace_apply duration_ms=3"
+        );
     }
 
     #[test]
@@ -9771,6 +9795,15 @@ mod tests {
             max_output_bytes
         );
         assert_eq!(packet.budget.used.output_bytes as usize, serialized_len);
+        append_packet_non_trace_phase(&mut packet.answer, "output_budget", Instant::now());
+        enforce_packet_output_budget(packet_fixture_project_root(), &mut packet);
+        let serialized_len = serde_json::to_vec(&packet)
+            .expect("serialize packet after output budget marker")
+            .len();
+        assert_eq!(
+            packet.budget.used.output_bytes as usize, serialized_len,
+            "final diagnostic marker must be included in packet output accounting"
+        );
         assert!(
             packet
                 .answer

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -82,7 +82,7 @@ use crate::agent::retrieval_primary::{
 use crate::agent::trace::{TraceRecorder, field};
 use crate::agent::trace_export;
 use crate::{
-    AppController, FocusedSourceContext, HybridSearchScoredHit,
+    AppController, FocusedSourceContext, HybridSearchScoredHit, clamp_u128_to_u32,
     fallback_mermaid as diagnostic_mermaid, hybrid_retrieval_enabled, mermaid_flowchart,
     mermaid_gantt, mermaid_sequence, query_mentions_non_primary_source,
 };
@@ -443,9 +443,13 @@ pub(crate) fn agent_packet(
         &mut answer,
     );
     packet_latency.apply_to_trace(&mut answer);
+
+    let phase_started = Instant::now();
     rank_packet_evidence(&question, &mut answer);
     maybe_annotate_packet_candidate_window(&question, &limits, &mut answer);
+    append_packet_non_trace_phase(&mut answer, "rank_and_window", phase_started);
 
+    let phase_started = Instant::now();
     if answer.retrieval_trace.retrieval_shadow.is_none()
         && let Some(shadow) =
             maybe_run_retrieval_shadow(controller, &question, req.latency_budget_ms)
@@ -461,8 +465,10 @@ pub(crate) fn agent_packet(
     }
     maybe_log_rollback_after_packet(controller, answer.retrieval_trace.retrieval_shadow.as_ref());
     append_packet_step_trace_annotation(&mut answer);
+    append_packet_non_trace_phase(&mut answer, "shadow_and_trace", phase_started);
 
     let sufficiency_extra_probes = packet_plan_sufficiency_extra_probes(&plan, &extra_probes);
+    let phase_started = Instant::now();
     let budget = apply_packet_budget_with_extra(
         &project_root,
         &question,
@@ -472,7 +478,11 @@ pub(crate) fn agent_packet(
         &mut answer,
         &sufficiency_extra_probes,
     );
+    append_packet_non_trace_phase(&mut answer, "budget", phase_started);
+    let phase_started = Instant::now();
     append_packet_evidence_sections(&mut answer, plan.task_class, &limits);
+    append_packet_non_trace_phase(&mut answer, "evidence_sections", phase_started);
+    let phase_started = Instant::now();
     let sufficiency = build_packet_sufficiency_with_extra(
         &project_root,
         &question,
@@ -481,7 +491,10 @@ pub(crate) fn agent_packet(
         &budget,
         &sufficiency_extra_probes,
     );
+    append_packet_non_trace_phase(&mut answer, "sufficiency", phase_started);
+    let phase_started = Instant::now();
     let retrieval_trace_summary = trace_export::packet_retrieval_trace_summary(&answer);
+    append_packet_non_trace_phase(&mut answer, "trace_summary", phase_started);
 
     let mut packet = AgentPacketDto {
         packet_id: answer.answer_id.clone(),
@@ -501,6 +514,20 @@ pub(crate) fn agent_packet(
     }
 
     Ok(packet)
+}
+
+fn append_packet_non_trace_phase(answer: &mut AgentAnswerDto, label: &str, started_at: Instant) {
+    answer
+        .retrieval_trace
+        .annotations
+        .push(packet_non_trace_phase_annotation(
+            label,
+            clamp_u128_to_u32(started_at.elapsed().as_millis()),
+        ));
+}
+
+fn packet_non_trace_phase_annotation(label: &str, duration_ms: u32) -> String {
+    format!("packet_non_trace_phase label={label} duration_ms={duration_ms}")
 }
 
 fn packet_plan_sufficiency_extra_probes(
@@ -9196,6 +9223,14 @@ mod tests {
         assert_eq!(answer.retrieval_trace.total_latency_ms, 1_150);
         assert!(answer.retrieval_trace.sla_missed);
         assert_eq!(answer.retrieval_trace.sla_target_ms, Some(1_000));
+    }
+
+    #[test]
+    fn packet_non_trace_phase_annotation_is_machine_readable() {
+        assert_eq!(
+            packet_non_trace_phase_annotation("budget", 42),
+            "packet_non_trace_phase label=budget duration_ms=42"
+        );
     }
 
     #[test]

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -4074,6 +4074,42 @@ function packetBatchTiming(timings, label, key) {
   return finiteNumber(timings.find((timing) => timing.label === label)?.[key]);
 }
 
+function packetNonTracePhaseTimings(annotations) {
+  if (!Array.isArray(annotations)) {
+    return [];
+  }
+  const pattern = /^packet_non_trace_phase label=([a-z_]+) duration_ms=(\d+)$/;
+  return annotations
+    .map((annotation) => pattern.exec(String(annotation ?? "")))
+    .filter(Boolean)
+    .map((match) => ({
+      label: match[1],
+      duration_ms: Number(match[2]),
+    }));
+}
+
+function packetNonTracePhaseTiming(timings, label) {
+  return finiteNumber(timings.find((timing) => timing.label === label)?.duration_ms);
+}
+
+function packetStdioPhaseTimings(annotations) {
+  if (!Array.isArray(annotations)) {
+    return [];
+  }
+  const pattern = /^packet_stdio_phase label=([a-z_]+) duration_ms=(\d+)$/;
+  return annotations
+    .map((annotation) => pattern.exec(String(annotation ?? "")))
+    .filter(Boolean)
+    .map((match) => ({
+      label: match[1],
+      duration_ms: Number(match[2]),
+    }));
+}
+
+function packetStdioPhaseTiming(timings, label) {
+  return finiteNumber(timings.find((timing) => timing.label === label)?.duration_ms);
+}
+
 function topPacketSearchQueries(searchSteps, limit = 8) {
   return [...searchSteps]
     .sort((left, right) => {
@@ -4097,6 +4133,8 @@ function packetLatencyTelemetry(packet, wallMs) {
   const topStep = [...steps].sort((left, right) => (right.duration_ms ?? 0) - (left.duration_ms ?? 0))[0] ?? null;
   const searchSteps = packetSearchStepTelemetry(steps);
   const batchTimings = packetBatchTimings(retrievalTrace?.annotations);
+  const nonTracePhaseTimings = packetNonTracePhaseTimings(retrievalTrace?.annotations);
+  const stdioPhaseTimings = packetStdioPhaseTimings(retrievalTrace?.annotations);
   const retrievalTotalMs = finiteNumber(retrievalTrace?.total_latency_ms);
   const freshnessMs = finiteNumber(freshness?.duration_ms);
   const accountedTraceMs =
@@ -4138,6 +4176,18 @@ function packetLatencyTelemetry(packet, wallMs) {
     packet_lexical_subquery_batch_attributed_query_ms: packetBatchTiming(batchTimings, "packet_lexical_subquery_batch", "attributed_query_ms"),
     packet_lexical_subquery_batch_overhead_ms: packetBatchTiming(batchTimings, "packet_lexical_subquery_batch", "overhead_ms"),
     packet_lexical_subquery_batch_queries: packetBatchTiming(batchTimings, "packet_lexical_subquery_batch", "queries"),
+    packet_non_trace_phase_timings: nonTracePhaseTimings,
+    packet_non_trace_phase_total_ms: nonTracePhaseTimings.reduce((sum, timing) => sum + timing.duration_ms, 0),
+    packet_rank_and_window_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "rank_and_window"),
+    packet_shadow_and_trace_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "shadow_and_trace"),
+    packet_budget_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "budget"),
+    packet_evidence_sections_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "evidence_sections"),
+    packet_sufficiency_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "sufficiency"),
+    packet_trace_summary_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "trace_summary"),
+    packet_stdio_phase_timings: stdioPhaseTimings,
+    packet_stdio_phase_total_ms: stdioPhaseTimings.reduce((sum, timing) => sum + timing.duration_ms, 0),
+    packet_stdio_text_materialization_ms: packetStdioPhaseTiming(stdioPhaseTimings, "text_materialization"),
+    packet_stdio_tool_response_materialization_ms: packetStdioPhaseTiming(stdioPhaseTimings, "tool_response_materialization"),
     retrieval_shadow: retrievalShadow,
   };
 }
@@ -4441,6 +4491,16 @@ function summarizePacketRuntimeRuns(results) {
       median_packet_batch_overhead_ms: median(latencyRows.map((row) => row.packet_latency?.packet_batch_overhead_ms)),
       median_packet_anchor_probe_batch_overhead_ms: median(latencyRows.map((row) => row.packet_latency?.packet_anchor_probe_batch_overhead_ms)),
       median_packet_lexical_subquery_batch_overhead_ms: median(latencyRows.map((row) => row.packet_latency?.packet_lexical_subquery_batch_overhead_ms)),
+      median_packet_non_trace_phase_total_ms: median(latencyRows.map((row) => row.packet_latency?.packet_non_trace_phase_total_ms)),
+      median_packet_rank_and_window_ms: median(latencyRows.map((row) => row.packet_latency?.packet_rank_and_window_ms)),
+      median_packet_shadow_and_trace_ms: median(latencyRows.map((row) => row.packet_latency?.packet_shadow_and_trace_ms)),
+      median_packet_budget_ms: median(latencyRows.map((row) => row.packet_latency?.packet_budget_ms)),
+      median_packet_evidence_sections_ms: median(latencyRows.map((row) => row.packet_latency?.packet_evidence_sections_ms)),
+      median_packet_sufficiency_ms: median(latencyRows.map((row) => row.packet_latency?.packet_sufficiency_ms)),
+      median_packet_trace_summary_ms: median(latencyRows.map((row) => row.packet_latency?.packet_trace_summary_ms)),
+      median_packet_stdio_phase_total_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_phase_total_ms)),
+      median_packet_stdio_text_materialization_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_text_materialization_ms)),
+      median_packet_stdio_tool_response_materialization_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_tool_response_materialization_ms)),
       packet_sla_missed_runs: latencyRows.filter((row) => row.packet_latency?.sla_missed === true).length,
       warm_stdio_packet_cache_hit_runs: successful.filter((row) => row.warm_stdio_packet_cache_hit === true).length,
       retrieval_shadow_cache_hit_runs: shadowRows.filter((shadow) => shadow.cache_hit === true).length,
@@ -4465,8 +4525,8 @@ function packetRuntimeMarkdown(summary) {
   const lines = [
     "# Packet Runtime Benchmark",
     "",
-    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Post-retrieval phases ms median | Stdio phases ms median | Budget ms median | Sufficiency ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const row of summary) {
     lines.push(packetRuntimeMarkdownRow(row));
@@ -4491,6 +4551,10 @@ function packetRuntimeMarkdownRow(row) {
     formatValue(row.median_packet_retrieval_total_ms),
     formatValue(row.median_packet_freshness_ms),
     formatValue(row.median_packet_unaccounted_ms),
+    formatValue(row.median_packet_non_trace_phase_total_ms),
+    formatValue(row.median_packet_stdio_phase_total_ms),
+    formatValue(row.median_packet_budget_ms),
+    formatValue(row.median_packet_sufficiency_ms),
     formatValue(row.median_packet_batch_total_ms),
     formatValue(row.median_packet_batch_attributed_query_ms),
     formatValue(row.median_packet_batch_overhead_ms),
@@ -5879,6 +5943,10 @@ function runSelfTest() {
         annotations: [
           "packet_anchor_probe_batch total_ms=25 attributed_query_ms=20 overhead_ms=5 queries=2",
           "packet_lexical_subquery_batch total_ms=40 attributed_query_ms=31 overhead_ms=9 queries=3",
+          "packet_non_trace_phase label=budget duration_ms=7",
+          "packet_non_trace_phase label=sufficiency duration_ms=11",
+          "packet_stdio_phase label=text_materialization duration_ms=3",
+          "packet_stdio_phase label=tool_response_materialization duration_ms=4",
         ],
         steps: [],
       },
@@ -5899,6 +5967,12 @@ function runSelfTest() {
   assert.equal(packetLatency.packet_batch_overhead_ms, 14);
   assert.equal(packetLatency.packet_anchor_probe_batch_overhead_ms, 5);
   assert.equal(packetLatency.packet_lexical_subquery_batch_overhead_ms, 9);
+  assert.equal(packetLatency.packet_non_trace_phase_total_ms, 18);
+  assert.equal(packetLatency.packet_budget_ms, 7);
+  assert.equal(packetLatency.packet_sufficiency_ms, 11);
+  assert.equal(packetLatency.packet_stdio_phase_total_ms, 7);
+  assert.equal(packetLatency.packet_stdio_text_materialization_ms, 3);
+  assert.equal(packetLatency.packet_stdio_tool_response_materialization_ms, 4);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }), true);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }, { publishable: true }), false);
   const weakPacketTelemetry = packetSufficiencyTelemetry(

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -4110,6 +4110,48 @@ function packetStdioPhaseTiming(timings, label) {
   return finiteNumber(timings.find((timing) => timing.label === label)?.duration_ms);
 }
 
+function stdioRequestIdKey(value) {
+  return JSON.stringify(value ?? null);
+}
+
+function parseStdioServerPhaseLine(line) {
+  const match = /^packet_stdio_server_phase request_id=(\S+) label=([a-z_]+) duration_ms=(\d+)$/.exec(String(line ?? ""));
+  if (!match) {
+    return null;
+  }
+  let requestId = match[1];
+  try {
+    requestId = stdioRequestIdKey(JSON.parse(requestId));
+  } catch {
+    // ponytail: raw key is fine if a future diagnostic id is not JSON.
+  }
+  return {
+    request_id: requestId,
+    label: match[2],
+    duration_ms: Number(match[3]),
+  };
+}
+
+function stdioServerPhaseTiming(timings, label) {
+  return finiteNumber(timings.find((timing) => timing.label === label)?.duration_ms);
+}
+
+function stdioServerPhaseTransportTimings(timings) {
+  const serializationMs = stdioServerPhaseTiming(timings, "response_serialization");
+  const newlineWriteMs = stdioServerPhaseTiming(timings, "newline_write");
+  const flushMs = stdioServerPhaseTiming(timings, "flush");
+  const phases = [serializationMs, newlineWriteMs, flushMs];
+  return {
+    stdio_server_phase_timings: timings,
+    stdio_server_output_total_ms: phases.every(Number.isFinite)
+      ? phases.reduce((sum, durationMs) => sum + durationMs, 0)
+      : null,
+    stdio_server_response_serialization_ms: serializationMs,
+    stdio_server_newline_write_ms: newlineWriteMs,
+    stdio_server_flush_ms: flushMs,
+  };
+}
+
 function topPacketSearchQueries(searchSteps, limit = 8) {
   return [...searchSteps]
     .sort((left, right) => {
@@ -4184,6 +4226,8 @@ function packetLatencyTelemetry(packet, wallMs) {
     packet_evidence_sections_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "evidence_sections"),
     packet_sufficiency_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "sufficiency"),
     packet_trace_summary_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "trace_summary"),
+    packet_dto_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "packet_dto"),
+    packet_output_budget_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "output_budget"),
     packet_stdio_phase_timings: stdioPhaseTimings,
     packet_stdio_phase_total_ms: stdioPhaseTimings.reduce((sum, timing) => sum + timing.duration_ms, 0),
     packet_stdio_text_materialization_ms: packetStdioPhaseTiming(stdioPhaseTimings, "text_materialization"),
@@ -4262,8 +4306,39 @@ function createStdioClient(command, args, opts) {
   });
   let buffer = "";
   let stderr = "";
+  let stderrBuffer = "";
+  const serverPhaseTimingsByRequestId = new Map();
   const pending = [];
   let closedError = null;
+  function recordStderr(chunk) {
+    stderr += chunk;
+    stderrBuffer += chunk;
+    for (;;) {
+      const newline = stderrBuffer.indexOf("\n");
+      if (newline < 0) {
+        break;
+      }
+      const line = stderrBuffer.slice(0, newline).trim();
+      stderrBuffer = stderrBuffer.slice(newline + 1);
+      const serverPhase = parseStdioServerPhaseLine(line);
+      if (!serverPhase) {
+        continue;
+      }
+      const timings = serverPhaseTimingsByRequestId.get(serverPhase.request_id) ?? [];
+      timings.push({
+        label: serverPhase.label,
+        duration_ms: serverPhase.duration_ms,
+      });
+      serverPhaseTimingsByRequestId.set(serverPhase.request_id, timings);
+    }
+  }
+  function serverPhaseTimingsForRequest(requestIdKey) {
+    return [...(serverPhaseTimingsByRequestId.get(requestIdKey) ?? [])];
+  }
+  function hasAllServerPhaseTimings(requestIdKey) {
+    const labels = new Set(serverPhaseTimingsForRequest(requestIdKey).map((timing) => timing.label));
+    return ["response_serialization", "newline_write", "flush"].every((label) => labels.has(label));
+  }
   function rejectPending(error) {
     while (pending.length) {
       const waiter = pending.shift();
@@ -4284,12 +4359,18 @@ function createStdioClient(command, args, opts) {
       }
       const waiter = pending.shift();
       if (waiter) {
-        waiter.resolve(line);
+        waiter.resolve({
+          line,
+          timings: {
+            ...waiter.timings,
+            stdio_response_wait_ms: Math.round((performance.now() - waiter.responseWaitStarted) * 1000) / 1000,
+          },
+        });
       }
     }
   });
   child.stderr.on("data", (chunk) => {
-    stderr += chunk.toString();
+    recordStderr(chunk.toString());
   });
   child.on("error", (error) => {
     closedError = error;
@@ -4306,6 +4387,9 @@ function createStdioClient(command, args, opts) {
     child,
     stderr: () => stderr,
     request(payload) {
+      return this.requestWithTimings(payload).then((result) => result.line);
+    },
+    requestWithTimings(payload) {
       return new Promise((resolve, reject) => {
         if (closedError) {
           reject(closedError);
@@ -4319,10 +4403,22 @@ function createStdioClient(command, args, opts) {
           }
           reject(new Error(`stdio request timed out after ${opts.timeoutMs}ms: ${stderr}`));
         }, opts.timeoutMs);
+        const stringifyStarted = performance.now();
+        const requestLine = `${JSON.stringify(payload)}\n`;
+        const requestIdKey = stdioRequestIdKey(payload?.id);
+        const timings = {
+          stdio_request_json_ms: Math.round((performance.now() - stringifyStarted) * 1000) / 1000,
+        };
         waiter = {
+          requestIdKey,
+          timings,
+          responseWaitStarted: performance.now(),
           resolve: (line) => {
             clearTimeout(timer);
-            resolve(line);
+            resolve({
+              ...line,
+              requestIdKey,
+            });
           },
           reject: (error) => {
             clearTimeout(timer);
@@ -4330,7 +4426,22 @@ function createStdioClient(command, args, opts) {
           },
         };
         pending.push(waiter);
-        child.stdin.write(`${JSON.stringify(payload)}\n`);
+        const writeStarted = performance.now();
+        child.stdin.write(requestLine);
+        waiter.timings.stdio_request_write_ms = Math.round((performance.now() - writeStarted) * 1000) / 1000;
+      });
+    },
+    waitForServerPhaseTimings(requestIdKey, timeoutMs = 250) {
+      const started = performance.now();
+      return new Promise((resolve) => {
+        const poll = () => {
+          if (hasAllServerPhaseTimings(requestIdKey) || performance.now() - started >= timeoutMs) {
+            resolve(serverPhaseTimingsForRequest(requestIdKey));
+            return;
+          }
+          setTimeout(poll, 5);
+        };
+        poll();
       });
     },
     close() {
@@ -4366,7 +4477,7 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
     for (const task of tasks) {
       for (let repeat = 1; repeat <= opts.repeats; repeat += 1) {
         const started = performance.now();
-        const responseLine = await client.request({
+        const responseResult = await client.requestWithTimings({
           jsonrpc: "2.0",
           id: `${task.id}-${repeat}`,
           method: "tools/call",
@@ -4380,7 +4491,15 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
           },
         });
         const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
+        const responseLine = responseResult.line;
+        const serverPhaseTimings = await client.waitForServerPhaseTimings(responseResult.requestIdKey);
+        const parseStarted = performance.now();
         const response = JSON.parse(responseLine);
+        const stdioTransport = {
+          ...responseResult.timings,
+          ...stdioServerPhaseTransportTimings(serverPhaseTimings),
+          stdio_response_parse_ms: Math.round((performance.now() - parseStarted) * 1000) / 1000,
+        };
         const packet = response.result?.structuredContent ?? null;
         const isError = response.result?.isError === true || response.error;
         const packetFingerprint = packet && !isError ? JSON.stringify(packet) : null;
@@ -4418,6 +4537,7 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
           error: response.error?.message ?? (isError ? response.result?.content?.[0]?.text : null),
           wall_ms: wallMs,
           response_bytes: Buffer.byteLength(responseLine, "utf8"),
+          stdio_transport: stdioTransport,
           warm_stdio_packet_cache_hit: warmStdioPacketCacheHit,
           warm_stdio_packet_cache_reference_repeat: warmStdioPacketCacheHit ? previousPacket.repeat : null,
           warm_stdio_packet_cache_reference_wall_ms: warmStdioPacketCacheHit ? previousPacket.wallMs : null,
@@ -4495,12 +4615,22 @@ function summarizePacketRuntimeRuns(results) {
       median_packet_rank_and_window_ms: median(latencyRows.map((row) => row.packet_latency?.packet_rank_and_window_ms)),
       median_packet_shadow_and_trace_ms: median(latencyRows.map((row) => row.packet_latency?.packet_shadow_and_trace_ms)),
       median_packet_budget_ms: median(latencyRows.map((row) => row.packet_latency?.packet_budget_ms)),
+      median_packet_dto_ms: median(latencyRows.map((row) => row.packet_latency?.packet_dto_ms)),
+      median_packet_output_budget_ms: median(latencyRows.map((row) => row.packet_latency?.packet_output_budget_ms)),
       median_packet_evidence_sections_ms: median(latencyRows.map((row) => row.packet_latency?.packet_evidence_sections_ms)),
       median_packet_sufficiency_ms: median(latencyRows.map((row) => row.packet_latency?.packet_sufficiency_ms)),
       median_packet_trace_summary_ms: median(latencyRows.map((row) => row.packet_latency?.packet_trace_summary_ms)),
       median_packet_stdio_phase_total_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_phase_total_ms)),
       median_packet_stdio_text_materialization_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_text_materialization_ms)),
       median_packet_stdio_tool_response_materialization_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_tool_response_materialization_ms)),
+      median_stdio_request_json_ms: median(successful.map((row) => row.stdio_transport?.stdio_request_json_ms)),
+      median_stdio_request_write_ms: median(successful.map((row) => row.stdio_transport?.stdio_request_write_ms)),
+      median_stdio_response_wait_ms: median(successful.map((row) => row.stdio_transport?.stdio_response_wait_ms)),
+      median_stdio_server_output_total_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_output_total_ms)),
+      median_stdio_server_response_serialization_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_response_serialization_ms)),
+      median_stdio_server_newline_write_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_newline_write_ms)),
+      median_stdio_server_flush_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_flush_ms)),
+      median_stdio_response_parse_ms: median(successful.map((row) => row.stdio_transport?.stdio_response_parse_ms)),
       packet_sla_missed_runs: latencyRows.filter((row) => row.packet_latency?.sla_missed === true).length,
       warm_stdio_packet_cache_hit_runs: successful.filter((row) => row.warm_stdio_packet_cache_hit === true).length,
       retrieval_shadow_cache_hit_runs: shadowRows.filter((shadow) => shadow.cache_hit === true).length,
@@ -4525,8 +4655,8 @@ function packetRuntimeMarkdown(summary) {
   const lines = [
     "# Packet Runtime Benchmark",
     "",
-    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Post-retrieval phases ms median | Stdio phases ms median | Budget ms median | Sufficiency ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Post-retrieval phases ms median | Stdio phases ms median | Budget ms median | DTO ms median | Output budget ms median | Sufficiency ms median | Stdio req JSON ms median | Stdio req write ms median | Stdio resp wait ms median | Server output ms median | Server serialize ms median | Server newline ms median | Server flush ms median | Stdio resp parse ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const row of summary) {
     lines.push(packetRuntimeMarkdownRow(row));
@@ -4554,7 +4684,17 @@ function packetRuntimeMarkdownRow(row) {
     formatValue(row.median_packet_non_trace_phase_total_ms),
     formatValue(row.median_packet_stdio_phase_total_ms),
     formatValue(row.median_packet_budget_ms),
+    formatValue(row.median_packet_dto_ms),
+    formatValue(row.median_packet_output_budget_ms),
     formatValue(row.median_packet_sufficiency_ms),
+    formatValue(row.median_stdio_request_json_ms),
+    formatValue(row.median_stdio_request_write_ms),
+    formatValue(row.median_stdio_response_wait_ms),
+    formatValue(row.median_stdio_server_output_total_ms),
+    formatValue(row.median_stdio_server_response_serialization_ms),
+    formatValue(row.median_stdio_server_newline_write_ms),
+    formatValue(row.median_stdio_server_flush_ms),
+    formatValue(row.median_stdio_response_parse_ms),
     formatValue(row.median_packet_batch_total_ms),
     formatValue(row.median_packet_batch_attributed_query_ms),
     formatValue(row.median_packet_batch_overhead_ms),
@@ -5945,6 +6085,8 @@ function runSelfTest() {
           "packet_lexical_subquery_batch total_ms=40 attributed_query_ms=31 overhead_ms=9 queries=3",
           "packet_non_trace_phase label=budget duration_ms=7",
           "packet_non_trace_phase label=sufficiency duration_ms=11",
+          "packet_non_trace_phase label=packet_dto duration_ms=2",
+          "packet_non_trace_phase label=output_budget duration_ms=5",
           "packet_stdio_phase label=text_materialization duration_ms=3",
           "packet_stdio_phase label=tool_response_materialization duration_ms=4",
         ],
@@ -5967,12 +6109,31 @@ function runSelfTest() {
   assert.equal(packetLatency.packet_batch_overhead_ms, 14);
   assert.equal(packetLatency.packet_anchor_probe_batch_overhead_ms, 5);
   assert.equal(packetLatency.packet_lexical_subquery_batch_overhead_ms, 9);
-  assert.equal(packetLatency.packet_non_trace_phase_total_ms, 18);
+  assert.equal(packetLatency.packet_non_trace_phase_total_ms, 25);
   assert.equal(packetLatency.packet_budget_ms, 7);
   assert.equal(packetLatency.packet_sufficiency_ms, 11);
+  assert.equal(packetLatency.packet_dto_ms, 2);
+  assert.equal(packetLatency.packet_output_budget_ms, 5);
   assert.equal(packetLatency.packet_stdio_phase_total_ms, 7);
   assert.equal(packetLatency.packet_stdio_text_materialization_ms, 3);
   assert.equal(packetLatency.packet_stdio_tool_response_materialization_ms, 4);
+  const serverPhase = parseStdioServerPhaseLine(
+    'packet_stdio_server_phase request_id="java-commons-lang-string-utils-1" label=response_serialization duration_ms=12',
+  );
+  assert.deepEqual(serverPhase, {
+    request_id: '"java-commons-lang-string-utils-1"',
+    label: "response_serialization",
+    duration_ms: 12,
+  });
+  const serverTransport = stdioServerPhaseTransportTimings([
+    { label: "response_serialization", duration_ms: 12 },
+    { label: "newline_write", duration_ms: 1 },
+    { label: "flush", duration_ms: 2 },
+  ]);
+  assert.equal(serverTransport.stdio_server_output_total_ms, 15);
+  assert.equal(serverTransport.stdio_server_response_serialization_ms, 12);
+  assert.equal(serverTransport.stdio_server_newline_write_ms, 1);
+  assert.equal(serverTransport.stdio_server_flush_ms, 2);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }), true);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }, { publishable: true }), false);
   const weakPacketTelemetry = packetSufficiencyTelemetry(


### PR DESCRIPTION
## Context

Closes #124.

This lands the reviewed warm packet non-trace diagnostic stack only. It leaves #95, #98, #89, #87, #78, #74, and #73 open.

The latest focused Apache/Redis evidence still records packet-runtime SLA misses, so this PR is diagnostic evidence, not packet SLA clearance.

## What Changed

- Added packet `packet_non_trace_phase` annotations for post-retrieval packet assembly boundaries.
- Added stdio packet/materialization and server-side response phase diagnostics.
- Extended the packet-runtime harness summary/reporting to parse those diagnostic surfaces.
- Collapsed the reviewed #101/#105/#115 diagnostic stack into this live #95 branch.

## How To Review

- Confirm the PR closes only #124.
- Confirm packet quality, sufficiency, scorer, SLA thresholds, and sidecar behavior are unchanged.
- Review the two accepted diagnostic caveats:
  - `output_budget` timing names the phase but does not count both enforcement calls as total paid cost.
  - `packet_stdio_server_phase` is emitted on stderr as an intentional harness/diagnostic surface and does not affect JSON-RPC stdout.

## Verification

Review gate for current head `c692931fca3f58934baf0a83320bbe21948bab70`:

```powershell
git diff --check origin/main...origin/pr/97
node --check scripts\codestory-agent-ab-benchmark.mjs
node scripts\codestory-agent-ab-benchmark.mjs --self-test
```

Live checks:

- `linux-contracts`: passed.
- Issue-link guard: rerun expected after this retarget.

Cargo was not rerun for this disposition update because the branch did not change after read-only review and `linux-contracts` is green.

## Risk

The diagnostic surfaces are useful for future packet-runtime work, but they do not explain or clear the remaining SLA miss. Keep #95/#98/#89/#87/#78 open until a focused current-main slice clears or residual risk is explicitly accepted.

## Skills used

- repo-local `codestory-grounding`
- `github:github`
- `superpowers:verification-before-completion`
- `best-practices`
- `performance`