### PR TITLE
[codex] Move browser surface gate out of overview

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -89,40 +89,12 @@ Important rules:
 
 ### Browser surface gate
 
-Status: deferred.
-
-`codestory-cli` `explore` and `serve --stdio` remain the current browser
-surfaces. Do not add a new `browse` command, web UI route, or browser-specific UI
-until all of the gates below have current evidence in the repo.
-
-Before starting web UI work:
-
-- Tool, resource, and prompt manifests must be stable under stdio catalog tests.
-- HTTP and stdio browser contracts must stay aligned with the read-only browser
-  service.
-- Warm stdio/browser-loop p50, p95, and p99 timings must be recorded and must
-  meet the active Current Promotion Budget in
-  `docs/testing/codestory-stdio-warm-loop-stats.md`: small-fixture smoke p95
-  stays under the smoke budget, and a current real-repo run meets the Web
-  Cockpit Promotion Budget.
-- Browser stress lanes must pass at the intended scale, and synthetic evidence
-  must not be treated as real-repository promotion proof.
-- `explore` must demonstrate the browser workflow in JSON/Markdown and
-  keyboard-first TUI paths.
-- Screenshot-visible review must be planned before implementation, with one
-  reviewer for the full viewport and one reviewer for the changed surface or
-  acceptance path.
-
-Evidence sources: `crates/codestory-cli/tests/stdio_protocol_contracts.rs`,
-`crates/codestory-cli/tests/http_transport_contracts.rs`,
-`crates/codestory-cli/tests/stdio_warm_loop_stats.rs`,
-`docs/testing/codestory-stdio-warm-loop-stats.md`,
-`docs/testing/codestory-stress-lanes.md`, and
-`crates/codestory-cli/tests/cli_golden_path.rs`.
-
-If the gates are satisfied, start with a written implementation plan that names
-why the new surface is not a duplicate of `explore`, the exact routes or
-commands to add, the screenshot-visible review loop, and the promotion guard path.
+`explore` and `serve --stdio` are the current browser-capable read surfaces.
+The architecture invariant is that browser adapters stay read-only and
+runtime-owned. Any new `browse` command, web UI route, or browser-specific UI
+must preserve those contracts and satisfy the
+[browser surface gate](../testing/codestory-stdio-warm-loop-stats.md#browser-surface-gate)
+before promotion.
 
 ### Layer boundaries
 

--- a/docs/architecture/runtime-execution-path.md
+++ b/docs/architecture/runtime-execution-path.md
@@ -99,11 +99,11 @@ reuses the same runtime calls for `/definition`, `/references`, `/symbols`, and
 stdio MCP-style resources/prompts/tools. `doctor` opens the project summary and
 reports cache/index/retrieval health without mutating state.
 
-`explore` remains the browser surface until the
-[browser surface gate](overview.md#browser-surface-gate) is satisfied. Do not add a
-separate `browse` command, web UI route, or browser-specific UI without
-current manifest, warm-loop, stress-lane, explore, and screenshot-review
-evidence.
+`explore` and `serve --stdio` remain the browser-capable read surfaces until the
+[browser surface gate](../testing/codestory-stdio-warm-loop-stats.md#browser-surface-gate)
+is satisfied. Do not add a separate `browse` command, web UI route, or
+browser-specific UI without current manifest, warm-loop, stress-lane, explore,
+and screenshot-review evidence.
 
 ## Ownership Notes
 

--- a/docs/testing/codestory-stdio-warm-loop-stats.md
+++ b/docs/testing/codestory-stdio-warm-loop-stats.md
@@ -51,6 +51,38 @@ The browser surface gate stays closed until a current real-repo run in this log
 meets the Web UI Promotion Budget, and the stress-lane gate for the target
 scale also passes.
 
+## Browser Surface Gate
+
+`explore` and `serve --stdio` are the current browser-capable read surfaces. Do
+not promote a new `browse` command, web UI route, or browser-specific UI until
+the repo has current evidence for each gate:
+
+- Tool, resource, and prompt manifests are stable under stdio catalog tests.
+- HTTP and stdio browser contracts stay aligned with the read-only browser
+  service.
+- Warm stdio/browser-loop p50, p95, and p99 timings are recorded here: small
+  fixture smoke p95 stays under the Smoke Budget, and a current real-repo run
+  meets the Web UI Promotion Budget.
+- Browser stress lanes pass at the intended scale, and synthetic evidence is not
+  treated as real-repository promotion proof.
+- `explore` demonstrates the browser workflow in JSON/Markdown and
+  keyboard-first TUI paths.
+- Screenshot-visible review is planned before implementation, with one reviewer
+  for the full viewport and one reviewer for the changed surface or acceptance
+  path.
+
+Evidence sources: `crates/codestory-cli/tests/stdio_protocol_contracts.rs`,
+`crates/codestory-cli/tests/http_transport_contracts.rs`,
+`crates/codestory-cli/tests/stdio_warm_loop_stats.rs`,
+`docs/testing/codestory-stdio-warm-loop-stats.md`,
+`docs/testing/codestory-stress-lanes.md`, and
+`crates/codestory-cli/tests/cli_golden_path.rs`.
+
+If the gates are satisfied, start with a written implementation plan that names
+why the new surface is not a duplicate of `explore`, the exact routes or
+commands to add, the screenshot-visible review loop, and the promotion guard
+path.
+
 ## Baseline Payload Sizes
 
 From the 2026-05-06 baseline:


### PR DESCRIPTION
## Context

Closes #328
Refs #324
Refs #38

`docs/architecture/overview.md` carried the full browser-surface promotion checklist, which made the architecture overview read like a stale planning memo. The runtime path also linked directly to that overview anchor.

## What Changed

- Kept a compact `overview.md#browser-surface-gate` replacement that states the stable architecture invariant: `explore` and `serve --stdio` are the current browser-capable read surfaces, and browser adapters must remain runtime-owned and read-only.
- Moved the detailed browser promotion checklist into `docs/testing/codestory-stdio-warm-loop-stats.md`, next to the current smoke and Web UI promotion budgets.
- Updated `docs/architecture/runtime-execution-path.md` so runtime/browser contributors land on the durable testing gate instead of the architecture overview.

## How To Review

- Read `docs/architecture/overview.md#browser-surface-gate` and confirm it is now an architecture invariant, not the full process checklist.
- Follow the runtime execution path link to `docs/testing/codestory-stdio-warm-loop-stats.md#browser-surface-gate` and confirm the manifest, warm-loop, stress-lane, explore, and screenshot-review evidence remains discoverable.
- Confirm the current browser surfaces and invariant are clear: `explore` and `serve --stdio`; new surfaces must preserve runtime/read-only contracts.

## Verification

- Read changed docs back from architecture-maintainer and runtime/browser contributor perspectives.
- `rg -n "overview\.md#browser-surface-gate|#browser-surface-gate|Browser surface gate|explore|serve --stdio" docs\architecture\overview.md docs\architecture\runtime-execution-path.md docs\testing\codestory-stdio-warm-loop-stats.md`
- `git diff --check`
- No Cargo run; this is a docs-only lane.

## Risk

- External links to `overview.md#browser-surface-gate` still resolve to the compact invariant, but reviewers should use the testing-doc gate for detailed promotion evidence.
