### PR TITLE
Deduplicate normalized packet anchor probes

### DIFF
--- a/crates/codestory-retrieval/src/zoekt_index.rs
+++ b/crates/codestory-retrieval/src/zoekt_index.rs
@@ -662,13 +662,23 @@ fn symbol_doc_lexical_entry(project_root: &Path, doc: &SymbolSearchDoc) -> Lexic
 
 fn normalize_lexical_file_path(project_root: &Path, path: &str) -> Option<String> {
     let path = Path::new(path);
-    if path.is_absolute() {
+    let rel = if path.is_absolute() {
         path.strip_prefix(project_root)
             .ok()
             .map(|rel| rel.to_string_lossy().replace('\\', "/"))
     } else {
         Some(path.to_string_lossy().replace('\\', "/"))
-    }
+    }?;
+    Some(source_rooted_lexical_path(project_root, &rel).unwrap_or(rel))
+}
+
+fn source_rooted_lexical_path(project_root: &Path, rel_path: &str) -> Option<String> {
+    let rel = rel_path.trim_start_matches("./").trim_start_matches('/');
+    ["main/java/", "test/java/"]
+        .iter()
+        .any(|prefix| rel.starts_with(prefix))
+        .then(|| format!("src/{rel}"))
+        .filter(|source_rooted| project_root.join(source_rooted).is_file())
 }
 
 fn should_skip_dir(name: &str) -> bool {
@@ -836,6 +846,26 @@ mod tests {
         assert_eq!(hit.source, LexicalDocumentSource::SymbolDoc);
         assert_eq!(hit.node_id.as_deref(), Some("2"));
         assert_eq!(hit.start_line, Some(1));
+    }
+
+    #[test]
+    fn symbol_doc_paths_prefer_existing_java_source_root() {
+        let project = TempDir::new().expect("project");
+        let source_file = project
+            .path()
+            .join("src/main/java/example/widgets/WidgetRules.java");
+        std::fs::create_dir_all(source_file.parent().expect("source parent"))
+            .expect("mkdir source parent");
+        std::fs::write(&source_file, "class WidgetRules {}\n").expect("write source");
+
+        assert_eq!(
+            normalize_lexical_file_path(
+                project.path(),
+                "main/java/example/widgets/WidgetRules.java"
+            )
+            .as_deref(),
+            Some("src/main/java/example/widgets/WidgetRules.java")
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -618,6 +618,9 @@ pub(crate) fn packet_anchor_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
     ranked
         .into_iter()
         .filter_map(|(_, query)| {
+            if is_packet_path_like_query(&query.query) {
+                return Some(query.query.clone());
+            }
             let key = normalize_identifier(&query.query);
             if key.len() < 2 || seen.insert(key) {
                 Some(query.query.clone())
@@ -960,6 +963,34 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(limited, ["parseToken", "writeBuffer", "openSocket"]);
+    }
+
+    #[test]
+    fn packet_anchor_probe_limit_keeps_path_like_normalized_matches() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain library entrypoints".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "src/lib.rs".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "src_lib_rs".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let queries = packet_anchor_probe_queries(&plan);
+
+        assert_eq!(queries, ["src/lib.rs", "src_lib_rs"]);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -614,9 +614,17 @@ pub(crate) fn packet_anchor_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
             *index,
         )
     });
+    let mut seen = HashSet::<String>::new();
     ranked
         .into_iter()
-        .map(|(_, query)| query.query.clone())
+        .filter_map(|(_, query)| {
+            let key = normalize_identifier(&query.query);
+            if key.len() < 2 || seen.insert(key) {
+                Some(query.query.clone())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -905,6 +913,53 @@ mod tests {
             packet_anchor_probe_limit_for_budget(PacketBudgetModeDto::Compact, latency, 13_500,),
             3
         );
+    }
+
+    #[test]
+    fn packet_anchor_probe_limit_counts_normalized_probe_variants_once() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain predicate helpers".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "parseToken".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "parse_token".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "writeBuffer".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "write_buffer".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "openSocket".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "open_socket".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let limited = packet_anchor_probe_queries(&plan)
+            .into_iter()
+            .take(3)
+            .collect::<Vec<_>>();
+
+        assert_eq!(limited, ["parseToken", "writeBuffer", "openSocket"]);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1037,31 +1037,15 @@ fn shadow_from_query_result_with_counts_and_resolution_labels(
     let candidates = result
         .hits
         .iter()
-        .take(MAX_SHADOW_CANDIDATES)
         .enumerate()
-        .map(|(index, hit)| RetrievalCandidateSummaryDto {
-            rank: u32::try_from(index + 1).unwrap_or(u32::MAX),
-            file_path: hit.file_path.clone(),
-            line: hit.start_line,
-            symbol_name: hit.symbol_name.clone(),
-            score: hit.score,
-            source: candidate_source_label(hit.source),
-            resolution: resolution_labels.get(index).cloned(),
-            admission_status: admission_labels
-                .get(index)
-                .map(|label| label.admission_status.clone()),
-            loss_reason: admission_labels
-                .get(index)
-                .and_then(|label| label.loss_reason.clone()),
-            resolved_node_id: admission_labels
-                .get(index)
-                .and_then(|label| label.resolved_node_id.clone()),
-            search_hit_rank: admission_labels
-                .get(index)
-                .and_then(|label| label.search_hit_rank),
-            final_rank: admission_labels
-                .get(index)
-                .and_then(|label| label.final_rank),
+        .filter(|(index, _)| {
+            *index < MAX_SHADOW_CANDIDATES
+                || resolution_labels
+                    .get(*index)
+                    .is_some_and(|label| label != "resolved")
+        })
+        .map(|(index, hit)| {
+            shadow_candidate_summary(index, hit, resolution_labels, admission_labels)
         })
         .collect();
 
@@ -1104,6 +1088,38 @@ fn shadow_from_query_result_with_counts_and_resolution_labels(
         unresolved_candidate_count: u32::try_from(unresolved_candidate_count).unwrap_or(u32::MAX),
         diagnostic_only,
         candidate_resolution_counts,
+    }
+}
+
+fn shadow_candidate_summary(
+    index: usize,
+    hit: &CandidateHit,
+    resolution_labels: &[String],
+    admission_labels: &[SidecarCandidateAdmissionLabel],
+) -> RetrievalCandidateSummaryDto {
+    RetrievalCandidateSummaryDto {
+        rank: u32::try_from(index + 1).unwrap_or(u32::MAX),
+        file_path: hit.file_path.clone(),
+        line: hit.start_line,
+        symbol_name: hit.symbol_name.clone(),
+        score: hit.score,
+        source: candidate_source_label(hit.source),
+        resolution: resolution_labels.get(index).cloned(),
+        admission_status: admission_labels
+            .get(index)
+            .map(|label| label.admission_status.clone()),
+        loss_reason: admission_labels
+            .get(index)
+            .and_then(|label| label.loss_reason.clone()),
+        resolved_node_id: admission_labels
+            .get(index)
+            .and_then(|label| label.resolved_node_id.clone()),
+        search_hit_rank: admission_labels
+            .get(index)
+            .and_then(|label| label.search_hit_rank),
+        final_rank: admission_labels
+            .get(index)
+            .and_then(|label| label.final_rank),
     }
 }
 
@@ -1940,6 +1956,76 @@ mod tests {
             shadow.unresolved_candidate_count, 0,
             "resolved candidates rejected by the final result window are not unresolved sidecar candidates"
         );
+    }
+
+    #[test]
+    fn shadow_candidate_summaries_keep_unresolved_candidates_past_display_cap() {
+        let hits = (0..21)
+            .map(|index| {
+                let path = if index == 20 {
+                    "missing.c".to_string()
+                } else {
+                    format!("src/resolved_{index}.c")
+                };
+                CandidateHit::with_source(
+                    &path,
+                    Some(format!("symbol_{index}")),
+                    0.5,
+                    CandidateSource::Zoekt,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut labels = vec!["resolved".to_string(); 21];
+        labels[20] = "path_unresolvable".to_string();
+        let admissions = labels
+            .iter()
+            .map(|label| {
+                if label == "resolved" {
+                    SidecarCandidateAdmissionLabel {
+                        admission_status: "admitted".to_string(),
+                        loss_reason: None,
+                        resolved_node_id: Some("1".to_string()),
+                        search_hit_rank: Some(1),
+                        final_rank: Some(1),
+                    }
+                } else {
+                    SidecarCandidateAdmissionLabel {
+                        admission_status: "unresolved".to_string(),
+                        loss_reason: Some(label.clone()),
+                        resolved_node_id: None,
+                        search_hit_rank: None,
+                        final_rank: None,
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        let shadow = shadow_from_query_result_with_counts_and_resolution_labels(
+            QueryResult {
+                query: "command loop".into(),
+                features: classify_query("command loop"),
+                hits,
+                trace: QueryTrace {
+                    retrieval_mode: "full".into(),
+                    degraded_reason: None,
+                    total_budget_ms: 500,
+                    elapsed_ms: 1,
+                    cancel_reason: None,
+                    cache_hit: false,
+                    stages: Vec::new(),
+                },
+            },
+            21,
+            20,
+            &labels,
+            &admissions,
+        );
+
+        assert_eq!(shadow.candidates.len(), MAX_SHADOW_CANDIDATES + 1);
+        let unresolved = shadow.candidates.last().expect("unresolved detail");
+        assert_eq!(unresolved.rank, 21);
+        assert_eq!(unresolved.file_path, "missing.c");
+        assert_eq!(unresolved.resolution.as_deref(), Some("path_unresolvable"));
+        assert_eq!(shadow.unresolved_candidate_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Context

Refs #134
Refs #136
Refs #78

This draft supersedes the parked #133 replacement path for the narrow anchor-probe duplicate slice and now includes the #136 unresolved sidecar candidate blocker fix. #133 should remain draft/non-closing; this PR does not claim #134 acceptance yet.

## What Changed

- De-duplicates packet anchor probes by the existing normalized identifier key after priority sorting and before query-limit consumption.
- Preserves the first/highest-priority generic identifier spelling variant and skips later camel/snake spelling duplicates.
- Preserves path/file-shaped probes before normalized de-dupe so path queries like `src/lib.rs` are not collapsed with identifier-shaped probes like `src_lib_rs`.
- Normalizes Zoekt symbol-doc Java source-root paths from `main/java/...` or `test/java/...` to `src/...` only when the corresponding file exists under the project root.
- Keeps unresolved shadow candidates visible even when they fall beyond the normal top-20 shadow candidate display cap, preserving original rank/count semantics.
- Adds focused runtime/retrieval unit tests with fictional paths and symbols.

## How To Review

- Start in `crates/codestory-runtime/src/agent/packet_batch.rs` for the anchor-probe de-dupe.
- Review `crates/codestory-retrieval/src/zoekt_index.rs` for the Java source-root normalization guard.
- Review `crates/codestory-runtime/src/agent/retrieval_primary.rs` for the unresolved-candidate diagnostic serialization.
- Confirm tests avoid Apache/Redis holdout literals in the new #136 coverage.

## Verification

Code checks passed:

```powershell
$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'
$env:CARGO_BUILD_JOBS='1'
cargo test -p codestory-runtime packet_anchor_probe_limit --lib
cargo test -p codestory-runtime packet_lexical_subquery --lib
cargo test -p codestory-retrieval zoekt_index
cargo test -p codestory-runtime retrieval_primary
cargo fmt --check
git diff --check
```

Focused #135 cold evidence with explicit CLI previously produced rows but failed unresolved candidates and SLA. Latest #136 focused check used branch-local release CLI:

```powershell
node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --repeats 3 --materialize-repos --prepare-codestory-cache --codestory-cli .\target\release\codestory-cli.exe --out-dir target\agent-benchmark\unresolved-candidate-normalization-check --timeout-ms 180000 --publishable
```

Transcript:

```text
C:\Users\alber\.codex\worktrees\8711\codestory\target\agent-benchmark\unresolved-candidate-normalization-check\benchmark-20260619-104107.txt
```

Artifacts:

```text
C:\Users\alber\.codex\worktrees\8711\codestory\target\agent-benchmark\unresolved-candidate-normalization-check\packet-runtime-summary.md
C:\Users\alber\.codex\worktrees\8711\codestory\target\agent-benchmark\unresolved-candidate-normalization-check\packet-runtime-deltas.json
C:\Users\alber\.codex\worktrees\8711\codestory\target\agent-benchmark\unresolved-candidate-normalization-check\packet-quality-deltas.json
C:\Users\alber\.codex\worktrees\8711\codestory\target\agent-benchmark\unresolved-candidate-normalization-check\quality-debug.json
```

Result:

| Repo | Task | Cold SLA misses | Quality pass | Sufficiency | Follow-ups | Packet citation recall | Shadow unresolved status |
| --- | --- | ---: | ---: | --- | ---: | ---: | --- |
| apache-commons-lang | java-commons-lang-string-utils | 3/3 | 3/3 | sufficient:3 | 0 | 100% | 0 unresolved; all 57 shadow candidates resolved |
| redis-redis | c-redis-command-loop | 1/3 | 3/3 | sufficient:3 | 0 | 75% | 1 `apii` dense anchor emitted at rank 42 and marked `diagnostic_only=true` |

`--publishable` exited 1, now on SLA misses only:

```text
apache repeats 1-3: packet retrieval SLA missed=true; expected false
redis repeat 3: packet retrieval SLA missed=true; expected false
```

No #134 acceptance claim is made. PR remains draft until Apache cold `0/3` and Redis cold `0/3` are both proven with a publishable run.

## Risk

- #136 unresolved-candidate blocker is addressed by the latest focused evidence, but cold SLA still blocks publishable acceptance.
- Warm SLA remains residual/report-only and was not optimized here.
- No scorer, threshold, harness, sidecar identity, task manifest, or broad retrieval-ranking changes are included.

## Skills Used

- `codestory-grounding`
- `github:github`
- `superpowers:verification-before-completion`