### PR TITLE
[codex] fix stdio packet budget timing

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -4339,6 +4339,7 @@ mod tests {
                 resolved_hit_count: 1,
                 unresolved_candidate_count: 0,
                 candidate_resolution_counts: Vec::new(),
+                diagnostic_only: false,
             }),
             freshness: None,
             limit_per_source: 1,

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -241,16 +241,16 @@ fn stdio_jsonrpc_tool_call_from_legacy(
     stdio_jsonrpc_success(id, stdio_tool_call_success(response))
 }
 
-fn stdio_tool_call_success(mut structured_content: serde_json::Value) -> serde_json::Value {
+fn stdio_tool_call_success(structured_content: serde_json::Value) -> serde_json::Value {
     let is_packet = stdio_is_packet(&structured_content);
+    let mut stdio_phases = Vec::new();
     let text_started = Instant::now();
     let text = stdio_tool_text(&structured_content);
     if is_packet {
-        append_stdio_packet_phase(
-            &mut structured_content,
+        stdio_phases.push(stdio_packet_phase(
             "text_materialization",
             stdio_elapsed_ms(text_started),
-        );
+        ));
     }
 
     let response_started = Instant::now();
@@ -263,12 +263,17 @@ fn stdio_tool_call_success(mut structured_content: serde_json::Value) -> serde_j
         ],
         "structuredContent": structured_content
     });
-    if is_packet && let Some(structured_content) = response.get_mut("structuredContent") {
-        append_stdio_packet_phase(
-            structured_content,
+    if is_packet {
+        stdio_phases.push(stdio_packet_phase(
             "tool_response_materialization",
             stdio_elapsed_ms(response_started),
-        );
+        ));
+        if let Some(response) = response.as_object_mut() {
+            response.insert(
+                "_meta".to_string(),
+                serde_json::json!({ "codestory_stdio_phases": stdio_phases }),
+            );
+        }
     }
     response
 }
@@ -284,15 +289,10 @@ fn stdio_is_packet(value: &serde_json::Value) -> bool {
     value.get("packet_id").is_some() && value.get("answer").is_some()
 }
 
-fn append_stdio_packet_phase(packet: &mut serde_json::Value, label: &str, duration_ms: u32) {
-    if let Some(annotations) = packet
-        .pointer_mut("/answer/retrieval_trace/annotations")
-        .and_then(|value| value.as_array_mut())
-    {
-        annotations.push(serde_json::Value::String(format!(
-            "packet_stdio_phase label={label} duration_ms={duration_ms}"
-        )));
-    }
+fn stdio_packet_phase(label: &str, duration_ms: u32) -> serde_json::Value {
+    serde_json::Value::String(format!(
+        "packet_stdio_phase label={label} duration_ms={duration_ms}"
+    ))
 }
 
 fn stdio_elapsed_ms(started_at: Instant) -> u32 {
@@ -1911,19 +1911,66 @@ mod tests {
     }
 
     #[test]
-    fn stdio_tool_call_success_times_packet_materialization() {
-        let response = stdio_tool_call_success(json!({
+    fn stdio_tool_call_success_keeps_packet_timing_out_of_structured_content() {
+        let mut packet = json!({
             "packet_id": "packet-1",
             "answer": {
                 "retrieval_trace": {
                     "annotations": []
                 }
+            },
+            "budget": {
+                "limits": {
+                    "max_output_bytes": 0
+                },
+                "used": {
+                    "output_bytes": 0
+                }
             }
-        }));
+        });
+        for _ in 0..4 {
+            let len = serde_json::to_vec(&packet).expect("serialize packet").len();
+            packet["budget"]["limits"]["max_output_bytes"] = json!(len);
+            packet["budget"]["used"]["output_bytes"] = json!(len);
+        }
+
+        let response = stdio_tool_call_success(packet);
         let annotations = response
             .pointer("/structuredContent/answer/retrieval_trace/annotations")
             .and_then(|value| value.as_array())
             .expect("packet annotations");
+        assert!(
+            annotations.is_empty(),
+            "stdio timings should not mutate budgeted packet content: {annotations:?}"
+        );
+
+        let packet = response
+            .get("structuredContent")
+            .expect("structured packet content");
+        let packet_bytes = serde_json::to_vec(packet)
+            .expect("serialize structured packet")
+            .len();
+        let max_output_bytes = packet
+            .pointer("/budget/limits/max_output_bytes")
+            .and_then(|value| value.as_u64())
+            .expect("packet max output bytes") as usize;
+        let used_output_bytes = packet
+            .pointer("/budget/used/output_bytes")
+            .and_then(|value| value.as_u64())
+            .expect("packet used output bytes") as usize;
+        assert_eq!(
+            used_output_bytes, packet_bytes,
+            "stdio packet content should not make output byte telemetry stale"
+        );
+        assert!(
+            packet_bytes <= max_output_bytes,
+            "stdio packet content should stay inside the enforced budget: {packet_bytes} > {max_output_bytes}"
+        );
+
+        let annotations = response
+            .pointer("/_meta/codestory_stdio_phases")
+            .and_then(|value| value.as_array())
+            .expect("stdio phases");
 
         assert!(annotations.iter().any(|annotation| {
             annotation.as_str().is_some_and(|value| {


### PR DESCRIPTION
## Context

Stdio packet tool responses were appending packet materialization timing annotations into `structuredContent.answer.retrieval_trace.annotations` after the runtime packet budget enforcement had already measured the packet DTO. That could make the structured packet content larger than `budget.used.output_bytes` or stale relative to `budget.limits.max_output_bytes`.

Closes #158
Refs #78
Refs #38

## What Changed

- Moved stdio packet timing diagnostics out of the packet DTO and into response `_meta.codestory_stdio_phases`.
- Added a focused unit test proving stdio response materialization does not mutate structured packet annotations, stale `budget.used.output_bytes`, or push the structured packet over its advertised output cap.
- Updated one stale CLI test fixture with the current `RetrievalShadowDto.diagnostic_only` field so the focused `codestory-cli` test target compiles.

## How To Review

- Start with `crates/codestory-cli/src/stdio_transport.rs` around `stdio_tool_call_success`.
- Confirm packet timing diagnostics remain present in `_meta.codestory_stdio_phases` while `structuredContent` remains budget-accounted packet content.
- Check the focused regression test in the same file.

## Verification

- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; $env:CARGO_BUILD_JOBS='1'; cargo test -p codestory-cli stdio_tool_call_success_keeps_packet_timing_out_of_structured_content` - 1 passed; existing `codestory-runtime` dead-code warnings emitted.
- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; $env:CARGO_BUILD_JOBS='1'; cargo test -p codestory-cli search_why_markdown_puts_evidence_before_diagnostics` - 1 passed; existing `codestory-runtime` dead-code warnings emitted.
- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; cargo fmt --check` - passed.
- `git diff --check` - passed before commit.
- `git diff --check origin/main...HEAD` - passed after push.

## Risk

- Low behavior risk: packet content semantics, SLA thresholds, retrieval scoring, sidecar behavior, and runtime packet budgeting are unchanged.
- Consumers that were reading stdio timing annotations from packet `answer.retrieval_trace.annotations` should read response `_meta.codestory_stdio_phases` instead.

## Skills used

- `codestory-grounding`
- `github:github`
- `github:yeet`
- `superpowers:receiving-code-review`
- `superpowers:systematic-debugging`
- `superpowers:verification-before-completion`
