### PR TITLE
Split final packet output residual wall

### DIFF
--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -39,9 +39,19 @@ pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
             continue;
         }
         if let Some(response) = handle_stdio_message(&runtime, &mut state, &line) {
+            let response_id = stdio_response_id_label(&response);
+            let serialize_started = Instant::now();
             serde_json::to_writer(&mut stdout, &response)?;
+            let serialization_ms = stdio_elapsed_ms(serialize_started);
+            let newline_started = Instant::now();
             stdout.write_all(b"\n")?;
+            let newline_write_ms = stdio_elapsed_ms(newline_started);
+            let flush_started = Instant::now();
             stdout.flush()?;
+            let flush_ms = stdio_elapsed_ms(flush_started);
+            report_stdio_server_phase(&response_id, "response_serialization", serialization_ms);
+            report_stdio_server_phase(&response_id, "newline_write", newline_write_ms);
+            report_stdio_server_phase(&response_id, "flush", flush_ms);
         }
     }
     Ok(())
@@ -287,6 +297,19 @@ fn append_stdio_packet_phase(packet: &mut serde_json::Value, label: &str, durati
 
 fn stdio_elapsed_ms(started_at: Instant) -> u32 {
     started_at.elapsed().as_millis().min(u128::from(u32::MAX)) as u32
+}
+
+fn stdio_response_id_label(response: &serde_json::Value) -> String {
+    response
+        .get("id")
+        .map(stdio_json_text)
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn report_stdio_server_phase(request_id: &str, label: &str, duration_ms: u32) {
+    eprintln!(
+        "packet_stdio_server_phase request_id={request_id} label={label} duration_ms={duration_ms}"
+    );
 }
 
 fn stdio_packet_text(packet: &serde_json::Value) -> String {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -39,7 +39,8 @@ pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
             continue;
         }
         if let Some(response) = handle_stdio_message(&runtime, &mut state, &line) {
-            writeln!(stdout, "{}", serde_json::to_string(&response)?)?;
+            serde_json::to_writer(&mut stdout, &response)?;
+            stdout.write_all(b"\n")?;
             stdout.flush()?;
         }
     }
@@ -1884,6 +1885,35 @@ mod tests {
             storage_fingerprint: storage_fingerprint.to_string(),
             ..base_packet_cache_key_input(question)
         })
+    }
+
+    #[test]
+    fn stdio_tool_call_success_times_packet_materialization() {
+        let response = stdio_tool_call_success(json!({
+            "packet_id": "packet-1",
+            "answer": {
+                "retrieval_trace": {
+                    "annotations": []
+                }
+            }
+        }));
+        let annotations = response
+            .pointer("/structuredContent/answer/retrieval_trace/annotations")
+            .and_then(|value| value.as_array())
+            .expect("packet annotations");
+
+        assert!(annotations.iter().any(|annotation| {
+            annotation.as_str().is_some_and(|value| {
+                value.starts_with("packet_stdio_phase label=text_materialization duration_ms=")
+            })
+        }));
+        assert!(annotations.iter().any(|annotation| {
+            annotation.as_str().is_some_and(|value| {
+                value.starts_with(
+                    "packet_stdio_phase label=tool_response_materialization duration_ms=",
+                )
+            })
+        }));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -431,6 +431,7 @@ pub(crate) fn agent_packet(
         &rank_terms,
         &mut answer,
     )?;
+    let phase_started = Instant::now();
     maybe_append_sql_schema_file_citations(&project_root, &question, &mut answer);
     maybe_append_generic_source_shape_citations(&project_root, &question, &mut answer);
     let file_scoped_source_probes =
@@ -442,7 +443,10 @@ pub(crate) fn agent_packet(
         &file_scoped_source_probes,
         &mut answer,
     );
+    append_packet_non_trace_phase(&mut answer, "pre_rank_citations", phase_started);
+    let phase_started = Instant::now();
     packet_latency.apply_to_trace(&mut answer);
+    append_packet_non_trace_phase(&mut answer, "trace_apply", phase_started);
 
     let phase_started = Instant::now();
     rank_packet_evidence(&question, &mut answer);
@@ -9242,6 +9246,14 @@ mod tests {
         assert_eq!(
             packet_non_trace_phase_annotation("budget", 42),
             "packet_non_trace_phase label=budget duration_ms=42"
+        );
+        assert_eq!(
+            packet_non_trace_phase_annotation("pre_rank_citations", 7),
+            "packet_non_trace_phase label=pre_rank_citations duration_ms=7"
+        );
+        assert_eq!(
+            packet_non_trace_phase_annotation("trace_apply", 3),
+            "packet_non_trace_phase label=trace_apply duration_ms=3"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -511,6 +511,7 @@ pub(crate) fn agent_packet(
     let phase_started = Instant::now();
     enforce_packet_output_budget(&project_root, &mut packet);
     append_packet_non_trace_phase(&mut packet.answer, "output_budget", phase_started);
+    enforce_packet_output_budget(&project_root, &mut packet);
 
     if let Some(diagnostic) = trace_export::write_packet_step_trace_from_env(&packet.answer) {
         packet.answer.retrieval_trace.annotations.push(diagnostic);
@@ -521,6 +522,7 @@ pub(crate) fn agent_packet(
             "trace_artifact_output_budget",
             phase_started,
         );
+        enforce_packet_output_budget(&project_root, &mut packet);
     }
 
     Ok(packet)
@@ -9781,6 +9783,15 @@ mod tests {
             max_output_bytes
         );
         assert_eq!(packet.budget.used.output_bytes as usize, serialized_len);
+        append_packet_non_trace_phase(&mut packet.answer, "output_budget", Instant::now());
+        enforce_packet_output_budget(packet_fixture_project_root(), &mut packet);
+        let serialized_len = serde_json::to_vec(&packet)
+            .expect("serialize packet after output budget marker")
+            .len();
+        assert_eq!(
+            packet.budget.used.output_bytes as usize, serialized_len,
+            "final diagnostic marker must be included in packet output accounting"
+        );
         assert!(
             packet
                 .answer

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -496,6 +496,7 @@ pub(crate) fn agent_packet(
     let retrieval_trace_summary = trace_export::packet_retrieval_trace_summary(&answer);
     append_packet_non_trace_phase(&mut answer, "trace_summary", phase_started);
 
+    let phase_started = Instant::now();
     let mut packet = AgentPacketDto {
         packet_id: answer.answer_id.clone(),
         question,
@@ -506,11 +507,20 @@ pub(crate) fn agent_packet(
         sufficiency,
         retrieval_trace_summary,
     };
+    append_packet_non_trace_phase(&mut packet.answer, "packet_dto", phase_started);
+    let phase_started = Instant::now();
     enforce_packet_output_budget(&project_root, &mut packet);
+    append_packet_non_trace_phase(&mut packet.answer, "output_budget", phase_started);
 
     if let Some(diagnostic) = trace_export::write_packet_step_trace_from_env(&packet.answer) {
         packet.answer.retrieval_trace.annotations.push(diagnostic);
+        let phase_started = Instant::now();
         enforce_packet_output_budget(&project_root, &mut packet);
+        append_packet_non_trace_phase(
+            &mut packet.answer,
+            "trace_artifact_output_budget",
+            phase_started,
+        );
     }
 
     Ok(packet)

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -4110,6 +4110,48 @@ function packetStdioPhaseTiming(timings, label) {
   return finiteNumber(timings.find((timing) => timing.label === label)?.duration_ms);
 }
 
+function stdioRequestIdKey(value) {
+  return JSON.stringify(value ?? null);
+}
+
+function parseStdioServerPhaseLine(line) {
+  const match = /^packet_stdio_server_phase request_id=(\S+) label=([a-z_]+) duration_ms=(\d+)$/.exec(String(line ?? ""));
+  if (!match) {
+    return null;
+  }
+  let requestId = match[1];
+  try {
+    requestId = stdioRequestIdKey(JSON.parse(requestId));
+  } catch {
+    // ponytail: raw key is fine if a future diagnostic id is not JSON.
+  }
+  return {
+    request_id: requestId,
+    label: match[2],
+    duration_ms: Number(match[3]),
+  };
+}
+
+function stdioServerPhaseTiming(timings, label) {
+  return finiteNumber(timings.find((timing) => timing.label === label)?.duration_ms);
+}
+
+function stdioServerPhaseTransportTimings(timings) {
+  const serializationMs = stdioServerPhaseTiming(timings, "response_serialization");
+  const newlineWriteMs = stdioServerPhaseTiming(timings, "newline_write");
+  const flushMs = stdioServerPhaseTiming(timings, "flush");
+  const phases = [serializationMs, newlineWriteMs, flushMs];
+  return {
+    stdio_server_phase_timings: timings,
+    stdio_server_output_total_ms: phases.every(Number.isFinite)
+      ? phases.reduce((sum, durationMs) => sum + durationMs, 0)
+      : null,
+    stdio_server_response_serialization_ms: serializationMs,
+    stdio_server_newline_write_ms: newlineWriteMs,
+    stdio_server_flush_ms: flushMs,
+  };
+}
+
 function topPacketSearchQueries(searchSteps, limit = 8) {
   return [...searchSteps]
     .sort((left, right) => {
@@ -4264,8 +4306,39 @@ function createStdioClient(command, args, opts) {
   });
   let buffer = "";
   let stderr = "";
+  let stderrBuffer = "";
+  const serverPhaseTimingsByRequestId = new Map();
   const pending = [];
   let closedError = null;
+  function recordStderr(chunk) {
+    stderr += chunk;
+    stderrBuffer += chunk;
+    for (;;) {
+      const newline = stderrBuffer.indexOf("\n");
+      if (newline < 0) {
+        break;
+      }
+      const line = stderrBuffer.slice(0, newline).trim();
+      stderrBuffer = stderrBuffer.slice(newline + 1);
+      const serverPhase = parseStdioServerPhaseLine(line);
+      if (!serverPhase) {
+        continue;
+      }
+      const timings = serverPhaseTimingsByRequestId.get(serverPhase.request_id) ?? [];
+      timings.push({
+        label: serverPhase.label,
+        duration_ms: serverPhase.duration_ms,
+      });
+      serverPhaseTimingsByRequestId.set(serverPhase.request_id, timings);
+    }
+  }
+  function serverPhaseTimingsForRequest(requestIdKey) {
+    return [...(serverPhaseTimingsByRequestId.get(requestIdKey) ?? [])];
+  }
+  function hasAllServerPhaseTimings(requestIdKey) {
+    const labels = new Set(serverPhaseTimingsForRequest(requestIdKey).map((timing) => timing.label));
+    return ["response_serialization", "newline_write", "flush"].every((label) => labels.has(label));
+  }
   function rejectPending(error) {
     while (pending.length) {
       const waiter = pending.shift();
@@ -4297,7 +4370,7 @@ function createStdioClient(command, args, opts) {
     }
   });
   child.stderr.on("data", (chunk) => {
-    stderr += chunk.toString();
+    recordStderr(chunk.toString());
   });
   child.on("error", (error) => {
     closedError = error;
@@ -4332,15 +4405,20 @@ function createStdioClient(command, args, opts) {
         }, opts.timeoutMs);
         const stringifyStarted = performance.now();
         const requestLine = `${JSON.stringify(payload)}\n`;
+        const requestIdKey = stdioRequestIdKey(payload?.id);
         const timings = {
           stdio_request_json_ms: Math.round((performance.now() - stringifyStarted) * 1000) / 1000,
         };
         waiter = {
+          requestIdKey,
           timings,
           responseWaitStarted: performance.now(),
           resolve: (line) => {
             clearTimeout(timer);
-            resolve(line);
+            resolve({
+              ...line,
+              requestIdKey,
+            });
           },
           reject: (error) => {
             clearTimeout(timer);
@@ -4351,6 +4429,19 @@ function createStdioClient(command, args, opts) {
         const writeStarted = performance.now();
         child.stdin.write(requestLine);
         waiter.timings.stdio_request_write_ms = Math.round((performance.now() - writeStarted) * 1000) / 1000;
+      });
+    },
+    waitForServerPhaseTimings(requestIdKey, timeoutMs = 250) {
+      const started = performance.now();
+      return new Promise((resolve) => {
+        const poll = () => {
+          if (hasAllServerPhaseTimings(requestIdKey) || performance.now() - started >= timeoutMs) {
+            resolve(serverPhaseTimingsForRequest(requestIdKey));
+            return;
+          }
+          setTimeout(poll, 5);
+        };
+        poll();
       });
     },
     close() {
@@ -4401,10 +4492,12 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
         });
         const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
         const responseLine = responseResult.line;
+        const serverPhaseTimings = await client.waitForServerPhaseTimings(responseResult.requestIdKey);
         const parseStarted = performance.now();
         const response = JSON.parse(responseLine);
         const stdioTransport = {
           ...responseResult.timings,
+          ...stdioServerPhaseTransportTimings(serverPhaseTimings),
           stdio_response_parse_ms: Math.round((performance.now() - parseStarted) * 1000) / 1000,
         };
         const packet = response.result?.structuredContent ?? null;
@@ -4533,6 +4626,10 @@ function summarizePacketRuntimeRuns(results) {
       median_stdio_request_json_ms: median(successful.map((row) => row.stdio_transport?.stdio_request_json_ms)),
       median_stdio_request_write_ms: median(successful.map((row) => row.stdio_transport?.stdio_request_write_ms)),
       median_stdio_response_wait_ms: median(successful.map((row) => row.stdio_transport?.stdio_response_wait_ms)),
+      median_stdio_server_output_total_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_output_total_ms)),
+      median_stdio_server_response_serialization_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_response_serialization_ms)),
+      median_stdio_server_newline_write_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_newline_write_ms)),
+      median_stdio_server_flush_ms: median(successful.map((row) => row.stdio_transport?.stdio_server_flush_ms)),
       median_stdio_response_parse_ms: median(successful.map((row) => row.stdio_transport?.stdio_response_parse_ms)),
       packet_sla_missed_runs: latencyRows.filter((row) => row.packet_latency?.sla_missed === true).length,
       warm_stdio_packet_cache_hit_runs: successful.filter((row) => row.warm_stdio_packet_cache_hit === true).length,
@@ -4558,8 +4655,8 @@ function packetRuntimeMarkdown(summary) {
   const lines = [
     "# Packet Runtime Benchmark",
     "",
-    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Post-retrieval phases ms median | Stdio phases ms median | Budget ms median | DTO ms median | Output budget ms median | Sufficiency ms median | Stdio req JSON ms median | Stdio req write ms median | Stdio resp wait ms median | Stdio resp parse ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Post-retrieval phases ms median | Stdio phases ms median | Budget ms median | DTO ms median | Output budget ms median | Sufficiency ms median | Stdio req JSON ms median | Stdio req write ms median | Stdio resp wait ms median | Server output ms median | Server serialize ms median | Server newline ms median | Server flush ms median | Stdio resp parse ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const row of summary) {
     lines.push(packetRuntimeMarkdownRow(row));
@@ -4593,6 +4690,10 @@ function packetRuntimeMarkdownRow(row) {
     formatValue(row.median_stdio_request_json_ms),
     formatValue(row.median_stdio_request_write_ms),
     formatValue(row.median_stdio_response_wait_ms),
+    formatValue(row.median_stdio_server_output_total_ms),
+    formatValue(row.median_stdio_server_response_serialization_ms),
+    formatValue(row.median_stdio_server_newline_write_ms),
+    formatValue(row.median_stdio_server_flush_ms),
     formatValue(row.median_stdio_response_parse_ms),
     formatValue(row.median_packet_batch_total_ms),
     formatValue(row.median_packet_batch_attributed_query_ms),
@@ -6016,6 +6117,23 @@ function runSelfTest() {
   assert.equal(packetLatency.packet_stdio_phase_total_ms, 7);
   assert.equal(packetLatency.packet_stdio_text_materialization_ms, 3);
   assert.equal(packetLatency.packet_stdio_tool_response_materialization_ms, 4);
+  const serverPhase = parseStdioServerPhaseLine(
+    'packet_stdio_server_phase request_id="java-commons-lang-string-utils-1" label=response_serialization duration_ms=12',
+  );
+  assert.deepEqual(serverPhase, {
+    request_id: '"java-commons-lang-string-utils-1"',
+    label: "response_serialization",
+    duration_ms: 12,
+  });
+  const serverTransport = stdioServerPhaseTransportTimings([
+    { label: "response_serialization", duration_ms: 12 },
+    { label: "newline_write", duration_ms: 1 },
+    { label: "flush", duration_ms: 2 },
+  ]);
+  assert.equal(serverTransport.stdio_server_output_total_ms, 15);
+  assert.equal(serverTransport.stdio_server_response_serialization_ms, 12);
+  assert.equal(serverTransport.stdio_server_newline_write_ms, 1);
+  assert.equal(serverTransport.stdio_server_flush_ms, 2);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }), true);
   assert.equal(preludeAllowsAgentRun({ status: "pass_with_warnings" }, { publishable: true }), false);
   const weakPacketTelemetry = packetSufficiencyTelemetry(

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -4184,6 +4184,8 @@ function packetLatencyTelemetry(packet, wallMs) {
     packet_evidence_sections_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "evidence_sections"),
     packet_sufficiency_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "sufficiency"),
     packet_trace_summary_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "trace_summary"),
+    packet_dto_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "packet_dto"),
+    packet_output_budget_ms: packetNonTracePhaseTiming(nonTracePhaseTimings, "output_budget"),
     packet_stdio_phase_timings: stdioPhaseTimings,
     packet_stdio_phase_total_ms: stdioPhaseTimings.reduce((sum, timing) => sum + timing.duration_ms, 0),
     packet_stdio_text_materialization_ms: packetStdioPhaseTiming(stdioPhaseTimings, "text_materialization"),
@@ -4284,7 +4286,13 @@ function createStdioClient(command, args, opts) {
       }
       const waiter = pending.shift();
       if (waiter) {
-        waiter.resolve(line);
+        waiter.resolve({
+          line,
+          timings: {
+            ...waiter.timings,
+            stdio_response_wait_ms: Math.round((performance.now() - waiter.responseWaitStarted) * 1000) / 1000,
+          },
+        });
       }
     }
   });
@@ -4306,6 +4314,9 @@ function createStdioClient(command, args, opts) {
     child,
     stderr: () => stderr,
     request(payload) {
+      return this.requestWithTimings(payload).then((result) => result.line);
+    },
+    requestWithTimings(payload) {
       return new Promise((resolve, reject) => {
         if (closedError) {
           reject(closedError);
@@ -4319,7 +4330,14 @@ function createStdioClient(command, args, opts) {
           }
           reject(new Error(`stdio request timed out after ${opts.timeoutMs}ms: ${stderr}`));
         }, opts.timeoutMs);
+        const stringifyStarted = performance.now();
+        const requestLine = `${JSON.stringify(payload)}\n`;
+        const timings = {
+          stdio_request_json_ms: Math.round((performance.now() - stringifyStarted) * 1000) / 1000,
+        };
         waiter = {
+          timings,
+          responseWaitStarted: performance.now(),
           resolve: (line) => {
             clearTimeout(timer);
             resolve(line);
@@ -4330,7 +4348,9 @@ function createStdioClient(command, args, opts) {
           },
         };
         pending.push(waiter);
-        child.stdin.write(`${JSON.stringify(payload)}\n`);
+        const writeStarted = performance.now();
+        child.stdin.write(requestLine);
+        waiter.timings.stdio_request_write_ms = Math.round((performance.now() - writeStarted) * 1000) / 1000;
       });
     },
     close() {
@@ -4366,7 +4386,7 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
     for (const task of tasks) {
       for (let repeat = 1; repeat <= opts.repeats; repeat += 1) {
         const started = performance.now();
-        const responseLine = await client.request({
+        const responseResult = await client.requestWithTimings({
           jsonrpc: "2.0",
           id: `${task.id}-${repeat}`,
           method: "tools/call",
@@ -4380,7 +4400,13 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
           },
         });
         const wallMs = Math.round((performance.now() - started) * 1000) / 1000;
+        const responseLine = responseResult.line;
+        const parseStarted = performance.now();
         const response = JSON.parse(responseLine);
+        const stdioTransport = {
+          ...responseResult.timings,
+          stdio_response_parse_ms: Math.round((performance.now() - parseStarted) * 1000) / 1000,
+        };
         const packet = response.result?.structuredContent ?? null;
         const isError = response.result?.isError === true || response.error;
         const packetFingerprint = packet && !isError ? JSON.stringify(packet) : null;
@@ -4418,6 +4444,7 @@ async function runWarmPacketRuntimeGroup(opts, repoName, tasks, outDir) {
           error: response.error?.message ?? (isError ? response.result?.content?.[0]?.text : null),
           wall_ms: wallMs,
           response_bytes: Buffer.byteLength(responseLine, "utf8"),
+          stdio_transport: stdioTransport,
           warm_stdio_packet_cache_hit: warmStdioPacketCacheHit,
           warm_stdio_packet_cache_reference_repeat: warmStdioPacketCacheHit ? previousPacket.repeat : null,
           warm_stdio_packet_cache_reference_wall_ms: warmStdioPacketCacheHit ? previousPacket.wallMs : null,
@@ -4495,12 +4522,18 @@ function summarizePacketRuntimeRuns(results) {
       median_packet_rank_and_window_ms: median(latencyRows.map((row) => row.packet_latency?.packet_rank_and_window_ms)),
       median_packet_shadow_and_trace_ms: median(latencyRows.map((row) => row.packet_latency?.packet_shadow_and_trace_ms)),
       median_packet_budget_ms: median(latencyRows.map((row) => row.packet_latency?.packet_budget_ms)),
+      median_packet_dto_ms: median(latencyRows.map((row) => row.packet_latency?.packet_dto_ms)),
+      median_packet_output_budget_ms: median(latencyRows.map((row) => row.packet_latency?.packet_output_budget_ms)),
       median_packet_evidence_sections_ms: median(latencyRows.map((row) => row.packet_latency?.packet_evidence_sections_ms)),
       median_packet_sufficiency_ms: median(latencyRows.map((row) => row.packet_latency?.packet_sufficiency_ms)),
       median_packet_trace_summary_ms: median(latencyRows.map((row) => row.packet_latency?.packet_trace_summary_ms)),
       median_packet_stdio_phase_total_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_phase_total_ms)),
       median_packet_stdio_text_materialization_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_text_materialization_ms)),
       median_packet_stdio_tool_response_materialization_ms: median(latencyRows.map((row) => row.packet_latency?.packet_stdio_tool_response_materialization_ms)),
+      median_stdio_request_json_ms: median(successful.map((row) => row.stdio_transport?.stdio_request_json_ms)),
+      median_stdio_request_write_ms: median(successful.map((row) => row.stdio_transport?.stdio_request_write_ms)),
+      median_stdio_response_wait_ms: median(successful.map((row) => row.stdio_transport?.stdio_response_wait_ms)),
+      median_stdio_response_parse_ms: median(successful.map((row) => row.stdio_transport?.stdio_response_parse_ms)),
       packet_sla_missed_runs: latencyRows.filter((row) => row.packet_latency?.sla_missed === true).length,
       warm_stdio_packet_cache_hit_runs: successful.filter((row) => row.warm_stdio_packet_cache_hit === true).length,
       retrieval_shadow_cache_hit_runs: shadowRows.filter((shadow) => shadow.cache_hit === true).length,
@@ -4525,8 +4558,8 @@ function packetRuntimeMarkdown(summary) {
   const lines = [
     "# Packet Runtime Benchmark",
     "",
-    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Post-retrieval phases ms median | Stdio phases ms median | Budget ms median | Sufficiency ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| Repo | Task | Mode | Runs | Pass | Quality Pass | Sufficiency | Suff/quality gaps | Wall ms median | Retrieval ms median | Freshness ms median | Non-trace wall ms median | Post-retrieval phases ms median | Stdio phases ms median | Budget ms median | DTO ms median | Output budget ms median | Sufficiency ms median | Stdio req JSON ms median | Stdio req write ms median | Stdio resp wait ms median | Stdio resp parse ms median | Batch total ms median | Batch attributed ms median | Batch overhead ms median | Anchor batch overhead ms median | Lexical batch overhead ms median | Top step | Top step ms median | SLA misses | Packet-cache hits | Retrieval cache-hit runs | Stage cache-hit runs | Response bytes median | Packet bytes median | Graph bytes median | Avoid-open median | Follow-up median | File recall | Citation coverage | Packet citation recall | Packet answer-surface recall | Packet structured recall |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   ];
   for (const row of summary) {
     lines.push(packetRuntimeMarkdownRow(row));
@@ -4554,7 +4587,13 @@ function packetRuntimeMarkdownRow(row) {
     formatValue(row.median_packet_non_trace_phase_total_ms),
     formatValue(row.median_packet_stdio_phase_total_ms),
     formatValue(row.median_packet_budget_ms),
+    formatValue(row.median_packet_dto_ms),
+    formatValue(row.median_packet_output_budget_ms),
     formatValue(row.median_packet_sufficiency_ms),
+    formatValue(row.median_stdio_request_json_ms),
+    formatValue(row.median_stdio_request_write_ms),
+    formatValue(row.median_stdio_response_wait_ms),
+    formatValue(row.median_stdio_response_parse_ms),
     formatValue(row.median_packet_batch_total_ms),
     formatValue(row.median_packet_batch_attributed_query_ms),
     formatValue(row.median_packet_batch_overhead_ms),
@@ -5945,6 +5984,8 @@ function runSelfTest() {
           "packet_lexical_subquery_batch total_ms=40 attributed_query_ms=31 overhead_ms=9 queries=3",
           "packet_non_trace_phase label=budget duration_ms=7",
           "packet_non_trace_phase label=sufficiency duration_ms=11",
+          "packet_non_trace_phase label=packet_dto duration_ms=2",
+          "packet_non_trace_phase label=output_budget duration_ms=5",
           "packet_stdio_phase label=text_materialization duration_ms=3",
           "packet_stdio_phase label=tool_response_materialization duration_ms=4",
         ],
@@ -5967,9 +6008,11 @@ function runSelfTest() {
   assert.equal(packetLatency.packet_batch_overhead_ms, 14);
   assert.equal(packetLatency.packet_anchor_probe_batch_overhead_ms, 5);
   assert.equal(packetLatency.packet_lexical_subquery_batch_overhead_ms, 9);
-  assert.equal(packetLatency.packet_non_trace_phase_total_ms, 18);
+  assert.equal(packetLatency.packet_non_trace_phase_total_ms, 25);
   assert.equal(packetLatency.packet_budget_ms, 7);
   assert.equal(packetLatency.packet_sufficiency_ms, 11);
+  assert.equal(packetLatency.packet_dto_ms, 2);
+  assert.equal(packetLatency.packet_output_budget_ms, 5);
   assert.equal(packetLatency.packet_stdio_phase_total_ms, 7);
   assert.equal(packetLatency.packet_stdio_text_materialization_ms, 3);
   assert.equal(packetLatency.packet_stdio_tool_response_materialization_ms, 4);


### PR DESCRIPTION
## Context

Refs #98.

PR #97 left a common warm packet residual after coarse post-retrieval and stdio annotations. This stacked diagnostic PR now includes the #98 final DTO/output-budget/client-stdio split plus the #105 server-side stdio serialization/write/flush split. It narrows the wall; it does not clear #98 or the parent #95/#89/#87/#78 chain.

## What Changed

- Added packet `packet_non_trace_phase` labels for final packet DTO construction and final output budget enforcement.
- Extended the packet-runtime harness summary with DTO/output-budget medians plus client-side stdio request JSON, write, response wait, and response parse medians.
- Replaced stdio response `serde_json::to_string` + `writeln!` with direct `serde_json::to_writer` + newline write to avoid allocating an extra full response string.
- Added stderr-only `packet_stdio_server_phase` diagnostics around server response serialization, newline write, and stdout flush, keyed by JSON-RPC response id for harness joining.
- Added the focused stdio packet materialization unit test. The stale CLI DTO fixture blocker was removed separately by #106 / PR #109.

## Focused Evidence

#98 artifact root:
`C:\Users\alber\.codex\worktrees\3567\codestory\target\agent-benchmark\issue-98-final-output-wall-warm-stdio`

| Row | Wall | Retrieval | Freshness | Non-trace wall | Named post-retrieval phases | Rank/window | DTO | Output budget | Client stdio parse | Residual after named phases | SLA | Quality | Sufficiency |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
| Apache warm | 20522.690 ms | 15770 ms | 432 ms | 4320.690 ms | 1892 ms | 1554 ms | 0 ms | 109 ms | 0.451 ms | 2428.690 ms | met | 1/1 | sufficient |
| Redis warm | 20889.620 ms | 15215 ms | 1011 ms | 4663.620 ms | 2097 ms | 1551 ms | 0 ms | 183 ms | 0.462 ms | 2566.620 ms | missed | 1/1 | sufficient |

#105 server-output artifact root:
`target/agent-benchmark/issue-105-server-stdio-flush-wall`

| Row | Wall | Stdio response wait | Server output | Serialize | Newline | Flush | SLA implication |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Apache warm | 24606.486 ms | 24606.383 ms | 1 ms | 1 ms | 0 ms | 0 ms | server output tail not material |
| Redis warm | 27218.818 ms | 27218.733 ms | 0 ms | 0 ms | 0 ms | 0 ms | server output tail not material |

Interpretation:

- Final packet DTO construction is not the residual wall.
- Final output budget enforcement is visible but not dominant.
- Client-side stdio request/write/parse is sub-millisecond.
- Server-side serialization/newline/flush is not material in the focused #105 run.
- The remaining #98 residual is still outside these named output boundaries, so this PR stays draft/partial and must not close #98.

## Verification

Reported by the implementation lanes and independent review:

```powershell
node --check scripts\codestory-agent-ab-benchmark.mjs
node scripts\codestory-agent-ab-benchmark.mjs --self-test
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime packet_non_trace_phase_annotation_is_machine_readable -- --nocapture
cargo build --release -p codestory-cli
cargo test -p codestory-cli stdio_tool_call_success_times_packet_materialization -- --nocapture
cargo fmt --check
git diff --check
```

The #105 review also reran `cargo check -p codestory-cli` and found no blocking issues. Linux contracts are green for this draft stack.

## Remaining Risk / Next Decision

#106 is closed as test-fixture cleanup and #105 is closed as server-output boundary evidence. #98 remains open because the residual is now outside DTO construction, output-budget enforcement, client stdio parse/write, and server serialization/write/flush. The next coordinator decision is whether another narrower boundary exists or whether this residual becomes explicit release risk for #78/#74.

## Skills used

- repo-local `codestory-grounding`
- `github:github`
- `github:yeet`
- `performance`
- `best-practices`
- `superpowers:verification-before-completion`
