### PR TITLE
[codex] skip redundant packet sidecar preflight

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_search.rs
+++ b/crates/codestory-runtime/src/agent/packet_search.rs
@@ -203,8 +203,16 @@ mod tests {
     #[test]
     fn packet_subquery_warmup_fails_closed_without_sidecar_primary() {
         let _lock = crate::process_env_test_lock();
-        let _retrieval_env = EnvVarGuard::cleared("CODESTORY_RETRIEVAL");
+        let _retrieval_env = EnvVarGuard {
+            key: "CODESTORY_RETRIEVAL",
+            previous: std::env::var_os("CODESTORY_RETRIEVAL"),
+        };
         let _deprecated_retrieval_env = EnvVarGuard::cleared("CODESTORY_RETRIEVAL_V2");
+        let _deprecated_shadow_env = EnvVarGuard::cleared("CODESTORY_RETRIEVAL_V2_SHADOW");
+        // SAFETY: test-only env mutation under the shared process env lock.
+        unsafe {
+            std::env::set_var("CODESTORY_RETRIEVAL", "0");
+        }
         let controller = AppController::new();
 
         let error = controller
@@ -214,7 +222,7 @@ mod tests {
         assert!(
             error
                 .message
-                .contains("sidecar retrieval primary requires an open project"),
+                .contains("CODESTORY_RETRIEVAL=0 is unsupported"),
             "warmup should report the mandatory sidecar gate, got: {}",
             error.message
         );

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -714,8 +714,20 @@ fn sidecar_packet_batch_rejection_reason(
     None
 }
 
-pub(crate) fn packet_batch_should_use_sidecar(controller: &AppController) -> bool {
-    sidecar_retrieval_primary_enabled(controller)
+pub(crate) fn packet_batch_should_use_sidecar(_controller: &AppController) -> bool {
+    if let Some(env) = unsupported_deprecated_env() {
+        tracing::error!(
+            env,
+            "unsupported retrieval env alias; sidecar retrieval aliases are dead"
+        );
+        return false;
+    }
+    if retrieval_env_override() == Some(false) {
+        tracing::error!("CODESTORY_RETRIEVAL=0 is unsupported; sidecar retrieval is mandatory");
+        return false;
+    }
+    // ponytail: strict batch execution validates full mode; avoid repeating the slow status probe.
+    true
 }
 
 pub(crate) fn maybe_log_rollback_after_packet(
@@ -2813,5 +2825,23 @@ mod tests {
         unsafe {
             std::env::remove_var(RETRIEVAL_SHADOW_ENV_DEPRECATED);
         }
+    }
+
+    #[test]
+    fn packet_batch_attempt_skips_redundant_full_mode_preflight() {
+        let _lock = env_test_lock();
+        // SAFETY: test-only env cleanup; no concurrent tests rely on these variables.
+        unsafe {
+            std::env::remove_var(RETRIEVAL_ENV);
+            std::env::remove_var(RETRIEVAL_ENV_DEPRECATED);
+            std::env::remove_var(RETRIEVAL_SHADOW_ENV_DEPRECATED);
+        }
+
+        let controller = AppController::new();
+
+        assert!(
+            packet_batch_should_use_sidecar(&controller),
+            "packet batches should attempt strict execution and let that path validate full mode"
+        );
     }
 }


### PR DESCRIPTION
## Context

Refs #142
Refs #78

Issue #141's cold artifacts narrowed the remaining Apache residual to strict sidecar packet batch accounting after #140 removed the Redis lexical batch problem. The per-run annotations point at wrapper overhead around packet batch execution, especially repeated `unattributed_batch_gap_ms` in anchor and lexical batches.

## What Changed

- Removed the duplicate packet-batch sidecar full-mode preflight from the hot wrapper path.
- Kept strict batch execution as the authoritative full-mode validator, so packet batches still fail closed if sidecars are unavailable or degraded.
- Preserved env-disabled and deprecated-alias rejection before attempting strict execution.
- Updated the focused warmup/env test and added coverage for skipping the redundant preflight.

## How To Review

- Base this review against #140's branch: `codex/issue-139-lexical-batch-overhead`.
- Start with `crates/codestory-runtime/src/agent/retrieval_primary.rs`, especially `packet_batch_should_use_sidecar`.
- Then check the env-gate test update in `crates/codestory-runtime/src/agent/packet_search.rs`.

## Verification

- `cargo run --release -p codestory-cli -- doctor --project .`
  - Result: `status: needs_attention`; local packet/search evidence blocked because this worktree has `stats: nodes=0 edges=0 files=0` and `sidecar_retrieval: mode=unavailable degraded_reason=retrieval_manifest_missing`.
- `cargo test -p codestory-runtime retrieval_primary --lib`
  - Result: 32 passed, 0 failed.
- `cargo test -p codestory-runtime packet_batch --lib`
  - Result: 19 passed, 0 failed.
- `cargo test -p codestory-retrieval query --lib`
  - Result: 16 passed, 0 failed, 1 ignored live-sidecar test.
- `cargo test -p codestory-runtime packet_subquery_warmup_fails_closed_without_sidecar_primary --lib`
  - Result: 1 passed, 0 failed.
- `cargo fmt --check`
  - Result: passed.
- `git diff --check`
  - Result: passed.

## Artifacts

- Read #141/#140 evidence roots:
  - `C:\Users\alber\.codex\worktrees\8711\codestory\target\agent-benchmark\cold-batch-overhead-attribution`
  - `C:\Users\alber\.codex\worktrees\87c0\codestory\target\agent-benchmark\issue-139-lexical-batch-overhead-cold-publishable-reviewfix`
- Existing artifact attribution: Apache residual shows repeated strict sidecar batch wrapper gaps; Redis clears in the #141 root after #140.
- No fresh focused Apache/Redis cold rows were produced from this worktree because doctor reports missing local index/sidecar manifest. This PR is therefore draft until a repaired sidecar evidence run confirms the cold acceptance effect.

## Risk

- This intentionally relies on strict batch execution to reject non-full sidecar mode instead of checking full mode twice.
- It does not change scorer thresholds, task manifests, expected answers, sidecar/cache identity, candidate diagnostics, SLA gates, sufficiency, or quality gates.
- Do not treat this as clearing #78 or #139 until focused cold evidence clears the SLA rows.

## Skills Used

- `codestory-grounding`
- `github:github`
- `superpowers:systematic-debugging`
- `superpowers:verification-before-completion`
- `performance`