### PR TITLE
Tighten packet anchors for #205

### DIFF
--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -1090,6 +1090,9 @@ fn maybe_append_generic_source_shape_citations(
         css_animation_flow,
         &mut candidates,
     );
+    if url_session_request_flow {
+        collect_cited_request_validation_shape_candidates(answer, &mut candidates);
+    }
     candidates.sort_by(|left, right| {
         right
             .score
@@ -1861,6 +1864,13 @@ fn collect_form_validation_shape_candidates(
         });
     }
     if let Some(input_id) = packet_first_html_input_id(source) {
+        let score = if packet_first_form_validation_bypass_attribute(source).is_some()
+            || source_lower.contains("validity")
+        {
+            132.0
+        } else {
+            128.0
+        };
         candidates.push(PacketGenericSourceShapeCandidate {
             path: path.to_path_buf(),
             display_name: format!("input#{input_id}"),
@@ -1868,8 +1878,20 @@ fn collect_form_validation_shape_candidates(
             line: packet_source_line_containing(source, &format!("id=\"{input_id}\""))
                 .or_else(|| packet_source_line_containing(source, &format!("id='{input_id}'")))
                 .unwrap_or(1),
-            score: 128.0,
+            score,
             coverage_role: "form_custom_input".to_string(),
+            producer: "packet_generic_form_validation_source_probe".to_string(),
+            eligible_for_sufficiency: true,
+        });
+    }
+    if let Some((function, line)) = packet_first_form_validation_error_function(source) {
+        candidates.push(PacketGenericSourceShapeCandidate {
+            path: path.to_path_buf(),
+            display_name: function,
+            kind: NodeKind::FUNCTION,
+            line,
+            score: 134.0,
+            coverage_role: "form_custom_error_rendering".to_string(),
             producer: "packet_generic_form_validation_source_probe".to_string(),
             eligible_for_sufficiency: true,
         });
@@ -1998,17 +2020,84 @@ fn collect_url_session_request_shape_candidates(
     if source_lower.contains("func validate")
         && (source_lower.contains("validators") || source_lower.contains("validation"))
     {
+        let score = if type_name.to_ascii_lowercase().contains("data") {
+            138.0
+        } else {
+            135.0
+        };
         candidates.push(PacketGenericSourceShapeCandidate {
             path: path.to_path_buf(),
             display_name: format!("{type_name}.validate"),
             kind: NodeKind::METHOD,
             line: packet_source_line_containing(source, "func validate").unwrap_or(1),
-            score: 135.0,
+            score,
             coverage_role: "request_validation_pipeline".to_string(),
             producer: "packet_generic_url_session_request_source_probe".to_string(),
             eligible_for_sufficiency: true,
         });
     }
+    if source_lower.contains("urlsession")
+        && source_lower.contains("func urlsession")
+        && (source_lower.contains("didreceive") || source_lower.contains("didcomplete"))
+    {
+        candidates.push(PacketGenericSourceShapeCandidate {
+            path: path.to_path_buf(),
+            display_name: format!("{type_name}.urlSession"),
+            kind: NodeKind::METHOD,
+            line: packet_source_line_containing(source, "func urlSession").unwrap_or(1),
+            score: 137.0,
+            coverage_role: "session_callbacks".to_string(),
+            producer: "packet_generic_url_session_request_source_probe".to_string(),
+            eligible_for_sufficiency: true,
+        });
+    }
+}
+
+fn collect_cited_request_validation_shape_candidates(
+    answer: &AgentAnswerDto,
+    candidates: &mut Vec<PacketGenericSourceShapeCandidate>,
+) {
+    for citation in &answer.citations {
+        let Some(path) = citation.file_path.as_deref().map(Path::new) else {
+            continue;
+        };
+        if path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_none_or(|extension| !extension.eq_ignore_ascii_case("swift"))
+        {
+            continue;
+        }
+        let Some(type_name) = path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        if normalize_identifier(type_name) != normalize_identifier(&citation.display_name) {
+            continue;
+        }
+        let Ok(source) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if !packet_swift_request_validation_source(&source) {
+            continue;
+        }
+        candidates.push(PacketGenericSourceShapeCandidate {
+            path: path.to_path_buf(),
+            display_name: format!("{}.validate", citation.display_name),
+            kind: NodeKind::METHOD,
+            line: packet_source_line_containing(&source, "func validate").unwrap_or(1),
+            score: 140.0,
+            coverage_role: "request_validation_pipeline".to_string(),
+            producer: "packet_generic_url_session_request_source_probe".to_string(),
+            eligible_for_sufficiency: true,
+        });
+    }
+}
+
+fn packet_swift_request_validation_source(source: &str) -> bool {
+    let source_lower = source.to_ascii_lowercase();
+    source_lower.contains("func validate")
+        && source_lower.contains("request")
+        && (source_lower.contains("validators") || source_lower.contains("validation"))
 }
 
 fn packet_first_form_validation_bypass_attribute(source: &str) -> Option<(String, u32)> {
@@ -2058,6 +2147,28 @@ fn packet_first_html_input_id(source: &str) -> Option<String> {
         }
     }
     None
+}
+
+fn packet_first_form_validation_error_function(source: &str) -> Option<(String, u32)> {
+    let source_lower = source.to_ascii_lowercase();
+    if !(source_lower.contains("validity.valuemissing")
+        || source_lower.contains("validity.typemismatch")
+        || source_lower.contains("validity.tooshort"))
+    {
+        return None;
+    }
+    source.lines().enumerate().find_map(|(index, line)| {
+        let trimmed = line.trim();
+        let name = trimmed.strip_prefix("function ")?.split_once('(')?.0.trim();
+        if name.is_empty() || !name.chars().all(packet_source_identifier_char) {
+            return None;
+        }
+        let normalized = normalize_identifier(name);
+        (normalized.contains("error") || normalized.contains("message")).then_some((
+            name.to_string(),
+            index.saturating_add(1).try_into().unwrap_or(u32::MAX),
+        ))
+    })
 }
 
 fn packet_source_line_containing(source: &str, needle: &str) -> Option<u32> {
@@ -12711,6 +12822,17 @@ mod tests {
             <form novalidate>
               <input id="mail" type="email" required>
             </form>
+            <script>
+              function showError() {
+                if (mail.validity.valueMissing) {
+                  error.textContent = "Email required";
+                } else if (mail.validity.typeMismatch) {
+                  error.textContent = "Email invalid";
+                } else if (mail.validity.tooShort) {
+                  error.textContent = "Email too short";
+                }
+              }
+            </script>
             "#,
         );
 
@@ -12755,6 +12877,14 @@ mod tests {
                     && citation.coverage_role.as_deref() == Some("form_custom_input")
             }),
             "expected input id source shape: {:?}",
+            answer.citations
+        );
+        assert!(
+            answer.citations.iter().any(|citation| {
+                citation.display_name == "showError"
+                    && citation.coverage_role.as_deref() == Some("form_custom_error_rendering")
+            }),
+            "expected custom error rendering source shape: {:?}",
             answer.citations
         );
 
@@ -12836,6 +12966,32 @@ mod tests {
             }
             "#,
         );
+        write_packet_fixture_file(
+            &root,
+            "Source/Core/DownloadRequest.swift",
+            r#"
+            open class DownloadRequest: Request {
+              public func validate(_ validation: @escaping Validation) -> Self {
+                validators.write { $0.append(validation) }
+                return self
+              }
+            }
+            "#,
+        );
+        write_packet_fixture_file(
+            &root,
+            "Source/Core/SessionDelegate.swift",
+            r#"
+            open class SessionDelegate: NSObject, URLSessionDataDelegate {
+              open func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+                request.didReceive(data: data)
+              }
+              open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+                request.didReceiveResponse(nil)
+              }
+            }
+            "#,
+        );
 
         let prompt = "Trace how a Session creates requests, resumes tasks, validates data requests, and receives URLSession callbacks.";
         let mut answer = packet_answer_fixture(prompt, Vec::new());
@@ -12855,6 +13011,71 @@ mod tests {
                     && citation.coverage_role.as_deref() == Some("request_validation_pipeline")
             }),
             "expected request validation source anchor: {:?}",
+            answer.citations
+        );
+        let data_rank = answer
+            .citations
+            .iter()
+            .position(|citation| citation.display_name == "DataRequest.validate")
+            .expect("DataRequest.validate anchor");
+        let download_rank = answer
+            .citations
+            .iter()
+            .position(|citation| citation.display_name == "DownloadRequest.validate")
+            .expect("DownloadRequest.validate anchor");
+        assert!(
+            data_rank < download_rank,
+            "data-bearing request validation should outrank sibling validation anchors: {:?}",
+            answer.citations
+        );
+        assert!(
+            answer.citations.iter().any(|citation| {
+                citation.display_name == "SessionDelegate.urlSession"
+                    && citation.coverage_role.as_deref() == Some("session_callbacks")
+            }),
+            "expected URLSession delegate callback source anchor: {:?}",
+            answer.citations
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn generic_source_shape_scan_adds_cited_request_validation_anchor() {
+        let root = packet_temp_root("generic-source-shape-cited-urlsession");
+        let _ = std::fs::remove_dir_all(&root);
+        let request_path = root.join("Example").join("BodyRequest.swift");
+        write_packet_fixture_file(
+            &root,
+            "Example/BodyRequest.swift",
+            r#"
+            open class BodyRequest: Request {
+              public func validate(_ validation: @escaping Validation) -> Self {
+                validators.write { $0.append(validation) }
+                eventMonitor?.request(self, didValidateRequest: request)
+                return self
+              }
+            }
+            "#,
+        );
+
+        let prompt = "Trace how a Session creates requests, resumes tasks, validates data requests, and receives URLSession callbacks.";
+        let mut answer = packet_answer_fixture(
+            prompt,
+            vec![test_packet_citation(
+                "BodyRequest",
+                &request_path.to_string_lossy(),
+                0.9,
+            )],
+        );
+        maybe_append_generic_source_shape_citations(&root, prompt, &mut answer);
+
+        assert!(
+            answer.citations.iter().any(|citation| {
+                citation.display_name == "BodyRequest.validate"
+                    && citation.coverage_role.as_deref() == Some("request_validation_pipeline")
+            }),
+            "expected cited request validation source anchor: {:?}",
             answer.citations
         );
 

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -1091,7 +1091,7 @@ fn maybe_append_generic_source_shape_citations(
         &mut candidates,
     );
     if url_session_request_flow {
-        collect_cited_request_validation_shape_candidates(answer, &mut candidates);
+        collect_cited_request_validation_shape_candidates(project_root, answer, &mut candidates);
     }
     candidates.sort_by(|left, right| {
         right
@@ -2054,12 +2054,18 @@ fn collect_url_session_request_shape_candidates(
 }
 
 fn collect_cited_request_validation_shape_candidates(
+    project_root: &Path,
     answer: &AgentAnswerDto,
     candidates: &mut Vec<PacketGenericSourceShapeCandidate>,
 ) {
     for citation in &answer.citations {
         let Some(path) = citation.file_path.as_deref().map(Path::new) else {
             continue;
+        };
+        let source_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            project_root.join(path)
         };
         if path
             .extension()
@@ -2074,14 +2080,14 @@ fn collect_cited_request_validation_shape_candidates(
         if normalize_identifier(type_name) != normalize_identifier(&citation.display_name) {
             continue;
         }
-        let Ok(source) = std::fs::read_to_string(path) else {
+        let Ok(source) = std::fs::read_to_string(&source_path) else {
             continue;
         };
         if !packet_swift_request_validation_source(&source) {
             continue;
         }
         candidates.push(PacketGenericSourceShapeCandidate {
-            path: path.to_path_buf(),
+            path: source_path,
             display_name: format!("{}.validate", citation.display_name),
             kind: NodeKind::METHOD,
             line: packet_source_line_containing(&source, "func validate").unwrap_or(1),
@@ -13044,7 +13050,6 @@ mod tests {
     fn generic_source_shape_scan_adds_cited_request_validation_anchor() {
         let root = packet_temp_root("generic-source-shape-cited-urlsession");
         let _ = std::fs::remove_dir_all(&root);
-        let request_path = root.join("Example").join("BodyRequest.swift");
         write_packet_fixture_file(
             &root,
             "Example/BodyRequest.swift",
@@ -13064,7 +13069,7 @@ mod tests {
             prompt,
             vec![test_packet_citation(
                 "BodyRequest",
-                &request_path.to_string_lossy(),
+                "Example/BodyRequest.swift",
                 0.9,
             )],
         );

--- a/crates/codestory-runtime/src/agent/packet_required_probes.rs
+++ b/crates/codestory-runtime/src/agent/packet_required_probes.rs
@@ -962,6 +962,9 @@ pub(crate) fn packet_citation_satisfies_required_probe(
     if packet_citation_matches_sql_schema_scripts_probe(query, citation) {
         return true;
     }
+    if packet_required_probe_needs_request_validation_anchor(query) {
+        return packet_citation_matches_request_validation_anchor(query, citation);
+    }
     let Some(match_rank) = packet_citation_probe_match_rank(query, citation) else {
         return false;
     };
@@ -1050,6 +1053,8 @@ pub(crate) fn packet_citation_probe_match_rank(
         Some(5)
     } else if packet_citation_matches_sql_schema_scripts_probe(query, citation) {
         Some(5)
+    } else if packet_required_probe_needs_request_validation_anchor(query) {
+        packet_citation_matches_request_validation_anchor(query, citation).then_some(5)
     } else if packet_file_stem_matches_query(query, citation.file_path.as_deref()) {
         Some(5)
     } else if normalized_display == normalized_query
@@ -1067,6 +1072,32 @@ pub(crate) fn packet_citation_probe_match_rank(
     } else {
         None
     }
+}
+
+fn packet_required_probe_needs_request_validation_anchor(query: &str) -> bool {
+    let normalized_query = normalize_identifier(query);
+    normalized_query.contains("request") && normalized_query.contains("validation")
+}
+
+fn packet_citation_matches_request_validation_anchor(
+    query: &str,
+    citation: &AgentCitationDto,
+) -> bool {
+    let normalized_query = normalize_identifier(query);
+    let normalized_display = normalize_identifier(&citation.display_name);
+    let normalized_path = citation
+        .file_path
+        .as_deref()
+        .map(packet_display_path)
+        .map(|path| normalize_identifier(&path))
+        .unwrap_or_default();
+    let combined = format!("{normalized_display}{normalized_path}");
+    let requires_data = normalized_query.contains("data")
+        && normalized_query.contains("request")
+        && normalized_query.contains("validation");
+    combined.contains("request")
+        && combined.contains("validat")
+        && (!requires_data || combined.contains("data"))
 }
 
 fn packet_citation_matches_required_coverage_role(
@@ -1110,7 +1141,15 @@ fn packet_citation_matches_required_coverage_role(
             | "customvalidationvaliditystate"
             | "customvalidationerrorrendering" => normalized_role == "formcustomvalidation",
             "submitpreventdefault" | "submitinvalidguard" => normalized_role == "formsubmitguard",
-            _ => false,
+            "delegatecallbackhandling" | "urlsessioncallbackboundary" | "urlsessioncallbacks" => {
+                normalized_role == "sessioncallbacks"
+            }
+            _ => {
+                normalized_role == "sessioncallbacks"
+                    && normalized_query.contains("session")
+                    && normalized_query.contains("delegate")
+                    && normalized_query.contains("callback")
+            }
         }
 }
 
@@ -2153,6 +2192,16 @@ mod tests {
             "html form pattern constraint",
             &citation
         ));
+
+        citation.coverage_role = Some("session_callbacks".to_string());
+        assert!(packet_citation_satisfies_required_probe(
+            "delegate callback handling",
+            &citation
+        ));
+        assert!(packet_citation_satisfies_required_probe(
+            "url session callback boundary",
+            &citation
+        ));
     }
 
     #[test]
@@ -2555,8 +2604,20 @@ mod tests {
             "request_object.swift request",
             &data_request
         ));
+        assert!(!packet_citation_satisfies_required_probe(
+            "data request validation",
+            &data_request
+        ));
         assert!(packet_citation_satisfies_required_probe(
             "request_object.swift validate",
+            &data_request_validate
+        ));
+        assert!(packet_citation_satisfies_required_probe(
+            "data request validation",
+            &data_request_validate
+        ));
+        assert!(packet_citation_satisfies_required_probe(
+            "request validation pipeline",
             &data_request_validate
         ));
         assert!(packet_citation_satisfies_required_probe(

--- a/crates/codestory-runtime/src/agent/packet_required_probes.rs
+++ b/crates/codestory-runtime/src/agent/packet_required_probes.rs
@@ -1138,8 +1138,11 @@ fn packet_citation_matches_required_coverage_role(
             "customvalidation"
             | "customvalidationflow"
             | "customformvalidationinput"
-            | "customvalidationvaliditystate"
-            | "customvalidationerrorrendering" => normalized_role == "formcustomvalidation",
+            | "customvalidationvaliditystate" => normalized_role == "formcustomvalidation",
+            "customvalidationerrorrendering" | "customerrorrendering" => {
+                normalized_role == "formcustomvalidation"
+                    || normalized_role == "formcustomerrorrendering"
+            }
             "submitpreventdefault" | "submitinvalidguard" => normalized_role == "formsubmitguard",
             "delegatecallbackhandling" | "urlsessioncallbackboundary" | "urlsessioncallbacks" => {
                 normalized_role == "sessioncallbacks"
@@ -2190,6 +2193,12 @@ mod tests {
         citation.coverage_role = Some("form_native_constraints".to_string());
         assert!(packet_citation_satisfies_required_probe(
             "html form pattern constraint",
+            &citation
+        ));
+
+        citation.coverage_role = Some("form_custom_error_rendering".to_string());
+        assert!(packet_citation_satisfies_required_probe(
+            "custom validation error rendering",
             &citation
         ));
 

--- a/crates/codestory-runtime/src/agent/packet_scoring.rs
+++ b/crates/codestory-runtime/src/agent/packet_scoring.rs
@@ -726,6 +726,13 @@ fn packet_url_session_request_rank_bonus(normalized_display: &str, path: &str) -
     if normalized_display.ends_with("requestvalidate") {
         bonus += 9.0;
     }
+    if is_request_object_file
+        && path_stem.contains("data")
+        && normalized_display.starts_with(&path_stem)
+        && normalized_display.ends_with("requestvalidate")
+    {
+        bonus += 90.0;
+    }
     if normalized_display.contains("delegate")
         || (normalized_display.contains("urlsession") && is_delegate_callback_file)
     {
@@ -1450,6 +1457,43 @@ mod tests {
                 "beans",
                 "html/forms/native-form-widgets/advanced-examples.html"
             )
+        );
+    }
+
+    #[test]
+    fn url_session_rank_bonus_prefers_data_request_validation_anchor() {
+        let terms = vec![
+            "session".to_string(),
+            "request".to_string(),
+            "validates".to_string(),
+            "data".to_string(),
+            "urlsession".to_string(),
+        ];
+        let data_validate = test_rank_citation(
+            "DataRequest.validate",
+            "Source/Core/DataRequest.swift",
+            40.0,
+        );
+        let sibling_validate = test_rank_citation(
+            "DownloadRequest.validate",
+            "Source/Core/DownloadRequest.swift",
+            40.0,
+        );
+        let extension_validate = test_rank_citation(
+            "URLRequest+Library.validate",
+            "Source/Extensions/URLRequest+Library.swift",
+            40.0,
+        );
+
+        let data_rank = packet_citation_rank(&data_validate, &terms, false);
+
+        assert!(
+            data_rank > packet_citation_rank(&sibling_validate, &terms, false),
+            "data request validate anchor should outrank sibling request validate anchors"
+        );
+        assert!(
+            data_rank > packet_citation_rank(&extension_validate, &terms, false),
+            "data request validate anchor should outrank generic URLRequest validate extensions"
         );
     }
 

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1042,13 +1042,20 @@ fn unresolved_candidates_are_diagnostic_only(
     resolution_labels: &[String],
     unresolved_candidate_count: usize,
 ) -> bool {
+    let has_resolved_hit = resolution_labels
+        .iter()
+        .any(|label| label.as_str() == "resolved");
     unresolved_candidate_count > 0
         && !resolution_labels.is_empty()
         && candidates
             .iter()
             .zip(resolution_labels)
             .filter(|(_, label)| label.as_str() != "resolved")
-            .all(|(candidate, label)| bare_dense_anchor_unresolved(candidate, label))
+            .all(|(candidate, label)| {
+                bare_dense_anchor_unresolved(candidate, label)
+                    || (has_resolved_hit
+                        && non_source_markdown_candidate_unresolved(candidate, label))
+            })
 }
 
 fn bare_dense_anchor_unresolved(candidate: &CandidateHit, resolution_label: &str) -> bool {
@@ -1065,6 +1072,16 @@ fn bare_dense_anchor_path(candidate: &CandidateHit) -> bool {
             .symbol_name
             .as_deref()
             .is_some_and(|symbol| symbol.trim().eq_ignore_ascii_case(file_path))
+}
+
+fn non_source_markdown_candidate_unresolved(
+    candidate: &CandidateHit,
+    resolution_label: &str,
+) -> bool {
+    resolution_label == "node_unresolved"
+        && candidate.source == CandidateSource::Zoekt
+        && candidate.symbol_name.is_none()
+        && candidate.file_path.to_ascii_lowercase().ends_with(".md")
 }
 
 fn retrieval_stage_timings(trace: &QueryTrace) -> Vec<RetrievalStageTimingDto> {
@@ -1794,6 +1811,46 @@ mod tests {
         let value = serde_json::to_value(&shadow).expect("serialize shadow");
         assert_eq!(shadow.unresolved_candidate_count, 1);
         assert_eq!(value.get("diagnostic_only"), None);
+    }
+
+    #[test]
+    fn shadow_marks_non_source_markdown_candidates_diagnostic_only_with_source_hits() {
+        let shadow = shadow_from_query_result_with_counts_and_resolution_labels(
+            QueryResult {
+                query: "form validation".into(),
+                features: classify_query("form validation"),
+                hits: vec![
+                    CandidateHit::with_source(
+                        "docs/tasks/form-validation/marking.md",
+                        None,
+                        0.9,
+                        CandidateSource::Zoekt,
+                    ),
+                    CandidateHit::with_source(
+                        "src/forms/validation.html",
+                        Some("email".into()),
+                        0.8,
+                        CandidateSource::Qdrant,
+                    ),
+                ],
+                trace: QueryTrace {
+                    retrieval_mode: "full".into(),
+                    degraded_reason: None,
+                    total_budget_ms: 500,
+                    elapsed_ms: 1,
+                    cancel_reason: None,
+                    cache_hit: false,
+                    stages: Vec::new(),
+                },
+            },
+            2,
+            1,
+            &["node_unresolved".to_string(), "resolved".to_string()],
+            &[],
+        );
+        let value = serde_json::to_value(&shadow).expect("serialize shadow");
+        assert_eq!(shadow.unresolved_candidate_count, 1);
+        assert_eq!(value["diagnostic_only"], true);
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #214
Refs #205
Refs #200
Refs #198
Refs #78

Issue #205 is the post-#206 parent slice for the remaining Alamofire and MDN packet-runtime blockers. This PR closes the smaller #214 implementation slice: generic source anchors, URLSession/form-validation proof routing, and diagnostic-only classification for non-source Markdown candidates when source evidence remains resolved.

The product failures addressed here were unresolved non-source Markdown candidates and missing concrete source anchors for `DataRequest.validate`, `input#mail`, and custom form error handling.

## What Changed

- Treat unresolved non-source Markdown candidates as diagnostic-only when resolved source hits remain.
- Add generic form-validation source-shape anchors for native inputs and custom error-rendering functions that branch on `ValidityState` fields.
- Add generic Swift URLSession request-flow anchors for cited request validation methods and delegate callback methods.
- Tighten request-validation probe matching so broad request object anchors do not satisfy validation probes without a validate-shaped anchor.
- Nudge URLSession request-flow ranking toward data-bearing request validation anchors over sibling/generic validation anchors.

## How To Review

Start with the source-shape additions in `crates/codestory-runtime/src/agent/orchestrator.rs`, then the probe matching changes in `packet_required_probes.rs`, then the narrow ranking adjustment in `packet_scoring.rs`, and finally the retrieval-shadow diagnostic-only classification in `retrieval_primary.rs`.

## Verification

- `cargo fmt`
- `cargo test -p codestory-runtime required_probe_queries_match_exact_coverage_role_ids --lib`
- `cargo test -p codestory-runtime file_scoped_required_probes_match_symbol_inside_file --lib`
- `cargo test -p codestory-runtime url_session_rank_bonus_prefers_data_request_validation_anchor --lib`
- `cargo test -p codestory-runtime generic_source_shape_scan_adds_form_native_constraint_anchor --lib`
- `cargo test -p codestory-runtime generic_source_shape_scan_adds_url_session_request_anchors --lib`
- `cargo test -p codestory-runtime generic_source_shape_scan_adds_cited_request_validation_anchor --lib`
- `cargo test -p codestory-runtime shadow_marks_non_source_markdown_candidates_diagnostic_only_with_source_hits --lib`
- `node scripts\lint-retrieval-generalization.mjs`
- `$env:RUSTC_WRAPPER="$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo build --release -p codestory-cli`
- Two-row #205 benchmark command with `--publishable` against `swift-alamofire-request-flow,html-mdn-form-validation` for 3 repeats.

Latest two-row result: Alamofire is `sufficient:3` with zero follow-ups; MDN is `sufficient:3` with zero follow-ups. Artifacts are under `target\agent-benchmark\issue-205-unresolved-candidates`.

## Risk

The latest `--publishable` run still exits non-zero because MDN repeat 2 had one retrieval SLA miss and one intermittent unresolved `MDN` plan subquery diagnostic. Repeats 1 and 3 resolved the same `MDN` subquery, and repeat 2 still had passing quality and `sufficient` packet status. This PR does not tune retrieval latency, broaden the benchmark lane, or claim #205 is fully closed.