### PR TITLE
[codex] reorder contributor verification lanes

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -1,6 +1,51 @@
 # Contributor Setup
 
-## First Commands
+## Choose The Verification Lane First
+
+Before running Cargo or setting up sidecars, answer two questions:
+
+1. Which crate owns the behavior?
+2. What is the smallest proof that covers the change?
+
+Use this lane picker from the repo root:
+
+| Change | Start here | Escalate when |
+| --- | --- | --- |
+| Docs only, including `README.md` or `docs/**` | Read the changed pages back, then run `git diff --check`. | The doc depends on new code behavior, command output, generated docs, or release evidence. |
+| CLI args, help, or output envelopes | `cargo test -p codestory-cli` | The CLI path crosses runtime behavior; use the runtime-backed CLI lane in the testing matrix. |
+| Runtime, search, grounding, or orchestration | `cargo test -p codestory-runtime` and `cargo test -p codestory-runtime --test retrieval_eval` | Agent-facing `packet` or `search` readiness is claimed; use the full sidecar proof path below. |
+| Indexer, graph, language, or semantic resolution | The full indexer fidelity suites in the testing matrix. | Language-level packet quality is claimed; use the manifest-backed packet-runtime lane. |
+| Store, snapshots, trails, bookmarks, or search docs | `cargo test -p codestory-store` | The change affects repo-scale semantic or cold-start behavior. |
+| Release or version bump | The release scripts in the testing matrix. | Packet/search readiness is part of the release claim; use the sidecar evidence tiers. |
+
+## Crate Ownership
+
+Before changing code, decide where the change belongs:
+
+```mermaid
+flowchart TD
+    start["Before changing code"] --> owner{"Which crate owns the behavior?"}
+    owner -->|"Manifest or discovery"| workspace["codestory-workspace"]
+    owner -->|"Parse, extract, or resolution"| indexer["codestory-indexer"]
+    owner -->|"SQLite, snapshots, trails, bookmarks, or search docs"| store["codestory-store"]
+    owner -->|"Search, grounding, orchestration, or agent flows"| runtime["codestory-runtime"]
+    owner -->|"Args or output rendering"| cli["codestory-cli"]
+    owner -->|"Shared DTOs, graph, or events"| contracts["codestory-contracts"]
+    start --> truth{"Source of truth or derived read model?"}
+    truth -->|"Source of truth"| first["Change the owning crate first"]
+    truth -->|"Derived or read model"| follow["Verify store and runtime boundaries before patching projections"]
+```
+
+Use this mapping:
+
+- manifest or discovery issue: `codestory-workspace`
+- parse, extract, or resolution issue: `codestory-indexer`
+- SQLite, snapshots, trails, bookmarks, or search docs: `codestory-store`
+- search ranking, grounding, orchestration, or agent flows: `codestory-runtime`
+- args or output rendering: `codestory-cli`
+- shared DTOs or graph/event types: `codestory-contracts`
+
+## Basic Cargo Lane
 
 Run these from the repo root:
 
@@ -12,12 +57,15 @@ cargo test -p codestory-cli
 
 Run them serially. This workspace shares Cargo build locks.
 
-If you touch graph extraction or semantic resolution, plan to run the fidelity suites from the testing matrix before you finish.
-If you touch runtime search, grounding, or repo-scale indexing behavior, check the testing matrix before you finish so you know whether the repo-scale runtime gate is required or can be deferred on a memory-constrained machine.
+Use this lane after the picker says broad Rust checks are useful. If you touch
+graph extraction, semantic resolution, runtime search, grounding, or repo-scale
+indexing behavior, check the testing matrix before you finish so the heavy lane
+is explicit instead of accidental.
 
-## First CLI Loop
+## Local CLI Loop
 
-After the basic cargo checks, verify the shipped CLI flow with the built binary instead of `cargo run`:
+When CLI behavior is in scope, verify the shipped flow with the built binary
+instead of `cargo run`:
 
 ```sh
 cargo build --release -p codestory-cli
@@ -38,7 +86,8 @@ below before treating those commands as product-quality proof.
 
 ## Hybrid Retrieval Setup
 
-Use the managed full-sidecar path before debugging ranking quality:
+Use this lane only for packet/search, retrieval, ranking-quality, or sidecar
+work. Prepare the managed full-sidecar path before debugging ranking quality:
 
 - managed real-model setup: `node scripts/setup-retrieval-env.mjs --fetch-embed-model`, then `codestory-cli retrieval bootstrap --project .`
 - default symbol-doc scope: durable symbols only; set `CODESTORY_SEMANTIC_DOC_SCOPE=all` when you intentionally need the broad all-symbol diagnostic symbol-doc set
@@ -72,36 +121,6 @@ Build a mental model in this order before editing the biggest implementation pat
 5. the subsystem page for the owning crate
 6. [Debugging guide](debugging.md)
 7. [Testing matrix](testing-matrix.md)
-
-## Mental Model
-
-Before changing code, answer these two questions:
-
-1. Which crate owns the behavior?
-2. Is the change source-of-truth logic or a derived/read-model concern?
-
-```mermaid
-flowchart TD
-    start["Before changing code"] --> owner{"Which crate owns the behavior?"}
-    owner -->|"Manifest or discovery"| workspace["codestory-workspace"]
-    owner -->|"Parse, extract, or resolution"| indexer["codestory-indexer"]
-    owner -->|"SQLite, snapshots, trails, bookmarks, or search docs"| store["codestory-store"]
-    owner -->|"Search, grounding, orchestration, or agent flows"| runtime["codestory-runtime"]
-    owner -->|"Args or output rendering"| cli["codestory-cli"]
-    owner -->|"Shared DTOs, graph, or events"| contracts["codestory-contracts"]
-    start --> truth{"Source of truth or derived read model?"}
-    truth -->|"Source of truth"| first["Change the owning crate first"]
-    truth -->|"Derived or read model"| follow["Verify store and runtime boundaries before patching projections"]
-```
-
-Use this mapping:
-
-- manifest or discovery issue: `codestory-workspace`
-- parse, extract, or resolution issue: `codestory-indexer`
-- SQLite, snapshots, trails, bookmarks, or search docs: `codestory-store`
-- search ranking, grounding, orchestration, or agent flows: `codestory-runtime`
-- args or output rendering: `codestory-cli`
-- shared DTOs or graph/event types: `codestory-contracts`
 
 ## Rustdoc Baseline
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -1,8 +1,9 @@
 # Testing Matrix
 
-Run Cargo verifications serially in this repo. The workspace shares build locks.
-Examples use POSIX shell syntax. On Windows PowerShell, use environment
-assignments such as `$env:NAME = "value"`.
+Choose the verification lane before running broad checks. Run Cargo
+verifications serially in this repo when the lane needs them; the workspace
+shares build locks. Examples use POSIX shell syntax. On Windows PowerShell, use
+environment assignments such as `$env:NAME = "value"`.
 
 ```mermaid
 flowchart TD
@@ -33,7 +34,8 @@ cargo test
 cargo clippy --all-targets -- -D warnings
 ```
 
-These are the default checks for any contributor change.
+These are the default broad checks for code changes after the lane picker says
+workspace-wide proof is useful.
 
 ## Release And Version Bumps
 


### PR DESCRIPTION
## Context

Closes #327
Refs #324
Refs #38

`docs/contributors/getting-started.md` previously started with Cargo and release-build loops before a contributor knew whether they were in a docs-only, CLI, runtime/search, indexer, sidecar, or release lane. The testing matrix already had a docs-only fast path, so the two pages could steer maintainers differently.

## What Changed

- Moved contributor setup to start with a verification lane picker.
- Moved the crate ownership mental model near the top so contributors can route changes before expensive commands.
- Made the basic Cargo, local CLI, and hybrid retrieval setup sections conditional on the chosen lane.
- Updated the testing matrix intro and whole-workspace wording so it agrees that lane selection comes before broad checks.

## How To Review

1. Read `docs/contributors/getting-started.md` from the top as a docs-only maintainer and confirm `git diff --check` is reachable before Cargo, release builds, or sidecar setup.
2. Read the same page as a runtime/search contributor and confirm agent-facing packet/search readiness still points to the full sidecar path and `retrieval_mode=full`.
3. Check `docs/contributors/testing-matrix.md` for agreement with the same first verification decision.

## Verification

- Read `docs/contributors/getting-started.md` back from docs-only and runtime/search contributor perspectives.
- Read the changed top of `docs/contributors/testing-matrix.md` back for contradiction with the docs-only fast path.
- `git diff --check`

## Risk

This is docs-only guidance. I did not run Cargo, indexing, sidecars, benchmarks, generated docs, CSVs, SVGs, or release ledgers.