### PR TITLE
[codex] resolve current release cli

### DIFF
--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -164,6 +164,16 @@ function Get-ExpectedCodeStoryCliVersion {
     throw "Unable to read expected codestory-cli version from $manifest."
 }
 
+function Get-CodeStoryInstallDir {
+    if ($env:CODESTORY_HOME) {
+        return (Join-Path $env:CODESTORY_HOME "bin")
+    }
+    if ($env:LOCALAPPDATA) {
+        return (Join-Path $env:LOCALAPPDATA "CodeStory\bin")
+    }
+    return (Join-Path $HOME ".codestory\bin")
+}
+
 function Get-CodeStoryCliCandidates {
     param([string]$Root)
 
@@ -176,6 +186,13 @@ function Get-CodeStoryCliCandidates {
     if ($pathCli) {
         $candidates += $pathCli.Source
     }
+
+    $installDir = Get-CodeStoryInstallDir
+    $candidates += @(
+        (Join-Path $installDir "codestory-cli.exe"),
+        (Join-Path $installDir "codestory-cli.cmd"),
+        (Join-Path $installDir "codestory-cli")
+    )
 
     $candidates += @(
         (Join-Path $Root "target\release\codestory-cli.exe"),
@@ -225,6 +242,23 @@ function Find-CodeStoryCli {
         $message += " Stale candidates: $($staleCandidates -join '; ')."
     }
     throw $message
+}
+
+function Invoke-CurrentReleaseCliInstall {
+    param(
+        [string]$Root,
+        [string]$ExpectedVersion
+    )
+
+    $installer = Join-Path $PSScriptRoot "install-codestory.ps1"
+    if (-not (Test-Path -LiteralPath $installer)) {
+        throw "Current-release installer is missing: $installer"
+    }
+
+    Write-Host ""
+    Write-Host "==> Install current release CLI"
+    Write-Host "Trying codestory-cli $ExpectedVersion release install before Cargo build."
+    & $installer -Project $Root -Version $ExpectedVersion
 }
 
 function Same-Path {
@@ -288,14 +322,23 @@ try {
     try {
         $cli = Find-CodeStoryCli $projectPath
     } catch {
-        if ($ResolveCliOnly) {
-            throw "$($_.Exception.Message) Re-run without -ResolveCliOnly to build with cargo, or set CODESTORY_CLI to a ready binary."
+        $resolveError = $_.Exception.Message
+        $expectedVersion = Get-ExpectedCodeStoryCliVersion $projectPath
+        try {
+            Invoke-CurrentReleaseCliInstall $projectPath $expectedVersion
+            $cli = Find-CodeStoryCli $projectPath
+        } catch {
+            $installError = $_.Exception.Message
+            $installCommand = ".\scripts\install-codestory.ps1 -Project . -Version $expectedVersion"
+            if ($ResolveCliOnly) {
+                throw "$resolveError Current-release install failed: $installError. Run $installCommand, or set CODESTORY_CLI to a ready binary."
+            }
+            Write-Host ""
+            Write-Host "==> Build release CLI"
+            Write-Warning "$resolveError Current-release install failed: $installError. Building release CLI with cargo."
+            Invoke-Checked "cargo" @("build", "--release", "-p", "codestory-cli")
+            $cli = Find-CodeStoryCli $projectPath
         }
-        Write-Host ""
-        Write-Host "==> Build release CLI"
-        Write-Warning "$($_.Exception.Message) Building release CLI with cargo."
-        Invoke-Checked "cargo" @("build", "--release", "-p", "codestory-cli")
-        $cli = Find-CodeStoryCli $projectPath
     }
 
     Write-Host "CODESTORY_CLI=$cli"

--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -450,22 +450,22 @@ function Assert-SelfTest {
 }
 
 function Invoke-SelfTest {
-    Set-RequiredVersion "v0.11.3"
+    Set-RequiredVersion "v0.11.4"
     Test-WindowsX64 | Out-Null
     Assert-SelfTest (Test-PathListContains "C:\Tools;C:\CodeStory\bin\" "C:\CodeStory\bin") "path-list check should ignore trailing slash"
     Assert-SelfTest (-not (Test-PathListContains "C:\Tools" "C:\CodeStory\bin")) "path-list check should reject missing directory"
-    Assert-SelfTest ((Convert-ReleaseTagToVersion "v0.11.3") -eq "0.11.3") "release tag parser should strip v prefix"
-    $parsedVersion = Convert-VersionText "codestory-cli 0.11.3"
+    Assert-SelfTest ((Convert-ReleaseTagToVersion "v0.11.4") -eq "0.11.4") "release tag parser should strip v prefix"
+    $parsedVersion = Convert-VersionText "codestory-cli 0.11.4"
     Assert-SelfTest (Test-RequiredVersion $parsedVersion) "version gate should accept current release"
-    Assert-SelfTest (-not (Test-RequiredVersion ([Version]"0.11.2"))) "version gate should reject stale 0.11.2"
+    Assert-SelfTest (-not (Test-RequiredVersion ([Version]"0.11.3"))) "version gate should reject stale 0.11.3"
 
     $explicitStale = $false
     try {
         $staleCli = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-stale-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
-        Set-Content -LiteralPath $staleCli -Value "@echo codestory-cli 0.11.2" -Encoding ASCII
+        Set-Content -LiteralPath $staleCli -Value "@echo codestory-cli 0.11.3" -Encoding ASCII
         Find-ExistingCli $staleCli $null | Out-Null
     } catch {
-        $explicitStale = $_.Exception.Message -match "requires 0.11.3"
+        $explicitStale = $_.Exception.Message -match "requires 0.11.4"
     } finally {
         if ($staleCli -and (Test-Path -LiteralPath $staleCli)) {
             Remove-Item -LiteralPath $staleCli -Force
@@ -475,9 +475,9 @@ function Invoke-SelfTest {
 
     try {
         $currentCli = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-current-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
-        Set-Content -LiteralPath $currentCli -Value "@echo codestory-cli 0.11.3" -Encoding ASCII
+        Set-Content -LiteralPath $currentCli -Value "@echo codestory-cli 0.11.4" -Encoding ASCII
         $current = Find-ExistingCli $currentCli $null
-        Assert-SelfTest ($current.Version -eq [Version]"0.11.3") "explicit current codestory-cli override should be accepted"
+        Assert-SelfTest ($current.Version -eq [Version]"0.11.4") "explicit current codestory-cli override should be accepted"
     } finally {
         if ($currentCli -and (Test-Path -LiteralPath $currentCli)) {
             Remove-Item -LiteralPath $currentCli -Force


### PR DESCRIPTION
## Context

Closes #363
Refs #38
Refs #359
Refs #360
Refs #361
Refs #362

#361 exposed the dogfood friction: a fresh docs child worktree ran `scripts/codex-worktree-setup.ps1 -ResolveCliOnly`, saw only stale `codestory-cli` candidates such as `0.11.3` and older, then skipped CodeStory packet/search and used direct source reads. After the `0.11.4` release exists, setup should try the current release path before telling the child lane to cold-build or continue source-only.

```mermaid
flowchart TD
    A["Resolve ready CLI"] --> B{"Manifest version found?"}
    B -->|"yes"| C["Use CLI path"]
    B -->|"no"| D["Run release installer for manifest version"]
    D --> E{"Current CLI resolved?"}
    E -->|"yes"| C
    E -->|"no"| F["ResolveCliOnly prints install action; full setup can still Cargo fallback"]
    C --> G["Existing doctor readiness handoff"]
```

## What Changed

- Added the default CodeStory install bin to `scripts/codex-worktree-setup.ps1` ready-CLI candidates, so a released CLI installed by `scripts/install-codestory.ps1` is found directly.
- When no exact manifest-version CLI is ready, `codex-worktree-setup.ps1` now invokes `scripts/install-codestory.ps1 -Version <manifest version>` before Cargo build fallback.
- Preserved explicit stale-binary rejection in the error path; if current-release install fails, `-ResolveCliOnly` reports the stale candidates plus the exact non-cold install command to run.
- Updated `scripts/install-codestory.ps1 -SelfTest` to treat `0.11.4` as current and `0.11.3` as stale.

## How To Review

- Start in `scripts/codex-worktree-setup.ps1` around `Get-CodeStoryCliCandidates`, `Invoke-CurrentReleaseCliInstall`, and the `Find-CodeStoryCli` catch path.
- Confirm stale candidates are still rejected rather than accepted silently.
- Confirm the existing doctor-derived readiness handoff remains after CLI resolution; this PR changes CLI acquisition only.

## Verification

- Confirmed issue scope with `gh issue view 363 --repo TheGreenCedar/CodeStory --json number,title,state,body,url,comments`.
- Confirmed #362 merge base with `gh pr view 362 --repo TheGreenCedar/CodeStory --json number,title,state,mergeCommit,baseRefName,headRefName,url` and current branch at `cbca617e3a93d659d68199bc679eb62270c5f7af` before editing.
- Confirmed `v0.11.4` release assets exist with `gh release view v0.11.4 --repo TheGreenCedar/CodeStory --json tagName,isDraft,isPrerelease,assets,url`.
- Reproduced pre-fix stale-candidate behavior with a temp `CODESTORY_CLI` shim reporting `codestory-cli 0.11.3`; setup rejected it and only suggested Cargo/manual `CODESTORY_CLI`.
- `powershell -NoProfile -Command '$null = [scriptblock]::Create((Get-Content -Raw -LiteralPath "scripts\codex-worktree-setup.ps1")); $null = [scriptblock]::Create((Get-Content -Raw -LiteralPath "scripts\install-codestory.ps1")); "PowerShell parser check: ok"'`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\install-codestory.ps1 -SelfTest`
- Temp-copy fallback smoke: stale `0.11.3` shim first, fake installer writes `0.11.4`, setup prints `==> Install current release CLI` then resolves the current `CODESTORY_CLI` path.
- Temp install-dir smoke: stale `0.11.3` `CODESTORY_CLI` plus temp CodeStory bin `0.11.4` resolved the current path without Cargo.
- `git diff --check`

## Risk

The automatic installer still only downloads on Windows x64. On unsupported hosts or installer failure, `-ResolveCliOnly` now prints the exact current-release install command, and full setup keeps the previous Cargo fallback. I did not run broad Cargo, sidecar rebuilds, benchmarks, release bumps, or marketplace edits.
