### PR TITLE
Add managed plugin CLI launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ strict startup grounding plus request-aware packets before the agent opens
 source files. Codex uses the plugin's MCP server plus the
 `@CodeStory` skill.
 
-The plugin launches `codestory-cli serve --stdio --refresh none` on your
-machine. It does not edit your repository. Other local MCP-style clients can
-run the same stdio surface directly. Install details, binary bootstrap, and
-uninstall notes live in the [plugin README](plugins/codestory/README.md).
+The plugin launches a managed MCP adapter that starts
+`codestory-cli serve --stdio --refresh none` on your machine. It does not edit
+your repository. Other local MCP-style clients can run the same stdio surface
+directly. Install details, binary bootstrap, and uninstall notes live in the
+[plugin README](plugins/codestory/README.md).
 
 **Verify without the agent:**
 

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -16,6 +16,8 @@ use codestory_contracts::api::{
     TrailCallerScope, TrailDirection, TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
+use sha2::{Digest, Sha256};
+use std::fs::File;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -2004,7 +2006,9 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         "manifest_generation": manifest_generation.clone(),
         "manifest_input_hash": manifest_input_hash.clone(),
     });
-    let (server_executable, server_warnings) = stdio_server_executable_status();
+    let (server_executable, server_executable_sha256, server_warnings) =
+        stdio_server_executable_status();
+    let plugin_runtime = stdio_plugin_runtime_status();
     let setup_repair = stdio_setup_repair_input(server_executable.as_deref());
     let readiness = crate::readiness::build_readiness_verdicts(crate::readiness::ReadinessInputs {
         project: &summary.root,
@@ -2023,6 +2027,12 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     Ok(serde_json::json!({
         "server_version": env!("CARGO_PKG_VERSION"),
         "server_executable": server_executable,
+        "server_executable_sha256": server_executable_sha256,
+        "plugin_runtime": plugin_runtime,
+        "runtime_boundary": {
+            "restart_required_for_runtime_change": true,
+            "message": "A running MCP server keeps using the CLI process it was launched with; install, override, or PATH changes require a host reload/restart and a fresh codestory://status readback."
+        },
         "warnings": server_warnings,
         "project_root": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
         "storage_path": crate::display::clean_path_string(&runtime.storage_path.to_string_lossy()),
@@ -2297,17 +2307,65 @@ fn stdio_recommended_next_call(command: &str) -> serde_json::Value {
     })
 }
 
-fn stdio_server_executable_status() -> (Option<String>, Vec<String>) {
+fn stdio_server_executable_status() -> (Option<String>, Option<String>, Vec<String>) {
     match std::env::current_exe() {
-        Ok(path) => (
-            Some(crate::display::clean_path_string(&path.to_string_lossy())),
-            Vec::new(),
-        ),
+        Ok(path) => {
+            let display = crate::display::clean_path_string(&path.to_string_lossy());
+            match sha256_file(&path) {
+                Ok(sha256) => (Some(display), Some(sha256), Vec::new()),
+                Err(error) => (
+                    Some(display),
+                    None,
+                    vec![format!("server_executable_checksum_unavailable: {error}")],
+                ),
+            }
+        }
         Err(error) => (
+            None,
             None,
             vec![format!("server_executable_unavailable: {error}")],
         ),
     }
+}
+
+fn stdio_plugin_runtime_status() -> serde_json::Value {
+    let cli_source = env_nonempty("CODESTORY_PLUGIN_CLI_SOURCE")
+        .unwrap_or_else(|| "direct_cli_launch".to_string());
+    let warnings = env_nonempty("CODESTORY_PLUGIN_CLI_WARNINGS")
+        .map(|value| {
+            value
+                .split(';')
+                .filter(|item| !item.trim().is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    serde_json::json!({
+        "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        "cli_source": cli_source,
+        "cli_path": env_nonempty("CODESTORY_PLUGIN_CLI_PATH"),
+        "cli_sha256": env_nonempty("CODESTORY_PLUGIN_CLI_SHA256"),
+        "local_dev_override": cli_source == "local_dev_override",
+        "path_fallback": cli_source == "path_fallback",
+        "managed_binary_path": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_PATH") } else { None },
+        "managed_binary_sha256": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_SHA256") } else { None },
+        "managed_manifest_path": env_nonempty("CODESTORY_PLUGIN_CLI_MANIFEST_PATH"),
+        "warnings": warnings
+    })
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).with_context(|| format!("hash {}", path.display()))?;
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn stdio_allowed_surfaces(readiness: &[ReadinessVerdictDto]) -> serde_json::Value {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2003,6 +2003,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     let sidecar = serde_json::json!({
         "retrieval_mode": sidecar_mode.clone(),
         "degraded_reason": degraded_reason.clone(),
+        "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "manifest_generation": manifest_generation.clone(),
         "manifest_input_hash": manifest_input_hash.clone(),
     });
@@ -2026,8 +2027,10 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     let recommended_next_calls = stdio_status_recommended_next_calls(&readiness);
     Ok(serde_json::json!({
         "server_version": env!("CARGO_PKG_VERSION"),
+        "cli_version": env!("CARGO_PKG_VERSION"),
         "server_executable": server_executable,
         "server_executable_sha256": server_executable_sha256,
+        "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "plugin_runtime": plugin_runtime,
         "runtime_boundary": {
             "restart_required_for_runtime_change": true,
@@ -2342,9 +2345,15 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         .unwrap_or_default();
     serde_json::json!({
         "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        "cli_version": env_nonempty("CODESTORY_PLUGIN_CLI_VERSION"),
         "cli_source": cli_source,
         "cli_path": env_nonempty("CODESTORY_PLUGIN_CLI_PATH"),
         "cli_sha256": env_nonempty("CODESTORY_PLUGIN_CLI_SHA256"),
+        "build_source": env_nonempty("CODESTORY_PLUGIN_CLI_BUILD_SOURCE"),
+        "repo_ref": env_nonempty("CODESTORY_PLUGIN_CLI_REPO_REF"),
+        "archive_sha256": env_nonempty("CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256"),
+        "archive_url": env_nonempty("CODESTORY_PLUGIN_CLI_ARCHIVE_URL"),
+        "provisioned_at": env_nonempty("CODESTORY_PLUGIN_CLI_PROVISIONED_AT"),
         "local_dev_override": cli_source == "local_dev_override",
         "path_fallback": cli_source == "path_fallback",
         "managed_binary_path": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_PATH") } else { None },

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1977,6 +1977,22 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         "status should expose server_executable or an explicit warning: {status}"
     );
     assert!(
+        status["server_executable_sha256"]
+            .as_str()
+            .is_some_and(|sha256| sha256.len() == 64),
+        "status should expose the active server executable checksum: {status}"
+    );
+    assert_eq!(
+        status["runtime_boundary"]["restart_required_for_runtime_change"],
+        json!(true),
+        "status should make the MCP restart boundary explicit: {status}"
+    );
+    assert_eq!(
+        status["plugin_runtime"]["cli_source"],
+        json!("direct_cli_launch"),
+        "direct cargo stdio tests should label the non-plugin launch boundary: {status}"
+    );
+    assert!(
         status
             .get("project_root")
             .or_else(|| status.get("root"))

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1967,6 +1967,19 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         json!(env!("CARGO_PKG_VERSION")),
         "status should identify the serving package version: {status}"
     );
+    assert_eq!(
+        status["cli_version"],
+        json!(env!("CARGO_PKG_VERSION")),
+        "status should identify the active CLI version: {status}"
+    );
+    assert!(
+        status["sidecar_contract_version"].is_number(),
+        "status should expose the sidecar contract version: {status}"
+    );
+    assert!(
+        status["sidecar_retrieval"]["sidecar_contract_version"].is_number(),
+        "sidecar status should expose the sidecar contract version: {status}"
+    );
     assert!(
         status["server_executable"]
             .as_str()

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -11,7 +11,7 @@ packet-runtime, drill, or benchmark evidence tier.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current MCP `server_version`, `server_executable`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `codestory://status` | Current MCP `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -11,7 +11,7 @@ packet-runtime, drill, or benchmark evidence tier.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current MCP `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,8 +13,8 @@ debugging, transcripts, and direct stdio integration.
 
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
-| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `server_executable`, and `allowed_surfaces`. |
+| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
+| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -101,7 +101,8 @@ codestory-cli ground --project <target-workspace> --why
 **Key guidance:**
 
 When MCP is live, use `codestory://status` as the runtime truth. Its
-`server_version` and `server_executable` fields identify the active server, and
+`server_version`, `server_executable`, `server_executable_sha256`, and
+`plugin_runtime` fields identify the active server and plugin launch source, and
 `allowed_surfaces` tells the agent which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
@@ -157,7 +158,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `server_executable`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ debugging, transcripts, and direct stdio integration.
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`. |
+| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -101,8 +101,10 @@ codestory-cli ground --project <target-workspace> --why
 **Key guidance:**
 
 When MCP is live, use `codestory://status` as the runtime truth. Its
-`server_version`, `server_executable`, `server_executable_sha256`, and
-`plugin_runtime` fields identify the active server and plugin launch source, and
+`server_version`, `cli_version`, `server_executable`,
+`server_executable_sha256`, `sidecar_contract_version`, and `plugin_runtime`
+fields identify the active server, CLI, sidecar contract, plugin launch source,
+`build_source`, and `repo_ref`, and
 `allowed_surfaces` tells the agent which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
@@ -158,7 +160,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/plugins/codestory/.mcp.json
+++ b/plugins/codestory/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "codestory": {
-      "command": "codestory-cli",
-      "args": ["serve", "--stdio", "--refresh", "none"],
+      "command": "node",
+      "args": ["./scripts/codestory-mcp.cjs"],
       "tool_timeout_sec": 300
     }
   }

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -50,7 +50,7 @@ running server.
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
@@ -58,9 +58,11 @@ This package stays thin:
 
 - `.codex-plugin/plugin.json` describes the Codex plugin package.
 - `.mcp.json` launches `scripts/codestory-mcp.cjs`, which prefers a
-  checksummed plugin-managed CLI from plugin data, labels `CODESTORY_CLI` as a
-  local-dev override, and only falls back to `PATH` when no managed binary is
-  available.
+  checksummed plugin-managed CLI from plugin data. If none exists, the adapter
+  provisions the current plugin version from the GitHub release
+  `SHA256SUMS.txt`, records `build_source=github_release` and `repo_ref`, labels
+  `CODESTORY_CLI` as a local-dev override, and only falls back to `PATH` when
+  provisioning is unavailable.
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
@@ -122,9 +124,9 @@ If the host does not expose lifecycle hooks yet, use the explicit prompt:
 
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
 live through MCP by reading `codestory://status`. If MCP is live, the agent uses
-`server_version`, `server_executable`, `server_executable_sha256`,
-`plugin_runtime`, and `allowed_surfaces` from status instead of rechecking PATH
-or release metadata.
+`server_version`, `cli_version`, `server_executable`,
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
+`allowed_surfaces` from status instead of rechecking PATH or release metadata.
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
 missing, status reports a suspect runtime, or you are debugging/repairing the
@@ -217,10 +219,12 @@ proof that `packet`, `search`, or `context` is ready.
 ### Agent runtime repair
 
 The plugin launches through `scripts/codestory-mcp.cjs`. That adapter prefers a
-checksummed CLI under plugin-managed data, labels `CODESTORY_CLI` as a
-local-dev override, and reports `path_fallback` if it had to use
-`codestory-cli` from `PATH`. Once MCP is live, `codestory://status` is the
-runtime proof. Use `where.exe codestory-cli`, `codestory-cli --version`, and
+checksummed CLI under plugin-managed data and provisions the current plugin
+version from GitHub release assets when needed. Status reports the plugin
+version, CLI version, binary path/SHA, `build_source`, `repo_ref`, and sidecar
+contract version. `CODESTORY_CLI` stays a local-dev override, and `path_fallback`
+means no managed binary could be used. Once MCP is live, `codestory://status` is
+the runtime proof. Use `where.exe codestory-cli`, `codestory-cli --version`, and
 release repair checks only when MCP is missing or status shows `path_fallback`
 or stale binary drift.
 
@@ -228,10 +232,8 @@ If status reports `repair_setup`, the active CLI is older than the latest
 release. The agent runs the installer command from `recommended_next_calls`
 before using local navigation, packet, search, or context.
 If a running `codestory-cli serve --stdio --refresh none` process locks the old
-binary, install the current release into versioned managed storage or a
-versioned directory before stale `PATH` entries. A Codex host/app restart may be
-needed before a fresh agent thread sees the new launch choice; confirm with a
-fresh `codestory://status` readback.
+binary, let the plugin provision the current release into versioned managed
+storage or install a versioned directory before stale `PATH` entries. Codex host/app restart may be needed before a fresh agent thread sees the new launch choice; confirm with a fresh `codestory://status` readback.
 
 Use source fallback only when no release asset fits the host:
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -41,23 +41,26 @@ or non-code folders.
 
 The status resource is the contract. When MCP is live, read
 `codestory://status` first and obey `allowed_surfaces`. Treat
-`server_version` and `server_executable` from status as the active runtime
-evidence; source docs, marketplace cache contents, and local build outputs can
-all differ from the running server.
+`server_version`, `server_executable`, `server_executable_sha256`, and
+`plugin_runtime` from status as the active runtime evidence; source docs,
+marketplace cache contents, and local build outputs can all differ from the
+running server.
 
 | Status lane | Allows | Does not allow |
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `server_executable`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `server_executable`, `server_executable_sha256`, `plugin_runtime`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
 This package stays thin:
 
 - `.codex-plugin/plugin.json` describes the Codex plugin package.
-- `.mcp.json` launches `codestory-cli serve --stdio --refresh none` from the
-  agent host `PATH`.
+- `.mcp.json` launches `scripts/codestory-mcp.cjs`, which prefers a
+  checksummed plugin-managed CLI from plugin data, labels `CODESTORY_CLI` as a
+  local-dev override, and only falls back to `PATH` when no managed binary is
+  available.
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
@@ -99,7 +102,8 @@ rather than the terminal. Use the UI path when the CLI marketplace command is
 unavailable.
 
 Start a new Codex thread after installation or refresh. The installed package
-launches `codestory-cli serve --stdio --refresh none` from `PATH`.
+launches the managed MCP adapter, which then starts
+`codestory-cli serve --stdio --refresh none`.
 
 ### After install
 
@@ -118,8 +122,9 @@ If the host does not expose lifecycle hooks yet, use the explicit prompt:
 
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
 live through MCP by reading `codestory://status`. If MCP is live, the agent uses
-`server_version`, `server_executable`, and `allowed_surfaces` from status
-instead of rechecking PATH or release metadata.
+`server_version`, `server_executable`, `server_executable_sha256`,
+`plugin_runtime`, and `allowed_surfaces` from status instead of rechecking PATH
+or release metadata.
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
 missing, status reports a suspect runtime, or you are debugging/repairing the
@@ -211,21 +216,22 @@ proof that `packet`, `search`, or `context` is ready.
 
 ### Agent runtime repair
 
-The plugin does not bundle the binary. The installed MCP runtime launches
-`codestory-cli serve --stdio --refresh none` from the agent host `PATH`. Once
-MCP is live, `codestory://status` is the runtime proof. Use
-`where.exe codestory-cli`, `codestory-cli --version`, and release repair checks
-only when MCP is missing or the status fields show stale binary drift.
+The plugin launches through `scripts/codestory-mcp.cjs`. That adapter prefers a
+checksummed CLI under plugin-managed data, labels `CODESTORY_CLI` as a
+local-dev override, and reports `path_fallback` if it had to use
+`codestory-cli` from `PATH`. Once MCP is live, `codestory://status` is the
+runtime proof. Use `where.exe codestory-cli`, `codestory-cli --version`, and
+release repair checks only when MCP is missing or status shows `path_fallback`
+or stale binary drift.
 
 If status reports `repair_setup`, the active CLI is older than the latest
 release. The agent runs the installer command from `recommended_next_calls`
 before using local navigation, packet, search, or context.
 If a running `codestory-cli serve --stdio --refresh none` process locks the old
-binary, install the current release into a versioned directory and put that
-directory before stale entries on `PATH`; verify the command that MCP will
-launch with `codestory-cli --version`. If `PATH` changed, mention restart only
-after the current binary is installed and verified; a Codex host/app restart may
-be needed before a fresh agent thread sees the new `PATH`.
+binary, install the current release into versioned managed storage or a
+versioned directory before stale `PATH` entries. A Codex host/app restart may be
+needed before a fresh agent thread sees the new launch choice; confirm with a
+fresh `codestory://status` readback.
 
 Use source fallback only when no release asset fits the host:
 
@@ -233,9 +239,9 @@ Use source fallback only when no release asset fits the host:
 cargo build --release -p codestory-cli
 ```
 
-Then put `target/release` on the agent host `PATH` for installed MCP runtime
-use. Set `CODESTORY_CLI` only for manual CLI fallback commands or source-build
-debugging; `.mcp.json` does not launch through that variable.
+Then set `CODESTORY_CLI` to the source-built binary for local-dev MCP testing or
+manual CLI fallback commands. Status labels this as `local_dev_override`; do
+not treat it as the installed managed runtime.
 
 Source docs, marketplace source checkout/cache, and the active installed MCP
 runtime can differ. Before claiming an installed behavior is live, verify the

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -1,12 +1,18 @@
 #!/usr/bin/env node
 
 const { spawn } = require('child_process');
+const { spawnSync } = require('child_process');
 const { createHash } = require('crypto');
 const fs = require('fs');
+const https = require('https');
+const os = require('os');
 const path = require('path');
 
 const pluginRoot = path.dirname(__dirname);
 const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codestory-cli';
+const fallbackBinaryNames = process.platform === 'win32'
+  ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
+  : ['codestory-cli'];
 
 function readJson(file) {
   try {
@@ -18,6 +24,19 @@ function readJson(file) {
 
 function fileSha256(file) {
   return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function findFile(root, names) {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isFile() && names.includes(entry.name)) return fullPath;
+    if (entry.isDirectory()) {
+      const found = findFile(fullPath, names);
+      if (found) return found;
+    }
+  }
+  return null;
 }
 
 function pluginVersion() {
@@ -41,10 +60,143 @@ function resolveManifest(manifestPath) {
   if (expected && expected.toLowerCase() !== sha256) {
     return { warning: `managed_cli_checksum_mismatch:${manifestPath}` };
   }
-  return { path: cliPath, sha256, manifestPath };
+  return {
+    path: cliPath,
+    sha256,
+    manifestPath,
+    cliVersion: manifest.version || manifest.cli_version || null,
+    repoRef: manifest.repo_ref || null,
+    buildSource: manifest.build_source || manifest.source || null,
+    archiveSha256: manifest.archive_sha256 || null,
+    archiveUrl: manifest.archive_url || null,
+    provisionedAt: manifest.provisioned_at || null,
+  };
 }
 
-function resolveManagedCli(dataDir, version) {
+function assetTarget() {
+  const platform = process.platform;
+  const arch = process.arch;
+  if (platform === 'win32' && arch === 'x64') return 'windows-x64';
+  if (platform === 'win32' && arch === 'arm64') return 'windows-arm64';
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64';
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64';
+  if (platform === 'darwin' && arch === 'arm64') return 'macos-arm64';
+  return null;
+}
+
+function archiveName(version, target = assetTarget()) {
+  if (!target) return null;
+  const extension = target.startsWith('windows-') ? 'zip' : 'tar.gz';
+  return `codestory-cli-v${version}-${target}.${extension}`;
+}
+
+function expectedArchiveHash(sumsText, name) {
+  for (const line of sumsText.split(/\r?\n/u)) {
+    const match = line.match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/u);
+    if (match && match[2].trim() === name) return match[1].toLowerCase();
+  }
+  throw new Error(`SHA256SUMS.txt did not contain ${name}`);
+}
+
+function copyLocalReleaseFile(releaseDir, name, destination) {
+  fs.copyFileSync(path.join(releaseDir, name), destination);
+}
+
+function downloadFile(url, destination) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+        response.resume();
+        downloadFile(response.headers.location, destination).then(resolve, reject);
+        return;
+      }
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`download failed ${response.statusCode}: ${url}`));
+        return;
+      }
+      const output = fs.createWriteStream(destination);
+      response.pipe(output);
+      output.on('finish', () => output.close(resolve));
+      output.on('error', reject);
+    });
+    request.setTimeout(15000, () => request.destroy(new Error(`download timed out: ${url}`)));
+    request.on('error', reject);
+  });
+}
+
+async function fetchReleaseFile(version, name, destination) {
+  if (process.env.CODESTORY_PLUGIN_RELEASE_DIR) {
+    copyLocalReleaseFile(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name, destination);
+    return `file://${path.join(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name)}`;
+  }
+  const baseUrl = process.env.CODESTORY_PLUGIN_RELEASE_BASE_URL ||
+    `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}`;
+  const url = `${baseUrl.replace(/\/$/u, '')}/${name}`;
+  await downloadFile(url, destination);
+  return url;
+}
+
+function extractArchive(archivePath, destination) {
+  fs.mkdirSync(destination, { recursive: true });
+  const result = spawnSync('tar', ['-xf', archivePath, '-C', destination], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    throw new Error(`tar extract failed: ${result.stderr || result.error?.message || result.status}`);
+  }
+}
+
+async function provisionManagedCli(dataDir, version) {
+  if (!dataDir || !version || process.env.CODESTORY_PLUGIN_DISABLE_PROVISION === '1') return null;
+  const target = assetTarget();
+  const asset = archiveName(version, target);
+  if (!target || !asset) throw new Error(`unsupported_release_target:${process.platform}-${process.arch}`);
+
+  const versionDir = path.join(dataDir, 'codestory-cli', version);
+  const binDir = path.join(versionDir, 'bin');
+  const manifestPath = path.join(versionDir, 'manifest.json');
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codestory-plugin-cli-'));
+  const sumsPath = path.join(tempRoot, 'SHA256SUMS.txt');
+  const archivePath = path.join(tempRoot, asset);
+  const extractDir = path.join(tempRoot, 'extract');
+  try {
+    await fetchReleaseFile(version, 'SHA256SUMS.txt', sumsPath);
+    const archiveUrl = await fetchReleaseFile(version, asset, archivePath);
+    const expected = expectedArchiveHash(fs.readFileSync(sumsPath, 'utf8'), asset);
+    const actual = fileSha256(archivePath);
+    if (actual !== expected) {
+      throw new Error(`archive_checksum_mismatch:${asset}`);
+    }
+    extractArchive(archivePath, extractDir);
+    const extracted = findFile(extractDir, fallbackBinaryNames);
+    if (!extracted) throw new Error(`archive_missing_cli:${asset}`);
+
+    fs.mkdirSync(binDir, { recursive: true });
+    const destination = path.join(binDir, path.basename(extracted));
+    fs.copyFileSync(extracted, destination);
+    if (process.platform !== 'win32') fs.chmodSync(destination, 0o755);
+    const binarySha256 = fileSha256(destination);
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      path: path.relative(versionDir, destination).replace(/\\/gu, '/'),
+      sha256: binarySha256,
+      version,
+      build_source: 'github_release',
+      repo_ref: `v${version}`,
+      archive: asset,
+      archive_url: archiveUrl,
+      archive_sha256: actual,
+      target,
+      provisioned_at: new Date().toISOString(),
+    }, null, 2));
+    return resolveManifest(manifestPath);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function resolveManagedCli(dataDir, version, warnings) {
   if (!dataDir || !version) return null;
   for (const manifestPath of [
     path.join(dataDir, 'codestory-cli', version, 'manifest.json'),
@@ -62,10 +214,15 @@ function resolveManagedCli(dataDir, version) {
       return { path: cliPath, sha256: fileSha256(cliPath), manifestPath: null };
     }
   }
+  try {
+    return await provisionManagedCli(dataDir, version);
+  } catch (error) {
+    warnings.push(`managed_cli_provision_failed:${error.message}`);
+  }
   return null;
 }
 
-function resolveCli() {
+async function resolveCli() {
   const version = pluginVersion();
   const warnings = [];
   if (process.env.CODESTORY_CLI) {
@@ -74,18 +231,36 @@ function resolveCli() {
       path: process.env.CODESTORY_CLI,
       sha256: fs.existsSync(process.env.CODESTORY_CLI) ? fileSha256(process.env.CODESTORY_CLI) : null,
       version,
+      cliVersion: null,
+      repoRef: null,
+      buildSource: 'local_dev_override',
+      archiveSha256: null,
+      archiveUrl: null,
+      provisionedAt: null,
       warnings,
     };
   }
 
-  const managed = resolveManagedCli(pluginDataDir(), version);
+  const managed = await resolveManagedCli(pluginDataDir(), version, warnings);
   if (managed && managed.warning) warnings.push(managed.warning);
   if (managed && managed.path) {
     return { source: 'managed', version, warnings, ...managed };
   }
 
   warnings.push('managed_cli_unavailable_using_path_fallback');
-  return { source: 'path_fallback', path: 'codestory-cli', sha256: null, version, warnings };
+  return {
+    source: 'path_fallback',
+    path: 'codestory-cli',
+    sha256: null,
+    version,
+    cliVersion: null,
+    repoRef: null,
+    buildSource: 'path_fallback',
+    archiveSha256: null,
+    archiveUrl: null,
+    provisionedAt: null,
+    warnings,
+  };
 }
 
 function rememberLaunch(resolved) {
@@ -99,6 +274,12 @@ function rememberLaunch(resolved) {
       sha256: resolved.sha256,
       pluginVersion: resolved.version,
       manifestPath: resolved.manifestPath || null,
+      cliVersion: resolved.cliVersion || null,
+      repoRef: resolved.repoRef || null,
+      buildSource: resolved.buildSource || null,
+      archiveSha256: resolved.archiveSha256 || null,
+      archiveUrl: resolved.archiveUrl || null,
+      provisionedAt: resolved.provisionedAt || null,
       updatedAt: new Date().toISOString(),
     }, null, 2));
   } catch {
@@ -106,30 +287,43 @@ function rememberLaunch(resolved) {
   }
 }
 
-const resolved = resolveCli();
-rememberLaunch(resolved);
+async function main() {
+  const resolved = await resolveCli();
+  rememberLaunch(resolved);
 
-const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
-  stdio: 'inherit',
-  shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
-  windowsHide: true,
-  env: {
-    ...process.env,
-    CODESTORY_PLUGIN_VERSION: resolved.version || '',
-    CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
-    CODESTORY_PLUGIN_CLI_PATH: resolved.path,
-    CODESTORY_PLUGIN_CLI_SHA256: resolved.sha256 || '',
-    CODESTORY_PLUGIN_CLI_MANIFEST_PATH: resolved.manifestPath || '',
-    CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
-  },
-});
+  const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    windowsHide: true,
+    env: {
+      ...process.env,
+      CODESTORY_PLUGIN_VERSION: resolved.version || '',
+      CODESTORY_PLUGIN_CLI_VERSION: resolved.cliVersion || resolved.version || '',
+      CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
+      CODESTORY_PLUGIN_CLI_PATH: resolved.path,
+      CODESTORY_PLUGIN_CLI_SHA256: resolved.sha256 || '',
+      CODESTORY_PLUGIN_CLI_MANIFEST_PATH: resolved.manifestPath || '',
+      CODESTORY_PLUGIN_CLI_BUILD_SOURCE: resolved.buildSource || '',
+      CODESTORY_PLUGIN_CLI_REPO_REF: resolved.repoRef || '',
+      CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256: resolved.archiveSha256 || '',
+      CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
+      CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
+      CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+    },
+  });
 
-child.on('exit', (code, signal) => {
-  if (signal) process.kill(process.pid, signal);
-  process.exit(code || 0);
-});
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    process.exit(code || 0);
+  });
 
-child.on('error', (error) => {
+  child.on('error', (error) => {
+    process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
+    process.exit(1);
+  });
+}
+
+main().catch((error) => {
   process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
   process.exit(1);
 });

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const { createHash } = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const pluginRoot = path.dirname(__dirname);
+const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codestory-cli';
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function fileSha256(file) {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function pluginVersion() {
+  const manifest = readJson(path.join(pluginRoot, '.codex-plugin', 'plugin.json'));
+  return manifest && typeof manifest.version === 'string' ? manifest.version : null;
+}
+
+function pluginDataDir() {
+  return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
+}
+
+function resolveManifest(manifestPath) {
+  const manifest = readJson(manifestPath);
+  if (!manifest) return null;
+  const executable = manifest.executable_path || manifest.executablePath || manifest.path;
+  if (!executable) return null;
+  const cliPath = path.resolve(path.dirname(manifestPath), executable);
+  if (!fs.existsSync(cliPath)) return null;
+  const sha256 = fileSha256(cliPath);
+  const expected = manifest.sha256 || manifest.executable_sha256 || manifest.executableSha256;
+  if (expected && expected.toLowerCase() !== sha256) {
+    return { warning: `managed_cli_checksum_mismatch:${manifestPath}` };
+  }
+  return { path: cliPath, sha256, manifestPath };
+}
+
+function resolveManagedCli(dataDir, version) {
+  if (!dataDir || !version) return null;
+  for (const manifestPath of [
+    path.join(dataDir, 'codestory-cli', version, 'manifest.json'),
+    path.join(dataDir, 'codestory-cli', 'manifest.json'),
+  ]) {
+    const resolved = resolveManifest(manifestPath);
+    if (resolved) return resolved;
+  }
+
+  for (const cliPath of [
+    path.join(dataDir, 'codestory-cli', version, binaryName),
+    path.join(dataDir, 'codestory-cli', version, 'bin', binaryName),
+  ]) {
+    if (fs.existsSync(cliPath)) {
+      return { path: cliPath, sha256: fileSha256(cliPath), manifestPath: null };
+    }
+  }
+  return null;
+}
+
+function resolveCli() {
+  const version = pluginVersion();
+  const warnings = [];
+  if (process.env.CODESTORY_CLI) {
+    return {
+      source: 'local_dev_override',
+      path: process.env.CODESTORY_CLI,
+      sha256: fs.existsSync(process.env.CODESTORY_CLI) ? fileSha256(process.env.CODESTORY_CLI) : null,
+      version,
+      warnings,
+    };
+  }
+
+  const managed = resolveManagedCli(pluginDataDir(), version);
+  if (managed && managed.warning) warnings.push(managed.warning);
+  if (managed && managed.path) {
+    return { source: 'managed', version, warnings, ...managed };
+  }
+
+  warnings.push('managed_cli_unavailable_using_path_fallback');
+  return { source: 'path_fallback', path: 'codestory-cli', sha256: null, version, warnings };
+}
+
+function rememberLaunch(resolved) {
+  const dataDir = pluginDataDir();
+  if (!dataDir) return;
+  try {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, '.codestory-mcp-runtime.json'), JSON.stringify({
+      source: resolved.source,
+      path: resolved.path,
+      sha256: resolved.sha256,
+      pluginVersion: resolved.version,
+      manifestPath: resolved.manifestPath || null,
+      updatedAt: new Date().toISOString(),
+    }, null, 2));
+  } catch {
+    // Best effort only. Launch metadata must not block MCP startup.
+  }
+}
+
+const resolved = resolveCli();
+rememberLaunch(resolved);
+
+const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
+  stdio: 'inherit',
+  shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+  windowsHide: true,
+  env: {
+    ...process.env,
+    CODESTORY_PLUGIN_VERSION: resolved.version || '',
+    CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
+    CODESTORY_PLUGIN_CLI_PATH: resolved.path,
+    CODESTORY_PLUGIN_CLI_SHA256: resolved.sha256 || '',
+    CODESTORY_PLUGIN_CLI_MANIFEST_PATH: resolved.manifestPath || '',
+    CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+  },
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code || 0);
+});
+
+child.on('error', (error) => {
+  process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
+  process.exit(1);
+});

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -44,14 +44,16 @@ Use status fields this way:
 | --- | --- | --- |
 | `server_version` | Version of the active MCP server binary. | Use as active runtime evidence once MCP is live. |
 | `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
+| `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
+| `plugin_runtime` | Plugin launch source and managed CLI metadata. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 
 Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
-source-build checks only when MCP is missing, the plugin needs repair, or the
-user asks for a CLI transcript. `CODESTORY_CLI` is for manual CLI/source
-fallback commands; `.mcp.json` launches `codestory-cli` from the agent host
-`PATH`.
+source-build checks only when MCP is missing, the plugin needs repair, status
+shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
+is an explicit local-dev override; installed `.mcp.json` launches the managed
+adapter first and records the launch source in `plugin_runtime`.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -43,9 +43,11 @@ Use status fields this way:
 | Status field | Meaning | Agent action |
 | --- | --- | --- |
 | `server_version` | Version of the active MCP server binary. | Use as active runtime evidence once MCP is live. |
+| `cli_version` | Version reported by the active CLI runtime. | Use as the active CLI version, not the source checkout version. |
 | `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
 | `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
-| `plugin_runtime` | Plugin launch source and managed CLI metadata. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
+| `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
+| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `build_source` and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 
@@ -53,7 +55,8 @@ Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
 source-build checks only when MCP is missing, the plugin needs repair, status
 shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
 is an explicit local-dev override; installed `.mcp.json` launches the managed
-adapter first and records the launch source in `plugin_runtime`.
+adapter first, provisions from `github_release` when needed, and records the
+launch source in `plugin_runtime`.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -9,11 +9,13 @@ codestory-cli serve --stdio --refresh none
 ```
 
 The installed plugin starts `scripts/codestory-mcp.cjs`, which prefers a
-checksummed plugin-managed CLI and only falls back to `PATH` when no managed
+checksummed plugin-managed CLI, provisions the current version from
+`github_release` when needed, and only falls back to `PATH` when no managed
 binary is available. Once MCP is live, `codestory://status` is the runtime
-truth: use `server_version`, `server_executable`, `server_executable_sha256`,
-`plugin_runtime`, and `allowed_surfaces` from status before any local grounding,
-packet, or search call.
+truth: use `server_version`, `cli_version`, `server_executable`,
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
+`allowed_surfaces` from status before any local grounding, packet, or search
+call.
 
 ## Usage
 
@@ -56,8 +58,10 @@ packet, or search call.
 | Status field | Use |
 |--------------|-----|
 | `server_version` | Active MCP server version. Prefer this over source checkout or package version once MCP is live. |
+| `cli_version` | Active CLI runtime version. |
 | `server_executable` / `server_executable_sha256` | Active MCP server executable path and checksum. Use them to diagnose stale runtime or binary drift. |
-| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. |
+| `sidecar_contract_version` | Active sidecar schema contract version compiled into the CLI. |
+| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. Provisioned records include `build_source=github_release` and `repo_ref`. |
 | `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Allows `packet`, `search`, and `context` only when the surface bit is true and `retrieval_mode=full`. |

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -2,16 +2,18 @@
 
 Serves the indexed project over either a small HTTP JSON API or an MCP-style JSON-lines stdio protocol. It is for local browser/editor integrations after the cache is ready.
 
-For the installed plugin, `.mcp.json` starts:
+For direct MCP-style clients:
 
 ```text
 codestory-cli serve --stdio --refresh none
 ```
 
-The process resolves `codestory-cli` from the agent host `PATH`. Once MCP is
-live, `codestory://status` is the runtime truth: use `server_version`,
-`server_executable`, and `allowed_surfaces` from status before any local
-grounding, packet, or search call.
+The installed plugin starts `scripts/codestory-mcp.cjs`, which prefers a
+checksummed plugin-managed CLI and only falls back to `PATH` when no managed
+binary is available. Once MCP is live, `codestory://status` is the runtime
+truth: use `server_version`, `server_executable`, `server_executable_sha256`,
+`plugin_runtime`, and `allowed_surfaces` from status before any local grounding,
+packet, or search call.
 
 ## Usage
 
@@ -54,13 +56,16 @@ grounding, packet, or search call.
 | Status field | Use |
 |--------------|-----|
 | `server_version` | Active MCP server version. Prefer this over source checkout or package version once MCP is live. |
-| `server_executable` | Active MCP server executable path. Use it to diagnose stale PATH or binary drift. |
+| `server_executable` / `server_executable_sha256` | Active MCP server executable path and checksum. Use them to diagnose stale runtime or binary drift. |
+| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. |
+| `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Allows `packet`, `search`, and `context` only when the surface bit is true and `retrieval_mode=full`. |
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is not
-registered, status is unavailable, or the status executable/version indicates a
-stale binary. If PATH changes during repair, start a fresh Codex host/app session before checking status again.
+registered, status is unavailable, status reports `path_fallback`, or the status
+executable/version indicates a stale binary. If launch inputs change during
+repair, start a fresh Codex host/app session before checking status again.
 
 ## Notes
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -27,6 +27,41 @@ function readCargoVersion(manifestText) {
   assert.fail("Cargo package must declare version");
 }
 
+function releaseAssetForPlatform(version) {
+  const target = process.platform === "win32" && process.arch === "x64"
+    ? "windows-x64"
+    : process.platform === "win32" && process.arch === "arm64"
+      ? "windows-arm64"
+      : process.platform === "linux" && process.arch === "x64"
+        ? "linux-x64"
+        : process.platform === "linux" && process.arch === "arm64"
+          ? "linux-arm64"
+          : process.platform === "darwin" && process.arch === "arm64"
+            ? "macos-arm64"
+            : null;
+  assert.ok(target, `unsupported test platform: ${process.platform}-${process.arch}`);
+  const archiveBase = `codestory-cli-v${version}-${target}`;
+  const archiveName = `${archiveBase}.${target.startsWith("windows-") ? "zip" : "tar.gz"}`;
+  return { archiveBase, archiveName };
+}
+
+async function writeFakeCli(cliPath) {
+  if (process.platform === "win32") {
+    await writeFile(
+      cliPath,
+      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))" %*\r\n`,
+      "utf8",
+    );
+    return;
+  }
+  await writeFile(
+    cliPath,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))' "$@"\n`,
+    "utf8",
+  );
+  await chmod(cliPath, 0o755);
+}
+
 test("plugin metadata maps skill and direct stdio server", async () => {
   const manifest = JSON.parse(
     await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
@@ -95,20 +130,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
 
   try {
     await mkdir(cliDir, { recursive: true });
-    if (process.platform === "win32") {
-      await writeFile(
-        cliPath,
-        `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,args:process.argv.slice(1)}))" %*\r\n`,
-        "utf8",
-      );
-    } else {
-      await writeFile(
-        cliPath,
-        "#!/bin/sh\nnode -e 'require(\"fs\").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,args:process.argv.slice(1)}))' \"$@\"\n",
-        "utf8",
-      );
-      await chmod(cliPath, 0o755);
-    }
+    await writeFakeCli(cliPath);
     const sha256 = createHash("sha256")
       .update(await readFile(cliPath))
       .digest("hex");
@@ -136,6 +158,78 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher provisions a checksummed release asset into plugin data", async (t) => {
+  const { spawnSync } = await import("node:child_process");
+  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
+  if (tarProbe.status !== 0) {
+    t.skip("tar unavailable for archive fixture");
+    return;
+  }
+
+  const version = "0.11.15";
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
+  const outFile = join(dataDir, "env.json");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const { archiveBase, archiveName } = releaseAssetForPlatform(version);
+  const stageDir = join(releaseDir, archiveBase);
+  const cliName = process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli";
+  const cliPath = join(stageDir, cliName);
+  const archivePath = join(releaseDir, archiveName);
+
+  try {
+    await mkdir(stageDir, { recursive: true });
+    await writeFakeCli(cliPath);
+    const packArgs = archiveName.endsWith(".zip")
+      ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
+      : ["-czf", archivePath, "-C", releaseDir, archiveBase];
+    const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
+    assert.equal(pack.status, 0, pack.stderr);
+    const archiveSha256 = createHash("sha256")
+      .update(await readFile(archivePath))
+      .digest("hex");
+    await writeFile(
+      join(releaseDir, "SHA256SUMS.txt"),
+      `${archiveSha256}  ${archiveName}\n`,
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: "",
+        CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
+        PLUGIN_DATA: dataDir,
+        TEST_OUT: outFile,
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const observed = JSON.parse(await readFile(outFile, "utf8"));
+    assert.equal(observed.source, "managed");
+    assert.equal(observed.version, version);
+    assert.equal(observed.repoRef, `v${version}`);
+    assert.equal(observed.buildSource, "github_release");
+    assert.equal(observed.archiveSha256, archiveSha256);
+    assert.match(observed.path, /codestory-cli[\\/]+0\.11\.15[\\/]bin[\\/]codestory-cli/u);
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+
+    const manifest = JSON.parse(
+      await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
+    );
+    assert.equal(manifest.version, version);
+    assert.equal(manifest.repo_ref, `v${version}`);
+    assert.equal(manifest.build_source, "github_release");
+    assert.equal(manifest.archive, archiveName);
+    assert.equal(manifest.archive_sha256, archiveSha256);
+    assert.equal(typeof manifest.sha256, "string");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
   }
 });
 
@@ -434,15 +528,20 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
   const statusRuntimeRequired = [
     "codestory://status",
     "server_version",
+    "cli_version",
     "server_executable",
     "server_executable_sha256",
+    "sidecar_contract_version",
     "plugin_runtime",
+    "build_source",
+    "repo_ref",
     "allowed_surfaces",
   ];
   const cliRepairRequired = ["where.exe codestory-cli", "codestory-cli --version"];
   const stdioLaunchRequired = [
     "codestory-cli serve --stdio --refresh none",
     "scripts/codestory-mcp.cjs",
+    "github_release",
     "path_fallback",
   ];
   const marketplaceSourceRequired = [

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { access, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { dirname, join, delimiter } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -41,12 +42,9 @@ test("plugin metadata maps skill and direct stdio server", async () => {
     manifest.interface.capabilities.includes("Lifecycle hooks"),
     true,
   );
-  assert.equal(mcp.mcpServers.codestory.command, "codestory-cli");
+  assert.equal(mcp.mcpServers.codestory.command, "node");
   assert.deepEqual(mcp.mcpServers.codestory.args, [
-    "serve",
-    "--stdio",
-    "--refresh",
-    "none",
+    "./scripts/codestory-mcp.cjs",
   ]);
   assert.equal(Object.hasOwn(mcp.mcpServers.codestory, "cwd"), false);
 });
@@ -81,9 +79,64 @@ test("codestory repo ships plugin source, not marketplace catalog or server adap
       join(repoRoot, ".agents", "skills", "codestory-grounding", "SKILL.md"),
     ),
   );
-  await assert.rejects(
-    access(join(pluginRoot, "scripts", "codestory-mcp.mjs")),
+  await access(join(pluginRoot, "scripts", "codestory-mcp.cjs"));
+});
+
+test("mcp launcher prefers a checksummed managed cli without PATH", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-cli-"));
+  const outFile = join(dataDir, "env.json");
+  const cliDir = join(dataDir, "codestory-cli", "0.11.15");
+  const cliPath = join(
+    cliDir,
+    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
   );
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    if (process.platform === "win32") {
+      await writeFile(
+        cliPath,
+        `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,args:process.argv.slice(1)}))" %*\r\n`,
+        "utf8",
+      );
+    } else {
+      await writeFile(
+        cliPath,
+        "#!/bin/sh\nnode -e 'require(\"fs\").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,args:process.argv.slice(1)}))' \"$@\"\n",
+        "utf8",
+      );
+      await chmod(cliPath, 0o755);
+    }
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: dataDir,
+        TEST_OUT: outFile,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const observed = JSON.parse(await readFile(outFile, "utf8"));
+    assert.equal(observed.source, "managed");
+    assert.equal(observed.path, cliPath);
+    assert.equal(observed.sha256, sha256);
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
 });
 
 test("session-start hooks are thin and host manifests point at them", async () => {
@@ -382,12 +435,15 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "codestory://status",
     "server_version",
     "server_executable",
+    "server_executable_sha256",
+    "plugin_runtime",
     "allowed_surfaces",
   ];
   const cliRepairRequired = ["where.exe codestory-cli", "codestory-cli --version"];
   const stdioLaunchRequired = [
     "codestory-cli serve --stdio --refresh none",
-    "agent host `PATH`",
+    "scripts/codestory-mcp.cjs",
+    "path_fallback",
   ];
   const marketplaceSourceRequired = [
     "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",
@@ -470,6 +526,7 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "Install details, binary bootstrap",
     "[plugin README](plugins/codestory/README.md)",
     "`codestory-cli serve --stdio --refresh none`",
+    "managed MCP adapter",
     "Codex uses the plugin's MCP server plus the\n`@CodeStory` skill",
   ];
   for (const text of [readme, skill]) {


### PR DESCRIPTION
## Context

Closes https://github.com/TheGreenCedar/CodeStory/issues/442.

The plugin MCP manifest used to launch `codestory-cli serve --stdio --refresh none` directly, so a plugin session depended on whatever `codestory-cli` the agent host found on `PATH`. This PR moves that boundary into the plugin adapter and makes the active runtime/provisioning state visible from `codestory://status`.

## What Changed

- Rebased onto current `dev/codestory-next` after #443 and #450 landed.
- Pointed `plugins/codestory/.mcp.json` at `scripts/codestory-mcp.cjs` instead of launching `codestory-cli` directly.
- Added plugin-managed CLI provisioning in the MCP adapter:
  - `CODESTORY_CLI` remains an explicit `local_dev_override`.
  - existing plugin-data manifests are verified by SHA-256 and reused.
  - when no managed binary exists, the adapter downloads the current plugin version's GitHub release archive plus `SHA256SUMS.txt`, verifies the archive checksum, extracts the CLI into `PLUGIN_DATA/codestory-cli/<version>/bin`, writes a versioned manifest, and launches that binary.
  - `PATH` is only a labeled `path_fallback` when managed provisioning is unavailable.
- Extended `codestory://status` with `cli_version`, `server_executable_sha256`, `sidecar_contract_version`, and richer `plugin_runtime` metadata: plugin version, CLI version, binary path/SHA, `build_source`, `repo_ref`, archive SHA/URL, manifest path, and override/fallback flags.
- Updated plugin/operator docs and focused static/stdout status tests around the new launch contract.

```mermaid
flowchart LR
  Host["Plugin host"] --> Adapter["scripts/codestory-mcp.cjs"]
  Adapter -->|manifest exists| Managed["verified managed CLI"]
  Adapter -->|no manifest| Release["GitHub release + SHA256SUMS"]
  Release --> Managed
  Adapter -->|CODESTORY_CLI| Dev["local_dev_override"]
  Adapter -->|provision unavailable| Path["path_fallback"]
  Managed --> Status["codestory://status plugin_runtime"]
  Dev --> Status
  Path --> Status
```

## How To Review

- Start with `plugins/codestory/scripts/codestory-mcp.cjs` and `plugins/codestory/.mcp.json` to verify launch and provisioning precedence.
- Check `crates/codestory-cli/src/stdio_transport.rs` for the status fields and restart boundary.
- Review `plugins/codestory/tests/plugin-static.test.mjs` for both managed-manifest reuse and provisioning from a checksummed release archive.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` passed: 12 tests.
- `cargo fmt --check` passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls -- --nocapture` passed: 1 test, 30 filtered.
- `git diff --check` passed.

## Risk

Provisioning depends on release assets and `SHA256SUMS.txt` being available for the plugin version and platform. If network, platform, checksum, extraction, or permission checks fail, the adapter does not silently pretend success: it records a provisioning warning and labels the launch as `path_fallback` if it must use ambient `PATH`.
