### PR TITLE
[codex] harden saga issue-link guard

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -6,6 +6,7 @@ const workflowRoot = path.join(".github", "workflows");
 const trustedOwners = new Set(["actions", "github"]);
 const shaPattern = /^[0-9a-f]{40}$/i;
 const violations = [];
+const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
 
 for (const file of fs
   .readdirSync(workflowRoot)
@@ -38,9 +39,35 @@ for (const file of fs
   });
 }
 
+if (fs.existsSync(sagaIssueLinkGuard)) {
+  const content = fs.readFileSync(sagaIssueLinkGuard, "utf8");
+  const closingRef =
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:#\d+|https:\/\/github\.com\/TheGreenCedar\/CodeStory\/issues\/\d+)\b/im;
+
+  if (!content.includes("review/codestory-saga-")) {
+    violations.push("saga-issue-link-guard.yml must guard review/codestory-saga-* branches");
+  }
+
+  if (
+    !content.includes(
+      'r"(?:#\\d+|https://github\\.com/TheGreenCedar/CodeStory/issues/\\d+)\\b"',
+    )
+  ) {
+    violations.push("saga-issue-link-guard.yml closing refs must require # or a full issue URL");
+  }
+
+  if (
+    closingRef.test("Closes 123") ||
+    !closingRef.test("Closes #123") ||
+    !closingRef.test("Closes https://github.com/TheGreenCedar/CodeStory/issues/123")
+  ) {
+    violations.push("saga-issue-link-guard.yml closing ref policy must reject bare numbers and accept # or full issue URLs");
+  }
+}
+
 if (violations.length > 0) {
   console.error(violations.join("\n"));
   process.exit(1);
 }
 
-console.log("Workflow policy passed: third-party actions are SHA-pinned.");
+console.log("Workflow policy passed: third-party actions and saga issue-link guard are valid.");

--- a/.github/workflows/saga-issue-link-guard.yml
+++ b/.github/workflows/saga-issue-link-guard.yml
@@ -13,6 +13,7 @@ jobs:
     name: require closing issue link
     if: >-
       startsWith(github.event.pull_request.head.ref, 'codex/') ||
+      startsWith(github.event.pull_request.head.ref, 'review/codestory-saga-') ||
       startsWith(github.event.pull_request.title, '[codex]') ||
       contains(github.event.pull_request.labels.*.name, 'saga:codestory-intelligence')
     runs-on: ubuntu-latest
@@ -36,6 +37,7 @@ jobs:
 
           guarded = (
               head_ref.startswith("codex/")
+              or head_ref.startswith("review/codestory-saga-")
               or title.startswith("[codex]")
               or "saga:codestory-intelligence" in labels
           )
@@ -46,7 +48,7 @@ jobs:
 
           closing_keyword = re.compile(
               r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+"
-              r"(?:https://github\.com/TheGreenCedar/CodeStory/issues/)?#?\d+\b"
+              r"(?:#\d+|https://github\.com/TheGreenCedar/CodeStory/issues/\d+)\b"
           )
 
           if closing_keyword.search(body):


### PR DESCRIPTION
## Context
Issue #157 found two gaps in the saga issue-link guard: review saga branches were only covered when labeled, and the closing-reference regex accepted bare issue numbers such as `Closes 123`.

Closes #157
Refs #38

## What Changed
- Added `review/codestory-saga-` branch coverage to the workflow job condition and the in-script guard check.
- Tightened closing references so `Closes #123` and full CodeStory issue URLs pass, while `Closes 123` fails.
- Added focused regression assertions to the existing workflow policy script.

## How To Review
- Review `.github/workflows/saga-issue-link-guard.yml` for the guarded branch predicate and closing-reference regex.
- Review `.github/scripts/check-workflow-policy.mjs` for the focused acceptance checks.

## Verification
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

## Risk
- Low. This is scoped to the saga issue-link guard and preserves non-closing reference handling.
