### PR TITLE
Use canonical repository identity for sidecar generations

### DIFF
--- a/crates/codestory-retrieval/src/generation.rs
+++ b/crates/codestory-retrieval/src/generation.rs
@@ -2,7 +2,7 @@ use codestory_contracts::graph::NodeKind;
 use codestory_store::{LlmSymbolDoc, RetrievalIndexManifest, Store};
 use std::collections::BTreeMap;
 
-pub const SIDECAR_SCHEMA_VERSION: i32 = 1;
+pub const SIDECAR_SCHEMA_VERSION: i32 = 2;
 pub const SEMANTIC_POLICY_VERSION: &str = "graph_first_v1";
 pub const SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED: &str =
     "sidecar_semantic_doc_embedding_contract_changed";
@@ -391,6 +391,10 @@ mod tests {
         ));
 
         let mut legacy = current;
+        legacy.sidecar_schema_version = Some(1);
+        assert!(!manifest_has_current_sidecar_contract(project_id, &legacy));
+
+        let mut legacy = manifest(project_id, hash);
         legacy.sidecar_schema_version = None;
         assert!(!manifest_has_current_sidecar_contract(project_id, &legacy));
     }

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -68,6 +68,11 @@ pub fn project_id_for_root(project_root: &Path) -> String {
     fnv1a_hex(canonical.to_string_lossy().as_bytes())
 }
 
+pub fn sidecar_project_id_for_root(project_root: &Path) -> String {
+    codestory_workspace::sidecar_project_identity(project_root, project_id_for_root(project_root))
+        .project_id
+}
+
 pub fn repair_project_qdrant_collection(
     project_root: &Path,
     storage_path: &Path,
@@ -76,7 +81,7 @@ pub fn repair_project_qdrant_collection(
         return Ok(None);
     }
 
-    let project_id = project_id_for_root(project_root);
+    let project_id = sidecar_project_id_for_root(project_root);
     let storage = Store::open(storage_path).context("open storage for qdrant project repair")?;
     let Some(manifest) = storage
         .get_retrieval_index_manifest(&project_id)
@@ -174,7 +179,7 @@ pub fn finalize_index(project_root: &Path, storage_path: &Path) -> Result<Finali
     let layout = SidecarLayout::from_env();
     layout.ensure_data_dirs()?;
 
-    let project_id = project_id_for_root(project_root);
+    let project_id = sidecar_project_id_for_root(project_root);
     let degraded_modes = Vec::new();
     let zoekt_stubbed = false;
     let qdrant_stubbed = false;
@@ -1178,6 +1183,70 @@ mod tests {
     }
 
     #[test]
+    fn canonical_sidecar_generation_is_stable_across_clean_roots_with_same_input() {
+        let Some(first_project) = git_project() else {
+            return;
+        };
+        let Some(second_project) = git_project() else {
+            return;
+        };
+        let first_storage_dir = TempDir::new().expect("first storage dir");
+        let second_storage_dir = TempDir::new().expect("second storage dir");
+        let first_storage_path = first_storage_dir.path().join("codestory.db");
+        let second_storage_path = second_storage_dir.path().join("codestory.db");
+        let mut first_storage = Store::open(&first_storage_path).expect("first store");
+        let mut second_storage = Store::open(&second_storage_path).expect("second store");
+        insert_matching_semantic_doc(&mut first_storage, first_project.path());
+        insert_matching_semantic_doc(&mut second_storage, second_project.path());
+
+        let first_project_id = sidecar_project_id_for_root(first_project.path());
+        let second_project_id = sidecar_project_id_for_root(second_project.path());
+        assert_eq!(first_project_id, second_project_id);
+        assert_ne!(
+            project_id_for_root(first_project.path()),
+            project_id_for_root(second_project.path())
+        );
+
+        let first_input = compute_sidecar_input_fingerprint(
+            &first_storage,
+            &first_storage_path,
+            first_project.path(),
+            &first_project_id,
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+        )
+        .expect("first input");
+        let second_input = compute_sidecar_input_fingerprint(
+            &second_storage,
+            &second_storage_path,
+            second_project.path(),
+            &second_project_id,
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+        )
+        .expect("second input");
+
+        assert_eq!(first_input.hash, second_input.hash);
+        assert_eq!(
+            sidecar_generation_id(&first_project_id, &first_input.hash),
+            sidecar_generation_id(&second_project_id, &second_input.hash)
+        );
+    }
+
+    #[test]
+    fn dirty_canonical_repo_falls_back_to_root_sidecar_project_id() {
+        let Some(project) = git_project() else {
+            return;
+        };
+        let clean = sidecar_project_id_for_root(project.path());
+        std::fs::write(project.path().join("lib.rs"), "pub fn dirty() {}\n").expect("dirty source");
+        let dirty = sidecar_project_id_for_root(project.path());
+
+        assert_ne!(clean, dirty);
+        assert_eq!(dirty, project_id_for_root(project.path()));
+    }
+
+    #[test]
     fn sidecar_input_hash_changes_when_embedding_values_change() {
         let project = TempDir::new().expect("project dir");
         std::fs::write(project.path().join("lib.rs"), "pub fn do_work() {}\n")
@@ -1245,5 +1314,85 @@ mod tests {
         assert_eq!(first.dense_projection_count, 1);
         assert_eq!(first.dense_reason_counts_json, "{\"public_api\":1}");
         assert_ne!(first.hash, second.hash);
+    }
+
+    fn insert_matching_semantic_doc(storage: &mut Store, project_root: &Path) {
+        storage
+            .insert_nodes_batch(&[Node {
+                id: NodeId(1),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "do_work".into(),
+                ..Default::default()
+            }])
+            .expect("node");
+        storage
+            .upsert_llm_symbol_docs_batch(&[LlmSymbolDoc {
+                node_id: NodeId(1),
+                file_node_id: None,
+                kind: NodeKind::FUNCTION,
+                display_name: "do_work".into(),
+                qualified_name: Some("pkg::do_work".into()),
+                file_path: Some(project_root.join("lib.rs").display().to_string()),
+                start_line: Some(1),
+                doc_text: "semantic doc".into(),
+                doc_version: 4,
+                doc_hash: "hash".into(),
+                embedding_profile: Some("bge-base-en-v1.5".into()),
+                embedding_model: "BAAI/bge-base-en-v1.5-local|backend=onnx".into(),
+                embedding_backend: Some("onnx".into()),
+                embedding_dim: crate::embeddings::RETRIEVAL_EMBEDDING_DIM as u32,
+                doc_shape: Some("semantic_doc_version=4;scope=durable_symbols".into()),
+                semantic_policy_version: Some(crate::generation::SEMANTIC_POLICY_VERSION.into()),
+                dense_reason: Some("public_api".into()),
+                embedding: vec![0.01; crate::embeddings::RETRIEVAL_EMBEDDING_DIM],
+                updated_at_epoch_ms: 123,
+            }])
+            .expect("semantic doc");
+    }
+
+    fn git_project() -> Option<TempDir> {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return None;
+        }
+        let project = TempDir::new().expect("project");
+        git(project.path(), &["init"]);
+        git(
+            project.path(),
+            &["config", "user.email", "codestory@example.invalid"],
+        );
+        git(project.path(), &["config", "user.name", "CodeStory Test"]);
+        git(
+            project.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/TheGreenCedar/CodeStory.git",
+            ],
+        );
+        std::fs::write(project.path().join("lib.rs"), "pub fn do_work() {}\n")
+            .expect("write source");
+        git(project.path(), &["add", "."]);
+        git(project.path(), &["commit", "-m", "init"]);
+        Some(project)
+    }
+
+    fn git(project: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(project)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -56,7 +56,7 @@ pub use health::{
 };
 pub use index::{
     FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, project_id_for_root,
-    repair_project_qdrant_collection,
+    repair_project_qdrant_collection, sidecar_project_id_for_root,
 };
 pub use mode::RetrievalDegradedMode;
 pub use mode::derive_degraded_mode;

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -2,7 +2,7 @@ use crate::cache::RetrievalCache;
 use crate::config::SidecarLayout;
 use crate::executor::{QueryExecutor, QueryResult, cancellation_flag};
 use crate::generation::manifest_unavailable_reason;
-use crate::index::project_id_for_root;
+use crate::index::sidecar_project_id_for_root;
 use crate::sidecar::validate_strict_sidecar_readiness;
 use crate::sidecar_search::LiveSidecarSearch;
 use anyhow::{Context, Result, bail};
@@ -30,7 +30,7 @@ pub fn execute_retrieval_query_with_cache(
     cache: &mut RetrievalCache,
 ) -> Result<QueryResult> {
     let layout = SidecarLayout::from_env();
-    let project_id = project_id_for_root(request.project_root);
+    let project_id = sidecar_project_id_for_root(request.project_root);
     let (manifest, file_roles) = if request.storage_path.exists() {
         let storage = Store::open(request.storage_path).context("open storage for query")?;
         let manifest = storage

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -4,7 +4,7 @@ use crate::generation::{
     manifest_staleness_reason, manifest_unavailable_reason,
 };
 use crate::health::{RetrievalStatusReport, attach_manifest_contract, probe_sidecar_health};
-use crate::index::{compute_sidecar_input_fingerprint, project_id_for_root};
+use crate::index::{compute_sidecar_input_fingerprint, sidecar_project_id_for_root};
 use anyhow::{Context, Result};
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext,
@@ -70,7 +70,7 @@ fn sidecar_status_inner(
     strict: bool,
 ) -> Result<RetrievalStatusReport> {
     let layout = SidecarLayout::from_env();
-    let project_id = project_id_for_root(project_root);
+    let project_id = sidecar_project_id_for_root(project_root);
     let manifest = if let Some(path) = storage_path.filter(|path| path.exists()) {
         let storage = Store::open(path).context("open storage for manifest")?;
         let manifest = storage
@@ -140,7 +140,7 @@ pub(crate) fn validate_strict_sidecar_readiness(
     storage_path: &Path,
     storage: &Store,
 ) -> Result<()> {
-    let project_id = project_id_for_root(project_root);
+    let project_id = sidecar_project_id_for_root(project_root);
     let Some(manifest) = storage
         .get_retrieval_index_manifest(&project_id)
         .context("load retrieval manifest for strict readiness")?
@@ -277,7 +277,7 @@ mod tests {
     use crate::generation::{
         SIDECAR_SCHEMA_VERSION, sidecar_generation_id, sidecar_qdrant_collection,
     };
-    use crate::index::compute_sidecar_input_fingerprint;
+    use crate::index::{compute_sidecar_input_fingerprint, project_id_for_root};
     use crate::test_support::retrieval_manifest_fixture;
     use codestory_store::{FileInfo, FileRole};
     use tempfile::TempDir;

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -13,7 +13,7 @@ use codestory_contracts::api::{
 use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
 use codestory_retrieval::{
     CandidateHit, CandidateSource, QueryRequest, QueryResult, QueryTrace,
-    execute_retrieval_query_with_cache, is_phantom_sidecar_hit, project_id_for_root,
+    execute_retrieval_query_with_cache, is_phantom_sidecar_hit, sidecar_project_id_for_root,
     strict_sidecar_status,
 };
 use codestory_store::Store;
@@ -241,7 +241,7 @@ fn retrieval_manifest_exists(storage_path: &Path, project_root: &Path) -> bool {
     let Ok(storage) = Store::open(storage_path) else {
         return false;
     };
-    let project_id = project_id_for_root(project_root);
+    let project_id = sidecar_project_id_for_root(project_root);
     storage
         .get_retrieval_index_manifest(&project_id)
         .ok()
@@ -1374,7 +1374,7 @@ mod tests {
     use super::*;
     use codestory_retrieval::{
         CandidateHit, QueryTrace, RetrievalStageKind, StageTrace, classify_query,
-        test_support::retrieval_manifest_fixture,
+        project_id_for_root, test_support::retrieval_manifest_fixture,
     };
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -1784,6 +1784,37 @@ mod tests {
     }
 
     #[test]
+    fn retrieval_manifest_exists_uses_canonical_sidecar_project_id_for_clean_repos() {
+        let Some(project) = git_project() else {
+            return;
+        };
+        let storage_dir = tempfile::tempdir().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let canonical_id = sidecar_project_id_for_root(project.path());
+        let root_id = project_id_for_root(project.path());
+        assert_ne!(canonical_id, root_id);
+        upsert_manifest(&storage_path, &canonical_id);
+
+        assert!(retrieval_manifest_exists(&storage_path, project.path()));
+
+        std::fs::write(project.path().join("lib.rs"), "pub fn dirty() {}\n").expect("dirty source");
+        assert!(!retrieval_manifest_exists(&storage_path, project.path()));
+    }
+
+    #[test]
+    fn retrieval_manifest_exists_uses_root_id_for_unidentifiable_repos() {
+        let project = tempfile::tempdir().expect("project");
+        let storage_dir = tempfile::tempdir().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        upsert_manifest(&storage_path, "repo-v1-ffffffffffffffff");
+        assert!(!retrieval_manifest_exists(&storage_path, project.path()));
+
+        let root_id = project_id_for_root(project.path());
+        upsert_manifest(&storage_path, &root_id);
+        assert!(retrieval_manifest_exists(&storage_path, project.path()));
+    }
+
+    #[test]
     fn sidecar_mode_status_rejects_stale_manifest_before_health_probe() {
         let project = tempfile::tempdir().expect("project");
         let storage_dir = tempfile::tempdir().expect("storage");
@@ -1808,6 +1839,84 @@ mod tests {
         assert!(
             reason.contains("sidecar_embedding_backend_changed"),
             "expected embedding backend detail, got: {reason}"
+        );
+    }
+
+    fn upsert_manifest(storage_path: &Path, project_id: &str) {
+        let hash = "deadbeefcafebabe";
+        let generation = format!("{project_id}-{hash}");
+        let qdrant_collection = format!("codestory_{project_id}_{hash}");
+        let built_at_epoch_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_millis() as i64;
+        let mut storage = Store::open(storage_path).expect("open storage");
+        storage
+            .upsert_retrieval_index_manifest(&codestory_store::RetrievalIndexManifest {
+                project_id: project_id.into(),
+                zoekt_version: "zoekt-real-v1".into(),
+                qdrant_collection,
+                scip_revision: Some("graph-test".into()),
+                built_at_epoch_ms,
+                disk_bytes: None,
+                degraded_modes_json: "[]".into(),
+                embedding_backend: Some(codestory_retrieval::embedding_runtime_id()),
+                embedding_dim: Some(codestory_retrieval::RETRIEVAL_EMBEDDING_DIM as i32),
+                sidecar_schema_version: Some(codestory_retrieval::SIDECAR_SCHEMA_VERSION),
+                sidecar_input_hash: Some(hash.into()),
+                sidecar_generation: Some(generation),
+                projection_count: Some(0),
+                symbol_doc_count: Some(0),
+                dense_projection_count: Some(0),
+                semantic_policy_version: Some("graph_first_v1".into()),
+                graph_artifact_hash: Some("graph-test-hash".into()),
+                dense_reason_counts_json: Some("{}".into()),
+            })
+            .expect("manifest");
+    }
+
+    fn git_project() -> Option<tempfile::TempDir> {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return None;
+        }
+        let project = tempfile::tempdir().expect("project");
+        git(project.path(), &["init"]);
+        git(
+            project.path(),
+            &["config", "user.email", "codestory@example.invalid"],
+        );
+        git(project.path(), &["config", "user.name", "CodeStory Test"]);
+        git(
+            project.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/TheGreenCedar/CodeStory.git",
+            ],
+        );
+        std::fs::write(project.path().join("lib.rs"), "pub fn run() {}\n").expect("write source");
+        git(project.path(), &["add", "."]);
+        git(project.path(), &["commit", "-m", "init"]);
+        Some(project)
+    }
+
+    fn git(project: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(project)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
         );
     }
 

--- a/crates/codestory-runtime/src/repository_identity.rs
+++ b/crates/codestory-runtime/src/repository_identity.rs
@@ -1,8 +1,7 @@
 use serde::Serialize;
 use std::path::Path;
-use std::process::Command;
 
-pub const REPOSITORY_IDENTITY_SCHEMA_VERSION: u32 = 1;
+pub use codestory_workspace::REPOSITORY_IDENTITY_SCHEMA_VERSION;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RepositoryIdentityReport {
@@ -21,27 +20,19 @@ pub struct RepositoryIdentityReport {
 
 pub fn inspect_repository_identity(project_root: &Path) -> RepositoryIdentityReport {
     let root_derived_project_id = codestory_retrieval::project_id_for_root(project_root);
-    let remote = git_output(project_root, &["config", "--get", "remote.origin.url"]).ok();
-    let tree = git_output(project_root, &["rev-parse", "HEAD^{tree}"]).ok();
-    let dirty = git_output(project_root, &["status", "--porcelain"])
-        .map(|status| !status.trim().is_empty())
-        .unwrap_or(true);
-    let normalized = remote.as_deref().and_then(normalize_repository_identity);
-    let canonical_repository_id = normalized.as_deref().map(canonical_repository_id);
-    let (portable_reuse_eligible, portable_reuse_reason) =
-        portable_reuse_status(normalized.as_deref(), tree.as_deref(), dirty);
+    let identity = codestory_workspace::inspect_repository_identity(project_root);
 
     RepositoryIdentityReport {
         project: project_root.to_string_lossy().to_string(),
         root_derived_project_id,
-        canonical_repository_id,
-        repository_identity_schema_version: REPOSITORY_IDENTITY_SCHEMA_VERSION,
-        normalized_repository_identity: normalized,
-        git_remote: remote,
-        git_tree: tree,
+        canonical_repository_id: identity.canonical_repository_id,
+        repository_identity_schema_version: identity.repository_identity_schema_version,
+        normalized_repository_identity: identity.normalized_repository_identity,
+        git_remote: identity.git_remote,
+        git_tree: identity.git_tree,
         cache_schema_version: codestory_store::CURRENT_SCHEMA_VERSION,
-        portable_reuse_eligible,
-        portable_reuse_reason,
+        portable_reuse_eligible: identity.portable_reuse_eligible,
+        portable_reuse_reason: identity.portable_reuse_reason,
         freshness_inputs: vec![
             "git_tree".into(),
             "cache_schema_version".into(),
@@ -50,161 +41,12 @@ pub fn inspect_repository_identity(project_root: &Path) -> RepositoryIdentityRep
     }
 }
 
-fn portable_reuse_status(
-    normalized: Option<&str>,
-    tree: Option<&str>,
-    dirty: bool,
-) -> (bool, String) {
-    if normalized.is_none() {
-        return (false, "git_remote_missing".into());
-    }
-    if tree.is_none() {
-        return (false, "git_tree_unavailable".into());
-    }
-    if dirty {
-        return (false, "git_worktree_dirty".into());
-    }
-    (true, "eligible".into())
-}
-
-fn canonical_repository_id(normalized_repository_identity: &str) -> String {
-    let mut state = 0xcbf29ce484222325_u64;
-    mix_str(&mut state, "codestory-repository-identity");
-    mix_u32(&mut state, REPOSITORY_IDENTITY_SCHEMA_VERSION);
-    mix_str(&mut state, normalized_repository_identity);
-    format!("repo-v{REPOSITORY_IDENTITY_SCHEMA_VERSION}-{state:016x}")
-}
-
-fn normalize_repository_identity(remote: &str) -> Option<String> {
-    let value = remote.trim().replace('\\', "/");
-    if value.is_empty() {
-        return None;
-    }
-
-    if let Some((_, rest)) = value.split_once("://") {
-        return normalize_url_repository_identity(rest);
-    }
-
-    let without_user = strip_userinfo(&value);
-    let scp_like = without_user.find(':').is_some_and(|colon| {
-        without_user[..colon].find('/').is_none() && without_user[colon + 1..].contains('/')
-    });
-    let normalized = if scp_like {
-        without_user.replacen(':', "/", 1)
-    } else {
-        without_user.to_string()
-    };
-    normalize_repository_path(&normalized)
-}
-
-fn normalize_url_repository_identity(rest: &str) -> Option<String> {
-    let rest = strip_userinfo(rest);
-    let (authority, path) = rest.split_once('/')?;
-    let host = authority
-        .split_once(':')
-        .map_or(authority, |(host, _)| host);
-    normalize_repository_path(&format!("{host}/{path}"))
-}
-
-fn strip_userinfo(value: &str) -> &str {
-    value.split_once('@').map(|(_, rest)| rest).unwrap_or(value)
-}
-
-fn normalize_repository_path(value: &str) -> Option<String> {
-    let lower = value.to_ascii_lowercase();
-    let normalized = lower
-        .trim_start_matches('/')
-        .trim_end_matches('/')
-        .trim_end_matches(".git")
-        .trim_end_matches('/')
-        .to_string();
-    (!normalized.is_empty()).then_some(normalized)
-}
-
-fn git_output(project: &Path, args: &[&str]) -> Result<String, ()> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(project)
-        .args(args)
-        .output()
-        .map_err(|_| ())?;
-    if !output.status.success() {
-        return Err(());
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
-
-fn mix_u32(state: &mut u64, value: u32) {
-    for byte in value.to_le_bytes() {
-        *state ^= u64::from(byte);
-        *state = state.wrapping_mul(0x00000100000001B3);
-    }
-}
-
-fn mix_str(state: &mut u64, value: &str) {
-    for byte in value.as_bytes() {
-        *state ^= u64::from(*byte);
-        *state = state.wrapping_mul(0x00000100000001B3);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+    use std::process::Command;
     use tempfile::tempdir;
-
-    #[test]
-    fn normalizes_common_git_remote_forms() {
-        for (remote, expected) in [
-            (
-                "https://github.com/TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "ssh://git@github.com/TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "ssh://git@github.com:22/TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "git@github.com:TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "https://github.com/TheGreenCedar/CodeStory.git/",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "HTTPS://GITHUB.COM/TheGreenCedar/CodeStory.GIT",
-                "github.com/thegreencedar/codestory",
-            ),
-        ] {
-            assert_eq!(
-                normalize_repository_identity(remote).as_deref(),
-                Some(expected),
-                "remote: {remote}"
-            );
-        }
-    }
-
-    #[test]
-    fn portable_reuse_eligibility_fails_closed_without_identity_or_clean_tree() {
-        assert_eq!(
-            portable_reuse_status(None, Some("tree"), false),
-            (false, "git_remote_missing".into())
-        );
-        assert_eq!(
-            portable_reuse_status(Some("github.com/org/repo"), None, false),
-            (false, "git_tree_unavailable".into())
-        );
-        assert_eq!(
-            portable_reuse_status(Some("github.com/org/repo"), Some("tree"), true),
-            (false, "git_worktree_dirty".into())
-        );
-    }
 
     #[test]
     fn canonical_identity_uses_repo_identity_not_tree_state() {

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -10,6 +10,12 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
 
+mod repository_identity;
+pub use repository_identity::{
+    REPOSITORY_IDENTITY_SCHEMA_VERSION, RepositoryIdentity, SidecarProjectIdentity,
+    inspect_repository_identity, sidecar_project_identity,
+};
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Language {
     Cxx,

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -1,0 +1,285 @@
+use serde::Serialize;
+use std::path::Path;
+use std::process::Command;
+
+pub const REPOSITORY_IDENTITY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositoryIdentity {
+    pub canonical_repository_id: Option<String>,
+    pub repository_identity_schema_version: u32,
+    pub normalized_repository_identity: Option<String>,
+    pub git_remote: Option<String>,
+    pub git_tree: Option<String>,
+    pub portable_reuse_eligible: bool,
+    pub portable_reuse_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidecarProjectIdentity {
+    pub project_id: String,
+    pub canonical_repository_id: Option<String>,
+    pub root_derived_project_id: String,
+    pub portable_reuse_eligible: bool,
+    pub portable_reuse_reason: String,
+}
+
+pub fn inspect_repository_identity(project_root: &Path) -> RepositoryIdentity {
+    let remote = git_output(project_root, &["config", "--get", "remote.origin.url"]).ok();
+    let tree = git_output(project_root, &["rev-parse", "HEAD^{tree}"]).ok();
+    let dirty = git_output(project_root, &["status", "--porcelain"])
+        .map(|status| !status.trim().is_empty())
+        .unwrap_or(true);
+    let normalized = remote.as_deref().and_then(normalize_repository_identity);
+    let canonical_repository_id = normalized.as_deref().map(canonical_repository_id);
+    let (portable_reuse_eligible, portable_reuse_reason) =
+        portable_reuse_status(normalized.as_deref(), tree.as_deref(), dirty);
+
+    RepositoryIdentity {
+        canonical_repository_id,
+        repository_identity_schema_version: REPOSITORY_IDENTITY_SCHEMA_VERSION,
+        normalized_repository_identity: normalized,
+        git_remote: remote,
+        git_tree: tree,
+        portable_reuse_eligible,
+        portable_reuse_reason,
+    }
+}
+
+pub fn sidecar_project_identity(
+    project_root: &Path,
+    root_derived_project_id: String,
+) -> SidecarProjectIdentity {
+    let identity = inspect_repository_identity(project_root);
+    let project_id = if identity.portable_reuse_eligible {
+        identity
+            .canonical_repository_id
+            .clone()
+            .unwrap_or_else(|| root_derived_project_id.clone())
+    } else {
+        root_derived_project_id.clone()
+    };
+
+    SidecarProjectIdentity {
+        project_id,
+        canonical_repository_id: identity.canonical_repository_id,
+        root_derived_project_id,
+        portable_reuse_eligible: identity.portable_reuse_eligible,
+        portable_reuse_reason: identity.portable_reuse_reason,
+    }
+}
+
+fn portable_reuse_status(
+    normalized: Option<&str>,
+    tree: Option<&str>,
+    dirty: bool,
+) -> (bool, String) {
+    if normalized.is_none() {
+        return (false, "git_remote_missing".into());
+    }
+    if tree.is_none() {
+        return (false, "git_tree_unavailable".into());
+    }
+    if dirty {
+        return (false, "git_worktree_dirty".into());
+    }
+    (true, "eligible".into())
+}
+
+fn canonical_repository_id(normalized_repository_identity: &str) -> String {
+    let mut state = 0xcbf29ce484222325_u64;
+    mix_str(&mut state, "codestory-repository-identity");
+    mix_u32(&mut state, REPOSITORY_IDENTITY_SCHEMA_VERSION);
+    mix_str(&mut state, normalized_repository_identity);
+    format!("repo-v{REPOSITORY_IDENTITY_SCHEMA_VERSION}-{state:016x}")
+}
+
+fn normalize_repository_identity(remote: &str) -> Option<String> {
+    let value = remote.trim().replace('\\', "/");
+    if value.is_empty() {
+        return None;
+    }
+
+    if let Some((_, rest)) = value.split_once("://") {
+        return normalize_url_repository_identity(rest);
+    }
+
+    let without_user = strip_userinfo(&value);
+    let scp_like = without_user.find(':').is_some_and(|colon| {
+        without_user[..colon].find('/').is_none() && without_user[colon + 1..].contains('/')
+    });
+    let normalized = if scp_like {
+        without_user.replacen(':', "/", 1)
+    } else {
+        without_user.to_string()
+    };
+    normalize_repository_path(&normalized)
+}
+
+fn normalize_url_repository_identity(rest: &str) -> Option<String> {
+    let rest = strip_userinfo(rest);
+    let (authority, path) = rest.split_once('/')?;
+    let host = authority
+        .split_once(':')
+        .map_or(authority, |(host, _)| host);
+    normalize_repository_path(&format!("{host}/{path}"))
+}
+
+fn strip_userinfo(value: &str) -> &str {
+    value.split_once('@').map(|(_, rest)| rest).unwrap_or(value)
+}
+
+fn normalize_repository_path(value: &str) -> Option<String> {
+    let lower = value.to_ascii_lowercase();
+    let normalized = lower
+        .trim_start_matches('/')
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/')
+        .to_string();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn git_output(project: &Path, args: &[&str]) -> Result<String, ()> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project)
+        .args(args)
+        .output()
+        .map_err(|_| ())?;
+    if !output.status.success() {
+        return Err(());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn mix_u32(state: &mut u64, value: u32) {
+    for byte in value.to_le_bytes() {
+        *state ^= u64::from(byte);
+        *state = state.wrapping_mul(0x00000100000001B3);
+    }
+}
+
+fn mix_str(state: &mut u64, value: &str) {
+    for byte in value.as_bytes() {
+        *state ^= u64::from(*byte);
+        *state = state.wrapping_mul(0x00000100000001B3);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn normalizes_common_git_remote_forms() {
+        for (remote, expected) in [
+            (
+                "https://github.com/TheGreenCedar/CodeStory.git",
+                "github.com/thegreencedar/codestory",
+            ),
+            (
+                "ssh://git@github.com/TheGreenCedar/CodeStory.git",
+                "github.com/thegreencedar/codestory",
+            ),
+            (
+                "ssh://git@github.com:22/TheGreenCedar/CodeStory.git",
+                "github.com/thegreencedar/codestory",
+            ),
+            (
+                "git@github.com:TheGreenCedar/CodeStory.git",
+                "github.com/thegreencedar/codestory",
+            ),
+            (
+                "https://github.com/TheGreenCedar/CodeStory.git/",
+                "github.com/thegreencedar/codestory",
+            ),
+            (
+                "HTTPS://GITHUB.COM/TheGreenCedar/CodeStory.GIT",
+                "github.com/thegreencedar/codestory",
+            ),
+        ] {
+            assert_eq!(
+                normalize_repository_identity(remote).as_deref(),
+                Some(expected),
+                "remote: {remote}"
+            );
+        }
+    }
+
+    #[test]
+    fn portable_reuse_eligibility_fails_closed_without_identity_or_clean_tree() {
+        assert_eq!(
+            portable_reuse_status(None, Some("tree"), false),
+            (false, "git_remote_missing".into())
+        );
+        assert_eq!(
+            portable_reuse_status(Some("github.com/org/repo"), None, false),
+            (false, "git_tree_unavailable".into())
+        );
+        assert_eq!(
+            portable_reuse_status(Some("github.com/org/repo"), Some("tree"), true),
+            (false, "git_worktree_dirty".into())
+        );
+    }
+
+    #[test]
+    fn sidecar_project_identity_uses_canonical_id_only_when_clean_and_identifiable() {
+        let Some(project) = git_project() else {
+            return;
+        };
+
+        let clean = sidecar_project_identity(project.path(), "root-id".into());
+        assert!(clean.portable_reuse_eligible);
+        assert_eq!(clean.project_id, clean.canonical_repository_id.unwrap());
+
+        fs::write(project.path().join("lib.rs"), "pub fn dirty() {}\n").expect("dirty source");
+        let dirty = sidecar_project_identity(project.path(), "root-id".into());
+        assert!(!dirty.portable_reuse_eligible);
+        assert_eq!(dirty.portable_reuse_reason, "git_worktree_dirty");
+        assert_eq!(dirty.project_id, "root-id");
+    }
+
+    fn git_project() -> Option<tempfile::TempDir> {
+        if Command::new("git").arg("--version").output().is_err() {
+            return None;
+        }
+        let project = tempdir().expect("project");
+        git(project.path(), &["init"]);
+        git(
+            project.path(),
+            &["config", "user.email", "codestory@example.invalid"],
+        );
+        git(project.path(), &["config", "user.name", "CodeStory Test"]);
+        git(
+            project.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/TheGreenCedar/CodeStory.git",
+            ],
+        );
+        fs::write(project.path().join("lib.rs"), "pub fn run() {}\n").expect("write source");
+        git(project.path(), &["add", "."]);
+        git(project.path(), &["commit", "-m", "init"]);
+        Some(project)
+    }
+
+    fn git(project: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}


### PR DESCRIPTION
Summary: Use canonical repository identity for retrieval sidecar generations when a repository is clean and identifiable, while keeping unsafe worktrees on root-derived sidecar ids.

Links: Closes #111. Related #82 and #38.

---

## Context

Issue #111 needed retrieval sidecar generations to use canonical repository identity when it is safe, so compatible clean worktrees stop deriving different sidecar namespaces from absolute root paths. This keeps PR #84 out of scope and does not add portable index artifact-cache keys.

## What Changed

- Moved the reusable repository identity primitive into `codestory-workspace` and kept the runtime identity command as a report wrapper.
- Added a retrieval sidecar project-id resolver that uses the canonical repository id only for clean, identifiable Git repositories.
- Kept dirty or unidentifiable roots on root-derived ids.
- Routed sidecar finalize, repair, status, query, and runtime primary-retrieval manifest lookup through that resolver.
- Bumped the sidecar schema contract to v2 so old root-derived manifests fail closed and rebuild instead of being silently reused.
- Added narrow tests for same remote/same input across two roots, dirty fallback, schema-v1 manifest invalidation, and runtime primary retrieval seeing canonical-id manifests.

## How To Review

- Start in `crates/codestory-workspace/src/repository_identity.rs` to see the moved primitive and eligibility gate.
- Then review `crates/codestory-retrieval/src/index.rs` for `sidecar_project_id_for_root` and the finalize/repair call sites.
- Check `crates/codestory-retrieval/src/sidecar.rs`, `crates/codestory-retrieval/src/query.rs`, and `crates/codestory-runtime/src/agent/retrieval_primary.rs` to confirm lookup uses the same resolver as generation.
- Confirm `SIDECAR_SCHEMA_VERSION = 2` in `crates/codestory-retrieval/src/generation.rs` is the invalidation mechanism.

## Verification

- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo run --release -p codestory-cli -- doctor --project .`
  - Result: completed; doctor reported `needs_attention` because this worktree had no retrieval manifest, so packet/search were not used as evidence.
- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo test -p codestory-workspace repository_identity`
  - Result: 3 passed.
- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo test -p codestory-retrieval generation`
  - Result: 7 passed.
- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo test -p codestory-retrieval sidecar`
  - Result: 18 passed.
- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo test -p codestory-runtime retrieval_primary`
  - Result: 27 passed; existing `packet_sufficiency` dead-code warnings remained.
- `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo fmt --check`
  - Result: passed.
- `git diff --check` and `git diff --cached --check`
  - Result: passed.

## Risk

Canonical repository identity now controls sidecar manifest namespace only when the repo is clean and identifiable. Portable artifact cache keys are still a follow-up, and dirty/unidentifiable worktrees intentionally fall back to root-derived sidecar ids, which can surface a missing manifest instead of reusing a canonical one.
