### PR TITLE
[codex] taper compact packet probes

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -570,6 +570,8 @@ pub(crate) fn packet_anchor_probe_limit_for_budget(
         (base / 4).max(1)
     } else if usage_pct >= 50 {
         (base / 2).max(1)
+    } else if budget == PacketBudgetModeDto::Compact && usage_pct >= 25 {
+        (base / 2).max(1)
     } else {
         base
     }
@@ -891,6 +893,10 @@ mod tests {
     #[test]
     fn compact_packet_anchor_probe_limit_tapers_under_budget_pressure() {
         let latency = PacketLatencyBudget::new(Some(18_000));
+        assert_eq!(
+            packet_anchor_probe_limit_for_budget(PacketBudgetModeDto::Compact, latency, 4_500,),
+            6
+        );
         assert_eq!(
             packet_anchor_probe_limit_for_budget(PacketBudgetModeDto::Compact, latency, 9_000,),
             6


### PR DESCRIPTION
## Context
Closes #87.
Refs #78.

Post-#125 Apache/Redis packet-runtime evidence showed cold CLI first-request SLA misses while warm stdio was clean. The misses were concentrated in compact packet batch/search work after the initial retrieval had already spent a material slice of the 18s packet budget.

## What Changed

- Taper compact packet anchor probes earlier when prior retrieval has consumed at least 25% of the packet latency budget.
- Kept standard/deep packet budget taper thresholds unchanged.
- Added a focused unit assertion for the 4.5s / 18s compact budget-pressure case.

## How To Review

- Review `crates/codestory-runtime/src/agent/packet_batch.rs`.
- The production diff is intentionally tiny: compact mode now halves anchor probes at 25% consumed budget, while existing 50% and 75% taper behavior remains.
- Confirm this does not alter scorer, sufficiency, quality thresholds, sidecar freshness, fail-closed behavior, or add holdout-specific production logic.

## Verification

- `cargo test -p codestory-runtime compact_packet_anchor_probe_limit_tapers_under_budget_pressure --lib` passed after red/green.
- `cargo test -p codestory-runtime agent::packet_batch::tests --lib` passed: 7 passed.
- `cargo build --release -p codestory-cli` passed.
- Focused packet-runtime rerun passed SLA target for Apache/Redis cold and warm rows:
  - Artifact: `C:\Users\alber\.codex\worktrees\73f9\codestory\target\agent-benchmark\issue-87-cold-batch-sla`
  - Apache cold CLI: SLA `0/3`, quality `3/3`, sufficiency `sufficient:3`, follow-ups `0`.
  - Redis cold CLI: SLA `0/3`, quality `3/3`, sufficiency `sufficient:3`, follow-ups `0`.
  - Apache warm stdio: SLA `0/3`, quality `3/3`, sufficiency `sufficient:3`, follow-ups `0`.
  - Redis warm stdio: SLA `0/3`, quality `3/3`, sufficiency `sufficient:3`, follow-ups `0`.
- Spec/evidence review: PASS.
- E2e performance-optimizer review: PASS_WITH_NOTES; this is a real focused improvement, not publishable readiness.
- Code-quality review: PASS.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

- Publishable promotion remains blocked by unresolved packet diagnostics: Apache still reports `56` unresolved candidates per row, Redis still reports `1` per row.
- This PR deliberately does not chase unresolved-candidate diagnostics; #78 remains open for that publishable blocker.