### PR TITLE
Document rustdoc baseline

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -103,6 +103,48 @@ Use this mapping:
 - args or output rendering: `codestory-cli`
 - shared DTOs or graph/event types: `codestory-contracts`
 
+## Rustdoc Baseline
+
+Run the rustdoc baseline before raising documentation or public API cleanup PRs:
+
+```sh
+cargo doc --workspace --no-deps
+```
+
+Document public Rust APIs that a maintainer, integration, or downstream crate
+would need to call correctly. Keep comments operational:
+
+- Start each public crate and intentionally public module with `//!` docs that
+  name the crate boundary, source of truth, and runtime side effects.
+- Put `///` docs on public structs, enums, traits, type aliases, constants,
+  re-exports, and functions that are meant to be reused across crates.
+- State invariants, cache or sidecar effects, error behavior, and required
+  verification commands when those details affect correct use.
+- Avoid issue history, benchmark holdout names, local machine paths, and
+  process narration in rustdoc.
+- Prefer one accurate paragraph over examples that would duplicate tests or
+  drift from real command behavior.
+
+Public API documentation priority:
+
+| Crate | Public surface to document first |
+| --- | --- |
+| `codestory-contracts` | Shared DTOs, graph model, events, language support contracts, and query/trail types. |
+| `codestory-runtime` | Headless orchestration, service facades, cache rehydration, search/runtime exports, and repository identity reports. |
+| `codestory-retrieval` | Sidecar health, query planning/execution, index manifests, cache keys, and degraded-mode contracts. |
+| `codestory-workspace` | Workspace discovery/settings, refresh planning, language settings, and repository/sidecar identity. |
+| `codestory-store` | Storage facades and projection/snapshot/file-store contracts. |
+| `codestory-indexer` | Public indexing config/results/events, language config, semantic-resolution contracts, and candidate path helpers. |
+| `codestory-cli` | Binary command behavior belongs in user/contributor docs; add rustdoc only for reusable library APIs if one is introduced. |
+| `codestory-bench` | Publish-false benchmark helpers; document only helpers reused outside a single benchmark lane. |
+
+Do not enable workspace-wide or crate-wide `missing_docs` yet. The current
+public surface is broad enough that a crate-wide lint would force a noisy sweep.
+Phase it in behind explicit allowlists: start with module-scoped
+`#![warn(missing_docs)]` on newly cleaned public modules, allow known transitional
+exports explicitly, and move to crate-wide lints only after the crate root and
+intentional re-exports are documented.
+
 ## Before Large Changes
 
 Read these pages first:


### PR DESCRIPTION
## Context

Closes #220
Refs #215
Refs #38

Issue #220 needs the first reviewable rustdoc standard and baseline under the product-grade intelligence saga, without turning this into a broad public API documentation sweep or CI gate.

## What Changed

- Added a `Rustdoc Baseline` section to `docs/contributors/getting-started.md`.
- Defined the baseline command: `cargo doc --workspace --no-deps`.
- Mapped the workspace crates whose public APIs should be documented first.
- Set the `missing_docs` direction as phased/module-scoped behind explicit allowlists, not workspace-wide or crate-wide yet.

## How To Review

1. Read `docs/contributors/getting-started.md` around the new `Rustdoc Baseline` section.
2. Check that the crate priority map matches the current workspace surfaces.
3. Confirm the `missing_docs` policy avoids a noisy lint sweep while giving future cleanup PRs a concrete path.

## Verification

- `cargo doc --workspace --no-deps` exit 0. Baseline generated docs for the eight workspace crates and ended at `target\doc\codestory_bench\index.html`; no rustdoc warnings appeared in the captured output.
- `cargo fmt --check` exit 0.
- `git diff --check` exit 0.

## Risk

- Docs-only change. No behavior, CI, sidecar, index, search, query, packet, benchmark, or release artifact changes.
- The crate priority map is a first baseline and may need refinement as public APIs are intentionally narrowed or hidden.