### PR TITLE
[codex] document retrieval runtime rustdoc contracts

### DIFF
--- a/crates/codestory-retrieval/src/cache.rs
+++ b/crates/codestory-retrieval/src/cache.rs
@@ -3,6 +3,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 
 /// Cache key ties results to a published retrieval manifest generation.
+///
+/// This is the boundary that prevents lexical/vector evidence from one sidecar build from being
+/// reused after the manifest identity changes. The query fingerprint is not enough on its own.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RetrievalCacheKey {
     pub project_id: String,
@@ -38,6 +41,10 @@ impl RetrievalCacheKey {
 const DEFAULT_RETRIEVAL_CACHE_CAPACITY: usize = 128;
 
 /// In-memory version-keyed query result cache.
+///
+/// Entries are safe only for the manifest identity captured by [`RetrievalCacheKey`]. Cache
+/// rehydration across worktrees must invalidate copied retrieval manifests before this cache is
+/// trusted again.
 #[derive(Debug)]
 pub struct RetrievalCache {
     entries: HashMap<RetrievalCacheKey, Vec<super::CandidateHit>>,

--- a/crates/codestory-retrieval/src/candidate.rs
+++ b/crates/codestory-retrieval/src/candidate.rs
@@ -12,6 +12,10 @@ pub struct RankFeatures {
 }
 
 /// Unified retrieval candidate from any sidecar lane.
+///
+/// Candidates are navigation evidence until the runtime resolves them back to indexed symbols.
+/// Dense anchors, lexical hits, and graph neighbors should keep their `provenance` labels so
+/// packet diagnostics can distinguish evidence lanes from unresolved sidecar output.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CandidateHit {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -35,6 +39,7 @@ pub struct CandidateHit {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Sidecar lane that produced a retrieval candidate.
 pub enum CandidateSource {
     Zoekt,
     Qdrant,

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -17,6 +17,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Trace for one retrieval stage.
+///
+/// `degraded` and `stub_reason` are diagnostic fields. A stage trace does not make partial
+/// sidecar output eligible for packet/search primary results.
 pub struct StageTrace {
     pub stage: RetrievalStageKind,
     pub budget_ms: u64,
@@ -37,6 +41,10 @@ fn is_false(value: &bool) -> bool {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Trace for a complete sidecar query.
+///
+/// `retrieval_mode="full"` is the only product-ready mode. `degraded_reason`, cancellation, and
+/// cache-hit fields explain why a query could not provide fresh full-mode evidence.
 pub struct QueryTrace {
     pub retrieval_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -50,6 +58,10 @@ pub struct QueryTrace {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Result of executing one retrieval query against the sidecar stack.
+///
+/// Hits may include lexical, graph, or dense-anchor candidates. Runtime packet code must still
+/// resolve candidates to indexed symbols before treating them as answer support.
 pub struct QueryResult {
     pub query: String,
     pub features: QueryFeatures,
@@ -57,6 +69,10 @@ pub struct QueryResult {
     pub trace: QueryTrace,
 }
 
+/// Executes sidecar retrieval stages with manifest-scoped caching.
+///
+/// The executor is fail-closed: live degraded modes return an error instead of serving partial
+/// results. Tests may use `mode_override`, but product callers should rely on live health probes.
 pub struct QueryExecutor<'a> {
     pub sidecars: &'a dyn SidecarSearch,
     pub cache: &'a mut RetrievalCache,
@@ -68,6 +84,10 @@ pub struct QueryExecutor<'a> {
 }
 
 impl<'a> QueryExecutor<'a> {
+    /// Run one query within the provided total budget.
+    ///
+    /// `total_budget_ms` caps retrieval work only; it does not include runtime candidate
+    /// resolution, packet sufficiency checks, or answer composition.
     pub fn execute(&mut self, query: &str, total_budget_ms: Option<u64>) -> Result<QueryResult> {
         let features = classify_query(query);
         let fingerprint = query_fingerprint(&features.raw_query);

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -1,4 +1,13 @@
 //! Retrieval v2 sidecar orchestration: health probes, local-dev clients, and index manifests.
+//!
+//! Public query APIs in this crate are sidecar-first. A result with
+//! `retrieval_mode=full` means the manifest, lexical index, graph artifacts, and dense-anchor
+//! collection agreed at query time; other modes are degraded diagnostics and must not be treated
+//! as product-equivalent answer evidence.
+//!
+//! Cache keys and status reports intentionally carry manifest generation, input-hash, schema, and
+//! projection counts. Callers that copy caches or reuse worktrees must preserve those identity
+//! checks and revalidate sidecars before serving cached retrieval results.
 
 mod cache;
 mod candidate;

--- a/crates/codestory-retrieval/src/mode.rs
+++ b/crates/codestory-retrieval/src/mode.rs
@@ -1,6 +1,10 @@
 use crate::health::{ComponentHealth, ComponentStatus};
 
-/// v2 mandatory sidecar mode matrix row (design doc § Mandatory sidecar mode matrix).
+/// v2 mandatory sidecar mode matrix row.
+///
+/// Only [`RetrievalDegradedMode::Full`] is promotion-eligible for packet/search primary results.
+/// All degraded rows carry failure-mode diagnostics so callers can repair sidecars without
+/// silently falling back to partial lexical, graph, or vector evidence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RetrievalDegradedMode {

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -2,7 +2,11 @@ use crate::mode::RetrievalDegradedMode;
 use crate::query_features::{QueryFeatures, QueryShape};
 use serde::{Deserialize, Serialize};
 
-/// Staged retrieval lane (design doc staged retrieval).
+/// Staged retrieval lane.
+///
+/// Stage labels are part of the trace contract consumed by runtime packet diagnostics. Repo-text
+/// fallback is represented here for diagnostics only; full sidecar plans do not use it as product
+/// evidence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RetrievalStageKind {
@@ -46,6 +50,7 @@ impl RetrievalStageKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// One planned stage with its local budget and candidate cap.
 pub struct PlannedStage {
     pub kind: RetrievalStageKind,
     pub budget_ms: u64,
@@ -53,6 +58,10 @@ pub struct PlannedStage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Query plan for one sidecar request.
+///
+/// Non-full degraded modes intentionally produce no stages so callers fail closed instead of
+/// presenting partial sidecar coverage as complete retrieval.
 pub struct RetrievalPlan {
     pub stages: Vec<PlannedStage>,
     pub total_budget_ms: u64,
@@ -64,6 +73,10 @@ const DEFAULT_TOTAL_BUDGET_MS: u64 = 1_000;
 const MARGINAL_GAIN_THRESHOLD: f32 = 0.05;
 const LOW_GAIN_STREAK: u32 = 2;
 
+/// Build the sidecar plan for a classified query and live retrieval mode.
+///
+/// Budget values are per-request guardrails, not SLA proof. Packet orchestration may divide a
+/// larger packet budget across several calls before invoking this planner.
 pub fn plan_query(features: &QueryFeatures, mode: RetrievalDegradedMode) -> RetrievalPlan {
     if mode != RetrievalDegradedMode::Full {
         return RetrievalPlan {

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -15,6 +15,10 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Runtime state file written by `sidecar_up`.
+///
+/// The file records local sidecar endpoints and data roots only. It is not a readiness manifest;
+/// callers must use `sidecar_status` or `strict_sidecar_status` before trusting retrieval output.
 pub struct SidecarStateFile {
     pub zoekt_http_port: u16,
     pub qdrant_http_port: u16,
@@ -50,6 +54,10 @@ pub fn sidecar_down() -> Result<()> {
     Ok(())
 }
 
+/// Probe sidecar health and attach the latest retrieval manifest when storage is available.
+///
+/// A healthy infrastructure report is still weaker than strict readiness: it may show running
+/// services while the manifest is stale for the current worktree.
 pub fn sidecar_status(
     project_root: &Path,
     storage_path: Option<&Path>,
@@ -57,6 +65,9 @@ pub fn sidecar_status(
     sidecar_status_inner(project_root, storage_path, false)
 }
 
+/// Probe sidecar health and fail stale manifest identity checks.
+///
+/// This is the status surface to use before serving `retrieval_mode=full` packet/search evidence.
 pub fn strict_sidecar_status(
     project_root: &Path,
     storage_path: Option<&Path>,

--- a/crates/codestory-runtime/src/agent/trace_export.rs
+++ b/crates/codestory-runtime/src/agent/trace_export.rs
@@ -68,6 +68,10 @@ fn step_output_u32(step: &AgentRetrievalStepDto, key: &str) -> Option<u32> {
     step_output_string(step, key).and_then(|value| value.parse::<u32>().ok())
 }
 
+/// Export packet retrieval timing and sidecar diagnostics as JSON.
+///
+/// This is an observability surface for scoring and latency triage. It should not be treated as
+/// proof of answer sufficiency without the packet sufficiency fields on the answer itself.
 pub fn packet_step_trace_json(answer: &AgentAnswerDto) -> Value {
     let rows = packet_step_trace_rows(answer);
     let attributable_rows = attributable_step_rows(&rows);

--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -7,6 +7,11 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Clone)]
+/// Request to copy a compatible CodeStory cache between sibling worktrees.
+///
+/// Source and target must share git remote, tree, schema, and freshness. Retrieval manifests are
+/// path- and sidecar-bound, so successful rehydrate invalidates them before the target can serve
+/// sidecar retrieval.
 pub struct CacheRehydrateRequest<'a> {
     pub source_project: &'a Path,
     pub source_cache_dir: &'a Path,
@@ -16,6 +21,11 @@ pub struct CacheRehydrateRequest<'a> {
 }
 
 #[derive(Debug, Clone, Serialize)]
+/// Machine-readable result of a cache rehydrate attempt.
+///
+/// `preserved_scope` and `retrieval` explain the contract boundary: SQLite graph/search/doc rows
+/// may be reused after rebasing, but sidecar directories and retrieval manifests must be rebuilt
+/// or revalidated for the target worktree.
 pub struct CacheRehydrateOutput {
     pub status: String,
     pub reason: Option<String>,
@@ -39,6 +49,10 @@ pub struct CacheRehydrateOutput {
     pub next_commands: Vec<String>,
 }
 
+/// Copy a compatible cache, rebase path-bound rows, and invalidate copied retrieval manifests.
+///
+/// Skipped results are intentional safety outcomes, not hard failures. They preserve correctness
+/// when cache identity, freshness, or directory boundaries are not strong enough.
 pub fn rehydrate_cache(request: CacheRehydrateRequest<'_>) -> Result<CacheRehydrateOutput> {
     let source_db = request.source_cache_dir.join("codestory.db");
     let target_db = request.target_cache_dir.join("codestory.db");

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -1,3 +1,9 @@
+//! Headless CodeStory runtime orchestration.
+//!
+//! The public controller owns project state, search, packet generation, cache rehydration, and
+//! retrieval sidecar coordination. Packet/search methods are sidecar-primary: degraded retrieval
+//! is surfaced as diagnostics or errors, not as product-equivalent answer evidence.
+
 use codestory_contracts::api::{
     AffectedAnalysisDto, AffectedAnalysisRequest, AffectedChangeKindDto, AffectedChangeRecordDto,
     AffectedMatchedFileDto, AffectedRouteDto, AffectedSymbolDto, AffectedTestFileDto,
@@ -7094,6 +7100,8 @@ fn clear_search_engine(state: &mut AppState) {
 ///
 /// This is intentionally "headless": any app shell (CLI, desktop, IDE integration)
 /// should call methods on this controller and subscribe to `AppEventPayload`.
+/// The controller also owns the per-runtime sidecar query cache, so callers should reuse a
+/// controller for one open project but re-open state when project or storage identity changes.
 #[derive(Clone)]
 pub struct AppController {
     state: Arc<Mutex<AppState>>,
@@ -8616,10 +8624,18 @@ impl AppController {
             .collect()
     }
 
+    /// Run sidecar-primary search and return only the hit list.
+    ///
+    /// Use [`AppController::search_results`] when the caller needs retrieval mode, diagnostics,
+    /// or search-plan metadata.
     pub fn search(&self, req: SearchRequest) -> Result<Vec<SearchHit>, ApiError> {
         Ok(self.search_results(req)?.hits)
     }
 
+    /// Run sidecar-primary search with retrieval state metadata.
+    ///
+    /// The returned retrieval state distinguishes full sidecar evidence from degraded or
+    /// diagnostic-only paths. Callers should not collapse those states into a generic success.
     pub fn search_results(&self, req: SearchRequest) -> Result<SearchResultsDto, ApiError> {
         self.ensure_consistent_read_state("Search")?;
         let original_query = req.query.clone();
@@ -9429,6 +9445,10 @@ impl AppController {
         Ok((results.hits, results.retrieval))
     }
 
+    /// Run hybrid search through the same sidecar-primary contract as `search_results`.
+    ///
+    /// `max_results` limits returned hits; it is not a retrieval budget and does not prove packet
+    /// sufficiency.
     pub fn search_hybrid(
         &self,
         req: SearchRequest,
@@ -9714,6 +9734,10 @@ impl AppController {
             .collect()
     }
 
+    /// Build an answer from indexed source and sidecar-primary retrieval.
+    ///
+    /// Degraded sidecar state is reported through retrieval diagnostics or an error rather than
+    /// silently substituting legacy search as answer-quality proof.
     pub fn agent_ask(&self, req: AgentAskRequest) -> Result<AgentAnswerDto, ApiError> {
         agent::agent_ask(self, req)
     }
@@ -9728,6 +9752,11 @@ impl AppController {
         self.state.lock().last_hybrid_instrumentation.take()
     }
 
+    /// Build an evidence packet with sufficiency, diagnostics, and budget metadata.
+    ///
+    /// Packet sufficiency is a runtime judgment over resolved evidence. Full-mode sidecar
+    /// candidates that fail symbol resolution remain diagnostics and do not become supported
+    /// claims merely because retrieval returned them.
     pub fn agent_packet(&self, req: AgentPacketRequestDto) -> Result<AgentPacketDto, ApiError> {
         agent::agent_packet(self, req)
     }


### PR DESCRIPTION
Summary: Rustdoc-only retrieval/runtime documentation for full-mode readiness, degraded retrieval, sidecar manifests, packet traces, and cache boundaries.

## Context

Issue #231 asks for the smallest useful rustdoc-only pass over retrieval/runtime sidecar and packet contracts. The risky reader mistake is treating degraded sidecar output, unresolved sidecar candidates, or copied cache state as product-equivalent packet/search evidence.

Closes #231
Refs #215
Refs #38

## What Changed

- Added crate/module/type/function rustdoc in `codestory-retrieval` for full-mode readiness, degraded modes, sidecar manifests, provenance lanes, query traces, planner budgets, and manifest-scoped cache keys.
- Added runtime rustdoc for public controller search/packet/ask surfaces, packet trace export, and cache rehydrate invariants.
- Kept the change docs-only: no DTO, manifest, scoring, budget, stage ordering, cache identity, sidecar, or packet behavior changes.

## How To Review

Start with `crates/codestory-retrieval/src/lib.rs`, then skim the touched public items in `executor.rs`, `planner.rs`, `sidecar.rs`, and `cache.rs`. For runtime, review `crates/codestory-runtime/src/lib.rs`, `cache_rehydrate.rs`, and `agent/trace_export.rs` for contract wording only.

## Verification

- `cargo fmt --check`
- `cargo doc -p codestory-retrieval -p codestory-runtime --no-deps`
- `git diff --check`

No doctests/examples were added, so `cargo test --doc -p codestory-retrieval -p codestory-runtime` was not required.

## Risk

Low: rustdoc-only. Remaining risk is wording precision, especially whether reviewers want even less or more coverage on internal `pub(crate)` packet modules.

