### PR TITLE
[codex] fix duplicate RetrievalShadowDto fixture field

### DIFF
--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -4340,7 +4340,6 @@ mod tests {
                 unresolved_candidate_count: 0,
                 diagnostic_only: false,
                 candidate_resolution_counts: Vec::new(),
-                diagnostic_only: false,
             }),
             freshness: None,
             limit_per_source: 1,


### PR DESCRIPTION
## Context

PR #163 and PR #165 both touched the same `RetrievalShadowDto` fixture drift, leaving `main` with two `diagnostic_only` fields in the same CLI test fixture after the merge stack landed.

Closes #168
Refs #154
Refs #158
Refs #38

## What Changed

- Removed the duplicate `diagnostic_only: false` field from `crates/codestory-cli/src/output.rs`.
- Kept the single required fixture field in place.
- No behavior changes.

## How To Review

- Inspect the one-line diff in `crates/codestory-cli/src/output.rs`.
- Confirm the fixture has exactly one `diagnostic_only` field.

## Verification

- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; $env:CARGO_BUILD_JOBS='1'; cargo check -p codestory-cli --all-targets` - passed in 2m24s with existing runtime dead-code warnings.
- `cargo fmt --check` - passed.
- `git diff --check` - passed.

## Risk

Low; fixture-only integration repair.

## Skills used

- `codestory-grounding`
- `github:github`
- `superpowers:receiving-code-review`
- `superpowers:verification-before-completion`