### PR TITLE
[codex] add Docker Compose structural source-proof collector

### DIFF
--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -138,6 +138,13 @@ const GITHUB_ACTIONS_WORKFLOW_UNSUPPORTED_SHAPES: &[&str] = &[
     "Matrix expansion, expressions, reusable-workflow calls, and shell bodies are not semantically resolved.",
     "The collector records exact source anchors; it does not validate GitHub Actions execution semantics.",
 ];
+const DOCKER_COMPOSE_NODE_KINDS: &[NodeKind] =
+    &[NodeKind::MODULE, NodeKind::FUNCTION, NodeKind::ANNOTATION];
+const DOCKER_COMPOSE_UNSUPPORTED_SHAPES: &[&str] = &[
+    "YAML anchors, aliases, merge keys, and includes are not interpreted.",
+    "Variable interpolation, profiles, healthchecks, depends_on behavior, and startup order are not semantically resolved.",
+    "The collector records exact source anchors; it does not validate Docker Compose runtime or container behavior.",
+];
 
 pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = &[
     StructuralSourceProofContract {
@@ -150,6 +157,18 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         confidence: 1.0,
         unsupported_shape_notes: GITHUB_ACTIONS_WORKFLOW_UNSUPPORTED_SHAPES,
         claim_boundary: "structural exact-source proof only; not parser-backed graph parity, typed semantic resolution, or packet semantic-proof admission",
+        semantic_proof_allowed: false,
+    },
+    StructuralSourceProofContract {
+        collector_name: "docker_compose",
+        path_pattern: "{compose,docker-compose}.{yml,yaml} plus docker/*-compose.{yml,yaml}",
+        emitted_node_kinds: DOCKER_COMPOSE_NODE_KINDS,
+        source_span: "1-based source line and column span for the matched stack, service, image/build, ports, environment key, or volume anchor",
+        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
+        confidence: 1.0,
+        unsupported_shape_notes: DOCKER_COMPOSE_UNSUPPORTED_SHAPES,
+        claim_boundary: "structural exact-source proof only; not parser-backed graph parity, Compose runtime semantics, dependency/startup-order proof, or packet semantic-proof admission",
         semantic_proof_allowed: false,
     },
 ];
@@ -288,6 +307,28 @@ pub fn is_github_actions_workflow_path(path: &str) -> bool {
     (file_name.ends_with(".yml") || file_name.ends_with(".yaml"))
         && parent == "workflows"
         && grandparent == ".github"
+}
+
+pub fn is_docker_compose_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/").to_ascii_lowercase();
+    let mut parts = normalized.rsplit('/');
+    let Some(file_name) = parts.next().filter(|part| !part.is_empty()) else {
+        return false;
+    };
+    if !(file_name.ends_with(".yml") || file_name.ends_with(".yaml")) {
+        return false;
+    }
+    if matches!(
+        file_name,
+        "compose.yml" | "compose.yaml" | "docker-compose.yml" | "docker-compose.yaml"
+    ) {
+        return true;
+    }
+    let Some(parent) = parts.next() else {
+        return false;
+    };
+    parent == "docker"
+        && (file_name.ends_with("-compose.yml") || file_name.ends_with("-compose.yaml"))
 }
 
 pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
@@ -446,6 +487,35 @@ mod tests {
     }
 
     #[test]
+    fn docker_compose_structural_contract_is_exact_source_not_semantic() {
+        let contract = STRUCTURAL_SOURCE_PROOF_CONTRACTS
+            .iter()
+            .find(|contract| contract.collector_name == "docker_compose")
+            .expect("docker compose structural contract");
+        assert_eq!(
+            contract.path_pattern,
+            "{compose,docker-compose}.{yml,yaml} plus docker/*-compose.{yml,yaml}"
+        );
+        assert!(contract.emitted_node_kinds.contains(&NodeKind::MODULE));
+        assert!(contract.emitted_node_kinds.contains(&NodeKind::FUNCTION));
+        assert!(contract.emitted_node_kinds.contains(&NodeKind::ANNOTATION));
+        assert_eq!(contract.evidence_tier, PacketEvidenceTierDto::ExactSource);
+        assert_eq!(
+            contract.resolution,
+            PacketEvidenceResolutionDto::SourceRangeOnly
+        );
+        assert_eq!(contract.confidence, 1.0);
+        assert!(
+            contract
+                .unsupported_shape_notes
+                .iter()
+                .any(|note| note.contains("interpolation"))
+        );
+        assert!(!contract.semantic_proof_allowed);
+        assert!(contract.claim_boundary.contains("not parser-backed"));
+    }
+
+    #[test]
     fn github_actions_workflow_path_is_path_scoped_not_yaml_support() {
         assert!(is_github_actions_workflow_path(
             "repo/.github/workflows/ci.yml"
@@ -463,6 +533,19 @@ mod tests {
         assert!(!is_github_actions_workflow_path(
             "repo/.github/workflows/readme.md"
         ));
+        assert!(language_support_profile_for_ext("yaml").is_none());
+    }
+
+    #[test]
+    fn docker_compose_path_is_path_scoped_not_yaml_support() {
+        assert!(is_docker_compose_path("compose.yml"));
+        assert!(is_docker_compose_path("compose.yaml"));
+        assert!(is_docker_compose_path("deploy/docker-compose.yml"));
+        assert!(is_docker_compose_path("docker/retrieval-compose.yml"));
+        assert!(is_docker_compose_path(r"docker\retrieval-compose.yaml"));
+        assert!(!is_docker_compose_path("openapi.yaml"));
+        assert!(!is_docker_compose_path("docs/retrieval-compose.yml"));
+        assert!(!is_docker_compose_path("docker/retrieval.yml"));
         assert!(language_support_profile_for_ext("yaml").is_none());
     }
 }

--- a/crates/codestory-indexer/src/structural/common.rs
+++ b/crates/codestory-indexer/src/structural/common.rs
@@ -4,7 +4,7 @@ use codestory_contracts::graph::{
     ResolutionCertainty, SourceLocation,
 };
 use codestory_contracts::language_support::{
-    is_github_actions_workflow_path, structural_language_name_for_path,
+    is_docker_compose_path, is_github_actions_workflow_path, structural_language_name_for_path,
 };
 use std::path::Path;
 
@@ -12,6 +12,9 @@ pub(crate) fn structural_language_name(path: &Path) -> &'static str {
     let path = path.to_string_lossy();
     if is_github_actions_workflow_path(path.as_ref()) {
         return "github_actions_workflow";
+    }
+    if is_docker_compose_path(path.as_ref()) {
+        return "docker_compose";
     }
     structural_language_name_for_path(Some(path.as_ref())).unwrap_or("structural")
 }

--- a/crates/codestory-indexer/src/structural/docker_compose.rs
+++ b/crates/codestory-indexer/src/structural/docker_compose.rs
@@ -1,0 +1,359 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use std::path::Path;
+
+use super::common::{push_member_edge, push_structural_node};
+
+pub(crate) fn collect_docker_compose_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) {
+    let path_key = path.to_string_lossy().replace('\\', "/");
+    let Some((stack_name, stack_line, stack_col)) = stack_anchor(source) else {
+        return;
+    };
+    let stack_id = push_structural_node(
+        storage,
+        file_id,
+        NodeKind::MODULE,
+        &stack_name,
+        &format!("docker-compose:stack:{path_key}"),
+        stack_line,
+        stack_col,
+    );
+    push_member_edge(storage, file_id, file_id, stack_id, stack_line);
+
+    collect_services(&path_key, source, file_id, storage, stack_id);
+}
+
+fn collect_services(
+    path_key: &str,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+    stack_id: NodeId,
+) {
+    let mut in_services = false;
+    let mut service_indent = None;
+    let mut current_service: Option<(usize, NodeId, String)> = None;
+    let mut active_block: Option<(&str, usize)> = None;
+    let mut anchor_index = 0usize;
+
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line = line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX);
+        let trimmed = line_text.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = leading_spaces(line_text);
+
+        if indent == 0 && trimmed == "services:" {
+            in_services = true;
+            current_service = None;
+            active_block = None;
+            continue;
+        }
+        if !in_services {
+            continue;
+        }
+        if indent == 0 {
+            break;
+        }
+
+        if let Some(expected_indent) = service_indent
+            && indent == expected_indent
+            && !trimmed.starts_with('-')
+            && let Some(service_name) = yaml_mapping_key(trimmed)
+        {
+            let service_id = push_service(
+                storage,
+                file_id,
+                stack_id,
+                path_key,
+                &service_name,
+                line,
+                indent,
+            );
+            current_service = Some((indent, service_id, service_name));
+            active_block = None;
+            anchor_index = 0;
+            continue;
+        }
+
+        if service_indent.is_none()
+            && indent > 0
+            && !trimmed.starts_with('-')
+            && let Some(service_name) = yaml_mapping_key(trimmed)
+        {
+            service_indent = Some(indent);
+            let service_id = push_service(
+                storage,
+                file_id,
+                stack_id,
+                path_key,
+                &service_name,
+                line,
+                indent,
+            );
+            current_service = Some((indent, service_id, service_name));
+            active_block = None;
+            anchor_index = 0;
+            continue;
+        }
+
+        let Some((current_service_indent, service_id, service_name)) = current_service.as_ref()
+        else {
+            continue;
+        };
+        if indent <= *current_service_indent {
+            active_block = None;
+            continue;
+        }
+
+        if service_field_is(trimmed, "image") || service_field_is(trimmed, "build") {
+            push_compose_anchor(
+                storage,
+                file_id,
+                *service_id,
+                path_key,
+                service_name,
+                field_name(trimmed).unwrap_or("field"),
+                trimmed,
+                line,
+                indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                &mut anchor_index,
+            );
+            active_block = None;
+            continue;
+        }
+
+        if let Some(block) = service_block(trimmed) {
+            push_compose_anchor(
+                storage,
+                file_id,
+                *service_id,
+                path_key,
+                service_name,
+                block,
+                trimmed,
+                line,
+                indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                &mut anchor_index,
+            );
+            active_block = Some((block, indent));
+            continue;
+        }
+
+        let Some((block, block_indent)) = active_block else {
+            continue;
+        };
+        if indent <= block_indent {
+            active_block = None;
+            continue;
+        }
+        match block {
+            "ports" | "volumes" => {
+                if let Some((anchor, col)) = list_anchor(line_text) {
+                    push_compose_anchor(
+                        storage,
+                        file_id,
+                        *service_id,
+                        path_key,
+                        service_name,
+                        block,
+                        &anchor,
+                        line,
+                        col,
+                        &mut anchor_index,
+                    );
+                }
+            }
+            "environment" => {
+                if let Some((key, col)) = environment_key_anchor(line_text) {
+                    push_compose_anchor(
+                        storage,
+                        file_id,
+                        *service_id,
+                        path_key,
+                        service_name,
+                        block,
+                        &key,
+                        line,
+                        col,
+                        &mut anchor_index,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn push_service(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    stack_id: NodeId,
+    path_key: &str,
+    service_name: &str,
+    line: u32,
+    indent: usize,
+) -> NodeId {
+    let service_id = push_structural_node(
+        storage,
+        file_id,
+        NodeKind::FUNCTION,
+        service_name,
+        &format!("docker-compose:service:{path_key}:{service_name}"),
+        line,
+        indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+    );
+    push_member_edge(storage, file_id, stack_id, service_id, line);
+    service_id
+}
+
+fn push_compose_anchor(
+    storage: &mut IntermediateStorage,
+    file_id: NodeId,
+    service_id: NodeId,
+    path_key: &str,
+    service_name: &str,
+    anchor_kind: &str,
+    anchor: &str,
+    line: u32,
+    col: u32,
+    anchor_index: &mut usize,
+) {
+    *anchor_index = (*anchor_index).saturating_add(1);
+    let anchor_id = push_structural_node(
+        storage,
+        file_id,
+        NodeKind::ANNOTATION,
+        anchor,
+        &format!(
+            "docker-compose:{anchor_kind}:{path_key}:{service_name}:{}",
+            *anchor_index
+        ),
+        line,
+        col,
+    );
+    push_member_edge(storage, file_id, service_id, anchor_id, line);
+}
+
+fn stack_anchor(source: &str) -> Option<(String, u32, u32)> {
+    top_level_compose_name(source).or_else(|| top_level_services_anchor(source))
+}
+
+fn top_level_compose_name(source: &str) -> Option<(String, u32, u32)> {
+    for (line_idx, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if leading_spaces(line) == 0
+            && let Some(rest) = trimmed.strip_prefix("name:")
+        {
+            let value_text = rest.trim_start();
+            let value = clean_yaml_scalar(value_text);
+            if !value.is_empty() {
+                let value_offset = rest.len().saturating_sub(value_text.len())
+                    + value_text.find(&value).unwrap_or(0);
+                let col = "name:".len().saturating_add(value_offset).saturating_add(1);
+                return Some((
+                    value,
+                    line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                    col.try_into().unwrap_or(u32::MAX),
+                ));
+            }
+        }
+    }
+    None
+}
+
+fn top_level_services_anchor(source: &str) -> Option<(String, u32, u32)> {
+    source.lines().enumerate().find_map(|(line_idx, line)| {
+        (leading_spaces(line) == 0 && line.trim_start() == "services:").then(|| {
+            (
+                "services:".to_string(),
+                line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX),
+                line.find("services:").unwrap_or(0).saturating_add(1) as u32,
+            )
+        })
+    })
+}
+
+fn service_field_is(trimmed_line: &str, expected: &str) -> bool {
+    field_name(trimmed_line).is_some_and(|name| name == expected)
+}
+
+fn service_block(trimmed_line: &str) -> Option<&'static str> {
+    match field_name(trimmed_line)? {
+        "ports" => Some("ports"),
+        "environment" => Some("environment"),
+        "volumes" => Some("volumes"),
+        _ => None,
+    }
+}
+
+fn field_name(trimmed_line: &str) -> Option<&str> {
+    let (key, _) = trimmed_line.split_once(':')?;
+    Some(key.trim())
+}
+
+fn yaml_mapping_key(trimmed_line: &str) -> Option<String> {
+    let (key, _) = trimmed_line.split_once(':')?;
+    let key = key.trim();
+    if key.is_empty() || key.contains(' ') || !key.chars().all(compose_key_char) {
+        return None;
+    }
+    Some(key.to_string())
+}
+
+fn list_anchor(line: &str) -> Option<(String, u32)> {
+    let indent = leading_spaces(line);
+    let trimmed = line.trim_start();
+    trimmed.strip_prefix("- ")?;
+    Some((
+        trimmed.to_string(),
+        indent.saturating_add(1).try_into().unwrap_or(u32::MAX),
+    ))
+}
+
+fn environment_key_anchor(line: &str) -> Option<(String, u32)> {
+    let indent = leading_spaces(line);
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("- ") {
+        let value = rest.trim_start();
+        let key = value
+            .split(['=', ':'])
+            .next()
+            .map(str::trim)
+            .filter(|key| !key.is_empty())?;
+        let value_offset = rest.len().saturating_sub(value.len());
+        return Some((
+            key.to_string(),
+            indent
+                .saturating_add(3)
+                .saturating_add(value_offset)
+                .try_into()
+                .unwrap_or(u32::MAX),
+        ));
+    }
+    let key = yaml_mapping_key(trimmed)?;
+    Some((key, indent.saturating_add(1).try_into().unwrap_or(u32::MAX)))
+}
+
+fn clean_yaml_scalar(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string()
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.chars().take_while(|ch| *ch == ' ').count()
+}
+
+fn compose_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')
+}

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -3,6 +3,7 @@
 mod blanking;
 mod common;
 pub(crate) mod css;
+mod docker_compose;
 mod github_actions;
 mod html;
 mod sql;
@@ -18,11 +19,16 @@ pub fn structural_language_name(path: &Path) -> &'static str {
 use crate::intermediate_storage::IntermediateStorage;
 use anyhow::Result;
 use codestory_contracts::graph::NodeId;
-use codestory_contracts::language_support::is_github_actions_workflow_path;
+use codestory_contracts::language_support::{
+    is_docker_compose_path, is_github_actions_workflow_path,
+};
 use std::path::Path;
 
 pub fn is_structural_candidate_path(path: &Path) -> bool {
-    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+    let path_text = path.to_string_lossy();
+    if is_github_actions_workflow_path(path_text.as_ref())
+        || is_docker_compose_path(path_text.as_ref())
+    {
         return true;
     }
     matches!(
@@ -61,13 +67,16 @@ pub fn index_structural_source(path: &Path, source: &str) -> Result<Intermediate
     });
     storage.nodes.push(file_node);
 
-    if is_github_actions_workflow_path(path.to_string_lossy().as_ref()) {
+    let path_text = path.to_string_lossy();
+    if is_github_actions_workflow_path(path_text.as_ref()) {
         github_actions::collect_github_actions_workflow_entities(
             path,
             source,
             file_id,
             &mut storage,
         );
+    } else if is_docker_compose_path(path_text.as_ref()) {
+        docker_compose::collect_docker_compose_entities(path, source, file_id, &mut storage);
     } else {
         match structural_extension(path).as_deref() {
             Some("html" | "htm") => {
@@ -185,6 +194,96 @@ jobs:
     }
 
     #[test]
+    fn indexes_docker_compose_services_as_structural_source_proof() {
+        let compose = r#"name: codestory-retrieval
+
+services:
+  qdrant:
+    image: qdrant/qdrant:v1.12.5
+    ports:
+      - "127.0.0.1:${CODESTORY_QDRANT_HTTP_PORT:-6333}:6333"
+    environment:
+      QDRANT__LOG_LEVEL: INFO
+    volumes:
+      - type: bind
+        source: ${CODESTORY_QDRANT_DATA_DIR:?set CODESTORY_QDRANT_DATA_DIR}
+        target: /qdrant/storage
+  api:
+    build: .
+    environment:
+      - RUST_LOG=info
+"#;
+
+        let storage = index_structural_source(Path::new("docker/retrieval-compose.yml"), compose)
+            .expect("index compose");
+
+        assert_eq!(storage.files[0].language, "docker_compose");
+        assert!(
+            storage.nodes.iter().any(|node| {
+                node.kind == NodeKind::MODULE
+                    && node.serialized_name == "codestory-retrieval"
+                    && node.start_line == Some(1)
+                    && node.start_col == Some(7)
+            }),
+            "compose stack name should be an exact source-span node"
+        );
+        let qdrant = storage
+            .nodes
+            .iter()
+            .find(|node| {
+                node.kind == NodeKind::FUNCTION
+                    && node.serialized_name == "qdrant"
+                    && node
+                        .canonical_id
+                        .as_deref()
+                        .is_some_and(|value| value.contains("docker-compose:service:"))
+            })
+            .expect("qdrant service node");
+        assert_eq!(qdrant.start_line, Some(4));
+        assert_eq!(qdrant.start_col, Some(3));
+        assert_exact_compose_anchor(&storage, "image: qdrant/qdrant:v1.12.5", 5, 5);
+        assert_exact_compose_anchor(
+            &storage,
+            r#"- "127.0.0.1:${CODESTORY_QDRANT_HTTP_PORT:-6333}:6333""#,
+            7,
+            7,
+        );
+        assert_exact_compose_anchor(&storage, "QDRANT__LOG_LEVEL", 9, 7);
+        assert_exact_compose_anchor(&storage, "- type: bind", 11, 7);
+        assert_exact_compose_anchor(&storage, "build: .", 15, 5);
+        assert_exact_compose_anchor(&storage, "RUST_LOG", 17, 9);
+        assert!(
+            storage
+                .edges
+                .iter()
+                .any(|edge| edge.kind == EdgeKind::MEMBER)
+        );
+    }
+
+    #[test]
+    fn docker_compose_admission_is_path_scoped_not_generic_yaml() {
+        assert!(is_structural_candidate_path(Path::new(
+            "docker/retrieval-compose.yml"
+        )));
+        assert!(is_structural_candidate_path(Path::new("compose.yaml")));
+        assert!(!is_structural_candidate_path(Path::new("openapi.yaml")));
+        assert!(!is_structural_candidate_path(Path::new("docs/config.yml")));
+
+        let storage = index_structural_source(Path::new("compose.yml"), "openapi: 3.1.0\n")
+            .expect("index unsupported compose-shaped yaml");
+        assert!(
+            storage.nodes.iter().all(|node| {
+                !node
+                    .canonical_id
+                    .as_deref()
+                    .unwrap_or_default()
+                    .starts_with("docker-compose:")
+            }),
+            "unsupported compose-shaped yaml should not invent compose anchors"
+        );
+    }
+
+    #[test]
     fn unnamed_github_actions_workflow_uses_jobs_source_anchor() {
         let yaml = r#"on:
   push:
@@ -279,6 +378,26 @@ jobs:
             node.end_col,
             Some(col + source_anchor.len() as u32 - 1),
             "step span must cover only source text"
+        );
+    }
+
+    fn assert_exact_compose_anchor(
+        storage: &IntermediateStorage,
+        source_anchor: &str,
+        line: u32,
+        col: u32,
+    ) {
+        let node = storage
+            .nodes
+            .iter()
+            .find(|node| node.kind == NodeKind::ANNOTATION && node.serialized_name == source_anchor)
+            .unwrap_or_else(|| panic!("missing exact compose anchor {source_anchor}"));
+        assert_eq!(node.start_line, Some(line));
+        assert_eq!(node.start_col, Some(col));
+        assert_eq!(
+            node.end_col,
+            Some(col + source_anchor.len() as u32 - 1),
+            "compose span must cover only source text"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -4,7 +4,9 @@ use codestory_contracts::api::{
     AgentCitationDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto, SearchHit,
     SearchHitOrigin,
 };
-use codestory_contracts::language_support::is_github_actions_workflow_path;
+use codestory_contracts::language_support::{
+    is_docker_compose_path, is_github_actions_workflow_path,
+};
 
 pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
 pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
@@ -66,8 +68,11 @@ pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &
     if citation_is_structural_source_proof(citation) {
         citation.evidence_tier = Some(PacketEvidenceTier::ExactSource);
         citation.resolution_status = Some(evidence_resolution_for_citation(citation));
-        citation.evidence_producer =
-            Some("structural_github_actions_workflow_collector".to_string());
+        citation.evidence_producer = Some(
+            structural_source_proof_producer(citation.file_path.as_deref())
+                .unwrap_or("structural_source_proof_collector")
+                .to_string(),
+        );
         citation.eligible_for_sufficiency = Some(false);
         return;
     }
@@ -165,8 +170,8 @@ pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceReso
 }
 
 pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
-    if hit_is_structural_source_proof(hit) {
-        return "structural_github_actions_workflow_collector".to_string();
+    if let Some(producer) = structural_source_proof_producer(hit.file_path.as_deref()) {
+        return producer.to_string();
     }
     if let Some(producer) = hit.evidence_producer.as_ref() {
         return producer.clone();
@@ -228,16 +233,22 @@ fn evidence_resolution_for_citation(citation: &AgentCitationDto) -> PacketEviden
 }
 
 fn hit_is_structural_source_proof(hit: &SearchHit) -> bool {
-    hit.file_path
-        .as_deref()
-        .is_some_and(is_github_actions_workflow_path)
+    structural_source_proof_producer(hit.file_path.as_deref()).is_some()
 }
 
 fn citation_is_structural_source_proof(citation: &AgentCitationDto) -> bool {
-    citation
-        .file_path
-        .as_deref()
-        .is_some_and(is_github_actions_workflow_path)
+    structural_source_proof_producer(citation.file_path.as_deref()).is_some()
+}
+
+fn structural_source_proof_producer(path: Option<&str>) -> Option<&'static str> {
+    let path = path?;
+    if is_github_actions_workflow_path(path) {
+        return Some("structural_github_actions_workflow_collector");
+    }
+    if is_docker_compose_path(path) {
+        return Some("structural_docker_compose_collector");
+    }
+    None
 }
 
 #[cfg(test)]
@@ -290,6 +301,28 @@ mod tests {
         assert_eq!(
             hit.evidence_producer.as_deref(),
             Some("structural_github_actions_workflow_collector")
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn docker_compose_structural_hit_is_exact_source_diagnostic() {
+        let mut hit = workflow_hit();
+        hit.node_id = NodeId("compose-qdrant".to_string());
+        hit.display_name = "qdrant".to_string();
+        hit.file_path = Some("docker/retrieval-compose.yml".to_string());
+        hit.line = Some(4);
+
+        decorate_search_hit_evidence(&mut hit);
+
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(
+            hit.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("structural_docker_compose_collector")
         );
         assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -26,7 +26,7 @@ profiles to parser and rule construction in `get_language_for_ext`.
 | Runtime claim | Languages | Evidence floor | Safe claim |
 | --- | --- | --- | --- |
 | Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | fidelity lab, tictactoe coverage, raw graph contracts, targeted rule/resolution suites, opt-in OSS corpus | daily graph navigation on typical code, with caveats |
-| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows | structural collector tests | exact-source structural anchors |
+| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests | structural collector tests | exact-source structural anchors |
 
 Agent-facing packet/search quality is separate. The language-expansion A/B
 report is not blanket promotion proof for every parser-backed language.
@@ -71,12 +71,23 @@ the collector does not validate GitHub Actions execution semantics. Packet
 evidence treats these anchors as diagnostic unless a future structural role
 explicitly admits them; they must not satisfy semantic proof roles.
 
+Docker Compose support is path-scoped to `compose.yml`, `compose.yaml`,
+`docker-compose.yml`, `docker-compose.yaml`, and repo-local
+`docker/*-compose.{yml,yaml}` manifests. The collector emits stack, service,
+image/build, ports, environment-key, and volume anchors with `exact_source` /
+`source_range_only` evidence. Unsupported shapes stay explicit: YAML anchors,
+merge keys, includes, interpolation, profiles, healthchecks, dependency
+behavior, startup order, and container runtime behavior are not semantically
+resolved. Packet evidence treats these anchors as diagnostic unless a future
+structural role explicitly admits them; they must not satisfy semantic proof
+roles.
+
 Safe wording: packet-runtime is implemented and completing the suite, but
 publishable agent-facing packet quality is not promoted until a coherent run has
 all quality, sufficiency, and cold-SLA gates green. This evidence is a
 development/proof-gate signal, not public product-grade proof for every
-parser-backed language. HTML, CSS, SQL, and GitHub Actions workflows remain
-structural source-proof collectors.
+parser-backed language. HTML, CSS, SQL, GitHub Actions workflows, and Docker
+Compose manifests remain structural source-proof collectors.
 
 Older development comparison: the language-expansion comparison artifact built
 on 2026-06-17:
@@ -146,8 +157,8 @@ Workspace parser policy:
 
 Validation: each listed candidate passed an isolated `cargo check` probe with
 the policy pins; wired parser rows also passed a parse smoke. HTML, CSS, SQL,
-and GitHub Actions workflows remain structural runtime paths, not parser-backed
-runtime claims.
+GitHub Actions workflows, and Docker Compose manifests remain structural runtime
+paths, not parser-backed runtime claims.
 
 | Language | Candidate crate | Version checked | Decision |
 | --- | --- | ---: | --- |


### PR DESCRIPTION
## Context
Refs #172.

Issue #172 adds the next structural source-proof collector after the GitHub Actions pilot. The goal is exact-source Docker Compose anchors without widening YAML support or implying parser-backed graph/runtime semantics.

## What Changed
- Added path-scoped Docker Compose admission for standard Compose filenames plus repo-local `docker/*-compose.{yml,yaml}` manifests.
- Added a structural Compose collector for stack, service, image/build, ports, environment-key, and volume anchors with member edges and source spans.
- Added contract metadata/docs for Compose as `exact_source` / `source_range_only` structural evidence with `semantic_proof_allowed = false`.
- Updated packet evidence decoration so Compose structural hits stay diagnostic and ineligible for sufficiency unless a future role explicitly admits them.

## How To Review
- Start with `crates/codestory-indexer/src/structural/docker_compose.rs` and the tests in `crates/codestory-indexer/src/structural/mod.rs`.
- Check the path contract in `crates/codestory-contracts/src/language_support.rs` against the docs wording in `docs/architecture/language-support.md`.
- Confirm `crates/codestory-runtime/src/agent/packet_evidence.rs` keeps structural Compose hits out of sufficiency proof.

## Verification
- `cargo test -p codestory-indexer structural --lib` - 15 passed
- `cargo test -p codestory-contracts docker_compose --lib` - 2 passed
- `cargo test -p codestory-runtime packet_evidence --lib` - 6 passed
- `cargo fmt --check`
- `git diff --check`

Review lanes:
- PR-style correctness review: no blocking findings.
- Spec/boundary review: found two wording issues; both fixed before final verification.

## Risk
The collector is intentionally line-oriented and non-semantic. It does not interpret YAML anchors, merge keys, includes, interpolation, profiles, healthchecks, dependency behavior, startup order, or container runtime behavior. Richer Compose variants should be follow-up issues if they become necessary.