### PR TITLE
[codex] Fix stdio missing-index startup

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -8156,10 +8156,10 @@ fn render_affected_footer(
 fn run_serve(cmd: ServeCommand) -> Result<()> {
     let runtime = RuntimeContext::new_agent_sidecar(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
-    ensure_index_ready(&opened, "serve")?;
     if cmd.stdio {
         return stdio_transport::run_stdio_server(runtime);
     }
+    ensure_index_ready(&opened, "serve")?;
     let listener = TcpListener::bind(&cmd.addr)
         .with_context(|| format!("Failed to bind server to {}", cmd.addr))?;
     eprintln!("codestory serve listening on http://{}", cmd.addr);

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -103,6 +103,20 @@ fn indexed_fixture() -> StdioFixture {
     indexed_fixture_with_embedding_mode(true)
 }
 
+fn unindexed_fixture() -> StdioFixture {
+    let workspace = tempfile::tempdir().expect("workspace dir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    StdioFixture {
+        workspace,
+        cache_dir,
+        hash_embeddings: true,
+        latest_release_version: env!("CARGO_PKG_VERSION").to_string(),
+        disable_installed_cli_probe: false,
+    }
+}
+
 fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
     let workspace = tempfile::tempdir().expect("workspace dir");
     let cache_dir = tempfile::tempdir().expect("cache dir");
@@ -2096,6 +2110,72 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
             .and_then(Value::as_array)
             .is_some_and(|calls| !calls.is_empty()),
         "status should include recommended next calls: {status}"
+    );
+}
+
+#[test]
+fn stdio_starts_without_index_and_reports_repair_status() {
+    let fixture = unindexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let init_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init-unindexed",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "contract-test", "version": "0"}
+            }
+        }),
+    );
+    assert_success_envelope(&init_response, json!("init-unindexed"));
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-unindexed",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let status_result = assert_success_envelope(&status_response, json!("status-unindexed"));
+    let status = json_resource_content(status_result, "codestory://status");
+    assert_allowed_surface(&status, "ground", false, "local_navigation", "repair_index");
+    assert_allowed_surface(
+        &status,
+        "packet",
+        false,
+        "agent_packet_search",
+        "repair_index",
+    );
+    assert!(
+        status["recommended_next_calls"]
+            .to_string()
+            .contains("codestory-cli ready --goal local --repair"),
+        "unindexed stdio status should recommend local index repair: {status}"
+    );
+
+    let ground_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-unindexed",
+            "method": "tools/call",
+            "params": {"name": "ground", "arguments": {"budget": "balanced"}}
+        }),
+    );
+    let error = assert_tool_error(&ground_response, json!("ground-unindexed"));
+    assert_eq!(
+        error.pointer("/code").and_then(Value::as_str),
+        Some("codestory_tool_blocked")
+    );
+    assert_eq!(
+        error.pointer("/status").and_then(Value::as_str),
+        Some("repair_index")
     );
 }
 

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -46,7 +46,7 @@ grounding, packet, or search call.
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
-| Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `ready --goal local --repair --project <target-workspace> --format json`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
+| Failure path | For HTTP serve, if serve reports missing index, run `doctor --project <target-workspace>` and `ready --goal local --repair --project <target-workspace> --format json`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. For `serve --stdio`, read `codestory://status`: missing index is reported as `repair_index` with repair commands instead of closing the MCP transport. | Distinguishes cache readiness from port conflicts and keeps MCP diagnostics fail-open. |
 | Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `affected`, `packet`, `search`, `symbol`, `trail`, `definition`, `references`, `symbols`, `snippet`, `context`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
 
 ## Stdio Runtime Contract
@@ -66,5 +66,6 @@ stale binary. If PATH changes during repair, start a fresh Codex host/app sessio
 
 - `serve` is local by default on `127.0.0.1`; do not bind wider unless the user explicitly needs remote access.
 - HTTP only accepts GET requests for the documented routes.
-- Start it after a successful index or with an intentional refresh mode.
+- HTTP serve starts after a successful index or with an intentional refresh mode.
+- `serve --stdio` may start without an index so MCP clients can read `codestory://status` and receive repair guidance.
 - In one `serve --stdio` process, identical successful `packet` and search-fragment requests are cached with small LRUs keyed by request arguments, the current SQLite/WAL fingerprint, and a mandatory sidecar-readiness fingerprint. The sidecar fingerprint includes the active embedding backend, sidecar state-file metadata, strict retrieval mode, degraded reason, manifest generation/input hash/backend/dimension, and status errors. This is for repeated agent calls only; changed index files, sidecar state drift, and strict stale/unavailable readiness bypass the cache.


### PR DESCRIPTION
## Context

Refs #441.

This PR fixes one concrete transport-close path found while investigating #441: `codestory-cli serve --stdio --refresh none` used the same eager missing-index gate as HTTP serve. When the MCP host launches the plugin server from a directory with no CodeStory index, the process exits before it can answer `initialize`, `codestory://status`, or a blocked `ground` call. Codex can only report that as a closed transport.

Follow-up review found this is a prerequisite fix, not sufficient closure for #441. Direct stdio `ground` succeeds against the indexed coordinator checkout when `--project C:/Users/alber/source/repos/codestory` is explicit, but the installed plugin `.mcp.json` launches `codestory-cli serve --stdio --refresh none` without a project. If the host launch cwd is the plugin cache, the current installed binary exits before JSON-RPC; with this PR build it stays alive and reports `repair_index` for the plugin cache path. That prevents the hard close, but it still does not ground the coordinator repo.

The remaining #441 layer is MCP project/workspace selection between Codex host/app registration and `codestory-cli serve --stdio` startup.

## What Changed

- Let `serve --stdio` start after opening the runtime even when the selected local index is not ready.
- Kept the existing missing-index hard stop for HTTP `serve`, where there is no MCP status resource to return repair guidance.
- Added a stdio regression that starts an unindexed fixture, completes MCP `initialize`, reads `codestory://status`, and confirms `ground` returns a structured `codestory_tool_blocked` / `repair_index` result.
- Updated the packaged `serve` runbook to document the stdio fail-open repair path.

```mermaid
flowchart LR
    A["MCP host launches serve --stdio"] --> B["Runtime opens selected cwd/project"]
    B --> C["stdio server starts"]
    C --> D["codestory://status"]
    D --> E{"selected project indexed?"}
    E -->|yes| F["ground/files allowed"]
    E -->|no| G["repair_index diagnostic"]
    G --> H["tools/call ground returns structured blocked result"]
```

## How To Review

- Read `run_serve` in `crates/codestory-cli/src/main.rs`; the moved guard should affect only the stdio path.
- Read `stdio_starts_without_index_and_reports_repair_status` in `crates/codestory-cli/tests/stdio_protocol_contracts.rs`; it is the regression for transport closure before diagnostics.
- Check `plugins/codestory/skills/codestory-grounding/references/serve.md` for the operator-facing behavior change.

## Verification

Original PR checks:

- `cargo test -p codestory-cli --test stdio_protocol_contracts stdio_starts_without_index_and_reports_repair_status -- --nocapture` - pass
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls -- --nocapture` - pass
- `cargo test -p codestory-cli --test stdio_protocol_contracts ground_tool_returns_budgeted_grounding_snapshot -- --nocapture` - pass
- `cargo test -p codestory-cli --test stdio_protocol_contracts tool_calls_block_all_surfaces_when_active_cli_is_stale -- --nocapture` - pass
- `cargo test -p codestory-cli --test stdio_protocol_contracts search_tool_fails_closed_without_full_retrieval_sidecars -- --nocapture` - pass
- `cargo fmt --check` - pass
- `git diff --check` - pass
- `node --test plugins\codestory\tests\plugin-static.test.mjs` - pass

Follow-up smoke evidence:

- PR build, explicit indexed coordinator repo: `target/debug/codestory-cli.exe serve --stdio --refresh none --project C:/Users/alber/source/repos/codestory`, then JSON-RPC `initialize`, `tools/list`, `tools/call ground` - pass, 3 responses, `ground` response 57,205 bytes.
- Installed `codestory-cli 0.11.15`, explicit indexed coordinator repo: same JSON-RPC sequence - pass, 3 responses, `ground` response 57,205 bytes.
- Installed `codestory-cli 0.11.15`, plugin cache cwd, no `--project`: exits with code 1 before stdout JSON-RPC; stderr says no indexed files are available for `serve` in the plugin cache path.
- PR build, plugin cache cwd, no `--project`: `initialize`, `codestory://status`, and `tools/call ground` all respond; status reports plugin cache root with `allowed_surfaces.ground.status=repair_index`, and `ground` returns structured `codestory_tool_blocked`.

## Risk

- Keep this PR draft. It fixes a hard transport-close prerequisite, but it does not satisfy #441's acceptance that `mcp__codestory.ground({"budget":"balanced"})` returns grounding for the user's active repository.
- Remaining work needs a project-selection contract for installed MCP launch. The current plugin `.mcp.json` does not pass `--project`, and the repo-owned CLI cannot infer the Codex session workspace unless the host launches it from that workspace or passes a trusted workspace signal.
- HTTP `serve` keeps its existing missing-index failure behavior.
