### PR TITLE
Make artifact cache keys portable

### DIFF
--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -169,7 +169,43 @@ fn portable_compile_flag(root: &Path, flag: &str) -> Option<String> {
     if !root_text.is_empty() && flag.contains(root_text.as_ref()) {
         return None;
     }
+    if has_unportable_embedded_absolute_path(flag) {
+        return None;
+    }
     Some(format!("flag:{flag}"))
+}
+
+fn has_unportable_embedded_absolute_path(flag: &str) -> bool {
+    if flag.contains("=/") || flag.contains("=\\") {
+        return true;
+    }
+    if flag.as_bytes().windows(3).any(|bytes| {
+        bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && is_path_separator(bytes[2])
+    }) {
+        return true;
+    }
+    ["-include", "-imacros", "-include-pch", "-isysroot"]
+        .iter()
+        .any(|prefix| {
+            flag.strip_prefix(prefix)
+                .is_some_and(|value| starts_with_absolute_path_like(value))
+        })
+}
+
+fn starts_with_absolute_path_like(value: &str) -> bool {
+    value.starts_with('/') || value.starts_with('\\') || is_windows_absolute_path_like(value)
+}
+
+fn is_windows_absolute_path_like(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && is_path_separator(bytes[2])
+}
+
+fn is_path_separator(byte: u8) -> bool {
+    byte == b'/' || byte == b'\\'
 }
 
 fn mix_path(state: &mut u64, path: &Path) -> Option<()> {
@@ -312,6 +348,36 @@ mod tests {
         );
 
         assert!(key.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_artifact_cache_key_skips_unportable_raw_compile_flags() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("root");
+        let config = crate::get_language_for_ext("cpp").expect("cpp config");
+
+        for flag in ["--sysroot=/abs/sdk", "-include/abs/header.h"] {
+            let key = build_index_artifact_cache_key(
+                &root,
+                Path::new("src/main.cpp"),
+                b"int main() { return 0; }",
+                &config,
+                Some(&CompilationInfo {
+                    file: root.join("src/main.cpp"),
+                    working_directory: root.clone(),
+                    include_paths: Vec::new(),
+                    system_include_paths: Vec::new(),
+                    defines: HashMap::new(),
+                    standard: None,
+                    other_flags: vec![flag.to_string()],
+                }),
+                false,
+                true,
+            );
+
+            assert!(key.is_none(), "{flag} must fail closed");
+        }
         Ok(())
     }
 }

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -5,9 +5,9 @@ use codestory_contracts::graph::{
 };
 use codestory_store::FileInfo;
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
-const INDEX_ARTIFACT_CACHE_VERSION: u32 = 1;
+const INDEX_ARTIFACT_CACHE_VERSION: u32 = 2;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x00000100000001B3;
 
@@ -50,55 +50,83 @@ impl CachedIndexArtifact {
 }
 
 pub(crate) fn build_index_artifact_cache_key(
-    path: &Path,
+    root: &Path,
+    cache_path: &Path,
     source_bytes: &[u8],
     language_config: &LanguageConfig,
     compilation_info: Option<&CompilationInfo>,
     legacy_edge_identity: bool,
     lazy_graph_execution: bool,
-) -> String {
+) -> Option<String> {
     let mut state = FNV_OFFSET_BASIS;
     mix_str(&mut state, "index-artifact");
     mix_u32(&mut state, INDEX_ARTIFACT_CACHE_VERSION);
-    mix_str(&mut state, &path.to_string_lossy());
+    mix_path(&mut state, cache_path)?;
     mix_bytes(&mut state, source_bytes);
     mix_str(&mut state, language_config.language_name);
     mix_str(&mut state, language_config.graph_query);
     mix_optional_str(&mut state, language_config.tags_query);
     mix_bool(&mut state, legacy_edge_identity);
     mix_bool(&mut state, lazy_graph_execution);
-    mix_compilation_info(&mut state, compilation_info);
-    format!("v{INDEX_ARTIFACT_CACHE_VERSION}:{state:016x}")
+    mix_compilation_info(&mut state, root, compilation_info)?;
+    Some(format!("v{INDEX_ARTIFACT_CACHE_VERSION}:{state:016x}"))
 }
 
-fn mix_compilation_info(state: &mut u64, compilation_info: Option<&CompilationInfo>) {
+pub(crate) fn index_artifact_cache_path(root: &Path, path: &Path) -> Option<PathBuf> {
+    let relative = if path.is_absolute() {
+        path.strip_prefix(root).ok()?
+    } else {
+        path
+    };
+    let mut portable = PathBuf::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(part) => portable.push(part),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    if portable.as_os_str().is_empty() {
+        return Some(PathBuf::from("."));
+    }
+    Some(portable)
+}
+
+fn mix_compilation_info(
+    state: &mut u64,
+    root: &Path,
+    compilation_info: Option<&CompilationInfo>,
+) -> Option<()> {
     let Some(compilation_info) = compilation_info else {
         mix_bool(state, false);
-        return;
+        return Some(());
     };
     mix_bool(state, true);
-    mix_str(state, &compilation_info.file.to_string_lossy());
-    mix_str(state, &compilation_info.working_directory.to_string_lossy());
+    mix_path(state, &portable_compile_path(root, &compilation_info.file)?)?;
+    mix_path(
+        state,
+        &portable_compile_path(root, &compilation_info.working_directory)?,
+    )?;
     mix_optional_standard(state, compilation_info.standard);
 
     let mut include_paths = compilation_info
         .include_paths
         .iter()
-        .map(|path| path.to_string_lossy().to_string())
-        .collect::<Vec<_>>();
+        .map(|path| portable_compile_path(root, path))
+        .collect::<Option<Vec<_>>>()?;
     include_paths.sort_unstable();
     for include_path in include_paths {
-        mix_str(state, &include_path);
+        mix_path(state, &include_path)?;
     }
 
     let mut system_include_paths = compilation_info
         .system_include_paths
         .iter()
-        .map(|path| path.to_string_lossy().to_string())
-        .collect::<Vec<_>>();
+        .map(|path| portable_compile_path(root, path))
+        .collect::<Option<Vec<_>>>()?;
     system_include_paths.sort_unstable();
     for system_include_path in system_include_paths {
-        mix_str(state, &system_include_path);
+        mix_path(state, &system_include_path)?;
     }
 
     let mut defines = compilation_info
@@ -112,11 +140,42 @@ fn mix_compilation_info(state: &mut u64, compilation_info: Option<&CompilationIn
         mix_optional_string(state, value.as_ref());
     }
 
-    let mut other_flags = compilation_info.other_flags.clone();
+    let mut other_flags = compilation_info
+        .other_flags
+        .iter()
+        .map(|flag| portable_compile_flag(root, flag))
+        .collect::<Option<Vec<_>>>()?;
     other_flags.sort_unstable();
     for flag in other_flags {
         mix_str(state, &flag);
     }
+    Some(())
+}
+
+fn portable_compile_path(root: &Path, path: &Path) -> Option<PathBuf> {
+    if !path.is_absolute() {
+        return index_artifact_cache_path(root, path);
+    }
+    index_artifact_cache_path(root, path)
+}
+
+fn portable_compile_flag(root: &Path, flag: &str) -> Option<String> {
+    let path = Path::new(flag);
+    if path.is_absolute() {
+        return index_artifact_cache_path(root, path)
+            .map(|path| format!("path:{}", path.to_string_lossy()));
+    }
+    let root_text = root.to_string_lossy();
+    if !root_text.is_empty() && flag.contains(root_text.as_ref()) {
+        return None;
+    }
+    Some(format!("flag:{flag}"))
+}
+
+fn mix_path(state: &mut u64, path: &Path) -> Option<()> {
+    let token = index_artifact_cache_path(Path::new(""), path)?;
+    mix_str(state, &token.to_string_lossy().replace('\\', "/"));
+    Some(())
 }
 
 fn mix_optional_standard(state: &mut u64, standard: Option<CxxStandard>) {
@@ -169,5 +228,90 @@ fn mix_bytes(state: &mut u64, bytes: &[u8]) {
     for byte in bytes {
         *state ^= u64::from(*byte);
         *state = state.wrapping_mul(FNV_PRIME);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_artifact_cache_key_is_portable_across_roots() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root_a = temp.path().join("root-a");
+        let root_b = temp.path().join("root-b");
+        let config = crate::get_language_for_ext("cpp").expect("cpp config");
+        let source = b"int main() { return 0; }";
+        let cache_path = Path::new("src/main.cpp");
+
+        let key_a = build_index_artifact_cache_key(
+            &root_a,
+            cache_path,
+            source,
+            &config,
+            Some(&CompilationInfo {
+                file: root_a.join("src/main.cpp"),
+                working_directory: root_a.clone(),
+                include_paths: vec![root_a.join("include")],
+                system_include_paths: Vec::new(),
+                defines: HashMap::from([("FOO".to_string(), Some("1".to_string()))]),
+                standard: Some(CxxStandard::Cxx20),
+                other_flags: vec!["src/main.cpp".to_string()],
+            }),
+            false,
+            true,
+        )
+        .expect("portable source-root compile info");
+        let key_b = build_index_artifact_cache_key(
+            &root_b,
+            cache_path,
+            source,
+            &config,
+            Some(&CompilationInfo {
+                file: root_b.join("src/main.cpp"),
+                working_directory: root_b.clone(),
+                include_paths: vec![root_b.join("include")],
+                system_include_paths: Vec::new(),
+                defines: HashMap::from([("FOO".to_string(), Some("1".to_string()))]),
+                standard: Some(CxxStandard::Cxx20),
+                other_flags: vec!["src/main.cpp".to_string()],
+            }),
+            false,
+            true,
+        )
+        .expect("portable target-root compile info");
+
+        assert_eq!(key_a, key_b);
+        Ok(())
+    }
+
+    #[test]
+    fn test_artifact_cache_key_skips_unportable_compile_paths() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("root");
+        let outside = temp.path().join("outside");
+        let config = crate::get_language_for_ext("cpp").expect("cpp config");
+
+        let key = build_index_artifact_cache_key(
+            &root,
+            Path::new("src/main.cpp"),
+            b"int main() { return 0; }",
+            &config,
+            Some(&CompilationInfo {
+                file: root.join("src/main.cpp"),
+                working_directory: root.clone(),
+                include_paths: vec![outside.join("include")],
+                system_include_paths: Vec::new(),
+                defines: HashMap::new(),
+                standard: None,
+                other_flags: Vec::new(),
+            }),
+            false,
+            true,
+        );
+
+        assert!(key.is_none());
+        Ok(())
     }
 }

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -165,6 +165,9 @@ fn portable_compile_flag(root: &Path, flag: &str) -> Option<String> {
         return index_artifact_cache_path(root, path)
             .map(|path| format!("path:{}", path.to_string_lossy()));
     }
+    if is_standalone_slash_root_path_like(flag) {
+        return None;
+    }
     let root_text = root.to_string_lossy();
     if !root_text.is_empty() && flag.contains(root_text.as_ref()) {
         return None;
@@ -173,6 +176,13 @@ fn portable_compile_flag(root: &Path, flag: &str) -> Option<String> {
         return None;
     }
     Some(format!("flag:{flag}"))
+}
+
+fn is_standalone_slash_root_path_like(flag: &str) -> bool {
+    let Some(rest) = flag.strip_prefix('/').or_else(|| flag.strip_prefix('\\')) else {
+        return false;
+    };
+    rest.contains('/') || rest.contains('\\')
 }
 
 fn has_unportable_embedded_absolute_path(flag: &str) -> bool {
@@ -357,7 +367,13 @@ mod tests {
         let root = temp.path().join("root");
         let config = crate::get_language_for_ext("cpp").expect("cpp config");
 
-        for flag in ["--sysroot=/abs/sdk", "-include/abs/header.h"] {
+        for flag in [
+            "--sysroot=/abs/sdk",
+            "-include/abs/header.h",
+            "/abs/sdk",
+            "\\abs\\sdk",
+            "/abs/header.h",
+        ] {
             let key = build_index_artifact_cache_key(
                 &root,
                 Path::new("src/main.cpp"),

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -13530,7 +13530,7 @@ fn remap_edges(
         }
         edge.file_node_id = Some(new_file_id);
         if !flags.legacy_edge_identity {
-            ensure_callsite_identity(edge, None);
+            refresh_callsite_identity(edge);
         }
         edge.id = EdgeId(generate_edge_id_for_edge(edge, flags));
     }
@@ -18335,6 +18335,25 @@ fn ensure_callsite_identity(edge: &mut Edge, col: Option<u32>) {
     }
     edge.callsite_identity =
         canonical_callsite_identity(edge.file_node_id, edge.line, col, edge.target);
+}
+
+fn refresh_callsite_identity(edge: &mut Edge) {
+    if edge.kind != EdgeKind::CALL {
+        return;
+    }
+    let existing = edge.callsite_identity.take();
+    let col = existing.as_deref().and_then(callsite_identity_start_col);
+    let marker_parts = existing
+        .as_deref()
+        .into_iter()
+        .flat_map(|identity| identity.split('|').skip(1))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    edge.callsite_identity =
+        canonical_callsite_identity(edge.file_node_id, edge.line, col, edge.target);
+    for marker in marker_parts {
+        append_callsite_part(edge, &marker);
+    }
 }
 
 fn append_callsite_marker(edge: &mut Edge, marker: &'static str) {

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -29,7 +29,7 @@ pub mod semantic;
 pub mod structural;
 pub mod symbol_table;
 pub mod template_pipeline;
-use cache::{CachedIndexArtifact, build_index_artifact_cache_key};
+use cache::{CachedIndexArtifact, build_index_artifact_cache_key, index_artifact_cache_path};
 pub use cancellation::CancellationToken;
 use intermediate_storage::IntermediateStorage;
 use symbol_table::SymbolTable;
@@ -706,10 +706,11 @@ pub struct IncrementalIndexingStats {
 #[derive(Debug)]
 struct PreparedIndexInput {
     full_path: PathBuf,
+    artifact_cache_path: Option<PathBuf>,
     source: String,
     compilation_info: Option<compilation_database::CompilationInfo>,
     language_config: LanguageConfig,
-    artifact_cache_key: String,
+    artifact_cache_key: Option<String>,
 }
 
 enum PreparedIndexWork {
@@ -1430,21 +1431,54 @@ impl WorkspaceIndexer {
             language_config = upgraded;
         }
         let flags = index_feature_flags();
-        let artifact_cache_key = build_index_artifact_cache_key(
-            &full_path,
-            source.as_bytes(),
-            &language_config,
-            compilation_info.as_ref(),
-            flags.legacy_edge_identity,
-            flags.lazy_graph_execution,
-        );
+        let artifact_cache_path = index_artifact_cache_path(root, &full_path);
+        let artifact_cache_key = artifact_cache_path.as_ref().and_then(|cache_path| {
+            build_index_artifact_cache_key(
+                root,
+                cache_path,
+                source.as_bytes(),
+                &language_config,
+                compilation_info.as_ref(),
+                flags.legacy_edge_identity,
+                flags.lazy_graph_execution,
+            )
+        });
 
-        match storage.get_index_artifact_cache(&full_path, &artifact_cache_key) {
+        let Some(cache_path) = artifact_cache_path.as_ref() else {
+            stats.artifact_cache_misses += 1;
+            return Ok(PreparedIndexWork::Parse(PreparedIndexInput {
+                full_path,
+                artifact_cache_path,
+                source,
+                compilation_info,
+                language_config,
+                artifact_cache_key,
+            }));
+        };
+        let Some(cache_key) = artifact_cache_key.as_ref() else {
+            stats.artifact_cache_misses += 1;
+            return Ok(PreparedIndexWork::Parse(PreparedIndexInput {
+                full_path,
+                artifact_cache_path,
+                source,
+                compilation_info,
+                language_config,
+                artifact_cache_key,
+            }));
+        };
+
+        match storage.get_index_artifact_cache(cache_path, cache_key) {
             Ok(Some(blob)) => match serde_json::from_slice::<CachedIndexArtifact>(&blob) {
-                Ok(mut artifact) => {
+                Ok(artifact) => {
+                    let mut artifact = rebase_cached_index_artifact(
+                        artifact,
+                        &full_path,
+                        &source,
+                        language_config.language_name,
+                        flags,
+                    );
                     if let Some(file_info) = artifact.files.first_mut() {
                         file_info.modification_time = file_modification_time(&full_path);
-                        file_info.path = full_path.clone();
                     }
                     stats.artifact_cache_hits += 1;
                     if existing_projection_id.is_some() {
@@ -1478,6 +1512,7 @@ impl WorkspaceIndexer {
                     stats.artifact_cache_misses += 1;
                     Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                         full_path,
+                        artifact_cache_path,
                         source,
                         compilation_info,
                         language_config,
@@ -1489,6 +1524,7 @@ impl WorkspaceIndexer {
                 stats.artifact_cache_misses += 1;
                 Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                     full_path,
+                    artifact_cache_path,
                     source,
                     compilation_info,
                     language_config,
@@ -1499,6 +1535,7 @@ impl WorkspaceIndexer {
                 stats.artifact_cache_misses += 1;
                 Ok(PreparedIndexWork::Parse(PreparedIndexInput {
                     full_path,
+                    artifact_cache_path,
                     source,
                     compilation_info,
                     language_config,
@@ -1566,14 +1603,19 @@ impl WorkspaceIndexer {
         ) {
             Ok(index_result) => {
                 let artifact = CachedIndexArtifact::from_index_result(index_result);
-                let cache_write =
-                    serde_json::to_vec(&artifact)
-                        .ok()
-                        .map(|artifact_blob| ArtifactCacheWrite {
-                            path: prepared_input.full_path.clone(),
-                            cache_key: prepared_input.artifact_cache_key.clone(),
-                            artifact_blob,
-                        });
+                let cache_write = prepared_input
+                    .artifact_cache_path
+                    .as_ref()
+                    .zip(prepared_input.artifact_cache_key.as_ref())
+                    .and_then(|(path, cache_key)| {
+                        serde_json::to_vec(&artifact)
+                            .ok()
+                            .map(|artifact_blob| ArtifactCacheWrite {
+                                path: path.clone(),
+                                cache_key: cache_key.clone(),
+                                artifact_blob,
+                            })
+                    });
                 let local_storage = artifact.into_intermediate_storage();
                 PreparedIndexJobResult {
                     local_storage,
@@ -1673,6 +1715,64 @@ pub(crate) fn file_node_from_source(path: &Path, source: &str) -> (Node, String,
     };
 
     (file_node, file_name, file_id)
+}
+
+fn rebase_cached_index_artifact(
+    mut artifact: CachedIndexArtifact,
+    full_path: &Path,
+    source: &str,
+    language_name: &str,
+    flags: IndexFeatureFlags,
+) -> CachedIndexArtifact {
+    let file_name = full_path.to_string_lossy().to_string();
+    for node in &mut artifact.nodes {
+        if node.kind == NodeKind::FILE {
+            node.serialized_name = file_name.clone();
+            node.qualified_name = None;
+            node.canonical_id = None;
+        }
+    }
+
+    let old_file_id = artifact.files.first().map(|file| NodeId(file.id));
+    let (nodes, id_remap) = canonicalize_nodes(&file_name, artifact.nodes, &HashMap::new());
+    let fallback_file_id = NodeId(WorkspaceIndexer::canonical_file_node_id_for_path(full_path));
+    let new_file_id = old_file_id
+        .and_then(|file_id| id_remap.get(&file_id).copied())
+        .unwrap_or(fallback_file_id);
+    let final_node_ids = nodes.iter().map(|node| node.id).collect::<HashSet<_>>();
+
+    artifact.nodes = nodes;
+    remap_file_affinity(&mut artifact.nodes, new_file_id);
+    remap_edges(&mut artifact.edges, new_file_id, &id_remap, flags);
+    remap_occurrences(&mut artifact.occurrences, &id_remap);
+    artifact.component_access = artifact
+        .component_access
+        .into_iter()
+        .filter_map(|(node_id, access)| {
+            let remapped = id_remap.get(&node_id).copied().unwrap_or(node_id);
+            final_node_ids
+                .contains(&remapped)
+                .then_some((remapped, access))
+        })
+        .collect();
+    artifact.impl_anchor_node_ids = artifact
+        .impl_anchor_node_ids
+        .into_iter()
+        .map(|node_id| id_remap.get(&node_id).copied().unwrap_or(node_id))
+        .filter(|node_id| final_node_ids.contains(node_id))
+        .collect();
+    artifact.impl_anchor_node_ids.sort_unstable();
+    artifact.impl_anchor_node_ids.dedup();
+
+    if let Some(file_info) = artifact.files.first_mut() {
+        file_info.id = new_file_id.0;
+        file_info.path = full_path.to_path_buf();
+        file_info.language = language_name.to_string();
+        file_info.line_count = source.lines().count() as u32;
+    }
+    artifact.callable_projection_states =
+        build_callable_projection_states(&artifact.nodes, &artifact.edges, &artifact.occurrences);
+    artifact
 }
 
 fn incomplete_file_storage(
@@ -13422,6 +13522,11 @@ fn remap_edges(
             && let Some(new_id) = id_remap.get(&resolved_target)
         {
             edge.resolved_target = Some(*new_id);
+        }
+        for candidate in &mut edge.candidate_targets {
+            if let Some(new_id) = id_remap.get(candidate) {
+                *candidate = *new_id;
+            }
         }
         edge.file_node_id = Some(new_file_id);
         if !flags.legacy_edge_identity {

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -292,6 +292,10 @@ fn test_index_artifact_cache_copies_across_compatible_roots() -> anyhow::Result<
     let first_stats =
         run_incremental_indexing(&source_root, &mut source_storage, vec![source_file])?;
     assert_eq!(first_stats.artifact_cache_writes, 1);
+    let source_file_id = source_storage
+        .get_file_by_path(&source_root.join("src/main.rs"))?
+        .map(|file| file.id)
+        .ok_or_else(|| anyhow::anyhow!("missing source file"))?;
     drop(source_storage);
 
     let mut target_storage = Storage::open(&target_db)?;
@@ -305,6 +309,10 @@ fn test_index_artifact_cache_copies_across_compatible_roots() -> anyhow::Result<
     assert_eq!(target_stats.artifact_cache_misses, 0);
 
     let source_root_text = source_root.to_string_lossy();
+    let target_file_id = target_storage
+        .get_file_by_path(&target_file)?
+        .map(|file| file.id)
+        .ok_or_else(|| anyhow::anyhow!("missing target file"))?;
     for node in target_storage.get_nodes()? {
         assert!(!node.serialized_name.contains(source_root_text.as_ref()));
         assert!(
@@ -314,6 +322,22 @@ fn test_index_artifact_cache_copies_across_compatible_roots() -> anyhow::Result<
                 .unwrap_or_default()
                 .contains(source_root_text.as_ref())
         );
+    }
+    for edge in target_storage.get_edges()? {
+        if edge.kind == EdgeKind::CALL {
+            let identity = edge
+                .callsite_identity
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("missing callsite identity"))?;
+            assert!(
+                identity.starts_with(&format!("{target_file_id}:")),
+                "callsite identity should use target file id: {identity}"
+            );
+            assert!(
+                !identity.starts_with(&format!("{source_file_id}:")),
+                "callsite identity should not retain source file id: {identity}"
+            );
+        }
     }
     assert_eq!(
         target_storage

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -274,6 +274,58 @@ fn test_incremental_indexing_second_run_reuses_unchanged_extraction_cache_and_re
 }
 
 #[test]
+fn test_index_artifact_cache_copies_across_compatible_roots() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let source_root = dir.path().join("source");
+    let target_root = dir.path().join("target");
+    fs::create_dir_all(source_root.join("src"))?;
+    fs::create_dir_all(target_root.join("src"))?;
+    let source_file = source_root.join("src/main.rs");
+    let target_file = target_root.join("src/main.rs");
+    let source = "fn helper() {}\nfn run() { helper(); }\n";
+    fs::write(&source_file, source)?;
+    fs::write(&target_file, source)?;
+
+    let source_db = dir.path().join("source.db");
+    let target_db = dir.path().join("target.db");
+    let mut source_storage = Storage::open(&source_db)?;
+    let first_stats =
+        run_incremental_indexing(&source_root, &mut source_storage, vec![source_file])?;
+    assert_eq!(first_stats.artifact_cache_writes, 1);
+    drop(source_storage);
+
+    let mut target_storage = Storage::open(&target_db)?;
+    assert_eq!(
+        target_storage.copy_index_artifact_cache_from(&source_db)?,
+        1
+    );
+    let target_stats =
+        run_incremental_indexing(&target_root, &mut target_storage, vec![target_file.clone()])?;
+    assert_eq!(target_stats.artifact_cache_hits, 1);
+    assert_eq!(target_stats.artifact_cache_misses, 0);
+
+    let source_root_text = source_root.to_string_lossy();
+    for node in target_storage.get_nodes()? {
+        assert!(!node.serialized_name.contains(source_root_text.as_ref()));
+        assert!(
+            !node
+                .canonical_id
+                .as_deref()
+                .unwrap_or_default()
+                .contains(source_root_text.as_ref())
+        );
+    }
+    assert_eq!(
+        target_storage
+            .get_file_by_path(&target_file)?
+            .map(|file| file.path),
+        Some(target_file)
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_incremental_indexing_body_only_change_updates_changed_callable_projection()
 -> anyhow::Result<()> {
     let dir = tempdir()?;

--- a/docs/architecture/indexing-pipeline.md
+++ b/docs/architecture/indexing-pipeline.md
@@ -108,7 +108,7 @@ Files that disappeared from discovery are collected into `files_to_remove`.
 - it picks a parser-backed language configuration or structural collector for
   each file and skips unsupported files before any parse work
 
-Compilation metadata matters mostly for native-language parsing and is part of the artifact-cache key, so changes to compiler flags or include paths can invalidate cached artifacts.
+Compilation metadata matters mostly for native-language parsing and is part of the artifact-cache key, so changes to compiler flags or include paths can invalidate cached artifacts. Artifact-cache identity uses the root-relative file path so compatible clean worktrees can reuse copied artifact rows.
 
 ### 5. Artifact cache decides parse versus reuse
 
@@ -116,11 +116,11 @@ Compilation metadata matters mostly for native-language parsing and is part of t
 
 The cache key includes:
 
-- the file path
+- the root-relative file path
 - file bytes
 - language queries
 - feature-flag values that affect graph shape
-- compilation metadata when present
+- compilation metadata when present and root-relative enough to be portable
 
 A cache hit can reuse the serialized indexing artifact and turn it back into `IntermediateStorage`. A cache miss sends the file through parse and extract work.
 
@@ -241,7 +241,7 @@ compatibility records.
 
 ### How `compile_commands.json` participates
 
-`WorkspaceIndexer::new` looks for a compilation database near the workspace root. When present, parsed compilation info informs language configuration and becomes part of the artifact-cache key.
+`WorkspaceIndexer::new` looks for a compilation database near the workspace root. When present, parsed compilation info informs language configuration and becomes part of the artifact-cache key. If compile-command paths cannot be made relative to the workspace root, the indexer skips artifact-cache lookup/write for that file and rebuilds instead.
 
 ### Where artifact caching is used
 


### PR DESCRIPTION
## Context

Closes #117. This is the next narrow #82 slice after #111 / PR #114 landed canonical retrieval sidecar generation identity. Draft PR #84 still invalidates index artifact rows because `main` made artifact-cache identity path-bound.

On current `main`, `crates/codestory-indexer/src/cache.rs` mixed absolute source paths and compile-command paths into the artifact key, while `crates/codestory-indexer/src/lib.rs` looked up rows by the current worktree `full_path`. Compatible clean worktrees therefore could not hit copied artifact rows.

## What Changed

- Bumped the index artifact cache key contract to v2 and mixed the root-relative artifact path instead of the absolute worktree path.
- Made compile metadata portable only when source/workdir/include/flag path inputs can be made workspace-relative; otherwise artifact-cache lookup/write is skipped for that file and indexing rebuilds normally.
- Stored artifact rows under the portable cache path and rebased cached artifact IDs, file paths, edge/occurrence references, component access, impl anchors, and callable projection state when a copied row is hit in another worktree.
- Refreshed cached CALL edge `callsite_identity` during artifact rebasing so regenerated edge ids and callable projection body hashes use the target worktree file id while preserving marker suffixes.
- Added a regression that copies artifact-cache rows between two temp roots and proves the target root gets a cache hit without source-root path text or source file ids in CALL callsite identity.
- Updated the indexing architecture note with the portable-key and fail-closed compile-path behavior.

## How To Review

Start with `crates/codestory-indexer/src/cache.rs` for the key contract, then read `rebase_cached_index_artifact`, `remap_edges`, and `refresh_callsite_identity` in `crates/codestory-indexer/src/lib.rs`. The integration test `test_index_artifact_cache_copies_across_compatible_roots` is the copied-row acceptance path.

## Verification

All Cargo commands were run serialized with `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"`.

- `cargo run -p codestory-cli -- doctor --project .`
  - Completed; reported `needs_attention` because this fresh worktree has no built index or retrieval manifest yet.
- `cargo test -p codestory-indexer --test integration test_index_artifact_cache_copies_across_compatible_roots -- --nocapture`
  - Failed before the fix with a copied CALL callsite identity retaining the source file id.
  - Passed after refreshing cached callsite identities during edge rebasing.
- `cargo test -p codestory-indexer cache`
  - Passed: 5 unit tests plus 2 matching integration tests, including the copied-row portable cache hit.
- `cargo test -p codestory-store index_artifact`
  - Passed: 1 test. Store shape was not changed.
- `cargo fmt --check`
  - Passed.
- `git diff --check`
  - Passed.

## Risk

- This does not edit or stack onto draft PR #84. When PR #84 lands or is refreshed, its rehydrate evidence still needs to be updated/reviewed to preserve portable v2 artifact rows instead of blanket invalidation.
- Native compile-command cases with absolute paths outside the workspace fail closed to rebuild. That is intentional for this slice; broader canonicalization can be added only with source-backed proof.
- Retrieval sidecar reuse remains out of scope for this PR.

