### PR TITLE
Add Docker Compose structural source-proof collector

### DIFF
--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -138,6 +138,13 @@ const GITHUB_ACTIONS_WORKFLOW_UNSUPPORTED_SHAPES: &[&str] = &[
     "Matrix expansion, expressions, reusable-workflow calls, and shell bodies are not semantically resolved.",
     "The collector records exact source anchors; it does not validate GitHub Actions execution semantics.",
 ];
+const DOCKER_COMPOSE_NODE_KINDS: &[NodeKind] =
+    &[NodeKind::MODULE, NodeKind::FUNCTION, NodeKind::ANNOTATION];
+const DOCKER_COMPOSE_UNSUPPORTED_SHAPES: &[&str] = &[
+    "Variable interpolation and env-file expansion are not resolved.",
+    "Profiles, extends, health checks, dependency order, and runtime container behavior are not interpreted.",
+    "The collector records exact source anchors; it does not validate Docker Compose execution semantics.",
+];
 
 pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = &[
     StructuralSourceProofContract {
@@ -150,6 +157,18 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         confidence: 1.0,
         unsupported_shape_notes: GITHUB_ACTIONS_WORKFLOW_UNSUPPORTED_SHAPES,
         claim_boundary: "structural exact-source proof only; not parser-backed graph parity, typed semantic resolution, or packet semantic-proof admission",
+        semantic_proof_allowed: false,
+    },
+    StructuralSourceProofContract {
+        collector_name: "docker_compose",
+        path_pattern: "compose*.{yml,yaml}, docker-compose*.{yml,yaml}, docker/*-compose.{yml,yaml}",
+        emitted_node_kinds: DOCKER_COMPOSE_NODE_KINDS,
+        source_span: "1-based source line and column span for the matched stack, service, or service property anchor",
+        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
+        confidence: 1.0,
+        unsupported_shape_notes: DOCKER_COMPOSE_UNSUPPORTED_SHAPES,
+        claim_boundary: "structural exact-source proof only; not parser-backed graph parity, typed semantic resolution, container runtime behavior, or packet semantic-proof admission",
         semantic_proof_allowed: false,
     },
 ];
@@ -288,6 +307,26 @@ pub fn is_github_actions_workflow_path(path: &str) -> bool {
     (file_name.ends_with(".yml") || file_name.ends_with(".yaml"))
         && parent == "workflows"
         && grandparent == ".github"
+}
+
+pub fn is_docker_compose_file_path(path: &str) -> bool {
+    if is_github_actions_workflow_path(path) {
+        return false;
+    }
+    let normalized = path.replace('\\', "/").to_ascii_lowercase();
+    let mut parts = normalized.rsplit('/');
+    let Some(file_name) = parts.next().filter(|part| !part.is_empty()) else {
+        return false;
+    };
+    let Some((stem, ext)) = file_name.rsplit_once('.') else {
+        return false;
+    };
+    if !matches!(ext, "yml" | "yaml") {
+        return false;
+    }
+    stem.starts_with("compose")
+        || stem.starts_with("docker-compose")
+        || (stem.ends_with("-compose") && parts.any(|part| part == "docker"))
 }
 
 pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
@@ -443,6 +482,45 @@ mod tests {
         assert!(!contract.unsupported_shape_notes.is_empty());
         assert!(!contract.semantic_proof_allowed);
         assert!(contract.claim_boundary.contains("not parser-backed"));
+
+        let compose_contract = STRUCTURAL_SOURCE_PROOF_CONTRACTS
+            .iter()
+            .find(|contract| contract.collector_name == "docker_compose")
+            .expect("docker compose structural contract");
+        assert_eq!(
+            compose_contract.path_pattern,
+            "compose*.{yml,yaml}, docker-compose*.{yml,yaml}, docker/*-compose.{yml,yaml}"
+        );
+        assert!(
+            compose_contract
+                .emitted_node_kinds
+                .contains(&NodeKind::MODULE)
+        );
+        assert!(
+            compose_contract
+                .emitted_node_kinds
+                .contains(&NodeKind::FUNCTION)
+        );
+        assert!(
+            compose_contract
+                .emitted_node_kinds
+                .contains(&NodeKind::ANNOTATION)
+        );
+        assert_eq!(
+            compose_contract.evidence_tier,
+            PacketEvidenceTierDto::ExactSource
+        );
+        assert_eq!(
+            compose_contract.resolution,
+            PacketEvidenceResolutionDto::SourceRangeOnly
+        );
+        assert!(!compose_contract.semantic_proof_allowed);
+        assert!(
+            compose_contract
+                .unsupported_shape_notes
+                .iter()
+                .any(|note| note.contains("interpolation"))
+        );
     }
 
     #[test]
@@ -463,6 +541,20 @@ mod tests {
         assert!(!is_github_actions_workflow_path(
             "repo/.github/workflows/readme.md"
         ));
+        assert!(language_support_profile_for_ext("yaml").is_none());
+    }
+
+    #[test]
+    fn docker_compose_path_is_path_scoped_not_yaml_support() {
+        assert!(is_docker_compose_file_path("compose.yaml"));
+        assert!(is_docker_compose_file_path("deploy/compose.yml"));
+        assert!(is_docker_compose_file_path("docker-compose.override.yml"));
+        assert!(is_docker_compose_file_path(
+            r"repo\docker\retrieval-compose.yml"
+        ));
+        assert!(!is_docker_compose_file_path(".github/workflows/ci.yml"));
+        assert!(!is_docker_compose_file_path("openapi.yaml"));
+        assert!(!is_docker_compose_file_path("docs/service.yml"));
         assert!(language_support_profile_for_ext("yaml").is_none());
     }
 }

--- a/crates/codestory-indexer/src/structural/common.rs
+++ b/crates/codestory-indexer/src/structural/common.rs
@@ -4,7 +4,7 @@ use codestory_contracts::graph::{
     ResolutionCertainty, SourceLocation,
 };
 use codestory_contracts::language_support::{
-    is_github_actions_workflow_path, structural_language_name_for_path,
+    is_docker_compose_file_path, is_github_actions_workflow_path, structural_language_name_for_path,
 };
 use std::path::Path;
 
@@ -12,6 +12,9 @@ pub(crate) fn structural_language_name(path: &Path) -> &'static str {
     let path = path.to_string_lossy();
     if is_github_actions_workflow_path(path.as_ref()) {
         return "github_actions_workflow";
+    }
+    if is_docker_compose_file_path(path.as_ref()) {
+        return "docker_compose";
     }
     structural_language_name_for_path(Some(path.as_ref())).unwrap_or("structural")
 }

--- a/crates/codestory-indexer/src/structural/docker_compose.rs
+++ b/crates/codestory-indexer/src/structural/docker_compose.rs
@@ -11,6 +11,9 @@ pub(crate) fn collect_docker_compose_entities(
     storage: &mut IntermediateStorage,
 ) {
     let path_key = path.to_string_lossy().replace('\\', "/");
+    if !has_service_anchor(source) {
+        return;
+    }
     let Some((stack_name, stack_line, stack_col)) = compose_stack_anchor(source) else {
         return;
     };
@@ -205,6 +208,37 @@ fn push_anchor(
 
 fn compose_stack_anchor(source: &str) -> Option<(String, u32, u32)> {
     top_level_name(source).or_else(|| top_level_services_anchor(source))
+}
+
+fn has_service_anchor(source: &str) -> bool {
+    let mut in_services = false;
+    let mut service_indent = None;
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line);
+
+        if indent == 0 && trimmed == "services:" {
+            in_services = true;
+            continue;
+        }
+        if !in_services {
+            continue;
+        }
+        if indent == 0 {
+            return false;
+        }
+        if service_indent.is_none() && indent > 0 {
+            service_indent = Some(indent);
+        }
+        if Some(indent) == service_indent && yaml_mapping_key(trimmed).is_some() {
+            return true;
+        }
+    }
+    false
 }
 
 fn top_level_name(source: &str) -> Option<(String, u32, u32)> {

--- a/crates/codestory-indexer/src/structural/docker_compose.rs
+++ b/crates/codestory-indexer/src/structural/docker_compose.rs
@@ -1,0 +1,299 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use std::path::Path;
+
+use super::common::{push_member_edge, push_structural_node};
+
+pub(crate) fn collect_docker_compose_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) {
+    let path_key = path.to_string_lossy().replace('\\', "/");
+    let Some((stack_name, stack_line, stack_col)) = compose_stack_anchor(source) else {
+        return;
+    };
+    let stack_id = push_structural_node(
+        storage,
+        file_id,
+        NodeKind::MODULE,
+        &stack_name,
+        &format!("docker-compose:stack:{path_key}"),
+        stack_line,
+        stack_col,
+    );
+    push_member_edge(storage, file_id, file_id, stack_id, stack_line);
+    collect_services(&path_key, source, file_id, storage, stack_id);
+}
+
+fn collect_services(
+    path_key: &str,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    stack_id: NodeId,
+) {
+    let mut in_services = false;
+    let mut service_indent = None;
+    let mut current_service: Option<(usize, NodeId, String)> = None;
+    let mut section: Option<(&str, usize)> = None;
+    let mut anchor_index = 0usize;
+
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line = line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX);
+        let trimmed = line_text.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line_text);
+
+        if indent == 0 && trimmed == "services:" {
+            in_services = true;
+            continue;
+        }
+        if !in_services {
+            continue;
+        }
+        if indent == 0 {
+            break;
+        }
+
+        if service_indent.is_none()
+            && indent > 0
+            && let Some(service_name) = yaml_mapping_key(trimmed)
+        {
+            service_indent = Some(indent);
+            let service_id = push_service(
+                storage,
+                file_id,
+                stack_id,
+                path_key,
+                &service_name,
+                line,
+                indent,
+            );
+            current_service = Some((indent, service_id, service_name));
+            section = None;
+            continue;
+        }
+
+        if let Some(expected_indent) = service_indent
+            && indent == expected_indent
+            && let Some(service_name) = yaml_mapping_key(trimmed)
+        {
+            let service_id = push_service(
+                storage,
+                file_id,
+                stack_id,
+                path_key,
+                &service_name,
+                line,
+                indent,
+            );
+            current_service = Some((indent, service_id, service_name));
+            section = None;
+            continue;
+        }
+
+        let Some((current_indent, service_id, service_name)) = current_service.as_ref() else {
+            continue;
+        };
+        if indent <= *current_indent {
+            section = None;
+            continue;
+        }
+
+        if let Some((field, section_indent)) = section
+            && indent > section_indent
+            && let Some((anchor, col)) = section_anchor(field, line_text)
+        {
+            anchor_index = anchor_index.saturating_add(1);
+            push_anchor(
+                storage,
+                file_id,
+                *service_id,
+                path_key,
+                service_name,
+                &anchor,
+                anchor_index,
+                line,
+                col,
+            );
+            continue;
+        }
+
+        let Some(field) = yaml_mapping_key(trimmed) else {
+            continue;
+        };
+        match field.as_str() {
+            "image" | "build" => {
+                anchor_index = anchor_index.saturating_add(1);
+                push_anchor(
+                    storage,
+                    file_id,
+                    *service_id,
+                    path_key,
+                    service_name,
+                    trimmed,
+                    anchor_index,
+                    line,
+                    indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                );
+            }
+            "ports" | "environment" | "volumes" => {
+                section = Some((
+                    match field.as_str() {
+                        "ports" => "ports",
+                        "environment" => "environment",
+                        _ => "volumes",
+                    },
+                    indent,
+                ));
+            }
+            _ => {
+                section = None;
+            }
+        }
+    }
+}
+
+fn push_service(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    stack_id: NodeId,
+    path_key: &str,
+    service_name: &str,
+    line: u32,
+    indent: usize,
+) -> NodeId {
+    let service_id = push_structural_node(
+        storage,
+        file_id,
+        NodeKind::FUNCTION,
+        service_name,
+        &format!("docker-compose:service:{path_key}:{service_name}"),
+        line,
+        indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+    );
+    push_member_edge(storage, file_id, stack_id, service_id, line);
+    service_id
+}
+
+fn push_anchor(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    service_id: NodeId,
+    path_key: &str,
+    service_name: &str,
+    anchor: &str,
+    anchor_index: usize,
+    line: u32,
+    col: u32,
+) {
+    let anchor_id = push_structural_node(
+        storage,
+        file_id,
+        NodeKind::ANNOTATION,
+        anchor,
+        &format!("docker-compose:anchor:{path_key}:{service_name}:{anchor_index}"),
+        line,
+        col,
+    );
+    push_member_edge(storage, file_id, service_id, anchor_id, line);
+}
+
+fn compose_stack_anchor(source: &str) -> Option<(String, u32, u32)> {
+    top_level_name(source).or_else(|| top_level_services_anchor(source))
+}
+
+fn top_level_name(source: &str) -> Option<(String, u32, u32)> {
+    for (line_idx, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if leading_spaces(line) == 0
+            && let Some(rest) = trimmed.strip_prefix("name:")
+        {
+            let value_text = rest.trim_start();
+            let value = clean_yaml_scalar(value_text);
+            if !value.is_empty() {
+                let value_offset = rest.len().saturating_sub(value_text.len())
+                    + value_text.find(&value).unwrap_or(0);
+                let col = "name:".len().saturating_add(value_offset).saturating_add(1);
+                return Some((
+                    value,
+                    line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                    col.try_into().unwrap_or(u32::MAX),
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn top_level_services_anchor(source: &str) -> Option<(String, u32, u32)> {
+    source.lines().enumerate().find_map(|(line_idx, line)| {
+        (leading_spaces(line) == 0 && line.trim_start() == "services:").then(|| {
+            (
+                "services:".to_string(),
+                line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                line.find("services:").unwrap_or(0).saturating_add(1) as u32,
+            )
+        })
+    })
+}
+
+fn section_anchor(field: &str, line: &str) -> Option<(String, u32)> {
+    let indent = leading_spaces(line);
+    let trimmed = line.trim_start();
+    match field {
+        "ports" | "volumes" => trimmed.strip_prefix("- ").map(|_| {
+            (
+                trimmed.to_string(),
+                indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+            )
+        }),
+        "environment" => environment_anchor(trimmed, indent),
+        _ => None,
+    }
+}
+
+fn environment_anchor(trimmed: &str, indent: usize) -> Option<(String, u32)> {
+    if let Some(rest) = trimmed.strip_prefix("- ") {
+        let key = rest.split_once('=')?.0.trim();
+        if key.is_empty() {
+            return None;
+        }
+        return Some((
+            key.to_string(),
+            indent.saturating_add(3).try_into().unwrap_or(u32::MAX),
+        ));
+    }
+    let key = yaml_mapping_key(trimmed)?;
+    Some((key, indent.saturating_add(1).try_into().unwrap_or(u32::MAX)))
+}
+
+fn yaml_mapping_key(trimmed_line: &str) -> Option<String> {
+    let (key, _) = trimmed_line.split_once(':')?;
+    let key = key.trim();
+    if key.is_empty() || key.contains(' ') || !key.chars().all(compose_key_char) {
+        return None;
+    }
+    Some(key.to_string())
+}
+
+fn clean_yaml_scalar(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.chars().take_while(|ch| *ch == ' ').count()
+}
+
+fn compose_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')
+}

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -3,6 +3,7 @@
 mod blanking;
 mod common;
 pub(crate) mod css;
+mod docker_compose;
 mod github_actions;
 mod html;
 mod sql;
@@ -18,11 +19,16 @@ pub fn structural_language_name(path: &Path) -> &'static str {
 use crate::intermediate_storage::IntermediateStorage;
 use anyhow::Result;
 use codestory_contracts::graph::NodeId;
-use codestory_contracts::language_support::is_github_actions_workflow_path;
+use codestory_contracts::language_support::{
+    is_docker_compose_file_path, is_github_actions_workflow_path,
+};
 use std::path::Path;
 
 pub fn is_structural_candidate_path(path: &Path) -> bool {
-    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+    let path_text = path.to_string_lossy();
+    if is_github_actions_workflow_path(path_text.as_ref())
+        || is_docker_compose_file_path(path_text.as_ref())
+    {
         return true;
     }
     matches!(
@@ -61,13 +67,16 @@ pub fn index_structural_source(path: &Path, source: &str) -> Result<Intermediate
     });
     storage.nodes.push(file_node);
 
-    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+    let path_key = path.to_string_lossy();
+    if is_github_actions_workflow_path(path_key.as_ref()) {
         github_actions::collect_github_actions_workflow_entities(
             path,
             source,
             file_id,
             &mut storage,
         );
+    } else if is_docker_compose_file_path(path_key.as_ref()) {
+        docker_compose::collect_docker_compose_entities(path, source, file_id, &mut storage);
     } else {
         match structural_extension(path).as_deref() {
             Some("html" | "htm") => {
@@ -185,6 +194,105 @@ jobs:
     }
 
     #[test]
+    fn indexes_docker_compose_services_as_structural_source_proof() {
+        let source = r#"name: demo-stack
+services:
+  web:
+    image: nginx:1.27
+    ports:
+      - "8080:80"
+    environment:
+      RACK_ENV: production
+      FEATURE_FLAG: "true"
+    volumes:
+      - ./site:/usr/share/nginx/html:ro
+  worker:
+    build: ./worker
+    environment:
+      - QUEUE=critical
+    volumes:
+      - worker-cache:/cache
+"#;
+
+        let storage =
+            index_structural_source(Path::new("docker/demo-compose.yml"), source).unwrap();
+
+        assert_eq!(storage.files[0].language, "docker_compose");
+        assert!(
+            storage.nodes.iter().any(|node| {
+                node.kind == NodeKind::MODULE
+                    && node.serialized_name == "demo-stack"
+                    && node.start_line == Some(1)
+                    && node.start_col == Some(7)
+                    && node.end_col == Some(16)
+            }),
+            "compose stack name should be an exact source-span node"
+        );
+        assert_compose_node_span(&storage, NodeKind::FUNCTION, "web", 3, 3);
+        assert_compose_node_span(&storage, NodeKind::FUNCTION, "worker", 12, 3);
+        assert_compose_node_span(&storage, NodeKind::ANNOTATION, "image: nginx:1.27", 4, 5);
+        assert_compose_node_span(&storage, NodeKind::ANNOTATION, "build: ./worker", 13, 5);
+        assert_compose_node_span(&storage, NodeKind::ANNOTATION, "- \"8080:80\"", 6, 7);
+        assert_compose_node_span(&storage, NodeKind::ANNOTATION, "RACK_ENV", 8, 7);
+        assert_compose_node_span(&storage, NodeKind::ANNOTATION, "FEATURE_FLAG", 9, 7);
+        assert_compose_node_span(&storage, NodeKind::ANNOTATION, "QUEUE", 15, 9);
+        assert_compose_node_span(
+            &storage,
+            NodeKind::ANNOTATION,
+            "- ./site:/usr/share/nginx/html:ro",
+            11,
+            7,
+        );
+        assert_compose_node_span(
+            &storage,
+            NodeKind::ANNOTATION,
+            "- worker-cache:/cache",
+            17,
+            7,
+        );
+        assert!(
+            storage
+                .edges
+                .iter()
+                .any(|edge| edge.kind == EdgeKind::MEMBER)
+        );
+    }
+
+    #[test]
+    fn docker_compose_admission_is_path_scoped_not_generic_yaml() {
+        assert!(is_structural_candidate_path(Path::new(
+            "docker/retrieval-compose.yml"
+        )));
+        assert!(is_structural_candidate_path(Path::new("compose.yaml")));
+        assert!(is_structural_candidate_path(Path::new(
+            "docker-compose.override.yml"
+        )));
+        assert!(is_structural_candidate_path(Path::new(
+            r"deploy\compose.yaml"
+        )));
+        assert!(is_structural_candidate_path(Path::new(
+            ".github/workflows/ci.yml"
+        )));
+        assert!(!is_structural_candidate_path(Path::new("openapi.yaml")));
+        assert!(!is_structural_candidate_path(Path::new(
+            "docs/workflow.yml"
+        )));
+
+        let storage = index_structural_source(Path::new("compose.yml"), "openapi: 3.1.0\n")
+            .expect("index unsupported compose-shaped yaml");
+        assert!(
+            storage.nodes.iter().all(|node| {
+                !node
+                    .canonical_id
+                    .as_deref()
+                    .unwrap_or_default()
+                    .starts_with("docker-compose:")
+            }),
+            "unsupported compose-shaped yaml should not invent compose anchors"
+        );
+    }
+
+    #[test]
     fn unnamed_github_actions_workflow_uses_jobs_source_anchor() {
         let yaml = r#"on:
   push:
@@ -279,6 +387,27 @@ jobs:
             node.end_col,
             Some(col + source_anchor.len() as u32 - 1),
             "step span must cover only source text"
+        );
+    }
+
+    fn assert_compose_node_span(
+        storage: &IntermediateStorage,
+        kind: NodeKind,
+        source_anchor: &str,
+        line: u32,
+        col: u32,
+    ) {
+        let node = storage
+            .nodes
+            .iter()
+            .find(|node| node.kind == kind && node.serialized_name == source_anchor)
+            .unwrap_or_else(|| panic!("missing compose source anchor {source_anchor}"));
+        assert_eq!(node.start_line, Some(line));
+        assert_eq!(node.start_col, Some(col));
+        assert_eq!(
+            node.end_col,
+            Some(col + source_anchor.len() as u32 - 1),
+            "compose span must cover only source text"
         );
     }
 

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -293,6 +293,23 @@ services:
     }
 
     #[test]
+    fn docker_compose_requires_services_section_to_emit_anchors() {
+        let storage =
+            index_structural_source(Path::new("compose.yaml"), "name: api\nopenapi: 3.1.0\n")
+                .expect("index admitted non-compose yaml");
+        assert!(
+            storage.nodes.iter().all(|node| {
+                !node
+                    .canonical_id
+                    .as_deref()
+                    .unwrap_or_default()
+                    .starts_with("docker-compose:")
+            }),
+            "compose-looking yaml without services must not invent compose anchors"
+        );
+    }
+
+    #[test]
     fn unnamed_github_actions_workflow_uses_jobs_source_anchor() {
         let yaml = r#"on:
   push:

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -4,7 +4,9 @@ use codestory_contracts::api::{
     AgentCitationDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto, SearchHit,
     SearchHitOrigin,
 };
-use codestory_contracts::language_support::is_github_actions_workflow_path;
+use codestory_contracts::language_support::{
+    is_docker_compose_file_path, is_github_actions_workflow_path,
+};
 
 pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
 pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
@@ -66,8 +68,11 @@ pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &
     if citation_is_structural_source_proof(citation) {
         citation.evidence_tier = Some(PacketEvidenceTier::ExactSource);
         citation.resolution_status = Some(evidence_resolution_for_citation(citation));
-        citation.evidence_producer =
-            Some("structural_github_actions_workflow_collector".to_string());
+        citation.evidence_producer = citation
+            .file_path
+            .as_deref()
+            .and_then(structural_source_proof_producer)
+            .map(str::to_string);
         citation.eligible_for_sufficiency = Some(false);
         return;
     }
@@ -166,7 +171,12 @@ pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceReso
 
 pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
     if hit_is_structural_source_proof(hit) {
-        return "structural_github_actions_workflow_collector".to_string();
+        return hit
+            .file_path
+            .as_deref()
+            .and_then(structural_source_proof_producer)
+            .unwrap_or("structural_source_proof_collector")
+            .to_string();
     }
     if let Some(producer) = hit.evidence_producer.as_ref() {
         return producer.clone();
@@ -230,14 +240,28 @@ fn evidence_resolution_for_citation(citation: &AgentCitationDto) -> PacketEviden
 fn hit_is_structural_source_proof(hit: &SearchHit) -> bool {
     hit.file_path
         .as_deref()
-        .is_some_and(is_github_actions_workflow_path)
+        .is_some_and(is_structural_source_proof_path)
 }
 
 fn citation_is_structural_source_proof(citation: &AgentCitationDto) -> bool {
     citation
         .file_path
         .as_deref()
-        .is_some_and(is_github_actions_workflow_path)
+        .is_some_and(is_structural_source_proof_path)
+}
+
+fn is_structural_source_proof_path(path: &str) -> bool {
+    is_github_actions_workflow_path(path) || is_docker_compose_file_path(path)
+}
+
+fn structural_source_proof_producer(path: &str) -> Option<&'static str> {
+    if is_github_actions_workflow_path(path) {
+        return Some("structural_github_actions_workflow_collector");
+    }
+    if is_docker_compose_file_path(path) {
+        return Some("structural_docker_compose_collector");
+    }
+    None
 }
 
 #[cfg(test)]
@@ -290,6 +314,28 @@ mod tests {
         assert_eq!(
             hit.evidence_producer.as_deref(),
             Some("structural_github_actions_workflow_collector")
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn docker_compose_structural_hit_is_exact_source_diagnostic() {
+        let mut hit = workflow_hit();
+        hit.node_id = NodeId("compose-web".to_string());
+        hit.display_name = "web".to_string();
+        hit.file_path = Some("docker/retrieval-compose.yml".to_string());
+        hit.line = Some(9);
+
+        decorate_search_hit_evidence(&mut hit);
+
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(
+            hit.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("structural_docker_compose_collector")
         );
         assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -26,7 +26,7 @@ profiles to parser and rule construction in `get_language_for_ext`.
 | Runtime claim | Languages | Evidence floor | Safe claim |
 | --- | --- | --- | --- |
 | Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | fidelity lab, tictactoe coverage, raw graph contracts, targeted rule/resolution suites, opt-in OSS corpus | daily graph navigation on typical code, with caveats |
-| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows | structural collector tests | exact-source structural anchors |
+| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests | structural collector tests | exact-source structural anchors |
 
 Agent-facing packet/search quality is separate. The language-expansion A/B
 report is not blanket promotion proof for every parser-backed language.
@@ -64,10 +64,15 @@ status. It is blocked:
 
 GitHub Actions workflow support is path-scoped to `.github/workflows/*.{yml,yaml}`.
 The pilot emits workflow, job, and step anchors with `exact_source` /
-`source_range_only` evidence. Unsupported shapes stay explicit: YAML anchors and
-merge keys are not interpreted, matrix expansion and expressions are not
-resolved, reusable workflows and shell bodies are not semantically traced, and
-the collector does not validate GitHub Actions execution semantics. Packet
+`source_range_only` evidence. Docker Compose support is path-scoped to
+`compose*.{yml,yaml}`, `docker-compose*.{yml,yaml}`, and
+`docker/*-compose.{yml,yaml}` style manifests; it emits stack, service, image or
+build, ports, environment key, and volume anchors with the same exact-source
+boundary. Unsupported shapes stay explicit: YAML anchors and merge keys are not
+interpreted, matrix expansion and expressions are not resolved, reusable
+workflows and shell bodies are not semantically traced, Compose interpolation,
+profiles, health checks, dependency order, and runtime container behavior are
+not interpreted, and neither collector validates execution semantics. Packet
 evidence treats these anchors as diagnostic unless a future structural role
 explicitly admits them; they must not satisfy semantic proof roles.
 
@@ -146,8 +151,8 @@ Workspace parser policy:
 
 Validation: each listed candidate passed an isolated `cargo check` probe with
 the policy pins; wired parser rows also passed a parse smoke. HTML, CSS, SQL,
-and GitHub Actions workflows remain structural runtime paths, not parser-backed
-runtime claims.
+GitHub Actions workflows, and Docker Compose manifests remain structural runtime
+paths, not parser-backed runtime claims.
 
 | Language | Candidate crate | Version checked | Decision |
 | --- | --- | ---: | --- |

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -80,8 +80,8 @@ Safe wording: packet-runtime is implemented and completing the suite, but
 publishable agent-facing packet quality is not promoted until a coherent run has
 all quality, sufficiency, and cold-SLA gates green. This evidence is a
 development/proof-gate signal, not public product-grade proof for every
-parser-backed language. HTML, CSS, SQL, and GitHub Actions workflows remain
-structural source-proof collectors.
+parser-backed language. HTML, CSS, SQL, GitHub Actions workflows, and Docker
+Compose manifests remain structural source-proof collectors.
 
 Older development comparison: the language-expansion comparison artifact built
 on 2026-06-17:


### PR DESCRIPTION
## Context

Closes #172. Refs #150. Refs #38.

Docker Compose service manifests are the next tiny structural collector after the GitHub Actions pilot. The goal is exact-source infra anchors without claiming YAML support, parser-backed graph parity, or container/runtime semantics.

## What Changed

- Added a path-scoped Docker Compose predicate and structural source-proof contract.
- Added a small Docker Compose collector for stack, service, image/build, ports, environment key, and volume anchors with source spans and member edges.
- Marked Compose packet/search hits as diagnostic `exact_source` / `source_range_only` evidence with a Compose-specific producer.
- Updated the language support contract docs.
- Adopted the parked `28eb` negative-shape guard so compose-shaped OpenAPI YAML does not invent Compose anchors.

## How To Review

- Start in `crates/codestory-indexer/src/structural/docker_compose.rs` for the collector boundary.
- Check `crates/codestory-contracts/src/language_support.rs` for the path predicate and non-semantic contract.
- Check `crates/codestory-runtime/src/agent/packet_evidence.rs` for diagnostic packet evidence behavior.

## Verification

- `cargo test -p codestory-indexer structural --lib` - 15 passed
- `cargo test -p codestory-contracts docker_compose --lib` - 1 passed
- `cargo test -p codestory-contracts structural_source_proof_contract_is_exact_source_not_semantic --lib` - 1 passed
- `cargo test -p codestory-runtime docker_compose_structural_hit_is_exact_source_diagnostic --lib` - 1 passed
- `cargo test -p codestory-runtime github_actions_structural_hit_is_exact_source_diagnostic --lib` - 1 passed
- `cargo fmt --check`
- `git diff --check`

All Cargo commands used `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe` and were run serially.

## Risk

This is intentionally a line-scanning structural collector, not a YAML parser. It does not resolve interpolation, profiles, health checks, dependency order, or runtime/container behavior. It should remain diagnostic evidence unless a future role explicitly admits structural Compose proof.