### PR TITLE
[codex] sync plugin package version with cli

### DIFF
--- a/.github/scripts/check-codestory-release.py
+++ b/.github/scripts/check-codestory-release.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 import tomllib
@@ -49,6 +50,18 @@ def lock_packages(root: Path) -> dict[str, set[str]]:
     return packages
 
 
+def plugin_version(root: Path) -> str:
+    manifest_path = root / "plugins" / "codestory" / ".codex-plugin" / "plugin.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"{manifest_path} does not exist") from exc
+    version = manifest.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"{manifest_path} must declare a string version")
+    return version
+
+
 def fail(message: str) -> None:
     print(f"error: {message}", file=sys.stderr)
     raise SystemExit(1)
@@ -77,6 +90,13 @@ def main() -> None:
         fail(f"{cli_manifest} package.name is {cli_name!r}, expected 'codestory-cli'")
     if cli_version != expected:
         fail(f"codestory-cli version is {cli_version}, expected {expected}")
+
+    current_plugin_version = plugin_version(root)
+    if current_plugin_version != expected:
+        fail(
+            "plugins/codestory/.codex-plugin/plugin.json version is "
+            f"{current_plugin_version}, expected {expected}"
+        )
 
     workspace_versions: dict[str, str] = {}
     for manifest_path in workspace_members(root):
@@ -111,7 +131,7 @@ def main() -> None:
 
     print(
         f"CodeStory release version {expected} is synchronized across "
-        f"{len(workspace_versions)} workspace crates and Cargo.lock."
+        f"{len(workspace_versions)} workspace crates, Cargo.lock, and the codestory plugin."
     )
 
 

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.1.0",
+  "version": "0.11.5",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -7,6 +7,24 @@ import { fileURLToPath } from "node:url";
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
 
+function readCargoVersion(manifestText) {
+  let inPackage = false;
+  for (const line of manifestText.split(/\r?\n/u)) {
+    if (/^\[[^\]]+\]/u.test(line)) {
+      inPackage = line.trim() === "[package]";
+      continue;
+    }
+    if (!inPackage) {
+      continue;
+    }
+    const versionMatch = line.match(/^version\s*=\s*"([^"]+)"/u);
+    if (versionMatch) {
+      return versionMatch[1];
+    }
+  }
+  assert.fail("Cargo package must declare version");
+}
+
 test("plugin metadata maps skill and direct stdio server", async () => {
   const manifest = JSON.parse(
     await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
@@ -25,6 +43,18 @@ test("plugin metadata maps skill and direct stdio server", async () => {
     "none",
   ]);
   assert.equal(Object.hasOwn(mcp.mcpServers.codestory, "cwd"), false);
+});
+
+test("plugin package version tracks the codestory-cli release version", async () => {
+  const manifest = JSON.parse(
+    await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+  );
+  const cliManifest = await readFile(
+    join(repoRoot, "crates", "codestory-cli", "Cargo.toml"),
+    "utf8",
+  );
+
+  assert.equal(manifest.version, readCargoVersion(cliManifest));
 });
 
 test("codestory repo ships plugin source, not marketplace catalog or adapter runtime", async () => {


### PR DESCRIPTION
## Context

Closes #378
Refs #38, #373, #374

#373 showed the plugin marketplace install could refresh the CodeStory plugin package while the active `codestory-cli` on PATH stayed stale. One reason that was easy to miss: the plugin package version was still `0.1.0` even after the CLI release advanced to `0.11.5`, and the release validator did not check the plugin manifest at all.

This PR fixes the update signal and adds guards so the next CLI release cannot leave the plugin package version behind silently. #374 remains open for the separate stale runtime/PATH repair boundary.

```mermaid
flowchart LR
    Cargo["codestory-cli Cargo.toml"] --> ReleaseCheck["release version check"]
    Plugin["plugin.json version"] --> ReleaseCheck
    Cargo --> StaticTest["plugin static test"]
    Plugin --> StaticTest
    ReleaseCheck --> UpdateSignal["plugin cache sees new package version"]
```

## What Changed

- Bumped `plugins/codestory/.codex-plugin/plugin.json` from `0.1.0` to `0.11.5` to match `codestory-cli`.
- Added a plugin static test that asserts the plugin package version equals `crates/codestory-cli/Cargo.toml`.
- Extended `.github/scripts/check-codestory-release.py` so release checks fail when the plugin manifest version does not match the requested release version.

## How To Review

- Check that the plugin manifest version now matches the CLI release version.
- Check that future release bumps have two guards: plugin static test and release checker.
- Confirm this keeps direct `codestory-cli serve --stdio --refresh none`; no Node MCP wrapper or marketplace catalog change is introduced.

## Verification

- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> pass, 5 tests.
- `python .github\scripts\check-codestory-release.py --version 0.11.5` -> pass.
- `python -m py_compile .github\scripts\check-codestory-release.py` -> pass.
- `git diff --check` -> pass.

## Risk

This does not by itself kill already-running stale `codestory-cli.exe serve --stdio --refresh none` processes or rewrite a locked binary on PATH. It closes the packaging/version drift hole so plugin updates can signal the current release and future release checks fail if the plugin version is forgotten.
