### PR TITLE
[codex] Reframe usage guide around operator workflows

### DIFF
--- a/docs/concepts/how-codestory-works.md
+++ b/docs/concepts/how-codestory-works.md
@@ -4,7 +4,7 @@ CodeStory indexes a workspace into a local graph, then serves read commands
 against that graph. It does not replace tests or judgment; it structures the
 first pass.
 
-Command loop: [README - What You Get](../../README.md#what-you-get).
+Command loop: [README - What Your Agent Gets](../../README.md#what-your-agent-gets).
 Readiness lanes: [usage.md](../usage.md#readiness-tracks).
 
 ```mermaid

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,304 +1,179 @@
 # CodeStory Usage
 
-Setup, workflows, sidecars, recovery. Shell examples are POSIX unless noted.
-Windows: `.\target\release\codestory-cli.exe`, `$env:NAME = "value"`.
+Start with the operator task, then run the smallest command path that proves the
+state you need.
 
-## Install The Plugin
+| Task | Use | Done when |
+| --- | --- | --- |
+| Install and first grounding | Plugin install, then `doctor`, `index`, `ground` | Local navigation reports ready and the first grounding names files/gaps. |
+| Navigate locally | `ground`, `files`, `symbol`, `trail`, `snippet`, `context --id`, `affected` | Output cites concrete files, symbols, snippets, or node ids. |
+| Ask a broad packet/search question | `packet` or `search` | Retrieval reports `retrieval_mode=full`. |
+| Fix stale local cache | `doctor`, `index --refresh full`, `doctor` | The refreshed cache is healthy before you trust local output. |
+| Repair sidecars | `retrieval bootstrap`, `retrieval index`, `retrieval status` | `agent_packet_search` is ready and `retrieval_mode=full`. |
+| Verify a docs or code change | The narrow repo check for the changed surface | Verification output matches the claim you plan to make. |
 
-Install the CodeStory plugin once, then point the agent at explicit target
-workspaces. See [README - Install as an agent plugin](../README.md#install-as-an-agent-plugin)
-and [the plugin README](../plugins/codestory/README.md) for the agent-first
-install and binary setup flow.
+Packet/search output from degraded retrieval, missing sidecars, stale manifests,
+or any non-`full` retrieval mode is navigation help only. It is not proof.
 
-The canonical skill package lives at
+Most humans should start from the plugin flow in
+[README - Use It With An Agent](../README.md#use-it-with-an-agent). Use the CLI
+when you need a direct setup, repair, or debug transcript.
+
+Shell examples below are POSIX unless noted. On Windows PowerShell, use
+`.\target\release\codestory-cli.exe` for a source-built binary and set
+environment variables with `$env:NAME = "value"`.
+
+## Install And Ground A Repo
+
+Install the CodeStory plugin once, then start a fresh agent thread for the
+workspace you want to ground. The canonical skill package lives at
 [../plugins/codestory/skills/codestory-grounding/SKILL.md](../plugins/codestory/skills/codestory-grounding/SKILL.md).
-If you use its source-build setup fallback and need a different source artifact,
-set `CODESTORY_REPO_URL` and `CODESTORY_REPO_REF` before running setup. Without
-an explicit ref, setup fetches and builds the remote default branch.
 
-For humans and repair lanes, use the CLI directly. The CLI tells you whether
-local navigation or packet/search is ready; do not infer readiness from a
-successful command that reports degraded state.
+For a direct CLI transcript:
 
-## Use From Source
+```sh
+codestory-cli doctor --project <target-workspace>
+codestory-cli index --project <target-workspace> --refresh auto
+codestory-cli ground --project <target-workspace> --why
+```
 
-Use this path when you are changing CodeStory itself or testing the current
-checkout.
+`doctor` separates local navigation readiness from agent packet/search
+readiness. Do not infer packet/search readiness from a successful local
+grounding command.
+
+When changing CodeStory itself or testing the current checkout:
 
 ```sh
 cargo build --release -p codestory-cli
 CODESTORY_CLI="./target/release/codestory-cli"
-"$CODESTORY_CLI" --help
+"$CODESTORY_CLI" doctor --project <target-workspace>
 ```
 
-Pick a target workspace explicitly:
+The plugin source-build setup fallback accepts `CODESTORY_REPO_URL` and
+`CODESTORY_REPO_REF` when you need a specific source artifact. Without an
+explicit ref, setup fetches and builds the remote default branch.
 
-```sh
-TARGET_WORKSPACE="/path/to/repo"
-"$CODESTORY_CLI" doctor --project "$TARGET_WORKSPACE"
-"$CODESTORY_CLI" index --project "$TARGET_WORKSPACE" --refresh auto
-"$CODESTORY_CLI" ground --project "$TARGET_WORKSPACE" --why
-```
+## Readiness Lanes
 
-## Readiness Tracks
-
-Two lanes - do not mix them when judging `packet` or `search` output.
+Keep the lanes separate when judging output:
 
 | | Local navigation | Agent packet/search |
 | --- | --- | --- |
 | Lane id | `local_navigation` | `agent_packet_search` |
-| Built by | `index` | `index` then `retrieval index` |
-| Requires | Healthy SQLite cache and graph | Sidecars healthy and `retrieval_mode=full` |
-| Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `context --id`, `affected` | `packet`, `search`, query-based candidate discovery |
-| Does not prove | Sidecar readiness | That cache-only browse is enough for agent search |
+| Built by | `index` | `index`, then `retrieval index` |
+| Requires | Healthy SQLite cache and graph | Healthy sidecars and `retrieval_mode=full` |
+| Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `context --id`, `affected` | `packet`, `search`, broad `context --query` discovery |
+| Does not prove | Sidecar readiness | That cache-only browsing is enough for broad agent search |
 
-`doctor` reports lane status. Sidecar topology:
+Sidecar topology:
 [architecture/overview.md](architecture/overview.md),
 [ops/retrieval-sidecars.md](ops/retrieval-sidecars.md).
 
-## Common Workflows
+## Local Navigation
 
-### I need a repo overview
+Use this lane when you need to understand files, symbols, and likely impact
+without broad sidecar search.
 
 ```sh
-codestory-cli doctor --project <target-workspace>
-codestory-cli index --project <target-workspace> --refresh full
 codestory-cli ground --project <target-workspace> --why
-codestory-cli report --project <target-workspace> --output-file codestory-report.md
-codestory-cli report --project <target-workspace> --format json --output-file codestory-graph.json
-```
-
-Health check, orientation, optional report and graph export. Regenerate reports
-after index changes; they are artifacts, not source-of-truth state.
-
-### I need evidence for a broad question
-
-```sh
-codestory-cli packet --project <target-workspace> --question "<broad task question>" --budget compact
-```
-
-Returns `sufficient`, `partial`, or `blocked` with citations and follow-ups.
-Requires `retrieval_mode=full`.
-
-### I need to understand one symbol or file
-
-With full sidecar readiness, use `search` for candidate discovery:
-
-```sh
-codestory-cli search --project <target-workspace> --query "<symbol/file/literal>" --why
+codestory-cli files --project <target-workspace> --path src --limit 80
+codestory-cli symbol --project <target-workspace> --id <node-id>
 codestory-cli trail --project <target-workspace> --id <node-id> --story --hide-speculative
 codestory-cli snippet --project <target-workspace> --id <node-id> --context 40
-```
-
-Without sidecars, stay on the local navigation lane until you have a concrete
-target:
-
-```sh
-codestory-cli ground --project <target-workspace> --why
-codestory-cli report --project <target-workspace> --output-file codestory-report.md
-codestory-cli files --project <target-workspace> --path src --limit 80
-```
-
-Then use `symbol`, `trail`, `snippet`, or `context --id` with an exact node id
-from local output. Do not treat `search` or `context --query` as cache-only
-fallbacks; query-based discovery is part of the agent packet/search lane.
-
-### I changed files and need likely impact
-
-```sh
-codestory-cli index --project <target-workspace> --refresh incremental
 codestory-cli affected --project <target-workspace> --format markdown
+```
+
+For review planning, you can pipe changed files into `affected`:
+
+```sh
 git diff --name-only HEAD | codestory-cli affected --project <target-workspace> --stdin --format json
 ```
 
-Impacted symbols and test hints - not a substitute for running tests.
+Impact hints are not a substitute for running the relevant tests.
 
-### The cache or local navigation looks stale
+## Broad Packet/Search
+
+Use this lane when the question is too broad for known node ids or file paths.
+
+```sh
+codestory-cli retrieval status --project <target-workspace> --format json
+codestory-cli packet --project <target-workspace> --question "<broad task question>" --budget compact
+codestory-cli search --project <target-workspace> --query "<symbol/file/literal/behavior>" --why
+```
+
+Trust the result only when retrieval status reports `retrieval_mode: "full"`.
+If `packet`, `search`, or broad `context --query` reports
+`retrieval_unavailable`, degraded retrieval, or a non-`full` mode, use the
+output only as a navigation hint and repair the sidecar lane before treating it
+as evidence.
+
+## Stale Local Cache
+
+When local navigation looks stale, refresh the SQLite graph before repeating
+read commands:
 
 ```sh
 codestory-cli doctor --project <target-workspace>
 codestory-cli index --project <target-workspace> --refresh full
 codestory-cli doctor --project <target-workspace>
 ```
-
-Fix inventory or indexing errors before trusting local navigation output. If
-`packet`, `search`, or `context --query` reports `retrieval_unavailable`, repair
-the sidecar lane instead of repeating the same command.
-
-### For agent-facing packet/search recovery
-
-```sh
-codestory-cli retrieval bootstrap --project <target-workspace> --format json
-codestory-cli retrieval index --project <target-workspace> --refresh full --format json
-codestory-cli retrieval status --project <target-workspace> --format json
-codestory-cli doctor --project <target-workspace> --format markdown
-```
-
-Target `retrieval_mode=full`. Core index problems may require `index` first -
-see `ready --goal agent`.
-
-## Core Commands
-
-- `doctor`: read-only health check for project, cache, index, retrieval, and
-  environment readiness.
-- `index`: build or refresh the SQLite graph, snapshots, search state,
-  graph-native symbol docs, component reports, and selected dense anchors.
-- `ground`: broad repo-level orientation snapshot; `--why` explains retrieval
-  mode, coverage, gaps, and next commands.
-- `report`: derived Markdown repo report or JSON graph export from the current
-  SQLite store; use `--output-file` to keep artifacts separate from terminal
-  logs.
-- `packet`: bounded broad-task evidence packet with citations, budget usage,
-  gaps, and follow-up commands; requires agent packet/search readiness.
-- `search`: sidecar-backed candidate discovery for symbols, files, literals,
-  API paths, modules, and behavior terms.
-- `symbol`: inspect one exact symbol and relationships.
-- `trail`: follow caller, callee, and reference relationships around a symbol.
-- `snippet`: fetch source context around a symbol.
-- `explore`: bundled navigation packet or terminal explorer around a target.
-- `context`: deep evidence bundle for one concrete target. `--id` and
-  `--bookmark` are exact-target paths; `--query` must be treated like
-  sidecar-backed discovery.
-- `affected`: map changed files to impacted symbols and likely tests.
-- `files`: inspect indexed file inventory, language counts, roles, and coverage
-  notes.
-- `query`: run structured graph-query pipelines.
-- `bookmark`: save, list, or remove investigation focus nodes.
-- `drill`: write a deterministic investigation report for selected anchors.
-- `setup embeddings`: install managed local embedding assets.
-- `serve --stdio`: persistent local read surface for repeated agent queries.
-  Use `get_node`, `neighbors`, `shortest_path`, or `query_subgraph` for cheap
-  graph probes from known node ids before asking for a broad `packet`.
-- `generate-completions`: emit shell completions from the command model.
-
-## Index Options
-
-`codestory-cli index` accepts these common options:
-
-| Option | Default | Notes |
-| --- | --- | --- |
-| `--project <PROJECT>` | `.` | Repository root to index. `--path` is an alias. |
-| `--cache-dir <DIR>` | per-project user cache | Uses the exact directory passed. |
-| `--refresh <auto|full|incremental|none>` | `auto` | Controls indexing work before the summary returns. |
-| `--format <markdown|json>` | `markdown` | JSON exposes the same summary for tests and automation. |
-| `--output-file <PATH>` | stdout | Parent directory must already exist. |
-| `--dry-run` | off | Computes the refresh plan without parsing or writing storage. |
-| `--summarize` | off | Generates cached symbol summaries after indexing. |
-| `--progress` | off | Prints progress to stderr so stdout stays parseable. |
-| `--watch` | off | Keeps running and incrementally refreshes after file changes. |
-
-Refresh modes:
-
-| Mode | Behavior |
-| --- | --- |
-| `auto` | Full on an empty cache, incremental once indexed files exist. |
-| `full` | Rebuilds the workspace graph and publishes a staged SQLite database. |
-| `incremental` | Reindexes changed, new, and removed files in the live cache. |
-| `none` | Opens the existing cache and returns a summary without indexing. |
 
 Read commands default to `--refresh none`. Use `--refresh incremental` when a
 read should refresh an existing cache first, and `--refresh full` after a cache
 reset, schema change, or suspected stale-state incident.
 
-## Predictable Output Modes
+If the cache directory itself is suspect, get the exact project cache path from
+`doctor`, verify it is under the CodeStory cache root, move it aside, rebuild,
+and delete the backup only after `doctor` is healthy.
 
-Most commands default to Markdown for human review. Use `--format json` when
-automation needs the complete structured result, including exact field
-comparisons such as `retrieval_mode` or cache paths. Use `--output-file <PATH>`
-when the artifact should live outside terminal logs. The parent directory must
-already exist.
+## Sidecar Repair
 
-`explore` opens the terminal UI by default when a TUI is available. Use
-`--no-tui`, `--plain`, or `CODESTORY_NO_TUI=1` for predictable command output in
-agent runs, tests, non-interactive terminals, and CI logs.
-
-Agent-facing Markdown may start with `Status`, `Trust`, `Next Action`, and
-`Proof Tier` before dense citations. Use `search --why --plan-details` only when
-you need the full broad-query search plan.
-
-## Retrieval Defaults
-
-Sidecar retrieval is mandatory for agent-facing packet/search workflows. Agent
-packet/search readiness means sidecar packet/search evidence is trustworthy only
-when retrieval status reports `retrieval_mode=full`; missing sidecars, stale
-manifests, or embedding-contract drift fail closed instead of falling back to an
-older local search path.
-
-Basic local index:
-
-```sh
-codestory-cli doctor --project <target-workspace>
-codestory-cli index --project <target-workspace> --refresh full
-codestory-cli ground --project <target-workspace> --why
-```
-
-That lane builds and reads the local SQLite cache. It does not start sidecars,
-write the retrieval manifest, or prove agent packet/search readiness.
-
-Product sidecar setup for agent-facing packet/search:
+Agent packet/search requires product sidecars and the `bge-base-en-v1.5`
+llama.cpp embedding contract.
 
 ```sh
 node scripts/setup-retrieval-env.mjs --fetch-embed-model
 export CODESTORY_EMBED_MODEL_DIR="$(pwd)/target/retrieval-models"
 export CODESTORY_EMBED_BACKEND="llamacpp"
 export CODESTORY_EMBED_LLAMACPP_URL="http://127.0.0.1:8080/v1/embeddings"
-codestory-cli retrieval bootstrap --project <target-workspace> --format json
 
+codestory-cli retrieval bootstrap --project <target-workspace> --format json
 codestory-cli index --project <target-workspace> --refresh full
-codestory-cli retrieval index --project <target-workspace> --refresh full
+codestory-cli retrieval index --project <target-workspace> --refresh full --format json
 codestory-cli retrieval status --project <target-workspace> --format json
-codestory-cli doctor --project <target-workspace>
+codestory-cli doctor --project <target-workspace> --format markdown
 ```
 
-`setup-retrieval-env.mjs --fetch-embed-model` downloads the configured GGUF to a
-temporary path and verifies the pinned artifact before renaming it into
-`CODESTORY_EMBED_MODEL_DIR`. The accepted artifact is exactly `117974304` bytes
-with SHA-256
-`ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`; all
-configured mirrors must pass the same check.
+`setup-retrieval-env.mjs --fetch-embed-model` verifies the pinned GGUF before
+renaming it into `CODESTORY_EMBED_MODEL_DIR`. The accepted artifact is exactly
+`117974304` bytes with SHA-256
+`ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`.
 
-Run `codestory-cli retrieval bootstrap` for the same target workspace you will
-query. Then run `codestory-cli retrieval index` only after the local sidecar
-services, llama.cpp embedding endpoint, and `bge-base-en-v1.5` model
-configuration are ready. Require `retrieval status --format json` to report
-`retrieval_mode: "full"` before trusting agent-facing packet/search evidence.
-The status JSON also reports `query_embedding_backend`,
-`manifest_vector_embedding_backend`, and `stored_doc_vector_producer_backend`
-so backend drift is visible.
+`retrieval status --format json` reports `query_embedding_backend`,
+`manifest_vector_embedding_backend`, and
+`stored_doc_vector_producer_backend` so backend drift is visible.
 
-Legacy managed embedding setup is local semantic/diagnostic only:
+Legacy managed embeddings are diagnostic only:
 
 ```sh
 codestory-cli setup embeddings --project <target-workspace> --dry-run --format json
 codestory-cli setup embeddings --project <target-workspace>
 ```
 
-Those commands install managed ONNX assets. They do not start llama.cpp, create
-the retrieval manifest, or prove agent packet/search readiness. Retrieval sidecar
-commands do not silently switch to ONNX mode just because managed assets are
-installed; unset retrieval backend means the product llama.cpp sidecar contract.
+Those commands do not start llama.cpp, create the retrieval manifest, or prove
+agent packet/search readiness.
 
-Useful environment knobs:
+## Output And Configuration
 
-- `CODESTORY_EMBED_BACKEND=llamacpp`: product embedding sidecar selection.
-- `CODESTORY_EMBED_LLAMACPP_URL=http://127.0.0.1:8080/v1/embeddings`: local
-  bge-base-en-v1.5 embedding endpoint.
-- `CODESTORY_SEMANTIC_DOC_SCOPE=all`: include lower-signal symbols while
-  investigating.
-- `CODESTORY_LLM_DOC_EMBED_BATCH_SIZE=<n>`: override only while profiling.
+Most commands default to Markdown. Use `--format json` for automation and
+`--output-file <PATH>` when the artifact should live outside terminal logs. The
+parent directory must already exist.
 
-Hash embeddings, ONNX-only experiments, lexical-only switches, and non-sidecar
-embedding paths are diagnostic or historical comparison modes only.
-Agent packet/search readiness requires repaired sidecars and
-`retrieval_mode=full`.
+`explore` opens the terminal UI by default when a TUI is available. Use
+`--no-tui`, `--plain`, or `CODESTORY_NO_TUI=1` for predictable command output in
+agent runs, tests, non-interactive terminals, and CI logs.
 
-`index`, `ground`, `search`, `context`, and `doctor` report retrieval mode and
-degraded-state notes when retrieval state is available.
-
-## Workspace And Config
-
-CodeStory supports an optional `codestory_workspace.json` file at the repository
-root for monorepo sessions:
+Optional project config:
 
 ```json
 {
@@ -306,128 +181,50 @@ root for monorepo sessions:
 }
 ```
 
-Use `codestory_project.json` when one project needs explicit source groups:
-
-```json
-{
-  "name": "api",
-  "version": 1,
-  "source_groups": [
-    {
-      "id": "11111111-1111-4111-8111-111111111111",
-      "language": "TypeScript",
-      "standard": "Default",
-      "source_paths": ["src/"],
-      "exclude_patterns": ["**/node_modules/**", "**/dist/**"],
-      "include_paths": [],
-      "defines": {},
-      "language_specific": "Other"
-    }
-  ]
-}
-```
-
 Team or user defaults can live in `.codestory.toml` at the project root or in
 the user home directory. The home file loads first, the project file overrides
 it for project-safe preferences, and explicit environment variables still win.
-
-Example:
-
-```toml
-embedding_profile = "bge-base-en-v1.5"
-embedding_model_id = "BAAI/bge-base-en-v1.5-local"
-hybrid_retrieval_enabled = true
-```
 
 Project `.codestory.toml` files are not trusted to choose cache roots,
 network/source-egress settings, or model selectors for source-egress calls. Put
 `cache_dir` in the user home `.codestory.toml` or pass `--cache-dir`. Put
 summary endpoints/models or embedding endpoints in trusted environment
 variables such as `CODESTORY_SUMMARY_ENDPOINT`, `CODESTORY_SUMMARY_MODEL`, or
-`CODESTORY_EMBED_LLAMACPP_URL`; a project file containing `summary_endpoint`,
-`summary_model`, or `embedding_endpoint` is rejected unless
-`CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG=1` is set deliberately for that run.
+`CODESTORY_EMBED_LLAMACPP_URL`.
 
-`semantic_doc_scope` is intentionally omitted above because durable semantic
-docs are the default. Set it only when opting into the broader all-symbol scope;
-accepted all-symbol values are `all`, `full`, `all-symbols`, and `all_symbols`.
-Other values currently resolve to the durable default.
+## Command Cheat Sheet
 
-## Cache Recovery
-
-Typical recovery flow:
-
-```sh
-codestory-cli doctor --project <target-workspace>
-codestory-cli index --project <target-workspace> --refresh full
-codestory-cli ground --project <target-workspace> --why
-```
-
-If the cache directory itself is suspect, get the exact project cache path from
-`doctor`, verify that it is under the CodeStory cache root, move it aside first,
-then rebuild. Remove the backup only after the fresh index is healthy:
-
-```sh
-cache_dir="<project-cache-dir-from-doctor>"
-cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/codestory"
-resolved_cache="$(realpath "$cache_dir")"
-resolved_root="$(realpath "$cache_root")"
-case "$resolved_cache" in
-  "$resolved_root"/*) ;;
-  *) echo "Refusing to touch cache outside CodeStory cache root: $resolved_cache" >&2; exit 1 ;;
-esac
-backup="${resolved_cache}.bak-$(date +%Y%m%d%H%M%S)"
-mv "$resolved_cache" "$backup"
-codestory-cli index --project <target-workspace> --refresh full &&
-  codestory-cli doctor --project <target-workspace> &&
-  rm -rf "$backup"
-```
-
-On Windows PowerShell:
-
-```powershell
-$ErrorActionPreference = "Stop"
-$cacheDir = "<project-cache-dir-from-doctor>"
-$cacheRoot = Join-Path $env:LOCALAPPDATA "codestory\cache"
-$resolvedCache = (Resolve-Path -LiteralPath $cacheDir -ErrorAction Stop).ProviderPath
-$resolvedRoot = (Resolve-Path -LiteralPath $cacheRoot -ErrorAction Stop).ProviderPath
-$rootPrefix = $resolvedRoot.TrimEnd("\", "/") + "\"
-if (-not $resolvedCache.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
-  throw "Refusing to touch cache outside CodeStory cache root: $resolvedCache"
-}
-$backup = "$resolvedCache.bak-$(Get-Date -Format yyyyMMddHHmmss)"
-Move-Item -LiteralPath $resolvedCache -Destination $backup -ErrorAction Stop
-codestory-cli index --project <target-workspace> --refresh full
-if ($LASTEXITCODE -ne 0) { throw "Index rebuild failed; leaving backup at $backup" }
-codestory-cli doctor --project <target-workspace>
-if ($LASTEXITCODE -ne 0) { throw "Doctor check failed; leaving backup at $backup" }
-Remove-Item -LiteralPath $backup -Recurse -ErrorAction Stop
-```
-
-Low-memory guidance:
-
-- Prefer `index --refresh incremental` over repeated full refreshes.
-- Avoid running multiple Cargo commands at once in this repo.
-- If embedding assets or retrieval sidecars are unavailable, fix that setup
-  layer before using packet/search evidence for broad agent grounding.
-- If a cold index is slow, inspect semantic timing before changing parser or
-  graph code.
+| Command | Use |
+| --- | --- |
+| `doctor` | Read-only health check for project, cache, index, retrieval, and environment readiness. |
+| `index` | Build or refresh the SQLite graph and derived local read models. |
+| `ground` | Broad repo-level orientation snapshot. |
+| `report` | Derived Markdown repo report or JSON graph export from the current SQLite store. |
+| `files` | Indexed file inventory, language counts, roles, and coverage notes. |
+| `symbol`, `trail`, `snippet`, `context --id` | Exact-target source inspection once you have a node id. |
+| `affected` | Changed-file impact hints for review planning. |
+| `packet`, `search`, `context --query` | Broad sidecar-backed discovery; trust only with `retrieval_mode=full`. |
+| `retrieval bootstrap`, `retrieval index`, `retrieval status` | Sidecar setup, indexing, and readiness checks. |
+| `serve --stdio` | Persistent local read surface for repeated agent queries. |
+| `generate-completions` | Shell completions from the command model. |
 
 ## Verification
 
-Run Cargo commands serially in this repo:
+Run Cargo commands serially in this repo.
+
+Docs-only lane:
+
+```sh
+git diff --check
+```
+
+Routine code lane:
 
 ```sh
 cargo fmt --check
 cargo check
 cargo test
 cargo clippy --all-targets -- -D warnings
-```
-
-Docs-only lane:
-
-```sh
-git diff --check
 ```
 
 Release-blocking fidelity lanes:
@@ -437,10 +234,6 @@ cargo test -p codestory-indexer --test fidelity_regression
 cargo test -p codestory-indexer --test tictactoe_language_coverage
 cargo test -p codestory-runtime --test retrieval_eval
 ```
-
-`retrieval_eval` runs a fail-closed sidecar-primary check by default. Set
-`CODESTORY_RETRIEVAL_EVAL_FULL_TESTS=1` only in an environment with real full sidecars to run the
-semantic quality assertions.
 
 Heavy repo-scale timing lane:
 
@@ -461,4 +254,4 @@ changes.
 - [architecture/runtime-execution-path.md](architecture/runtime-execution-path.md)
 - [contributors/debugging.md](contributors/debugging.md)
 - [contributors/testing-matrix.md](contributors/testing-matrix.md)
-- [testing/codestory-stdio-warm-loop-stats.md](testing/codestory-stdio-warm-loop-stats.md)
+- [ops/retrieval-sidecars.md](ops/retrieval-sidecars.md)


### PR DESCRIPTION
## Context
Closes #325
Refs #324
Refs #38

Issue #325 identified that `docs/usage.md` still opened like a CLI inventory and carried stale README anchors after the root README rewrite.

## What Changed
- Reframed `docs/usage.md` around operator tasks: install/first grounding, local navigation, broad packet/search, stale cache, sidecar repair, and verification.
- Demoted the command inventory into a short command cheat sheet so workflows lead the page.
- Repaired README anchors in `docs/usage.md` and `docs/concepts/how-codestory-works.md`.
- Preserved the packet/search trust boundary: degraded or non-`full` retrieval output is navigation help, not proof.

## How To Review
- Start at `docs/usage.md` and check whether the first screen answers what an operator should do next.
- Confirm the README links resolve to `#use-it-with-an-agent` and `#what-your-agent-gets`.
- Confirm the command reference no longer dominates the page.

## Verification
- Read `docs/usage.md` back from a first-time operator perspective after editing.
- `git diff --check`

No Cargo, indexing, sidecars, packet/search, benchmarks, generated docs, CSVs, SVGs, ledgers, or plugin/static docs tests were run. This lane touched only durable Markdown docs outside plugin/static-tested surfaces.

## Risk
Low. The change is docs-only. Remaining risk is that some removed command-option detail may still belong in a dedicated reference page later, but it was actively hurting this operator guide.