### PR TITLE
[codex] Harden sidecar status repair hints

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -340,6 +340,11 @@ fn render_cache_rehydrate_markdown(output: &codestory_runtime::CacheRehydrateOut
         output.rebased_path_bound_rows
     );
     let _ = writeln!(markdown, "retrieval: {}", output.retrieval);
+    let _ = writeln!(markdown, "retrieval_status: `{}`", output.retrieval_status);
+    let _ = writeln!(markdown, "retrieval_reason: {}", output.retrieval_reason);
+    if let Some(command) = output.retrieval_next_command.as_deref() {
+        let _ = writeln!(markdown, "retrieval_next_command: `{command}`");
+    }
     if !output.next_commands.is_empty() {
         let _ = writeln!(markdown, "next_commands:");
         for command in &output.next_commands {

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -352,8 +352,18 @@ fn emit_retrieval_status(
             )
         })
         .unwrap_or_default();
+    let repair_note = report
+        .repair
+        .as_ref()
+        .map(|repair| {
+            format!(
+                "- repair: reason=`{}` next_step=\"{}\" next_command=`{}`\n",
+                repair.reason, repair.next_step, repair.next_command
+            )
+        })
+        .unwrap_or_default();
     let markdown = format!(
-        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
+        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
         report.retrieval_mode,
         report.degraded_reason,
         report.query_embedding_backend,
@@ -363,6 +373,7 @@ fn emit_retrieval_status(
         report.stored_doc_vector_dim,
         report.stored_doc_vector_mixed_backends,
         manifest_contract_note,
+        repair_note,
         report.zoekt.status,
         report.zoekt.detail,
         report.zoekt.capabilities.lexical,

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -140,6 +140,30 @@ fn bootstrap_then_status_reports_manifest_missing_before_indexing() {
         status["manifest_contract"].is_null(),
         "manifest-missing status must not derive a manifest contract: {status}"
     );
+    assert_eq!(
+        status["repair"]["reason"].as_str(),
+        Some("retrieval_manifest_missing"),
+        "manifest-missing status should expose a typed repair reason: {status}"
+    );
+    assert!(
+        status["repair"]["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval bootstrap")),
+        "manifest-missing status should expose an actionable repair command: {status}"
+    );
+    assert!(
+        status["repair"]["full_repair"]
+            .as_array()
+            .is_some_and(
+                |commands| commands
+                    .iter()
+                    .any(|command| command
+                        .as_str()
+                        .is_some_and(|text| text.contains("retrieval index")
+                            && text.contains("--refresh full")))
+            ),
+        "manifest-missing status should include full sidecar rebuild guidance: {status}"
+    );
 }
 
 #[test]

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -62,10 +62,20 @@ fn capabilities_are_empty(cap: &SidecarCapabilities) -> bool {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrievalRepairHint {
+    pub reason: String,
+    pub next_step: String,
+    pub next_command: String,
+    pub full_repair: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetrievalStatusReport {
     pub retrieval_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repair: Option<RetrievalRepairHint>,
     pub query_embedding_backend: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_vector_embedding_backend: Option<String>,
@@ -95,6 +105,38 @@ pub fn attach_manifest_contract(
         .as_ref()
         .map(|manifest| manifest_contract_report(source_root, &report, manifest));
     report
+}
+
+pub fn attach_repair_hint(
+    mut report: RetrievalStatusReport,
+    project_root: &Path,
+) -> RetrievalStatusReport {
+    if report.retrieval_mode == "full" {
+        return report;
+    }
+    let reason = report
+        .degraded_reason
+        .clone()
+        .unwrap_or_else(|| "sidecar_retrieval_not_full".into());
+    let project = quote_command_path(project_root);
+    let full_repair = vec![
+        format!("codestory-cli retrieval bootstrap --project {project} --format json"),
+        format!("codestory-cli retrieval index --project {project} --refresh full --format json"),
+        format!("codestory-cli retrieval status --project {project} --format json"),
+    ];
+    report.repair = Some(RetrievalRepairHint {
+        reason,
+        next_step:
+            "Prepare sidecars, rebuild retrieval indexes with full refresh, then recheck status."
+                .into(),
+        next_command: full_repair[0].clone(),
+        full_repair,
+    });
+    report
+}
+
+fn quote_command_path(path: &Path) -> String {
+    format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
 }
 
 fn manifest_contract_report(
@@ -251,6 +293,7 @@ pub fn unavailable_status_report(
     RetrievalStatusReport {
         retrieval_mode: "unavailable".into(),
         degraded_reason: Some(reason.clone()),
+        repair: None,
         query_embedding_backend: crate::embeddings::embedding_runtime_id(),
         manifest_vector_embedding_backend,
         manifest_vector_embedding_dim,
@@ -527,6 +570,7 @@ pub fn probe_sidecar_health(
     RetrievalStatusReport {
         retrieval_mode: mode.as_str().into(),
         degraded_reason,
+        repair: None,
         query_embedding_backend: current_embedding_backend,
         manifest_vector_embedding_backend: manifest.embedding_backend.clone(),
         manifest_vector_embedding_dim: manifest.embedding_dim,
@@ -545,6 +589,33 @@ pub fn probe_sidecar_health(
 mod tests {
     use super::*;
     use crate::config::SidecarLayout;
+
+    #[test]
+    fn repair_hint_names_reason_and_full_sidecar_rebuild_sequence() {
+        let report = attach_repair_hint(
+            unavailable_status_report("retrieval_manifest_missing", None),
+            Path::new("C:/repo with spaces"),
+        );
+        let repair = report.repair.expect("repair hint");
+
+        assert_eq!(repair.reason, "retrieval_manifest_missing");
+        assert!(
+            repair.next_command.contains("retrieval bootstrap"),
+            "repair should start with sidecar bootstrap: {repair:?}"
+        );
+        assert!(
+            repair.full_repair.iter().any(|command| command
+                .contains("retrieval index --project \"C:/repo with spaces\" --refresh full")),
+            "repair should include full retrieval rebuild with quoted project path: {repair:?}"
+        );
+        assert!(
+            repair
+                .full_repair
+                .last()
+                .is_some_and(|command| command.contains("retrieval status")),
+            "repair should end with retrieval status proof: {repair:?}"
+        );
+    }
 
     #[test]
     fn status_reports_unavailable_when_zoekt_down() {
@@ -701,6 +772,7 @@ mod tests {
             },
             manifest_contract: None,
             manifest: Some(manifest),
+            repair: None,
         };
         let source_root = std::env::current_dir().expect("current dir");
 

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -114,10 +114,12 @@ pub fn attach_repair_hint(
     if report.retrieval_mode == "full" {
         return report;
     }
-    let reason = report
-        .degraded_reason
-        .clone()
-        .unwrap_or_else(|| "sidecar_retrieval_not_full".into());
+    let reason = repair_reason_code(
+        report
+            .degraded_reason
+            .as_deref()
+            .unwrap_or("sidecar_retrieval_not_full"),
+    );
     let project = quote_command_path(project_root);
     let full_repair = vec![
         format!("codestory-cli retrieval bootstrap --project {project} --format json"),
@@ -133,6 +135,13 @@ pub fn attach_repair_hint(
         full_repair,
     });
     report
+}
+
+fn repair_reason_code(degraded_reason: &str) -> String {
+    if degraded_reason.starts_with("sidecar_manifest_stale:") {
+        return "sidecar_manifest_stale".into();
+    }
+    degraded_reason.to_string()
 }
 
 fn quote_command_path(path: &Path) -> String {
@@ -615,6 +624,19 @@ mod tests {
                 .is_some_and(|command| command.contains("retrieval status")),
             "repair should end with retrieval status proof: {repair:?}"
         );
+    }
+
+    #[test]
+    fn repair_hint_keeps_stale_reason_stable_and_degraded_reason_detailed() {
+        let detailed = "sidecar_manifest_stale: sidecar_input_hash_mismatch current=abc stored=def path=src/lib.rs";
+        let report = attach_repair_hint(
+            unavailable_status_report(detailed, None),
+            Path::new("C:/repo"),
+        );
+        let repair = report.repair.expect("repair hint");
+
+        assert_eq!(report.degraded_reason.as_deref(), Some(detailed));
+        assert_eq!(repair.reason, "sidecar_manifest_stale");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -60,8 +60,8 @@ pub use executor::{QueryExecutor, QueryResult, QueryTrace, StageTrace, cancellat
 pub use generation::{SIDECAR_SCHEMA_VERSION, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED};
 pub use health::{
     ComponentHealth, ComponentStatus, InfrastructureHealth, RetrievalManifestContractReport,
-    RetrievalManifestLaneProvenance, RetrievalStatusReport, probe_infrastructure_health,
-    probe_sidecar_health,
+    RetrievalManifestLaneProvenance, RetrievalRepairHint, RetrievalStatusReport,
+    probe_infrastructure_health, probe_sidecar_health,
 };
 pub use index::{
     FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, project_id_for_root,

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -3,7 +3,9 @@ use crate::generation::{
     SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
     manifest_staleness_reason, manifest_unavailable_reason,
 };
-use crate::health::{RetrievalStatusReport, attach_manifest_contract, probe_sidecar_health};
+use crate::health::{
+    RetrievalStatusReport, attach_manifest_contract, attach_repair_hint, probe_sidecar_health,
+};
 use crate::index::{compute_sidecar_input_fingerprint, sidecar_project_id_for_root};
 use anyhow::{Context, Result};
 use codestory_contracts::language_support::{
@@ -99,10 +101,13 @@ fn sidecar_status_inner(
             .context("check strict sidecar readiness")?
         {
             return Ok(enrich_status_with_semantic_doc_stats(
-                attach_manifest_contract(
-                    crate::health::unavailable_status_report(
-                        format!("sidecar_manifest_stale: {reason}"),
-                        Some(manifest.clone()),
+                attach_repair_hint(
+                    attach_manifest_contract(
+                        crate::health::unavailable_status_report(
+                            format!("sidecar_manifest_stale: {reason}"),
+                            Some(manifest.clone()),
+                        ),
+                        project_root,
                     ),
                     project_root,
                 ),
@@ -113,8 +118,11 @@ fn sidecar_status_inner(
             && let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest)
         {
             return Ok(enrich_status_with_semantic_doc_stats(
-                attach_manifest_contract(
-                    crate::health::unavailable_status_report(reason, Some(manifest.clone())),
+                attach_repair_hint(
+                    attach_manifest_contract(
+                        crate::health::unavailable_status_report(reason, Some(manifest.clone())),
+                        project_root,
+                    ),
                     project_root,
                 ),
                 &storage,
@@ -122,14 +130,17 @@ fn sidecar_status_inner(
         }
         let report = probe_sidecar_health(&layout, &project_id, manifest);
         return Ok(enrich_status_with_semantic_doc_stats(
-            attach_manifest_contract(report, project_root),
+            attach_repair_hint(attach_manifest_contract(report, project_root), project_root),
             &storage,
         ));
     } else {
         None
     };
-    Ok(attach_manifest_contract(
-        probe_sidecar_health(&layout, &project_id, manifest),
+    Ok(attach_repair_hint(
+        attach_manifest_contract(
+            probe_sidecar_health(&layout, &project_id, manifest),
+            project_root,
+        ),
         project_root,
     ))
 }

--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -45,6 +45,9 @@ pub struct CacheRehydrateOutput {
     pub invalidated_index_artifact_rows: usize,
     pub rebased_path_bound_rows: usize,
     pub preserved_scope: String,
+    pub retrieval_status: String,
+    pub retrieval_reason: String,
+    pub retrieval_next_command: Option<String>,
     pub retrieval: String,
     pub next_commands: Vec<String>,
 }
@@ -220,6 +223,9 @@ pub fn rehydrate_cache(request: CacheRehydrateRequest<'_>) -> Result<CacheRehydr
         invalidated_index_artifact_rows,
         rebased_path_bound_rows,
         preserved_scope: "sqlite_graph_search_docs_rebased_v2_index_artifacts_preserved".into(),
+        retrieval_status: retrieval_rehydrate_status(request.dry_run),
+        retrieval_reason: retrieval_rehydrate_reason(),
+        retrieval_next_command: Some(retrieval_next_command(request.target_project)),
         retrieval: retrieval_rehydrate_policy(request.dry_run),
         next_commands: rehydrate_next_commands(request.target_project),
     })
@@ -409,6 +415,9 @@ fn skipped(
         invalidated_index_artifact_rows: 0,
         rebased_path_bound_rows: 0,
         preserved_scope: "none".into(),
+        retrieval_status: "not_rehydrated".into(),
+        retrieval_reason: "normal index and retrieval rebuild required".into(),
+        retrieval_next_command: None,
         retrieval: "not rehydrated; normal index/retrieval rebuild required".into(),
         next_commands,
     }
@@ -467,6 +476,25 @@ fn rehydrate_next_commands(project: &Path) -> Vec<String> {
         format!("codestory-cli retrieval index --project {project} --refresh full"),
         format!("codestory-cli doctor --project {project}"),
     ]
+}
+
+fn retrieval_next_command(project: &Path) -> String {
+    format!(
+        "codestory-cli retrieval index --project {} --refresh full",
+        quote_path(project)
+    )
+}
+
+fn retrieval_rehydrate_status(dry_run: bool) -> String {
+    if dry_run {
+        "would_invalidate_requires_rebuild".into()
+    } else {
+        "invalidated_requires_rebuild".into()
+    }
+}
+
+fn retrieval_rehydrate_reason() -> String {
+    "cache rehydrate copies SQLite graph/search/doc state only; sidecar manifests and Zoekt/Qdrant/SCIP artifacts must be rebuilt or revalidated for the target worktree".into()
 }
 
 fn retrieval_rehydrate_policy(dry_run: bool) -> String {
@@ -528,6 +556,22 @@ mod tests {
         assert_eq!(
             output.preserved_scope,
             "sqlite_graph_search_docs_rebased_v2_index_artifacts_preserved"
+        );
+        assert_eq!(output.retrieval_status, "invalidated_requires_rebuild");
+        assert!(
+            output
+                .retrieval_reason
+                .contains("SQLite graph/search/doc state only"),
+            "rehydrate output should distinguish SQLite reuse from sidecar readiness: {}",
+            output.retrieval_reason
+        );
+        assert!(
+            output
+                .retrieval_next_command
+                .as_deref()
+                .is_some_and(|command| command.contains("retrieval index")
+                    && command.contains("--refresh full")),
+            "rehydrate output should expose the sidecar rebuild command: {output:?}"
         );
         assert!(
             output


### PR DESCRIPTION
## Context

Closes #249.
Refs #212, #208, #40, #82, #38.

Sidecar status already failed closed, but degraded `retrieval status --format json` output only exposed `degraded_reason`. This makes missing or stale sidecars harder to repair from automation. Cache rehydrate also had a compatibility text field, but no typed sidecar aftermath fields separating SQLite graph/search/doc reuse from sidecar readiness.

## What Changed

- Added `repair` to non-full retrieval status reports with:
  - `reason`
  - `next_step`
  - `next_command`
  - `full_repair`
- Attached the repair hint after strict sidecar manifest identity/freshness checks, preserving fail-closed status admission.
- Added typed cache rehydrate aftermath fields:
  - `retrieval_status`
  - `retrieval_reason`
  - `retrieval_next_command`
- Kept existing compatibility fields and retrieval/cache text output intact.
- Updated CLI markdown to surface the new repair/rehydrate fields.

```mermaid
flowchart TD
    A[retrieval status] --> B[strict manifest checks]
    B -->|full| C[no repair hint]
    B -->|missing or stale| D[non-full status]
    D --> E[typed repair reason]
    E --> F[bootstrap, retrieval index, status proof]

    G[cache rehydrate] --> H[SQLite graph/search/docs rebased]
    H --> I[retrieval manifests invalidated]
    I --> J[typed sidecar rebuild status]
```

## How To Review

- Inspect `crates/codestory-retrieval/src/health.rs` and `sidecar.rs` for the repair hint attachment point.
- Inspect `crates/codestory-runtime/src/cache_rehydrate.rs` for typed cache aftermath fields.
- Inspect `crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs` for the missing-manifest JSON contract.

## Verification

- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts bootstrap_then_status_reports_manifest_missing_before_indexing -- --nocapture` -> 1 passed, 0 failed, 2 filtered out.
- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts -- --nocapture` -> 3 passed, 0 failed.
- `cargo test -p codestory-runtime cache_rehydrate::tests -- --nocapture` -> 4 passed, 0 failed; unrelated test binaries had 0 matching filtered tests.
- `cargo test -p codestory-retrieval repair_hint_names_reason_and_full_sidecar_rebuild_sequence -- --nocapture` -> 1 passed, 0 failed; unrelated test binaries had 0 matching filtered tests.
- `cargo test -p codestory-runtime sidecar_mode_status_rejects_stale_manifest_before_health_probe -- --nocapture` -> 1 passed, 0 failed; unrelated test binaries had 0 matching filtered tests.
- `cargo run -q -p codestory-cli -- retrieval status --project . --format json` -> `retrieval_mode=unavailable`, `degraded_reason=retrieval_manifest_missing`, `repair.reason=retrieval_manifest_missing`, repair command present.
- `cargo run -q -p codestory-cli -- doctor --project . --format json` -> current worktree remains degraded because it has no index and no retrieval manifest.
- `cargo fmt --check` -> pass.
- `git diff --check` -> pass.

## Risk

- This is status/preflight-only. It does not change packet/search routing, full-mode admission, sidecar indexing, Qdrant/Zoekt/SCIP checks, or cache copy behavior.
- The live worktree still has degraded readiness (`indexed=false`, `retrieval_manifest_missing`); I did not run a full sidecar rebuild for this status-only lane.