### PR TITLE
[codex] add agent preflight

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -11,8 +11,8 @@ use codestory_contracts::api::{
     BookmarkCategoryDto, BookmarkDto, ClaimReadinessDto, EvidencePacketDto, GroundingBudgetDto,
     IndexDryRunDto, IndexFreshnessDto, IndexedFileRoleDto, IndexingPhaseTimings, LayoutDirection,
     NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto, ProjectSummary, ReadinessGoalDto,
-    ReadinessVerdictDto, RepoTextScanStatsDto, RetrievalScoreBreakdownDto, RetrievalShadowDto,
-    RetrievalStateDto, SearchHitOrigin, SearchMatchQualityDto, SearchPlanDto,
+    ReadinessStatusDto, ReadinessVerdictDto, RepoTextScanStatsDto, RetrievalScoreBreakdownDto,
+    RetrievalShadowDto, RetrievalStateDto, SearchHitOrigin, SearchMatchQualityDto, SearchPlanDto,
     SearchQueryAssessmentDto, SnippetContextDto, SummaryGenerationDto, SymbolContextDto,
     TrailCallerScope, TrailContextDto, TrailDirection, TrailMode,
 };
@@ -67,6 +67,8 @@ pub(crate) enum Command {
     Doctor(DoctorCommand),
     #[command(about = "Print compact readiness verdicts for local navigation or agent search.")]
     Ready(ReadyCommand),
+    #[command(about = "Agent-facing readiness and repair helpers.")]
+    Agent(AgentCommand),
     #[command(about = "Install or check local setup assets.")]
     Setup(SetupCommand),
     #[command(about = "Prepare or inspect local cache artifacts.")]
@@ -487,6 +489,32 @@ pub(crate) struct ReadyCommand {
     )]
     pub(crate) repair: bool,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct AgentCommand {
+    #[command(subcommand)]
+    pub(crate) action: AgentAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum AgentAction {
+    #[command(about = "Print one JSON contract for safe agent CodeStory surfaces.")]
+    Preflight(AgentPreflightCommand),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct AgentPreflightCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(
         long,
@@ -1296,6 +1324,25 @@ pub(crate) struct IndexOutput<'a> {
 #[derive(Debug, Serialize)]
 pub(crate) struct ReadyOutput {
     pub(crate) verdicts: Vec<ReadinessVerdictDto>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentPreflightLaneOutput {
+    pub(crate) ready: bool,
+    pub(crate) status: ReadinessStatusDto,
+    pub(crate) summary: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentPreflightOutput {
+    pub(crate) usable: bool,
+    pub(crate) mode: String,
+    pub(crate) local_graph: AgentPreflightLaneOutput,
+    pub(crate) full_retrieval: AgentPreflightLaneOutput,
+    pub(crate) safe_surfaces: Vec<String>,
+    pub(crate) blocked_surfaces: Vec<String>,
+    pub(crate) repair_command: Option<String>,
+    pub(crate) human_summary: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -22,10 +22,11 @@ use codestory_contracts::api::{
     EvidenceSourceLocationDto, EvidenceTypeDto, FrameworkRouteCoverageDto, GraphArtifactDto,
     IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode, IndexedFilesRequest, NodeId, NodeKind,
     NodeOccurrencesRequest, PacketBudgetModeDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
-    RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalScoreBreakdownDto,
-    RetrievalShadowDto, SearchHit, SearchMatchQualityDto, SearchQueryAssessmentDto,
-    SearchRepoTextMode, SearchRequest, SourceOccurrenceDto, SourceTruthCheckDto, TrailCallerScope,
-    TrailConfigDto, TrailContextDto, TrailDirection, TrailMode,
+    ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto, RetrievalFallbackReasonDto,
+    RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit, SearchMatchQualityDto,
+    SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest, SourceOccurrenceDto,
+    SourceTruthCheckDto, TrailCallerScope, TrailConfigDto, TrailContextDto, TrailDirection,
+    TrailMode,
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -182,6 +183,7 @@ fn main() -> Result<()> {
         Command::Packet(cmd) => run_packet(cmd),
         Command::Doctor(cmd) => run_doctor(cmd),
         Command::Ready(cmd) => run_ready(cmd),
+        Command::Agent(cmd) => run_agent(cmd),
         Command::Setup(cmd) => run_setup(cmd),
         Command::Cache(cmd) => run_cache(cmd),
         Command::Search(cmd) => run_search(cmd),
@@ -1266,6 +1268,29 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
 
+fn run_agent(cmd: args::AgentCommand) -> Result<()> {
+    match cmd.action {
+        args::AgentAction::Preflight(cmd) => run_agent_preflight(cmd),
+    }
+}
+
+fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, "agent preflight")?;
+    preflight_output_file(cmd.output_file.as_deref())?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let summary = runtime.open_project_summary()?;
+    let sidecar = doctor_sidecar_status(&runtime);
+    let readiness = build_summary_readiness(
+        &summary.root,
+        &summary.stats,
+        summary.freshness.as_ref(),
+        &sidecar,
+    );
+    let output = build_agent_preflight_output(&readiness);
+    let markdown = render_agent_preflight_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
 fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -> Result<()> {
     let opened = runtime.ensure_open(args::RefreshMode::Auto)?;
     ensure_index_ready(&opened, "ready repair")?;
@@ -1301,6 +1326,114 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
     codestory_retrieval::strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
         .context("ready repair final retrieval status")?;
     Ok(())
+}
+
+const LOCAL_GRAPH_AGENT_SURFACES: &[&str] =
+    &["ground", "files", "symbol", "trail", "snippet", "affected"];
+const FULL_RETRIEVAL_AGENT_SURFACES: &[&str] = &["packet_full", "search_full", "context_full"];
+
+fn build_agent_preflight_output(
+    readiness: &[codestory_contracts::api::ReadinessVerdictDto],
+) -> args::AgentPreflightOutput {
+    let local = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation)
+        .expect("local_navigation readiness verdict");
+    let agent = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::AgentPacketSearch)
+        .expect("agent_packet_search readiness verdict");
+    let local_ready = local.status == ReadinessStatusDto::Ready;
+    let full_ready = agent.status == ReadinessStatusDto::Ready;
+    let mut safe_surfaces = Vec::new();
+    let mut blocked_surfaces = Vec::new();
+
+    if local_ready {
+        safe_surfaces.extend(surface_strings(LOCAL_GRAPH_AGENT_SURFACES));
+    } else {
+        blocked_surfaces.extend(surface_strings(LOCAL_GRAPH_AGENT_SURFACES));
+    }
+    if full_ready {
+        safe_surfaces.extend(surface_strings(FULL_RETRIEVAL_AGENT_SURFACES));
+    } else {
+        blocked_surfaces.extend(surface_strings(FULL_RETRIEVAL_AGENT_SURFACES));
+    }
+
+    let mode = if full_ready {
+        "full_retrieval"
+    } else if local_ready {
+        "local_graph"
+    } else {
+        "blocked"
+    };
+    let repair_command = readiness::primary_non_ready(readiness)
+        .and_then(|verdict| verdict.full_repair.first().cloned());
+    let human_summary = agent_preflight_summary(local_ready, full_ready, local);
+
+    args::AgentPreflightOutput {
+        usable: local_ready || full_ready,
+        mode: mode.to_string(),
+        local_graph: agent_preflight_lane(local),
+        full_retrieval: agent_preflight_lane(agent),
+        safe_surfaces,
+        blocked_surfaces,
+        repair_command,
+        human_summary,
+    }
+}
+
+fn surface_strings(surfaces: &[&str]) -> Vec<String> {
+    surfaces
+        .iter()
+        .map(|surface| (*surface).to_string())
+        .collect()
+}
+
+fn agent_preflight_lane(
+    verdict: &codestory_contracts::api::ReadinessVerdictDto,
+) -> args::AgentPreflightLaneOutput {
+    args::AgentPreflightLaneOutput {
+        ready: verdict.status == ReadinessStatusDto::Ready,
+        status: verdict.status,
+        summary: verdict.summary.clone(),
+    }
+}
+
+fn agent_preflight_summary(
+    local_ready: bool,
+    full_ready: bool,
+    local: &codestory_contracts::api::ReadinessVerdictDto,
+) -> String {
+    match (local_ready, full_ready) {
+        (_, true) => "Local graph and full retrieval are ready.".to_string(),
+        (true, false) => "Local graph is ready. Full retrieval needs sidecar repair.".to_string(),
+        (false, _) => format!(
+            "Local graph is not ready: {} Full retrieval is also unavailable for agent packet/search.",
+            local.summary
+        ),
+    }
+}
+
+fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(markdown, "# Agent Preflight");
+    let _ = writeln!(markdown, "usable: `{}`", output.usable);
+    let _ = writeln!(markdown, "mode: `{}`", output.mode);
+    let _ = writeln!(
+        markdown,
+        "local_graph: {}",
+        readiness::status_label(output.local_graph.status)
+    );
+    let _ = writeln!(
+        markdown,
+        "full_retrieval: {}",
+        readiness::status_label(output.full_retrieval.status)
+    );
+    let _ = writeln!(markdown, "human_summary: {}", output.human_summary);
+    if let Some(command) = output.repair_command.as_deref() {
+        let _ = writeln!(markdown, "repair_command: `{command}`");
+    }
+    markdown
 }
 
 fn run_search(cmd: SearchCommand) -> Result<()> {

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -733,6 +733,61 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
 }
 
 #[test]
+fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+
+    let preflight = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["agent", "preflight", "--format", "json"],
+    );
+
+    assert_eq!(preflight["usable"], true, "{preflight:#}");
+    assert_eq!(preflight["mode"], "local_graph", "{preflight:#}");
+    assert_eq!(preflight["local_graph"]["ready"], true, "{preflight:#}");
+    assert_eq!(
+        preflight["full_retrieval"]["status"], "repair_retrieval",
+        "{preflight:#}"
+    );
+    assert!(
+        preflight["safe_surfaces"]
+            .as_array()
+            .expect("safe surfaces")
+            .iter()
+            .any(|surface| surface == "ground"),
+        "local graph surfaces should be safe: {preflight:#}"
+    );
+    assert!(
+        preflight["blocked_surfaces"]
+            .as_array()
+            .expect("blocked surfaces")
+            .iter()
+            .any(|surface| surface == "packet_full"),
+        "full retrieval surfaces should be blocked: {preflight:#}"
+    );
+    assert!(
+        preflight["repair_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("ready --goal agent --repair")),
+        "preflight should point at the existing agent repair path: {preflight:#}"
+    );
+    assert!(
+        preflight["human_summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("Local graph is ready")),
+        "preflight should include a human summary: {preflight:#}"
+    );
+}
+
+#[test]
 fn doctor_reports_current_and_stored_semantic_doc_embedding_contract() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,6 +105,15 @@ When MCP is live, use `codestory://status` as the runtime truth. Its
 `allowed_surfaces` tells the agent which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
+When MCP is not live, use the CLI preflight contract instead:
+
+```sh
+codestory-cli agent preflight --project <target-workspace> --format json
+```
+
+Use its `safe_surfaces`, `blocked_surfaces`, and `repair_command` fields as the
+agent handoff.
+
 **Next steps after installation:**
 
 If the agent reports that local graph surfaces are allowed but `packet`,

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -9,11 +9,11 @@ const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, read codestory://status first.
+2. If the CodeStory MCP server is live, read codestory://status first; otherwise run codestory-cli agent preflight --project <repo> --format json.
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
-6. If MCP is missing, use codestory-cli ready --goal local --repair as an incremental-by-default setup/repair fallback; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
+6. If MCP is missing, use the preflight repair_command as the setup/repair fallback; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
 
 Do this without waiting for the user to mention CodeStory.`;
 
@@ -59,11 +59,11 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live, then use the allowed CodeStory surface that fits the task.
+Before manually opening source files, first read codestory://status when MCP is live; when it is not, run codestory-cli agent preflight --project <repo> --format json and use the reported safe_surfaces.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.
-Use incremental ready repair as the default setup path once a repository target is known.
+Use the preflight repair_command as the default setup path once a repository target is known.
 
 ${body}`;
 }


### PR DESCRIPTION
## Context

Closes #443.

Agents currently have to stitch together `doctor`, `ready`, retrieval status, and MCP status to decide what CodeStory surfaces are safe. This adds the narrow CLI contract requested by the issue without changing existing doctor/ready readiness computation.

## What Changed

- Added `codestory-cli agent preflight --project <repo> --format json`.
- Reused existing `local_navigation` and `agent_packet_search` readiness verdicts to emit:
  - `usable`
  - `mode`
  - `local_graph`
  - `full_retrieval`
  - `safe_surfaces`
  - `blocked_surfaces`
  - `repair_command`
  - `human_summary`
- Added a golden-path regression for the local-graph-ready / retrieval-degraded case.
- Updated usage docs and hook guidance so agents can use preflight when MCP status is unavailable.

## How To Review

1. Start in `crates/codestory-cli/src/main.rs` at `run_agent_preflight` and `build_agent_preflight_output`.
2. Confirm the command only consumes existing readiness verdicts from `build_summary_readiness`.
3. Check `crates/codestory-cli/tests/cli_golden_path.rs` for the degraded retrieval contract.
4. Check `docs/usage.md` and `plugins/codestory/hooks/codestory-instructions.cjs` for the agent-facing handoff wording.

## Verification

- `cargo fmt`
- `cargo test -p codestory-cli --test cli_golden_path agent_preflight_reports_local_graph_when_retrieval_is_degraded -- --nocapture`
- `cargo test -p codestory-cli args::tests`
- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs`
- `cargo build --release -p codestory-cli`
- `target\\release\\codestory-cli.exe agent preflight --project 'C:\\Users\\alber\\.codex\\worktrees\\f3c1\\codestory' --format json`
- `git diff --check`

## Risk

Low. The new command is a thin read-only wrapper around existing readiness verdicts. It does not change doctor, ready, indexing, retrieval repair, or packet/search execution behavior. The only notable choice is the compact surface vocabulary: full retrieval surfaces are reported as `packet_full`, `search_full`, and `context_full` so local graph readiness cannot be confused with sidecar-backed proof.