### PR TITLE
[docs] document cross-platform cache recovery

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -373,9 +373,9 @@ case "$resolved_cache" in
 esac
 backup="${resolved_cache}.bak-$(date +%Y%m%d%H%M%S)"
 mv "$resolved_cache" "$backup"
-codestory-cli index --project <target-workspace> --refresh full
-codestory-cli doctor --project <target-workspace>
-rm -rf "$backup"
+codestory-cli index --project <target-workspace> --refresh full &&
+  codestory-cli doctor --project <target-workspace> &&
+  rm -rf "$backup"
 ```
 
 On Windows PowerShell:
@@ -392,7 +392,9 @@ if (-not $resolvedCache.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnor
 $backup = "$resolvedCache.bak-$(Get-Date -Format yyyyMMddHHmmss)"
 Move-Item -LiteralPath $resolvedCache -Destination $backup
 codestory-cli index --project <target-workspace> --refresh full
+if ($LASTEXITCODE -ne 0) { throw "Index rebuild failed; leaving backup at $backup" }
 codestory-cli doctor --project <target-workspace>
+if ($LASTEXITCODE -ne 0) { throw "Doctor check failed; leaving backup at $backup" }
 Remove-Item -LiteralPath $backup -Recurse
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -378,6 +378,24 @@ codestory-cli doctor --project <target-workspace>
 rm -rf "$backup"
 ```
 
+On Windows PowerShell:
+
+```powershell
+$cacheDir = "<project-cache-dir-from-doctor>"
+$cacheRoot = Join-Path $env:LOCALAPPDATA "codestory\cache"
+$resolvedCache = (Resolve-Path -LiteralPath $cacheDir).ProviderPath
+$resolvedRoot = (Resolve-Path -LiteralPath $cacheRoot).ProviderPath
+$rootPrefix = $resolvedRoot.TrimEnd("\", "/") + "\"
+if (-not $resolvedCache.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+  throw "Refusing to touch cache outside CodeStory cache root: $resolvedCache"
+}
+$backup = "$resolvedCache.bak-$(Get-Date -Format yyyyMMddHHmmss)"
+Move-Item -LiteralPath $resolvedCache -Destination $backup
+codestory-cli index --project <target-workspace> --refresh full
+codestory-cli doctor --project <target-workspace>
+Remove-Item -LiteralPath $backup -Recurse
+```
+
 Low-memory guidance:
 
 - Prefer `index --refresh incremental` over repeated full refreshes.


### PR DESCRIPTION
## What changed

- Added the missing Windows PowerShell cache-directory recovery path to `docs/usage.md` alongside the existing POSIX shell flow.
- Kept both examples on the same recovery contract: resolve the project cache path from `doctor`, verify it sits under the CodeStory cache root, move it aside, rebuild, re-run `doctor`, then remove the backup.
- Gated backup cleanup so the backup is removed only after both rebuild and `doctor` succeed.

## Why it changed

Release review for the #74 / #38 docs lane needed cross-platform operator guidance. The cache recovery section already had POSIX shell instructions, but no Windows PowerShell sibling. Review also found that cleanup could run after failed rebuild or health checks, which could discard the backup operators need for recovery.

Closes #147
Refs #74
Refs #38

## How verified

- Read the changed `docs/usage.md` cache recovery section.
- Ran a PowerShell behavior check proving the backup is kept when simulated native `index` or `doctor` commands fail.
- `git diff --check`
- `git status --short --branch`

## Remaining risk or follow-up

- Docs-only change; no runtime behavior changed.
- The commands still require the operator to copy the exact project cache path reported by `doctor` before moving any cache directory.