### PR TITLE
[codex] fix CodeStory installer PATH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ The canonical plugin skill is
 [plugins/codestory/skills/codestory-grounding/SKILL.md](plugins/codestory/skills/codestory-grounding/SKILL.md).
 The plugin launches `codestory-cli serve --stdio --refresh none` directly.
 The skill owns the runtime check: it should verify `codestory-cli --version`,
-resolve the latest GitHub release when needed, and restart the agent thread if
-`PATH` changed.
+resolve the latest GitHub release when needed, and restart the Codex host/app
+before starting a new agent thread if `PATH` changed.
 
 ## Readiness Contract
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -132,7 +132,8 @@ The plugin does not bundle the binary. The agent should run
 against the latest GitHub release, resolve the latest release, download and
 unpack the matching host asset, verify it when practical, place it in a stable
 user bin directory, and re-check `codestory-cli --version`. If the host `PATH`
-changes, start a new agent thread so the MCP process can see the binary.
+changes, restart the Codex host/app before starting a new agent thread so the
+MCP process can see the binary.
 
 For latest tag `vX.Y.Z`, choose the host asset derived from that tag:
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -38,7 +38,8 @@ tool source unless the user is editing CodeStory itself.
 5. Put the binary in a stable user bin directory, verify
    `codestory-cli --version`, and prefer checking `SHA256SUMS.txt` from the
    same release when the host has the tools. If `PATH` changed, say that the
-   plugin MCP process may need a new agent thread to see it.
+   plugin MCP process may need a Codex host/app restart before a new agent thread
+   can see it.
 6. Use `scripts/setup.ps1` or `scripts/setup.sh` from this skill only for the
    source-build fallback or explicit source-artifact setup.
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -75,6 +75,7 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "downloads the latest matching release asset",
     "uses source fallback only when no release asset fits the host",
     "Agent runtime bootstrap",
+    "restart the Codex host/app before starting a new agent thread",
     "Source docs, marketplace source checkout/cache, and the active installed MCP",
     "active runtime surface",
     "For normal Codex use, refresh or uninstall the plugin from the Codex plugin",
@@ -93,6 +94,7 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
   const skillRequired = [
     "download and unpack only",
     "plugin MCP process may need",
+    "Codex host/app restart before a new agent thread",
     "new agent thread",
     "Read `codestory://grounding`",
     "Always pass `--project <target-workspace>` explicitly",

--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -172,12 +172,70 @@ function Find-ExistingCli {
 }
 
 function Test-WindowsX64 {
-    $isWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+    $hostIsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
         [System.Runtime.InteropServices.OSPlatform]::Windows
     )
     $isX64 = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq `
         [System.Runtime.InteropServices.Architecture]::X64
-    return ($isWindows -and $isX64)
+    return ($hostIsWindows -and $isX64)
+}
+
+function Normalize-PathListEntry {
+    param([string]$Value)
+
+    if (-not $Value) {
+        return ""
+    }
+    return ($Value.Trim() -replace "[\\/]+$", "")
+}
+
+function Test-PathListContains {
+    param(
+        [string]$PathList,
+        [string]$Directory
+    )
+
+    $normalizedDirectory = Normalize-PathListEntry $Directory
+    foreach ($entry in ($PathList -split ";")) {
+        if ((Normalize-PathListEntry $entry) -ieq $normalizedDirectory) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Ensure-InstallDirOnPath {
+    param(
+        [string]$InstallDirectory,
+        [string]$CliPath
+    )
+
+    $resolvedInstallDir = Resolve-Path -LiteralPath $InstallDirectory -ErrorAction SilentlyContinue
+    if (-not $resolvedInstallDir) {
+        return
+    }
+    $resolvedCli = Resolve-Path -LiteralPath $CliPath -ErrorAction SilentlyContinue
+    if (-not $resolvedCli) {
+        return
+    }
+    $installPath = $resolvedInstallDir.Path
+    $cliDir = Split-Path -Parent $resolvedCli.Path
+    if ((Normalize-PathListEntry $cliDir) -ine (Normalize-PathListEntry $installPath)) {
+        return
+    }
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if (-not (Test-PathListContains $userPath $installPath)) {
+        $prefix = if ($userPath) { $userPath.TrimEnd(";") + ";" } else { "" }
+        [Environment]::SetEnvironmentVariable("Path", $prefix + $installPath, "User")
+        Write-Host "PATH updated for future Codex host processes: $installPath"
+    }
+
+    $processPath = [Environment]::GetEnvironmentVariable("Path", "Process")
+    if (-not (Test-PathListContains $processPath $installPath)) {
+        $prefix = if ($processPath) { $processPath.TrimEnd(";") + ";" } else { "" }
+        [Environment]::SetEnvironmentVariable("Path", $prefix + $installPath, "Process")
+    }
 }
 
 function Get-ExpectedHash {
@@ -393,6 +451,9 @@ function Assert-SelfTest {
 
 function Invoke-SelfTest {
     Set-RequiredVersion "v0.11.2"
+    Test-WindowsX64 | Out-Null
+    Assert-SelfTest (Test-PathListContains "C:\Tools;C:\CodeStory\bin\" "C:\CodeStory\bin") "path-list check should ignore trailing slash"
+    Assert-SelfTest (-not (Test-PathListContains "C:\Tools" "C:\CodeStory\bin")) "path-list check should reject missing directory"
     Assert-SelfTest ((Convert-ReleaseTagToVersion "v0.11.2") -eq "0.11.2") "release tag parser should strip v prefix"
     $parsedVersion = Convert-VersionText "codestory-cli 0.11.2"
     Assert-SelfTest (Test-RequiredVersion $parsedVersion) "version gate should accept current release"
@@ -506,6 +567,7 @@ if (-not $cliInfo) {
     }
     $cliInfo = Install-ReleaseCli $InstallDir $Version
 }
+Ensure-InstallDirOnPath $InstallDir $cliInfo.Path
 
 $projectPath = (Resolve-Path -LiteralPath $Project).Path
 $doctor = Invoke-DoctorJson $cliInfo.Path $projectPath


### PR DESCRIPTION
## Context

Closes #313
Refs #38

Issue #313 asked for a dogfood pass before the next version-bump issue. The fresh lane started from `dev/codestory-next` at `b15ce21f79a4dce7f386be38deb7babba5852ad3` with no `CODESTORY_CLI`, no PATH `codestory-cli.exe`, no local `target\release\codestory-cli.exe`, and stale sibling/user-bin binaries.

The repo-owned blocker was in the Windows release installer and bootstrap docs:

```mermaid
flowchart LR
  A[Fresh Codex host] --> B[Plugin starts codestory-cli]
  B --> C{PATH has current CLI?}
  C -- no --> D[Installer downloads release asset]
  D --> E[User bin has 0.11.2]
  E --> F[Persist user PATH]
  F --> G[Restart Codex host/app]
  G --> H[New agent thread can launch MCP]
```

## What Changed

- Fixed `scripts/install-codestory.ps1` on Windows PowerShell by avoiding the read-only `$IsWindows` automatic variable collision.
- Added installer PATH persistence for the verified install-dir binary so the plugin's `command: "codestory-cli"` can resolve after a Codex host/app restart.
- Added installer self-test coverage for the host probe and PATH-list matching.
- Updated root/plugin/skill docs to say the real boundary is Codex host/app restart before a new agent thread when PATH changes.
- Added static plugin-doc assertions for that restart wording.

## How To Review

1. Review `scripts/install-codestory.ps1` first; the functional change is scoped to host detection and PATH setup after a verified release binary is found.
2. Review the three docs surfaces for the restart wording: root README, plugin README, and the shipped `codestory-grounding` skill.
3. Confirm no marketplace catalog files or Rust runtime paths changed.

## Verification

- `node --test plugins\codestory\tests\plugin-static.test.mjs` passed: 4/4 tests.
- `python C:\Users\alber\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py plugins\codestory` passed.
- `.\scripts\install-codestory.ps1 -SelfTest` passed.
- `git diff --check` passed.
- Dogfood release install after the fix: `.\scripts\install-codestory.ps1 -Project .` reported `binary installed: ready - C:\Users\alber\AppData\Local\CodeStory\bin\codestory-cli.exe (codestory-cli 0.11.2, existing)` with no Cargo build.
- Before the PATH fix, the installer failed with `Cannot overwrite variable IsWindows because it is read-only or constant.`
- Before the PATH fix, `C:\Users\alber\AppData\Local\CodeStory\bin\codestory-cli.exe` existed but reported `codestory-cli 0.11.1`, `Get-Command codestory-cli.exe` returned nothing, this worktree had no local `target\release\codestory-cli.exe`, and sibling release binaries were stale (`0.10.0`, `0.9.0`).
- After installing and loading persisted user PATH in a fresh-process simulation, `Get-Command codestory-cli.exe` resolved `C:\Users\alber\AppData\Local\CodeStory\bin\codestory-cli.exe` and `codestory-cli.exe --version` returned `codestory-cli 0.11.2`.
- `codex.cmd plugin add codestory@TheGreenCedar` refreshed the installed plugin cache at `C:\Users\alber\.codex\plugins\cache\TheGreenCedar\codestory\0.1.0`; the cached skill now contains latest-release-aware setup wording.
- Current-thread tool discovery still did not expose CodeStory MCP tools after plugin refresh; this is expected because the active thread/tool surface and Codex host environment were already loaded.
- Direct stdio probe with the installed `0.11.2` binary reached `serve --stdio --refresh none`, but this worktree has no existing index, so `serve` correctly refused with `No indexed files are available`. No index/reindex was run because #313 excludes that work.

## Risk

- The installer updates user PATH only when the verified binary lives in the installer-managed install directory. Existing PATH or explicit CLI overrides are not rewritten.
- A still-running Codex host/app may not observe user PATH changes. The docs now call out restarting the Codex host/app before starting a new agent thread.
- This PR does not claim packet/search readiness for this worktree; `doctor` still reports `repair_index` and `retrieval_manifest_missing` until normal indexing/sidecar setup is run outside this lane.
