### PR TITLE
[codex] avoid cold cli builds in worktree setup

### DIFF
--- a/.agents/skills/codestory-grounding/SKILL.md
+++ b/.agents/skills/codestory-grounding/SKILL.md
@@ -12,8 +12,10 @@ checkout is only the tool artifact unless the user is editing CodeStory itself.
 
 ## Core Loop
 
-1. Prefer `CODESTORY_CLI`, then `codestory-cli` on `PATH`; run `scripts/setup.ps1`
-   or `scripts/setup.sh` from this skill only when no binary is available.
+1. Prefer `CODESTORY_CLI`, `codestory-cli` on `PATH`, this worktree's
+   `target/release/codestory-cli*`, then a sibling worktree's release binary;
+   run `scripts/setup.ps1` or `scripts/setup.sh` from this skill only when no
+   ready binary is available.
 2. Always pass `--project <target-workspace>` explicitly.
 3. Use `doctor` when cache, freshness, or retrieval health matters; use
    `index --refresh full` for first runs or historical indexing failures, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@
 - CLI runtime: `cargo run --release -p codestory-cli -- index --project .`.
 - Skill-first grounding: `cargo run --release -p codestory-cli -- ground --project .`.
 - Codex worktree setup runs `scripts/codex-worktree-setup.ps1` before the thread
-  starts: it builds the release CLI with `sccache`, tries `cache rehydrate` from
-  a sibling worktree, refreshes the SQLite index, then best-effort refreshes
-  retrieval sidecars/status.
+  starts: it resolves a ready CLI from `CODESTORY_CLI`, PATH, this worktree, or a
+  sibling worktree before building with `sccache`; then it tries `cache
+  rehydrate`, refreshes the SQLite index, and best-effort refreshes retrieval
+  sidecars/status.
 - Release version checks: `python .github/scripts/check-codestory-release.py --version <version>` and `node .github/scripts/check-workflow-policy.mjs`.
 - On Windows, the Codex npm shim should be invoked as `codex.cmd` (typically under `%APPDATA%\\npm`); using the extensionless `codex` shim can fail with `os error 193`.
 - In this PowerShell environment, large parallel file reads can truncate output; when investigating a single large file, prefer one direct read command (for example `Get-Content` or `cmd /c type`) before parallelizing.

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 param(
-    [string]$Project = "."
+    [string]$Project = ".",
+    [switch]$ResolveCliOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -36,19 +37,72 @@ function Invoke-SetupStep {
     }
 }
 
-function Find-CodeStoryCli {
+function Test-CodeStoryCli {
+    param([string]$Candidate)
+
+    if (-not $Candidate) {
+        return $false
+    }
+    if (-not (Get-Command $Candidate -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+
+    # ponytail: --help proves the binary is runnable; doctor remains the real trust gate.
+    & $Candidate --help >$null 2>$null
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-CodeStoryCliCandidates {
     param([string]$Root)
 
-    $candidates = @(
+    $candidates = @()
+    if ($env:CODESTORY_CLI) {
+        $candidates += $env:CODESTORY_CLI
+    }
+
+    $pathCli = Get-Command "codestory-cli" -ErrorAction SilentlyContinue
+    if ($pathCli) {
+        $candidates += $pathCli.Source
+    }
+
+    $candidates += @(
         (Join-Path $Root "target\release\codestory-cli.exe"),
         (Join-Path $Root "target\release\codestory-cli")
     )
+
+    $lines = if (Get-Command git -ErrorAction SilentlyContinue) {
+        & git worktree list --porcelain 2>$null
+    } else {
+        @()
+    }
+    if ($LASTEXITCODE -eq 0) {
+        foreach ($line in $lines) {
+            if (-not $line.StartsWith("worktree ")) {
+                continue
+            }
+            $candidateRoot = $line.Substring("worktree ".Length)
+            if (Same-Path $candidateRoot $Root) {
+                continue
+            }
+            $candidates += (Join-Path $candidateRoot "target\release\codestory-cli.exe")
+            $candidates += (Join-Path $candidateRoot "target\release\codestory-cli")
+        }
+    }
+
+    return $candidates | Where-Object { $_ } | Select-Object -Unique
+}
+
+function Find-CodeStoryCli {
+    param([string]$Root)
+
+    $candidates = Get-CodeStoryCliCandidates $Root
     foreach ($candidate in $candidates) {
-        if (Test-Path -LiteralPath $candidate) {
+        if (Test-CodeStoryCli $candidate) {
             return $candidate
         }
     }
-    throw "codestory-cli release binary was not found under target\release"
+
+    throw "No ready codestory-cli found via CODESTORY_CLI, PATH, this worktree's target\release, or sibling worktree target\release directories."
 }
 
 function Same-Path {
@@ -109,11 +163,24 @@ try {
         Write-Host "Using RUSTC_WRAPPER=$sccache"
     }
 
-    Invoke-SetupStep "Build release CLI" {
+    try {
+        $cli = Find-CodeStoryCli $projectPath
+    } catch {
+        if ($ResolveCliOnly) {
+            throw "$($_.Exception.Message) Re-run without -ResolveCliOnly to build with cargo, or set CODESTORY_CLI to a ready binary."
+        }
+        Write-Host ""
+        Write-Host "==> Build release CLI"
+        Write-Warning "$($_.Exception.Message) Building release CLI with cargo."
         Invoke-Checked "cargo" @("build", "--release", "-p", "codestory-cli")
+        $cli = Find-CodeStoryCli $projectPath
     }
 
-    $cli = Find-CodeStoryCli $projectPath
+    Write-Host "CODESTORY_CLI=$cli"
+    if ($ResolveCliOnly) {
+        return
+    }
+
     $source = Find-RehydrateSource $projectPath
     if ($source) {
         Invoke-SetupStep "Rehydrate CodeStory cache from $source" {


### PR DESCRIPTION
Summary: Resolve a ready `codestory-cli` in fresh worktrees before falling back to Cargo builds.

Links:
- Closes #240
- Refs #238
- Refs #38

---

## Context

Fresh CodeStory agent worktrees need to run `doctor --project . --format json` as a read-only trust gate without accidentally cold-compiling `codestory-cli` first. Issue #240 is separate from cache/sidecar readiness: finding a runnable CLI should not imply packet/search is trustworthy.

```mermaid
flowchart LR
    setup["worktree setup"] --> resolve["resolve ready CLI"]
    resolve --> env["CODESTORY_CLI"]
    resolve --> path["PATH"]
    resolve --> local["local target/release"]
    resolve --> sibling["sibling target/release"]
    resolve --> build["cargo build fallback"]
    env --> doctor["doctor trust gate"]
    path --> doctor
    local --> doctor
    sibling --> doctor
    build --> doctor
```

## What Changed

- `scripts/codex-worktree-setup.ps1` now tries `CODESTORY_CLI`, `codestory-cli` on PATH, this worktree's `target/release`, and sibling worktree `target/release` binaries before building.
- Added `-ResolveCliOnly` so fresh-worktree CLI discovery can be smoke-tested without cache rehydrate, indexing, sidecar bootstrap, or Cargo fallback.
- Updated repo and skill guidance to describe the ready-binary lookup order.

## How To Review

- Start with `scripts/codex-worktree-setup.ps1`; the only behavior change is CLI resolution before the existing build/cache/index flow.
- Check that `-ResolveCliOnly` exits after printing `CODESTORY_CLI=...` and does not run the later setup steps.
- Confirm the docs do not claim that CLI availability means `doctor` or retrieval is ready.

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\codex-worktree-setup.ps1 -Project . -ResolveCliOnly` exited 0 and printed `CODESTORY_CLI=C:\Users\alber\source\repos\codestory\target\release\codestory-cli.exe` without running Cargo.
- `& 'C:\Users\alber\source\repos\codestory\target\release\codestory-cli.exe' doctor --project . --format json` exited 0. It reported `indexed: false`, `retrieval_mode: unavailable`, and `degraded_reason: retrieval_manifest_missing`, so the resolver did not hide stale/degraded retrieval state.
- Negative smoke with an isolated temp project, empty `CODESTORY_CLI`, and restricted PATH exited 1 with: `No ready codestory-cli found via CODESTORY_CLI, PATH, this worktree's target\release, or sibling worktree target\release directories. Re-run without -ResolveCliOnly to build with cargo, or set CODESTORY_CLI to a ready binary.`
- `git diff --check` exited 0.

## Risk

- The ready-binary check is intentionally shallow: it runs `--help` to prove the candidate is executable, then leaves actual project/index/retrieval validity to `doctor`.
- This does not repair the current worktree's missing index or sidecar manifest; that remains a separate setup/cache/retrieval concern.