### PR TITLE
Guard stale CodeStory plugin runtime

### DIFF
--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -77,6 +77,20 @@ unavailable.
 Start a new Codex thread after installation or refresh. The installed package
 launches `codestory-cli serve --stdio --refresh none` from `PATH`.
 
+Before starting that fresh thread, run the runtime preflight from this plugin
+package:
+
+```console
+node plugins/codestory/scripts/check-runtime.mjs
+```
+
+It checks the `codestory-cli` resolved from `PATH` against the plugin package
+version. If it fails, install the matching release asset into a stable user bin
+directory, put that directory before older `codestory-cli` entries on `PATH`,
+stop existing `codestory-cli serve --stdio --refresh none` processes before
+replacing a locked binary, restart the Codex host/app if `PATH` changed, and
+then start a fresh thread.
+
 ### After install
 
 Open Codex in the repo you want to ground and ask the agent to check readiness
@@ -174,6 +188,17 @@ The plugin does not bundle the binary. The agent-owned skill verifies
 `codestory-cli --version`, compares it with the latest GitHub release, installs
 the matching release asset when practical, and checks `SHA256SUMS.txt` when the
 host can. If `PATH` changed, the skill tells the human that a Codex host/app restart may be needed before a fresh agent thread can see it.
+
+For installed MCP runtime, the host-safe preflight is:
+
+```console
+node plugins/codestory/scripts/check-runtime.mjs
+```
+
+Use the same repair rule on failure: install the matching release asset earlier
+on `PATH`, stop locked `codestory-cli serve --stdio --refresh none` processes
+before replacing an older binary, restart the Codex host/app if needed, and only
+then launch a fresh plugin thread.
 
 Use source fallback only when no release asset fits the host:
 

--- a/plugins/codestory/scripts/check-runtime.mjs
+++ b/plugins/codestory/scripts/check-runtime.mjs
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { accessSync, constants } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const manifest = JSON.parse(
+  await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+);
+const expectedVersion = manifest.version;
+const pathDirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+const extensions =
+  process.platform === "win32"
+    ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+        .split(";")
+        .filter(Boolean)
+    : [""];
+
+function findOnPath(command) {
+  const names = extensions.map((extension) => command + extension.toLowerCase());
+  for (const dir of pathDirs) {
+    for (const name of names) {
+      const candidate = join(dir, name);
+      try {
+        accessSync(candidate, constants.X_OK);
+        return candidate;
+      } catch {
+        // Keep scanning PATH.
+      }
+    }
+  }
+  return null;
+}
+
+function fail(message) {
+  console.error(message);
+  console.error("");
+  console.error("Repair:");
+  console.error(
+    "- Install the CodeStory release asset matching plugin version " +
+      expectedVersion +
+      " into a stable user bin directory.",
+  );
+  console.error(
+    "- Put that directory before older codestory-cli entries on PATH.",
+  );
+  console.error(
+    "- Stop existing `codestory-cli serve --stdio --refresh none` processes before replacing a locked binary.",
+  );
+  console.error(
+    "- Restart the Codex host/app if PATH changed, then start a fresh thread.",
+  );
+  process.exit(1);
+}
+
+const resolved = findOnPath("codestory-cli");
+if (!resolved) {
+  fail("codestory-cli was not found on PATH; installed MCP launch would fail.");
+}
+
+const isWindowsScript =
+  process.platform === "win32" && /\.(bat|cmd)$/iu.test(resolved);
+const version = isWindowsScript
+  ? spawnSync(
+      process.env.ComSpec ?? "cmd.exe",
+      ["/d", "/c", resolved, "--version"],
+      {
+        encoding: "utf8",
+      },
+    )
+  : spawnSync(resolved, ["--version"], {
+      encoding: "utf8",
+    });
+if (version.error || version.status !== 0) {
+  fail(
+    "Failed to run `" +
+      resolved +
+      " --version`; installed MCP launch may resolve a broken runtime.",
+  );
+}
+
+const output = (version.stdout + version.stderr).trim();
+const match = output.match(/\b(\d+\.\d+\.\d+)\b/u);
+if (!match) {
+  fail("Could not parse codestory-cli version from: " + output);
+}
+
+const actualVersion = match[1];
+if (actualVersion !== expectedVersion) {
+  fail(
+    "Resolved codestory-cli is " +
+      actualVersion +
+      ", but plugin package expects " +
+      expectedVersion +
+      ": " +
+      resolved,
+  );
+}
+
+console.log(
+  "codestory-cli runtime OK: " + resolved + " (version " + actualVersion + ")",
+);

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -32,6 +32,9 @@ tool source unless the user is editing CodeStory itself.
 2. For installed plugin MCP runtime, `.mcp.json` launches `codestory-cli` from
    the agent host `PATH`. Use `CODESTORY_CLI` only for manual CLI/source
    fallback commands, not as the installed MCP launch path.
+   When the plugin package source is available, run
+   `node plugins/codestory/scripts/check-runtime.mjs` before MCP launch to
+   confirm the `PATH` runtime matches the plugin package version.
 3. Resolve `<codestory-cli>` for explicit CLI commands:
    - prefer `CODESTORY_CLI` when set;
    - otherwise use `codestory-cli` on `PATH`;
@@ -54,6 +57,9 @@ tool source unless the user is editing CodeStory itself.
 6. Put the binary in a stable user bin directory, verify
    `codestory-cli --version`, and prefer checking `SHA256SUMS.txt` from the
    same release when the host has the tools. If `PATH` changed, say the plugin MCP process may need a Codex host/app restart before a new agent thread can see it.
+   If an older binary is locked, stop existing
+   `codestory-cli serve --stdio --refresh none` processes before replacing it,
+   or install the matching release asset in an earlier `PATH` directory.
 7. Use `scripts/setup.ps1` or `scripts/setup.sh` from this skill only for the
    source-build fallback or explicit source-artifact setup.
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { access, readFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -69,6 +71,7 @@ test("codestory repo ships plugin source, not marketplace catalog or adapter run
   await assert.rejects(
     access(join(pluginRoot, "scripts", "codestory-mcp.mjs")),
   );
+  await access(join(pluginRoot, "scripts", "check-runtime.mjs"));
 });
 
 test("plugin docs are agent-first, marketplace-aware, and latest-release aware", async () => {
@@ -148,6 +151,9 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
     "https://github.com/TheGreenCedar/CodeStory.git",
     "plugins/codestory",
     "codestory-cli serve --stdio --refresh none",
+    "node plugins/codestory/scripts/check-runtime.mjs",
+    "stop existing `codestory-cli serve --stdio --refresh none` processes",
+    "put that directory before older `codestory-cli` entries on `PATH`",
   ];
   const skillRequired = [
     "download and unpack only",
@@ -155,6 +161,10 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
     "not as the installed MCP launch path",
     "plugin MCP process may need",
     "Codex host/app restart before a new agent thread",
+    "node plugins/codestory/scripts/check-runtime.mjs",
+    "stop existing",
+    "codestory-cli serve --stdio --refresh none",
+    "earlier `PATH` directory",
     "new agent thread",
     "Read `codestory://grounding`",
     "Always pass `--project <target-workspace>` explicitly",
@@ -200,6 +210,41 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
   for (const phrase of skillRequired) {
     assert.equal(skill.includes(phrase), true, phrase);
   }
+});
+
+test("runtime preflight rejects stale codestory-cli on PATH", async () => {
+  const tempRoot = join(tmpdir(), "codestory-plugin-static-stale-runtime");
+  await rm(tempRoot, { recursive: true, force: true });
+  await mkdir(tempRoot, { recursive: true });
+
+  const command =
+    process.platform === "win32"
+      ? join(tempRoot, "codestory-cli.cmd")
+      : join(tempRoot, "codestory-cli");
+  const script =
+    process.platform === "win32"
+      ? "@echo off\r\necho codestory-cli 0.0.1\r\n"
+      : "#!/bin/sh\necho codestory-cli 0.0.1\n";
+  await writeFile(command, script, { mode: 0o755 });
+
+  const result = spawnSync(
+    process.execPath,
+    [join(pluginRoot, "scripts", "check-runtime.mjs")],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: tempRoot + delimiter + process.env.PATH,
+        PATHEXT: ".CMD;.EXE;.BAT;.COM",
+      },
+    },
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /plugin package expects/u);
+  assert.match(result.stderr, /serve --stdio --refresh none/u);
+  assert.match(result.stderr, /older codestory-cli entries on PATH/u);
 });
 
 test("canonical grounding skill ships with plugin references", async () => {


### PR DESCRIPTION
## Context

Issue #374 stayed open after #377/#378 because plugin package metadata now tracks the CLI version, but installed MCP runtime still launches `codestory-cli serve --stdio --refresh none` from the agent host `PATH`. A marketplace/plugin refresh can therefore leave new MCP launches on an older `codestory-cli` if PATH still resolves a stale or locked binary.

Closes #374
Refs #38, #373

## What Changed

- Added `plugins/codestory/scripts/check-runtime.mjs`, a dependency-free preflight that reads the installed plugin package version, resolves `codestory-cli` from the same `PATH` used by `.mcp.json`, runs `--version`, and fails if the resolved runtime does not match.
- Updated the plugin README and shipped `codestory-grounding` skill setup gate to run that preflight before a fresh MCP/plugin thread.
- Added repair guidance for PATH ordering, locked `codestory-cli serve --stdio --refresh none` processes, and Codex host/app restarts after PATH changes.
- Extended the plugin static test with a fake stale `codestory-cli` earlier on PATH so the guard and repair text are covered.

## How To Review

1. Read `plugins/codestory/scripts/check-runtime.mjs` first; it is the only new executable surface.
2. Check that `.mcp.json` still launches direct CLI stdio and no Node adapter was added.
3. Confirm the README and skill guidance point users/agents to the preflight before starting a fresh plugin thread.
4. Review the stale-runtime test in `plugins/codestory/tests/plugin-static.test.mjs`.

## Verification

- `node plugins\codestory\scripts\check-runtime.mjs` -> passed; resolved `C:\Users\alber\.local\bin\codestory-cli.exe` version `0.11.5`.
- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> passed; 6 tests.
- `node --check plugins\codestory\scripts\check-runtime.mjs` -> passed.
- `git diff --check` -> passed.
- `codestory-cli doctor --project . --format json` -> read-only snapshot completed; this worktree is not indexed and reports `retrieval_manifest_missing`, so packet/search was not used as proof.

## Risk

- The preflight is an explicit command, not a wrapper around MCP launch. That preserves the direct runtime shape but depends on agents/users running the check before starting a fresh plugin thread.
- It compares against the plugin package version, which is now guarded to match `codestory-cli`; if future plugin compatibility intentionally spans multiple CLI versions, this check would need a version range.