### PR TITLE
[codex] probe tantivy lexical rerank parity

### DIFF
--- a/crates/codestory-runtime/examples/lexical_compare.rs
+++ b/crates/codestory-runtime/examples/lexical_compare.rs
@@ -17,6 +17,7 @@ const LEXICAL_INDEX_FILE: &str = "lexical-index.jsonl";
 const CANDIDATE_DIR_PREFIX: &str = "codestory-lexical-tantivy-";
 const DEFAULT_TOP_K: usize = 10;
 const DEFAULT_REPEATS: usize = 7;
+const DEFAULT_PREFILTER_LIMIT: usize = 2048;
 
 fn main() -> Result<()> {
     let opts = Options::parse(std::env::args().skip(1).collect())?;
@@ -189,6 +190,8 @@ struct CompareReport {
     top_k: usize,
     repeats: usize,
     missing_artifact_failure_behavior: String,
+    candidate_strategy: String,
+    candidate_prefilter_limit: usize,
     queries: Vec<QueryReport>,
     aggregate: AggregateReport,
 }
@@ -223,6 +226,7 @@ struct SearchHit {
     symbol_name: Option<String>,
     start_line: Option<u32>,
     score: f32,
+    doc_id: Option<usize>,
 }
 
 fn run_compare(opts: &Options) -> Result<CompareReport> {
@@ -255,7 +259,7 @@ fn run_compare(opts: &Options) -> Result<CompareReport> {
 
     let mut query_reports = Vec::new();
     for query in &opts.queries {
-        let _ = candidate.search(query, opts.top_k)?;
+        let _ = candidate.search_reranked(&entries, query, opts.top_k)?;
         let _ = jsonl_search(&entries, query, opts.top_k);
 
         let mut jsonl_times = Vec::new();
@@ -268,7 +272,7 @@ fn run_compare(opts: &Options) -> Result<CompareReport> {
             jsonl_times.push(started.elapsed().as_secs_f64() * 1000.0);
 
             let started = Instant::now();
-            tantivy_hits = candidate.search(query, opts.top_k)?;
+            tantivy_hits = candidate.search_reranked(&entries, query, opts.top_k)?;
             tantivy_times.push(started.elapsed().as_secs_f64() * 1000.0);
         }
 
@@ -296,6 +300,9 @@ fn run_compare(opts: &Options) -> Result<CompareReport> {
         missing_artifact_failure_behavior:
             "missing lexical-index.jsonl returns an error before building the candidate index"
                 .into(),
+        candidate_strategy:
+            "tantivy_or_prefilter_then_current_jsonl_score_rerank; diagnostic-only".into(),
+        candidate_prefilter_limit: DEFAULT_PREFILTER_LIMIT,
         queries: query_reports,
         aggregate,
     })
@@ -325,6 +332,7 @@ struct TantivyCandidate {
     node_id_field: tantivy::schema::Field,
     symbol_name_field: tantivy::schema::Field,
     start_line_field: tantivy::schema::Field,
+    doc_id_field: tantivy::schema::Field,
 }
 
 impl TantivyCandidate {
@@ -364,10 +372,30 @@ impl TantivyCandidate {
             node_id_field,
             symbol_name_field,
             start_line_field,
+            doc_id_field,
         })
     }
 
-    fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>> {
+    fn search_reranked(
+        &self,
+        entries: &[LexicalIndexEntry],
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SearchHit>> {
+        let prefilter_hits = self.search_prefilter(query, DEFAULT_PREFILTER_LIMIT.max(limit))?;
+        let allowed_doc_ids = prefilter_hits
+            .iter()
+            .filter_map(|hit| hit.doc_id)
+            .collect::<HashSet<_>>();
+        Ok(jsonl_search_filtered(
+            entries,
+            query,
+            limit,
+            Some(&allowed_doc_ids),
+        ))
+    }
+
+    fn search_prefilter(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>> {
         let query = sanitize_tantivy_query(query);
         if query.is_empty() {
             return Ok(Vec::new());
@@ -404,6 +432,10 @@ impl TantivyCandidate {
                     .and_then(|value| u32::try_from(value).ok())
                     .filter(|value| *value > 0),
                 score,
+                doc_id: doc
+                    .get_first(self.doc_id_field)
+                    .and_then(|value| value.as_i64())
+                    .and_then(|value| usize::try_from(value).ok()),
             });
         }
         Ok(hits)
@@ -425,10 +457,19 @@ fn sanitize_tantivy_query(query: &str) -> String {
         .split(|ch: char| !(ch.is_alphanumeric() || ch == '_'))
         .filter(|token| token.len() >= 2)
         .collect::<Vec<_>>()
-        .join(" ")
+        .join(" OR ")
 }
 
 fn jsonl_search(entries: &[LexicalIndexEntry], query: &str, limit: usize) -> Vec<SearchHit> {
+    jsonl_search_filtered(entries, query, limit, None)
+}
+
+fn jsonl_search_filtered(
+    entries: &[LexicalIndexEntry],
+    query: &str,
+    limit: usize,
+    allowed_doc_ids: Option<&HashSet<usize>>,
+) -> Vec<SearchHit> {
     let tokens = lexical_query_tokens(query);
     if tokens.is_empty() {
         return Vec::new();
@@ -453,7 +494,10 @@ fn jsonl_search(entries: &[LexicalIndexEntry], query: &str, limit: usize) -> Vec
     let required_weight = required_lexical_match_weight(tokens.len(), total_weight);
     let mut hits = Vec::new();
 
-    for entry in entries {
+    for (doc_id, entry) in entries.iter().enumerate() {
+        if allowed_doc_ids.is_some_and(|allowed| !allowed.contains(&doc_id)) {
+            continue;
+        }
         let path_lower = entry.path.to_ascii_lowercase();
         let content_lower = entry.content.to_ascii_lowercase();
         let token_match = lexical_token_match(&tokens, &token_weights, &path_lower, &content_lower);
@@ -467,6 +511,7 @@ fn jsonl_search(entries: &[LexicalIndexEntry], query: &str, limit: usize) -> Vec
                 symbol_name: entry.symbol_name.clone(),
                 start_line: entry.start_line,
                 score: score_lexical_match(&entry.path, entry.source, &token_match),
+                doc_id: Some(doc_id),
             });
         }
     }


### PR DESCRIPTION
Summary: Diagnostic-only Tantivy lexical rerank probe; merged decision is to park embedded Tantivy as a production replacement and keep/harden JSONL for this wave.

## Context

Closes #229
Refs #209
Refs #212
Refs #38

PR #227 proved that a naive embedded Tantivy lexical candidate is much smaller and much faster than the current JSONL lexical shard, but it did not preserve current top-k behavior. This PR keeps the work diagnostic-only and tests the smallest useful parity probe: Tantivy as a broad prefilter, followed by the current JSONL scorer as the reranker.

Decision: park embedded Tantivy as a production replacement for this wave. #209 should keep and harden the current JSONL path. The only promising embedded shape from this probe is a hybrid prefilter/rerank path, and it still misses current JSONL hits on Apache while giving back most of the sub-millisecond Tantivy-only latency win.

## What Changed

- Updated `crates/codestory-runtime/examples/lexical_compare.rs` only.
- Added a diagnostic candidate strategy: `tantivy_or_prefilter_then_current_jsonl_score_rerank`.
- The harness now retrieves a broad Tantivy OR prefilter pool, maps hits back to source JSONL entries by document id, and reranks that pool with the existing JSONL scorer.
- The JSON report now includes `candidate_strategy` and `candidate_prefilter_limit` so the diagnostic boundary is visible in the artifact.

```mermaid
flowchart LR
    Q["query"] --> T["Tantivy OR prefilter"]
    T --> P["doc_id pool <= 2048"]
    P --> R["current JSONL scorer"]
    R --> K["reported top-k"]
    J["full JSONL baseline"] --> C["overlap and unresolved delta"]
    K --> C
```

## How To Review

1. Review the example file only; no production packet/search path changes.
2. Confirm the strategy is still labeled diagnostic-only in the output.
3. Compare the measurements below with PR #227's naive Tantivy baseline.

| Shard / query set | Candidate strategy | Current JSONL bytes | Candidate bytes | Cold candidate build | Warm JSONL p50 range | Warm candidate p50 range | Top-k overlap | Unresolved delta | Decision signal |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| #208 CodeStory, #227 baseline queries | naive Tantivy BM25 from #227 | 12,735,488 | 3,885,449 | 380 ms | 403.5-599.2 ms | 0.35-0.71 ms | 0/30 | -20 | Too different to replace JSONL. |
| #208 CodeStory, same queries | OR prefilter + JSONL rerank | 12,735,488 | 3,910,924 | 1,171 ms | 364.7-488.6 ms | 174.9-290.6 ms | 21/30; 21/21 returned JSONL hits | 0 | Parity improves, but latency win is much smaller. |
| Apache Commons Lang, #227 baseline queries | naive Tantivy BM25 from #227 | 19,090,398 | 5,432,108 | 290 ms | 539.8-984.7 ms | 0.23-0.82 ms | 4/30 | -5 | Too different to replace JSONL. |
| Apache Commons Lang, same queries | OR prefilter + JSONL rerank | 19,090,398 | 5,427,618 | 374 ms | 558.6-955.2 ms | 255.2-360.0 ms | 17/30; 17/26 returned JSONL hits | -1 | Better, but still misses JSONL hits. |

Measurement artifacts are local and intentionally uncommitted:

- `target/issue-229-lexical-compare/codestory-issue-208-rerank.json`
- `target/issue-229-lexical-compare/commons-lang-baseline-queries-rerank.json`
- Prior #227 artifacts read from sibling worktree: `C:\Users\alber\.codex\worktrees\ca4d\codestory\target\issue-209-lexical-compare\*.json`

## Verification

- `cargo fmt --check`
- `cargo check -p codestory-runtime --example lexical_compare`
- `cargo run -p codestory-runtime --example lexical_compare -- --self-test`
- `target\debug\examples\lexical_compare.exe --shard-dir C:\Users\alber\AppData\Local\codestory\codestory\cache\zoekt\shards\repo-v1-670ad7db4da1546b-861a704048fd3003 --top-k 10 --repeats 7`
- `target\debug\examples\lexical_compare.exe --shard-dir C:\Users\alber\AppData\Local\codestory\codestory\cache\zoekt\shards\repo-v1-336050b7d50f0035-947a5a8823256f6f --queries "StringUtils defaultIfBlank|NumberUtils createNumber|Apache Commons Lang builder reflection" --top-k 10 --repeats 7`
- `git diff --check`

## Risk

This does not change production packet/search behavior, sidecar readiness, manifest checks, or generated reports. The residual risk is measurement narrowness: two cached shards and three queries each are enough for #229's decision, not for a production migration. #212 can still use this as evidence for a future hybrid design, but #209 should not depend on embedded Tantivy replacement work for this wave.

