### PR TITLE
Refresh CLI DTO test fixtures

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -9855,6 +9855,27 @@ mod tests {
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
 
+    fn test_search_hit_defaults() -> SearchHit {
+        SearchHit {
+            node_id: NodeId(String::new()),
+            display_name: String::new(),
+            kind: NodeKind::UNKNOWN,
+            file_path: None,
+            line: None,
+            score: 0.0,
+            origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
+            match_quality: None,
+            resolvable: true,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: None,
+            score_breakdown: None,
+        }
+    }
+
     #[test]
     fn packet_markdown_labels_use_public_wire_values() {
         assert_eq!(
@@ -10317,6 +10338,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             }
         }
 
@@ -10770,6 +10792,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         };
         let queries = drill_native_related_queries("SourceGroupCxxCdb", &source_group);
         assert!(
@@ -10804,6 +10827,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         };
         assert!(drill_native_related_query_matches(
             &method_hit,
@@ -11091,6 +11115,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }];
         let repo_text_hits = vec![SearchHit {
             node_id: NodeId("repo-text".to_string()),
@@ -11103,6 +11128,7 @@ mod tests {
             match_quality: Some(codestory_contracts::api::SearchMatchQualityDto::RepoText),
             resolvable: false,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }];
 
         let output = build_search_output(SearchOutputParts {
@@ -11152,6 +11178,7 @@ mod tests {
             match_quality: Some(codestory_contracts::api::SearchMatchQualityDto::RepoText),
             resolvable: false,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }];
 
         let output = build_search_output(SearchOutputParts {
@@ -11284,6 +11311,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }];
 
         let output = build_search_output(SearchOutputParts {
@@ -11327,6 +11355,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }];
         let mut occurrences = HashMap::new();
         occurrences.insert(
@@ -11490,6 +11519,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }];
         let repo_text_hits = vec![SearchHit {
             node_id: NodeId("text-1".to_string()),
@@ -11502,6 +11532,7 @@ mod tests {
             match_quality: Some(codestory_contracts::api::SearchMatchQualityDto::RepoText),
             resolvable: false,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }];
 
         let output = build_search_output(SearchOutputParts {
@@ -11688,8 +11719,13 @@ mod tests {
                 semantic: 0.2,
                 graph: 0.1,
                 total: 0.9,
+                tier_cap: None,
+                boosts: Vec::new(),
+                dampening: Vec::new(),
+                final_rank_reason: None,
                 provenance: Vec::new(),
             }),
+            ..test_search_hit_defaults()
         }];
 
         let output = build_search_output(SearchOutputParts {
@@ -13025,6 +13061,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
             SearchHit {
                 node_id: NodeId("1".to_string()),
@@ -13037,6 +13074,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
         ];
 
@@ -13067,6 +13105,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
             SearchHit {
                 node_id: NodeId("1".to_string()),
@@ -13079,6 +13118,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
         ];
 
@@ -13102,6 +13142,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
             SearchHit {
                 node_id: NodeId("1".to_string()),
@@ -13114,6 +13155,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
         ];
 
@@ -13146,6 +13188,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
             SearchHit {
                 node_id: NodeId("implementation".to_string()),
@@ -13158,6 +13201,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
         ];
 
@@ -13194,6 +13238,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
             SearchHit {
                 node_id: NodeId("implementation".to_string()),
@@ -13206,6 +13251,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
         ];
 
@@ -13238,6 +13284,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
             SearchHit {
                 node_id: NodeId("implementation".to_string()),
@@ -13250,6 +13297,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
         ];
 
@@ -13275,6 +13323,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }
     }
 

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3694,6 +3694,27 @@ mod tests {
     use std::path::Path;
     use tempfile::tempdir;
 
+    fn test_search_hit_defaults() -> SearchHit {
+        SearchHit {
+            node_id: NodeId(String::new()),
+            display_name: String::new(),
+            kind: NodeKind::UNKNOWN,
+            file_path: None,
+            line: None,
+            score: 0.0,
+            origin: SearchHitOrigin::IndexedSymbol,
+            match_quality: None,
+            resolvable: true,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: None,
+            score_breakdown: None,
+        }
+    }
+
     fn assert_evidence_packet_shape(markdown: &str, intro_labels: &[&str]) {
         let lower = markdown.to_ascii_lowercase();
         let mut missing = Vec::new();
@@ -3946,6 +3967,7 @@ mod tests {
                 match_quality: None,
                 resolvable: true,
                 score_breakdown: None,
+                ..test_search_hit_defaults()
             },
             alternatives: Vec::new(),
         }
@@ -4140,6 +4162,10 @@ mod tests {
                 semantic: 0.1,
                 graph: 0.11,
                 total: 0.91,
+                tier_cap: None,
+                boosts: Vec::new(),
+                dampening: Vec::new(),
+                final_rank_reason: None,
                 provenance: Vec::new(),
             }),
             duplicate_of: None,
@@ -4184,6 +4210,12 @@ mod tests {
                 subgraph_id: None,
                 evidence_edge_ids: Vec::new(),
                 retrieval_score_breakdown: None,
+                evidence_tier: None,
+                evidence_producer: None,
+                resolution_status: None,
+                loss_reason: None,
+                coverage_role: None,
+                eligible_for_sufficiency: None,
             }],
             subgraph_ids: Vec::new(),
             retrieval_version: "test".to_string(),
@@ -4479,8 +4511,18 @@ mod tests {
                     semantic: 0.06,
                     graph: 0.05,
                     total: 0.21,
+                    tier_cap: None,
+                    boosts: Vec::new(),
+                    dampening: Vec::new(),
+                    final_rank_reason: None,
                     provenance: Vec::new(),
                 }),
+                evidence_tier: None,
+                evidence_producer: None,
+                resolution_status: None,
+                loss_reason: None,
+                coverage_role: None,
+                eligible_for_sufficiency: None,
             }],
             subgraph_ids: Vec::new(),
             retrieval_version: "test".to_string(),

--- a/crates/codestory-cli/src/query_resolution.rs
+++ b/crates/codestory-cli/src/query_resolution.rs
@@ -483,6 +483,27 @@ mod tests {
     use super::*;
     use codestory_contracts::api::{NodeId, SearchHitOrigin};
 
+    fn test_search_hit_defaults() -> SearchHit {
+        SearchHit {
+            node_id: NodeId(String::new()),
+            display_name: String::new(),
+            kind: NodeKind::UNKNOWN,
+            file_path: None,
+            line: None,
+            score: 0.0,
+            origin: SearchHitOrigin::IndexedSymbol,
+            match_quality: None,
+            resolvable: true,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: None,
+            score_breakdown: None,
+        }
+    }
+
     fn hit(id: &str, display_name: &str, kind: NodeKind, score: f32, path: &str) -> SearchHit {
         SearchHit {
             node_id: NodeId(id.to_string()),
@@ -495,6 +516,7 @@ mod tests {
             match_quality: None,
             resolvable: true,
             score_breakdown: None,
+            ..test_search_hit_defaults()
         }
     }
 


### PR DESCRIPTION
## Context

Closes #106.

Current `origin/main` reproduced the stale DTO fixture compile failure with the requested focused command. `codestory-cli` test compilation failed on `SearchHit`, `AgentCitationDto`, and `RetrievalScoreBreakdownDto` literals in `output.rs`, `query_resolution.rs`, and `main.rs` after those DTOs gained optional evidence/ranking metadata fields.

## What Changed

- Added test-only `SearchHit` default fixture helpers in the affected CLI test modules.
- Updated stale `SearchHit` literals to inherit empty optional metadata from those helpers.
- Filled `AgentCitationDto` and `RetrievalScoreBreakdownDto` test literals with explicit `None` / empty-vector metadata.

No production behavior, CLI output formatting, packet runtime logic, or performance paths changed.

## How To Review

- Start with the three changed files and confirm the edits stay inside test modules/fixtures.
- Check that new DTO fields are neutral fixture defaults, not asserted product behavior.
- Confirm the focused command compiles `codestory-cli` tests on this branch where it failed on `main`.

## Verification

- Baseline on `origin/main`: `cargo test -p codestory-cli stdio_tool_call_success_times_packet_materialization -- --nocapture` failed to compile with E0063 missing DTO fields.
- `cargo test -p codestory-cli stdio_tool_call_success_times_packet_materialization -- --nocapture` passed after the fix. Note: on current main this filter matches 0 tests, so this is a compile gate rather than an executed named test.
- `cargo test -p codestory-cli` passed: 170 unit tests plus integration suites, with existing ignored tests left ignored.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

Low. The change is test-only fixture maintenance. The main residual risk is that the originally named stdio test appears absent or renamed on current `main`, so this PR proves compilation and package tests, not execution of that exact named test.
