### PR TITLE
[codex] prove cross-platform plugin readiness

### DIFF
--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -17,16 +17,44 @@ search, and sidecar repair remain `codestory-cli` responsibilities.
 
 ## Install Prerequisite
 
-Install `codestory-cli` for the host OS and make it available on `PATH`.
+The plugin launches `codestory-cli` directly from the Codex host `PATH`.
+Install `codestory-cli` for that host OS, then start a new Codex thread after
+changing `PATH` so the plugin process can see it.
 
-| OS | Setup |
+The archive names below are release-bound to CodeStory `v0.11.0`; update this
+section with the release bump when the published assets move.
+
+| Host OS | Setup |
 | --- | --- |
-| Windows | Download `codestory-cli-v0.11.0-windows-x64.zip` or `codestory-cli-v0.11.0-windows-arm64.zip`, or run `powershell -ExecutionPolicy Bypass -File scripts/install-codestory.ps1` from a CodeStory checkout. |
-| macOS | Download `codestory-cli-v0.11.0-macos-arm64.tar.gz`, place `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed. macOS x64 should use the source fallback until a matching asset exists. |
-| Linux | Download `codestory-cli-v0.11.0-linux-x64.tar.gz` or `codestory-cli-v0.11.0-linux-arm64.tar.gz`, place `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed. |
+| Windows x64 | Download `codestory-cli-v0.11.0-windows-x64.zip`, or run `powershell -ExecutionPolicy Bypass -File scripts/install-codestory.ps1` from a CodeStory checkout. The helper's automatic download path is Windows x64 only. |
+| Windows arm64 | Download `codestory-cli-v0.11.0-windows-arm64.zip`, extract it, and put `codestory-cli.exe` on `PATH`. |
+| macOS arm64 | Download `codestory-cli-v0.11.0-macos-arm64.tar.gz`, extract it, put `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed. |
+| macOS x64 | Use the source fallback until a matching release asset exists. |
+| Linux x64 | Download `codestory-cli-v0.11.0-linux-x64.tar.gz`, extract it, put `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed. |
+| Linux arm64 | Download `codestory-cli-v0.11.0-linux-arm64.tar.gz`, extract it, put `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed. |
 
 Verify downloaded archives against `SHA256SUMS.txt`. Source fallback for any
-OS: build CodeStory and add `target/release` to `PATH`.
+OS: build CodeStory and add `target/release` to the Codex host `PATH`.
+
+## Readiness
+
+Check the binary first:
+
+```console
+codestory-cli --version
+```
+
+Then read `codestory://status` from the plugin. Without the plugin, the direct
+CLI equivalent is:
+
+```console
+codestory-cli doctor --project <repo> --format markdown
+```
+
+Local navigation is ready only when the status resource reports
+`local_navigation=ready`. Packet/search is ready only when strict sidecar status
+reports `retrieval_mode=full`; otherwise use the repair commands from the
+status resource and do not make packet/search-backed claims.
 
 ## Review Checks
 
@@ -35,7 +63,3 @@ python C:\Users\alber\.codex\skills\.system\plugin-creator\scripts\validate_plug
 node --test plugins\codestory\tests\plugin-static.test.mjs
 git diff --check
 ```
-
-Packet/search is ready only when `codestory://status` reports strict
-`retrieval_mode=full`. Otherwise use the repair commands from the status
-resource and do not make packet/search-backed claims.

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -10,24 +10,29 @@ implement indexing, runtime, retrieval, packet, search, or sidecar behavior.
 
 ## Setup First
 
-1. Make sure `codestory-cli` is installed and on `PATH`.
-2. If `codestory-cli` is missing, install the release binary for the current OS:
-   - Windows: download `codestory-cli-v0.11.0-windows-x64.zip` or
-     `codestory-cli-v0.11.0-windows-arm64.zip`, or run
+1. Make sure `codestory-cli` is installed and on the Codex host `PATH`. Start a
+   new Codex thread after changing `PATH`.
+2. The asset names below are release-bound to CodeStory `v0.11.0`; update them
+   with the release bump when the published assets move.
+3. If `codestory-cli` is missing, install the release binary for the current OS:
+   - Windows x64: download `codestory-cli-v0.11.0-windows-x64.zip`, or run
      `powershell -ExecutionPolicy Bypass -File scripts/install-codestory.ps1`
-     from a CodeStory checkout.
-   - macOS: download `codestory-cli-v0.11.0-macos-arm64.tar.gz`, place
+     from a CodeStory checkout. The helper's automatic download path is
+     Windows x64 only.
+   - Windows arm64: download `codestory-cli-v0.11.0-windows-arm64.zip`.
+   - macOS arm64: download `codestory-cli-v0.11.0-macos-arm64.tar.gz`, place
      `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed.
-     For macOS x64, use the source fallback until a matching asset exists.
-   - Linux: download `codestory-cli-v0.11.0-linux-x64.tar.gz` or
-     `codestory-cli-v0.11.0-linux-arm64.tar.gz`, place `codestory-cli` on
-     `PATH`, and run `chmod +x codestory-cli` if needed.
+   - macOS x64: use the source fallback until a matching release asset exists.
+   - Linux x64: download `codestory-cli-v0.11.0-linux-x64.tar.gz`, place
+     `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed.
+   - Linux arm64: download `codestory-cli-v0.11.0-linux-arm64.tar.gz`, place
+     `codestory-cli` on `PATH`, and run `chmod +x codestory-cli` if needed.
    - Source fallback: build `codestory-cli` from the CodeStory checkout and add
-     `target/release` to `PATH`.
-3. Read `codestory://status` before trusting any CodeStory result.
-4. If `local_navigation` is not `ready`, run the status resource's repair
+     `target/release` to the Codex host `PATH`.
+4. Read `codestory://status` before trusting any CodeStory result.
+5. If `local_navigation` is not `ready`, run the status resource's repair
    commands before relying on source claims.
-5. If `agent_packet_search` is not `ready`, packet/search is blocked. Run the
+6. If `agent_packet_search` is not `ready`, packet/search is blocked. Run the
    repair commands and re-read `codestory://status`.
 
 Packet/search claims are allowed only when strict sidecar status reports

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -24,3 +24,27 @@ test("codestory repo ships plugin source, not marketplace catalog or adapter run
   await assert.rejects(access(join(repoRoot, ".agents", "plugins", "marketplace.json")));
   await assert.rejects(access(join(pluginRoot, "scripts", "codestory-mcp.mjs")));
 });
+
+test("install guidance is cross-platform and release-bound", async () => {
+  const readme = await readFile(join(pluginRoot, "README.md"), "utf8");
+  const skill = await readFile(join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"), "utf8");
+  const required = [
+    "release-bound to CodeStory `v0.11.0`",
+    "codestory-cli-v0.11.0-windows-x64.zip",
+    "codestory-cli-v0.11.0-windows-arm64.zip",
+    "codestory-cli-v0.11.0-macos-arm64.tar.gz",
+    "macOS x64",
+    "codestory-cli-v0.11.0-linux-x64.tar.gz",
+    "codestory-cli-v0.11.0-linux-arm64.tar.gz",
+    "Source fallback",
+    "Codex host `PATH`",
+    "codestory://status",
+    "retrieval_mode=full",
+  ];
+
+  for (const text of [readme, skill]) {
+    for (const phrase of required) {
+      assert.equal(text.includes(phrase), true, phrase);
+    }
+  }
+});


### PR DESCRIPTION
## Context

Closes #265.
Refs #258.

The CodeStory plugin launches `codestory-cli` directly from `.mcp.json`. Issue #265 asked for honest Windows, macOS, and Linux setup/readiness guidance without adding an adapter runtime or changing Rust product behavior.

Latest published release assets are `v0.11.0`; #267 is still the pending `0.11.1` release-bump lane, so these docs mark the asset names as release-bound instead of guessing future filenames.

## What Changed

- Reworked `plugins/codestory/README.md` with per-OS install paths for Windows x64/arm64, macOS arm64/x64, and Linux x64/arm64.
- Mirrored the OS-aware missing-binary guidance in `plugins/codestory/skills/codestory-grounding/SKILL.md`.
- Added a static test that keeps the direct stdio launch path covered and asserts the cross-platform, release-bound setup guidance stays present.

## How To Review

- Read the README and skill setup sections for OS-specific paths, Codex host `PATH`, and the `v0.11.0` release-bound note.
- Confirm `.mcp.json` still invokes `codestory-cli serve --stdio --refresh none` directly.
- Confirm no Rust product code or marketplace catalog data changed.

## Verification

- `python C:\Users\alber\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py plugins\codestory` - passed.
- `node --test plugins\codestory\tests\plugin-static.test.mjs` - passed, 3/3 tests.
- `git diff --check` - passed.
- Readback confirmed Windows x64/arm64, macOS arm64/x64, Linux x64/arm64, source fallback, Codex host `PATH`, `codestory://status`, and strict `retrieval_mode=full` guidance.

## Risk

- macOS and Linux install paths were verified from release asset names and static readback only; this Windows lane did not run runtime installs on those OSes.
- The asset names intentionally point at latest published `v0.11.0`; update the same plugin docs when #267 publishes a new asset set.