### PR TITLE
[Docs] Add README benchmark proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,18 @@ readiness checks the human operator can inspect.
 <a href="Cargo.toml"><img alt="Rust 2024" src="https://img.shields.io/badge/rust-2024-orange"></a>
 </p>
 
-CodeStory is for a human who is about to let a coding agent work in a real
-repository.
+Coding agents are very good at sounding certain before they have grounded the
+repo in front of them. That is backwards. Before an operator asks for a plan,
+review, or edit, the agent needs current local context it can cite and the
+human can inspect.
 
-Its promise is narrow on purpose: the agent should begin from current local
-source evidence, cite the files and trails behind its claims, and tell you when
-broad packet/search evidence is not ready enough to trust.
+CodeStory gives the agent a read-only local MCP/CLI grounding surface: files,
+symbols, snippets, trails, packet/search, and readiness gates over the current
+checkout. The result is not magic. It is better plumbing: the agent starts from
+local evidence, knows when packet/search is trustworthy, and leaves claims a
+reviewer can follow back to source.
 
-Use CodeStory when the next agent answer needs to survive review:
+Use it when the next agent answer needs to survive review:
 
 - What is in this repo?
 - Which files changed, and what else might be affected?
@@ -26,7 +30,26 @@ Use CodeStory when the next agent answer needs to survive review:
 - Is broad packet/search ready enough to use as evidence?
 
 CodeStory does not replace source review, tests, or human judgment. It changes
-the starting point: local cited evidence first, confident-sounding guesses last.
+the starting point: local cited evidence first, confident guesses last.
+
+## Proof Before Trust
+
+These are documented regression and protocol numbers, not marketing claims.
+They do not prove token savings, answer quality, public benchmark promotion, or
+generalization.
+
+| What the repo evidence says | Number | Source | Trust boundary |
+| --- | ---: | --- | --- |
+| Repo-scale full-sidecar stats row | `75.36s` index, including `49.45s` semantic phase | 2026-06-18 `d8d59e9e+wt` #41 hardening row in [codestory-e2e-stats-log.md](docs/testing/codestory-e2e-stats-log.md); summarized in [performance-review-playbook.md](docs/testing/performance-review-playbook.md#current-ops-gates) | Regression telemetry only; the row says the real drill was intentionally skipped. |
+| Retrieval sidecar readiness on that row | `retrieval_mode full`, `4.34s` retrieval index, `0.39s` retrieval status | Same 2026-06-18 #41 hardening row and playbook snapshot | `retrieval_mode=full` proves infrastructure readiness for packet/search, not answer quality. |
+| Repeat full refresh cache reuse | `29.45s` repeat refresh with `750` reused and `0` embedded | Same 2026-06-18 #41 hardening row and playbook snapshot | Useful cache/reuse signal; not a quality or generalization result. |
+| Agent stdio loop smoke | `20` reps, `53.50ms` warm loop, protocol stdout-only | Small-fixture release-binary row in [codestory-stdio-warm-loop-stats.md](docs/testing/codestory-stdio-warm-loop-stats.md) | Protocol/read-surface smoke; not repo-scale packet/search proof. |
+
+The stricter rule is deliberate: local navigation readiness is useful, but broad
+packet/search claims require `agent_packet_search` ready and `retrieval_mode=full`.
+Even that is infrastructure readiness; public answer-quality claims need the
+separate packet-runtime or drill evidence described in
+[retrieval-architecture.md](docs/testing/retrieval-architecture.md).
 
 ## The Trust Loop
 


### PR DESCRIPTION
## Context
Closes #341
Refs #38

The root README opened with the right ingredients but did not quickly earn operator trust. Issue #341 asks for a STAR-shaped opening and near-top benchmark proof without promoting unsupported answer-quality, token-savings, or generalization claims.

I also checked the requested inspiration README from `DeusData/codebase-memory-mcp` for first-screen proof density only. I did not copy its claims, tone, install model, or architecture.

CodeStory grounding preflight: no ready CLI was discoverable without cold-building (`CODESTORY_CLI` unset, `where.exe codestory-cli` found nothing, and `target/release/codestory-cli.exe` was missing), so this lane used direct source reads.

## What Changed
- Rewrote the root README opening around the operator problem: agents make source claims before grounding the current local repo; the operator needs cited local context before planning, review, or edits; CodeStory provides a read-only MCP/CLI grounding surface with readiness gates.
- Added a near-top `Proof Before Trust` table that labels every number as regression/protocol evidence, not marketing proof.
- Kept plugin-first usage clear: install through the Codex plugin marketplace flow, start a fresh agent thread, ask the agent to check readiness and ground the repo. CLI remains setup, repair, debug, and transcript surface.
- Preserved trust boundaries: local navigation readiness is not packet/search proof, and `retrieval_mode=full` is infrastructure readiness, not answer-quality promotion.

## How To Review
- Start at `README.md` from the top through `Proof Before Trust` and `The Trust Loop`.
- Check that the README no longer starts with `CodeStory is for a human who...` phrasing.
- Verify that the marketplace text still points to `TheGreenCedar/AgentPluginMarketplace` and keeps this repo as source `TheGreenCedar/CodeStory` path `plugins/codestory`.
- Confirm no Rust/runtime files changed.

## Verification
- `git diff --check` passed.
- Markdown link/anchor spot checks passed by source read:
  - `docs/testing/codestory-e2e-stats-log.md` exists and contains the 2026-06-18 `d8d59e9e+wt` #41 hardening rows.
  - `docs/testing/performance-review-playbook.md` exists and contains `## Current Ops Gates`, which produces the README anchor `#current-ops-gates`.
  - `docs/testing/codestory-stdio-warm-loop-stats.md` exists and contains the small-fixture `53.50ms` warm-loop row.
  - `docs/testing/retrieval-architecture.md` exists and contains the `retrieval_mode=full` trust-boundary language.

Source-read evidence for benchmark numbers:
- `docs/testing/performance-review-playbook.md` lines 83-88 summarize the 2026-06-18 `d8d59e9e+wt` #41 hardening row: `retrieval_mode full`, `retrieval_index_seconds 4.34`, `retrieval_status_seconds 0.39`, repeat full refresh `29.45s` with `750` reused and `0` embedded, index `75.36s`, semantic phase `49.45s`, and states it does not prove answer quality because the real drill was intentionally skipped.
- `docs/testing/codestory-e2e-stats-log.md` line 232 contains the same #41 hardening row with `symbol_search_docs 13,862`, `dense anchors 750`, `dense skips 13,112`, `retrieval_index_seconds 4.34`, `retrieval_status_seconds 0.39`, repeat full refresh `29.45s` with `750` reused and `0` embedded, index `75.36s`, and semantic phase `49.45s`.
- `docs/testing/codestory-stdio-warm-loop-stats.md` lines 14-16 contain the small-fixture stdio row: `20` reps, `25.09ms` startup, `53.50ms` warm per-loop, and protocol stdout-only `true`; lines 110-114 label this as small-fixture smoke and explain the warm-loop metric.
- `docs/testing/retrieval-architecture.md` lines 28-30 state that `retrieval_mode=full` is mandatory infrastructure readiness for product packet paths and does not promote answer quality, agent usefulness, or public language quality without packet-runtime or drill evidence.

No Cargo/build/test work was run because this is a docs-only README lane and the issue explicitly excludes Cargo/build/test work.

## Risk
- The README now surfaces the stdio row, but labels it as small-fixture protocol/read-surface smoke rather than repo-scale proof.
- The #41 row is strong regression telemetry, but the README and PR deliberately do not claim token savings, public answer quality, 99%-style metrics, or generalization.