### PR TITLE
[codex] bootstrap worktree setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,4 +3,4 @@ version = 1
 name = "codestory"
 
 [setup]
-script = "cargo check"
+script = "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/codex-worktree-setup.ps1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@
 - Backend build/test: `cargo build`, `cargo test`, `cargo check`, `cargo fmt`, `cargo clippy`.
 - CLI runtime: `cargo run --release -p codestory-cli -- index --project .`.
 - Skill-first grounding: `cargo run --release -p codestory-cli -- ground --project .`.
+- Codex worktree setup runs `scripts/codex-worktree-setup.ps1` before the thread
+  starts: it builds the release CLI with `sccache`, tries `cache rehydrate` from
+  a sibling worktree, refreshes the SQLite index, then best-effort refreshes
+  retrieval sidecars/status.
 - Release version checks: `python .github/scripts/check-codestory-release.py --version <version>` and `node .github/scripts/check-workflow-policy.mjs`.
 - On Windows, the Codex npm shim should be invoked as `codex.cmd` (typically under `%APPDATA%\\npm`); using the extensionless `codex` shim can fail with `os error 193`.
 - In this PowerShell environment, large parallel file reads can truncate output; when investigating a single large file, prefer one direct read command (for example `Get-Content` or `cmd /c type`) before parallelizing.

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -1,0 +1,140 @@
+[CmdletBinding()]
+param(
+    [string]$Project = "."
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Checked {
+    param(
+        [string]$File,
+        [string[]]$Arguments
+    )
+
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$File $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Invoke-SetupStep {
+    param(
+        [string]$Label,
+        [scriptblock]$Step,
+        [switch]$Optional
+    )
+
+    Write-Host ""
+    Write-Host "==> $Label"
+    try {
+        & $Step
+    } catch {
+        if (-not $Optional) {
+            throw
+        }
+        Write-Warning $_.Exception.Message
+    }
+}
+
+function Find-CodeStoryCli {
+    param([string]$Root)
+
+    $candidates = @(
+        (Join-Path $Root "target\release\codestory-cli.exe"),
+        (Join-Path $Root "target\release\codestory-cli")
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+    throw "codestory-cli release binary was not found under target\release"
+}
+
+function Same-Path {
+    param(
+        [string]$Left,
+        [string]$Right
+    )
+
+    $trimChars = [char[]]@('\', '/')
+    $leftFull = [System.IO.Path]::GetFullPath($Left).TrimEnd($trimChars)
+    $rightFull = [System.IO.Path]::GetFullPath($Right).TrimEnd($trimChars)
+    return [string]::Equals($leftFull, $rightFull, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Find-RehydrateSource {
+    param([string]$Target)
+
+    if ($env:CODESTORY_REHYDRATE_FROM) {
+        $configured = (Resolve-Path -LiteralPath $env:CODESTORY_REHYDRATE_FROM).Path
+        if (-not (Same-Path $configured $Target)) {
+            return $configured
+        }
+    }
+
+    $lines = & git worktree list --porcelain 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    foreach ($line in $lines) {
+        if (-not $line.StartsWith("worktree ")) {
+            continue
+        }
+        $candidate = $line.Substring("worktree ".Length)
+        if (Same-Path $candidate $Target) {
+            continue
+        }
+        if (Test-Path -LiteralPath (Join-Path $candidate "Cargo.toml")) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+$projectPath = (Resolve-Path -LiteralPath $Project).Path
+
+Push-Location $projectPath
+try {
+    $sccache = Join-Path $env:USERPROFILE ".cargo\bin\sccache.exe"
+    if (Test-Path -LiteralPath $sccache) {
+        $env:RUSTC_WRAPPER = $sccache
+        Write-Host "Using RUSTC_WRAPPER=$sccache"
+    }
+
+    Invoke-SetupStep "Build release CLI" {
+        Invoke-Checked "cargo" @("build", "--release", "-p", "codestory-cli")
+    }
+
+    $cli = Find-CodeStoryCli $projectPath
+    $source = Find-RehydrateSource $projectPath
+    if ($source) {
+        Invoke-SetupStep "Rehydrate CodeStory cache from $source" {
+            Invoke-Checked $cli @("cache", "rehydrate", "--from-project", $source, "--project", $projectPath)
+        } -Optional
+    } else {
+        Write-Host ""
+        Write-Host "==> Rehydrate CodeStory cache"
+        Write-Host "No sibling source worktree found; refreshing this worktree directly."
+    }
+
+    Invoke-SetupStep "Refresh SQLite graph/search/doc cache" {
+        Invoke-Checked $cli @("index", "--project", $projectPath, "--refresh", "auto")
+    }
+
+    Invoke-SetupStep "Bootstrap retrieval sidecars" {
+        Invoke-Checked $cli @("retrieval", "bootstrap", "--project", $projectPath, "--wait-secs", "90")
+    } -Optional
+
+    Invoke-SetupStep "Refresh retrieval sidecar index" {
+        Invoke-Checked $cli @("retrieval", "index", "--project", $projectPath, "--refresh", "auto")
+    } -Optional
+
+    Invoke-SetupStep "Doctor" {
+        Invoke-Checked $cli @("doctor", "--project", $projectPath, "--format", "markdown")
+    } -Optional
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Context

New worktree threads were starting cold with a generic `cargo check`, then rediscovering the same setup work: build the release CLI, find or rebuild cache state, refresh the SQLite index, and repair retrieval sidecars. That made each thread slower before it could do useful issue work.

Closes #216
Refs #208
Refs #82
Refs #38

## What Changed

- Added `scripts/codex-worktree-setup.ps1` as the Codex environment setup entrypoint for worktrees.
- The wrapper uses the global `sccache` binary as `RUSTC_WRAPPER` when available, builds `codestory-cli` in release mode, tries `cache rehydrate` from a sibling worktree, refreshes the SQLite graph/search/doc index, then best-effort refreshes retrieval sidecars and `doctor` output.
- Updated `.codex/environments/environment.toml` to invoke the wrapper instead of plain `cargo check`.
- Added a short `AGENTS.md` note so future sessions know worktree setup is expected to prebuild and warm cache/index state.

```mermaid
flowchart LR
    A[Codex worktree starts] --> B[release CLI build]
    B --> C{Sibling worktree cache?}
    C -->|yes| D[cache rehydrate]
    C -->|no| E[direct refresh]
    D --> F[SQLite index refresh]
    E --> F
    F --> G[best-effort sidecar bootstrap]
    G --> H[best-effort sidecar index]
    H --> I[best-effort doctor]
```

## How To Review

- Review the wrapper for Windows-safe PowerShell and explicit checked command execution.
- Check that required setup stops on build/index failures while retrieval sidecar setup remains optional/reporting.
- Confirm the `.codex` environment points at the wrapper and the AGENTS note matches the actual setup behavior.

## Verification

- `PowerShell Parser::ParseFile('scripts\\codex-worktree-setup.ps1')` -> passed, no parser errors.
- `git diff --check -- .codex/environments/environment.toml AGENTS.md scripts/codex-worktree-setup.ps1` -> passed.
- `git diff --cached --check` -> passed before commit.

## Risk

- I did not run the full setup wrapper in this checkout because it intentionally performs a release build and index/sidecar work. The parser and diff checks validate the script shape; reviewers can run `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/codex-worktree-setup.ps1` for an end-to-end warm-start proof when the heavy-work queue is clear.
- Retrieval bootstrap/index/doctor are optional by design so a missing local sidecar dependency warns instead of blocking the thread from starting.
