### PR TITLE
[codex] bump codestory version to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Context

Closes #189
Refs #181
Refs #38

PR #185 landed the #186 stale pre-release docs cleanup on `main` at `6ccbed4b85398bf3d50e37cb4cc8664c24ed4139`. This PR performs the follow-up patch version bump only.

Requested shorthand `0.10.01` is normalized to Cargo/SemVer `0.10.1`.

## What Changed

- Bumped every `codestory-*` workspace crate manifest from `0.10.0` to `0.10.1`.
- Bumped the matching `codestory-*` package entries in `Cargo.lock` from `0.10.0` to `0.10.1`.
- Left historical `0.10.0` changelog text and unrelated dependency versions untouched.
- Did not create or push any `v*` release tag.

## How To Review

- Confirm the diff is limited to Cargo package-version surfaces and `Cargo.lock`.
- Use `crates/codestory-cli/Cargo.toml` as the release version source.
- Confirm no generated release ledgers, CSV/SVG reports, benchmark dashboards, or process docs were added.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.10.1` -> `CodeStory release version 0.10.1 is synchronized across 8 workspace crates and Cargo.lock.`
- `node .github/scripts/check-workflow-policy.mjs` -> `Workflow policy passed: third-party actions and saga issue-link guard are valid.`
- `cargo fmt --check` -> passed with no output.
- `cargo check --workspace` with `RUSTC_WRAPPER=$env:USERPROFILE\.cargo\bin\sccache.exe` and `CARGO_BUILD_JOBS=1` -> `Finished dev profile [unoptimized + debuginfo] target(s) in 7m 33s`.
- `git diff --check` -> passed with no output.

## Risk / follow-up

- Low: this is a version-only Cargo/SemVer bump after the #186/#185 cleanup landed.
- Release automation has not run yet; it should run only after this PR is merged to `main`.
- No manual `v*` tag was created or pushed.