### PR TITLE
[codex] guard ambient grounding

### DIFF
--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -16,6 +16,12 @@ CodeStory for status, grounding, file inventory, graph trails, snippets, packet,
 and search. The CLI is still there, but it is the escape hatch and repair
 surface, not the main user experience.
 
+The hook injects guidance, not repository evidence. Agents should first confirm
+they are in a repository with supported files, skip no-op ground output in huge
+or non-code folders, default setup to incremental `ready --goal local --repair`,
+and use `packet`, `search`, or `context` confidently once status reports full
+sidecar readiness.
+
 ## What The Agent Gets
 
 | Agent need | CodeStory surface | Human reading |

--- a/plugins/codestory/hooks/codestory-instructions.js
+++ b/plugins/codestory/hooks/codestory-instructions.js
@@ -7,11 +7,12 @@ const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 
 Before making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
-1. If the CodeStory MCP server is live, read codestory://status first.
-2. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
-3. Use local graph surfaces only when their own allowed_surfaces entry allows them.
-4. Use packet, search, or context only when that surface is allowed and retrieval_mode=full.
-5. If MCP is missing, use codestory-cli ready or doctor as a repair/debug fallback.
+1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
+2. If the CodeStory MCP server is live, read codestory://status first.
+3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
+4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
+5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
+6. If MCP is missing, use codestory-cli ready --goal local --repair as an incremental-by-default setup/repair fallback; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
 
 Do this without waiting for the user to mention CodeStory.`;
 
@@ -30,6 +31,9 @@ function getCodeStoryInstructions() {
   return `CODESTORY BACKGROUND GROUNDING ACTIVE
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
+First confirm the target is a repository with supported files; avoid no-op grounding context in huge or non-code folders.
+When retrieval sidecars are full and allowed, use packet, search, and context confidently.
+Use incremental ready repair as the default setup path once a repository target is known.
 
 ${body}`;
 }

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -11,6 +11,18 @@ agent can stop rediscovering the same files, symbols, and call paths every turn.
 The target is always the repository workspace being grounded. The CodeStory
 checkout is only tool source unless the user is editing CodeStory itself.
 
+## Ambient Scope Guard
+
+Lifecycle hooks provide instructions only; they do not run `ground`, index, or
+sidecar retrieval by themselves.
+
+Before calling CodeStory surfaces, confirm the target is a repository workspace.
+In huge or mixed folders, use repo/workspace cues first. If `status`, `ready`,
+or `ground` reports no repo, no supported files, or zero indexed files, stop the
+CodeStory path for that turn. Do not inject, summarize, or paste empty ground
+output as context. Fall back to ordinary source/file inspection or ask for the
+intended repo path when the target is genuinely ambiguous.
+
 ## Runtime Truth
 
 When plugin MCP is live, `codestory://status` is the first and canonical runtime
@@ -23,7 +35,7 @@ Use status fields this way:
 | `server_version` | Version of the active MCP server binary. | Use as active runtime evidence once MCP is live. |
 | `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
-| `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` only when their own allowed bit is true and `retrieval_mode=full`. |
+| `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 
 Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
 source-build checks only when MCP is missing, the plugin needs repair, or the
@@ -55,7 +67,9 @@ When the plugin MCP server is available:
    `retrieval_mode=full`; use `search` only when
    `allowed_surfaces.search.allowed` is true and `retrieval_mode=full`; use
    `context` only when `allowed_surfaces.context.allowed` is true and
-   `retrieval_mode=full`.
+   `retrieval_mode=full`. Once sidecars are installed and status reports full
+   readiness, prefer these surfaces for broad repo questions instead of
+   avoiding sidecar evidence.
 
 If the skill is visible but no `mcp__codestory` tools or `codestory://status`
 resource are exposed, call it a plugin MCP registration failure. Use CLI only
@@ -68,6 +82,9 @@ CLI directly:
 
 1. `ready --goal local --repair --project <target-workspace> --format json`
    before local navigation or delegation when the index is missing or stale.
+   This setup path is incremental by default; request a full rebuild only for
+   explicit stale-cache, corruption, schema-mismatch, moved-root, or user-chosen
+   reset cases.
 2. `ready --goal agent --repair --project <target-workspace> --format json`
    before packet/search claims when sidecars are missing or stale.
 3. `doctor --project <target-workspace>` for a read-only health transcript.

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -27,7 +27,7 @@ status field points to stale runtime or readiness evidence.
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> doctor --project <target-workspace>` | Reports project root, cache path, indexed stats, retrieval state, sidecar embedding setup, environment hints, and next commands. |
-| Failure path | If cache or index checks warn, run `index --project <target-workspace> --refresh full`; if mandatory sidecars are missing or stale, run the setup/index commands surfaced by `doctor`; if symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, rebuild before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
+| Failure path | If cache or index checks warn, run `ready --goal local --repair --project <target-workspace> --format json` or the setup/index command surfaced by `doctor`; use explicit `index --refresh full` only when the reported failure calls for a rebuild. If mandatory sidecars are missing or stale, run the sidecar setup/index commands surfaced by `doctor`; if symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, repair before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
 | Integration edge | Use doctor before `ground`, `search --why`, `explore`, `context`, or `serve`; its next commands are the safe follow-up loop. | Prevents read commands from silently querying the wrong or empty cache. |
 
 For MCP/runtime drift, collect binary evidence only after status is missing or

--- a/plugins/codestory/skills/codestory-grounding/references/index.md
+++ b/plugins/codestory/skills/codestory-grounding/references/index.md
@@ -28,14 +28,17 @@ synchronizes selected dense anchors when embedding assets are available.
 
 | Mode | Behavior |
 |------|----------|
-| `auto` | Use `full` for an empty cache and `incremental` otherwise. |
+| `auto` | Build the cache when it is empty, then use incremental refresh for existing caches. |
 | `full` | Rebuild the project graph, symbol docs, component reports, and dense anchors from the discovered workspace. |
 | `incremental` | Reindex changed/new/unindexed files, remove disappeared files, and prune touched symbol docs or dense anchors. |
 | `none` | Inspect the existing cache without refreshing it. Use only after a known-good same-session index. |
 
-Use `--refresh full` for first-time indexes, cache/schema uncertainty, and fixes
-for historical indexing failures. Incremental runs can leave stale error rows
-when previously failing files are not touched.
+Keep the default `auto` refresh for ordinary agent setup. It performs the needed
+first build for an empty repository cache and incremental refreshes after that.
+Use explicit `--refresh full` only for diagnosed cache/schema uncertainty,
+historical indexing failures, moved roots, or user-requested rebuild evidence.
+Incremental runs can leave stale error rows when previously failing files are
+not touched.
 
 ## Symbol Docs And Dense Anchors
 
@@ -50,7 +53,8 @@ unstructured docs. On a fresh machine, check the setup plan first:
 ```
 
 Then install assets with `setup embeddings --project <target-workspace>` if the
-plan is acceptable, and rerun `index --refresh full`.
+plan is acceptable, and rerun `index --project <target-workspace>` unless the
+setup plan explicitly asks for a full refresh.
 
 High-signal environment toggles:
 
@@ -87,7 +91,8 @@ Important timing fields are `timings_ms.parse`, `timings_ms.flush`,
 
 ```text
 <codestory-cli> index --project <target-workspace>
-<codestory-cli> index --project <target-workspace> --refresh full
+<codestory-cli> index --project <target-workspace> --refresh incremental
+<codestory-cli> index --project <target-workspace> --refresh full # explicit rebuild
 <codestory-cli> index --project <target-workspace> --dry-run
 <codestory-cli> index --project <target-workspace> --watch --progress
 CODESTORY_SUMMARY_ENDPOINT=local <codestory-cli> index --project <target-workspace> --summarize

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -46,7 +46,7 @@ grounding, packet, or search call.
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
-| Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `index --project <target-workspace> --refresh full`; if bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
+| Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `ready --goal local --repair --project <target-workspace> --format json`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
 | Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `affected`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, `context`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
 
 ## Stdio Runtime Contract

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -137,6 +137,18 @@ test("hook output injects CodeStory grounding context without CLI work", async (
     output.hookSpecificOutput.additionalContext,
     /codestory:\/\/status/u,
   );
+  assert.match(
+    output.hookSpecificOutput.additionalContext,
+    /avoid no-op grounding context/u,
+  );
+  assert.match(
+    output.hookSpecificOutput.additionalContext,
+    /use packet, search, and context confidently/u,
+  );
+  assert.match(
+    output.hookSpecificOutput.additionalContext,
+    /incremental ready repair/u,
+  );
 });
 
 test("portable agent adapters are present", async () => {
@@ -197,6 +209,16 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
       "codestory-grounding",
       "references",
       "serve.md",
+    ),
+    "utf8",
+  );
+  const indexReference = await readFile(
+    join(
+      pluginRoot,
+      "skills",
+      "codestory-grounding",
+      "references",
+      "index.md",
     ),
     "utf8",
   );
@@ -268,6 +290,19 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "`allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full`",
     "`context` is not a local-only browse surface",
   ];
+  const ambientScopeRequired = [
+    "The hook injects guidance, not repository evidence",
+    "skip no-op ground output in huge\nor non-code folders",
+    "Lifecycle hooks provide instructions only; they do not run `ground`, index, or\nsidecar retrieval by themselves",
+    "no repo, no supported files, or zero indexed files",
+    "Do not inject, summarize, or paste empty ground\noutput as context",
+    "incremental by default",
+    "Use `packet`, `search`, and `context` confidently",
+    "Once sidecars are installed and status reports full\n   readiness, prefer these surfaces",
+    "Keep the default `auto` refresh for ordinary agent setup",
+    "Use explicit `--refresh full` only",
+    "ready --goal local --repair --project <target-workspace> --format json",
+  ];
   const forbidden = [
     "release-bound to " + "CodeStory `v" + "0.11.1`",
     "use that version " + "unless",
@@ -319,6 +354,17 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
   }
   for (const phrase of marketplaceSourceRequired) {
     assert.equal(readme.includes(phrase), true, phrase);
+  }
+  for (const phrase of ambientScopeRequired) {
+    assert.equal(
+      readme.includes(phrase) ||
+        skill.includes(phrase) ||
+        indexReference.includes(phrase) ||
+        doctorReference.includes(phrase) ||
+        serveReference.includes(phrase),
+      true,
+      phrase,
+    );
   }
   for (const phrase of ambientHookRequired) {
     assert.equal(readme.includes(phrase), true, phrase);


### PR DESCRIPTION
## Context

The portable adapter rollout made CodeStory ambient for host agents. A post-merge review found three instruction-contract edges that should be explicit: skip no-op grounding in huge non-code folders, trust full sidecar surfaces when status allows them, and make repo setup incremental by default.

Closes #421

## What Changed

- Added an ambient scope guard to the shipped grounding skill: verify the target is a repo, stop on no repo/no supported files/zero indexed files, and do not paste empty ground output.
- Updated the hook fallback and injected preface with the same no-op grounding, sidecar confidence, and incremental-ready rules.
- Updated `index`, `doctor`, and `serve` skill references so ordinary setup uses `ready` or default `auto`; explicit full refresh is reserved for diagnosed rebuild cases.
- Added README wording and static assertions so future adapter changes keep these behaviors.

## How To Review

1. Read `plugins/codestory/hooks/codestory-instructions.js` and confirm the fallback stays instruction-only.
2. Read `plugins/codestory/skills/codestory-grounding/SKILL.md` and the `index`/`doctor`/`serve` references for status-first, incremental-default routing.
3. Read `plugins/codestory/tests/plugin-static.test.mjs` for the regression coverage.

## Verification

- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs` - 8 passed
- `claude plugin validate plugins\\codestory` - passed
- `git diff --check` - passed
- `codex.cmd plugin validate plugins\\codestory` - unavailable in this installed Codex CLI; `codex plugin` does not expose a `validate` subcommand here

## Risk

Docs and hook-message only. The runtime still does not index or retrieve from the lifecycle hook itself.