### PR TITLE
[codex] Fix turbovec diagnostic harness backend gate

### DIFF
--- a/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
+++ b/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
@@ -13,6 +13,7 @@ fn main() -> anyhow::Result<()> {
 #[cfg(windows)]
 mod windows_gate {
     use anyhow::{Context, Result, bail};
+    use codestory_contracts::graph::{NodeId, NodeKind};
     use codestory_retrieval::{
         QdrantClient, SidecarLayout, diagnostic_query_vector, embedding_runtime_id,
         qdrant_vector_dim, sidecar_project_id_for_root, strict_sidecar_status,
@@ -169,13 +170,20 @@ mod windows_gate {
         {
             bail!("dense_doc_dim_mismatch");
         }
-        if dense_docs
-            .iter()
-            .any(|doc| doc.embedding_backend.as_deref() != Some(backend.as_str()))
-        {
+        if dense_docs.iter().any(|doc| {
+            !stored_doc_backend_matches_runtime(doc.embedding_backend.as_deref(), &backend)
+        }) {
             bail!("dense_doc_backend_mismatch");
         }
         Ok(())
+    }
+
+    fn stored_doc_backend_matches_runtime(stored: Option<&str>, runtime: &str) -> bool {
+        stored == Some(runtime)
+            || matches!(
+                (stored, runtime),
+                (Some("llamacpp"), "llamacpp:bge-base-en-v1.5")
+            )
     }
 
     fn build_index(
@@ -185,8 +193,9 @@ mod windows_gate {
         let mut vectors = Vec::with_capacity(docs.len() * dim);
         let mut ids = Vec::with_capacity(docs.len());
         let mut id_to_doc = HashMap::with_capacity(docs.len());
-        for doc in docs {
-            let id = u64::try_from(doc.node_id.0).context("negative node id")?;
+        for (index, doc) in docs.iter().enumerate() {
+            // ponytail: local ids avoid unsigned casts for virtual graph ids; id_to_doc keeps real ids.
+            let id = u64::try_from(index + 1).context("too many dense docs")?;
             if doc.embedding.len() != dim {
                 bail!(
                     "dense_doc_vector_dim_mismatch: node_id={} vector_dim={} expected={dim}",
@@ -326,6 +335,40 @@ mod windows_gate {
         assert_eq!(ids[0], 11);
         assert_eq!(percentile(&[1.0, 2.0, 3.0], 95.0), 3.0);
         assert_eq!(overlap_ratio(&["a", "b"], &["b", "c"]), 0.5);
+        assert!(stored_doc_backend_matches_runtime(
+            Some("llamacpp"),
+            "llamacpp:bge-base-en-v1.5"
+        ));
+        assert!(!stored_doc_backend_matches_runtime(
+            Some("onnx"),
+            "llamacpp:bge-base-en-v1.5"
+        ));
+        let mut embedding = vec![0.0; qdrant_vector_dim()];
+        embedding[0] = 1.0;
+        let negative_doc = LlmSymbolDoc {
+            node_id: NodeId(-42),
+            file_node_id: None,
+            kind: NodeKind::FUNCTION,
+            display_name: "virtual_dense_anchor".into(),
+            qualified_name: None,
+            file_path: None,
+            start_line: None,
+            doc_text: "virtual dense anchor".into(),
+            doc_version: 5,
+            doc_hash: "virtual-dense-anchor".into(),
+            embedding_profile: Some("bge-base-en-v1.5".into()),
+            embedding_model: "BAAI/bge-base-en-v1.5-local".into(),
+            embedding_backend: Some("llamacpp".into()),
+            embedding_dim: qdrant_vector_dim() as u32,
+            doc_shape: Some("self-test".into()),
+            semantic_policy_version: Some("graph_first_v1".into()),
+            dense_reason: Some("component_report".into()),
+            embedding: embedding.clone(),
+            updated_at_epoch_ms: 0,
+        };
+        let (index, id_to_doc, _) = build_index(&[negative_doc])?;
+        let hits = turbovec_search(&index, &id_to_doc, &embedding, 1);
+        assert_eq!(hits[0].node_id, "-42");
         Ok(())
     }
 


### PR DESCRIPTION
## Context

Closes #246.
Refs #238, #244, #210, #212.

#246 prepared one full-sidecar diagnostic cache so the merged `turbovec_dense_anchor_gate` harness from #241 could run on Windows. The cache reached strict readiness, but the example harness had two diagnostic-only assumptions that blocked the real measurement:

- stored dense-doc producer backends are recorded as `llamacpp`, while the retrieval manifest/query runtime uses `llamacpp:bge-base-en-v1.5`
- dense-anchor node ids can be virtual/negative, but the temporary `turbovec::IdMapIndex` ids are `u64`

## What Changed

- Kept the manifest/runtime backend check strict.
- Allowed stored dense-doc backend `llamacpp` to match the product runtime id `llamacpp:bge-base-en-v1.5` inside the diagnostic example.
- Switched the temporary `turbovec` id map to local ordinal ids while preserving real node ids in the report map.
- Added self-test coverage for the backend mapping.

## How To Review

Review one file:

- `crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs`

The product retrieval route is unchanged. This remains a Windows-only diagnostic example gated by strict sidecar readiness.

Measurement summary from `target\issue-246\turbovec-harness-final.json`:

| Probe | overlap@10 | MRR delta | Qdrant p50/p95 ms | turbovec p50/p95 ms |
| --- | ---: | ---: | ---: | ---: |
| strict sidecar readiness | 1.00 | 0.00 | 32.236 / 45.832 | 32.490 / 43.505 |
| dense anchor selection | 0.80 | 0.00 | 27.213 / 32.161 | 18.802 / 19.548 |
| Qdrant query embedding | 1.00 | 0.00 | 26.922 / 31.206 | 56.805 / 170.120 |

Cache/readiness used for the run:

- worktree: `C:\Users\alber\.codex\worktrees\5ffd\codestory`
- storage: `C:\Users\alber\AppData\Local\codestory\codestory\cache\26cc5ea6500d5527\codestory.db`
- final manifest generation: `repo-v1-670ad7db4da1546b-1646d955e78905f7`
- Qdrant collection: `codestory_repo-v1-670ad7db4da1546b_1646d955e78905f7`
- dense anchors/Qdrant points: `883` / `883`
- `turbovec` artifact bytes: `355,830`
- build/write/load: `235 ms` / `1 ms` / `238 ms`

## Verification

- `cargo fmt --check`
- `cargo run -p codestory-retrieval --example turbovec_dense_anchor_gate -- --self-test`
- `git diff --check`
- `codestory-cli index --project . --refresh full --format json`
- `codestory-cli retrieval bootstrap --project . --wait-secs 90 --format json`
- `codestory-cli retrieval index --project . --refresh full --format json`
- `codestory-cli retrieval status --project . --format json` -> `retrieval_mode="full"`
- `codestory-cli doctor --project . --format json` -> `retrieval_mode="full"`, agent packet/search ready
- `cargo run -p codestory-retrieval --example turbovec_dense_anchor_gate -- --project C:\Users\alber\.codex\worktrees\5ffd\codestory --storage C:\Users\alber\AppData\Local\codestory\codestory\cache\26cc5ea6500d5527\codestory.db --artifact target\issue-246\codestory-turbovec-dense-anchor.tvim --repeats 5`

## Risk

Low product risk: no product packet/search routing changes, no manifest weakening, no sidecar removal. The remaining risk is measurement scope: three default text probes are enough to keep the vector lane alive as diagnostic/hybrid-only exploration, not enough to replace Qdrant.
