### PR TITLE
[codex] clarify plugin marketplace source split

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
 ```
 
 The marketplace source is `TheGreenCedar/AgentPluginMarketplace`.
-This repository remains the plugin source.
+This repository remains the plugin source. The catalog can list many plugins,
+and the CodeStory entry points at `plugins/codestory` in this repo.
 
 Then return to `/plugins` and install `TheGreenCedar -> codestory`. Some
 workspace plugin settings are managed from the Codex Apps/Plugins UI rather

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -61,7 +61,9 @@ codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
 ```
 
 The marketplace source is `TheGreenCedar/AgentPluginMarketplace`.
-This repository remains the plugin source.
+This repository remains the plugin source. One marketplace can list multiple plugins.
+CodeStory's entry points at `https://github.com/TheGreenCedar/CodeStory.git`
+with source path `plugins/codestory`.
 
 Then return to `/plugins` and install `TheGreenCedar -> codestory`. Some
 workspace plugin settings are managed from the Codex Apps/Plugins UI rather

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -27,6 +27,7 @@ test("codestory repo ships plugin source, not marketplace catalog or adapter run
 });
 
 test("plugin docs are agent-first, cross-platform, and latest-release aware", async () => {
+  const rootReadme = await readFile(join(repoRoot, "README.md"), "utf8");
   const readme = await readFile(join(pluginRoot, "README.md"), "utf8");
   const skill = await readFile(join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"), "utf8");
   const sharedRequired = [
@@ -92,6 +93,12 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "Read `codestory://grounding`",
     "Always pass `--project <target-workspace>` explicitly",
   ];
+  const rootReadmeRequired = [
+    "The marketplace source is `TheGreenCedar/AgentPluginMarketplace`",
+    "This repository remains the plugin source. The catalog can list many plugins",
+    "the CodeStory entry points at `plugins/codestory` in this repo",
+    "Then return to `/plugins` and install `TheGreenCedar -> codestory`",
+  ];
 
   for (const text of [readme, skill]) {
     for (const phrase of sharedRequired) {
@@ -104,8 +111,17 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
       assert.equal(pattern.test(text), false, String(pattern));
     }
   }
+  for (const phrase of forbidden) {
+    assert.equal(rootReadme.includes(phrase), false, phrase);
+  }
+  for (const pattern of forbiddenPatterns) {
+    assert.equal(pattern.test(rootReadme), false, String(pattern));
+  }
   for (const phrase of readmeRequired) {
     assert.equal(readme.includes(phrase), true, phrase);
+  }
+  for (const phrase of rootReadmeRequired) {
+    assert.equal(rootReadme.includes(phrase), true, phrase);
   }
   for (const phrase of skillRequired) {
     assert.equal(skill.includes(phrase), true, phrase);


### PR DESCRIPTION
## Context

Closes #302
Refs #38, #287, #288

#288 moved the plugin docs toward the same install shape used by `../autoresearch`: Codex plugin UI first, terminal marketplace command only when that Codex build supports it, and `codestory-cli` framed as the agent runtime/fallback surface. One remaining gap was that the catalog/source split was still a little too implicit in the install path.

```mermaid
flowchart LR
    Catalog["TheGreenCedar/AgentPluginMarketplace"] --> Entry["codestory catalog entry"]
    Entry --> Source["TheGreenCedar/CodeStory"]
    Source --> Package["plugins/codestory"]
```

## What Changed

- Clarified the root README install section: `TheGreenCedar/AgentPluginMarketplace` is the marketplace/catalog source, while this repo remains the CodeStory plugin source.
- Mirrored the same source split in `plugins/codestory/README.md` near the install flow, not only in the maintainer table.
- Extended the static plugin docs test so the root README also has to preserve the marketplace/source wording.

## How To Review

1. Read `README.md#install-as-an-agent-plugin` and confirm the flow still starts from `/plugins`.
2. Read `plugins/codestory/README.md#install-for-agent-use` and confirm the external catalog does not imply a marketplace file inside this repo.
3. Confirm the docs still keep CLI setup as fallback/repair, not the main human path.

## Verification

- `node --test plugins\codestory\tests\plugin-static.test.mjs`
- `python C:\Users\alber\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py plugins\codestory`
- `git diff --check`

## Risk

Low. This is docs plus static wording coverage only. The remaining live-runtime caveat is unchanged: installed plugin behavior still needs verification in a fresh Codex thread after install or refresh.