### PR TITLE
Split turbovec vector timing diagnostics

### DIFF
--- a/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
+++ b/crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs
@@ -225,18 +225,25 @@ mod windows_gate {
         k: usize,
         repeats: usize,
     ) -> Result<QueryReport> {
-        let qdrant_hits = qdrant
-            .search(collection, query, k)
-            .context("qdrant search")?;
         let query_vector = diagnostic_query_vector(query).context("embed query for turbovec")?;
+        let qdrant_hits = qdrant
+            .diagnostic_search_vector(collection, &query_vector, k)
+            .context("qdrant vector search")?;
         let turbovec_hits = turbovec_search(index, id_to_doc, &query_vector, k);
         let repeats = repeats.max(1);
         let _ = qdrant.search(collection, query, k);
-        let _ = diagnostic_query_vector(query).map(|vector| index.search(&vector, k));
-        let qdrant_ms = timed_repeats(repeats, || qdrant.search(collection, query, k).map(drop))?;
-        let turbovec_ms = timed_repeats(repeats, || {
-            let vector = diagnostic_query_vector(query)?;
-            let _ = index.search(&vector, k);
+        let _ = qdrant.diagnostic_search_vector(collection, &query_vector, k);
+        let _ = index.search(&query_vector, k);
+        let embedding_ms = timed_repeats(repeats, || diagnostic_query_vector(query).map(drop))?;
+        let qdrant_total_ms =
+            timed_repeats(repeats, || qdrant.search(collection, query, k).map(drop))?;
+        let qdrant_lookup_ms = timed_repeats(repeats, || {
+            qdrant
+                .diagnostic_search_vector(collection, &query_vector, k)
+                .map(drop)
+        })?;
+        let turbovec_lookup_ms = timed_repeats(repeats, || {
+            let _ = index.search(&query_vector, k);
             Ok(())
         })?;
         let qdrant_ids = qdrant_hits
@@ -251,10 +258,18 @@ mod windows_gate {
             query: query.to_string(),
             overlap_at_k: overlap_ratio(&qdrant_ids, &turbovec_ids),
             mrr_delta: mrr(&qdrant_ids, &qdrant_ids) - mrr(&qdrant_ids, &turbovec_ids),
-            qdrant_p50_ms: percentile(&qdrant_ms, 50.0),
-            qdrant_p95_ms: percentile(&qdrant_ms, 95.0),
-            turbovec_p50_ms: percentile(&turbovec_ms, 50.0),
-            turbovec_p95_ms: percentile(&turbovec_ms, 95.0),
+            query_embedding_p50_ms: percentile(&embedding_ms, 50.0),
+            query_embedding_p95_ms: percentile(&embedding_ms, 95.0),
+            query_embedding_p99_ms: percentile(&embedding_ms, 99.0),
+            qdrant_total_p50_ms: percentile(&qdrant_total_ms, 50.0),
+            qdrant_total_p95_ms: percentile(&qdrant_total_ms, 95.0),
+            qdrant_total_p99_ms: percentile(&qdrant_total_ms, 99.0),
+            qdrant_lookup_p50_ms: percentile(&qdrant_lookup_ms, 50.0),
+            qdrant_lookup_p95_ms: percentile(&qdrant_lookup_ms, 95.0),
+            qdrant_lookup_p99_ms: percentile(&qdrant_lookup_ms, 99.0),
+            turbovec_lookup_p50_ms: percentile(&turbovec_lookup_ms, 50.0),
+            turbovec_lookup_p95_ms: percentile(&turbovec_lookup_ms, 95.0),
+            turbovec_lookup_p99_ms: percentile(&turbovec_lookup_ms, 99.0),
             qdrant_top_k: qdrant_ids.into_iter().map(str::to_string).collect(),
             turbovec_top_k: turbovec_ids.into_iter().map(str::to_string).collect(),
         })
@@ -334,6 +349,7 @@ mod windows_gate {
         let (_scores, ids) = index.search(&vectors[0..dim], 1);
         assert_eq!(ids[0], 11);
         assert_eq!(percentile(&[1.0, 2.0, 3.0], 95.0), 3.0);
+        assert_eq!(percentile(&[1.0, 2.0, 3.0], 99.0), 3.0);
         assert_eq!(overlap_ratio(&["a", "b"], &["b", "c"]), 0.5);
         assert!(stored_doc_backend_matches_runtime(
             Some("llamacpp"),
@@ -461,10 +477,18 @@ mod windows_gate {
         query: String,
         overlap_at_k: f64,
         mrr_delta: f64,
-        qdrant_p50_ms: f64,
-        qdrant_p95_ms: f64,
-        turbovec_p50_ms: f64,
-        turbovec_p95_ms: f64,
+        query_embedding_p50_ms: f64,
+        query_embedding_p95_ms: f64,
+        query_embedding_p99_ms: f64,
+        qdrant_total_p50_ms: f64,
+        qdrant_total_p95_ms: f64,
+        qdrant_total_p99_ms: f64,
+        qdrant_lookup_p50_ms: f64,
+        qdrant_lookup_p95_ms: f64,
+        qdrant_lookup_p99_ms: f64,
+        turbovec_lookup_p50_ms: f64,
+        turbovec_lookup_p95_ms: f64,
+        turbovec_lookup_p99_ms: f64,
         qdrant_top_k: Vec<String>,
         turbovec_top_k: Vec<String>,
     }

--- a/crates/codestory-retrieval/src/qdrant_client.rs
+++ b/crates/codestory-retrieval/src/qdrant_client.rs
@@ -191,11 +191,40 @@ impl QdrantClient {
         query: &str,
         limit: usize,
     ) -> Result<Vec<super::CandidateHit>> {
+        let vector = query_vector(query)?;
+        self.search_vector(collection, &vector, limit)
+    }
+
+    /// Diagnostic-only vector lookup against Qdrant without query embedding.
+    ///
+    /// Product retrieval must keep using [`QdrantClient::search`] so query
+    /// embedding and Qdrant lookup stay in the mandatory sidecar path.
+    pub fn diagnostic_search_vector(
+        &self,
+        collection: &str,
+        vector: &[f32],
+        limit: usize,
+    ) -> Result<Vec<super::CandidateHit>> {
+        self.search_vector(collection, vector, limit)
+    }
+
+    fn search_vector(
+        &self,
+        collection: &str,
+        vector: &[f32],
+        limit: usize,
+    ) -> Result<Vec<super::CandidateHit>> {
         if !qdrant_enabled() {
             bail!("qdrant sidecar is mandatory; CODESTORY_QDRANT_ENABLED=false is unsupported");
         }
+        let expected_dim = active_vector_dim();
+        if vector.len() != expected_dim {
+            bail!(
+                "qdrant query vector dim mismatch: vector={} expected={expected_dim}",
+                vector.len()
+            );
+        }
         let url = format!("{}/collections/{collection}/points/query", self.base_url);
-        let vector = query_vector(query)?;
         let body = serde_json::json!({
             "query": vector,
             "limit": limit,


### PR DESCRIPTION
## Context

Closes #250
Refs #212
Refs #210
Refs #238
Refs #246
Refs #247
Refs #248
Refs #38

#250 needed the `turbovec_dense_anchor_gate` diagnostic to separate query embedding time from vector lookup time while keeping Qdrant as the product path.

Readiness used for the metric run:
- Project: `C:\Users\alber\.codex\worktrees\5ffd\codestory`
- Storage: `C:\Users\alber\AppData\Local\codestory\codestory\cache\26cc5ea6500d5527\codestory.db`
- `doctor`: `retrieval_mode=full`, fresh index, 267 files, 109961 nodes, 92968 edges
- `retrieval status`: Zoekt healthy, Qdrant healthy with `points_count=883`, SCIP healthy, manifest `retrieval_mode=full`

## What Changed

- Added `QdrantClient::diagnostic_search_vector(...)` for vector-only Qdrant timing without changing product `QdrantClient::search(...)`.
- Updated `turbovec_dense_anchor_gate` to report query embedding, Qdrant total text path, Qdrant vector-only lookup, and turbovec vector-only lookup p50/p95/p99.
- Kept the output marked `diagnostic_only: true` and `product_path_changed: false`.

## How To Review

1. Check `crates/codestory-retrieval/src/qdrant_client.rs` and confirm product callers still use `QdrantClient::search(...)`.
2. Check `crates/codestory-retrieval/examples/turbovec_dense_anchor_gate.rs` and confirm timings are split from one precomputed query vector.
3. Review the metric result below as diagnostic evidence only.

## Verification

```powershell
& 'C:\Users\alber\.codex\worktrees\ca4d\codestory\target\release\codestory-cli.exe' doctor --project 'C:\Users\alber\.codex\worktrees\5ffd\codestory' --cache-dir 'C:\Users\alber\AppData\Local\codestory\codestory\cache\26cc5ea6500d5527' --format json
& 'C:\Users\alber\.codex\worktrees\ca4d\codestory\target\release\codestory-cli.exe' retrieval status --project 'C:\Users\alber\.codex\worktrees\5ffd\codestory' --cache-dir 'C:\Users\alber\AppData\Local\codestory\codestory\cache\26cc5ea6500d5527' --format json
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo fmt --check
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo run -p codestory-retrieval --example turbovec_dense_anchor_gate -- --self-test
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo run --release -p codestory-retrieval --example turbovec_dense_anchor_gate -- --project 'C:\Users\alber\.codex\worktrees\5ffd\codestory' --storage 'C:\Users\alber\AppData\Local\codestory\codestory\cache\26cc5ea6500d5527\codestory.db' --repeats 5 --k 10
$env:RUSTC_WRAPPER = "$env:USERPROFILE\.cargo\bin\sccache.exe"; cargo check -p codestory-retrieval --examples
git diff --check
```

Metric run summary:

| Query | overlap@10 | MRR delta | embed p50/p95/p99 ms | Qdrant lookup p50/p95/p99 ms | turbovec lookup p50/p95/p99 ms |
| --- | ---: | ---: | ---: | ---: | ---: |
| strict sidecar readiness | 1.0 | 0.0 | 21.464 / 24.650 / 24.650 | 15.202 / 17.346 / 17.346 | 0.123 / 0.240 / 0.240 |
| dense anchor selection | 0.8 | 0.0 | 18.200 / 19.459 / 19.459 | 4.017 / 5.533 / 5.533 | 0.203 / 0.312 / 0.312 |
| Qdrant query embedding | 1.0 | 0.0 | 32.921 / 39.051 / 39.051 | 3.778 / 4.906 / 4.906 | 0.134 / 0.225 / 0.225 |

Artifact bytes: `355830`; dense anchors/Qdrant points: `883/883`.

Recommendation: vector lookup itself is not the observed cost center on this sample. Query embedding dominates Qdrant vector-only lookup, and `turbovec` lookup is much faster than Qdrant lookup, but this remains diagnostic evidence only; Qdrant stays the product path.

## Risk

- The metric run used the existing full-ready 5ffd worktree/cache, which is fresh for that worktree but older than the current `dev/codestory-next` source tip.
- `diagnostic_search_vector` is intentionally public for the example, so reviewers should keep it out of product packet/search routing.