### PR TITLE
[codex] bump CodeStory to 0.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.11.5
+
+CodeStory 0.11.5 carries the setup and documentation repair cleanup that
+landed after 0.11.4 onto `main` as a synchronized patch release. The version is
+aligned across every `codestory-*` workspace crate and `Cargo.lock`, with
+`crates/codestory-cli/Cargo.toml` still acting as the release version source.
+
+The release tightens the human operator path around sidecar repair and readiness
+checks. The docs now explain when local navigation is usable, when packet/search
+needs full sidecar evidence, and how to recover from stale or missing retrieval
+state without turning the changelog into a release ledger.
+
+Setup now handles locked installed CLI binaries more predictably. When an
+existing installed `codestory-cli` cannot be replaced directly, the installer
+falls back to a locked-safe path instead of leaving the operator with a stale
+binary and a quiet success signal.
+
+Supporting PRs: #368, #369. This release does not create manual tags, add new
+answer-quality claims, or change runtime behavior beyond the promoted setup,
+documentation, and version metadata.
+
 ## 0.11.4
 
 CodeStory 0.11.4 promotes the docs/plugin/setup wave from

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Context

Closes #370
Refs #38

PR #369 promoted the setup/docs cleanup to `main` after 0.11.4, including the locked installed CLI fallback from #368. This PR cuts the matching 0.11.5 patch release metadata without creating manual tags or adding generated release artifacts.

CodeStory dogfood friction: this worktree's installed `codestory-cli` is 0.11.2, and `codestory-cli.exe doctor --project .` reported `needs_attention` with `local_navigation=repair_index`, `agent_packet_search=repair_index`, and `sidecar_mode=unavailable` because `retrieval_manifest_missing`. I used direct source reads for the release bump instead of packet/search evidence.

## What Changed

- Bumped all eight `codestory-*` workspace crate versions from 0.11.4 to 0.11.5.
- Updated the matching `Cargo.lock` package versions for those workspace crates.
- Added a concise 0.11.5 changelog entry describing the docs/sidecar repair cleanup and locked installed CLI fallback from #368/#369.

## How To Review

- Check `crates/codestory-cli/Cargo.toml` as the release version source.
- Confirm every `crates/codestory-*/Cargo.toml` package version is 0.11.5.
- Confirm `Cargo.lock` changes are limited to the eight `codestory-*` workspace package versions.
- Read the new `CHANGELOG.md` entry for release-facing prose rather than generated ledger content.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.5` passed: synchronized across 8 workspace crates and Cargo.lock.
- `node .github/scripts/check-workflow-policy.mjs` passed: workflow policy and saga issue-link guard valid.
- `cargo check --workspace` passed with `RUSTC_WRAPPER=C:\Users\alber\.cargo\bin\sccache.exe`.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

Low. This is a release metadata and changelog-only change. Merge to `main` owns release automation; no manual tags were created.
