### PR TITLE
Consolidate retrieval stage metadata

### DIFF
--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -337,14 +337,7 @@ fn should_skip_zero_dense_stage(
 }
 
 fn annotate_stage_provenance(stage: &PlannedStage, hits: &mut [CandidateHit]) {
-    let label = match stage.kind {
-        RetrievalStageKind::Stage0ScipAnchor => Some("exact"),
-        RetrievalStageKind::Stage1ZoektLexical => None,
-        RetrievalStageKind::Stage1bQdrantSemantic => Some("dense_anchor"),
-        RetrievalStageKind::Stage2ScipExpand => Some("graph_neighbor"),
-        RetrievalStageKind::Stage3RepoTextFallback => None,
-    };
-    if let Some(label) = label {
+    if let Some(label) = stage.kind.provenance_label() {
         for hit in hits {
             hit.add_provenance(label);
         }

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -202,26 +202,40 @@ mod tests {
 
     #[test]
     fn stage_kind_metadata_matches_sidecar_stage_contract() {
-        assert_eq!(
-            RetrievalStageKind::Stage0ScipAnchor.label(),
-            "stage0_scip_anchor"
-        );
-        assert_eq!(
-            RetrievalStageKind::Stage1bQdrantSemantic.provenance_label(),
-            Some("dense_anchor")
-        );
-        assert_eq!(
-            RetrievalStageKind::Stage2ScipExpand.provenance_label(),
-            Some("graph_neighbor")
-        );
-        assert_eq!(
-            RetrievalStageKind::Stage1ZoektLexical.sidecar_latency_ms(42),
-            Some(42)
-        );
-        assert_eq!(
-            RetrievalStageKind::Stage3RepoTextFallback.sidecar_latency_ms(42),
-            None
-        );
+        let cases = [
+            (RetrievalStageKind::Stage0ScipAnchor, Some("exact"), true),
+            (RetrievalStageKind::Stage1ZoektLexical, None, true),
+            (
+                RetrievalStageKind::Stage1bQdrantSemantic,
+                Some("dense_anchor"),
+                true,
+            ),
+            (
+                RetrievalStageKind::Stage2ScipExpand,
+                Some("graph_neighbor"),
+                true,
+            ),
+            (RetrievalStageKind::Stage3RepoTextFallback, None, false),
+        ];
+
+        assert_eq!(cases.len(), 5);
+        for (kind, expected_provenance, has_sidecar_latency) in cases {
+            let serde_label = serde_json::to_value(kind).expect("stage kind serializes");
+
+            assert_eq!(
+                kind.label(),
+                serde_label
+                    .as_str()
+                    .expect("stage kind serializes as a string")
+            );
+            assert_eq!(kind.provenance_label(), expected_provenance);
+            assert_eq!(kind.sidecar_latency_ms(0), has_sidecar_latency.then_some(0));
+            assert_eq!(
+                kind.sidecar_latency_ms(u32::MAX.into()),
+                has_sidecar_latency.then_some(u32::MAX)
+            );
+            assert_eq!(kind.sidecar_latency_ms(u64::from(u32::MAX) + 1), None);
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -13,6 +13,38 @@ pub enum RetrievalStageKind {
     Stage3RepoTextFallback,
 }
 
+impl RetrievalStageKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            RetrievalStageKind::Stage0ScipAnchor => "stage0_scip_anchor",
+            RetrievalStageKind::Stage1ZoektLexical => "stage1_zoekt_lexical",
+            RetrievalStageKind::Stage1bQdrantSemantic => "stage1b_qdrant_semantic",
+            RetrievalStageKind::Stage2ScipExpand => "stage2_scip_expand",
+            RetrievalStageKind::Stage3RepoTextFallback => "stage3_repo_text_fallback",
+        }
+    }
+
+    pub fn provenance_label(self) -> Option<&'static str> {
+        match self {
+            RetrievalStageKind::Stage0ScipAnchor => Some("exact"),
+            RetrievalStageKind::Stage1ZoektLexical => None,
+            RetrievalStageKind::Stage1bQdrantSemantic => Some("dense_anchor"),
+            RetrievalStageKind::Stage2ScipExpand => Some("graph_neighbor"),
+            RetrievalStageKind::Stage3RepoTextFallback => None,
+        }
+    }
+
+    pub fn sidecar_latency_ms(self, elapsed_ms: u64) -> Option<u32> {
+        match self {
+            RetrievalStageKind::Stage0ScipAnchor
+            | RetrievalStageKind::Stage1ZoektLexical
+            | RetrievalStageKind::Stage1bQdrantSemantic
+            | RetrievalStageKind::Stage2ScipExpand => u32::try_from(elapsed_ms).ok(),
+            RetrievalStageKind::Stage3RepoTextFallback => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlannedStage {
     pub kind: RetrievalStageKind,
@@ -165,6 +197,30 @@ mod tests {
                 < kinds
                     .iter()
                     .position(|kind| *kind == RetrievalStageKind::Stage1bQdrantSemantic)
+        );
+    }
+
+    #[test]
+    fn stage_kind_metadata_matches_sidecar_stage_contract() {
+        assert_eq!(
+            RetrievalStageKind::Stage0ScipAnchor.label(),
+            "stage0_scip_anchor"
+        );
+        assert_eq!(
+            RetrievalStageKind::Stage1bQdrantSemantic.provenance_label(),
+            Some("dense_anchor")
+        );
+        assert_eq!(
+            RetrievalStageKind::Stage2ScipExpand.provenance_label(),
+            Some("graph_neighbor")
+        );
+        assert_eq!(
+            RetrievalStageKind::Stage1ZoektLexical.sidecar_latency_ms(42),
+            Some(42)
+        );
+        assert_eq!(
+            RetrievalStageKind::Stage3RepoTextFallback.sidecar_latency_ms(42),
+            None
         );
     }
 

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -12,7 +12,7 @@ use codestory_contracts::api::{
 };
 use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
 use codestory_retrieval::{
-    CandidateHit, CandidateSource, QueryRequest, QueryResult, QueryTrace, RetrievalStageKind,
+    CandidateHit, CandidateSource, QueryRequest, QueryResult, QueryTrace,
     execute_retrieval_query_with_cache, is_phantom_sidecar_hit, project_id_for_root,
     strict_sidecar_status,
 };
@@ -748,7 +748,7 @@ pub(crate) fn sidecar_rejection_diagnostic(
                 .unwrap_or_default();
             format!(
                 "{} added={} elapsed_ms={}{}",
-                stage_kind_label(stage.stage),
+                stage.stage.label(),
                 stage.candidates_added,
                 stage.elapsed_ms,
                 cancel,
@@ -1051,25 +1051,18 @@ fn retrieval_stage_timings(trace: &QueryTrace) -> Vec<RetrievalStageTimingDto> {
         .stages
         .iter()
         .map(|stage| RetrievalStageTimingDto {
-            stage: stage_kind_label(stage.stage),
+            stage: stage.stage.label().to_string(),
             deadline_ms: u32::try_from(stage.budget_ms).ok(),
             elapsed_ms: u32::try_from(stage.elapsed_ms).unwrap_or(u32::MAX),
             candidates_added: u32::try_from(stage.candidates_added).unwrap_or(u32::MAX),
             marginal_gain: stage.marginal_gain,
             cancel_reason: stage.cancel_reason.clone(),
             cache_hit: stage.cache_hit,
-            sidecar_latency_ms: sidecar_stage_latency_ms(stage.stage, stage.elapsed_ms),
+            sidecar_latency_ms: stage.stage.sidecar_latency_ms(stage.elapsed_ms),
             degraded: stage.degraded,
             stub_reason: stage.stub_reason.clone(),
         })
         .collect()
-}
-
-fn stage_kind_label(kind: RetrievalStageKind) -> String {
-    serde_json::to_value(kind)
-        .ok()
-        .and_then(|value| value.as_str().map(str::to_string))
-        .unwrap_or_else(|| format!("{kind:?}"))
 }
 
 fn candidate_source_label(source: CandidateSource) -> String {
@@ -1077,16 +1070,6 @@ fn candidate_source_label(source: CandidateSource) -> String {
         .ok()
         .and_then(|value| value.as_str().map(str::to_string))
         .unwrap_or_else(|| format!("{source:?}"))
-}
-
-fn sidecar_stage_latency_ms(kind: RetrievalStageKind, elapsed_ms: u64) -> Option<u32> {
-    match kind {
-        RetrievalStageKind::Stage0ScipAnchor
-        | RetrievalStageKind::Stage1ZoektLexical
-        | RetrievalStageKind::Stage1bQdrantSemantic
-        | RetrievalStageKind::Stage2ScipExpand => u32::try_from(elapsed_ms).ok(),
-        RetrievalStageKind::Stage3RepoTextFallback => None,
-    }
 }
 
 fn candidate_path_resolvable(project_root: &Path, file_path: &str) -> bool {


### PR DESCRIPTION
## Context

Closes #104.

Issue #104 asks for the smallest behavior-preserving slice that moves repeated retrieval-stage labels, provenance, and sidecar latency metadata onto `RetrievalStageKind` without changing readiness, ranking, freshness, SLA, scorer, or packet quality behavior.

## What Changed

- Added `RetrievalStageKind::label`, `provenance_label`, and `sidecar_latency_ms` in `crates/codestory-retrieval/src/planner.rs`.
- Replaced the executor-local stage provenance match with `stage.kind.provenance_label()`.
- Replaced runtime-local stage label and latency helpers in `retrieval_primary.rs` with the enum helpers.
- Made the metadata contract test exhaustive across the current stage variants, including serde label parity, provenance, sidecar latency eligibility, and overflow behavior.

## How To Review

- Start with `crates/codestory-retrieval/src/planner.rs` and confirm the helper values match the existing metadata strings.
- Check `crates/codestory-retrieval/src/executor.rs` to confirm only provenance annotation changed.
- Check `crates/codestory-runtime/src/agent/retrieval_primary.rs` to confirm trace label and sidecar latency output now use the helper and fail-closed readiness code remains unchanged.

## Verification

After rebasing on current `origin/main` (`2bdb46ca`):

- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo test -p codestory-retrieval` passed: 111 unit tests passed, 1 ignored; package test binaries passed, including 2 bootstrap repair tests, 1 degraded-mode test, and 4 holdout ranking tests.
- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo test -p codestory-runtime retrieval_primary` passed: 25 retrieval_primary tests passed, 537 filtered out. It still reports three pre-existing dead-code warnings in `agent/packet_sufficiency.rs`.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

Low. This centralizes static metadata only. The sidecar execution match, skip logic, ranking, readiness gates, and rejection behavior stay in place.
