### PR TITLE
[codex] release CodeStory 0.11.7 and close saga

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.11.7
+
+CodeStory 0.11.7 closes the product-grade intelligence saga with the final
+post-release polish from `dev/codestory-next` promoted to `main`.
+
+The docs now describe the plugin path as an agent plugin backed by the local
+`codestory-cli serve --stdio --refresh none` surface, while keeping
+Codex-specific installation wording in the Codex plugin flow. The stdio/MCP
+initialize response now reports the crate package version instead of the old
+hard-coded `0.1.0`, and the protocol contract covers both version fields.
+
+Supporting PRs: #389, #390. This release does not add a wrapper layer, move the
+marketplace catalog into CodeStory, claim new sidecar performance, or broaden
+packet/search readiness beyond the existing sidecar evidence gates.
+
 ## 0.11.6
 
 CodeStory 0.11.6 promotes the reviewed `dev/codestory-next` release delta onto

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Per-task medians, ranges, reproduction commands, and boundary notes:
 
 ## Quick start
 
-The normal path is the **Codex plugin**. The CLI and MCP server are for setup, repair, and transcripts.
+The normal path is an **agent plugin** backed by the local stdio server. The
+CLI is for setup, repair, debugging, and transcripts.
+
+For Codex:
 
 1. Open Codex in the repository you want to ground.
 2. Run `/plugins`, then install **TheGreenCedar → codestory**.
@@ -37,7 +40,10 @@ The normal path is the **Codex plugin**. The CLI and MCP server are for setup, r
 @CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
 ```
 
-The plugin launches `codestory-cli serve --stdio --refresh none` on your machine. It does not edit your repository. Install details, binary bootstrap, and uninstall notes live in the [plugin README](plugins/codestory/README.md).
+The plugin launches `codestory-cli serve --stdio --refresh none` on your
+machine. It does not edit your repository. Other local MCP-style clients can
+run the same stdio surface directly. Install details, binary bootstrap, and
+uninstall notes live in the [plugin README](plugins/codestory/README.md).
 
 **Verify without the agent:**
 

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -539,13 +539,14 @@ fn stdio_initialize_result_json(request: &serde_json::Value) -> serde_json::Valu
         .pointer("/params/protocolVersion")
         .and_then(|value| value.as_str())
         .unwrap_or("2024-11-05");
+    let version = env!("CARGO_PKG_VERSION");
     serde_json::json!({
         "protocolVersion": protocol_version,
         "name": "codestory",
-        "version": "0.1.0",
+        "version": version,
         "serverInfo": {
             "name": "codestory",
-            "version": "0.1.0"
+            "version": version
         },
         "capabilities": {
             "tools": {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -700,6 +700,16 @@ fn initialize_preserves_id_and_reports_server_info_and_capabilities() {
             .is_some_and(|name| name == "codestory"),
         "initialize should report codestory server info: {response}"
     );
+    assert_eq!(
+        result.get("version"),
+        Some(&json!(env!("CARGO_PKG_VERSION"))),
+        "initialize top-level version should match the CLI package version: {response}"
+    );
+    assert_eq!(
+        result.pointer("/serverInfo/version"),
+        Some(&json!(env!("CARGO_PKG_VERSION"))),
+        "initialize serverInfo version should match the CLI package version: {response}"
+    );
     assert!(
         result.get("capabilities").is_some(),
         "initialize should report server capabilities: {response}"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2024"
 
 [dependencies]

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ path, repair path, architecture, verification, and research evidence.
 
 | Reader job | Canonical doc | Use it to decide | Trust boundary |
 | --- | --- | --- | --- |
-| Operator using an agent | [Usage](usage.md) | How to install, ground a repo, and keep the plugin-first path straight. | The plugin is the normal path; the CLI is for setup, repair, debugging, and transcripts. |
+| Operator using an agent | [Usage](usage.md) | How to install, ground a repo, and keep the plugin-first path straight. | The agent plugin is the normal path; the CLI is for setup, repair, debugging, and transcripts. |
 | Maintainer debugging readiness | [Retrieval sidecars operations](ops/retrieval-sidecars.md) | How to repair local navigation versus packet/search readiness. | Packet/search is proof-bearing only when `retrieval_mode` is `full`. |
 | Contributor changing code | [Contributor setup](contributors/getting-started.md) | Which crate owns the change and which verification lane is enough. | Pick the smallest lane that covers the behavior; run Cargo checks serially. |
 | Reviewer verifying claims | [Testing matrix](contributors/testing-matrix.md) | Which command or evidence tier supports a PR claim. | Logs and benchmark pages are evidence records or playbooks, not product promises by themselves. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,14 +6,14 @@ last turn. CodeStory indexes once and serves evidence from that map so the agent
 can answer from citations instead of re-exploring the tree.
 
 Start with the human task, then run the smallest path that proves the state you
-need. The plugin is the normal path. The CLI is for setup, repair, debugging,
-and transcripts.
+need. The agent plugin is the normal path. The CLI is for setup, repair,
+debugging, transcripts, and direct stdio integration.
 
 ## Operator Journey
 
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
-| Install | Install the `codestory` plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
+| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
 | First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | `local_navigation` is ready before using local graph output. |
 | Source work | Ask for a plan, review, or code path. | Use `files`, `symbol`, `trail`, `snippet`, `context`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Use `packet` or `search`. | Trust only when `agent_packet_search` is ready and `retrieval_mode=full`. |
@@ -76,7 +76,7 @@ Install the CodeStory plugin once, then start a fresh agent thread for the
 workspace you want to ground. The canonical skill package lives at
 [../plugins/codestory/skills/codestory-grounding/SKILL.md](../plugins/codestory/skills/codestory-grounding/SKILL.md).
 
-**Plugin installation flow:**
+**Codex plugin installation flow:**
 
 1. Open Codex in the repository you want to ground
 2. Run `/plugins` and install **TheGreenCedar → codestory**

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",


### PR DESCRIPTION
## Context

Closes #38
Refs #389, #390

This promotes the final post-0.11.6 `dev/codestory-next` delta to `main` as CodeStory 0.11.7 and closes the product-grade intelligence saga.

The promoted delta is intentionally small: post-release plugin/docs wording cleanup plus the stdio/MCP initialize version metadata fix. The release bump keeps the workspace crate versions, `Cargo.lock`, and the CodeStory plugin package version synchronized.

## What Changed

- Bumped every `codestory-*` workspace crate, `Cargo.lock`, and `plugins/codestory/.codex-plugin/plugin.json` to `0.11.7`.
- Added a human-readable `CHANGELOG.md` entry for 0.11.7.
- Promotes PR #389 docs wording: agent plugin backed by direct `codestory-cli serve --stdio --refresh none`, with Codex install wording scoped to the Codex plugin flow.
- Promotes PR #390 stdio/MCP metadata: initialize now reports the crate package version instead of hard-coded `0.1.0`, with a focused protocol contract.

## How To Review

- Confirm the diff from `main` is limited to release/version surfaces plus the already-reviewed #389/#390 deltas.
- Check `CHANGELOG.md` for a real 0.11.7 description and explicit non-claims.
- Check `crates/codestory-cli/src/stdio_transport.rs` and `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the version metadata contract.
- Confirm no marketplace catalog files, generated ledgers, release reports, benchmark artifacts, or sidecar performance claims are committed.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.7`: passed.
- `node .github/scripts/check-workflow-policy.mjs`: passed.
- `node --test plugins/codestory/tests/plugin-static.test.mjs`: passed, 5 tests.
- `cargo fmt --check`: passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts initialize_preserves_id_and_reports_server_info_and_capabilities -- --nocapture`: passed, 1 passed; 28 filtered out.
- `cargo check --workspace`: passed.
- `git diff --check`: passed.

## Risk

Low. This is a patch release promotion of already-reviewed dev branch work plus synchronized release metadata. It does not add a wrapper layer, move the marketplace catalog into CodeStory, claim new sidecar performance, or broaden packet/search readiness beyond existing sidecar gates.