### PR TITLE
[codex] clarify sidecar repair docs

### DIFF
--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -91,9 +91,11 @@ Recovery order:
 
 1. Confirm whether the miss is in `indexed_symbol_hits`, `repo_text_hits`, or both.
 2. Confirm the reported retrieval mode and degraded-state reason before touching search ranking code.
-3. For product sidecar evidence, run `codestory-cli retrieval bootstrap --project .`, set
-   `CODESTORY_EMBED_BACKEND=llamacpp`, and point `CODESTORY_EMBED_LLAMACPP_URL` at the local
-   bge-base-en-v1.5 llama.cpp `/v1/embeddings` endpoint before reindexing.
+3. For product sidecar evidence, fetch the pinned GGUF when needed with
+   `node scripts/setup-retrieval-env.mjs --fetch-embed-model`, then run
+   `codestory-cli retrieval bootstrap --project .`. Set
+   `CODESTORY_EMBED_BACKEND=llamacpp` and `CODESTORY_EMBED_LLAMACPP_URL` only
+   when your local sidecar endpoint differs from the default.
 4. Rebuild once with `codestory-cli index --project . --refresh full`, then
    `codestory-cli retrieval index --project . --refresh full`.
 5. Require `codestory-cli retrieval status --project . --format json` to report

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -27,7 +27,8 @@ flowchart LR
 - Rust toolchain with `cargo`, or an already-built `codestory-cli` binary.
 - Docker Desktop or Docker Engine for automated Qdrant, Zoekt, and llama.cpp
   sidecars.
-- Optional Node.js 18+ for `scripts/setup-retrieval-env.mjs`.
+- Node.js 18+ if you need `scripts/setup-retrieval-env.mjs` to fetch or verify
+  the pinned GGUF.
 - Localhost ports available: Zoekt `6070`, Qdrant HTTP `6333`, Qdrant gRPC
   `6334`, and llama.cpp embeddings `8080`.
 - GGUF embedding model available through `CODESTORY_EMBED_MODEL_DIR`, or fetched
@@ -61,14 +62,13 @@ From the CodeStory repository root:
 
 ```sh
 node scripts/setup-retrieval-env.mjs --fetch-embed-model
-export CODESTORY_EMBED_MODEL_DIR="$(pwd)/target/retrieval-models"
-export CODESTORY_EMBED_BACKEND="llamacpp"
-export CODESTORY_EMBED_LLAMACPP_URL="http://127.0.0.1:8080/v1/embeddings"
 cargo run -p codestory-cli -- retrieval bootstrap --project <repo> --format json
 ```
 
-On Windows PowerShell, use `$env:...` assignments and
-`.\target\release\codestory-cli.exe` if you are running a built binary.
+Use the environment variables from the minimum table only when the defaults do
+not match your machine. On Windows PowerShell, set them with `$env:NAME =
+"value"` and use `.\target\release\codestory-cli.exe` if you are running a
+built binary.
 
 `retrieval bootstrap` may start Docker Compose, create sidecar cache dirs, write
 `retrieval-sidecars.json`, and repair CodeStory-owned local sidecar state. For a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,10 +229,6 @@ llama.cpp embedding contract.
 
 ```sh
 node scripts/setup-retrieval-env.mjs --fetch-embed-model
-export CODESTORY_EMBED_MODEL_DIR="$(pwd)/target/retrieval-models"
-export CODESTORY_EMBED_BACKEND="llamacpp"
-export CODESTORY_EMBED_LLAMACPP_URL="http://127.0.0.1:8080/v1/embeddings"
-
 codestory-cli retrieval bootstrap --project <target-workspace> --format json
 codestory-cli index --project <target-workspace> --refresh full
 codestory-cli retrieval index --project <target-workspace> --refresh full --format json
@@ -240,36 +236,12 @@ codestory-cli retrieval status --project <target-workspace> --format json
 codestory-cli doctor --project <target-workspace> --format markdown
 ```
 
-**Key concepts for sidecar repair:**
-
-- **`setup-retrieval-env.mjs --fetch-embed-model`**: Verifies the pinned GGUF before renaming it into `CODESTORY_EMBED_MODEL_DIR`. The accepted artifact is exactly `117974304` bytes with SHA-256 `ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`.
-- **`retrieval status --format json`**: Reports `query_embedding_backend`, `manifest_vector_embedding_backend`, and `stored_doc_vector_producer_backend` so backend drift is visible.
-- **Legacy managed embeddings**: Diagnostic only; do not start llama.cpp, create the retrieval manifest, or prove agent packet/search readiness.
-
-**Sidecar readiness verification:**
-
-The `retrieval status --format json` command provides detailed information about:
-
-- `query_embedding_backend`: The backend used for query embeddings
-- `manifest_vector_embedding_backend`: The backend used for manifest vector embeddings
-- `stored_doc_vector_producer_backend`: The backend used for stored document vector production
-
-This allows you to detect backend drift and ensure all components are using the correct embedding backend.
-
-**Sidecar repair process:**
-
-1. **Setup retrieval environment**: Fetch the required embedding model and configure environment variables
-2. **Bootstrap retrieval**: Initialize the retrieval system with the embedding model
-3. **Index the repository**: Build the SQLite graph and retrieval indexes
-4. **Verify sidecar status**: Check that retrieval mode is `full` and all components are healthy
-5. **Final verification**: Run `doctor` to confirm overall system health
-
-**Common sidecar issues and solutions:**
-
-- **Missing embedding model**: Use `setup-retrieval-env.mjs --fetch-embed-model` to download and verify the model
-- **Backend configuration errors**: Check `CODESTORY_EMBED_BACKEND` and related environment variables
-- **Retrieval manifest issues**: Re-run `retrieval bootstrap` and `retrieval index` with `--refresh full`
-- **Stale cache**: Use `index --refresh full` to rebuild the SQLite graph
+`setup-retrieval-env.mjs --fetch-embed-model` verifies the pinned GGUF before
+accepting it under `target/retrieval-models` or `CODESTORY_EMBED_MODEL_DIR`.
+Leave `CODESTORY_EMBED_BACKEND` and `CODESTORY_EMBED_LLAMACPP_URL` unset unless
+your machine needs non-default sidecar settings. `retrieval status --format
+json` reports the query, manifest, and stored-vector backends so backend drift
+is visible before packet/search is trusted.
 
 Legacy managed embeddings are diagnostic only:
 


### PR DESCRIPTION
## Context

Closes #361
Refs #38, #358, #360

CodeStory 0.11.4 documentation needed a currentness pass after the plugin/setup/readiness wave. I audited the durable docs against the current implementation surfaces for plugin stdio launch, `serve --stdio` exposed tools/resources/prompts, the post-#360 worktree setup script, marketplace ownership, and sidecar readiness handling.

Dogfood friction: this worktree started at `53c5520390948df6cba0d7740fd93f92f7320781` with no ready current `codestory-cli` 0.11.4 binary. `scripts/codex-worktree-setup.ps1 -ResolveCliOnly` found only stale candidates (`0.11.3`, `0.11.2`, and older), so I did not cold-build or use CodeStory packet/search. I used direct source reads instead.

## What Changed

- Tightened `docs/usage.md` sidecar repair guidance so the operator path is: fetch/verify the pinned GGUF when needed, bootstrap sidecars, refresh SQLite, refresh retrieval sidecars, check retrieval status, then run doctor.
- Updated `docs/ops/retrieval-sidecars.md` to say Node is needed when using the setup wrapper for GGUF fetch/verification and to stop implying default sidecar env vars must always be hand-set.
- Updated `docs/contributors/debugging.md` so product sidecar recovery fetches the pinned GGUF before bootstrap when needed and treats backend/env overrides as non-default machine-specific settings.

## How To Review

- Read the three changed docs as an operator trying to repair packet/search readiness.
- Check that the command order still matches the implementation surfaces in `scripts/setup-retrieval-env.mjs`, `scripts/codex-worktree-setup.ps1`, and the retrieval status/doctor readiness contract.
- Confirm the diff does not touch runtime behavior, release versions, generated ledgers, benchmark artifacts, or marketplace repo state.

## Verification

- `git diff --check` - passed with no output.
- `node --test .\plugins\codestory\tests\plugin-static.test.mjs` - passed, 4 tests.
- Link/path spot checks for touched docs - linked files existed; `README.md#quick-start` and retrieval-sidecars headings were present.
- Readback from operator/maintainer/reviewer perspectives - the changed docs now keep default sidecar env vars optional, keep managed ONNX diagnostic-only, and preserve `retrieval_mode=full` as the packet/search trust gate.

## Risk

Low. This is docs-only and intentionally removes stale/duplicative repair prose instead of changing runtime behavior. I did not run broad Cargo or sidecar rebuilds because no Rust code changed and the issue explicitly scoped this as a PR-sized docs currentness pass.
