### PR TITLE
[codex] align plugin install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ marketplaces, add or refresh this marketplace first:
 codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
 ```
 
-The marketplace source is `TheGreenCedar/AgentPluginMarketplace`.
-This repository remains the plugin source. The catalog can list many plugins,
-and the CodeStory entry points at `plugins/codestory` in this repo.
-Marketplace edits do not live in this repo.
+The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`; its
+marketplace display/name concept is `TheGreenCedar`. This repository remains
+the plugin source at `https://github.com/TheGreenCedar/CodeStory.git`, with
+source path `plugins/codestory`. The CodeStory repo does not contain the marketplace catalog.
 
 Start a new Codex thread after install or refresh so the MCP process can see
 the current environment. A good first prompt is:
@@ -102,9 +102,9 @@ the current environment. A good first prompt is:
 The canonical plugin skill is
 [plugins/codestory/skills/codestory-grounding/SKILL.md](plugins/codestory/skills/codestory-grounding/SKILL.md).
 The plugin launches `codestory-cli serve --stdio --refresh none` directly.
-The skill owns the runtime check: it should verify `codestory-cli --version`,
-resolve the latest GitHub release when needed, and restart the Codex host/app
-before starting a new agent thread if `PATH` changed.
+The skill owns binary setup: it checks `codestory-cli --version`, resolves the
+latest GitHub release when needed, and restarts the Codex host/app before
+starting a new agent thread if `PATH` changed.
 
 ## Readiness Contract
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -60,10 +60,10 @@ marketplaces, add or refresh this marketplace first:
 codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
 ```
 
-The marketplace source is `TheGreenCedar/AgentPluginMarketplace`.
-This repository remains the plugin source. One marketplace can list multiple plugins.
-CodeStory's entry points at `https://github.com/TheGreenCedar/CodeStory.git`
-with source path `plugins/codestory`.
+The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`; its
+marketplace display/name concept is `TheGreenCedar`. This repository remains
+the plugin source at `https://github.com/TheGreenCedar/CodeStory.git`, with
+source path `plugins/codestory`. The CodeStory repo does not contain the marketplace catalog.
 
 Some workspace plugin settings are managed from the Codex Apps/Plugins UI
 rather than the terminal. Use the UI path when the CLI marketplace command is
@@ -82,7 +82,7 @@ before planning or editing:
 ```
 
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
-present and current, downloads the latest matching release asset when needed,
+present and current, installs the latest matching release asset when needed,
 and uses source fallback only when no release asset fits the host.
 
 ## What To Ask
@@ -127,27 +127,13 @@ nonsense with a straight face.
 
 ### Agent runtime bootstrap
 
-The plugin does not bundle the binary. The agent should run
-`codestory-cli --version` first. If `codestory-cli` is missing or outdated
-against the latest GitHub release, resolve the latest release, download and
-unpack the matching host asset, verify it when practical, place it in a stable
-user bin directory, and re-check `codestory-cli --version`. If the host `PATH`
-changes, restart the Codex host/app before starting a new agent thread so the
-MCP process can see the binary.
+The plugin does not bundle the binary. The agent-owned skill verifies
+`codestory-cli --version`, compares it with the latest GitHub release, installs
+the matching release asset when practical, checks `SHA256SUMS.txt` when the host
+can, and restarts the Codex host/app before starting a new agent thread if the
+MCP process needs a fresh `PATH`.
 
-For latest tag `vX.Y.Z`, choose the host asset derived from that tag:
-
-| Host OS | Binary setup |
-| --- | --- |
-| Windows x64 | Download `codestory-cli-vX.Y.Z-windows-x64.zip`, extract `codestory-cli.exe`, and put it on `PATH`. |
-| Windows arm64 | Download `codestory-cli-vX.Y.Z-windows-arm64.zip`, extract `codestory-cli.exe`, and put it on `PATH`. |
-| macOS arm64 | Download `codestory-cli-vX.Y.Z-macos-arm64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
-| macOS x64 | Use the source fallback until a matching release asset exists. |
-| Linux x64 | Download `codestory-cli-vX.Y.Z-linux-x64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
-| Linux arm64 | Download `codestory-cli-vX.Y.Z-linux-arm64.tar.gz`, extract `codestory-cli`, put it on `PATH`, and run `chmod +x codestory-cli` if needed. |
-
-Verify downloaded archives against `SHA256SUMS.txt` from the release when the
-host has the tools to do it. Source fallback for any OS:
+Use source fallback only when no release asset fits the host:
 
 ```sh
 cargo build --release -p codestory-cli
@@ -191,8 +177,8 @@ The marketplace catalog is external. One marketplace can list multiple plugins.
 
 | Field | Value |
 | --- | --- |
-| Catalog repo | `TheGreenCedar/AgentPluginMarketplace` |
-| Catalog name | `TheGreenCedar` |
+| Marketplace catalog repo | `TheGreenCedar/AgentPluginMarketplace` |
+| Marketplace display/name | `TheGreenCedar` |
 | Plugin entry | `codestory` |
 | Source kind | `git-subdir` |
 | Source repo | `https://github.com/TheGreenCedar/CodeStory.git` |

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -26,23 +26,24 @@ test("codestory repo ships plugin source, not marketplace catalog or adapter run
   await assert.rejects(access(join(pluginRoot, "scripts", "codestory-mcp.mjs")));
 });
 
-test("plugin docs are agent-first, cross-platform, and latest-release aware", async () => {
+test("plugin docs are agent-first, marketplace-aware, and latest-release aware", async () => {
   const rootReadme = await readFile(join(repoRoot, "README.md"), "utf8");
   const readme = await readFile(join(pluginRoot, "README.md"), "utf8");
   const skill = await readFile(join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"), "utf8");
   const sharedRequired = [
     "latest GitHub release",
     "codestory-cli --version",
+    "SHA256SUMS.txt",
+    "retrieval_mode=full",
+  ];
+  const skillReleaseRequired = [
     "missing or outdated",
     "codestory-cli-vX.Y.Z-windows-x64.zip",
     "codestory-cli-vX.Y.Z-windows-arm64.zip",
     "codestory-cli-vX.Y.Z-macos-arm64.tar.gz",
-    "macOS x64",
     "codestory-cli-vX.Y.Z-linux-x64.tar.gz",
     "codestory-cli-vX.Y.Z-linux-arm64.tar.gz",
     "Source fallback",
-    "SHA256SUMS.txt",
-    "retrieval_mode=full",
   ];
   const forbidden = [
     "release-bound to " + "CodeStory `v" + "0.11.1`",
@@ -64,18 +65,22 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "TheGreenCedar -> codestory -> Install plugin",
     "add or refresh this marketplace first",
     "codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace",
-    "The marketplace source is `TheGreenCedar/AgentPluginMarketplace`",
-    "This repository remains the plugin source",
-    "One marketplace can list multiple plugins",
+    "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",
+    "marketplace display/name concept is `TheGreenCedar`",
+    "plugin source at `https://github.com/TheGreenCedar/CodeStory.git`",
+    "source path `plugins/codestory`",
+    "The CodeStory repo does not contain the marketplace catalog",
     "workspace plugin settings are managed from the Codex Apps/Plugins UI",
     "UI path when the CLI marketplace command is",
     "Start a new Codex thread after installation or refresh",
     "check whether this repository is ready for local navigation and packet/search",
     "The first run should be agent-owned",
-    "downloads the latest matching release asset",
+    "installs the latest matching release asset",
     "uses source fallback only when no release asset fits the host",
     "Agent runtime bootstrap",
-    "restart the Codex host/app before starting a new agent thread",
+    "restarts the Codex host/app before starting a new agent thread",
+    "The plugin does not bundle the binary",
+    "Use source fallback only when no release asset fits the host",
     "Source docs, marketplace source checkout/cache, and the active installed MCP",
     "active runtime surface",
     "For normal Codex use, refresh or uninstall the plugin from the Codex plugin",
@@ -83,8 +88,8 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "codex plugin marketplace remove TheGreenCedar",
     "commands only for source registration",
     "The plugin does not bundle the binary",
-    "TheGreenCedar/AgentPluginMarketplace",
-    "Catalog name",
+    "Marketplace catalog repo",
+    "Marketplace display/name",
     "Plugin entry",
     "git-subdir",
     "https://github.com/TheGreenCedar/CodeStory.git",
@@ -100,12 +105,16 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
     "Always pass `--project <target-workspace>` explicitly",
   ];
   const rootReadmeRequired = [
-    "The marketplace source is `TheGreenCedar/AgentPluginMarketplace`",
-    "This repository remains the plugin source. The catalog can list many plugins",
-    "the CodeStory entry points at `plugins/codestory` in this repo",
+    "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",
+    "marketplace display/name concept is `TheGreenCedar`",
+    "plugin source at `https://github.com/TheGreenCedar/CodeStory.git`",
+    "source path `plugins/codestory`",
+    "The CodeStory repo does not contain the marketplace catalog",
     "add or refresh this marketplace first",
     "The plugin launches `codestory-cli serve --stdio --refresh none` directly",
-    "The skill owns the runtime check",
+    "The skill owns binary setup",
+    "restarts the Codex host/app before",
+    "starting a new agent thread if `PATH` changed",
   ];
 
   for (const text of [readme, skill]) {
@@ -127,6 +136,10 @@ test("plugin docs are agent-first, cross-platform, and latest-release aware", as
   }
   for (const phrase of readmeRequired) {
     assert.equal(readme.includes(phrase), true, phrase);
+  }
+  for (const phrase of skillReleaseRequired) {
+    assert.equal(skill.includes(phrase), true, phrase);
+    assert.equal(readme.includes(phrase), false, phrase);
   }
   for (const phrase of rootReadmeRequired) {
     assert.equal(rootReadme.includes(phrase), true, phrase);


### PR DESCRIPTION
## Context

Closes #314.
Refs #38

CodeStory's plugin install docs should match the cleaner local pattern used by Autoresearch: UI install first, terminal marketplace commands only as a conditional fallback, then a new Codex thread with one concrete first prompt.

## What Changed

- Updated the root README install flow to name the external marketplace catalog, the `TheGreenCedar` marketplace display/name concept, the CodeStory plugin source repo, and the `plugins/codestory` source path.
- Trimmed `plugins/codestory/README.md` so human install docs summarize binary setup instead of carrying the release-asset tutorial.
- Updated `plugins/codestory/tests/plugin-static.test.mjs` to protect the critical install flow and catalog/source facts while keeping exact release asset mechanics owned by the shipped grounding skill.

## How To Review

- Read `README.md` under `Install As An Agent Plugin`.
- Read `plugins/codestory/README.md` under `Install For Agent Use`, `Agent runtime bootstrap`, and `Marketplace maintainer details`.
- Check that terminal `codex plugin marketplace ...` commands are fallback-only and that the first prompt stays agent-shaped.

## Verification

- `python C:\Users\alber\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py plugins\codestory` - passed.
- `node --test plugins\codestory\tests\plugin-static.test.mjs` - passed, 4 tests.
- `git diff --check` - passed.

## Risk

Low. This is docs plus a static-doc guard only. The main remaining risk is Codex UI wording drifting outside this repo; the docs keep the terminal marketplace commands conditional for that reason.
