### PR TITLE
[codex] add embedding identity probe

### DIFF
--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -3040,6 +3040,131 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    fn embedding_identity_probe_from_env() -> Result<()> {
+        let _lock = ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let query = std::env::var("CODESTORY_EMBED_IDENTITY_PROBE_QUERY").unwrap_or_else(|_| {
+            "Where is the retrieval sidecar embedding contract enforced?".into()
+        });
+        let docs = std::env::var("CODESTORY_EMBED_IDENTITY_PROBE_DOCS_JSON")
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Vec<String>>(&raw).ok())
+            .filter(|docs| !docs.is_empty())
+            .unwrap_or_else(|| {
+                vec![
+                    "llama.cpp embedding sidecar is mandatory for product retrieval_mode full."
+                        .into(),
+                    "Managed ONNX assets are diagnostic until fresh quality evidence exists."
+                        .into(),
+                    "Hash projection is deterministic but not semantic product readiness.".into(),
+                    "Packet and search readiness require full sidecar retrieval evidence.".into(),
+                ]
+            });
+
+        let load_started = std::time::Instant::now();
+        let runtime = match EmbeddingRuntime::from_env() {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                println!(
+                    "CODESTORY_EMBEDDING_IDENTITY_PROBE_JSON={}",
+                    serde_json::to_string(&serde_json::json!({
+                        "ok": false,
+                        "failure_text": error.to_string(),
+                        "backend_env": std::env::var(EMBEDDING_BACKEND_ENV).ok(),
+                        "profile_env": std::env::var(EMBEDDING_PROFILE_ENV).ok(),
+                        "model_env": std::env::var(ONNX_MODEL_PATH_ENV).ok(),
+                        "tokenizer_env": std::env::var(ONNX_TOKENIZER_PATH_ENV).ok(),
+                        "url_env": std::env::var(LLAMACPP_EMBEDDINGS_URL_ENV).ok(),
+                    }))?
+                );
+                return Ok(());
+            }
+        };
+        let model_load_ms = load_started.elapsed().as_secs_f64() * 1000.0;
+
+        let query_started = std::time::Instant::now();
+        let query_embedding = runtime.embed_query(&query)?;
+        let query_embedding_ms = query_started.elapsed().as_secs_f64() * 1000.0;
+
+        let batch_started = std::time::Instant::now();
+        let document_embeddings = runtime.embed_texts(&docs)?;
+        let batch_document_embedding_ms = batch_started.elapsed().as_secs_f64() * 1000.0;
+
+        let mut scored = document_embeddings
+            .iter()
+            .enumerate()
+            .map(|(index, embedding)| (index, dot_product(&query_embedding, embedding)))
+            .collect::<Vec<_>>();
+        scored.sort_by(|left, right| {
+            right
+                .1
+                .partial_cmp(&left.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| left.0.cmp(&right.0))
+        });
+
+        let model_path = runtime.model_path();
+        let cache_bytes = file_len(model_path)
+            .into_iter()
+            .chain(
+                std::env::var(ONNX_TOKENIZER_PATH_ENV)
+                    .ok()
+                    .and_then(|path| file_len(std::path::Path::new(&path))),
+            )
+            .sum::<u64>();
+        let cache_bytes = if cache_bytes == 0 {
+            None
+        } else {
+            Some(cache_bytes)
+        };
+
+        println!(
+            "CODESTORY_EMBEDDING_IDENTITY_PROBE_JSON={}",
+            serde_json::to_string(&serde_json::json!({
+                "ok": true,
+                "model_id": runtime.model_id(),
+                "model_path": model_path.to_string_lossy(),
+                "model_load_ms": model_load_ms,
+                "query_embedding_ms": query_embedding_ms,
+                "batch_document_embedding_ms": batch_document_embedding_ms,
+                "cache_bytes": cache_bytes,
+                "vector_dimension": query_embedding.len(),
+                "finite_vector_check": all_finite(&query_embedding) && document_embeddings.iter().all(|vector| all_finite(vector)),
+                "l2_normalized_vector_check": l2_normalized(&query_embedding) && document_embeddings.iter().all(|vector| l2_normalized(vector)),
+                "document_count": docs.len(),
+                "top_k": scored.iter().take(3).map(|(index, score)| serde_json::json!({
+                    "index": index,
+                    "score": score,
+                    "text": docs.get(*index).cloned().unwrap_or_default(),
+                })).collect::<Vec<_>>(),
+            }))?
+        );
+        Ok(())
+    }
+
+    fn file_len(path: &std::path::Path) -> Option<u64> {
+        std::fs::metadata(path).ok().map(|metadata| metadata.len())
+    }
+
+    fn dot_product(left: &[f32], right: &[f32]) -> f32 {
+        left.iter()
+            .zip(right.iter())
+            .map(|(left, right)| left * right)
+            .sum()
+    }
+
+    fn all_finite(vector: &[f32]) -> bool {
+        !vector.is_empty() && vector.iter().all(|value| value.is_finite())
+    }
+
+    fn l2_normalized(vector: &[f32]) -> bool {
+        let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
+        (norm - 1.0).abs() <= 0.05
+    }
+
+    #[test]
     fn llamacpp_endpoint_parse_accepts_openai_embeddings_url() -> Result<()> {
         let endpoint = LlamaCppEndpoint::parse("http://127.0.0.1:8080/v1/embeddings")?;
 

--- a/docs/testing/embedding-backend-benchmarks.md
+++ b/docs/testing/embedding-backend-benchmarks.md
@@ -34,6 +34,19 @@ As of the mandatory sidecar reset, older ONNX and hash-projection rows are
 historical diagnostics. Add a fresh sidecar row before calling the active runtime
 promoted on quality and cross-repo evidence.
 
+## Diagnostic Identity Probe
+
+Use `node scripts/codestory-embedding-runtime-compare.mjs` for the smallest local
+ONNX-vs-llama embedding identity check. It reports model load time, query and
+document embedding time, cache bytes, vector shape checks, and top-k overlap for
+a fixed fixture set.
+
+The probe is diagnostic only. ONNX output from this path cannot satisfy product
+`retrieval_mode=full` by itself, and hash projection remains rejected as product
+semantic readiness. If llama.cpp or managed ONNX assets are unavailable, keep the
+reported failure text as the evidence instead of rerunning broad benchmark
+suites.
+
 ## Primary Comparison Matrix
 
 | Candidate or lane | Best relevant evidence | Quality signal | Speed and footprint signal | Decision |

--- a/scripts/codestory-embedding-runtime-compare.mjs
+++ b/scripts/codestory-embedding-runtime-compare.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const marker = "CODESTORY_EMBEDDING_IDENTITY_PROBE_JSON=";
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const query = "Where is the retrieval sidecar embedding contract enforced?";
+const docs = [
+  "llama.cpp embedding sidecar is mandatory for product retrieval_mode full.",
+  "Managed ONNX assets are diagnostic until fresh quality evidence exists.",
+  "Hash projection is deterministic but not semantic product readiness.",
+  "Packet and search readiness require full sidecar retrieval evidence.",
+];
+
+function main() {
+  if (process.argv.includes("--self-test")) {
+    selfTest();
+    console.log("self-test ok");
+    return;
+  }
+
+  const llama = runProbe("llama_control_208", llamaEnv());
+  const onnx = runProbe("onnx_candidate_diagnostic", onnxEnv());
+  const report = {
+    diagnostic_only: true,
+    product_default_changes: false,
+    full_ab_suite: false,
+    hash_projection_product_readiness: "rejected",
+    comparators: {
+      llama_control_208: labelResult(llama, true),
+      onnx_candidate_diagnostic: labelResult(onnx, false),
+    },
+    top_k_overlap: topKOverlap(llama, onnx),
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+function runProbe(name, extraEnv) {
+  const env = {
+    ...process.env,
+    ...extraEnv,
+    CODESTORY_EMBED_PROFILE: "bge-base-en-v1.5",
+    CODESTORY_EMBED_IDENTITY_PROBE_QUERY: query,
+    CODESTORY_EMBED_IDENTITY_PROBE_DOCS_JSON: JSON.stringify(docs),
+  };
+  if (!env.RUSTC_WRAPPER && process.env.USERPROFILE) {
+    env.RUSTC_WRAPPER = path.join(process.env.USERPROFILE, ".cargo", "bin", "sccache.exe");
+  }
+
+  const args = [
+    "test",
+    "-p",
+    "codestory-runtime",
+    "embedding_identity_probe_from_env",
+    "--",
+    "--ignored",
+    "--nocapture",
+  ];
+  const result = spawnSync("cargo", args, {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+  const line = output.split(/\r?\n/).find((item) => item.startsWith(marker));
+  let parsed = null;
+  if (line) {
+    parsed = JSON.parse(line.slice(marker.length));
+  }
+  return {
+    name,
+    command: `cargo ${args.join(" ")}`,
+    exit_code: result.status,
+    ...(
+      parsed ?? {
+        ok: false,
+        failure_text: compactFailure(output) || result.error?.message || "probe emitted no JSON marker",
+      }
+    ),
+  };
+}
+
+function llamaEnv() {
+  return {
+    CODESTORY_EMBED_BACKEND: "llamacpp",
+    CODESTORY_EMBED_LLAMACPP_URL:
+      process.env.CODESTORY_EMBED_LLAMACPP_URL ?? "http://127.0.0.1:8080/v1/embeddings",
+  };
+}
+
+function onnxEnv() {
+  const env = {
+    CODESTORY_EMBED_BACKEND: "onnx",
+    CODESTORY_EMBED_ONNX_PROVIDER: process.env.CODESTORY_EMBED_ONNX_PROVIDER ?? defaultOnnxProvider(),
+  };
+  if (process.env.CODESTORY_EMBED_ONNX_MODEL && process.env.CODESTORY_EMBED_ONNX_TOKENIZER) {
+    env.CODESTORY_EMBED_ONNX_MODEL = process.env.CODESTORY_EMBED_ONNX_MODEL;
+    env.CODESTORY_EMBED_ONNX_TOKENIZER = process.env.CODESTORY_EMBED_ONNX_TOKENIZER;
+    return env;
+  }
+
+  const managed = findManagedOnnxAssets();
+  if (managed) {
+    env.CODESTORY_EMBED_ONNX_MODEL = managed.model;
+    env.CODESTORY_EMBED_ONNX_TOKENIZER = managed.tokenizer;
+  }
+  return env;
+}
+
+function defaultOnnxProvider() {
+  return process.platform === "win32" ? "directml" : "cpu";
+}
+
+function findManagedOnnxAssets() {
+  const roots = [
+    process.env.CODESTORY_MANAGED_EMBEDDINGS_ROOT,
+    process.env.CODESTORY_CACHE_DIR && path.join(process.env.CODESTORY_CACHE_DIR, "managed-embeddings"),
+    ...commonManagedRoots(),
+  ].filter(Boolean);
+  for (const root of roots) {
+    const fromManifest = readManagedManifest(root);
+    if (fromManifest) {
+      return fromManifest;
+    }
+    const model = path.join(root, "models", "bge-base-en-v1.5-onnx-qdrant", "model_optimized_cls_pool.onnx");
+    const tokenizer = path.join(root, "models", "bge-base-en-v1.5-onnx-qdrant", "tokenizer.json");
+    if (existsSync(model) && existsSync(tokenizer)) {
+      return { model, tokenizer };
+    }
+  }
+  return null;
+}
+
+function commonManagedRoots() {
+  if (process.platform === "win32") {
+    const local = process.env.LOCALAPPDATA;
+    if (!local) {
+      return [];
+    }
+    return [
+      path.join(local, "codestory", "codestory", "cache", "managed-embeddings"),
+      path.join(local, "dev", "codestory", "codestory", "cache", "managed-embeddings"),
+    ];
+  }
+  const home = os.homedir();
+  return [
+    path.join(home, ".cache", "codestory", "managed-embeddings"),
+    path.join(home, ".cache", "dev", "codestory", "managed-embeddings"),
+  ];
+}
+
+function readManagedManifest(root) {
+  const manifestPath = path.join(root, "manifest.json");
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const model = manifest.onnx_model_path;
+    const tokenizer = manifest.onnx_tokenizer_path;
+    if (model && tokenizer && existsSync(model) && existsSync(tokenizer)) {
+      return { model, tokenizer };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function labelResult(result, productEligible) {
+  const backend = result.name.startsWith("onnx") ? "onnx" : "llamacpp";
+  return {
+    ...result,
+    backend,
+    cache_bytes: result.cache_bytes ?? cacheBytesFromResult(result),
+    diagnostic_label: productEligible
+      ? "#208 llama sidecar control comparator"
+      : "diagnostic only; cannot satisfy product retrieval_mode=full by itself",
+    product_full_retrieval_eligible: productEligible,
+  };
+}
+
+function cacheBytesFromResult(result) {
+  if (!result.model_path || /^https?:/.test(result.model_path)) {
+    return null;
+  }
+  try {
+    return statSync(result.model_path).size;
+  } catch {
+    return null;
+  }
+}
+
+function topKOverlap(left, right) {
+  if (!left.ok || !right.ok) {
+    return {
+      status: "not_measured",
+      reason: [left, right]
+        .filter((item) => !item.ok)
+        .map((item) => `${item.name}: ${item.failure_text ?? "unavailable"}`)
+        .join("; "),
+    };
+  }
+  const leftTop = topIndexes(left);
+  const rightTop = topIndexes(right);
+  const overlap = leftTop.filter((index) => rightTop.includes(index));
+  return {
+    status: "measured",
+    k: Math.min(leftTop.length, rightTop.length),
+    overlap_count: overlap.length,
+    overlap_ratio: overlap.length / Math.max(1, Math.min(leftTop.length, rightTop.length)),
+    llama_top_k: leftTop,
+    onnx_top_k: rightTop,
+  };
+}
+
+function topIndexes(result) {
+  return (result.top_k ?? []).map((item) => item.index);
+}
+
+function compactFailure(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-12)
+    .join("\n");
+}
+
+function selfTest() {
+  const left = { name: "left", ok: true, top_k: [{ index: 1 }, { index: 2 }, { index: 3 }] };
+  const right = { name: "right", ok: true, top_k: [{ index: 2 }, { index: 4 }, { index: 1 }] };
+  assert.equal(topKOverlap(left, right).overlap_count, 2);
+  assert.equal(labelResult({ name: "onnx_candidate_diagnostic", ok: true }, false).product_full_retrieval_eligible, false);
+  assert.equal(labelResult({ name: "llama_control_208", ok: true }, true).diagnostic_label, "#208 llama sidecar control comparator");
+}
+
+main();


### PR DESCRIPTION
## Context

Issue #222 asks for a PR-sized diagnostic spike under #211/#212: compare the existing in-tree ONNX/ORT path against the current llama.cpp sidecar embedding contract without changing product defaults or weakening packet/search readiness.

Closes #222
Refs #211
Refs #212
Refs #38

## What Changed

- Added `scripts/codestory-embedding-runtime-compare.mjs`, a diagnostic wrapper that runs the real runtime embedding path through an ignored Cargo test hook for llama.cpp and ONNX.
- Added the ignored `embedding_identity_probe_from_env` runtime test hook, which reports model load ms, query embedding ms, batch document embedding ms, cache bytes, vector dimension, finite/L2 checks, top-k fixture order, and failure text.
- Documented the probe as diagnostic-only in `docs/testing/embedding-backend-benchmarks.md`.

No product default changed. ONNX output remains labeled diagnostic and cannot satisfy product `retrieval_mode=full` by itself. Hash projection remains rejected as product semantic readiness.

## How To Review

1. Read the script first: `scripts/codestory-embedding-runtime-compare.mjs`.
2. Check the runtime hook in `crates/codestory-runtime/src/search/engine.rs`; it is ignored and only runs when the script invokes the exact test filter.
3. Confirm the docs note does not add a generated ledger or promotion claim.
4. Run `node scripts/codestory-embedding-runtime-compare.mjs --self-test` for the no-asset smoke, then run the full script only where llama.cpp and managed ONNX assets are available.

## Verification

- `node --check scripts\codestory-embedding-runtime-compare.mjs` passed.
- `node scripts\codestory-embedding-runtime-compare.mjs --self-test` passed: `self-test ok`.
- `cargo fmt --check` passed with `RUSTC_WRAPPER=%USERPROFILE%\.cargo\bin\sccache.exe`.
- `git diff --check` and `git diff --cached --check` passed.
- `node scripts\codestory-embedding-runtime-compare.mjs` passed and ran the focused Cargo probe twice.

Measured local evidence from the full script:

| Comparator | Load ms | Query ms | Batch docs ms | Cache bytes | Dim | Finite | L2 | Top-k |
| --- | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
| #208 llama sidecar control | 3.1697 | 259.9413 | 124.1276 | n/a | 768 | true | true | `[0, 3, 1]` |
| ONNX diagnostic candidate | 1108.1751 | 388.1062 | 196.5238 | 218535688 | 768 | true | true | `[0, 3, 1]` |

Top-k overlap: `3/3` on the fixed diagnostic fixture.

## Risk

This is a diagnostic fixture, not a quality gate or benchmark promotion. It does not run the full AB suite, does not prove cross-repo retrieval quality, and does not make ONNX product-ready for `retrieval_mode=full`. First run cost includes normal Cargo compile time when the worktree has no built artifacts.
