### PR TITLE
[codex] report restart after cli repair

### DIFF
--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -20,6 +20,8 @@ pub(crate) struct ReadinessSetupInput {
     pub(crate) active_path: String,
     pub(crate) active_version: String,
     pub(crate) latest_version: String,
+    pub(crate) newer_installed_path: Option<String>,
+    pub(crate) newer_installed_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -115,6 +117,31 @@ fn verdict_state(
     project_arg: &str,
 ) -> (ReadinessStatusDto, String, Vec<String>, Vec<String>) {
     if let Some(setup) = setup {
+        if let (Some(newer_path), Some(newer_version)) = (
+            setup.newer_installed_path.as_ref(),
+            setup.newer_installed_version.as_ref(),
+        ) {
+            let restart = format!(
+                "Restart/reload the Codex host/app so MCP relaunches codestory-cli {newer_version} from {newer_path}; then open a fresh agent thread and read codestory://status."
+            );
+            return (
+                ReadinessStatusDto::RepairSetup,
+                format!(
+                    "Active codestory-cli {} at {} is older than latest release {}; a newer installed codestory-cli {} exists at {}. Restart or reload the host before retrying CodeStory surfaces.",
+                    setup.active_version,
+                    setup.active_path,
+                    setup.latest_version,
+                    newer_version,
+                    newer_path
+                ),
+                vec![restart.clone()],
+                vec![
+                    restart,
+                    "where.exe codestory-cli".to_string(),
+                    "codestory-cli --version".to_string(),
+                ],
+            );
+        }
         let install = format!(
             "powershell -NoProfile -ExecutionPolicy Bypass -Command '$installer = Join-Path $env:TEMP \"install-codestory.ps1\"; Invoke-WebRequest -UseBasicParsing -Uri \"https://raw.githubusercontent.com/TheGreenCedar/CodeStory/v{}/scripts/install-codestory.ps1\" -OutFile $installer; & $installer -Project {project_arg} -Version {}'",
             setup.latest_version, setup.latest_version
@@ -321,6 +348,8 @@ fn readiness_setup_snapshot(input: &ReadinessSetupInput) -> ReadinessSetupSnapsh
         active_path: input.active_path.to_string(),
         active_version: input.active_version.to_string(),
         latest_version: input.latest_version.to_string(),
+        newer_installed_path: input.newer_installed_path.clone(),
+        newer_installed_version: input.newer_installed_version.clone(),
     }
 }
 
@@ -419,6 +448,8 @@ mod tests {
                 active_path: "C:/Users/alber/.local/bin/codestory-cli.exe".to_string(),
                 active_version: "0.11.6".to_string(),
                 latest_version: "0.11.9".to_string(),
+                newer_installed_path: None,
+                newer_installed_version: None,
             }),
             sidecar: Some(ReadinessSidecarInput {
                 retrieval_mode: "full",
@@ -446,6 +477,55 @@ mod tests {
                 verdict.minimum_next[0].contains("install-codestory.ps1")
                     && verdict.minimum_next[0].contains("0.11.9"),
                 "stale CLI repair must be an install action, not advice: {verdict:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn stale_active_cli_with_newer_installed_binary_reports_restart_boundary() {
+        let stats = stats(3);
+        let freshness = freshness(IndexFreshnessStatusDto::Fresh);
+        let verdicts = build_readiness_verdicts(ReadinessInputs {
+            project: "C:/workspace/project",
+            stats: &stats,
+            freshness: Some(&freshness),
+            setup: Some(&ReadinessSetupInput {
+                active_path: "C:/Users/alber/.local/bin/codestory-cli.exe".to_string(),
+                active_version: "0.11.10".to_string(),
+                latest_version: "0.11.12".to_string(),
+                newer_installed_path: Some(
+                    "C:/Users/alber/AppData/Local/CodeStory/bin/codestory-cli.exe".to_string(),
+                ),
+                newer_installed_version: Some("0.11.11".to_string()),
+            }),
+            sidecar: Some(ReadinessSidecarInput {
+                retrieval_mode: "full",
+                degraded_reason: None,
+                manifest_generation: Some("generation"),
+                manifest_input_hash: Some("hash"),
+            }),
+        });
+
+        assert!(
+            verdicts
+                .iter()
+                .all(|verdict| verdict.status == ReadinessStatusDto::RepairSetup),
+            "stale active CLI must remain a setup repair state: {verdicts:?}"
+        );
+        for verdict in verdicts {
+            let setup = verdict.setup.as_ref().expect("setup snapshot");
+            assert_eq!(
+                setup.newer_installed_path.as_deref(),
+                Some("C:/Users/alber/AppData/Local/CodeStory/bin/codestory-cli.exe")
+            );
+            assert_eq!(setup.newer_installed_version.as_deref(), Some("0.11.11"));
+            assert!(
+                verdict.minimum_next[0].contains("Restart/reload the Codex host/app"),
+                "stale CLI with newer installed binary should report the host boundary: {verdict:?}"
+            );
+            assert!(
+                !verdict.minimum_next[0].contains("install-codestory.ps1"),
+                "minimum_next should not repeat the installer after a newer binary is present: {verdict:?}"
             );
         }
     }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -17,6 +17,8 @@ use codestory_contracts::api::{
 };
 use codestory_retrieval::SidecarLayout;
 use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::Duration as StdDuration;
 
 use crate::args;
@@ -2049,13 +2051,140 @@ fn stdio_setup_repair_input(
     let latest = stdio_latest_release_version()?;
     let active = env!("CARGO_PKG_VERSION");
     if compare_semver(active, &latest).is_some_and(|ordering| ordering.is_lt()) {
+        let newer = stdio_newer_installed_cli(active, &latest, server_executable);
         return Some(crate::readiness::ReadinessSetupInput {
             active_path: server_executable.unwrap_or("<unknown>").to_string(),
             active_version: active.to_string(),
             latest_version: latest,
+            newer_installed_path: newer.as_ref().map(|cli| cli.path.clone()),
+            newer_installed_version: newer.map(|cli| cli.version),
         });
     }
     None
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct InstalledCliCandidate {
+    path: String,
+    version: String,
+}
+
+fn stdio_newer_installed_cli(
+    active_version: &str,
+    latest_version: &str,
+    server_executable: Option<&str>,
+) -> Option<InstalledCliCandidate> {
+    if std::env::var("CODESTORY_DISABLE_INSTALLED_CLI_PROBE").is_ok() {
+        return None;
+    }
+    stdio_installed_cli_candidates(latest_version)
+        .into_iter()
+        .filter(|candidate| {
+            server_executable.is_none_or(|active| !same_path_text(candidate, active))
+        })
+        .filter_map(|candidate| stdio_cli_version(&candidate).map(|version| (candidate, version)))
+        .filter(|(_, version)| {
+            compare_semver(version, active_version).is_some_and(|ordering| ordering.is_gt())
+        })
+        .max_by(|left, right| {
+            semver_triplet(&left.1)
+                .unwrap_or_default()
+                .cmp(&semver_triplet(&right.1).unwrap_or_default())
+        })
+        .map(|(path, version)| InstalledCliCandidate { path, version })
+}
+
+fn stdio_installed_cli_candidates(latest_version: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Ok(cli) = std::env::var("CODESTORY_CLI")
+        && !cli.trim().is_empty()
+    {
+        candidates.push(cli);
+    }
+    for home in stdio_codestory_home_candidates() {
+        let bin = home.join("bin");
+        push_cli_candidate_paths(&mut candidates, &bin);
+        push_cli_candidate_paths(&mut candidates, &bin.join("releases").join(latest_version));
+    }
+    dedupe_path_text(candidates)
+}
+
+fn stdio_codestory_home_candidates() -> Vec<PathBuf> {
+    let mut homes = Vec::new();
+    if let Ok(home) = std::env::var("CODESTORY_HOME")
+        && !home.trim().is_empty()
+    {
+        homes.push(PathBuf::from(home));
+    }
+    if let Ok(local_app_data) = std::env::var("LOCALAPPDATA")
+        && !local_app_data.trim().is_empty()
+    {
+        homes.push(PathBuf::from(local_app_data).join("CodeStory"));
+    }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.trim().is_empty()
+    {
+        homes.push(PathBuf::from(home).join(".codestory"));
+    }
+    dedupe_pathbufs(homes)
+}
+
+fn push_cli_candidate_paths(candidates: &mut Vec<String>, directory: &Path) {
+    candidates.push(
+        directory
+            .join(if cfg!(windows) {
+                "codestory-cli.exe"
+            } else {
+                "codestory-cli"
+            })
+            .to_string_lossy()
+            .to_string(),
+    );
+    candidates.push(
+        directory
+            .join("codestory-cli")
+            .to_string_lossy()
+            .to_string(),
+    );
+}
+
+fn stdio_cli_version(candidate: &str) -> Option<String> {
+    let output = Command::new(candidate).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.split_whitespace().find_map(normalize_release_version)
+}
+
+fn same_path_text(left: &str, right: &str) -> bool {
+    left.trim_end_matches(['\\', '/'])
+        .eq_ignore_ascii_case(right.trim_end_matches(['\\', '/']))
+}
+
+fn dedupe_path_text(paths: Vec<String>) -> Vec<String> {
+    let mut deduped: Vec<String> = Vec::new();
+    for path in paths {
+        if path.trim().is_empty() || deduped.iter().any(|seen| same_path_text(seen, &path)) {
+            continue;
+        }
+        deduped.push(path);
+    }
+    deduped
+}
+
+fn dedupe_pathbufs(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut deduped: Vec<PathBuf> = Vec::new();
+    for path in paths {
+        if deduped
+            .iter()
+            .any(|seen| same_path_text(&seen.to_string_lossy(), &path.to_string_lossy()))
+        {
+            continue;
+        }
+        deduped.push(path);
+    }
+    deduped
 }
 
 fn stdio_latest_release_version() -> Option<String> {
@@ -2098,12 +2227,7 @@ fn stdio_status_recommended_next_calls(readiness: &[ReadinessVerdictDto]) -> ser
             non_ready
                 .full_repair
                 .iter()
-                .map(|command| {
-                    serde_json::json!({
-                        "method": "cli",
-                        "command": command
-                    })
-                })
+                .map(|command| stdio_recommended_next_call(command))
                 .chain([
                     serde_json::json!({
                         "method": "resources/read",
@@ -2158,6 +2282,19 @@ fn stdio_status_recommended_next_calls(readiness: &[ReadinessVerdictDto]) -> ser
             "uri": "codestory://trail/<node_id-from-search>"
         }
     ])
+}
+
+fn stdio_recommended_next_call(command: &str) -> serde_json::Value {
+    if command.starts_with("Restart/reload the Codex host/app") {
+        return serde_json::json!({
+            "method": "host/restart",
+            "instruction": command
+        });
+    }
+    serde_json::json!({
+        "method": "cli",
+        "command": command
+    })
 }
 
 fn stdio_server_executable_status() -> (Option<String>, Vec<String>) {
@@ -2522,6 +2659,31 @@ mod tests {
             storage_fingerprint: storage_fingerprint.to_string(),
             ..base_packet_cache_key_input(question)
         })
+    }
+
+    #[test]
+    fn stdio_recommended_next_calls_labels_restart_boundary_as_host_action() {
+        let restart =
+            "Restart/reload the Codex host/app so MCP relaunches codestory-cli 0.11.11 from C:/Users/alber/AppData/Local/CodeStory/bin/codestory-cli.exe; then open a fresh agent thread and read codestory://status."
+                .to_string();
+        let calls = stdio_status_recommended_next_calls(&[ReadinessVerdictDto {
+            goal: ReadinessGoalDto::LocalNavigation,
+            status: ReadinessStatusDto::RepairSetup,
+            summary: "A newer installed codestory-cli exists outside the active process."
+                .to_string(),
+            minimum_next: vec![restart.clone()],
+            full_repair: vec![restart.clone()],
+            setup: None,
+            index: None,
+            sidecar: None,
+        }]);
+
+        assert_eq!(calls[0]["method"], json!("host/restart"));
+        assert_eq!(calls[0]["instruction"], json!(restart));
+        assert!(
+            calls[0].get("command").is_none(),
+            "restart boundary should not be exposed as a CLI command: {calls}"
+        );
     }
 
     #[test]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -13,6 +13,7 @@ struct StdioFixture {
     cache_dir: TempDir,
     hash_embeddings: bool,
     latest_release_version: String,
+    disable_installed_cli_probe: bool,
 }
 
 struct StdioServer {
@@ -132,6 +133,7 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
         cache_dir,
         hash_embeddings,
         latest_release_version: env!("CARGO_PKG_VERSION").to_string(),
+        disable_installed_cli_probe: false,
     }
 }
 
@@ -222,6 +224,9 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
         "CODESTORY_LATEST_RELEASE_VERSION",
         &fixture.latest_release_version,
     );
+    if fixture.disable_installed_cli_probe {
+        command.env("CODESTORY_DISABLE_INSTALLED_CLI_PROBE", "1");
+    }
     let mut child = command.spawn().expect("spawn stdio server");
 
     let stdin = child.stdin.take().expect("stdio stdin");
@@ -2098,6 +2103,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
 fn resources_read_status_blocks_all_surfaces_when_active_cli_is_stale() {
     let mut fixture = indexed_fixture();
     fixture.latest_release_version = "999.0.0".to_string();
+    fixture.disable_installed_cli_probe = true;
     let mut server = spawn_stdio_server(&fixture);
 
     let response = send_json(
@@ -2143,6 +2149,7 @@ fn resources_read_status_blocks_all_surfaces_when_active_cli_is_stale() {
 fn tool_calls_block_all_surfaces_when_active_cli_is_stale() {
     let mut fixture = indexed_fixture();
     fixture.latest_release_version = "999.0.0".to_string();
+    fixture.disable_installed_cli_probe = true;
     let mut server = spawn_stdio_server(&fixture);
 
     for (tool, arguments) in [

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -323,6 +323,10 @@ pub struct ReadinessSetupSnapshotDto {
     pub active_path: String,
     pub active_version: String,
     pub latest_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub newer_installed_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub newer_installed_version: Option<String>,
 }
 
 /// Index state snapshot used inside readiness verdicts.


### PR DESCRIPTION
## Context

Closes #427.

A stale active `codestory-cli serve --stdio` process can stay on an older binary after installer repair succeeds elsewhere. Before this change, readiness kept returning the same installer command because it only knew active version vs latest release.

```mermaid
flowchart LR
    A[Active stdio process stale] --> B{Newer installed CLI found?}
    B -- no --> C[Recommend installer repair]
    B -- yes --> D[Report host restart/reload boundary]
    D --> E[Fresh host launches newer binary]
```

## What Changed

- Added optional `newer_installed_path` and `newer_installed_version` fields to the readiness setup snapshot.
- Taught stdio stale-active setup detection to probe `CODESTORY_CLI` and installer-managed CodeStory home paths for a binary newer than the active process.
- Updated the shared readiness verdict path so a found newer installed binary reports `Restart/reload the Codex host/app...` as `minimum_next` instead of repeating `install-codestory.ps1`.
- Labeled that status recommendation as `method: host/restart` rather than `method: cli`.
- Kept existing installer-loop behavior covered by disabling the installed-binary probe only in the legacy stale-CLI protocol tests.

## How To Review

- Start with `crates/codestory-cli/src/readiness.rs` for the shared verdict behavior.
- Then inspect `crates/codestory-cli/src/stdio_transport.rs` for the installed-binary probe and `recommended_next_calls` mapping.
- Check `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for deterministic protocol coverage of the no-replacement installer path.

## Verification

- `cargo fmt --check` -> passed
- `cargo test -p codestory-cli readiness` -> passed, 13 passed plus filtered integration binaries
- `cargo test -p codestory-cli stdio_recommended_next_calls_labels_restart_boundary_as_host_action` -> passed
- `cargo test -p codestory-cli --test stdio_protocol_contracts` -> passed, 23 passed, 8 ignored live sidecar tests
- `git diff --check` -> passed

## Risk

Low. The probe only runs when the active stdio binary is stale and ignores candidates that do not execute or do not report a version newer than the active process. If no newer installed binary is found, the previous installer guidance remains intact.
