### PR TITLE
[codex] Fix stdio initialize version metadata

### DIFF
--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -539,13 +539,14 @@ fn stdio_initialize_result_json(request: &serde_json::Value) -> serde_json::Valu
         .pointer("/params/protocolVersion")
         .and_then(|value| value.as_str())
         .unwrap_or("2024-11-05");
+    let version = env!("CARGO_PKG_VERSION");
     serde_json::json!({
         "protocolVersion": protocol_version,
         "name": "codestory",
-        "version": "0.1.0",
+        "version": version,
         "serverInfo": {
             "name": "codestory",
-            "version": "0.1.0"
+            "version": version
         },
         "capabilities": {
             "tools": {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -700,6 +700,16 @@ fn initialize_preserves_id_and_reports_server_info_and_capabilities() {
             .is_some_and(|name| name == "codestory"),
         "initialize should report codestory server info: {response}"
     );
+    assert_eq!(
+        result.get("version"),
+        Some(&json!(env!("CARGO_PKG_VERSION"))),
+        "initialize top-level version should match the CLI package version: {response}"
+    );
+    assert_eq!(
+        result.pointer("/serverInfo/version"),
+        Some(&json!(env!("CARGO_PKG_VERSION"))),
+        "initialize serverInfo version should match the CLI package version: {response}"
+    );
     assert!(
         result.get("capabilities").is_some(),
         "initialize should report server capabilities: {response}"


### PR DESCRIPTION
## Context
Closes #388
Refs #386, #38

Issue #386 dogfood found that released codestory-cli 0.11.6 still reported JSON-RPC initialize metadata as version 0.1.0. The stdio initialize helper had both the top-level version and serverInfo.version hard-coded.

## What Changed
- Read initialize metadata from `env!("CARGO_PKG_VERSION")` in `crates/codestory-cli/src/stdio_transport.rs`.
- Extended the existing stdio initialize contract to assert both version fields match the CLI package version.

## How To Review
- Check `stdio_initialize_result_json` in `crates/codestory-cli/src/stdio_transport.rs`.
- Check `initialize_preserves_id_and_reports_server_info_and_capabilities` in `crates/codestory-cli/tests/stdio_protocol_contracts.rs`.
- Confirm no tool/resource behavior changed.

## Verification
- `cargo test -p codestory-cli --test stdio_protocol_contracts initialize_preserves_id_and_reports_server_info_and_capabilities -- --nocapture`: passed, 1 passed; 0 failed; 28 filtered out.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.
- `codestory-cli doctor --project C:\Users\alber\.codex\worktrees\6f46\codestory`: needs_attention; local_navigation=repair_index, agent_packet_search=repair_index, sidecar_mode=unavailable, degraded_reason=retrieval_manifest_missing. Used direct source reads instead of packet/search evidence.

## Risk
Low. This only changes initialize metadata to follow the crate package version and adds a focused contract assertion. Remaining risk is limited to clients that depended on the incorrect 0.1.0 value.
