### PR TITLE
[codex] resync dev branch to 0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.11.6
+
+CodeStory 0.11.6 promotes the reviewed `dev/codestory-next` release delta onto
+`main` as a synchronized patch release. The version is aligned across every
+`codestory-*` workspace crate, `Cargo.lock`, and the CodeStory plugin manifest
+so future release checks catch plugin/package drift before a PR reaches review.
+
+The plugin and release path now make stale runtime repair more explicit. The
+plugin package version tracks the CLI release, while the Windows installer can
+recover when an old stdio server keeps the default `codestory-cli` binary
+locked: it installs the current release into a versioned directory, moves that
+directory ahead of stale PATH entries for new launches, and fails loudly if
+`codestory-cli --version` still resolves to the wrong binary.
+
+The documentation cleanup keeps readers on the durable operating surfaces:
+usage for operator flow, architecture pages for subsystem ownership, sidecar
+runbooks for packet/search readiness, and benchmark/testing docs for promotion
+evidence. Packet/search remains proof-bearing only when sidecar retrieval is
+full.
+
+Supporting PRs: #376, #377, #379. This release does not claim new answer-quality
+proof, sidecar performance improvement, benchmark promotion, marketplace
+publication, or live installed plugin proof beyond the source and release
+checks in the promotion PR.
+
 ## 0.11.5
 
 CodeStory 0.11.5 carries the setup and documentation repair cleanup that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",


### PR DESCRIPTION
## Context

PR #383 released CodeStory 0.11.6 to `main` as squash commit `2e0789fcbbb252fd0dffe0e636406aabe9d9d8cc`, while `origin/dev/codestory-next` remained at `d438d5dbe3e17cee9ac84ab79e7842c4bc8aacf0`. This PR uses the reviewable path: a tiny content sync into `dev/codestory-next` instead of directly updating the protected development branch.

Closes #384
Refs #38

## What Changed

- Restored the release surfaces from `origin/main` onto a branch from `origin/dev/codestory-next`.
- Brought `CHANGELOG.md`, `Cargo.lock`, all eight crate manifests, and `plugins/codestory/.codex-plugin/plugin.json` to 0.11.6.
- Resolved the known plugin metadata conflict by taking the `main` value: `"version": "0.11.6"`.

## How To Review

- Confirm the file list is limited to release surfaces.
- Confirm `git diff --name-status HEAD..origin/main` is empty on this branch, meaning the synced content matches `main`.
- Confirm the base is `dev/codestory-next`; this PR does not touch `main` and creates no tags.

## Verification

- `git fetch origin main dev/codestory-next --prune` passed.
- Pre-sync ancestry: `origin/main` = `2e0789fcbbb252fd0dffe0e636406aabe9d9d8cc`, `origin/dev/codestory-next` = `d438d5dbe3e17cee9ac84ab79e7842c4bc8aacf0`, merge-base = `b50cfd2ca1c514331e03204a13ba8327839ce6b2`, ahead/behind = `5 1`.
- Pre-sync diff: only `CHANGELOG.md`, `Cargo.lock`, eight crate manifests, and `plugins/codestory/.codex-plugin/plugin.json`.
- Post-sync diff: `git diff --name-status HEAD..origin/main` produced no output.
- `python .github/scripts/check-codestory-release.py --version 0.11.6` passed: release version synchronized across 8 workspace crates, Cargo.lock, and the codestory plugin.
- `node --test plugins/codestory/tests/plugin-static.test.mjs` passed: 5/5 tests.
- `git diff --check` passed.
- `git diff --check HEAD~1..HEAD` passed.

CodeStory grounding was not usable for packet/search: `doctor` reported `status: needs_attention`, `local_navigation=repair_index`, `agent_packet_search=repair_index`, and `degraded_reason=retrieval_manifest_missing`, so this PR is grounded in direct Git/source evidence.

## Risk

Low. The PR is metadata-only and intentionally mirrors the release surfaces already on `main`. Remaining risk is reviewer preference for a direct maintainer branch sync instead of merging this tiny PR.