### PR TITLE
[codex] release CodeStory 0.11.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.11.11
+
+CodeStory 0.11.11 carries the post-adapter guardrail cleanup and release
+metadata sync. Ambient agent instructions now avoid wasting context in huge or
+non-code folders, trust `packet`, `search`, and `context` when status reports
+full sidecar readiness, and keep ordinary setup on incremental/default refresh
+paths before explicit rebuilds.
+
+The plugin package versions are aligned with the CLI release, and the Codex
+plugin category is now Developer Tools.
+
+## 0.11.10
+
+CodeStory 0.11.10 shipped the portable agent adapter source and marketplace
+publication split. The CodeStory repo owns the plugin source, manifests, hooks,
+skill, and runtime docs, while the external marketplace catalog repo owns the
+host marketplace entries.
+
+The adapter hooks inject status-first grounding guidance at session start
+without running indexing, packet, search, or repair work themselves. Claude Code
+and GitHub Copilot host manifests now ship beside the existing Codex plugin
+source.
+
 ## 0.11.9
 
 CodeStory 0.11.9 promotes the plugin grounding consolidation so Codex sessions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",
@@ -17,7 +17,7 @@
     "shortDescription": "Use local CodeStory grounding from Codex",
     "longDescription": "CodeStory gives Codex a local, read-only grounding surface backed by codestory-cli. It exposes the existing CodeStory skill plus the local stdio protocol without duplicating indexing, retrieval, packet, or sidecar logic in the plugin.",
     "developerName": "The Green Cedar",
-    "category": "Coding",
+    "category": "Developer Tools",
     "capabilities": ["Interactive", "Read"],
     "websiteURL": "https://github.com/TheGreenCedar/CodeStory",
     "privacyPolicyURL": "https://github.com/TheGreenCedar/CodeStory",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context

Release CodeStory 0.11.11 after the ambient adapter and grounding guardrail work landed on main.

Closes #423

## What Changed

- Bumped all eight `codestory-*` workspace crates and `Cargo.lock` to `0.11.11`.
- Bumped Codex, Claude Code, and GitHub Copilot plugin manifests to `0.11.11`.
- Updated the changelog with `0.11.11` plus the missing `0.11.10` adapter/catalog entry.
- Moved the Codex plugin category metadata to Developer Tools.

## Verification

- `cargo metadata --format-version 1 --no-deps`
- `python .github\\scripts\\check-codestory-release.py --version 0.11.11`
- `node .github\\scripts\\check-workflow-policy.mjs`
- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs`
- `claude plugin validate plugins\\codestory`
- `python C:\\Users\\alber\\.codex\\skills\\.system\\plugin-creator\\scripts\\validate_plugin.py plugins\\codestory`
- `cargo fmt --check`
- `cargo check --workspace`
- `git diff --check`

## Risk

Metadata and docs-only release bump. No runtime code changed.