### PR TITLE
[Docs] Rewrite README around product story

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">CodeStory</h1>
 
 <p align="center">
-Local codebase grounding for coding agents, with cited repository evidence and
-readiness checks the human operator can inspect.
+Local code intelligence for coding agents: graph-backed context, source
+citations, and explicit uncertainty.
 </p>
 
 <p align="center">
@@ -10,139 +10,122 @@ readiness checks the human operator can inspect.
 <a href="Cargo.toml"><img alt="Rust 2024" src="https://img.shields.io/badge/rust-2024-orange"></a>
 </p>
 
-Coding agents are very good at sounding certain before they have grounded the
-repo in front of them. That is backwards. Before an operator asks for a plan,
-review, or edit, the agent needs current local context it can cite and the
-human can inspect.
+CodeStory builds a local map/code-intelligence layer for a repository so an
+agent can inspect code relationships, retrieve source, trace behavior, and cite
+what it found.
 
-CodeStory gives the agent a read-only local MCP/CLI grounding surface: files,
-symbols, snippets, trails, packet/search, and readiness gates over the current
-checkout. The result is not magic. It is better plumbing: the agent starts from
-local evidence, knows when packet/search is trustworthy, and leaves claims a
-reviewer can follow back to source.
+Coding agents can sound certain before they have actually mapped the current
+checkout. That is the review problem: plausible prose arrives before the agent
+knows the files, symbols, ownership boundaries, or call paths it is talking
+about.
 
-Use it when the next agent answer needs to survive review:
+The human task is not to get more confident prose. It is to get answers that can
+survive source review. CodeStory gives the agent a local, read-only code graph,
+source snippets, trails, changed-file impact hints, and optional sidecar-backed
+packet/search evidence.
 
-- What is in this repo?
-- Which files changed, and what else might be affected?
-- Where is this behavior implemented?
-- Which symbols, references, snippets, and trails support the answer?
-- Is broad packet/search ready enough to use as evidence?
+The useful result is smaller and better: the agent starts from evidence it can
+cite, says when the evidence is stale or partial, and treats degraded retrieval
+as a lead to inspect instead of a fact to repeat.
 
-CodeStory does not replace source review, tests, or human judgment. It changes
-the starting point: local cited evidence first, confident guesses last.
+## See It First
 
-## Proof Before Trust
+Ask the agent for evidence before it plans:
 
-These are documented regression and protocol numbers, not marketing claims.
-They do not prove token savings, answer quality, public benchmark promotion, or
-generalization.
-
-| What the repo evidence says | Number | Source | Trust boundary |
-| --- | ---: | --- | --- |
-| Repo-scale full-sidecar stats row | `75.36s` index, including `49.45s` semantic phase | 2026-06-18 `d8d59e9e+wt` #41 hardening row in [codestory-e2e-stats-log.md](docs/testing/codestory-e2e-stats-log.md); summarized in [performance-review-playbook.md](docs/testing/performance-review-playbook.md#current-ops-gates) | Regression telemetry only; the row says the real drill was intentionally skipped. |
-| Retrieval sidecar readiness on that row | `retrieval_mode full`, `4.34s` retrieval index, `0.39s` retrieval status | Same 2026-06-18 #41 hardening row and playbook snapshot | `retrieval_mode=full` proves infrastructure readiness for packet/search, not answer quality. |
-| Repeat full refresh cache reuse | `29.45s` repeat refresh with `750` reused and `0` embedded | Same 2026-06-18 #41 hardening row and playbook snapshot | Useful cache/reuse signal; not a quality or generalization result. |
-| Agent stdio loop smoke | `20` reps, `53.50ms` warm loop, protocol stdout-only | Small-fixture release-binary row in [codestory-stdio-warm-loop-stats.md](docs/testing/codestory-stdio-warm-loop-stats.md) | Protocol/read-surface smoke; not repo-scale packet/search proof. |
-
-The stricter rule is deliberate: local navigation readiness is useful, but broad
-packet/search claims require `agent_packet_search` ready and `retrieval_mode=full`.
-Even that is infrastructure readiness; public answer-quality claims need the
-separate packet-runtime or drill evidence described in
-[retrieval-architecture.md](docs/testing/retrieval-architecture.md).
-
-## The Trust Loop
-
-```mermaid
-flowchart LR
-    Human["Human operator"] --> Prompt["Ask the agent to ground the repo"]
-    Prompt --> Plugin["CodeStory plugin"]
-    Plugin --> Runtime["codestory-cli serve --stdio --refresh none"]
-    Runtime --> Evidence["Local graph, files, snippets, trails"]
-    Runtime --> Readiness["doctor/readiness status"]
-    Evidence --> Agent["Agent plans, reviews, or edits"]
-    Readiness --> Agent
-    Agent --> Human
-    Readiness -. "packet/search only when retrieval_mode=full" .-> Packet["packet/search evidence"]
+```text
+@CodeStory Ground this repository, then trace where request routing is owned and identify the tests most likely affected by changing it.
 ```
 
-The normal path is plugin-first. The CLI exists for setup, repair, debugging,
-and transcripts.
+A CodeStory-backed answer should come back shaped like this. This is a
+representative result shape, not a transcript from this README branch.
+
+| Result part | What CodeStory gives the agent | How to trust it |
+| --- | --- | --- |
+| Readiness | `local_navigation: ready`; `agent_packet_search: ready`; `retrieval_mode: full` when sidecars are healthy | Local graph output is usable from the SQLite index. Broad packet/search evidence needs full retrieval. |
+| Source evidence | Files, symbols, definitions, references, snippets, and trails with concrete source anchors | Evidence: cite these paths, symbols, and snippets in the answer. |
+| Behavior trace | A bounded trail such as entrypoint -> handler -> helper -> persistence call | Evidence when the trail comes from indexed graph/source rows; inspect snippets before editing. |
+| Impact hints | Changed-file dependents and likely test files | Lead: review planning help, not a substitute for running tests. |
+| Packet/search gaps | Missing sidecars, stale manifests, partial retrieval, truncation, or follow-up commands | Lead only until repaired or source-verified. |
+
+## What Your Agent Gets
+
+- A current file inventory and language coverage notes for the local checkout.
+- Indexed files, symbols, definitions, references, occurrences, and snippets.
+- Graph trails for following callers, callees, imports, overrides, and nearby
+  relationships.
+- Changed-file impact hints for review planning and test selection.
+- Bounded `packet` output for broad repository questions, with citations, gaps,
+  truncation notes, and follow-up commands.
+- `search` for candidate discovery when the retrieval lane is full.
+- Clear degraded-state signals when the cache, index, or sidecars cannot support
+  a proof-bearing claim.
 
 ## Use It With An Agent
 
-Most humans should install CodeStory through the agent plugin, not memorize CLI
-commands. Open Codex in the workspace you want to ground and use:
+The easiest way to use CodeStory today is through its Codex plugin. The CLI and
+read-only MCP server are also available directly, but they are the setup, repair,
+and transcript path.
 
-```text
-/plugins
-```
-
-Choose:
-
-```text
-TheGreenCedar -> codestory -> Install plugin
-```
-
-If your Codex build exposes terminal marketplace management for source
-marketplaces, add or refresh this marketplace first:
-
-```bash
-codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
-```
-
-The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`. Its
-marketplace display/name concept is `TheGreenCedar`. This repository is the
-plugin source at `https://github.com/TheGreenCedar/CodeStory.git`, with source path `plugins/codestory`. The CodeStory repo does not contain the marketplace catalog.
-
-Start a new Codex thread after install or refresh. A useful first prompt is:
+1. Open Codex in the repository you want to ground.
+2. Use `/plugins`, then install `TheGreenCedar -> codestory`.
+3. Start a fresh thread and ask:
 
 ```text
 @CodeStory check whether this repository is ready for local navigation and packet/search, then ground it before planning changes.
 ```
 
-The plugin launches `codestory-cli serve --stdio --refresh none` directly. The
-local MCP server is read-only: it gives the agent grounding, inventory, graph,
-snippet, packet, and search tools; it does not edit your repository.
+The plugin launches the local `codestory-cli serve --stdio --refresh none`
+runtime. It does not edit your repository. Marketplace catalog details, binary
+bootstrap behavior, source fallback, refresh, and uninstall notes live in the
+[plugin README](plugins/codestory/README.md).
 
-The skill owns binary setup. It checks `codestory-cli --version`, compares the
-installed binary with the latest GitHub release, installs a matching release
-asset when practical, and checks `SHA256SUMS.txt` when the host can. If `PATH`
-changed, the skill tells the human that a Codex host/app restart may be needed
-before a fresh agent thread can see it.
+## How CodeStory Works
 
-CodeStory publishes cross-platform CLI assets for Windows, macOS, and Linux.
-Source fallback is available when a release asset does not fit the host.
+```mermaid
+flowchart LR
+    Repo["Repository checkout"] --> Discovery["Discovery + refresh plan"]
+    Discovery --> Indexer["Parser-backed and structural indexer"]
+    Indexer --> Graph["SQLite graph, snippets, snapshots"]
+    Graph --> Sidecars["Optional retrieval sidecars: Zoekt, Qdrant, SCIP, llama.cpp"]
+    Graph --> Runtime["codestory-runtime"]
+    Sidecars --> Runtime
+    Runtime --> Surfaces["MCP server, CLI, Codex plugin"]
+```
 
-## What Your Agent Gets
+The repository is discovered locally, indexed into SQLite-backed graph state,
+and served through the runtime. Optional sidecars add full packet/search
+retrieval when they are healthy. The plugin is the normal agent entry point; the
+CLI is the direct operator path.
 
-| Human question | CodeStory surface | Trust boundary |
+## Trust And Privacy
+
+> [!IMPORTANT]
+> CodeStory is local and read-only by default. Graph navigation comes from the
+> local SQLite index. Broad `packet` and `search` output counts as evidence only
+> when the retrieval lane reports `full`; degraded output is a lead to inspect,
+> not a fact to repeat. Setup may fetch release binaries or sidecar assets, but
+> indexed repository evidence stays in the local cache unless you copy it
+> elsewhere.
+
+## Language Support
+
+Public support claims come from
+[`crates/codestory-contracts/src/language_support.rs`](crates/codestory-contracts/src/language_support.rs)
+and the contract summary in
+[language-support.md](docs/architecture/language-support.md).
+
+| Claim tier | Current surfaces | Safe wording |
 | --- | --- | --- |
-| Is this repository ready to use? | `codestory://status`, `doctor` | Separates local navigation from packet/search readiness. |
-| What is in this repo? | `codestory://grounding`, `ground`, `files` | Source-backed orientation, not a proof of every behavior. |
-| What changed, and what might be affected? | `affected` | Review planning help; still run the relevant tests. |
-| Where should we inspect next? | `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, `context` | Follow concrete source anchors before claiming facts. |
-| Can we ask a broad codebase question? | `packet`, `search` | Proof only with `agent_packet_search` ready and `retrieval_mode=full`. |
+| Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | Daily graph navigation on typical code, with caveats. |
+| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, basename-scoped `Cargo.toml`, dedicated OpenAPI/Swagger endpoint schema anchors | Exact source/schema anchors; not parser-backed graph extraction or semantic runtime proof. |
 
-The canonical plugin skill is
-[plugins/codestory/skills/codestory-grounding/SKILL.md](plugins/codestory/skills/codestory-grounding/SKILL.md).
+Language support does not automatically prove typed semantic edges, framework
+route completeness, packet answer quality, token savings, or generalization.
+Those claims need their own tests or benchmark artifacts.
 
-## Trust And Readiness
+## CLI Escape Hatch
 
-| Lane | Use it for | Trust it when | If not ready |
-| --- | --- | --- | --- |
-| Local navigation | Grounding, file inventory, changed-file impact, graph/source follow-up. | `local_navigation` is ready. | Refresh or rebuild the local cache, then source-read the named files. |
-| Packet/search | Broad repo questions and candidate discovery. | `agent_packet_search` is ready and `retrieval_mode=full`. | Treat output as navigation help only, then repair sidecars or fall back to direct source reads. |
-
-Non-`full` packet/search output is not proof. Degraded, partial, stale, fallback,
-or missing sidecar output may help the agent choose files to inspect; it cannot
-carry a product-grade claim.
-
-## When To Use The CLI
-
-Use the CLI when you need a direct setup, repair, or debug transcript.
-
-Setup and local navigation:
+Use the CLI when you need a direct setup, repair, or debug transcript:
 
 ```sh
 codestory-cli doctor --project <repo>
@@ -152,49 +135,31 @@ codestory-cli files --project <repo> --limit 80
 codestory-cli affected --project <repo> --format markdown
 ```
 
-Repair a stale local cache:
-
-```sh
-codestory-cli doctor --project <repo>
-codestory-cli index --project <repo> --refresh full
-codestory-cli doctor --project <repo>
-```
-
-Debug packet/search readiness:
+When packet/search readiness is the question, check the sidecar lane directly:
 
 ```sh
 codestory-cli retrieval status --project <repo> --format json
 ```
 
-Repair packet/search sidecars:
+Repair commands and sidecar setup details are in
+[docs/usage.md](docs/usage.md) and
+[docs/ops/retrieval-sidecars.md](docs/ops/retrieval-sidecars.md).
 
-```sh
-codestory-cli retrieval bootstrap --project <repo> --format json
-codestory-cli retrieval index --project <repo> --refresh full
-codestory-cli retrieval status --project <repo> --format json
-```
+## Performance And Verification Evidence
 
-For source checkout work:
+These records are regression and protocol evidence. They are not product proof
+of answer quality, token savings, public benchmark promotion, or generalization.
 
-```sh
-cargo build --release -p codestory-cli
-```
+| Evidence lane | Current recorded signal | Source | Boundary |
+| --- | --- | --- | --- |
+| Repo-scale full-sidecar stats | 2026-06-18 `d8d59e9e+wt` #41 hardening row: `75.36s` index, `49.45s` semantic phase, `retrieval_mode full`, `4.34s` retrieval index, `0.39s` retrieval status | [codestory-e2e-stats-log.md](docs/testing/codestory-e2e-stats-log.md), summarized in [performance-review-playbook.md](docs/testing/performance-review-playbook.md#current-ops-gates) | Regression telemetry only; that row says the real drill was intentionally skipped. |
+| Repeat full refresh | `29.45s` repeat refresh with `750` reused and `0` embedded | Same 2026-06-18 #41 hardening row | Cache/reuse signal, not quality or generalization proof. |
+| Stdio agent loop smoke | Small fixture release-binary run: `20` reps, `53.50ms` warm loop, protocol stdout-only | [codestory-stdio-warm-loop-stats.md](docs/testing/codestory-stdio-warm-loop-stats.md) | Protocol/read-surface smoke, not repo-scale packet/search proof. |
 
-On Windows PowerShell, use `.\target\release\codestory-cli.exe` and normal
-Windows paths. The release-binary installer path is:
-
-```powershell
-.\scripts\install-codestory.ps1 -Project C:\path\to\repo
-```
-
-See [docs/usage.md](docs/usage.md) for task-shaped flows and
-[docs/ops/retrieval-sidecars.md](docs/ops/retrieval-sidecars.md) for
-packet/search setup and repair.
-
-## Docs For Operators And Contributors
-
-Start with the [docs entry map](docs/README.md) to choose the right durable
-page for setup, repair, architecture, verification, or research evidence.
+Use [retrieval-architecture.md](docs/testing/retrieval-architecture.md) for
+packet/search promotion gates and
+[docs/README.md](docs/README.md) to choose the right operator, architecture,
+verification, or research document.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,44 @@ of answer quality, token savings, public benchmark promotion, or generalization.
 | Repeat full refresh | `29.45s` repeat refresh with `750` reused and `0` embedded | Same 2026-06-18 #41 hardening row | Cache/reuse signal, not quality or generalization proof. |
 | Stdio agent loop smoke | Small fixture release-binary run: `20` reps, `53.50ms` warm loop, protocol stdout-only | [codestory-stdio-warm-loop-stats.md](docs/testing/codestory-stdio-warm-loop-stats.md) | Protocol/read-surface smoke, not repo-scale packet/search proof. |
 
+## Speed And Context Value
+
+CodeStory's speed and token value come from avoiding the same broad repository
+scan over and over. The agent can ask for bounded graph, source, trail, impact,
+and packet evidence, then cite that evidence instead of repeatedly stuffing raw
+files into context.
+
+That mechanism is useful even without a token-savings percentage: local graph
+navigation narrows the next source reads, `affected` narrows review planning,
+and full `packet`/`search` returns bounded citations plus gaps instead of an
+unbounded repo sweep. Exact token-savings measurements are not currently
+published in this README, so the claim stays at mechanism and evidence shape,
+not a numeric savings promise.
+
+The committed timing evidence does show cache behavior that matters to operator
+flow: the 2026-06-18 #41 hardening row recorded a repeat full refresh at
+`29.45s` with `750` semantic docs reused and `0` embedded. Treat that as
+cache/reuse telemetry, not answer-quality proof.
+
+## Cache And Worktree Lifecycle
+
+Initial indexing is the expensive pass; pay it once when possible. CodeStory
+stores per-project SQLite graph/search/doc state in the local cache, and the
+Codex worktree setup script can run `cache rehydrate --from-project <source>`
+from a sibling worktree before refreshing the target checkout.
+
+After cache reuse or rehydrate, the normal path is still to verify freshness:
+run `doctor`, refresh with `index --refresh auto` or `--refresh incremental`,
+then trust local graph navigation only when readiness says it is current. For
+ordinary source edits, prefer incremental indexing so CodeStory reprocesses the
+changed files instead of rebuilding the world.
+
+Sidecar and artifact reuse has a stricter boundary. Retrieval manifests,
+sidecar input hashes, embedding backend identity, and stored candidate
+resolution still need revalidation after reuse. If packet/search does not report
+`retrieval_mode full`, the output is a lead for source inspection, not reusable
+proof.
+
 Use [retrieval-architecture.md](docs/testing/retrieval-architecture.md) for
 packet/search promotion gates and
 [docs/README.md](docs/README.md) to choose the right operator, architecture,


### PR DESCRIPTION
## Context
Closes #343
Refs #38

Manual review after #342 said the root README kept the STAR spine but still read like an internal acceptance checklist: product story after telemetry, install mechanics before desire, and repeated readiness warnings before a reader saw CodeStory doing anything.

This PR keeps the trust boundary but moves the first read around the actual product: local code intelligence for agents, concrete source evidence, explicit uncertainty, and the practical value of bounded evidence reuse.

## What Changed
- Rewrote the root README opening around CodeStory as a local map/code-intelligence layer for a repository.
- Added one agent prompt plus a labeled representative result shape that separates evidence from leads.
- Replaced the workflow receipt Mermaid with the product architecture path: repository -> discovery/indexer -> SQLite graph -> optional retrieval sidecars -> runtime -> MCP/CLI/plugin.
- Reduced root onboarding to the short plugin happy path and linked plugin docs for marketplace/catalog and binary bootstrap details.
- Restored a compact language support summary from the current language support contract and moved performance telemetry near the bottom as regression/protocol evidence.
- Added `Speed And Context Value` to explain the mechanism: bounded graph/source/packet evidence reduces repeated repo scanning and context waste, while plainly saying exact token-savings measurements are not published here.
- Added `Cache And Worktree Lifecycle` to explain paying initial indexing once when possible, rehydrating/reusing cache across worktrees where supported, preferring incremental indexing after reuse, and revalidating sidecar/retrieval surfaces before treating packet/search as proof.

README flow now:

```mermaid
flowchart LR
    Story["Product story"] --> Example["Prompt + result shape"]
    Example --> Onboarding["Plugin happy path"]
    Onboarding --> Architecture["Architecture + trust box"]
    Architecture --> Evidence["Language + performance evidence"]
    Evidence --> Value["Speed + cache lifecycle"]
```

## How To Review
- Read `README.md` from the top through `Trust And Privacy` and check whether it now explains CodeStory before setup plumbing.
- Review `Speed And Context Value` for the intended mechanism without invented token-savings percentages.
- Review `Cache And Worktree Lifecycle` against `scripts/codex-worktree-setup.ps1`, `docs/usage.md`, and retrieval readiness boundaries.
- Compare `Language Support` against `crates/codestory-contracts/src/language_support.rs` and `docs/architecture/language-support.md`.
- Confirm the README still points deeper setup and repair detail to `plugins/codestory/README.md`, `docs/usage.md`, and `docs/ops/retrieval-sidecars.md`.
- Confirm no runtime behavior, plugin docs, generated docs, Cargo surfaces, or #345 paths changed.

## Verification
- Read back the changed `README.md` locally.
- `git diff --check`
- `git diff --cached --check`
- Local PowerShell README check for missing relative Markdown links plus balanced Mermaid/code fences.
- `codestory-cli doctor --project ...` was attempted during the first README pass but no ready `codestory-cli` was available without building, so this stayed on direct source reads per the issue instruction.

No Cargo build was run; this is README-only. Plugin validation/static tests were not run because plugin docs and plugin static assertions were not touched.

## Risk
- The result shape is representative rather than captured command output; the README labels it as such.
- The speed/token-value section explains the mechanism and existing cache telemetry, but does not claim measured token savings because exact token-savings measurements are not published here.
- Mermaid was checked for fence/content sanity, but `mmdc` was not installed in this environment, so there is no generated diagram image attached.
- The language summary and cache lifecycle are intentionally compact; deeper claim tiers and repair details remain in the linked docs.
