### PR TITLE
[codex] expose stdio files tool

### DIFF
--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -480,6 +480,7 @@ impl SchemaObject {
 
 const TEXT_HIT_ORIGINS: &[&str] = &["indexed_symbol", "text_match"];
 const SEARCH_REPO_TEXT_MODES: &[&str] = &["auto", "on", "off"];
+const INDEXED_FILE_ROLES: &[&str] = &["source", "test", "generated", "vendor", "unknown"];
 const SNIPPET_SCOPES: &[&str] = &["line_context", "function_body"];
 const GROUNDING_BUDGETS: &[&str] = &["strict", "balanced", "max"];
 const PACKET_BUDGETS: &[&str] = &["tiny", "compact", "standard", "deep"];
@@ -636,6 +637,45 @@ static SYMBOLS_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
     )],
     &["symbols"],
 );
+
+static INDEXED_FILE_SCHEMA: SchemaObject = SchemaObject::object(
+    "Indexed file coverage row.",
+    &[
+        SchemaProperty::string("path", "Project-relative file path."),
+        SchemaProperty::string("language", "Detected language."),
+        SchemaProperty::boolean("indexed", "Whether the file was indexed."),
+        SchemaProperty::boolean("complete", "Whether indexing completed for this file."),
+        SchemaProperty::integer("line_count", "Line count."),
+        SchemaProperty::string("role", "Inferred file role.").with_enum(INDEXED_FILE_ROLES),
+        SchemaProperty::integer("error_count", "File-level index error count."),
+    ],
+    &[
+        "path",
+        "language",
+        "indexed",
+        "complete",
+        "line_count",
+        "role",
+    ],
+);
+
+static INDEXED_FILES_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Indexed file inventory and coverage summary.",
+    &[
+        SchemaProperty::string("project_root", "Project root."),
+        SchemaProperty::boolean("usable", "Whether the index has usable files."),
+        SchemaProperty::object("summary", "Indexed file summary DTO."),
+        SchemaProperty::array("files", "Indexed file rows.", &INDEXED_FILE_SCHEMA),
+        SchemaProperty::string("code", "Typed API error code."),
+        SchemaProperty::string("message", "Human-readable API error message."),
+        SchemaProperty::object("details", "Structured API error repair guidance.").nullable(),
+    ],
+    &[],
+)
+.with_any_of_required(&[
+    &["project_root", "usable", "summary", "files"],
+    &["code", "message"],
+]);
 
 static GROUNDING_SNAPSHOT_SCHEMA: SchemaObject = SchemaObject::object(
     "CodeStory grounding snapshot DTO for compact repository orientation.",
@@ -988,6 +1028,20 @@ static SYMBOLS_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     &[],
 );
 
+static FILES_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "List indexed files from the existing local index.",
+    &[
+        SchemaProperty::string("path", "Only include files whose path contains this text."),
+        SchemaProperty::string("language", "Only include files for this language."),
+        SchemaProperty::string("role", "Only include files with this inferred role.")
+            .with_enum(INDEXED_FILE_ROLES),
+        SchemaProperty::integer("limit", "Maximum files returned.")
+            .with_default(ValueLiteral::Integer(500))
+            .with_bounds(1, 5000),
+    ],
+    &[],
+);
+
 static CONTEXT_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     "Build a deep evidence packet for one concrete retrieval target.",
     &[
@@ -1062,6 +1116,13 @@ static TOOLS: &[ToolSpec] = &[
         description: "Return a compact repository map for orientation after status and before packet/search; equivalent to codestory://grounding.",
         input_schema: GROUND_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GROUNDING_SNAPSHOT_SCHEMA)),
+        safety: SafetyMetadata::read_only(),
+    },
+    ToolSpec {
+        name: "files",
+        description: "List indexed files and coverage from the existing local index; never refreshes, indexes, or bootstraps sidecars.",
+        input_schema: FILES_INPUT_SCHEMA,
+        output_schema: Some(SchemaSpec::Object(INDEXED_FILES_OUTPUT_SCHEMA)),
         safety: SafetyMetadata::read_only(),
     },
     ToolSpec {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -9,9 +9,9 @@ use anyhow::{Context, Result, bail};
 use codestory_contracts::api::{
     AgentAskRequest, AgentPacketRequestDto, AgentResponseModeDto, AgentRetrievalPresetDto,
     AgentRetrievalProfileSelectionDto, ApiError, GraphResponse, GroundingBudgetDto,
-    ListChildrenSymbolsRequest, ListRootSymbolsRequest, NodeDetailsDto, NodeDetailsRequest, NodeId,
-    NodeKind, PacketBudgetModeDto, PacketTaskClassDto, SearchRepoTextMode, SearchRequest,
-    TrailCallerScope, TrailDirection, TrailMode,
+    IndexedFileRoleDto, IndexedFilesRequest, ListChildrenSymbolsRequest, ListRootSymbolsRequest,
+    NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto,
+    SearchRepoTextMode, SearchRequest, TrailCallerScope, TrailDirection, TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
 use std::io::{BufRead, Write};
@@ -579,6 +579,7 @@ fn handle_stdio_tool_call(
         "packet" => handle_stdio_packet(runtime, state, request),
         "search" => handle_stdio_search(runtime, state, request, query),
         "ground" => handle_stdio_ground(runtime, request),
+        "files" => handle_stdio_files(runtime, request),
         "symbol" => handle_stdio_symbol(runtime, request),
         "trail" => handle_stdio_trail(runtime, request),
         "get_node" => handle_stdio_get_node(runtime, request),
@@ -604,6 +605,52 @@ fn handle_stdio_ground(runtime: &RuntimeContext, request: &serde_json::Value) ->
         .grounding_snapshot(budget)
         .map(|snapshot| serde_json::json!({"result": snapshot}))
         .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}))
+}
+
+fn handle_stdio_files(runtime: &RuntimeContext, request: &serde_json::Value) -> serde_json::Value {
+    let role = match stdio_file_role(request) {
+        Ok(role) => role,
+        Err(error) => return serde_json::json!({"error": error.to_string()}),
+    };
+    let limit = request
+        .pointer("/params/arguments/limit")
+        .and_then(|value| value.as_u64())
+        .map(|value| value.clamp(1, 5000) as u32)
+        .unwrap_or(500);
+    runtime
+        .browser
+        .indexed_files(IndexedFilesRequest {
+            path_contains: request
+                .pointer("/params/arguments/path")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+            language: request
+                .pointer("/params/arguments/language")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+            role,
+            limit: Some(limit),
+        })
+        .map(|result| serde_json::json!({"result": result}))
+        .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}))
+}
+
+fn stdio_file_role(request: &serde_json::Value) -> Result<Option<IndexedFileRoleDto>> {
+    let Some(role) = request
+        .pointer("/params/arguments/role")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+    match role {
+        "source" => Ok(Some(IndexedFileRoleDto::Source)),
+        "test" => Ok(Some(IndexedFileRoleDto::Test)),
+        "generated" => Ok(Some(IndexedFileRoleDto::Generated)),
+        "vendor" => Ok(Some(IndexedFileRoleDto::Vendor)),
+        "unknown" => Ok(Some(IndexedFileRoleDto::Unknown)),
+        _ => bail!("files.role must be one of source, test, generated, vendor, unknown"),
+    }
 }
 
 fn handle_stdio_packet(

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -755,6 +755,7 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
         vec![
             "context",
             "definition",
+            "files",
             "get_node",
             "ground",
             "neighbors",
@@ -772,9 +773,7 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
     );
     assert!(
         !tool_names.iter().any(|name| name.starts_with("codestory_"))
-            && !tool_names
-                .iter()
-                .any(|name| matches!(*name, "files" | "affected")),
+            && !tool_names.iter().any(|name| matches!(*name, "affected")),
         "stdio tool names should stay agent-facing and avoid shell/file mutation surfaces: {tool_names:?}"
     );
     let packet_description = tool_by_name(&tools, "packet")["description"]
@@ -804,6 +803,15 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
             && ground_description.contains("before packet/search")
             && ground_description.contains("codestory://grounding"),
         "ground description should connect the tool to orientation and the grounding resource: {ground_description}"
+    );
+    let files_description = tool_by_name(&tools, "files")["description"]
+        .as_str()
+        .expect("files description");
+    assert!(
+        files_description.contains("indexed files")
+            && files_description.contains("existing local index")
+            && files_description.contains("never refreshes"),
+        "files description should make the read-only index boundary explicit: {files_description}"
     );
     let snippet_description = tool_by_name(&tools, "snippet")["description"]
         .as_str()
@@ -941,6 +949,34 @@ fn tool_catalog_input_schemas_capture_stable_arguments() {
         "ground.budget should document the stdio default: {ground}"
     );
 
+    let files = tool_input_schema(&tools, "files");
+    assert_eq!(
+        schema_property(files, "path")["type"],
+        "string",
+        "files.path should be a string filter: {files}"
+    );
+    assert_eq!(
+        schema_property(files, "language")["type"],
+        "string",
+        "files.language should be a string filter: {files}"
+    );
+    assert_schema_enum_values(
+        files,
+        "/properties/role/enum",
+        &["source", "test", "generated", "vendor", "unknown"],
+    );
+    let files_limit = schema_property(files, "limit");
+    assert_eq!(
+        files_limit.get("default"),
+        Some(&json!(500)),
+        "files.limit should document the CLI-backed default: {files}"
+    );
+    assert_eq!(
+        files_limit.get("maximum"),
+        Some(&json!(5000)),
+        "files.limit should document the runtime clamp: {files}"
+    );
+
     for name in ["symbol", "definition", "references", "snippet"] {
         let schema = tool_input_schema(&tools, name);
         let required = required_fields(schema);
@@ -1068,6 +1104,7 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
     for name in [
         "context",
         "definition",
+        "files",
         "ground",
         "packet",
         "references",
@@ -1145,6 +1182,31 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
                     "ground outputSchema should require grounding DTO field {field}: {tool}"
                 );
             }
+        }
+        if name == "files" {
+            for field in ["project_root", "usable", "summary", "files"] {
+                assert!(
+                    output_schema["anyOf"]
+                        .as_array()
+                        .is_some_and(|any_of| any_of
+                            .iter()
+                            .any(|branch| required_fields(branch).contains(field))),
+                    "files outputSchema should accept successful DTO field {field}: {tool}"
+                );
+            }
+            let file_schema = output_schema
+                .pointer("/properties/files/items")
+                .unwrap_or_else(|| panic!("files outputSchema should describe file rows: {tool}"));
+            assert_eq!(
+                schema_property(file_schema, "path")["type"],
+                "string",
+                "file rows should expose project-relative paths: {tool}"
+            );
+            assert_schema_enum_values(
+                file_schema,
+                "/properties/role/enum",
+                &["source", "test", "generated", "vendor", "unknown"],
+            );
         }
     }
 
@@ -1318,6 +1380,7 @@ fn transcript_lists_tools_resources_templates_and_prompts() {
         .collect();
     for expected in [
         "ground",
+        "files",
         "search",
         "symbol",
         "trail",
@@ -1468,6 +1531,75 @@ fn ground_tool_returns_budgeted_grounding_snapshot() {
             .as_str()
             .is_some_and(|message| message.contains("ground.budget")),
         "ground tool should fail closed on unknown budgets: {bad_response}"
+    );
+}
+
+#[test]
+fn files_tool_lists_indexed_files_without_sidecars() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "files-source",
+            "method": "tools/call",
+            "params": {
+                "name": "files",
+                "arguments": {
+                    "path": "src/",
+                    "language": "rust",
+                    "role": "source",
+                    "limit": 2
+                }
+            }
+        }),
+    );
+
+    let result = assert_tool_success(&response, json!("files-source"));
+    assert!(
+        result["usable"].as_bool() == Some(true),
+        "files tool should report a usable indexed fixture: {result}"
+    );
+    assert!(
+        result
+            .pointer("/summary/visible_file_count")
+            .and_then(Value::as_u64)
+            .is_some_and(|count| count <= 2),
+        "files tool should respect the requested cap: {result}"
+    );
+    let files = result["files"]
+        .as_array()
+        .unwrap_or_else(|| panic!("files tool should return file rows: {result}"));
+    assert!(
+        !files.is_empty()
+            && files.iter().all(|file| file["path"]
+                .as_str()
+                .is_some_and(|path| path.contains("src/")))
+            && files.iter().all(|file| file["language"] == json!("rust"))
+            && files.iter().all(|file| file["role"] == json!("source")),
+        "files tool should apply path/language/role filters: {result}"
+    );
+
+    let bad_role = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "files-bad-role",
+            "method": "tools/call",
+            "params": {
+                "name": "files",
+                "arguments": {"role": "workspace"}
+            }
+        }),
+    );
+    let error = assert_tool_error(&bad_role, json!("files-bad-role"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("files.role")),
+        "files tool should fail closed on unknown roles: {bad_role}"
     );
 }
 


### PR DESCRIPTION
## Context

Closes #294
Refs #293
Refs #38

Issue #294 asks for the next smallest useful read-only grounding tools directly from `codestory-cli serve --stdio`. This checkout already exposed `search`, `ground`, `context`, symbol, snippet, trail, and graph helpers, so the remaining PR-sized gap from the requested candidate set was `files`.

## What Changed

- Added a read-only `files` tool to the stdio catalog with concrete input/output schemas and safety metadata.
- Routed `tools/call` `name=files` through the existing `runtime.browser.indexed_files` path with `path`, `language`, `role`, and bounded `limit` arguments.
- Kept refresh, indexing, sidecar bootstrap, cache mutation, benchmarks, and marketplace surfaces out of scope.
- Added stdio protocol coverage for catalog/schema shape, successful file listing without sidecars, and bad-role fail-closed behavior.

```mermaid
graph LR
    Client["MCP tools/call files"] --> Stdio["stdio transport"]
    Stdio --> Browser["runtime.browser.indexed_files"]
    Browser --> Store["existing local index"]
    Stdio -. excluded .-> Heavy["index or sidecar bootstrap"]
```

## How To Review

- Review `crates/codestory-cli/src/stdio_catalog.rs` for the new tool contract and read-only metadata.
- Review `crates/codestory-cli/src/stdio_transport.rs` for the small dispatch path into the existing runtime browser method.
- Review `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for catalog, schema, success, and fail-closed coverage.

## Verification

- `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe cargo fmt --check`
- `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe cargo test -p codestory-cli --test stdio_protocol_contracts` (19 passed, 8 ignored live sidecar tests)
- `git diff --check`

## Risk

No background indexing, no sidecar readiness relaxation, no Node wrapper, no marketplace repo edits, and no benchmark or SLA claim. `serve --stdio --refresh none` still requires an indexed workspace at startup; the new tool only reads the already-open local index.