### PR TITLE
Demote OpenAPI endpoint evidence

### DIFF
--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -145,6 +145,12 @@ const DOCKER_COMPOSE_UNSUPPORTED_SHAPES: &[&str] = &[
     "Profiles, extends, health checks, dependency order, and runtime container behavior are not interpreted.",
     "The collector records exact source anchors; it does not validate Docker Compose execution semantics.",
 ];
+const OPENAPI_ENDPOINT_NODE_KINDS: &[NodeKind] = &[NodeKind::FUNCTION];
+const OPENAPI_ENDPOINT_UNSUPPORTED_SHAPES: &[&str] = &[
+    "Handler implementation, auth behavior, request validation, response semantics, and runtime route behavior are not proven.",
+    "Generated-client correctness is not proven.",
+    "The dedicated OpenAPI indexer records exact schema endpoint anchors; it is not generic YAML structural routing.",
+];
 
 pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = &[
     StructuralSourceProofContract {
@@ -169,6 +175,18 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         confidence: 1.0,
         unsupported_shape_notes: DOCKER_COMPOSE_UNSUPPORTED_SHAPES,
         claim_boundary: "structural exact-source proof only; not parser-backed graph parity, typed semantic resolution, container runtime behavior, or packet semantic-proof admission",
+        semantic_proof_allowed: false,
+    },
+    StructuralSourceProofContract {
+        collector_name: "openapi_endpoint_schema",
+        path_pattern: "OpenAPI/Swagger JSON or YAML schema files with paths",
+        emitted_node_kinds: OPENAPI_ENDPOINT_NODE_KINDS,
+        source_span: "1-based source line and column span for the matched schema endpoint method anchor",
+        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
+        confidence: 1.0,
+        unsupported_shape_notes: OPENAPI_ENDPOINT_UNSUPPORTED_SHAPES,
+        claim_boundary: "dedicated OpenAPI exact-source schema anchor only; not handler implementation, auth behavior, request validation, response semantics, runtime route proof, generated-client correctness, generic YAML support, or packet semantic-proof admission",
         semantic_proof_allowed: false,
     },
 ];
@@ -520,6 +538,35 @@ mod tests {
                 .unsupported_shape_notes
                 .iter()
                 .any(|note| note.contains("interpolation"))
+        );
+
+        let openapi_contract = STRUCTURAL_SOURCE_PROOF_CONTRACTS
+            .iter()
+            .find(|contract| contract.collector_name == "openapi_endpoint_schema")
+            .expect("OpenAPI endpoint schema contract");
+        assert_eq!(
+            openapi_contract.path_pattern,
+            "OpenAPI/Swagger JSON or YAML schema files with paths"
+        );
+        assert_eq!(openapi_contract.emitted_node_kinds, &[NodeKind::FUNCTION]);
+        assert_eq!(
+            openapi_contract.evidence_tier,
+            PacketEvidenceTierDto::ExactSource
+        );
+        assert_eq!(
+            openapi_contract.resolution,
+            PacketEvidenceResolutionDto::SourceRangeOnly
+        );
+        assert!(!openapi_contract.semantic_proof_allowed);
+        assert!(
+            openapi_contract
+                .claim_boundary
+                .contains("not handler implementation")
+        );
+        assert!(
+            openapi_contract
+                .claim_boundary
+                .contains("generic YAML support")
         );
     }
 

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -21032,6 +21032,38 @@ function render() {
     }
 
     #[test]
+    fn openapi_components_only_schema_emits_no_endpoint_anchors() -> Result<()> {
+        let schema = r#"{
+  "openapi": "3.1.0",
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object"
+      }
+    }
+  }
+}"#;
+
+        let storage = index_openapi_schema_file(Path::new("openapi.json"), schema)?;
+
+        assert!(storage.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn generic_yaml_with_paths_key_is_not_openapi() -> Result<()> {
+        let yaml = r#"name: build
+paths:
+  cache: target
+"#;
+
+        let storage = index_openapi_schema_file(Path::new("config.yml"), yaml)?;
+
+        assert!(storage.is_none());
+        Ok(())
+    }
+
+    #[test]
     fn github_actions_workflow_with_openapi_keys_stays_structural() -> Result<()> {
         let temp = tempdir()?;
         let workflow_dir = temp.path().join(".github").join("workflows");

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -8,6 +8,8 @@ use codestory_contracts::language_support::{
     is_docker_compose_file_path, is_github_actions_workflow_path,
 };
 
+const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
+
 pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
 pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
 
@@ -39,7 +41,7 @@ pub(crate) fn evidence_candidate_from_hit(hit: &SearchHit) -> EvidenceCandidate 
 
 pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
     let candidate = evidence_candidate_from_hit(hit);
-    let structural_source_proof = hit_is_structural_source_proof(hit);
+    let diagnostic_source_proof = hit_is_diagnostic_source_proof(hit);
     hit.evidence_tier = Some(candidate.tier);
     hit.evidence_producer = Some(candidate.producer);
     hit.resolution_status = Some(candidate.resolution);
@@ -47,7 +49,7 @@ pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
         hit.loss_reason = candidate.loss_reason;
     }
     hit.eligible_for_sufficiency = Some(
-        !structural_source_proof
+        !diagnostic_source_proof
             && evidence_is_sufficiency_eligible(candidate.tier, candidate.resolution),
     );
 }
@@ -65,14 +67,16 @@ pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &
         .or_else(|| Some(evidence_resolution_for_hit(hit)));
     citation.loss_reason = hit.loss_reason.clone();
     citation.coverage_role = hit.coverage_role.clone();
-    if citation_is_structural_source_proof(citation) {
+    if citation_is_diagnostic_source_proof(citation) {
         citation.evidence_tier = Some(PacketEvidenceTier::ExactSource);
         citation.resolution_status = Some(evidence_resolution_for_citation(citation));
-        citation.evidence_producer = citation
-            .file_path
-            .as_deref()
-            .and_then(structural_source_proof_producer)
-            .map(str::to_string);
+        if citation.evidence_producer.is_none() {
+            citation.evidence_producer = citation
+                .file_path
+                .as_deref()
+                .and_then(structural_source_proof_producer)
+                .map(str::to_string);
+        }
         citation.eligible_for_sufficiency = Some(false);
         return;
     }
@@ -104,7 +108,7 @@ pub(crate) fn evidence_is_sufficiency_eligible(
 }
 
 pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool {
-    if citation_is_structural_source_proof(citation) {
+    if citation_is_diagnostic_source_proof(citation) {
         return citation.eligible_for_sufficiency.unwrap_or(false);
     }
     let tier = citation
@@ -119,7 +123,7 @@ pub(crate) fn citation_sufficiency_eligible(citation: &AgentCitationDto) -> bool
 }
 
 pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
-    if hit_is_structural_source_proof(hit) {
+    if hit_is_diagnostic_source_proof(hit) {
         return PacketEvidenceTier::ExactSource;
     }
     if let Some(tier) = hit.evidence_tier {
@@ -150,7 +154,7 @@ pub(crate) fn evidence_tier_for_hit(hit: &SearchHit) -> PacketEvidenceTier {
 }
 
 pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceResolution {
-    if hit_is_structural_source_proof(hit) {
+    if hit_is_diagnostic_source_proof(hit) {
         return if hit.file_path.is_some() && hit.line.is_some() {
             PacketEvidenceResolution::SourceRangeOnly
         } else {
@@ -170,6 +174,9 @@ pub(crate) fn evidence_resolution_for_hit(hit: &SearchHit) -> PacketEvidenceReso
 }
 
 pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
+    if hit_is_openapi_endpoint_schema(hit) {
+        return OPENAPI_ENDPOINT_SCHEMA_PRODUCER.to_string();
+    }
     if hit_is_structural_source_proof(hit) {
         return hit
             .file_path
@@ -193,7 +200,7 @@ pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
 }
 
 fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
-    if citation_is_structural_source_proof(citation) {
+    if citation_is_diagnostic_source_proof(citation) {
         return PacketEvidenceTier::ExactSource;
     }
     if let Some(breakdown) = citation.retrieval_score_breakdown.as_ref() {
@@ -221,7 +228,7 @@ fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier
 }
 
 fn evidence_resolution_for_citation(citation: &AgentCitationDto) -> PacketEvidenceResolution {
-    if citation_is_structural_source_proof(citation) {
+    if citation_is_diagnostic_source_proof(citation) {
         return if citation.file_path.is_some() && citation.line.is_some() {
             PacketEvidenceResolution::SourceRangeOnly
         } else {
@@ -243,11 +250,27 @@ fn hit_is_structural_source_proof(hit: &SearchHit) -> bool {
         .is_some_and(is_structural_source_proof_path)
 }
 
+fn hit_is_diagnostic_source_proof(hit: &SearchHit) -> bool {
+    hit_is_structural_source_proof(hit) || hit_is_openapi_endpoint_schema(hit)
+}
+
+fn hit_is_openapi_endpoint_schema(hit: &SearchHit) -> bool {
+    hit.evidence_producer.as_deref() == Some(OPENAPI_ENDPOINT_SCHEMA_PRODUCER)
+}
+
 fn citation_is_structural_source_proof(citation: &AgentCitationDto) -> bool {
     citation
         .file_path
         .as_deref()
         .is_some_and(is_structural_source_proof_path)
+}
+
+fn citation_is_diagnostic_source_proof(citation: &AgentCitationDto) -> bool {
+    citation_is_structural_source_proof(citation) || citation_is_openapi_endpoint_schema(citation)
+}
+
+fn citation_is_openapi_endpoint_schema(citation: &AgentCitationDto) -> bool {
+    citation.evidence_producer.as_deref() == Some(OPENAPI_ENDPOINT_SCHEMA_PRODUCER)
 }
 
 fn is_structural_source_proof_path(path: &str) -> bool {
@@ -267,7 +290,9 @@ fn structural_source_proof_producer(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use codestory_contracts::api::{NodeId, NodeKind, RetrievalScoreBreakdownDto, SearchHitOrigin};
+    use codestory_contracts::api::{
+        AgentCitationDto, NodeId, NodeKind, RetrievalScoreBreakdownDto, SearchHitOrigin,
+    };
 
     fn workflow_hit() -> SearchHit {
         SearchHit {
@@ -338,5 +363,74 @@ mod tests {
             Some("structural_docker_compose_collector")
         );
         assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn openapi_endpoint_hit_is_exact_source_diagnostic() {
+        let mut hit = workflow_hit();
+        hit.node_id = NodeId("openapi-endpoint".to_string());
+        hit.display_name = "GET /api/users".to_string();
+        hit.file_path = Some("openapi.json".to_string());
+        hit.evidence_producer = Some("openapi_endpoint_schema".to_string());
+
+        decorate_search_hit_evidence(&mut hit);
+
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(
+            hit.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("openapi_endpoint_schema")
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn openapi_endpoint_citation_is_not_sufficiency_eligible() {
+        let mut hit = workflow_hit();
+        hit.node_id = NodeId("openapi-endpoint".to_string());
+        hit.display_name = "GET /api/users".to_string();
+        hit.file_path = Some("openapi.json".to_string());
+        hit.evidence_producer = Some("openapi_endpoint_schema".to_string());
+        decorate_search_hit_evidence(&mut hit);
+
+        let mut citation = AgentCitationDto {
+            node_id: hit.node_id.clone(),
+            display_name: hit.display_name.clone(),
+            kind: hit.kind,
+            file_path: hit.file_path.clone(),
+            line: hit.line,
+            score: hit.score,
+            origin: hit.origin,
+            resolvable: hit.resolvable,
+            subgraph_id: None,
+            evidence_edge_ids: Vec::new(),
+            retrieval_score_breakdown: None,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: None,
+        };
+
+        decorate_citation_from_hit(&mut citation, &hit);
+
+        assert_eq!(
+            citation.evidence_tier,
+            Some(PacketEvidenceTier::ExactSource)
+        );
+        assert_eq!(
+            citation.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
+        assert_eq!(
+            citation.evidence_producer.as_deref(),
+            Some("openapi_endpoint_schema")
+        );
+        assert_eq!(citation.eligible_for_sufficiency, Some(false));
+        assert!(!citation_sufficiency_eligible(&citation));
     }
 }

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -2939,6 +2939,29 @@ mod tests {
     }
 
     #[test]
+    fn openapi_endpoint_exact_source_does_not_satisfy_semantic_packet_proof() {
+        let mut citation = cited_anchor_with_tier(
+            "GET /api/users",
+            "openapi.json",
+            PacketEvidenceTierDto::ExactSource,
+            None,
+        );
+        citation.evidence_producer = Some("openapi_endpoint_schema".to_string());
+        citation.resolution_status = Some(PacketEvidenceResolutionDto::SourceRangeOnly);
+        let claim = cited_claim(
+            "The schema declares GET /api/users.",
+            Some("request_entrypoint"),
+            citation,
+            None,
+        );
+
+        assert!(
+            !packet_claim_can_satisfy_sufficiency(&claim),
+            "OpenAPI endpoint schema anchors are diagnostic source ranges, not handler/runtime proof"
+        );
+    }
+
+    #[test]
     fn covered_flow_roles_make_missing_probe_queries_follow_up_hints() {
         let question = "Explain how the form validation examples combine native HTML constraints with custom JavaScript validation.";
         let answer = answer_fixture(question);

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -7390,6 +7390,11 @@ impl AppController {
             }
         }
 
+        let openapi_endpoint = node
+            .canonical_id
+            .as_deref()
+            .is_some_and(|value| value.starts_with("openapi:endpoint:"));
+
         Some(SearchHit {
             node_id: NodeId::from(id),
             display_name,
@@ -7400,14 +7405,27 @@ impl AppController {
             origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
             match_quality: None,
             resolvable: true,
-            evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::ResolvedGraph),
-            evidence_producer: Some("route_endpoint".to_string()),
-            resolution_status: Some(
-                codestory_contracts::api::PacketEvidenceResolutionDto::Resolved,
+            evidence_tier: Some(if openapi_endpoint {
+                codestory_contracts::api::PacketEvidenceTierDto::ExactSource
+            } else {
+                codestory_contracts::api::PacketEvidenceTierDto::ResolvedGraph
+            }),
+            evidence_producer: Some(
+                if openapi_endpoint {
+                    "openapi_endpoint_schema"
+                } else {
+                    "route_endpoint"
+                }
+                .to_string(),
             ),
+            resolution_status: Some(if openapi_endpoint {
+                codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly
+            } else {
+                codestory_contracts::api::PacketEvidenceResolutionDto::Resolved
+            }),
             loss_reason: None,
             coverage_role: None,
-            eligible_for_sufficiency: Some(true),
+            eligible_for_sufficiency: Some(!openapi_endpoint),
             score_breakdown: None,
         })
     }
@@ -13973,6 +13991,48 @@ fn build_llm_symbol_doc_text() -> String {
         let mut hits = [text_only, ast.clone()];
         hits.sort_by(|left, right| compare_search_hits("/api/users", left, right));
         assert_eq!(hits.first().map(|hit| &hit.node_id), Some(&ast.node_id));
+    }
+
+    #[test]
+    fn build_search_hit_marks_openapi_endpoints_as_diagnostic_source() {
+        let mut storage = Storage::new_in_memory().expect("storage");
+        storage
+            .insert_nodes_batch(&[
+                Node {
+                    id: CoreNodeId(30),
+                    kind: NodeKind::FILE,
+                    serialized_name: "openapi.json".to_string(),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(31),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "GET /api/users".to_string(),
+                    file_node_id: Some(CoreNodeId(30)),
+                    canonical_id: Some("openapi:endpoint:GET /api/users".to_string()),
+                    start_line: Some(7),
+                    ..Default::default()
+                },
+            ])
+            .expect("insert OpenAPI nodes");
+        let node_names = HashMap::from([(CoreNodeId(31), "GET /api/users".to_string())]);
+
+        let hit = AppController::build_search_hit(&storage, &node_names, CoreNodeId(31), 1.0)
+            .expect("OpenAPI endpoint hit");
+
+        assert_eq!(
+            hit.evidence_tier,
+            Some(codestory_contracts::api::PacketEvidenceTierDto::ExactSource)
+        );
+        assert_eq!(
+            hit.resolution_status,
+            Some(codestory_contracts::api::PacketEvidenceResolutionDto::SourceRangeOnly)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("openapi_endpoint_schema")
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }
 
     #[test]

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -26,7 +26,7 @@ profiles to parser and rule construction in `get_language_for_ext`.
 | Runtime claim | Languages | Evidence floor | Safe claim |
 | --- | --- | --- | --- |
 | Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | fidelity lab, tictactoe coverage, raw graph contracts, targeted rule/resolution suites, opt-in OSS corpus | daily graph navigation on typical code, with caveats |
-| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests | structural collector tests | exact-source structural anchors |
+| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, dedicated OpenAPI/Swagger endpoint schema anchors | structural collector and OpenAPI schema-anchor tests | exact-source structural/schema anchors |
 
 Agent-facing packet/search quality is separate. The language-expansion A/B
 report is not blanket promotion proof for every parser-backed language.
@@ -68,20 +68,28 @@ The pilot emits workflow, job, and step anchors with `exact_source` /
 `compose*.{yml,yaml}`, `docker-compose*.{yml,yaml}`, and
 `docker/*-compose.{yml,yaml}` style manifests; it emits stack, service, image or
 build, ports, environment key, and volume anchors with the same exact-source
-boundary. Unsupported shapes stay explicit: YAML anchors and merge keys are not
+boundary. OpenAPI/Swagger endpoint schemas stay on the dedicated OpenAPI
+indexing path and emit `openapi:endpoint:*` anchors as `exact_source` /
+`source_range_only` diagnostic evidence only; they do not make generic YAML an
+OpenAPI surface. Unsupported shapes stay explicit: YAML anchors and merge keys are not
 interpreted, matrix expansion and expressions are not resolved, reusable
 workflows and shell bodies are not semantically traced, Compose interpolation,
 profiles, health checks, dependency order, and runtime container behavior are
-not interpreted, and neither collector validates execution semantics. Packet
-evidence treats these anchors as diagnostic unless a future structural role
-explicitly admits them; they must not satisfy semantic proof roles.
+not interpreted, and schema endpoint anchors do not prove handler
+implementation, auth behavior, request validation, response semantics, runtime
+route behavior, or generated-client correctness. Packet evidence treats these
+anchors as diagnostic unless a future structural role explicitly admits them;
+they must not satisfy semantic proof roles.
 
-Safe wording: packet-runtime is implemented and completing the suite, but
+Safe wording: OpenAPI endpoint anchors prove only that a schema declares the
+method/path at the cited source range. Packet-runtime is implemented and
+completing the suite, but
 publishable agent-facing packet quality is not promoted until a coherent run has
 all quality, sufficiency, and cold-SLA gates green. This evidence is a
 development/proof-gate signal, not public product-grade proof for every
 parser-backed language. HTML, CSS, SQL, GitHub Actions workflows, and Docker
-Compose manifests remain structural source-proof collectors.
+Compose manifests remain structural source-proof collectors; OpenAPI schemas
+remain a dedicated schema-anchor path.
 
 Older development comparison: the language-expansion comparison artifact built
 on 2026-06-17:


### PR DESCRIPTION
## Context

OpenAPI endpoint schema anchors already exist, but #176 asks that packet/search evidence make the proof boundary explicit. These anchors prove only the schema source range, not handler implementation, auth behavior, request validation, response semantics, runtime routing, or generated-client correctness.

Closes #176
Refs #174
Refs #150
Refs #38

## What Changed

- Mark OpenAPI endpoint search hits/citations as `exact_source` / `source_range_only` diagnostic evidence via the existing OpenAPI canonical id path.
- Keep `openapi:endpoint:*` anchors on the dedicated OpenAPI indexing path and out of generic structural YAML routing.
- Add contract/docs wording for OpenAPI endpoint schema anchors and their non-proof boundaries.
- Add guards for workflow YAML with OpenAPI-like keys, components-only schemas, generic YAML with `paths:`, and Docker Compose structural routing.

## How To Review

- Start with `crates/codestory-runtime/src/lib.rs` to see where OpenAPI endpoint search hits are tagged.
- Then read `crates/codestory-runtime/src/agent/packet_evidence.rs` and `packet_sufficiency.rs` for diagnostic demotion and sufficiency exclusion.
- Check `crates/codestory-indexer/src/lib.rs` for OpenAPI/routing negative cases.
- Check `crates/codestory-contracts/src/language_support.rs` and `docs/architecture/language-support.md` for the updated contract wording.

## Verification

- `cargo test -p codestory-runtime openapi_endpoint --lib -- --nocapture`
- `cargo test -p codestory-indexer openapi --lib -- --nocapture`
- `cargo test -p codestory-contracts structural_source_proof_contract_is_exact_source_not_semantic --lib -- --nocapture`
- `cargo test -p codestory-indexer docker_compose --lib -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

## Risk

Low. The change is scoped to OpenAPI endpoint evidence metadata and packet sufficiency eligibility. It does not change OpenAPI parsing, YAML parsing, workflow routing, Docker Compose structural collection, or generic YAML admission.