### PR TITLE
[codex] key Cargo caches by Rust release

### DIFF
--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -82,6 +82,12 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
@@ -91,8 +97,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
             ${{ runner.os }}-cargo-stable-
 
       - name: Runtime sidecar and packet contract tests
@@ -136,6 +143,12 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        run: |
+          $release = rustc -Vv | Select-String '^release: ' | ForEach-Object { $_.ToString().Substring(9) }
+          "version=$release" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
@@ -145,8 +158,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
             ${{ runner.os }}-cargo-stable-
 
       - name: Retrieval bootstrap manifest-missing contract

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -43,6 +43,12 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
@@ -52,8 +58,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-rustdoc-stable-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-
             ${{ runner.os }}-rustdoc-stable-
 
       - name: Deny rustdoc warnings


### PR DESCRIPTION
## Context

Closes #450.

The current workflows already cache Cargo registry/git data and `target`, and base-branch seeding is live on `main` and `dev/codestory-next`. Hosted evidence showed the pre-fix cache path was working after #437/#439, but the key still used moving `stable` instead of the resolved compiler release:

- `retrieval-sidecar-smoke` base push `28064936408`: cache miss on `Linux-cargo-stable-f0c993...`, downloaded crates, compiled cold, then saved the cache.
- Later PR run `28067741011`: exact hit on `Linux-cargo-stable-f0c993...`, restored about 886 MB including `target`, and skipped save.
- `rustdoc` PR run `28067741035`: exact hit on `Linux-rustdoc-stable-f0c993...`, restored about 284 MB, and finished docs in about 6s.

Remaining cache-key bug: both workflows install moving `stable`, but the cache key only said `stable`. When Rust stable advances without a `Cargo.lock` change, Actions can restore an exact old compiler cache, Cargo recompiles against the new compiler, and the save step skips because the old key was still an exact hit. That leaves repeat recompiles until another input changes the key.

```mermaid
flowchart LR
  A[install stable] --> B[capture rustc release]
  B --> C[restore cache by OS + channel + rustc release + Cargo.lock]
  C --> D{exact hit?}
  D -->|yes| E[run tests/docs without saving]
  D -->|no| F[reuse broader cache if any]
  F --> G[save fresh release-specific cache]
```

## What Changed

- Added a `Capture Rust cache key` step after Rust installation in `retrieval-sidecar-smoke` Linux and Windows jobs.
- Added the same capture step in `rustdoc`.
- Added the captured `rustc` release to Cargo cache primary keys, while keeping broader restore keys so the first run after a compiler bump can reuse older downloads/build output and then save a fresh versioned cache.

## How To Review

- Confirm the only changed surfaces are `.github/workflows/retrieval-sidecar-smoke.yml` and `.github/workflows/rustdoc.yml`.
- Confirm the cache primary key now includes `${{ steps.rust-cache-key.outputs.version }}`.
- Confirm the broader `*-stable-` restore key remains for first-run reuse after Rust stable changes.

## Verification

- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `python -c 'import sys, yaml; [yaml.safe_load(open(p, encoding="utf-8")) for p in sys.argv[1:]]; print("yaml parsed")' .github/workflows/retrieval-sidecar-smoke.yml .github/workflows/rustdoc.yml` -> `yaml parsed`.
- `git diff --check` -> passed.
- PR #452 `retrieval-sidecar-smoke` run `28068744973` -> `linux-contracts` passed in 2m9s; restored old broader key `Linux-cargo-stable-f0c993...`, then saved new key `Linux-cargo-stable-1.96.0-f0c993...`.
- PR #452 `rustdoc` run `28068745014` -> passed in 25s; restored old broader key `Linux-rustdoc-stable-f0c993...`, then saved new key `Linux-rustdoc-stable-1.96.0-f0c993...`.
- Saga issue-link guard passed; Windows manifest-missing job skipped by existing label/dispatch gate.

## Risk

Low. The first run for a newly observed Rust release may still rebuild after restoring a broader cache, but it now saves the new release-specific primary key so subsequent unchanged runs stop repeating that compiler-version mismatch work.
