### PR TITLE
[codex] reduce enum conversion boilerplate

### DIFF
--- a/crates/codestory-contracts/src/api/types.rs
+++ b/crates/codestory-contracts/src/api/types.rs
@@ -1,6 +1,26 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
+macro_rules! impl_mirrored_enum_conversions {
+    ($api:ty, $core:ty, [$($variant:ident),+ $(,)?]) => {
+        impl From<$core> for $api {
+            fn from(value: $core) -> Self {
+                match value {
+                    $(<$core>::$variant => Self::$variant,)+
+                }
+            }
+        }
+
+        impl From<$api> for $core {
+            fn from(value: $api) -> Self {
+                match value {
+                    $(<$api>::$variant => Self::$variant,)+
+                }
+            }
+        }
+    };
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
 pub enum IndexMode {
     Full,
@@ -43,63 +63,34 @@ pub enum NodeKind {
     UNKNOWN,
 }
 
-impl From<crate::graph::NodeKind> for NodeKind {
-    fn from(value: crate::graph::NodeKind) -> Self {
-        match value {
-            crate::graph::NodeKind::MODULE => Self::MODULE,
-            crate::graph::NodeKind::NAMESPACE => Self::NAMESPACE,
-            crate::graph::NodeKind::PACKAGE => Self::PACKAGE,
-            crate::graph::NodeKind::FILE => Self::FILE,
-            crate::graph::NodeKind::STRUCT => Self::STRUCT,
-            crate::graph::NodeKind::CLASS => Self::CLASS,
-            crate::graph::NodeKind::INTERFACE => Self::INTERFACE,
-            crate::graph::NodeKind::ANNOTATION => Self::ANNOTATION,
-            crate::graph::NodeKind::UNION => Self::UNION,
-            crate::graph::NodeKind::ENUM => Self::ENUM,
-            crate::graph::NodeKind::TYPEDEF => Self::TYPEDEF,
-            crate::graph::NodeKind::TYPE_PARAMETER => Self::TYPE_PARAMETER,
-            crate::graph::NodeKind::BUILTIN_TYPE => Self::BUILTIN_TYPE,
-            crate::graph::NodeKind::FUNCTION => Self::FUNCTION,
-            crate::graph::NodeKind::METHOD => Self::METHOD,
-            crate::graph::NodeKind::MACRO => Self::MACRO,
-            crate::graph::NodeKind::GLOBAL_VARIABLE => Self::GLOBAL_VARIABLE,
-            crate::graph::NodeKind::FIELD => Self::FIELD,
-            crate::graph::NodeKind::VARIABLE => Self::VARIABLE,
-            crate::graph::NodeKind::CONSTANT => Self::CONSTANT,
-            crate::graph::NodeKind::ENUM_CONSTANT => Self::ENUM_CONSTANT,
-            crate::graph::NodeKind::UNKNOWN => Self::UNKNOWN,
-        }
-    }
-}
-
-impl From<NodeKind> for crate::graph::NodeKind {
-    fn from(value: NodeKind) -> Self {
-        match value {
-            NodeKind::MODULE => Self::MODULE,
-            NodeKind::NAMESPACE => Self::NAMESPACE,
-            NodeKind::PACKAGE => Self::PACKAGE,
-            NodeKind::FILE => Self::FILE,
-            NodeKind::STRUCT => Self::STRUCT,
-            NodeKind::CLASS => Self::CLASS,
-            NodeKind::INTERFACE => Self::INTERFACE,
-            NodeKind::ANNOTATION => Self::ANNOTATION,
-            NodeKind::UNION => Self::UNION,
-            NodeKind::ENUM => Self::ENUM,
-            NodeKind::TYPEDEF => Self::TYPEDEF,
-            NodeKind::TYPE_PARAMETER => Self::TYPE_PARAMETER,
-            NodeKind::BUILTIN_TYPE => Self::BUILTIN_TYPE,
-            NodeKind::FUNCTION => Self::FUNCTION,
-            NodeKind::METHOD => Self::METHOD,
-            NodeKind::MACRO => Self::MACRO,
-            NodeKind::GLOBAL_VARIABLE => Self::GLOBAL_VARIABLE,
-            NodeKind::FIELD => Self::FIELD,
-            NodeKind::VARIABLE => Self::VARIABLE,
-            NodeKind::CONSTANT => Self::CONSTANT,
-            NodeKind::ENUM_CONSTANT => Self::ENUM_CONSTANT,
-            NodeKind::UNKNOWN => Self::UNKNOWN,
-        }
-    }
-}
+impl_mirrored_enum_conversions!(
+    NodeKind,
+    crate::graph::NodeKind,
+    [
+        MODULE,
+        NAMESPACE,
+        PACKAGE,
+        FILE,
+        STRUCT,
+        CLASS,
+        INTERFACE,
+        ANNOTATION,
+        UNION,
+        ENUM,
+        TYPEDEF,
+        TYPE_PARAMETER,
+        BUILTIN_TYPE,
+        FUNCTION,
+        METHOD,
+        MACRO,
+        GLOBAL_VARIABLE,
+        FIELD,
+        VARIABLE,
+        CONSTANT,
+        ENUM_CONSTANT,
+        UNKNOWN,
+    ]
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
 #[allow(non_camel_case_types)]
@@ -119,45 +110,25 @@ pub enum EdgeKind {
     UNKNOWN,
 }
 
-impl From<crate::graph::EdgeKind> for EdgeKind {
-    fn from(value: crate::graph::EdgeKind) -> Self {
-        match value {
-            crate::graph::EdgeKind::MEMBER => Self::MEMBER,
-            crate::graph::EdgeKind::TYPE_USAGE => Self::TYPE_USAGE,
-            crate::graph::EdgeKind::USAGE => Self::USAGE,
-            crate::graph::EdgeKind::CALL => Self::CALL,
-            crate::graph::EdgeKind::INHERITANCE => Self::INHERITANCE,
-            crate::graph::EdgeKind::OVERRIDE => Self::OVERRIDE,
-            crate::graph::EdgeKind::TYPE_ARGUMENT => Self::TYPE_ARGUMENT,
-            crate::graph::EdgeKind::TEMPLATE_SPECIALIZATION => Self::TEMPLATE_SPECIALIZATION,
-            crate::graph::EdgeKind::INCLUDE => Self::INCLUDE,
-            crate::graph::EdgeKind::IMPORT => Self::IMPORT,
-            crate::graph::EdgeKind::MACRO_USAGE => Self::MACRO_USAGE,
-            crate::graph::EdgeKind::ANNOTATION_USAGE => Self::ANNOTATION_USAGE,
-            crate::graph::EdgeKind::UNKNOWN => Self::UNKNOWN,
-        }
-    }
-}
-
-impl From<EdgeKind> for crate::graph::EdgeKind {
-    fn from(value: EdgeKind) -> Self {
-        match value {
-            EdgeKind::MEMBER => Self::MEMBER,
-            EdgeKind::TYPE_USAGE => Self::TYPE_USAGE,
-            EdgeKind::USAGE => Self::USAGE,
-            EdgeKind::CALL => Self::CALL,
-            EdgeKind::INHERITANCE => Self::INHERITANCE,
-            EdgeKind::OVERRIDE => Self::OVERRIDE,
-            EdgeKind::TYPE_ARGUMENT => Self::TYPE_ARGUMENT,
-            EdgeKind::TEMPLATE_SPECIALIZATION => Self::TEMPLATE_SPECIALIZATION,
-            EdgeKind::INCLUDE => Self::INCLUDE,
-            EdgeKind::IMPORT => Self::IMPORT,
-            EdgeKind::MACRO_USAGE => Self::MACRO_USAGE,
-            EdgeKind::ANNOTATION_USAGE => Self::ANNOTATION_USAGE,
-            EdgeKind::UNKNOWN => Self::UNKNOWN,
-        }
-    }
-}
+impl_mirrored_enum_conversions!(
+    EdgeKind,
+    crate::graph::EdgeKind,
+    [
+        MEMBER,
+        TYPE_USAGE,
+        USAGE,
+        CALL,
+        INHERITANCE,
+        OVERRIDE,
+        TYPE_ARGUMENT,
+        TEMPLATE_SPECIALIZATION,
+        INCLUDE,
+        IMPORT,
+        MACRO_USAGE,
+        ANNOTATION_USAGE,
+        UNKNOWN,
+    ]
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type, Default)]
 pub enum TrailMode {
@@ -168,27 +139,11 @@ pub enum TrailMode {
     ToTargetSymbol,
 }
 
-impl From<crate::graph::TrailMode> for TrailMode {
-    fn from(value: crate::graph::TrailMode) -> Self {
-        match value {
-            crate::graph::TrailMode::Neighborhood => Self::Neighborhood,
-            crate::graph::TrailMode::AllReferenced => Self::AllReferenced,
-            crate::graph::TrailMode::AllReferencing => Self::AllReferencing,
-            crate::graph::TrailMode::ToTargetSymbol => Self::ToTargetSymbol,
-        }
-    }
-}
-
-impl From<TrailMode> for crate::graph::TrailMode {
-    fn from(value: TrailMode) -> Self {
-        match value {
-            TrailMode::Neighborhood => Self::Neighborhood,
-            TrailMode::AllReferenced => Self::AllReferenced,
-            TrailMode::AllReferencing => Self::AllReferencing,
-            TrailMode::ToTargetSymbol => Self::ToTargetSymbol,
-        }
-    }
-}
+impl_mirrored_enum_conversions!(
+    TrailMode,
+    crate::graph::TrailMode,
+    [Neighborhood, AllReferenced, AllReferencing, ToTargetSymbol,]
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type)]
 pub enum TrailDirection {
@@ -197,15 +152,11 @@ pub enum TrailDirection {
     Both,
 }
 
-impl From<crate::graph::TrailDirection> for TrailDirection {
-    fn from(value: crate::graph::TrailDirection) -> Self {
-        match value {
-            crate::graph::TrailDirection::Incoming => Self::Incoming,
-            crate::graph::TrailDirection::Outgoing => Self::Outgoing,
-            crate::graph::TrailDirection::Both => Self::Both,
-        }
-    }
-}
+impl_mirrored_enum_conversions!(
+    TrailDirection,
+    crate::graph::TrailDirection,
+    [Incoming, Outgoing, Both,]
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type, Default)]
 pub enum TrailCallerScope {
@@ -214,33 +165,11 @@ pub enum TrailCallerScope {
     IncludeTestsAndBenches,
 }
 
-impl From<crate::graph::TrailCallerScope> for TrailCallerScope {
-    fn from(value: crate::graph::TrailCallerScope) -> Self {
-        match value {
-            crate::graph::TrailCallerScope::ProductionOnly => Self::ProductionOnly,
-            crate::graph::TrailCallerScope::IncludeTestsAndBenches => Self::IncludeTestsAndBenches,
-        }
-    }
-}
-
-impl From<TrailCallerScope> for crate::graph::TrailCallerScope {
-    fn from(value: TrailCallerScope) -> Self {
-        match value {
-            TrailCallerScope::ProductionOnly => Self::ProductionOnly,
-            TrailCallerScope::IncludeTestsAndBenches => Self::IncludeTestsAndBenches,
-        }
-    }
-}
-
-impl From<TrailDirection> for crate::graph::TrailDirection {
-    fn from(value: TrailDirection) -> Self {
-        match value {
-            TrailDirection::Incoming => Self::Incoming,
-            TrailDirection::Outgoing => Self::Outgoing,
-            TrailDirection::Both => Self::Both,
-        }
-    }
-}
+impl_mirrored_enum_conversions!(
+    TrailCallerScope,
+    crate::graph::TrailCallerScope,
+    [ProductionOnly, IncludeTestsAndBenches,]
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type, Default)]
 pub enum LayoutDirection {
@@ -249,23 +178,11 @@ pub enum LayoutDirection {
     Vertical,
 }
 
-impl From<crate::graph::LayoutDirection> for LayoutDirection {
-    fn from(value: crate::graph::LayoutDirection) -> Self {
-        match value {
-            crate::graph::LayoutDirection::Horizontal => Self::Horizontal,
-            crate::graph::LayoutDirection::Vertical => Self::Vertical,
-        }
-    }
-}
-
-impl From<LayoutDirection> for crate::graph::LayoutDirection {
-    fn from(value: LayoutDirection) -> Self {
-        match value {
-            LayoutDirection::Horizontal => Self::Horizontal,
-            LayoutDirection::Vertical => Self::Vertical,
-        }
-    }
-}
+impl_mirrored_enum_conversions!(
+    LayoutDirection,
+    crate::graph::LayoutDirection,
+    [Horizontal, Vertical,]
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Type, Default)]
 pub enum MemberAccess {
@@ -276,24 +193,8 @@ pub enum MemberAccess {
     Default,
 }
 
-impl From<crate::graph::AccessKind> for MemberAccess {
-    fn from(value: crate::graph::AccessKind) -> Self {
-        match value {
-            crate::graph::AccessKind::Public => Self::Public,
-            crate::graph::AccessKind::Protected => Self::Protected,
-            crate::graph::AccessKind::Private => Self::Private,
-            crate::graph::AccessKind::Default => Self::Default,
-        }
-    }
-}
-
-impl From<MemberAccess> for crate::graph::AccessKind {
-    fn from(value: MemberAccess) -> Self {
-        match value {
-            MemberAccess::Public => Self::Public,
-            MemberAccess::Protected => Self::Protected,
-            MemberAccess::Private => Self::Private,
-            MemberAccess::Default => Self::Default,
-        }
-    }
-}
+impl_mirrored_enum_conversions!(
+    MemberAccess,
+    crate::graph::AccessKind,
+    [Public, Protected, Private, Default,]
+);


### PR DESCRIPTION
## Context

Closes #100.

Issue #100 is the second #96 abstraction-leverage slice: reduce mirrored API/core enum conversion boilerplate without changing public DTO or contract shape. Coordinator review and Linux contracts passed at head `234c90c4c70ae607b83ca4e9d4c4f31140d782ab`.

## What Changed

- Added one local `impl_mirrored_enum_conversions!` macro in `crates/codestory-contracts/src/api/types.rs`.
- Replaced hand-written bidirectional `From` impls for `NodeKind`, `EdgeKind`, `TrailMode`, `TrailDirection`, `TrailCallerScope`, `LayoutDirection`, and `MemberAccess` with explicit mirrored variant lists.
- Left enum definitions, derives, serde behavior, specta derives, defaults, aliases, and DTO field shapes untouched.
- Did not add a dependency. `enum_dispatch` exists elsewhere in the workspace, but this slice is plain conversion generation rather than trait dispatch, and adding it to `codestory-contracts` would be extra machinery for no contract benefit.

## How To Review

- Start with `crates/codestory-contracts/src/api/types.rs` and compare each macro variant list against the removed match arms.
- Confirm the public enum declarations and attributes did not move or change.
- Confirm the generated matches remain exhaustive for both API-to-core and core-to-API directions.

## Verification

- `cargo run --release -p codestory-cli -- doctor --project .` returned `needs_attention` because the worktree had no indexed symbols and sidecar retrieval was unavailable; direct source reads were used instead of packet/search evidence.
- `cargo test -p codestory-contracts` passed: 29 tests, doc-tests clean.
- `cargo check -p codestory-cli -p codestory-runtime` passed with 3 existing dead-code warnings in `crates/codestory-runtime/src/agent/packet_sufficiency.rs`.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- GitHub `linux-contracts` passed on PR #103.

## Risk / Follow-Up

- This is contract-adjacent, so the main review risk is a mistaken variant list. Compile-time exhaustiveness catches missing variants, but reviewers should still eyeball each mirrored list.
- Parent issue #96 remains open for the broader abstraction-reduction follow-up; this PR closes only #100.
