### PR TITLE
[codex] expose affected stdio tool

### DIFF
--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -484,6 +484,15 @@ const INDEXED_FILE_ROLES: &[&str] = &["source", "test", "generated", "vendor", "
 const SNIPPET_SCOPES: &[&str] = &["line_context", "function_body"];
 const GROUNDING_BUDGETS: &[&str] = &["strict", "balanced", "max"];
 const PACKET_BUDGETS: &[&str] = &["tiny", "compact", "standard", "deep"];
+const AFFECTED_CHANGE_KINDS: &[&str] = &[
+    "added",
+    "modified",
+    "deleted",
+    "renamed",
+    "copied",
+    "untracked",
+    "unknown",
+];
 const PACKET_TASK_CLASSES: &[&str] = &[
     "architecture_explanation",
     "bug_localization",
@@ -674,6 +683,96 @@ static INDEXED_FILES_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
 )
 .with_any_of_required(&[
     &["project_root", "usable", "summary", "files"],
+    &["code", "message"],
+]);
+
+static AFFECTED_CHANGE_RECORD_SCHEMA: SchemaObject = SchemaObject::object(
+    "Changed file record.",
+    &[
+        SchemaProperty::string_required("path", "Changed repo-relative path.").with_min_length(1),
+        SchemaProperty::string("kind", "Change kind.").with_enum(AFFECTED_CHANGE_KINDS),
+        SchemaProperty::string(
+            "status",
+            "Optional raw git-style status such as M, A, D, R100, C100, or ??.",
+        ),
+        SchemaProperty::string("previous_path", "Previous path for renames or copies.").nullable(),
+    ],
+    &["path", "kind"],
+);
+
+static AFFECTED_MATCHED_FILE_SCHEMA: SchemaObject = SchemaObject::object(
+    "Matched indexed file row.",
+    &[
+        SchemaProperty::string("path", "Project-relative file path."),
+        SchemaProperty::string("role", "Inferred file role.").with_enum(INDEXED_FILE_ROLES),
+        SchemaProperty::boolean("indexed", "Whether the file was indexed."),
+        SchemaProperty::boolean("complete", "Whether indexing completed for this file."),
+        SchemaProperty::string("change_kind", "Matched change kind.")
+            .with_enum(AFFECTED_CHANGE_KINDS)
+            .nullable(),
+        SchemaProperty::string("change_status", "Matched raw change status.").nullable(),
+        SchemaProperty::integer("error_count", "File-level index error count."),
+    ],
+    &["path", "role", "indexed", "complete", "error_count"],
+);
+
+static AFFECTED_ANALYSIS_OUTPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Changed-file impact analysis DTO from the existing local index.",
+    &[
+        SchemaProperty::string("project_root", "Project root."),
+        SchemaProperty::string_array("changed_paths", "Changed repo-relative paths."),
+        SchemaProperty::array(
+            "change_records",
+            "Normalized changed file records.",
+            &AFFECTED_CHANGE_RECORD_SCHEMA,
+        ),
+        SchemaProperty::array(
+            "matched_files",
+            "Changed paths matched to indexed files.",
+            &AFFECTED_MATCHED_FILE_SCHEMA,
+        ),
+        SchemaProperty::array(
+            "unmatched_paths",
+            "Changed paths that did not match indexed files.",
+            &GENERIC_OBJECT_SCHEMA,
+        ),
+        SchemaProperty::integer("matched_file_count", "Number of matched indexed files."),
+        SchemaProperty::integer("depth", "Applied dependent graph walk depth."),
+        SchemaProperty::array(
+            "impacted_symbols",
+            "Impacted symbol DTOs.",
+            &GENERIC_OBJECT_SCHEMA,
+        ),
+        SchemaProperty::array(
+            "impacted_routes",
+            "Impacted route or endpoint DTOs.",
+            &GENERIC_OBJECT_SCHEMA,
+        ),
+        SchemaProperty::array(
+            "impacted_tests",
+            "Likely impacted test file DTOs.",
+            &GENERIC_OBJECT_SCHEMA,
+        ),
+        SchemaProperty::string_array("blind_spots", "Known impact-analysis blind spots."),
+        SchemaProperty::string_array("next_commands", "Suggested follow-up commands."),
+        SchemaProperty::string_array("notes", "Additional analysis notes."),
+        SchemaProperty::string("code", "Typed API error code."),
+        SchemaProperty::string("message", "Human-readable API error message."),
+        SchemaProperty::object("details", "Structured API error repair guidance.").nullable(),
+    ],
+    &[],
+)
+.with_any_of_required(&[
+    &[
+        "project_root",
+        "changed_paths",
+        "change_records",
+        "matched_files",
+        "matched_file_count",
+        "depth",
+        "impacted_symbols",
+        "impacted_tests",
+    ],
     &["code", "message"],
 ]);
 
@@ -1042,6 +1141,27 @@ static FILES_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     &[],
 );
 
+static AFFECTED_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Analyze explicit changed paths or change records against the existing local index.",
+    &[
+        SchemaProperty::string_array("changed_paths", "Changed repo-relative paths to analyze."),
+        SchemaProperty::array(
+            "change_records",
+            "Changed file records with path, kind, optional status, and optional previous_path.",
+            &AFFECTED_CHANGE_RECORD_SCHEMA,
+        ),
+        SchemaProperty::integer("depth", "Dependent graph walk depth.")
+            .with_default(ValueLiteral::Integer(2))
+            .with_bounds(1, 8),
+        SchemaProperty::string(
+            "filter",
+            "Optional impacted-symbol filter by path or display-name substring.",
+        ),
+    ],
+    &[],
+)
+.with_any_of_required(&[&["changed_paths"], &["change_records"]]);
+
 static CONTEXT_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     "Build a deep evidence packet for one concrete retrieval target.",
     &[
@@ -1123,6 +1243,13 @@ static TOOLS: &[ToolSpec] = &[
         description: "List indexed files and coverage from the existing local index; never refreshes, indexes, or bootstraps sidecars.",
         input_schema: FILES_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(INDEXED_FILES_OUTPUT_SCHEMA)),
+        safety: SafetyMetadata::read_only(),
+    },
+    ToolSpec {
+        name: "affected",
+        description: "Analyze explicit changed paths against the existing local index; never discovers git changes, refreshes, indexes, or bootstraps sidecars.",
+        input_schema: AFFECTED_INPUT_SCHEMA,
+        output_schema: Some(SchemaSpec::Object(AFFECTED_ANALYSIS_OUTPUT_SCHEMA)),
         safety: SafetyMetadata::read_only(),
     },
     ToolSpec {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -7,7 +7,8 @@
 
 use anyhow::{Context, Result, bail};
 use codestory_contracts::api::{
-    AgentAskRequest, AgentPacketRequestDto, AgentResponseModeDto, AgentRetrievalPresetDto,
+    AffectedAnalysisRequest, AffectedChangeKindDto, AffectedChangeRecordDto, AgentAskRequest,
+    AgentPacketRequestDto, AgentResponseModeDto, AgentRetrievalPresetDto,
     AgentRetrievalProfileSelectionDto, ApiError, GraphResponse, GroundingBudgetDto,
     IndexedFileRoleDto, IndexedFilesRequest, ListChildrenSymbolsRequest, ListRootSymbolsRequest,
     NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto,
@@ -580,6 +581,7 @@ fn handle_stdio_tool_call(
         "search" => handle_stdio_search(runtime, state, request, query),
         "ground" => handle_stdio_ground(runtime, request),
         "files" => handle_stdio_files(runtime, request),
+        "affected" => handle_stdio_affected(runtime, request),
         "symbol" => handle_stdio_symbol(runtime, request),
         "trail" => handle_stdio_trail(runtime, request),
         "get_node" => handle_stdio_get_node(runtime, request),
@@ -635,6 +637,21 @@ fn handle_stdio_files(runtime: &RuntimeContext, request: &serde_json::Value) -> 
         .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}))
 }
 
+fn handle_stdio_affected(
+    runtime: &RuntimeContext,
+    request: &serde_json::Value,
+) -> serde_json::Value {
+    let affected = match stdio_affected_request(request) {
+        Ok(request) => request,
+        Err(error) => return serde_json::json!({"error": error.to_string()}),
+    };
+    runtime
+        .browser
+        .affected_analysis(affected)
+        .map(|result| serde_json::json!({"result": result}))
+        .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}))
+}
+
 fn stdio_file_role(request: &serde_json::Value) -> Result<Option<IndexedFileRoleDto>> {
     let Some(role) = request
         .pointer("/params/arguments/role")
@@ -651,6 +668,155 @@ fn stdio_file_role(request: &serde_json::Value) -> Result<Option<IndexedFileRole
         "unknown" => Ok(Some(IndexedFileRoleDto::Unknown)),
         _ => bail!("files.role must be one of source, test, generated, vendor, unknown"),
     }
+}
+
+fn stdio_affected_request(request: &serde_json::Value) -> Result<AffectedAnalysisRequest> {
+    let changed_paths = stdio_affected_changed_paths(request)?;
+    let change_records = stdio_affected_change_records(request)?;
+    if changed_paths.is_empty() && change_records.is_empty() {
+        bail!("affected.changed_paths or affected.change_records is required");
+    }
+    Ok(AffectedAnalysisRequest {
+        changed_paths,
+        change_records,
+        depth: stdio_affected_depth(request)?,
+        filter: stdio_affected_filter(request)?,
+    })
+}
+
+fn stdio_affected_changed_paths(request: &serde_json::Value) -> Result<Vec<String>> {
+    let Some(value) = request.pointer("/params/arguments/changed_paths") else {
+        return Ok(Vec::new());
+    };
+    let Some(values) = value.as_array() else {
+        bail!("affected.changed_paths must be an array of non-empty strings");
+    };
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(str::to_string)
+                .with_context(|| {
+                    "affected.changed_paths must be an array of non-empty strings".to_string()
+                })
+        })
+        .collect()
+}
+
+fn stdio_affected_change_records(
+    request: &serde_json::Value,
+) -> Result<Vec<AffectedChangeRecordDto>> {
+    let Some(value) = request.pointer("/params/arguments/change_records") else {
+        return Ok(Vec::new());
+    };
+    let Some(values) = value.as_array() else {
+        bail!("affected.change_records must be an array of objects");
+    };
+    values.iter().map(stdio_affected_change_record).collect()
+}
+
+fn stdio_affected_change_record(value: &serde_json::Value) -> Result<AffectedChangeRecordDto> {
+    let object = value
+        .as_object()
+        .context("affected.change_records entries must be objects")?;
+    let path = object
+        .get("path")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .context("affected.change_records[].path must be a non-empty string")?;
+    let kind_value = object
+        .get("kind")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .context("affected.change_records[].kind is required")?;
+    let kind = stdio_affected_change_kind(kind_value)?;
+    let status = object
+        .get("status")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|status| !status.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| stdio_affected_default_status(&kind).to_string());
+    let previous_path = match object.get("previous_path") {
+        Some(value) if !value.is_null() => Some(
+            value
+                .as_str()
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .context("affected.change_records[].previous_path must be a non-empty string")?
+                .to_string(),
+        ),
+        _ => None,
+    };
+    Ok(AffectedChangeRecordDto {
+        path: path.to_string(),
+        kind,
+        status,
+        previous_path,
+    })
+}
+
+fn stdio_affected_change_kind(value: &str) -> Result<AffectedChangeKindDto> {
+    match value {
+        "added" => Ok(AffectedChangeKindDto::Added),
+        "modified" => Ok(AffectedChangeKindDto::Modified),
+        "deleted" => Ok(AffectedChangeKindDto::Deleted),
+        "renamed" => Ok(AffectedChangeKindDto::Renamed),
+        "copied" => Ok(AffectedChangeKindDto::Copied),
+        "untracked" => Ok(AffectedChangeKindDto::Untracked),
+        "unknown" => Ok(AffectedChangeKindDto::Unknown),
+        value => bail!(
+            "affected.change_records[].kind must be one of added, modified, deleted, renamed, copied, untracked, or unknown; got {value}"
+        ),
+    }
+}
+
+fn stdio_affected_default_status(kind: &AffectedChangeKindDto) -> &'static str {
+    match kind {
+        AffectedChangeKindDto::Added => "A",
+        AffectedChangeKindDto::Modified => "M",
+        AffectedChangeKindDto::Deleted => "D",
+        AffectedChangeKindDto::Renamed => "R",
+        AffectedChangeKindDto::Copied => "C",
+        AffectedChangeKindDto::Untracked => "??",
+        AffectedChangeKindDto::Unknown => "path",
+    }
+}
+
+fn stdio_affected_depth(request: &serde_json::Value) -> Result<Option<u32>> {
+    let Some(value) = request.pointer("/params/arguments/depth") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(depth) = value.as_u64() else {
+        bail!("affected.depth must be an integer between 1 and 8");
+    };
+    if !(1..=8).contains(&depth) {
+        bail!("affected.depth must be between 1 and 8");
+    }
+    Ok(Some(depth as u32))
+}
+
+fn stdio_affected_filter(request: &serde_json::Value) -> Result<Option<String>> {
+    let Some(value) = request.pointer("/params/arguments/filter") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .map(Some)
+        .context("affected.filter must be a string")
 }
 
 fn handle_stdio_packet(

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -304,6 +304,11 @@ fn stdio_tool_catalog_stays_aligned_with_read_only_browser_service_operations() 
         ),
         ("trail", ".trail_context(", "pub fn trail_context"),
         ("snippet", ".snippet_context(", "pub fn snippet_context"),
+        (
+            "affected",
+            ".affected_analysis(",
+            "pub fn affected_analysis",
+        ),
         ("context", ".ask(", "pub fn ask"),
     ];
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -753,6 +753,7 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
     assert_eq!(
         tool_names,
         vec![
+            "affected",
             "context",
             "definition",
             "files",
@@ -772,8 +773,7 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
         "stdio browser tool names should stay stable and read-only: {tools}"
     );
     assert!(
-        !tool_names.iter().any(|name| name.starts_with("codestory_"))
-            && !tool_names.iter().any(|name| matches!(*name, "affected")),
+        !tool_names.iter().any(|name| name.starts_with("codestory_")),
         "stdio tool names should stay agent-facing and avoid shell/file mutation surfaces: {tool_names:?}"
     );
     let packet_description = tool_by_name(&tools, "packet")["description"]
@@ -812,6 +812,17 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
             && files_description.contains("existing local index")
             && files_description.contains("never refreshes"),
         "files description should make the read-only index boundary explicit: {files_description}"
+    );
+    let affected_description = tool_by_name(&tools, "affected")["description"]
+        .as_str()
+        .expect("affected description");
+    assert!(
+        affected_description.contains("changed paths")
+            && affected_description.contains("existing local index")
+            && affected_description.contains("never discovers git changes")
+            && affected_description.contains("never")
+            && affected_description.contains("indexes"),
+        "affected description should make the explicit-read-only boundary clear: {affected_description}"
     );
     let snippet_description = tool_by_name(&tools, "snippet")["description"]
         .as_str()
@@ -977,6 +988,77 @@ fn tool_catalog_input_schemas_capture_stable_arguments() {
         "files.limit should document the runtime clamp: {files}"
     );
 
+    let affected = tool_input_schema(&tools, "affected");
+    assert_eq!(
+        schema_property(affected, "changed_paths")["type"],
+        "array",
+        "affected.changed_paths should be an array: {affected}"
+    );
+    assert_eq!(
+        schema_property(affected, "changed_paths")["items"]["type"],
+        "string",
+        "affected.changed_paths should contain strings: {affected}"
+    );
+    let change_records = schema_property(affected, "change_records");
+    assert_eq!(
+        change_records["type"], "array",
+        "affected.change_records should be an array: {affected}"
+    );
+    let change_record = change_records
+        .get("items")
+        .unwrap_or_else(|| panic!("change_records should describe item schema: {affected}"));
+    assert!(
+        required_fields(change_record).contains("path")
+            && required_fields(change_record).contains("kind"),
+        "affected.change_records should require path and kind: {affected}"
+    );
+    assert_schema_enum_values(
+        change_record,
+        "/properties/kind/enum",
+        &[
+            "added",
+            "modified",
+            "deleted",
+            "renamed",
+            "copied",
+            "untracked",
+            "unknown",
+        ],
+    );
+    let affected_depth = schema_property(affected, "depth");
+    assert_eq!(
+        affected_depth.get("default"),
+        Some(&json!(2)),
+        "affected.depth should document the runtime default: {affected}"
+    );
+    assert_eq!(
+        affected_depth.get("minimum"),
+        Some(&json!(1)),
+        "affected.depth should document the lower bound: {affected}"
+    );
+    assert_eq!(
+        affected_depth.get("maximum"),
+        Some(&json!(8)),
+        "affected.depth should document the runtime clamp: {affected}"
+    );
+    assert_eq!(
+        schema_property(affected, "filter")["type"],
+        "string",
+        "affected.filter should be a string: {affected}"
+    );
+    let affected_any_of = affected["anyOf"].as_array().unwrap_or_else(|| {
+        panic!("affected should require paths or records via anyOf: {affected}")
+    });
+    assert!(
+        affected_any_of
+            .iter()
+            .any(|branch| required_fields(branch).contains("changed_paths"))
+            && affected_any_of
+                .iter()
+                .any(|branch| required_fields(branch).contains("change_records")),
+        "affected should require explicit changed_paths or change_records: {affected}"
+    );
+
     for name in ["symbol", "definition", "references", "snippet"] {
         let schema = tool_input_schema(&tools, name);
         let required = required_fields(schema);
@@ -1102,6 +1184,7 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
     .clone();
 
     for name in [
+        "affected",
         "context",
         "definition",
         "files",
@@ -1206,6 +1289,50 @@ fn tool_catalog_exposes_output_schemas_for_stable_dto_backed_tools() {
                 file_schema,
                 "/properties/role/enum",
                 &["source", "test", "generated", "vendor", "unknown"],
+            );
+        }
+        if name == "affected" {
+            for field in [
+                "project_root",
+                "changed_paths",
+                "change_records",
+                "matched_files",
+                "matched_file_count",
+                "depth",
+                "impacted_symbols",
+                "impacted_tests",
+            ] {
+                assert!(
+                    output_schema["anyOf"]
+                        .as_array()
+                        .is_some_and(|any_of| any_of
+                            .iter()
+                            .any(|branch| required_fields(branch).contains(field))),
+                    "affected outputSchema should accept successful DTO field {field}: {tool}"
+                );
+            }
+            assert_eq!(
+                schema_property(output_schema, "changed_paths")["items"]["type"],
+                "string",
+                "affected outputSchema should expose changed path strings: {tool}"
+            );
+            let record_schema = output_schema
+                .pointer("/properties/change_records/items")
+                .unwrap_or_else(|| {
+                    panic!("affected outputSchema should describe change records: {tool}")
+                });
+            assert_schema_enum_values(
+                record_schema,
+                "/properties/kind/enum",
+                &[
+                    "added",
+                    "modified",
+                    "deleted",
+                    "renamed",
+                    "copied",
+                    "untracked",
+                    "unknown",
+                ],
             );
         }
     }
@@ -1381,6 +1508,7 @@ fn transcript_lists_tools_resources_templates_and_prompts() {
     for expected in [
         "ground",
         "files",
+        "affected",
         "search",
         "symbol",
         "trail",
@@ -1600,6 +1728,113 @@ fn files_tool_lists_indexed_files_without_sidecars() {
             .as_str()
             .is_some_and(|message| message.contains("files.role")),
         "files tool should fail closed on unknown roles: {bad_role}"
+    );
+}
+
+#[test]
+fn affected_tool_maps_explicit_changed_paths_without_sidecars() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "affected-runtime",
+            "method": "tools/call",
+            "params": {
+                "name": "affected",
+                "arguments": {
+                    "changed_paths": ["src/runtime.rs"],
+                    "change_records": [
+                        {
+                            "path": "src/runtime.rs",
+                            "kind": "modified",
+                            "status": "M"
+                        }
+                    ],
+                    "depth": 2
+                }
+            }
+        }),
+    );
+
+    let result = assert_tool_success(&response, json!("affected-runtime"));
+    assert_eq!(
+        result["changed_paths"],
+        json!(["src/runtime.rs"]),
+        "affected should preserve explicit changed paths: {result}"
+    );
+    assert_eq!(
+        result["change_records"][0]["kind"],
+        json!("modified"),
+        "affected should preserve explicit change records: {result}"
+    );
+    assert_eq!(
+        result["matched_file_count"],
+        json!(1),
+        "affected should match the indexed changed file: {result}"
+    );
+    assert_eq!(
+        result["matched_files"][0]["path"],
+        json!("src/runtime.rs"),
+        "affected should expose matched file rows: {result}"
+    );
+    assert!(
+        result["impacted_symbols"]
+            .as_array()
+            .is_some_and(|symbols| !symbols.is_empty()),
+        "affected should expand matched files to impacted symbols: {result}"
+    );
+}
+
+#[test]
+fn affected_tool_rejects_invalid_arguments_without_transport_crash() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let bad_paths = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "affected-bad-paths",
+            "method": "tools/call",
+            "params": {
+                "name": "affected",
+                "arguments": {"changed_paths": "src/runtime.rs"}
+            }
+        }),
+    );
+    let error = assert_tool_error(&bad_paths, json!("affected-bad-paths"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("affected.changed_paths")),
+        "affected should fail closed on malformed path input: {bad_paths}"
+    );
+
+    let bad_record = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "affected-bad-record",
+            "method": "tools/call",
+            "params": {
+                "name": "affected",
+                "arguments": {
+                    "change_records": [
+                        {"path": "src/runtime.rs", "kind": "touched"}
+                    ]
+                }
+            }
+        }),
+    );
+    let error = assert_tool_error(&bad_record, json!("affected-bad-record"));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("affected.change_records")),
+        "affected should fail closed on malformed change records: {bad_record}"
     );
 }
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -102,7 +102,7 @@ Always pass `--project <target-workspace>` explicitly.
 - Broad task packet: MCP/CLI `packet`.
 - Candidate discovery: MCP/CLI `search --why`.
 - Focused source view: `symbol`, `trail`, `snippet`, `context`, `explore`.
-- Coverage and impact: `files`, `affected`.
+- Coverage and impact: MCP/CLI `files`, `affected`.
 - Reusable targets: `bookmark`.
 - Structured evaluation: `drill`, `drill-suite`.
 - Local integration surface: `serve --stdio`.

--- a/plugins/codestory/skills/codestory-grounding/references/affected.md
+++ b/plugins/codestory/skills/codestory-grounding/references/affected.md
@@ -31,6 +31,7 @@ repo gates.
 |------|---------|-----------------|
 | Current diff | `<codestory-cli> affected --project <target-workspace> --format markdown` | Impact summary based on `git diff --name-status HEAD`. |
 | Explicit paths | `<codestory-cli> affected --project <target-workspace> src/lib.rs --depth 3 --format json` | Matched/unmatched paths, impacted symbols, impacted routes/endpoints, likely tests, blind spots, and next commands. |
+| MCP explicit paths | `tools/call affected` with `changed_paths` or `change_records` | Same local-index impact DTO; stdio never discovers git changes, refreshes, indexes, or bootstraps sidecars. |
 | Stdin paths | `git diff --name-only HEAD | <codestory-cli> affected --project <target-workspace> --stdin` | Same analysis using external path selection. |
 | Stdin status | `git diff --name-status HEAD | <codestory-cli> affected --project <target-workspace> --stdin --stdin-format name-status --format json` | Preserves add/modify/delete/rename/copy status in `change_records`. |
 


### PR DESCRIPTION
## Context

Closes #308
Refs #38

The CLI and runtime already expose `affected` impact analysis. The stdio/MCP surface had the neighboring `files` read-only path, but not `affected`.

## What Changed

- Added `affected` to stdio `tools/list` with read-only/local-only/idempotent safety metadata.
- Added input schema for explicit `changed_paths` and `change_records`, plus optional `depth` and `filter`.
- Routed `tools/call affected` through `RuntimeContext.browser.affected_analysis(...)` with validation errors returned as tool-call errors.
- Documented the packaged skill discoverability path without claiming packet/search or sidecar readiness.

```mermaid
flowchart LR
  A["tools/call affected"] --> B["validate explicit paths/records"]
  B --> C["RuntimeContext.browser.affected_analysis"]
  C --> D["existing local index"]
```

## How To Review

- Start in `crates/codestory-cli/src/stdio_catalog.rs` for the schema and safety metadata.
- Check `crates/codestory-cli/src/stdio_transport.rs` for the no-git-discovery stdio route and argument validation.
- Review `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for success, invalid argument, and catalog coverage.

## Verification

- `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe cargo test -p codestory-cli --test stdio_protocol_contracts affected_tool_ -- --nocapture` passed: 2 tests.
- `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe cargo test -p codestory-cli --test stdio_protocol_contracts tool_catalog_ -- --nocapture` passed: 3 tests.
- `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe cargo test -p codestory-cli --test architecture_contracts stdio_tool_catalog_stays_aligned_with_read_only_browser_service_operations` passed: 1 test.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

- Stdio `affected` intentionally accepts explicit paths/records only; CLI git-diff discovery remains CLI-only.
- Dogfood friction: no current ready CLI was available without cold-building. Local `CODESTORY_CLI` was unset, no `codestory-cli.exe` was on PATH, this worktree had no `target\release\codestory-cli.exe`, and sibling release binaries were stale (`0.10.0`, `0.9.0`) versus crate `0.11.2`.