### PR TITLE
[codex] fix docs truth drift

### DIFF
--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -10,10 +10,11 @@ with `retrieval_mode=full`.
   answers smoke queries against source files plus generated graph-native symbol
   docs and component-report virtual docs.
 - Qdrant collection exists, has at least the manifest dense-anchor projection
-  count, uses the product llama.cpp `bge-base-en-v1.5` embedding backend, and
-  answers semantic smoke queries when the active semantic policy selects one or
-  more dense anchors. If the active policy selects zero dense anchors, Qdrant is
-  explicitly not required for that generation.
+  count, matches the product-compatible BGE-base embedding contract, and answers
+  semantic smoke queries from the live llama.cpp sidecar when the active
+  semantic policy selects one or more dense anchors. If the active policy
+  selects zero dense anchors, Qdrant is explicitly not required for that
+  generation.
 - SCIP graph artifacts exist and are not stub markers.
 - The SQLite `retrieval_index_manifest` has the current schema version,
   sidecar input hash, sidecar generation, Qdrant collection, embedding backend,

--- a/docs/architecture/runtime-execution-path.md
+++ b/docs/architecture/runtime-execution-path.md
@@ -63,7 +63,7 @@ sequenceDiagram
     participant Graph as runtime graph builders
 
     CLI->>Runtime: concrete target request
-    Runtime->>Retrieval: validate full sidecar status and resolve target
+    Runtime->>Retrieval: record retrieval state for target context
     Runtime->>Graph: neighborhood, trail, snippets, citations
     Runtime-->>CLI: context packet with trace and evidence
     CLI->>CLI: render markdown/json and optional bundle
@@ -71,13 +71,12 @@ sequenceDiagram
 
 `context` is target-first. The CLI resolves `--id`, `--query`, or `--bookmark`
 to one concrete target. Query target selection may use read-only indexed-symbol
-resolution to choose that target, but context answer/evidence retrieval still
-fails closed unless strict sidecar status reports `retrieval_mode = full`.
+resolution to choose that target; it is not broad packet/search discovery.
 Runtime then builds the deep evidence packet from graph neighborhoods, trails,
 snippets, and citations. It is not a question-answering command and does not
-interpret broad natural-language prompts. Repo-text or hybrid state can guide
-diagnostics, but `retrieval_mode = full` sidecar evidence is the only
-product-serving retrieval state.
+interpret broad natural-language prompts. Use `packet` or `search` for broad
+sidecar-backed discovery, and treat non-`full` packet/search retrieval as a
+navigation hint until repaired.
 
 ## Ground, Symbol, Trail, and Snippet Commands
 

--- a/docs/architecture/runtime-execution-path.md
+++ b/docs/architecture/runtime-execution-path.md
@@ -63,7 +63,7 @@ sequenceDiagram
     participant Graph as runtime graph builders
 
     CLI->>Runtime: concrete target request
-    Runtime->>Retrieval: record retrieval state for target context
+    Runtime->>Retrieval: Investigate sidecar-primary retrieval
     Runtime->>Graph: neighborhood, trail, snippets, citations
     Runtime-->>CLI: context packet with trace and evidence
     CLI->>CLI: render markdown/json and optional bundle
@@ -72,11 +72,16 @@ sequenceDiagram
 `context` is target-first. The CLI resolves `--id`, `--query`, or `--bookmark`
 to one concrete target. Query target selection may use read-only indexed-symbol
 resolution to choose that target; it is not broad packet/search discovery.
-Runtime then builds the deep evidence packet from graph neighborhoods, trails,
-snippets, and citations. It is not a question-answering command and does not
-interpret broad natural-language prompts. Use `packet` or `search` for broad
-sidecar-backed discovery, and treat non-`full` packet/search retrieval as a
-navigation hint until repaired.
+The context packet still delegates to `runtime.browser.ask` with the
+`Investigate` retrieval profile and the selected `focus_node_id`. Runtime then
+builds the deep evidence packet from sidecar-primary retrieval, graph
+neighborhoods, trails, snippets, and citations. If sidecar primary is
+unavailable, rejected, disabled, or non-`full`, the Investigate path can fail
+closed rather than serving a DB-only answer packet. It is not a
+question-answering command and does not interpret broad natural-language
+prompts. Use `symbol`, `trail`, `snippet`, or `explore` for cache-only local
+navigation when sidecars are degraded; use `packet` or `search` for broad
+sidecar-backed discovery.
 
 ## Ground, Symbol, Trail, and Snippet Commands
 

--- a/docs/architecture/subsystems/cli.md
+++ b/docs/architecture/subsystems/cli.md
@@ -85,7 +85,7 @@ rather than the general CLI architecture page.
 
 `query` is intentionally small. It parses source operations (`search`, `symbol`, `trail`) followed by stream refinements (`filter`, `limit`) and rejects malformed or unknown named arguments rather than silently ignoring typos.
 
-`context` is target context: DB-first evidence for one concrete target. It resolves that target from `--id`, `--query`, or `--bookmark`, delegates to `codestory-runtime` retrieval orchestration, includes citations and retrieval traces, and always uses DB-first synthesis. It is not a natural-language question-answering surface and is not a replacement for broad `packet`, `search`, or `drill` questions. `--bundle <DIR>` writes Markdown, JSON, and Mermaid artifacts for handoff.
+`context` is target context: DB-first evidence for one concrete target. It resolves that target from `--id`, `--query`, or `--bookmark`, delegates to `codestory-runtime` retrieval orchestration, includes citations and retrieval traces, and always uses DB-first synthesis. `--query` must identify a concrete target, not a broad natural-language question. It is not a replacement for broad `packet`, `search`, or `drill` questions. `--bundle <DIR>` writes Markdown, JSON, and Mermaid artifacts for handoff.
 
 `doctor` is a read-only health report for project path resolution, cache
 presence, index counts, retrieval state, managed embedding setup, relevant
@@ -111,7 +111,7 @@ not expose ranking knobs for product search/context calls.
 
 HTTP serving keeps the current small GET/query-string shape. The stable routes are `/health`, `/search`, `/symbol`, `/definition`, `/references`, `/symbols`, and `/trail`. Definition and references accept either `q` or `id`, so agents can resolve from a query first and then reuse exact node ids.
 
-`serve --stdio` is MCP-style JSON lines. It exposes tools for ground, files, packet, search, context, symbol, trail, definition, references, symbols, snippet, and warm graph primitives (`get_node`, `neighbors`, `shortest_path`, and `query_subgraph`); resources for project, grounding, and root symbols; resource templates for node-specific symbol/reference/snippet/trail reads; and prompts for explain-symbol, callflow tracing, and impact analysis.
+`serve --stdio` is MCP-style JSON lines. It exposes tools for ground, files, affected, packet, search, context, symbol, trail, definition, references, symbols, snippet, and warm graph primitives (`get_node`, `neighbors`, `shortest_path`, and `query_subgraph`); resources for project, grounding, and root symbols; resource templates for node-specific symbol/reference/snippet/trail reads; and prompts for explain-symbol, callflow tracing, and impact analysis.
 
 The warm graph primitives are intentionally narrower than `packet`. They resolve exact node ids or bounded local graph neighborhoods before an agent asks for a broad evidence packet. Their responses include stable node ids, project-relative file refs when available, certainty metadata, count/truncation fields, and explicit result limits. `packet` remains the broad task tool with sufficiency, citations, retrieval traces, and budget accounting.
 

--- a/docs/architecture/subsystems/cli.md
+++ b/docs/architecture/subsystems/cli.md
@@ -85,7 +85,7 @@ rather than the general CLI architecture page.
 
 `query` is intentionally small. It parses source operations (`search`, `symbol`, `trail`) followed by stream refinements (`filter`, `limit`) and rejects malformed or unknown named arguments rather than silently ignoring typos.
 
-`context` is target context: DB-first evidence for one concrete target. It resolves that target from `--id`, `--query`, or `--bookmark`, delegates to `codestory-runtime` retrieval orchestration, includes citations and retrieval traces, and always uses DB-first synthesis. `--query` must identify a concrete target, not a broad natural-language question. It is not a replacement for broad `packet`, `search`, or `drill` questions. `--bundle <DIR>` writes Markdown, JSON, and Mermaid artifacts for handoff.
+`context` is target context for one concrete target. It resolves that target from `--id`, `--query`, or `--bookmark`; `--query` must identify a concrete target, not a broad natural-language question. After target selection, the CLI delegates to `codestory-runtime` through the Investigate agent path with a focused node id. The context answer/evidence packet needs full sidecar-primary retrieval and can fail closed when sidecars are unavailable, rejected, disabled, or non-`full`; use `symbol`, `trail`, `snippet`, or `explore` for cache-only local navigation. `context` is not a replacement for broad `packet`, `search`, or `drill` questions. `--bundle <DIR>` writes Markdown, JSON, and Mermaid artifacts for handoff.
 
 `doctor` is a read-only health report for project path resolution, cache
 presence, index counts, retrieval state, managed embedding setup, relevant

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -47,11 +47,13 @@ Important tuning surfaces:
 - `CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT`: local llama.cpp request concurrency, clamped from `1` to `16`.
 - `CODESTORY_LLM_DOC_EMBED_BATCH_SIZE`: semantic doc embedding batch size, default `128`.
 
-Product packet/search evidence is served through mandatory sidecars. The
-manifest must record `llamacpp:bge-base-en-v1.5` and live health must report
-`retrieval_mode=full`. ONNX, hash, and in-process embedding paths are historical
-or diagnostic research lanes unless a future spec promotes them with fresh
-sidecar-quality evidence. Current benchmark findings live in
+Product packet/search evidence is served through mandatory sidecars. The live
+query sidecar must use `llamacpp:bge-base-en-v1.5`, and health must report
+`retrieval_mode=full`. Stored product-compatible BGE-base dense docs may have
+ONNX or llama.cpp producer metadata when the dimension/backend contract matches
+the retrieval manifest; hash and other in-process embedding paths remain
+diagnostic unless a future spec promotes them with fresh sidecar-quality
+evidence. Current benchmark findings live in
 [embedding-backend-benchmarks.md](../../testing/embedding-backend-benchmarks.md).
 
 The CLI owns managed embedding setup. `codestory-cli retrieval bootstrap` starts

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -109,12 +109,14 @@ node scripts/codestory-agent-ab-benchmark.mjs \
   --codestory-cli ./target/release/codestory-cli \
   --out-dir target/agent-benchmark/language-expansion-publishable-full-form-command-shapes \
   --timeout-ms 180000 \
+  --max-source-reads-after-packet 0 \
   --publishable
 ```
 
 The packet-runtime artifact bundle must cover cold and warm modes, three repeats, row
 concurrency `--jobs 4`, prepared sidecars, full sidecar provenance, no
-`--allow-failures`, no quality misses, no sufficiency gaps, and no SLA misses.
+`--allow-failures`, no quality misses, no sufficiency gaps, no post-packet
+source reads for packet-only promotion, and no SLA misses.
 Keep `--prepare-codestory-jobs` lower or capped; examples use `2` unless the
 prep lane is intentionally serial.
 
@@ -182,7 +184,7 @@ Release-readiness evidence is tiered:
 | Stats-only / degraded sidecar | Diagnostic timing or contract evidence without prepared full sidecars, or stats output whose `proof_tier` is `stats_only` | Useful local regression signal only; not release proof for packet/search readiness. The current passing `codestory_repo_release_e2e_emits_stats` harness asserts full sidecar status instead of completing as a passing no-full-sidecar row. |
 | Full sidecar | `codestory_repo_release_e2e_emits_stats` emits `proof_tier: "full_sidecar"` after local Zoekt, SCIP, and required dense-anchor Qdrant/llama.cpp are prepared; `retrieval index --refresh full` succeeds; `retrieval status --format json` reports `retrieval_mode: "full"` with current symbol-doc and dense-anchor manifest fields; and search shadow mode is `full` | Required before claiming agent-facing packet/search readiness on the current workspace. This is the normal tier for a passing stats JSON object from the release e2e stats harness. |
 | Real-repo drill | `CODESTORY_REAL_REPO_DRILL_CASES` points at prepared manifests and the drill cases run without skip allowances | Required before claiming the release was exercised beyond the CodeStory checkout. |
-| Promotion-grade benchmark | Full holdout packet-runtime rows cover cold and warm modes with three repeats, `--jobs 4`, prepared sidecars, `--publishable`, no `--allow-failures`, full sidecar provenance, no quality misses, no sufficiency gaps, and no SLA misses. Fixed-baseline A/B rows are supporting diagnostics only unless fingerprint-compatible. | Required for performance or retrieval-quality promotion claims. |
+| Promotion-grade benchmark | Full holdout packet-runtime rows cover cold and warm modes with three repeats, `--jobs 4`, prepared sidecars, `--publishable`, explicit `--max-source-reads-after-packet 0`, no `--allow-failures`, full sidecar provenance, no quality misses, no sufficiency gaps, and no SLA misses. Fixed-baseline A/B rows are supporting diagnostics only unless fingerprint-compatible. | Required for performance or retrieval-quality promotion claims. |
 
 When logging release evidence, state the highest tier reached and the exact
 skip env vars used. The stats JSON reports `proof_tier` as the highest tier

--- a/docs/testing/agent-benchmark-harness-verification.md
+++ b/docs/testing/agent-benchmark-harness-verification.md
@@ -65,6 +65,7 @@ node scripts/codestory-agent-ab-benchmark.mjs `
   --codestory-cli target/release/codestory-cli.exe `
   --out-dir target/agent-benchmark/language-expansion-publishable-full-form-command-shapes `
   --timeout-ms 180000 `
+  --max-source-reads-after-packet 0 `
   --publishable
 ```
 
@@ -171,6 +172,7 @@ node scripts\codestory-agent-ab-benchmark.mjs `
   --codestory-cli target\release\codestory-cli.exe `
   --out-dir target\agent-benchmark\<run-name> `
   --timeout-ms 180000 `
+  --max-source-reads-after-packet 0 `
   --publishable
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,8 +63,15 @@ explicit ref, setup fetches and builds the remote default branch.
 | Built by | `index` | `index`, then `retrieval index` |
 | Requires | Healthy SQLite cache and graph | Healthy sidecars and `retrieval_mode=full` |
 | Good for | Known files, symbols, trails, snippets, changed-file impact | Broad candidate discovery and bounded task packets |
-| Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `context --id`, `context --query <exact target>`, `affected` | `packet`, `search` |
+| Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `affected` | `packet`, `search`, `context` packet construction after target selection |
 | Does not prove | Broad sidecar search is ready | That cache-only browsing is enough for broad agent search |
+
+`context` straddles these lanes. Target selection is local/index-first:
+`--id`, `--bookmark`, or `--query <exact target>` chooses one concrete focus.
+The context answer/evidence packet then runs through the Investigate agent path
+and may fail closed unless sidecar-primary retrieval is full. Use `symbol`,
+`trail`, `snippet`, or `explore` for cache-only local navigation when sidecars
+are degraded.
 
 Sidecar topology:
 [architecture/overview.md](architecture/overview.md),
@@ -202,7 +209,8 @@ variables such as `CODESTORY_SUMMARY_ENDPOINT`, `CODESTORY_SUMMARY_MODEL`, or
 | `ground` | Broad repo-level orientation snapshot. |
 | `report` | Derived Markdown repo report or JSON graph export from the current SQLite store. |
 | `files` | Indexed file inventory, language counts, roles, and coverage notes. |
-| `symbol`, `trail`, `snippet`, `context --id` | Exact-target source inspection once you have a node id. |
+| `symbol`, `trail`, `snippet`, `explore` | Cache-local exact-target source inspection once you have a node id or target. |
+| `context --id`, `context --query <exact target>`, `context --bookmark` | Target-first Investigate context packet; target selection is local/index-first, answer/evidence retrieval needs full sidecar primary. |
 | `affected` | Changed-file impact hints for review planning. |
 | `packet`, `search` | Broad sidecar-backed discovery; trust only with `retrieval_mode=full`. |
 | `retrieval bootstrap`, `retrieval index`, `retrieval status` | Sidecar setup, indexing, and readiness checks. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,7 +63,7 @@ explicit ref, setup fetches and builds the remote default branch.
 | Built by | `index` | `index`, then `retrieval index` |
 | Requires | Healthy SQLite cache and graph | Healthy sidecars and `retrieval_mode=full` |
 | Good for | Known files, symbols, trails, snippets, changed-file impact | Broad candidate discovery and bounded task packets |
-| Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `context --id`, `affected` | `packet`, `search`, broad `context --query` discovery |
+| Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `context --id`, `context --query <exact target>`, `affected` | `packet`, `search` |
 | Does not prove | Broad sidecar search is ready | That cache-only browsing is enough for broad agent search |
 
 Sidecar topology:
@@ -103,7 +103,7 @@ codestory-cli search --project <target-workspace> --query "<symbol/file/literal/
 ```
 
 Trust the result only when retrieval status reports `retrieval_mode: "full"`.
-If `packet`, `search`, or broad `context --query` reports
+If `packet` or `search` reports
 `retrieval_unavailable`, degraded retrieval, or a non-`full` mode, use the
 output only as a navigation hint and repair the sidecar lane before treating it
 as evidence.
@@ -204,7 +204,7 @@ variables such as `CODESTORY_SUMMARY_ENDPOINT`, `CODESTORY_SUMMARY_MODEL`, or
 | `files` | Indexed file inventory, language counts, roles, and coverage notes. |
 | `symbol`, `trail`, `snippet`, `context --id` | Exact-target source inspection once you have a node id. |
 | `affected` | Changed-file impact hints for review planning. |
-| `packet`, `search`, `context --query` | Broad sidecar-backed discovery; trust only with `retrieval_mode=full`. |
+| `packet`, `search` | Broad sidecar-backed discovery; trust only with `retrieval_mode=full`. |
 | `retrieval bootstrap`, `retrieval index`, `retrieval status` | Sidecar setup, indexing, and readiness checks. |
 | `serve --stdio` | Persistent local read surface for repeated agent queries. |
 | `generate-completions` | Shell completions from the command model. |

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -16,20 +16,23 @@ packet, and search. The CLI is still there, but it is the escape hatch and repai
 | What should I do next? | `codestory://agent-guide` | Let the skill route normal setup and repair. |
 | Give me a compact repo map. | `codestory://grounding` | Start from current local files. |
 | Inspect indexed file inventory and coverage. | `files` tool | Use for scope, language mix, and missing coverage. |
+| Map changed files to likely impact. | `affected` tool | Use for review planning and focused test choice. |
 | Find candidate symbols, paths, or behavior terms. | `search` tool, only with full sidecars | Navigation only unless packet/search is full. |
 | Answer a broad repo question with evidence. | `packet` tool, only with full sidecars | Proof only when strict sidecars are ready. |
 | Follow a concrete target. | `symbol`, `trail`, `references`, `snippet`, `context` | Source anchors still matter. |
 
 The status resource is the contract. Local navigation is ready only when
-`local_navigation` is ready. Agent packet/search is ready only when strict
-sidecar status reports `retrieval_mode=full`.
+`local_navigation` is ready. Agent packet/search is eligible only when strict
+sidecar status reports `retrieval_mode=full`; answer quality still needs the
+matching packet-runtime, drill, or benchmark proof.
 
 ## How It Runs
 
 This package stays thin:
 
 - `.codex-plugin/plugin.json` describes the Codex plugin package.
-- `.mcp.json` launches `codestory-cli serve --stdio --refresh none` directly.
+- `.mcp.json` launches `codestory-cli serve --stdio --refresh none` from the
+  agent host `PATH`.
 - `skills/codestory-grounding` is the single canonical CodeStory grounding
   skill shipped by this repository.
 
@@ -67,7 +70,7 @@ rather than the terminal. Use the UI path when the CLI marketplace command is
 unavailable.
 
 Start a new Codex thread after installation or refresh. The installed package
-launches `codestory-cli serve --stdio --refresh none` directly.
+launches `codestory-cli serve --stdio --refresh none` from `PATH`.
 
 ### After install
 
@@ -134,8 +137,9 @@ Use source fallback only when no release asset fits the host:
 cargo build --release -p codestory-cli
 ```
 
-Then put `target/release` on the agent host `PATH`, or set `CODESTORY_CLI` for
-manual CLI fallback commands.
+Then put `target/release` on the agent host `PATH` for installed MCP runtime
+use. Set `CODESTORY_CLI` only for manual CLI fallback commands or source-build
+debugging; `.mcp.json` does not launch through that variable.
 
 Source docs, marketplace source checkout/cache, and the active installed MCP
 runtime can differ. Before claiming an installed behavior is live, verify the
@@ -182,7 +186,10 @@ The marketplace catalog is external. One marketplace can list multiple plugins.
 ## Review Checks
 
 ```powershell
-python C:\Users\alber\.codex\skills\.system\plugin-creator\scripts\validate_plugin.py plugins\codestory
+python <path-to-plugin-creator>\scripts\validate_plugin.py plugins\codestory
 node --test plugins\codestory\tests\plugin-static.test.mjs
 git diff --check
 ```
+
+The plugin validator path is maintainer-local. The committed repo check for
+plugin docs/static contracts is the Node test above.

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -16,16 +16,19 @@ tool source unless the user is editing CodeStory itself.
 
 1. Resolve `<target-workspace>` explicitly. Do not infer the target from the
    current shell if the user named another repo.
-2. Resolve `<codestory-cli>`:
+2. For installed plugin MCP runtime, `.mcp.json` launches `codestory-cli` from
+   the agent host `PATH`. Use `CODESTORY_CLI` only for manual CLI/source
+   fallback commands, not as the installed MCP launch path.
+3. Resolve `<codestory-cli>` for explicit CLI commands:
    - prefer `CODESTORY_CLI` when set;
    - otherwise use `codestory-cli` on `PATH`;
    - otherwise use a nearby `target/release/codestory-cli*` from the current or
      sibling CodeStory checkout;
    - otherwise install the released binary for the host OS.
-3. Resolve the latest GitHub release tag. If `codestory-cli` exists, compare
+4. Resolve the latest GitHub release tag. If `codestory-cli` exists, compare
    `codestory-cli --version` with that tag and keep the binary only when it
    already matches the latest release.
-4. If `codestory-cli` is missing or outdated, download and unpack only the
+5. If `codestory-cli` is missing or outdated, download and unpack only the
    matching host asset derived from the latest tag. Do this before asking the
    human to install or run manual commands unless network access, permissions,
    or a missing release asset blocks the setup. For latest tag `vX.Y.Z`, use:
@@ -35,10 +38,10 @@ tool source unless the user is editing CodeStory itself.
    - Linux x64: `codestory-cli-vX.Y.Z-linux-x64.tar.gz`
    - Linux arm64: `codestory-cli-vX.Y.Z-linux-arm64.tar.gz`
    - macOS x64 or missing asset: Source fallback. Build from source.
-5. Put the binary in a stable user bin directory, verify
+6. Put the binary in a stable user bin directory, verify
    `codestory-cli --version`, and prefer checking `SHA256SUMS.txt` from the
    same release when the host has the tools. If `PATH` changed, say the plugin MCP process may need a Codex host/app restart before a new agent thread can see it.
-6. Use `scripts/setup.ps1` or `scripts/setup.sh` from this skill only for the
+7. Use `scripts/setup.ps1` or `scripts/setup.sh` from this skill only for the
    source-build fallback or explicit source-artifact setup.
 
 ## MCP Loop
@@ -92,7 +95,8 @@ Always pass `--project <target-workspace>` explicitly.
   hints only.
 - `retrieval_mode=full` means graph and lexical sidecars are complete, generated
   symbol docs/component reports are current, and dense anchors are valid for the
-  selected corpus. Anything weaker is not product packet/search proof.
+  selected corpus. It is infrastructure eligibility, not answer-quality proof.
+  Anything weaker is not product packet/search proof.
 - Do not run broad reindexing, sidecar rebuilds, benchmarks, or Cargo builds in
   parallel with another noise-sensitive lane unless the user accepts the timing
   noise.

--- a/plugins/codestory/skills/codestory-grounding/references/context.md
+++ b/plugins/codestory/skills/codestory-grounding/references/context.md
@@ -1,6 +1,6 @@
 # `context` - Target Context For One Concrete Target
 
-Builds DB-first target context around one concrete retrieval target. This is not a question-answering or chat command: it does not interpret natural-language questions, and `--query` must name a concrete symbol, file, literal, API path, module, or behavior term. Use `packet` for broad task questions, `search` for candidate discovery, and `drill` for repeatable investigation reports.
+Builds target context around one concrete retrieval target. Target selection is DB/index-first: `--query` must name a concrete symbol, file, literal, API path, module, or behavior term. The context packet itself runs through the Investigate agent path with the selected focus node and can fail closed unless sidecar-primary retrieval is full. This is not a question-answering or chat command: it does not interpret natural-language questions. Use `packet` for broad task questions, `search` for candidate discovery, and `drill` for repeatable investigation reports.
 
 ## Usage
 
@@ -28,7 +28,7 @@ Builds DB-first target context around one concrete retrieval target. This is not
 
 | Path | Command | Expected result |
 |------|---------|-----------------|
-| Normal path | `<codestory-cli> context --project <target-workspace> --query AppController` | Markdown context packet with resolution metadata, retrieval trace, citations, gaps, and next commands. |
+| Normal path | `<codestory-cli> context --project <target-workspace> --query AppController` | Markdown context packet with resolution metadata, retrieval trace, citations, gaps, and next commands when sidecar-primary retrieval is full. |
 | Failure path | If the target is ambiguous or missing, run `search --project <target-workspace> --query "<target>" --why`, choose a concrete `node_id`, then rerun `context --id <node_id>`. If local navigation readiness is weak, run `doctor --project <target-workspace>`, `setup embeddings --project <target-workspace>` when needed, and `index --project <target-workspace> --refresh full`. | Keeps target context tied to a resolvable target and avoids treating stale retrieval as strong evidence. |
 | Integration edge | Use `search --why`, `explore`, or `bookmark list` first, then pass the selected node via `--id <node_id>` or `--bookmark <bookmark_id>`; use `--bundle out/context-AppController` for reviewer handoff. | Converts candidate discovery into a deeper, shareable evidence packet. |
 
@@ -36,4 +36,5 @@ Builds DB-first target context around one concrete retrieval target. This is not
 
 - Do not pass broad questions to `context`. Use `packet --question` for broad task questions, `search --why` for candidate discovery, `drill` for deterministic reports, and then `context --id <node_id>` for selected anchors.
 - Good `--query` values are symbol names, file names, string literals, API paths, module names, and specific behavior terms.
+- Use `symbol`, `trail`, `snippet`, or `explore` for cache-only local navigation when sidecars are degraded.
 - Treat `context` output as incomplete when it reports weak hits, semantic stale/partial/failed states, missing snippets, no citations, or unresolved graph edges.

--- a/plugins/codestory/skills/codestory-grounding/references/context.md
+++ b/plugins/codestory/skills/codestory-grounding/references/context.md
@@ -1,6 +1,6 @@
 # `context` - Target Context For One Concrete Target
 
-Builds DB-first target context around one concrete retrieval target. This is not a question-answering or chat command: it does not interpret natural-language questions. Use `packet` for broad task questions, `search` for candidate discovery, and `drill` for repeatable investigation reports.
+Builds DB-first target context around one concrete retrieval target. This is not a question-answering or chat command: it does not interpret natural-language questions, and `--query` must name a concrete symbol, file, literal, API path, module, or behavior term. Use `packet` for broad task questions, `search` for candidate discovery, and `drill` for repeatable investigation reports.
 
 ## Usage
 
@@ -34,6 +34,6 @@ Builds DB-first target context around one concrete retrieval target. This is not
 
 ## Notes
 
-- Do not pass broad questions to `context`. Use `packet --question` for broad task questions, `search --repo-text on --why` for candidate discovery, `drill` for deterministic reports, and then `context --id <node_id>` for selected anchors.
+- Do not pass broad questions to `context`. Use `packet --question` for broad task questions, `search --why` for candidate discovery, `drill` for deterministic reports, and then `context --id <node_id>` for selected anchors.
 - Good `--query` values are symbol names, file names, string literals, API paths, module names, and specific behavior terms.
 - Treat `context` output as incomplete when it reports weak hits, semantic stale/partial/failed states, missing snippets, no citations, or unresolved graph edges.

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -36,7 +36,7 @@ Serves the indexed project over either a small HTTP JSON API or an MCP-style JSO
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
 | Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `index --project <target-workspace> --refresh full`; if bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
-| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, and `context`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
+| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `affected`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, and `context`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
 
 ## Notes
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -60,6 +60,7 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
     "codestory://status",
     "codestory://grounding",
     "Inspect indexed file inventory and coverage.",
+    "Map changed files to likely impact.",
     "For normal Codex use, install the plugin through the Codex plugin flow for your",
     "/plugins",
     "TheGreenCedar -> codestory -> Install plugin",
@@ -83,6 +84,11 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
     "Use source fallback only when no release asset fits the host",
     "Source docs, marketplace source checkout/cache, and the active installed MCP",
     "active runtime surface",
+    "agent host `PATH`",
+    "Set `CODESTORY_CLI` only for manual CLI fallback commands",
+    ".mcp.json` does not launch through that variable",
+    "python <path-to-plugin-creator>\\scripts\\validate_plugin.py plugins\\codestory",
+    "The plugin validator path is maintainer-local",
     "For normal Codex use, refresh or uninstall the plugin from the Codex plugin",
     "codex plugin marketplace upgrade TheGreenCedar",
     "codex plugin marketplace remove TheGreenCedar",
@@ -98,6 +104,8 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
   ];
   const skillRequired = [
     "download and unpack only",
+    "Use `CODESTORY_CLI` only for manual CLI/source",
+    "not as the installed MCP launch path",
     "plugin MCP process may need",
     "Codex host/app restart before a new agent thread",
     "new agent thread",
@@ -124,6 +132,11 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
   for (const phrase of forbidden) {
     assert.equal(rootReadme.includes(phrase), false, phrase);
   }
+  assert.equal(
+    readme.includes("C:\\Users\\alber"),
+    false,
+    "public plugin README must not contain maintainer workstation paths",
+  );
   for (const pattern of forbiddenPatterns) {
     assert.equal(pattern.test(rootReadme), false, String(pattern));
   }


### PR DESCRIPTION
## Context
Closes #353
Refs #351, #352, #348, #38

Release #351 is paused until the #352 metrics lane and this docs-truth lane land and the promotion review is rechecked. This PR keeps #353 scoped to stale command/runtime/proof wording and does not take over the separate README with-vs-without savings metrics work in #352.

Local CodeStory packet/search proof is not claimed here: `codestory-cli` was not available on PATH in this worktree, matching the coordinator note that local sidecars are not a trustworthy proof surface for this lane.

## What Changed
- Split target `context` guidance from broad packet/search discovery without implying DB-only context packets: target selection is local/index-first, but context packet construction runs through the Investigate agent path and can fail closed unless sidecar-primary retrieval is full.
- Updated plugin docs and the shipped grounding skill to say installed MCP runtime launches `codestory-cli` from PATH, while `CODESTORY_CLI` is only a manual CLI/source fallback.
- Documented `files` and `affected` as live read-only stdio/MCP tools, and extended the plugin static test to guard that contract.
- Removed the public private-workstation validator command from the plugin README and labeled the validator path maintainer-local.
- Added explicit `--max-source-reads-after-packet 0` to publishable benchmark command examples and the promotion-grade checklist.
- Clarified retrieval docs so `retrieval_mode=full` stays infrastructure eligibility, not answer-quality proof, and so stored BGE-base dense docs are not described as llama.cpp-only when product-compatible ONNX-produced stored docs can exist while live query/smoke remains llama.cpp sidecar-backed.

Docs-review items deliberately not changed:
- #352 README savings/value metrics were left alone because that is a separate lane.
- Root README/performance stats already separated regression telemetry from answer-quality and savings proof on this branch base, so this PR avoided a broad README rewrite.
- No generated ledgers, release comparisons, CSVs, screenshots, or new docs pages were added.

## How To Review
- Read `plugins/codestory/README.md` and `plugins/codestory/skills/codestory-grounding/SKILL.md` for the PATH versus `CODESTORY_CLI` runtime contract.
- Read `docs/usage.md`, `docs/architecture/runtime-execution-path.md`, `docs/architecture/subsystems/cli.md`, and `plugins/codestory/skills/codestory-grounding/references/context.md` for the exact-target context split and the sidecar fail-closed Investigate packet path.
- Check `docs/contributors/testing-matrix.md` and `docs/testing/agent-benchmark-harness-verification.md` for publishable command examples with the explicit post-packet source-read budget.
- Check `docs/architecture/retrieval-design.md` and `docs/architecture/subsystems/runtime.md` for the dense-doc/backend wording.

## Verification
- Read changed docs back after editing.
- `git diff --check` passed.
- `node --test .\plugins\codestory\tests\plugin-static.test.mjs` passed: 4/4 tests.
- Coordinator source review verified `run_context`, stdio `handle_stdio_context`, `agent_ask`, and sidecar-primary fail-closed runtime flow against the corrected docs wording.
- Cargo was not run because this is docs/static-test-only and does not change Rust behavior.

## Risk
Docs-only risk: wording could still lag a future runtime change, but the touched claims are grounded in the current `.mcp.json`, `stdio_transport.rs`, CLI `run_context`, and runtime sidecar-primary flow. No runtime behavior, release version, or benchmark artifacts changed.
