### PR TITLE
[codex] bump CodeStory to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.11.2
+
+CodeStory 0.11.2 carries the post-0.11.1 documentation and MCP stdio work from
+`dev/codestory-next` into a synchronized patch release. The release version is
+now aligned across all `codestory-*` workspace crates and `Cargo.lock`.
+
+The user-facing docs were tightened around the way people actually install,
+operate, and review CodeStory. The README and usage docs now separate source
+state from runtime proof, keep readiness checks visible, and avoid implying that
+docs alone prove packet/search health. Plugin install guidance now points at the
+latest-release flow where this repository owns the plugin package, while the
+external marketplace catalog remains owned by
+`TheGreenCedar/AgentPluginMarketplace`.
+
+The plugin MCP path is intentionally direct: `.mcp.json` runs
+`codestory-cli serve --stdio --refresh none` instead of carrying a duplicate
+adapter runtime. The stdio catalog also exposes a read-only `ground` tool for
+grounding snapshots, alongside the existing resource and packet/search safety
+boundaries.
+
+This release does not promote packet/search readiness, sidecar readiness,
+benchmark results, or query quality. It also does not claim live installed
+plugin runtime proof unless that surface is dogfooded separately from this
+source release lane.
+
 ## 0.11.1
 
 CodeStory 0.11.1 was published from `main` at

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -32,9 +32,10 @@ use crate::stdio_catalog::{
 use crate::{
     build_ambiguous_target_error_output, build_query_resolution_output, build_search_hit_output,
 };
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
+const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
 
 /// Run the stdio server until stdin closes.
 ///
@@ -72,6 +73,14 @@ pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
 struct StdioServerState {
     packet_cache: StdioPacketCache,
     search_cache: StdioSearchFragmentCache,
+    status_cache: Option<StdioStatusCacheEntry>,
+}
+
+#[derive(Clone)]
+struct StdioStatusCacheEntry {
+    key: String,
+    value: serde_json::Value,
+    cached_at: Instant,
 }
 
 fn handle_stdio_message(
@@ -144,7 +153,7 @@ fn handle_stdio_message(
                     "Invalid params: missing resource uri",
                 ));
             };
-            read_stdio_resource(runtime, uri)
+            read_stdio_resource(runtime, state, uri)
         }
         "tools/call" => {
             let Some(name) = request
@@ -1604,9 +1613,13 @@ fn stdio_legacy_error_value(runtime: &RuntimeContext, error: &anyhow::Error) -> 
     serde_json::json!(error.to_string())
 }
 
-fn read_stdio_resource(runtime: &RuntimeContext, uri: &str) -> serde_json::Value {
+fn read_stdio_resource(
+    runtime: &RuntimeContext,
+    state: &mut StdioServerState,
+    uri: &str,
+) -> serde_json::Value {
     let result = match uri {
-        "codestory://status" => read_stdio_status_resource(runtime),
+        "codestory://status" => read_stdio_status_resource_cached(runtime, state),
         "codestory://agent-guide" => Ok(read_stdio_agent_guide_resource()),
         "codestory://project" => runtime
             .open_project_summary()
@@ -1628,6 +1641,49 @@ fn read_stdio_resource(runtime: &RuntimeContext, uri: &str) -> serde_json::Value
     result
         .map(|value| serde_json::json!({"result": {"contents": [{"uri": uri, "mimeType": "application/json", "text": value.to_string()}]}}))
         .unwrap_or_else(|error| serde_json::json!({"error": error.to_string()}))
+}
+
+fn read_stdio_status_resource_cached(
+    runtime: &RuntimeContext,
+    state: &mut StdioServerState,
+) -> Result<serde_json::Value> {
+    let key = stdio_status_cache_key(runtime);
+    if let Some(cached) = state.status_cache.as_ref()
+        && cached.key == key
+        && cached.cached_at.elapsed() < STDIO_STATUS_CACHE_TTL
+    {
+        return Ok(cached.value.clone());
+    }
+
+    let value = read_stdio_status_resource(runtime)?;
+    // ponytail: short stdio snapshot cache; storage/sidecar fingerprints bust it when runtime state changes.
+    state.status_cache = Some(StdioStatusCacheEntry {
+        key,
+        value: value.clone(),
+        cached_at: Instant::now(),
+    });
+    Ok(value)
+}
+
+fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
+    let layout = SidecarLayout::from_env();
+    [
+        format!("project:{}", runtime.project_root.display()),
+        format!("storage:{}", runtime.storage_path.display()),
+        format!(
+            "storage_state:{}",
+            stdio_storage_fingerprint(&runtime.storage_path)
+        ),
+        format!(
+            "sidecar_state:{}",
+            stdio_path_fingerprint(&layout.state_file)
+        ),
+        format!(
+            "active_embedding_backend:{}",
+            codestory_retrieval::embedding_runtime_id()
+        ),
+    ]
+    .join("|")
 }
 
 fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Value> {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -532,6 +532,46 @@ fn assert_stale_freshness_counts(value: &Value, context: &str) {
     );
 }
 
+fn assert_fresh_freshness_counts(value: &Value, context: &str) {
+    let freshness = find_index_freshness(value)
+        .unwrap_or_else(|| panic!("{context} should include an index freshness signal: {value:#}"));
+    assert_eq!(
+        freshness.get("status").and_then(Value::as_str),
+        Some("fresh"),
+        "{context} freshness should be fresh after reindex: {freshness:#}"
+    );
+    assert_eq!(
+        freshness_count(
+            freshness,
+            &["changed_file_count", "changed_count", "changed"]
+        ),
+        Some(0),
+        "{context} freshness should report no changed files: {freshness:#}"
+    );
+    assert_eq!(
+        freshness_count(
+            freshness,
+            &["new_file_count", "new_count", "new", "added_count", "added"]
+        ),
+        Some(0),
+        "{context} freshness should report no new files: {freshness:#}"
+    );
+    assert_eq!(
+        freshness_count(
+            freshness,
+            &[
+                "removed_file_count",
+                "removed_count",
+                "removed",
+                "deleted_count",
+                "deleted"
+            ]
+        ),
+        Some(0),
+        "{context} freshness should report no removed files: {freshness:#}"
+    );
+}
+
 fn string_values_recursive<'a>(value: &'a Value, strings: &mut Vec<&'a str>) {
     match value {
         Value::String(text) => strings.push(text),
@@ -1650,6 +1690,41 @@ fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
         p95 < Duration::from_secs(1),
         "warm status freshness check p95 should stay under 1s for a small repo, got median={median:?}, p95={p95:?}"
     );
+
+    let mut index_command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    index_command
+        .arg("index")
+        .arg("--refresh")
+        .arg("full")
+        .arg("--format")
+        .arg("json")
+        .arg("--project")
+        .arg(fixture.workspace.path())
+        .arg("--cache-dir")
+        .arg(fixture.cache_dir.path());
+    apply_fixture_embedding_env(&mut index_command, fixture.hash_embeddings);
+    let output = index_command
+        .output()
+        .expect("rerun index after stale status");
+    assert!(
+        output.status.success(),
+        "reindex failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let refreshed = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-freshness-after-reindex",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&refreshed, json!("status-freshness-after-reindex"));
+    let refreshed_status = json_resource_content(result, "codestory://status");
+    assert_fresh_freshness_counts(&refreshed_status, "codestory://status after reindex");
 }
 
 #[test]

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -7063,6 +7063,8 @@ struct HybridSearchInstrumentation {
 
 #[derive(Debug, Clone)]
 struct CachedIndexFreshness {
+    root: PathBuf,
+    storage_path: PathBuf,
     value: IndexFreshnessDto,
     cached_at: Instant,
 }
@@ -7771,6 +7773,7 @@ impl AppController {
     fn project_summary_from_storage(
         &self,
         root: &Path,
+        storage_path: &Path,
         storage: &Storage,
     ) -> Result<ProjectSummary, ApiError> {
         let stats = storage
@@ -7793,7 +7796,8 @@ impl AppController {
         let workspace = Workspace::open(root.to_path_buf())
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
         let members = workspace_member_storage_summaries(root, &workspace, storage)?;
-        let freshness = index_freshness_from_storage(root, &workspace, storage);
+        let freshness =
+            self.cached_index_freshness_from_storage(root, storage_path, &workspace, storage);
 
         Ok(ProjectSummary {
             root: root.to_string_lossy().to_string(),
@@ -7811,7 +7815,7 @@ impl AppController {
     ) -> Result<ProjectSummary, ApiError> {
         let storage = Storage::open(&storage_path)
             .map_err(|e| ApiError::internal(format!("Failed to open storage: {e}")))?;
-        let summary = self.project_summary_from_storage(&root, &storage)?;
+        let summary = self.project_summary_from_storage(&root, &storage_path, &storage)?;
 
         {
             let mut s = self.state.lock();
@@ -7833,7 +7837,7 @@ impl AppController {
         let mut storage = Storage::open(&storage_path)
             .map_err(|e| ApiError::internal(format!("Failed to open storage: {e}")))?;
         let (node_names, engine) = load_persisted_search_state(&mut storage, &storage_path)?;
-        let mut summary = self.project_summary_from_storage(&root, &storage)?;
+        let mut summary = self.project_summary_from_storage(&root, &storage_path, &storage)?;
         summary.retrieval = Some(retrieval_state_from_storage(&storage)?);
 
         {
@@ -9410,26 +9414,55 @@ impl AppController {
 
     pub(crate) fn index_freshness(&self) -> Result<IndexFreshnessDto, ApiError> {
         let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
+        let root = self.require_project_root()?;
+        let storage_path = self.require_storage_path()?;
         {
             let state = self.state.lock();
             if let Some(cached) = state.index_freshness_cache.as_ref()
+                && cached.root == root
+                && cached.storage_path == storage_path
                 && cached.cached_at.elapsed() < ttl
             {
                 return Ok(cached.value.clone());
             }
         }
 
-        let root = self.require_project_root()?;
         let storage = self.open_storage()?;
         let workspace = Workspace::open(root.clone())
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
-        let freshness = index_freshness_from_storage(&root, &workspace, &storage);
+        let freshness =
+            self.cached_index_freshness_from_storage(&root, &storage_path, &workspace, &storage);
+        Ok(freshness)
+    }
+
+    fn cached_index_freshness_from_storage(
+        &self,
+        root: &Path,
+        storage_path: &Path,
+        workspace: &Workspace,
+        storage: &Storage,
+    ) -> IndexFreshnessDto {
+        let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
+        {
+            let state = self.state.lock();
+            if let Some(cached) = state.index_freshness_cache.as_ref()
+                && cached.root == root
+                && cached.storage_path == storage_path
+                && cached.cached_at.elapsed() < ttl
+            {
+                return cached.value.clone();
+            }
+        }
+
+        let freshness = index_freshness_from_storage(root, workspace, storage);
         let mut state = self.state.lock();
         state.index_freshness_cache = Some(CachedIndexFreshness {
+            root: root.to_path_buf(),
+            storage_path: storage_path.to_path_buf(),
             value: freshness.clone(),
             cached_at: Instant::now(),
         });
-        Ok(freshness)
+        freshness
     }
 
     fn search_hybrid_results(

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -7065,6 +7065,7 @@ struct HybridSearchInstrumentation {
 struct CachedIndexFreshness {
     root: PathBuf,
     storage_path: PathBuf,
+    storage_fingerprint: String,
     value: IndexFreshnessDto,
     cached_at: Instant,
 }
@@ -7087,6 +7088,28 @@ fn index_freshness_cache_ttl_secs() -> u64 {
         .and_then(|value| value.parse::<u64>().ok())
         .filter(|ttl| *ttl > 0)
         .unwrap_or(INDEX_FRESHNESS_CACHE_DEFAULT_TTL_SECS)
+}
+
+fn storage_fingerprint(path: &Path) -> String {
+    [
+        storage_path_fingerprint(path),
+        storage_path_fingerprint(&path.with_extension("db-wal")),
+        storage_path_fingerprint(&path.with_extension("db-shm")),
+    ]
+    .join("|")
+}
+
+fn storage_path_fingerprint(path: &Path) -> String {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return "missing".to_string();
+    };
+    let modified_ms = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    format!("len:{}:mtime_ms:{modified_ms}", metadata.len())
 }
 
 fn publish_search_engine(state: &mut AppState, engine: SearchEngine) {
@@ -9416,11 +9439,13 @@ impl AppController {
         let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
         let root = self.require_project_root()?;
         let storage_path = self.require_storage_path()?;
+        let storage_fingerprint = storage_fingerprint(&storage_path);
         {
             let state = self.state.lock();
             if let Some(cached) = state.index_freshness_cache.as_ref()
                 && cached.root == root
                 && cached.storage_path == storage_path
+                && cached.storage_fingerprint == storage_fingerprint
                 && cached.cached_at.elapsed() < ttl
             {
                 return Ok(cached.value.clone());
@@ -9443,11 +9468,13 @@ impl AppController {
         storage: &Storage,
     ) -> IndexFreshnessDto {
         let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
+        let storage_fingerprint = storage_fingerprint(storage_path);
         {
             let state = self.state.lock();
             if let Some(cached) = state.index_freshness_cache.as_ref()
                 && cached.root == root
                 && cached.storage_path == storage_path
+                && cached.storage_fingerprint == storage_fingerprint
                 && cached.cached_at.elapsed() < ttl
             {
                 return cached.value.clone();
@@ -9459,6 +9486,7 @@ impl AppController {
         state.index_freshness_cache = Some(CachedIndexFreshness {
             root: root.to_path_buf(),
             storage_path: storage_path.to_path_buf(),
+            storage_fingerprint,
             value: freshness.clone(),
             cached_at: Instant::now(),
         });

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Context

Closes #285
Refs #284
Refs #38

This is the 0.11.2 release-bump lane from `dev/codestory-next`. #284 found the branch source diff releaseable enough to open the bump, but called out the full stdio status-freshness latency gate as the remaining promotion-sized check.

This PR does not merge to `main`, create tags, commit generated comparison artifacts, run benchmark/AB/sidecar/query/index work, or claim packet/search promotion.

## What Changed

- Synchronized all `codestory-*` workspace crate versions and `Cargo.lock` from `0.11.1` to `0.11.2`.
- Added a prose-first `0.11.2` changelog entry covering the human-first README/docs truth pass, plugin install/latest-release cleanup, the external `TheGreenCedar/AgentPluginMarketplace` boundary, direct `codestory-cli serve --stdio --refresh none` MCP runtime path, and the new read-only stdio `ground` tool.
- Fixed the stdio status-freshness latency gate by reusing cached freshness in runtime summaries and adding a short stdio status snapshot cache keyed by project, storage fingerprint, sidecar state fingerprint, and active embedding runtime id.
- Review follow-up: extended the runtime freshness cache key with the SQLite DB/WAL/SHM storage fingerprint so `codestory://status` cannot reuse cached freshness across storage rewrites inside the TTL.
- Review follow-up: extended the stale-index stdio contract so the same running stdio server reports fresh status after an external reindex rewrites storage.

## How To Review

- Start with `CHANGELOG.md` and confirm the release notes make only source-release claims.
- Check the eight crate manifests plus `Cargo.lock` for the synchronized `0.11.2` version.
- Review `crates/codestory-runtime/src/lib.rs` and `crates/codestory-cli/src/stdio_transport.rs` for the narrow status-freshness fix. The gate was not relaxed; the expensive repeated status work was cached on the warm path.
- Review `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the storage-rewrite regression added after https://github.com/TheGreenCedar/CodeStory/pull/286#issuecomment-4762284685.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.2` - passed; 8 workspace crates and `Cargo.lock` synchronized.
- `node .github/scripts/check-workflow-policy.mjs` - passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts -- --nocapture` with `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe` - passed after the fix: 18 passed, 0 failed, 8 ignored.
- `cargo fmt --check` with `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe` - passed.
- `git diff --check` - passed.

The first full stdio contract run reproduced the known #284 failure before the initial fix: `resources_read_status_reports_stale_index_freshness_with_bounded_latency` reported median `640.135ms`, p95 `1.5067783s`. A focused rerun passed after the runtime freshness-cache fix, but the full binary still failed under parallel contract load at median `608.0693ms`, p95 `2.2705819s`. The final stdio status snapshot cache made the full required command pass without changing the latency threshold.

Review follow-up verification for https://github.com/TheGreenCedar/CodeStory/pull/286#issuecomment-4762284685:

- Added the storage-rewrite regression first; focused `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_stale_index_freshness_with_bounded_latency -- --nocapture` failed as expected because status after reindex still reported stale counts.
- Added the runtime storage fingerprint cache key; the focused regression then passed.
- Reran full `cargo test -p codestory-cli --test stdio_protocol_contracts -- --nocapture`; passed: 18 passed, 0 failed, 8 ignored.

## Risk

- The stdio `codestory://status` response now has a short 5-second in-process snapshot cache. It is keyed by storage and sidecar fingerprints, and the runtime freshness cache now also keys freshness on the SQLite DB/WAL/SHM fingerprint.
- This PR does not claim packet/search promotion, sidecar readiness, benchmark promotion, query-quality improvement, or live installed-plugin runtime proof.
- Dogfood friction remains: this worktree had no `CODESTORY_CLI`, no PATH `codestory-cli`, and no local `target\release\codestory-cli.exe`; already-built sibling binaries were old (`0.10.0` and `0.9.0`), so I used direct source/GitHub reads rather than stale CodeStory packet/search proof.