### PR TITLE
[codex] reduce strict packet batch probes

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -95,13 +95,7 @@ pub(crate) fn run_packet_planned_subqueries(
         return Ok(());
     }
 
-    let pending: Vec<(usize, &PacketPlanQueryDto)> = plan
-        .queries
-        .iter()
-        .enumerate()
-        .skip(1)
-        .take(limit)
-        .collect();
+    let pending = packet_planned_subqueries(plan, budget, limit);
     if pending.is_empty() {
         return Ok(());
     }
@@ -407,6 +401,37 @@ fn packet_subquery_limit(budget: PacketBudgetModeDto) -> usize {
     }
 }
 
+fn packet_planned_subqueries(
+    plan: &PacketPlanDto,
+    budget: PacketBudgetModeDto,
+    limit: usize,
+) -> Vec<(usize, &PacketPlanQueryDto)> {
+    plan.queries
+        .iter()
+        .enumerate()
+        .skip(1)
+        .take(limit)
+        .filter(|(_, query)| packet_planned_subquery_should_run(budget, query))
+        .collect()
+}
+
+fn packet_planned_subquery_should_run(
+    budget: PacketBudgetModeDto,
+    query: &PacketPlanQueryDto,
+) -> bool {
+    if !packet_subquery_is_lexical_only(budget, query) {
+        return true;
+    }
+    if !query
+        .purpose
+        .contains("concrete symbol, file, route, or code term")
+    {
+        return true;
+    }
+    let trimmed = query.query.trim();
+    query_has_symbol_or_literal_signal(trimmed) || is_packet_code_like_term(trimmed)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn run_packet_anchor_expansion(
     controller: &AppController,
@@ -630,9 +655,20 @@ pub(crate) fn packet_anchor_probe_queries(plan: &PacketPlanDto) -> Vec<String> {
             *index,
         )
     });
+    let mut seen = HashSet::<String>::new();
     ranked
         .into_iter()
-        .map(|(_, query)| query.query.clone())
+        .filter_map(|(_, query)| {
+            if is_packet_path_like_query(&query.query) {
+                return Some(query.query.clone());
+            }
+            let key = normalize_identifier(&query.query);
+            if key.len() < 2 || seen.insert(key) {
+                Some(query.query.clone())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -842,6 +878,78 @@ mod tests {
     }
 
     #[test]
+    fn packet_planned_subqueries_skip_low_signal_lexical_concrete_terms() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::RouteTracing,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Trace how Redis initializes command routing".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Trace".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Redis".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "initializes".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let pending = packet_planned_subqueries(&plan, PacketBudgetModeDto::Compact, 3);
+
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn packet_planned_subqueries_keep_code_like_terms_and_deep_semantic_terms() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain string predicate helpers".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "StringUtils".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "CharSequenceUtils".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "Commons".to_string(),
+                    purpose: "concrete symbol, file, route, or code term".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let compact = packet_planned_subqueries(&plan, PacketBudgetModeDto::Compact, 3)
+            .into_iter()
+            .map(|(_, query)| query.query.as_str())
+            .collect::<Vec<_>>();
+        let deep = packet_planned_subqueries(&plan, PacketBudgetModeDto::Deep, 3)
+            .into_iter()
+            .map(|(_, query)| query.query.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(compact, ["StringUtils", "CharSequenceUtils"]);
+        assert_eq!(deep, ["StringUtils", "CharSequenceUtils", "Commons"]);
+    }
+
+    #[test]
     fn packet_anchor_probe_queries_prioritize_symbol_probes_under_reduced_windows() {
         let plan = PacketPlanDto {
             task_class: PacketTaskClassDto::ArchitectureExplanation,
@@ -890,6 +998,75 @@ mod tests {
                 "exec_events.rs".to_string(),
                 "workspace/app/src/lib.rs".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn packet_anchor_probe_queries_count_normalized_variants_once() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain predicate helpers".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "isBlank".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "is_blank".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "StringUtils.java isBlank".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let queries = packet_anchor_probe_queries(&plan);
+
+        assert_eq!(
+            queries,
+            [
+                "isBlank".to_string(),
+                "StringUtils.java isBlank".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn packet_anchor_probe_queries_keep_path_like_normalized_matches() {
+        let plan = PacketPlanDto {
+            task_class: PacketTaskClassDto::ArchitectureExplanation,
+            inferred_task_class: false,
+            queries: vec![
+                PacketPlanQueryDto {
+                    query: "Explain library entrypoints".to_string(),
+                    purpose: "original task phrasing for sidecar-primary source-backed retrieval"
+                        .to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "src/lib.rs".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+                PacketPlanQueryDto {
+                    query: "src_lib_rs".to_string(),
+                    purpose: "symbol probe expanded from task wording".to_string(),
+                },
+            ],
+            trace: Vec::new(),
+        };
+
+        let queries = packet_anchor_probe_queries(&plan);
+
+        assert_eq!(
+            queries,
+            ["src/lib.rs".to_string(), "src_lib_rs".to_string()]
         );
     }
 


### PR DESCRIPTION
## Context

Closes #190
Refs #78

PR #187 made `batch_query_wall_ms` visible and the post-#187 Apache/Redis artifact showed the residual inside strict sidecar batch query execution/wait, not DTO/export plumbing. This PR keeps the lane to one product-safe reduction: ask the strict sidecar batch for fewer redundant or low-signal packet probes.

This is draft. When accepted, it closes #190 only; it does not claim full #78 closure beyond the Apache/Redis focused lane.

## What Changed

- Filters planned subqueries after the existing packet budget window so lexical-only concrete terms run only when they have symbol/literal/code-like signal. There is no backfill, so the change can only reduce that strict batch.
- Deduplicates normalized non-path anchor probe variants before the strict sidecar batch while preserving path-like probes.
- Adds focused tests for low-signal lexical pruning, Deep semantic preservation, code-like planned terms, normalized anchor dedupe, and path-like anchor preservation.

```mermaid
flowchart LR
    A["packet plan"] --> B["budget window"]
    B --> C["planned subquery filter"]
    C --> D["strict sidecar batch"]
    A --> E["anchor probes"]
    E --> F["normalized dedupe"]
    F --> D
```

## How To Review

- Start in `crates/codestory-runtime/src/agent/packet_batch.rs` at `packet_planned_subqueries` and `packet_anchor_probe_queries`.
- Check that the planned-subquery filter only applies to lexical-only concrete-term queries; Deep semantic planned subqueries remain eligible.
- Check that anchor dedupe skips only normalized non-path duplicates and keeps path-like probes.

## Verification

- `cargo run --release -p codestory-cli -- doctor --project .`
  - Result: completed, `status: needs_attention`; local index has `nodes=0 edges=0 files=0`, sidecar retrieval is `mode=unavailable degraded_reason=retrieval_manifest_missing`. I did not use this worktree's packet/search as source truth.
- `cargo test -p codestory-runtime packet_batch --lib`
  - Result: 16 passed, 0 failed.
- `cargo test -p codestory-runtime retrieval_primary --lib`
  - Result: 29 passed, 0 failed.
- `cargo test -p codestory-retrieval query --lib`
  - Result: 15 passed, 0 failed, 1 ignored live-sidecar test.
- `cargo fmt --check`
  - Result: passed.
- `git diff --check`
  - Result: passed.
- `cargo build --release -p codestory-cli`
  - Result: passed.
- Focused Apache/Redis cold packet-runtime publishable run:
  - Command: `node scripts\codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite language-expansion-holdout --task-ids java-commons-lang-string-utils,c-redis-command-loop --repeats 3 --materialize-repos --jobs 1 --prepare-codestory-jobs 1 --codestory-cli .\target\release\codestory-cli.exe --out-dir target\agent-benchmark\issue-190-strict-sidecar-batch-wait --timeout-ms 180000 --max-source-reads-after-packet 0 --publishable`
  - Result: exited 0 and wrote `C:\Users\alber\.codex\worktrees\3a12\codestory\target\agent-benchmark\issue-190-strict-sidecar-batch-wait`.
  - Apache: `0/3` SLA misses, quality `3/3`, sufficiency `sufficient:3`, trace SLA retrieval median `13281 ms`.
  - Redis: `0/3` SLA misses, quality `3/3`, sufficiency `sufficient:3`, trace SLA retrieval median `9561 ms`.
  - Old post-#187 strict batch wall medians to this run: Apache anchor `3983 -> 3195 ms`, Apache lexical `2151 -> 1865 ms`; Redis anchor `2796 -> 2280 ms`, Redis lexical `2400 ms -> no lexical subquery batch`.

## Risk

- Evidence is intentionally focused to Apache/Redis cold packet-runtime rows. No full AB suite or warm lane was run.
- This changes which low-signal lexical-only planned terms are queried; focused quality and sufficiency stayed green, and tests cover Deep/path-like safety boundaries.
- #78 remains broader than this PR unless the coordinator accepts the focused lane as sufficient for that saga state.
