### PR TITLE
[codex] Add docs entry map

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,8 @@ packet/search setup and repair.
 
 ## Docs For Operators And Contributors
 
-- [docs/usage.md](docs/usage.md)
-- [docs/concepts/how-codestory-works.md](docs/concepts/how-codestory-works.md)
-- [docs/architecture/overview.md](docs/architecture/overview.md)
-- [docs/architecture/language-support.md](docs/architecture/language-support.md)
-- [docs/contributors/getting-started.md](docs/contributors/getting-started.md)
-- [docs/contributors/debugging.md](docs/contributors/debugging.md)
-- [docs/contributors/testing-matrix.md](docs/contributors/testing-matrix.md)
+Start with the [docs entry map](docs/README.md) to choose the right durable
+page for setup, repair, architecture, verification, or research evidence.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# CodeStory docs
+
+Start from the job you need to do. CodeStory docs are split by trust boundary:
+operator path, repair path, architecture, verification, and research evidence.
+
+## First stop
+
+| Reader job | Canonical doc | Use it to decide | Trust boundary |
+| --- | --- | --- | --- |
+| Operator using an agent | [Usage](usage.md) | How to install, ground a repo, and keep the plugin-first path straight. | The plugin is the normal path; the CLI is for setup, repair, debugging, and transcripts. |
+| Maintainer debugging readiness | [Retrieval sidecars operations](ops/retrieval-sidecars.md) | How to repair local navigation versus packet/search readiness. | Packet/search is proof-bearing only when `retrieval_mode` is `full`. |
+| Contributor changing code | [Contributor setup](contributors/getting-started.md) | Which crate owns the change and which verification lane is enough. | Pick the smallest lane that covers the behavior; run Cargo checks serially. |
+| Reviewer verifying claims | [Testing matrix](contributors/testing-matrix.md) | Which command or evidence tier supports a PR claim. | Logs and benchmark pages are evidence records or playbooks, not product promises by themselves. |
+| Researcher comparing retrieval choices | [Research handbook](research.md) | Which retrieval, embedding, or sidecar decision is current enough to build on. | Research rows must stay tied to the comparison matrix and proof tier that produced them. |
+
+## Common paths
+
+| Question | Start here | Then read |
+| --- | --- | --- |
+| Where do I start as a first-time user? | [README - Use It With An Agent](../README.md#use-it-with-an-agent) | [Usage - Operator Journey](usage.md#operator-journey) |
+| How do I repair readiness? | [Usage - Stale Local Cache](usage.md#stale-local-cache) | [Retrieval sidecars operations - Operator repair path](ops/retrieval-sidecars.md#operator-repair-path) |
+| How does CodeStory work internally? | [How CodeStory Works](concepts/how-codestory-works.md) | [Architecture overview](architecture/overview.md) and [runtime execution path](architecture/runtime-execution-path.md) |
+| Which docs define sidecar architecture? | [Retrieval design](architecture/retrieval-design.md) | [Retrieval architecture and promotion guide](testing/retrieval-architecture.md) |
+| Which language support claims are safe? | [Language support](architecture/language-support.md) | [Testing matrix - Indexer And Graph Fidelity](contributors/testing-matrix.md#indexer-and-graph-fidelity) |
+| Which test proves my docs-only change? | [Testing matrix - Docs-Only Fast Path](contributors/testing-matrix.md#docs-only-fast-path) | [Contributor setup - Choose The Verification Lane First](contributors/getting-started.md#choose-the-verification-lane-first) |
+| Where are timing and benchmark records? | [E2E stats log](testing/codestory-e2e-stats-log.md) | [Performance review playbook](testing/performance-review-playbook.md) and [embedding backend benchmarks](testing/embedding-backend-benchmarks.md) |
+
+## Evidence surfaces
+
+| Surface | Treat as | Do not treat as |
+| --- | --- | --- |
+| [codestory-e2e-stats-log.md](testing/codestory-e2e-stats-log.md) | Rolling release-style timing and readiness record. | A promise that current packet/search is ready on your machine. |
+| [retrieval-architecture.md](testing/retrieval-architecture.md) | Promotion gates and proof tiers for sidecar packet/search work. | A substitute for fresh benchmark or drill evidence. |
+| [embedding-backend-benchmarks.md](testing/embedding-backend-benchmarks.md) | Comparison matrix for embedding and retrieval experiments. | A shortcut around rerunning the relevant quality gates. |
+| [performance-review-playbook.md](testing/performance-review-playbook.md) | Review playbook for performance claims. | A generated ledger or release artifact. |
+
+## Maintenance rule
+
+When a doc repeats an entry path, keep the durable version here or in the owning
+task doc, not both. Use this page for routing. Use the target page for commands,
+contracts, and recovery details.


### PR DESCRIPTION
## Context

Closes #337
Refs #38

The docs tree had useful operator, readiness, architecture, verification, and research pages, but no durable front door that told a first-time reader which page to trust for which job. This keeps the rewrite PR-sized and preserves the #335 contract: plugin-first normal path, CLI for setup/repair/debug/transcripts, direct `codestory-cli serve --stdio --refresh none`, non-`full` packet/search as navigation help only, and the marketplace catalog outside this repo.

## What Changed

- Added `docs/README.md` as the docs entry map, organized by reader job: operator, maintainer, contributor, reviewer, and researcher.
- Marked benchmark/evidence surfaces as logs, proof-tier guides, matrices, or playbooks instead of current product promises.
- Replaced the root README's repeated docs list with a single pointer to the docs entry map.

## How To Review

1. Start at `README.md#docs-for-operators-and-contributors` and follow the new docs entry map.
2. Read `docs/README.md` as three readers: first-time operator, readiness maintainer, and evidence reviewer.
3. Confirm each table answers a routing decision rather than adding generic link soup.

## Verification

- `git diff --check`
- Link path spot check for every docs path added to `docs/README.md`.
- Anchor spot check for the explicit added anchors:
  - `../README.md#use-it-with-an-agent`
  - `usage.md#operator-journey`
  - `usage.md#stale-local-cache`
  - `ops/retrieval-sidecars.md#operator-repair-path`
  - `contributors/testing-matrix.md#indexer-and-graph-fidelity`
  - `contributors/testing-matrix.md#docs-only-fast-path`
  - `contributors/getting-started.md#choose-the-verification-lane-first`
- Readback as first-time human operator, maintainer debugging install/readiness, and reviewer checking evidence sufficiency.

## Risk

Docs-only change. No Cargo was run because no runtime, Rust, sidecar, benchmark, release, plugin package, or marketplace files changed. Remaining risk is that this is a spot-check of added links and anchors, not a full markdown link-crawler pass.
