### PR TITLE
Add Cargo manifest structural source proof

### DIFF
--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -151,6 +151,13 @@ const OPENAPI_ENDPOINT_UNSUPPORTED_SHAPES: &[&str] = &[
     "Generated-client correctness is not proven.",
     "The dedicated OpenAPI indexer records exact schema endpoint anchors; it is not generic YAML structural routing.",
 ];
+const CARGO_MANIFEST_NODE_KINDS: &[NodeKind] =
+    &[NodeKind::MODULE, NodeKind::PACKAGE, NodeKind::ANNOTATION];
+const CARGO_MANIFEST_UNSUPPORTED_SHAPES: &[&str] = &[
+    "Dependency resolution, feature activation, workspace inheritance, build-script behavior, and lockfile proof are not interpreted.",
+    "Target-scoped dependency tables, workspace dependency tables, dependency subtables, features, patch, and replace tables are not semantic proof.",
+    "The collector records exact source anchors for selected manifest keys only; it does not validate Cargo behavior.",
+];
 
 pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = &[
     StructuralSourceProofContract {
@@ -187,6 +194,18 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
         confidence: 1.0,
         unsupported_shape_notes: OPENAPI_ENDPOINT_UNSUPPORTED_SHAPES,
         claim_boundary: "dedicated OpenAPI exact-source schema anchor only; not handler implementation, auth behavior, request validation, response semantics, runtime route proof, generated-client correctness, generic YAML support, or packet semantic-proof admission",
+        semantic_proof_allowed: false,
+    },
+    StructuralSourceProofContract {
+        collector_name: "cargo_manifest",
+        path_pattern: "**/Cargo.toml",
+        emitted_node_kinds: CARGO_MANIFEST_NODE_KINDS,
+        source_span: "1-based source line and column span for matched workspace member, package name, or direct dependency key anchors",
+        evidence_tier: PacketEvidenceTierDto::ExactSource,
+        resolution: PacketEvidenceResolutionDto::SourceRangeOnly,
+        confidence: 1.0,
+        unsupported_shape_notes: CARGO_MANIFEST_UNSUPPORTED_SHAPES,
+        claim_boundary: "structural exact-source proof only; not parser-backed graph parity, typed semantic resolution, not semantic dependency proof, Cargo resolution, or packet semantic-proof admission",
         semantic_proof_allowed: false,
     },
 ];
@@ -345,6 +364,13 @@ pub fn is_docker_compose_file_path(path: &str) -> bool {
     stem.starts_with("compose")
         || stem.starts_with("docker-compose")
         || (stem.ends_with("-compose") && parts.any(|part| part == "docker"))
+}
+
+pub fn is_cargo_manifest_file_path(path: &str) -> bool {
+    path.replace('\\', "/")
+        .rsplit('/')
+        .next()
+        .is_some_and(|file_name| file_name == "Cargo.toml")
 }
 
 pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
@@ -568,6 +594,41 @@ mod tests {
                 .claim_boundary
                 .contains("generic YAML support")
         );
+
+        let cargo_contract = STRUCTURAL_SOURCE_PROOF_CONTRACTS
+            .iter()
+            .find(|contract| contract.collector_name == "cargo_manifest")
+            .expect("cargo manifest structural contract");
+        assert_eq!(cargo_contract.path_pattern, "**/Cargo.toml");
+        assert!(
+            cargo_contract
+                .emitted_node_kinds
+                .contains(&NodeKind::MODULE)
+        );
+        assert!(
+            cargo_contract
+                .emitted_node_kinds
+                .contains(&NodeKind::PACKAGE)
+        );
+        assert!(
+            cargo_contract
+                .emitted_node_kinds
+                .contains(&NodeKind::ANNOTATION)
+        );
+        assert_eq!(
+            cargo_contract.evidence_tier,
+            PacketEvidenceTierDto::ExactSource
+        );
+        assert_eq!(
+            cargo_contract.resolution,
+            PacketEvidenceResolutionDto::SourceRangeOnly
+        );
+        assert!(!cargo_contract.semantic_proof_allowed);
+        assert!(
+            cargo_contract
+                .claim_boundary
+                .contains("not semantic dependency proof")
+        );
     }
 
     #[test]
@@ -603,5 +664,17 @@ mod tests {
         assert!(!is_docker_compose_file_path("openapi.yaml"));
         assert!(!is_docker_compose_file_path("docs/service.yml"));
         assert!(language_support_profile_for_ext("yaml").is_none());
+    }
+
+    #[test]
+    fn cargo_manifest_path_is_basename_scoped_not_toml_support() {
+        assert!(is_cargo_manifest_file_path("Cargo.toml"));
+        assert!(is_cargo_manifest_file_path("crates/tool/Cargo.toml"));
+        assert!(is_cargo_manifest_file_path(r"crates\tool\Cargo.toml"));
+        assert!(!is_cargo_manifest_file_path("cargo.toml"));
+        assert!(!is_cargo_manifest_file_path("config.toml"));
+        assert!(!is_cargo_manifest_file_path(".cargo/config.toml"));
+        assert!(!is_cargo_manifest_file_path("Cargo.lock"));
+        assert!(language_support_profile_for_ext("toml").is_none());
     }
 }

--- a/crates/codestory-indexer/src/structural/cargo_manifest.rs
+++ b/crates/codestory-indexer/src/structural/cargo_manifest.rs
@@ -1,0 +1,181 @@
+use crate::intermediate_storage::IntermediateStorage;
+use codestory_contracts::graph::{NodeId, NodeKind};
+use std::path::Path;
+
+use super::common::{push_member_edge, push_structural_node};
+
+pub(crate) fn collect_cargo_manifest_entities(
+    path: &Path,
+    source: &str,
+    file_id: NodeId,
+    storage: &mut IntermediateStorage,
+) {
+    let path_key = path.to_string_lossy().replace('\\', "/");
+    let mut section = Section::Other;
+    let mut package_id = None;
+    let mut in_workspace_members = false;
+
+    for (line_idx, line_text) in source.lines().enumerate() {
+        let line = line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX);
+        let trimmed = line_text.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        if let Some(next) = section_header(trimmed) {
+            section = next;
+            in_workspace_members = false;
+            continue;
+        }
+
+        if section == Section::Workspace
+            && (in_workspace_members || toml_key(trimmed) == Some("members"))
+        {
+            in_workspace_members = !line_text.contains(']');
+            for (member, col) in quoted_values(line_text) {
+                let member_id = push_structural_node(
+                    storage,
+                    file_id,
+                    NodeKind::MODULE,
+                    &member,
+                    &format!("cargo-manifest:workspace-member:{path_key}:{member}"),
+                    line,
+                    col,
+                );
+                push_member_edge(storage, file_id, file_id, member_id, line);
+            }
+            continue;
+        }
+
+        if section == Section::Package && toml_key(trimmed) == Some("name") {
+            if let Some((name, col)) = first_quoted_value(line_text) {
+                let id = push_structural_node(
+                    storage,
+                    file_id,
+                    NodeKind::PACKAGE,
+                    &name,
+                    &format!("cargo-manifest:package:{path_key}:{name}"),
+                    line,
+                    col,
+                );
+                push_member_edge(storage, file_id, file_id, id, line);
+                package_id = Some(id);
+            }
+            continue;
+        }
+
+        if section.is_dependency_table()
+            && let Some((dependency, col)) = dependency_key(line_text)
+        {
+            let dep_id = push_structural_node(
+                storage,
+                file_id,
+                NodeKind::ANNOTATION,
+                &dependency,
+                &format!(
+                    "cargo-manifest:dependency:{path_key}:{}:{dependency}",
+                    section.name()
+                ),
+                line,
+                col,
+            );
+            push_member_edge(
+                storage,
+                file_id,
+                package_id.unwrap_or(file_id),
+                dep_id,
+                line,
+            );
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Section {
+    Workspace,
+    Package,
+    Dependencies,
+    DevDependencies,
+    BuildDependencies,
+    Other,
+}
+
+impl Section {
+    fn is_dependency_table(self) -> bool {
+        matches!(
+            self,
+            Self::Dependencies | Self::DevDependencies | Self::BuildDependencies
+        )
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Dependencies => "dependencies",
+            Self::DevDependencies => "dev-dependencies",
+            Self::BuildDependencies => "build-dependencies",
+            _ => "manifest",
+        }
+    }
+}
+
+fn section_header(trimmed: &str) -> Option<Section> {
+    let inner = trimmed.strip_prefix('[')?.strip_suffix(']')?;
+    Some(match inner {
+        "workspace" => Section::Workspace,
+        "package" => Section::Package,
+        "dependencies" => Section::Dependencies,
+        "dev-dependencies" => Section::DevDependencies,
+        "build-dependencies" => Section::BuildDependencies,
+        _ => Section::Other,
+    })
+}
+
+fn toml_key(trimmed: &str) -> Option<&str> {
+    trimmed.split_once('=')?.0.trim().split_whitespace().next()
+}
+
+fn dependency_key(line: &str) -> Option<(String, u32)> {
+    let (raw_key, _) = line.split_once('=')?;
+    let key = raw_key.trim();
+    if key.is_empty() || key.contains('.') {
+        return None;
+    }
+    let key = key.trim_matches('"').trim_matches('\'');
+    let start = raw_key.find(key)?;
+    Some((
+        key.to_string(),
+        start.saturating_add(1).try_into().unwrap_or(u32::MAX),
+    ))
+}
+
+fn first_quoted_value(line: &str) -> Option<(String, u32)> {
+    quoted_values(line).into_iter().next()
+}
+
+fn quoted_values(line: &str) -> Vec<(String, u32)> {
+    let mut values = Vec::new();
+    let bytes = line.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if !matches!(bytes[index], b'"' | b'\'') {
+            index += 1;
+            continue;
+        }
+        let quote = bytes[index];
+        let start = index + 1;
+        let mut end = start;
+        while end < bytes.len() && bytes[end] != quote {
+            end += 1;
+        }
+        if end < bytes.len() {
+            values.push((
+                line[start..end].to_string(),
+                start.saturating_add(1).try_into().unwrap_or(u32::MAX),
+            ));
+            index = end + 1;
+        } else {
+            break;
+        }
+    }
+    values
+}

--- a/crates/codestory-indexer/src/structural/cargo_manifest.rs
+++ b/crates/codestory-indexer/src/structural/cargo_manifest.rs
@@ -17,7 +17,8 @@ pub(crate) fn collect_cargo_manifest_entities(
 
     for (line_idx, line_text) in source.lines().enumerate() {
         let line = line_idx.saturating_add(1).try_into().unwrap_or(u32::MAX);
-        let trimmed = line_text.trim();
+        let code_text = strip_toml_comment(line_text);
+        let trimmed = code_text.trim();
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
@@ -31,8 +32,8 @@ pub(crate) fn collect_cargo_manifest_entities(
         if section == Section::Workspace
             && (in_workspace_members || toml_key(trimmed) == Some("members"))
         {
-            in_workspace_members = !line_text.contains(']');
-            for (member, col) in quoted_values(line_text) {
+            in_workspace_members = !code_text.contains(']');
+            for (member, col) in quoted_values(code_text) {
                 let member_id = push_structural_node(
                     storage,
                     file_id,
@@ -48,7 +49,7 @@ pub(crate) fn collect_cargo_manifest_entities(
         }
 
         if section == Section::Package && toml_key(trimmed) == Some("name") {
-            if let Some((name, col)) = first_quoted_value(line_text) {
+            if let Some((name, col)) = first_quoted_value(code_text) {
                 let id = push_structural_node(
                     storage,
                     file_id,
@@ -65,7 +66,7 @@ pub(crate) fn collect_cargo_manifest_entities(
         }
 
         if section.is_dependency_table()
-            && let Some((dependency, col)) = dependency_key(line_text)
+            && let Some((dependency, col)) = dependency_key(code_text)
         {
             let dep_id = push_structural_node(
                 storage,
@@ -128,6 +129,25 @@ fn section_header(trimmed: &str) -> Option<Section> {
         "build-dependencies" => Section::BuildDependencies,
         _ => Section::Other,
     })
+}
+
+fn strip_toml_comment(line: &str) -> &str {
+    let mut quote = None;
+    let mut escaped = false;
+    for (idx, ch) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match (quote, ch) {
+            (Some('"'), '\\') => escaped = true,
+            (Some(current), value) if value == current => quote = None,
+            (None, '"' | '\'') => quote = Some(ch),
+            (None, '#') => return &line[..idx],
+            _ => {}
+        }
+    }
+    line
 }
 
 fn toml_key(trimmed: &str) -> Option<&str> {

--- a/crates/codestory-indexer/src/structural/common.rs
+++ b/crates/codestory-indexer/src/structural/common.rs
@@ -4,7 +4,8 @@ use codestory_contracts::graph::{
     ResolutionCertainty, SourceLocation,
 };
 use codestory_contracts::language_support::{
-    is_docker_compose_file_path, is_github_actions_workflow_path, structural_language_name_for_path,
+    is_cargo_manifest_file_path, is_docker_compose_file_path, is_github_actions_workflow_path,
+    structural_language_name_for_path,
 };
 use std::path::Path;
 
@@ -15,6 +16,9 @@ pub(crate) fn structural_language_name(path: &Path) -> &'static str {
     }
     if is_docker_compose_file_path(path.as_ref()) {
         return "docker_compose";
+    }
+    if is_cargo_manifest_file_path(path.as_ref()) {
+        return "cargo_manifest";
     }
     structural_language_name_for_path(Some(path.as_ref())).unwrap_or("structural")
 }

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -328,13 +328,13 @@ services:
 
     #[test]
     fn indexes_cargo_manifest_source_proof_anchors() {
-        let source = r#"[workspace]
-members = ["crates/api", "crates/cli"]
+        let source = r#"[workspace] # workspace table
+members = ["crates/api", "crates/cli"] # "not-a-member"
 
 [package]
 name = "demo"
 
-[dependencies]
+[dependencies] # direct dependencies only
 serde = "1"
 tokio = { version = "1" }
 
@@ -358,6 +358,9 @@ default = ["serde"]
 
 [patch.crates-io]
 serde = { git = "https://example.invalid/serde" }
+
+[replace]
+replace_serde = { path = "vendor/serde" }
 "#;
 
         let storage = index_structural_source(Path::new("Cargo.toml"), source).unwrap();
@@ -370,7 +373,14 @@ serde = { git = "https://example.invalid/serde" }
         assert_manifest_node_span(&storage, NodeKind::ANNOTATION, "tokio", 9, 1);
         assert_manifest_node_span(&storage, NodeKind::ANNOTATION, "pretty_assertions", 12, 1);
         assert_manifest_node_span(&storage, NodeKind::ANNOTATION, "cc", 15, 1);
-        for ignored in ["libc", "anyhow", "tracing", "default"] {
+        for ignored in [
+            "libc",
+            "anyhow",
+            "tracing",
+            "default",
+            "not-a-member",
+            "replace_serde",
+        ] {
             assert!(
                 !storage
                     .nodes

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -1,6 +1,7 @@
 //! Structural-language entity collectors (HTML, CSS, SQL) with explicit node/edge mapping.
 
 mod blanking;
+mod cargo_manifest;
 mod common;
 pub(crate) mod css;
 mod docker_compose;
@@ -20,7 +21,7 @@ use crate::intermediate_storage::IntermediateStorage;
 use anyhow::Result;
 use codestory_contracts::graph::NodeId;
 use codestory_contracts::language_support::{
-    is_docker_compose_file_path, is_github_actions_workflow_path,
+    is_cargo_manifest_file_path, is_docker_compose_file_path, is_github_actions_workflow_path,
 };
 use std::path::Path;
 
@@ -28,6 +29,7 @@ pub fn is_structural_candidate_path(path: &Path) -> bool {
     let path_text = path.to_string_lossy();
     if is_github_actions_workflow_path(path_text.as_ref())
         || is_docker_compose_file_path(path_text.as_ref())
+        || is_cargo_manifest_file_path(path_text.as_ref())
     {
         return true;
     }
@@ -77,6 +79,8 @@ pub fn index_structural_source(path: &Path, source: &str) -> Result<Intermediate
         );
     } else if is_docker_compose_file_path(path_key.as_ref()) {
         docker_compose::collect_docker_compose_entities(path, source, file_id, &mut storage);
+    } else if is_cargo_manifest_file_path(path_key.as_ref()) {
+        cargo_manifest::collect_cargo_manifest_entities(path, source, file_id, &mut storage);
     } else {
         match structural_extension(path).as_deref() {
             Some("html" | "htm") => {
@@ -310,6 +314,74 @@ services:
     }
 
     #[test]
+    fn cargo_manifest_admission_is_basename_scoped_not_generic_toml() {
+        assert!(is_structural_candidate_path(Path::new("Cargo.toml")));
+        assert!(is_structural_candidate_path(Path::new(
+            "crates/codestory-cli/Cargo.toml"
+        )));
+        assert!(!is_structural_candidate_path(Path::new("config.toml")));
+        assert!(!is_structural_candidate_path(Path::new(
+            ".cargo/config.toml"
+        )));
+        assert!(!is_structural_candidate_path(Path::new("Cargo.lock")));
+    }
+
+    #[test]
+    fn indexes_cargo_manifest_source_proof_anchors() {
+        let source = r#"[workspace]
+members = ["crates/api", "crates/cli"]
+
+[package]
+name = "demo"
+
+[dependencies]
+serde = "1"
+tokio = { version = "1" }
+
+[dev-dependencies]
+pretty_assertions = "1"
+
+[build-dependencies]
+cc = "1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[workspace.dependencies]
+anyhow = "1"
+
+[dependencies.tracing]
+version = "0.1"
+
+[features]
+default = ["serde"]
+
+[patch.crates-io]
+serde = { git = "https://example.invalid/serde" }
+"#;
+
+        let storage = index_structural_source(Path::new("Cargo.toml"), source).unwrap();
+
+        assert_eq!(storage.files[0].language, "cargo_manifest");
+        assert_manifest_node_span(&storage, NodeKind::MODULE, "crates/api", 2, 13);
+        assert_manifest_node_span(&storage, NodeKind::MODULE, "crates/cli", 2, 27);
+        assert_manifest_node_span(&storage, NodeKind::PACKAGE, "demo", 5, 9);
+        assert_manifest_node_span(&storage, NodeKind::ANNOTATION, "serde", 8, 1);
+        assert_manifest_node_span(&storage, NodeKind::ANNOTATION, "tokio", 9, 1);
+        assert_manifest_node_span(&storage, NodeKind::ANNOTATION, "pretty_assertions", 12, 1);
+        assert_manifest_node_span(&storage, NodeKind::ANNOTATION, "cc", 15, 1);
+        for ignored in ["libc", "anyhow", "tracing", "default"] {
+            assert!(
+                !storage
+                    .nodes
+                    .iter()
+                    .any(|node| node.serialized_name == ignored),
+                "unsupported Cargo table should not emit {ignored}"
+            );
+        }
+    }
+
+    #[test]
     fn unnamed_github_actions_workflow_uses_jobs_source_anchor() {
         let yaml = r#"on:
   push:
@@ -425,6 +497,27 @@ jobs:
             node.end_col,
             Some(col + source_anchor.len() as u32 - 1),
             "compose span must cover only source text"
+        );
+    }
+
+    fn assert_manifest_node_span(
+        storage: &IntermediateStorage,
+        kind: NodeKind,
+        source_anchor: &str,
+        line: u32,
+        col: u32,
+    ) {
+        let node = storage
+            .nodes
+            .iter()
+            .find(|node| node.kind == kind && node.serialized_name == source_anchor)
+            .unwrap_or_else(|| panic!("missing Cargo manifest source anchor {source_anchor}"));
+        assert_eq!(node.start_line, Some(line));
+        assert_eq!(node.start_col, Some(col));
+        assert_eq!(
+            node.end_col,
+            Some(col + source_anchor.len() as u32 - 1),
+            "Cargo manifest span must cover only source text"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -5,7 +5,7 @@ use codestory_contracts::api::{
     SearchHitOrigin,
 };
 use codestory_contracts::language_support::{
-    is_docker_compose_file_path, is_github_actions_workflow_path,
+    is_cargo_manifest_file_path, is_docker_compose_file_path, is_github_actions_workflow_path,
 };
 
 const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
@@ -274,7 +274,9 @@ fn citation_is_openapi_endpoint_schema(citation: &AgentCitationDto) -> bool {
 }
 
 fn is_structural_source_proof_path(path: &str) -> bool {
-    is_github_actions_workflow_path(path) || is_docker_compose_file_path(path)
+    is_github_actions_workflow_path(path)
+        || is_docker_compose_file_path(path)
+        || is_cargo_manifest_file_path(path)
 }
 
 fn structural_source_proof_producer(path: &str) -> Option<&'static str> {
@@ -283,6 +285,9 @@ fn structural_source_proof_producer(path: &str) -> Option<&'static str> {
     }
     if is_docker_compose_file_path(path) {
         return Some("structural_docker_compose_collector");
+    }
+    if is_cargo_manifest_file_path(path) {
+        return Some("structural_cargo_manifest_collector");
     }
     None
 }
@@ -383,6 +388,28 @@ mod tests {
         assert_eq!(
             hit.evidence_producer.as_deref(),
             Some("openapi_endpoint_schema")
+        );
+        assert_eq!(hit.eligible_for_sufficiency, Some(false));
+    }
+
+    #[test]
+    fn cargo_manifest_structural_hit_is_exact_source_diagnostic() {
+        let mut hit = workflow_hit();
+        hit.node_id = NodeId("cargo-serde".to_string());
+        hit.display_name = "serde".to_string();
+        hit.file_path = Some("crates/app/Cargo.toml".to_string());
+        hit.line = Some(8);
+
+        decorate_search_hit_evidence(&mut hit);
+
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::ExactSource));
+        assert_eq!(
+            hit.resolution_status,
+            Some(PacketEvidenceResolution::SourceRangeOnly)
+        );
+        assert_eq!(
+            hit.evidence_producer.as_deref(),
+            Some("structural_cargo_manifest_collector")
         );
         assert_eq!(hit.eligible_for_sufficiency, Some(false));
     }

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -611,6 +611,14 @@ fn normalize_exclude_match_key(path: &Path) -> String {
 }
 
 fn matches_source_group_language(path: &Path, language: &Language) -> bool {
+    if matches!(language, Language::Rust)
+        && codestory_contracts::language_support::is_cargo_manifest_file_path(
+            path.to_string_lossy().as_ref(),
+        )
+    {
+        return true;
+    }
+
     let Some(extension) = path
         .extension()
         .and_then(|ext| ext.to_str())
@@ -980,6 +988,26 @@ mod tests {
                 "compatibility-only source extension should stay accepted by workspace discovery: {extension}"
             );
         }
+    }
+
+    #[test]
+    fn rust_source_groups_keep_cargo_manifest_but_not_generic_toml() {
+        assert!(matches_source_group_language(
+            Path::new("Cargo.toml"),
+            &Language::Rust
+        ));
+        assert!(matches_source_group_language(
+            Path::new("crates/tool/Cargo.toml"),
+            &Language::Rust
+        ));
+        assert!(!matches_source_group_language(
+            Path::new("config.toml"),
+            &Language::Rust
+        ));
+        assert!(!matches_source_group_language(
+            Path::new("Cargo.lock"),
+            &Language::Rust
+        ));
     }
 
     #[test]

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -26,7 +26,7 @@ profiles to parser and rule construction in `get_language_for_ext`.
 | Runtime claim | Languages | Evidence floor | Safe claim |
 | --- | --- | --- | --- |
 | Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | fidelity lab, tictactoe coverage, raw graph contracts, targeted rule/resolution suites, opt-in OSS corpus | daily graph navigation on typical code, with caveats |
-| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, dedicated OpenAPI/Swagger endpoint schema anchors | structural collector and OpenAPI schema-anchor tests | exact-source structural/schema anchors |
+| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, basename-scoped Cargo manifests, dedicated OpenAPI/Swagger endpoint schema anchors | structural collector and OpenAPI schema-anchor tests | exact-source structural/schema anchors |
 
 Agent-facing packet/search quality is separate. The language-expansion A/B
 report is not blanket promotion proof for every parser-backed language.
@@ -77,9 +77,18 @@ workflows and shell bodies are not semantically traced, Compose interpolation,
 profiles, health checks, dependency order, and runtime container behavior are
 not interpreted, and schema endpoint anchors do not prove handler
 implementation, auth behavior, request validation, response semantics, runtime
-route behavior, or generated-client correctness. Packet evidence treats these
-anchors as diagnostic unless a future structural role explicitly admits them;
-they must not satisfy semantic proof roles.
+route behavior, or generated-client correctness. Neither collector validates
+execution semantics.
+Cargo manifest support is basename-scoped to `Cargo.toml`. It emits `[workspace]`
+member, `[package]` name, and direct dependency-key anchors from `[dependencies]`,
+`[dev-dependencies]`, and `[build-dependencies]` with the same exact-source /
+source-range-only boundary. It does not admit generic TOML, `Cargo.lock`,
+target-scoped dependency tables, `[workspace.dependencies]`, dependency
+subtables, feature tables, patch or replace tables, dependency resolution,
+feature activation, workspace inheritance, build-script behavior, or lockfile
+proof. Packet evidence treats these anchors as diagnostic unless a future
+structural role explicitly admits them; they must not satisfy semantic proof
+roles or semantic dependency proof.
 
 Safe wording: OpenAPI endpoint anchors prove only that a schema declares the
 method/path at the cited source range. Packet-runtime is implemented and
@@ -87,9 +96,9 @@ completing the suite, but
 publishable agent-facing packet quality is not promoted until a coherent run has
 all quality, sufficiency, and cold-SLA gates green. This evidence is a
 development/proof-gate signal, not public product-grade proof for every
-parser-backed language. HTML, CSS, SQL, GitHub Actions workflows, and Docker
-Compose manifests remain structural source-proof collectors; OpenAPI schemas
-remain a dedicated schema-anchor path.
+parser-backed language. HTML, CSS, SQL, GitHub Actions workflows, Docker Compose
+manifests, and Cargo manifests remain structural source-proof collectors;
+OpenAPI schemas remain a dedicated schema-anchor path.
 
 Older development comparison: the language-expansion comparison artifact built
 on 2026-06-17:


### PR DESCRIPTION
## Context
Closes #178
Refs #173
Refs #150
Refs #38

#178 adds a Cargo manifest structural source-proof seed after the Docker Compose collector and after #180's OpenAPI diagnostic evidence landed on `main`.

## What Changed
- Added basename-scoped `Cargo.toml` structural routing, rejecting generic `.toml` files and `Cargo.lock`.
- Added a minimal Cargo manifest collector for `[workspace]` members, `[package]` name, and direct dependency keys in `[dependencies]`, `[dev-dependencies]`, and `[build-dependencies]`.
- Kept target-scoped dependency tables, `[workspace.dependencies]`, dependency subtables, feature tables, patch/replace tables, and semantic dependency claims out of the collector.
- Updated structural proof contracts, Rust source-group discovery, packet evidence diagnostics, and language-support docs.

## How To Review
- Start with `crates/codestory-indexer/src/structural/cargo_manifest.rs` and the new structural tests in `crates/codestory-indexer/src/structural/mod.rs`.
- Check `crates/codestory-contracts/src/language_support.rs` for exact-source/source-range-only contract wording alongside the OpenAPI contract from #180.
- Check `crates/codestory-workspace/src/lib.rs` for the Rust-only `Cargo.toml` discovery exception.
- Check `crates/codestory-runtime/src/agent/packet_evidence.rs` to confirm Cargo manifest evidence remains diagnostic and sufficiency-ineligible.

## Verification
- `cargo run --release -p codestory-cli -- doctor --project . --format json` with `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe` (degraded: `retrieval_manifest_missing`; source/tests used as proof layer)
- `cargo test -p codestory-indexer structural::tests:: --lib`
- `cargo test -p codestory-contracts cargo_manifest --lib`
- `cargo test -p codestory-contracts structural_source_proof_contract_is_exact_source_not_semantic --lib`
- `cargo test -p codestory-workspace rust_source_groups_keep_cargo_manifest_but_not_generic_toml --lib`
- `cargo test -p codestory-runtime agent::packet_evidence::tests:: --lib`
- `cargo test -p codestory-indexer github_actions_workflow_with_openapi_keys_stays_structural --lib`
- `cargo fmt --check`
- `git diff --check`

## Risk
- The collector is intentionally line-oriented and source-range-only; it does not parse or validate Cargo semantics.
- Multi-line arrays are handled for quoted workspace members, but Cargo resolution, features, workspace inheritance, build scripts, lockfiles, and target-specific dependencies remain out of scope.
- Packet/search readiness was not trusted from this worktree because `doctor` reported missing retrieval sidecar state.