### PR TITLE
[codex] make README agent-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <h1 align="center">CodeStory</h1>
 
 <p align="center">
-Local source evidence for coding agents and the humans reviewing them.
+Local codebase grounding for coding agents, with explicit readiness checks for
+the humans operating them.
 </p>
 
 <p align="center">
@@ -9,107 +10,65 @@ Local source evidence for coding agents and the humans reviewing them.
 <a href="Cargo.toml"><img alt="Rust 2024" src="https://img.shields.io/badge/rust-2024-orange"></a>
 </p>
 
-CodeStory turns a repository into a local evidence surface: files, symbols,
-calls, imports, snippets, graph walks, reports, and sidecar-backed packet/search
-results. Use it when an agent needs to work from source-backed context instead
-of guessing from a few open files.
+CodeStory is not a CLI tutorial with an agent bolted on. It is a local evidence
+surface for coding agents.
 
-The product contract is simple:
+The human job is to install or enable the CodeStory plugin/runtime, check
+readiness when something looks off, and use the CLI for operation and debugging.
+The agent job is to read status first, use the local MCP/stdio grounding tools,
+and make source claims only from evidence that is ready enough to trust.
 
-1. Local navigation starts from a healthy SQLite graph.
-2. Agent packet/search starts only after sidecars report `retrieval_mode=full`.
-3. Output must name its evidence or say why the evidence is stale, partial, or
-   unavailable.
+| Who | Uses CodeStory for |
+| --- | --- |
+| Coding agent | Repo orientation, file inventory, graph/source follow-up, broad packets, and search candidates before planning or editing. |
+| Human operator | Plugin install, binary/runtime setup, readiness repair, transcripts, and debugging. |
+| Reviewer | Evidence paths, cited files/symbols, readiness state, and clear non-claims when packet/search is not ready. |
+
+First rule: packet/search is product evidence only when sidecars report
+`retrieval_mode=full`. Everything weaker is a navigation hint.
 
 ```mermaid
 flowchart LR
-    Repo["workspace files"] --> Index["index"]
-    Index --> Store["local SQLite graph"]
-    Store --> Local["local navigation"]
-    Store --> RetrievalIndex["retrieval index"]
-    RetrievalIndex --> Sidecars["Zoekt + Qdrant + SCIP + llama.cpp"]
-    Sidecars --> PacketSearch["packet + search"]
+    Human["human installs/enables"] --> Runtime["codestory-cli runtime"]
+    Runtime --> Stdio["serve --stdio"]
+    Stdio --> Agent["agent MCP tools"]
+    Agent --> Local["ground, files, affected, graph/source tools"]
+    Agent --> Broad["packet + search"]
+    Runtime --> CLI["operator CLI"]
+    Broad --> Gate["requires retrieval_mode=full"]
 ```
 
-## When To Use It
+## Primary Flow
 
-| Situation | Start with | Trust only when |
+1. Install the CodeStory plugin, or make `codestory-cli` available where the
+   agent runs.
+2. Read readiness before trusting output: local navigation and agent
+   packet/search are separate lanes.
+3. Let the agent use the read-only MCP/stdio surfaces for grounding, inventory,
+   graph traversal, snippets, packets, and search.
+4. Use CLI commands when a human needs setup, repair, a transcript, or a direct
+   debug run.
+
+## What The Agent Gets
+
+| Need | Surface | Trust gate |
 | --- | --- | --- |
-| Find the repo shape before editing | `doctor`, `index`, `ground`, `report` | `local_navigation=ready` |
-| Follow one symbol, call path, or file | `symbol`, `trail`, `snippet`, `context --id` | the target came from indexed output |
-| Explain broad behavior with citations | `packet` | `agent_packet_search=ready` and `retrieval_mode=full` |
-| Find candidates by behavior term | `search --why` | `agent_packet_search=ready` and `retrieval_mode=full` |
-| Diagnose a stale cache or sidecar | `doctor`, `retrieval status` | the repair command has been rerun and rechecked |
+| Check whether the repo is usable | `codestory://status`, `doctor` | Readiness lane says `ready` |
+| Learn how to proceed | `codestory://agent-guide` | Same target workspace |
+| Get a compact repo map | `codestory://grounding`, `ground` | `local_navigation=ready` |
+| Inspect file inventory and coverage | `files` | `local_navigation=ready` |
+| Map changed files to likely impact | `affected` | `local_navigation=ready` |
+| Follow concrete graph/source targets | `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, `context` | Exact target from indexed output |
+| Find candidates by behavior, symbol, path, or API term | `search` | `agent_packet_search=ready` and `retrieval_mode=full` |
+| Answer a broad repo question with bounded evidence | `packet` | `agent_packet_search=ready` and `retrieval_mode=full` |
 
-Do not use a degraded packet/search result as product evidence. If sidecars are
-missing, stale, or non-`full`, stay on exact local navigation or read source
-directly.
-
-## Start Here
-
-For agent use, install the CodeStory plugin package. The canonical grounding skill is
-[plugins/codestory/skills/codestory-grounding/SKILL.md](plugins/codestory/skills/codestory-grounding/SKILL.md).
-That skill tells the agent to read readiness first, use packet/search only when
-sidecars are ready, and fall back to direct source reads when they are not.
-If `codestory-cli` is missing or outdated on the agent host, the skill tells the
-agent to resolve the latest GitHub release, download the matching host asset,
-and fall back to a source build only when a release asset is unavailable.
-
-For operator or repair work from this checkout:
-
-```sh
-cargo build --release -p codestory-cli
-CODESTORY_CLI="./target/release/codestory-cli"
-TARGET_WORKSPACE="/path/to/repo"
-
-"$CODESTORY_CLI" doctor --project "$TARGET_WORKSPACE"
-"$CODESTORY_CLI" index --project "$TARGET_WORKSPACE" --refresh full
-"$CODESTORY_CLI" ground --project "$TARGET_WORKSPACE" --why
-"$CODESTORY_CLI" report --project "$TARGET_WORKSPACE" --output-file codestory-report.md
-```
-
-On Windows PowerShell, use `.\target\release\codestory-cli.exe`,
-`$env:TARGET_WORKSPACE = "C:\path\to\repo"`, and normal Windows paths.
-
-For a release-binary first Windows check:
-
-```powershell
-.\scripts\install-codestory.ps1 -Project C:\path\to\repo
-```
-
-The installer reuses `-CodestoryCli`, `CODESTORY_CLI`, or `PATH` before
-downloading the Windows x64 release asset. Its output separates executable
-install, local navigation readiness, and agent packet/search readiness.
-
-## Readiness
-
-| Lane | Built by | Proves | Does not prove |
-| --- | --- | --- | --- |
-| `local_navigation` | `index` | the SQLite graph can support `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, exact `context`, and `affected` | sidecar packet/search quality |
-| `agent_packet_search` | `index` plus `retrieval index` | `packet` and `search` can use the required sidecars for broad source evidence | answer quality beyond the cited evidence |
-
-Only `ready` proves the lane. `needs_attention`, `repair_index`, and
-non-`full` retrieval modes are stop signs for broad packet/search claims.
-
-For packet/search readiness:
-
-```sh
-"$CODESTORY_CLI" retrieval bootstrap --project "$TARGET_WORKSPACE" --format json
-"$CODESTORY_CLI" retrieval index --project "$TARGET_WORKSPACE" --refresh full
-"$CODESTORY_CLI" retrieval status --project "$TARGET_WORKSPACE" --format json
-"$CODESTORY_CLI" packet --project "$TARGET_WORKSPACE" --question "what owns request routing?"
-"$CODESTORY_CLI" search --project "$TARGET_WORKSPACE" --query "request routing" --why
-```
-
-`retrieval status` must report `retrieval_mode: "full"` before trusting
-`packet` or `search`. See [docs/usage.md](docs/usage.md) for task-shaped flows
-and [docs/ops/retrieval-sidecars.md](docs/ops/retrieval-sidecars.md) for
-sidecar setup and repair.
+The MCP server is local and read-only. It is for grounding, not for changing the
+repository.
 
 ## Install As An Agent Plugin
 
-For normal Codex use, install the plugin through the Codex plugin flow for your
-workspace. Open Codex in the repo you want to ground, then use:
+For normal Codex use, install the plugin through the Codex plugin flow in the
+workspace you want to ground:
 
 ```text
 /plugins
@@ -131,88 +90,122 @@ codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
 The marketplace source is `TheGreenCedar/AgentPluginMarketplace`.
 This repository remains the plugin source. The catalog can list many plugins,
 and the CodeStory entry points at `plugins/codestory` in this repo.
+Marketplace edits do not live in this repo.
 
-Some workspace plugin settings are managed from the Codex Apps/Plugins UI rather
-than the terminal. Use the UI path when the CLI marketplace command is
-unavailable.
-
-Start a new Codex thread after installation or refresh. A good first prompt is:
+Start a new Codex thread after install or refresh so the MCP process can see
+the current environment. A good first prompt is:
 
 ```text
 @CodeStory check whether this repository is ready for local navigation and packet/search, then ground it before planning changes.
 ```
 
-The canonical skill ships inside this repository's plugin package at
-[`plugins/codestory/skills/codestory-grounding/SKILL.md`](plugins/codestory/skills/codestory-grounding/SKILL.md).
-
+The canonical plugin skill is
+[plugins/codestory/skills/codestory-grounding/SKILL.md](plugins/codestory/skills/codestory-grounding/SKILL.md).
 The plugin launches `codestory-cli serve --stdio --refresh none` directly.
-The skill owns the runtime check: it should compare `codestory-cli --version`
-against the latest GitHub release, download and unpack the matching host asset
-when the binary is missing or outdated, and restart the agent thread if `PATH`
-changed.
+The skill owns the runtime check: it should verify `codestory-cli --version`,
+resolve the latest GitHub release when needed, and restart the agent thread if
+`PATH` changed.
 
-## Command Surfaces
+## Readiness Contract
+
+CodeStory has two readiness lanes. Do not mix them.
+
+| Lane | Built by | Proves | Does not prove |
+| --- | --- | --- | --- |
+| `local_navigation` | `index` | The SQLite graph can support `ground`, `files`, `affected`, and focused graph/source tools. | Sidecar packet/search quality. |
+| `agent_packet_search` | `index` plus `retrieval index` | `packet` and `search` can use the required sidecars for broad source evidence. | That the answer is good beyond its cited evidence. |
+
+`ready` is the only green light. `needs_attention`, `repair_index`,
+`retrieval_unavailable`, stale manifests, backend drift, and non-`full`
+retrieval modes are stop signs for broad packet/search claims.
+
+## Operator CLI
+
+Use the CLI when you need a direct setup or debug transcript. Always pass the
+target workspace explicitly.
+
+```sh
+codestory-cli doctor --project <repo>
+codestory-cli index --project <repo> --refresh full
+codestory-cli ground --project <repo> --why
+codestory-cli files --project <repo> --limit 80
+codestory-cli affected --project <repo> --format markdown
+```
+
+For sidecar-backed packet/search readiness:
+
+```sh
+codestory-cli retrieval bootstrap --project <repo> --format json
+codestory-cli retrieval index --project <repo> --refresh full
+codestory-cli retrieval status --project <repo> --format json
+codestory-cli packet --project <repo> --question "what owns request routing?"
+codestory-cli search --project <repo> --query "request routing" --why
+```
+
+`retrieval status` must report `retrieval_mode: "full"` before trusting
+`packet` or `search`.
+
+For source checkout work:
+
+```sh
+cargo build --release -p codestory-cli
+```
+
+On Windows PowerShell, use `.\target\release\codestory-cli.exe` and normal
+Windows paths. The release-binary installer path is:
+
+```powershell
+.\scripts\install-codestory.ps1 -Project C:\path\to\repo
+```
+
+## Command Reference
 
 | Task | Command |
 | --- | --- |
 | Cache and readiness health | `doctor --project <repo>` |
 | Build or refresh the graph | `index --project <repo> --refresh full` |
 | Repo orientation | `ground --project <repo> --why` |
-| Report artifact | `report --project <repo> --output-file codestory-report.md` |
-| Candidate discovery with sidecars | `search --project <repo> --query "..." --why` |
-| Call graph | `trail --project <repo> --id <node-id> --story` |
-| Source context | `snippet --project <repo> --id <node-id>` |
-| Target bundle | `context --project <repo> --id <node-id>` |
 | File inventory and coverage | `files --project <repo> --limit 80` |
+| Changed-file impact | `affected --project <repo>` |
+| Candidate discovery with sidecars | `search --project <repo> --query "..." --why` |
 | Broad task packet with sidecars | `packet --project <repo> --question "..."` |
-| Persistent local reads | `serve --project <repo> --stdio` |
+| Focused source context | `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, `context` |
+| Persistent local agent surface | `serve --project <repo> --stdio --refresh none` |
 
-The CLI is an operator and repair surface, not the whole product experience.
-Agent workflows should start from readiness and source evidence, then use the
-smallest command that answers the current question.
+See [docs/usage.md](docs/usage.md) for task-shaped flows and
+[docs/ops/retrieval-sidecars.md](docs/ops/retrieval-sidecars.md) for sidecar
+setup and repair.
 
 ## Language Support
 
 CodeStory separates parser-backed graph coverage, structural collectors,
 regression-tested fidelity, and agent packet/search readiness. The current
-contract is documented in
+contract is in
 [docs/architecture/language-support.md](docs/architecture/language-support.md).
 
-Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#,
-Kotlin, Swift, Dart, and Bash are fidelity-gated parser-backed graph languages.
-HTML, CSS, and SQL use structural collectors.
+Parser-backed graph languages include Python, Java, Rust, JavaScript,
+TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, and Bash. HTML,
+CSS, and SQL use structural collectors.
 
-## Evidence
+## Evidence And Contributing
 
-Benchmark notes are environment- and repository-specific evidence. Do not turn
-one row into a universal savings claim. Run-specific scorecards, generated
-comparison docs, and benchmark ledgers belong in PRs, issues, release notes, or
-ignored `target/` artifacts instead of committed durable docs.
+Benchmark rows are environment-specific evidence, not universal product claims.
+Generated comparison docs, CSVs, ledgers, and scorecards belong in PRs, issues,
+release notes, or ignored `target/` artifacts unless they become durable product
+documentation.
 
-- Verification tiers and commands: [docs/contributors/testing-matrix.md](docs/contributors/testing-matrix.md)
-- Repo-scale timing history: [docs/testing/codestory-e2e-stats-log.md](docs/testing/codestory-e2e-stats-log.md)
-- Warm stdio loop history: [docs/testing/codestory-stdio-warm-loop-stats.md](docs/testing/codestory-stdio-warm-loop-stats.md)
-- Repeatable with/without harness: [scripts/codestory-agent-ab-benchmark.mjs](scripts/codestory-agent-ab-benchmark.mjs)
+Useful docs:
 
-## Contributing
-
-Start with the contributor docs, then run Cargo checks serially because this
-workspace shares build locks.
-
+- [docs/usage.md](docs/usage.md)
+- [docs/concepts/how-codestory-works.md](docs/concepts/how-codestory-works.md)
+- [docs/architecture/overview.md](docs/architecture/overview.md)
 - [docs/contributors/getting-started.md](docs/contributors/getting-started.md)
 - [docs/contributors/debugging.md](docs/contributors/debugging.md)
 - [docs/contributors/testing-matrix.md](docs/contributors/testing-matrix.md)
-- [docs/architecture/overview.md](docs/architecture/overview.md)
-- [docs/architecture/runtime-execution-path.md](docs/architecture/runtime-execution-path.md)
+- [docs/testing/codestory-e2e-stats-log.md](docs/testing/codestory-e2e-stats-log.md)
+- [docs/testing/codestory-stdio-warm-loop-stats.md](docs/testing/codestory-stdio-warm-loop-stats.md)
 
-## Docs Map
-
-- Usage: [docs/usage.md](docs/usage.md)
-- Concepts: [docs/concepts/how-codestory-works.md](docs/concepts/how-codestory-works.md)
-- Architecture: [docs/architecture/overview.md](docs/architecture/overview.md)
-- Languages: [docs/architecture/language-support.md](docs/architecture/language-support.md)
-- Testing: [docs/contributors/testing-matrix.md](docs/contributors/testing-matrix.md)
-- Contributing: [docs/contributors/getting-started.md](docs/contributors/getting-started.md)
+Run Cargo verification serially in this repo because build locks are shared.
 
 ## License
 


### PR DESCRIPTION
## Context

Closes #310
Refs #38

Related docs context: #293, #295, and #306.

The root README was still too CLI-first for the product shape. CodeStory is meant to be local codebase grounding for agents; the human installs or enables it, checks readiness, and uses CLI commands mostly for setup, repair, and debugging.

## What Changed

- Rewrote the first screen around agent use: what CodeStory is, who uses it, what the agent gets, and what the human operates.
- Made the primary path explicit: install/enable plugin or CLI runtime, read readiness, let the agent use MCP/stdio grounding tools, then use CLI commands as the operator/debug surface.
- Kept the current read-only grounding surface visible: `ground`, `files`, `affected`, focused graph/source tools, `search`, and `packet`.
- Preserved sidecar readiness caveats for `packet` and `search`, including the `retrieval_mode=full` gate.
- Preserved the external catalog split: `TheGreenCedar/AgentPluginMarketplace` is the marketplace catalog; this repo owns `plugins/codestory`, the runtime, and the CLI.

## How To Review

- Read the README from the top through `Command Reference` as a first-time human installer/operator.
- Confirm the CLI examples are still present but no longer dominate the product introduction.
- Confirm the marketplace/catalog wording points to `TheGreenCedar/AgentPluginMarketplace` without implying catalog edits live in this repo.
- Confirm this is README-only: no Rust/runtime behavior, release version, marketplace repo, generated artifact, or broad docs rewrite.

## Verification

- `git diff --check` passed.
- `rg "AgentPluginMarkeplace|AgentPluginMarketplace|codestory marketplace|serve --stdio" README.md docs plugins` passed; no `AgentPluginMarkeplace` typo appeared, and expected marketplace/runtime references remain.
- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs` passed: 4 tests, 4 passing.
- Manual README read-through from a first-time human installer/operator perspective.

## Risk

Docs-only risk. The biggest risk is wording drift rather than runtime behavior.

Dogfood friction: this lane could read the CodeStory grounding skill, but no CodeStory MCP tools were exposed through tool discovery in this child thread, so the rewrite was grounded with direct source reads, issue text, and static checks rather than live CodeStory packet/search output.
