### PR TITLE
[codex] Release CodeStory 0.11.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.11.14
+
+CodeStory 0.11.14 makes plugin lifecycle hooks ambient instead of merely
+instructional. Hook-enabled hosts now keep CodeStory-first grounding in hidden
+context, attempt a strict startup ground snapshot, and attempt request-aware
+packet grounding from the actual user prompt.
+
+Hooks still fail open: missing runtime pieces, degraded retrieval, non-repo
+folders, empty output, or hook-budget timeouts leave next-step guidance instead
+of blocking the agent session.
+
 ## 0.11.13
 
 CodeStory 0.11.13 reports the host restart/reload boundary after a stale

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ For Codex:
 
 Claude Code, GitHub Copilot, and Cursor adapters can load the same
 status-first grounding rules automatically when their host supports hooks or
-project instructions. Codex uses the plugin's MCP server plus the
+project instructions. Hook-enabled hosts keep CodeStory ambient and can attempt
+strict startup grounding plus request-aware packets before the agent opens
+source files. Codex uses the plugin's MCP server plus the
 `@CodeStory` skill.
 
 The plugin launches `codestory-cli serve --stdio --refresh none` on your

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -9,18 +9,22 @@ plans, reviews, or edits a repository. Index once; answer from evidence with
 citations instead of re-exploring the tree on every prompt.
 
 The human job is simple: install the plugin and start a fresh thread in the
-repo. Hosts with lifecycle-hook adapters inject CodeStory's status-first
-grounding rules at session start, so the agent can check readiness before it
-makes source claims without waiting for a special prompt. The agent uses
-CodeStory for status, grounding, file inventory, graph trails, snippets, packet,
-and search. The CLI is still there, but it is the escape hatch and repair
-surface, not the main user experience.
+repo. Hosts with lifecycle-hook adapters keep CodeStory ambient: on session
+start, resume, clear, and compact, the hook injects CodeStory-first grounding
+rules and attempts a strict `ground` snapshot from the session cwd; on each user
+prompt, it attempts a tiny `packet` using that exact prompt. The agent should
+use CodeStory before source files whenever it needs to verify repository facts,
+plan edits, choose tests, or review changes. The CLI is still there, but it is
+the escape hatch and repair surface, not the main user experience.
 
-The hook injects guidance, not repository evidence. Agents should first confirm
-they are in a repository with supported files, skip no-op ground output in huge
-or non-code folders, default setup to incremental `ready --goal local --repair`,
-and use `packet`, `search`, or `context` confidently once status reports full
-sidecar readiness.
+This is strict startup grounding plus request-aware packets, not a random
+repository summary. Hooks fail open. Missing `node`, missing `codestory-cli`, missing MCP, degraded
+sidecars, timeouts, non-repo folders, and empty output must not block the host
+session. If the hook cannot produce useful grounding, it leaves the agent with
+the next CodeStory check to run: usually `codestory://status`, an allowed
+`packet`/`search`/`context` call, or incremental
+`ready --goal local --repair`. Agents still skip no-op ground output in huge
+or non-code folders.
 
 ## What The Agent Gets
 
@@ -54,8 +58,9 @@ This package stays thin:
 - `.codex-plugin/plugin.json` describes the Codex plugin package.
 - `.mcp.json` launches `codestory-cli serve --stdio --refresh none` from the
   agent host `PATH`.
-- `hooks/` injects status-first grounding rules at session start for host
-  adapters that support lifecycle hooks.
+- `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
+  hooks: `SessionStart` attempts strict startup grounding and
+  `UserPromptSubmit` attempts request-aware packet grounding.
 - `skills/codestory-grounding` is the single canonical CodeStory grounding
   skill shipped by this repository.
 
@@ -100,7 +105,10 @@ launches `codestory-cli serve --stdio --refresh none` from `PATH`.
 
 Open the agent host in the repo you want to ground and ask normal repository
 questions. With lifecycle hooks enabled, the agent should first check CodeStory
-status and allowed surfaces before planning or editing.
+status and allowed surfaces before planning, editing, or reading source files.
+If the prompt is concrete enough, the hook should already have supplied a tiny
+packet tied to that exact prompt. Treat that packet as a starting point and
+follow any gaps or next commands before making source claims.
 
 If the host does not expose lifecycle hooks yet, use the explicit prompt:
 

--- a/plugins/codestory/docs/agent-portability.md
+++ b/plugins/codestory/docs/agent-portability.md
@@ -1,13 +1,15 @@
 # Agent Portability
 
 CodeStory ships one grounding skill and thin host adapters. The skill owns the
-runtime rules; adapters only make the rules ambient in hosts that support
-lifecycle hooks or project instruction files.
+runtime rules; adapters make the rules ambient in hosts that support lifecycle
+hooks or project instruction files. Where the host exposes prompt input, the
+hook attempts request-aware packet grounding before the agent opens source
+files.
 
 | Host | Files | Behavior |
 | --- | --- | --- |
 | Codex | `.codex-plugin/plugin.json`, `.mcp.json`, `skills/` | Starts the stdio MCP server and ships the grounding skill. |
-| Claude Code | `.claude-plugin/plugin.json`, `hooks/claude-codex-hooks.json` | Injects status-first grounding rules at session start. |
+| Claude Code | `.claude-plugin/plugin.json`, `hooks/claude-codex-hooks.json` | Attempts strict session grounding and request-aware packet grounding through lifecycle hooks. |
 | GitHub Copilot CLI | `.github/plugin/`, `hooks/copilot-hooks.json`, `skills/` | Injects status-first grounding rules at session start. |
 | GitHub Copilot editor | `.github/copilot-instructions.md` | Repository instruction fallback. |
 | Cursor | `.cursor/rules/codestory.mdc` | Always-on project rule fallback. |
@@ -19,3 +21,4 @@ instructions, keep the copied rule text aligned with the root instruction file.
 Every adapter should preserve the same first check: read `codestory://status`
 when MCP is live, then trust only the surfaces allowed by status. Broad
 `packet`, `search`, and `context` use still requires `retrieval_mode=full`.
+Hooks are best-effort startup context, not a blocking dependency.

--- a/plugins/codestory/hooks/claude-codex-hooks.json
+++ b/plugins/codestory/hooks/claude-codex-hooks.json
@@ -6,10 +6,23 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.js"],
+            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.js\" || exit 0",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.js\" }",
             "timeout": 5,
             "statusMessage": "Loading CodeStory grounding..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.js\" || exit 0",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.js\" }",
+            "timeout": 5,
+            "statusMessage": "Preparing CodeStory packet..."
           }
         ]
       }

--- a/plugins/codestory/hooks/codestory-activate.js
+++ b/plugins/codestory/hooks/codestory-activate.js
@@ -1,10 +1,139 @@
 #!/usr/bin/env node
 
+const { spawnSync } = require('child_process');
 const { getCodeStoryInstructions } = require('./codestory-instructions');
-const { writeHookOutput } = require('./codestory-runtime');
+const { rememberActiveState, writeHookOutput } = require('./codestory-runtime');
 
-try {
-  writeHookOutput('SessionStart', getCodeStoryInstructions());
-} catch (e) {
-  // Best effort only. A hook failure must not block the agent session.
+const MAX_OUTPUT_CHARS = 12000;
+const RUNTIME_TIMEOUT_MS = 3500;
+
+function readHookInput() {
+  return new Promise((resolve) => {
+    let input = '';
+    process.stdin.on('data', (chunk) => { input += chunk; });
+    process.stdin.on('end', () => {
+      if (!input.trim()) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(input.replace(/^\uFEFF/, '')));
+      } catch (e) {
+        resolve({});
+      }
+    });
+  });
 }
+
+function truncate(text) {
+  const value = String(text || '').trim();
+  if (value.length <= MAX_OUTPUT_CHARS) return value;
+  return `${value.slice(0, MAX_OUTPUT_CHARS)}\n\n... CodeStory hook output truncated by hook budget.`;
+}
+
+function hookCommand(input, event) {
+  const project = input.cwd || process.cwd();
+  if (!project) return null;
+
+  if (event === 'UserPromptSubmit' && String(input.prompt || '').trim()) {
+    return {
+      kind: 'request packet',
+      args: [
+        'packet',
+        '--project', project,
+        '--question', String(input.prompt),
+        '--budget', 'tiny',
+        '--refresh', 'none',
+        '--latency-budget-ms', '1500',
+      ],
+      next: 'If the packet is partial or unavailable, read codestory://status and run the packet/search/context follow-up that status allows before opening source files.',
+    };
+  }
+
+  if (event === 'SessionStart') {
+    return {
+      kind: 'session ground',
+      args: [
+        'ground',
+        '--project', project,
+        '--budget', 'strict',
+        '--refresh', 'none',
+      ],
+      next: 'If the ground snapshot is unavailable, read codestory://status and run ready --goal local --repair for the target repo before source reads.',
+    };
+  }
+
+  return null;
+}
+
+function runCodeStory(input, event) {
+  if (process.env.CODESTORY_HOOK_DISABLE_RUNTIME === '1') {
+    return {
+      kind: 'disabled',
+      output: 'Runtime grounding disabled for this hook invocation. The agent must use codestory://status before source reads.',
+    };
+  }
+
+  const command = hookCommand(input, event);
+  if (!command) return null;
+  const cli = process.env.CODESTORY_CLI || 'codestory-cli';
+
+  const result = spawnSync(cli, command.args, {
+    cwd: input.cwd || process.cwd(),
+    encoding: 'utf8',
+    timeout: RUNTIME_TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT_CHARS * 4,
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
+    windowsHide: true,
+  });
+
+  if (result.status === 0 && result.stdout.trim()) {
+    return {
+      kind: command.kind,
+      output: truncate(result.stdout),
+      next: command.next,
+    };
+  }
+
+  const reason = result.error
+    ? result.error.message
+    : truncate(result.stderr || `codestory-cli exited with status ${result.status}`);
+
+  return {
+    kind: command.kind,
+    output: [
+      `CodeStory hook attempted ${command.kind} but did not receive usable output.`,
+      reason ? `Reason: ${reason}` : null,
+      command.next,
+    ].filter(Boolean).join('\n'),
+  };
+}
+
+function buildContext(input, event) {
+  const runtime = runCodeStory(input, event);
+  const parts = [getCodeStoryInstructions(event, input)];
+
+  if (runtime && runtime.output) {
+    parts.push([
+      `CODESTORY HOOK ${runtime.kind.toUpperCase()}`,
+      runtime.output,
+      runtime.next ? `Next: ${runtime.next}` : null,
+    ].filter(Boolean).join('\n\n'));
+  }
+
+  return parts.join('\n\n');
+}
+
+readHookInput().then((input) => {
+  const event = input.hook_event_name || 'SessionStart';
+  try {
+    rememberActiveState({
+      event,
+      cwd: input.cwd || process.cwd(),
+      source: input.source || input.trigger || null,
+    });
+    writeHookOutput(event, buildContext(input, event));
+  } catch (e) {
+    // Best effort only. A hook failure must not block the agent session.
+  }
+});

--- a/plugins/codestory/hooks/codestory-instructions.js
+++ b/plugins/codestory/hooks/codestory-instructions.js
@@ -2,10 +2,11 @@ const fs = require('fs');
 const path = require('path');
 
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'codestory-grounding', 'SKILL.md');
+const MAX_PROMPT_CHARS = 600;
 
 const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 
-Before making source claims, planning edits, choosing tests, or reviewing changes in a repository:
+Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
 2. If the CodeStory MCP server is live, read codestory://status first.
@@ -24,14 +25,43 @@ function skillBody() {
   }
 }
 
-function getCodeStoryInstructions() {
-  const body = skillBody();
-  if (!body) return FALLBACK;
+function compactPrompt(prompt) {
+  const text = String(prompt || '').replace(/\s+/g, ' ').trim();
+  if (text.length <= MAX_PROMPT_CHARS) return text;
+  return `${text.slice(0, MAX_PROMPT_CHARS)}...`;
+}
 
-  return `CODESTORY BACKGROUND GROUNDING ACTIVE
+function eventHeader(event, input = {}) {
+  if (event === 'UserPromptSubmit') {
+    const prompt = compactPrompt(input.prompt);
+    return [
+      'CODESTORY REQUEST GROUNDING ACTIVE',
+      '',
+      'Use CodeStory before source files for this user prompt.',
+      prompt ? `Prompt: ${prompt}` : 'Prompt: unavailable from hook input.',
+      '',
+    ].join('\n');
+  }
+
+  const source = input.source ? ` (${input.source})` : '';
+  return [
+    `CODESTORY SESSION GROUNDING ACTIVE${source}`,
+    '',
+    'Keep CodeStory ambient in this session. Before source reads, claims, edits, reviews, or test choices, check CodeStory status and use allowed grounding surfaces first.',
+    '',
+  ].join('\n');
+}
+
+function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
+  const body = skillBody();
+  if (!body) return `${eventHeader(event, input)}${FALLBACK}`;
+
+  return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-First confirm the target is a repository with supported files; avoid no-op grounding context in huge or non-code folders.
+Before manually opening source files, first read codestory://status when MCP is live, then use the allowed CodeStory surface that fits the task.
+For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
+Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.
 Use incremental ready repair as the default setup path once a repository target is known.
 
@@ -40,5 +70,6 @@ ${body}`;
 
 module.exports = {
   FALLBACK,
+  compactPrompt,
   getCodeStoryInstructions,
 };

--- a/plugins/codestory/hooks/codestory-runtime.js
+++ b/plugins/codestory/hooks/codestory-runtime.js
@@ -1,5 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
 const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
+
+const STATE_FILE = '.codestory-active';
+
+function pluginDataDir() {
+  if (isCodex) return process.env.PLUGIN_DATA;
+  if (isCopilot) return process.env.COPILOT_PLUGIN_DATA;
+  return null;
+}
+
+function rememberActiveState(state) {
+  const stateDir = pluginDataDir();
+  if (!stateDir) return;
+
+  try {
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, STATE_FILE), JSON.stringify({
+      ...state,
+      updatedAt: new Date().toISOString(),
+    }));
+  } catch (e) {
+    // Best effort only. Hook state must not block the host session.
+  }
+}
 
 function writeHookOutput(event, context) {
   if (isCopilot) {
@@ -8,13 +34,16 @@ function writeHookOutput(event, context) {
   }
 
   if (isCodex) {
-    process.stdout.write(JSON.stringify({
+    const output = {
       systemMessage: 'CODESTORY:BACKGROUND',
-      hookSpecificOutput: {
+    };
+    if (context) {
+      output.hookSpecificOutput = {
         hookEventName: event,
         additionalContext: context,
-      },
-    }));
+      };
+    }
+    process.stdout.write(JSON.stringify(output));
     return;
   }
 
@@ -22,5 +51,6 @@ function writeHookOutput(event, context) {
 }
 
 module.exports = {
+  rememberActiveState,
   writeHookOutput,
 };

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -13,8 +13,18 @@ checkout is only tool source unless the user is editing CodeStory itself.
 
 ## Ambient Scope Guard
 
-Lifecycle hooks provide instructions only; they do not run `ground`, index, or
-sidecar retrieval by themselves.
+Lifecycle hooks keep CodeStory ambient in hosts that support them. On session
+start, resume, clear, and compact they inject CodeStory-first grounding rules
+and attempt a strict `ground` snapshot from the session cwd. On user prompts,
+they attempt a tiny `packet` using the actual prompt text. Hook output is
+best-effort and must fail open: missing `node`, missing `codestory-cli`, missing
+MCP, degraded sidecars, timeouts, non-repo folders, and empty output never block
+the host session.
+
+Hook output is a starting packet, not final proof. Before opening source files,
+read `codestory://status` when MCP is live and use the allowed CodeStory
+surface that fits the task. If the hook could not provide useful grounding,
+follow its repair or packet/search/context next step first.
 
 Before calling CodeStory surfaces, confirm the target is a repository workspace.
 In huge or mixed folders, use repo/workspace cues first. If `status`, `ready`,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { access, readFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { access, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, delimiter } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -99,19 +100,18 @@ test("session-start hooks are thin and host manifests point at them", async () =
   const hookScript = /hooks[\\/]([\w.-]+\.(?:js|mjs|cjs|ps1|sh))/u;
 
   assert.equal(copilotHookConfig.hooks.sessionStart.length, 1);
+  assert.equal(hookConfig.hooks.UserPromptSubmit.length, 1);
 
   for (const hook of hookCommands) {
-    assert.equal(hook.command, "node");
-    assert.deepEqual(hook.args, [
-      "${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.js",
-    ]);
+    assert.match(hook.command, /codestory-activate\.js/u);
+    assert.match(hook.commandWindows, /codestory-activate\.js/u);
     assert.equal(
-      Object.hasOwn(hook, "commandWindows"),
+      Object.hasOwn(hook, "args"),
       false,
-      "Claude hook schema does not read commandWindows",
+      "shell-guarded hooks should not rely on args-only launch",
     );
-    const match = hook.args[0].match(hookScript);
-    assert.ok(match, `cannot find hook script in args: ${hook.args[0]}`);
+    const match = `${hook.command}\n${hook.commandWindows}`.match(hookScript);
+    assert.ok(match, `cannot find hook script in command: ${hook.command}`);
     await access(join(pluginRoot, "hooks", match[1]));
   }
 
@@ -119,7 +119,101 @@ test("session-start hooks are thin and host manifests point at them", async () =
   assert.equal(manifest.hooks, "./hooks/claude-codex-hooks.json");
 });
 
-test("hook output injects CodeStory grounding context without CLI work", async () => {
+async function withFakeCodeStoryCli(callback) {
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-test-"));
+  const shPath = join(binDir, "codestory-cli");
+  const cmdPath = join(binDir, "codestory-cli.cmd");
+
+  await writeFile(
+    shPath,
+    "#!/bin/sh\nprintf 'FAKE_CODESTORY_CLI %s\\n' \"$*\"\n",
+    "utf8",
+  );
+  await chmod(shPath, 0o755);
+  await writeFile(
+    cmdPath,
+    "@echo off\r\necho FAKE_CODESTORY_CLI %*\r\n",
+    "utf8",
+  );
+
+  try {
+    await callback(binDir);
+  } finally {
+    await rm(binDir, { recursive: true, force: true });
+  }
+}
+
+test("hook output keeps CodeStory ambient and attempts request-aware grounding", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const hookPath = join(pluginRoot, "hooks", "codestory-activate.js");
+
+  await withFakeCodeStoryCli(async (binDir) => {
+    const fakeCli = process.platform === "win32"
+      ? join(binDir, "codestory-cli.cmd")
+      : join(binDir, "codestory-cli");
+    const env = {
+      ...process.env,
+      CODESTORY_CLI: fakeCli,
+      COPILOT_PLUGIN_DATA: "",
+      PLUGIN_DATA: join(repoRoot, ".tmp-plugin-data"),
+      PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
+    };
+
+    const sessionResult = spawnSync(process.execPath, [hookPath], {
+      env,
+      input: JSON.stringify({
+        hook_event_name: "SessionStart",
+        source: "startup",
+        cwd: repoRoot,
+      }),
+      encoding: "utf8",
+    });
+
+    assert.equal(sessionResult.status, 0, sessionResult.stderr);
+    const sessionOutput = JSON.parse(sessionResult.stdout);
+    assert.equal(sessionOutput.systemMessage, "CODESTORY:BACKGROUND");
+    assert.match(
+      sessionOutput.hookSpecificOutput.additionalContext,
+      /CODESTORY SESSION GROUNDING ACTIVE \(startup\)/u,
+    );
+    assert.match(
+      sessionOutput.hookSpecificOutput.additionalContext,
+      /Before manually opening source files/u,
+    );
+    assert.match(
+      sessionOutput.hookSpecificOutput.additionalContext,
+      /FAKE_CODESTORY_CLI ground --project/u,
+    );
+
+    const promptResult = spawnSync(process.execPath, [hookPath], {
+      env,
+      input: JSON.stringify({
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Where is RefreshMode defined?",
+        cwd: repoRoot,
+      }),
+      encoding: "utf8",
+    });
+
+    assert.equal(promptResult.status, 0, promptResult.stderr);
+    const promptOutput = JSON.parse(promptResult.stdout);
+    assert.equal(promptOutput.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+    assert.match(
+      promptOutput.hookSpecificOutput.additionalContext,
+      /Prompt: Where is RefreshMode defined\?/u,
+    );
+    assert.match(
+      promptOutput.hookSpecificOutput.additionalContext,
+      /FAKE_CODESTORY_CLI packet --project/u,
+    );
+    assert.match(
+      promptOutput.hookSpecificOutput.additionalContext,
+      /--question Where is RefreshMode defined\?/u,
+    );
+  });
+});
+
+test("hook output fails open when runtime grounding is unavailable", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.js");
   const result = spawnSync(process.execPath, [hookPath], {
@@ -127,32 +221,25 @@ test("hook output injects CodeStory grounding context without CLI work", async (
       ...process.env,
       COPILOT_PLUGIN_DATA: "",
       PLUGIN_DATA: join(repoRoot, ".tmp-plugin-data"),
+      PATH: "",
     },
+    input: JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      prompt: "Explain indexing flow.",
+      cwd: repoRoot,
+    }),
     encoding: "utf8",
   });
 
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
-  assert.equal(output.systemMessage, "CODESTORY:BACKGROUND");
   assert.match(
     output.hookSpecificOutput.additionalContext,
-    /CODESTORY BACKGROUND GROUNDING ACTIVE/u,
+    /attempted request packet but did not receive usable output/u,
   );
   assert.match(
     output.hookSpecificOutput.additionalContext,
     /codestory:\/\/status/u,
-  );
-  assert.match(
-    output.hookSpecificOutput.additionalContext,
-    /avoid no-op grounding context/u,
-  );
-  assert.match(
-    output.hookSpecificOutput.additionalContext,
-    /use packet, search, and context confidently/u,
-  );
-  assert.match(
-    output.hookSpecificOutput.additionalContext,
-    /incremental ready repair/u,
   );
 });
 
@@ -251,7 +338,7 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "git-subdir",
   ];
   const ambientHookRequired = [
-    "Hosts with lifecycle-hook adapters inject CodeStory's status-first\ngrounding rules at session start",
+    "Hosts with lifecycle-hook adapters keep CodeStory ambient",
     "With lifecycle hooks enabled, the agent should first check CodeStory\nstatus",
     "If the host does not expose lifecycle hooks yet",
     "Agent Portability",
@@ -296,9 +383,10 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "`context` is not a local-only browse surface",
   ];
   const ambientScopeRequired = [
-    "The hook injects guidance, not repository evidence",
+    "strict startup grounding plus request-aware packets",
+    "Hooks fail open",
+    "Hook output is a starting packet, not final proof",
     "skip no-op ground output in huge\nor non-code folders",
-    "Lifecycle hooks provide instructions only; they do not run `ground`, index, or\nsidecar retrieval by themselves",
     "no repo, no supported files, or zero indexed files",
     "Do not inject, summarize, or paste empty ground\noutput as context",
     "incremental by default",


### PR DESCRIPTION
## Context

Closes #431.
Refs #432.

`0.11.13` made the stale-stdio restart boundary available, and `dev/codestory-next` was moved back to the new main head. The next bug was the hook UX itself: CodeStory hooks were too weak. PR #432 landed the ambient hook behavior on `dev/codestory-next`; this main-based release PR cherry-picks that fix and bumps the release surfaces to `0.11.14`.

## What Changed

- Cherry-picked PR #432's hook behavior:
  - `SessionStart` attempts strict startup grounding from the session cwd.
  - `UserPromptSubmit` attempts `packet --question <actual user prompt>` with a tiny budget.
  - Hook output keeps CodeStory-first instructions in hidden context even when runtime grounding fails.
  - Hooks fail open under missing runtime pieces, degraded retrieval, non-repo folders, empty output, and timeouts.
- Bumped all CodeStory workspace crates, `Cargo.lock`, and plugin manifests to `0.11.14`.
- Added the `0.11.14` changelog entry.

```mermaid
flowchart LR
  A[Hook event] --> B{event}
  B -->|SessionStart| C[strict ground]
  B -->|UserPromptSubmit| D[tiny packet from prompt]
  C --> E[hidden CodeStory context]
  D --> E
  C --> F[fail-open next step]
  D --> F
```

## How To Review

- Compare this PR against #432 for the hook behavior; the only additional change here should be release metadata and changelog.
- Check `crates/codestory-cli/Cargo.toml` as the release version source.
- Check `plugins/codestory/.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, and `.github/plugin/plugin.json` for plugin package version sync.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.14`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `git diff --check`
- `cargo fmt --check`
- `cargo check --workspace`

## Risk

The behavior risk is hook latency: request-aware packets are bounded by a 3.5s child-process budget inside a 5s host hook timeout. That means degraded or slow repos may get a fail-open next step rather than a full packet, which is intentional for lifecycle hooks.
