### PR TITLE
[codex] fix release package skill path

### DIFF
--- a/.github/scripts/package-codestory-release.py
+++ b/.github/scripts/package-codestory-release.py
@@ -80,7 +80,7 @@ def main() -> None:
         copy_required_file(root, "README.md", stage_root)
         copy_required_file(root, "LICENSE", stage_root)
         copy_required_file(root, "docs/usage.md", stage_root)
-        copy_required_dir(root, ".agents/skills/codestory-grounding", stage_root)
+        copy_required_dir(root, "plugins/codestory/skills/codestory-grounding", stage_root)
 
         if archive_ext == ".zip":
             archive_zip(stage_root, archive_path)


### PR DESCRIPTION
## Context

The `v0.11.2` Auto Release built and smoked binaries, then failed while packaging release assets because `.github/scripts/package-codestory-release.py` still copied the old `.agents/skills/codestory-grounding` path. The canonical CodeStory skill now ships under `plugins/codestory/skills/codestory-grounding`.

Closes #291
Refs #38

## What Changed

Updated the release packager to copy `plugins/codestory/skills/codestory-grounding` into release archives instead of the removed `.agents/skills/codestory-grounding` path.

No Rust code, crate versions, changelog prose, marketplace catalog ownership, or release tags were changed.

## How To Review

Check `.github/scripts/package-codestory-release.py` and confirm the release package includes the canonical plugin skill path. The existing plugin-static test already asserts the stale `.agents` skill path is absent and the canonical plugin skill references exist.

## Verification

- `python .github/scripts/package-codestory-release.py --version 0.11.2 --target linux-x64 --binary C:\Users\alber\AppData\Local\Temp\codestory-issue-291-ea278380d7104f87be1285eb2045ee3f\bin\codestory-cli --out-dir C:\Users\alber\AppData\Local\Temp\codestory-issue-291-ea278380d7104f87be1285eb2045ee3f\dist-linux`
  - produced `codestory-cli-v0.11.2-linux-x64.tar.gz`
  - archive inspection: `HAS_CANONICAL True`, `HAS_AGENTS False`
- `python .github/scripts/package-codestory-release.py --version 0.11.2 --target windows-x64 --binary C:\Users\alber\AppData\Local\Temp\codestory-issue-291-ea278380d7104f87be1285eb2045ee3f\bin\codestory-cli.exe --out-dir C:\Users\alber\AppData\Local\Temp\codestory-issue-291-ea278380d7104f87be1285eb2045ee3f\dist-windows`
  - produced `codestory-cli-v0.11.2-windows-x64.zip`
  - archive inspection: `HAS_CANONICAL True`, `HAS_AGENTS False`
- `python .github/scripts/check-codestory-release.py --version 0.11.2`
  - `CodeStory release version 0.11.2 is synchronized across 8 workspace crates and Cargo.lock.`
- `node .github/scripts/check-workflow-policy.mjs`
  - `Workflow policy passed: third-party actions and saga issue-link guard are valid.`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
  - 4 tests passed
- `git diff --check`
  - passed

## Risk

The smoke uses dummy binaries, so it proves the packaging path and archive contents, not executable behavior. The failed release run had already reached binary build/smoke before the packaging step.