### PR TITLE
[codex] bump CodeStory to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.11.1
+
+CodeStory 0.11.1 is the patch release lane for the Codex plugin packaging work
+that landed after `v0.11.0`. It keeps the release version synchronized while
+making the new plugin path reviewable before the eventual main promotion:
+install/readiness stays in the CLI wrapper, the plugin package owns only Codex
+metadata and skill text, and `.mcp.json` launches `codestory-cli serve --stdio`
+directly instead of carrying a Node adapter.
+
+The marketplace catalog is still a non-claim for this release prep. Issue #264
+remains open, and PR #262 explicitly left the `TheGreenCedar/AgentPluginMarketplace`
+entry outside this repository. This changelog entry also does not claim new
+binary assets, a pushed `v0.11.1` tag, packet/search readiness, sidecar
+promotion, or benchmark improvement.
+
+### Shipped Since 0.11.0
+
+| Area | Delivered in 0.11.1 | Evidence |
+| --- | --- | --- |
+| Release version | All `codestory-*` workspace crates and `Cargo.lock` are synchronized at `0.11.1`. | Issue #267 |
+| Plugin packaging | `plugins/codestory` now contains the Codex plugin manifest, MCP metadata, package README, grounding skill, and static package tests. | PR #262 |
+| Direct CLI MCP launch | The plugin `.mcp.json` launches `codestory-cli serve --stdio --refresh none` directly, with no in-package Node adapter or duplicated retrieval/runtime logic. | PR #262 |
+| Install and readiness wrapper | `scripts/install-codestory.ps1` added the Windows x64 happy path for finding or installing `codestory-cli`, then reporting binary, local-navigation, and packet/search readiness from `doctor`. | PR #261 |
+| Release-note hygiene | Stale generated 0.11 pre-release docs and ledger-style artifacts were removed from committed docs before this patch release lane. | PR #260 |
+
+Automatic install remains Windows x64 first. The plugin docs point other
+platforms at the available release assets or an explicit `codestory-cli` on
+`PATH`, and macOS x64 remains source/manual until a matching asset exists.
+
 ## 0.11.0
 
 CodeStory 0.11.0 was published from `main` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ install/readiness stays in the CLI wrapper, the plugin package owns only Codex
 metadata and skill text, and `.mcp.json` launches `codestory-cli serve --stdio`
 directly instead of carrying a Node adapter.
 
-The marketplace catalog is still a non-claim for this release prep. Issue #264
-remains open, and PR #262 explicitly left the `TheGreenCedar/AgentPluginMarketplace`
-entry outside this repository. This changelog entry also does not claim new
-binary assets, a pushed `v0.11.1` tag, packet/search readiness, sidecar
-promotion, or benchmark improvement.
+The marketplace catalog is still outside this repository. Issue #264 closed the
+separate `TheGreenCedar/AgentPluginMarketplace` catalog lane, while PR #262 left
+CodeStory owning only the plugin package source under `plugins/codestory`. This
+changelog entry does not claim new binary assets, a pushed `v0.11.1` tag,
+packet/search readiness, sidecar promotion, or benchmark improvement.
 
 ### Shipped Since 0.11.0
 
@@ -23,11 +23,11 @@ promotion, or benchmark improvement.
 | Plugin packaging | `plugins/codestory` now contains the Codex plugin manifest, MCP metadata, package README, grounding skill, and static package tests. | PR #262 |
 | Direct CLI MCP launch | The plugin `.mcp.json` launches `codestory-cli serve --stdio --refresh none` directly, with no in-package Node adapter or duplicated retrieval/runtime logic. | PR #262 |
 | Install and readiness wrapper | `scripts/install-codestory.ps1` added the Windows x64 happy path for finding or installing `codestory-cli`, then reporting binary, local-navigation, and packet/search readiness from `doctor`. | PR #261 |
+| Cross-platform plugin readiness | Plugin README, skill guidance, and static tests now cover Windows, macOS, and Linux install/readiness paths without adding an adapter runtime or changing Rust product behavior. | PR #269 |
 | Release-note hygiene | Stale generated 0.11 pre-release docs and ledger-style artifacts were removed from committed docs before this patch release lane. | PR #260 |
 
-Automatic install remains Windows x64 first. The plugin docs point other
-platforms at the available release assets or an explicit `codestory-cli` on
-`PATH`, and macOS x64 remains source/manual until a matching asset exists.
+The plugin docs keep current archive names release-bound to `v0.11.0`; update
+them with the main release workflow when `0.11.1` assets exist.
 
 ## 0.11.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.10.1"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.10.1"
+version = "0.11.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Context

Closes #267
Refs #38 #264 #265

`dev/codestory-next` is ahead of `v0.11.0` with plugin packaging work, and now includes PR #269 at `d7902a7f0cdaf1f4a5ea9fb0411a02740ed9ed43`. This PR prepares the `0.11.1` patch release lane without creating tags, release assets, generated ledgers, or pre-release reports.

The live release list still reports `v0.11.0` as latest. Issue #264 is closed as the external `TheGreenCedar/AgentPluginMarketplace` catalog lane; this PR still claims only CodeStory repository changes.

## What Changed

- Bumped all eight `codestory-*` workspace crate manifests to `0.11.1`.
- Updated the matching `Cargo.lock` `codestory-*` package entries to `0.11.1`.
- Added a `CHANGELOG.md` `0.11.1` section before the PR table/list shape, covering the post-`v0.11.0` plugin packaging lane, direct CLI MCP launch path, install/readiness wrapper, cross-platform plugin readiness docs/static tests from PR #269, stale doc cleanup, the external marketplace catalog lane, and explicit non-claims.
- Rebased the branch onto the current `origin/dev/codestory-next` tip `d7902a7f0cdaf1f4a5ea9fb0411a02740ed9ed43` after PR #269 merged.

## How To Review

1. Start at the new `CHANGELOG.md` `0.11.1` section and check that the narrative matches the narrow post-`v0.11.0` CodeStory diff: PR #260, PR #261, PR #262, and PR #269.
2. Confirm the changelog does not claim a `v0.11.1` tag, release assets, CodeStory-owned marketplace catalog edits, packet/search readiness, sidecar promotion, or benchmark improvement.
3. Inspect the crate manifests and `Cargo.lock` package entries for synchronized `0.11.1` versions only.
4. Confirm no generated pre-release reports, CSVs, SVGs, or ledgers are added.

## Verification

- `python .github\scripts\check-codestory-release.py --version 0.11.1` - passed after the #269 rebase; 8 workspace crates and `Cargo.lock` synchronized.
- `git diff --check` - passed after the #269 changelog update.
- `git diff --cached --check` - passed before the changelog amend.
- `git diff --check origin/dev/codestory-next...HEAD` - passed after the rebase/amend.
- `$env:RUSTC_WRAPPER = 'C:\Users\alber\.cargo\bin\sccache.exe'; cargo fmt --check` - passed before the Markdown-only follow-ups; not rerun after the #269 update because no Rust files changed.

No `cargo build` or broad tests were run; this is version/changelog release prep only.

## Risk

- `v0.11.1` is not tagged or published by this PR. The main promotion/release workflow still owns tags and binary assets.
- The plugin docs still keep current archive names release-bound to `v0.11.0` until `0.11.1` assets exist; this PR only prepares the workspace release version and changelog.
- The marketplace catalog lane is complete in the separate `TheGreenCedar/AgentPluginMarketplace` repo, not in CodeStory; this PR does not vendor, publish, or smoke the CodeStory plugin from that catalog.
- Packet/search readiness and sidecar promotion are not claimed without fresh sidecar evidence.