### PR TITLE
Explain sidecar rehydrate invalidation

### DIFF
--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -176,7 +176,7 @@ pub fn rehydrate_cache(request: CacheRehydrateRequest<'_>) -> Result<CacheRehydr
         invalidated_index_artifact_rows,
         rebased_path_bound_rows,
         preserved_scope: "sqlite_graph_search_docs_rebased_v2_index_artifacts_preserved".into(),
-        retrieval: "path-bound SQLite graph/search/doc rows rebased; portable v2 index artifact rows preserved; retrieval manifests invalidated because sidecar identities are root derived".into(),
+        retrieval: retrieval_rehydrate_policy(request.dry_run),
         next_commands: rehydrate_next_commands(request.target_project),
     })
 }
@@ -403,6 +403,17 @@ fn rehydrate_next_commands(project: &Path) -> Vec<String> {
     ]
 }
 
+fn retrieval_rehydrate_policy(dry_run: bool) -> String {
+    let action = if dry_run {
+        "would be invalidated"
+    } else {
+        "invalidated"
+    };
+    format!(
+        "path-bound SQLite graph/search/doc rows rebased; portable v2 index artifact rows preserved; retrieval manifests {action} because cache rehydrate copies SQLite cache state only; Zoekt/Qdrant/SCIP sidecar directories live outside the copied cache and must be revalidated by retrieval index before reuse"
+    )
+}
+
 fn quote_path(path: &Path) -> String {
     let value = path.to_string_lossy();
     if value.contains([' ', '"', '\'']) {
@@ -451,6 +462,13 @@ mod tests {
         assert_eq!(
             output.preserved_scope,
             "sqlite_graph_search_docs_rebased_v2_index_artifacts_preserved"
+        );
+        assert!(
+            output
+                .retrieval
+                .contains("retrieval manifests invalidated because cache rehydrate copies SQLite cache state only"),
+            "rehydrate output should name the fail-closed sidecar rebuild reason: {}",
+            output.retrieval
         );
         let storage = Store::open(target_cache_path.join("codestory.db")).expect("open target");
         assert!(


### PR DESCRIPTION
Closes #119

## Context

PR #84 landed the SQLite cache rehydrate command, but its retrieval message still said manifests are invalidated because sidecar identities are root-derived. After #111/#114, sidecar generation identity is canonical when the source and target repos are clean and compatible, so that reason is stale.

This keeps the product-safe #119 slice fail-closed: rehydrate still invalidates copied retrieval manifests, but now reports the source-backed boundary that `cache rehydrate` copies SQLite cache state only. The external Zoekt/Qdrant/SCIP sidecar directories must be revalidated by `retrieval index`, which can reuse healthy generated sidecars or rebuild.

## What Changed

- Replaced the stale root-derived invalidation message with a dry-run-aware retrieval policy string.
- Added a focused cache rehydrate assertion so compatible SQLite rehydrate output names the sidecar rebuild/revalidation reason.

## How To Review

- Review `crates/codestory-runtime/src/cache_rehydrate.rs` only.
- Confirm this does not preserve manifests or weaken freshness checks; it only makes the fail-closed rebuild boundary explicit.

## Verification

All Cargo commands were run serialized with `$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"`.

- `cargo test -p codestory-runtime cache_rehydrate -- --nocapture`
  - Passed: 3 passed, 0 failed.
- `cargo fmt --check`
  - Passed.
- `git diff --check`
  - Passed.

Existing warning observed during runtime Cargo build: three `packet_sufficiency` dead-code warnings unrelated to this branch.

## Risk

This does not complete full retrieval sidecar reuse for #82. It keeps rehydrate fail-closed and tells operators why `retrieval index` remains required after copying the SQLite cache.
