### PR TITLE
[codex] update plugin marketplace source docs

### DIFF
--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -63,7 +63,7 @@ If your Codex build exposes terminal marketplace management for source
 marketplaces, add or refresh this marketplace first:
 
 ```bash
-codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace
+codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace --ref main
 ```
 
 The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`; its
@@ -209,9 +209,12 @@ If your Codex build exposes terminal marketplace management for source
 marketplaces, these commands may be available:
 
 ```bash
+codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace --ref main
 codex plugin marketplace upgrade TheGreenCedar
 codex plugin marketplace remove TheGreenCedar
 ```
+
+If TheGreenCedar was added from a local path, remove it and add the Git marketplace source again before using upgrade.
 
 `marketplace remove` removes the source marketplace registration. It may not
 uninstall an already installed workspace plugin. Prefer the plugin UI for


### PR DESCRIPTION
## Context

The CodeStory plugin README marketplace instructions need to pin the Git marketplace source to `main` so refresh/update guidance uses the same source form as install.

Closes #394

## What Changed

- Added `--ref main` to the install marketplace add command.
- Added the Git marketplace add command before upgrade/remove.
- Added the local-path warning requested for marketplace upgrade users.

## How To Review

- Read `plugins/codestory/README.md` around the install and Update Or Remove sections.
- Confirm the only changed command is `codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace --ref main`.

## Verification

- `git diff --check`
- `git diff --check origin/main..HEAD`
- `git status --short --branch`

## Risk

Low. Docs-only marketplace instruction update; no product code, plugin manifest, MCP config, sidecar/readiness docs, or release/version files changed.