### PR TITLE
[codex] narrow cold lexical packet subqueries

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -96,13 +96,7 @@ pub(crate) fn run_packet_planned_subqueries(
         return Ok(());
     }
 
-    let pending: Vec<(usize, &PacketPlanQueryDto)> = plan
-        .queries
-        .iter()
-        .enumerate()
-        .skip(1)
-        .take(limit)
-        .collect();
+    let pending = packet_planned_subqueries(plan, budget, limit);
     if pending.is_empty() {
         return Ok(());
     }
@@ -416,6 +410,34 @@ fn packet_subquery_limit(budget: PacketBudgetModeDto) -> usize {
         PacketBudgetModeDto::Standard => 4,
         PacketBudgetModeDto::Deep => 6,
     }
+}
+
+fn packet_planned_subqueries(
+    plan: &PacketPlanDto,
+    budget: PacketBudgetModeDto,
+    limit: usize,
+) -> Vec<(usize, &PacketPlanQueryDto)> {
+    plan.queries
+        .iter()
+        .enumerate()
+        .skip(1)
+        .take(limit)
+        .filter(|(_, query)| packet_subquery_should_run(budget, query))
+        .collect()
+}
+
+fn packet_subquery_should_run(budget: PacketBudgetModeDto, query: &PacketPlanQueryDto) -> bool {
+    if !packet_subquery_is_lexical_only(budget, query) {
+        return true;
+    }
+    if !query
+        .purpose
+        .contains("concrete symbol, file, route, or code term")
+    {
+        return true;
+    }
+    let trimmed = query.query.trim();
+    query_has_symbol_or_literal_signal(trimmed) || is_packet_code_like_term(trimmed)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -863,6 +885,116 @@ mod tests {
                 query.query
             );
         }
+    }
+
+    #[test]
+    fn packet_planned_subqueries_drop_low_signal_concrete_terms_without_backfill() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::RouteTracing,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Trace how Redis initializes command routing".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Trace".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Redis".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "initializes".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "event loop".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let pending = packet_planned_subqueries(&plan, PacketBudgetModeDto::Compact, 3);
+
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn packet_planned_subqueries_keep_deep_semantic_concrete_terms() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::RouteTracing,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Trace how Redis initializes command routing".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Trace".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Redis".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "initializes".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let pending = packet_planned_subqueries(&plan, PacketBudgetModeDto::Deep, 3)
+            .into_iter()
+            .map(|(_, query)| query.query.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(pending, ["Trace", "Redis", "initializes"]);
+    }
+
+    #[test]
+    fn packet_planned_subqueries_keep_code_like_concrete_terms() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain string predicate helpers".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "StringUtils".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "CharSequenceUtils".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Commons".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "isBlank".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let pending = packet_planned_subqueries(&plan, PacketBudgetModeDto::Compact, 3)
+            .into_iter()
+            .map(|(_, query)| query.query.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(pending, ["StringUtils", "CharSequenceUtils"]);
     }
 
     #[test]


### PR DESCRIPTION
## Context

#138 added `packet_sidecar_batch_timing` evidence showing cold packet-runtime overhead was still concentrated in Apache lexical packet subquery batching. This PR is a stacked #139 slice on top of #138.

Refs #139
Refs #78
Depends on #138

## What Changed

- Added a small `packet_planned_subqueries` filter before planned packet subquery execution.
- Low-signal `concrete symbol, file, route, or code term` queries are skipped only when they are actually lexical-only for the current budget.
- Preserved Deep-mode semantic planned subqueries after coordinator review feedback found the first candidate filtered too broadly.
- Added focused tests for Compact low-signal pruning, code-like concrete terms, and the Deep semantic boundary.

## Why It Changed

The cold #138 evidence showed Compact packet subqueries spent extra lexical batch work on early broad prompt terms such as `Commons`, `Trace`, `Redis`, and `initializes`. The narrow reduction removes that low-signal lexical-only work without changing SLA gates, sufficiency, quality, scorer thresholds, task manifests, sidecar/cache identity, or benchmark expected answers.

## How To Review

- Review `crates/codestory-runtime/src/agent/packet_batch.rs`.
- Check that `packet_subquery_should_run` first confirms `packet_subquery_is_lexical_only(budget, query)` before filtering concrete-purpose queries.
- Check the Deep boundary test: low-signal concrete queries remain planned when they would flow through semantic retrieval.

## Verification

Serialized Cargo environment:

```powershell
$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'
$env:CARGO_BUILD_JOBS='1'
```

Code checks:

```powershell
cargo test -p codestory-runtime packet_planned_subqueries --lib
# 3 passed

cargo test -p codestory-runtime packet_lexical_subquery --lib
# 4 passed

cargo test -p codestory-runtime packet_anchor_probe_limit --lib
# 6 passed

cargo test -p codestory-runtime retrieval_primary
# 31 passed; existing dead-code warnings in packet_sufficiency.rs

cargo fmt --check
# pass

git diff --check
# pass

cargo build --release -p codestory-cli
# pass; existing dead-code warnings in packet_sufficiency.rs
```

Focused cold packet-runtime evidence:

```text
C:\Users\alber\.codex\worktrees\87c0\codestory\target\agent-benchmark\issue-139-lexical-batch-overhead-cold-publishable-reviewfix
```

Command:

```powershell
node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --repeats 3 --materialize-repos --jobs 4 --prepare-codestory-jobs 2 --codestory-cli .\target\release\codestory-cli.exe --out-dir target\agent-benchmark\issue-139-lexical-batch-overhead-cold-publishable-reviewfix --timeout-ms 180000 --max-source-reads-after-packet 0 --publishable
```

Result: publishable gate exited nonzero.

| Repo | Quality | Sufficiency | Cold SLA misses | Retrieval median ms | Lexical batch overhead median ms |
| --- | ---: | --- | ---: | ---: | ---: |
| apache-commons-lang | 3/3 | sufficient:3 | 3/3 | 21432 | 4014 |
| redis-redis | 3/3 | sufficient:3 | 0/3 | 10142 | n/a |

Additional evidence note: Redis packet rows passed quality/sufficiency/SLA, and `retrieval status` reported `retrieval_mode=full` with `graph_first_v1 selected zero dense anchors; qdrant not required`. The publishable harness still flagged the legacy cache provenance field `semantic_ready=false` for Redis as an environment blocker.

## Risk / Follow-up

- This does not clear #139/#78 because Apache still misses cold SLA 3/3.
- Apache lexical batch query count dropped from 3 to 2 and median lexical overhead moved from #138's 4473 ms to 4014 ms, but residual wall remains in batch overhead and non-trace wall.
- Redis no longer runs the extra lexical subquery batch under this slice, but the focused publishable command remains non-passing because of the Redis legacy semantic-doc readiness gate.
- Next smallest stop line is Apache batch overhead after lexical narrowing, especially the unattributed batch gap and anchor batch overhead visible in `packet_sidecar_batch_timing`.

## Skills used

`codestory-grounding`, `github:github`, `github:yeet`, `superpowers:systematic-debugging`, `superpowers:verification-before-completion`, `performance`