### PR TITLE
[codex] add turbovec dense-anchor diagnostic gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -308,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cblas-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6feecd82cce51b0204cf063f0041d69f24ce83f680d87514b004248e7b0fa65"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -538,6 +561,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "turbovec",
  "ureq 2.12.1",
 ]
 
@@ -595,6 +619,12 @@ dependencies = [
  "tempfile",
  "uuid",
 ]
+
+[[package]]
+name = "coe-rs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8f1e641542c07631228b1e0dc04b69ae3c1d58ef65d5691a439711d805c698"
 
 [[package]]
 name = "colorchoice"
@@ -930,6 +960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
 
 [[package]]
+name = "dbgf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ca96b45ca70b8045e0462f191bd209fcb3c3bfe8dbfb1257ada54c4dd59169"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,10 +1108,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dyn-stack"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6fa63092e3ca9f602f6500fddd05502412b748c4c4682938565b44eb9e0066"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro 0.2.1",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro 0.4.2",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "equivalent"
@@ -1117,6 +1230,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "faer"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b19b8c3570ea226e507fe3dbae2aa9d7e0f16676abd35ea3adeeb9f90f7b5d"
+dependencies = [
+ "bytemuck",
+ "coe-rs",
+ "dbgf",
+ "dyn-stack 0.11.0",
+ "equator 0.4.2",
+ "faer-entity",
+ "gemm",
+ "generativity",
+ "libm",
+ "matrixcompare",
+ "matrixcompare-core",
+ "nano-gemm",
+ "npyz",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "rand 0.8.6",
+ "rand_distr",
+ "rayon",
+ "reborrow",
+ "serde",
+]
+
+[[package]]
+name = "faer-entity"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072f96f1bc8b2b30dfc26c086baeadb63aae08019b1ed84721809b9fd2006685"
+dependencies = [
+ "bytemuck",
+ "coe-rs",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp 0.18.22",
+ "reborrow",
 ]
 
 [[package]]
@@ -1296,6 +1453,131 @@ dependencies = [
 ]
 
 [[package]]
+name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f16",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.13.2",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.21.5",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common",
+ "gemm-f32",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack 0.13.2",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "generativity"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,8 +1648,10 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1928,6 +2212,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "matrixcompare"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37832ba820e47c93d66b4360198dccb004b43c74abc3ac1ce1fed54e65a80445"
+dependencies = [
+ "matrixcompare-core",
+ "num-traits",
+]
+
+[[package]]
+name = "matrixcompare-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bdabb30db18805d5290b3da7ceaccbddba795620b86c02145d688e04900a73"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2333,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.6",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "nano-gemm"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5ba2bea1c00e53de11f6ab5bd0761ba87dc0045d63b0c87ee471d2d3061376"
+dependencies = [
+ "equator 0.2.2",
+ "nano-gemm-c32",
+ "nano-gemm-c64",
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "nano-gemm-f32",
+ "nano-gemm-f64",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40449e57a5713464c3a1208c4c3301c8d29ee1344711822cf022bc91373a91b"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743a6e6211358fba85d1009616751e4107da86f4c95b24e684ce85f25c25b3bf"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-codegen"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963bf7c7110d55430169dc74c67096375491ed580cd2ef84842550ac72e781fa"
+
+[[package]]
+name = "nano-gemm-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3fc4f83ae8861bad79dc3c016bd6b0220da5f9de302e07d3112d16efc24aa6"
+
+[[package]]
+name = "nano-gemm-f32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3681b7ce35658f79da94b7f62c60a005e29c373c7111ed070e3bf64546a8bb"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
+name = "nano-gemm-f64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1e619ed04d801809e1f63e61b669d380c4119e8b0cdd6ed184c6b111f046d8"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,6 +2454,8 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
+ "cblas-sys",
+ "libc",
  "matrixmultiply",
  "num-complex",
  "num-integer",
@@ -2115,6 +2516,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "npyz"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0e759e014e630f90af745101b614f761306ddc541681e546649068e25ec1b9"
+dependencies = [
+ "byteorder",
+ "num-bigint",
+ "py_literal",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,12 +2546,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2169,12 +2593,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2604,6 +3039,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.18.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-complex",
+ "reborrow",
+]
+
+[[package]]
+name = "pulp"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "py_literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +3098,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2633,8 +3109,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2652,6 +3138,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2660,6 +3149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2764,6 +3263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +3307,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -3007,6 +3521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3605,12 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -3224,6 +3753,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3327,6 +3869,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f697a07e4606a0a25c044de247e583a330dbb1731d11bc7350b81f48ad567255"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3950,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.13.0",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
 ]
 
 [[package]]
@@ -4054,6 +4622,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbovec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0715a5a1365e86d0ae6396fa0c011f319b8e8024b3896cd16e6468e29ed3a325"
+dependencies = [
+ "faer",
+ "ndarray",
+ "ordered-float 4.6.0",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rand_distr",
+ "rayon",
+ "statrs",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4493,6 +5077,16 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ tempfile = "3.10"
 toml = "0.8"
 sha2 = "0.10"
 ureq = "2.12"
+turbovec = "0.9.0"
 
 criterion = "0.8.2"
 proptest = "1.5"

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -22,3 +22,4 @@ ureq = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+turbovec = { workspace = true }

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -22,4 +22,6 @@ ureq = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[target.'cfg(windows)'.dev-dependencies]
 turbovec = { workspace = true }

--- a/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
+++ b/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
@@ -1,397 +1,434 @@
-use anyhow::{Context, Result, bail};
-use codestory_retrieval::{
-    QdrantClient, SidecarLayout, diagnostic_query_vector, embedding_runtime_id, qdrant_vector_dim,
-    sidecar_project_id_for_root,
-};
-use codestory_store::{LlmSymbolDoc, Store};
-use serde::Serialize;
-use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
-use std::time::{Duration, Instant};
-use turbovec::IdMapIndex;
+#[cfg(not(windows))]
+fn main() -> anyhow::Result<()> {
+    anyhow::bail!(
+        "turbovec_dense_anchor_gate is Windows-only until turbovec 0.9.0 no longer requires a system BLAS link on Linux/macOS"
+    )
+}
 
-const DEFAULT_QUERIES: &[&str] = &[
-    "Where is strict retrieval sidecar readiness enforced?",
-    "How are dense anchors selected for semantic retrieval?",
-    "Where does Qdrant text query search embed the query?",
-];
+#[cfg(windows)]
+fn main() -> anyhow::Result<()> {
+    windows_gate::run()
+}
 
-fn main() -> Result<()> {
-    let args = Args::parse()?;
-    if args.self_test {
-        self_test()?;
-        println!("self-test ok");
-        return Ok(());
-    }
-
-    let project = args.project.context("missing --project")?;
-    let storage_path = args.storage.context("missing --storage")?;
-    let project_id = sidecar_project_id_for_root(&project);
-    let storage = Store::open(&storage_path).context("open storage")?;
-    let manifest = storage
-        .get_retrieval_index_manifest(&project_id)
-        .context("load retrieval manifest")?
-        .with_context(|| format!("retrieval_manifest_missing for project_id={project_id}"))?;
-
-    let dense_docs = dense_docs(&storage)?;
-    validate_identity(&storage, &manifest, &dense_docs)?;
-
-    let layout = SidecarLayout::from_env();
-    let qdrant = QdrantClient::new(&layout);
-    let qdrant_count = qdrant
-        .count_points_exact(&manifest.qdrant_collection)
-        .context("qdrant count failed")?;
-    if Some(qdrant_count as i64) != manifest.dense_projection_count {
-        bail!(
-            "qdrant_count_mismatch: manifest={:?} qdrant={qdrant_count}",
-            manifest.dense_projection_count
-        );
-    }
-
-    let (index, id_to_doc, build_ms) = build_index(&dense_docs)?;
-    let artifact = args.artifact.unwrap_or_else(default_artifact_path);
-    let write_started = Instant::now();
-    index.write(&artifact).context("write turbovec artifact")?;
-    let write_ms = elapsed_ms(write_started.elapsed());
-    let artifact_bytes = artifact.metadata().map(|meta| meta.len()).unwrap_or(0);
-    let load_started = Instant::now();
-    let loaded = IdMapIndex::load(&artifact).context("load turbovec artifact")?;
-    loaded.prepare();
-    let load_ms = elapsed_ms(load_started.elapsed());
-
-    let mut query_reports = Vec::new();
-    for query in args.queries {
-        query_reports.push(compare_query(
-            &qdrant,
-            &manifest.qdrant_collection,
-            &loaded,
-            &id_to_doc,
-            &query,
-            args.k,
-            args.repeats,
-        )?);
-    }
-
-    let report = Report {
-        diagnostic_only: true,
-        product_path_changed: false,
-        project: project.display().to_string(),
-        storage: storage_path.display().to_string(),
-        project_id,
-        qdrant_collection: manifest.qdrant_collection,
-        manifest_embedding_backend: manifest.embedding_backend,
-        query_embedding_backend: embedding_runtime_id(),
-        embedding_dim: qdrant_vector_dim(),
-        dense_anchor_count: dense_docs.len(),
-        qdrant_count,
-        artifact: artifact.display().to_string(),
-        artifact_bytes,
-        build_ms,
-        write_ms,
-        load_ms,
-        queries: query_reports,
-        recommendation: "diagnostic measurement only; Qdrant remains product path",
+#[cfg(windows)]
+mod windows_gate {
+    use anyhow::{Context, Result, bail};
+    use codestory_retrieval::{
+        QdrantClient, SidecarLayout, diagnostic_query_vector, embedding_runtime_id,
+        qdrant_vector_dim, sidecar_project_id_for_root, strict_sidecar_status,
     };
-    println!("{}", serde_json::to_string_pretty(&report)?);
-    Ok(())
-}
+    use codestory_store::{LlmSymbolDoc, Store};
+    use serde::Serialize;
+    use std::collections::{HashMap, HashSet};
+    use std::path::PathBuf;
+    use std::time::{Duration, Instant};
+    use turbovec::IdMapIndex;
 
-fn dense_docs(storage: &Store) -> Result<Vec<LlmSymbolDoc>> {
-    Ok(storage
-        .get_all_llm_symbol_docs()
-        .context("load stored symbol docs")?
-        .into_iter()
-        .filter(|doc| doc.dense_reason.is_some())
-        .collect())
-}
+    const DEFAULT_QUERIES: &[&str] = &[
+        "Where is strict retrieval sidecar readiness enforced?",
+        "How are dense anchors selected for semantic retrieval?",
+        "Where does Qdrant text query search embed the query?",
+    ];
 
-fn validate_identity(
-    storage: &Store,
-    manifest: &codestory_store::RetrievalIndexManifest,
-    dense_docs: &[LlmSymbolDoc],
-) -> Result<()> {
-    let backend = embedding_runtime_id();
-    let dim = qdrant_vector_dim();
-    if manifest.embedding_backend.as_deref() != Some(backend.as_str()) {
-        bail!(
-            "manifest_backend_mismatch: manifest={:?} current={backend}",
-            manifest.embedding_backend
-        );
-    }
-    if manifest.embedding_dim != Some(dim as i32) {
-        bail!(
-            "manifest_dim_mismatch: manifest={:?} current={dim}",
-            manifest.embedding_dim
-        );
-    }
-    if manifest.dense_projection_count != Some(dense_docs.len() as i64) {
-        bail!(
-            "dense_anchor_count_mismatch: manifest={:?} stored={}",
-            manifest.dense_projection_count,
-            dense_docs.len()
-        );
-    }
-    let stats = storage
-        .get_llm_symbol_doc_stats()
-        .context("load stored doc vector stats")?;
-    if stats.mixed_embedding_backends || stats.mixed_dimensions {
-        bail!("stored_doc_vector_contract_mixed");
-    }
-    if dense_docs
-        .iter()
-        .any(|doc| doc.embedding_dim as usize != dim)
-    {
-        bail!("dense_doc_dim_mismatch");
-    }
-    if dense_docs
-        .iter()
-        .any(|doc| doc.embedding_backend.as_deref() != Some(backend.as_str()))
-    {
-        bail!("dense_doc_backend_mismatch");
-    }
-    Ok(())
-}
+    pub fn run() -> Result<()> {
+        let args = Args::parse()?;
+        if args.self_test {
+            self_test()?;
+            println!("self-test ok");
+            return Ok(());
+        }
 
-fn build_index(docs: &[LlmSymbolDoc]) -> Result<(IdMapIndex, HashMap<u64, LlmSymbolDoc>, u128)> {
-    let dim = qdrant_vector_dim();
-    let mut vectors = Vec::with_capacity(docs.len() * dim);
-    let mut ids = Vec::with_capacity(docs.len());
-    let mut id_to_doc = HashMap::with_capacity(docs.len());
-    for doc in docs {
-        let id = u64::try_from(doc.node_id.0).context("negative node id")?;
-        if doc.embedding.len() != dim {
+        let project = args.project.context("missing --project")?;
+        let storage_path = args.storage.context("missing --storage")?;
+        let project_id = sidecar_project_id_for_root(&project);
+        let storage = Store::open(&storage_path).context("open storage")?;
+        let strict_status = strict_sidecar_status(&project, Some(&storage_path))
+            .context("check strict sidecar readiness")?;
+        if strict_status.retrieval_mode != "full" {
             bail!(
-                "dense_doc_vector_dim_mismatch: node_id={} vector_dim={} expected={dim}",
-                doc.node_id.0,
-                doc.embedding.len()
+                "strict_sidecar_unavailable: mode={} reason={}",
+                strict_status.retrieval_mode,
+                strict_status
+                    .degraded_reason
+                    .as_deref()
+                    .unwrap_or("<missing>")
             );
         }
-        vectors.extend_from_slice(&doc.embedding);
-        ids.push(id);
-        id_to_doc.insert(id, doc.clone());
-    }
-    let started = Instant::now();
-    let mut index = IdMapIndex::new(dim, 4).context("construct turbovec index")?;
-    index
-        .add_with_ids(&vectors, &ids)
-        .context("add dense anchors to turbovec")?;
-    index.prepare();
-    Ok((index, id_to_doc, elapsed_ms(started.elapsed())))
-}
+        let manifest = storage
+            .get_retrieval_index_manifest(&project_id)
+            .context("load retrieval manifest")?
+            .with_context(|| format!("retrieval_manifest_missing for project_id={project_id}"))?;
 
-fn compare_query(
-    qdrant: &QdrantClient,
-    collection: &str,
-    index: &IdMapIndex,
-    id_to_doc: &HashMap<u64, LlmSymbolDoc>,
-    query: &str,
-    k: usize,
-    repeats: usize,
-) -> Result<QueryReport> {
-    let qdrant_hits = qdrant
-        .search(collection, query, k)
-        .context("qdrant search")?;
-    let query_vector = diagnostic_query_vector(query).context("embed query for turbovec")?;
-    let turbovec_hits = turbovec_search(index, id_to_doc, &query_vector, k);
-    let repeats = repeats.max(1);
-    let _ = qdrant.search(collection, query, k);
-    let _ = diagnostic_query_vector(query).map(|vector| index.search(&vector, k));
-    let qdrant_ms = timed_repeats(repeats, || qdrant.search(collection, query, k).map(drop))?;
-    let turbovec_ms = timed_repeats(repeats, || {
-        let vector = diagnostic_query_vector(query)?;
-        let _ = index.search(&vector, k);
-        Ok(())
-    })?;
-    let qdrant_ids = qdrant_hits
-        .iter()
-        .filter_map(|hit| hit.node_id.as_deref())
-        .collect::<Vec<_>>();
-    let turbovec_ids = turbovec_hits
-        .iter()
-        .map(|hit| hit.node_id.as_str())
-        .collect::<Vec<_>>();
-    Ok(QueryReport {
-        query: query.to_string(),
-        overlap_at_k: overlap_ratio(&qdrant_ids, &turbovec_ids),
-        mrr_delta: mrr(&qdrant_ids, &qdrant_ids) - mrr(&qdrant_ids, &turbovec_ids),
-        qdrant_p50_ms: percentile(&qdrant_ms, 50.0),
-        qdrant_p95_ms: percentile(&qdrant_ms, 95.0),
-        turbovec_p50_ms: percentile(&turbovec_ms, 50.0),
-        turbovec_p95_ms: percentile(&turbovec_ms, 95.0),
-        qdrant_top_k: qdrant_ids.into_iter().map(str::to_string).collect(),
-        turbovec_top_k: turbovec_ids.into_iter().map(str::to_string).collect(),
-    })
-}
+        let dense_docs = dense_docs(&storage)?;
+        validate_identity(&storage, &manifest, &dense_docs)?;
 
-fn turbovec_search(
-    index: &IdMapIndex,
-    id_to_doc: &HashMap<u64, LlmSymbolDoc>,
-    query_vector: &[f32],
-    k: usize,
-) -> Vec<TurbovecHit> {
-    let (scores, ids) = index.search(query_vector, k);
-    ids.into_iter()
-        .zip(scores)
-        .filter_map(|(id, score)| {
-            let doc = id_to_doc.get(&id)?;
-            Some(TurbovecHit {
-                node_id: doc.node_id.0.to_string(),
-                score,
-            })
-        })
-        .collect()
-}
-
-fn timed_repeats(mut repeats: usize, mut f: impl FnMut() -> Result<()>) -> Result<Vec<f64>> {
-    let mut timings = Vec::with_capacity(repeats);
-    while repeats > 0 {
-        let started = Instant::now();
-        f()?;
-        timings.push(started.elapsed().as_secs_f64() * 1000.0);
-        repeats -= 1;
-    }
-    Ok(timings)
-}
-
-fn overlap_ratio(left: &[&str], right: &[&str]) -> f64 {
-    let left = left.iter().copied().collect::<HashSet<_>>();
-    let overlap = right.iter().filter(|id| left.contains(**id)).count();
-    overlap as f64 / left.len().max(1) as f64
-}
-
-fn mrr(expected: &[&str], actual: &[&str]) -> f64 {
-    for (rank, id) in actual.iter().enumerate() {
-        if expected.contains(id) {
-            return 1.0 / (rank + 1) as f64;
+        let layout = SidecarLayout::from_env();
+        let qdrant = QdrantClient::new(&layout);
+        let qdrant_count = qdrant
+            .count_points_exact(&manifest.qdrant_collection)
+            .context("qdrant count failed")?;
+        if Some(qdrant_count as i64) != manifest.dense_projection_count {
+            bail!(
+                "qdrant_count_mismatch: manifest={:?} qdrant={qdrant_count}",
+                manifest.dense_projection_count
+            );
         }
-    }
-    0.0
-}
 
-fn percentile(values: &[f64], percentile: f64) -> f64 {
-    let mut values = values.to_vec();
-    values.sort_by(f64::total_cmp);
-    let index = ((values.len().saturating_sub(1)) as f64 * percentile / 100.0).ceil() as usize;
-    values[index.min(values.len().saturating_sub(1))]
-}
+        let (index, id_to_doc, build_ms) = build_index(&dense_docs)?;
+        let artifact = args.artifact.unwrap_or_else(default_artifact_path);
+        let write_started = Instant::now();
+        index.write(&artifact).context("write turbovec artifact")?;
+        let write_ms = elapsed_ms(write_started.elapsed());
+        let artifact_bytes = artifact.metadata().map(|meta| meta.len()).unwrap_or(0);
+        let load_started = Instant::now();
+        let loaded = IdMapIndex::load(&artifact).context("load turbovec artifact")?;
+        loaded.prepare();
+        let load_ms = elapsed_ms(load_started.elapsed());
 
-fn elapsed_ms(duration: Duration) -> u128 {
-    duration.as_millis()
-}
+        let mut query_reports = Vec::new();
+        for query in args.queries {
+            query_reports.push(compare_query(
+                &qdrant,
+                &manifest.qdrant_collection,
+                &loaded,
+                &id_to_doc,
+                &query,
+                args.k,
+                args.repeats,
+            )?);
+        }
 
-fn default_artifact_path() -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "codestory-turbovec-dense-anchor-{}.tvim",
-        std::process::id()
-    ))
-}
-
-fn self_test() -> Result<()> {
-    let dim = 8;
-    let vectors = vec![
-        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
-        0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-    ];
-    let mut index = IdMapIndex::new(dim, 4)?;
-    index.add_with_ids(&vectors, &[11, 22])?;
-    let (_scores, ids) = index.search(&vectors[0..dim], 1);
-    assert_eq!(ids[0], 11);
-    assert_eq!(percentile(&[1.0, 2.0, 3.0], 95.0), 3.0);
-    assert_eq!(overlap_ratio(&["a", "b"], &["b", "c"]), 0.5);
-    Ok(())
-}
-
-#[derive(Debug)]
-struct Args {
-    project: Option<PathBuf>,
-    storage: Option<PathBuf>,
-    artifact: Option<PathBuf>,
-    queries: Vec<String>,
-    k: usize,
-    repeats: usize,
-    self_test: bool,
-}
-
-impl Args {
-    fn parse() -> Result<Self> {
-        let mut args = std::env::args().skip(1);
-        let mut parsed = Self {
-            project: None,
-            storage: None,
-            artifact: None,
-            queries: Vec::new(),
-            k: 10,
-            repeats: 5,
-            self_test: false,
+        let report = Report {
+            diagnostic_only: true,
+            product_path_changed: false,
+            project: project.display().to_string(),
+            storage: storage_path.display().to_string(),
+            project_id,
+            qdrant_collection: manifest.qdrant_collection,
+            manifest_embedding_backend: manifest.embedding_backend,
+            query_embedding_backend: embedding_runtime_id(),
+            embedding_dim: qdrant_vector_dim(),
+            dense_anchor_count: dense_docs.len(),
+            qdrant_count,
+            artifact: artifact.display().to_string(),
+            artifact_bytes,
+            build_ms,
+            write_ms,
+            load_ms,
+            queries: query_reports,
+            recommendation: "diagnostic measurement only; Qdrant remains product path",
         };
-        while let Some(arg) = args.next() {
-            match arg.as_str() {
-                "--project" => parsed.project = Some(PathBuf::from(next_value(&mut args, &arg)?)),
-                "--storage" => parsed.storage = Some(PathBuf::from(next_value(&mut args, &arg)?)),
-                "--artifact" => parsed.artifact = Some(PathBuf::from(next_value(&mut args, &arg)?)),
-                "--query" => parsed.queries.push(next_value(&mut args, &arg)?),
-                "--k" => parsed.k = next_value(&mut args, &arg)?.parse().context("parse --k")?,
-                "--repeats" => {
-                    parsed.repeats = next_value(&mut args, &arg)?
-                        .parse()
-                        .context("parse --repeats")?
-                }
-                "--self-test" => parsed.self_test = true,
-                _ => bail!("unknown argument: {arg}"),
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        Ok(())
+    }
+
+    fn dense_docs(storage: &Store) -> Result<Vec<LlmSymbolDoc>> {
+        Ok(storage
+            .get_all_llm_symbol_docs()
+            .context("load stored symbol docs")?
+            .into_iter()
+            .filter(|doc| doc.dense_reason.is_some())
+            .collect())
+    }
+
+    fn validate_identity(
+        storage: &Store,
+        manifest: &codestory_store::RetrievalIndexManifest,
+        dense_docs: &[LlmSymbolDoc],
+    ) -> Result<()> {
+        let backend = embedding_runtime_id();
+        let dim = qdrant_vector_dim();
+        if manifest.embedding_backend.as_deref() != Some(backend.as_str()) {
+            bail!(
+                "manifest_backend_mismatch: manifest={:?} current={backend}",
+                manifest.embedding_backend
+            );
+        }
+        if manifest.embedding_dim != Some(dim as i32) {
+            bail!(
+                "manifest_dim_mismatch: manifest={:?} current={dim}",
+                manifest.embedding_dim
+            );
+        }
+        if manifest.dense_projection_count != Some(dense_docs.len() as i64) {
+            bail!(
+                "dense_anchor_count_mismatch: manifest={:?} stored={}",
+                manifest.dense_projection_count,
+                dense_docs.len()
+            );
+        }
+        let stats = storage
+            .get_llm_symbol_doc_stats()
+            .context("load stored doc vector stats")?;
+        if stats.mixed_embedding_backends || stats.mixed_dimensions {
+            bail!("stored_doc_vector_contract_mixed");
+        }
+        if dense_docs
+            .iter()
+            .any(|doc| doc.embedding_dim as usize != dim)
+        {
+            bail!("dense_doc_dim_mismatch");
+        }
+        if dense_docs
+            .iter()
+            .any(|doc| doc.embedding_backend.as_deref() != Some(backend.as_str()))
+        {
+            bail!("dense_doc_backend_mismatch");
+        }
+        Ok(())
+    }
+
+    fn build_index(
+        docs: &[LlmSymbolDoc],
+    ) -> Result<(IdMapIndex, HashMap<u64, LlmSymbolDoc>, u128)> {
+        let dim = qdrant_vector_dim();
+        let mut vectors = Vec::with_capacity(docs.len() * dim);
+        let mut ids = Vec::with_capacity(docs.len());
+        let mut id_to_doc = HashMap::with_capacity(docs.len());
+        for doc in docs {
+            let id = u64::try_from(doc.node_id.0).context("negative node id")?;
+            if doc.embedding.len() != dim {
+                bail!(
+                    "dense_doc_vector_dim_mismatch: node_id={} vector_dim={} expected={dim}",
+                    doc.node_id.0,
+                    doc.embedding.len()
+                );
+            }
+            vectors.extend_from_slice(&doc.embedding);
+            ids.push(id);
+            id_to_doc.insert(id, doc.clone());
+        }
+        let started = Instant::now();
+        let mut index = IdMapIndex::new(dim, 4).context("construct turbovec index")?;
+        index
+            .add_with_ids(&vectors, &ids)
+            .context("add dense anchors to turbovec")?;
+        index.prepare();
+        Ok((index, id_to_doc, elapsed_ms(started.elapsed())))
+    }
+
+    fn compare_query(
+        qdrant: &QdrantClient,
+        collection: &str,
+        index: &IdMapIndex,
+        id_to_doc: &HashMap<u64, LlmSymbolDoc>,
+        query: &str,
+        k: usize,
+        repeats: usize,
+    ) -> Result<QueryReport> {
+        let qdrant_hits = qdrant
+            .search(collection, query, k)
+            .context("qdrant search")?;
+        let query_vector = diagnostic_query_vector(query).context("embed query for turbovec")?;
+        let turbovec_hits = turbovec_search(index, id_to_doc, &query_vector, k);
+        let repeats = repeats.max(1);
+        let _ = qdrant.search(collection, query, k);
+        let _ = diagnostic_query_vector(query).map(|vector| index.search(&vector, k));
+        let qdrant_ms = timed_repeats(repeats, || qdrant.search(collection, query, k).map(drop))?;
+        let turbovec_ms = timed_repeats(repeats, || {
+            let vector = diagnostic_query_vector(query)?;
+            let _ = index.search(&vector, k);
+            Ok(())
+        })?;
+        let qdrant_ids = qdrant_hits
+            .iter()
+            .filter_map(|hit| hit.node_id.as_deref())
+            .collect::<Vec<_>>();
+        let turbovec_ids = turbovec_hits
+            .iter()
+            .map(|hit| hit.node_id.as_str())
+            .collect::<Vec<_>>();
+        Ok(QueryReport {
+            query: query.to_string(),
+            overlap_at_k: overlap_ratio(&qdrant_ids, &turbovec_ids),
+            mrr_delta: mrr(&qdrant_ids, &qdrant_ids) - mrr(&qdrant_ids, &turbovec_ids),
+            qdrant_p50_ms: percentile(&qdrant_ms, 50.0),
+            qdrant_p95_ms: percentile(&qdrant_ms, 95.0),
+            turbovec_p50_ms: percentile(&turbovec_ms, 50.0),
+            turbovec_p95_ms: percentile(&turbovec_ms, 95.0),
+            qdrant_top_k: qdrant_ids.into_iter().map(str::to_string).collect(),
+            turbovec_top_k: turbovec_ids.into_iter().map(str::to_string).collect(),
+        })
+    }
+
+    fn turbovec_search(
+        index: &IdMapIndex,
+        id_to_doc: &HashMap<u64, LlmSymbolDoc>,
+        query_vector: &[f32],
+        k: usize,
+    ) -> Vec<TurbovecHit> {
+        let (scores, ids) = index.search(query_vector, k);
+        ids.into_iter()
+            .zip(scores)
+            .filter_map(|(id, score)| {
+                let doc = id_to_doc.get(&id)?;
+                Some(TurbovecHit {
+                    node_id: doc.node_id.0.to_string(),
+                    score,
+                })
+            })
+            .collect()
+    }
+
+    fn timed_repeats(mut repeats: usize, mut f: impl FnMut() -> Result<()>) -> Result<Vec<f64>> {
+        let mut timings = Vec::with_capacity(repeats);
+        while repeats > 0 {
+            let started = Instant::now();
+            f()?;
+            timings.push(started.elapsed().as_secs_f64() * 1000.0);
+            repeats -= 1;
+        }
+        Ok(timings)
+    }
+
+    fn overlap_ratio(left: &[&str], right: &[&str]) -> f64 {
+        let left = left.iter().copied().collect::<HashSet<_>>();
+        let overlap = right.iter().filter(|id| left.contains(**id)).count();
+        overlap as f64 / left.len().max(1) as f64
+    }
+
+    fn mrr(expected: &[&str], actual: &[&str]) -> f64 {
+        for (rank, id) in actual.iter().enumerate() {
+            if expected.contains(id) {
+                return 1.0 / (rank + 1) as f64;
             }
         }
-        if parsed.queries.is_empty() {
-            parsed.queries = DEFAULT_QUERIES
-                .iter()
-                .map(|query| query.to_string())
-                .collect();
-        }
-        Ok(parsed)
+        0.0
     }
-}
 
-fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
-    args.next()
-        .with_context(|| format!("missing value for {flag}"))
-}
+    fn percentile(values: &[f64], percentile: f64) -> f64 {
+        let mut values = values.to_vec();
+        values.sort_by(f64::total_cmp);
+        let index = ((values.len().saturating_sub(1)) as f64 * percentile / 100.0).ceil() as usize;
+        values[index.min(values.len().saturating_sub(1))]
+    }
 
-#[derive(Serialize)]
-struct Report {
-    diagnostic_only: bool,
-    product_path_changed: bool,
-    project: String,
-    storage: String,
-    project_id: String,
-    qdrant_collection: String,
-    manifest_embedding_backend: Option<String>,
-    query_embedding_backend: String,
-    embedding_dim: usize,
-    dense_anchor_count: usize,
-    qdrant_count: u64,
-    artifact: String,
-    artifact_bytes: u64,
-    build_ms: u128,
-    write_ms: u128,
-    load_ms: u128,
-    queries: Vec<QueryReport>,
-    recommendation: &'static str,
-}
+    fn elapsed_ms(duration: Duration) -> u128 {
+        duration.as_millis()
+    }
 
-#[derive(Serialize)]
-struct QueryReport {
-    query: String,
-    overlap_at_k: f64,
-    mrr_delta: f64,
-    qdrant_p50_ms: f64,
-    qdrant_p95_ms: f64,
-    turbovec_p50_ms: f64,
-    turbovec_p95_ms: f64,
-    qdrant_top_k: Vec<String>,
-    turbovec_top_k: Vec<String>,
-}
+    fn default_artifact_path() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "codestory-turbovec-dense-anchor-{}.tvim",
+            std::process::id()
+        ))
+    }
 
-struct TurbovecHit {
-    node_id: String,
-    #[allow(dead_code)]
-    score: f32,
+    fn self_test() -> Result<()> {
+        let dim = 8;
+        let vectors = vec![
+            1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        ];
+        let mut index = IdMapIndex::new(dim, 4)?;
+        index.add_with_ids(&vectors, &[11, 22])?;
+        let (_scores, ids) = index.search(&vectors[0..dim], 1);
+        assert_eq!(ids[0], 11);
+        assert_eq!(percentile(&[1.0, 2.0, 3.0], 95.0), 3.0);
+        assert_eq!(overlap_ratio(&["a", "b"], &["b", "c"]), 0.5);
+        Ok(())
+    }
+
+    #[derive(Debug)]
+    struct Args {
+        project: Option<PathBuf>,
+        storage: Option<PathBuf>,
+        artifact: Option<PathBuf>,
+        queries: Vec<String>,
+        k: usize,
+        repeats: usize,
+        self_test: bool,
+    }
+
+    impl Args {
+        fn parse() -> Result<Self> {
+            let mut args = std::env::args().skip(1);
+            let mut parsed = Self {
+                project: None,
+                storage: None,
+                artifact: None,
+                queries: Vec::new(),
+                k: 10,
+                repeats: 5,
+                self_test: false,
+            };
+            while let Some(arg) = args.next() {
+                match arg.as_str() {
+                    "--project" => {
+                        parsed.project = Some(PathBuf::from(next_value(&mut args, &arg)?))
+                    }
+                    "--storage" => {
+                        parsed.storage = Some(PathBuf::from(next_value(&mut args, &arg)?))
+                    }
+                    "--artifact" => {
+                        parsed.artifact = Some(PathBuf::from(next_value(&mut args, &arg)?))
+                    }
+                    "--query" => parsed.queries.push(next_value(&mut args, &arg)?),
+                    "--k" => {
+                        parsed.k = next_value(&mut args, &arg)?.parse().context("parse --k")?
+                    }
+                    "--repeats" => {
+                        parsed.repeats = next_value(&mut args, &arg)?
+                            .parse()
+                            .context("parse --repeats")?
+                    }
+                    "--self-test" => parsed.self_test = true,
+                    _ => bail!("unknown argument: {arg}"),
+                }
+            }
+            if parsed.queries.is_empty() {
+                parsed.queries = DEFAULT_QUERIES
+                    .iter()
+                    .map(|query| query.to_string())
+                    .collect();
+            }
+            Ok(parsed)
+        }
+    }
+
+    fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
+        args.next()
+            .with_context(|| format!("missing value for {flag}"))
+    }
+
+    #[derive(Serialize)]
+    struct Report {
+        diagnostic_only: bool,
+        product_path_changed: bool,
+        project: String,
+        storage: String,
+        project_id: String,
+        qdrant_collection: String,
+        manifest_embedding_backend: Option<String>,
+        query_embedding_backend: String,
+        embedding_dim: usize,
+        dense_anchor_count: usize,
+        qdrant_count: u64,
+        artifact: String,
+        artifact_bytes: u64,
+        build_ms: u128,
+        write_ms: u128,
+        load_ms: u128,
+        queries: Vec<QueryReport>,
+        recommendation: &'static str,
+    }
+
+    #[derive(Serialize)]
+    struct QueryReport {
+        query: String,
+        overlap_at_k: f64,
+        mrr_delta: f64,
+        qdrant_p50_ms: f64,
+        qdrant_p95_ms: f64,
+        turbovec_p50_ms: f64,
+        turbovec_p95_ms: f64,
+        qdrant_top_k: Vec<String>,
+        turbovec_top_k: Vec<String>,
+    }
+
+    struct TurbovecHit {
+        node_id: String,
+        #[allow(dead_code)]
+        score: f32,
+    }
 }

--- a/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
+++ b/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
@@ -1,0 +1,397 @@
+use anyhow::{Context, Result, bail};
+use codestory_retrieval::{
+    QdrantClient, SidecarLayout, diagnostic_query_vector, embedding_runtime_id, qdrant_vector_dim,
+    sidecar_project_id_for_root,
+};
+use codestory_store::{LlmSymbolDoc, Store};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+use turbovec::IdMapIndex;
+
+const DEFAULT_QUERIES: &[&str] = &[
+    "Where is strict retrieval sidecar readiness enforced?",
+    "How are dense anchors selected for semantic retrieval?",
+    "Where does Qdrant text query search embed the query?",
+];
+
+fn main() -> Result<()> {
+    let args = Args::parse()?;
+    if args.self_test {
+        self_test()?;
+        println!("self-test ok");
+        return Ok(());
+    }
+
+    let project = args.project.context("missing --project")?;
+    let storage_path = args.storage.context("missing --storage")?;
+    let project_id = sidecar_project_id_for_root(&project);
+    let storage = Store::open(&storage_path).context("open storage")?;
+    let manifest = storage
+        .get_retrieval_index_manifest(&project_id)
+        .context("load retrieval manifest")?
+        .with_context(|| format!("retrieval_manifest_missing for project_id={project_id}"))?;
+
+    let dense_docs = dense_docs(&storage)?;
+    validate_identity(&storage, &manifest, &dense_docs)?;
+
+    let layout = SidecarLayout::from_env();
+    let qdrant = QdrantClient::new(&layout);
+    let qdrant_count = qdrant
+        .count_points_exact(&manifest.qdrant_collection)
+        .context("qdrant count failed")?;
+    if Some(qdrant_count as i64) != manifest.dense_projection_count {
+        bail!(
+            "qdrant_count_mismatch: manifest={:?} qdrant={qdrant_count}",
+            manifest.dense_projection_count
+        );
+    }
+
+    let (index, id_to_doc, build_ms) = build_index(&dense_docs)?;
+    let artifact = args.artifact.unwrap_or_else(default_artifact_path);
+    let write_started = Instant::now();
+    index.write(&artifact).context("write turbovec artifact")?;
+    let write_ms = elapsed_ms(write_started.elapsed());
+    let artifact_bytes = artifact.metadata().map(|meta| meta.len()).unwrap_or(0);
+    let load_started = Instant::now();
+    let loaded = IdMapIndex::load(&artifact).context("load turbovec artifact")?;
+    loaded.prepare();
+    let load_ms = elapsed_ms(load_started.elapsed());
+
+    let mut query_reports = Vec::new();
+    for query in args.queries {
+        query_reports.push(compare_query(
+            &qdrant,
+            &manifest.qdrant_collection,
+            &loaded,
+            &id_to_doc,
+            &query,
+            args.k,
+            args.repeats,
+        )?);
+    }
+
+    let report = Report {
+        diagnostic_only: true,
+        product_path_changed: false,
+        project: project.display().to_string(),
+        storage: storage_path.display().to_string(),
+        project_id,
+        qdrant_collection: manifest.qdrant_collection,
+        manifest_embedding_backend: manifest.embedding_backend,
+        query_embedding_backend: embedding_runtime_id(),
+        embedding_dim: qdrant_vector_dim(),
+        dense_anchor_count: dense_docs.len(),
+        qdrant_count,
+        artifact: artifact.display().to_string(),
+        artifact_bytes,
+        build_ms,
+        write_ms,
+        load_ms,
+        queries: query_reports,
+        recommendation: "diagnostic measurement only; Qdrant remains product path",
+    };
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+fn dense_docs(storage: &Store) -> Result<Vec<LlmSymbolDoc>> {
+    Ok(storage
+        .get_all_llm_symbol_docs()
+        .context("load stored symbol docs")?
+        .into_iter()
+        .filter(|doc| doc.dense_reason.is_some())
+        .collect())
+}
+
+fn validate_identity(
+    storage: &Store,
+    manifest: &codestory_store::RetrievalIndexManifest,
+    dense_docs: &[LlmSymbolDoc],
+) -> Result<()> {
+    let backend = embedding_runtime_id();
+    let dim = qdrant_vector_dim();
+    if manifest.embedding_backend.as_deref() != Some(backend.as_str()) {
+        bail!(
+            "manifest_backend_mismatch: manifest={:?} current={backend}",
+            manifest.embedding_backend
+        );
+    }
+    if manifest.embedding_dim != Some(dim as i32) {
+        bail!(
+            "manifest_dim_mismatch: manifest={:?} current={dim}",
+            manifest.embedding_dim
+        );
+    }
+    if manifest.dense_projection_count != Some(dense_docs.len() as i64) {
+        bail!(
+            "dense_anchor_count_mismatch: manifest={:?} stored={}",
+            manifest.dense_projection_count,
+            dense_docs.len()
+        );
+    }
+    let stats = storage
+        .get_llm_symbol_doc_stats()
+        .context("load stored doc vector stats")?;
+    if stats.mixed_embedding_backends || stats.mixed_dimensions {
+        bail!("stored_doc_vector_contract_mixed");
+    }
+    if dense_docs
+        .iter()
+        .any(|doc| doc.embedding_dim as usize != dim)
+    {
+        bail!("dense_doc_dim_mismatch");
+    }
+    if dense_docs
+        .iter()
+        .any(|doc| doc.embedding_backend.as_deref() != Some(backend.as_str()))
+    {
+        bail!("dense_doc_backend_mismatch");
+    }
+    Ok(())
+}
+
+fn build_index(docs: &[LlmSymbolDoc]) -> Result<(IdMapIndex, HashMap<u64, LlmSymbolDoc>, u128)> {
+    let dim = qdrant_vector_dim();
+    let mut vectors = Vec::with_capacity(docs.len() * dim);
+    let mut ids = Vec::with_capacity(docs.len());
+    let mut id_to_doc = HashMap::with_capacity(docs.len());
+    for doc in docs {
+        let id = u64::try_from(doc.node_id.0).context("negative node id")?;
+        if doc.embedding.len() != dim {
+            bail!(
+                "dense_doc_vector_dim_mismatch: node_id={} vector_dim={} expected={dim}",
+                doc.node_id.0,
+                doc.embedding.len()
+            );
+        }
+        vectors.extend_from_slice(&doc.embedding);
+        ids.push(id);
+        id_to_doc.insert(id, doc.clone());
+    }
+    let started = Instant::now();
+    let mut index = IdMapIndex::new(dim, 4).context("construct turbovec index")?;
+    index
+        .add_with_ids(&vectors, &ids)
+        .context("add dense anchors to turbovec")?;
+    index.prepare();
+    Ok((index, id_to_doc, elapsed_ms(started.elapsed())))
+}
+
+fn compare_query(
+    qdrant: &QdrantClient,
+    collection: &str,
+    index: &IdMapIndex,
+    id_to_doc: &HashMap<u64, LlmSymbolDoc>,
+    query: &str,
+    k: usize,
+    repeats: usize,
+) -> Result<QueryReport> {
+    let qdrant_hits = qdrant
+        .search(collection, query, k)
+        .context("qdrant search")?;
+    let query_vector = diagnostic_query_vector(query).context("embed query for turbovec")?;
+    let turbovec_hits = turbovec_search(index, id_to_doc, &query_vector, k);
+    let repeats = repeats.max(1);
+    let _ = qdrant.search(collection, query, k);
+    let _ = diagnostic_query_vector(query).map(|vector| index.search(&vector, k));
+    let qdrant_ms = timed_repeats(repeats, || qdrant.search(collection, query, k).map(drop))?;
+    let turbovec_ms = timed_repeats(repeats, || {
+        let vector = diagnostic_query_vector(query)?;
+        let _ = index.search(&vector, k);
+        Ok(())
+    })?;
+    let qdrant_ids = qdrant_hits
+        .iter()
+        .filter_map(|hit| hit.node_id.as_deref())
+        .collect::<Vec<_>>();
+    let turbovec_ids = turbovec_hits
+        .iter()
+        .map(|hit| hit.node_id.as_str())
+        .collect::<Vec<_>>();
+    Ok(QueryReport {
+        query: query.to_string(),
+        overlap_at_k: overlap_ratio(&qdrant_ids, &turbovec_ids),
+        mrr_delta: mrr(&qdrant_ids, &qdrant_ids) - mrr(&qdrant_ids, &turbovec_ids),
+        qdrant_p50_ms: percentile(&qdrant_ms, 50.0),
+        qdrant_p95_ms: percentile(&qdrant_ms, 95.0),
+        turbovec_p50_ms: percentile(&turbovec_ms, 50.0),
+        turbovec_p95_ms: percentile(&turbovec_ms, 95.0),
+        qdrant_top_k: qdrant_ids.into_iter().map(str::to_string).collect(),
+        turbovec_top_k: turbovec_ids.into_iter().map(str::to_string).collect(),
+    })
+}
+
+fn turbovec_search(
+    index: &IdMapIndex,
+    id_to_doc: &HashMap<u64, LlmSymbolDoc>,
+    query_vector: &[f32],
+    k: usize,
+) -> Vec<TurbovecHit> {
+    let (scores, ids) = index.search(query_vector, k);
+    ids.into_iter()
+        .zip(scores)
+        .filter_map(|(id, score)| {
+            let doc = id_to_doc.get(&id)?;
+            Some(TurbovecHit {
+                node_id: doc.node_id.0.to_string(),
+                score,
+            })
+        })
+        .collect()
+}
+
+fn timed_repeats(mut repeats: usize, mut f: impl FnMut() -> Result<()>) -> Result<Vec<f64>> {
+    let mut timings = Vec::with_capacity(repeats);
+    while repeats > 0 {
+        let started = Instant::now();
+        f()?;
+        timings.push(started.elapsed().as_secs_f64() * 1000.0);
+        repeats -= 1;
+    }
+    Ok(timings)
+}
+
+fn overlap_ratio(left: &[&str], right: &[&str]) -> f64 {
+    let left = left.iter().copied().collect::<HashSet<_>>();
+    let overlap = right.iter().filter(|id| left.contains(**id)).count();
+    overlap as f64 / left.len().max(1) as f64
+}
+
+fn mrr(expected: &[&str], actual: &[&str]) -> f64 {
+    for (rank, id) in actual.iter().enumerate() {
+        if expected.contains(id) {
+            return 1.0 / (rank + 1) as f64;
+        }
+    }
+    0.0
+}
+
+fn percentile(values: &[f64], percentile: f64) -> f64 {
+    let mut values = values.to_vec();
+    values.sort_by(f64::total_cmp);
+    let index = ((values.len().saturating_sub(1)) as f64 * percentile / 100.0).ceil() as usize;
+    values[index.min(values.len().saturating_sub(1))]
+}
+
+fn elapsed_ms(duration: Duration) -> u128 {
+    duration.as_millis()
+}
+
+fn default_artifact_path() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "codestory-turbovec-dense-anchor-{}.tvim",
+        std::process::id()
+    ))
+}
+
+fn self_test() -> Result<()> {
+    let dim = 8;
+    let vectors = vec![
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
+        0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    ];
+    let mut index = IdMapIndex::new(dim, 4)?;
+    index.add_with_ids(&vectors, &[11, 22])?;
+    let (_scores, ids) = index.search(&vectors[0..dim], 1);
+    assert_eq!(ids[0], 11);
+    assert_eq!(percentile(&[1.0, 2.0, 3.0], 95.0), 3.0);
+    assert_eq!(overlap_ratio(&["a", "b"], &["b", "c"]), 0.5);
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Args {
+    project: Option<PathBuf>,
+    storage: Option<PathBuf>,
+    artifact: Option<PathBuf>,
+    queries: Vec<String>,
+    k: usize,
+    repeats: usize,
+    self_test: bool,
+}
+
+impl Args {
+    fn parse() -> Result<Self> {
+        let mut args = std::env::args().skip(1);
+        let mut parsed = Self {
+            project: None,
+            storage: None,
+            artifact: None,
+            queries: Vec::new(),
+            k: 10,
+            repeats: 5,
+            self_test: false,
+        };
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--project" => parsed.project = Some(PathBuf::from(next_value(&mut args, &arg)?)),
+                "--storage" => parsed.storage = Some(PathBuf::from(next_value(&mut args, &arg)?)),
+                "--artifact" => parsed.artifact = Some(PathBuf::from(next_value(&mut args, &arg)?)),
+                "--query" => parsed.queries.push(next_value(&mut args, &arg)?),
+                "--k" => parsed.k = next_value(&mut args, &arg)?.parse().context("parse --k")?,
+                "--repeats" => {
+                    parsed.repeats = next_value(&mut args, &arg)?
+                        .parse()
+                        .context("parse --repeats")?
+                }
+                "--self-test" => parsed.self_test = true,
+                _ => bail!("unknown argument: {arg}"),
+            }
+        }
+        if parsed.queries.is_empty() {
+            parsed.queries = DEFAULT_QUERIES
+                .iter()
+                .map(|query| query.to_string())
+                .collect();
+        }
+        Ok(parsed)
+    }
+}
+
+fn next_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
+    args.next()
+        .with_context(|| format!("missing value for {flag}"))
+}
+
+#[derive(Serialize)]
+struct Report {
+    diagnostic_only: bool,
+    product_path_changed: bool,
+    project: String,
+    storage: String,
+    project_id: String,
+    qdrant_collection: String,
+    manifest_embedding_backend: Option<String>,
+    query_embedding_backend: String,
+    embedding_dim: usize,
+    dense_anchor_count: usize,
+    qdrant_count: u64,
+    artifact: String,
+    artifact_bytes: u64,
+    build_ms: u128,
+    write_ms: u128,
+    load_ms: u128,
+    queries: Vec<QueryReport>,
+    recommendation: &'static str,
+}
+
+#[derive(Serialize)]
+struct QueryReport {
+    query: String,
+    overlap_at_k: f64,
+    mrr_delta: f64,
+    qdrant_p50_ms: f64,
+    qdrant_p95_ms: f64,
+    turbovec_p50_ms: f64,
+    turbovec_p95_ms: f64,
+    qdrant_top_k: Vec<String>,
+    turbovec_top_k: Vec<String>,
+}
+
+struct TurbovecHit {
+    node_id: String,
+    #[allow(dead_code)]
+    score: f32,
+}

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -72,6 +72,7 @@ pub use mode::derive_degraded_mode;
 pub use planner::{PlannedStage, RetrievalPlan, RetrievalStageKind, plan_query};
 pub use qdrant_client::{
     QDRANT_INDEX_UPSERT_BATCH_SIZE, QDRANT_VECTOR_DIM, QdrantClient, QdrantUpsertPoint,
+    diagnostic_query_vector,
 };
 pub use qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION,

--- a/crates/codestory-retrieval/src/qdrant_client.rs
+++ b/crates/codestory-retrieval/src/qdrant_client.rs
@@ -544,6 +544,14 @@ fn query_vector(query: &str) -> Result<Vec<f32>> {
     }
 }
 
+/// Diagnostic-only helper for offline vector-index parity checks.
+///
+/// Product retrieval must keep using [`QdrantClient::search`], which embeds and
+/// queries the mandatory Qdrant sidecar collection in one fail-closed path.
+pub fn diagnostic_query_vector(query: &str) -> Result<Vec<f32>> {
+    query_vector(query)
+}
+
 fn document_vectors(labels: &[String]) -> Result<Vec<Vec<f32>>> {
     if qdrant_semantic_vectors_enabled() {
         embeddings::embed_documents(labels)


### PR DESCRIPTION
Summary: Add a diagnostic-only `turbovec` dense-anchor gate shell that can compare text-query behavior with Qdrant when pointed at a prepared full-sidecar cache.

Links:
- Closes #243
- Refs #238
- Refs #210
- Refs #212
- Refs #38
- Related setup follow-up: #240

---

## Context

Issue #238 asks for the smallest diagnostic-only `turbovec` gate before any embedded-vector replacement decision. This PR lands the mergeable harness shell only: Qdrant remains the product path, #238 stays open, and live Qdrant-vs-`turbovec` measurement still requires a prepared full-sidecar cache.

```mermaid
flowchart LR
    S["strict sidecar status"] --> Gate["manifest/backend/dim/count gate"]
    DB["codestory.db dense docs"] --> Gate
    Q["text query"] --> Embed["same query vector helper"]
    Gate --> TV["turbovec IdMapIndex"]
    Gate --> QC["Qdrant count check"]
    Embed --> TV
    Q --> QD["Qdrant search"]
    TV --> Compare["overlap/MRR + p50/p95"]
    QD --> Compare
```

## What Changed

- Added `crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs`.
- Added a diagnostic-only `diagnostic_query_vector` helper so the harness uses the same query embedding path as Qdrant search.
- Added `turbovec` as a Windows-only retrieval dev-dependency because `turbovec` links BLAS on Linux/macOS.
- Added a non-Windows fail-closed stub so Linux contract CI does not link OpenBLAS.
- The harness requires explicit `--project` and `--storage`; it does not index, rehydrate, bootstrap sidecars, or change packet/search routing.
- The harness calls strict sidecar readiness before manifest load, Qdrant count, index build, artifact write, query metrics, or report emission.

## How To Review

1. Confirm product routing still goes through Qdrant search.
2. Confirm the example fails closed unless strict retrieval mode is `full`.
3. On a Windows worktree with full sidecar readiness, run:

```powershell
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"
cargo run -p codestory-retrieval --example turbovec_dense_anchor_gate -- --project <repo> --storage <codestory.db> --repeats 5
```

4. Confirm the JSON report includes artifact bytes, build/write/load timing, Qdrant and `turbovec` warm p50/p95, overlap@k, MRR delta, and top-k IDs.

## Verification

Initial harness checks:

- `cargo run -p codestory-retrieval --example turbovec_dense_anchor_gate -- --self-test` -> pass, `self-test ok`.
- Current-cache run -> expected fail-closed blocker: `retrieval_manifest_missing for project_id=e348ce837d62f72d`.
- `cargo fmt --check` -> pass.
- `git diff --check` -> pass.
- `cargo check -p codestory-retrieval --examples` -> pass.
- `doctor --project . --format json` -> worktree cache exists but `indexed=false`, `retrieval_mode=unavailable`, `degraded_reason=retrieval_manifest_missing`, `semantic_doc_count=0`.

Review-fix checks:

- `cargo run -p codestory-retrieval --example turbovec_dense_anchor_gate -- --self-test` -> pass.
- Current-cache run -> expected strict-gate blocker: `strict_sidecar_unavailable: mode=unavailable reason=retrieval_manifest_missing`.
- `cargo check -p codestory-retrieval --examples` -> pass.
- `cargo fmt --check` -> pass.
- `git diff --check` -> pass.
- `cargo tree -p codestory-retrieval --target x86_64-unknown-linux-gnu -e normal | rg "turbovec|openblas|cblas"` -> no matches.
- Remote checks on `b1a9a903df3906a7e5d349197c4566b2d47006bc`: `linux-contracts` success, rustdoc success, saga issue link guard success, `windows-manifest-missing` skipped.

Measurement table:

| Metric | Result in this worktree |
| --- | --- |
| Strict sidecar gate | blocked: `retrieval_manifest_missing` |
| Artifact bytes | not produced |
| Build/open/load time | not produced |
| Warm query p50/p95 | not produced |
| Top-k overlap / MRR delta | not produced |
| Recommendation | merge the diagnostic harness shell; keep #238 open until live full-sidecar comparison evidence exists |

## Risk

- The `turbovec` path is Windows-only in this PR to avoid Linux/macOS OpenBLAS linkage in normal contract CI.
- No product route changes were made; `retrieval_mode=full` still depends on the existing Qdrant sidecar readiness path.
- The remaining risk is measurement availability: a full-sidecar worktree/cache is required before making an advance/kill decision for embedded vector search.