### PR TITLE
[codex] promote cache seeding workflows

### DIFF
--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -28,6 +28,34 @@ on:
       - docs/testing/retrieval-architecture.md
       - docker/retrieval-compose.yml
       - .github/workflows/retrieval-sidecar-smoke.yml
+  # Base-branch runs seed caches that sibling PRs are allowed to restore.
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - crates/codestory-retrieval/**
+      - crates/codestory-contracts/**
+      - crates/codestory-store/Cargo.toml
+      - crates/codestory-store/src/**
+      - crates/codestory-cli/src/retrieval.rs
+      - crates/codestory-cli/src/main.rs
+      - crates/codestory-cli/src/args.rs
+      - crates/codestory-cli/src/runtime.rs
+      - crates/codestory-cli/src/stdio_*.rs
+      - crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+      - crates/codestory-cli/tests/search_json_output.rs
+      - crates/codestory-cli/tests/stdio_protocol_contracts.rs
+      - crates/codestory-runtime/src/**
+      - crates/codestory-indexer/Cargo.toml
+      - crates/codestory-indexer/src/lib.rs
+      - scripts/lint-retrieval-generalization.mjs
+      - scripts/**retrieval**
+      - docs/ops/retrieval-sidecars.md
+      - docs/architecture/retrieval-*.md
+      - docs/testing/retrieval-architecture.md
+      - docker/retrieval-compose.yml
+      - .github/workflows/retrieval-sidecar-smoke.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -9,6 +9,18 @@ on:
       - docs/contributors/getting-started.md
       - docs/contributors/testing-matrix.md
       - .github/workflows/rustdoc.yml
+  # Base-branch runs seed caches that sibling PRs are allowed to restore.
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - docs/contributors/getting-started.md
+      - docs/contributors/testing-matrix.md
+      - .github/workflows/rustdoc.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Context

Closes #439. References #438.

#438 landed on `dev/codestory-next` as `e080bdbf` and proved the base-branch cache-seeding path on `dev/codestory-next` with successful push runs:

- `retrieval-sidecar-smoke` run `28064936408`
- `rustdoc` run `28064936403`

`main` still lacks the same trusted push triggers, so main-branch cache seeding cannot execute until the workflow-only diff is promoted.

This is workflow promotion only. It does not bump CLI, crate, plugin, or marketplace versions.

## What Changed

- Restored `.github/workflows/retrieval-sidecar-smoke.yml` from `origin/dev/codestory-next`.
- Restored `.github/workflows/rustdoc.yml` from `origin/dev/codestory-next`.
- No other files changed.

## How To Review

- Confirm the diff is only the two workflow files from #438.
- Confirm the new `push` filters target `main` and `dev/codestory-next` and preserve the existing path filters.
- Confirm Cargo cache keys and cached paths are unchanged.

## Verification

- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `git diff --check` -> passed.
- `python -c 'import sys, yaml; [yaml.safe_load(open(p, encoding="utf-8")) for p in sys.argv[1:]]; print("yaml parsed")' .github/workflows/retrieval-sidecar-smoke.yml .github/workflows/rustdoc.yml` -> `yaml parsed`.

## Risk

Low. This promotes the already-green #438 workflow diff to `main`. The required remaining proof is post-merge: verify the `main` push runs for `retrieval-sidecar-smoke` and `rustdoc` start and pass, proving main cache seeding executes.
