### PR TITLE
[codex] fix release helper version gate

### DIFF
--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -4,13 +4,33 @@ param(
     [string]$Project = ".",
     [string]$CodestoryCli,
     [string]$InstallDir,
-    [string]$Version = "0.11.1",
+    [string]$Version,
     [switch]$NoDownload,
     [switch]$SelfTest
 )
 
 $ErrorActionPreference = "Stop"
-$MinimumVersion = [Version]"0.11.1"
+$RequiredVersion = $null
+
+function Convert-ReleaseTagToVersion {
+    param([string]$Tag)
+
+    if ($Tag -match "^v?(\d+\.\d+\.\d+)$") {
+        return $matches[1]
+    }
+    throw "Unable to parse CodeStory release tag: $Tag"
+}
+
+function Get-LatestReleaseVersion {
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/TheGreenCedar/CodeStory/releases/latest" -UseBasicParsing
+    return Convert-ReleaseTagToVersion $release.tag_name
+}
+
+function Set-RequiredVersion {
+    param([string]$ReleaseVersion)
+
+    $script:RequiredVersion = [Version](Convert-ReleaseTagToVersion $ReleaseVersion)
+}
 
 function Get-CodeStoryHome {
     if ($env:CODESTORY_HOME) {
@@ -48,10 +68,10 @@ function Invoke-CliVersion {
     }
 }
 
-function Test-MinimumVersion {
+function Test-RequiredVersion {
     param([Version]$Candidate)
 
-    return $Candidate.CompareTo($MinimumVersion) -ge 0
+    return $Candidate.CompareTo($script:RequiredVersion) -eq 0
 }
 
 function Resolve-CandidatePath {
@@ -122,8 +142,8 @@ function Find-ExistingCli {
             throw "Explicit codestory-cli path was not found or runnable: $ExplicitCli"
         }
         $version = Invoke-CliVersion $resolved
-        if (-not (Test-MinimumVersion $version.Version)) {
-            throw "Explicit codestory-cli is $($version.Version), but CodeStory readiness wrapper requires >= $MinimumVersion`: $resolved"
+        if (-not (Test-RequiredVersion $version.Version)) {
+            throw "Explicit codestory-cli is $($version.Version), but CodeStory readiness wrapper requires $script:RequiredVersion`: $resolved"
         }
         return [PSCustomObject]@{
             Path = $resolved
@@ -136,7 +156,7 @@ function Find-ExistingCli {
     foreach ($candidate in (Get-CliCandidates $ExplicitCli $InstallDirectory)) {
         try {
             $version = Invoke-CliVersion $candidate
-            if (Test-MinimumVersion $version.Version) {
+            if (Test-RequiredVersion $version.Version) {
                 return [PSCustomObject]@{
                     Path = $candidate
                     VersionText = $version.Text
@@ -199,7 +219,7 @@ function Install-ReleaseCli {
     )
 
     if (-not (Test-WindowsX64)) {
-        throw "Automatic download currently supports Windows x64 only. Pass -CodestoryCli or set CODESTORY_CLI to reuse an existing >= $MinimumVersion binary."
+        throw "Automatic download currently supports Windows x64 only. Pass -CodestoryCli or set CODESTORY_CLI to reuse an existing $script:RequiredVersion binary."
     }
 
     $archiveName = "codestory-cli-v$ReleaseVersion-windows-x64.zip"
@@ -229,8 +249,8 @@ function Install-ReleaseCli {
         $dest = Join-Path $InstallDirectory "codestory-cli.exe"
         Copy-Item -LiteralPath $binary.FullName -Destination $dest -Force
         $version = Invoke-CliVersion $dest
-        if (-not (Test-MinimumVersion $version.Version)) {
-            throw "Downloaded codestory-cli is $($version.Version), expected >= $MinimumVersion"
+        if (-not (Test-RequiredVersion $version.Version)) {
+            throw "Downloaded codestory-cli is $($version.Version), expected $script:RequiredVersion"
         }
         return [PSCustomObject]@{
             Path = (Resolve-Path -LiteralPath $dest).Path
@@ -372,9 +392,36 @@ function Assert-SelfTest {
 }
 
 function Invoke-SelfTest {
-    $parsedVersion = Convert-VersionText "codestory-cli 0.11.1"
-    Assert-SelfTest (Test-MinimumVersion $parsedVersion) "version parser should accept 0.11.1"
-    Assert-SelfTest (-not (Test-MinimumVersion ([Version]"0.11.0"))) "version gate should reject 0.11.0"
+    Set-RequiredVersion "v0.11.2"
+    Assert-SelfTest ((Convert-ReleaseTagToVersion "v0.11.2") -eq "0.11.2") "release tag parser should strip v prefix"
+    $parsedVersion = Convert-VersionText "codestory-cli 0.11.2"
+    Assert-SelfTest (Test-RequiredVersion $parsedVersion) "version gate should accept current release"
+    Assert-SelfTest (-not (Test-RequiredVersion ([Version]"0.11.1"))) "version gate should reject stale 0.11.1"
+
+    $explicitStale = $false
+    try {
+        $staleCli = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-stale-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
+        Set-Content -LiteralPath $staleCli -Value "@echo codestory-cli 0.11.1" -Encoding ASCII
+        Find-ExistingCli $staleCli $null | Out-Null
+    } catch {
+        $explicitStale = $_.Exception.Message -match "requires 0.11.2"
+    } finally {
+        if ($staleCli -and (Test-Path -LiteralPath $staleCli)) {
+            Remove-Item -LiteralPath $staleCli -Force
+        }
+    }
+    Assert-SelfTest $explicitStale "explicit stale codestory-cli override should fail loudly"
+
+    try {
+        $currentCli = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-current-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
+        Set-Content -LiteralPath $currentCli -Value "@echo codestory-cli 0.11.2" -Encoding ASCII
+        $current = Find-ExistingCli $currentCli $null
+        Assert-SelfTest ($current.Version -eq [Version]"0.11.2") "explicit current codestory-cli override should be accepted"
+    } finally {
+        if ($currentCli -and (Test-Path -LiteralPath $currentCli)) {
+            Remove-Item -LiteralPath $currentCli -Force
+        }
+    }
 
     $staleDoctor = @'
 {
@@ -445,10 +492,17 @@ if (-not $InstallDir) {
     $InstallDir = Get-DefaultInstallDir
 }
 
+if (-not $Version) {
+    $Version = Get-LatestReleaseVersion
+} else {
+    $Version = Convert-ReleaseTagToVersion $Version
+}
+Set-RequiredVersion $Version
+
 $cliInfo = Find-ExistingCli $CodestoryCli $InstallDir
 if (-not $cliInfo) {
     if ($NoDownload) {
-        throw "No existing codestory-cli >= $MinimumVersion found. Pass -CodestoryCli, set CODESTORY_CLI, add codestory-cli to PATH, or rerun without -NoDownload on Windows x64."
+        throw "No existing codestory-cli $script:RequiredVersion found. Pass -CodestoryCli, set CODESTORY_CLI, add codestory-cli to PATH, or rerun without -NoDownload on Windows x64."
     }
     $cliInfo = Install-ReleaseCli $InstallDir $Version
 }


### PR DESCRIPTION
## Context

Closes #296
Refs #293
Refs #38

`scripts/install-codestory.ps1` still treated `0.11.1` as the default acceptable readiness binary even though the plugin docs now describe a latest-release fallback after `v0.11.2`.

## What Changed

- Removed the hard-coded `0.11.1` default from the Windows readiness helper.
- Resolve the latest GitHub release for the default path, then require existing, explicit, or downloaded binaries to match that release exactly.
- Kept explicit `-CodestoryCli` overrides fail-closed: stale explicit paths now throw instead of being replaced by another candidate.
- Extended the existing PowerShell self-test with release-tag parsing plus stale/current binary assertions.

## How To Review

1. Review `scripts/install-codestory.ps1` only; this PR does not change plugin docs, package files, Cargo code, sidecars, indexes, or benchmark surfaces.
2. Check the default path: missing `-Version` calls the GitHub latest release endpoint and uses that version for asset and checksum URLs.
3. Check the override path: explicit stale `-CodestoryCli` fails loudly, while implicit stale candidates are skipped before download.

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\install-codestory.ps1 -SelfTest` -> passed: `install-codestory self-test: ok`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\install-codestory.ps1 -NoDownload` -> expected failure, resolved latest as `0.11.2` and reported `No existing codestory-cli 0.11.2 found...`
- `git diff --check` -> passed

Not run: `node --test plugins/codestory/tests/plugin-static.test.mjs` and plugin validation, because this PR does not change plugin docs, tests, or package files.

## Risk

Low. The helper now depends on GitHub latest-release resolution on the default path, so offline default runs need explicit `-Version` or an already-current binary. Windows x64 remains the only automatic download path; this PR does not claim macOS/Linux install support.
