### PR TITLE
[codex] document CLI rustdoc integration surfaces

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1,3 +1,11 @@
+//! Command-line argument and serialized output contracts.
+//!
+//! The types in this module are the public integration shape of the CLI crate:
+//! `clap` reads command arguments into these structs, and `serde` writes many of
+//! them as `--format json` responses. Keep field names, enum casing, aliases,
+//! and `skip_serializing_if` behavior stable unless the command output contract
+//! is intentionally changing.
+
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use codestory_contracts::api::{
     BookmarkCategoryDto, BookmarkDto, ClaimReadinessDto, EvidencePacketDto, GroundingBudgetDto,
@@ -30,12 +38,20 @@ For agent packet/search readiness, first run retrieval bootstrap + retrieval ind
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Skill-first repo grounding runtime", long_about = CLI_LONG_ABOUT)]
+/// Top-level CLI parser.
+///
+/// `Command` is the dispatch boundary used by `main`; adding a variant here
+/// requires a matching handler and output contract decision.
 pub(crate) struct Cli {
     #[command(subcommand)]
     pub(crate) command: Command,
 }
 
 #[derive(Subcommand, Debug)]
+/// Subcommands exposed by the executable.
+///
+/// Variants should stay thin: argument validation that affects help text lives
+/// in `clap` attributes, while runtime validation belongs in the handler.
 pub(crate) enum Command {
     #[command(about = "Build or refresh the repository index.")]
     Index(IndexCommand),
@@ -86,6 +102,10 @@ pub(crate) enum Command {
 }
 
 #[derive(Args, Debug, Clone)]
+/// Shared project and cache selector for commands that operate on a repository.
+///
+/// `project` is canonicalized by `RuntimeContext`; `cache_dir` is an exact
+/// override and bypasses the per-project hashed cache root.
 pub(crate) struct ProjectArgs {
     #[arg(
         long,
@@ -102,6 +122,10 @@ pub(crate) struct ProjectArgs {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// Output family requested by a command.
+///
+/// Markdown and JSON go through `output::emit`; DOT is intentionally accepted
+/// only by graph-producing handlers that short-circuit to text emission.
 pub(crate) enum OutputFormat {
     Markdown,
     Json,
@@ -131,6 +155,10 @@ fn parse_positive_usize(value: &str) -> Result<usize, String> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// Index refresh policy requested by a command.
+///
+/// The runtime resolves `Auto` against the current cache summary before any
+/// indexing work starts. Read-oriented commands usually default to `None`.
 pub(crate) enum RefreshMode {
     Auto,
     Full,
@@ -1240,6 +1268,10 @@ pub(crate) struct GenerateCompletionsCommand {
 }
 
 #[derive(Debug, Serialize)]
+/// JSON contract for `index`.
+///
+/// The markdown renderer is presentation-only; these fields are the machine
+/// contract for callers using `--format json`.
 pub(crate) struct IndexOutput<'a> {
     pub(crate) project: &'a str,
     pub(crate) storage_path: &'a str,
@@ -1274,6 +1306,10 @@ pub(crate) enum QuerySelectorOutput {
 }
 
 #[derive(Debug, Clone, Serialize)]
+/// Normalized search hit returned by navigation and search commands.
+///
+/// Optional fields are omitted when absent to keep CLI JSON compact without
+/// changing the meaning of missing retrieval, occurrence, or resolution data.
 pub(crate) struct SearchHitOutput {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) number: Option<usize>,
@@ -1321,6 +1357,10 @@ pub(crate) struct VerificationTargetOutput {
 }
 
 #[derive(Debug, Clone, Serialize)]
+/// JSON contract for `search`.
+///
+/// Retrieval readiness and repo-text mode are explicit so consumers can
+/// distinguish full sidecar evidence from degraded or fallback search paths.
 pub(crate) struct SearchOutput {
     pub(crate) query: String,
     pub(crate) retrieval: RetrievalStateDto,
@@ -1347,6 +1387,11 @@ pub(crate) struct SearchOutput {
 }
 
 #[derive(Debug, Clone, Serialize)]
+/// JSON contract for target resolution shared by context, symbol, trail, and
+/// snippet commands.
+///
+/// `alternatives` is populated when a selected target needs review context;
+/// callers should not assume it lists every indexed match.
 pub(crate) struct QueryResolutionOutput {
     pub(crate) selector: QuerySelectorOutput,
     pub(crate) requested: String,
@@ -2045,6 +2090,10 @@ pub(crate) struct DoctorSidecarStatusOutput {
 }
 
 #[derive(Debug, Clone, Serialize)]
+/// JSON contract for `doctor`.
+///
+/// This output reports cache/index/retrieval health as observed; it does not
+/// imply packet or search readiness unless the readiness fields say so.
 pub(crate) struct DoctorOutput {
     pub(crate) project: String,
     pub(crate) storage_path: String,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1,3 +1,15 @@
+//! Command-line integration entry point for CodeStory.
+//!
+//! This binary keeps command parsing, runtime setup, and output emission in one
+//! place so extension work has a single dispatch boundary. Subcommands should
+//! parse into types from `args`, open project state through `RuntimeContext`,
+//! and emit through `output` helpers so markdown, JSON, DOT, stdout, and
+//! `--output-file` behavior stays consistent.
+//!
+//! User-facing command usage belongs in CLI help and external docs. Rustdoc in
+//! this crate documents the code contracts that command handlers, output DTOs,
+//! and local integration transports rely on.
+
 use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, Parser};
 use clap_complete::{Shell, generate};

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -1,3 +1,10 @@
+//! Output emission and renderer contracts for CLI commands.
+//!
+//! Command handlers build typed DTOs, then call these helpers to choose markdown
+//! or pretty JSON and to honor `--output-file`. Renderer functions should not
+//! perform runtime reads or change command behavior; they only materialize the
+//! already-computed response.
+
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentResponseBlockDto, AgentRetrievalPolicyModeDto,
@@ -42,6 +49,10 @@ pub(crate) fn emit<T: Serialize>(
     emit_content(&content, output_file)
 }
 
+/// Emit plain text while preserving the CLI newline contract.
+///
+/// Use this for DOT, Mermaid, and other text surfaces that do not have a typed
+/// JSON representation for the selected command mode.
 pub(crate) fn emit_text(content: String, output_file: Option<&Path>) -> Result<()> {
     let mut content = content;
     if !content.ends_with('\n') {
@@ -77,6 +88,10 @@ fn render_output_content<T: Serialize>(
     Ok(content)
 }
 
+/// Validate `--output-file` without creating files.
+///
+/// Command handlers call this before expensive work so a bad output path fails
+/// before indexing, retrieval, or report generation begins.
 pub(crate) fn validate_output_file_parent(path: &Path) -> Result<()> {
     if let Some(parent) = path
         .parent()
@@ -1862,6 +1877,10 @@ fn render_agent_step_summary(step: &AgentRetrievalStepDto) -> String {
     )
 }
 
+/// Render one citation line for markdown output.
+///
+/// The output keeps retrieval provenance visible so callers can distinguish
+/// indexed-symbol, repo-text, and hybrid retrieval evidence.
 pub(crate) fn render_agent_citation(
     project_root: &Path,
     citation: &AgentCitationDto,
@@ -1978,6 +1997,10 @@ fn quoted_cli_arg(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\\\""))
 }
 
+/// Render the human-facing markdown form of a context packet.
+///
+/// JSON callers should use `context_packet_json` instead; this renderer may
+/// reorder or relabel sections for readability while preserving the evidence.
 pub(crate) fn render_context_markdown(project_root: &Path, answer: &AgentAnswerDto) -> String {
     let mut markdown = String::new();
     let _ = writeln!(markdown, "# Context");
@@ -2059,6 +2082,10 @@ fn context_operator_next_action(answer: &AgentAnswerDto) -> &'static str {
     }
 }
 
+/// Normalize context answers into the CLI JSON packet contract.
+///
+/// This preserves the underlying answer data while renaming fields that are
+/// shared with packet-style integration consumers.
 pub(crate) fn context_packet_json(answer: &AgentAnswerDto) -> Value {
     let mut value = serde_json::to_value(answer).unwrap_or_else(|_| serde_json::json!({}));
     normalize_context_packet_json(&mut value);

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -1,3 +1,10 @@
+//! Runtime boundary between CLI commands and CodeStory services.
+//!
+//! Command handlers use this module to resolve a project, choose the cache root,
+//! open the runtime services, refresh indexes when requested, and translate API
+//! failures into CLI-facing errors. Keep command-specific output formatting out
+//! of this layer.
+
 use anyhow::{Context, Result, anyhow, bail};
 use codestory_contracts::api::{
     ApiError, AppEventPayload, IndexMode, IndexingPhaseTimings, NodeDetailsDto, NodeDetailsRequest,
@@ -22,12 +29,21 @@ use crate::query_resolution::{
 const HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT: usize = 10;
 
 #[derive(Debug)]
+/// Project state after a command has opened or refreshed the repository.
+///
+/// `refresh_mode` records the resolved indexing action, not merely the user
+/// request, so output can distinguish `auto(full)` from `auto(incremental)`.
 pub(crate) struct OpenedProject {
     pub(crate) summary: ProjectSummary,
     pub(crate) refresh_mode: Option<IndexMode>,
     pub(crate) phase_timings: Option<IndexingPhaseTimings>,
 }
 
+/// Shared service handles and filesystem roots for a CLI command.
+///
+/// `RuntimeContext::new` may start installed managed embeddings before runtime
+/// access; use `new_inspect_only` for health and cache commands that should not
+/// mutate or start background dependencies.
 pub(crate) struct RuntimeContext {
     pub(crate) project: ProjectService,
     pub(crate) index: IndexService,
@@ -48,12 +64,17 @@ struct ResolutionCandidateRank {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Managed embedding startup behavior for runtime construction.
 pub(crate) enum ManagedEmbeddingStartup {
     AutostartIfInstalled,
     InspectOnly,
 }
 
 #[derive(Debug, Clone)]
+/// A query or id after CLI target resolution has selected one graph-backed hit.
+///
+/// `alternatives` is ordered for reviewer/operator display and may be truncated
+/// by the search layer; it is not a complete search result set.
 pub(crate) struct ResolvedTarget {
     pub(crate) selector: QuerySelectorOutput,
     pub(crate) requested: String,
@@ -63,6 +84,10 @@ pub(crate) struct ResolvedTarget {
 }
 
 #[derive(Debug, Clone)]
+/// Error returned when a query has multiple equally valid CLI targets.
+///
+/// Handlers render this as structured resolution output where possible so
+/// callers can rerun with `--choose` instead of guessing.
 pub(crate) struct AmbiguousTargetError {
     pub(crate) query: String,
     pub(crate) file_filter: Option<String>,
@@ -79,10 +104,12 @@ impl std::fmt::Display for AmbiguousTargetError {
 impl std::error::Error for AmbiguousTargetError {}
 
 impl RuntimeContext {
+    /// Open runtime services for a command that may use managed embeddings.
     pub(crate) fn new(args: &ProjectArgs) -> Result<Self> {
         Self::new_with_startup(args, ManagedEmbeddingStartup::AutostartIfInstalled)
     }
 
+    /// Open runtime services without starting managed embedding processes.
     pub(crate) fn new_inspect_only(args: &ProjectArgs) -> Result<Self> {
         Self::new_with_startup(args, ManagedEmbeddingStartup::InspectOnly)
     }
@@ -114,11 +141,19 @@ impl RuntimeContext {
         })
     }
 
+    /// Open the project and run the resolved refresh request when needed.
+    ///
+    /// `RefreshMode::None` is read-only with respect to indexing; commands that
+    /// require cached graph data must call `ensure_index_ready` after this.
     pub(crate) fn ensure_open(&self, refresh: RefreshMode) -> Result<OpenedProject> {
         let summary = self.open_project_summary()?;
         self.ensure_open_from_summary(refresh, summary)
     }
 
+    /// Open project state from an already-read summary.
+    ///
+    /// This keeps commands such as drill from reading the same summary twice
+    /// before deciding whether a refresh is necessary.
     pub(crate) fn ensure_open_from_summary(
         &self,
         refresh: RefreshMode,
@@ -146,6 +181,7 @@ impl RuntimeContext {
         self.ensure_open(refresh)
     }
 
+    /// Open the project summary using the resolved storage path.
     pub(crate) fn open_project_summary(&self) -> Result<ProjectSummary> {
         self.project
             .open_project_summary_with_storage_path(
@@ -156,6 +192,11 @@ impl RuntimeContext {
     }
 }
 
+/// Resolve a CLI target selector into one graph-backed search hit.
+///
+/// Id selectors bypass search. Query selectors use indexed symbol candidates,
+/// apply the optional file filter, and fail on ambiguous top-ranked matches so
+/// command handlers do not silently pick the wrong symbol.
 pub(crate) fn resolve_target(
     runtime: &RuntimeContext,
     target: TargetSelection,
@@ -373,6 +414,7 @@ fn tied_top_alternatives(
         .collect()
 }
 
+/// Canonicalize a project argument before deriving cache identity.
 pub(crate) fn canonicalize_project_root(project: &Path) -> Result<PathBuf> {
     let project = if project.is_absolute() {
         project.to_path_buf()
@@ -390,6 +432,10 @@ pub(crate) fn canonicalize_project_root(project: &Path) -> Result<PathBuf> {
     })
 }
 
+/// Return the cache directory used for one project.
+///
+/// Explicit overrides are returned unchanged; otherwise the cache root is a
+/// stable hash of the canonical project path under the platform cache directory.
 pub(crate) fn cache_root_for_project(
     project_root: &Path,
     override_dir: Option<&Path>,
@@ -405,6 +451,7 @@ pub(crate) fn cache_root_for_project(
     }
 }
 
+/// Small stable hash used for path-derived cache directory names.
 pub(crate) fn fnv1a_hex(bytes: &[u8]) -> String {
     let mut hash = 0xcbf29ce484222325_u64;
     for byte in bytes {
@@ -414,6 +461,7 @@ pub(crate) fn fnv1a_hex(bytes: &[u8]) -> String {
     format!("{hash:016x}")
 }
 
+/// Convert a requested refresh mode into the indexing action to run.
 pub(crate) fn resolve_refresh_request(
     refresh: RefreshMode,
     summary: &ProjectSummary,
@@ -430,6 +478,7 @@ pub(crate) fn resolve_refresh_request(
     }
 }
 
+/// Human-readable label for the requested and resolved refresh pair.
 pub(crate) fn refresh_label(requested: RefreshMode, resolved: Option<IndexMode>) -> String {
     match (requested, resolved) {
         (RefreshMode::Auto, Some(IndexMode::Full)) => "auto(full)".to_string(),
@@ -441,6 +490,7 @@ pub(crate) fn refresh_label(requested: RefreshMode, resolved: Option<IndexMode>)
     }
 }
 
+/// Fail read commands early when the cache has no indexed graph data.
 pub(crate) fn ensure_index_ready(opened: &OpenedProject, subcommand: &str) -> Result<()> {
     if opened.summary.stats.node_count == 0 {
         let project = clean_path_string(&opened.summary.root);
@@ -451,10 +501,12 @@ pub(crate) fn ensure_index_ready(opened: &OpenedProject, subcommand: &str) -> Re
     Ok(())
 }
 
+/// Map runtime API errors into CLI errors with repair commands when available.
 pub(crate) fn map_api_error(error: ApiError) -> anyhow::Error {
     map_api_error_with_project(error, None)
 }
 
+/// Map runtime API errors with project-specific cache repair guidance.
 pub(crate) fn map_api_error_for_project(error: ApiError, project: &Path) -> anyhow::Error {
     map_api_error_with_project(error, Some(project))
 }
@@ -489,6 +541,7 @@ fn map_api_error_with_project(error: ApiError, project: Option<&Path>) -> anyhow
     anyhow!(message)
 }
 
+/// Rewrite cache-busy errors from non-API paths into the standard CLI message.
 pub(crate) fn map_cache_busy_anyhow(error: anyhow::Error, project: &Path) -> anyhow::Error {
     if is_cache_busy_text(&error.to_string()) {
         return anyhow!(cache_busy_message(Some(project)));

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -1,12 +1,24 @@
+//! Catalog for the stdio integration surface.
+//!
+//! This module defines the tool/resource/prompt metadata exposed by
+//! `serve --stdio`. The catalog is declarative JSON shape: keep names, schemas,
+//! annotations, and safety metadata stable because clients discover behavior
+//! from these responses before calling into the transport.
+
 use anyhow::Result;
 use serde_json::{Map, Value, json};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Side-effect class advertised for a stdio tool.
+///
+/// The current stdio surface is read-only and local-only; adding a new effect
+/// requires updating both safety metadata and tool annotations.
 pub(crate) enum ToolEffect {
     Read,
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Safety metadata emitted in both legacy and annotation-style catalog fields.
 pub(crate) struct SafetyMetadata {
     effect: ToolEffect,
 }
@@ -42,6 +54,7 @@ impl SafetyMetadata {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Declarative stdio tool description returned by `tools/list`.
 pub(crate) struct ToolSpec {
     name: &'static str,
     description: &'static str,
@@ -67,6 +80,7 @@ impl ToolSpec {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Declarative resource description returned by `resources/list`.
 pub(crate) struct ResourceSpec {
     uri: &'static str,
     name: &'static str,
@@ -84,6 +98,7 @@ impl ResourceSpec {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Declarative resource template returned by `resources/templates/list`.
 pub(crate) struct ResourceTemplateSpec {
     uri_template: &'static str,
     name: &'static str,
@@ -101,6 +116,7 @@ impl ResourceTemplateSpec {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Declarative prompt description returned by `prompts/list` and `prompts/get`.
 pub(crate) struct PromptSpec {
     name: &'static str,
     description: &'static str,
@@ -1139,10 +1155,12 @@ static PROMPTS: &[PromptSpec] = &[
     },
 ];
 
+/// Return whether a name is a registered stdio tool.
 pub(crate) fn is_tool_name(name: &str) -> bool {
     TOOLS.iter().any(|tool| tool.name == name)
 }
 
+/// Build the `tools/list` response.
 pub(crate) fn tools_list_json() -> Value {
     debug_assert_read_only_catalog();
     json!({
@@ -1152,6 +1170,7 @@ pub(crate) fn tools_list_json() -> Value {
     })
 }
 
+/// Build the `resources/list` response.
 pub(crate) fn resources_list_json() -> Value {
     json!({
         "result": {
@@ -1160,6 +1179,7 @@ pub(crate) fn resources_list_json() -> Value {
     })
 }
 
+/// Build the `resources/templates/list` response.
 pub(crate) fn resource_templates_list_json() -> Value {
     json!({
         "result": {
@@ -1171,6 +1191,7 @@ pub(crate) fn resource_templates_list_json() -> Value {
     })
 }
 
+/// Build the `prompts/list` response.
 pub(crate) fn prompts_list_json() -> Value {
     json!({
         "result": {
@@ -1179,6 +1200,7 @@ pub(crate) fn prompts_list_json() -> Value {
     })
 }
 
+/// Build the `prompts/get` response or fail when the prompt is unknown.
 pub(crate) fn prompt_get_json(name: &str) -> Result<Value> {
     PROMPTS
         .iter()

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1,3 +1,10 @@
+//! JSON-lines stdio transport for the local integration server.
+//!
+//! `serve --stdio` reads one JSON-RPC request per stdin line and writes one
+//! JSON response per stdout line. Protocol errors are returned as JSON-RPC
+//! errors; tool execution failures are encoded as tool-call results so clients
+//! can display structured failure content without losing the response envelope.
+
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::{
     AgentAskRequest, AgentPacketRequestDto, AgentResponseModeDto, AgentRetrievalPresetDto,
@@ -29,6 +36,10 @@ use std::time::Instant;
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 
+/// Run the stdio server until stdin closes.
+///
+/// The server is local, stateful only for small packet/search caches, and keeps
+/// telemetry on stderr so stdout remains a newline-delimited JSON stream.
 pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
     let stdin = std::io::stdin();
     let mut stdout = std::io::stdout();


### PR DESCRIPTION
Summary: Rustdoc-only CLI integration-surface documentation for command boundaries, output/rendering contracts, runtime setup, and stdio tool/catalog behavior.

## Context

Closes #232
Refs #215
Refs #38

Issue #232 asks for rustdoc on the CLI crate's public integration surfaces after the lower-level API docs landed, without duplicating user-facing command docs or changing CLI behavior.

## What Changed

- Added crate/module rustdoc for the CLI dispatch boundary in `main.rs`.
- Documented high-value CLI argument and JSON output contracts in `args.rs`, including command dispatch, project/cache selection, output formats, refresh mode, search output, target resolution output, and doctor output.
- Documented runtime integration boundaries in `runtime.rs`: project/cache resolution, refresh decisions, target resolution, managed embedding startup behavior, and CLI error mapping.
- Documented output emission/rendering contracts in `output.rs`, including newline handling, `--output-file` preflight, citation rendering, and context packet JSON normalization.
- Documented stdio catalog and transport contracts in `stdio_catalog.rs` and `stdio_transport.rs`, including read-only/local safety metadata, catalog response builders, JSON-lines framing, stderr telemetry, and tool failure envelope behavior.

No command behavior, output field names, serialization attributes, or transport code paths changed.

## How To Review

Start with the module docs at the top of `crates/codestory-cli/src/main.rs`, `args.rs`, `runtime.rs`, `output.rs`, `stdio_catalog.rs`, and `stdio_transport.rs`, then scan the added item-level docs around the command/output/runtime/stdio boundary types.

The intended review question is whether these docs describe code contracts and invariants for maintainers, not whether they replace CLI usage docs.

## Verification

- `cargo fmt --check` passed.
- `git diff --check` passed.
- `cargo doc -p codestory-cli --no-deps` passed on rerun and generated `target/doc/codestory_cli/index.html`.

The first `cargo doc -p codestory-cli --no-deps` attempt failed while compiling third-party `idna_adapter` through `sccache` with rustc exit code 1 and no source diagnostic in the captured output. The same command was rerun after dependency artifacts were warmed and completed successfully.

`cargo test --doc -p codestory-cli` was not run because this PR adds no doctests or examples.

## Risk

Low: comments-only rustdoc change. Main residual risk is wording drift if future CLI behavior changes without updating these docs.
