### PR TITLE
[codex] attribute cold packet batch overhead

### DIFF
--- a/crates/codestory-retrieval/src/zoekt_index.rs
+++ b/crates/codestory-retrieval/src/zoekt_index.rs
@@ -662,13 +662,23 @@ fn symbol_doc_lexical_entry(project_root: &Path, doc: &SymbolSearchDoc) -> Lexic
 
 fn normalize_lexical_file_path(project_root: &Path, path: &str) -> Option<String> {
     let path = Path::new(path);
-    if path.is_absolute() {
+    let rel = if path.is_absolute() {
         path.strip_prefix(project_root)
             .ok()
             .map(|rel| rel.to_string_lossy().replace('\\', "/"))
     } else {
         Some(path.to_string_lossy().replace('\\', "/"))
-    }
+    }?;
+    Some(source_rooted_lexical_path(project_root, &rel).unwrap_or(rel))
+}
+
+fn source_rooted_lexical_path(project_root: &Path, rel_path: &str) -> Option<String> {
+    let rel = rel_path.trim_start_matches("./").trim_start_matches('/');
+    ["main/java/", "test/java/"]
+        .iter()
+        .any(|prefix| rel.starts_with(prefix))
+        .then(|| format!("src/{rel}"))
+        .filter(|source_rooted| project_root.join(source_rooted).is_file())
 }
 
 fn should_skip_dir(name: &str) -> bool {
@@ -836,6 +846,26 @@ mod tests {
         assert_eq!(hit.source, LexicalDocumentSource::SymbolDoc);
         assert_eq!(hit.node_id.as_deref(), Some("2"));
         assert_eq!(hit.start_line, Some(1));
+    }
+
+    #[test]
+    fn symbol_doc_paths_prefer_existing_java_source_root() {
+        let project = TempDir::new().expect("project");
+        let source_file = project
+            .path()
+            .join("src/main/java/example/widgets/WidgetRules.java");
+        std::fs::create_dir_all(source_file.parent().expect("source parent"))
+            .expect("mkdir source parent");
+        std::fs::write(&source_file, "class WidgetRules {}\n").expect("write source");
+
+        assert_eq!(
+            normalize_lexical_file_path(
+                project.path(),
+                "main/java/example/widgets/WidgetRules.java"
+            )
+            .as_deref(),
+            Some("src/main/java/example/widgets/WidgetRules.java")
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -13,6 +13,7 @@ use super::packet_trace::{
 };
 use super::planning::packet_subquery_hybrid_weights;
 use super::trace::field;
+use crate::agent::retrieval_primary::SidecarPacketBatchTiming;
 use crate::{AppController, clamp_u128_to_u32, query_has_symbol_or_literal_signal};
 use codestory_contracts::api::{
     AgentAnswerDto, AgentHybridWeightsDto, AgentRetrievalStepDto, AgentRetrievalStepKindDto,
@@ -155,11 +156,13 @@ pub(crate) fn run_packet_planned_subqueries(
                     .extend(outcome.sidecar_diagnostics.clone());
                 let results = outcome.results;
                 let diagnostics = outcome.sidecar_diagnostics;
+                let timing = outcome.sidecar_batch_timing;
                 annotate_packet_batch_timing(
                     answer,
                     "packet_lexical_subquery_batch",
                     duration_ms,
                     &diagnostics,
+                    timing.as_ref(),
                 );
                 merge_packet_lexical_subquery_batch(
                     answer,
@@ -212,12 +215,14 @@ pub(crate) fn run_packet_planned_subqueries(
                                 .packet_sidecar_diagnostics
                                 .extend(outcome.sidecar_diagnostics.clone());
                             let diagnostics = outcome.sidecar_diagnostics;
+                            let timing = outcome.sidecar_batch_timing;
                             record_semantic_fallbacks(answer, &outcome.fallbacks);
                             annotate_packet_batch_timing(
                                 answer,
                                 "packet_lexical_subquery_hybrid_retry_batch",
                                 retry_duration_ms,
                                 &diagnostics,
+                                timing.as_ref(),
                             );
                             merge_packet_semantic_subquery_batch(
                                 answer,
@@ -282,12 +287,14 @@ pub(crate) fn run_packet_planned_subqueries(
                         .packet_sidecar_diagnostics
                         .extend(outcome.sidecar_diagnostics.clone());
                     let diagnostics = outcome.sidecar_diagnostics;
+                    let timing = outcome.sidecar_batch_timing;
                     record_semantic_fallbacks(answer, &outcome.fallbacks);
                     annotate_packet_batch_timing(
                         answer,
                         "packet_semantic_subquery_batch",
                         duration_ms,
                         &diagnostics,
+                        timing.as_ref(),
                     );
                     merge_packet_semantic_subquery_batch(
                         answer,
@@ -349,6 +356,7 @@ fn annotate_packet_batch_timing(
     label: &str,
     duration_ms: u32,
     diagnostics: &[PacketSidecarQueryDiagnosticDto],
+    timing: Option<&SidecarPacketBatchTiming>,
 ) {
     let attributed_ms = diagnostics
         .iter()
@@ -362,6 +370,25 @@ fn annotate_packet_batch_timing(
         overhead_ms,
         diagnostics.len()
     ));
+    if let Some(timing) = timing {
+        let measured_internal_ms = timing
+            .prepare_ms
+            .saturating_add(timing.query_loop_wall_ms)
+            .saturating_add(timing.result_build_ms);
+        answer.retrieval_trace.annotations.push(format!(
+            "packet_sidecar_batch_timing label={} query_count={} batch_wall_ms={} prepare_ms={} query_loop_wall_ms={} sum_query_total_elapsed_ms={} sum_sidecar_query_ms={} sum_candidate_resolution_ms={} result_build_ms={} unattributed_batch_gap_ms={}",
+            label,
+            diagnostics.len(),
+            duration_ms,
+            timing.prepare_ms,
+            timing.query_loop_wall_ms,
+            timing.sum_query_total_elapsed_ms,
+            timing.sum_sidecar_query_ms,
+            timing.sum_candidate_resolution_ms,
+            timing.result_build_ms,
+            duration_ms.saturating_sub(measured_internal_ms)
+        ));
+    }
 }
 
 fn packet_anchor_timing_annotation(diagnostic: Option<&PacketSidecarQueryDiagnosticDto>) -> String {
@@ -466,11 +493,13 @@ pub(crate) fn run_packet_anchor_expansion(
                 .packet_sidecar_diagnostics
                 .extend(outcome.sidecar_diagnostics.clone());
             let diagnostics = outcome.sidecar_diagnostics;
+            let timing = outcome.sidecar_batch_timing;
             annotate_packet_batch_timing(
                 answer,
                 "packet_anchor_probe_batch",
                 duration_ms,
                 &diagnostics,
+                timing.as_ref(),
             );
             let results = outcome.results;
             let per_step_duration = duration_ms / results.len().max(1) as u32;
@@ -1030,6 +1059,81 @@ mod tests {
         assert!(queries.contains(&"run".to_string()));
         assert!(queries.contains(&"entrypoint".to_string()));
         assert!(!queries.contains(&"architecture entrypoint".to_string()));
+    }
+
+    #[test]
+    fn packet_lexical_subquery_batch_timing_annotation_includes_gap_fields() {
+        let mut answer = AgentAnswerDto {
+            answer_id: "answer".to_string(),
+            prompt: "trace request handling".to_string(),
+            summary: "summary".to_string(),
+            freshness: None,
+            sections: Vec::new(),
+            citations: Vec::new(),
+            subgraph_ids: Vec::new(),
+            retrieval_version: "hybrid-v1".to_string(),
+            graphs: Vec::new(),
+            retrieval_trace: codestory_contracts::api::AgentRetrievalTraceDto {
+                request_id: "request".to_string(),
+                resolved_profile: codestory_contracts::api::AgentRetrievalPresetDto::Architecture,
+                policy_mode: codestory_contracts::api::AgentRetrievalPolicyModeDto::LatencyFirst,
+                total_latency_ms: 0,
+                sla_target_ms: None,
+                sla_missed: false,
+                semantic_fallback_count: 0,
+                semantic_fallbacks: Vec::new(),
+                annotations: Vec::new(),
+                steps: Vec::new(),
+                packet_sidecar_diagnostics: Vec::new(),
+                retrieval_shadow: None,
+            },
+        };
+        let diagnostics = vec![PacketSidecarQueryDiagnosticDto {
+            query: "dispatchRequest".to_string(),
+            retrieval_mode: "full".to_string(),
+            sidecar_query_ms: Some(7),
+            candidate_resolution_ms: Some(3),
+            total_elapsed_ms: Some(10),
+            sidecar_stage_count: 0,
+            sidecar_stage_total_ms: None,
+            candidate_count: 1,
+            resolved_hit_count: 1,
+            unresolved_candidate_count: 0,
+            diagnostic: None,
+        }];
+        let timing = SidecarPacketBatchTiming {
+            prepare_ms: 2,
+            query_loop_wall_ms: 11,
+            sum_query_total_elapsed_ms: 10,
+            sum_sidecar_query_ms: 7,
+            sum_candidate_resolution_ms: 3,
+            result_build_ms: 4,
+        };
+
+        annotate_packet_batch_timing(
+            &mut answer,
+            "packet_lexical_subquery_batch",
+            25,
+            &diagnostics,
+            Some(&timing),
+        );
+
+        let annotation = answer
+            .retrieval_trace
+            .annotations
+            .iter()
+            .find(|entry| entry.starts_with("packet_sidecar_batch_timing "))
+            .expect("packet sidecar batch timing annotation");
+        assert!(annotation.contains("label=packet_lexical_subquery_batch"));
+        assert!(annotation.contains("query_count=1"));
+        assert!(annotation.contains("batch_wall_ms=25"));
+        assert!(annotation.contains("prepare_ms=2"));
+        assert!(annotation.contains("query_loop_wall_ms=11"));
+        assert!(annotation.contains("sum_query_total_elapsed_ms=10"));
+        assert!(annotation.contains("sum_sidecar_query_ms=7"));
+        assert!(annotation.contains("sum_candidate_resolution_ms=3"));
+        assert!(annotation.contains("result_build_ms=4"));
+        assert!(annotation.contains("unattributed_batch_gap_ms=8"));
     }
 }
 

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -618,6 +618,9 @@ pub(crate) fn packet_anchor_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
     ranked
         .into_iter()
         .filter_map(|(_, query)| {
+            if is_packet_path_like_query(&query.query) {
+                return Some(query.query.clone());
+            }
             let key = normalize_identifier(&query.query);
             if key.len() < 2 || seen.insert(key) {
                 Some(query.query.clone())
@@ -960,6 +963,34 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(limited, ["parseToken", "writeBuffer", "openSocket"]);
+    }
+
+    #[test]
+    fn packet_anchor_probe_limit_keeps_path_like_normalized_matches() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain library entrypoints".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "src/lib.rs".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "src_lib_rs".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let queries = packet_anchor_probe_queries(&plan);
+
+        assert_eq!(queries, ["src/lib.rs", "src_lib_rs"]);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -614,9 +614,17 @@ pub(crate) fn packet_anchor_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
             *index,
         )
     });
+    let mut seen = HashSet::<String>::new();
     ranked
         .into_iter()
-        .map(|(_, query)| query.query.clone())
+        .filter_map(|(_, query)| {
+            let key = normalize_identifier(&query.query);
+            if key.len() < 2 || seen.insert(key) {
+                Some(query.query.clone())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -905,6 +913,53 @@ mod tests {
             packet_anchor_probe_limit_for_budget(PacketBudgetModeDto::Compact, latency, 13_500,),
             3
         );
+    }
+
+    #[test]
+    fn packet_anchor_probe_limit_counts_normalized_probe_variants_once() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain predicate helpers".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "parseToken".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "parse_token".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "writeBuffer".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "write_buffer".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "openSocket".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "open_socket".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let limited = packet_anchor_probe_queries(&plan)
+            .into_iter()
+            .take(3)
+            .collect::<Vec<_>>();
+
+        assert_eq!(limited, ["parseToken", "writeBuffer", "openSocket"]);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/packet_search.rs
+++ b/crates/codestory-runtime/src/agent/packet_search.rs
@@ -1,7 +1,7 @@
 //! AppController batch search paths for packet retrieval.
 
 use crate::agent::retrieval_primary::{
-    packet_batch_should_use_sidecar, search_sidecar_packet_batch,
+    SidecarPacketBatchTiming, packet_batch_should_use_sidecar, search_sidecar_packet_batch,
     sidecar_retrieval_unavailable_error, sidecar_retrieval_unavailable_reason,
 };
 use crate::{AppController, HybridSearchScoredHit};
@@ -14,11 +14,13 @@ pub(crate) struct SemanticHybridBatchOutcome {
     pub results: Vec<(String, Vec<HybridSearchScoredHit>)>,
     pub fallbacks: Vec<SemanticFallbackRecordDto>,
     pub sidecar_diagnostics: Vec<PacketSidecarQueryDiagnosticDto>,
+    pub sidecar_batch_timing: Option<SidecarPacketBatchTiming>,
 }
 
 pub(crate) struct LexicalBatchOutcome {
     pub results: Vec<(String, Vec<SearchHit>)>,
     pub sidecar_diagnostics: Vec<PacketSidecarQueryDiagnosticDto>,
+    pub sidecar_batch_timing: Option<SidecarPacketBatchTiming>,
 }
 
 impl AppController {
@@ -44,6 +46,7 @@ impl AppController {
             return Ok(LexicalBatchOutcome {
                 results: Vec::new(),
                 sidecar_diagnostics: Vec::new(),
+                sidecar_batch_timing: None,
             });
         }
         if packet_batch_should_use_sidecar(self) {
@@ -52,6 +55,7 @@ impl AppController {
                     return Ok(LexicalBatchOutcome {
                         results: outcome.results,
                         sidecar_diagnostics: outcome.diagnostics,
+                        sidecar_batch_timing: Some(outcome.timing),
                     });
                 }
                 Err(error) => {
@@ -87,6 +91,7 @@ impl AppController {
                 results: Vec::new(),
                 fallbacks: Vec::new(),
                 sidecar_diagnostics: Vec::new(),
+                sidecar_batch_timing: None,
             });
         }
         if packet_batch_should_use_sidecar(self) {
@@ -117,6 +122,7 @@ impl AppController {
                             .collect(),
                         fallbacks: Vec::new(),
                         sidecar_diagnostics: outcome.diagnostics,
+                        sidecar_batch_timing: Some(outcome.timing),
                     });
                 }
                 Err(error) => {

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -529,6 +529,17 @@ pub(crate) fn search_sidecar_packet_batch(
 pub(crate) struct SidecarPacketBatchOutcome {
     pub results: Vec<(String, Vec<SearchHit>)>,
     pub diagnostics: Vec<PacketSidecarQueryDiagnosticDto>,
+    pub timing: SidecarPacketBatchTiming,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SidecarPacketBatchTiming {
+    pub prepare_ms: u32,
+    pub query_loop_wall_ms: u32,
+    pub sum_query_total_elapsed_ms: u32,
+    pub sum_sidecar_query_ms: u32,
+    pub sum_candidate_resolution_ms: u32,
+    pub result_build_ms: u32,
 }
 
 struct SidecarCandidateResolutionOutcome {
@@ -588,6 +599,7 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
         &[(String, u64)],
     ) -> Result<Vec<QueryResult>, AnyhowError>,
 ) -> Result<SidecarPacketBatchOutcome, ApiError> {
+    let prepare_started_at = Instant::now();
     let per_query_budget = sidecar_packet_batch_budget_ms(latency_budget_ms)
         .checked_div(queries.len().max(1) as u64)
         .unwrap_or(100)
@@ -596,12 +608,15 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
         .iter()
         .map(|(query, _)| (query.clone(), per_query_budget))
         .collect::<Vec<_>>();
+    let prepare_ms = clamp_elapsed_ms(prepare_started_at);
+    let query_loop_started_at = Instant::now();
     let query_results = run_query_batch(controller, &batch_queries).map_err(|error| {
         sidecar_retrieval_unavailable_error(
             controller,
             format!("sidecar retrieval batch query failed: {error}"),
         )
     })?;
+    let query_loop_wall_ms = clamp_elapsed_ms(query_loop_started_at);
     if query_results.len() != queries.len() {
         return Err(sidecar_retrieval_unavailable_error(
             controller,
@@ -612,8 +627,12 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
             ),
         ));
     }
+    let result_build_started_at = Instant::now();
     let mut results = Vec::with_capacity(queries.len());
     let mut diagnostics = Vec::with_capacity(queries.len());
+    let mut sum_sidecar_query_ms = 0_u32;
+    let mut sum_candidate_resolution_ms = 0_u32;
+    let mut sum_query_total_elapsed_ms = 0_u32;
     for ((query, max_results), query_result) in queries.iter().zip(query_results) {
         if query_result.query != *query {
             return Err(sidecar_retrieval_unavailable_error(
@@ -639,6 +658,11 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
                     )
                 })?;
         let candidate_resolution_ms = clamp_elapsed_ms(resolution_started_at);
+        sum_sidecar_query_ms = sum_sidecar_query_ms.saturating_add(sidecar_query_ms);
+        sum_candidate_resolution_ms =
+            sum_candidate_resolution_ms.saturating_add(candidate_resolution_ms);
+        sum_query_total_elapsed_ms = sum_query_total_elapsed_ms
+            .saturating_add(sidecar_query_ms.saturating_add(candidate_resolution_ms));
         diagnostics.push(packet_sidecar_query_diagnostic(
             &query_result,
             &resolution,
@@ -658,9 +682,18 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
         }
         results.push((query.clone(), resolved_hits));
     }
+    let result_build_ms = clamp_elapsed_ms(result_build_started_at);
     Ok(SidecarPacketBatchOutcome {
         results,
         diagnostics,
+        timing: SidecarPacketBatchTiming {
+            prepare_ms,
+            query_loop_wall_ms,
+            sum_query_total_elapsed_ms,
+            sum_sidecar_query_ms,
+            sum_candidate_resolution_ms,
+            result_build_ms,
+        },
     })
 }
 
@@ -2629,6 +2662,14 @@ mod tests {
         assert_eq!(outcome.results.len(), queries.len());
         assert_eq!(batch_call_count, 1);
         assert_eq!(observed_budgets, vec![4_500, 4_500, 4_500, 4_500]);
+        assert_eq!(outcome.timing.sum_sidecar_query_ms, 4);
+        assert_eq!(
+            outcome.timing.sum_query_total_elapsed_ms,
+            outcome
+                .timing
+                .sum_sidecar_query_ms
+                .saturating_add(outcome.timing.sum_candidate_resolution_ms)
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1037,31 +1037,15 @@ fn shadow_from_query_result_with_counts_and_resolution_labels(
     let candidates = result
         .hits
         .iter()
-        .take(MAX_SHADOW_CANDIDATES)
         .enumerate()
-        .map(|(index, hit)| RetrievalCandidateSummaryDto {
-            rank: u32::try_from(index + 1).unwrap_or(u32::MAX),
-            file_path: hit.file_path.clone(),
-            line: hit.start_line,
-            symbol_name: hit.symbol_name.clone(),
-            score: hit.score,
-            source: candidate_source_label(hit.source),
-            resolution: resolution_labels.get(index).cloned(),
-            admission_status: admission_labels
-                .get(index)
-                .map(|label| label.admission_status.clone()),
-            loss_reason: admission_labels
-                .get(index)
-                .and_then(|label| label.loss_reason.clone()),
-            resolved_node_id: admission_labels
-                .get(index)
-                .and_then(|label| label.resolved_node_id.clone()),
-            search_hit_rank: admission_labels
-                .get(index)
-                .and_then(|label| label.search_hit_rank),
-            final_rank: admission_labels
-                .get(index)
-                .and_then(|label| label.final_rank),
+        .filter(|(index, _)| {
+            *index < MAX_SHADOW_CANDIDATES
+                || resolution_labels
+                    .get(*index)
+                    .is_some_and(|label| label != "resolved")
+        })
+        .map(|(index, hit)| {
+            shadow_candidate_summary(index, hit, resolution_labels, admission_labels)
         })
         .collect();
 
@@ -1104,6 +1088,38 @@ fn shadow_from_query_result_with_counts_and_resolution_labels(
         unresolved_candidate_count: u32::try_from(unresolved_candidate_count).unwrap_or(u32::MAX),
         diagnostic_only,
         candidate_resolution_counts,
+    }
+}
+
+fn shadow_candidate_summary(
+    index: usize,
+    hit: &CandidateHit,
+    resolution_labels: &[String],
+    admission_labels: &[SidecarCandidateAdmissionLabel],
+) -> RetrievalCandidateSummaryDto {
+    RetrievalCandidateSummaryDto {
+        rank: u32::try_from(index + 1).unwrap_or(u32::MAX),
+        file_path: hit.file_path.clone(),
+        line: hit.start_line,
+        symbol_name: hit.symbol_name.clone(),
+        score: hit.score,
+        source: candidate_source_label(hit.source),
+        resolution: resolution_labels.get(index).cloned(),
+        admission_status: admission_labels
+            .get(index)
+            .map(|label| label.admission_status.clone()),
+        loss_reason: admission_labels
+            .get(index)
+            .and_then(|label| label.loss_reason.clone()),
+        resolved_node_id: admission_labels
+            .get(index)
+            .and_then(|label| label.resolved_node_id.clone()),
+        search_hit_rank: admission_labels
+            .get(index)
+            .and_then(|label| label.search_hit_rank),
+        final_rank: admission_labels
+            .get(index)
+            .and_then(|label| label.final_rank),
     }
 }
 
@@ -1940,6 +1956,76 @@ mod tests {
             shadow.unresolved_candidate_count, 0,
             "resolved candidates rejected by the final result window are not unresolved sidecar candidates"
         );
+    }
+
+    #[test]
+    fn shadow_candidate_summaries_keep_unresolved_candidates_past_display_cap() {
+        let hits = (0..21)
+            .map(|index| {
+                let path = if index == 20 {
+                    "missing.c".to_string()
+                } else {
+                    format!("src/resolved_{index}.c")
+                };
+                CandidateHit::with_source(
+                    &path,
+                    Some(format!("symbol_{index}")),
+                    0.5,
+                    CandidateSource::Zoekt,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut labels = vec!["resolved".to_string(); 21];
+        labels[20] = "path_unresolvable".to_string();
+        let admissions = labels
+            .iter()
+            .map(|label| {
+                if label == "resolved" {
+                    SidecarCandidateAdmissionLabel {
+                        admission_status: "admitted".to_string(),
+                        loss_reason: None,
+                        resolved_node_id: Some("1".to_string()),
+                        search_hit_rank: Some(1),
+                        final_rank: Some(1),
+                    }
+                } else {
+                    SidecarCandidateAdmissionLabel {
+                        admission_status: "unresolved".to_string(),
+                        loss_reason: Some(label.clone()),
+                        resolved_node_id: None,
+                        search_hit_rank: None,
+                        final_rank: None,
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        let shadow = shadow_from_query_result_with_counts_and_resolution_labels(
+            QueryResult {
+                query: "command loop".into(),
+                features: classify_query("command loop"),
+                hits,
+                trace: QueryTrace {
+                    retrieval_mode: "full".into(),
+                    degraded_reason: None,
+                    total_budget_ms: 500,
+                    elapsed_ms: 1,
+                    cancel_reason: None,
+                    cache_hit: false,
+                    stages: Vec::new(),
+                },
+            },
+            21,
+            20,
+            &labels,
+            &admissions,
+        );
+
+        assert_eq!(shadow.candidates.len(), MAX_SHADOW_CANDIDATES + 1);
+        let unresolved = shadow.candidates.last().expect("unresolved detail");
+        assert_eq!(unresolved.rank, 21);
+        assert_eq!(unresolved.file_path, "missing.c");
+        assert_eq!(unresolved.resolution.as_deref(), Some("path_unresolvable"));
+        assert_eq!(shadow.unresolved_candidate_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Added internal sidecar packet batch timing collection in `retrieval_primary`.
- Threaded timing through packet search outcomes.
- Emitted a machine-readable `packet_sidecar_batch_timing` retrieval trace annotation with `label`, `query_count`, `batch_wall_ms`, `prepare_ms`, `query_loop_wall_ms`, `sum_query_total_elapsed_ms`, `sum_sidecar_query_ms`, `sum_candidate_resolution_ms`, `result_build_ms`, and `unattributed_batch_gap_ms`.
- Added focused tests for timing sums and annotation fields.

## Why

#137 needed attribution for cold packet batch wall overhead before any product optimization. This is diagnostic-only instrumentation; it does not change ranking, scoring, thresholds, task manifests, sidecar identity, warm SLA behavior, publishable gates, or candidate diagnostics.

Refs #137
Refs #78
Refs #134
Related draft PR #135
Follow-up issue #139

## Verification

Code checks reported by the implementation thread:

- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; $env:CARGO_BUILD_JOBS='1'; cargo test -p codestory-runtime retrieval_primary`
- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; $env:CARGO_BUILD_JOBS='1'; cargo test -p codestory-runtime packet_anchor_probe_limit --lib`
- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; $env:CARGO_BUILD_JOBS='1'; cargo test -p codestory-runtime packet_lexical_subquery --lib`
- `cargo fmt --check`
- `git diff --check`

Independent instrumentation review:

- Review agent `019ee07c-8911-7f51-a1ad-02132e876e90` found no issues in diff range `e0c648ba3a032ba538f424959819b71b6e641cf5..385733398b4347660058c1d21347c38fdda564c9`.
- Verdict: review-clean for evidence-driven follow-up.

Focused branch-local cold packet-runtime artifact:

```text
C:\Users\alber\.codex\worktrees\8711\codestory\target\agent-benchmark\cold-batch-overhead-attribution
```

Artifact files checked:

```text
packet-runtime-summary.md
packet-runtime-summary.json
packet-runtime-deltas.json
packet-runtime-runs.jsonl
```

Current result:

| Repo | Task | Cold SLA misses | Quality | Sufficiency | Follow-ups | Retrieval median ms | Batch total median ms | Batch attributed median ms | Batch overhead median ms | Anchor overhead median ms | Lexical overhead median ms | Non-trace wall median ms |
| --- | --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| apache-commons-lang | java-commons-lang-string-utils | 3/3 | 3/3 | sufficient:3 | 0 | 21049 | 12543 | 5379 | 7164 | 2597 | 4473 | 6538.553 |
| redis-redis | c-redis-command-loop | 2/3 | 3/3 | sufficient:3 | 0 | 13688 | 8320 | 6467 | 1568 | 458 | 1297 | 6130.065 |

Run-level evidence:

| Repo | Repeat | SLA missed | Retrieval ms | Batch overhead ms | Anchor overhead ms | Lexical overhead ms | Quality | Sufficiency |
| --- | ---: | --- | ---: | ---: | ---: | ---: | --- | --- |
| apache-commons-lang | 1 | yes | 25793 | 7428 | 2597 | 4831 | pass | sufficient |
| apache-commons-lang | 2 | yes | 21049 | 7164 | 2691 | 4473 | pass | sufficient |
| apache-commons-lang | 3 | yes | 19570 | 5782 | 1537 | 4245 | pass | sufficient |
| redis-redis | 1 | yes | 16612 | 1568 | 271 | 1297 | pass | sufficient |
| redis-redis | 2 | no | 13688 | 1324 | 479 | 845 | pass | sufficient |
| redis-redis | 3 | yes | 13274 | 1853 | 458 | 1395 | pass | sufficient |

Current interpretation: #136 candidate diagnostics are no longer the publishable blocker, but #137/#138 do not clear #78. Apache remains dominated by packet batch overhead, especially lexical batch overhead; Redis still has two cold SLA misses even though its median batch overhead is much smaller. #139 now owns the smallest follow-up product-safe reduction attempt.

## Remaining risk / follow-up

- Keep this PR draft/non-closing unless the coordinator decides to land diagnostics separately.
- Do not claim #78 acceptance: Apache cold remains `3/3` missed and Redis cold remains `2/3` missed in this artifact.
- #139 owns the next implementation lane; #135 and #138 remain draft evidence until an accepted successor path is proven.

## Skills used

`codestory-grounding`, `github:github`, `superpowers:systematic-debugging`, `github:yeet`