### PR TITLE
[codex] Fix ready llama env

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1237,6 +1237,9 @@ fn run_doctor(cmd: DoctorCommand) -> Result<()> {
 fn run_ready(cmd: ReadyCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "ready")?;
     preflight_output_file(cmd.output_file.as_deref())?;
+    if cmd.repair && matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
+        managed_embeddings::prepare_bundled_llamacpp_client_env_defaults();
+    }
     let runtime = if cmd.repair {
         RuntimeContext::new(&cmd.project)?
     } else {

--- a/crates/codestory-cli/src/managed_embeddings.rs
+++ b/crates/codestory-cli/src/managed_embeddings.rs
@@ -23,6 +23,8 @@ const MANAGED_DOC_EMBED_BATCH_SIZE: usize = 2048;
 const MANAGED_SEMANTIC_DOC_MAX_TOKENS: usize = 512;
 const MANAGED_ONNX_BATCH_TOKENS: usize = 32_768;
 const MANAGED_STORED_VECTOR_ENCODING: &str = "int8";
+const BUNDLED_LLAMACPP_BACKEND_LABEL: &str = "llamacpp";
+const BUNDLED_LLAMACPP_URL: &str = "http://127.0.0.1:8080/v1/embeddings";
 const MANAGED_DIR_NAME: &str = "managed-embeddings";
 const MANAGED_POOLED_ONNX_MODEL_NAME: &str = "model_optimized_cls_pool.onnx";
 const ONNX_SOURCE_OUTPUT_NAME: &str = "last_hidden_state";
@@ -329,6 +331,20 @@ pub(crate) fn prepare_runtime_if_installed(root: &Path) {
     }
     if managed_endpoint_assets_available(root) {
         set_managed_endpoint_env(root);
+    }
+}
+
+pub(crate) fn prepare_bundled_llamacpp_client_env_defaults() {
+    unsafe {
+        if env_value_is_unset("CODESTORY_EMBED_RUNTIME_MODE")
+            && env_value_is_unset("CODESTORY_EMBED_BACKEND")
+        {
+            set_env_default_str("CODESTORY_EMBED_BACKEND", BUNDLED_LLAMACPP_BACKEND_LABEL);
+        }
+        if legacy_llamacpp_backend_selected() && env_value_is_unset("CODESTORY_EMBED_LLAMACPP_URL")
+        {
+            set_env_default_str("CODESTORY_EMBED_LLAMACPP_URL", BUNDLED_LLAMACPP_URL);
+        }
     }
 }
 

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -910,4 +910,57 @@ mod tests {
         assert!(env::var("CODESTORY_EMBED_ONNX_MODEL").is_ok());
         assert!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").is_ok());
     }
+
+    #[test]
+    fn bundled_llamacpp_defaults_prevent_managed_onnx_autostart_for_agent_repair() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let _env_snapshot = EnvSnapshot::clear(MANAGED_ENV_VARS);
+        let temp = tempdir().expect("temp dir");
+        let project = temp.path().join("repo");
+        let cache = temp.path().join("cache");
+        fs::create_dir_all(&project).expect("create project");
+        write_fake_managed_onnx_assets(&cache.join("managed-embeddings"));
+
+        crate::managed_embeddings::prepare_bundled_llamacpp_client_env_defaults();
+        RuntimeContext::new(&ProjectArgs {
+            project,
+            cache_dir: Some(cache),
+        })
+        .expect("runtime context");
+
+        assert_eq!(
+            env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
+            Some("llamacpp")
+        );
+        assert_eq!(
+            env::var("CODESTORY_EMBED_LLAMACPP_URL").ok().as_deref(),
+            Some("http://127.0.0.1:8080/v1/embeddings")
+        );
+        assert_eq!(env::var("CODESTORY_EMBED_ONNX_MODEL").ok(), None);
+        assert_eq!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").ok(), None);
+    }
+
+    #[test]
+    fn bundled_llamacpp_defaults_preserve_explicit_user_env() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let _env_snapshot = EnvSnapshot::clear(MANAGED_ENV_VARS);
+        unsafe {
+            env::set_var("CODESTORY_EMBED_BACKEND", "llamacpp");
+            env::set_var(
+                "CODESTORY_EMBED_LLAMACPP_URL",
+                "http://127.0.0.1:18080/v1/embeddings",
+            );
+        }
+
+        crate::managed_embeddings::prepare_bundled_llamacpp_client_env_defaults();
+
+        assert_eq!(
+            env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
+            Some("llamacpp")
+        );
+        assert_eq!(
+            env::var("CODESTORY_EMBED_LLAMACPP_URL").ok().as_deref(),
+            Some("http://127.0.0.1:18080/v1/embeddings")
+        );
+    }
 }


### PR DESCRIPTION
## Context

#399 proved the sidecars could reach `agent_packet_search=ready` / `retrieval_mode=full`, but the bare source command failed because the agent repair path reached retrieval index finalize without llama.cpp client env. The issue is the CLI orchestration boundary around `ready --goal agent --repair`, not sidecar health or retrieval design.

Closes #400

```mermaid
flowchart LR
    Ready[ready --goal agent --repair] --> Defaults[set bundled llama.cpp client defaults]
    Defaults --> Runtime[open mutating runtime]
    Runtime --> Bootstrap[bootstrap sidecars]
    Bootstrap --> Index[index refresh]
    Index --> Finalize[finalize retrieval index]
    Finalize --> Full[retrieval_mode=full]
```

## What Changed

- Before agent repair opens the mutating runtime, the CLI now defaults unset embedding client env to the bundled llama.cpp endpoint:
  - `CODESTORY_EMBED_BACKEND=llamacpp`
  - `CODESTORY_EMBED_LLAMACPP_URL=http://127.0.0.1:8080/v1/embeddings`
- Explicit user env remains authoritative, including custom llama.cpp URLs.
- Added focused unit coverage for the managed ONNX autostart collision and explicit URL preservation.

## How To Review

- Start in `crates/codestory-cli/src/main.rs` at `run_ready`; the new call is only for `--repair` when the requested goal includes agent readiness.
- Then review `crates/codestory-cli/src/managed_embeddings.rs`; the helper sets defaults only when env is unset or already llama.cpp-shaped.
- Finally review the tests in `crates/codestory-cli/src/runtime.rs`; they model the previous failure mode where managed ONNX assets existed and would otherwise set ONNX env before agent repair indexing.

## Verification

```powershell
cargo fmt
cargo test -p codestory-cli runtime::tests::bundled_llamacpp_defaults --bin codestory-cli
# 2 passed; 0 failed

cargo build --release -p codestory-cli
# Finished release profile

Remove-Item Env:\CODESTORY_EMBED_BACKEND -ErrorAction SilentlyContinue
Remove-Item Env:\CODESTORY_EMBED_RUNTIME_MODE -ErrorAction SilentlyContinue
Remove-Item Env:\CODESTORY_EMBED_LLAMACPP_URL -ErrorAction SilentlyContinue
.\target\release\codestory-cli.exe ready --goal agent --repair --project . --format json
# exit 0
# agent_packet_search: ready
# sidecar.retrieval_mode: full
# manifest_generation: fe0b766440101c99-d54a570eedf5b081

Remove-Item Env:\CODESTORY_EMBED_BACKEND -ErrorAction SilentlyContinue
Remove-Item Env:\CODESTORY_EMBED_RUNTIME_MODE -ErrorAction SilentlyContinue
Remove-Item Env:\CODESTORY_EMBED_LLAMACPP_URL -ErrorAction SilentlyContinue
.\target\release\codestory-cli.exe retrieval status --project . --format json
# retrieval_mode: full
# query_embedding_backend: llamacpp:bge-base-en-v1.5
# manifest_vector_embedding_backend: llamacpp:bge-base-en-v1.5
# manifest_vector_embedding_dim: 768

git diff --check
# passed
```

## Risk

Low. This does not relax the product sidecar contract or change retrieval indexing semantics. It only makes the agent repair path select the bundled llama.cpp client defaults before managed ONNX autostart can set a conflicting backend. Explicit non-llama user env still remains explicit and can still fail product sidecar indexing rather than silently downgrading.