### PR TITLE
[codex] release CodeStory 0.11.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.11.9
+
+CodeStory 0.11.9 promotes the plugin grounding consolidation so Codex sessions
+can trust the active MCP status before choosing a tool.
+
+The stdio status resource now reports `server_version`, best-effort
+`server_executable`, warnings, and per-surface `allowed_surfaces`. Local graph
+surfaces stay usable when local navigation is ready, while `packet`, `search`,
+and `context` stay blocked unless full agent packet/search readiness is present.
+The plugin README, grounding skill, sidecar docs, usage docs, and static tests
+now point agents at that same status-first contract.
+
+This release does not claim new packet/search answer-quality proof, sidecar
+performance improvement, benchmark promotion, or live installed plugin proof
+beyond the source and release checks in the promotion PR.
+
 ## 0.11.8
 
 CodeStory 0.11.8 promotes the latest reviewed readiness and plugin guidance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -12,7 +12,8 @@ use codestory_contracts::api::{
     AgentRetrievalProfileSelectionDto, ApiError, GraphResponse, GroundingBudgetDto,
     IndexedFileRoleDto, IndexedFilesRequest, ListChildrenSymbolsRequest, ListRootSymbolsRequest,
     NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto,
-    SearchRepoTextMode, SearchRequest, TrailCallerScope, TrailDirection, TrailMode,
+    ReadinessGoalDto, ReadinessStatusDto, ReadinessVerdictDto, SearchRepoTextMode, SearchRequest,
+    TrailCallerScope, TrailDirection, TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
 use std::io::{BufRead, Write};
@@ -1948,8 +1949,13 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
             manifest_input_hash: manifest_input_hash.as_deref(),
         }),
     });
+    let allowed_surfaces = stdio_allowed_surfaces(&readiness);
     let recommended_next_calls = stdio_status_recommended_next_calls(&readiness);
+    let (server_executable, server_warnings) = stdio_server_executable_status();
     Ok(serde_json::json!({
+        "server_version": env!("CARGO_PKG_VERSION"),
+        "server_executable": server_executable,
+        "warnings": server_warnings,
         "project_root": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
         "storage_path": crate::display::clean_path_string(&runtime.storage_path.to_string_lossy()),
         "storage_exists": runtime.storage_path.exists(),
@@ -1966,13 +1972,12 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         },
         "index_freshness": summary.freshness,
         "readiness": readiness,
+        "allowed_surfaces": allowed_surfaces,
         "recommended_next_calls": recommended_next_calls
     }))
 }
 
-fn stdio_status_recommended_next_calls(
-    readiness: &[codestory_contracts::api::ReadinessVerdictDto],
-) -> serde_json::Value {
+fn stdio_status_recommended_next_calls(readiness: &[ReadinessVerdictDto]) -> serde_json::Value {
     if let Some(non_ready) = crate::readiness::primary_non_ready(readiness) {
         return serde_json::Value::Array(
             non_ready
@@ -2040,6 +2045,77 @@ fn stdio_status_recommended_next_calls(
     ])
 }
 
+fn stdio_server_executable_status() -> (Option<String>, Vec<String>) {
+    match std::env::current_exe() {
+        Ok(path) => (
+            Some(crate::display::clean_path_string(&path.to_string_lossy())),
+            Vec::new(),
+        ),
+        Err(error) => (
+            None,
+            vec![format!("server_executable_unavailable: {error}")],
+        ),
+    }
+}
+
+fn stdio_allowed_surfaces(readiness: &[ReadinessVerdictDto]) -> serde_json::Value {
+    let local = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation);
+    let agent = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::AgentPacketSearch);
+
+    let mut surfaces = serde_json::Map::new();
+    for surface in [
+        "ground",
+        "files",
+        "symbol",
+        "definition",
+        "get_node",
+        "neighbors",
+        "shortest_path",
+        "query_subgraph",
+        "symbols",
+        "trail",
+        "references",
+        "snippet",
+        "affected",
+    ] {
+        surfaces.insert(surface.to_string(), stdio_allowed_surface(local));
+    }
+    for surface in ["packet", "search", "context"] {
+        surfaces.insert(surface.to_string(), stdio_allowed_surface(agent));
+    }
+    serde_json::Value::Object(surfaces)
+}
+
+fn stdio_allowed_surface(verdict: Option<&ReadinessVerdictDto>) -> serde_json::Value {
+    match verdict {
+        Some(verdict) => {
+            let allowed = verdict.status == ReadinessStatusDto::Ready;
+            serde_json::json!({
+                "allowed": allowed,
+                "readiness_goal": crate::readiness::goal_label(verdict.goal),
+                "status": crate::readiness::status_label(verdict.status),
+                "summary": verdict.summary,
+                "blocked_reason": if allowed { None } else { Some(verdict.summary.as_str()) },
+                "minimum_next": verdict.minimum_next,
+                "full_repair": verdict.full_repair,
+            })
+        }
+        None => serde_json::json!({
+            "allowed": false,
+            "readiness_goal": null,
+            "status": "unknown",
+            "summary": "Readiness verdict was not available for this surface.",
+            "blocked_reason": "Readiness verdict was not available for this surface.",
+            "minimum_next": [],
+            "full_repair": [],
+        }),
+    }
+}
+
 fn read_stdio_agent_guide_resource() -> serde_json::Value {
     serde_json::json!({
         "purpose": "Default read-only CodeStory browser loop for local codebase grounding.",
@@ -2047,77 +2123,122 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
             {
                 "method": "resources/read",
                 "uri": "codestory://status"
+            }
+        ],
+        "readiness_lanes": [
+            {
+                "readiness_goal": "local_navigation",
+                "condition": "Use only surfaces whose codestory://status allowed_surfaces.<surface>.allowed value is true.",
+                "surfaces": ["ground", "files", "symbol", "definition", "get_node", "neighbors", "shortest_path", "query_subgraph", "symbols", "snippet", "references", "trail", "affected"],
+                "calls": [
+                    {
+                        "method": "tools/call",
+                        "tool": "ground",
+                        "arguments": {
+                            "budget": "balanced"
+                        }
+                    },
+                    {
+                        "method": "tools/call",
+                        "tool": "files",
+                        "arguments": {
+                            "limit": 50
+                        }
+                    },
+                    {
+                        "method": "tools/call",
+                        "tool": "definition",
+                        "arguments": {
+                            "id": "<best-node-id>"
+                        }
+                    },
+                    {
+                        "method": "tools/call",
+                        "tool": "get_node",
+                        "arguments": {
+                            "id": "<best-node-id>"
+                        }
+                    },
+                    {
+                        "method": "tools/call",
+                        "tool": "neighbors",
+                        "arguments": {
+                            "id": "<best-node-id>",
+                            "depth": 1
+                        }
+                    },
+                    {
+                        "method": "tools/call",
+                        "tool": "symbols",
+                        "arguments": {
+                            "limit": 50
+                        }
+                    },
+                    {
+                        "method": "resources/read",
+                        "uri": "codestory://snippet/<best-node-id>"
+                    },
+                    {
+                        "method": "resources/read",
+                        "uri": "codestory://references/<best-node-id>"
+                    },
+                    {
+                        "method": "resources/read",
+                        "uri": "codestory://trail/<best-node-id>"
+                    }
+                ]
             },
             {
-                "method": "tools/call",
-                "tool": "ground",
-                "arguments": {
-                    "budget": "balanced"
-                }
-            },
-            {
-                "method": "tools/call",
-                "tool": "packet",
-                "arguments": {
-                    "question": "<broad-task-question>",
-                    "budget": "compact"
-                }
-            },
-            {
-                "method": "tools/call",
-                "tool": "search",
-                "arguments": {
-                    "query": "<symbol-or-task>",
-                    "limit": 10
-                }
-            },
-            {
-                "method": "tools/call",
-                "tool": "context",
-                "arguments": {
-                    "id": "<best-node-id>"
-                }
-            },
-            {
-                "method": "tools/call",
-                "tool": "definition",
-                "arguments": {
-                    "id": "<best-node-id>"
-                }
-            },
-            {
-                "method": "resources/read",
-                "uri": "codestory://snippet/<best-node-id>"
-            },
-            {
-                "method": "resources/read",
-                "uri": "codestory://references/<best-node-id>"
-            },
-            {
-                "method": "resources/read",
-                "uri": "codestory://trail/<best-node-id>"
+                "readiness_goal": "agent_packet_search",
+                "condition": "Use packet/search/context only when their codestory://status allowed_surfaces entries are true.",
+                "surfaces": ["packet", "search", "context"],
+                "calls": [
+                    {
+                        "method": "tools/call",
+                        "tool": "packet",
+                        "arguments": {
+                            "question": "<broad-task-question>",
+                            "budget": "compact"
+                        }
+                    },
+                    {
+                        "method": "tools/call",
+                        "tool": "search",
+                        "arguments": {
+                            "query": "<symbol-or-task>",
+                            "limit": 10
+                        }
+                    },
+                    {
+                        "method": "tools/call",
+                        "tool": "context",
+                        "arguments": {
+                            "id": "<best-node-id>"
+                        }
+                    }
+                ]
             }
         ],
         "surface_decisions": [
             {
                 "surface": "ground",
                 "kind": "tool and codestory://grounding resource",
-                "when": "Use after status for compact repo orientation before planning, packet, search, or source reads."
+                "when": "Use after status when allowed_surfaces.ground.allowed is true."
             },
             {
                 "surface": "packet",
                 "kind": "tool",
-                "when": "Use for broad structural questions only when packet/search readiness is ready and strict retrieval is full."
+                "when": "Use for broad structural questions only when allowed_surfaces.packet.allowed is true and strict retrieval is full."
             },
             {
                 "surface": "search",
                 "kind": "tool",
-                "when": "Use for bounded candidate discovery after readiness allows packet/search."
+                "when": "Use for bounded candidate discovery only when allowed_surfaces.search.allowed is true."
             },
             {
                 "surface": "context",
                 "kind": "tool",
-                "when": "Use after selecting one concrete target for proof-bearing source/graph evidence."
+                "when": "Use after selecting one concrete target only when allowed_surfaces.context.allowed is true."
             },
             {
                 "surface": "direct_source_reads",
@@ -2125,15 +2246,16 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
                 "when": "Use when status reports missing, stale, or degraded index/sidecar state."
             },
             {
-                "surface": "files, affected, cache identity, retrieval status",
+                "surface": "cache identity, retrieval status",
                 "kind": "deferred",
                 "when": "Use CLI or resources until these receive explicit read-only stdio contracts."
             }
         ],
         "safety_notes": [
             "All stdio tools are read-only, non-destructive, idempotent, local-only, and closed-world.",
-            "Use ground for compact repository orientation after status.",
-            "Use packet for broad task questions before snippet/source reads; use context only after selecting one concrete target.",
+            "Read codestory://status first and branch on allowed_surfaces before choosing tools.",
+            "Use ground for compact repository orientation after status when local_navigation is ready.",
+            "Use packet for broad task questions only when packet/search status is allowed; use context only when allowed_surfaces.context.allowed is true.",
             "Treat packet status other than sufficient as unsafe to claim until gaps, open_next, and follow_up_commands are resolved.",
             "Use continuation links from search or definition results before broadening retrieval.",
             "Keep search limits bounded; stdio search clamps limit to 1..50.",

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -572,6 +572,58 @@ fn assert_fresh_freshness_counts(value: &Value, context: &str) {
     );
 }
 
+fn assert_allowed_surface(
+    status: &Value,
+    surface: &str,
+    expected_allowed: bool,
+    expected_goal: &str,
+    expected_status: &str,
+) {
+    let surface_status = status
+        .pointer(&format!("/allowed_surfaces/{surface}"))
+        .unwrap_or_else(|| panic!("status should include allowed_surfaces.{surface}: {status}"));
+    assert_eq!(
+        surface_status["allowed"],
+        json!(expected_allowed),
+        "unexpected allowed state for {surface}: {surface_status}"
+    );
+    assert_eq!(
+        surface_status["readiness_goal"],
+        json!(expected_goal),
+        "unexpected readiness goal for {surface}: {surface_status}"
+    );
+    assert_eq!(
+        surface_status["status"],
+        json!(expected_status),
+        "unexpected readiness status for {surface}: {surface_status}"
+    );
+    assert!(
+        surface_status["summary"]
+            .as_str()
+            .is_some_and(|text| !text.is_empty()),
+        "surface status should include a readiness summary for {surface}: {surface_status}"
+    );
+    if expected_allowed {
+        assert!(
+            surface_status["blocked_reason"].is_null(),
+            "allowed surface {surface} should not include a blocked reason: {surface_status}"
+        );
+    } else {
+        assert!(
+            surface_status["blocked_reason"]
+                .as_str()
+                .is_some_and(|text| !text.is_empty()),
+            "blocked surface {surface} should explain why it is blocked: {surface_status}"
+        );
+        assert!(
+            surface_status["minimum_next"]
+                .as_array()
+                .is_some_and(|commands| !commands.is_empty()),
+            "blocked surface {surface} should include minimum repair guidance: {surface_status}"
+        );
+    }
+}
+
 fn string_values_recursive<'a>(value: &'a Value, strings: &mut Vec<&'a str>) {
     match value {
         Value::String(text) => strings.push(text),
@@ -1899,6 +1951,20 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
 
     let result = assert_success_envelope(&response, json!("status-resource"));
     let status = json_resource_content(result, "codestory://status");
+    assert_eq!(
+        status["server_version"],
+        json!(env!("CARGO_PKG_VERSION")),
+        "status should identify the serving package version: {status}"
+    );
+    assert!(
+        status["server_executable"]
+            .as_str()
+            .is_some_and(|path| !path.is_empty())
+            || status["warnings"]
+                .as_array()
+                .is_some_and(|warnings| !warnings.is_empty()),
+        "status should expose server_executable or an explicit warning: {status}"
+    );
     assert!(
         status
             .get("project_root")
@@ -1951,6 +2017,32 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     let readiness = status["readiness"]
         .as_array()
         .unwrap_or_else(|| panic!("status should include readiness verdicts: {status}"));
+    for surface in [
+        "ground",
+        "files",
+        "symbol",
+        "definition",
+        "get_node",
+        "neighbors",
+        "shortest_path",
+        "query_subgraph",
+        "symbols",
+        "trail",
+        "references",
+        "snippet",
+        "affected",
+    ] {
+        assert_allowed_surface(&status, surface, true, "local_navigation", "ready");
+    }
+    for surface in ["packet", "search", "context"] {
+        assert_allowed_surface(
+            &status,
+            surface,
+            false,
+            "agent_packet_search",
+            "repair_retrieval",
+        );
+    }
     assert!(
         readiness
             .iter()
@@ -2126,9 +2218,69 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
             .or_else(|| guide.get("recommended_call_sequence"))
             .or_else(|| guide.get("recommended_next_calls"))
             .and_then(Value::as_array)
-            .is_some_and(|calls| calls.len() >= 3),
+            .is_some_and(|calls| {
+                calls
+                    .iter()
+                    .any(|call| call["uri"] == json!("codestory://status"))
+            })
+            && guide
+                .get("readiness_lanes")
+                .and_then(Value::as_array)
+                .is_some_and(|lanes| lanes.len() >= 2),
         "agent guide should include a concise default browser loop or call sequence: {guide}"
     );
+    let local_lane = guide["readiness_lanes"]
+        .as_array()
+        .and_then(|lanes| {
+            lanes
+                .iter()
+                .find(|lane| lane["readiness_goal"] == json!("local_navigation"))
+        })
+        .unwrap_or_else(|| panic!("agent guide should include local_navigation lane: {guide}"));
+    let local_surfaces = local_lane["surfaces"]
+        .as_array()
+        .unwrap_or_else(|| panic!("local lane should list surfaces: {guide}"));
+    for expected in [
+        "ground",
+        "files",
+        "symbol",
+        "definition",
+        "get_node",
+        "neighbors",
+        "shortest_path",
+        "query_subgraph",
+        "symbols",
+        "snippet",
+        "references",
+        "trail",
+        "affected",
+    ] {
+        assert!(
+            local_surfaces.iter().any(|surface| surface == expected),
+            "local lane should include {expected}: {guide}"
+        );
+    }
+    assert!(
+        !local_surfaces.iter().any(|surface| surface == "context"),
+        "context is sidecar-backed and should not be in the local lane: {guide}"
+    );
+    let agent_lane = guide["readiness_lanes"]
+        .as_array()
+        .and_then(|lanes| {
+            lanes
+                .iter()
+                .find(|lane| lane["readiness_goal"] == json!("agent_packet_search"))
+        })
+        .unwrap_or_else(|| panic!("agent guide should include agent_packet_search lane: {guide}"));
+    let agent_surfaces = agent_lane["surfaces"]
+        .as_array()
+        .unwrap_or_else(|| panic!("agent lane should list surfaces: {guide}"));
+    for expected in ["packet", "search", "context"] {
+        assert!(
+            agent_surfaces.iter().any(|surface| surface == expected),
+            "agent lane should include {expected}: {guide}"
+        );
+    }
     let mut strings = Vec::new();
     string_values_recursive(&guide, &mut strings);
     for expected in [
@@ -2145,6 +2297,22 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
         );
     }
     let guide_text = strings.join("\n").to_ascii_lowercase();
+    let unconditional_sequence_text = guide
+        .get("recommended_call_sequence")
+        .and_then(Value::as_array)
+        .map(|calls| Value::Array(calls.clone()).to_string())
+        .unwrap_or_default();
+    assert!(
+        !unconditional_sequence_text.contains("\"tool\":\"packet\"")
+            && !unconditional_sequence_text.contains("\"tool\":\"search\""),
+        "packet/search should not be unconditional normal next steps: {guide}"
+    );
+    assert!(
+        guide_text.contains("allowed_surfaces.packet.allowed")
+            && guide_text.contains("allowed_surfaces.search.allowed")
+            && guide_text.contains("allowed_surfaces.context.allowed"),
+        "agent guide should make packet/search/context conditional on status allowed_surfaces: {guide}"
+    );
     assert!(
         guide_text.contains("repo-text hits as navigation clues"),
         "agent guide should treat repo-text hits as navigation clues: {guide}"
@@ -2164,9 +2332,21 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
         "agent guide should name the direct source-read fallback: {guide}"
     );
     assert!(
-        guide_text.contains("files, affected, cache identity, retrieval status")
-            && guide_text.contains("deferred"),
-        "agent guide should record deferred stdio surfaces: {guide}"
+        guide_text.contains("ground")
+            && guide_text.contains("files")
+            && guide_text.contains("definition")
+            && guide_text.contains("get_node")
+            && guide_text.contains("neighbors")
+            && guide_text.contains("shortest_path")
+            && guide_text.contains("query_subgraph")
+            && guide_text.contains("symbols")
+            && guide_text.contains("affected")
+            && guide_text.contains("local_navigation"),
+        "agent guide should record local navigation surfaces: {guide}"
+    );
+    assert!(
+        !guide_text.contains("files, affected, cache identity, retrieval status"),
+        "agent guide should not describe allowed files/affected surfaces as deferred: {guide}"
     );
     assert!(
         !guide_text.contains("repo-text hits as evidence"),
@@ -2189,6 +2369,21 @@ fn transcript_calls_search_tool() {
         return;
     };
     let mut server = spawn_stdio_server(&fixture);
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "full-retrieval-status",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let status_result = assert_success_envelope(&status_response, json!("full-retrieval-status"));
+    let status = json_resource_content(status_result, "codestory://status");
+    for surface in ["packet", "search", "context"] {
+        assert_allowed_surface(&status, surface, true, "agent_packet_search", "ready");
+    }
 
     let response = send_json(
         &mut server,

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2024"
 
 [dependencies]

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -1,13 +1,24 @@
 # Retrieval sidecars operations
 
-Local Zoekt, Qdrant, SCIP, and llama.cpp sidecars back agent `packet` and
-`search`. They are required for `agent_packet_search` infrastructure readiness:
-`retrieval status` must report `retrieval_mode: "full"` before packet/search
-evidence can claim full sidecar retrieval.
+Local Zoekt, Qdrant, SCIP, and llama.cpp sidecars back agent `packet`, `search`,
+and `context`. They are required for `agent_packet_search` infrastructure
+readiness: `retrieval status` must report `retrieval_mode: "full"` before those
+surfaces can claim full sidecar retrieval.
 
 A healthy SQLite cache alone is not enough. Full sidecars also do not prove
 answer quality by themselves; answer quality still needs the matching
 packet-runtime, drill, or benchmark evidence tier.
+
+| Runtime truth | Allows | Blocks |
+| --- | --- | --- |
+| `codestory://status` | Current MCP `server_version`, `server_executable`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
+| `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
+
+For local-only audits, do not run sidecar repair just because `packet`, `search`,
+or `context` is blocked. Use this runbook when the task needs one of those
+surfaces or when status says `agent_packet_search` should be repaired.
+`context` is not a local-only browse surface.
 
 Design: [`retrieval-design.md`](../architecture/retrieval-design.md).
 Promotion checks: [`retrieval-architecture.md`](../testing/retrieval-architecture.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,9 +14,9 @@ debugging, transcripts, and direct stdio integration.
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | `local_navigation` is ready before using local graph output. |
-| Source work | Ask for a plan, review, or code path. | Use `files`, `symbol`, `trail`, `snippet`, `context`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
-| Broad discovery | Ask a repo-wide question. | Use `packet` or `search`. | Trust only when `agent_packet_search` is ready and `retrieval_mode=full`. |
+| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `server_executable`, and `allowed_surfaces`. |
+| Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
+| Broad discovery | Ask a repo-wide question. | Use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
 
 Packet/search output from degraded retrieval, missing sidecars, stale manifests,
@@ -31,7 +31,7 @@ exact setup, repair, or debug record.
 **Portable templates (any repository):**
 
 ```text
-@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+@CodeStory read codestory://status, report allowed_surfaces for this checkout, ground the repo if allowed, and tell me whether packet/search/context need sidecar repair before I use them.
 ```
 
 ```text
@@ -51,7 +51,7 @@ sidecars or coverage are degraded.
 Use concrete repo terms, not generic architecture words:
 
 ```text
-@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet on codestory-indexer changes.
+@CodeStory read codestory://status, report allowed_surfaces for this checkout, ground the repo if allowed, and tell me whether packet/search/context need sidecar repair before codestory-indexer changes.
 ```
 
 ```text
@@ -83,7 +83,7 @@ workspace you want to ground. The canonical skill package lives at
 3. Start a fresh thread and ask:
 
 ```text
-@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+@CodeStory read codestory://status, report allowed_surfaces for this checkout, ground the repo if allowed, and tell me whether packet/search/context need sidecar repair before I use them.
 ```
 
 **Direct CLI transcript (for setup, repair, or debugging):**
@@ -100,11 +100,16 @@ codestory-cli ground --project <target-workspace> --why
 
 **Key guidance:**
 
-Do not infer packet/search readiness from a successful local grounding command. Use `doctor` to check both readiness lanes separately.
+When MCP is live, use `codestory://status` as the runtime truth. Its
+`server_version` and `server_executable` fields identify the active server, and
+`allowed_surfaces` tells the agent which tools are safe now. Do not infer
+packet/search readiness from a successful local grounding command.
 
 **Next steps after installation:**
 
-If the agent reports that local navigation is ready but agent packet/search is not ready, repair the sidecar lane with:
+If the agent reports that local graph surfaces are allowed but `packet`,
+`search`, or `context` is not allowed, local browse work can continue. Repair
+the sidecar lane only when the task needs those sidecar-backed surfaces:
 
 ```sh
 codestory-cli ready --goal agent --repair --project <target-workspace> --format json
@@ -112,19 +117,20 @@ codestory-cli ready --goal agent --repair --project <target-workspace> --format 
 
 **Common next steps:**
 
-- If `agent_packet_search` is not ready: The agent will guide you through setting up retrieval sidecars
-- If `local_navigation` is not ready: The agent will guide you through indexing the repository
+- If `packet`, `search`, or `context` is not allowed: Keep local browse work local; repair retrieval sidecars only when the task needs those surfaces
+- If `ground` or `files` is not allowed: The agent will guide you through indexing the repository
 - If both are ready: You can proceed with using CodeStory for your task
 
 **Verification checkpoints:**
 
-After the initial setup, you can verify readiness with:
+After the initial setup, you can collect CLI health evidence with:
 
 ```sh
 codestory-cli doctor --project <target-workspace>
 ```
 
-This will tell you exactly what is ready and what needs to be repaired before you can use packet/search features.
+Use this when MCP is missing, a repair transcript is needed, or the status
+resource points to stale runtime evidence.
 
 When changing CodeStory itself or testing the current checkout:
 
@@ -138,30 +144,19 @@ The plugin source-build setup fallback accepts `CODESTORY_REPO_URL` and
 `CODESTORY_REPO_REF` when you need a specific source artifact. Without an
 explicit ref, setup fetches and builds the remote default branch.
 
-## Readiness Lanes
+## Readiness Contract
 
-| Question | Local navigation | Agent packet/search |
+| Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| Lane id | `local_navigation` | `agent_packet_search` |
-| Built by | `index` | `index`, then `retrieval index` |
-| Requires | Healthy SQLite cache and graph | Healthy sidecars and `retrieval_mode=full` |
-| Good for | Known files, symbols, trails, snippets, changed-file impact | Broad candidate discovery and bounded task packets |
-| Commands | `ground`, `report`, `files`, `symbol`, `trail`, `snippet`, `explore`, `affected` | `packet`, `search`, `context` packet construction after target selection |
-| Does not prove | Broad sidecar search is ready | That cache-only browsing is enough for broad agent search |
+| `codestory://status` | Current `server_version`, `server_executable`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
+| `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 
-**Key concepts for readiness lanes:**
-
-- **Local navigation**: SQLite cache, graph, and DB-backed browse commands (`ground`, `report`, `files`, `trail`, `snippet`, `context --id`, etc.) are usable.
-- **Agent packet/search**: Sidecars are healthy and `retrieval_mode=full`; required for trustworthy `packet`, `search`, and query-based candidate discovery.
-- **Retrieval mode**: Sidecar status contract; only `full` serves agent packet/search.
-- **Semantic ready**: Dense-anchor embedding state matches policy; not the same as agent packet/search readiness.
-
-`context` straddles these lanes. Target selection is local/index-first:
-`--id`, `--bookmark`, or `--query <exact target>` chooses one concrete focus.
-The context answer/evidence packet then runs through the Investigate agent path
-and may fail closed unless sidecar-primary retrieval is full. Use `symbol`,
-`trail`, `snippet`, or `explore` for cache-only local navigation when sidecars
-are degraded.
+`context` is not a local-only browse surface. Even when the target is concrete,
+use it only when `allowed_surfaces.context.allowed` is true and
+`retrieval_mode=full`. Use each allowed MCP local graph surface's own status bit
+for cache-only local navigation when sidecars are degraded. `explore` is
+CLI-only and is not an MCP `allowed_surfaces` entry.
 
 Sidecar topology:
 [architecture/overview.md](architecture/overview.md),

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -17,19 +17,26 @@ packet, and search. The CLI is still there, but it is the escape hatch and repai
 
 | Agent need | CodeStory surface | Human reading |
 | --- | --- | --- |
-| Is this repo indexed and safe to use? | `codestory://status` | Check readiness before trusting claims. |
+| Is this repo indexed and safe to use? | `codestory://status` | Read first; status is the runtime truth. |
 | What should I do next? | `codestory://agent-guide` | Let the skill route normal setup and repair. |
 | Give me a compact repo map. | `codestory://grounding` | Start from current local files. |
 | Inspect indexed file inventory and coverage. | `files` tool | Use for scope, language mix, and missing coverage. |
 | Map changed files to likely impact. | `affected` tool | Use for review planning and focused test choice. |
-| Find candidate symbols, paths, or behavior terms. | `search` tool, only with full sidecars | Navigation only unless packet/search is full. |
-| Answer a broad repo question with evidence. | `packet` tool, only with full sidecars | Proof only when strict sidecars are ready. |
-| Follow a concrete target. | `symbol`, `trail`, `references`, `snippet`, `context` | Source anchors still matter. |
+| Follow a local graph target. | `symbol`, `definition`, `trail`, `references`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph` | Check each surface's own allowed bit. |
+| Find candidate symbols, paths, or behavior terms. | `search` tool, only when status allows search | Requires `retrieval_mode=full`. |
+| Answer a broad repo question or build an evidence context. | `packet` or `context`, only when status allows that surface | Requires `retrieval_mode=full`. |
 
-The status resource is the contract. Local navigation is ready only when
-`local_navigation` is ready. Agent packet/search is eligible only when strict
-sidecar status reports `retrieval_mode=full`; answer quality still needs the
-matching packet-runtime, drill, or benchmark proof.
+The status resource is the contract. When MCP is live, read
+`codestory://status` first and obey `allowed_surfaces`. Treat
+`server_version` and `server_executable` from status as the active runtime
+evidence; source docs, marketplace cache contents, and local build outputs can
+all differ from the running server.
+
+| Status lane | Allows | Does not allow |
+| --- | --- | --- |
+| `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
+| `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
+| `codestory://status` fields | Current `server_version`, `server_executable`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
@@ -83,13 +90,18 @@ Open Codex in the repo you want to ground and ask the agent to check readiness
 before planning or editing:
 
 ```text
-@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+@CodeStory read codestory://status, report allowed_surfaces for this checkout, ground the repo if allowed, and tell me whether packet/search/context need sidecar repair before I use them.
 ```
 
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
-present and current, compares `codestory-cli --version` with the latest GitHub
-release, installs the latest matching release asset when needed, verifies
-`SHA256SUMS.txt` when the host can, and uses source fallback only when no release asset fits the host.
+live through MCP by reading `codestory://status`. If MCP is live, the agent uses
+`server_version`, `server_executable`, and `allowed_surfaces` from status
+instead of rechecking PATH or release metadata.
+
+Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
+missing, status reports a suspect runtime, or you are debugging/repairing the
+installed CLI. If PATH changed during repair, start a fresh Codex host/app
+session before treating a new MCP runtime as live.
 
 ## What To Ask
 
@@ -98,7 +110,7 @@ repository; adapt paths and symbols to your project:
 
 **For checking readiness before editing:**
 
-- `@CodeStory check local_navigation and agent_packet_search on this checkout before I edit codestory-indexer.`
+- `@CodeStory read codestory://status and check allowed_surfaces before I edit codestory-indexer.`
 
 **For finding ownership:**
 
@@ -117,7 +129,7 @@ repository; adapt paths and symbols to your project:
 **For checking readiness before editing any crate:**
 
 ```text
-@CodeStory check local_navigation and agent_packet_search on this checkout before I edit [TARGET_CRATE].
+@CodeStory read codestory://status and check allowed_surfaces before I edit [TARGET_CRATE].
 ```
 
 **For finding ownership of a feature:**
@@ -142,7 +154,7 @@ Avoid prompts that erase the trust boundary:
 
 - `Run every CodeStory command.`
 - `Search broadly and summarize whatever comes back.`
-- `Trust packet/search even though status says sidecars are degraded.`
+- `Trust packet/search/context even though status says sidecars are degraded.`
 
 ## Manual CLI Escape Hatch
 
@@ -150,6 +162,7 @@ Use the CLI when the agent needs to repair setup, produce a transcript, or debug
 why the MCP server is not ready:
 
 ```console
+where.exe codestory-cli
 codestory-cli --version
 codestory-cli ready --goal local --repair --project <repo> --format json
 codestory-cli ready --goal agent --repair --project <repo> --format json
@@ -170,15 +183,19 @@ codestory-cli ready --goal agent --repair --project <repo> --format json
 codestory-cli retrieval status --project <repo> --format json
 ```
 
-Do not treat `ground`, `symbol`, `trail`, or `snippet` readiness as proof that
-agent packet/search is ready.
+Do not treat `ground`, `symbol`, `trail`, `snippet`, or local graph readiness as
+proof that `packet`, `search`, or `context` is ready.
 
-### Agent runtime bootstrap
+### Agent runtime repair
 
-The plugin does not bundle the binary. The agent-owned skill verifies
-`codestory-cli --version`, compares it with the latest GitHub release, installs
-the matching release asset when practical, and checks `SHA256SUMS.txt` when the
-host can. If `PATH` changed, the skill tells the human that a Codex host/app restart may be needed before a fresh agent thread can see it.
+The plugin does not bundle the binary. The installed MCP runtime launches
+`codestory-cli serve --stdio --refresh none` from the agent host `PATH`. Once
+MCP is live, `codestory://status` is the runtime proof. Use
+`where.exe codestory-cli`, `codestory-cli --version`, and release repair checks
+only when MCP is missing or the status fields show stale binary drift.
+
+If `PATH` changed, the skill tells the human that a Codex host/app restart may
+be needed before a fresh agent thread can see it.
 If a running `codestory-cli serve --stdio --refresh none` process locks the old
 binary, install the current release into a versioned directory and put that
 directory before stale entries on `PATH`; verify the command that MCP will

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -5,89 +5,60 @@ description: Use when an agent should ground a local repository with CodeStory b
 
 # CodeStory Grounding
 
-Agents usually rediscover a repository on every question: search files, read
-snippets, chase imports, and spend context rebuilding the same map. CodeStory
-indexes once and serves read-only evidence from that map so you can answer from
-citations instead of repeating discovery work.
+CodeStory indexes a repository once and serves read-only local evidence so an
+agent can stop rediscovering the same files, symbols, and call paths every turn.
 
-Use CodeStory to keep source claims tied to the current local repository. Prefer
-the plugin MCP server when it is installed and healthy. Use the CLI for setup,
-repair, explicit transcripts, or when MCP is unavailable.
+The target is always the repository workspace being grounded. The CodeStory
+checkout is only tool source unless the user is editing CodeStory itself.
 
-**Key concepts:**
+## Runtime Truth
 
-- **Repository rediscovery**: The repeated agent work of searching files, reading snippets, and rebuilding a mental map on every new question. CodeStory indexes once to reduce that cost.
-- **Local navigation**: SQLite cache, graph, and DB-backed browse commands (`ground`, `report`, `files`, `trail`, `snippet`, `context --id`, etc.) are usable.
-- **Agent packet/search**: Sidecars are healthy and `retrieval_mode=full`; required for trustworthy `packet`, `search`, and query-based candidate discovery.
-- **Retrieval mode**: Sidecar status contract; only `full` serves agent packet/search.
-- **Semantic ready**: Dense-anchor embedding state matches policy; not the same as agent packet/search readiness.
+When plugin MCP is live, `codestory://status` is the first and canonical runtime
+truth. Read it before `ground`, `files`, `packet`, or `search`.
 
-The target is always a repository workspace. The CodeStory checkout is only the
-tool source unless the user is editing CodeStory itself.
+Use status fields this way:
 
-## Setup Gate
+| Status field | Meaning | Agent action |
+| --- | --- | --- |
+| `server_version` | Version of the active MCP server binary. | Use as active runtime evidence once MCP is live. |
+| `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
+| `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
+| `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` only when their own allowed bit is true and `retrieval_mode=full`. |
 
-1. Resolve `<target-workspace>` explicitly. Do not infer the target from the
-   current shell if the user named another repo.
-2. For installed plugin MCP runtime, `.mcp.json` launches `codestory-cli` from
-   the agent host `PATH`. Use `CODESTORY_CLI` only for manual CLI/source
-   fallback commands, not as the installed MCP launch path.
-3. When the user explicitly invokes CodeStory, check that the `mcp__codestory`
-   tools or `codestory://status` resource are actually exposed. If the skill is
-   visible but the MCP namespace is missing, call it a plugin MCP registration
-   failure and use CLI only as a degraded fallback while reporting that setup
-   defect.
-4. Resolve `<codestory-cli>` for explicit CLI commands:
-   - prefer `CODESTORY_CLI` when set;
-   - otherwise use `codestory-cli` on `PATH`;
-   - otherwise use a nearby `target/release/codestory-cli*` from the current or
-     sibling CodeStory checkout;
-   - otherwise install the released binary for the host OS.
-5. Resolve the latest GitHub release tag. If `codestory-cli` exists, compare
-   `codestory-cli --version` with that tag and keep the binary only when it
-   already matches the latest release.
-6. If `codestory-cli` is missing or outdated, download and unpack only the
-   matching host asset derived from the latest tag. Do this before asking the
-   human to install or run manual commands unless network access, permissions,
-   or a missing release asset blocks the setup. For latest tag `vX.Y.Z`, use:
-   - Windows x64: `codestory-cli-vX.Y.Z-windows-x64.zip`
-   - Windows arm64: `codestory-cli-vX.Y.Z-windows-arm64.zip`
-   - macOS arm64: `codestory-cli-vX.Y.Z-macos-arm64.tar.gz`
-   - Linux x64: `codestory-cli-vX.Y.Z-linux-x64.tar.gz`
-   - Linux arm64: `codestory-cli-vX.Y.Z-linux-arm64.tar.gz`
-   - macOS x64 or missing asset: Source fallback. Build from source.
-7. Put the binary in a stable user bin directory, verify
-   `codestory-cli --version`, and prefer checking `SHA256SUMS.txt` from the
-   same release when the host has the tools. If `PATH` changed, say the plugin MCP process may need a Codex host/app restart before a new agent thread can see it.
-   If a running `codestory-cli serve --stdio --refresh none` process locks the
-   old binary, install the current release into a versioned directory and put
-   that directory before stale entries on `PATH`; verify `codestory-cli
-   --version` from `PATH` before launch.
-8. Use `scripts/setup.ps1` or `scripts/setup.sh` from this skill only for the
-   source-build fallback or explicit source-artifact setup.
+Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
+source-build checks only when MCP is missing, the plugin needs repair, or the
+user asks for a CLI transcript. `CODESTORY_CLI` is for manual CLI/source
+fallback commands; `.mcp.json` launches `codestory-cli` from the agent host
+`PATH`.
 
 ## MCP Loop
 
 When the plugin MCP server is available:
 
-1. Read `codestory://status`.
-2. Read `codestory://agent-guide`.
-3. Read `codestory://grounding` or call `ground` for a compact repo map before planning.
-4. Use `files` when you need indexed file inventory, language coverage, or
-   role counts from the existing cache.
-5. Use `packet` for broad repo questions only when status says
-   `agent_packet_search` is ready and strict sidecar status reports
+1. Resolve `<target-workspace>` explicitly.
+2. Read `codestory://status`.
+3. Obey `allowed_surfaces`.
+4. Read `codestory://agent-guide` when you need the runtime's recommended next
+   calls.
+5. Read `codestory://grounding` or call `ground` when
+   `allowed_surfaces.ground.allowed` is true.
+6. Use `files`, `symbol`, `definition`, `trail`, `references`, `snippet`,
+   `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and
+   `query_subgraph` only when each corresponding surface is allowed.
+7. Use `packet` only when `allowed_surfaces.packet.allowed` is true and
+   `retrieval_mode=full`; use `search` only when
+   `allowed_surfaces.search.allowed` is true and `retrieval_mode=full`; use
+   `context` only when `allowed_surfaces.context.allowed` is true and
    `retrieval_mode=full`.
-6. Use `search` to discover candidates only when packet/search is ready.
-7. Use `symbol`, `trail`, `references`, `snippet`, and `context` after selecting
-   a concrete target.
 
-If status is degraded, fall back to direct source reads or CLI local-navigation
-commands and label packet/search as blocked.
+If the skill is visible but no `mcp__codestory` tools or `codestory://status`
+resource are exposed, call it a plugin MCP registration failure. Use CLI only
+as a degraded fallback and report that MCP was not live.
 
 ## CLI Loop
 
-When MCP is unavailable or a transcript is needed, use the CLI directly:
+When MCP is unavailable, repair is needed, or a transcript is requested, use the
+CLI directly:
 
 1. `ready --goal local --repair --project <target-workspace> --format json`
    before local navigation or delegation when the index is missing or stale.
@@ -96,14 +67,18 @@ When MCP is unavailable or a transcript is needed, use the CLI directly:
 3. `doctor --project <target-workspace>` for a read-only health transcript.
 4. `ground --project <target-workspace> --why` for compact orientation.
 5. `files --project <target-workspace>` for indexed file inventory.
-6. `context`, `symbol`, `trail --story --hide-speculative`, `snippet`, `files`,
-   and `affected` for concrete source-backed follow-up.
+6. `symbol`, `trail --story --hide-speculative`, `snippet`, `files`, `symbols`,
+   `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`
+   for concrete local graph follow-up.
 7. `search --project <target-workspace> --query ... --why` for candidate
    discovery after sidecars are full.
-8. `packet --project <target-workspace> --question ...` for broad answers only
-   when packet/search readiness is full.
+8. `packet`, `search`, and `context` for broad or evidence-packet answers only
+   when agent packet/search readiness is full.
 
 Always pass `--project <target-workspace>` explicitly.
+
+For binary repair details, use [serve](references/serve.md) for MCP/PATH
+behavior and [doctor](references/doctor.md) for health and repair evidence.
 
 ## Evidence Rules
 
@@ -132,7 +107,8 @@ Always pass `--project <target-workspace>` explicitly.
 | Agent orientation | MCP `ground` / `codestory://grounding` or CLI `ground` |
 | Broad task packet | MCP/CLI `packet` |
 | Candidate discovery | MCP/CLI `search --why` |
-| Focused source view | `symbol`, `trail`, `snippet`, `context`, `explore` |
+| Focused source view | `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, `explore` |
+| Sidecar-backed evidence packet | `packet`, `search`, `context` |
 | Coverage and impact | MCP/CLI `files`, `affected` |
 | Reusable targets | `bookmark` |
 | Structured evaluation | `drill`, `drill-suite` |

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -2,6 +2,11 @@
 
 Reads project/cache/index/retrieval health without mutating the index. Use it at the start of an LLM browser loop and when a read command fails unexpectedly.
 
+When plugin MCP is live, read `codestory://status` first and treat its
+`server_version`, `server_executable`, and `allowed_surfaces` as active runtime
+truth. Use `doctor` when MCP is missing, a repair transcript is needed, or a
+status field points to stale runtime or readiness evidence.
+
 ## Usage
 
 ```
@@ -24,6 +29,18 @@ Reads project/cache/index/retrieval health without mutating the index. Use it at
 | Normal path | `<codestory-cli> doctor --project <target-workspace>` | Reports project root, cache path, indexed stats, retrieval state, sidecar embedding setup, environment hints, and next commands. |
 | Failure path | If cache or index checks warn, run `index --project <target-workspace> --refresh full`; if mandatory sidecars are missing or stale, run the setup/index commands surfaced by `doctor`; if symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, rebuild before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
 | Integration edge | Use doctor before `ground`, `search --why`, `explore`, `context`, or `serve`; its next commands are the safe follow-up loop. | Prevents read commands from silently querying the wrong or empty cache. |
+
+For MCP/runtime drift, collect binary evidence only after status is missing or
+suspect:
+
+```powershell
+where.exe codestory-cli
+codestory-cli --version
+codestory-cli doctor --project <target-workspace> --format json
+```
+
+If PATH repair changes which binary `codestory-cli` resolves to, start a fresh
+Codex host/app session before treating the plugin MCP runtime as updated.
 
 ## Notes
 

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -2,6 +2,17 @@
 
 Serves the indexed project over either a small HTTP JSON API or an MCP-style JSON-lines stdio protocol. It is for local browser/editor integrations after the cache is ready.
 
+For the installed plugin, `.mcp.json` starts:
+
+```text
+codestory-cli serve --stdio --refresh none
+```
+
+The process resolves `codestory-cli` from the agent host `PATH`. Once MCP is
+live, `codestory://status` is the runtime truth: use `server_version`,
+`server_executable`, and `allowed_surfaces` from status before any local
+grounding, packet, or search call.
+
 ## Usage
 
 ```
@@ -36,7 +47,20 @@ Serves the indexed project over either a small HTTP JSON API or an MCP-style JSO
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
 | Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `index --project <target-workspace> --refresh full`; if bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
-| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `affected`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, and `context`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
+| Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `affected`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, `context`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
+
+## Stdio Runtime Contract
+
+| Status field | Use |
+|--------------|-----|
+| `server_version` | Active MCP server version. Prefer this over source checkout or package version once MCP is live. |
+| `server_executable` | Active MCP server executable path. Use it to diagnose stale PATH or binary drift. |
+| `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |
+| `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Allows `packet`, `search`, and `context` only when the surface bit is true and `retrieval_mode=full`. |
+
+Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is not
+registered, status is unavailable, or the status executable/version indicates a
+stale binary. If PATH changes during repair, start a fresh Codex host/app session before checking status again.
 
 ## Notes
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -71,112 +71,107 @@ test("codestory repo ships plugin source, not marketplace catalog or adapter run
   );
 });
 
-test("plugin docs are agent-first, marketplace-aware, and latest-release aware", async () => {
+test("plugin docs are agent-first, status-first, and marketplace-aware", async () => {
   const rootReadme = await readFile(join(repoRoot, "README.md"), "utf8");
   const readme = await readFile(join(pluginRoot, "README.md"), "utf8");
   const skill = await readFile(
     join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"),
     "utf8",
   );
-  const sharedRequired = [
-    "latest GitHub release",
-    "codestory-cli --version",
-    "SHA256SUMS.txt",
-    "retrieval_mode=full",
+  const doctorReference = await readFile(
+    join(
+      pluginRoot,
+      "skills",
+      "codestory-grounding",
+      "references",
+      "doctor.md",
+    ),
+    "utf8",
+  );
+  const serveReference = await readFile(
+    join(
+      pluginRoot,
+      "skills",
+      "codestory-grounding",
+      "references",
+      "serve.md",
+    ),
+    "utf8",
+  );
+  const usage = await readFile(join(repoRoot, "docs", "usage.md"), "utf8");
+  const retrievalSidecars = await readFile(
+    join(repoRoot, "docs", "ops", "retrieval-sidecars.md"),
+    "utf8",
+  );
+  const statusRuntimeRequired = [
+    "codestory://status",
+    "server_version",
+    "server_executable",
+    "allowed_surfaces",
   ];
-  const skillReleaseRequired = [
-    "missing or outdated",
-    "codestory-cli-vX.Y.Z-windows-x64.zip",
-    "codestory-cli-vX.Y.Z-windows-arm64.zip",
-    "codestory-cli-vX.Y.Z-macos-arm64.tar.gz",
-    "codestory-cli-vX.Y.Z-linux-x64.tar.gz",
-    "codestory-cli-vX.Y.Z-linux-arm64.tar.gz",
-    "Source fallback",
+  const cliRepairRequired = ["where.exe codestory-cli", "codestory-cli --version"];
+  const stdioLaunchRequired = [
+    "codestory-cli serve --stdio --refresh none",
+    "agent host `PATH`",
+  ];
+  const marketplaceSourceRequired = [
+    "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",
+    "plugin source at `https://github.com/TheGreenCedar/CodeStory.git`",
+    "source path `plugins/codestory`",
+    "The CodeStory repo does not contain the marketplace catalog",
+    "git-subdir",
+  ];
+  const restartBoundaryRequired = [
+    "Codex host/app restart may",
+    "fresh Codex host/app session",
+  ];
+  const perSurfaceRequired = [
+    "`allowed_surfaces.<surface>.allowed`",
+    "`allowed_surfaces.packet.allowed`",
+    "`allowed_surfaces.search.allowed`",
+    "`allowed_surfaces.context.allowed`",
+    "`retrieval_mode=full`",
+  ];
+  const localGraphSurfaceNames = [
+    "ground",
+    "files",
+    "symbol",
+    "definition",
+    "trail",
+    "references",
+    "snippet",
+    "affected",
+    "symbols",
+    "get_node",
+    "neighbors",
+    "shortest_path",
+    "query_subgraph",
+  ];
+  const sidecarSurfaceNames = ["packet", "search", "context"];
+  const publicSurfaceRequired = [
+    "`allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`",
+    "check each surface's own `.allowed` bit",
+    "`allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full`",
+    "`context` is not a local-only browse surface",
   ];
   const forbidden = [
     "release-bound to " + "CodeStory `v" + "0.11.1`",
     "use that version " + "unless",
     "Install plugin entry `codestory` from the external marketplace catalog:",
+    "The first run should be agent-owned. The skill checks whether `codestory-cli` is\npresent and current",
   ];
   const forbiddenPatterns = [
     /\bcodestory-cli-v\d+\.\d+\.\d+/,
+    /\bcodestory-cli-vX\.Y\.Z/u,
     /release-bound to CodeStory `v\d+\.\d+\.\d+`/,
-  ];
-  const readmeRequired = [
-    "The human job is simple",
-    "The CLI is still there, but it is the escape hatch and repair surface",
-    "codestory://status",
-    "codestory://grounding",
-    "mcp__codestory",
-    "plugin MCP registration",
-    "ready --goal local --repair",
-    "ready --goal agent --repair",
-    "Inspect indexed file inventory and coverage.",
-    "Map changed files to likely impact.",
-    "For normal Codex use, install the plugin through the Codex plugin flow for your",
-    "/plugins",
-    "TheGreenCedar -> codestory -> Install plugin",
-    "add or refresh this marketplace first",
-    "codex plugin marketplace add TheGreenCedar/AgentPluginMarketplace",
-    "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",
-    "marketplace display/name concept is `TheGreenCedar`",
-    "plugin source at `https://github.com/TheGreenCedar/CodeStory.git`",
-    "source path `plugins/codestory`",
-    "The CodeStory repo does not contain the marketplace catalog",
-    "workspace plugin settings are managed from the Codex Apps/Plugins UI",
-    "UI path when the CLI marketplace command is",
-    "Start a new Codex thread after installation or refresh",
-    "The first run should be agent-owned",
-    "installs the latest matching release asset",
-    "uses source fallback only when no release asset fits the host",
-    "Agent runtime bootstrap",
-    "the skill tells the human that a Codex host/app restart may be needed",
-    "running `codestory-cli serve --stdio --refresh none` process locks the old",
-    "before stale entries on `PATH`",
-    "command that MCP will",
-    "The plugin does not bundle the binary",
-    "Use source fallback only when no release asset fits the host",
-    "Source docs, marketplace source checkout/cache, and the active installed MCP",
-    "active runtime surface",
-    "agent host `PATH`",
-    "Set `CODESTORY_CLI` only for manual CLI fallback commands",
-    ".mcp.json` does not launch through that variable",
-    "python <path-to-plugin-creator>\\scripts\\validate_plugin.py plugins\\codestory",
-    "The plugin validator path is maintainer-local",
-    "For normal Codex use, refresh or uninstall the plugin from the Codex plugin",
-    "codex plugin marketplace upgrade TheGreenCedar",
-    "codex plugin marketplace remove TheGreenCedar",
-    "commands only for source registration",
-    "The plugin does not bundle the binary",
-    "Marketplace catalog repo",
-    "Marketplace display/name",
-    "Plugin entry",
-    "git-subdir",
-    "https://github.com/TheGreenCedar/CodeStory.git",
-    "plugins/codestory",
-    "codestory-cli serve --stdio --refresh none",
-  ];
-  const skillRequired = [
-    "download and unpack only",
-    "Use `CODESTORY_CLI` only for manual CLI/source",
-    "not as the installed MCP launch path",
-    "plugin MCP process may need",
-    "Codex host/app restart before a new agent thread",
-    "new agent thread",
-    "Read `codestory://grounding`",
-    "plugin MCP registration",
-    "ready --goal local --repair",
-    "ready --goal agent --repair",
-    "Always pass `--project <target-workspace>` explicitly",
   ];
   const rootReadmeRequired = [
     "Install details, binary bootstrap",
     "[plugin README](plugins/codestory/README.md)",
     "`codestory-cli serve --stdio --refresh none`",
   ];
-
   for (const text of [readme, skill]) {
-    for (const phrase of sharedRequired) {
+    for (const phrase of statusRuntimeRequired) {
       assert.equal(text.includes(phrase), true, phrase);
     }
     for (const phrase of forbidden) {
@@ -197,18 +192,58 @@ test("plugin docs are agent-first, marketplace-aware, and latest-release aware",
   for (const pattern of forbiddenPatterns) {
     assert.equal(pattern.test(rootReadme), false, String(pattern));
   }
-  for (const phrase of readmeRequired) {
+  for (const phrase of cliRepairRequired) {
+    assert.equal(readme.includes(phrase), true, phrase);
+    assert.equal(skill.includes(phrase), true, phrase);
+    assert.equal(doctorReference.includes(phrase), true, phrase);
+    assert.equal(serveReference.includes(phrase), true, phrase);
+  }
+  for (const phrase of stdioLaunchRequired) {
+    assert.equal(readme.includes(phrase), true, phrase);
+    assert.equal(serveReference.includes(phrase), true, phrase);
+  }
+  for (const phrase of marketplaceSourceRequired) {
     assert.equal(readme.includes(phrase), true, phrase);
   }
-  for (const phrase of skillReleaseRequired) {
-    assert.equal(skill.includes(phrase), true, phrase);
-    assert.equal(readme.includes(phrase), false, phrase);
+  assert.equal(
+    restartBoundaryRequired.some((phrase) => readme.includes(phrase)),
+    true,
+    "readme must mention restart boundary",
+  );
+  assert.equal(
+    restartBoundaryRequired.some((phrase) => serveReference.includes(phrase)),
+    true,
+    "serve reference must mention restart boundary",
+  );
+  for (const phrase of statusRuntimeRequired) {
+    assert.equal(serveReference.includes(phrase), true, phrase);
   }
   for (const phrase of rootReadmeRequired) {
     assert.equal(rootReadme.includes(phrase), true, phrase);
   }
-  for (const phrase of skillRequired) {
+  for (const phrase of perSurfaceRequired) {
     assert.equal(skill.includes(phrase), true, phrase);
+    assert.equal(serveReference.includes(phrase), true, phrase);
+  }
+  for (const surface of localGraphSurfaceNames) {
+    assert.equal(readme.includes(surface), true, surface);
+    assert.equal(skill.includes(surface), true, surface);
+    assert.equal(serveReference.includes(surface), true, surface);
+    assert.equal(usage.includes(surface), true, surface);
+    assert.equal(retrievalSidecars.includes(surface), true, surface);
+  }
+  for (const surface of sidecarSurfaceNames) {
+    assert.equal(readme.includes(`allowed_surfaces.${surface}.allowed`), true, surface);
+    assert.equal(skill.includes(`allowed_surfaces.${surface}.allowed`), true, surface);
+    assert.equal(serveReference.includes(`allowed_surfaces.${surface}.allowed`), true, surface);
+  }
+  for (const text of [usage, retrievalSidecars]) {
+    for (const phrase of statusRuntimeRequired) {
+      assert.equal(text.includes(phrase), true, phrase);
+    }
+    for (const phrase of publicSurfaceRequired) {
+      assert.equal(text.includes(phrase), true, phrase);
+    }
   }
 });
 


### PR DESCRIPTION
## Context

This is the clean main-based promotion of the `dev/codestory-next` plugin grounding consolidation to CodeStory 0.11.9. The direct dev-to-main PR was closed because its ancestry was conflicting.

Closes #404.

## What Changed

- Promotes the `codestory://status` runtime contract with `server_version`, best-effort `server_executable`, warnings, and per-surface `allowed_surfaces`.
- Keeps local graph surfaces separate from sidecar-backed `packet`, `search`, and `context` in runtime guidance and plugin/docs wording.
- Synchronizes all CodeStory release surfaces to `0.11.9`.
- Keeps the rejected ops plan/checklist docs out of the release diff.

## How To Review

1. Confirm the changed file list has no `docs/ops/codestory-plugin-consolidation-plan.md` and no `docs/ops/codestory-plugin-dogfood-checklist.md`.
2. Read `crates/codestory-cli/src/stdio_transport.rs` around `codestory://status` and the agent guide.
3. Check `CHANGELOG.md`, `Cargo.lock`, the eight crate manifests, and `plugins/codestory/.codex-plugin/plugin.json` for `0.11.9`.

## Verification

Local verification:

- `python .github\scripts\check-codestory-release.py --version 0.11.9`
- `node .github\scripts\check-workflow-policy.mjs`
- `node plugins\codestory\tests\plugin-static.test.mjs`
- `cargo fmt --check`
- `git diff --check`

Earlier verification on the same final dev tree before #405 merged:

- `cargo test -p codestory-cli --test stdio_protocol_contracts`
- `cargo test -p codestory-cli --test ready_command`
- `cargo check --workspace`
- GitHub #405: `require closing issue link`, `deny rustdoc warnings`, and `linux-contracts` passed; `windows-manifest-missing` skipped as expected.

## Risk

The ignored live full-retrieval stdio tests were not run, so full sidecar behavior is contract-covered but not live-proven here. This release does not claim new packet/search answer-quality proof.