### PR TITLE
[Docs] add README with-vs-without metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,22 +158,47 @@ of answer quality, token savings, public benchmark promotion, or generalization.
 
 ## Speed And Context Value
 
-CodeStory's speed and token value come from avoiding the same broad repository
-scan over and over. The agent can ask for bounded graph, source, trail, impact,
-and packet evidence, then cite that evidence instead of repeatedly stuffing raw
-files into context.
+The product comparison is with CodeStory versus ordinary local exploration on
+the same repo task. The current README evidence uses the focused
+`readme-with-without` task
+[`codestory-index-refresh-mode`](benchmarks/tasks/readme-with-without/codestory-index-refresh-mode.task.json):
+identify the `RefreshMode` enum that defines index refresh modes, cite the
+owning file, and pass the manifest quality gate.
 
-That mechanism is useful even without a token-savings percentage: local graph
-navigation narrows the next source reads, `affected` narrows review planning,
-and full `packet`/`search` returns bounded citations plus gaps instead of an
-unbounded repo sweep. Exact token-savings measurements are not currently
-published in this README, so the claim stays at mechanism and evidence shape,
-not a numeric savings promise.
+Command:
 
-The committed timing evidence does show cache behavior that matters to operator
-flow: the 2026-06-18 #41 hardening row recorded a repeat full refresh at
-`29.45s` with `750` semantic docs reused and `0` embedded. Treat that as
-cache/reuse telemetry, not answer-quality proof.
+```powershell
+node .\scripts\codestory-agent-ab-benchmark.mjs `
+  --task-suite readme-with-without `
+  --arms without_codestory,with_codestory `
+  --repeats 1 `
+  --codestory-cli .\target\release\codestory-cli.exe `
+  --out-dir .\target\agent-benchmark\issue-352-readme-with-without-v4 `
+  --timeout-ms 300000
+```
+
+Evidence artifact: `target/agent-benchmark/issue-352-readme-with-without-v4`.
+Both arms passed the task quality gate (`1/1`), the CodeStory packet manifest
+passed (`1/1`), packet/search readiness was `retrieval_mode full`, and the
+CodeStory arm used zero post-packet source reads.
+
+| Metric | Without CodeStory | With CodeStory | Result |
+| --- | ---: | ---: | --- |
+| Token/context spend | `198,109` tokens | `35,218` tokens | `82.2%` lower: `(198109 - 35218) / 198109` |
+| Repeat-task wall time | `76.571s` | `63.399s` | `17.2%` saved: `(76.571 - 63.399) / 76.571` |
+| Tool calls / commands | `11` | `1` | `90.9%` lower: `(11 - 1) / 11` |
+| Direct source reads | `8` | `0` | `100%` lower |
+| All-in wall time, including ready-cache check | `76.571s` | `76.793s` | `0.3%` slower; setup verification is not hidden |
+
+First setup is separate from repeat-task savings. This run used an already
+indexed repo with full retrieval sidecars; the ready-cache check still recorded
+`13.394s`, including `7.839s` for retrieval index refresh. Cold setup requires
+building or installing `codestory-cli`, running `index --refresh full`, and
+preparing retrieval sidecars before packet/search numbers are comparable.
+
+Scope matters: this is one small source-ownership task, not a broad
+answer-quality or generalization benchmark. Broader public savings claims still
+need repeated paired benchmark rows.
 
 ## Cache And Worktree Lifecycle
 

--- a/benchmarks/tasks/readme-with-without/codestory-index-refresh-mode.task.json
+++ b/benchmarks/tasks/readme-with-without/codestory-index-refresh-mode.task.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "../manifest.schema.json",
+  "id": "codestory-index-refresh-mode",
+  "version": 1,
+  "suite": "readme-with-without",
+  "task_class": "route_tracing",
+  "repo": {
+    "name": "codestory",
+    "url": "https://github.com/TheGreenCedar/CodeStory.git",
+    "ref": "1f8e851c2e27709171bcc8a230ae9ba687ccc4bf",
+    "workspace_root": ".",
+    "languages": [
+      "Rust"
+    ]
+  },
+  "prompt": "Identify the local CodeStory CLI enum that defines index refresh modes. Cite the file and symbol.",
+  "expected_files": [
+    "crates/codestory-cli/src/args.rs"
+  ],
+  "expected_symbols": [
+    {
+      "name": "RefreshMode",
+      "path": "crates/codestory-cli/src/args.rs",
+      "kind": "enum",
+      "why": "Defines the refresh-mode values used by indexing."
+    }
+  ],
+  "expected_claims": [
+    {
+      "text": "`RefreshMode` defines the refresh-mode values used by the index command in `crates/codestory-cli/src/args.rs`."
+    }
+  ],
+  "forbidden_claims": [
+    {
+      "text": "The index refresh-mode enum lives outside `crates/codestory-cli/src/args.rs`.",
+      "severity": "critical"
+    },
+    {
+      "text": "The `index` command requires remote packet retrieval before it can run indexing.",
+      "severity": "major"
+    }
+  ],
+  "quality_thresholds": {
+    "min_expected_anchor_recall": 1,
+    "min_expected_file_recall": 1,
+    "min_expected_symbol_recall": 1,
+    "min_expected_claim_recall": 1,
+    "min_citation_coverage": 1,
+    "max_forbidden_claims": 0
+  },
+  "notes": [
+    "Small README value-comparison task; intended for scoped with-vs-without accounting, not broad promotion.",
+    "Runtime call-path proof is intentionally out of scope for this README metric."
+  ],
+  "tags": [
+    "readme",
+    "value-comparison",
+    "indexing"
+  ]
+}


### PR DESCRIPTION
## Context

Closes #352
Refs #351
Refs #348
Refs #38

#352 blocks the 0.11.4 promotion lane because the README speed/value section described mechanism and cache timing, but did not show the product comparison readers asked for: with CodeStory vs without CodeStory.

## What Changed

- Replaced the root README `Speed And Context Value` section with a with-vs-without comparison table.
- Added `benchmarks/tasks/readme-with-without/codestory-index-refresh-mode.task.json`, a deliberately tiny manifest that makes the README metric reproducible and quality-gated.
- Kept first setup separate from repeat-task savings and called out the ready-cache check/all-in timing.

Metric scope: one CodeStory self-task, `codestory-index-refresh-mode`, asking the agent to identify the `RefreshMode` enum owner in `crates/codestory-cli/src/args.rs`. Both arms passed the task quality gate; the CodeStory packet manifest also passed.

| Metric | Without CodeStory | With CodeStory | Result |
| --- | ---: | ---: | --- |
| Token/context spend | `198,109` tokens | `35,218` tokens | `82.2%` lower: `(198109 - 35218) / 198109` |
| Repeat-task wall time | `76.571s` | `63.399s` | `17.2%` saved: `(76.571 - 63.399) / 76.571` |
| Tool calls / commands | `11` | `1` | `90.9%` lower: `(11 - 1) / 11` |
| Direct source reads | `8` | `0` | `100%` lower |
| All-in wall time, including ready-cache check | `76.571s` | `76.793s` | `0.3%` slower; setup verification is not hidden |

## How To Review

1. Read the README `Speed And Context Value` section and verify the claim is scoped to the small manifest task.
2. Inspect the new manifest under `benchmarks/tasks/readme-with-without/`.
3. Re-run the measurement if needed:

```powershell
node .\scripts\codestory-agent-ab-benchmark.mjs `
  --task-suite readme-with-without `
  --arms without_codestory,with_codestory `
  --repeats 1 `
  --codestory-cli .\target\release\codestory-cli.exe `
  --out-dir .\target\agent-benchmark\issue-352-readme-with-without-v4 `
  --timeout-ms 300000
```

## Verification

- `cargo build --release -p codestory-cli` -> pass, built `codestory-cli 0.11.3`.
- `codestory-cli index --project . --refresh full` -> pass, local navigation ready.
- `codestory-cli retrieval bootstrap --project . --format json` -> pass, Zoekt/Qdrant/llama.cpp reachable.
- `codestory-cli retrieval index --project . --refresh full --format json` -> pass, no degraded modes.
- `codestory-cli retrieval status --project . --format json` -> pass, `retrieval_mode: full`.
- `node .\scripts\codestory-agent-ab-benchmark.mjs --task-suite readme-with-without --arms without_codestory,with_codestory --repeats 1 --codestory-cli .\target\release\codestory-cli.exe --out-dir .\target\agent-benchmark\issue-352-readme-with-without-v4 --timeout-ms 300000` -> pass; both arms quality `1/1`, packet manifest `1/1`.
- `node --test .\plugins\codestory\tests\plugin-static.test.mjs` -> pass, 4 tests.
- `git diff --check` -> pass.

## Risk

- This is a scoped README evidence row, not a broad public benchmark or generalization claim.
- `--repeats 1` is intentionally small for the README blocker; broader savings language still needs repeated paired rows.
- All-in wall time is effectively flat because ready-cache verification is included; the README shows that instead of hiding it.