### PR TITLE
document stdio files tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ if `PATH` changed.
 | Call graph | `trail --project <repo> --id <node-id> --story` |
 | Source context | `snippet --project <repo> --id <node-id>` |
 | Target bundle | `context --project <repo> --id <node-id>` |
+| File inventory and coverage | `files --project <repo> --limit 80` |
 | Broad task packet with sidecars | `packet --project <repo> --question "..."` |
 | Persistent local reads | `serve --project <repo> --stdio` |
 

--- a/docs/architecture/subsystems/cli.md
+++ b/docs/architecture/subsystems/cli.md
@@ -100,7 +100,7 @@ not expose ranking knobs for product search/context calls.
 
 HTTP serving keeps the current small GET/query-string shape. The stable routes are `/health`, `/search`, `/symbol`, `/definition`, `/references`, `/symbols`, and `/trail`. Definition and references accept either `q` or `id`, so agents can resolve from a query first and then reuse exact node ids.
 
-`serve --stdio` is MCP-style JSON lines. It exposes tools for search, context, symbol, trail, definition, references, symbols, snippet, and warm graph primitives (`get_node`, `neighbors`, `shortest_path`, and `query_subgraph`); resources for project, grounding, and root symbols; resource templates for node-specific symbol/reference/snippet/trail reads; and prompts for explain-symbol, callflow tracing, and impact analysis.
+`serve --stdio` is MCP-style JSON lines. It exposes tools for ground, files, packet, search, context, symbol, trail, definition, references, symbols, snippet, and warm graph primitives (`get_node`, `neighbors`, `shortest_path`, and `query_subgraph`); resources for project, grounding, and root symbols; resource templates for node-specific symbol/reference/snippet/trail reads; and prompts for explain-symbol, callflow tracing, and impact analysis.
 
 The warm graph primitives are intentionally narrower than `packet`. They resolve exact node ids or bounded local graph neighborhoods before an agent asks for a broad evidence packet. Their responses include stable node ids, project-relative file refs when available, certainty metadata, count/truncation fields, and explicit result limits. `packet` remains the broad task tool with sufficiency, citations, retrieval traces, and budget accounting.
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -17,6 +17,7 @@ not the main user experience.
 | Is this repo indexed and safe to use? | `codestory://status` |
 | What should I do next? | `codestory://agent-guide` |
 | Give me a compact repo map. | `codestory://grounding` |
+| Inspect indexed file inventory and coverage. | `files` tool |
 | Answer a broad repo question with evidence. | `packet` tool, only with full sidecars |
 | Find candidate symbols, paths, or behavior terms. | `search` tool, only with full sidecars |
 | Follow a concrete target. | `symbol`, `trail`, `references`, `snippet`, `context` |

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -48,11 +48,13 @@ When the plugin MCP server is available:
 1. Read `codestory://status`.
 2. Read `codestory://agent-guide`.
 3. Read `codestory://grounding` or call `ground` for a compact repo map before planning.
-4. Use `packet` for broad repo questions only when status says
+4. Use `files` when you need indexed file inventory, language coverage, or
+   role counts from the existing cache.
+5. Use `packet` for broad repo questions only when status says
    `agent_packet_search` is ready and strict sidecar status reports
    `retrieval_mode=full`.
-5. Use `search` to discover candidates only when packet/search is ready.
-6. Use `symbol`, `trail`, `references`, `snippet`, and `context` after selecting
+6. Use `search` to discover candidates only when packet/search is ready.
+7. Use `symbol`, `trail`, `references`, `snippet`, and `context` after selecting
    a concrete target.
 
 If status is degraded, fall back to direct source reads or CLI local-navigation

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -36,7 +36,7 @@ Serves the indexed project over either a small HTTP JSON API or an MCP-style JSO
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
 | Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `index --project <target-workspace> --refresh full`; if bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
-| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, and `context`, plus project/grounding resources and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
+| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, and `context`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
 
 ## Notes
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -58,6 +58,7 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "The CLI is still there, but it is the escape hatch and repair surface",
     "codestory://status",
     "codestory://grounding",
+    "Inspect indexed file inventory and coverage.",
     "For normal Codex use, install the plugin through the Codex plugin flow for your",
     "/plugins",
     "TheGreenCedar -> codestory -> Install plugin",


### PR DESCRIPTION
## Context

Refs #295
Closes #304

PR #301 added the read-only stdio `files` tool, but the high-traffic agent/operator docs still described the older stdio surface in a few places. This is a small docs-only audit slice after syncing to `origin/dev/codestory-next` at `854c688ceb7ed50bb654ce03adc8183afccbda81`.

Dogfood friction: this worktree still had no `CODESTORY_CLI`, no `codestory-cli` on `PATH`, and no local `target/release/codestory-cli.exe`. A sibling binary existed but reported `codestory-cli 0.10.0`; `doctor --project C:\Users\alber\.codex\worktrees\8835\codestory` reported `status: needs_attention`, `nodes=0 edges=0 files=0`, `local_navigation=repair_index`, `agent_packet_search=repair_index`, and `retrieval_manifest_missing`. I did not cold-build, index, rebuild sidecars, or run Cargo.

## What Changed

- Added `files --project <repo> --limit 80` to the root README command surface.
- Added the `files` tool to the plugin README's agent-facing surface table.
- Updated the canonical grounding skill MCP loop to name `files` for indexed file inventory, language coverage, and role counts from the existing cache.
- Updated stdio integration docs in `docs/architecture/subsystems/cli.md` and `references/serve.md` so their tool lists include `files` and no longer omit `ground`/`packet` in the architecture summary.
- Added plugin static coverage for the new plugin README row.

## How To Review

- Confirm the changed docs are describing the existing #301 stdio `files` tool, not adding any new behavior.
- Confirm the normal agent path remains status/guide/grounding first, with packet/search still gated on full sidecars.
- Confirm no Rust/runtime/Cargo/sidecar/benchmark/release automation/marketplace repo files changed.

## Verification

- `node --test plugins\codestory\tests\plugin-static.test.mjs` passed: 4 tests, 0 failures.
- `git diff --check` passed.

## Risk

Low. Docs and static docs test only. #295 remains open for the broader ranked audit and any follow-up slices.