### PR TITLE
Label pre-rank packet phases

### DIFF
--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -431,6 +431,7 @@ pub(crate) fn agent_packet(
         &rank_terms,
         &mut answer,
     )?;
+    let phase_started = Instant::now();
     maybe_append_sql_schema_file_citations(&project_root, &question, &mut answer);
     maybe_append_generic_source_shape_citations(&project_root, &question, &mut answer);
     let file_scoped_source_probes =
@@ -442,7 +443,10 @@ pub(crate) fn agent_packet(
         &file_scoped_source_probes,
         &mut answer,
     );
+    append_packet_non_trace_phase(&mut answer, "pre_rank_citations", phase_started);
+    let phase_started = Instant::now();
     packet_latency.apply_to_trace(&mut answer);
+    append_packet_non_trace_phase(&mut answer, "trace_apply", phase_started);
 
     let phase_started = Instant::now();
     rank_packet_evidence(&question, &mut answer);
@@ -9242,6 +9246,14 @@ mod tests {
         assert_eq!(
             packet_non_trace_phase_annotation("budget", 42),
             "packet_non_trace_phase label=budget duration_ms=42"
+        );
+        assert_eq!(
+            packet_non_trace_phase_annotation("pre_rank_citations", 7),
+            "packet_non_trace_phase label=pre_rank_citations duration_ms=7"
+        );
+        assert_eq!(
+            packet_non_trace_phase_annotation("trace_apply", 3),
+            "packet_non_trace_phase label=trace_apply duration_ms=3"
         );
     }
 


### PR DESCRIPTION
## Context

Refs #115.

Issue #115 asks for a diagnostic-only split of the remaining warm packet non-trace gap immediately before `rank_and_window`. PR #101 already ruled out final DTO construction, output-budget enforcement, client stdio parse/write, and server output serialization/write/flush as material causes.

## What Changed

- Added `packet_non_trace_phase` diagnostics around pre-rank citation enrichment as `pre_rank_citations`.
- Added `packet_non_trace_phase` diagnostics around packet latency trace application as `trace_apply`.
- Extended the existing machine-readable annotation unit test for both new labels.

No packet DTO shape, output-budget semantics, stdio response behavior, sidecar visibility, scorer, sufficiency, quality, compact-probe, or SLA threshold changes.

## Why

The previous evidence left a shared unnamed non-trace residual after planned packet retrieval and before/around ranking. These labels make the pre-rank citation and trace-application boundary visible in the existing harness without changing product output contracts.

## How To Review

1. Review `crates/codestory-runtime/src/agent/orchestrator.rs` around the pre-rank block after planned subqueries.
2. Confirm both labels use the existing `packet_non_trace_phase label=... duration_ms=...` annotation surface.
3. Check the warm evidence artifacts for `pre_rank_citations` and `trace_apply` under `packet_latency.packet_non_trace_phase_timings`.

## Focused Warm Evidence

Artifact root:
`C:\Users\alber\.codex\worktrees\961a\codestory\target\agent-benchmark\issue-115-pre-rank-non-trace-gap-warm-stdio`

| Row | Wall | Retrieval | Freshness | Non-trace wall | Pre-rank citations | Trace apply | Rank/window | Named non-trace phases | Residual after named phases | SLA | Quality | Sufficiency |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
| Apache warm | 19178.933 ms | 14376 ms | 394 ms | 4408.933 ms | 23 ms | 0 ms | 1702 ms | 2105 ms | 2303.933 ms | met | 1/1 | sufficient |
| Redis warm | 18403.812 ms | 13486 ms | 766 ms | 4151.812 ms | 571 ms | 0 ms | 1202 ms | 2343 ms | 1808.812 ms | met | 1/1 | sufficient |

Supporting artifacts:

- `packet-runtime-summary.md`
- `packet-runtime-summary.json`
- `packet-runtime-runs.jsonl`
- `quality-debug.json`
- `packet-composition.json`

Conclusion: `trace_apply` is not material in this slice. `pre_rank_citations` is visible on Redis (571 ms) but small on Apache (23 ms), so the remaining residual is still mostly outside these two new labels. No product-safe dedupe/reuse was obvious from this one-repeat diagnostic run.

## Verification

```powershell
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo test -p codestory-runtime packet_non_trace_phase_annotation_is_machine_readable -- --nocapture
cargo build --release -p codestory-cli
cargo fmt --check
git diff --check
node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode warm-stdio --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --repeats 1 --materialize-repos --codestory-cli .\target\release\codestory-cli.exe --benchmark-run-id issue-115-pre-rank-non-trace-gap --out-dir target\agent-benchmark\issue-115-pre-rank-non-trace-gap-warm-stdio --timeout-ms 180000
```

Results:

- Runtime test: 1 passed, 0 failed.
- Release CLI build: passed with existing runtime dead-code warnings.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.
- Focused warm packet-runtime slice: 2/2 success, 2/2 quality pass, 2/2 sufficient, 0 SLA misses.

## Risk / Follow-up

This is diagnostic-only and intentionally narrow. It does not close #98/#95/#89/#87/#78, does not reopen packet batch overhead work, and does not claim publishable A/B promotion. The exact residual conclusion is that Redis has a visible pre-rank citation component, trace application is zero, and a remaining unnamed warm non-trace residual still exists after named phases.

## Skills used

- repo-local `codestory-grounding`
- `github:github`
- `github:yeet`
- `performance`
- `best-practices`
- `superpowers:using-git-worktrees`
- `superpowers:verification-before-completion`
