### PR TITLE
[codex] report worktree readiness

### DIFF
--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -37,6 +37,93 @@ function Invoke-SetupStep {
     }
 }
 
+function Get-ReadinessVerdict {
+    param(
+        $Doctor,
+        [string]$Goal
+    )
+
+    foreach ($verdict in @($Doctor.readiness)) {
+        if ($verdict.goal -eq $Goal) {
+            return $verdict
+        }
+    }
+
+    return $null
+}
+
+function Test-ReadinessReady {
+    param($Verdict)
+
+    return ($Verdict -and $Verdict.status -eq "ready")
+}
+
+function Get-MinimumNextCommand {
+    param(
+        $LocalVerdict,
+        $AgentVerdict,
+        $Doctor
+    )
+
+    foreach ($verdict in @($LocalVerdict, $AgentVerdict)) {
+        if (-not (Test-ReadinessReady $verdict)) {
+            foreach ($command in @($verdict.minimum_next)) {
+                if ($command) {
+                    return [string]$command
+                }
+            }
+        }
+    }
+
+    foreach ($command in @($Doctor.next_commands)) {
+        if ($command) {
+            return [string]$command
+        }
+    }
+
+    return $null
+}
+
+function Invoke-DoctorJson {
+    param(
+        [string]$Cli,
+        [string]$ProjectPath
+    )
+
+    $json = (& $Cli doctor --project $ProjectPath --format json 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        throw "codestory-cli doctor failed with exit code $LASTEXITCODE`n$json"
+    }
+
+    return ($json | ConvertFrom-Json)
+}
+
+function Write-DoctorReadinessSummary {
+    param($Doctor)
+
+    $local = Get-ReadinessVerdict $Doctor "local_navigation"
+    $agent = Get-ReadinessVerdict $Doctor "agent_packet_search"
+    $minimumNext = Get-MinimumNextCommand $local $agent $Doctor
+
+    Write-Host "CodeStory worktree readiness"
+    Write-Host ("  local_navigation: {0}" -f $(if ($local) { $local.status } else { "unknown" }))
+    if ($local -and $local.summary) {
+        Write-Host ("    reason: {0}" -f $local.summary)
+    }
+    Write-Host ("  agent_packet_search: {0}" -f $(if ($agent) { $agent.status } else { "unknown" }))
+    if ($agent -and $agent.summary) {
+        Write-Host ("    reason: {0}" -f $agent.summary)
+    }
+    Write-Host ("  retrieval_mode: {0}" -f $Doctor.retrieval_mode)
+    Write-Host ("  degraded_reason: {0}" -f $(if ($Doctor.degraded_reason) { $Doctor.degraded_reason } else { "none" }))
+    if ($minimumNext) {
+        Write-Host ("  minimum_next: {0}" -f $minimumNext)
+    }
+    if (-not (Test-ReadinessReady $agent)) {
+        Write-Host "  handoff: CodeStory packet/search is unavailable; use direct source reads until the minimum_next command repairs readiness."
+    }
+}
+
 function Test-CodeStoryCli {
     param(
         [string]$Candidate,
@@ -239,8 +326,9 @@ try {
         Invoke-Checked $cli @("retrieval", "index", "--project", $projectPath, "--refresh", "auto")
     } -Optional
 
-    Invoke-SetupStep "Doctor" {
-        Invoke-Checked $cli @("doctor", "--project", $projectPath, "--format", "markdown")
+    Invoke-SetupStep "Doctor readiness handoff" {
+        $doctor = Invoke-DoctorJson $cli $projectPath
+        Write-DoctorReadinessSummary $doctor
     } -Optional
 } finally {
     Pop-Location


### PR DESCRIPTION
## Context

Closes #359
Refs #38, #351, #358, #240, #82

Delegated CodeStory worktrees can start with local CodeStory navigation and packet/search unavailable, but the old setup tail only ran doctor markdown. Child threads had to rediscover whether `local_navigation` and `agent_packet_search` were usable before deciding whether to trust packet/search or fall back to direct source reads.

This worktree initially reproduced the dogfood friction: `scripts/codex-worktree-setup.ps1 -ResolveCliOnly` found no ready `codestory-cli 0.11.4`; PATH/user-bin and sibling binaries were stale (`0.11.2`, `0.11.3`, older). I used direct source reads for the implementation, then downloaded the published `v0.11.4` Windows x64 release asset for verification without a source build.

## What Changed

- `scripts/codex-worktree-setup.ps1` now runs final `doctor --format json` and prints a compact handoff:
  - `local_navigation` status and reason
  - `agent_packet_search` status and reason
  - `retrieval_mode`
  - `degraded_reason`
  - one `minimum_next` command
  - explicit direct-source-read handoff when packet/search is not ready
- The script still uses the existing doctor/readiness contract. No product readiness gates, sidecar rules, packet/search rules, benchmarks, or release metadata changed.

```mermaid
flowchart LR
    A["setup index/sidecars"] --> B["doctor --format json"]
    B --> C["print local_navigation"]
    B --> D["print agent_packet_search"]
    D --> E{"agent ready?"}
    E -->|"yes"| F["packet/search may be used"]
    E -->|"no"| G["show minimum_next and use direct reads"]
```

## How To Review

- Inspect `scripts/codex-worktree-setup.ps1` only.
- Confirm the new reporting is a renderer over `doctor --format json`, not a separate readiness model.
- Confirm the setup sequence still uses the existing index/bootstrap/retrieval-index steps and only changes the final readiness handoff.

## Verification

Worktree and branch preflight:

```text
worktree: C:\Users\alber\.codex\worktrees\bae9\codestory
branch before work: detached HEAD at 31a82731380682307e7a56ae819ae4efe4f19d74
base: origin/dev/codestory-next, tag v0.11.4
initial status: ## HEAD (no branch)
```

Ready CLI friction, before using the release asset:

```text
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\codex-worktree-setup.ps1 -Project . -ResolveCliOnly
exit code: 1
No ready codestory-cli 0.11.4 found via CODESTORY_CLI, PATH, this worktree's target\release, or sibling worktree target\release directories.
Stale candidates included 0.11.2, 0.11.3, 0.10.0, 0.9.0, and 0.7.0 binaries.
```

Release CLI used for verification:

```text
C:\Users\alber\AppData\Local\Temp\codestory-cli-v0.11.4-issue359\expanded\codestory-cli-v0.11.4-windows-x64\codestory-cli.exe --version
codestory-cli 0.11.4
```

Baseline doctor before setup smoke:

```text
codestory-cli doctor --project C:\Users\alber\.codex\worktrees\bae9\codestory --format json
indexed: false
local_navigation: repair_index
agent_packet_search: repair_index
retrieval_mode: unavailable
degraded_reason: retrieval_manifest_missing
minimum_next: codestory-cli index --project "C:/Users/alber/.codex/worktrees/bae9/codestory" --refresh full
```

Setup/readiness smoke:

```text
$env:CODESTORY_CLI = 'C:\Users\alber\AppData\Local\Temp\codestory-cli-v0.11.4-issue359\expanded\codestory-cli-v0.11.4-windows-x64\codestory-cli.exe'
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\codex-worktree-setup.ps1 -Project C:\Users\alber\.codex\worktrees\bae9\codestory
exit code: 0
```

Final setup handoff output:

```text
==> Doctor readiness handoff
CodeStory worktree readiness
  local_navigation: ready
    reason: Local navigation can use the current index.
  agent_packet_search: ready
    reason: Agent packet/search can use the current index and sidecar retrieval.
  retrieval_mode: full
  degraded_reason: none
  minimum_next: codestory-cli ground --project "C:/Users/alber/.codex/worktrees/bae9/codestory"
```

Fresh doctor check after the setup smoke matched that handoff:

```text
codestory-cli doctor --project C:\Users\alber\.codex\worktrees\bae9\codestory --format json
{
  "local_navigation": "ready",
  "agent_packet_search": "ready",
  "retrieval_mode": "full",
  "degraded_reason": "none",
  "minimum_next": "codestory-cli ground --project \"C:/Users/alber/.codex/worktrees/bae9/codestory\""
}
```

PowerShell syntax check:

```text
$script = Get-Content -LiteralPath scripts\codex-worktree-setup.ps1 -Raw; $null = [scriptblock]::Create($script); 'syntax ok'
syntax ok
```

Whitespace check:

```text
git diff --check
exit code: 0
```

## Risk

- This changes only the setup script's final reporting surface.
- The setup smoke repaired this particular worktree to `retrieval_mode=full`; degraded-path rendering was checked against the baseline doctor JSON and the script's existing optional-step behavior, not by intentionally breaking sidecars after repair.
- The local ready binary was supplied by the `v0.11.4` release asset because no ready 0.11.4 binary was already present on PATH or in sibling worktrees.
