### PR TITLE
[codex] ignore stale rehydrate env source

### DIFF
--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -67,8 +67,13 @@ function Find-RehydrateSource {
     param([string]$Target)
 
     if ($env:CODESTORY_REHYDRATE_FROM) {
-        $configured = (Resolve-Path -LiteralPath $env:CODESTORY_REHYDRATE_FROM).Path
-        if (-not (Same-Path $configured $Target)) {
+        try {
+            $configured = (Resolve-Path -LiteralPath $env:CODESTORY_REHYDRATE_FROM -ErrorAction Stop).Path
+        } catch {
+            Write-Warning "Ignoring CODESTORY_REHYDRATE_FROM='$env:CODESTORY_REHYDRATE_FROM': $($_.Exception.Message)"
+            $configured = $null
+        }
+        if ($configured -and -not (Same-Path $configured $Target)) {
             return $configured
         }
     }


### PR DESCRIPTION
## Context

PR #217 made cache rehydrate best-effort, but the setup wrapper still resolved `CODESTORY_REHYDRATE_FROM` before the optional cache reuse step. A stale env path could abort before required build/index ran.

Closes #218
Refs #216
Refs #82
Refs #208

## What Changed

- Wrap configured `CODESTORY_REHYDRATE_FROM` resolution in a local try/catch.
- Warn and continue sibling discovery when configured source is stale or invalid.
- Leave valid configured source behavior unchanged.

## How To Review

- Read `Find-RehydrateSource` in `scripts/codex-worktree-setup.ps1`.
- Confirm only invalid configured source handling changed.

## Verification

- `Parser::ParseFile(...)` on `scripts/codex-worktree-setup.ps1` -> `parser ok`
- Function-only stale env check extracting `Same-Path` and `Find-RehydrateSource` -> `stale rehydrate env check ok`
- `git diff --check` -> exit 0

Not run by design: Cargo, setup wrapper, sidecar/index/search/query/packet/benchmark/reindex per #218 scope.

## Risk

Low. Valid configured paths still return before sibling discovery; invalid paths now warn and fall through.