### PR TITLE
Promote human docs and setup guidance

### DIFF
--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -91,9 +91,11 @@ Recovery order:
 
 1. Confirm whether the miss is in `indexed_symbol_hits`, `repo_text_hits`, or both.
 2. Confirm the reported retrieval mode and degraded-state reason before touching search ranking code.
-3. For product sidecar evidence, run `codestory-cli retrieval bootstrap --project .`, set
-   `CODESTORY_EMBED_BACKEND=llamacpp`, and point `CODESTORY_EMBED_LLAMACPP_URL` at the local
-   bge-base-en-v1.5 llama.cpp `/v1/embeddings` endpoint before reindexing.
+3. For product sidecar evidence, fetch the pinned GGUF when needed with
+   `node scripts/setup-retrieval-env.mjs --fetch-embed-model`, then run
+   `codestory-cli retrieval bootstrap --project .`. Set
+   `CODESTORY_EMBED_BACKEND=llamacpp` and `CODESTORY_EMBED_LLAMACPP_URL` only
+   when your local sidecar endpoint differs from the default.
 4. Rebuild once with `codestory-cli index --project . --refresh full`, then
    `codestory-cli retrieval index --project . --refresh full`.
 5. Require `codestory-cli retrieval status --project . --format json` to report

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -27,7 +27,8 @@ flowchart LR
 - Rust toolchain with `cargo`, or an already-built `codestory-cli` binary.
 - Docker Desktop or Docker Engine for automated Qdrant, Zoekt, and llama.cpp
   sidecars.
-- Optional Node.js 18+ for `scripts/setup-retrieval-env.mjs`.
+- Node.js 18+ if you need `scripts/setup-retrieval-env.mjs` to fetch or verify
+  the pinned GGUF.
 - Localhost ports available: Zoekt `6070`, Qdrant HTTP `6333`, Qdrant gRPC
   `6334`, and llama.cpp embeddings `8080`.
 - GGUF embedding model available through `CODESTORY_EMBED_MODEL_DIR`, or fetched
@@ -61,14 +62,13 @@ From the CodeStory repository root:
 
 ```sh
 node scripts/setup-retrieval-env.mjs --fetch-embed-model
-export CODESTORY_EMBED_MODEL_DIR="$(pwd)/target/retrieval-models"
-export CODESTORY_EMBED_BACKEND="llamacpp"
-export CODESTORY_EMBED_LLAMACPP_URL="http://127.0.0.1:8080/v1/embeddings"
 cargo run -p codestory-cli -- retrieval bootstrap --project <repo> --format json
 ```
 
-On Windows PowerShell, use `$env:...` assignments and
-`.\target\release\codestory-cli.exe` if you are running a built binary.
+Use the environment variables from the minimum table only when the defaults do
+not match your machine. On Windows PowerShell, set them with `$env:NAME =
+"value"` and use `.\target\release\codestory-cli.exe` if you are running a
+built binary.
 
 `retrieval bootstrap` may start Docker Compose, create sidecar cache dirs, write
 `retrieval-sidecars.json`, and repair CodeStory-owned local sidecar state. For a

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -229,10 +229,6 @@ llama.cpp embedding contract.
 
 ```sh
 node scripts/setup-retrieval-env.mjs --fetch-embed-model
-export CODESTORY_EMBED_MODEL_DIR="$(pwd)/target/retrieval-models"
-export CODESTORY_EMBED_BACKEND="llamacpp"
-export CODESTORY_EMBED_LLAMACPP_URL="http://127.0.0.1:8080/v1/embeddings"
-
 codestory-cli retrieval bootstrap --project <target-workspace> --format json
 codestory-cli index --project <target-workspace> --refresh full
 codestory-cli retrieval index --project <target-workspace> --refresh full --format json
@@ -240,36 +236,12 @@ codestory-cli retrieval status --project <target-workspace> --format json
 codestory-cli doctor --project <target-workspace> --format markdown
 ```
 
-**Key concepts for sidecar repair:**
-
-- **`setup-retrieval-env.mjs --fetch-embed-model`**: Verifies the pinned GGUF before renaming it into `CODESTORY_EMBED_MODEL_DIR`. The accepted artifact is exactly `117974304` bytes with SHA-256 `ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`.
-- **`retrieval status --format json`**: Reports `query_embedding_backend`, `manifest_vector_embedding_backend`, and `stored_doc_vector_producer_backend` so backend drift is visible.
-- **Legacy managed embeddings**: Diagnostic only; do not start llama.cpp, create the retrieval manifest, or prove agent packet/search readiness.
-
-**Sidecar readiness verification:**
-
-The `retrieval status --format json` command provides detailed information about:
-
-- `query_embedding_backend`: The backend used for query embeddings
-- `manifest_vector_embedding_backend`: The backend used for manifest vector embeddings
-- `stored_doc_vector_producer_backend`: The backend used for stored document vector production
-
-This allows you to detect backend drift and ensure all components are using the correct embedding backend.
-
-**Sidecar repair process:**
-
-1. **Setup retrieval environment**: Fetch the required embedding model and configure environment variables
-2. **Bootstrap retrieval**: Initialize the retrieval system with the embedding model
-3. **Index the repository**: Build the SQLite graph and retrieval indexes
-4. **Verify sidecar status**: Check that retrieval mode is `full` and all components are healthy
-5. **Final verification**: Run `doctor` to confirm overall system health
-
-**Common sidecar issues and solutions:**
-
-- **Missing embedding model**: Use `setup-retrieval-env.mjs --fetch-embed-model` to download and verify the model
-- **Backend configuration errors**: Check `CODESTORY_EMBED_BACKEND` and related environment variables
-- **Retrieval manifest issues**: Re-run `retrieval bootstrap` and `retrieval index` with `--refresh full`
-- **Stale cache**: Use `index --refresh full` to rebuild the SQLite graph
+`setup-retrieval-env.mjs --fetch-embed-model` verifies the pinned GGUF before
+accepting it under `target/retrieval-models` or `CODESTORY_EMBED_MODEL_DIR`.
+Leave `CODESTORY_EMBED_BACKEND` and `CODESTORY_EMBED_LLAMACPP_URL` unset unless
+your machine needs non-default sidecar settings. `retrieval status --format
+json` reports the query, manifest, and stored-vector backends so backend drift
+is visible before packet/search is trusted.
 
 Legacy managed embeddings are diagnostic only:
 

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -37,6 +37,93 @@ function Invoke-SetupStep {
     }
 }
 
+function Get-ReadinessVerdict {
+    param(
+        $Doctor,
+        [string]$Goal
+    )
+
+    foreach ($verdict in @($Doctor.readiness)) {
+        if ($verdict.goal -eq $Goal) {
+            return $verdict
+        }
+    }
+
+    return $null
+}
+
+function Test-ReadinessReady {
+    param($Verdict)
+
+    return ($Verdict -and $Verdict.status -eq "ready")
+}
+
+function Get-MinimumNextCommand {
+    param(
+        $LocalVerdict,
+        $AgentVerdict,
+        $Doctor
+    )
+
+    foreach ($verdict in @($LocalVerdict, $AgentVerdict)) {
+        if (-not (Test-ReadinessReady $verdict)) {
+            foreach ($command in @($verdict.minimum_next)) {
+                if ($command) {
+                    return [string]$command
+                }
+            }
+        }
+    }
+
+    foreach ($command in @($Doctor.next_commands)) {
+        if ($command) {
+            return [string]$command
+        }
+    }
+
+    return $null
+}
+
+function Invoke-DoctorJson {
+    param(
+        [string]$Cli,
+        [string]$ProjectPath
+    )
+
+    $json = (& $Cli doctor --project $ProjectPath --format json 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) {
+        throw "codestory-cli doctor failed with exit code $LASTEXITCODE`n$json"
+    }
+
+    return ($json | ConvertFrom-Json)
+}
+
+function Write-DoctorReadinessSummary {
+    param($Doctor)
+
+    $local = Get-ReadinessVerdict $Doctor "local_navigation"
+    $agent = Get-ReadinessVerdict $Doctor "agent_packet_search"
+    $minimumNext = Get-MinimumNextCommand $local $agent $Doctor
+
+    Write-Host "CodeStory worktree readiness"
+    Write-Host ("  local_navigation: {0}" -f $(if ($local) { $local.status } else { "unknown" }))
+    if ($local -and $local.summary) {
+        Write-Host ("    reason: {0}" -f $local.summary)
+    }
+    Write-Host ("  agent_packet_search: {0}" -f $(if ($agent) { $agent.status } else { "unknown" }))
+    if ($agent -and $agent.summary) {
+        Write-Host ("    reason: {0}" -f $agent.summary)
+    }
+    Write-Host ("  retrieval_mode: {0}" -f $Doctor.retrieval_mode)
+    Write-Host ("  degraded_reason: {0}" -f $(if ($Doctor.degraded_reason) { $Doctor.degraded_reason } else { "none" }))
+    if ($minimumNext) {
+        Write-Host ("  minimum_next: {0}" -f $minimumNext)
+    }
+    if (-not (Test-ReadinessReady $agent)) {
+        Write-Host "  handoff: CodeStory packet/search is unavailable; use direct source reads until the minimum_next command repairs readiness."
+    }
+}
+
 function Test-CodeStoryCli {
     param(
         [string]$Candidate,
@@ -239,8 +326,9 @@ try {
         Invoke-Checked $cli @("retrieval", "index", "--project", $projectPath, "--refresh", "auto")
     } -Optional
 
-    Invoke-SetupStep "Doctor" {
-        Invoke-Checked $cli @("doctor", "--project", $projectPath, "--format", "markdown")
+    Invoke-SetupStep "Doctor readiness handoff" {
+        $doctor = Invoke-DoctorJson $cli $projectPath
+        Write-DoctorReadinessSummary $doctor
     } -Optional
 } finally {
     Pop-Location

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -1,7 +1,8 @@
 [CmdletBinding()]
 param(
     [string]$Project = ".",
-    [switch]$ResolveCliOnly
+    [switch]$ResolveCliOnly,
+    [switch]$SelfTest
 )
 
 $ErrorActionPreference = "Stop"
@@ -174,8 +175,17 @@ function Get-CodeStoryInstallDir {
     return (Join-Path $HOME ".codestory\bin")
 }
 
+function Get-VersionedCodeStoryInstallDir {
+    param([string]$Version)
+
+    return (Join-Path (Join-Path (Get-CodeStoryInstallDir) "releases") $Version)
+}
+
 function Get-CodeStoryCliCandidates {
-    param([string]$Root)
+    param(
+        [string]$Root,
+        [string]$ExpectedVersion
+    )
 
     $candidates = @()
     if ($env:CODESTORY_CLI) {
@@ -193,6 +203,14 @@ function Get-CodeStoryCliCandidates {
         (Join-Path $installDir "codestory-cli.cmd"),
         (Join-Path $installDir "codestory-cli")
     )
+    if ($ExpectedVersion) {
+        $versionedInstallDir = Get-VersionedCodeStoryInstallDir $ExpectedVersion
+        $candidates += @(
+            (Join-Path $versionedInstallDir "codestory-cli.exe"),
+            (Join-Path $versionedInstallDir "codestory-cli.cmd"),
+            (Join-Path $versionedInstallDir "codestory-cli")
+        )
+    }
 
     $candidates += @(
         (Join-Path $Root "target\release\codestory-cli.exe"),
@@ -225,7 +243,7 @@ function Find-CodeStoryCli {
     param([string]$Root)
 
     $expectedVersion = Get-ExpectedCodeStoryCliVersion $Root
-    $candidates = Get-CodeStoryCliCandidates $Root
+    $candidates = Get-CodeStoryCliCandidates $Root $expectedVersion
     $staleCandidates = @()
     foreach ($candidate in $candidates) {
         $actualVersion = $null
@@ -273,6 +291,71 @@ function Same-Path {
     return [string]::Equals($leftFull, $rightFull, [System.StringComparison]::OrdinalIgnoreCase)
 }
 
+function Assert-SelfTest {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+
+    if (-not $Condition) {
+        throw "Self-test failed: $Message"
+    }
+}
+
+function Remove-SetupSelfTestTemp {
+    param([string]$Path)
+
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        return
+    }
+    $tempRoot = [System.IO.Path]::GetTempPath()
+    $leaf = Split-Path -Leaf $resolved.Path
+    if (-not $resolved.Path.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove setup self-test temp outside system temp: $($resolved.Path)"
+    }
+    if (-not $leaf.StartsWith("codestory-setup-", [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove unexpected setup self-test temp: $($resolved.Path)"
+    }
+    Remove-Item -LiteralPath $resolved.Path -Recurse -Force
+}
+
+function Invoke-SelfTest {
+    $oldCodeStoryHome = $env:CODESTORY_HOME
+    $oldCodeStoryCli = $env:CODESTORY_CLI
+    $oldPath = $env:PATH
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-setup-" + [System.Guid]::NewGuid().ToString("N"))
+    try {
+        $isolatedPath = Join-Path $tempRoot "path"
+        New-Item -ItemType Directory -Force -Path $isolatedPath | Out-Null
+        $env:CODESTORY_CLI = $null
+        $env:PATH = $isolatedPath
+
+        $projectRoot = Join-Path $tempRoot "project"
+        $manifestDir = Join-Path $projectRoot "crates\codestory-cli"
+        New-Item -ItemType Directory -Force -Path $manifestDir | Out-Null
+        Set-Content -LiteralPath (Join-Path $manifestDir "Cargo.toml") -Value 'version = "0.11.4"' -Encoding ASCII
+
+        $env:CODESTORY_HOME = Join-Path $tempRoot "home"
+        $installDir = Get-CodeStoryInstallDir
+        $versionedInstallDir = Get-VersionedCodeStoryInstallDir "0.11.4"
+        New-Item -ItemType Directory -Force -Path $installDir, $versionedInstallDir | Out-Null
+        Set-Content -LiteralPath (Join-Path $installDir "codestory-cli.cmd") -Value "@echo codestory-cli 0.11.3" -Encoding ASCII
+        $currentCli = Join-Path $versionedInstallDir "codestory-cli.cmd"
+        Set-Content -LiteralPath $currentCli -Value "@echo codestory-cli 0.11.4" -Encoding ASCII
+
+        $resolvedCli = Find-CodeStoryCli $projectRoot
+        Assert-SelfTest (Same-Path $resolvedCli $currentCli) "stale default install should be rejected and versioned current install should be used"
+    } finally {
+        $env:CODESTORY_HOME = $oldCodeStoryHome
+        $env:CODESTORY_CLI = $oldCodeStoryCli
+        $env:PATH = $oldPath
+        Remove-SetupSelfTestTemp $tempRoot
+    }
+
+    Write-Host "codex-worktree-setup self-test: ok"
+}
+
 function Find-RehydrateSource {
     param([string]$Target)
 
@@ -307,6 +390,11 @@ function Find-RehydrateSource {
     }
 
     return $null
+}
+
+if ($SelfTest) {
+    Invoke-SelfTest
+    return
 }
 
 $projectPath = (Resolve-Path -LiteralPath $Project).Path

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -164,6 +164,16 @@ function Get-ExpectedCodeStoryCliVersion {
     throw "Unable to read expected codestory-cli version from $manifest."
 }
 
+function Get-CodeStoryInstallDir {
+    if ($env:CODESTORY_HOME) {
+        return (Join-Path $env:CODESTORY_HOME "bin")
+    }
+    if ($env:LOCALAPPDATA) {
+        return (Join-Path $env:LOCALAPPDATA "CodeStory\bin")
+    }
+    return (Join-Path $HOME ".codestory\bin")
+}
+
 function Get-CodeStoryCliCandidates {
     param([string]$Root)
 
@@ -176,6 +186,13 @@ function Get-CodeStoryCliCandidates {
     if ($pathCli) {
         $candidates += $pathCli.Source
     }
+
+    $installDir = Get-CodeStoryInstallDir
+    $candidates += @(
+        (Join-Path $installDir "codestory-cli.exe"),
+        (Join-Path $installDir "codestory-cli.cmd"),
+        (Join-Path $installDir "codestory-cli")
+    )
 
     $candidates += @(
         (Join-Path $Root "target\release\codestory-cli.exe"),
@@ -225,6 +242,23 @@ function Find-CodeStoryCli {
         $message += " Stale candidates: $($staleCandidates -join '; ')."
     }
     throw $message
+}
+
+function Invoke-CurrentReleaseCliInstall {
+    param(
+        [string]$Root,
+        [string]$ExpectedVersion
+    )
+
+    $installer = Join-Path $PSScriptRoot "install-codestory.ps1"
+    if (-not (Test-Path -LiteralPath $installer)) {
+        throw "Current-release installer is missing: $installer"
+    }
+
+    Write-Host ""
+    Write-Host "==> Install current release CLI"
+    Write-Host "Trying codestory-cli $ExpectedVersion release install before Cargo build."
+    & $installer -Project $Root -Version $ExpectedVersion
 }
 
 function Same-Path {
@@ -288,14 +322,23 @@ try {
     try {
         $cli = Find-CodeStoryCli $projectPath
     } catch {
-        if ($ResolveCliOnly) {
-            throw "$($_.Exception.Message) Re-run without -ResolveCliOnly to build with cargo, or set CODESTORY_CLI to a ready binary."
+        $resolveError = $_.Exception.Message
+        $expectedVersion = Get-ExpectedCodeStoryCliVersion $projectPath
+        try {
+            Invoke-CurrentReleaseCliInstall $projectPath $expectedVersion
+            $cli = Find-CodeStoryCli $projectPath
+        } catch {
+            $installError = $_.Exception.Message
+            $installCommand = ".\scripts\install-codestory.ps1 -Project . -Version $expectedVersion"
+            if ($ResolveCliOnly) {
+                throw "$resolveError Current-release install failed: $installError. Run $installCommand, or set CODESTORY_CLI to a ready binary."
+            }
+            Write-Host ""
+            Write-Host "==> Build release CLI"
+            Write-Warning "$resolveError Current-release install failed: $installError. Building release CLI with cargo."
+            Invoke-Checked "cargo" @("build", "--release", "-p", "codestory-cli")
+            $cli = Find-CodeStoryCli $projectPath
         }
-        Write-Host ""
-        Write-Host "==> Build release CLI"
-        Write-Warning "$($_.Exception.Message) Building release CLI with cargo."
-        Invoke-Checked "cargo" @("build", "--release", "-p", "codestory-cli")
-        $cli = Find-CodeStoryCli $projectPath
     }
 
     Write-Host "CODESTORY_CLI=$cli"

--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -46,6 +46,15 @@ function Get-DefaultInstallDir {
     return (Join-Path (Get-CodeStoryHome) "bin")
 }
 
+function Get-VersionedInstallDir {
+    param(
+        [string]$InstallDirectory,
+        [string]$ReleaseVersion
+    )
+
+    return (Join-Path (Join-Path $InstallDirectory "releases") $ReleaseVersion)
+}
+
 function Convert-VersionText {
     param([string]$Text)
 
@@ -106,6 +115,11 @@ function Get-CliCandidates {
     if ($InstallDirectory) {
         $candidates += (Join-Path $InstallDirectory "codestory-cli.exe")
         $candidates += (Join-Path $InstallDirectory "codestory-cli")
+        if ($script:RequiredVersion) {
+            $versionedInstallDir = Get-VersionedInstallDir $InstallDirectory $script:RequiredVersion.ToString()
+            $candidates += (Join-Path $versionedInstallDir "codestory-cli.exe")
+            $candidates += (Join-Path $versionedInstallDir "codestory-cli")
+        }
     }
     $pathCli = Get-Command "codestory-cli" -ErrorAction SilentlyContinue
     if ($pathCli) {
@@ -270,6 +284,34 @@ function Remove-InstallerTemp {
     Remove-Item -LiteralPath $resolved.Path -Recurse -Force
 }
 
+function Copy-ReleaseCliBinary {
+    param(
+        [string]$BinaryPath,
+        [string]$InstallDirectory,
+        [string]$ReleaseVersion
+    )
+
+    $dest = Join-Path $InstallDirectory "codestory-cli.exe"
+    try {
+        Copy-Item -LiteralPath $BinaryPath -Destination $dest -Force
+        return $dest
+    } catch {
+        $defaultError = $_.Exception.Message
+    }
+
+    $versionedInstallDir = Get-VersionedInstallDir $InstallDirectory $ReleaseVersion
+    $versionedDest = Join-Path $versionedInstallDir "codestory-cli.exe"
+    try {
+        New-Item -ItemType Directory -Force -Path $versionedInstallDir | Out-Null
+        Copy-Item -LiteralPath $BinaryPath -Destination $versionedDest -Force
+    } catch {
+        throw "Default install path is locked or not writable: $defaultError. Alternate install path also failed: $($_.Exception.Message). Stop the process holding $dest or restart the host, then run .\scripts\install-codestory.ps1 -Project . -Version $ReleaseVersion."
+    }
+
+    Write-Warning "Default install path is locked or not writable: $defaultError. Installed current release to $versionedDest. To replace the default binary later, stop the locking process or restart the host, then run .\scripts\install-codestory.ps1 -Project . -Version $ReleaseVersion."
+    return $versionedDest
+}
+
 function Install-ReleaseCli {
     param(
         [string]$InstallDirectory,
@@ -304,8 +346,7 @@ function Install-ReleaseCli {
         if (-not $binary) {
             throw "Downloaded archive did not contain codestory-cli.exe"
         }
-        $dest = Join-Path $InstallDirectory "codestory-cli.exe"
-        Copy-Item -LiteralPath $binary.FullName -Destination $dest -Force
+        $dest = Copy-ReleaseCliBinary $binary.FullName $InstallDirectory $ReleaseVersion
         $version = Invoke-CliVersion $dest
         if (-not (Test-RequiredVersion $version.Version)) {
             throw "Downloaded codestory-cli is $($version.Version), expected $script:RequiredVersion"
@@ -458,6 +499,29 @@ function Invoke-SelfTest {
     $parsedVersion = Convert-VersionText "codestory-cli 0.11.4"
     Assert-SelfTest (Test-RequiredVersion $parsedVersion) "version gate should accept current release"
     Assert-SelfTest (-not (Test-RequiredVersion ([Version]"0.11.3"))) "version gate should reject stale 0.11.3"
+
+    $lockRoot = $null
+    $lockStream = $null
+    try {
+        $lockRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-install-" + [System.Guid]::NewGuid().ToString("N"))
+        $lockInstallDir = Join-Path $lockRoot "bin"
+        New-Item -ItemType Directory -Force -Path $lockInstallDir | Out-Null
+        $sourceCli = Join-Path $lockRoot "source.exe"
+        $lockedDefault = Join-Path $lockInstallDir "codestory-cli.exe"
+        Set-Content -LiteralPath $sourceCli -Value "current" -Encoding ASCII
+        Set-Content -LiteralPath $lockedDefault -Value "stale" -Encoding ASCII
+        $lockStream = [System.IO.File]::Open($lockedDefault, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        $fallback = Copy-ReleaseCliBinary $sourceCli $lockInstallDir "0.11.4"
+        $expectedFallback = Join-Path (Get-VersionedInstallDir $lockInstallDir "0.11.4") "codestory-cli.exe"
+        Assert-SelfTest ($fallback -ieq $expectedFallback) "locked default install should fall back to versioned release path"
+    } finally {
+        if ($lockStream) {
+            $lockStream.Dispose()
+        }
+        if ($lockRoot) {
+            Remove-InstallerTemp $lockRoot
+        }
+    }
 
     $explicitStale = $false
     try {

--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -450,22 +450,22 @@ function Assert-SelfTest {
 }
 
 function Invoke-SelfTest {
-    Set-RequiredVersion "v0.11.3"
+    Set-RequiredVersion "v0.11.4"
     Test-WindowsX64 | Out-Null
     Assert-SelfTest (Test-PathListContains "C:\Tools;C:\CodeStory\bin\" "C:\CodeStory\bin") "path-list check should ignore trailing slash"
     Assert-SelfTest (-not (Test-PathListContains "C:\Tools" "C:\CodeStory\bin")) "path-list check should reject missing directory"
-    Assert-SelfTest ((Convert-ReleaseTagToVersion "v0.11.3") -eq "0.11.3") "release tag parser should strip v prefix"
-    $parsedVersion = Convert-VersionText "codestory-cli 0.11.3"
+    Assert-SelfTest ((Convert-ReleaseTagToVersion "v0.11.4") -eq "0.11.4") "release tag parser should strip v prefix"
+    $parsedVersion = Convert-VersionText "codestory-cli 0.11.4"
     Assert-SelfTest (Test-RequiredVersion $parsedVersion) "version gate should accept current release"
-    Assert-SelfTest (-not (Test-RequiredVersion ([Version]"0.11.2"))) "version gate should reject stale 0.11.2"
+    Assert-SelfTest (-not (Test-RequiredVersion ([Version]"0.11.3"))) "version gate should reject stale 0.11.3"
 
     $explicitStale = $false
     try {
         $staleCli = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-stale-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
-        Set-Content -LiteralPath $staleCli -Value "@echo codestory-cli 0.11.2" -Encoding ASCII
+        Set-Content -LiteralPath $staleCli -Value "@echo codestory-cli 0.11.3" -Encoding ASCII
         Find-ExistingCli $staleCli $null | Out-Null
     } catch {
-        $explicitStale = $_.Exception.Message -match "requires 0.11.3"
+        $explicitStale = $_.Exception.Message -match "requires 0.11.4"
     } finally {
         if ($staleCli -and (Test-Path -LiteralPath $staleCli)) {
             Remove-Item -LiteralPath $staleCli -Force
@@ -475,9 +475,9 @@ function Invoke-SelfTest {
 
     try {
         $currentCli = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-current-" + [System.Guid]::NewGuid().ToString("N") + ".cmd")
-        Set-Content -LiteralPath $currentCli -Value "@echo codestory-cli 0.11.3" -Encoding ASCII
+        Set-Content -LiteralPath $currentCli -Value "@echo codestory-cli 0.11.4" -Encoding ASCII
         $current = Find-ExistingCli $currentCli $null
-        Assert-SelfTest ($current.Version -eq [Version]"0.11.3") "explicit current codestory-cli override should be accepted"
+        Assert-SelfTest ($current.Version -eq [Version]"0.11.4") "explicit current codestory-cli override should be accepted"
     } finally {
         if ($currentCli -and (Test-Path -LiteralPath $currentCli)) {
             Remove-Item -LiteralPath $currentCli -Force


### PR DESCRIPTION
## Context

Closes #367
Refs #38
Refs #368

This promotes the current `dev/codestory-next` branch to `main` after the human docs pass and the locked-installed-CLI setup fix. The diff is intentionally small: three operator/docs files plus the two PowerShell setup scripts that own current-release CLI resolution.

## What Changed

- Tightened sidecar repair docs in `docs/usage.md`, `docs/ops/retrieval-sidecars.md`, and `docs/contributors/debugging.md` so the happy path is concrete: fetch/verify the pinned GGUF when needed, bootstrap retrieval, rebuild the core and sidecar indexes, then trust packet/search only when status reports `retrieval_mode: "full"`.
- Removed over-explained sidecar prose from usage docs and kept the operator proof surface focused on commands and status fields.
- Updated `scripts/codex-worktree-setup.ps1` so worktrees resolve a ready current `codestory-cli`, try the current-release installer before Cargo, and report `doctor` readiness as local-navigation plus agent packet/search status.
- Updated `scripts/install-codestory.ps1` so a locked default installed Windows binary no longer forces a cold Cargo build: the installer falls back to `bin\releases\<version>\codestory-cli.exe`, and setup discovery accepts that exact-version path while still rejecting stale binaries.
- Added focused PowerShell self-tests for the installer locked-file fallback and the worktree setup resolver path.

```mermaid
flowchart LR
    A["No ready codestory-cli"] --> B["Try current release install"]
    B --> C{"default binary writable?"}
    C -->|"yes"| D["bin/codestory-cli.exe"]
    C -->|"locked"| E["bin/releases/<version>/codestory-cli.exe"]
    D --> F["exact version check"]
    E --> F
    F --> G["rehydrate, index, doctor readiness"]
```

## How To Review

1. Read the sidecar repair sections in `docs/usage.md` and `docs/ops/retrieval-sidecars.md` as an operator who needs to recover packet/search readiness.
2. Inspect `scripts/install-codestory.ps1`: `Copy-ReleaseCliBinary` should try the default install path first, then use the versioned release path with an actionable warning when the default binary is locked.
3. Inspect `scripts/codex-worktree-setup.ps1`: setup should search `CODESTORY_CLI`, PATH, default install, versioned install, local target, and sibling targets while preserving exact version matching.
4. Confirm no Cargo manifests, runtime behavior, sidecar implementation, marketplace catalog, benchmark harness, or release automation files changed.

## Verification

- `git diff --check origin/main...HEAD`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\install-codestory.ps1 -SelfTest`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\codex-worktree-setup.ps1 -SelfTest`
- `node .github\scripts\check-workflow-policy.mjs`

## Risk

- I did not run a full worktree setup, Cargo build, retrieval bootstrap, or sidecar indexing cycle in this checkout. The setup and installer resolver paths were tested directly; live sidecar readiness still depends on the operator machine and Docker/embedding assets.
- The locked-file fallback leaves the locked default binary in place and installs the current release beside it. Replacing the default binary still requires stopping the locking process or restarting the host.
