### PR TITLE
tighten docs audit guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,9 @@ improvement.
 | Cross-platform plugin readiness | Plugin README, skill guidance, and static tests now cover Windows, macOS, and Linux install/readiness paths without adding an adapter runtime or changing Rust product behavior. | PR #269 |
 | Release-note hygiene | Stale generated 0.11 pre-release docs and ledger-style artifacts were removed from committed docs before this release. | PR #260 |
 
-Binary release assets are packaging evidence only. The plugin docs and installer
-defaults keep current archive names release-bound to `v0.11.1`; the marketplace
-catalog remains outside this repository.
+Binary release assets are packaging evidence only. In this release, the plugin
+docs and installer defaults kept archive names release-bound to `v0.11.1`; the
+marketplace catalog remains outside this repository.
 
 ## 0.11.0
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ sidecar setup and repair.
 
 ## Install As An Agent Plugin
 
-For normal Codex use, open Codex in the repo you want to ground, then use:
+For normal Codex use, install the plugin through the Codex plugin flow for your
+workspace. Open Codex in the repo you want to ground, then use:
 
 ```text
 /plugins
@@ -120,7 +121,7 @@ Choose:
 TheGreenCedar -> codestory -> Install plugin
 ```
 
-If the `TheGreenCedar` catalog is not listed and your Codex build supports
+If the `TheGreenCedar` catalog is not listed and your Codex build exposes
 terminal marketplace management for source marketplaces, add or refresh the
 external catalog first:
 
@@ -129,8 +130,7 @@ codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
 ```
 
 The marketplace source is `TheGreenCedar/AgentPluginMarketplace`.
-This repository remains the plugin source. The catalog can list many plugins,
-and the CodeStory entry points at `plugins/codestory` in this repo.
+This repository remains the plugin source.
 
 Then return to `/plugins` and install `TheGreenCedar -> codestory`. Some
 workspace plugin settings are managed from the Codex Apps/Plugins UI rather

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -52,19 +52,16 @@ Choose:
 TheGreenCedar -> codestory -> Install plugin
 ```
 
-Use the equivalent marketplace display wording if your Codex build shows a
-longer human name for the `TheGreenCedar` catalog. If the catalog is not listed
-and your Codex build exposes terminal marketplace management for source
-marketplaces, add or refresh the external catalog first:
+If the `TheGreenCedar` catalog is not listed and your Codex build exposes
+terminal marketplace management for source marketplaces, add or refresh the
+external catalog first:
 
 ```bash
 codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
 ```
 
 The marketplace source is `TheGreenCedar/AgentPluginMarketplace`.
-This repository remains the plugin source. One marketplace can list multiple plugins.
-CodeStory's entry points at `https://github.com/TheGreenCedar/CodeStory.git`
-with source path `plugins/codestory`.
+This repository remains the plugin source.
 
 Then return to `/plugins` and install `TheGreenCedar -> codestory`. Some
 workspace plugin settings are managed from the Codex Apps/Plugins UI rather
@@ -74,19 +71,6 @@ unavailable.
 Start a new Codex thread after installation or refresh. The installed package
 launches `codestory-cli serve --stdio --refresh none` directly.
 
-### Marketplace maintainer details
-
-The marketplace catalog is external:
-
-| Field | Value |
-| --- | --- |
-| Catalog repo | `TheGreenCedar/AgentPluginMarketplace` |
-| Catalog name | `TheGreenCedar` |
-| Plugin entry | `codestory` |
-| Source kind | `git-subdir` |
-| Source repo | `https://github.com/TheGreenCedar/CodeStory.git` |
-| Source path | `plugins/codestory` |
-
 ### After install
 
 Open Codex in the repo you want to ground and ask the agent to check readiness
@@ -95,40 +79,6 @@ before planning or editing:
 ```text
 @CodeStory check whether this repository is ready for local navigation and packet/search, then ground it before planning changes.
 ```
-
-### Runtime latest-release fallback
-
-The plugin does not bundle the binary. The agent should run
-`codestory-cli --version` first. If `codestory-cli` is missing or outdated
-against the latest GitHub release, resolve the latest release, download and
-unpack the matching host asset, verify it when practical, place it in a stable
-user bin directory, and re-check `codestory-cli --version`. If the host `PATH`
-changes, start a new agent thread so the MCP process can see the binary.
-
-For latest tag `vX.Y.Z`, choose the host asset derived from that tag:
-
-| Host OS | Binary setup |
-| --- | --- |
-| Windows x64 | Download `codestory-cli-vX.Y.Z-windows-x64.zip`, extract `codestory-cli.exe`, and put it on `PATH`. |
-| Windows arm64 | Download `codestory-cli-vX.Y.Z-windows-arm64.zip`, extract `codestory-cli.exe`, and put it on `PATH`. |
-| macOS arm64 | Download `codestory-cli-vX.Y.Z-macos-arm64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
-| macOS x64 | Use the source fallback until a matching release asset exists. |
-| Linux x64 | Download `codestory-cli-vX.Y.Z-linux-x64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
-| Linux arm64 | Download `codestory-cli-vX.Y.Z-linux-arm64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
-
-Verify downloaded archives against `SHA256SUMS.txt` from the release when the
-host has the tools to do it. Source fallback for any OS:
-
-```sh
-cargo build --release -p codestory-cli
-```
-
-Then put `target/release` on the agent host `PATH`, or set `CODESTORY_CLI` for
-manual CLI fallback commands.
-
-Source docs, marketplace source checkout/cache, and the active installed MCP
-runtime can differ. Before claiming an installed behavior is live, verify the
-active runtime surface in the target Codex thread.
 
 ## What To Ask
 
@@ -169,6 +119,78 @@ codestory-cli retrieval status --project <repo> --format json
 Do not treat `ground`, `symbol`, `trail`, or `snippet` readiness as proof that
 agent packet/search is ready. That mistake is how agents write confident
 nonsense with a straight face.
+
+### Runtime latest-release fallback
+
+The plugin does not bundle the binary. The agent should run
+`codestory-cli --version` first. If `codestory-cli` is missing or outdated
+against the latest GitHub release, resolve the latest release, download and
+unpack the matching host asset, verify it when practical, place it in a stable
+user bin directory, and re-check `codestory-cli --version`. If the host `PATH`
+changes, start a new agent thread so the MCP process can see the binary.
+
+For latest tag `vX.Y.Z`, choose the host asset derived from that tag:
+
+| Host OS | Binary setup |
+| --- | --- |
+| Windows x64 | Download `codestory-cli-vX.Y.Z-windows-x64.zip`, extract `codestory-cli.exe`, and put it on `PATH`. |
+| Windows arm64 | Download `codestory-cli-vX.Y.Z-windows-arm64.zip`, extract `codestory-cli.exe`, and put it on `PATH`. |
+| macOS arm64 | Download `codestory-cli-vX.Y.Z-macos-arm64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
+| macOS x64 | Use the source fallback until a matching release asset exists. |
+| Linux x64 | Download `codestory-cli-vX.Y.Z-linux-x64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
+| Linux arm64 | Download `codestory-cli-vX.Y.Z-linux-arm64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
+
+Verify downloaded archives against `SHA256SUMS.txt` from the release when the
+host has the tools to do it. Source fallback for any OS:
+
+```sh
+cargo build --release -p codestory-cli
+```
+
+Then put `target/release` on the agent host `PATH`, or set `CODESTORY_CLI` for
+manual CLI fallback commands.
+
+Source docs, marketplace source checkout/cache, and the active installed MCP
+runtime can differ. Before claiming an installed behavior is live, verify the
+active runtime surface in the target Codex thread.
+
+## Update Or Remove
+
+For normal Codex use, refresh or uninstall the plugin from the Codex plugin
+surface:
+
+```text
+/plugins
+```
+
+Then choose the installed `codestory` plugin and use the available refresh or
+uninstall action.
+
+If your Codex build exposes terminal marketplace management for source
+marketplaces, these commands may be available:
+
+```bash
+codex plugin marketplace upgrade TheGreenCedar
+codex plugin marketplace remove TheGreenCedar
+```
+
+`marketplace remove` removes the source marketplace registration. It may not
+uninstall an already installed workspace plugin. Prefer the plugin UI for
+installed-plugin refresh/uninstall actions, and use terminal marketplace
+commands only for source registration when your Codex build supports them.
+
+### Marketplace maintainer details
+
+The marketplace catalog is external. One marketplace can list multiple plugins.
+
+| Field | Value |
+| --- | --- |
+| Catalog repo | `TheGreenCedar/AgentPluginMarketplace` |
+| Catalog name | `TheGreenCedar` |
+| Plugin entry | `codestory` |
+| Source kind | `git-subdir` |
+| Source repo | `https://github.com/TheGreenCedar/CodeStory.git` |
+| Source path | `plugins/codestory` |
 
 ## Review Checks
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -45,9 +45,12 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
   ];
   const forbidden = [
     "release-bound to " + "CodeStory `v" + "0.11.1`",
-    "codestory-cli-v" + "0.11.1",
     "use that version " + "unless",
     "Install plugin entry `codestory` from the external marketplace catalog:",
+  ];
+  const forbiddenPatterns = [
+    /\bcodestory-cli-v\d+\.\d+\.\d+/,
+    /release-bound to CodeStory `v\d+\.\d+\.\d+`/,
   ];
   const readmeRequired = [
     "The human job is simple",
@@ -57,7 +60,7 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "For normal Codex use, install the plugin through the Codex plugin flow for your",
     "/plugins",
     "TheGreenCedar -> codestory -> Install plugin",
-    "If the catalog is not listed",
+    "If the `TheGreenCedar` catalog is not listed",
     "codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace",
     "The marketplace source is `TheGreenCedar/AgentPluginMarketplace`",
     "This repository remains the plugin source",
@@ -69,6 +72,10 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "check whether this repository is ready for local navigation and packet/search",
     "Source docs, marketplace source checkout/cache, and the active installed MCP",
     "active runtime surface",
+    "For normal Codex use, refresh or uninstall the plugin from the Codex plugin",
+    "codex plugin marketplace upgrade TheGreenCedar",
+    "codex plugin marketplace remove TheGreenCedar",
+    "commands only for source registration",
     "The plugin does not bundle the binary",
     "TheGreenCedar/AgentPluginMarketplace",
     "Catalog name",
@@ -92,6 +99,9 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     }
     for (const phrase of forbidden) {
       assert.equal(text.includes(phrase), false, phrase);
+    }
+    for (const pattern of forbiddenPatterns) {
+      assert.equal(pattern.test(text), false, String(pattern));
     }
   }
   for (const phrase of readmeRequired) {


### PR DESCRIPTION
## Context

Refs #295
Closes #297
Closes #300

CodeStory 0.11.2 is published, and #295 asks for a human-first docs audit without turning release ledgers or generated benchmark evidence into committed docs. This PR remains a small docs-audit slice, not the full #295 closeout.

The follow-up pass compared CodeStory install docs with `../autoresearch/README.md`. Autoresearch keeps normal install UI-first, with terminal marketplace commands later as fallback/source-registration mechanics; this PR now applies the same shape to CodeStory while preserving CodeStory-specific runtime and marketplace truths.

Dogfood friction from the original audit: this worktree did not have `CODESTORY_CLI`, `codestory-cli` on `PATH`, or a local `target/release/codestory-cli*`. A sibling ready binary existed, but it was stale (`codestory-cli 0.10.0`). `doctor --project C:\Users\alber\.codex\worktrees\8835\codestory` reported `status: needs_attention`, `nodes=0 edges=0 files=0`, `local_navigation=repair_index`, `agent_packet_search=repair_index`, and `sidecar_retrieval: mode=unavailable degraded_reason=retrieval_manifest_missing`. I did not run indexing, sidecar, benchmark, or Cargo work in this docs lane, so the audit used direct source reads plus `rg`.

## What Changed

- Reworded the 0.11.1 changelog note so it no longer says `v0.11.1` archive names are current after the 0.11.2 release.
- Aligned root/plugin install instructions with the Autoresearch pattern: `/plugins` first, `TheGreenCedar -> codestory -> Install plugin`, terminal marketplace add only when the catalog is missing and the build exposes source-marketplace commands, then start a new Codex thread.
- Moved plugin runtime asset fallback and marketplace maintainer mechanics out of the first install path.
- Added plugin update/remove guidance that prefers the plugin UI and describes marketplace upgrade/remove commands as source-registration commands.
- Tightened `plugins/codestory/tests/plugin-static.test.mjs` so plugin docs reject hard-coded semver archive names and keep the install/update boundary covered.

## Audit Inventory

| Surface | Reader | Decision | Evidence |
| --- | --- | --- | --- |
| `README.md` | agent operator and reviewer | small rewrite done | now follows the Autoresearch install order and keeps marketplace fallback terse |
| `plugins/codestory/README.md` | plugin installer/operator and marketplace maintainer | rewrite done | UI-first install path, CLI marketplace commands moved to fallback/update/remove, maintainer source fields moved later |
| `plugins/codestory/skills/codestory-grounding/SKILL.md` | agent using CodeStory | keep | setup gate resolves latest release, uses MCP/status first, packet/search only with `retrieval_mode=full`, falls back to source reads when degraded |
| `CHANGELOG.md` | maintainer/reviewer | small stale wording rewrite done | 0.11.2 truth is present; the 0.11.1 archive-name wording now reads as historical |
| `AGENTS.md` | contributor/agent maintainer | keep | current workflow rules include docs-only fast paths, guarded PR linkage, and no generated ledger commits |
| `docs/usage.md`, `docs/contributors/getting-started.md`, `docs/contributors/testing-matrix.md`, `docs/contributors/debugging.md` | operator/contributor | keep for now | task-shaped workflows and verification lanes; no obvious stale install/version text found by the scan |
| `docs/architecture/**`, `docs/ops/retrieval-sidecars.md` | maintainer/operator | keep for now | architecture and runbooks are contract-focused; heavier rewrite should be a separate slice because they touch sidecar/retrieval proof language |
| `docs/testing/codestory-e2e-stats-log.md`, `docs/testing/codestory-stdio-warm-loop-stats.md`, benchmark/playbook docs | maintainer measuring regressions | defer | evidence logs are durable timing/proof records, not generated comparison docs; pruning/restructuring them is larger than this patch |
| generated comparison docs / CSV / SVG / saga ledgers | reviewer only, outside repo | remove/avoid | none added here; repo guidance keeps these in PRs, issues, project updates, or external artifacts |

## How To Review

- Compare `README.md` and `plugins/codestory/README.md` against `../autoresearch/README.md` install/update shape.
- Check the 0.11.1 changelog wording in `CHANGELOG.md` and confirm it now reads as historical release evidence.
- Check the plugin static test guard and confirm it still allows `codestory-cli-vX.Y.Z-*` placeholder asset names while rejecting pinned semver archive names in plugin docs.
- Confirm this PR does not touch Rust/runtime behavior, Cargo manifests, sidecars, benchmarks, release automation, marketplace catalog files, or generated evidence artifacts.

## Verification

- Read `../autoresearch/README.md` install and `Update or remove` sections directly and compared them with CodeStory root/plugin README install text.
- `rg -n "pre-release|saga ledger|prompt instructions|this document will|codestory-cli-v0\.11\.1|v0\.11\.1|\.agents/skills|AgentPluginMarkeplace|Windows-only|CodeX|Codex" README.md CHANGELOG.md AGENTS.md docs plugins\codestory` found only expected current Codex/plugin and historical changelog references after the patch.
- `rg -n "codestory-cli-v\d+\.\d+\.\d+|release-bound to CodeStory `v\d+\.\d+\.\d+`|use that version unless|Install plugin entry `codestory` from the external marketplace catalog" README.md plugins\codestory\README.md plugins\codestory\skills\codestory-grounding\SKILL.md` exited 1 with no matches.
- `node --test plugins\codestory\tests\plugin-static.test.mjs` passed: 4 tests, 0 failures.
- `git diff --check` passed.

## Risk

Low. This is docs wording plus a docs contract test. It intentionally does not claim #295 is complete; remaining work is the broader ranked follow-up issue/comment pass for deeper docs rewrite candidates.