### PR TITLE
[release] bump CodeStory to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.10.0
+
+- Ship the synchronized CodeStory workspace release after the #74 pre-release
+  review artifacts landed in PR #145 and PR #146.
+- Preserve the `v0.9.0` reviewer comparison surface:
+  `https://github.com/TheGreenCedar/CodeStory/compare/v0.9.0...review/codestory-saga-from-v0.9.0-f4f6d3d6`.
+- Carry #78 packet-runtime SLA misses as accepted/deferred release risk; this
+  release does not claim packet-runtime SLA clearance.
+
 ## 0.7.0
 
 - Current synchronized workspace release baseline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Context

#74 is complete: package report PR #145 and Windows cache docs PR #146 are merged, and the reviewer branch exists at `review/codestory-saga-from-v0.9.0-f4f6d3d6`.

Reviewer compare: https://github.com/TheGreenCedar/CodeStory/compare/v0.9.0...review/codestory-saga-from-v0.9.0-f4f6d3d6

#72 evidence remains part of the release chain: `docs/testing/issue-72-promotion-audit-2026-06-18-f61e6717cbbf.md` records the promotion audit, including sidecar readiness after repair and the failed publishable packet-runtime benchmark. #78 remains open as accepted/deferred release risk; this PR does not claim packet-runtime SLA clearance.

Closes #73
Refs #38
Refs #74
Refs #72
Refs #78

## What Changed

- Bumped every `codestory-*` workspace crate from `0.9.0` to `0.10.0`, using `crates/codestory-cli/Cargo.toml` as the release version source.
- Updated `Cargo.lock` for the same eight workspace package versions only.
- Added a `CHANGELOG.md` entry for `0.10.0` that cites the #74 artifacts, the reviewer compare URL, and the accepted/deferred #78 risk.

## How To Review

- Confirm the version-only package diff across `crates/*/Cargo.toml` and `Cargo.lock`.
- Confirm the changelog language stays release-facing and does not overstate #78.
- Use the reviewer compare URL above for the saga diff without version-bump noise.

## Verification

Serialized in `C:\Users\alber\.codex\worktrees\issue-73-version-bump\codestory` with `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'` and `$env:CARGO_BUILD_JOBS='1'`:

- `python .github/scripts/check-codestory-release.py --version 0.10.0` passed: synchronized across 8 workspace crates and `Cargo.lock`.
- `node .github/scripts/check-workflow-policy.mjs` passed: third-party actions are SHA-pinned.
- `cargo check --workspace` passed in 8m19s; existing dead-code warnings remain in `packet_sufficiency.rs`.
- `git diff --check` passed.

## Risk

- #78 packet-runtime SLA work is not cleared; it remains open and deferred as accepted release risk.
- No tags were created. The repo auto-release workflow owns tags and binary assets after merge to `main`.