### PR TITLE
[codex] fix stdio retrieval backend defaults

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1237,11 +1237,12 @@ fn run_doctor(cmd: DoctorCommand) -> Result<()> {
 fn run_ready(cmd: ReadyCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "ready")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    if cmd.repair && matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
-        managed_embeddings::prepare_bundled_llamacpp_client_env_defaults();
-    }
     let runtime = if cmd.repair {
-        RuntimeContext::new(&cmd.project)?
+        if matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
+            RuntimeContext::new_agent_sidecar(&cmd.project)?
+        } else {
+            RuntimeContext::new(&cmd.project)?
+        }
     } else {
         RuntimeContext::new_inspect_only(&cmd.project)?
     };
@@ -8153,7 +8154,7 @@ fn render_affected_footer(
 }
 
 fn run_serve(cmd: ServeCommand) -> Result<()> {
-    let runtime = RuntimeContext::new(&cmd.project)?;
+    let runtime = RuntimeContext::new_agent_sidecar(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "serve")?;
     if cmd.stdio {

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -109,6 +109,12 @@ impl RuntimeContext {
         Self::new_with_startup(args, ManagedEmbeddingStartup::AutostartIfInstalled)
     }
 
+    /// Open runtime services for agent-facing packet/search commands.
+    pub(crate) fn new_agent_sidecar(args: &ProjectArgs) -> Result<Self> {
+        crate::managed_embeddings::prepare_bundled_llamacpp_client_env_defaults();
+        Self::new(args)
+    }
+
     /// Open runtime services without starting managed embedding processes.
     pub(crate) fn new_inspect_only(args: &ProjectArgs) -> Result<Self> {
         Self::new_with_startup(args, ManagedEmbeddingStartup::InspectOnly)
@@ -912,7 +918,7 @@ mod tests {
     }
 
     #[test]
-    fn bundled_llamacpp_defaults_prevent_managed_onnx_autostart_for_agent_repair() {
+    fn agent_sidecar_runtime_defaults_prevent_managed_onnx_autostart() {
         let _env_lock = crate::config::config_env_test_lock();
         let _env_snapshot = EnvSnapshot::clear(MANAGED_ENV_VARS);
         let temp = tempdir().expect("temp dir");
@@ -921,8 +927,7 @@ mod tests {
         fs::create_dir_all(&project).expect("create project");
         write_fake_managed_onnx_assets(&cache.join("managed-embeddings"));
 
-        crate::managed_embeddings::prepare_bundled_llamacpp_client_env_defaults();
-        RuntimeContext::new(&ProjectArgs {
+        RuntimeContext::new_agent_sidecar(&ProjectArgs {
             project,
             cache_dir: Some(cache),
         })


### PR DESCRIPTION
## Context

Closes #414.

PR #413 made stdio fail closed correctly when packet/search readiness is not ready. External ComiComic proof then exposed a narrower mismatch: `ready --goal agent --repair` and `retrieval status` agreed on `llamacpp:bge-base-en-v1.5`, but `serve --stdio --refresh none` built its runtime with the default hash embedding identity and reported `sidecar_embedding_backend_changed`.

## What Changed

- Added `RuntimeContext::new_agent_sidecar()` to apply the existing bundled llama.cpp client defaults before opening runtime services for agent-facing packet/search surfaces.
- Switched `serve` to use that agent-sidecar runtime constructor so stdio/MCP readiness compares the manifest against the same product embedding backend as agent repair.
- Kept local-only `ready --goal local --repair` on the generic runtime path; agent repair now uses the shared constructor instead of carrying the defaulting call inline.
- Updated the focused runtime test so the managed ONNX autostart guard covers the shared agent-sidecar constructor.

## How To Review

1. Start in `crates/codestory-cli/src/runtime.rs` and confirm `new_agent_sidecar()` only wraps the existing `prepare_bundled_llamacpp_client_env_defaults()` behavior.
2. Check `crates/codestory-cli/src/main.rs` to verify only agent-facing repair and `serve` switched to that constructor.
3. Confirm explicit user embedding env still wins through the existing `bundled_llamacpp_defaults_preserve_explicit_user_env` test and stale/missing sidecar stdio gates still fail closed.

## Verification

- `cargo test -p codestory-cli runtime::tests::agent_sidecar_runtime_defaults_prevent_managed_onnx_autostart`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls`
- `cargo test -p codestory-cli --test stdio_protocol_contracts tool_calls_block_all_surfaces_when_active_cli_is_stale`
- `cargo test -p codestory-cli --test stdio_protocol_contracts search_tool_fails_closed_without_full_retrieval_sidecars`
- `cargo fmt --check`
- `git diff --check`

External ComiComic proof using this branch's `target\debug\codestory-cli.exe`:

- `ready --goal agent --repair --format json --project C:\Users\alber\source\repos\comicomic`: `agent_packet_search.status=ready`, sidecar `retrieval_mode=full`.
- `retrieval status --format json --project C:\Users\alber\source\repos\comicomic`: `retrieval_mode=full`, `query_embedding_backend=llamacpp:bge-base-en-v1.5`, manifest backend matches, Zoekt/Qdrant/SCIP healthy.
- `serve --stdio --refresh none --project C:\Users\alber\source\repos\comicomic` with `CODESTORY_EMBED_*` removed in the child env: `codestory://status` returned `agent_status=ready`, `retrieval_mode=full`, `allowed_surfaces.search.allowed=true`, no sidecar degraded reason.
- Same stdio session: `tools/call search` for `Reference Studio` returned `isError=false`, no `codestory_tool_blocked`, and 3 hits.

## Risk

Small runtime-construction change. The main risk is over-broad defaulting for non-agent serve use, but `serve` exposes packet/search/context surfaces and explicit user embedding env is preserved by existing default logic.
