### PR TITLE
[codex] fix MCP search error schema

### DIFF
--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -592,7 +592,13 @@ static SEARCH_RESULTS_SCHEMA: SchemaObject = SchemaObject::object(
         ),
         SchemaProperty::array("repo_text_hits", "Repo text hits.", &SEARCH_HIT_SCHEMA),
         SchemaProperty::array("hits", "Merged hit list.", &SEARCH_HIT_SCHEMA),
+        SchemaProperty::string("code", "Typed API error code."),
+        SchemaProperty::string("message", "Human-readable API error message."),
+        SchemaProperty::object("details", "Structured API error repair guidance.").nullable(),
     ],
+    &[],
+)
+.with_any_of_required(&[
     &[
         "query",
         "retrieval",
@@ -601,7 +607,8 @@ static SEARCH_RESULTS_SCHEMA: SchemaObject = SchemaObject::object(
         "repo_text_enabled",
         "hits",
     ],
-);
+    &["code", "message"],
+]);
 
 static SYMBOL_CONTEXT_SCHEMA: SchemaObject = SchemaObject::object(
     "CodeStory symbol context DTO.",

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1082,6 +1082,28 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
         "search outputSchema should expose optional retrieval_shadow DTOs: {search_output_schema}"
     );
     assert!(
+        schema_property(search_output_schema, "code")["type"] == "string"
+            && schema_property(search_output_schema, "message")["type"] == "string",
+        "search outputSchema should also admit typed API errors returned as tool errors: {search_output_schema}"
+    );
+    assert!(
+        required_fields(search_output_schema).is_empty(),
+        "search outputSchema should not globally require success-only fields because tool errors reuse the same outputSchema: {search_output_schema}"
+    );
+    assert!(
+        search_output_schema["anyOf"]
+            .as_array()
+            .is_some_and(|any_of| {
+                any_of
+                    .iter()
+                    .any(|branch| required_fields(branch).contains("code"))
+                    && any_of
+                        .iter()
+                        .any(|branch| required_fields(branch).contains("query"))
+            }),
+        "search outputSchema should accept either search results or typed API errors: {search_output_schema}"
+    );
+    assert!(
         !required_fields(search_hit_schema).contains("match_quality"),
         "SearchHit.match_quality is optional and must not be required: {search_hit_schema}"
     );


### PR DESCRIPTION
## Context

Closes #259.

The non-Codex MCP SDK smoke against `codestory-cli serve --stdio --refresh none` found a narrow protocol/catalog defect: degraded `tools/call search` returned the correct fail-closed `retrieval_unavailable` payload, but the advertised `search.outputSchema` only described successful search results. The MCP SDK rejected the tool result before clients could read the repair guidance.

## What Changed

- Updated the stdio `search` output schema to admit either:
  - the normal search result DTO, or
  - the existing typed API error envelope with `code`, `message`, and optional `details`.
- Tightened the stdio catalog regression so `search.outputSchema` no longer globally requires success-only fields and explicitly includes the typed error branch.

No adapter, Node bridge, sidecar readiness weakening, retrieval repair, or benchmark path was added.

## How To Review

- Review `crates/codestory-cli/src/stdio_catalog.rs` for the contract-only schema change.
- Review `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the catalog regression that would have caught the SDK schema rejection.
- Confirm the fail-closed `search` transport behavior still returns `isError: true` and structured repair guidance rather than pretending retrieval is ready.

## Verification

- `npm exec --yes --package=@modelcontextprotocol/sdk@1.29.0 -- node --input-type=module -e '<SDK smoke>'`
  - Result: exit 0.
  - Proved initialize/connect, `tools/list` with 13 tools, `resources/list`, `resources/read codestory://status`, `tools/call symbols`, and degraded `tools/call search` through the MCP SDK.
  - Degraded search returned `isError: true`, `code: retrieval_unavailable`, `failedLayer: retrieval_sidecar`, and sidecar repair commands.
- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; cargo test -p codestory-cli --test stdio_protocol_contracts tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools -- --exact --nocapture`
  - Result: passed.
- `$env:RUSTC_WRAPPER='C:\Users\alber\.cargo\bin\sccache.exe'; cargo test -p codestory-cli --test stdio_protocol_contracts search_tool_fails_closed_without_full_retrieval_sidecars -- --exact --nocapture`
  - Result: passed.
- `cargo fmt --check`
  - Result: passed after applying `cargo fmt` once.
- `git diff --check`
  - Result: passed.

## Risk

- This does not prove full packet/search success with full retrieval sidecars. The SDK proof intentionally used an indexed-but-degraded fixture and preserves `retrieval_manifest_missing` / `repair_retrieval` behavior.
- The server still reports `serverInfo.version: "0.1.0"` while the binary reports `codestory-cli 0.10.1`; that polish gap is not part of this protocol/schema fix.
