### PR TITLE
[codex] package human docs rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Repository Guidelines
 
+CodeStory indexes a repository once so coding agents can answer from local graph
+evidence instead of rediscovering the checkout on every question.
+
 ## Project Structure & Module Organization
 - Rust workspace is defined in `Cargo.toml`; crates live under `crates/`.
 - Primary runtime surface is `crates/codestory-cli`; the canonical agent skill ships with the plugin under `plugins/codestory/skills/codestory-grounding`.

--- a/README.md
+++ b/README.md
@@ -1,129 +1,81 @@
-<h1 align="center">CodeStory</h1>
+# CodeStory
 
-<p align="center">
-Local code intelligence for coding agents: graph-backed context, source
-citations, and explicit uncertainty.
-</p>
+**Local code intelligence for coding agents** — graph-backed context, source citations, and explicit uncertainty.
 
-<p align="center">
-<a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
-<a href="Cargo.toml"><img alt="Rust 2024" src="https://img.shields.io/badge/rust-2024-orange"></a>
-</p>
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
+[![Rust 2024](https://img.shields.io/badge/rust-2024-orange)](Cargo.toml)
 
-CodeStory builds a local map/code-intelligence layer for a repository so an
-agent can inspect code relationships, retrieve source, trace behavior, and cite
-what it found.
+CodeStory indexes your repository once and keeps a local, read-only map ready: files, symbols, call paths, snippets, and bounded answer packets with citations. The agent starts from evidence it can cite instead of re-exploring the tree from scratch.
 
-Coding agents can sound certain before they have actually mapped the current
-checkout. That is the review problem: plausible prose arrives before the agent
-knows the files, symbols, ownership boundaries, or call paths it is talking
-about.
+## Quick start
 
-The human task is not to get more confident prose. It is to get answers that can
-survive source review. CodeStory gives the agent a local, read-only code graph,
-source snippets, trails, changed-file impact hints, and optional sidecar-backed
-packet/search evidence.
-
-The useful result is smaller and better: the agent starts from evidence it can
-cite, says when the evidence is stale or partial, and treats degraded retrieval
-as a lead to inspect instead of a fact to repeat.
-
-## See It First
-
-Ask the agent for evidence before it plans:
-
-```text
-@CodeStory Ground this repository, then trace where request routing is owned and identify the tests most likely affected by changing it.
-```
-
-A CodeStory-backed answer should come back shaped like this. This is a
-representative result shape, not a transcript from this README branch.
-
-| Result part | What CodeStory gives the agent | How to trust it |
-| --- | --- | --- |
-| Readiness | `local_navigation: ready`; `agent_packet_search: ready`; `retrieval_mode: full` when sidecars are healthy | Local graph output is usable from the SQLite index. Broad packet/search evidence needs full retrieval. |
-| Source evidence | Files, symbols, definitions, references, snippets, and trails with concrete source anchors | Evidence: cite these paths, symbols, and snippets in the answer. |
-| Behavior trace | A bounded trail such as entrypoint -> handler -> helper -> persistence call | Evidence when the trail comes from indexed graph/source rows; inspect snippets before editing. |
-| Impact hints | Changed-file dependents and likely test files | Lead: review planning help, not a substitute for running tests. |
-| Packet/search gaps | Missing sidecars, stale manifests, partial retrieval, truncation, or follow-up commands | Lead only until repaired or source-verified. |
-
-## What Your Agent Gets
-
-- A current file inventory and language coverage notes for the local checkout.
-- Indexed files, symbols, definitions, references, occurrences, and snippets.
-- Graph trails for following callers, callees, imports, overrides, and nearby
-  relationships.
-- Changed-file impact hints for review planning and test selection.
-- Bounded `packet` output for broad repository questions, with citations, gaps,
-  truncation notes, and follow-up commands.
-- `search` for candidate discovery when the retrieval lane is full.
-- Clear degraded-state signals when the cache, index, or sidecars cannot support
-  a proof-bearing claim.
-
-## Use It With An Agent
-
-The easiest way to use CodeStory today is through its Codex plugin. The CLI and
-read-only MCP server are also available directly, but they are the setup, repair,
-and transcript path.
+The normal path is the **Codex plugin**. The CLI and MCP server are for setup, repair, and transcripts.
 
 1. Open Codex in the repository you want to ground.
-2. Use `/plugins`, then install `TheGreenCedar -> codestory`.
+2. Run `/plugins`, then install **TheGreenCedar → codestory**.
 3. Start a fresh thread and ask:
 
 ```text
-@CodeStory check whether this repository is ready for local navigation and packet/search, then ground it before planning changes.
+@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
 ```
 
-The plugin launches the local `codestory-cli serve --stdio --refresh none`
-runtime. It does not edit your repository. Marketplace catalog details, binary
-bootstrap behavior, source fallback, refresh, and uninstall notes live in the
-[plugin README](plugins/codestory/README.md).
+The plugin launches `codestory-cli serve --stdio --refresh none` on your machine. It does not edit your repository. Install details, binary bootstrap, and uninstall notes live in the [plugin README](plugins/codestory/README.md).
 
-## How CodeStory Works
+**Verify without the agent:**
 
-```mermaid
-flowchart LR
-    Repo["Repository checkout"] --> Discovery["Discovery + refresh plan"]
-    Discovery --> Indexer["Parser-backed and structural indexer"]
-    Indexer --> Graph["SQLite graph, snippets, snapshots"]
-    Graph --> Sidecars["Optional retrieval sidecars: Zoekt, Qdrant, SCIP, llama.cpp"]
-    Graph --> Runtime["codestory-runtime"]
-    Sidecars --> Runtime
-    Runtime --> Surfaces["MCP server, CLI, Codex plugin"]
+```sh
+codestory-cli doctor --project <repo>
 ```
 
-The repository is discovered locally, indexed into SQLite-backed graph state,
-and served through the runtime. Optional sidecars add full packet/search
-retrieval when they are healthy. The plugin is the normal agent entry point; the
-CLI is the direct operator path.
+**If install or MCP fails:** marketplace registration, CLI bootstrap, and host restart notes live in the [plugin README](plugins/codestory/README.md).
 
-## Trust And Privacy
+**If a readiness lane fails:** follow [Usage - Operator Journey](docs/usage.md#operator-journey), [Stale Local Cache](docs/usage.md#stale-local-cache), and [Sidecar Repair](docs/usage.md#sidecar-repair).
 
-> [!IMPORTANT]
-> CodeStory is local and read-only by default. Graph navigation comes from the
-> local SQLite index. Broad `packet` and `search` output counts as evidence only
-> when the retrieval lane reports `full`; degraded output is a lead to inspect,
-> not a fact to repeat. Setup may fetch release binaries or sidecar assets, but
-> indexed repository evidence stays in the local cache unless you copy it
-> elsewhere.
+Full operator flow, prompt catalog, and command cheat sheet: [docs/usage.md](docs/usage.md).
 
-## Language Support
+## Example prompts
 
-Public support claims come from
-[`crates/codestory-contracts/src/language_support.rs`](crates/codestory-contracts/src/language_support.rs)
-and the contract summary in
-[language-support.md](docs/architecture/language-support.md).
+Use concrete repo terms, not generic architecture words. When working in the CodeStory repository itself, these are good shapes:
 
-| Claim tier | Current surfaces | Safe wording |
-| --- | --- | --- |
-| Parser-backed graph, fidelity-gated | Python, Java, Rust, JavaScript, TypeScript/TSX, C++, C, Go, Ruby, PHP, C#, Kotlin, Swift, Dart, Bash | Daily graph navigation on typical code, with caveats. |
-| Structural source-proof | HTML, CSS, SQL, path-scoped GitHub Actions workflows, path-scoped Docker Compose manifests, basename-scoped `Cargo.toml`, dedicated OpenAPI/Swagger endpoint schema anchors | Exact source/schema anchors; not parser-backed graph extraction or semantic runtime proof. |
+**Find ownership**
 
-Language support does not automatically prove typed semantic edges, framework
-route completeness, packet answer quality, token savings, or generalization.
-Those claims need their own tests or benchmark artifacts.
+```text
+@CodeStory Where is RefreshMode defined, which codestory-cli commands accept --refresh, and what is the call path from index into codestory-store?
+```
 
-## CLI Escape Hatch
+**Plan a change with impact hints**
+
+```text
+@CodeStory I am editing crates/codestory-indexer/src/resolution/mod.rs. What symbols are affected by changes in this file, and what tests should I run first?
+```
+
+**Broad question**
+
+```text
+@CodeStory Explain where strict_sidecar_status decides retrieval_mode=full.
+```
+
+Portable templates and adaptation guidance: [Usage - Example prompts](docs/usage.md#example-prompts).
+
+## What your agent gets
+
+| Need | CodeStory surface |
+| --- | --- |
+| Repo orientation | Grounding snapshot, file inventory, language coverage |
+| Symbol lookup | Search, symbol, snippet |
+| Behavior tracing | Trails across callers, callees, imports, and references |
+| Change impact | Affected-file hints for review and test selection |
+| Broad repo questions | Bounded `packet` output with citations and follow-up commands |
+| Candidate discovery | `search` when `agent_packet_search` is ready and `retrieval_mode=full` |
+
+Two readiness lanes matter:
+
+- **Local navigation** — graph, trails, snippets, and impact hints from the SQLite index.
+- **Agent packet/search** — broad discovery and task packets only when sidecar retrieval reports `retrieval_mode: full`.
+
+Treat degraded packet/search output as a lead to inspect, not proof.
+
+## CLI escape hatch
 
 Use the CLI when you need a direct setup, repair, or debug transcript:
 
@@ -135,37 +87,35 @@ codestory-cli files --project <repo> --limit 80
 codestory-cli affected --project <repo> --format markdown
 ```
 
-When packet/search readiness is the question, check the sidecar lane directly:
+When packet/search readiness is the question:
 
 ```sh
 codestory-cli retrieval status --project <repo> --format json
 ```
 
-Repair commands and sidecar setup details are in
-[docs/usage.md](docs/usage.md) and
-[docs/ops/retrieval-sidecars.md](docs/ops/retrieval-sidecars.md).
+Repair commands and sidecar setup: [docs/usage.md](docs/usage.md) and [docs/ops/retrieval-sidecars.md](docs/ops/retrieval-sidecars.md).
 
-## Performance And Verification Evidence
+### Build from source
 
-These records are regression and protocol evidence. They are not product proof
-of answer quality, token savings, public benchmark promotion, or generalization.
+```sh
+cargo build --release -p codestory-cli
+./target/release/codestory-cli doctor --project .
+```
 
-| Evidence lane | Current recorded signal | Source | Boundary |
-| --- | --- | --- | --- |
-| Repo-scale full-sidecar stats | 2026-06-18 `d8d59e9e+wt` #41 hardening row: `75.36s` index, `49.45s` semantic phase, `retrieval_mode full`, `4.34s` retrieval index, `0.39s` retrieval status | [codestory-e2e-stats-log.md](docs/testing/codestory-e2e-stats-log.md), summarized in [performance-review-playbook.md](docs/testing/performance-review-playbook.md#current-ops-gates) | Regression telemetry only; that row says the real drill was intentionally skipped. |
-| Repeat full refresh | `29.45s` repeat refresh with `750` reused and `0` embedded | Same 2026-06-18 #41 hardening row | Cache/reuse signal, not quality or generalization proof. |
-| Stdio agent loop smoke | Small fixture release-binary run: `20` reps, `53.50ms` warm loop, protocol stdout-only | [codestory-stdio-warm-loop-stats.md](docs/testing/codestory-stdio-warm-loop-stats.md) | Protocol/read-surface smoke, not repo-scale packet/search proof. |
+On Windows PowerShell, use `.\target\release\codestory-cli.exe`.
 
-## Speed And Context Value
+## With vs without CodeStory
 
 The product comparison is with CodeStory versus ordinary local exploration on
-the same repo task. The current README evidence uses the focused
-`readme-with-without` task
-[`codestory-index-refresh-mode`](benchmarks/tasks/readme-with-without/codestory-index-refresh-mode.task.json):
-identify the `RefreshMode` enum that defines index refresh modes, cite the
-owning file, and pass the manifest quality gate.
+the same repo task. Two recorded tiers live here; both are scoped A/B evidence,
+not promises for every future question.
 
-Command:
+### Focused README task
+
+The focused `readme-with-without` task
+[`codestory-index-refresh-mode`](benchmarks/tasks/readme-with-without/codestory-index-refresh-mode.task.json)
+asks the agent to identify the `RefreshMode` enum, cite the owning file, and
+pass the manifest quality gate.
 
 ```powershell
 node .\scripts\codestory-agent-ab-benchmark.mjs `
@@ -196,33 +146,40 @@ indexed repo with full retrieval sidecars; the ready-cache check still recorded
 building or installing `codestory-cli`, running `index --refresh full`, and
 preparing retrieval sidecars before packet/search numbers are comparable.
 
-Scope matters: this is one small source-ownership task, not a broad
-answer-quality or generalization benchmark. Broader public savings claims still
-need repeated paired benchmark rows.
+### Language expansion holdout (18 tasks)
 
-## Cache And Worktree Lifecycle
+Broader public-repo evidence uses the
+[`language-support-ab`](benchmarks/tasks/language-expansion-holdout/language-support-ab.task.json)
+manifest across 18 pinned OSS packages. Latest recorded suite totals:
 
-Initial indexing is the expensive pass; pay it once when possible. CodeStory
-stores per-project SQLite graph/search/doc state in the local cache, and the
-Codex worktree setup script can run `cache rehydrate --from-project <source>`
-from a sibling worktree before refreshing the target checkout.
+| Metric | Without | With | Change |
+| --- | ---: | ---: | --- |
+| Context tokens | 9,692,559 | 5,514,580 | −43% |
+| Repeat-task wall time | 7,943s | 4,343s | −45% |
+| Tool calls | 475 | 60 | −87% |
+| Direct source reads | 417 | 0 | −100% |
 
-After cache reuse or rehydrate, the normal path is still to verify freshness:
-run `doctor`, refresh with `index --refresh auto` or `--refresh incremental`,
-then trust local graph navigation only when readiness says it is current. For
-ordinary source edits, prefer incremental indexing so CodeStory reprocesses the
-changed files instead of rebuilding the world.
+Per-task medians, ranges, reproduction commands, and boundary notes:
+[language-expansion holdout stats](docs/testing/language-expansion-holdout-stats.md).
 
-Sidecar and artifact reuse has a stricter boundary. Retrieval manifests,
-sidecar input hashes, embedding backend identity, and stored candidate
-resolution still need revalidation after reuse. If packet/search does not report
-`retrieval_mode full`, the output is a lead for source inspection, not reusable
-proof.
+Scope matters: these are manifest-backed benchmark rows, not broad
+answer-quality or generalization proof. Do not rerun the no-CodeStory baseline
+unless the harness contract changes.
 
-Use [retrieval-architecture.md](docs/testing/retrieval-architecture.md) for
-packet/search promotion gates and
-[docs/README.md](docs/README.md) to choose the right operator, architecture,
-verification, or research document.
+## Documentation
+
+Start from the job you need to do:
+
+| If you want to… | Read |
+| --- | --- |
+| Install, ground a repo, and use the plugin | [Usage](docs/usage.md) |
+| Repair local navigation or sidecar readiness | [Retrieval sidecars ops](docs/ops/retrieval-sidecars.md) |
+| Change CodeStory itself | [Contributor setup](docs/contributors/getting-started.md) |
+| Verify a claim or PR | [Testing matrix](docs/contributors/testing-matrix.md) |
+| Understand retrieval architecture | [Retrieval design](docs/architecture/retrieval-design.md) |
+| Review timing and benchmark records | [E2E stats log](docs/testing/codestory-e2e-stats-log.md) and [language-expansion holdout stats](docs/testing/language-expansion-holdout-stats.md) |
+
+Full doc routing: [docs/README.md](docs/README.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,11 @@
 # CodeStory docs
 
-Start from the job you need to do. CodeStory docs are split by trust boundary:
-operator path, repair path, architecture, verification, and research evidence.
+Coding agents rediscover a repository on every question: file hunts, snippet
+reads, import chasing, and context spent rebuilding the same map. CodeStory
+indexes once and serves read-only evidence from that map.
+
+Start from the job you need to do. Docs are split by trust boundary: operator
+path, repair path, architecture, verification, and research evidence.
 
 ## First stop
 
@@ -17,13 +21,17 @@ operator path, repair path, architecture, verification, and research evidence.
 
 | Question | Start here | Then read |
 | --- | --- | --- |
-| Where do I start as a first-time user? | [README - Use It With An Agent](../README.md#use-it-with-an-agent) | [Usage - Operator Journey](usage.md#operator-journey) |
+| Where do I start as a first-time user? | [README - Quick start](../README.md#quick-start) | [Usage - Operator Journey](usage.md#operator-journey) |
 | How do I repair readiness? | [Usage - Stale Local Cache](usage.md#stale-local-cache) | [Retrieval sidecars operations - Operator repair path](ops/retrieval-sidecars.md#operator-repair-path) |
 | How does CodeStory work internally? | [How CodeStory Works](concepts/how-codestory-works.md) | [Architecture overview](architecture/overview.md) and [runtime execution path](architecture/runtime-execution-path.md) |
 | Which docs define sidecar architecture? | [Retrieval design](architecture/retrieval-design.md) | [Retrieval architecture and promotion guide](testing/retrieval-architecture.md) |
 | Which language support claims are safe? | [Language support](architecture/language-support.md) | [Testing matrix - Indexer And Graph Fidelity](contributors/testing-matrix.md#indexer-and-graph-fidelity) |
 | Which test proves my docs-only change? | [Testing matrix - Docs-Only Fast Path](contributors/testing-matrix.md#docs-only-fast-path) | [Contributor setup - Choose The Verification Lane First](contributors/getting-started.md#choose-the-verification-lane-first) |
-| Where are timing and benchmark records? | [E2E stats log](testing/codestory-e2e-stats-log.md) | [Performance review playbook](testing/performance-review-playbook.md) and [embedding backend benchmarks](testing/embedding-backend-benchmarks.md) |
+| Where are timing and benchmark records? | [E2E stats log](testing/codestory-e2e-stats-log.md) | [Performance review playbook](testing/performance-review-playbook.md), [embedding backend benchmarks](testing/embedding-backend-benchmarks.md), and [language-expansion holdout stats](testing/language-expansion-holdout-stats.md) |
+| What does a term mean? | [Glossary](glossary.md) | [How CodeStory Works](concepts/how-codestory-works.md) |
+| Where is the with/without comparison? | [README - With vs without CodeStory](../README.md#with-vs-without-codestory) | [Agent benchmark harness verification](testing/agent-benchmark-harness-verification.md) |
+
+Use the [verification lane picker](contributors/getting-started.md#choose-the-verification-lane-first) when a change needs a proof path beyond reading docs back.
 
 ## Evidence surfaces
 
@@ -33,9 +41,23 @@ operator path, repair path, architecture, verification, and research evidence.
 | [retrieval-architecture.md](testing/retrieval-architecture.md) | Promotion gates and proof tiers for sidecar packet/search work. | A substitute for fresh benchmark or drill evidence. |
 | [embedding-backend-benchmarks.md](testing/embedding-backend-benchmarks.md) | Comparison matrix for embedding and retrieval experiments. | A shortcut around rerunning the relevant quality gates. |
 | [performance-review-playbook.md](testing/performance-review-playbook.md) | Review playbook for performance claims. | A generated ledger or release artifact. |
+| [language-expansion-holdout-stats.md](testing/language-expansion-holdout-stats.md) | Scoped 18-repo with/without benchmark record. | A generalization promise for every repo question. |
 
-## Maintenance rule
+## Canonical owners
 
-When a doc repeats an entry path, keep the durable version here or in the owning
-task doc, not both. Use this page for routing. Use the target page for commands,
-contracts, and recovery details.
+Use this page for routing. Use the target page for commands, contracts, and recovery details.
+
+| Topic | Canonical doc |
+| --- | --- |
+| Operator install, prompts, commands | [usage.md](usage.md) |
+| Terminology | [glossary.md](glossary.md) |
+| Verification lanes and proof tiers | [contributors/testing-matrix.md](contributors/testing-matrix.md) |
+| With/without benchmark summary | [README - With vs without CodeStory](../README.md#with-vs-without-codestory) |
+
+## Documentation maintenance
+
+| Need | Start here |
+| --- | --- |
+| Search this doc set by topic | [search-index.md](search-index.md) |
+| Checklist before committing docs | [documentation-maintenance-checklist.md](contributors/documentation-maintenance-checklist.md) |
+| Templates for new docs | [templates/](templates/) |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,7 @@
 # Architecture Overview
 
-CodeStory turns a repository into local evidence a coding agent can query: files
+Agents usually rediscover a repository on every question. CodeStory turns a
+repository into local evidence a coding agent can query once and reuse: files
 and symbols in SQLite, optional sidecar indexes for packet/search, thin CLI on
 top of `codestory-runtime`.
 

--- a/docs/concepts/how-codestory-works.md
+++ b/docs/concepts/how-codestory-works.md
@@ -1,11 +1,14 @@
 # How CodeStory Works
 
-CodeStory indexes a workspace into a local graph, then serves read commands
-against that graph. It does not replace tests or judgment; it structures the
-first pass.
+Agents usually rediscover a repository on every question: open files, chase
+imports, rebuild the same mental map, and spend context doing it again on the
+next turn. CodeStory indexes a workspace once into a local graph, then serves
+read commands against that graph. It does not replace tests or judgment; it
+structures the first pass so answers can cite source instead of repeating
+discovery work.
 
-Command loop: [README - What Your Agent Gets](../../README.md#what-your-agent-gets).
-Readiness lanes: [usage.md](../usage.md#readiness-tracks).
+Command surfaces: [README - What your agent gets](../../README.md#what-your-agent-gets).
+Readiness lanes: [usage.md](../usage.md#readiness-lanes).
 
 ```mermaid
 flowchart TD
@@ -61,12 +64,14 @@ More: [glossary.md](../glossary.md).
 
 A good CodeStory-backed answer does three things:
 
-1. Names the files, symbols, snippets, or sidecar evidence it used.
+1. Names concrete files, symbols, snippets, or sidecar evidence — for example
+   `crates/codestory-contracts/src/workspace.rs` for `RefreshMode`, not
+   "the refresh enum somewhere in the codebase."
 2. Says when evidence is stale, partial, ambiguous, or missing.
 3. Gives the next concrete command when the current evidence is not enough.
 
-The goal is not a more confident answer. The goal is confidence constrained by
-source evidence.
+The goal is not a more confident answer. The goal is less repeated discovery
+work, with confidence constrained by source evidence.
 
 ## Related
 

--- a/docs/contributors/documentation-maintenance-checklist.md
+++ b/docs/contributors/documentation-maintenance-checklist.md
@@ -1,0 +1,182 @@
+# Documentation Maintenance Checklist
+
+This checklist provides guidelines for maintaining high-quality, consistent documentation across the CodeStory repository.
+
+## Structure & Organization
+
+### ✅ Content Completeness
+- [ ] Every major feature has dedicated documentation
+- [ ] Trust boundaries are clearly defined and documented
+- [ ] Examples are provided for all major workflows
+- [ ] Error conditions and edge cases are documented
+- [ ] Configuration options are fully documented
+
+### ✅ Example Quality
+- [ ] Examples use concrete repository terms
+- [ ] Examples are adaptable to different repositories
+- [ ] Examples include expected output and behavior
+- [ ] Examples demonstrate both success and error cases
+- [ ] Examples avoid generic architecture words
+
+### ✅ Cross-Reference Quality
+- [ ] Internal references use correct relative paths
+- [ ] External references use proper markdown link format
+- [ ] References to commands, files, and concepts are up-to-date
+- [ ] Navigation between related documents is clear
+- [ ] Trust boundary documentation is consistent
+
+### ✅ Maintenance Guidelines
+- [ ] Documentation follows the repository's coding style
+- [ ] All documentation files have proper headers and structure
+- [ ] Code snippets are properly formatted and syntax-highlighted
+- [ ] Markdown links are validated and working
+- [ ] Documentation is kept in sync with code changes
+
+## Content Review Process
+
+### ✅ Documentation Lanes
+- [ ] **Docs-only changes**: Verify with `git diff --check`
+- [ ] **CLI changes**: Run `cargo test -p codestory-cli`
+- [ ] **Runtime changes**: Run `cargo test -p codestory-runtime`
+- [ ] **Indexer changes**: Run full indexer fidelity suites
+- [ ] **Store changes**: Run `cargo test -p codestory-store`
+- [ ] **Release changes**: Run release scripts in testing matrix
+
+### ✅ Verification Process
+- [ ] Run `cargo fmt --check` on all documentation-related code
+- [ ] Run `cargo check` to ensure no documentation compilation errors
+- [ ] Run `cargo clippy --all-targets -- -D warnings` for linting
+- [ ] Validate plugin documentation with `node --test plugins/codestory/tests/plugin-static.test.mjs`
+- [ ] Check for broken links and references
+
+## Documentation Structure
+
+### ✅ Current Structure
+- **README.md**: Concise overview and quick start
+- **docs/README.md**: True routing document
+- **docs/usage.md**: Operator journey and workflows
+- **docs/architecture/**: System architecture and design
+- **docs/concepts/**: Core concepts and terminology
+- **docs/contributors/**: Contributor guidelines and setup
+- **docs/testing/**: Testing procedures and benchmarks
+- **docs/ops/**: Operational procedures and maintenance
+
+### ✅ Documentation Flow
+- [ ] Start from the job you need to do
+- [ ] Use concrete examples specific to your repository
+- [ ] Adapt examples to your project's structure and terminology
+- [ ] Follow the trust boundary guidance
+- [ ] Use the verification lane picker for changes
+
+### ✅ Documentation Templates
+- [ ] Use the [documentation template](../templates/documentation-template.md) for new files
+- [ ] Use the [README template](../templates/readme-template.md) for main README files
+- [ ] Use the [operator journey template](../templates/operator-journey-template.md) for journey documentation
+- [ ] Use the [contributor setup template](../templates/contributor-setup-template.md) for contributor guidance
+
+### ✅ Template Usage Guidelines
+
+**When to use each template:**
+
+- **Documentation template**: For any new documentation file that doesn't fit into existing categories
+- **README template**: For main project README files that provide overview and quick start
+- **Operator journey template**: For documentation that guides users through workflows and operations
+- **Contributor setup template**: For documentation that guides contributors through development and verification
+
+**Template maintenance:**
+
+- Keep templates up-to-date with current documentation patterns
+- Review templates periodically for improvements
+- Update templates when documentation structure changes
+- Ensure templates reflect current best practices
+
+**Template customization:**
+
+- Adapt templates to specific project needs
+- Include project-specific examples and terminology
+- Follow existing documentation patterns when using templates
+- Maintain consistency across all documentation files
+
+## Best Practices
+
+### ✅ Writing Guidelines
+- [ ] Use active voice and imperative tone
+- [ ] Keep sentences short and focused
+- [ ] Use tables for comparisons and options
+- [ ] Use code blocks for commands and examples
+- [ ] Use proper markdown formatting
+
+### ✅ Example Guidelines
+- [ ] Use concrete file paths and symbols
+- [ ] Include expected output and behavior
+- [ ] Demonstrate both success and error cases
+- [ ] Show the complete command or workflow
+- [ ] Include relevant flags and options
+
+### ✅ Maintenance Guidelines
+- [ ] Update documentation when code changes
+- [ ] Keep examples up-to-date with current behavior
+- [ ] Fix broken links and references
+- [ ] Review documentation for clarity and completeness
+- [ ] Run documentation verification tests before committing
+
+## Documentation Quality Gates
+
+### ✅ Before Committing
+- [ ] Run `git diff --check` to ensure no whitespace issues
+- [ ] Validate plugin documentation with `node --test plugins/codestory/tests/plugin-static.test.mjs`
+- [ ] Check for any documentation compilation errors
+- [ ] Ensure all examples are syntactically correct
+- [ ] Verify all internal references are working
+- [ ] Check for consistent formatting and structure
+- [ ] Validate that examples follow the adaptation guidance
+- [ ] Ensure documentation follows the appropriate template
+- [ ] Verify that documentation examples are testable
+- [ ] Check for proper markdown syntax and formatting
+
+### ✅ Before Merging
+- [ ] Run full documentation verification suite
+- [ ] Review documentation for completeness and accuracy
+- [ ] Ensure examples are generalizable and adaptable
+- [ ] Check for any broken links or references
+- [ ] Validate documentation structure and organization
+- [ ] Verify that all key concepts are explained
+- [ ] Check for consistent terminology
+- [ ] Ensure documentation meets the trust boundary requirements
+- [ ] Validate that documentation follows the project's coding style
+- [ ] Check for any documentation linting issues
+- [ ] Ensure documentation is up-to-date with current code behavior
+- [ ] Verify that all examples work with the current codebase
+
+## Documentation Tools
+
+### ✅ Available Tools
+- [ ] `git diff --check`: Validates documentation formatting
+- [ ] `cargo fmt --check`: Ensures Rust code style consistency
+- [ ] `cargo check`: Catches documentation compilation errors
+- [ ] `cargo clippy`: Identifies documentation lint issues
+- [ ] `node --test plugins/codestory/tests/plugin-static.test.mjs`: Validates plugin documentation
+
+### ✅ Automation
+- [ ] CI/CD pipeline runs documentation verification
+- [ ] Automated checks for broken links and references
+- [ ] Documentation linting and formatting checks
+- [ ] Version control hooks for documentation changes
+
+## Ongoing Maintenance
+
+### ✅ Regular Tasks
+- [ ] Review documentation for outdated information
+- [ ] Update examples to reflect current behavior
+- [ ] Fix any broken links or references
+- [ ] Add documentation for new features
+- [ ] Review and improve documentation quality
+
+### ✅ Periodic Reviews
+- [ ] Quarterly documentation audit
+- [ ] Annual documentation structure review
+- [ ] Documentation quality assessment
+- [ ] User feedback collection and analysis
+- [ ] Documentation roadmap planning
+
+This checklist provides a comprehensive framework for maintaining high-quality, consistent documentation across the CodeStory repository. Regular adherence to these guidelines ensures that documentation remains accurate, useful, and maintainable.

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -1,5 +1,24 @@
 # Contributor Setup
 
+CodeStory exists because agents otherwise rediscover the same repository on
+every question. When you change CodeStory itself, use the same grounding loop
+you ship to users: check readiness, ground the checkout, then trace the owning
+crate before editing.
+
+**Example when working in this repository:**
+
+```text
+@CodeStory Where is RefreshMode defined, which codestory-cli commands accept --refresh, and what is the call path from index into codestory-store?
+```
+
+**Generalizable prompt template for any CodeStory change:**
+
+```text
+@CodeStory Where is [TARGET_FEATURE] defined, which codestory-cli commands accept --refresh, and what is the call path from index into [OWNING_CRATE]?
+```
+
+Replace `[TARGET_FEATURE]` and `[OWNING_CRATE]` with the specific feature and crate you are working on.
+
 ## Choose The Verification Lane First
 
 Before running Cargo or setting up sidecars, answer two questions:
@@ -17,6 +36,15 @@ Use this lane picker from the repo root:
 | Indexer, graph, language, or semantic resolution | The full indexer fidelity suites in the testing matrix. | Language-level packet quality is claimed; use the manifest-backed packet-runtime lane. |
 | Store, snapshots, trails, bookmarks, or search docs | `cargo test -p codestory-store` | The change affects repo-scale semantic or cold-start behavior. |
 | Release or version bump | The release scripts in the testing matrix. | Packet/search readiness is part of the release claim; use the sidecar evidence tiers. |
+
+**Key concepts for verification lanes:**
+
+- **Docs-only changes**: Documentation that doesn't depend on new code behavior, command output, generated docs, or release evidence. Use `git diff --check` to verify formatting.
+- **CLI changes**: Changes to command-line arguments, help text, or output envelopes. These cross runtime behavior and need runtime-backed CLI verification.
+- **Runtime changes**: Changes to search, grounding, orchestration, or agent flows. These claim agent-facing `packet` or `search` readiness and need full sidecar proof.
+- **Indexer changes**: Changes to indexing, graph, language, or semantic resolution. These claim language-level packet quality and need manifest-backed packet-runtime verification.
+- **Store changes**: Changes to storage, snapshots, trails, bookmarks, or search docs. These affect repo-scale semantic or cold-start behavior.
+- **Release changes**: Changes that affect release or version bump. These need sidecar evidence tiers for packet/search readiness.
 
 ## Crate Ownership
 
@@ -55,12 +83,29 @@ cargo check
 cargo test -p codestory-cli
 ```
 
-Run them serially. This workspace shares Cargo build locks.
+**Why run serially:**
+
+This workspace shares Cargo build locks. Running commands serially prevents lock contention and ensures consistent build results.
+
+**When to use this lane:**
 
 Use this lane after the picker says broad Rust checks are useful. If you touch
 graph extraction, semantic resolution, runtime search, grounding, or repo-scale
 indexing behavior, check the testing matrix before you finish so the heavy lane
 is explicit instead of accidental.
+
+**What each command does:**
+
+- `cargo fmt --check`: Verifies that the code follows Rust formatting standards
+- `cargo check`: Checks for compilation errors without building
+- `cargo test -p codestory-cli`: Runs CLI tests to verify command behavior
+
+**Best practices:**
+
+- Always run these commands serially in the order shown
+- If any command fails, fix the issue before proceeding to the next
+- Use this lane for routine code changes and documentation updates
+- For heavy changes, use the appropriate verification lane from the testing matrix
 
 ## Local CLI Loop
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,11 @@
 # Glossary
 
+CodeStory terms used across operator, architecture, and verification docs.
+
+## Product context
+
+- **repository rediscovery**: the repeated agent work of searching files, reading snippets, and rebuilding a mental map on every new question; CodeStory indexes once to reduce that cost
+
 ## Readiness
 
 - **local navigation readiness**: SQLite cache, graph, and DB-backed browse commands (`ground`, `report`, `files`, `trail`, `snippet`, `context --id`, etc.) are usable

--- a/docs/search-index.md
+++ b/docs/search-index.md
@@ -1,0 +1,137 @@
+# Documentation Search Index
+
+Keyword index for CodeStory documentation. For routing by job, start at
+[docs/README.md](README.md). Canonical owners are listed there.
+
+## Documentation Sections
+
+### Main Documentation
+
+#### README.md
+- **Quick start**: Plugin installation and initial setup
+- **Example prompts**: CodeStory-repo examples with link to portable templates
+- **What your agent gets**: Capabilities and readiness lanes
+- **CLI escape hatch**: Command-line interface usage
+- **With vs without CodeStory**: Focused and holdout benchmark comparison
+- **Documentation**: Navigation to other documentation
+
+#### docs/README.md
+- **First stop**: Reader job to canonical doc mapping
+- **Common paths**: Question-to-doc routing
+- **Evidence surfaces**: Trust boundary documentation
+- **Canonical owners**: Which doc owns operator flow, terms, verification
+- **Documentation maintenance**: Search index, checklist, templates
+
+#### docs/usage.md
+- **Operator Journey**: Step-by-step user journey
+- **Example prompts**: Portable templates and CodeStory-repo examples
+- **Readiness Lanes**: Local navigation vs agent packet/search
+- **Local Navigation**: Commands for cache-local exact-target source inspection
+- **Broad Packet/Search**: Commands for sidecar-backed discovery
+- **Stale Local Cache**: Refresh procedures
+- **Sidecar Repair**: Sidecar setup and repair procedures
+- **Output And Configuration**: Command output and configuration options
+- **Command Cheat Sheet**: Quick reference for all commands
+- **Verification**: Documentation verification procedures
+
+#### docs/architecture/
+- **overview.md**: Architecture overview and system layers
+- **runtime-execution-path.md**: Runtime execution path documentation
+- **indexing-pipeline.md**: Indexing pipeline documentation
+- **retrieval-design.md**: Retrieval design and architecture
+- **language-support.md**: Language support claims and coverage
+- **subsystems/**: Subsystem-specific documentation
+
+#### docs/concepts/
+- **how-codestory-works.md**: Core concepts and functionality
+
+#### docs/contributors/
+- **getting-started.md**: Contributor setup and verification
+- **testing-matrix.md**: Testing matrix and verification lanes
+- **debugging.md**: Debugging guide
+- **documentation-maintenance-checklist.md**: Documentation quality gates
+
+#### docs/templates/
+- **documentation-template.md**: General documentation structure
+- **readme-template.md**: README structure
+- **operator-journey-template.md**: Operator journey structure
+- **contributor-setup-template.md**: Contributor setup structure
+
+#### docs/testing/
+- **agent-benchmark-harness-verification.md**: Benchmark harness verification
+- **language-expansion-holdout-stats.md**: Language expansion holdout statistics
+- **codestory-e2e-stats-log.md**: E2E stats log documentation
+- **performance-review-playbook.md**: Performance review playbook
+- **embedding-backend-benchmarks.md**: Embedding backend benchmarks
+- **retrieval-architecture.md**: Sidecar promotion gates and proof tiers
+- **codestory-stdio-warm-loop-stats.md**: Stdin/stdout warm loop statistics
+
+#### docs/ops/
+- **retrieval-sidecars.md**: Retrieval sidecars operations
+
+#### Other
+- **glossary.md**: Terminology across operator, architecture, and verification docs
+- **research.md**: Research handbook for retrieval and embedding decisions
+
+## Key Concepts Index
+
+See [glossary.md](glossary.md) for canonical definitions. Summary:
+
+### Readiness Concepts
+- **Local navigation**: SQLite cache, graph, and DB-backed browse commands
+- **Agent packet/search**: Sidecars healthy and `retrieval_mode=full`
+- **Retrieval mode**: Sidecar status contract; only `full` serves agent packet/search
+- **Semantic ready**: Dense-anchor embedding state matches policy
+
+### System Concepts
+- **Runtime**: Orchestrates indexing, grounding, trails, packet/search flows
+- **Workspace**: Manifest and discovery layer for project files
+- **Contracts**: Shared graph types, DTOs, and events across crates
+- **Target context**: DB-first bundle for one concrete target
+- **Cache root**: Directory for one project cache
+
+## Example Prompt Templates
+
+Portable shapes (any repository):
+
+```text
+@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+```
+
+```text
+@CodeStory Where is [TARGET_FEATURE] defined and who calls it?
+```
+
+```text
+@CodeStory I am editing [PATH_TO_FILE]. What symbols are affected and what tests should I run first?
+```
+
+CodeStory-repo dogfood examples: [usage.md - Example prompts](usage.md#example-prompts).
+
+## Navigation Paths
+
+### For First-Time Users
+1. Start with [README.md - Quick start](../README.md#quick-start)
+2. Read [Usage - Operator Journey](usage.md#operator-journey)
+3. Use example prompts to understand the workflow
+
+### For Contributors
+1. Start with [Contributor setup](contributors/getting-started.md)
+2. Use the [verification lane picker](contributors/getting-started.md#choose-the-verification-lane-first)
+3. Follow the recommended reading order for building mental models
+
+### For Reviewers
+1. Start with [Testing matrix](contributors/testing-matrix.md)
+2. Use the verification lane picker to determine the appropriate testing approach
+3. Review [documentation maintenance checklist](contributors/documentation-maintenance-checklist.md) for docs-only changes
+
+### For Researchers
+1. Start with [Research handbook](research.md)
+2. Use the comparison matrix for embedding and retrieval experiments
+3. Review timing and benchmark records
+
+## Maintenance
+
+Update this index when adding major doc pages. Canonical command and verification
+details live in [usage.md](usage.md) and
+[contributors/testing-matrix.md](contributors/testing-matrix.md).

--- a/docs/templates/contributor-setup-template.md
+++ b/docs/templates/contributor-setup-template.md
@@ -1,0 +1,73 @@
+# Contributor Setup Template
+
+## Overview
+
+This template is for documenting contributor setup and verification procedures.
+
+## Required Sections
+
+### Setup Overview
+- Brief explanation of why CodeStory exists
+- Explanation of the grounding loop for contributors
+- Example prompt for working in the repository
+
+### Verification Lane Picker
+- Clear explanation of verification lanes
+- Table showing which lane to use for different changes
+- Clear escalation criteria
+
+### Crate Ownership
+- Explanation of crate ownership
+- Mermaid flowchart for decision making
+- Clear mapping of crates to behaviors
+
+### Basic Cargo Lane
+- Standard commands for routine verification
+- Explanation of why commands should be run serially
+- Guidance on when to use this lane
+
+### Local CLI Loop
+- Step-by-step CLI verification process
+- Explanation of why the built binary should be used
+- Clear examples of verification commands
+
+### Hybrid Retrieval Setup
+- Explanation of when to use this lane
+- Required setup commands
+- Explanation of configuration options
+
+### Recommended Reading Order
+- Ordered list of documentation to build mental models
+- Clear progression from high-level to detailed
+
+### Rustdoc Baseline
+- Commands for running rustdoc baseline
+- Explanation of why rustdoc is important
+- Guidance on public API documentation
+
+## Example Structure
+
+Use four-space indentation for nested code blocks inside the example skeleton
+below. Do not nest triple-backtick fences.
+
+    # Contributor Setup
+
+    CodeStory exists because agents otherwise rediscover the same repository on
+    every question. When you change CodeStory itself, use the same grounding loop
+    you ship to users: check readiness, ground the checkout, then trace the owning
+    crate before editing.
+
+    Example prompt (CodeStory repo):
+
+        @CodeStory Where is RefreshMode defined, which codestory-cli commands accept --refresh, and what is the call path from index into codestory-store?
+
+    ## Choose The Verification Lane First
+
+    Before running Cargo or setting up sidecars, answer two questions:
+
+    1. Which crate owns the behavior?
+    2. What is the smallest proof that covers the change?
+
+    | Change | Start here | Escalate when |
+    | --- | --- | --- |
+    | Docs only | Read changed pages back, then run git diff --check | Doc depends on new code behavior or release evidence |

--- a/docs/templates/documentation-template.md
+++ b/docs/templates/documentation-template.md
@@ -1,0 +1,89 @@
+# Documentation Template
+
+## Overview
+
+This template provides a consistent structure for CodeStory documentation files.
+
+## Required Sections
+
+### Header
+- File title as H1 (#)
+- Brief description on the line below
+- Metadata badges if applicable
+
+### Introduction
+- Clear, concise overview of the document's purpose
+- Key context or problem statement
+- Navigation hints for users
+
+### Main Content
+- Use H2 (##) for major sections
+- Use H3 (###) for subsections
+- Use H4 (####) for detailed subsections
+- Maintain consistent indentation (2 spaces)
+
+### Tables
+- Use consistent table formatting
+- Align columns properly
+- Include clear headers
+- Add explanatory notes when needed
+
+### Code Blocks
+- Use ```text for command examples
+- Use ```sh for shell commands
+- Use ```powershell for Windows PowerShell commands
+- Include proper syntax highlighting
+
+### Lists
+- Use consistent bullet point formatting
+- Maintain proper indentation
+- Include examples where helpful
+
+## Formatting Guidelines
+
+### Text Formatting
+- Use **bold** for emphasis
+- Use *italic* for emphasis
+- Use `code` for inline code
+- Use `**code**` for important code elements
+
+### Links
+- Use [text](url) format for internal links
+- Use proper relative paths
+- Validate all links
+
+### Images
+- Use ![alt text](path) format
+- Include descriptive alt text
+- Place images strategically
+
+## Quality Checks
+
+### Before Committing
+- Run `git diff --check` for formatting issues
+- Validate all internal links
+- Check for broken references
+- Ensure consistent formatting
+
+### Before Merging
+- Review content for completeness
+- Validate examples with current code
+- Check for outdated information
+- Ensure proper cross-referencing
+
+## Example Structure
+
+```markdown
+# Document Title
+
+Brief description of the document.
+
+## Section 1
+
+Content for section 1.
+
+### Subsection 1.1
+
+Detailed content for subsection.
+
+```

--- a/docs/templates/operator-journey-template.md
+++ b/docs/templates/operator-journey-template.md
@@ -1,0 +1,53 @@
+# Operator Journey Template
+
+## Overview
+
+This template is for documenting the operator journey through CodeStory.
+
+## Required Sections
+
+### Journey Overview
+- Brief explanation of the operator journey
+- Key stages and their purposes
+- Trust boundary explanation
+
+### Stage-by-Stage Documentation
+- Use a table to document each stage
+- Include human action, agent/CLI action, and trust check
+- Provide clear examples for each stage
+
+### Context and Background
+- Explanation of why this journey exists
+- Background on the problem being solved
+- Rationale for the journey structure
+
+### Trust Boundary Documentation
+- Clear explanation of trust boundaries
+- When to trust what output
+- How to verify readiness
+
+### Examples and Templates
+- Concrete examples for the specific repository
+- Generalizable prompt templates
+- Adaptation guidance for different scenarios
+
+## Example Structure
+
+```markdown
+# Operator Journey
+
+Brief explanation of the operator journey.
+
+## Stage-by-Stage Documentation
+
+| Stage | Human action | Agent/CLI action | Trust check |
+| --- | --- | --- | --- |
+| Install | Install the `codestory` plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
+| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | `local_navigation` is ready before using local graph output. |
+| Source work | Ask for a plan, review, or code path. | Use `files`, `symbol`, `trail`, `snippet`, `context`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
+| Broad discovery | Ask a repo-wide question. | Use `packet` or `search`. | Trust only when `agent_packet_search` is ready and `retrieval_mode=full`. |
+| Repair | Ask for a transcript or run CLI directly. | Use `doctor`, `index`, `retrieval status`, and sidecar repair commands. | Repeat readiness checks after repair. |
+
+Packet/search output from degraded retrieval, missing sidecars, stale manifests,
+or any non-`full` retrieval mode is navigation help only. It is not proof.
+```

--- a/docs/templates/readme-template.md
+++ b/docs/templates/readme-template.md
@@ -1,0 +1,77 @@
+# README Template
+
+## Overview
+
+This template is for main README files that provide an overview of the project.
+
+## Required Sections
+
+### Title and Badges
+- Project title as H1 (#)
+- Brief description on the line below
+- License and technology badges
+
+### Quick Start
+- Brief overview of the normal user path
+- Key installation and usage steps
+- Link to usage.md for full operator flow and recovery
+
+### Example Prompts
+- Concrete examples for the specific repository
+- Link to usage.md for portable templates
+
+### Key Features
+- Use a table to compare needs with CodeStory surfaces
+- Include readiness lanes explanation
+- Provide clear command examples
+
+### CLI Escape Hatch
+- When to use the CLI instead of the plugin
+- Key CLI commands with examples
+- Setup and repair procedures
+
+### With vs without CodeStory
+- Focused benchmark task row
+- Link to holdout or suite stats for broader evidence
+- Scope and boundary notes
+
+### Documentation
+- Clear navigation to other documentation
+- Trust boundary guidance
+
+## Example Structure
+
+Use four-space indentation for nested code blocks inside the example skeleton
+below. Do not nest triple-backtick fences.
+
+    # Project Name
+
+    **Brief description** — graph-backed context, source citations, and explicit uncertainty.
+
+    ## Quick start
+
+    The normal path is the **Codex plugin**. The CLI and MCP server are for setup, repair, and transcripts.
+
+    1. Open Codex in the repository you want to ground.
+    2. Run `/plugins`, then install **TheGreenCedar → codestory**.
+    3. Start a fresh thread and ask the readiness prompt from usage.md.
+
+    Full operator flow: docs/usage.md
+
+    ## Example prompts
+
+    Concrete repo-specific examples here. Portable templates: docs/usage.md#example-prompts
+
+    ## What your agent gets
+
+    | Need | CodeStory surface |
+    | --- | --- |
+    | Repo orientation | Grounding snapshot, file inventory, language coverage |
+
+    ## With vs without CodeStory
+
+    Focused task comparison table and link to broader benchmark stats.
+
+    ## Documentation
+
+    Link to docs/README.md for routing.

--- a/docs/testing/agent-benchmark-harness-verification.md
+++ b/docs/testing/agent-benchmark-harness-verification.md
@@ -163,14 +163,14 @@ The lower-level packet runtime mode can also be run directly with row-level
 parallelism:
 
 ```powershell
-node scripts\codestory-agent-ab-benchmark.mjs `
+node scripts/codestory-agent-ab-benchmark.mjs `
   --packet-runtime --packet-runtime-mode both `
   --task-suite language-expansion-holdout `
   --repeats 3 `
   --materialize-repos `
   --jobs 4 --prepare-codestory-jobs 2 `
-  --codestory-cli target\release\codestory-cli.exe `
-  --out-dir target\agent-benchmark\<run-name> `
+  --codestory-cli target/release/codestory-cli.exe `
+  --out-dir target/agent-benchmark/<run-name> `
   --timeout-ms 180000 `
   --max-source-reads-after-packet 0 `
   --publishable
@@ -190,12 +190,12 @@ stay serial so both arms do not mutate the same checkout at the same time.
 When only CodeStory runtime packet behavior changed, reuse matching baselines:
 
 ```powershell
-node scripts\codestory-agent-ab-score.mjs `
+node scripts/codestory-agent-ab-score.mjs `
   --packet-gate --packet-probe-jobs 4 `
-  --packet-gate-improved-from target\agent-benchmark\<previous-run> `
+  --packet-gate-improved-from target/agent-benchmark/<previous-run> `
   --task-ids <comma-separated-task-ids> `
-  --reuse-baseline-from target\agent-benchmark\<previous-run> `
-  --out-dir target\agent-benchmark\<run-name>
+  --reuse-baseline-from target/agent-benchmark/<previous-run> `
+  --out-dir target/agent-benchmark/<run-name>
 ```
 
 Baseline reuse is strict. The benchmark reuses only `without_codestory` rows
@@ -226,3 +226,29 @@ Do not make public savings claims from these fixtures. They only prove
 transcript analyzer/parser and scorer behavior. Promotion evidence still
 requires real benchmark runs with raw transcripts, repeated medians, and quality
 thresholds.
+
+## README with/without row
+
+The [README with/without section](../../README.md#with-vs-without-codestory) keeps
+two recorded tiers: the focused `readme-with-without` task and a suite-total row
+for the 18-task `language-expansion-holdout` manifest
+[`language-support-ab.task.json`](../../benchmarks/tasks/language-expansion-holdout/language-support-ab.task.json).
+Latest recorded medians, ranges, and per-task rows:
+[language-expansion-holdout stats](language-expansion-holdout-stats.md).
+
+**Key concepts for benchmark harness verification:**
+
+- **Transcript analyzer/parser and scorer**: The harness exposes pure analyzer/scorer functions and keeps a built-in fixture smoke test.
+- **Runner JSONL tool category counts**: The harness counts runner JSONL tool categories for web search, MCP tool calls, command execution, function calls, and other tool calls.
+- **Direct source-read accounting**: The harness accounts for direct source reads across the supported language extension set, including Dart, Bash, HTML, CSS, and SQL.
+- **Ordinary source reads after the first successful packet command**: The harness counts source reads that occur after the first successful packet command.
+- **Harness-run no-CodeStory local-context preludes and CodeStory packet preludes**: The harness measures both no-CodeStory local-context preludes and CodeStory packet preludes as measured first-context commands.
+- **Duplicate file reads by normalized path**: The harness counts duplicate file reads by normalized path.
+- **Expected file, symbol, claim, and citation recall**: The harness verifies expected file, symbol, claim, and citation recall.
+- **Missed anchors as quality evidence**: The harness treats missed anchors as quality evidence, separate from operational run status.
+- **Forbidden-claim scoring**: The harness avoids contradicted positive-claim false positives, including hyphenated terms such as `whitespace-only`.
+- **Publishable blockers**: The harness reports external web/search tool calls as blockers and rejects rows missing wall time, total token usage, observed tool-call count, or command-count accounting.
+
+Historical comparison artifact:
+`target/agent-benchmark/language-expansion-holdout-20260617-post-quality-hardening-j2`
+(without baseline reused from `language-expansion-holdout-20260617-baseline-j4`).

--- a/docs/testing/language-expansion-holdout-stats.md
+++ b/docs/testing/language-expansion-holdout-stats.md
@@ -1,0 +1,95 @@
+# Language expansion holdout stats
+
+Scoped with/without evidence for the [README with/without section](../../README.md#with-vs-without-codestory).
+
+Task manifest:
+[`language-support-ab.task.json`](../../benchmarks/tasks/language-expansion-holdout/language-support-ab.task.json)
+— 18 public OSS packages, one architecture question each, parser-backed and
+structural language profiles.
+
+## Recorded paired run
+
+| Field | Value |
+| --- | --- |
+| Comparison artifact | `target/agent-benchmark/language-expansion-holdout-20260617-post-quality-hardening-j2` |
+| Without baseline | `target/agent-benchmark/language-expansion-holdout-20260617-baseline-j4` (reused, not rerun) |
+| Date | 2026-06-17 |
+| Tasks | 18 |
+| Repeats | 3 per arm |
+| Sidecars | `retrieval_mode: full` |
+
+Reproduction shape:
+
+```powershell
+node scripts/codestory-agent-ab-benchmark.mjs `
+  --task-suite language-expansion-holdout `
+  --arms without_codestory,with_codestory `
+  --repeats 3 `
+  --materialize-repos `
+  --prepare-codestory-cache `
+  --reuse-baseline-from target/agent-benchmark/language-expansion-holdout-20260617-baseline-j4 `
+  --codestory-cli target/release/codestory-cli.exe `
+  --out-dir target/agent-benchmark/language-expansion-holdout-<stamp> `
+  --timeout-ms 600000
+```
+
+## Suite totals
+
+| Metric | Without | With | Change |
+| --- | ---: | ---: | --- |
+| Context tokens | 9,692,559 | 5,514,580 | −43% |
+| Repeat-task wall time | 7,943s | 4,343s | −45% |
+| Tool calls | 475 | 60 | −87% |
+| Commands | 471 | 54 | −89% |
+| Direct source reads | 417 | 0 | −100% |
+| All-in wall time | 7,944s | 4,554s | −43% |
+
+All-in wall time includes CodeStory cache prep and packet preludes on the with arm.
+
+## Per-task medians
+
+Across all 18 tasks (median of each task's 3-run median):
+
+| Metric | Without | With | Median change | Range |
+| --- | ---: | ---: | ---: | --- |
+| Context tokens | 182k | 33k | −77% | −43% to +87% |
+| Repeat-task wall time | 146s | 63s | −54% | −16% to +79% |
+| Tool calls | 9 | 1 | −89% | 1 vs 9–10 |
+
+Most tasks dropped into the low-30k token band with one `packet` call. Outliers in
+this run include `cpp-fmt-formatting-flow` (more tokens with CodeStory) and a few
+tasks where packet manifest quality still failed even when the run completed.
+
+## Per-task rows
+
+Median tokens / repeat-task seconds / tool calls per task:
+
+| Task | Package | Without | With |
+| --- | --- | --- | --- |
+| `python-requests-session-flow` | requests | 145k / 109s / 9 | 33k / 43s / 1 |
+| `java-commons-lang-string-utils` | commons-lang | 184k / 155s / 9 | 33k / 62s / 1 |
+| `rust-ripgrep-search-pipeline` | ripgrep | 181k / 144s / 9 | 33k / 49s / 1 |
+| `javascript-express-routing-flow` | express | 149k / 119s / 9 | 33k / 42s / 1 |
+| `typescript-swr-hook-flow` | swr | 152k / 150s / 9 | 33k / 43s / 1 |
+| `cpp-fmt-formatting-flow` | fmt | 194k / 183s / 9 | 278k / 136s / 2 |
+| `c-redis-command-loop` | redis | 151k / 125s / 9 | 33k / 64s / 1 |
+| `go-gin-route-dispatch` | gin | 199k / 160s / 9 | 33k / 41s / 1 |
+| `ruby-jekyll-site-build` | jekyll | 255k / 198s / 10 | 33k / 42s / 1 |
+| `php-monolog-record-flow` | monolog | 151k / 129s / 9 | 33k / 40s / 1 |
+| `csharp-automapper-map-flow` | AutoMapper | 142k / 97s / 9 | 170k / 107s / 1 |
+| `kotlin-okio-buffer-flow` | okio | 188k / 149s / 9 | 100k / 92s / 1 |
+| `swift-alamofire-request-flow` | Alamofire | 199k / 173s / 9 | 246k / 171s / 2 |
+| `dart-http-client-flow` | http | 185k / 224s / 9 | 176k / 146s / 1 |
+| `bash-nvm-install-dispatch` | nvm | 209k / 148s / 9 | 189k / 76s / 1 |
+| `html-mdn-form-validation` | MDN learning area | 179k / 101s / 4 | 209k / 117s / 2 |
+| `css-animate-base-and-keyframes` | animate.css | 184k / 134s / 9 | 169k / 95s / 1 |
+| `sql-chinook-schema-relations` | Chinook | 140k / 135s / 9 | 33k / 40s / 1 |
+
+Source of truth: `summary.md` and `runs.jsonl` in the comparison artifact directory.
+
+## Boundary
+
+This is scoped A/B evidence on 18 pinned public repos, not proof that every
+future repo question saves tokens or time. Do not rerun the no-CodeStory baseline
+unless the harness contract changes; reuse the recorded baseline artifact when
+comparing new CodeStory arms.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,10 @@
 # CodeStory Usage
 
+Every new agent question often restarts repository discovery: search, read,
+trace, repeat. That costs wall time and context on work you already did in the
+last turn. CodeStory indexes once and serves evidence from that map so the agent
+can answer from citations instead of re-exploring the tree.
+
 Start with the human task, then run the smallest path that proves the state you
 need. The plugin is the normal path. The CLI is for setup, repair, debugging,
 and transcripts.
@@ -18,8 +23,48 @@ Packet/search output from degraded retrieval, missing sidecars, stale manifests,
 or any non-`full` retrieval mode is navigation help only. It is not proof.
 
 Most humans should start from the plugin flow in
-[README - Use It With An Agent](../README.md#use-it-with-an-agent). Use the CLI
-when you need the exact setup, repair, or debug record.
+[README - Quick start](../README.md#quick-start). Use the CLI when you need the
+exact setup, repair, or debug record.
+
+### Example prompts
+
+**Portable templates (any repository):**
+
+```text
+@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+```
+
+```text
+@CodeStory Where is [TARGET_FEATURE] defined and who calls it?
+```
+
+```text
+@CodeStory I am editing [PATH_TO_FILE]. What symbols are affected and what tests should I run first?
+```
+
+Replace `[TARGET_FEATURE]` and `[PATH_TO_FILE]` with concrete symbols and paths
+from your project. A good answer cites concrete paths and flags gaps when
+sidecars or coverage are degraded.
+
+**CodeStory repository examples:**
+
+Use concrete repo terms, not generic architecture words:
+
+```text
+@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet on codestory-indexer changes.
+```
+
+```text
+@CodeStory Where is RefreshMode defined, which codestory-cli commands accept --refresh, and what is the call path from index into codestory-store?
+```
+
+```text
+@CodeStory I am editing crates/codestory-indexer/src/resolution/mod.rs. What symbols are affected by changes in this file, and what tests should I run first?
+```
+
+```text
+@CodeStory Explain where strict_sidecar_status decides retrieval_mode=full.
+```
 
 Shell examples below are POSIX unless noted. On Windows PowerShell, use
 `.\target\release\codestory-cli.exe` for a source-built binary and set
@@ -31,7 +76,17 @@ Install the CodeStory plugin once, then start a fresh agent thread for the
 workspace you want to ground. The canonical skill package lives at
 [../plugins/codestory/skills/codestory-grounding/SKILL.md](../plugins/codestory/skills/codestory-grounding/SKILL.md).
 
-For a direct CLI transcript:
+**Plugin installation flow:**
+
+1. Open Codex in the repository you want to ground
+2. Run `/plugins` and install **TheGreenCedar → codestory**
+3. Start a fresh thread and ask:
+
+```text
+@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+```
+
+**Direct CLI transcript (for setup, repair, or debugging):**
 
 ```sh
 codestory-cli doctor --project <target-workspace>
@@ -39,9 +94,35 @@ codestory-cli index --project <target-workspace> --refresh auto
 codestory-cli ground --project <target-workspace> --why
 ```
 
-`doctor` separates local navigation readiness from agent packet/search
-readiness. Do not infer packet/search readiness from a successful local
-grounding command.
+**What each command does:**
+
+- `doctor`: Separates local navigation readiness from agent packet/search readiness
+- `index`: Builds or refreshes the SQLite graph and derived local read models
+- `ground`: Provides a broad repo-level orientation snapshot
+
+**Key guidance:**
+
+Do not infer packet/search readiness from a successful local grounding command. Use `doctor` to check both readiness lanes separately.
+
+**Next steps after installation:**
+
+If the agent reports that local navigation is ready but agent packet/search is not ready, you may need to repair the sidecar lane. The agent will provide specific guidance on what to do next.
+
+**Common next steps:**
+
+- If `agent_packet_search` is not ready: The agent will guide you through setting up retrieval sidecars
+- If `local_navigation` is not ready: The agent will guide you through indexing the repository
+- If both are ready: You can proceed with using CodeStory for your task
+
+**Verification checkpoints:**
+
+After the initial setup, you can verify readiness with:
+
+```sh
+codestory-cli doctor --project <target-workspace>
+```
+
+This will tell you exactly what is ready and what needs to be repaired before you can use packet/search features.
 
 When changing CodeStory itself or testing the current checkout:
 
@@ -65,6 +146,13 @@ explicit ref, setup fetches and builds the remote default branch.
 | Good for | Known files, symbols, trails, snippets, changed-file impact | Broad candidate discovery and bounded task packets |
 | Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `affected` | `packet`, `search`, `context` packet construction after target selection |
 | Does not prove | Broad sidecar search is ready | That cache-only browsing is enough for broad agent search |
+
+**Key concepts for readiness lanes:**
+
+- **Local navigation**: SQLite cache, graph, and DB-backed browse commands (`ground`, `report`, `files`, `trail`, `snippet`, `context --id`, etc.) are usable.
+- **Agent packet/search**: Sidecars are healthy and `retrieval_mode=full`; required for trustworthy `packet`, `search`, and query-based candidate discovery.
+- **Retrieval mode**: Sidecar status contract; only `full` serves agent packet/search.
+- **Semantic ready**: Dense-anchor embedding state matches policy; not the same as agent packet/search readiness.
 
 `context` straddles these lanes. Target selection is local/index-first:
 `--id`, `--bookmark`, or `--query <exact target>` chooses one concrete focus.
@@ -152,14 +240,36 @@ codestory-cli retrieval status --project <target-workspace> --format json
 codestory-cli doctor --project <target-workspace> --format markdown
 ```
 
-`setup-retrieval-env.mjs --fetch-embed-model` verifies the pinned GGUF before
-renaming it into `CODESTORY_EMBED_MODEL_DIR`. The accepted artifact is exactly
-`117974304` bytes with SHA-256
-`ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`.
+**Key concepts for sidecar repair:**
 
-`retrieval status --format json` reports `query_embedding_backend`,
-`manifest_vector_embedding_backend`, and
-`stored_doc_vector_producer_backend` so backend drift is visible.
+- **`setup-retrieval-env.mjs --fetch-embed-model`**: Verifies the pinned GGUF before renaming it into `CODESTORY_EMBED_MODEL_DIR`. The accepted artifact is exactly `117974304` bytes with SHA-256 `ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`.
+- **`retrieval status --format json`**: Reports `query_embedding_backend`, `manifest_vector_embedding_backend`, and `stored_doc_vector_producer_backend` so backend drift is visible.
+- **Legacy managed embeddings**: Diagnostic only; do not start llama.cpp, create the retrieval manifest, or prove agent packet/search readiness.
+
+**Sidecar readiness verification:**
+
+The `retrieval status --format json` command provides detailed information about:
+
+- `query_embedding_backend`: The backend used for query embeddings
+- `manifest_vector_embedding_backend`: The backend used for manifest vector embeddings
+- `stored_doc_vector_producer_backend`: The backend used for stored document vector production
+
+This allows you to detect backend drift and ensure all components are using the correct embedding backend.
+
+**Sidecar repair process:**
+
+1. **Setup retrieval environment**: Fetch the required embedding model and configure environment variables
+2. **Bootstrap retrieval**: Initialize the retrieval system with the embedding model
+3. **Index the repository**: Build the SQLite graph and retrieval indexes
+4. **Verify sidecar status**: Check that retrieval mode is `full` and all components are healthy
+5. **Final verification**: Run `doctor` to confirm overall system health
+
+**Common sidecar issues and solutions:**
+
+- **Missing embedding model**: Use `setup-retrieval-env.mjs --fetch-embed-model` to download and verify the model
+- **Backend configuration errors**: Check `CODESTORY_EMBED_BACKEND` and related environment variables
+- **Retrieval manifest issues**: Re-run `retrieval bootstrap` and `retrieval index` with `--refresh full`
+- **Stale cache**: Use `index --refresh full` to rebuild the SQLite graph
 
 Legacy managed embeddings are diagnostic only:
 

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -23,9 +23,9 @@
     "privacyPolicyURL": "https://github.com/TheGreenCedar/CodeStory",
     "termsOfServiceURL": "https://github.com/TheGreenCedar/CodeStory",
     "defaultPrompt": [
-      "@CodeStory ground this repository before editing.",
-      "@CodeStory check whether packet/search is ready.",
-      "@CodeStory find the symbols involved in this task."
+      "@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.",
+      "@CodeStory Where is RefreshMode defined, which codestory-cli commands accept --refresh, and what is the call path from index into codestory-store?",
+      "@CodeStory I am editing a file in this repo. What symbols are affected and what tests should I run first?"
     ],
     "brandColor": "#2563EB",
     "screenshots": []

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -1,7 +1,12 @@
 # CodeStory Agent Plugin
 
+Every agent question often restarts repository discovery: hunt files, read
+snippets, chase imports, rebuild the map. That repeats on every turn and burns
+wall time plus context on work you already paid for.
+
 CodeStory gives a coding agent a local, read-only grounding surface before it
-plans, reviews, or edits a repository.
+plans, reviews, or edits a repository. Index once; answer from evidence with
+citations instead of re-exploring the tree on every prompt.
 
 The human job is simple: install the plugin, start a fresh thread in the repo,
 and ask the agent to check readiness before it makes source claims. The agent
@@ -78,21 +83,60 @@ Open Codex in the repo you want to ground and ask the agent to check readiness
 before planning or editing:
 
 ```text
-@CodeStory check whether this repository is ready for local navigation and packet/search, then ground it before planning changes.
+@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
 ```
 
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
-present and current, installs the latest matching release asset when needed,
-and uses source fallback only when no release asset fits the host.
+present and current, compares `codestory-cli --version` with the latest GitHub
+release, installs the latest matching release asset when needed, verifies
+`SHA256SUMS.txt` when the host can, and uses source fallback only when no release asset fits the host.
 
 ## What To Ask
 
-Good first prompts are agent-shaped:
+Use concrete repo terms. These examples are written for the CodeStory
+repository; adapt paths and symbols to your project:
 
-- `@CodeStory check whether this repository is ready for local navigation and packet/search.`
-- `@CodeStory ground this repository before you plan the change.`
-- `@CodeStory find the code paths involved in request routing, then inspect the concrete snippets.`
-- `@CodeStory answer where cache freshness is enforced, but only make packet/search claims if sidecars are full.`
+**For checking readiness before editing:**
+
+- `@CodeStory check local_navigation and agent_packet_search on this checkout before I edit codestory-indexer.`
+
+**For finding ownership:**
+
+- `@CodeStory Where is RefreshMode defined and which codestory-cli commands accept --refresh?`
+
+**For planning changes with impact hints:**
+
+- `@CodeStory I am editing crates/codestory-indexer/src/resolution/mod.rs. What symbols are affected and what tests should I run first?`
+
+**For understanding sidecar readiness:**
+
+- `@CodeStory Explain where strict_sidecar_status decides retrieval_mode=full.`
+
+**Generalizable prompt templates for any repository:**
+
+**For checking readiness before editing any crate:**
+
+```text
+@CodeStory check local_navigation and agent_packet_search on this checkout before I edit [TARGET_CRATE].
+```
+
+**For finding ownership of a feature:**
+
+```text
+@CodeStory Where is [TARGET_FEATURE] defined and which codestory-cli commands accept --refresh?
+```
+
+**For planning changes with impact hints:**
+
+```text
+@CodeStory I am editing [PATH_TO_FILE]. What symbols are affected by changes in this file, and what tests should I run first?
+```
+
+**For understanding sidecar readiness:**
+
+```text
+@CodeStory Explain where strict_sidecar_status decides retrieval_mode=full.
+```
 
 Avoid prompts that erase the trust boundary:
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -5,9 +5,22 @@ description: Use when an agent should ground a local repository with CodeStory b
 
 # CodeStory Grounding
 
+Agents usually rediscover a repository on every question: search files, read
+snippets, chase imports, and spend context rebuilding the same map. CodeStory
+indexes once and serves read-only evidence from that map so you can answer from
+citations instead of repeating discovery work.
+
 Use CodeStory to keep source claims tied to the current local repository. Prefer
 the plugin MCP server when it is installed and healthy. Use the CLI for setup,
 repair, explicit transcripts, or when MCP is unavailable.
+
+**Key concepts:**
+
+- **Repository rediscovery**: The repeated agent work of searching files, reading snippets, and rebuilding a mental map on every new question. CodeStory indexes once to reduce that cost.
+- **Local navigation**: SQLite cache, graph, and DB-backed browse commands (`ground`, `report`, `files`, `trail`, `snippet`, `context --id`, etc.) are usable.
+- **Agent packet/search**: Sidecars are healthy and `retrieval_mode=full`; required for trustworthy `packet`, `search`, and query-based candidate discovery.
+- **Retrieval mode**: Sidecar status contract; only `full` serves agent packet/search.
+- **Semantic ready**: Dense-anchor embedding state matches policy; not the same as agent packet/search readiness.
 
 The target is always a repository workspace. The CodeStory checkout is only the
 tool source unless the user is editing CodeStory itself.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -8,7 +8,9 @@ const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
 
 test("plugin metadata maps skill and direct stdio server", async () => {
-  const manifest = JSON.parse(await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"));
+  const manifest = JSON.parse(
+    await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+  );
   const mcp = JSON.parse(await readFile(join(pluginRoot, ".mcp.json"), "utf8"));
 
   assert.equal(manifest.name, "codestory");
@@ -16,20 +18,36 @@ test("plugin metadata maps skill and direct stdio server", async () => {
   assert.equal(manifest.mcpServers, "./.mcp.json");
   assert.equal(manifest.interface.capabilities.includes("Read"), true);
   assert.equal(mcp.mcpServers.codestory.command, "codestory-cli");
-  assert.deepEqual(mcp.mcpServers.codestory.args, ["serve", "--stdio", "--refresh", "none"]);
+  assert.deepEqual(mcp.mcpServers.codestory.args, [
+    "serve",
+    "--stdio",
+    "--refresh",
+    "none",
+  ]);
   assert.equal(Object.hasOwn(mcp.mcpServers.codestory, "cwd"), false);
 });
 
 test("codestory repo ships plugin source, not marketplace catalog or adapter runtime", async () => {
-  await assert.rejects(access(join(repoRoot, ".agents", "plugins", "marketplace.json")));
-  await assert.rejects(access(join(repoRoot, ".agents", "skills", "codestory-grounding", "SKILL.md")));
-  await assert.rejects(access(join(pluginRoot, "scripts", "codestory-mcp.mjs")));
+  await assert.rejects(
+    access(join(repoRoot, ".agents", "plugins", "marketplace.json")),
+  );
+  await assert.rejects(
+    access(
+      join(repoRoot, ".agents", "skills", "codestory-grounding", "SKILL.md"),
+    ),
+  );
+  await assert.rejects(
+    access(join(pluginRoot, "scripts", "codestory-mcp.mjs")),
+  );
 });
 
 test("plugin docs are agent-first, marketplace-aware, and latest-release aware", async () => {
   const rootReadme = await readFile(join(repoRoot, "README.md"), "utf8");
   const readme = await readFile(join(pluginRoot, "README.md"), "utf8");
-  const skill = await readFile(join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"), "utf8");
+  const skill = await readFile(
+    join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"),
+    "utf8",
+  );
   const sharedRequired = [
     "latest GitHub release",
     "codestory-cli --version",
@@ -74,7 +92,6 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
     "workspace plugin settings are managed from the Codex Apps/Plugins UI",
     "UI path when the CLI marketplace command is",
     "Start a new Codex thread after installation or refresh",
-    "check whether this repository is ready for local navigation and packet/search",
     "The first run should be agent-owned",
     "installs the latest matching release asset",
     "uses source fallback only when no release asset fits the host",
@@ -113,7 +130,7 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
     "Always pass `--project <target-workspace>` explicitly",
   ];
   const rootReadmeRequired = [
-    "Marketplace catalog details, binary",
+    "Install details, binary bootstrap",
     "[plugin README](plugins/codestory/README.md)",
     "`codestory-cli serve --stdio --refresh none`",
   ];
@@ -156,8 +173,28 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
 });
 
 test("canonical grounding skill ships with plugin references", async () => {
-  await access(join(pluginRoot, "skills", "codestory-grounding", "references", "ground.md"));
-  await access(join(pluginRoot, "skills", "codestory-grounding", "references", "packet.md"));
-  await access(join(pluginRoot, "skills", "codestory-grounding", "scripts", "setup.ps1"));
-  await access(join(pluginRoot, "skills", "codestory-grounding", "scripts", "setup.sh"));
+  await access(
+    join(
+      pluginRoot,
+      "skills",
+      "codestory-grounding",
+      "references",
+      "ground.md",
+    ),
+  );
+  await access(
+    join(
+      pluginRoot,
+      "skills",
+      "codestory-grounding",
+      "references",
+      "packet.md",
+    ),
+  );
+  await access(
+    join(pluginRoot, "skills", "codestory-grounding", "scripts", "setup.ps1"),
+  );
+  await access(
+    join(pluginRoot, "skills", "codestory-grounding", "scripts", "setup.sh"),
+  );
 });


### PR DESCRIPTION
## Context
Closes #356
Refs #351, #38

This packages the current human-authored docs rewrite that was already staged/edited on the dev branch. I kept the lane to packaging and verification rather than rewriting the docs again.

## What Changed
- Reworked the root README, docs entry points, glossary, usage guide, and architecture/concepts docs.
- Added documentation maintenance/search/template surfaces for future docs work.
- Updated plugin README, grounding skill, plugin metadata, and static tests to match the rewritten docs flow.
- Added the language-expansion holdout stats doc and benchmark harness doc updates present in the branch.

## How To Review
- Start with README.md, docs/README.md, and docs/search-index.md for the new reader path.
- Check plugins/codestory/README.md and plugins/codestory/skills/codestory-grounding/SKILL.md for plugin/skill flow.
- Inspect docs/templates/ and docs/contributors/documentation-maintenance-checklist.md for the new maintenance scaffolding.

## Verification
- git diff --cached --check -> pass before commit.
- node --test .\\plugins\\codestory\\tests\\plugin-static.test.mjs -> pass, 4 tests.

## Risk
Docs/plugin-docs only. I did not run cargo because no Rust behavior changed.