### PR TITLE
[codex] clarify embedding readiness docs

### DIFF
--- a/docs/architecture/subsystems/cli.md
+++ b/docs/architecture/subsystems/cli.md
@@ -87,7 +87,18 @@ rather than the general CLI architecture page.
 
 `context` is target context: DB-first evidence for one concrete target. It resolves that target from `--id`, `--query`, or `--bookmark`, delegates to `codestory-runtime` retrieval orchestration, includes citations and retrieval traces, and always uses DB-first synthesis. It is not a natural-language question-answering surface and is not a replacement for broad `packet`, `search`, or `drill` questions. `--bundle <DIR>` writes Markdown, JSON, and Mermaid artifacts for handoff.
 
-`doctor` is a read-only health report for project path resolution, cache presence, index counts, retrieval state, managed embedding setup, relevant embedding environment variables, and next commands. It should stay diagnostic; it should not mutate caches or fetch model assets. `setup embeddings` is the explicit mutating path for installing pinned ONNX Runtime BGE-base assets in the user cache. Managed setup does not launch or retain an embedding server.
+`doctor` is a read-only health report for project path resolution, cache
+presence, index counts, retrieval state, managed embedding setup, relevant
+embedding environment variables, and next commands. It should stay diagnostic;
+it should not mutate caches or fetch model assets.
+
+`setup embeddings` is the explicit mutating path for installing pinned ONNX
+Runtime BGE-base assets in the user cache. That managed setup path is for local
+semantic diagnostics and compatibility checks. It does not launch or retain an
+embedding server, and it does not prepare product `packet`/`search` retrieval.
+Product retrieval proof starts with `retrieval bootstrap`, then `retrieval index
+--refresh full`, then `retrieval status --format json` reporting
+`retrieval_mode: "full"`.
 
 ## Search And Context Research Boundary
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -79,10 +79,17 @@ cargo build --release -p codestory-cli
 
 On Windows PowerShell, use `.\target\release\codestory-cli.exe`.
 
-Read commands default to `--refresh none`. If a read command says the cache is empty, either run `index --refresh full` first or rerun the read command with an explicit refresh mode.
-The first loop above exercises local navigation only. Agent-facing `packet` and
-`search` evidence require full retrieval sidecars; prepare the sidecar lane
-below before treating those commands as product-quality proof.
+This loop proves the local CLI and managed ONNX diagnostic path are wired, but
+it is not product packet/search sidecar setup. Treat `setup embeddings
+--dry-run` as an asset-plan check only. It should not start an embedding server,
+write a product retrieval manifest, or make agent-facing retrieval evidence
+trustworthy by itself.
+
+Read commands default to `--refresh none`. If a read command says the cache is
+empty, either run `index --refresh full` first or rerun the read command with an
+explicit refresh mode. Agent-facing `packet` and `search` evidence require full
+retrieval sidecars; prepare the sidecar lane below before treating those
+commands as product-quality proof.
 
 ## Hybrid Retrieval Setup
 

--- a/docs/testing/embedding-backend-benchmarks.md
+++ b/docs/testing/embedding-backend-benchmarks.md
@@ -68,7 +68,7 @@ suites.
 | Token-budget narrowing and semantic-scope pruning | tok320 `863128.088009`; no-macros `838267.207245`; no-test-macros `862424.110651` | Lost quality or rank profile | Some rows reduced semantic time but not enough | Discard. Removing documents is not free. |
 | Direct hydration, file-path cache, and reload skipping | Direct hydration `843840.934147`; stable-order hydration `859167.697841`; file-path cache `862471.707786` | Quality or speed regressed | Did not remove enough cache/semantic time | Discard for now. |
 | Background semantic embedding | Buggy packet `949630.846470`; corrected packet `857789.768509` | Corrected packet had lower quality | Corrected speed did not beat the incumbent candidate | Discard. The apparent win was a measurement bug. |
-| Older ONNX rows | Historical only | Older ONNX rows predate the active replacement | Active runtime now carries ONNX directly | Do not use old ONNX evidence for new default decisions. Re-run speed, quality, and cross-repo gates on the active implementation before declaring a benchmark promotion. |
+| Older ONNX rows | Historical only | Older ONNX rows predate the active managed diagnostic path | Managed ONNX now runs in-process, but it is not product sidecar proof | Do not use old ONNX evidence for new default decisions. Re-run speed, quality, sidecar-contract, and cross-repo gates on the active implementation before declaring a benchmark promotion. |
 
 ## What Was Tried
 
@@ -109,9 +109,9 @@ The measured work covered these families:
 - VRAM was not measured on this Windows/Vulkan host because `nvidia-smi` did not
   return memory usage. Peak RAM is sampled working set evidence, not exact max
   RSS.
-- ONNX is now the active managed path. Older ONNX evidence should not drive new
-  choices until the current implementation has fresh speed, quality, and
-  cross-repo rows.
+- ONNX is the active managed diagnostic setup path. Older ONNX evidence should
+  not drive new product retrieval choices until the current implementation has
+  fresh speed, quality, sidecar-contract, and cross-repo rows.
 
 ## How To Use This Matrix
 


### PR DESCRIPTION
## Context
Closes #339
Refs #38

This docs-only slice fixes a stale trust boundary in the contributor/operator docs: managed ONNX setup was easy to read as packet/search readiness, even though current product retrieval proof requires the llama.cpp sidecar path and `retrieval_mode: "full"`.

Source evidence used for the corrected claims:
- `crates/codestory-cli/src/args.rs`: `setup embeddings` help is managed ONNX setup and does not start a server.
- `crates/codestory-cli/src/managed_embeddings.rs`: managed setup installs/probes ONNX assets and skips when llama.cpp/hash env modes are selected.
- `crates/codestory-runtime/src/search/engine.rs`: unset product embedding backend defaults to llama.cpp; explicit ONNX is a separate backend.
- `docs/ops/retrieval-sidecars.md` and `docs/architecture/subsystems/runtime.md`: product retrieval proof uses retrieval bootstrap/index/status and requires full sidecars.

Dogfood friction: no current ready `codestory-cli` was discoverable without setup work. `CODESTORY_CLI` was unset, `codestory-cli` was not on PATH, this worktree had no `target/release/codestory-cli.exe`, and the nearest sibling binary reported `codestory-cli 0.10.0` while the repo/latest release is `0.11.3`. I did not cold-build, download, index, or run sidecars; this audit used direct source reads.

## What Changed
- Clarified `docs/architecture/subsystems/cli.md` so `doctor`, `setup embeddings`, and product retrieval proof are separate surfaces.
- Reworked the local CLI loop in `docs/contributors/getting-started.md` so `setup embeddings --dry-run` is labeled as a managed-ONNX diagnostic check, not sidecar setup.
- Updated `docs/testing/embedding-backend-benchmarks.md` so ONNX rows are described as managed diagnostic evidence unless fresh sidecar-contract proof exists.

## How To Review
- Review the three docs together as one slice: managed ONNX diagnostics versus product packet/search sidecar readiness.
- Compare the wording against `crates/codestory-cli/src/args.rs`, `crates/codestory-cli/src/managed_embeddings.rs`, `crates/codestory-runtime/src/search/engine.rs`, `docs/ops/retrieval-sidecars.md`, and `docs/architecture/subsystems/runtime.md`.

## Verification
- `git diff --check` passed.
- Touched-doc link/path spot check passed: existing links in `docs/contributors/getting-started.md` resolve to `README.md`, `docs/architecture/overview.md`, `docs/architecture/runtime-execution-path.md`, `docs/architecture/indexing-pipeline.md`, `docs/contributors/debugging.md`, and `docs/contributors/testing-matrix.md`.
- Source-read evidence checked with `rg`/`Get-Content` against the implementation/doc files listed above.
- No Cargo/build/test commands were run because this is docs-only.

## Risk
- Narrow docs-only risk: this does not change CLI output. One follow-up candidate is `crates/codestory-cli/src/main.rs`, where some missing-embedding-runtime recovery text still mentions `setup embeddings` before packet/search trust; that may need a code/docs-aligned wording pass if it misroutes operators in practice.
- Broader docs follow-up candidates found but not patched here: `docs/testing/performance-review-playbook.md` and `docs/testing/retrieval-architecture.md` still carry dense sidecar proof language that should be audited against current manifest/status fields before the next retrieval-proof PR.