### PR TITLE
[codex] move contracts deps to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ tokenizers = { version = "0.23.1", default-features = false, features = ["onig"]
 # Utilities
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = "3.15.1"
+specta = { version = "2.0.0-rc.22", features = ["derive", "serde"] }
 tokio = { version = "1", features = ["full"] }
 fs4 = "0.13.1"
 rayon = "1.11"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -11,5 +11,5 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-serde_with = "3.15.1"
-specta = { version = "2.0.0-rc.22", features = ["derive", "serde"] }
+serde_with = { workspace = true }
+specta = { workspace = true }


### PR DESCRIPTION
## Context

`codestory-contracts` still declared `serde_with` and `specta` directly while nearby shared dependencies are owned from `[workspace.dependencies]`.

Closes #203
Refs #38

## What Changed

- Added `serde_with` and `specta` to root `[workspace.dependencies]`.
- Switched `crates/codestory-contracts/Cargo.toml` to `{ workspace = true }` for both dependencies.

## How To Review

- Review the two manifest changes only: `Cargo.toml` and `crates/codestory-contracts/Cargo.toml`.
- Confirm no generated docs, release ledgers, benchmark artifacts, or version numbers changed.

## Verification

- `cargo check -p codestory-contracts --locked`
- `cargo fmt --check`
- `git diff --check`

## Risk

Low. This is a manifest-only ownership cleanup using the same resolved lockfile dependencies.