### PR TITLE
[codex] add ground stdio tool

### DIFF
--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -481,6 +481,7 @@ impl SchemaObject {
 const TEXT_HIT_ORIGINS: &[&str] = &["indexed_symbol", "text_match"];
 const SEARCH_REPO_TEXT_MODES: &[&str] = &["auto", "on", "off"];
 const SNIPPET_SCOPES: &[&str] = &["line_context", "function_body"];
+const GROUNDING_BUDGETS: &[&str] = &["strict", "balanced", "max"];
 const PACKET_BUDGETS: &[&str] = &["tiny", "compact", "standard", "deep"];
 const PACKET_TASK_CLASSES: &[&str] = &[
     "architecture_explanation",
@@ -634,6 +635,40 @@ static SYMBOLS_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
         &SYMBOL_SUMMARY_SCHEMA,
     )],
     &["symbols"],
+);
+
+static GROUNDING_SNAPSHOT_SCHEMA: SchemaObject = SchemaObject::object(
+    "CodeStory grounding snapshot DTO for compact repository orientation.",
+    &[
+        SchemaProperty::string("root", "Project root."),
+        SchemaProperty::string("budget", "Grounding output budget.").with_enum(GROUNDING_BUDGETS),
+        SchemaProperty::integer("generated_at_epoch_ms", "Snapshot generation time."),
+        SchemaProperty::object("stats", "Indexed project stats."),
+        SchemaProperty::object("retrieval", "Optional retrieval state DTO.").nullable(),
+        SchemaProperty::object("coverage", "Grounding coverage summary."),
+        SchemaProperty::array(
+            "root_symbols",
+            "Root symbol digests.",
+            &GENERIC_OBJECT_SCHEMA,
+        ),
+        SchemaProperty::array("files", "File digests.", &GENERIC_OBJECT_SCHEMA),
+        SchemaProperty::array(
+            "coverage_buckets",
+            "Compressed coverage buckets.",
+            &GENERIC_OBJECT_SCHEMA,
+        ),
+        SchemaProperty::string_array("notes", "Grounding notes."),
+        SchemaProperty::string_array("recommended_queries", "Suggested follow-up queries."),
+    ],
+    &[
+        "root",
+        "budget",
+        "generated_at_epoch_ms",
+        "stats",
+        "coverage",
+        "root_symbols",
+        "files",
+    ],
 );
 
 static TRAIL_CONTEXT_SCHEMA: SchemaObject = SchemaObject::object(
@@ -816,6 +851,14 @@ static SEARCH_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
             .with_bounds(1, 50),
     ],
     &["query"],
+);
+
+static GROUND_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Return the same compact repository orientation as codestory://grounding.",
+    &[SchemaProperty::string("budget", "Grounding output budget.")
+        .with_enum(GROUNDING_BUDGETS)
+        .with_default(ValueLiteral::String("balanced"))],
+    &[],
 );
 
 static TRAIL_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
@@ -1012,6 +1055,13 @@ static TOOLS: &[ToolSpec] = &[
         description: "Discover candidate symbols and sidecar hits; for broad structural questions call packet before snippet/source reads.",
         input_schema: SEARCH_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(SEARCH_RESULTS_SCHEMA)),
+        safety: SafetyMetadata::read_only(),
+    },
+    ToolSpec {
+        name: "ground",
+        description: "Return a compact repository map for orientation after status and before packet/search; equivalent to codestory://grounding.",
+        input_schema: GROUND_INPUT_SCHEMA,
+        output_schema: Some(SchemaSpec::Object(GROUNDING_SNAPSHOT_SCHEMA)),
         safety: SafetyMetadata::read_only(),
     },
     ToolSpec {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -569,6 +569,7 @@ fn handle_stdio_tool_call(
     match name {
         "packet" => handle_stdio_packet(runtime, state, request),
         "search" => handle_stdio_search(runtime, state, request, query),
+        "ground" => handle_stdio_ground(runtime, request),
         "symbol" => handle_stdio_symbol(runtime, request),
         "trail" => handle_stdio_trail(runtime, request),
         "get_node" => handle_stdio_get_node(runtime, request),
@@ -582,6 +583,18 @@ fn handle_stdio_tool_call(
         "context" => handle_stdio_context(runtime, request),
         _ => serde_json::json!({"error": "unknown tool"}),
     }
+}
+
+fn handle_stdio_ground(runtime: &RuntimeContext, request: &serde_json::Value) -> serde_json::Value {
+    let budget = match stdio_grounding_budget(request) {
+        Ok(budget) => budget,
+        Err(error) => return serde_json::json!({"error": error.to_string()}),
+    };
+    runtime
+        .grounding
+        .grounding_snapshot(budget)
+        .map(|snapshot| serde_json::json!({"result": snapshot}))
+        .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}))
 }
 
 fn handle_stdio_packet(
@@ -868,6 +881,19 @@ fn stdio_path_fingerprint(path: &std::path::Path) -> String {
         .map(|duration| duration.as_millis())
         .unwrap_or_default();
     format!("len:{}:mtime_ms:{}", metadata.len(), modified_ms)
+}
+
+fn stdio_grounding_budget(request: &serde_json::Value) -> Result<GroundingBudgetDto> {
+    match request
+        .pointer("/params/arguments/budget")
+        .and_then(|value| value.as_str())
+        .unwrap_or("balanced")
+    {
+        "strict" => Ok(GroundingBudgetDto::Strict),
+        "balanced" => Ok(GroundingBudgetDto::Balanced),
+        "max" => Ok(GroundingBudgetDto::Max),
+        value => bail!("ground.budget must be one of strict, balanced, or max; got {value}"),
+    }
 }
 
 fn stdio_packet_budget(request: &serde_json::Value) -> Result<PacketBudgetModeDto> {
@@ -1709,6 +1735,13 @@ fn stdio_status_recommended_next_calls(
         },
         {
             "method": "tools/call",
+            "tool": "ground",
+            "arguments": {
+                "budget": "balanced"
+            }
+        },
+        {
+            "method": "tools/call",
             "tool": "packet",
             "arguments": {
                 "question": "<broad-task-question>",
@@ -1747,6 +1780,13 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
             },
             {
                 "method": "tools/call",
+                "tool": "ground",
+                "arguments": {
+                    "budget": "balanced"
+                }
+            },
+            {
+                "method": "tools/call",
                 "tool": "packet",
                 "arguments": {
                     "question": "<broad-task-question>",
@@ -1759,6 +1799,13 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
                 "arguments": {
                     "query": "<symbol-or-task>",
                     "limit": 10
+                }
+            },
+            {
+                "method": "tools/call",
+                "tool": "context",
+                "arguments": {
+                    "id": "<best-node-id>"
                 }
             },
             {
@@ -1781,8 +1828,41 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
                 "uri": "codestory://trail/<best-node-id>"
             }
         ],
+        "surface_decisions": [
+            {
+                "surface": "ground",
+                "kind": "tool and codestory://grounding resource",
+                "when": "Use after status for compact repo orientation before planning, packet, search, or source reads."
+            },
+            {
+                "surface": "packet",
+                "kind": "tool",
+                "when": "Use for broad structural questions only when packet/search readiness is ready and strict retrieval is full."
+            },
+            {
+                "surface": "search",
+                "kind": "tool",
+                "when": "Use for bounded candidate discovery after readiness allows packet/search."
+            },
+            {
+                "surface": "context",
+                "kind": "tool",
+                "when": "Use after selecting one concrete target for proof-bearing source/graph evidence."
+            },
+            {
+                "surface": "direct_source_reads",
+                "kind": "fallback",
+                "when": "Use when status reports missing, stale, or degraded index/sidecar state."
+            },
+            {
+                "surface": "files, affected, cache identity, retrieval status",
+                "kind": "deferred",
+                "when": "Use CLI or resources until these receive explicit read-only stdio contracts."
+            }
+        ],
         "safety_notes": [
             "All stdio tools are read-only, non-destructive, idempotent, local-only, and closed-world.",
+            "Use ground for compact repository orientation after status.",
             "Use packet for broad task questions before snippet/source reads; use context only after selecting one concrete target.",
             "Treat packet status other than sufficient as unsafe to claim until gaps, open_next, and follow_up_commands are resolved.",
             "Use continuation links from search or definition results before broadening retrieval.",

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -716,6 +716,7 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
             "context",
             "definition",
             "get_node",
+            "ground",
             "neighbors",
             "packet",
             "query_subgraph",
@@ -754,6 +755,15 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
         search_description.contains("Discover candidate")
             && search_description.contains("packet before snippet/source reads"),
         "search description should label discovery before source proof reads: {search_description}"
+    );
+    let ground_description = tool_by_name(&tools, "ground")["description"]
+        .as_str()
+        .expect("ground description");
+    assert!(
+        ground_description.contains("compact repository map")
+            && ground_description.contains("before packet/search")
+            && ground_description.contains("codestory://grounding"),
+        "ground description should connect the tool to orientation and the grounding resource: {ground_description}"
     );
     let snippet_description = tool_by_name(&tools, "snippet")["description"]
         .as_str()
@@ -877,6 +887,18 @@ fn tool_catalog_input_schemas_capture_stable_arguments() {
         schema_property(packet, "include_evidence").get("default"),
         Some(&json!(true)),
         "packet.include_evidence should document the stdio default: {packet}"
+    );
+
+    let ground = tool_input_schema(&tools, "ground");
+    assert_schema_enum_values(
+        ground,
+        "/properties/budget/enum",
+        &["strict", "balanced", "max"],
+    );
+    assert_eq!(
+        schema_property(ground, "budget").get("default"),
+        Some(&json!("balanced")),
+        "ground.budget should document the stdio default: {ground}"
     );
 
     for name in ["symbol", "definition", "references", "snippet"] {
@@ -1006,6 +1028,7 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
     for name in [
         "context",
         "definition",
+        "ground",
         "packet",
         "references",
         "search",
@@ -1062,6 +1085,24 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
                 assert!(
                     required_fields(output_schema).contains(field),
                     "packet outputSchema should require {field}: {tool}"
+                );
+            }
+        }
+        if name == "ground" {
+            assert_eq!(
+                schema_property(output_schema, "root")["type"],
+                "string",
+                "ground outputSchema should expose the project root: {tool}"
+            );
+            assert_schema_enum_values(
+                output_schema,
+                "/properties/budget/enum",
+                &["strict", "balanced", "max"],
+            );
+            for field in ["stats", "coverage", "root_symbols", "files"] {
+                assert!(
+                    required_fields(output_schema).contains(field),
+                    "ground outputSchema should require grounding DTO field {field}: {tool}"
                 );
             }
         }
@@ -1236,6 +1277,7 @@ fn transcript_lists_tools_resources_templates_and_prompts() {
         .filter_map(|tool| tool["name"].as_str())
         .collect();
     for expected in [
+        "ground",
         "search",
         "symbol",
         "trail",
@@ -1310,6 +1352,82 @@ fn transcript_lists_tools_resources_templates_and_prompts() {
             .iter()
             .any(|prompt| prompt["name"] == "explain_symbol"),
         "prompts/list should include explain_symbol: {prompts}"
+    );
+}
+
+#[test]
+fn ground_tool_returns_budgeted_grounding_snapshot() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-strict",
+            "method": "tools/call",
+            "params": {
+                "name": "ground",
+                "arguments": {"budget": "strict"}
+            }
+        }),
+    );
+
+    let snapshot = assert_tool_success(&response, json!("ground-strict"));
+    assert_eq!(
+        snapshot["budget"],
+        json!("strict"),
+        "ground tool should honor the requested grounding budget: {snapshot}"
+    );
+    assert!(
+        snapshot["root"]
+            .as_str()
+            .is_some_and(|root| !root.is_empty())
+            && snapshot
+                .pointer("/stats/node_count")
+                .and_then(Value::as_u64)
+                > Some(0)
+            && snapshot
+                .pointer("/coverage/represented_files")
+                .and_then(Value::as_u64)
+                > Some(0),
+        "ground tool should return a populated grounding snapshot: {snapshot}"
+    );
+
+    let default_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-default",
+            "method": "tools/call",
+            "params": {"name": "ground", "arguments": {}}
+        }),
+    );
+    let default_snapshot = assert_tool_success(&default_response, json!("ground-default"));
+    assert_eq!(
+        default_snapshot["budget"],
+        json!("balanced"),
+        "ground tool should default to the existing grounding resource budget: {default_snapshot}"
+    );
+
+    let bad_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-bad-budget",
+            "method": "tools/call",
+            "params": {
+                "name": "ground",
+                "arguments": {"budget": "huge"}
+            }
+        }),
+    );
+    let error = assert_tool_error(&bad_response, json!("ground-bad-budget"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("ground.budget")),
+        "ground tool should fail closed on unknown budgets: {bad_response}"
     );
 }
 
@@ -1562,7 +1680,14 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
     );
     let mut strings = Vec::new();
     string_values_recursive(&guide, &mut strings);
-    for expected in ["packet", "search", "definition", "snippet"] {
+    for expected in [
+        "ground",
+        "packet",
+        "search",
+        "context",
+        "definition",
+        "snippet",
+    ] {
         assert!(
             strings.iter().any(|value| value.contains(expected)),
             "agent guide should recommend {expected} in its call sequence: {guide}"
@@ -1581,6 +1706,16 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
     assert!(
         guide_text.contains("unsafe to claim") && guide_text.contains("follow_up_commands"),
         "agent guide should name unsafe-to-claim and follow-up states: {guide}"
+    );
+    assert!(
+        guide_text.contains("direct_source_reads")
+            && guide_text.contains("missing, stale, or degraded index/sidecar state"),
+        "agent guide should name the direct source-read fallback: {guide}"
+    );
+    assert!(
+        guide_text.contains("files, affected, cache identity, retrieval status")
+            && guide_text.contains("deferred"),
+        "agent guide should record deferred stdio surfaces: {guide}"
     );
     assert!(
         !guide_text.contains("repo-text hits as evidence"),

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -47,7 +47,7 @@ When the plugin MCP server is available:
 
 1. Read `codestory://status`.
 2. Read `codestory://agent-guide`.
-3. Read `codestory://grounding` for a compact repo map before planning.
+3. Read `codestory://grounding` or call `ground` for a compact repo map before planning.
 4. Use `packet` for broad repo questions only when status says
    `agent_packet_search` is ready and strict sidecar status reports
    `retrieval_mode=full`.
@@ -95,7 +95,7 @@ Always pass `--project <target-workspace>` explicitly.
 ## Command Routing
 
 - Setup and health: `setup embeddings`, `doctor`, `ready`, `index`, `cache`.
-- Agent orientation: MCP `codestory://grounding` or CLI `ground`.
+- Agent orientation: MCP `ground` / `codestory://grounding` or CLI `ground`.
 - Broad task packet: MCP/CLI `packet`.
 - Candidate discovery: MCP/CLI `search --why`.
 - Focused source view: `symbol`, `trail`, `snippet`, `context`, `explore`.

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -36,7 +36,7 @@ Serves the indexed project over either a small HTTP JSON API or an MCP-style JSO
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
 | Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `index --project <target-workspace> --refresh full`; if bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
-| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, and `context`, plus project/grounding resources and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
+| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, and `context`, plus project/grounding resources and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
 
 ## Notes
 


### PR DESCRIPTION
## Context

Closes #277
Refs #38

The stdio surface already had `codestory://grounding`, but agents could not discover a matching `ground` tool from `tools/list`. This PR promotes the existing grounding snapshot path into a read-only MCP/stdio tool without adding a Node adapter or exposing any mutating CLI operations.

```mermaid
flowchart TD
    A["resources/read codestory://status"] --> B["tools/call ground"]
    B --> C["tools/call packet"]
    B --> D["tools/call search"]
    D --> E["tools/call context"]
    D --> F["resources/read snippet/trail/references"]
    A --> G["direct source reads when index/sidecars are degraded"]
```

## What Changed

- Added a `ground` stdio tool with `strict`, `balanced`, and `max` budgets.
- Reused the existing grounding snapshot runtime path that backs `codestory://grounding`.
- Updated `codestory://agent-guide` so agents can discover when to use `ground`, `packet`, `search`, `context`, direct source reads, and deferred surfaces.
- Updated stdio contract tests for `tools/list`, schemas, `resources/list` discovery, agent-guide content, and the `ground` success/default/bad-budget path.
- Updated the packaged CodeStory grounding skill and `serve` reference to name the new tool.

## How To Review

- Start in `crates/codestory-cli/src/stdio_catalog.rs` to confirm the tool schema and read-only metadata.
- Read `crates/codestory-cli/src/stdio_transport.rs` to confirm `ground` only calls `runtime.grounding.grounding_snapshot(...)` and does not trigger setup, indexing, or sidecar repair.
- Check `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the discovery and call-path coverage.

## Verification

Passed:

- `cargo test -p codestory-cli --test stdio_protocol_contracts ground_tool_returns_budgeted_grounding_snapshot -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts tool_catalog -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts transcript_lists_tools_resources_templates_and_prompts -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_agent_guide_describes_default_browser_loop_and_safety -- --nocapture`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- Direct JSON-RPC smoke on a temp indexed Rust fixture: `initialize`, `tools/list`, `resources/list`, `tools/call ground` returned `groundBudget="balanced"`.
- `cargo fmt --check`
- `git diff --check`

Not runnable as written:

- `cargo test -p codestory-cli stdio --lib` exits with `error: no library targets found in package codestory-cli`.

Observed failure outside this slice:

- `cargo test -p codestory-cli --test stdio_protocol_contracts -- --nocapture` passed the new/catalog/resource tests but failed `resources_read_status_reports_stale_index_freshness_with_bounded_latency` on the stale-status latency gate. A focused rerun of that same timing test also failed. The failing path is status freshness latency, not `ground` routing.

## Risk

- The new tool is read-only, local-only, and idempotent through the existing stdio tool safety metadata.
- Missing index still fails before `serve --stdio` starts; no silent setup fallback was added.
- Packet/search sidecar readiness is unchanged.
- `files`, `affected`, `cache identity`, `retrieval status`, and `doctor/ready` remain deferred or CLI/resource-only in this PR-sized slice.