### PR TITLE
[codex] remove retrieval mode override helper

### DIFF
--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -65,7 +65,7 @@ pub fn execute_retrieval_query_with_cache(
         manifest,
         file_roles,
         cancelled,
-        mode_override: single_query_mode_override(),
+        mode_override: None,
     };
     executor.execute(request.query, request.budget_ms)
 }
@@ -232,10 +232,6 @@ fn strict_batch_worker_limit(query_count: usize) -> usize {
         .max(1)
 }
 
-fn single_query_mode_override() -> Option<RetrievalDegradedMode> {
-    None
-}
-
 struct QueryContext {
     layout: SidecarLayout,
     project_id: String,
@@ -334,11 +330,6 @@ mod tests {
         manifest.dense_projection_count = Some(projection_count);
         manifest.dense_reason_counts_json = Some(format!("{{\"public_api\":{projection_count}}}"));
         manifest
-    }
-
-    #[test]
-    fn single_query_mode_override_is_not_forced_by_packet_batch_strictness() {
-        assert_eq!(single_query_mode_override(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #160. Refs #38. Refs #96.

Issue #160 asks for the tiny S1/R0 code-reduction slice: remove the single-query retrieval mode override helper that only returned `None`, without taking the larger batch-executor ownership refactor.

## What Changed

- Passed `mode_override: None` directly for single retrieval queries.
- Removed the no-op `single_query_mode_override()` helper.
- Removed the unit test that only preserved the dead helper abstraction.
- Left the strict batch executor mode override path unchanged.

## How To Review

- Inspect `crates/codestory-retrieval/src/query.rs` and confirm the diff is limited to the direct no-override value plus deleted dead helper/test.
- Confirm the batch path still passes `mode_override: Some(mode)`.

## Verification

- `cargo test -p codestory-retrieval query --lib` - passed: 15 passed, 0 failed, 1 ignored, 101 filtered out.
- `cargo fmt --check` - passed.
- `git diff --check` - passed.
- CodeStory grounding preflight: built a local navigation index for the issue worktree with `codestory-cli index --project ... --refresh full` (`files=255`, `errors=0`). Full packet/search sidecar retrieval was unavailable (`retrieval_manifest_missing`), so exact anchors were verified with direct source reads.

## Risk

Low. The helper only returned `None`; the replacement preserves the same single-query no-override behavior. Remaining risk is limited to reviewer preference around keeping no dedicated test for a literal `None`, but existing query tests still exercise the retrieval query module and batch strictness path.

## Skills used

- `codestory-grounding`
- `github:github` / `github:yeet`
- `code-simplifier`
- `superpowers:receiving-code-review`
- `superpowers:verification-before-completion`
