### PR TITLE
[codex] document workspace-store-indexer rustdoc

### DIFF
--- a/crates/codestory-indexer/src/intermediate_storage.rs
+++ b/crates/codestory-indexer/src/intermediate_storage.rs
@@ -2,6 +2,11 @@ use codestory_contracts::graph::{
     AccessKind, CallableProjectionState, Edge, ErrorInfo, Node, NodeId, Occurrence,
 };
 
+/// Mutable projection accumulator used before flushing to storage.
+///
+/// Parser-backed indexers and structural collectors both fill this shape. A
+/// caller should merge or flush it as one coherent projection so file rows,
+/// nodes, edges, occurrences, and callable projection state stay aligned.
 #[derive(Default)]
 pub struct IntermediateStorage {
     pub files: Vec<codestory_store::FileInfo>,
@@ -15,30 +20,37 @@ pub struct IntermediateStorage {
 }
 
 impl IntermediateStorage {
+    /// Create an empty projection accumulator.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Append one graph node.
     pub fn add_node(&mut self, node: Node) {
         self.nodes.push(node);
     }
 
+    /// Append one graph edge.
     pub fn add_edge(&mut self, edge: Edge) {
         self.edges.push(edge);
     }
 
+    /// Append one source occurrence.
     pub fn add_occurrence(&mut self, occurrence: Occurrence) {
         self.occurrences.push(occurrence);
     }
 
+    /// Append one indexing error.
     pub fn add_error(&mut self, error: ErrorInfo) {
         self.errors.push(error);
     }
 
+    /// Append component-access metadata for a node.
     pub fn add_component_access(&mut self, node_id: NodeId, access: AccessKind) {
         self.component_access.push((node_id, access));
     }
 
+    /// Merge another accumulator into this one, preserving insertion order.
     pub fn merge(&mut self, other: IntermediateStorage) {
         self.files.extend(other.files);
         self.nodes.extend(other.nodes);
@@ -51,6 +63,7 @@ impl IntermediateStorage {
         self.errors.extend(other.errors);
     }
 
+    /// Remove all accumulated projection data and errors.
     pub fn clear(&mut self) {
         self.files.clear();
         self.nodes.clear();

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1,3 +1,16 @@
+//! Parser-backed and structural indexing pipeline.
+//!
+//! The indexer turns source files selected by `codestory-workspace` into graph
+//! projections persisted by `codestory-store`. Parser-backed languages use
+//! tree-sitter graph rules and optional semantic resolution. Structural
+//! collectors emit exact source anchors for files such as HTML, CSS, SQL,
+//! GitHub Actions workflows, Docker Compose files, and Cargo manifests; those
+//! anchors are source proof, not parser-backed language coverage.
+//!
+//! Freshness is owned by the caller's refresh plan. This crate assumes each
+//! `index_file` or `WorkspaceIndexer::run` input is scheduled for indexing and
+//! returns projection rows for storage to flush.
+
 use anyhow::{Result, anyhow};
 use codestory_contracts::graph::{
     AccessKind, CallableProjectionState, Edge, EdgeId, EdgeKind, Node, NodeId, NodeKind,
@@ -145,6 +158,11 @@ enum LanguageRuleset {
     Bash,
 }
 
+/// Tree-sitter language plus graph/tag rules used for parser-backed indexing.
+///
+/// A `LanguageConfig` means CodeStory has parser rules for the file extension.
+/// Structural collectors and text-only diagnostics are routed elsewhere and
+/// should not be described as parser-backed graph support.
 #[derive(Debug, Clone)]
 pub struct LanguageConfig {
     pub language: Language,
@@ -574,6 +592,10 @@ fn get_language_config_for_path(
     get_language_for_ext(ext)
 }
 
+/// Batch sizes used while flushing incremental indexing output.
+///
+/// These values tune memory and write granularity only. They do not change
+/// parser routing, graph semantics, or freshness decisions.
 #[derive(Debug, Clone, Copy)]
 pub struct IncrementalIndexingConfig {
     pub file_batch_size: usize,
@@ -613,6 +635,11 @@ impl IncrementalIndexingConfig {
     }
 }
 
+/// In-memory graph projection for one indexed source.
+///
+/// Callers pass these vectors to `codestory-store` as one coherent projection
+/// batch. `errors` are tracked separately in `IntermediateStorage` during
+/// workspace runs.
 pub struct IndexResult {
     pub files: Vec<codestory_store::FileInfo>,
     pub nodes: Vec<Node>,
@@ -633,12 +660,14 @@ enum ProjectionUpdateMode {
     FullReplace,
 }
 
+/// Progress event emitted by low-level indexing flows.
 pub enum IndexingEvent {
     Progress(u64),
     Error(String),
     Finished,
 }
 
+/// Timings and counters collected during a workspace indexing run.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct IncrementalIndexingStats {
     pub setup_existing_projection_ids_ms: u64,
@@ -729,6 +758,12 @@ struct ArtifactCacheWrite {
     artifact_blob: Vec<u8>,
 }
 
+/// Workspace-level indexer that executes refresh plans into a `Store`.
+///
+/// The indexer does not discover stale files; it consumes a
+/// `RefreshExecutionPlan` from `codestory-workspace`. Incremental runs seed
+/// enough existing symbol state to preserve stable projections, while full
+/// refreshes rebuild from the scheduled files.
 pub struct WorkspaceIndexer {
     root: PathBuf,
     compilation_db: Option<compilation_database::CompilationDatabase>,
@@ -737,6 +772,11 @@ pub struct WorkspaceIndexer {
 }
 
 impl WorkspaceIndexer {
+    /// Create an indexer rooted at a workspace directory.
+    ///
+    /// If a compilation database is present, C/C++ header routing can use it;
+    /// load failures are reported later through the event bus and indexing
+    /// continues without that metadata.
     pub fn new(root: PathBuf) -> Self {
         let (compilation_db, compilation_db_warning) = if let Some(path) =
             compilation_database::CompilationDatabase::find_in_directory(&root)
@@ -763,16 +803,18 @@ impl WorkspaceIndexer {
         }
     }
 
+    /// Override incremental flush batch sizes.
     pub fn with_batch_config(mut self, batch_config: IncrementalIndexingConfig) -> Self {
         self.batch_config = batch_config;
         self
     }
 
-    /// Returns the workspace root path
+    /// Return the workspace root path used to normalize refresh-plan inputs.
     pub fn root(&self) -> &PathBuf {
         &self.root
     }
 
+    /// Run an incremental plan built from legacy `RefreshInfo`.
     pub fn run_incremental(
         &self,
         storage: &mut Storage,
@@ -791,6 +833,12 @@ impl WorkspaceIndexer {
         self.run(storage, &plan, event_bus, cancel_token)
     }
 
+    /// Execute a workspace refresh plan and flush projections into storage.
+    ///
+    /// The plan supplies the freshness decision. This method parses scheduled
+    /// files, routes structural candidates to structural collectors, flushes
+    /// graph/search projection batches, and publishes progress. Cancellation is
+    /// cooperative and returns stats for completed work.
     pub fn run(
         &self,
         storage: &mut Storage,
@@ -14273,6 +14321,10 @@ impl FrameworkRoute {
     }
 }
 
+/// Return whether a path is eligible for OpenAPI schema diagnostics.
+///
+/// Eligibility is extension-only; `looks_like_openapi_schema` must still verify
+/// content before endpoint source proof is emitted.
 pub fn is_openapi_candidate_path(path: &Path) -> bool {
     let extension = path
         .extension()
@@ -14282,6 +14334,10 @@ pub fn is_openapi_candidate_path(path: &Path) -> bool {
     matches!(extension.as_str(), "json" | "yaml" | "yml")
 }
 
+/// Return whether a path can receive text-only framework diagnostics.
+///
+/// Text-only candidates can contribute source proof for framework routes or
+/// endpoint literals, but they are not parser-backed graph coverage.
 pub fn is_text_only_candidate_path(path: &Path) -> bool {
     let extension = path
         .extension()
@@ -14736,6 +14792,7 @@ fn index_openapi_schema_file(path: &Path, source: &str) -> Result<Option<Interme
     Ok(Some(local_storage))
 }
 
+/// Return whether text contains the minimum OpenAPI/Swagger markers.
 pub fn looks_like_openapi_schema(source: &str) -> bool {
     let lower = source.to_ascii_lowercase();
     contains_openapi_schema_marker(&lower) && contains_openapi_paths_marker(&lower)
@@ -17669,7 +17726,12 @@ fn enclosing_callable_node_id(nodes: &HashMap<NodeId, Node>, line: u32) -> Optio
         .map(|node| node.id)
 }
 
-/// Index a file and return the results.
+/// Index one file with an already selected parser-backed language config.
+///
+/// This function expects the caller to provide the source and matching
+/// `LanguageConfig`. It emits parser-backed nodes, edges, occurrences, and
+/// callable projection state for that file, plus delegated structural CSS from
+/// supported template files.
 pub fn index_file(
     path: &Path,
     source: &str,
@@ -18287,10 +18349,12 @@ pub fn index_file(
     })
 }
 
+/// Return the public language-support profile for a file extension.
 pub fn language_support_profile_for_ext(ext: &str) -> Option<LanguageSupportProfile> {
     codestory_contracts::language_support::language_support_profile_for_ext(ext).copied()
 }
 
+/// Return the public language-support profile for a language name.
 pub fn language_support_profile_for_language_name(
     language_name: &str,
 ) -> Option<LanguageSupportProfile> {
@@ -18298,10 +18362,15 @@ pub fn language_support_profile_for_language_name(
         .copied()
 }
 
+/// Return parser-backed indexer configuration for an extension.
+///
+/// `None` can still be supported by a structural collector or diagnostic path;
+/// consult the language-support profile before presenting support tiers.
 pub fn get_language_for_ext(ext: &str) -> Option<LanguageConfig> {
     language_configs::get_language_for_ext(ext)
 }
 
+/// Generate a stable deterministic id from a canonical graph name.
 pub fn generate_id(name: &str) -> i64 {
     let mut h: u64 = 0xcbf29ce484222325;
     for b in name.as_bytes() {

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -1,3 +1,11 @@
+//! Resolution pass for unresolved call/import graph edges.
+//!
+//! Parser rules create unresolved edges when the source proves a relationship
+//! but the target is not yet known. This pass resolves those edges against the
+//! stored graph using same-file/module/global strategies and optional semantic
+//! fallback. It records telemetry and candidate evidence without changing which
+//! files are fresh.
+
 use crate::semantic::{
     SemanticCandidateIndex, SemanticCandidateNodeSnapshot, SemanticResolutionCandidate,
     SemanticResolutionRequest, SemanticResolverRegistry,
@@ -48,6 +56,7 @@ type SameFileCacheKey = (i64, String, String);
 type SameModuleCacheKey = (String, String, String);
 type NameCacheKey = (String, String);
 type RelativeImportCacheKey = (String, String, String, String);
+/// Version for cached resolution-support snapshots.
 pub const RESOLUTION_SUPPORT_SNAPSHOT_VERSION: i64 = 4;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -124,6 +133,7 @@ struct ResolvedEdgeUpdate {
     touch_metadata: bool,
 }
 
+/// Counts and telemetry returned by a resolution pass.
 #[derive(Default, Debug)]
 pub struct ResolutionStats {
     pub unresolved_calls_before: usize,
@@ -291,6 +301,7 @@ impl OverrideSupport {
     }
 }
 
+/// Per-phase timing and semantic-request counters for resolution.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ResolutionPhaseTelemetry {
     pub scope_prepare_ms: u64,
@@ -354,6 +365,7 @@ impl ResolutionPhaseTelemetry {
     }
 }
 
+/// Counters for the resolution strategies that produced target matches.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ResolutionStrategyCounters {
     pub call_same_file: usize,
@@ -585,6 +597,7 @@ impl ResolutionPolicy {
     }
 }
 
+/// Resolves unresolved call/import edges in a `Store`.
 pub struct ResolutionPass {
     flags: ResolutionFlags,
     policy: ResolutionPolicy,
@@ -598,6 +611,7 @@ impl Default for ResolutionPass {
 }
 
 impl ResolutionPass {
+    /// Create a resolution pass using environment-controlled policy flags.
     pub fn new() -> Self {
         let flags = ResolutionFlags::from_env();
         let policy = ResolutionPolicy::for_flags(flags);
@@ -608,10 +622,15 @@ impl ResolutionPass {
         }
     }
 
+    /// Resolve all eligible unresolved edges in the store.
     pub fn run(&self, storage: &mut Storage) -> Result<ResolutionStats> {
         self.run_with_scope(storage, None)
     }
 
+    /// Resolve unresolved edges scoped to callers in selected file ids.
+    ///
+    /// Scoped runs are used after incremental indexing so stale resolutions
+    /// outside the changed caller set are left untouched.
     pub fn run_with_scope(
         &self,
         storage: &mut Storage,

--- a/crates/codestory-indexer/src/semantic/mod.rs
+++ b/crates/codestory-indexer/src/semantic/mod.rs
@@ -1,3 +1,10 @@
+//! Semantic fallback resolution for parser-backed graph edges.
+//!
+//! This module ranks candidate graph nodes after parser rules have emitted an
+//! unresolved call or import. Structural collector files can appear in the
+//! candidate index for language-family filtering, but resolver dispatch only
+//! uses parser-backed languages plus template script surfaces.
+
 use anyhow::Result;
 use codestory_contracts::graph::EdgeKind;
 use codestory_contracts::language_support::{
@@ -34,6 +41,7 @@ use ruby::RubySemanticResolver;
 use rust::RustSemanticResolver;
 use typescript::TypeScriptSemanticResolver;
 
+/// Request to resolve one unresolved parser-backed edge.
 #[derive(Debug, Clone)]
 pub struct SemanticResolutionRequest {
     pub edge_kind: EdgeKind,
@@ -43,6 +51,7 @@ pub struct SemanticResolutionRequest {
     pub target_name: String,
 }
 
+/// Candidate target returned by a semantic resolver.
 #[derive(Debug, Clone, Copy)]
 pub struct SemanticResolutionCandidate {
     pub target_node_id: i64,
@@ -71,6 +80,7 @@ pub(crate) struct SemanticCandidateNodeSnapshot {
     pub language_family: Option<String>,
 }
 
+/// In-memory candidate index loaded from stored graph nodes.
 #[derive(Debug, Clone, Default)]
 pub struct SemanticCandidateIndex {
     nodes: Vec<SemanticCandidateNode>,
@@ -282,6 +292,7 @@ impl SemanticCandidateIndex {
 }
 
 pub trait SemanticResolver: Send + Sync {
+    /// Return candidate targets for `request`, ordered by resolver confidence.
     fn resolve(
         &self,
         index: &SemanticCandidateIndex,
@@ -327,15 +338,18 @@ impl SemanticResolver for SemanticResolverKind {
     }
 }
 
+/// Registry that dispatches semantic resolution by caller file language.
 pub struct SemanticResolverRegistry {
     enabled: bool,
 }
 
 impl SemanticResolverRegistry {
+    /// Create a registry; disabled registries return no candidates.
     pub fn new(enabled: bool) -> Self {
         Self { enabled }
     }
 
+    /// Resolve a request with the parser-backed resolver for its caller path.
     pub fn resolve(
         &self,
         index: &SemanticCandidateIndex,

--- a/crates/codestory-indexer/src/structural/mod.rs
+++ b/crates/codestory-indexer/src/structural/mod.rs
@@ -1,4 +1,10 @@
-//! Structural-language entity collectors (HTML, CSS, SQL) with explicit node/edge mapping.
+//! Structural entity collectors with exact source-span anchors.
+//!
+//! Structural collectors cover source formats where CodeStory can extract
+//! useful evidence without claiming parser-backed language support. They emit
+//! file rows, nodes, edges, occurrences, and callable projection state with
+//! conservative certainty. Callers should present this output as structural
+//! source proof, not as semantic resolution or full graph coverage.
 
 mod blanking;
 mod cargo_manifest;
@@ -13,6 +19,7 @@ pub use blanking::{
     EmbeddedRegion, EmbeddedRegionKind, blank_non_script_regions, blank_outside_regions,
     extract_embedded_regions,
 };
+/// Return the structural language label stored for `path`.
 pub fn structural_language_name(path: &Path) -> &'static str {
     common::structural_language_name(path)
 }
@@ -25,6 +32,11 @@ use codestory_contracts::language_support::{
 };
 use std::path::Path;
 
+/// Return whether `path` is routed to a structural collector.
+///
+/// YAML/TOML admission is path-scoped for known workflow, compose, and Cargo
+/// manifest conventions. Generic YAML and TOML files are intentionally not
+/// admitted here.
 pub fn is_structural_candidate_path(path: &Path) -> bool {
     let path_text = path.to_string_lossy();
     if is_github_actions_workflow_path(path_text.as_ref())
@@ -39,11 +51,13 @@ pub fn is_structural_candidate_path(path: &Path) -> bool {
     )
 }
 
+/// Read and structurally index a file from disk.
 pub fn index_structural_file(path: &Path) -> Result<IntermediateStorage> {
     let source = std::fs::read_to_string(path)?;
     index_structural_source(path, &source)
 }
 
+/// Add CSS entities extracted from an embedded template style block.
 pub fn collect_embedded_style_css(
     path: &Path,
     style_source: &str,
@@ -54,6 +68,10 @@ pub fn collect_embedded_style_css(
     css::collect_css_entities(path, style_source, file_id, storage, line_offset);
 }
 
+/// Structurally index source text for an already admitted path.
+///
+/// The returned storage is ready to merge into a projection batch and includes
+/// callable projection state derived from the structural edges.
 pub fn index_structural_source(path: &Path, source: &str) -> Result<IntermediateStorage> {
     let mut storage = IntermediateStorage::default();
     let (file_node, _file_name, file_id) = crate::file_node_from_source(path, source);

--- a/crates/codestory-store/src/file_store.rs
+++ b/crates/codestory-store/src/file_store.rs
@@ -3,6 +3,12 @@ use codestory_contracts::workspace::StoredFileRecord;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+/// Read-only file inventory facade.
+///
+/// The inventory is the storage half of incremental refresh planning. Callers
+/// should pass records from this facade to `codestory-workspace` without
+/// rewriting paths or mtimes; freshness comparisons depend on the stored file
+/// ids and millisecond timestamps staying intact.
 pub struct FileStore<'a> {
     storage: &'a Store,
 }
@@ -12,10 +18,12 @@ impl<'a> FileStore<'a> {
         Self { storage }
     }
 
+    /// Return all stored file rows, including files that may need reindexing.
     pub fn get_files(&self) -> Result<Vec<FileInfo>, StorageError> {
         self.storage.get_files()
     }
 
+    /// Return stored file rows keyed by exact requested paths.
     pub fn get_files_by_paths(
         &self,
         paths: &[PathBuf],
@@ -23,10 +31,12 @@ impl<'a> FileStore<'a> {
         self.storage.get_files_by_paths(paths)
     }
 
+    /// Return the stored file row for one path, if present.
     pub fn get_file_by_path(&self, path: &Path) -> Result<Option<FileInfo>, StorageError> {
         self.storage.get_file_by_path(path)
     }
 
+    /// Return the compact inventory contract consumed by refresh planning.
     pub fn inventory(&self) -> Result<Vec<StoredFileRecord>, StorageError> {
         self.storage
             .get_files()?

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -1,3 +1,11 @@
+//! SQLite persistence facades for CodeStory graph, search, and snapshot state.
+//!
+//! `Store` owns the schema connection. The smaller facade types expose the
+//! pipeline contracts most callers need: file inventory for refresh planning,
+//! projection flushing for indexer output, and derived snapshot lifecycle for
+//! read-heavy grounding views. The store layer persists evidence; it does not
+//! upgrade structural source proof into parser-backed graph evidence.
+
 mod file_store;
 mod projection_store;
 mod snapshot_store;
@@ -18,14 +26,17 @@ pub use storage_impl::{
 };
 
 impl Store {
+    /// Access stored file inventory used by workspace refresh planning.
     pub fn files(&self) -> FileStore<'_> {
         FileStore::new(self)
     }
 
+    /// Access graph/search projection writes for indexer output.
     pub fn projections(&mut self) -> ProjectionStore<'_> {
         ProjectionStore::new(self)
     }
 
+    /// Access derived grounding snapshot lifecycle operations.
     pub fn snapshots(&self) -> SnapshotStore<'_> {
         SnapshotStore::new(self)
     }

--- a/crates/codestory-store/src/projection_store.rs
+++ b/crates/codestory-store/src/projection_store.rs
@@ -3,10 +3,17 @@ use codestory_contracts::graph::{
     AccessKind, CallableProjectionState, Edge, Node, NodeId, Occurrence,
 };
 
+/// Mutable graph/search projection facade.
+///
+/// Projection writes replace the indexed view for refreshed files and remove
+/// stale file-scoped errors before inserting new output. Callers must flush a
+/// coherent batch: file rows, nodes, edges, occurrences, component access, and
+/// callable projection state should describe the same indexing pass.
 pub struct ProjectionStore<'a> {
     storage: &'a mut Store,
 }
 
+/// Borrowed indexer output ready to persist as one projection flush.
 pub struct ProjectionBatch<'a> {
     pub files: &'a [FileInfo],
     pub nodes: &'a [Node],
@@ -21,6 +28,7 @@ impl<'a> ProjectionStore<'a> {
         Self { storage }
     }
 
+    /// Load callable projection state already persisted for a file node.
     pub fn get_callable_projection_states_for_file(
         &self,
         file_node_id: NodeId,
@@ -29,6 +37,7 @@ impl<'a> ProjectionStore<'a> {
             .get_callable_projection_states_for_file(file_node_id.0)
     }
 
+    /// Persist a coherent projection batch and return per-stage timing.
     pub fn flush_projection_batch(
         &mut self,
         batch: ProjectionBatch<'_>,

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -2,22 +2,31 @@ use crate::{GroundingSnapshotMetadata, StorageError, Store};
 use std::path::{Path, PathBuf};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+/// Timings for rebuilding both grounding snapshot layers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SnapshotRefreshStats {
     pub summary_snapshot_ms: u32,
     pub detail_snapshot_ms: u32,
 }
 
+/// Timings for making a staged snapshot safe to publish.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StagedSnapshotFinalizeStats {
     pub deferred_indexes_ms: u32,
     pub summary_snapshot_ms: u32,
 }
 
+/// Derived grounding snapshot facade.
+///
+/// Summary and detail snapshots are cached read models over the graph tables.
+/// Projection writes must invalidate them; callers publish or query them only
+/// after the relevant ready-state check succeeds.
 pub struct SnapshotStore<'a> {
     storage: &'a Store,
 }
 
+/// Temporary build database that can be finalized before replacing a live
+/// snapshot path.
 pub struct StagedSnapshot {
     path: PathBuf,
     store: Store,
@@ -28,6 +37,7 @@ impl<'a> SnapshotStore<'a> {
         Self { storage }
     }
 
+    /// Build a unique SQLite path beside the intended live database.
     pub fn staged_path(live_path: &Path) -> PathBuf {
         let parent = live_path.parent().unwrap_or_else(|| Path::new("."));
         let stem = live_path
@@ -42,26 +52,32 @@ impl<'a> SnapshotStore<'a> {
         parent.join(format!("{stem}.staged.{unique}.{extension}"))
     }
 
+    /// Open a fresh staged database in build mode.
     pub fn open_staged(live_path: &Path) -> Result<StagedSnapshot, StorageError> {
         StagedSnapshot::open(live_path)
     }
 
+    /// Remove a staged database and SQLite sidecars.
     pub fn discard_staged(staged_path: &Path) -> Result<(), StorageError> {
         Store::discard_staged_snapshot(staged_path)
     }
 
+    /// Atomically promote a finalized staged database to the live path.
     pub fn promote_staged(staged_path: &Path, live_path: &Path) -> Result<(), StorageError> {
         Store::promote_staged_snapshot(staged_path, live_path)
     }
 
+    /// Return current derived snapshot metadata, if any has been created.
     pub fn get_metadata(&self) -> Result<Option<GroundingSnapshotMetadata>, StorageError> {
         self.storage.get_grounding_snapshot_metadata()
     }
 
+    /// Create secondary indexes that are deferred during build-mode writes.
     pub fn create_deferred_indexes(&self) -> Result<(), StorageError> {
         self.storage.create_deferred_secondary_indexes()
     }
 
+    /// Create deferred indexes and refresh the summary snapshot for publish.
     pub fn finalize_staged(&self) -> Result<StagedSnapshotFinalizeStats, StorageError> {
         let deferred_started = Instant::now();
         self.create_deferred_indexes()?;
@@ -77,30 +93,37 @@ impl<'a> SnapshotStore<'a> {
         })
     }
 
+    /// Back-compatible wrapper for `finalize_staged`.
     pub fn prepare_staged_publish(&self) -> Result<(), StorageError> {
         self.finalize_staged().map(|_| ())
     }
 
+    /// Return whether the summary snapshot is ready for reads.
     pub fn has_ready_summary(&self) -> Result<bool, StorageError> {
         self.storage.has_ready_grounding_summary_snapshots()
     }
 
+    /// Return whether the detail snapshot is ready for reads.
     pub fn has_ready_detail(&self) -> Result<bool, StorageError> {
         self.storage.has_ready_grounding_detail_snapshots()
     }
 
+    /// Refresh the repository summary snapshot from current graph tables.
     pub fn refresh_summary(&self) -> Result<(), StorageError> {
         self.storage.refresh_grounding_summary_snapshots()
     }
 
+    /// Hydrate the detail snapshot from current graph tables.
     pub fn refresh_detail(&self) -> Result<(), StorageError> {
         self.storage.hydrate_grounding_detail_snapshots()
     }
 
+    /// Refresh both summary and detail snapshots.
     pub fn refresh_all(&self) -> Result<(), StorageError> {
         self.storage.refresh_grounding_snapshots()
     }
 
+    /// Refresh both snapshot layers and return timing stats.
     pub fn refresh_all_with_stats(&self) -> Result<SnapshotRefreshStats, StorageError> {
         let summary_started = Instant::now();
         self.refresh_summary()?;
@@ -116,6 +139,7 @@ impl<'a> SnapshotStore<'a> {
         })
     }
 
+    /// Mark derived snapshots dirty after projection changes.
     pub fn invalidate_derived(&self) -> Result<(), StorageError> {
         self.storage.invalidate_grounding_snapshots()
     }
@@ -128,24 +152,29 @@ impl StagedSnapshot {
         Ok(Self { path, store })
     }
 
+    /// Return the staged database path.
     pub fn path(&self) -> &Path {
         &self.path
     }
 
+    /// Borrow the mutable staged store for build writes.
     pub fn store_mut(&mut self) -> &mut Store {
         &mut self.store
     }
 
+    /// Access snapshot operations for the staged store.
     pub fn snapshots(&self) -> SnapshotStore<'_> {
         self.store.snapshots()
     }
 
+    /// Close and remove the staged database.
     pub fn discard(self) -> Result<(), StorageError> {
         let path = self.path;
         drop(self.store);
         SnapshotStore::discard_staged(&path)
     }
 
+    /// Close and promote the staged database to `live_path`.
     pub fn publish(self, live_path: &Path) -> Result<(), StorageError> {
         let path = self.path;
         drop(self.store);

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -29,6 +29,7 @@ use helpers::{
 };
 
 const SCHEMA_VERSION: u32 = 18;
+/// Current SQLite schema version expected by `Store`.
 pub const CURRENT_SCHEMA_VERSION: u32 = SCHEMA_VERSION;
 const GROUNDING_SNAPSHOT_VERSION: i64 = 1;
 const GROUNDING_SNAPSHOT_STATE_DIRTY: i64 = 0;
@@ -266,6 +267,7 @@ fn outside_file_node_predicate(file_param: &str) -> String {
     format!("(file_node_id IS NULL OR file_node_id != {file_param})")
 }
 
+/// Errors returned by storage facade operations.
 #[derive(Error, Debug)]
 pub enum StorageError {
     #[error("Database error: {0}")]
@@ -276,18 +278,28 @@ pub enum StorageError {
     Other(String),
 }
 
+/// SQLite-backed graph, search, file, and snapshot store.
+///
+/// The store is the persistence boundary for indexer output. It owns schema
+/// migration, projection replacement, retrieval manifest rows, and derived
+/// grounding snapshots. Callers must invalidate or rebuild derived snapshots
+/// after mutating graph/search projections.
 pub struct Storage {
     conn: Connection,
     cache: StorageCache,
     deferred_secondary_indexes: bool,
 }
 
+/// Opening mode for a SQLite store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StorageOpenMode {
+    /// Live stores create all indexes immediately and are ready for mixed reads.
     Live,
+    /// Build stores defer expensive secondary indexes until finalization.
     Build,
 }
 
+/// Per-table timing breakdown for a projection flush.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProjectionFlushBreakdown {
     pub files_ms: u32,
@@ -313,6 +325,11 @@ struct StorageCache {
         Arc<RwLock<HashMap<codestory_contracts::graph::NodeId, codestory_contracts::graph::Node>>>,
 }
 
+/// Stored file row persisted with graph projections.
+///
+/// `modification_time` is milliseconds since the Unix epoch and is compared by
+/// workspace refresh planning. `indexed` marks whether the file produced a
+/// completed projection in the current store.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileInfo {
     pub id: i64,
@@ -326,6 +343,10 @@ pub struct FileInfo {
     pub file_role: FileRole,
 }
 
+/// Heuristic role assigned to a file for ranking and summaries.
+///
+/// This role is diagnostic metadata; it must not be treated as parser-backed
+/// evidence about symbols or language support.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum FileRole {
@@ -460,6 +481,11 @@ impl FileRole {
     }
 }
 
+/// Counts describing the effective store contents.
+///
+/// When summary snapshots are ready, counts come from the snapshot read model;
+/// otherwise they are computed from live tables. Fatal errors are always counted
+/// from the error table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageStats {
     pub node_count: i64,
@@ -599,6 +625,7 @@ fn normalize_framework_source_path(path: &Path) -> String {
         .to_ascii_lowercase()
 }
 
+/// Freshness state for derived grounding snapshot layers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GroundingSnapshotState {
     Dirty,
@@ -625,6 +652,11 @@ impl GroundingSnapshotState {
     }
 }
 
+/// Metadata row for derived grounding snapshots.
+///
+/// Ready states mean the corresponding read model has been built from the
+/// current persisted graph at that point in time. Projection writes must mark
+/// these states dirty before callers rely on them again.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GroundingSnapshotMetadata {
     pub version: i64,
@@ -689,12 +721,14 @@ pub struct CallerProjectionRemovalSummary {
     pub removed_callable_projection_state_count: usize,
 }
 
+/// Lightweight symbol projection used by lexical search sidecars.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchSymbolProjection {
     pub node_id: NodeId,
     pub display_name: String,
 }
 
+/// Symbol projection plus source location details for review and diagnostics.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SearchSymbolProjectionDetail {
     pub node_id: NodeId,
@@ -705,6 +739,11 @@ pub struct SearchSymbolProjectionDetail {
     pub end_line: Option<u32>,
 }
 
+/// Stored generated symbol document and embedding payload.
+///
+/// The document records graph-derived text and embedding metadata. Dense
+/// readiness still depends on the retrieval manifest; the row alone does not
+/// prove a sidecar is current.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LlmSymbolDoc {
     pub node_id: NodeId,
@@ -733,6 +772,7 @@ pub struct LlmSymbolDoc {
     pub updated_at_epoch_ms: i64,
 }
 
+/// Reuse metadata for deciding whether a stored symbol document is still fresh.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmSymbolDocReuseMetadata {
     pub node_id: NodeId,
@@ -747,6 +787,7 @@ pub struct LlmSymbolDocReuseMetadata {
     pub dense_reason: Option<String>,
 }
 
+/// Aggregate metadata for stored generated symbol documents.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmSymbolDocStats {
     pub doc_count: u32,
@@ -768,6 +809,7 @@ pub struct LlmSymbolDocStats {
     pub mixed_semantic_policy_versions: bool,
 }
 
+/// Counts of dense-anchor selection reasons.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DenseReasonCounts {
     pub public_api: u32,
@@ -778,6 +820,7 @@ pub struct DenseReasonCounts {
     pub unstructured_doc: u32,
 }
 
+/// Graph-native symbol-search document used by retrieval sidecars.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SymbolSearchDoc {
     pub node_id: NodeId,
@@ -805,16 +848,19 @@ pub struct SymbolSummaryRecord {
 }
 
 impl Storage {
+    /// Open a live store, applying schema migrations and secondary indexes.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
         Self::open_with_mode(path, StorageOpenMode::Live)
     }
 
+    /// Open a build-mode store after removing stale SQLite sidecars.
     pub fn open_build<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
         let path = path.as_ref();
         cleanup_sqlite_sidecars(path)?;
         Self::open_with_mode(path, StorageOpenMode::Build)
     }
 
+    /// Open a store with explicit live or build indexing behavior.
     pub fn open_with_mode<P: AsRef<Path>>(
         path: P,
         mode: StorageOpenMode,
@@ -866,6 +912,7 @@ impl Storage {
         Ok(())
     }
 
+    /// Create an in-memory store for tests and short-lived callers.
     pub fn new_in_memory() -> Result<Self, StorageError> {
         let conn = Connection::open_in_memory()?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
@@ -878,7 +925,10 @@ impl Storage {
         Ok(storage)
     }
 
-    /// Expose raw connection for advanced operations (like batch processing).
+    /// Expose the raw connection for advanced read/write operations.
+    ///
+    /// Prefer typed store methods when they exist; direct writes must preserve
+    /// schema invariants and derived snapshot freshness manually.
     pub fn get_connection(&self) -> &Connection {
         &self.conn
     }
@@ -2501,6 +2551,12 @@ impl Storage {
         Ok(())
     }
 
+    /// Persist one coherent set of file, graph, occurrence, and projection
+    /// rows.
+    ///
+    /// File-scoped errors for refreshed files are cleared before insertion. A
+    /// successful flush updates graph/search tables only; callers that maintain
+    /// derived grounding snapshots must invalidate or refresh them separately.
     pub fn flush_projection_batch(
         &mut self,
         batch: ProjectionBatch<'_>,
@@ -5097,6 +5153,7 @@ impl Storage {
         Ok(nodes)
     }
 
+    /// Return store counts, preferring ready summary snapshots when available.
     pub fn get_stats(&self) -> Result<StorageStats, StorageError> {
         let fatal_error_count = self.fatal_error_count()?;
         if self.has_ready_grounding_summary_snapshots()? {

--- a/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
+++ b/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
@@ -1,6 +1,12 @@
 use super::{Storage, StorageError};
 use serde::{Deserialize, Serialize};
 
+/// Manifest row describing retrieval sidecar freshness for one project id.
+///
+/// Full retrieval readiness requires this row to match the current sidecar
+/// schema, input hash, artifact generation, and graph/search projection counts.
+/// Degraded modes are recorded explicitly so callers can fail closed instead of
+/// treating SQLite graph state as equivalent to fresh sidecars.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RetrievalIndexManifest {
     pub project_id: String,
@@ -35,6 +41,7 @@ pub struct RetrievalIndexManifest {
 }
 
 impl Storage {
+    /// Insert or replace the retrieval manifest for a project id.
     pub fn upsert_retrieval_index_manifest(
         &mut self,
         manifest: &RetrievalIndexManifest,
@@ -114,6 +121,7 @@ impl Storage {
         Ok(())
     }
 
+    /// Load the retrieval manifest for a project id, if one has been built.
     pub fn get_retrieval_index_manifest(
         &self,
         project_id: &str,
@@ -175,6 +183,7 @@ impl Storage {
         }))
     }
 
+    /// Return Qdrant collection names referenced by stored retrieval manifests.
     pub fn list_retrieval_qdrant_collections(&self) -> Result<Vec<String>, StorageError> {
         let mut stmt = self
             .conn

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -1,3 +1,14 @@
+//! Workspace discovery and refresh planning for the indexing pipeline.
+//!
+//! This crate turns a repository root plus optional CodeStory manifests into a
+//! stable set of source paths. It does not parse code and it does not persist
+//! graph state; its contract is to decide which files are in scope, which
+//! stored file records are stale, and which projections should be removed.
+//!
+//! Freshness is path- and mtime-based. Callers must provide inventory from the
+//! same project root they are planning, and must treat unreadable files as
+//! needing reindexing rather than as clean.
+
 use anyhow::Result;
 pub use codestory_contracts::workspace::{
     BuildMode, IndexedFileRecord, RefreshExecutionPlan, RefreshInfo, RefreshInputs, RefreshMode,
@@ -16,6 +27,12 @@ pub use repository_identity::{
     inspect_repository_identity, sidecar_project_identity,
 };
 
+/// Source-group language selector used during workspace discovery.
+///
+/// Parser support is defined by the shared language-support registry. Some
+/// variants are admitted as structural or text evidence only; matching a
+/// `Language` here means the file can enter a refresh plan, not that the
+/// indexer will emit parser-backed graph edges for it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Language {
     Cxx,
@@ -42,6 +59,10 @@ pub enum Language {
     Astro,
 }
 
+/// Optional language standard metadata carried by manifests.
+///
+/// Discovery preserves this value for downstream consumers. The workspace
+/// layer does not validate compiler flags or infer support tiers from it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LanguageStandard {
     Default,
@@ -54,6 +75,12 @@ pub enum LanguageStandard {
     Java17,
 }
 
+/// Serializable CodeStory project settings.
+///
+/// `source_groups` are the roots and filters used by discovery. A stored
+/// manifest with explicit groups filters by language; a synthetic default
+/// manifest keeps all supported paths so mixed-language repositories can be
+/// indexed without a hand-written config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceSettings {
     pub name: String,
@@ -61,6 +88,13 @@ pub struct WorkspaceSettings {
     pub source_groups: Vec<SourceGroupSettings>,
 }
 
+/// One discovered source group in a project manifest.
+///
+/// `source_paths` may be files or directories, relative to the manifest root or
+/// absolute. `exclude_patterns` are applied against both workspace-relative and
+/// source-root-relative paths so repo-local build output can be pruned without
+/// excluding an explicitly selected workspace under a directory such as
+/// `target`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceGroupSettings {
     pub id: Uuid,
@@ -73,6 +107,10 @@ pub struct SourceGroupSettings {
     pub language_specific: LanguageSpecificSettings,
 }
 
+/// Language-specific discovery metadata carried through the manifest.
+///
+/// These settings describe caller intent for later stages. Discovery itself
+/// only uses the source paths, excludes, and `Language` selector.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LanguageSpecificSettings {
     Cxx {
@@ -92,6 +130,13 @@ pub enum LanguageSpecificSettings {
     Other,
 }
 
+/// Loaded project manifest plus discovery state.
+///
+/// `WorkspaceManifest::open` prefers `codestory_workspace.json`, then
+/// `codestory_project.json`, then a synthetic default rooted at the requested
+/// directory. Synthetic manifests are intentionally broad: they keep
+/// non-Rust files so structural collectors and parser-backed indexers can make
+/// the final evidence-tier decision.
 #[derive(Debug, Clone)]
 pub struct WorkspaceManifest {
     settings: WorkspaceSettings,
@@ -100,11 +145,20 @@ pub struct WorkspaceManifest {
     members: Vec<PathBuf>,
 }
 
+/// Multi-member workspace manifest.
+///
+/// Each member becomes a synthetic source group rooted at that member path.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkspaceMembersManifest {
     pub members: Vec<PathBuf>,
 }
 
+/// Stateless discovery and refresh-planning facade.
+///
+/// Use this when the caller already has a manifest and stored inventory. The
+/// methods are pure with respect to CodeStory storage: they inspect the
+/// filesystem, compare stored mtimes and ids, and return a plan for the caller
+/// to execute.
 #[derive(Debug, Clone, Default)]
 pub struct WorkspaceDiscovery;
 
@@ -116,6 +170,10 @@ struct CompiledExcludePattern {
 }
 
 impl WorkspaceManifest {
+    /// Build a manifest from already-parsed settings.
+    ///
+    /// The manifest is treated as explicit configuration, so discovery filters
+    /// files by each source group's `Language`.
     pub fn from_parts(settings: WorkspaceSettings, manifest_path: PathBuf) -> Self {
         Self {
             settings,
@@ -125,6 +183,7 @@ impl WorkspaceManifest {
         }
     }
 
+    /// Load a `codestory_project.json` manifest from disk.
     pub fn load(path: PathBuf) -> Result<Self> {
         let content = fs::read_to_string(&path)?;
         let settings: WorkspaceSettings = serde_json::from_str(&content)?;
@@ -136,6 +195,10 @@ impl WorkspaceManifest {
         })
     }
 
+    /// Persist explicit project settings to `manifest_path`.
+    ///
+    /// Saving clears the synthetic-default marker, so subsequent discovery uses
+    /// the stored source-group language filters.
     pub fn save(&self) -> Result<()> {
         let content = serde_json::to_string_pretty(&self.settings)?;
         fs::write(&self.manifest_path, content)?;
@@ -143,6 +206,7 @@ impl WorkspaceManifest {
         Ok(())
     }
 
+    /// Create an empty explicit project manifest.
     pub fn new(name: String, manifest_path: PathBuf) -> Self {
         Self {
             settings: WorkspaceSettings {
@@ -156,6 +220,11 @@ impl WorkspaceManifest {
         }
     }
 
+    /// Open a repository root as a CodeStory workspace.
+    ///
+    /// Existing workspace/project manifests are honored. Without one, a
+    /// synthetic default manifest is returned; that fallback is intentionally
+    /// not a persisted configuration until `save` is called.
     pub fn open(root_path: PathBuf) -> Result<Self> {
         let workspace_file = root_path.join("codestory_workspace.json");
         if workspace_file.exists() {
@@ -231,14 +300,17 @@ impl WorkspaceManifest {
         Ok(manifest)
     }
 
+    /// Return the effective manifest settings used by discovery.
     pub fn settings(&self) -> &WorkspaceSettings {
         &self.settings
     }
 
+    /// Return the manifest path that defines the workspace root.
     pub fn manifest_path(&self) -> &Path {
         &self.manifest_path
     }
 
+    /// Return the directory used for relative source paths and inventory keys.
     pub fn root_dir(&self) -> PathBuf {
         self.manifest_path
             .parent()
@@ -246,6 +318,7 @@ impl WorkspaceManifest {
             .to_path_buf()
     }
 
+    /// Return member roots loaded from `codestory_workspace.json`.
     pub fn members(&self) -> &[PathBuf] {
         &self.members
     }
@@ -254,14 +327,23 @@ impl WorkspaceManifest {
         !self.is_synthetic_default.get()
     }
 
+    /// Discover all currently in-scope source files.
+    ///
+    /// Results are normalized, de-duplicated, and sorted. Symlinked directory
+    /// entries that escape the selected source root are rejected.
     pub fn source_files(&self) -> Result<Vec<PathBuf>> {
         WorkspaceDiscovery.source_files(self)
     }
 
+    /// Discover source files unless the candidate set exceeds `max_files`.
+    ///
+    /// Returns `Ok(None)` when the bound is exceeded, allowing callers to avoid
+    /// expensive planning in large or unexpected workspaces.
     pub fn source_files_bounded(&self, max_files: usize) -> Result<Option<Vec<PathBuf>>> {
         WorkspaceDiscovery.source_files_bounded(self, max_files)
     }
 
+    /// Build a full-refresh plan that indexes every currently discovered file.
     pub fn full_refresh_plan(&self) -> Result<RefreshPlan> {
         Ok(RefreshPlan {
             mode: RefreshMode::FullRefresh,
@@ -271,14 +353,23 @@ impl WorkspaceManifest {
         })
     }
 
+    /// Back-compatible alias for `full_refresh_plan`.
     pub fn full_refresh_execution_plan(&self) -> Result<RefreshPlan> {
         self.full_refresh_plan()
     }
 
+    /// Build an incremental refresh plan from stored file inventory.
+    ///
+    /// A file is scheduled when it is new, unreadable, previously unindexed, or
+    /// its filesystem mtime differs from the stored millisecond timestamp.
+    /// Stored file ids absent from current discovery are scheduled for removal.
     pub fn build_execution_plan(&self, inputs: &RefreshInputs) -> Result<RefreshPlan> {
         WorkspaceDiscovery.build_refresh_plan(self, inputs)
     }
 
+    /// Build an incremental refresh plan with a current-file discovery bound.
+    ///
+    /// Returns `Ok(None)` when discovery exceeds `max_current_files`.
     pub fn build_execution_plan_bounded(
         &self,
         inputs: &RefreshInputs,
@@ -289,11 +380,13 @@ impl WorkspaceManifest {
 }
 
 impl WorkspaceDiscovery {
+    /// Discover all source files for `manifest`.
     pub fn source_files(&self, manifest: &WorkspaceManifest) -> Result<Vec<PathBuf>> {
         self.source_files_inner(manifest, None)
             .map(|files| files.unwrap_or_default())
     }
 
+    /// Discover source files with a hard candidate-count bound.
     pub fn source_files_bounded(
         &self,
         manifest: &WorkspaceManifest,
@@ -388,6 +481,8 @@ impl WorkspaceDiscovery {
         Ok(Some(all_files))
     }
 
+    /// Compare current discovery with stored inventory and return an
+    /// incremental refresh plan.
     pub fn build_refresh_plan(
         &self,
         manifest: &WorkspaceManifest,
@@ -397,6 +492,8 @@ impl WorkspaceDiscovery {
             .map(|plan| plan.unwrap_or_else(empty_incremental_plan))
     }
 
+    /// Compare current discovery with stored inventory unless discovery exceeds
+    /// `max_current_files`.
     pub fn build_refresh_plan_bounded(
         &self,
         manifest: &WorkspaceManifest,
@@ -735,8 +832,11 @@ fn normalize_lexical_path(path: &Path) -> PathBuf {
     normalized
 }
 
+/// Back-compatible alias for the loaded workspace manifest.
 pub type Project = WorkspaceManifest;
+/// Back-compatible alias for serializable workspace settings.
 pub type ProjectSettings = WorkspaceSettings;
+/// Back-compatible alias for the loaded workspace manifest.
 pub type Workspace = WorkspaceManifest;
 
 #[cfg(test)]

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -2,8 +2,11 @@ use serde::Serialize;
 use std::path::Path;
 use std::process::Command;
 
+/// Version of the repository identity hashing contract.
 pub const REPOSITORY_IDENTITY_SCHEMA_VERSION: u32 = 1;
 
+/// Git-derived identity used to decide whether portable sidecar cache reuse is
+/// safe for a project root.
 #[derive(Debug, Clone, Serialize)]
 pub struct RepositoryIdentity {
     pub canonical_repository_id: Option<String>,
@@ -15,6 +18,11 @@ pub struct RepositoryIdentity {
     pub portable_reuse_reason: String,
 }
 
+/// Project id decision for sidecar artifacts.
+///
+/// Clean, identifiable Git repositories use a stable repository-derived id.
+/// Dirty, missing, or non-Git roots fall back to the root-derived id so cached
+/// sidecars do not cross an unsafe freshness boundary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SidecarProjectIdentity {
     pub project_id: String,
@@ -24,6 +32,7 @@ pub struct SidecarProjectIdentity {
     pub portable_reuse_reason: String,
 }
 
+/// Inspect Git remote, tree, and dirtiness for portable cache reuse.
 pub fn inspect_repository_identity(project_root: &Path) -> RepositoryIdentity {
     let remote = git_output(project_root, &["config", "--get", "remote.origin.url"]).ok();
     let tree = git_output(project_root, &["rev-parse", "HEAD^{tree}"]).ok();
@@ -46,6 +55,7 @@ pub fn inspect_repository_identity(project_root: &Path) -> RepositoryIdentity {
     }
 }
 
+/// Choose the sidecar project id while preserving the fallback reason.
 pub fn sidecar_project_identity(
     project_root: &Path,
     root_derived_project_id: String,


### PR DESCRIPTION
## Context

Closes #226
Refs #215
Refs #38

#226 asks for the smallest reviewable rustdoc slice covering the workspace, store, and indexer pipeline contracts. The goal is maintainer-facing API documentation, not generated reports or behavior changes.

## What Changed

- Added crate and API rustdoc for `codestory-workspace` discovery, synthetic manifests, source-group filtering, bounded discovery, refresh planning, and repository identity reuse boundaries.
- Added store rustdoc for file inventory, projection flushes, snapshot readiness, staged snapshot publish, schema/open modes, file freshness fields, derived snapshot metadata, symbol docs, and retrieval manifest sidecar freshness.
- Added indexer rustdoc for parser-backed indexing, structural collectors, text-only diagnostics, language support helpers, `WorkspaceIndexer`, `index_file`, intermediate storage, semantic fallback, and resolution pass boundaries.

## How To Review

- Start with `crates/codestory-workspace/src/lib.rs` for discovery and refresh-plan contracts.
- Review `crates/codestory-store/src/lib.rs`, the three facade files, and `storage_impl/retrieval_manifest.rs` for persistence and freshness invariants.
- Review `crates/codestory-indexer/src/lib.rs`, `structural/mod.rs`, `semantic/mod.rs`, and `resolution/mod.rs` for parser-backed vs structural evidence boundaries.
- Confirm the diff is rustdoc-only and does not change behavior, schema, DTOs, manifests, visibility, or generated artifacts.

## Verification

- `cargo doc -p codestory-workspace -p codestory-store -p codestory-indexer --no-deps` passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- No doctests were run because this PR adds no doctest examples.

## Risk

Low. The change is comment-only, but the main review risk is wording: rustdoc should stay precise about structural source proof, parser-backed graph coverage, and sidecar freshness without implying broader language or retrieval readiness.