### PR TITLE
[codex] split retrieval sidecar runbook

### DIFF
--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -1,12 +1,13 @@
-# Retrieval sidecars — Operations runbook
+# Retrieval sidecars operations
 
-Local Zoekt, Qdrant, SCIP, and llama.cpp processes for agent `packet` and
-`search`. Data dirs live under the user cache; default ports are 6070 (Zoekt)
-and 6333 (Qdrant).
+Local Zoekt, Qdrant, SCIP, and llama.cpp sidecars back agent `packet` and
+`search`. They are required for `agent_packet_search` infrastructure readiness:
+`retrieval status` must report `retrieval_mode: "full"` before packet/search
+evidence can claim full sidecar retrieval.
 
-Required for `agent_packet_search` infrastructure readiness
-(`retrieval_mode=full`). A healthy SQLite cache alone does not satisfy that
-lane, and full sidecars do not by themselves promote answer quality.
+A healthy SQLite cache alone is not enough. Full sidecars also do not prove
+answer quality by themselves; answer quality still needs the matching
+packet-runtime, drill, or benchmark evidence tier.
 
 Design: [`retrieval-design.md`](../architecture/retrieval-design.md).
 Promotion checks: [`retrieval-architecture.md`](../testing/retrieval-architecture.md).
@@ -19,543 +20,280 @@ flowchart LR
     cli --> embed[llama.cpp embedding endpoint]
 ```
 
----
+## Operator repair path
 
-## Prerequisites
+### Prerequisites
 
-- Rust toolchain with `cargo` (primary path)
-- Docker Desktop or Docker Engine for automated Qdrant, Zoekt, and embed sidecars
-- Optional: Node.js 18+ for `scripts/setup-retrieval-env.mjs` wrapper
-- Manual sidecar path: Zoekt webserver on `6070` and Qdrant on `6333` without Docker; all sidecars must still be healthy before agent-facing retrieval is valid
-- Network: localhost only for sidecars; holdout clone needs outbound git
+- Rust toolchain with `cargo`, or an already-built `codestory-cli` binary.
+- Docker Desktop or Docker Engine for automated Qdrant, Zoekt, and llama.cpp
+  sidecars.
+- Optional Node.js 18+ for `scripts/setup-retrieval-env.mjs`.
+- Localhost ports available: Zoekt `6070`, Qdrant HTTP `6333`, Qdrant gRPC
+  `6334`, and llama.cpp embeddings `8080`.
+- GGUF embedding model available through `CODESTORY_EMBED_MODEL_DIR`, or fetched
+  with the setup wrapper.
 
----
+Manual sidecar setup is allowed only when equivalent local Zoekt, Qdrant, and
+llama.cpp services are already healthy. Agent-facing retrieval is invalid until
+the CLI status proof below reports `full`.
 
-## Quick start: one command
+### Minimum environment
 
-From the CodeStory repository root (Windows, macOS, Linux):
+For product sidecar retrieval, leave most knobs unset. Set these only when the
+defaults do not match your machine:
 
-```sh
-cargo run -p codestory-cli -- retrieval bootstrap --project . --format json
-```
+| Variable | Minimum operator use |
+|----------|----------------------|
+| `CODESTORY_EMBED_MODEL_DIR` | Host path containing `bge-base-en-v1.5.Q8_0.gguf` for the compose embed service |
+| `CODESTORY_EMBED_BACKEND` | `llamacpp`; unset also means product llama.cpp mode for retrieval commands |
+| `CODESTORY_EMBED_LLAMACPP_URL` | Local embedding endpoint, default `http://127.0.0.1:8080/v1/embeddings` |
+| `CODESTORY_ZOEKT_PORT` | Override Zoekt HTTP port when `6070` is unavailable |
+| `CODESTORY_QDRANT_HTTP_PORT` | Override Qdrant HTTP port when `6333` is unavailable |
+| `CODESTORY_QDRANT_GRPC_PORT` | Override Qdrant gRPC port when `6334` is unavailable |
 
-This starts or checks the local sidecar services for the CodeStory checkout; it
-does not by itself finalize the retrieval manifest for every target workspace.
-The `--project .` is intentional here. For another repo, pass that repo path to
-`--project`.
+Keep endpoint and cache-root settings out of project `.codestory.toml` files.
+Use trusted user config, explicit CLI flags, or environment variables for those
+trust boundaries.
 
-Plain `codestory-cli index` builds the core SQLite code index only. It can make
-the local navigation lane usable, but it does not generate sidecar artifacts or
-prove agent packet/search infrastructure readiness. Use
-`codestory-cli retrieval index --project <repo>` to generate Zoekt, Qdrant, and
-SCIP sidecar artifacts, then use `codestory-cli retrieval status --project
-<repo> --format json` to verify `retrieval_mode: "full"` before using
-agent-facing packet/search evidence. Packet answer quality still requires the
-matching packet-runtime or drill evidence tier.
+### Bootstrap sidecars
 
-First-run evidence path:
+From the CodeStory repository root:
 
 ```sh
 node scripts/setup-retrieval-env.mjs --fetch-embed-model
 export CODESTORY_EMBED_MODEL_DIR="$(pwd)/target/retrieval-models"
 export CODESTORY_EMBED_BACKEND="llamacpp"
 export CODESTORY_EMBED_LLAMACPP_URL="http://127.0.0.1:8080/v1/embeddings"
-./target/release/codestory-cli retrieval bootstrap --project <repo> --format json
-./target/release/codestory-cli index --project <repo> --refresh full
-./target/release/codestory-cli retrieval index --project <repo> --refresh full
-./target/release/codestory-cli retrieval status --project <repo> --format json
+cargo run -p codestory-cli -- retrieval bootstrap --project <repo> --format json
 ```
 
-On Windows PowerShell, use `.\target\release\codestory-cli.exe` and `$env:...`
-assignments for the same flow.
+On Windows PowerShell, use `$env:...` assignments and
+`.\target\release\codestory-cli.exe` if you are running a built binary.
 
-`retrieval status` must show `retrieval_mode: "full"`. Its JSON backend fields
-distinguish the active query backend (`query_embedding_backend`), manifest
-vector contract (`manifest_vector_embedding_backend`), and stored dense-anchor
-producer (`stored_doc_vector_producer_backend`). Under `graph_first_v1`, a
-generation can be full with zero dense anchors; in that case status reports the
-Qdrant component as policy-skipped rather than querying a missing collection.
-When a retrieval manifest exists, status also includes `manifest_contract`: a
-derived proof envelope, not a new persisted manifest. It names `source_root`,
-`input_hash`, `generation`, `schema_version`, `graph_hash`,
-`symbol_doc_count`, `dense_anchor_count`, degraded modes, and compact lane
-provenance for `lexical`, `symbol_docs`, `semantic_dense`, and `graph`. If the
-manifest is missing, obsolete, stale, or partial, strict status remains
-non-`full`; stale/partial reports keep the contract fields visible for
-diagnosis, while manifest-missing reports have no `manifest_contract`.
-
-Status after bootstrap:
+`retrieval bootstrap` may start Docker Compose, create sidecar cache dirs, write
+`retrieval-sidecars.json`, and repair CodeStory-owned local sidecar state. For a
+no-change prerequisite check, run:
 
 ```sh
-cargo run -p codestory-cli -- retrieval status --project . --format json
+node scripts/setup-retrieval-env.mjs --check-only
 ```
 
-Optional aliases are defined in [`.cargo/config.toml`](../../.cargo/config.toml).
-They wrap the same project-dot bootstrap and status commands.
-
-**Bootstrap flags** (via `cargo run -p codestory-cli -- retrieval bootstrap ...`):
+Useful bootstrap flags:
 
 | Flag | Purpose |
 |------|---------|
-| `--skip-compose` | Cache dirs + state file only; use only when equivalent local sidecars are already running |
-| `--wait-secs <n>` | Health wait timeout (default `90`; `0` = no wait) |
+| `--skip-compose` | Cache dirs and state file only; use only when equivalent sidecars are already running |
+| `--wait-secs <n>` | Health wait timeout, default `90`; `0` means no wait |
 | `--compose-file <path>` | Override `docker/retrieval-compose.yml` |
 
-**Optional Node wrapper** (prerequisite checks, optional holdout clone):
+### Index and prove full mode
+
+Plain `codestory-cli index` builds the core SQLite code index only. It can make
+local navigation usable, but it does not generate sidecar artifacts or prove
+packet/search readiness.
+
+Run the full sidecar path for the target workspace:
 
 ```sh
-node scripts/setup-retrieval-env.mjs
-node scripts/setup-retrieval-env.mjs --check-only
-node scripts/setup-retrieval-env.mjs --skip-compose
-node scripts/setup-retrieval-env.mjs --with-holdout-clone
+cargo run -p codestory-cli -- index --project <repo> --refresh full
+cargo run -p codestory-cli -- retrieval index --project <repo> --refresh full
+cargo run -p codestory-cli -- retrieval status --project <repo> --format json
 ```
 
-| Wrapper flag | Purpose |
-|------|---------|
-| `--check-only` | Prerequisites report only; exit 1 if required tools missing |
-| `--skip-compose` | Passed to bootstrap |
-| `--skip-build` | Skip `cargo build` when the wrapper invokes bootstrap directly |
-| `--with-holdout-clone` | Also run `scripts/fetch-holdout-repos.mjs` (large git clones under `target/`) |
+The proof is the final status JSON:
 
-When `--fetch-embed-model` is present, the wrapper downloads
-`bge-base-en-v1.5.Q8_0.gguf` to a process-scoped temporary file, verifies the
-exact size (`117974304` bytes) and SHA-256
-(`ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`), and only
-then renames it into `CODESTORY_EMBED_MODEL_DIR` or `target/retrieval-models`.
-Existing model files must pass the same verification. Configured fallback URLs
-are mirrors only because the same checksum gates every accepted artifact.
+- `retrieval_mode` is exactly `"full"`.
+- `capabilities.lexical`, `capabilities.semantic`, and `capabilities.graph`
+  match the active manifest policy.
+- `manifest_contract` is present and matches the current source root, input
+  hash, generation, schema version, graph hash, symbol-doc count, dense-anchor
+  count, and lane provenance.
 
-**Direct CLI** (equivalent to alias):
+Under `graph_first_v1`, a generation can be full with zero dense anchors. In
+that case Qdrant is reported as policy-skipped instead of probing a missing
+collection. That is still full mode only when Zoekt, SCIP, and the manifest
+contract are complete.
 
-```sh
-cargo run -p codestory-cli -- retrieval bootstrap --project .
-```
+### Non-full status actions
 
-Compose file: [`docker/retrieval-compose.yml`](../../docker/retrieval-compose.yml). Env template:
-[`docker/retrieval.env.example`](../../docker/retrieval.env.example).
+Non-`full` modes are diagnostic only. Product packet/search paths must fail
+closed and must not claim sidecar-backed evidence.
 
----
+| Status or condition | Meaning | Operator action |
+|---------------------|---------|-----------------|
+| `retrieval_manifest_missing` | Sidecars may be running, but no finalized manifest proves this workspace | Run `retrieval index --project <repo> --refresh full`, then rerun status |
+| `unavailable` or Zoekt down | Lexical sidecar is unavailable | Free port `6070` or fix Zoekt, rerun bootstrap, then rerun index/status |
+| `no_semantic`, `lexical_only`, or Qdrant down when dense anchors are expected | Semantic sidecar is unavailable or stale | Fix Qdrant/model/backend, rerun bootstrap and retrieval index, then rerun status |
+| `no_scip` | Graph artifacts are missing or stale | Rerun retrieval index; inspect SCIP artifact paths if it repeats |
+| Obsolete, stale, or partial manifest | Source, schema, graph, symbol-doc, dense-anchor, or backend contract drifted | Rerun `retrieval index --project <repo> --refresh full` |
+| `full` with dense anchors `0` | Valid graph-first policy skip | No Qdrant repair needed; verify Zoekt, SCIP, and manifest contract fields |
 
-## Version pin policy
+Traces must include `retrieval_mode` and `degraded_reason`. A non-`full` mode is
+not an answer-quality claim and not a product packet/search success.
+
+### Cleanup and reset
+
+Generated sidecar artifacts are disposable local cache state. To recover from a
+bad setup:
+
+1. Stop the relevant Docker/sidecar services.
+2. Move the affected CodeStory-owned Qdrant, Zoekt, or SCIP cache directory
+   aside under the cache root.
+3. Rerun `retrieval bootstrap`.
+4. Rerun `retrieval index --project <repo> --refresh full`.
+5. Delete the backup only after status reports the expected mode.
+
+`retrieval down` clears the sidecar state file only. Stop Docker/Compose
+separately if containers must be removed.
+
+Default Windows cache locations:
+
+| Service | Default port | Data dir |
+|---------|--------------|----------|
+| Zoekt web/search | `6070` | `%LOCALAPPDATA%\codestory\cache\zoekt\` |
+| Qdrant HTTP | `6333` | `%LOCALAPPDATA%\codestory\cache\qdrant\` |
+| Qdrant gRPC | `6334` | `%LOCALAPPDATA%\codestory\cache\qdrant\` |
+| SCIP artifacts | n/a | `%LOCALAPPDATA%\codestory\cache\scip\<sidecar-generation>\` |
+| Sidecar state | n/a | `%LOCALAPPDATA%\codestory\cache\retrieval-sidecars.json` |
+
+Downloaded model artifacts under `CODESTORY_EMBED_MODEL_DIR` or
+`target/retrieval-models` are accepted only after pinned size and SHA-256
+verification by the setup wrapper. Remove that model directory to uninstall the
+downloaded GGUF. Managed ONNX assets from `setup embeddings` are separate and do
+not substitute for llama.cpp sidecar retrieval.
+
+## Operator troubleshooting
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| `retrieval up` port in use | Stale process or container | Run `retrieval down`; inspect `docker ps`, Task Manager, or `ps`; free the port |
+| Zoekt unhealthy or unreachable | Server not started or shard missing | Start Zoekt on `6070`, rerun retrieval index |
+| Qdrant unhealthy | Wrong image tag, stale collection, volume permissions, or model/backend mismatch | Rerun bootstrap; if repeated, move the Qdrant cache aside and rebuild |
+| Qdrant unavailable while dense-anchor count is `0` | Expected graph-first policy skip | Verify Zoekt, SCIP, and manifest contract fields |
+| SCIP `scip_unavailable` | Graph artifacts missing | Rerun retrieval index and inspect the SCIP cache path |
+| Smoke latency is high | Cold cache or oversized fixture | Retry once; then inspect tier envelope evidence |
+
+## Maintainer internals
+
+Operators should not need this section for basic recovery. Use it when changing
+sidecar implementation, CI policy, retention behavior, or promotion gates.
+
+### Version pins
 
 | Dependency | Pin policy | Pinned version | Notes |
 |------------|------------|----------------|-------|
-| Zoekt real | `COMPOSE_PROFILES=real` | `zoekt-20250506123554` | `sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4` + lexical shards |
+| Zoekt real | `COMPOSE_PROFILES=real` | `zoekt-20250506123554` | `sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4` plus lexical shards |
 | Qdrant | Fixed container image tag | `qdrant/qdrant:v1.12.5` | HTTP `6333`, gRPC `6334` |
 | SCIP | CodeStory graph artifact emitter | `graph-<hash>` | Generated local graph artifacts under the sidecar generation |
 
-Update this table when production Zoekt/SCIP toolchains are wired. CI `retrieval-sidecar-smoke` must use the
-same pins as local dev.
+CI `retrieval-sidecar-smoke` should use the same pins as local development.
 
----
+### Manifest and generation contract
 
-## Ports and data directories
+Project id is a stable FNV-1a hex hash of the canonical repo root, matching CLI
+cache hashing. Sidecar artifacts are content-addressed by:
 
-| Service | Default port | Data dir (Windows) |
-|---------|--------------|---------------------|
-| Zoekt web/search | `6070` | `%LOCALAPPDATA%\codestory\cache\zoekt\` |
-| Qdrant HTTP | `6333` | `%LOCALAPPDATA%\codestory\cache\qdrant\` |
-| Qdrant gRPC | `6334` | same |
-| SCIP artifacts | n/a (files) | `%LOCALAPPDATA%\codestory\cache\scip\<sidecar-generation>\` |
-| Sidecar state | n/a | `%LOCALAPPDATA%\codestory\cache\retrieval-sidecars.json` |
-
-Override ports with `CODESTORY_ZOEKT_PORT`, `CODESTORY_QDRANT_HTTP_PORT`, `CODESTORY_QDRANT_GRPC_PORT`.
-
-Project id is a stable FNV-1a hex hash of the canonical repo root (same scheme as CLI cache hashing).
-Sidecar artifacts are content-addressed by `sidecar_generation = <project-id>-<input-hash-prefix>`.
-The hash covers local source lexical input, generated `symbol_search_doc` virtual docs,
-component-report virtual docs, dense-anchor rows, semantic file roles, embedding
-backend/dim, semantic policy version, dense reason counts, and sidecar schema version.
-Re-running `retrieval index` with unchanged inputs validates
-the live generation and reuses it instead of rewriting Zoekt, Qdrant, or SCIP.
-
-`retrieval status` and `retrieval query` fail closed when the manifest is obsolete or stale. A valid
-manifest must include the current sidecar schema version, input hash, derived generation id, derived
-Qdrant collection, matching symbol-doc count, matching dense-anchor count, semantic policy version,
-graph artifact hash, and dense reason counts. If the SQLite graph projection, symbol docs, dense-anchor
-contract, or policy version changes after the manifest is written, rerun `retrieval index`; runtime paths
-will not infer or reuse bare project-id sidecars.
-`retrieval index --refresh auto` repairs stale stored symbol-doc or dense-anchor contracts by retrying once with a
-full refresh when finalization detects that the manifest would be unavailable immediately. Explicit
-`--refresh none` and failed explicit refreshes still fail closed instead of serving degraded sidecars.
-
-Confirm bindings with:
-
-```sh
-./target/release/codestory-cli retrieval status --project .
+```text
+sidecar_generation = <project-id>-<input-hash-prefix>
 ```
 
-## Local trust boundaries and cleanup
+The input hash covers local source lexical input, generated `symbol_search_doc`
+virtual docs, component-report virtual docs, dense-anchor rows, semantic file
+roles, embedding backend and dimension, semantic policy version, dense reason
+counts, and sidecar schema version.
 
-`retrieval bootstrap` is a local mutating setup command: it may start Compose,
-write `retrieval-sidecars.json`, create sidecar cache dirs, and repair/prune
-unprotected `codestory_*` Qdrant collections. Use
-`node scripts/setup-retrieval-env.mjs --check-only` for a no-change prerequisite
-check; there is no `retrieval bootstrap --dry-run` contract. `retrieval down`
-only clears the sidecar state file; stop Docker/Compose separately if containers
-must be removed.
+`retrieval status` and `retrieval query` fail closed when the manifest is
+obsolete or stale. Runtime paths must not infer or reuse bare project-id
+sidecars. `retrieval index --refresh auto` may repair stale stored symbol-doc or
+dense-anchor contracts by retrying once with a full refresh when finalization
+detects the manifest would be unavailable immediately. Explicit `--refresh none`
+and failed explicit refreshes still fail closed.
 
-Generated sidecar artifacts are disposable local cache state. To restore from a
-bad sidecar setup, stop sidecars, move the affected Qdrant, Zoekt, or SCIP cache
-dir aside under the CodeStory cache root, rebuild with `retrieval bootstrap` and
-`retrieval index`, and delete the backup only after `retrieval status --format
-json` reports the expected mode. To uninstall sidecar caches, remove the
-CodeStory-owned Qdrant, Zoekt, SCIP, and `retrieval-sidecars.json` paths listed
-above after the services are stopped.
-
-Downloaded model artifacts are local trust boundaries. The GGUF file under
-`CODESTORY_EMBED_MODEL_DIR` or `target/retrieval-models` is accepted only after
-size and SHA-256 verification; uninstall it by deleting that model directory.
-Managed ONNX assets installed by `setup embeddings` live under the
-`managed-embeddings` cache root; use `setup embeddings --dry-run --format json`
-to inspect the plan and remove that directory to uninstall them.
-
-General sidecar artifact import/export is a non-goal until a dedicated command
-exists. Existing reuse is limited to health-probed generated sidecars for the
-current manifest. `manifest_contract` proves sidecar readiness and freshness for
-the local source/input hash; it does not prove answer quality or agent
-usefulness without packet/drill evidence.
-
----
-
-## CLI workflow
-
-### Bootstrap (recommended: Compose + cache dirs + wait)
-
-```sh
-cargo build --release -p codestory-cli
-./target/release/codestory-cli retrieval bootstrap --project .
-```
-
-Starts `docker/retrieval-compose.yml` when Docker is available (`qdrant/qdrant:v1.12.5`, Zoekt
-webserver on `6070`, and llama.cpp embeddings on `8080`), writes
-`retrieval-sidecars.json`, and waits for Zoekt, Qdrant, and llama.cpp embedding HTTP probes.
-Bootstrap removes stale pre-mandatory `codestory-zoekt-stub` containers before starting the
-real sidecars. It discovers the embed model directory from `CODESTORY_EMBED_MODEL_DIR`,
-`target/retrieval-models`, or `models/gguf/bge-base-en-v1.5` when the GGUF file is present.
-The embed service uses the measured local request geometry (`-np 6`, `-b 1024`, `-ub 1024`).
-Qdrant document vectors are copied from the already-managed local `llm_symbol_doc` dense-anchor
-table when the stored embedding contract is the product BGE base profile
-(`bge-base-en-v1.5`, 768 dimensions, ONNX or llama.cpp backend). Under `graph_first_v1`, most code
-symbols live only in `symbol_search_doc` and Zoekt; Qdrant contains selected dense anchors such as
-entrypoints, public APIs, documented nontrivial symbols, central graph nodes, component reports, and
-unstructured docs. The llama.cpp sidecar remains mandatory for query embeddings and live semantic
-smoke checks when dense anchors exist, but cold sidecar indexing must not re-embed every code symbol
-just to populate Qdrant.
-Qdrant query-time search uses the current Query API
-`POST /collections/{collection}/points/query` and requires `result.points[]` in the response;
-older search response shapes are treated as contract drift. Exact symbol queries are served from
-exact sidecar evidence first: once SCIP or lexical stages produce an exact symbol anchor, semantic
-and graph expansion lanes are skipped for that query instead of letting broad semantic evidence
-displace the exact hit.
-
-Before Compose starts, bootstrap repairs Qdrant storage:
-
-1. **Protection scan** — builds a protected set from:
-   - every `codestory.db` under the default user cache root (hashed subdirs),
-   - the active `--cache-dir` tree when it differs from the default root (flat `codestory.db` or hashed subdirs),
-   - the active project `storage_path` when not already scanned.
-   Only manifest-recorded generated collections are protected; bare project-id collections are obsolete diagnostics and may be pruned.
-   Unreadable cache roots or DBs are recorded as `storage_repair.scan_errors` in bootstrap output; repair continues with partial protection (bootstrap does **not** abort solely because a cache tree could not be read).
-
-2. **Offline cleanup (Qdrant unreachable only)** — when the Qdrant HTTP probe fails, invalid `collections/codestory_*` dirs without Qdrant config are removed and obsolete in-collection stub markers are migrated to `codestory-stub-markers/`. When Qdrant is reachable, these on-disk steps are skipped to avoid races with a live server. Non-`codestory_*` collection dirs are never deleted by this step.
-
-3. **Retention (fail-closed on scan errors)** — excess `codestory_*` collections beyond the cap (64) may be pruned among **unprotected** collections only, ranked by manifest `built_at_epoch_ms` when known, else directory mtime. When every collection is protected but count exceeds the cap, bootstrap sets `overflow_protected=true` and prunes nothing. When `storage_repair.scan_errors` is non-empty, **all** retention deletes are skipped (`pruned_collections=0`) and `prune_suppressed_reason` is set to `protection_scan_error` unless `CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR=1` (default off).
-
-While Qdrant is reachable, pruning uses HTTP `DELETE /collections/{name}`; when offline, stale collection dirs are removed on disk.
-
-### Start sidecars (data dirs + state file only)
-
-```sh
-./target/release/codestory-cli retrieval up
-```
-
-Does **not** start Docker. Use `retrieval bootstrap` or the setup script for automated Compose.
-
-### Health check
-
-```sh
-./target/release/codestory-cli retrieval status --project .
-```
-
-JSON includes per-component `status`, `latency_ms`, `detail`, `capabilities` flags
-(`lexical`, `semantic`, `graph`), and top-level `retrieval_mode`
-(`full`, `no_scip`, `no_semantic`, `lexical_only`, `unavailable`). Only `full`
-is allowed to serve agent-facing retrieval.
-
-| Component | Healthy when |
-|-----------|--------------|
-| zoekt | HTTP reachable on `6070`, real shard dir (no `.zoekt-stub` marker) |
-| qdrant | when manifest dense-anchor count is >0: collection exists, no stub marker under `{qdrant_data_dir}/codestory-stub-markers/{collection}.qdrant-stub` (obsolete `collections/{collection}/.qdrant-stub` also counts as stubbed), reported point count is at least the manifest dense projection count, and semantic smoke search returns repo-relative paths; when dense-anchor count is 0: reported healthy/semantic with an explicit policy-skipped detail and no collection probe |
-| scip | `symbols.index.json`, `index.scip`, and non-empty `revision.txt` exist under the manifest generation, with no `index.scip.stub` |
-
-### Mandatory sidecars
-
-The default `docker/retrieval-compose.yml` stack starts the required product sidecars directly.
-Historical compose-profile overrides and hash-vector modes are rejected by product bootstrap/index
-paths. Stubbed, hash-vector, or partial sidecars report a non-`full` mode and fail closed for agent-facing packet/search
-paths. Sidecar-primary packet runs require a project-scoped lexical shard, live llama.cpp
-semantic state, and SCIP graph artifacts. `CODESTORY_RETRIEVAL=0` is unsupported.
-Managed `setup embeddings` output is not a substitute for this lane: it may
-install local semantic assets, but it does not start llama.cpp, build the
-retrieval manifest, or make `retrieval status` report `full`.
-
-**Shipped component status:**
-
-| Component | Status |
-|-----------|--------|
-| Zoekt | `retrieval index` builds `lexical-index.jsonl` shards for the active sidecar generation; client searches the manifest generation |
-| Qdrant | 768-d bge-base vectors copied from stored local dense anchors are mandatory when dense anchors exist; `semantic=true` only after smoke search succeeds against the manifest collection and manifest records the product embedding backend. If `graph_first_v1` selects zero dense anchors, Qdrant is intentionally skipped and full mode remains valid only with complete graph/lexical artifacts |
-| SCIP | Graph symbols emitted to `symbols.index.json` + `index.scip` under the active sidecar generation from the full SQLite symbol projection |
-
-### Real embeddings (bge-base-en-v1.5 + llama.cpp)
-
-Promotion uses **768-d** vectors. Qdrant document vectors come from stored
-dense anchors with product-compatible vector metadata. Query vectors come from
-the local llama.cpp sidecar so retrieval remains sidecar-backed and can
-smoke-test the live collection. With real vectors enabled, an unset retrieval
-backend means this product llama.cpp contract; explicit ONNX or hash modes are
-diagnostic only and never produce `retrieval_mode=full`.
-
-1. Download GGUF (once): `node scripts/setup-retrieval-env.mjs --fetch-embed-model`
-   verifies the pinned size/SHA-256 before the model is accepted.
-2. Export (see [`docker/retrieval.env.example`](../../docker/retrieval.env.example)):
-   - `CODESTORY_EMBED_MODEL_DIR=<repo>/target/retrieval-models`
-   - `CODESTORY_EMBED_BACKEND=llamacpp` (recommended explicit product mode; unset is also product mode for retrieval commands)
-   - `CODESTORY_EMBED_LLAMACPP_URL=http://127.0.0.1:8080/v1/embeddings`
-3. `./target/release/codestory-cli retrieval bootstrap --project <repo> --format json`
-   starts Qdrant, Zoekt webserver, and `codestory-embed` on `:8080`.
-4. Dim smoke: `curl -s http://127.0.0.1:8080/v1/embeddings -H "Content-Type: application/json" -d "{\"input\":[\"function\"]}"` → embedding length **768**
-5. `retrieval index --project <repo> --refresh full` (manifest records `embedding_backend`, `embedding_dim`, `sidecar_input_hash`, `sidecar_generation`, the generated Qdrant collection, `symbol_doc_count`, `dense_projection_count`, `semantic_policy_version`, `graph_artifact_hash`, and dense reason counts; the input hash includes symbol-doc and dense-anchor metadata plus the embedding contract)
-6. `retrieval status` → `retrieval_mode: full` and `capabilities.semantic=true`
-
-Wrong model dim with `CODESTORY_EMBED_BACKEND=llamacpp` fails loudly (no hash substitution).
-
-### Index project
-
-```sh
-./target/release/codestory-cli retrieval index --project . --refresh auto
-```
-
-Runs workspace index (same as `codestory index`) then persists `retrieval_index_manifest` in
-`codestory.db`. Zoekt, Qdrant, and SCIP are mandatory; missing sidecars or empty sidecar
-artifacts fail the command instead of writing stub markers.
-
-Index finalization writes new generations instead of mutating the manifest generation in place:
+Finalization writes new generations instead of mutating the active generation:
 
 - Zoekt shard: `zoekt/shards/<sidecar-generation>/`
 - Qdrant collection: `codestory_<project-id>_<input-hash-prefix>`
 - SCIP artifacts: `scip/<sidecar-generation>/`
 
-The manifest is updated only after the generated sidecars are emitted. If the manifest hash,
-schema version, symbol-doc count, dense-anchor count, semantic policy version, graph artifact hash,
-dense reason counts, embedding backend/dim, and live health still match, finalization
-returns the existing manifest and skips the rebuild path. This is the intended fast path for
-iterative evidence loops with `--refresh none` after a successful generation build.
+If a previous `retrieval index` emitted artifacts but failed before manifest
+persist, finalization probes the would-be generation before rebuilding. Qdrant
+reuse requires an exact point count at least as large as the current dense-anchor
+count; a one-point or partial collection is rebuilt instead of being blessed by
+semantic smoke alone.
 
-If a previous `retrieval index` attempt emitted generated artifacts but failed before manifest
-persist, finalization probes the would-be generation before rebuilding. Healthy Zoekt shards,
-complete Qdrant collections, and SCIP artifacts are reused independently. Qdrant reuse requires an
-exact point count at least as large as the current dense-anchor count; a one-point or otherwise
-partial collection is rebuilt instead of being blessed by semantic smoke alone. When dense-anchor
-count is zero, Qdrant reuse is skipped explicitly and cannot mask stale graph/lexical artifacts.
+### Bootstrap storage repair
 
-### Stop sidecars (state file only)
+Before Compose starts, bootstrap may repair Qdrant storage:
 
-```sh
-./target/release/codestory-cli retrieval down
+1. Protection scan builds a protected set from default user cache DBs, active
+   `--cache-dir`, and active project storage. Only manifest-recorded generated
+   collections are protected.
+2. Offline cleanup runs only when Qdrant HTTP is unreachable. It removes invalid
+   CodeStory collection dirs and migrates obsolete stub markers.
+3. Retention may prune unprotected `codestory_*` collections beyond the cap
+   (`64`). If scan errors exist, retention deletes are skipped unless
+   `CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR=1`.
+
+Non-`codestory_*` collection dirs are never deleted by this repair path.
+
+### Query and embedding contracts
+
+The default `docker/retrieval-compose.yml` stack starts product sidecars
+directly. Historical compose-profile overrides, hash-vector modes, stubbed
+sidecars, and partial sidecars are diagnostic only and cannot produce
+`retrieval_mode: "full"` for product packet/search evidence.
+
+Qdrant document vectors are copied from managed local `llm_symbol_doc`
+dense-anchor rows when the stored embedding contract is product BGE base profile:
+`bge-base-en-v1.5`, `768` dimensions, ONNX or llama.cpp backend. Query vectors
+come from the local llama.cpp sidecar so retrieval remains sidecar-backed and
+can smoke-test the live collection. Wrong model dimensions fail loudly.
+
+Qdrant query-time search uses:
+
+```text
+POST /collections/{collection}/points/query
 ```
 
-### Standalone Query
+The response must contain `result.points[]`; older response shapes are contract
+drift. Exact symbol queries are served from exact sidecar evidence first: once
+SCIP or lexical stages produce an exact symbol anchor, semantic and graph
+expansion lanes are skipped for that query.
 
-```sh
-./target/release/codestory-cli retrieval query "ExtensionService" --project .
+### CI policy
+
+`retrieval-sidecar-smoke` is a reduced CI contract lane, not the operator repair
+path and not a full sidecar proof. Linux carries generic
+lint/runtime/search/retrieval contract slices. Windows carries the
+manifest-missing bootstrap/status shape only when manually dispatched or when a
+PR has the `ci:windows-smoke` label.
+
+The reduced CI sequence does not start real sidecars, fetch
+`bge-base-en-v1.5.Q8_0.gguf`, build the project manifest required for full mode,
+or prove answer quality. Full-mode gates must start real sidecars, provision the
+GGUF model, index a fixture or target workspace, and verify:
+
+```text
+retrieval_mode == "full"
 ```
 
----
+Live full-mode contracts are ignored or env-gated by default. Run them only
+after dependencies are prepared, with `CODESTORY_STDIO_FULL_RETRIEVAL_TESTS=1`
+or `CODESTORY_RETRIEVAL_EVAL_FULL_TESTS=1` set for the relevant contract lane.
 
-## Preflight smoke contract
+Use CI trigger paths and exact pass criteria from
+[`.github/workflows/retrieval-sidecar-smoke.yml`](../../.github/workflows/retrieval-sidecar-smoke.yml),
+not from this operator runbook.
 
-Use the full sequence locally before index/query changes. The CI job
-`retrieval-sidecar-smoke` keeps default PR feedback on the fast Linux contract
-lane because full index/query on the monorepo can exceed runner budgets and CI
-does not fetch the GGUF embedding model. Linux carries the generic
-lint/runtime/search/retrieval contract slices. Windows keeps the path-sensitive
-manifest-missing bootstrap/status shape, but it runs only on `workflow_dispatch`
-or when a PR has the `ci:windows-smoke` label. Superseded PR runs are canceled
-automatically so a new push does not leave an older smoke run burning runner
-time.
+### Benchmark-only holdouts
 
-**Local full sequence:**
-
-1. `retrieval up` - exit 0
-2. `retrieval status` - JSON with expected shape; non-`full` status is a failure for agent use
-3. `retrieval index --project <fixture>` - manifest row in SQLite only when all sidecars are real
-4. `retrieval query "<smoke query>"` - standalone sidecar query
-5. `retrieval down` - clean shutdown
-
-**CI reduced sequence:**
-
-Linux `linux-contracts`:
-
-1. generalization lint - exit 0
-2. Targeted runtime sidecar and packet contract filters - exit 0:
-   - `cargo test -p codestory-runtime --lib agent::retrieval_primary::tests`
-   - `cargo test -p codestory-runtime --lib agent::packet_search::tests`
-   - `cargo test -p codestory-runtime --lib agent::packet_claim_profiles::tests`
-   - `cargo test -p codestory-runtime --lib search_rejects_natural_language_queries_without_full_sidecars`
-   - `cargo test -p codestory-runtime --lib search_results_ignores_repo_text_hits_without_full_sidecars`
-   - `cargo test -p codestory-runtime --lib repo_text_auto_fallback_is_not_product_search_without_full_sidecars`
-3. `cargo test -p codestory-cli --test stdio_protocol_contracts` - exit 0
-4. `cargo test -p codestory-cli --test search_json_output` - exit 0 for non-live fail-closed search contracts
-5. `cargo test -p codestory-retrieval` - exit 0
-
-Windows `windows-manifest-missing` (manual or `ci:windows-smoke` label):
-
-1. `cargo test -p codestory-cli --test retrieval_bootstrap_contracts` - exit 0;
-   this integration suite runs the clean pre-index bootstrap/status shape and
-   asserts `degraded_reason == "retrieval_manifest_missing"` without reporting
-   `retrieval_mode=full`
-
-The reduced CI sequence is not a full sidecar smoke and it is not a full runtime
-library sweep. It verifies generic runtime/stdio/search/retrieval contract slices
-on Linux. When the optional Windows lane runs, it creates local cache/state
-directories plus verifies manifest-missing status JSON on Windows. It does not start sidecars, fetch
-`bge-base-en-v1.5.Q8_0.gguf`, build the project manifest required for
-`retrieval_mode=full`, or run every `codestory-runtime --lib` test. The included
-`retrieval_bootstrap_contracts` suite builds the CLI through Cargo's
-integration-test path instead of a standalone release build step. The included
-`search_json_output` suite covers non-live fail-closed search behavior; it does
-not claim stdio, CLI, or runtime full-mode success. Full-mode gates must start
-real sidecars, provision the GGUF model, index a fixture or target workspace, and
-verify `retrieval_mode == "full"`. A full runtime library sweep remains a
-promotion/pre-merge lane for broad runtime work:
-
-```sh
-cargo test -p codestory-runtime --lib
-```
-
-The Rust fixture guard for the generalization lint is also a deep/manual lane,
-not a default PR smoke step. Run it when changing the lint itself or its fixture
-coverage:
-
-```sh
-cargo test -p codestory-runtime --test retrieval_generalization_guard
-```
-
-The live full-mode contracts are ignored or env-gated by default and should be
-run explicitly only after those dependencies are prepared: set
-`CODESTORY_STDIO_FULL_RETRIEVAL_TESTS=1` before running stdio full-mode contracts
-with `-- --ignored --nocapture`,
-`cargo test -p codestory-cli --test search_json_output -- --ignored --nocapture search_json_emits_sidecar_primary_results_without_repo_text_fallback`
-and the ignored `retrieval_eval_*` tests with `CODESTORY_RETRIEVAL_EVAL_FULL_TESTS=1`.
-
-**Failure policy:** PRs touching `codestory-retrieval` or sidecar wiring fail CI if smoke fails.
-
-**CI trigger paths:** match
-[`.github/workflows/retrieval-sidecar-smoke.yml`](../../.github/workflows/retrieval-sidecar-smoke.yml)
-`paths:` filters — `crates/codestory-retrieval/**`, `crates/codestory-contracts/**`,
-`crates/codestory-store/Cargo.toml`, `crates/codestory-store/src/**`, `crates/codestory-cli`
-retrieval/stdio sources (`retrieval.rs`, `main.rs`, `args.rs`, `runtime.rs`, `stdio_*.rs`),
-`crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs`,
-`search_json_output.rs`, `stdio_protocol_contracts.rs`, `crates/codestory-runtime/src/**`,
-`crates/codestory-indexer/Cargo.toml`, `crates/codestory-indexer/src/lib.rs`,
-`scripts/lint-retrieval-generalization.mjs`, `scripts/**retrieval**`,
-`docs/ops/retrieval-sidecars.md`, `docs/architecture/retrieval-*.md`,
-`docs/testing/retrieval-architecture.md`, `docker/retrieval-compose.yml`, and the workflow file itself.
-
-**CI pass criteria (`retrieval-sidecar-smoke`):**
-
-1. Linux generalization lint exits 0.
-2. Linux Rust cache restore/save completes or gracefully misses without masking later failures.
-3. Linux targeted runtime sidecar and packet contract filters exit 0.
-4. `cargo test -p codestory-cli --test stdio_protocol_contracts` exits 0.
-5. `cargo test -p codestory-cli --test search_json_output` exits 0 for non-live fail-closed search contracts.
-6. `cargo test -p codestory-retrieval` exits 0.
-7. If the Windows lane is requested, Windows Rust cache restore/save completes or gracefully misses without masking later failures.
-8. If the Windows lane is requested, `cargo test -p codestory-cli --test retrieval_bootstrap_contracts` exits 0, including the bootstrap/status assertion that reports `degraded_reason == "retrieval_manifest_missing"` and non-`full` mode on a clean temp project before indexing.
-
-Both jobs restore a Rust build cache before Cargo steps; a new cache key may
-still pay one cold compile, but later pushes should reuse warmed target and Cargo
-dependency state. Cache restore/save steps are non-blocking, and save runs after
-failed Cargo steps so follow-up pushes do not repeatedly pay the full cold-compile
-cost. The manifest-missing smoke lives in `retrieval_bootstrap_contracts`
-so Cargo builds the CLI through the integration-test path instead of paying for a
-standalone build step before the tests. The production generalization lint stays
-in the generic Linux job; the Rust fixture guard is reserved for lint-rule
-changes or promotion review.
-
-**Holdout prefetch (benchmark harness, not sidecar CLI):**
-
-```sh
-node scripts/codestory-agent-ab-benchmark.mjs \
-  --list --task-suite holdout-retrieval --materialize-repos
-```
-
-Clones land in `target/agent-benchmark/repos/` (gitignored).
-
-## Troubleshooting
-
-| Symptom | Likely cause | Action |
-|---------|--------------|--------|
-| `retrieval up` port in use | stale process | `retrieval down`; check `ps`, Task Manager, or `docker ps` |
-| Zoekt unhealthy, unreachable | server not started | start Zoekt on `6070` and rebuild the project shard |
-| Qdrant unhealthy | wrong image tag / volume permissions | `docker run -p 6333:6333 qdrant/qdrant:v1.12.5` |
-| Qdrant unavailable while manifest dense-anchor count is `0` | expected graph-first policy skip | Verify Zoekt and SCIP are healthy and manifest policy/count/hash fields match; the dense stage will be skipped explicitly |
-| SCIP `scip_unavailable` | graph artifacts missing | fix SCIP emission before using agent-facing retrieval |
-| Smoke > 100ms / 200ms | cold cache or oversized fixture | retry; check tier envelope |
-
----
-
-## Mandatory sidecar modes (operator view)
-
-When a sidecar is down, the sidecar executor selects a non-`full` mode per the
-[mode matrix](../architecture/retrieval-design.md#mode-matrix). Non-`full` modes
-are diagnostic only and fail closed for product packet/search paths.
-
-| Condition | User-visible mode | Action |
-|-----------|-------------------|--------|
-| Zoekt down | `unavailable` | Fix Zoekt; no product query should run |
-| Qdrant down, Zoekt up, dense anchors expected | `no_semantic` or `lexical_only` | Fix Qdrant; no product query should run |
-| Qdrant skipped, Zoekt up, SCIP up, dense anchors `0` | `full` | Valid graph/lexical full mode for the active policy; dense query stage is skipped |
-| SCIP down | `no_scip` | Fix SCIP artifacts; no product query should run |
-
-Traces must include `retrieval_mode` and `degraded_reason`.
-
----
-
-## Environment variables
-
-| Variable | Purpose |
-|----------|---------|
-| `CODESTORY_RETRIEVAL` | unset or `1` uses mandatory sidecar primary when mode is `full`; non-`full` modes fail closed; `0` is unsupported |
-| `CODESTORY_RETRIEVAL_SHADOW` | Historical diagnostic trace switch; unsupported in product benchmarks |
-| `CODESTORY_RETRIEVAL_REAL_EMBEDDINGS` | defaults to `1`; `0` is unsupported for product dense-anchor indexing or packet/search evidence when dense anchors exist |
-| `CODESTORY_EMBED_BACKEND` | unset/default product mode, `llamacpp`, or `llama_cpp` for sidecar query embeddings; explicit `onnx` is non-product for sidecar retrieval and cannot finalize/report full product mode |
-| `CODESTORY_EMBED_LLAMACPP_URL` | local OpenAI-compatible llama.cpp embedding endpoint (default `http://127.0.0.1:8080/v1/embeddings`) |
-| `CODESTORY_EMBED_MODEL_DIR` | Host path to `bge-base-en-v1.5.Q8_0.gguf` for compose `embed` service |
-| `CODESTORY_EMBED_PORT` | llama.cpp server port (default `8080`) |
-| `CODESTORY_RETRIEVAL_COMPOSE_PROFILE` | `real` by default; every other value is unsupported for product bootstrap |
-| `CODESTORY_ZOEKT_ENABLED` | on by default; `0` is unsupported for product retrieval |
-| `CODESTORY_QDRANT_ENABLED` | on by default; `0` is unsupported for product retrieval |
-| `CODESTORY_ZOEKT_PORT` | Zoekt HTTP port (default `6070`) |
-| `CODESTORY_QDRANT_HTTP_PORT` | Qdrant HTTP (default `6333`) |
-| `CODESTORY_QDRANT_GRPC_PORT` | Qdrant gRPC (default `6334`) |
-| `CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR` | `1` allows retention deletes despite protection-scan errors (default off; fail-closed prune) |
-| `CODESTORY_EVAL_PROBES` | Test-only benchmark probe catalog switch; production runtime ignores this env var |
-
-Keep endpoint and cache-root settings out of project `.codestory.toml` files.
-Project config may describe indexing and semantic-document preferences, but
-`cache_dir`, `summary_endpoint`, `summary_model`, and embedding endpoint fields
-are trust boundaries. Use trusted user config, explicit CLI flags such as
-`--cache-dir`, or environment variables such as `CODESTORY_SUMMARY_ENDPOINT`,
-`CODESTORY_SUMMARY_MODEL`, and `CODESTORY_EMBED_LLAMACPP_URL`. Set
-`CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG=1` only when intentionally allowing a
-project file to provide network endpoints for that run.
-
----
+Holdout repository prefetch belongs to benchmark lanes, not sidecar recovery.
+Do not ask operators to materialize holdout repos while repairing local
+packet/search sidecars.
 
 ## Related docs
 
-- [`retrieval-architecture.md`](../testing/retrieval-architecture.md) — proof tiers, promotion checklist, and north-star SLOs
-- [`retrieval-design.md`](../architecture/retrieval-design.md) — mode definitions, cost envelopes, and promotion guards
+- [`retrieval-architecture.md`](../testing/retrieval-architecture.md) - proof tiers, promotion checklist, and north-star SLOs
+- [`retrieval-design.md`](../architecture/retrieval-design.md) - mode definitions, cost envelopes, and promotion guards
+- [`docker/retrieval-compose.yml`](../../docker/retrieval-compose.yml) - local sidecar compose stack
+- [`docker/retrieval.env.example`](../../docker/retrieval.env.example) - environment template


### PR DESCRIPTION
## Context

Closes #326
Refs #324
Refs #38

`docs/ops/retrieval-sidecars.md` mixed operator recovery, sidecar implementation details, CI policy, Qdrant retention notes, and benchmark holdout prefetch in one long runbook. Operators needed the repair path and `retrieval_mode=full` proof before maintainer internals.

## What Changed

- Reframed the runbook around an operator-first repair path: prerequisites, minimum env vars, bootstrap, index/status proof, non-`full` actions, and cleanup.
- Kept degraded-mode and answer-quality non-claims explicit near the top and in the non-`full` table.
- Demoted version pins, manifest/generation details, Qdrant repair internals, CI policy, and benchmark holdout notes into a clearly labeled maintainer internals section.
- Removed the long CI trigger/pass-criteria listing from the operator flow and points maintainers to the workflow file for exact current policy.

## How To Review

1. Read the first half as an operator repairing degraded packet/search sidecars.
2. Confirm the `retrieval_mode == "full"` proof path is easy to find before internals.
3. Read the lower maintainer section and confirm CI/Qdrant/generation details are no longer blocking basic recovery.

## Verification

- Read `docs/ops/retrieval-sidecars.md` back from operator repair and maintainer internals perspectives.
- `git diff --check` exited 0.

No Cargo, indexing, sidecars, packet/search, benchmarks, or generated artifacts were run for this docs-only lane.

## Risk

Docs-only restructure. Main risk is that a maintainer may want some removed CI detail preserved elsewhere, but the durable source for exact trigger/pass criteria is the workflow file.