### PR TITLE
[codex] update 0.11.1 changelog truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,39 @@
 
 ## 0.11.1
 
-CodeStory 0.11.1 is the patch release lane for the Codex plugin packaging work
-that landed after `v0.11.0`. It keeps the release version synchronized while
-making the new plugin path reviewable before the eventual main promotion:
-install/readiness stays in the CLI wrapper, the plugin package owns only Codex
-metadata and skill text, and `.mcp.json` launches `codestory-cli serve --stdio`
-directly instead of carrying a Node adapter.
+CodeStory 0.11.1 was published from `main` at
+`9dc3a20e7de84b7955579e6ad8dd44945a47d47a`. It ships the Codex plugin
+packaging work that landed after `v0.11.0`: install/readiness stays in the CLI
+wrapper, the plugin package owns only Codex metadata and skill text, and
+`.mcp.json` launches `codestory-cli serve --stdio` directly instead of carrying
+a Node adapter.
+
+Release evidence:
+
+- GitHub release: https://github.com/TheGreenCedar/CodeStory/releases/tag/v0.11.1
+- Full comparison: https://github.com/TheGreenCedar/CodeStory/compare/v0.11.0...v0.11.1
+- Version and packaging lane: #267
 
 The marketplace catalog is still outside this repository. Issue #264 closed the
 separate `TheGreenCedar/AgentPluginMarketplace` catalog lane, while PR #262 left
 CodeStory owning only the plugin package source under `plugins/codestory`. This
-changelog entry does not claim new binary assets, a pushed `v0.11.1` tag,
-packet/search readiness, sidecar promotion, or benchmark improvement.
+release does not claim packet/search readiness, sidecar promotion, or benchmark
+improvement.
 
 ### Shipped Since 0.11.0
 
 | Area | Delivered in 0.11.1 | Evidence |
 | --- | --- | --- |
-| Release version | All `codestory-*` workspace crates and `Cargo.lock` are synchronized at `0.11.1`. | Issue #267 |
+| Release version | All `codestory-*` workspace crates and `Cargo.lock` are synchronized at `0.11.1`. | Issue #267; tag `v0.11.1` |
 | Plugin packaging | `plugins/codestory` now contains the Codex plugin manifest, MCP metadata, package README, grounding skill, and static package tests. | PR #262 |
 | Direct CLI MCP launch | The plugin `.mcp.json` launches `codestory-cli serve --stdio --refresh none` directly, with no in-package Node adapter or duplicated retrieval/runtime logic. | PR #262 |
 | Install and readiness wrapper | `scripts/install-codestory.ps1` added the Windows x64 happy path for finding or installing `codestory-cli`, then reporting binary, local-navigation, and packet/search readiness from `doctor`. | PR #261 |
 | Cross-platform plugin readiness | Plugin README, skill guidance, and static tests now cover Windows, macOS, and Linux install/readiness paths without adding an adapter runtime or changing Rust product behavior. | PR #269 |
-| Release-note hygiene | Stale generated 0.11 pre-release docs and ledger-style artifacts were removed from committed docs before this patch release lane. | PR #260 |
+| Release-note hygiene | Stale generated 0.11 pre-release docs and ledger-style artifacts were removed from committed docs before this release. | PR #260 |
 
-The plugin docs and installer defaults keep current archive names release-bound
-to `v0.11.1`; the marketplace catalog remains outside this repository.
+Binary release assets are packaging evidence only. The plugin docs and installer
+defaults keep current archive names release-bound to `v0.11.1`; the marketplace
+catalog remains outside this repository.
 
 ## 0.11.0
 


### PR DESCRIPTION
## Context

Closes #273
Refs #38 #272 #274

CodeStory `v0.11.1` is now published from `main` at `9dc3a20e7de84b7955579e6ad8dd44945a47d47a`. The durable changelog still described that work as a pre-main release lane and explicitly avoided claiming a pushed tag or binary assets.

Reviewed surfaces before editing: `README.md`, `CHANGELOG.md`, `AGENTS.md`, `docs/**`, `.agents/skills/codestory-grounding/**`, `plugins/codestory/**`, and doc contract/static tests.

## What Changed

- Updated the `0.11.1` changelog entry to say the release was published from `main` and to include the release URL, comparison URL, and tag evidence.
- Kept the marketplace ownership boundary in `TheGreenCedar/AgentPluginMarketplace` and the packet/search non-claims intact.
- Left plugin install docs unchanged because their `v0.11.1` archive names match the published release assets.

## How To Review

Read `CHANGELOG.md` under `0.11.1` and confirm the entry now matches the published release while still avoiding packet/search, sidecar-promotion, and benchmark-improvement claims.

Deferred map: `README.md`, `AGENTS.md`, `docs/**`, `.agents/skills/codestory-grounding/**`, and `plugins/codestory/**` did not need edits in this slice. Existing marketplace, direct `codestory-cli serve --stdio --refresh none`, sidecar-readiness, and generated-ledger guidance matched the current ownership and evidence boundaries.

## Verification

- `gh release view v0.11.1 --repo TheGreenCedar/CodeStory --json tagName,isDraft,isPrerelease,publishedAt,targetCommitish,assets,url` verified a non-draft release targeting `9dc3a20e7de84b7955579e6ad8dd44945a47d47a` with the expected CLI archives and `SHA256SUMS.txt`.
- `rg --files README.md CHANGELOG.md AGENTS.md docs .agents/skills/codestory-grounding plugins/codestory crates/codestory-cli/tests` mapped the requested docs and contract-test surfaces.
- `rg -n "eventual main promotion|does not claim new binary assets|pushed `v0\.11\.1` tag|patch release lane" CHANGELOG.md` exited `1`, confirming the stale phrases are gone.
- `rg -n "was published from `main`|releases/tag/v0\.11\.1|tag `v0\.11\.1`|Binary release assets are packaging evidence only" CHANGELOG.md` confirmed the replacement release claims.
- `git diff --check`

Not run: Cargo doc contract tests, because only `CHANGELOG.md` changed. Plugin static tests, because `plugins/codestory/**` did not change. No sidecar/index/search/query/packet/benchmark/reindex commands were run.

## Risk

Low. This is docs-only changelog text, but reviewers should verify the release evidence wording stays intentionally narrow and does not imply packet/search promotion.