### PR TITLE
[codex] handle locked stale cli installs

### DIFF
--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -1,7 +1,8 @@
 [CmdletBinding()]
 param(
     [string]$Project = ".",
-    [switch]$ResolveCliOnly
+    [switch]$ResolveCliOnly,
+    [switch]$SelfTest
 )
 
 $ErrorActionPreference = "Stop"
@@ -174,8 +175,17 @@ function Get-CodeStoryInstallDir {
     return (Join-Path $HOME ".codestory\bin")
 }
 
+function Get-VersionedCodeStoryInstallDir {
+    param([string]$Version)
+
+    return (Join-Path (Join-Path (Get-CodeStoryInstallDir) "releases") $Version)
+}
+
 function Get-CodeStoryCliCandidates {
-    param([string]$Root)
+    param(
+        [string]$Root,
+        [string]$ExpectedVersion
+    )
 
     $candidates = @()
     if ($env:CODESTORY_CLI) {
@@ -193,6 +203,14 @@ function Get-CodeStoryCliCandidates {
         (Join-Path $installDir "codestory-cli.cmd"),
         (Join-Path $installDir "codestory-cli")
     )
+    if ($ExpectedVersion) {
+        $versionedInstallDir = Get-VersionedCodeStoryInstallDir $ExpectedVersion
+        $candidates += @(
+            (Join-Path $versionedInstallDir "codestory-cli.exe"),
+            (Join-Path $versionedInstallDir "codestory-cli.cmd"),
+            (Join-Path $versionedInstallDir "codestory-cli")
+        )
+    }
 
     $candidates += @(
         (Join-Path $Root "target\release\codestory-cli.exe"),
@@ -225,7 +243,7 @@ function Find-CodeStoryCli {
     param([string]$Root)
 
     $expectedVersion = Get-ExpectedCodeStoryCliVersion $Root
-    $candidates = Get-CodeStoryCliCandidates $Root
+    $candidates = Get-CodeStoryCliCandidates $Root $expectedVersion
     $staleCandidates = @()
     foreach ($candidate in $candidates) {
         $actualVersion = $null
@@ -273,6 +291,62 @@ function Same-Path {
     return [string]::Equals($leftFull, $rightFull, [System.StringComparison]::OrdinalIgnoreCase)
 }
 
+function Assert-SelfTest {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw "Self-test failed: $Message"
+    }
+}
+
+function Remove-SetupSelfTestTemp {
+    param([string]$Path)
+
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        return
+    }
+    $tempRoot = [System.IO.Path]::GetTempPath()
+    $leaf = Split-Path -Leaf $resolved.Path
+    if (-not $resolved.Path.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove setup self-test temp outside system temp: $($resolved.Path)"
+    }
+    if (-not $leaf.StartsWith("codestory-setup-", [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove unexpected setup self-test temp: $($resolved.Path)"
+    }
+    Remove-Item -LiteralPath $resolved.Path -Recurse -Force
+}
+
+function Invoke-SelfTest {
+    $oldCodeStoryHome = $env:CODESTORY_HOME
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-setup-" + [System.Guid]::NewGuid().ToString("N"))
+    try {
+        $projectRoot = Join-Path $tempRoot "project"
+        $manifestDir = Join-Path $projectRoot "crates\codestory-cli"
+        New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+        Set-Content -LiteralPath (Join-Path $manifestDir "Cargo.toml") -Value 'version = "0.11.4"' -Encoding ASCII
+
+        $env:CODESTORY_HOME = Join-Path $tempRoot "home"
+        $installDir = Get-CodeStoryInstallDir
+        $versionedInstallDir = Get-VersionedCodeStoryInstallDir "0.11.4"
+        New-Item -ItemType Directory -Force -Path $installDir, $versionedInstallDir | Out-Null
+        Set-Content -LiteralPath (Join-Path $installDir "codestory-cli.cmd") -Value "@echo codestory-cli 0.11.3" -Encoding ASCII
+        $currentCli = Join-Path $versionedInstallDir "codestory-cli.cmd"
+        Set-Content -LiteralPath $currentCli -Value "@echo codestory-cli 0.11.4" -Encoding ASCII
+
+        $resolvedCli = Find-CodeStoryCli $projectRoot
+        Assert-SelfTest (Same-Path $resolvedCli $currentCli) "stale default install should be rejected and versioned current install should be used"
+    } finally {
+        $env:CODESTORY_HOME = $oldCodeStoryHome
+        Remove-SetupSelfTestTemp $tempRoot
+    }
+
+    Write-Host "codex-worktree-setup self-test: ok"
+}
+
 function Find-RehydrateSource {
     param([string]$Target)
 
@@ -307,6 +381,11 @@ function Find-RehydrateSource {
     }
 
     return $null
+}
+
+if ($SelfTest) {
+    Invoke-SelfTest
+    return
 }
 
 $projectPath = (Resolve-Path -LiteralPath $Project).Path

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -322,8 +322,15 @@ function Remove-SetupSelfTestTemp {
 
 function Invoke-SelfTest {
     $oldCodeStoryHome = $env:CODESTORY_HOME
+    $oldCodeStoryCli = $env:CODESTORY_CLI
+    $oldPath = $env:PATH
     $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-setup-" + [System.Guid]::NewGuid().ToString("N"))
     try {
+        $isolatedPath = Join-Path $tempRoot "path"
+        New-Item -ItemType Directory -Force -Path $isolatedPath | Out-Null
+        $env:CODESTORY_CLI = $null
+        $env:PATH = $isolatedPath
+
         $projectRoot = Join-Path $tempRoot "project"
         $manifestDir = Join-Path $projectRoot "crates\codestory-cli"
         New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
@@ -341,6 +348,8 @@ function Invoke-SelfTest {
         Assert-SelfTest (Same-Path $resolvedCli $currentCli) "stale default install should be rejected and versioned current install should be used"
     } finally {
         $env:CODESTORY_HOME = $oldCodeStoryHome
+        $env:CODESTORY_CLI = $oldCodeStoryCli
+        $env:PATH = $oldPath
         Remove-SetupSelfTestTemp $tempRoot
     }
 

--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -46,6 +46,15 @@ function Get-DefaultInstallDir {
     return (Join-Path (Get-CodeStoryHome) "bin")
 }
 
+function Get-VersionedInstallDir {
+    param(
+        [string]$InstallDirectory,
+        [string]$ReleaseVersion
+    )
+
+    return (Join-Path (Join-Path $InstallDirectory "releases") $ReleaseVersion)
+}
+
 function Convert-VersionText {
     param([string]$Text)
 
@@ -106,6 +115,11 @@ function Get-CliCandidates {
     if ($InstallDirectory) {
         $candidates += (Join-Path $InstallDirectory "codestory-cli.exe")
         $candidates += (Join-Path $InstallDirectory "codestory-cli")
+        if ($script:RequiredVersion) {
+            $versionedInstallDir = Get-VersionedInstallDir $InstallDirectory $script:RequiredVersion.ToString()
+            $candidates += (Join-Path $versionedInstallDir "codestory-cli.exe")
+            $candidates += (Join-Path $versionedInstallDir "codestory-cli")
+        }
     }
     $pathCli = Get-Command "codestory-cli" -ErrorAction SilentlyContinue
     if ($pathCli) {
@@ -270,6 +284,34 @@ function Remove-InstallerTemp {
     Remove-Item -LiteralPath $resolved.Path -Recurse -Force
 }
 
+function Copy-ReleaseCliBinary {
+    param(
+        [string]$BinaryPath,
+        [string]$InstallDirectory,
+        [string]$ReleaseVersion
+    )
+
+    $dest = Join-Path $InstallDirectory "codestory-cli.exe"
+    try {
+        Copy-Item -LiteralPath $BinaryPath -Destination $dest -Force
+        return $dest
+    } catch {
+        $defaultError = $_.Exception.Message
+    }
+
+    $versionedInstallDir = Get-VersionedInstallDir $InstallDirectory $ReleaseVersion
+    $versionedDest = Join-Path $versionedInstallDir "codestory-cli.exe"
+    try {
+        New-Item -ItemType Directory -Force -Path $versionedInstallDir | Out-Null
+        Copy-Item -LiteralPath $BinaryPath -Destination $versionedDest -Force
+    } catch {
+        throw "Default install path is locked or not writable: $defaultError. Alternate install path also failed: $($_.Exception.Message). Stop the process holding $dest or restart the host, then run .\scripts\install-codestory.ps1 -Project . -Version $ReleaseVersion."
+    }
+
+    Write-Warning "Default install path is locked or not writable: $defaultError. Installed current release to $versionedDest. To replace the default binary later, stop the locking process or restart the host, then run .\scripts\install-codestory.ps1 -Project . -Version $ReleaseVersion."
+    return $versionedDest
+}
+
 function Install-ReleaseCli {
     param(
         [string]$InstallDirectory,
@@ -304,8 +346,7 @@ function Install-ReleaseCli {
         if (-not $binary) {
             throw "Downloaded archive did not contain codestory-cli.exe"
         }
-        $dest = Join-Path $InstallDirectory "codestory-cli.exe"
-        Copy-Item -LiteralPath $binary.FullName -Destination $dest -Force
+        $dest = Copy-ReleaseCliBinary $binary.FullName $InstallDirectory $ReleaseVersion
         $version = Invoke-CliVersion $dest
         if (-not (Test-RequiredVersion $version.Version)) {
             throw "Downloaded codestory-cli is $($version.Version), expected $script:RequiredVersion"
@@ -458,6 +499,29 @@ function Invoke-SelfTest {
     $parsedVersion = Convert-VersionText "codestory-cli 0.11.4"
     Assert-SelfTest (Test-RequiredVersion $parsedVersion) "version gate should accept current release"
     Assert-SelfTest (-not (Test-RequiredVersion ([Version]"0.11.3"))) "version gate should reject stale 0.11.3"
+
+    $lockRoot = $null
+    $lockStream = $null
+    try {
+        $lockRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-install-" + [System.Guid]::NewGuid().ToString("N"))
+        $lockInstallDir = Join-Path $lockRoot "bin"
+        New-Item -ItemType Directory -Force -Path $lockInstallDir | Out-Null
+        $sourceCli = Join-Path $lockRoot "source.exe"
+        $lockedDefault = Join-Path $lockInstallDir "codestory-cli.exe"
+        Set-Content -LiteralPath $sourceCli -Value "current" -Encoding ASCII
+        Set-Content -LiteralPath $lockedDefault -Value "stale" -Encoding ASCII
+        $lockStream = [System.IO.File]::Open($lockedDefault, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        $fallback = Copy-ReleaseCliBinary $sourceCli $lockInstallDir "0.11.4"
+        $expectedFallback = Join-Path (Get-VersionedInstallDir $lockInstallDir "0.11.4") "codestory-cli.exe"
+        Assert-SelfTest ($fallback -ieq $expectedFallback) "locked default install should fall back to versioned release path"
+    } finally {
+        if ($lockStream) {
+            $lockStream.Dispose()
+        }
+        if ($lockRoot) {
+            Remove-InstallerTemp $lockRoot
+        }
+    }
 
     $explicitStale = $false
     try {


### PR DESCRIPTION
## Context

Closes #367.

Windows worktree setup can reject a stale default installed `codestory-cli.exe`, try the current-release installer, then still drift toward Cargo when that default file is locked by another process. This keeps the fix in setup/install scripts only.

## What Changed

- Added a versioned install fallback under `bin\releases\<version>\codestory-cli.exe` when copying over the default `bin\codestory-cli.exe` fails because the file is locked or not writable.
- Taught both installer and worktree setup candidate discovery to consider that versioned current-release path while still rejecting stale binaries by exact `--version` matching.
- Added a temp-file lock self-test in `scripts/install-codestory.ps1` and a setup resolver self-test in `scripts/codex-worktree-setup.ps1`.

## How To Review

- Start with `scripts/install-codestory.ps1`: `Copy-ReleaseCliBinary` tries the default path first, then falls back to the versioned path with an actionable warning.
- Then check `scripts/codex-worktree-setup.ps1`: `Find-CodeStoryCli` still reads the expected version from `crates\codestory-cli\Cargo.toml` and now searches the versioned install path before Cargo fallback.
- Confirm no product runtime, Cargo manifest, sidecar, benchmark, plugin-doc, marketplace, or release-automation files changed.

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-codestory.ps1 -SelfTest` -> exit 0; reproduced a locked temp default path and ended with `install-codestory self-test: ok`.
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\codex-worktree-setup.ps1 -SelfTest` -> exit 0; ended with `codex-worktree-setup self-test: ok`.
- `git diff --check` -> exit 0, no output.

No Cargo commands were run.

## Risk

- Remaining risk is Windows-specific filesystem behavior outside the temp-file lock smoke. The fallback does not replace the locked default binary; it installs the current release beside it and reports the path through normal resolver output.
- Dogfood friction: local `gh issue view 367 --repo TheGreenCedar/CodeStory --json ...` failed with `GraphQL: API rate limit already exceeded for user ID 14635636`, so issue/PR metadata used the GitHub connector. CodeStory packet/search was not used because this lane fixes the CLI install surface itself.