### PR TITLE
[codex] add rustdoc warning gate

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,61 @@
+name: rustdoc
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - docs/contributors/getting-started.md
+      - docs/contributors/testing-matrix.md
+      - .github/workflows/rustdoc.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rustdoc-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warnings:
+    name: deny rustdoc warnings
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Restore Cargo registry, git sources, and build output
+        id: cargo-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rustdoc-stable-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rustdoc-stable-
+
+      - name: Deny rustdoc warnings
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps
+
+      - name: Save Cargo registry, git sources, and build output
+        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -108,8 +108,13 @@ Use this mapping:
 Run the rustdoc baseline before raising documentation or public API cleanup PRs:
 
 ```sh
-cargo doc --workspace --no-deps
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
 ```
+
+CI runs the same rustdoc warning gate for Rust and contributor-doc changes. It
+keeps `codestory-bench` in the workspace pass for warning and link regressions,
+but `publish = false` benchmark helpers do not carry a broader missing-docs
+policy.
 
 Document public Rust APIs that a maintainer, integration, or downstream crate
 would need to call correctly. Keep comments operational:


### PR DESCRIPTION
Summary: Add a narrow rustdoc warnings-as-errors gate for workspace Rust docs, without enabling noisy workspace-wide `missing_docs` or changing product behavior.

Links: Closes #233. Refs #215 and #38.

---

## Context

Issue #233 asks for the smallest sustainable rustdoc regression gate after the documentation cleanup slices landed. The chosen gate is rustdoc warnings-as-errors for the workspace, not `missing_docs`, because it catches broken rustdoc links and warnings without forcing a noisy public API sweep.

Closes #233
Refs #215
Refs #38

```mermaid
flowchart LR
    pr["Rust or contributor-doc PR"] --> ci["rustdoc workflow"]
    ci --> cmd["RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps"]
    cmd --> gate["fail on rustdoc warnings or broken links"]
```

## What Changed

- Added `.github/workflows/rustdoc.yml`, a PR/workflow-dispatch gate that runs `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` with Cargo cache restore/save.
- Updated `docs/contributors/getting-started.md` so local contributor guidance names the same strict command.
- Kept `codestory-bench` in the workspace warning/link pass while documenting that its `publish = false` helper surface does not justify a broader missing-docs policy.

## How To Review

- Check that the workflow paths cover Rust/doc-sensitive changes without running for unrelated docs-only PRs.
- Check that the contributor guidance is agent-agnostic and does not imply workspace-wide `missing_docs` is ready.
- Confirm the gate is intentionally limited to rustdoc warnings/links and does not change runtime behavior.

## Verification

- `RUSTC_WRAPPER=$env:USERPROFILE\.cargo\bin\sccache.exe; RUSTDOCFLAGS=-D warnings; cargo doc --workspace --no-deps` - pass, initial proof in 3m07s before wiring CI.
- `RUSTC_WRAPPER=$env:USERPROFILE\.cargo\bin\sccache.exe; RUSTDOCFLAGS=-D warnings; cargo doc --workspace --no-deps` - pass after edits in 2.31s.
- `cargo fmt --check` - pass.
- `git diff --check` - pass.
- `node .github/scripts/check-workflow-policy.mjs` - pass.

## Risk

Low. The gate documents the workspace but does not enable `missing_docs`, run sidecar/index/benchmark work, or change product behavior. Main residual risk is first-run CI time on a cold cache; the job has a 20-minute timeout and reuses the same Cargo cache pattern as existing workflows.
