### PR TITLE
Document dev PR flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@
 ## Commit & Pull Request Guidelines
 - Commit messages are short, lowercase, imperative (e.g., `fix minimap`, `refactor graph style`).
 - PRs should include a summary, tests run, linked issues, and relevant artifacts for behavior changes.
+- Routine implementation PRs branch from and target `dev/codestory-next`. Do not target `main` directly unless the lane is an explicit release, hotfix, final comparison/review artifact, or promotion.
+- Agent branches should use the `codex/` prefix by default. Saga comparison/review branches may use `review/codestory-saga-*` when the branch exists only to support a reviewer comparison.
+- The saga issue-link guard applies to `codex/*` heads, `review/codestory-saga-*` heads, `[codex]` PR titles, and PRs labeled `saga:codestory-intelligence`. Guarded PRs must include a closing issue reference (`Closes #123`, `Fixes #123`, `Resolves #123`, or the full GitHub issue URL) for the PR-sized issue. Use `Refs #...` only for broader parents or related context. For PRs targeting `dev/codestory-next`, add both the issue and PR to the Project because GitHub's computed Linked pull requests field may not populate until default-branch promotion.
+- If a slice is partial under a larger saga, create or use a PR-sized child issue and close that issue in the PR body; do not close the parent until its acceptance criteria are actually met.
+- Keep release comparisons, ledgers, and generated pre-release evidence in PR bodies, issue comments, project updates, or external artifacts. Do not commit generated comparison docs/CSVs/SVGs into the repo unless they are intended to become durable product documentation.
 
 ## Release Guidelines
 - `crates/codestory-cli/Cargo.toml` is the release version source.


### PR DESCRIPTION
Closes #194

## What Changed
- Updated AGENTS.md with the canonical dev branch flow for routine implementation PRs.
- Documented the saga issue-link guard triggers and the required closing issue reference for PR-sized issues.
- Added the dev-targeted PR caveat: add both the issue and PR to the Project because GitHub's computed Linked pull requests field may not populate until default-branch promotion.
- Captured the rule that generated release comparison evidence belongs in PR bodies, issue comments, project updates, or external artifacts unless it is durable product documentation.

## Why
Future sessions were still at risk of targeting main, using non-closing Refs links that fail the saga guard/default-branch linking path, assuming dev-targeted PRs automatically fill the Project linked-PR field, or committing temporary review ledgers into repo docs.

## How I Verified
- git diff --check
- gh pr checks 195
- Project readback for #194/#195 after adding both items and marking them In Progress

## Risk / Follow-up
Guidance-only change. No runtime behavior changed.