### PR TITLE
Add retrieval manifest fixture helper

### DIFF
--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -3,6 +3,9 @@ name = "codestory-retrieval"
 version = "0.9.0"
 edition = "2024"
 
+[features]
+test-support = []
+
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true }

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -24,6 +24,9 @@ mod sidecar_search;
 mod zoekt_client;
 mod zoekt_index;
 
+#[cfg(any(test, feature = "test-support"))]
+pub mod test_support;
+
 pub use cache::{RetrievalCache, RetrievalCacheKey};
 pub use candidate::{CandidateHit, CandidateSource, RankFeatures};
 pub use candidate::{is_phantom_sidecar_hit, phantom_sidecar_candidates_only};

--- a/crates/codestory-retrieval/src/qdrant_storage.rs
+++ b/crates/codestory-retrieval/src/qdrant_storage.rs
@@ -540,6 +540,7 @@ fn execute_retention_via_http(
 mod tests {
     use super::*;
     use crate::qdrant_client::QdrantClient;
+    use crate::test_support::retrieval_manifest_fixture;
     use codestory_store::RetrievalIndexManifest;
     use std::fs;
     use std::sync::Mutex;
@@ -573,6 +574,15 @@ mod tests {
         if with_config {
             fs::write(dir.join("config.json"), "{}").expect("write config");
         }
+    }
+
+    fn manifest_for_collection(
+        project_id: &str,
+        qdrant_collection: &str,
+    ) -> RetrievalIndexManifest {
+        let mut manifest = retrieval_manifest_fixture(project_id, "hash");
+        manifest.qdrant_collection = qdrant_collection.into();
+        manifest
     }
 
     #[test]
@@ -635,26 +645,10 @@ mod tests {
         let custom_db = custom_cache.path().join("codestory.db");
         let mut storage = Store::open(&custom_db).expect("open custom db");
         storage
-            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
-                project_id: "custom".into(),
-                zoekt_version: "v1".into(),
-                qdrant_collection: "codestory_custom_flat".into(),
-                scip_revision: None,
-                built_at_epoch_ms: 42,
-                disk_bytes: None,
-                degraded_modes_json: "[]".into(),
-                embedding_backend: None,
-                embedding_dim: None,
-                sidecar_schema_version: None,
-                sidecar_input_hash: None,
-                sidecar_generation: None,
-                projection_count: None,
-                symbol_doc_count: None,
-                dense_projection_count: None,
-                semantic_policy_version: None,
-                graph_artifact_hash: None,
-                dense_reason_counts_json: None,
-            })
+            .upsert_retrieval_index_manifest(&manifest_for_collection(
+                "custom",
+                "codestory_custom_flat",
+            ))
             .expect("upsert");
 
         let scope = BootstrapStorageScope {
@@ -693,50 +687,12 @@ mod tests {
 
         let mut storage_a = Store::open(project_cache_a.join("codestory.db")).expect("open a");
         storage_a
-            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
-                project_id: "a".into(),
-                zoekt_version: "v1".into(),
-                qdrant_collection: "codestory_from_a".into(),
-                scip_revision: None,
-                built_at_epoch_ms: 1,
-                disk_bytes: None,
-                degraded_modes_json: "[]".into(),
-                embedding_backend: None,
-                embedding_dim: None,
-                sidecar_schema_version: None,
-                sidecar_input_hash: None,
-                sidecar_generation: None,
-                projection_count: None,
-                symbol_doc_count: None,
-                dense_projection_count: None,
-                semantic_policy_version: None,
-                graph_artifact_hash: None,
-                dense_reason_counts_json: None,
-            })
+            .upsert_retrieval_index_manifest(&manifest_for_collection("a", "codestory_from_a"))
             .expect("manifest a");
 
         let mut storage_b = Store::open(project_cache_b.join("codestory.db")).expect("open b");
         storage_b
-            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
-                project_id: "b".into(),
-                zoekt_version: "v1".into(),
-                qdrant_collection: "codestory_from_b".into(),
-                scip_revision: None,
-                built_at_epoch_ms: 1,
-                disk_bytes: None,
-                degraded_modes_json: "[]".into(),
-                embedding_backend: None,
-                embedding_dim: None,
-                sidecar_schema_version: None,
-                sidecar_input_hash: None,
-                sidecar_generation: None,
-                projection_count: None,
-                symbol_doc_count: None,
-                dense_projection_count: None,
-                semantic_policy_version: None,
-                graph_artifact_hash: None,
-                dense_reason_counts_json: None,
-            })
+            .upsert_retrieval_index_manifest(&manifest_for_collection("b", "codestory_from_b"))
             .expect("manifest b");
 
         let scope = BootstrapStorageScope {
@@ -779,26 +735,10 @@ mod tests {
         let flat_db = cache_root.path().join("codestory.db");
         let mut flat_storage = Store::open(&flat_db).expect("open flat db");
         flat_storage
-            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
-                project_id: "flat".into(),
-                zoekt_version: "v1".into(),
-                qdrant_collection: "codestory_flat_layout".into(),
-                scip_revision: None,
-                built_at_epoch_ms: 1,
-                disk_bytes: None,
-                degraded_modes_json: "[]".into(),
-                embedding_backend: None,
-                embedding_dim: None,
-                sidecar_schema_version: None,
-                sidecar_input_hash: None,
-                sidecar_generation: None,
-                projection_count: None,
-                symbol_doc_count: None,
-                dense_projection_count: None,
-                semantic_policy_version: None,
-                graph_artifact_hash: None,
-                dense_reason_counts_json: None,
-            })
+            .upsert_retrieval_index_manifest(&manifest_for_collection(
+                "flat",
+                "codestory_flat_layout",
+            ))
             .expect("flat manifest");
 
         let hashed_dir = cache_root.path().join("bbbbbbbbbbbbbbbb");
@@ -806,26 +746,10 @@ mod tests {
         let mut hashed_storage =
             Store::open(hashed_dir.join("codestory.db")).expect("open hashed db");
         hashed_storage
-            .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
-                project_id: "hashed".into(),
-                zoekt_version: "v1".into(),
-                qdrant_collection: "codestory_hashed_layout".into(),
-                scip_revision: None,
-                built_at_epoch_ms: 1,
-                disk_bytes: None,
-                degraded_modes_json: "[]".into(),
-                embedding_backend: None,
-                embedding_dim: None,
-                sidecar_schema_version: None,
-                sidecar_input_hash: None,
-                sidecar_generation: None,
-                projection_count: None,
-                symbol_doc_count: None,
-                dense_projection_count: None,
-                semantic_policy_version: None,
-                graph_artifact_hash: None,
-                dense_reason_counts_json: None,
-            })
+            .upsert_retrieval_index_manifest(&manifest_for_collection(
+                "hashed",
+                "codestory_hashed_layout",
+            ))
             .expect("hashed manifest");
 
         let scope = BootstrapStorageScope {

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -86,10 +86,8 @@ pub fn execute_retrieval_query_with_cache(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::generation::{
-        SIDECAR_SCHEMA_VERSION, sidecar_generation_id, sidecar_qdrant_collection,
-    };
     use crate::index::finalize_index;
+    use crate::test_support::retrieval_manifest_fixture;
     use crate::{QdrantClient, SidecarLayout, ZoektClient};
     use codestory_contracts::graph::{Node, NodeId, NodeKind};
     use codestory_store::{FileInfo, FileRole, LlmSymbolDoc, SearchSymbolProjection};
@@ -100,26 +98,12 @@ mod tests {
         hash: &str,
         projection_count: i64,
     ) -> codestory_store::RetrievalIndexManifest {
-        codestory_store::RetrievalIndexManifest {
-            project_id: project_id.into(),
-            zoekt_version: "zoekt-real-v1".into(),
-            qdrant_collection: sidecar_qdrant_collection(project_id, hash),
-            scip_revision: Some("graph-test".into()),
-            built_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
-            disk_bytes: None,
-            degraded_modes_json: "[]".into(),
-            embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
-            embedding_dim: Some(768),
-            sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
-            sidecar_input_hash: Some(hash.into()),
-            sidecar_generation: Some(sidecar_generation_id(project_id, hash)),
-            projection_count: Some(projection_count),
-            symbol_doc_count: Some(projection_count),
-            dense_projection_count: Some(projection_count),
-            semantic_policy_version: Some(crate::generation::SEMANTIC_POLICY_VERSION.into()),
-            graph_artifact_hash: Some("graph-test-hash".into()),
-            dense_reason_counts_json: Some(format!("{{\"public_api\":{projection_count}}}")),
-        }
+        let mut manifest = retrieval_manifest_fixture(project_id, hash);
+        manifest.projection_count = Some(projection_count);
+        manifest.symbol_doc_count = Some(projection_count);
+        manifest.dense_projection_count = Some(projection_count);
+        manifest.dense_reason_counts_json = Some(format!("{{\"public_api\":{projection_count}}}"));
+        manifest
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -278,6 +278,7 @@ mod tests {
         SIDECAR_SCHEMA_VERSION, sidecar_generation_id, sidecar_qdrant_collection,
     };
     use crate::index::compute_sidecar_input_fingerprint;
+    use crate::test_support::retrieval_manifest_fixture;
     use codestory_store::{FileInfo, FileRole};
     use tempfile::TempDir;
 
@@ -290,29 +291,13 @@ mod tests {
         let hash = "deadbeefcafebabe";
         {
             let mut storage = Store::open(&storage_path).expect("open db");
+            let mut manifest = retrieval_manifest_fixture(&project_id, hash);
+            manifest.projection_count = Some(10);
+            manifest.symbol_doc_count = Some(10);
+            manifest.dense_projection_count = Some(10);
+            manifest.dense_reason_counts_json = Some("{\"public_api\":10}".into());
             storage
-                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
-                    project_id: project_id.clone(),
-                    zoekt_version: "zoekt-real-v1".into(),
-                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
-                    scip_revision: Some("graph-test".into()),
-                    built_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
-                    disk_bytes: None,
-                    degraded_modes_json: "[]".into(),
-                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
-                    embedding_dim: Some(768),
-                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
-                    sidecar_input_hash: Some(hash.into()),
-                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
-                    projection_count: Some(10),
-                    symbol_doc_count: Some(10),
-                    dense_projection_count: Some(10),
-                    semantic_policy_version: Some(
-                        crate::generation::SEMANTIC_POLICY_VERSION.into(),
-                    ),
-                    graph_artifact_hash: Some("graph-test-hash".into()),
-                    dense_reason_counts_json: Some("{\"public_api\":10}".into()),
-                })
+                .upsert_retrieval_index_manifest(&manifest)
                 .expect("manifest");
         }
 
@@ -355,29 +340,10 @@ mod tests {
                     file_role: FileRole::Source,
                 })
                 .expect("insert indexed file");
+            let mut manifest = retrieval_manifest_fixture(&project_id, hash);
+            manifest.built_at_epoch_ms = indexed_mtime;
             storage
-                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
-                    project_id: project_id.clone(),
-                    zoekt_version: "zoekt-real-v1".into(),
-                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
-                    scip_revision: Some("graph-test".into()),
-                    built_at_epoch_ms: indexed_mtime,
-                    disk_bytes: None,
-                    degraded_modes_json: "[]".into(),
-                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
-                    embedding_dim: Some(768),
-                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
-                    sidecar_input_hash: Some(hash.into()),
-                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
-                    projection_count: Some(0),
-                    symbol_doc_count: Some(0),
-                    dense_projection_count: Some(0),
-                    semantic_policy_version: Some(
-                        crate::generation::SEMANTIC_POLICY_VERSION.into(),
-                    ),
-                    graph_artifact_hash: Some("graph-test-hash".into()),
-                    dense_reason_counts_json: Some("{}".into()),
-                })
+                .upsert_retrieval_index_manifest(&manifest)
                 .expect("manifest");
         }
 
@@ -435,29 +401,10 @@ mod tests {
                     file_role: FileRole::Source,
                 })
                 .expect("insert indexed file");
+            let mut manifest = retrieval_manifest_fixture(&project_id, hash);
+            manifest.built_at_epoch_ms = indexed_mtime;
             storage
-                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
-                    project_id: project_id.clone(),
-                    zoekt_version: "zoekt-real-v1".into(),
-                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
-                    scip_revision: Some("graph-test".into()),
-                    built_at_epoch_ms: indexed_mtime,
-                    disk_bytes: None,
-                    degraded_modes_json: "[]".into(),
-                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
-                    embedding_dim: Some(768),
-                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
-                    sidecar_input_hash: Some(hash.into()),
-                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
-                    projection_count: Some(0),
-                    symbol_doc_count: Some(0),
-                    dense_projection_count: Some(0),
-                    semantic_policy_version: Some(
-                        crate::generation::SEMANTIC_POLICY_VERSION.into(),
-                    ),
-                    graph_artifact_hash: Some("graph-test-hash".into()),
-                    dense_reason_counts_json: Some("{}".into()),
-                })
+                .upsert_retrieval_index_manifest(&manifest)
                 .expect("manifest");
         }
 
@@ -516,29 +463,10 @@ mod tests {
                     file_role: FileRole::Source,
                 })
                 .expect("insert indexed file");
+            let mut manifest = retrieval_manifest_fixture(&project_id, hash);
+            manifest.built_at_epoch_ms = indexed_mtime;
             storage
-                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
-                    project_id: project_id.clone(),
-                    zoekt_version: "zoekt-real-v1".into(),
-                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
-                    scip_revision: Some("graph-test".into()),
-                    built_at_epoch_ms: indexed_mtime,
-                    disk_bytes: None,
-                    degraded_modes_json: "[]".into(),
-                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
-                    embedding_dim: Some(768),
-                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
-                    sidecar_input_hash: Some(hash.into()),
-                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
-                    projection_count: Some(0),
-                    symbol_doc_count: Some(0),
-                    dense_projection_count: Some(0),
-                    semantic_policy_version: Some(
-                        crate::generation::SEMANTIC_POLICY_VERSION.into(),
-                    ),
-                    graph_artifact_hash: Some("graph-test-hash".into()),
-                    dense_reason_counts_json: Some("{}".into()),
-                })
+                .upsert_retrieval_index_manifest(&manifest)
                 .expect("manifest");
         }
 
@@ -588,29 +516,10 @@ mod tests {
                     file_role: FileRole::Source,
                 })
                 .expect("insert indexed file");
+            let mut manifest = retrieval_manifest_fixture(&project_id, hash);
+            manifest.built_at_epoch_ms = indexed_mtime;
             storage
-                .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
-                    project_id: project_id.clone(),
-                    zoekt_version: "zoekt-real-v1".into(),
-                    qdrant_collection: sidecar_qdrant_collection(&project_id, hash),
-                    scip_revision: Some("graph-test".into()),
-                    built_at_epoch_ms: indexed_mtime,
-                    disk_bytes: None,
-                    degraded_modes_json: "[]".into(),
-                    embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
-                    embedding_dim: Some(768),
-                    sidecar_schema_version: Some(SIDECAR_SCHEMA_VERSION),
-                    sidecar_input_hash: Some(hash.into()),
-                    sidecar_generation: Some(sidecar_generation_id(&project_id, hash)),
-                    projection_count: Some(0),
-                    symbol_doc_count: Some(0),
-                    dense_projection_count: Some(0),
-                    semantic_policy_version: Some(
-                        crate::generation::SEMANTIC_POLICY_VERSION.into(),
-                    ),
-                    graph_artifact_hash: Some("graph-test-hash".into()),
-                    dense_reason_counts_json: Some("{}".into()),
-                })
+                .upsert_retrieval_index_manifest(&manifest)
                 .expect("manifest");
         }
 

--- a/crates/codestory-retrieval/src/test_support.rs
+++ b/crates/codestory-retrieval/src/test_support.rs
@@ -1,0 +1,33 @@
+use codestory_store::RetrievalIndexManifest;
+
+pub fn retrieval_manifest_fixture(
+    project_id: &str,
+    sidecar_input_hash: &str,
+) -> RetrievalIndexManifest {
+    RetrievalIndexManifest {
+        project_id: project_id.into(),
+        zoekt_version: "zoekt-real-v1".into(),
+        qdrant_collection: crate::generation::sidecar_qdrant_collection(
+            project_id,
+            sidecar_input_hash,
+        ),
+        scip_revision: Some("graph-test".into()),
+        built_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
+        disk_bytes: None,
+        degraded_modes_json: "[]".into(),
+        embedding_backend: Some(crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID.into()),
+        embedding_dim: Some(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32),
+        sidecar_schema_version: Some(crate::generation::SIDECAR_SCHEMA_VERSION),
+        sidecar_input_hash: Some(sidecar_input_hash.into()),
+        sidecar_generation: Some(crate::generation::sidecar_generation_id(
+            project_id,
+            sidecar_input_hash,
+        )),
+        projection_count: Some(0),
+        symbol_doc_count: Some(0),
+        dense_projection_count: Some(0),
+        semantic_policy_version: Some(crate::generation::SEMANTIC_POLICY_VERSION.into()),
+        graph_artifact_hash: Some("graph-test-hash".into()),
+        dense_reason_counts_json: Some("{}".into()),
+    }
+}

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -26,4 +26,5 @@ tracing = { workspace = true }
 ureq = { workspace = true }
 
 [dev-dependencies]
+codestory-retrieval = { workspace = true, features = ["test-support"] }
 tempfile = { workspace = true }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1374,6 +1374,7 @@ mod tests {
     use super::*;
     use codestory_retrieval::{
         CandidateHit, QueryTrace, RetrievalStageKind, StageTrace, classify_query,
+        test_support::retrieval_manifest_fixture,
     };
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -1789,34 +1790,11 @@ mod tests {
         let storage_path = storage_dir.path().join("codestory.db");
         let project_id = project_id_for_root(project.path());
         let hash = "deadbeefcafebabe";
-        let generation = format!("{project_id}-{hash}");
-        let qdrant_collection = format!("codestory_{project_id}_{hash}");
-        let built_at_epoch_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system clock before unix epoch")
-            .as_millis() as i64;
         let mut storage = Store::open(&storage_path).expect("open storage");
+        let mut manifest = retrieval_manifest_fixture(&project_id, hash);
+        manifest.embedding_backend = Some("stale-backend".into());
         storage
-            .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
-                project_id: project_id.clone(),
-                zoekt_version: "zoekt-real-v1".into(),
-                qdrant_collection,
-                scip_revision: Some("graph-test".into()),
-                built_at_epoch_ms,
-                disk_bytes: None,
-                degraded_modes_json: "[]".into(),
-                embedding_backend: Some("stale-backend".into()),
-                embedding_dim: Some(codestory_retrieval::RETRIEVAL_EMBEDDING_DIM as i32),
-                sidecar_schema_version: Some(codestory_retrieval::SIDECAR_SCHEMA_VERSION),
-                sidecar_input_hash: Some(hash.into()),
-                sidecar_generation: Some(generation),
-                projection_count: Some(0),
-                symbol_doc_count: Some(0),
-                dense_projection_count: Some(0),
-                semantic_policy_version: Some("graph_first_v1".into()),
-                graph_artifact_hash: Some("graph-test-hash".into()),
-                dense_reason_counts_json: Some("{}".into()),
-            })
+            .upsert_retrieval_index_manifest(&manifest)
             .expect("manifest");
 
         let status = sidecar_mode_status_for_project(project.path(), &storage_path);


### PR DESCRIPTION
## Context

Tests repeat large `RetrievalIndexManifest` literals across retrieval and runtime surfaces. That makes sidecar contract changes noisy and hides the field each test actually cares about.

Closes #112

## What Changed

- Added a small `retrieval_manifest_fixture(project_id, sidecar_input_hash)` helper behind `cfg(test)` / `test-support` in `codestory-retrieval`.
- Replaced noisy manifest setup in retrieval sidecar, query, and Qdrant storage tests, plus the runtime `retrieval_primary` stale-backend test.
- Left old-contract, generation-contract, fingerprint, policy, graph hash, and core manifest-report tests explicit where those fields are the assertion.

## How To Review

- Start with `crates/codestory-retrieval/src/test_support.rs` for the default current-contract fixture.
- Review the sidecar and qdrant storage test diffs to confirm each test still names its behavior field: timestamp, collection, count, or stale backend.
- Check the remaining full manifest literals in query/sidecar/health/generation/cache tests; those are intentionally explicit contract assertions.

## Verification

With serialized Cargo and sccache:

- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"`
- `cargo test -p codestory-retrieval`
- `cargo test -p codestory-runtime retrieval_primary`
- `cargo fmt --check`
- `git diff --check`

## Risk

No production behavior change intended. The helper is only compiled for retrieval crate tests or when the `test-support` feature is enabled; runtime enables that feature only as a dev-dependency for tests.
