### PR TITLE
[codex] consolidate shared language registry

### DIFF
--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -227,24 +227,50 @@ pub fn normalize_extension(ext: &str) -> String {
 }
 
 pub fn language_support_profile_for_ext(ext: &str) -> Option<&'static LanguageSupportProfile> {
-    let ext = normalize_extension(ext);
-    LANGUAGE_SUPPORT_PROFILES
-        .iter()
-        .find(|profile| profile.extensions.iter().any(|candidate| *candidate == ext))
+    let ext = ext.trim().trim_start_matches('.');
+    LANGUAGE_SUPPORT_PROFILES.iter().find(|profile| {
+        profile
+            .extensions
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(ext))
+    })
 }
 
 pub fn language_support_profile_for_language_name(
     language_name: &str,
 ) -> Option<&'static LanguageSupportProfile> {
-    let language_name = language_name.trim().to_ascii_lowercase();
+    let language_name = language_name.trim();
     LANGUAGE_SUPPORT_PROFILES
         .iter()
-        .find(|profile| profile.language_name == language_name)
+        .find(|profile| profile.language_name.eq_ignore_ascii_case(language_name))
+}
+
+pub fn language_support_profile_for_path(
+    path: Option<&str>,
+) -> Option<&'static LanguageSupportProfile> {
+    let ext = path?.rsplit('.').next()?.trim_start_matches('.');
+    language_support_profile_for_ext(ext)
 }
 
 pub fn language_name_for_path(path: Option<&str>) -> Option<&'static str> {
-    let ext = path?.rsplit('.').next()?.trim_start_matches('.');
-    language_support_profile_for_ext(ext).map(|profile| profile.language_name)
+    language_support_profile_for_path(path).map(|profile| profile.language_name)
+}
+
+pub fn parser_backed_language_name_for_path(path: Option<&str>) -> Option<&'static str> {
+    language_support_profile_for_path(path)
+        .filter(|profile| profile.support_mode == LanguageSupportMode::ParserBackedGraph)
+        .map(|profile| profile.language_name)
+}
+
+pub fn structural_language_name_for_path(path: Option<&str>) -> Option<&'static str> {
+    language_support_profile_for_path(path)
+        .filter(|profile| profile.support_mode == LanguageSupportMode::StructuralCollector)
+        .map(|profile| profile.language_name)
+}
+
+pub fn is_structural_language_name(language_name: &str) -> bool {
+    language_support_profile_for_language_name(language_name)
+        .is_some_and(|profile| profile.support_mode == LanguageSupportMode::StructuralCollector)
 }
 
 pub fn is_github_actions_workflow_path(path: &str) -> bool {
@@ -312,6 +338,21 @@ mod tests {
                 .evidence_tier,
             LanguageEvidenceTier::StructuralOnly
         );
+        assert_eq!(
+            language_support_profile_for_path(Some("src/lib.RS"))
+                .expect("rust path profile")
+                .language_name,
+            "rust"
+        );
+        assert_eq!(
+            parser_backed_language_name_for_path(Some("src/app.tsx")),
+            Some("typescript")
+        );
+        assert_eq!(
+            structural_language_name_for_path(Some("assets/site.CSS")),
+            Some("css")
+        );
+        assert!(is_structural_language_name(" SQL "));
         assert!(
             language_name_for_path(Some("src/app/Program.cshtml")).is_none(),
             "Razor .cshtml files are workspace-compatible, but not a public parser-backed C# claim"

--- a/crates/codestory-indexer/src/language_configs.rs
+++ b/crates/codestory-indexer/src/language_configs.rs
@@ -5,26 +5,34 @@ use super::{
     RUST_TAGS_QUERY, SWIFT_GRAPH_QUERY, TSX_GRAPH_QUERY, TSX_TAGS_QUERY, TYPESCRIPT_GRAPH_QUERY,
     TYPESCRIPT_TAGS_QUERY, make_language_config,
 };
+use codestory_contracts::language_support::{
+    LanguageSupportMode, language_support_profile_for_ext, normalize_extension,
+};
 
 pub(super) fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
-    let ext = codestory_contracts::language_support::normalize_extension(ext);
-    match ext.as_str() {
-        "py" | "pyi" => Some(python()),
-        "java" => Some(java()),
-        "rs" => Some(rust()),
-        "js" | "jsx" | "mjs" | "cjs" => Some(javascript()),
-        "ts" | "mts" | "cts" => Some(typescript()),
-        "tsx" => Some(tsx()),
-        "cpp" | "cc" | "cxx" | "hpp" | "hh" | "hxx" => Some(cpp()),
-        "c" | "h" => Some(c()),
-        "go" => Some(go()),
-        "rb" => Some(ruby()),
-        "php" => Some(php()),
-        "cs" => Some(csharp()),
-        "kt" | "kts" => Some(kotlin()),
-        "swift" => Some(swift()),
-        "dart" => Some(dart()),
-        "sh" | "bash" => Some(bash()),
+    let ext = normalize_extension(ext);
+    let profile = language_support_profile_for_ext(&ext)?;
+    if profile.support_mode != LanguageSupportMode::ParserBackedGraph {
+        return None;
+    }
+
+    match (profile.language_name, ext.as_str()) {
+        ("python", _) => Some(python()),
+        ("java", _) => Some(java()),
+        ("rust", _) => Some(rust()),
+        ("javascript", _) => Some(javascript()),
+        ("typescript", "tsx") => Some(tsx()),
+        ("typescript", _) => Some(typescript()),
+        ("cpp", _) => Some(cpp()),
+        ("c", _) => Some(c()),
+        ("go", _) => Some(go()),
+        ("ruby", _) => Some(ruby()),
+        ("php", _) => Some(php()),
+        ("csharp", _) => Some(csharp()),
+        ("kotlin", _) => Some(kotlin()),
+        ("swift", _) => Some(swift()),
+        ("dart", _) => Some(dart()),
+        ("bash", _) => Some(bash()),
         _ => None,
     }
 }

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -1,9 +1,13 @@
 use anyhow::Result;
 use codestory_contracts::graph::EdgeKind;
+use codestory_contracts::language_support::{
+    is_structural_language_name, language_name_for_path, parser_backed_language_name_for_path,
+};
 use enum_dispatch::enum_dispatch;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 mod c;
 mod cpp;
@@ -330,43 +334,14 @@ impl SemanticResolverRegistry {
 
 pub(crate) fn detect_language(path: Option<&str>) -> Option<&'static str> {
     let path = path?;
-    let ext = path
-        .rsplit('.')
-        .next()?
-        .trim_start_matches('.')
-        .to_ascii_lowercase();
-    match ext.as_str() {
-        "c" => Some("c"),
-        "cc" | "cpp" | "cxx" | "hh" | "hpp" | "hxx" => Some("cpp"),
-        "h" => Some("c"),
-        "java" => Some("java"),
-        "js" | "jsx" | "mjs" | "cjs" => Some("javascript"),
-        "py" | "pyi" => Some("python"),
-        "rs" => Some("rust"),
-        "ts" | "tsx" | "mts" | "cts" => Some("typescript"),
-        "vue" => Some("vue"),
-        "svelte" => Some("svelte"),
-        "astro" => Some("astro"),
-        "go" => Some("go"),
-        "rb" => Some("ruby"),
-        "php" => Some("php"),
-        "cs" => Some("csharp"),
-        "kt" | "kts" => Some("kotlin"),
-        "swift" => Some("swift"),
-        "dart" => Some("dart"),
-        "sh" | "bash" => Some("bash"),
-        "html" | "htm" => Some("html"),
-        "css" => Some("css"),
-        "sql" => Some("sql"),
-        _ => None,
-    }
+    crate::template_pipeline::template_surface_language(Path::new(path))
+        .or_else(|| language_name_for_path(Some(path)))
 }
 
 pub(crate) fn detect_resolver_language(path: Option<&str>) -> Option<&'static str> {
-    match detect_language(path)? {
-        "html" | "css" | "sql" => None,
-        language => Some(language),
-    }
+    let path = path?;
+    parser_backed_language_name_for_path(Some(path))
+        .or_else(|| crate::template_pipeline::template_surface_language(Path::new(path)))
 }
 
 fn semantic_resolver_for_path(path: Option<&str>) -> Option<SemanticResolverKind> {
@@ -568,7 +543,7 @@ fn language_family_bucket(language: &'static str) -> &'static str {
         "swift" => "swift",
         "dart" => "dart",
         "bash" => "bash",
-        "html" | "css" | "sql" => "structural",
+        language if is_structural_language_name(language) => "structural",
         _ => language,
     }
 }

--- a/crates/codestory-indexer/src/structural/common.rs
+++ b/crates/codestory-indexer/src/structural/common.rs
@@ -3,25 +3,17 @@ use codestory_contracts::graph::{
     AccessKind, Edge, EdgeId, EdgeKind, Node, NodeId, NodeKind, Occurrence, OccurrenceKind,
     ResolutionCertainty, SourceLocation,
 };
-use codestory_contracts::language_support::is_github_actions_workflow_path;
+use codestory_contracts::language_support::{
+    is_github_actions_workflow_path, structural_language_name_for_path,
+};
 use std::path::Path;
 
 pub(crate) fn structural_language_name(path: &Path) -> &'static str {
-    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+    let path = path.to_string_lossy();
+    if is_github_actions_workflow_path(path.as_ref()) {
         return "github_actions_workflow";
     }
-    match path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .unwrap_or_default()
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "html" | "htm" => "html",
-        "css" => "css",
-        "sql" => "sql",
-        _ => "structural",
-    }
+    structural_language_name_for_path(Some(path.as_ref())).unwrap_or("structural")
 }
 
 pub(crate) fn push_member_edge(


### PR DESCRIPTION
## Context

Closes #99.

The #96 abstraction audit found that language metadata was still repeated across the support contract, indexer language config routing, semantic resolver eligibility, structural naming, and CLI output. This PR takes the first small slice: make the existing `LANGUAGE_SUPPORT_PROFILES` contract carry more of the routing metadata without adding macros or new dependencies.

## What Changed

- Added shared contracts helpers for path-to-profile lookup, parser-backed path routing, structural path routing, and structural language-name checks.
- Switched indexer extension routing to consult `LANGUAGE_SUPPORT_PROFILES` before selecting the concrete tree-sitter config, while preserving the special `tsx` ruleset.
- Switched semantic language detection/resolver eligibility and structural collector naming to the shared helpers.
- Kept Vue/Svelte/Astro as explicit template pseudo-languages because they are not public support profiles.

## How To Review

- Start with `crates/codestory-contracts/src/language_support.rs` to confirm helper behavior and claim-tier labels are unchanged.
- Check `crates/codestory-indexer/src/language_configs.rs` for the parser-backed profile gate and `tsx` exception.
- Check `crates/codestory-indexer/src/semantic/mod.rs` and `crates/codestory-indexer/src/structural/common.rs` for the deleted duplicate routing.

## Verification

- `cargo test -p codestory-contracts language_support` - 5 passed, 0 failed.
- `cargo test -p codestory-indexer language` - focused language/routing filter passed, including 13 unit tests plus matching integration tests.
- `cargo test -p codestory-indexer --test tictactoe_language_coverage` - 12 passed, 0 failed.
- `cargo test -p codestory-indexer --test fidelity_regression` - 8 passed, 0 failed.
- `cargo fmt --check` - passed.
- `git diff --check` - passed.

## Risk / Follow-Up

This is intentionally narrow. Future parser-backed languages still need a concrete tree-sitter config and resolver dispatch entry; the existing coverage tests now keep the public profile table and indexer parser routing from drifting silently. I did not change `crates/codestory-cli/src/output.rs` because snippet output already falls back to `language_name_for_path`, and the explicit fence labels for `tsx`, `jsx`, template files, JSON, TOML, Markdown, and YAML are separate display behavior.

Skills used: repo-local `codestory-grounding`, `github:github`, `github:yeet`, `code-simplifier`, `best-practices`, `superpowers:verification-before-completion`.
