### PR TITLE
[codex] cap compact packet fan-out under latency pressure

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -117,9 +117,27 @@ pub(crate) fn run_packet_planned_subqueries(
             semantic_pending.push(*entry);
         }
     }
+    let lexical_before_pressure_cap = lexical_pending.len();
+    let consumed_after_anchors_ms = answer.retrieval_trace.total_latency_ms;
+    let skipped_broad_lexical = cap_compact_lexical_subqueries_under_pressure(
+        budget,
+        packet_latency,
+        consumed_after_anchors_ms,
+        &mut lexical_pending,
+    );
+    if !skipped_broad_lexical.is_empty() {
+        answer.retrieval_trace.annotations.push(format!(
+            "packet_lexical_subqueries capped reason=latency_pressure skipped_broad={} kept={} usage_pct={} skipped={}",
+            skipped_broad_lexical.len(),
+            lexical_pending.len(),
+            packet_latency.budget_usage_percent(consumed_after_anchors_ms),
+            skipped_packet_subqueries_annotation(&skipped_broad_lexical)
+        ));
+    }
 
-    let warm_queries = pending
+    let warm_queries = lexical_pending
         .iter()
+        .chain(semantic_pending.iter())
         .map(|(_, query)| query.query.clone())
         .collect::<Vec<_>>();
     if let Err(error) = controller.warm_packet_subquery_embeddings(&warm_queries) {
@@ -133,8 +151,14 @@ pub(crate) fn run_packet_planned_subqueries(
         "packet_subqueries lexical_batch={} semantic={} total={}",
         lexical_pending.len(),
         semantic_pending.len(),
-        pending.len()
+        lexical_pending.len().saturating_add(semantic_pending.len())
     ));
+    if lexical_pending.is_empty() && lexical_before_pressure_cap > 0 {
+        answer
+            .retrieval_trace
+            .annotations
+            .push("packet_lexical_subqueries skipped reason=latency_pressure".to_string());
+    }
 
     if !lexical_pending.is_empty() {
         let batch = lexical_pending
@@ -389,6 +413,70 @@ fn packet_subquery_limit(budget: PacketBudgetModeDto) -> usize {
         PacketBudgetModeDto::Standard => 4,
         PacketBudgetModeDto::Deep => 6,
     }
+}
+
+fn cap_compact_lexical_subqueries_under_pressure(
+    budget: PacketBudgetModeDto,
+    packet_latency: PacketLatencyBudget,
+    consumed_trace_ms: u32,
+    lexical_pending: &mut Vec<(usize, &PacketPlanQueryDto)>,
+) -> Vec<SkippedPacketSubquery> {
+    if budget != PacketBudgetModeDto::Compact
+        || lexical_pending.is_empty()
+        || packet_latency.budget_usage_percent(consumed_trace_ms) < 25
+    {
+        return Vec::new();
+    }
+
+    let mut skipped = Vec::new();
+    lexical_pending.retain(|(_, query)| {
+        if packet_broad_lexical_subquery(query) {
+            skipped.push(SkippedPacketSubquery {
+                query: query.query.clone(),
+                purpose: query.purpose.clone(),
+            });
+            false
+        } else {
+            true
+        }
+    });
+    skipped
+}
+
+struct SkippedPacketSubquery {
+    query: String,
+    purpose: String,
+}
+
+fn skipped_packet_subqueries_annotation(skipped: &[SkippedPacketSubquery]) -> String {
+    skipped
+        .iter()
+        .take(3)
+        .map(|entry| {
+            format!(
+                "`{}` purpose=`{}`",
+                packet_annotation_value(&entry.query),
+                packet_annotation_value(&entry.purpose)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn packet_annotation_value(value: &str) -> String {
+    value.replace('`', "'")
+}
+
+fn packet_broad_lexical_subquery(query: &PacketPlanQueryDto) -> bool {
+    let trimmed = query.query.trim();
+    let lowered = trimmed.to_ascii_lowercase();
+    !query_has_symbol_or_literal_signal(trimmed)
+        && !is_packet_code_like_term(trimmed)
+        && !packet_task_seed_anchor_probe(trimmed)
+        && !packet_anchor_probe_is_required_flow_hint(trimmed)
+        && (packet_query_stop_term(&lowered)
+            || packet_adjacent_query_stop_term(&lowered)
+            || !trimmed.contains(char::is_whitespace))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -823,6 +911,96 @@ mod tests {
                 query.query
             );
         }
+    }
+
+    #[test]
+    fn packet_lexical_subquery_caps_broad_terms_under_compact_pressure() {
+        let trace = PacketPlanQueryDto {
+            query: "Trace".to_string(),
+            purpose: "concrete symbol, file, route, or code term".to_string(),
+        };
+        let redis = PacketPlanQueryDto {
+            query: "Redis".to_string(),
+            purpose: "concrete symbol, file, route, or code term".to_string(),
+        };
+        let initializes = PacketPlanQueryDto {
+            query: "initializes".to_string(),
+            purpose: "concrete symbol, file, route, or code term".to_string(),
+        };
+        let mut pending = vec![(1, &trace), (2, &redis), (3, &initializes)];
+
+        let skipped = cap_compact_lexical_subqueries_under_pressure(
+            PacketBudgetModeDto::Compact,
+            PacketLatencyBudget::new(Some(18_000)),
+            4_500,
+            &mut pending,
+        );
+
+        assert_eq!(skipped.len(), 3);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn packet_lexical_subquery_reports_skipped_symbol_like_terms() {
+        let command = PacketPlanQueryDto {
+            query: "Command".to_string(),
+            purpose: "concrete symbol, file, route, or code term".to_string(),
+        };
+        let mut pending = vec![(1, &command)];
+
+        let skipped = cap_compact_lexical_subqueries_under_pressure(
+            PacketBudgetModeDto::Compact,
+            PacketLatencyBudget::new(Some(18_000)),
+            4_500,
+            &mut pending,
+        );
+
+        let annotation = skipped_packet_subqueries_annotation(&skipped);
+        assert!(pending.is_empty());
+        assert!(annotation.contains("`Command`"));
+        assert!(annotation.contains("purpose=`concrete symbol, file, route, or code term`"));
+    }
+
+    #[test]
+    fn packet_lexical_subquery_pressure_cap_keeps_code_terms() {
+        let init_server = PacketPlanQueryDto {
+            query: "initServer".to_string(),
+            purpose: "symbol probe expanded from task wording".to_string(),
+        };
+        let scoped_main = PacketPlanQueryDto {
+            query: "src/server.c main".to_string(),
+            purpose: "concrete symbol, file, route, or code term".to_string(),
+        };
+        let mut pending = vec![(1, &init_server), (2, &scoped_main)];
+
+        let skipped = cap_compact_lexical_subqueries_under_pressure(
+            PacketBudgetModeDto::Compact,
+            PacketLatencyBudget::new(Some(18_000)),
+            4_500,
+            &mut pending,
+        );
+
+        assert!(skipped.is_empty());
+        assert_eq!(pending.len(), 2);
+    }
+
+    #[test]
+    fn packet_lexical_subquery_pressure_cap_skips_non_compact_budgets() {
+        let broad = PacketPlanQueryDto {
+            query: "Trace".to_string(),
+            purpose: "concrete symbol, file, route, or code term".to_string(),
+        };
+        let mut pending = vec![(1, &broad)];
+
+        let skipped = cap_compact_lexical_subqueries_under_pressure(
+            PacketBudgetModeDto::Standard,
+            PacketLatencyBudget::new(Some(18_000)),
+            4_500,
+            &mut pending,
+        );
+
+        assert!(skipped.is_empty());
+        assert_eq!(pending.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Context

Parent packet-runtime work remains blocked on publishable packet-runtime evidence. This draft narrowed one slice to the remaining Redis cold `c-redis-command-loop` SLA miss after the unresolved-candidate diagnostics landed. Warm Apache/Redis SLA misses are accepted residual risk for this release path and are not treated as this draft's acceptance blockers.

This PR is intentionally non-closing while evidence is blocked.

## What Changed

- Added a compact-mode latency-pressure cap for planned lexical packet subqueries after anchor expansion has already consumed at least 25% of the SLA budget.
- The cap drops broad lexical leftovers such as task wording terms while keeping code-shaped terms, task seed probes, required flow hints, semantic subqueries, and existing follow-up/sufficiency behavior.
- Trace annotations now report when broad lexical subqueries are capped or skipped because of latency pressure, including a bounded skipped-query sample.

## Current Evidence

Focused cold-only evidence was run from PR head `b45af82073a2ea378045deec5e6696a2e87a4a64` after rebuilding the branch-local release CLI with `C:\Users\alber\.cargo\bin\sccache.exe`.

Artifact path:
`target/agent-benchmark/post-131-current-main-packet-runtime-after-redis-cold-fanout-cap`

| Repo/task | Mode | SLA misses | Quality | Sufficiency | Follow-ups | Decision |
| --- | --- | ---: | ---: | --- | ---: | --- |
| apache / java-commons-lang-string-utils | cold | 3/3 | 3/3 | sufficient 3/3 | 0 | blocker after readiness repair |
| redis / c-redis-command-loop | cold | 0/3 | 3/3 | sufficient 3/3 | 0 | Redis cold target cleared |

Apache readiness was repaired before the latest rerun: `semantic_ready=true`, `semantic_doc_count=289`, dense projections `289`. Redis readiness was also clean: `semantic_ready=true`, `semantic_doc_count=70`, dense projections `70`.

## Verification

- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'`
- `cargo test -p codestory-runtime packet_anchor_probe_limit --lib` - passed, 4 tests.
- `cargo test -p codestory-runtime packet_lexical_subquery --lib` - passed, 7 tests after review follow-up.
- `cargo fmt --check` - passed.
- `git diff --check` - passed.
- Focused Apache/Redis cold-only packet-runtime rerun - not accepted because Apache cold missed `3/3` after readiness repair.

## Risk / Status

This PR is parked as draft evidence. It has useful evidence for the Redis cold target, but it cannot close the packet-runtime blocker as-is because it regresses or destabilizes the previously-clean Apache cold row. A tiny generic lexical-only cap experiment was attempted in the child worktree and not retained because Apache still failed. Warm SLA remains accepted residual risk/report evidence, not an implementation target for this branch.