### PR TITLE
[codex] fix plugin static guard

### DIFF
--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -105,16 +105,9 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
     "Always pass `--project <target-workspace>` explicitly",
   ];
   const rootReadmeRequired = [
-    "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",
-    "marketplace display/name concept is `TheGreenCedar`",
-    "plugin source at `https://github.com/TheGreenCedar/CodeStory.git`",
-    "source path `plugins/codestory`",
-    "The CodeStory repo does not contain the marketplace catalog",
-    "add or refresh this marketplace first",
-    "The plugin launches `codestory-cli serve --stdio --refresh none` directly",
-    "The skill owns binary setup",
-    "the skill tells the human that a Codex host/app restart may be needed",
-    "before a fresh agent thread can see it",
+    "Marketplace catalog details, binary",
+    "[plugin README](plugins/codestory/README.md)",
+    "`codestory-cli serve --stdio --refresh none`",
   ];
 
   for (const text of [readme, skill]) {


### PR DESCRIPTION
## Context

#348 found that the plugin static guard still required the root README to repeat marketplace catalog/source-boundary details after the root README moved those details to the plugin README.

Closes #349
Refs #348
Refs #38

## What Changed

Updated `plugins/codestory/tests/plugin-static.test.mjs` so the root README guard accepts delegation to `plugins/codestory/README.md` plus the `codestory-cli serve --stdio --refresh none` runtime command. The plugin README still carries the exact marketplace/source truth: external catalog `TheGreenCedar/AgentPluginMarketplace`, CodeStory source repo, and `plugins/codestory` source path.

## How To Review

Review the single test hunk in `plugins/codestory/tests/plugin-static.test.mjs` and confirm root README stays human/product-first while plugin README remains the marketplace/source-boundary surface.

## Verification

- `node --test .\plugins\codestory\tests\plugin-static.test.mjs` -> exit 0; 4 passed, 0 failed.
- `git diff --check` -> exit 0; no output.
- Read back changed hunk only with `git diff -- plugins\codestory\tests\plugin-static.test.mjs`.

## Risk

Docs/static-test only. No runtime behavior, Cargo, release, sidecar, packet/search, benchmark, or generated artifact changes.