### PR TITLE
[codex] document contracts API rustdoc

### DIFF
--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -1,3 +1,11 @@
+//! API-facing DTOs and mirrored enum types.
+//!
+//! These exports are the boundary between the runtime and external callers such
+//! as CLI JSON, UI bindings, and generated TypeScript types. The Rust names may
+//! look close to the core graph model, but the serialized forms are product
+//! contracts: preserve field names, serde aliases, defaults, and enum casing
+//! unless every caller can migrate in lockstep.
+
 mod dto;
 mod errors;
 mod events;

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -6,11 +6,14 @@ use super::types::{
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
+/// Request to open or bind the runtime to a project root.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct OpenProjectRequest {
+    /// Filesystem path supplied by the caller; producers normalize it before use.
     pub path: String,
 }
 
+/// Grounding output budget requested by callers.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum GroundingBudgetDto {
@@ -20,6 +23,10 @@ pub enum GroundingBudgetDto {
     Max,
 }
 
+/// Store counts returned in project summaries and diagnostics.
+///
+/// Counts are product evidence for the indexed store at response time. They are
+/// encoded as `u32` so generated TypeScript can keep using plain `number`.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct StorageStatsDto {
     // Use u32 so TS can safely represent these as `number` without BigInt.
@@ -31,6 +38,7 @@ pub struct StorageStatsDto {
     pub fatal_error_count: u32,
 }
 
+/// Project-level summary returned after opening or indexing a workspace.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct ProjectSummary {
     pub root: String,
@@ -76,6 +84,7 @@ pub struct SearchRequest {
     pub hybrid_limits: Option<SearchHybridLimitsDto>,
 }
 
+/// Search hit provenance before downstream reranking or packet admission.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchHitOrigin {
@@ -92,6 +101,10 @@ impl SearchHitOrigin {
     }
 }
 
+/// Match-quality label for ranking and diagnostics.
+///
+/// These values explain why a hit appeared; they do not by themselves prove the
+/// hit is sufficient evidence for an answer.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchMatchQualityDto {
@@ -103,6 +116,13 @@ pub enum SearchMatchQualityDto {
     RepoText,
 }
 
+/// Evidence provenance tier used by packet/search/citation surfaces.
+///
+/// Tiers are compatibility values. `ExactSource`, `ResolvedGraph`,
+/// `LexicalSource`, `SymbolDoc`, `ComponentReport`, and `DenseSemantic` are
+/// product evidence from indexed or sidecar sources. `SyntheticSourceScan` and
+/// `GeneratedSummary` are diagnostic or presentation evidence and should not be
+/// treated as source truth without a follow-up read.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketEvidenceTierDto {
@@ -116,6 +136,11 @@ pub enum PacketEvidenceTierDto {
     GeneratedSummary,
 }
 
+/// Whether a hit or citation resolved to a graph/source target.
+///
+/// `Resolved` is product evidence for a typed graph target. `SourceRangeOnly`
+/// is exact-source evidence without typed graph resolution. `Unresolved` and
+/// `DiagnosticOnly` are useful for troubleshooting but are not answer proof.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PacketEvidenceResolutionDto {
@@ -125,6 +150,7 @@ pub enum PacketEvidenceResolutionDto {
     DiagnosticOnly,
 }
 
+/// Current retrieval mode advertised to callers.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RetrievalModeDto {
@@ -132,6 +158,7 @@ pub enum RetrievalModeDto {
     Symbolic,
 }
 
+/// Why hybrid retrieval could not use the semantic path.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RetrievalFallbackReasonDto {
@@ -141,6 +168,7 @@ pub enum RetrievalFallbackReasonDto {
     DegradedRuntime,
 }
 
+/// Semantic retrieval readiness state.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SemanticModeDto {
@@ -156,6 +184,11 @@ pub struct SemanticFallbackRecordDto {
     pub reason: String,
 }
 
+/// Retrieval readiness and embedding compatibility visible to callers.
+///
+/// This is product evidence for the active index/retrieval surface. Diagnostic
+/// fallback fields explain why richer retrieval was not used; callers should
+/// not treat fallback output as equivalent to full sidecar readiness.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct RetrievalStateDto {
     pub mode: RetrievalModeDto,
@@ -176,6 +209,10 @@ pub struct RetrievalStateDto {
     pub fallback_message: Option<String>,
 }
 
+/// Embedding profile expected by the current runtime.
+///
+/// These fields are compatibility evidence used to compare active runtime
+/// configuration with stored semantic docs.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct EmbeddingProfileContractDto {
     pub profile: String,
@@ -187,6 +224,10 @@ pub struct EmbeddingProfileContractDto {
     pub doc_shape: String,
 }
 
+/// Semantic document profile stored in the index cache.
+///
+/// `mixed_*` flags are diagnostic evidence that the cache was built from more
+/// than one profile/model/backend/dimension/doc-shape and may need repair.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct StoredSemanticDocsContractDto {
     pub doc_count: u32,
@@ -257,6 +298,7 @@ pub struct IndexFreshnessDto {
     pub samples: Vec<IndexFreshnessSampleDto>,
 }
 
+/// Readiness goal being evaluated.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadinessGoalDto {
@@ -264,6 +306,7 @@ pub enum ReadinessGoalDto {
     AgentPacketSearch,
 }
 
+/// Repair-oriented readiness status.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ReadinessStatusDto {
@@ -273,6 +316,7 @@ pub enum ReadinessStatusDto {
     RepairRetrieval,
 }
 
+/// Index state snapshot used inside readiness verdicts.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct ReadinessIndexSnapshotDto {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -288,6 +332,7 @@ pub struct ReadinessIndexSnapshotDto {
     pub indexed_file_count: u32,
 }
 
+/// Sidecar state snapshot used inside readiness verdicts.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct ReadinessSidecarSnapshotDto {
     pub retrieval_mode: String,
@@ -299,6 +344,11 @@ pub struct ReadinessSidecarSnapshotDto {
     pub manifest_input_hash: Option<String>,
 }
 
+/// Readiness verdict for a caller goal.
+///
+/// `status` is the contract callers should branch on. `summary`,
+/// `minimum_next`, and `full_repair` are presentation/operation guidance. The
+/// optional snapshots are diagnostic evidence for explaining the verdict.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct ReadinessVerdictDto {
     pub goal: ReadinessGoalDto,
@@ -314,6 +364,11 @@ pub struct ReadinessVerdictDto {
     pub sidecar: Option<ReadinessSidecarSnapshotDto>,
 }
 
+/// Search result row shared by search, citations, and packet evidence.
+///
+/// Ranking fields (`score`, `score_breakdown`, `match_quality`) are diagnostic
+/// evidence. `evidence_tier`, `resolution_status`, `coverage_role`, and
+/// `eligible_for_sufficiency` control whether a hit may support an answer.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct SearchHit {
     pub node_id: NodeId,
@@ -536,6 +591,11 @@ pub struct SearchPlanDto {
     pub source_truth_checks: Vec<String>,
 }
 
+/// Search response with product hits and optional diagnostics.
+///
+/// `hits` is the merged presentation list. Source-specific lists and shadow
+/// fields are compatibility/diagnostic surfaces for callers that need to audit
+/// provenance, fallback, or sidecar behavior.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct SearchResultsDto {
     pub query: String,
@@ -597,6 +657,10 @@ pub struct IndexedFileDto {
     pub error_count: u32,
 }
 
+/// Per-language file count and support claim shown in indexed-file summaries.
+///
+/// `support_mode` and `evidence_tier` are product evidence from
+/// `language_support`; `claim_label` is presentation text.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct IndexedFileLanguageCountDto {
     pub language: String,
@@ -632,6 +696,12 @@ pub struct IndexedFilesDto {
     pub files: Vec<IndexedFileDto>,
 }
 
+/// Framework route coverage reported by indexed-file diagnostics.
+///
+/// `coverage_evidence`, `confidence_floor`, `handler_link_support`,
+/// `unsupported_patterns`, and `known_gaps` are product evidence boundaries.
+/// The `fixture_status` alias is backward compatibility only; new JSON should
+/// emit `coverage_evidence`.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct FrameworkRouteCoverageDto {
     pub framework: String,
@@ -1006,6 +1076,11 @@ pub enum CanonicalMemberVisibility {
     Default,
 }
 
+/// Trail request DTO used by API callers.
+///
+/// The shape is serialized API surface. `hide_speculative` filters uncertain
+/// evidence from presentation; it does not alter the graph. `story` asks the
+/// runtime to add narrative grouping when available.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct TrailConfigDto {
     pub root_id: NodeId,
@@ -1381,6 +1456,10 @@ pub struct SearchHybridLimitsDto {
     pub semantic: Option<u32>,
 }
 
+/// Request for answer-oriented retrieval.
+///
+/// `include_evidence` defaults to true because callers should preserve the
+/// source and readiness evidence needed to audit an answer.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct AgentAskRequest {
     pub prompt: String,
@@ -1604,6 +1683,10 @@ pub struct RetrievalCandidateResolutionCountDto {
 }
 
 /// Shadow sidecar retrieval diagnostics emitted alongside packet output.
+///
+/// This is diagnostic evidence for sidecar behavior and loss points. It should
+/// not be promoted to product readiness by itself; use `RetrievalStateDto` and
+/// packet sufficiency for caller decisions.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct RetrievalShadowDto {
     pub retrieval_mode: String,
@@ -1697,6 +1780,10 @@ pub struct AgentAnswerDto {
     pub retrieval_trace: AgentRetrievalTraceDto,
 }
 
+/// Evidence item kind in a packet.
+///
+/// Variants identify where evidence came from. `Negative` records absence or a
+/// rejected path and must not be counted as supporting proof.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceTypeDto {
@@ -1740,6 +1827,11 @@ pub struct EvidenceSourceLocationDto {
     pub line_end: Option<u32>,
 }
 
+/// One evidence row inside an evidence packet.
+///
+/// The row is auditable diagnostic/product evidence depending on
+/// `evidence_type`, `verification_status`, and optional source location. Artifact
+/// paths point to supporting files; they are not serialized source content.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct EvidenceItemDto {
     pub id: String,
@@ -1768,6 +1860,10 @@ pub struct SourceTruthCheckDto {
     pub required: bool,
 }
 
+/// Answer-readiness summary for packet consumers.
+///
+/// `safe_to_say` is supported output. `inferred_claims` and
+/// `needs_verification` are explicit non-claims until the listed checks pass.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct AnswerReadinessReportDto {
     pub overall_status: ClaimReadinessDto,
@@ -1930,6 +2026,11 @@ pub struct PacketRetrievalTraceSummaryDto {
     pub trail_steps: u32,
 }
 
+/// Packet response for source-grounded answer workflows.
+///
+/// This is a compatibility surface for budget, sufficiency, answer, and
+/// retrieval-trace semantics. `sufficiency.status` is the primary readiness
+/// decision; budget truncation or diagnostic traces should not override it.
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct AgentPacketDto {
     pub packet_id: String,

--- a/crates/codestory-contracts/src/events.rs
+++ b/crates/codestory-contracts/src/events.rs
@@ -1,3 +1,9 @@
+//! Runtime event contracts and in-process fanout.
+//!
+//! Events are lightweight status signals for progress, warnings, and telemetry.
+//! They are not durable audit records; consumers that need complete evidence
+//! should use the corresponding DTO, log, or artifact contract instead.
+
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
@@ -9,6 +15,7 @@ pub use telemetry::{
     new_correlation_id,
 };
 
+/// User-visible runtime status event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Event {
     IndexingStarted { file_count: usize },
@@ -18,6 +25,10 @@ pub enum Event {
     StatusUpdate { message: String },
 }
 
+/// In-process fanout bus for runtime events.
+///
+/// Publishing is best-effort: closed subscribers are dropped, and send failures
+/// are intentionally not surfaced to producers.
 #[derive(Clone)]
 pub struct EventBus {
     tx: Sender<Event>,

--- a/crates/codestory-contracts/src/graph.rs
+++ b/crates/codestory-contracts/src/graph.rs
@@ -1,3 +1,11 @@
+//! Core source graph contracts.
+//!
+//! The graph model is persisted and re-exposed through API DTOs, so ids, enum
+//! discriminants, source locations, and resolution metadata carry compatibility
+//! meaning. Producers may add richer analysis, but callers should treat these
+//! types as evidence records: unresolved endpoints and low-certainty edges are
+//! still useful diagnostics, not proof of an exact semantic relationship.
+
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -18,6 +26,10 @@ pub use location_type::LocationType;
 pub use node_type::{BundleInfo, NodeType};
 pub use token_component::{Token, TokenComponent};
 
+/// Stable identifier for a graph node in one indexed store.
+///
+/// The numeric value is store-local, not a cross-repo identity. Use
+/// `canonical_id` or qualified names when a caller needs a durable symbol key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NodeId(pub i64);
 
@@ -27,9 +39,15 @@ impl fmt::Display for NodeId {
     }
 }
 
+/// Stable identifier for a graph edge in one indexed store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct EdgeId(pub i64);
 
+/// Source graph node classification.
+///
+/// Variants intentionally mirror the persisted Sourcetrail-style integer
+/// discriminants. Append-only changes are safer than reordering existing
+/// variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 #[repr(i32)]
@@ -118,6 +136,10 @@ impl TryFrom<i32> for NodeKind {
     }
 }
 
+/// Source graph edge classification.
+///
+/// These variants describe observed or resolved relationships. `UNKNOWN` keeps
+/// imperfect extraction visible instead of dropping evidence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 #[repr(i32)]
@@ -174,6 +196,10 @@ impl TryFrom<i32> for EdgeKind {
     }
 }
 
+/// Confidence bucket for a resolved graph relationship.
+///
+/// This is diagnostic evidence. `Certain` is still an extractor confidence
+/// claim, not a guarantee that runtime behavior follows the edge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ResolutionCertainty {
@@ -223,6 +249,7 @@ impl FromStr for ResolutionCertainty {
     }
 }
 
+/// Persisted graph node with optional source span and durable names.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Node {
     pub id: NodeId,
@@ -237,6 +264,12 @@ pub struct Node {
     pub end_col: Option<u32>,
 }
 
+/// Persisted graph edge with raw and optionally resolved endpoints.
+///
+/// `source` and `target` retain the extracted relationship. `resolved_source`
+/// and `resolved_target` are product evidence for the best-known typed
+/// endpoints; callers that need the semantic endpoint should use
+/// `effective_source`, `effective_target`, or `effective_endpoints`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Edge {
     pub id: EdgeId,

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -1,9 +1,20 @@
+//! Language support and claim-tier contracts.
+//!
+//! These tables separate three claims that are easy to overstate:
+//! extension/file routing, parser-backed graph extraction, and answer-quality
+//! proof. A language profile is product evidence for what the runtime may index
+//! today; it is not proof that every framework pattern, semantic edge, or packet
+//! answer is supported.
+
 use crate::api::{PacketEvidenceResolutionDto, PacketEvidenceTierDto};
 use crate::graph::NodeKind;
 
+/// How CodeStory obtains product evidence for a language profile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageSupportMode {
+    /// Tree-sitter-backed extraction can produce graph nodes and edges.
     ParserBackedGraph,
+    /// Path- or syntax-specific collectors produce exact source anchors only.
     StructuralCollector,
 }
 
@@ -16,9 +27,12 @@ impl LanguageSupportMode {
     }
 }
 
+/// Evidence tier advertised by a language support profile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageEvidenceTier {
+    /// Parser-backed graph evidence covered by fidelity checks.
     GraphFidelity,
+    /// Exact source anchors without parser-backed graph parity.
     StructuralOnly,
 }
 
@@ -31,6 +45,11 @@ impl LanguageEvidenceTier {
     }
 }
 
+/// Specific claim a proof artifact is allowed to support.
+///
+/// Higher tiers are intentionally not implied by lower tiers. For example,
+/// filename routing does not prove parser support, and parser extraction does
+/// not prove packet answer quality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageClaimTier {
     FilenameRoute,
@@ -54,6 +73,7 @@ impl LanguageClaimTier {
     }
 }
 
+/// Kind of artifact accepted as proof for a language claim tier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LanguageProofRole {
     ExtensionRouting,
@@ -77,6 +97,7 @@ impl LanguageProofRole {
     }
 }
 
+/// Allowed proof roles and provenance expectations for one claim tier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LanguageClaimTierContract {
     pub tier: LanguageClaimTier,
@@ -117,6 +138,11 @@ pub const LANGUAGE_CLAIM_TIER_CONTRACTS: &[LanguageClaimTierContract] = &[
     },
 ];
 
+/// Structural collector contract for exact-source, non-semantic proof.
+///
+/// Each row is a product evidence boundary. `semantic_proof_allowed = false`
+/// means the collector may support navigation or diagnostics, but must not be
+/// promoted as typed semantic evidence without a separate proof tier.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct StructuralSourceProofContract {
     pub collector_name: &'static str,
@@ -210,6 +236,10 @@ pub const STRUCTURAL_SOURCE_PROOF_CONTRACTS: &[StructuralSourceProofContract] = 
     },
 ];
 
+/// Public language profile exposed to callers and diagnostics.
+///
+/// `claim_label` is presentation text, while `support_mode` and
+/// `evidence_tier` are compatibility surfaces for downstream logic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LanguageSupportProfile {
     pub language_name: &'static str,
@@ -278,10 +308,15 @@ const fn structural_profile(
     }
 }
 
+/// Normalize a file extension for registry lookup.
 pub fn normalize_extension(ext: &str) -> String {
     ext.trim().trim_start_matches('.').to_ascii_lowercase()
 }
 
+/// Look up a language profile by extension.
+///
+/// The lookup is case-insensitive and accepts a leading dot. A hit proves only
+/// the profile's declared claim tier, not parser or answer quality beyond it.
 pub fn language_support_profile_for_ext(ext: &str) -> Option<&'static LanguageSupportProfile> {
     let ext = ext.trim().trim_start_matches('.');
     LANGUAGE_SUPPORT_PROFILES.iter().find(|profile| {
@@ -292,6 +327,7 @@ pub fn language_support_profile_for_ext(ext: &str) -> Option<&'static LanguageSu
     })
 }
 
+/// Look up a profile by its public language name.
 pub fn language_support_profile_for_language_name(
     language_name: &str,
 ) -> Option<&'static LanguageSupportProfile> {
@@ -301,6 +337,7 @@ pub fn language_support_profile_for_language_name(
         .find(|profile| profile.language_name.eq_ignore_ascii_case(language_name))
 }
 
+/// Look up a profile from a file path's final extension.
 pub fn language_support_profile_for_path(
     path: Option<&str>,
 ) -> Option<&'static LanguageSupportProfile> {
@@ -308,27 +345,32 @@ pub fn language_support_profile_for_path(
     language_support_profile_for_ext(ext)
 }
 
+/// Return the public language name for a supported path.
 pub fn language_name_for_path(path: Option<&str>) -> Option<&'static str> {
     language_support_profile_for_path(path).map(|profile| profile.language_name)
 }
 
+/// Return a language name only when the path maps to parser-backed graph support.
 pub fn parser_backed_language_name_for_path(path: Option<&str>) -> Option<&'static str> {
     language_support_profile_for_path(path)
         .filter(|profile| profile.support_mode == LanguageSupportMode::ParserBackedGraph)
         .map(|profile| profile.language_name)
 }
 
+/// Return a language name only when the path maps to structural-only support.
 pub fn structural_language_name_for_path(path: Option<&str>) -> Option<&'static str> {
     language_support_profile_for_path(path)
         .filter(|profile| profile.support_mode == LanguageSupportMode::StructuralCollector)
         .map(|profile| profile.language_name)
 }
 
+/// Whether a public language name is structural-only.
 pub fn is_structural_language_name(language_name: &str) -> bool {
     language_support_profile_for_language_name(language_name)
         .is_some_and(|profile| profile.support_mode == LanguageSupportMode::StructuralCollector)
 }
 
+/// Whether a path is in the GitHub Actions workflow collector scope.
 pub fn is_github_actions_workflow_path(path: &str) -> bool {
     let normalized = path.replace('\\', "/").to_ascii_lowercase();
     let mut parts = normalized.rsplit('/');
@@ -346,6 +388,7 @@ pub fn is_github_actions_workflow_path(path: &str) -> bool {
         && grandparent == ".github"
 }
 
+/// Whether a path is in the Docker Compose collector scope.
 pub fn is_docker_compose_file_path(path: &str) -> bool {
     if is_github_actions_workflow_path(path) {
         return false;
@@ -366,6 +409,7 @@ pub fn is_docker_compose_file_path(path: &str) -> bool {
         || (stem.ends_with("-compose") && parts.any(|part| part == "docker"))
 }
 
+/// Whether a path is exactly a Cargo manifest by basename.
 pub fn is_cargo_manifest_file_path(path: &str) -> bool {
     path.replace('\\', "/")
         .rsplit('/')
@@ -373,12 +417,14 @@ pub fn is_cargo_manifest_file_path(path: &str) -> bool {
         .is_some_and(|file_name| file_name == "Cargo.toml")
 }
 
+/// All extensions that have a public language profile.
 pub fn supported_extensions() -> impl Iterator<Item = &'static str> {
     LANGUAGE_SUPPORT_PROFILES
         .iter()
         .flat_map(|profile| profile.extensions.iter().copied())
 }
 
+/// Claim tiers implied by a language support profile.
 pub fn language_claim_tiers_for_profile(
     profile: &LanguageSupportProfile,
 ) -> &'static [LanguageClaimTier] {
@@ -388,6 +434,7 @@ pub fn language_claim_tiers_for_profile(
     }
 }
 
+/// Contract row for one claim tier.
 pub fn language_claim_tier_contract(
     tier: LanguageClaimTier,
 ) -> Option<&'static LanguageClaimTierContract> {

--- a/crates/codestory-contracts/src/lib.rs
+++ b/crates/codestory-contracts/src/lib.rs
@@ -1,3 +1,15 @@
+//! Shared contracts for CodeStory crates and API consumers.
+//!
+//! This crate owns the serializable graph model, API DTOs, event payloads,
+//! query/trail shapes, and language support contracts that downstream crates
+//! exchange across process, cache, and UI boundaries. Public types here are
+//! compatibility surfaces: changing a serialized field name, enum spelling, or
+//! readiness meaning can break callers even when Rust still compiles.
+//!
+//! Keep behavior in producer crates. Keep this crate focused on stable shape,
+//! explicit evidence semantics, and small helpers that prevent callers from
+//! reinterpreting the same contract differently.
+
 pub mod api;
 pub mod events;
 pub mod graph;

--- a/crates/codestory-contracts/src/query.rs
+++ b/crates/codestory-contracts/src/query.rs
@@ -1,11 +1,22 @@
+//! Serializable graph-query AST.
+//!
+//! Query values describe caller intent, not an execution plan. Runtime crates
+//! remain responsible for resolving symbols, applying defaults, enforcing
+//! limits, and reporting partial evidence when the query cannot be satisfied.
+
 use crate::api::{NodeKind, TrailDirection};
 use serde::{Deserialize, Serialize};
 
+/// Ordered pipeline of graph-query operations.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GraphQueryAst {
     pub operations: Vec<GraphQueryOperation>,
 }
 
+/// One operation in a graph-query pipeline.
+///
+/// The serde tag is part of the JSON contract; callers should add operations
+/// append-only and keep existing tag spellings stable.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum GraphQueryOperation {

--- a/crates/codestory-contracts/src/trail.rs
+++ b/crates/codestory-contracts/src/trail.rs
@@ -1,2 +1,9 @@
+//! Trail contracts for graph-neighborhood and path views.
+//!
+//! This module re-exports the core trail model plus API DTOs so callers can use
+//! one import path for trail requests and responses. Trail output is navigation
+//! evidence: filtering, truncation, and speculative-edge hiding affect what is
+//! shown, not what exists in the underlying graph.
+
 pub use crate::api::{TrailConfigDto, TrailContextDto, TrailFilterOptionsDto};
 pub use crate::graph::{TrailCallerScope, TrailConfig, TrailDirection, TrailMode, TrailResult};


### PR DESCRIPTION
## Context

Closes #223
Refs #215
Refs #38

Issue #223 asks for the first narrow rustdoc slice on `codestory-contracts` public contracts after the baseline/style pass. The goal is to make the highest-value API, graph, language-support, query, trail, and event surfaces understandable without changing behavior or serialized DTO shape.

## What Changed

- Added crate and module rustdoc for `codestory-contracts`, `api`, `graph`, `query`, `trail`, `events`, and `language_support`.
- Documented compatibility expectations for API DTOs, mirrored enums, graph ids/kinds, query serde tags, and trail presentation filters.
- Added focused rustdoc for readiness, retrieval, search, packet/evidence, framework coverage, language claim-tier, and structural proof contracts.
- Called out where fields are product evidence, diagnostic evidence, compatibility surface, or presentation-only surface.

## How To Review

- Start with `crates/codestory-contracts/src/lib.rs`, `api.rs`, and `api/dto.rs` for serialized DTO contract language.
- Check `language_support.rs` for claim-tier and structural proof boundaries.
- Skim `graph.rs`, `query.rs`, `trail.rs`, and `events.rs` to confirm the new docs describe existing behavior without creating new claims.

## Verification

- `RUSTC_WRAPPER=%USERPROFILE%\.cargo\bin\sccache.exe cargo doc -p codestory-contracts --no-deps` - passed
- `RUSTC_WRAPPER=%USERPROFILE%\.cargo\bin\sccache.exe cargo fmt --check` - passed
- `git diff --check` - passed
- `cargo test --doc -p codestory-contracts` - not run; no doctests or examples were introduced

## Risk

Low. This is a rustdoc-only change. Residual risk is wording drift: reviewers should check that evidence/readiness labels match current product semantics and do not overclaim sidecar, packet, or language support readiness.