### PR TITLE
[codex] fix RetrievalShadowDto fixture drift

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -4338,6 +4338,7 @@ mod tests {
                 candidate_count: 1,
                 resolved_hit_count: 1,
                 unresolved_candidate_count: 0,
+                diagnostic_only: false,
                 candidate_resolution_counts: Vec::new(),
             }),
             freshness: None,


### PR DESCRIPTION
## Context

`cargo check --all-targets` was blocked by a stale CLI test fixture constructing `RetrievalShadowDto` without the `diagnostic_only` field added in the contracts DTO.

Closes #154
Refs #38

## What Changed

- Added `diagnostic_only: false` to the `RetrievalShadowDto` fixture in `crates/codestory-cli/src/output.rs`.
- Left DTO shape, retrieval behavior, CLI output behavior, and runtime behavior unchanged.

## How To Review

- Confirm the diff is limited to the missing fixture field.
- Confirm the value matches existing contracts-side fixtures.

## Verification

- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'`
- `$env:CARGO_BUILD_JOBS='1'`
- `cargo check --all-targets` passed in 9m36s. Existing `codestory-runtime` dead-code warnings were emitted.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk / Follow-up

Low risk: fixture-only compile drift fix. No behavior changes intended.
