### PR TITLE
[codex] Reject stale CLI during worktree setup

### DIFF
--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -38,7 +38,11 @@ function Invoke-SetupStep {
 }
 
 function Test-CodeStoryCli {
-    param([string]$Candidate)
+    param(
+        [string]$Candidate,
+        [string]$ExpectedVersion,
+        [ref]$ActualVersion
+    )
 
     if (-not $Candidate) {
         return $false
@@ -47,9 +51,30 @@ function Test-CodeStoryCli {
         return $false
     }
 
-    # ponytail: --help proves the binary is runnable; doctor remains the real trust gate.
-    & $Candidate --help >$null 2>$null
-    return $LASTEXITCODE -eq 0
+    $versionOutput = & $Candidate --version 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return $false
+    }
+    $versionLine = $versionOutput | Select-Object -First 1
+    if ($versionLine -notmatch '^codestory-cli\s+([0-9][0-9A-Za-z.+-]*)$') {
+        return $false
+    }
+
+    $ActualVersion.Value = $Matches[1]
+    return $ActualVersion.Value -eq $ExpectedVersion
+}
+
+function Get-ExpectedCodeStoryCliVersion {
+    param([string]$Root)
+
+    $manifest = Join-Path $Root "crates\codestory-cli\Cargo.toml"
+    foreach ($line in Get-Content -LiteralPath $manifest) {
+        if ($line -match '^\s*version\s*=\s*"([^"]+)"') {
+            return $Matches[1]
+        }
+    }
+
+    throw "Unable to read expected codestory-cli version from $manifest."
 }
 
 function Get-CodeStoryCliCandidates {
@@ -95,14 +120,24 @@ function Get-CodeStoryCliCandidates {
 function Find-CodeStoryCli {
     param([string]$Root)
 
+    $expectedVersion = Get-ExpectedCodeStoryCliVersion $Root
     $candidates = Get-CodeStoryCliCandidates $Root
+    $staleCandidates = @()
     foreach ($candidate in $candidates) {
-        if (Test-CodeStoryCli $candidate) {
+        $actualVersion = $null
+        if (Test-CodeStoryCli $candidate $expectedVersion ([ref]$actualVersion)) {
             return $candidate
+        }
+        if ($actualVersion) {
+            $staleCandidates += "$candidate reported $actualVersion"
         }
     }
 
-    throw "No ready codestory-cli found via CODESTORY_CLI, PATH, this worktree's target\release, or sibling worktree target\release directories."
+    $message = "No ready codestory-cli $expectedVersion found via CODESTORY_CLI, PATH, this worktree's target\release, or sibling worktree target\release directories."
+    if ($staleCandidates.Count -gt 0) {
+        $message += " Stale candidates: $($staleCandidates -join '; ')."
+    }
+    throw $message
 }
 
 function Same-Path {


### PR DESCRIPTION
## Context

Issue #346 covers the gap left by #240: the worktree setup resolver found runnable `codestory-cli` binaries, but `Test-CodeStoryCli` only ran `--help`, so stale binaries such as `codestory-cli 0.10.1` could become the binary used for `doctor`, index, cache, and retrieval setup.

Closes #346
Refs #38, #240

## What Changed

- `scripts/codex-worktree-setup.ps1` now reads the expected CLI version from `crates/codestory-cli/Cargo.toml`.
- `Test-CodeStoryCli` now runs `<candidate> --version`, parses `codestory-cli <version>`, and only accepts candidates matching the expected version.
- Stale candidates are skipped and reported when no compatible candidate is available.
- The existing normal fallback remains unchanged: `-ResolveCliOnly` fails clearly, while non-`-ResolveCliOnly` can still build the release CLI with Cargo/sccache.

## How To Review

1. Review `Test-CodeStoryCli` and `Find-CodeStoryCli` in `scripts/codex-worktree-setup.ps1`.
2. Confirm only the ready-CLI acceptance gate changed; `doctor`, cache rehydrate, sidecar freshness, and retrieval setup commands are untouched.
3. Confirm the stale-candidate diagnostic carries actual versions while continuing to preserve the existing candidate search order.

## Verification

Focused stale-candidate smoke with a temp mini-project and fake `CODESTORY_CLI` reporting `codestory-cli 0.10.1`; temp files were removed afterward.

```text
Using RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe
Exception: C:\Users\alber\.codex\worktrees\6769\codestory\scripts\codex-worktree-setup.ps1:205
Line |
 205 |              throw "$($_.Exception.Message) Re-run without -ResolveCli ...
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | No ready codestory-cli 0.11.3 found via CODESTORY_CLI, PATH, this worktree's target\release, or sibling worktree
     | target\release directories. Stale candidates:
     | C:\Users\alber\.codex\worktrees\6769\codestory\temp\issue-346-stale-cli-smoke\bin\codestory-cli.cmd reported
     | 0.10.1. Re-run without -ResolveCliOnly to build with cargo, or set CODESTORY_CLI to a ready binary.
SMOKE_EXIT=1
```

Requested local-state resolver check:

```powershell
powershell -ExecutionPolicy Bypass -File scripts\codex-worktree-setup.ps1 -Project . -ResolveCliOnly
```

Exit code: `1`, because every discovered local candidate was stale against expected `0.11.3`:

```text
Using RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe
No ready codestory-cli 0.11.3 found via CODESTORY_CLI, PATH, this worktree's target\release, or sibling worktree target\release directories. Stale candidates: C:\Users\alber\source\repos\codestory\target\release\codestory-cli.exe reported 0.10.1; C:\Users\alber\source\repos\codestory\target\release\codestory-cli reported 0.10.1; C:\Users\alber\.codex\worktrees\issue-172-compose-structural\codestory\target\release\codestory-cli.exe reported 0.10.0; C:\Users\alber\.codex\worktrees\issue-172-compose-structural\codestory\target\release\codestory-cli reported 0.10.0; C:\Users\alber\.codex\worktrees\post-97-packet-evidence\codestory\target\release\codestory-cli.exe reported 0.9.0; C:\Users\alber\.codex\worktrees\post-97-packet-evidence\codestory\target\release\codestory-cli reported 0.9.0; C:\Users\alber\source\repos\codestory\.worktrees\resolve-audit-findings\target\release\codestory-cli.exe reported 0.7.0; C:\Users\alber\source\repos\codestory\.worktrees\resolve-audit-findings\target\release\codestory-cli reported 0.7.0. Re-run without -ResolveCliOnly to build with cargo, or set CODESTORY_CLI to a ready binary.
At C:\Users\alber\.codex\worktrees\6769\codestory\scripts\codex-worktree-setup.ps1:205 char:13
+             throw "$($_.Exception.Message) Re-run without -ResolveCli ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```text
git diff --check
# exit code 0, no output
```

No Cargo build/test was run; the change is PowerShell-only and the requested resolver smoke covered the changed path.

## Risk

Low. This only tightens the pre-existing candidate acceptance gate. A machine with only stale binaries now reaches the already-existing Cargo release build fallback during normal setup, or fails clearly under `-ResolveCliOnly`.