### PR TITLE
[codex] seed base branch Cargo caches

### DIFF
--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -28,6 +28,34 @@ on:
       - docs/testing/retrieval-architecture.md
       - docker/retrieval-compose.yml
       - .github/workflows/retrieval-sidecar-smoke.yml
+  # Base-branch runs seed caches that sibling PRs are allowed to restore.
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - crates/codestory-retrieval/**
+      - crates/codestory-contracts/**
+      - crates/codestory-store/Cargo.toml
+      - crates/codestory-store/src/**
+      - crates/codestory-cli/src/retrieval.rs
+      - crates/codestory-cli/src/main.rs
+      - crates/codestory-cli/src/args.rs
+      - crates/codestory-cli/src/runtime.rs
+      - crates/codestory-cli/src/stdio_*.rs
+      - crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+      - crates/codestory-cli/tests/search_json_output.rs
+      - crates/codestory-cli/tests/stdio_protocol_contracts.rs
+      - crates/codestory-runtime/src/**
+      - crates/codestory-indexer/Cargo.toml
+      - crates/codestory-indexer/src/lib.rs
+      - scripts/lint-retrieval-generalization.mjs
+      - scripts/**retrieval**
+      - docs/ops/retrieval-sidecars.md
+      - docs/architecture/retrieval-*.md
+      - docs/testing/retrieval-architecture.md
+      - docker/retrieval-compose.yml
+      - .github/workflows/retrieval-sidecar-smoke.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -9,6 +9,18 @@ on:
       - docs/contributors/getting-started.md
       - docs/contributors/testing-matrix.md
       - .github/workflows/rustdoc.yml
+  # Base-branch runs seed caches that sibling PRs are allowed to restore.
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - docs/contributors/getting-started.md
+      - docs/contributors/testing-matrix.md
+      - .github/workflows/rustdoc.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Context

Closes #437.

Recent `retrieval-sidecar-smoke` runs for the release PRs saved useful Cargo caches, but every sibling PR missed them anyway. `gh cache list --json id,key,ref` showed the caches under refs like `refs/pull/436/merge`, `refs/pull/433/merge`, and `refs/pull/430/merge`. GitHub Actions cache scope allows PRs to restore current/base/default-branch caches, but not sibling PR merge-ref caches.

```mermaid
flowchart LR
  A[PR 433 cache] -->|refs/pull/433/merge only| X[PR 436 cannot restore]
  B[main/dev push cache] -->|base/default branch scope| C[next PR restore-keys]
```

## What Changed

- Added trusted `push` triggers for `main` and `dev/codestory-next` to `.github/workflows/retrieval-sidecar-smoke.yml`.
- Added the same base-branch cache seeding trigger to `.github/workflows/rustdoc.yml`, which uses the same Cargo cache pattern and showed the same PR-merge-ref cache behavior.
- Left the existing cache keys intact: OS + workflow lane + stable toolchain + `hashFiles('Cargo.lock')`, with the existing restore prefix. No generated artifacts or lock/toolchain invalidation were broadened.

## How To Review

- Confirm the new `push` path filters match each workflow's existing PR path filters.
- Confirm cache keys and cached paths are unchanged.
- Confirm the comments explain why the base-branch trigger exists.

## Verification

- `codestory-cli ready --goal local --repair --project . --format json` -> local navigation ready, 272 indexed files, sidecar packet/search still unavailable.
- `gh run view 28063022812 --repo TheGreenCedar/CodeStory --log | Select-String ...` -> `Cache not found for Linux-cargo-stable-f0c...` followed by dependency downloads/compiles, then cache save under the PR run.
- `gh cache list --repo TheGreenCedar/CodeStory --limit 20 --json id,key,ref,sizeInBytes,createdAt,lastAccessedAt` -> recent Cargo/rustdoc caches are scoped to `refs/pull/.../merge`.
- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `git diff --check` -> passed.
- `python -c 'import sys, yaml; [yaml.safe_load(open(p, encoding="utf-8")) for p in sys.argv[1:]]; print("yaml parsed")' .github/workflows/retrieval-sidecar-smoke.yml .github/workflows/rustdoc.yml` -> `yaml parsed`.

## Risk

Low. This runs existing workflows on trusted base branch pushes so future PRs can restore allowed caches. It does add CI work after relevant merges. `actionlint` was not installed locally, so syntax validation was limited to YAML parsing plus the repo workflow policy check.