### PR TITLE
[codex] clarify post-0.11.6 agent plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Per-task medians, ranges, reproduction commands, and boundary notes:
 
 ## Quick start
 
-The normal path is the **Codex plugin**. The CLI and MCP server are for setup, repair, and transcripts.
+The normal path is an **agent plugin** backed by the local stdio server. The
+CLI is for setup, repair, debugging, and transcripts.
+
+For Codex:
 
 1. Open Codex in the repository you want to ground.
 2. Run `/plugins`, then install **TheGreenCedar → codestory**.
@@ -37,7 +40,10 @@ The normal path is the **Codex plugin**. The CLI and MCP server are for setup, r
 @CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
 ```
 
-The plugin launches `codestory-cli serve --stdio --refresh none` on your machine. It does not edit your repository. Install details, binary bootstrap, and uninstall notes live in the [plugin README](plugins/codestory/README.md).
+The plugin launches `codestory-cli serve --stdio --refresh none` on your
+machine. It does not edit your repository. Other local MCP-style clients can
+run the same stdio surface directly. Install details, binary bootstrap, and
+uninstall notes live in the [plugin README](plugins/codestory/README.md).
 
 **Verify without the agent:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ path, repair path, architecture, verification, and research evidence.
 
 | Reader job | Canonical doc | Use it to decide | Trust boundary |
 | --- | --- | --- | --- |
-| Operator using an agent | [Usage](usage.md) | How to install, ground a repo, and keep the plugin-first path straight. | The plugin is the normal path; the CLI is for setup, repair, debugging, and transcripts. |
+| Operator using an agent | [Usage](usage.md) | How to install, ground a repo, and keep the plugin-first path straight. | The agent plugin is the normal path; the CLI is for setup, repair, debugging, and transcripts. |
 | Maintainer debugging readiness | [Retrieval sidecars operations](ops/retrieval-sidecars.md) | How to repair local navigation versus packet/search readiness. | Packet/search is proof-bearing only when `retrieval_mode` is `full`. |
 | Contributor changing code | [Contributor setup](contributors/getting-started.md) | Which crate owns the change and which verification lane is enough. | Pick the smallest lane that covers the behavior; run Cargo checks serially. |
 | Reviewer verifying claims | [Testing matrix](contributors/testing-matrix.md) | Which command or evidence tier supports a PR claim. | Logs and benchmark pages are evidence records or playbooks, not product promises by themselves. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,14 +6,14 @@ last turn. CodeStory indexes once and serves evidence from that map so the agent
 can answer from citations instead of re-exploring the tree.
 
 Start with the human task, then run the smallest path that proves the state you
-need. The plugin is the normal path. The CLI is for setup, repair, debugging,
-and transcripts.
+need. The agent plugin is the normal path. The CLI is for setup, repair,
+debugging, transcripts, and direct stdio integration.
 
 ## Operator Journey
 
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
-| Install | Install the `codestory` plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
+| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
 | First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | `local_navigation` is ready before using local graph output. |
 | Source work | Ask for a plan, review, or code path. | Use `files`, `symbol`, `trail`, `snippet`, `context`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Use `packet` or `search`. | Trust only when `agent_packet_search` is ready and `retrieval_mode=full`. |
@@ -76,7 +76,7 @@ Install the CodeStory plugin once, then start a fresh agent thread for the
 workspace you want to ground. The canonical skill package lives at
 [../plugins/codestory/skills/codestory-grounding/SKILL.md](../plugins/codestory/skills/codestory-grounding/SKILL.md).
 
-**Plugin installation flow:**
+**Codex plugin installation flow:**
 
 1. Open Codex in the repository you want to ground
 2. Run `/plugins` and install **TheGreenCedar → codestory**


### PR DESCRIPTION
## Context

Closes #387
Refs #38

Post-0.11.6 docs audit against the current CodeStory implementation and plugin contract. The branch is intentionally small: source truth already matched the direct stdio/MCP shape, plugin version sync, release-binary bootstrap, sidecar readiness, and marketplace ownership in the plugin docs and sidecar runbooks.

## What Changed

- Updated the public README quick start to describe the normal path as an agent plugin backed by `codestory-cli serve --stdio --refresh none`, with Codex as the concrete shipped install example.
- Updated docs routing and usage copy to keep product/operator docs agent-agnostic while preserving the Codex plugin installation steps where they belong.
- Left plugin README, grounding skill docs, setup reference, retrieval architecture, and sidecar operations unchanged after source-backed review because they already match the current static contract.

## How To Review

- Read `README.md#quick-start` and confirm the public product story no longer treats Codex as the whole product surface.
- Read `docs/usage.md#operator-journey` and `docs/usage.md#install-and-ground-a-repo` to confirm the agent-plugin language and Codex-specific install boundary are clear.
- Confirm the diff does not touch versioning, marketplace repo content, generated artifacts, or runtime behavior.

## Verification

- `git diff --check` - passed.
- `node --test plugins/codestory/tests/plugin-static.test.mjs` - passed, 5 tests.
- Link/anchor spot checks:
  - touched docs links were listed with `rg`;
  - `README.md#quick-start`, `docs/usage.md#operator-journey`, `docs/usage.md#stale-local-cache`, and `docs/usage.md#sidecar-repair` headings are present;
  - plugin README, grounding skill, and setup reference files exist.
- CodeStory dogfood: `codestory-cli 0.11.6` was available, but `codestory-cli doctor --project .` reported `local_navigation=repair_index`, `agent_packet_search=repair_index`, `sidecar_mode=unavailable`, and `degraded_reason=retrieval_manifest_missing`; this pass used direct source reads instead of packet/search evidence.

## Risk

Low docs-only risk. Remaining audit note: `docs/concepts/how-codestory-works.md` was listed in the issue scope but does not exist on this branch; current routing points humans through `docs/README.md`, `docs/usage.md`, and `docs/architecture/overview.md` instead of adding another concepts page.
