### PR TITLE
[codex] Rewrite docs around golden agent path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,37 @@ Per-task medians, ranges, reproduction commands, and boundary notes:
 
 ## Quick start
 
-The normal path is an **agent plugin** backed by the local stdio server. The
-CLI is for setup, repair, debugging, and transcripts.
+The golden path is: preflight the repo, install the **agent plugin**, then let
+the plugin's MCP server and hooks keep CodeStory ambient. The CLI is for
+preflight, repair, debugging, and transcripts.
 
 For Codex:
 
-1. Open Codex in the repository you want to ground.
-2. Run `/plugins`, then install **TheGreenCedar → codestory**.
+1. In the repository you want to ground, run:
+
+   ```sh
+   codestory-cli agent preflight --project <repo> --format json
+   ```
+
+   Use `safe_surfaces`, `blocked_surfaces`, and `repair_command` as the
+   handoff. If local graph surfaces are blocked, run the repair command first.
+   If only `packet`, `search`, or `context` is blocked, local navigation can
+   still proceed while sidecars are repaired later.
+
+2. Open Codex in that repository, run `/plugins`, then install
+   **TheGreenCedar → codestory**.
 3. Start a fresh thread and ask:
 
-```text
-@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
-```
+   ```text
+   @CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+   ```
 
 Claude Code, GitHub Copilot, and Cursor adapters can load the same
 status-first grounding rules automatically when their host supports hooks or
-project instructions. Hook-enabled hosts keep CodeStory ambient and can attempt
-strict startup grounding plus request-aware packets before the agent opens
-source files. Codex uses the plugin's MCP server plus the
+project instructions. Hook-enabled hosts keep CodeStory ambient: they ground on
+session start, try request-aware grounding on user prompts, carry guidance
+through resume/clear/compact handoffs, and fail open with the next CodeStory
+check to run. Codex uses the plugin's MCP server plus the
 `@CodeStory` skill.
 
 The plugin launches a managed MCP adapter that starts
@@ -56,7 +69,7 @@ directly. Install details, binary bootstrap, and uninstall notes live in the
 **Verify without the agent:**
 
 ```sh
-codestory-cli doctor --project <repo>
+codestory-cli agent preflight --project <repo> --format json
 ```
 
 **If install or MCP fails:** marketplace registration, CLI bootstrap, and host restart notes live in the [plugin README](plugins/codestory/README.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,17 +6,19 @@ last turn. CodeStory indexes once and serves evidence from that map so the agent
 can answer from citations instead of re-exploring the tree.
 
 Start with the human task, then run the smallest path that proves the state you
-need. The agent plugin is the normal path. The CLI is for setup, repair,
-debugging, transcripts, and direct stdio integration.
+need. The golden path is CLI preflight first, then the agent plugin/MCP/hooks
+path. The CLI is otherwise for repair, debugging, transcripts, and direct stdio
+integration.
 
 ## Operator Journey
 
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
+| Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
+| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
-| Broad discovery | Ask a repo-wide question. | Use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
+| Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
 
 Packet/search output from degraded retrieval, missing sidecars, stale manifests,
@@ -25,6 +27,11 @@ or any non-`full` retrieval mode is navigation help only. It is not proof.
 Most humans should start from the plugin flow in
 [README - Quick start](../README.md#quick-start). Use the CLI when you need the
 exact setup, repair, or debug record.
+
+Hook-enabled hosts keep CodeStory ambient. Hooks attempt strict grounding on
+session start, resume, clear, and compact handoff; they attempt request-aware
+packet grounding on each user prompt; and they fail open with the next
+CodeStory check instead of blocking the host.
 
 ### Example prompts
 
@@ -72,8 +79,19 @@ environment variables with `$env:NAME = "value"`.
 
 ## Install And Ground A Repo
 
-Install the CodeStory plugin once, then start a fresh agent thread for the
-workspace you want to ground. The canonical skill package lives at
+Run the CLI preflight in the workspace first:
+
+```sh
+codestory-cli agent preflight --project <target-workspace> --format json
+```
+
+Use its `safe_surfaces`, `blocked_surfaces`, and `repair_command` fields as the
+agent handoff. If local graph surfaces are blocked, run the repair command
+before source work. If only `packet`, `search`, or `context` is blocked, local
+navigation can continue while sidecars are repaired later.
+
+Install the CodeStory plugin once, then start a fresh agent thread for that
+workspace. The canonical skill package lives at
 [../plugins/codestory/skills/codestory-grounding/SKILL.md](../plugins/codestory/skills/codestory-grounding/SKILL.md).
 
 **Codex plugin installation flow:**
@@ -89,6 +107,7 @@ workspace you want to ground. The canonical skill package lives at
 **Direct CLI transcript (for setup, repair, or debugging):**
 
 ```sh
+codestory-cli agent preflight --project <target-workspace> --format json
 codestory-cli ready --goal local --repair --project <target-workspace> --format json
 codestory-cli ground --project <target-workspace> --why
 ```

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -8,14 +8,23 @@ CodeStory gives a coding agent a local, read-only grounding surface before it
 plans, reviews, or edits a repository. Index once; answer from evidence with
 citations instead of re-exploring the tree on every prompt.
 
-The human job is simple: install the plugin and start a fresh thread in the
-repo. Hosts with lifecycle-hook adapters keep CodeStory ambient: on session
-start, resume, clear, and compact, the hook injects CodeStory-first grounding
-rules and attempts a strict `ground` snapshot from the session cwd; on each user
-prompt, it attempts a tiny `packet` using that exact prompt. The agent should
-use CodeStory before source files whenever it needs to verify repository facts,
-plan edits, choose tests, or review changes. The CLI is still there, but it is
-the escape hatch and repair surface, not the main user experience.
+The human job is simple: run agent preflight in the repo, install the plugin,
+and start a fresh thread there.
+
+```sh
+codestory-cli agent preflight --project <repo> --format json
+```
+
+Use `safe_surfaces`, `blocked_surfaces`, and `repair_command` as the handoff.
+Then let the plugin path take over.
+Hosts with lifecycle-hook adapters keep CodeStory ambient. On session start,
+resume, clear, and compact, the hook
+injects CodeStory-first grounding rules and attempts a strict `ground` snapshot
+from the session cwd; on each user prompt, it attempts a tiny `packet` using
+that exact prompt. The agent should use CodeStory before source files whenever
+it needs to verify repository facts, plan edits, choose tests, or review
+changes. The CLI is still there, but it is the escape hatch and repair surface,
+not the main user experience.
 
 This is strict startup grounding plus request-aware packets, not a random
 repository summary. Hooks fail open. Missing `node`, missing `codestory-cli`, missing MCP, degraded
@@ -75,8 +84,18 @@ CLI/MCP runtime.
 
 ## Install For Agent Use
 
-For normal Codex use, install the plugin through the Codex plugin flow for your
-workspace. Open Codex in the repo you want to ground, then use:
+For normal Codex use, first preflight the repo:
+
+```bash
+codestory-cli agent preflight --project <repo> --format json
+```
+
+If local graph surfaces are blocked, run the emitted `repair_command` before
+source work. If only `packet`, `search`, or `context` is blocked, local
+navigation can continue while sidecars are repaired later.
+
+Then install the plugin through the Codex plugin flow for your workspace. Open
+Codex in the repo you want to ground, then use:
 
 ```text
 /plugins
@@ -192,6 +211,7 @@ Use the CLI when the agent needs to repair setup, produce a transcript, or debug
 why the MCP server is not ready:
 
 ```console
+codestory-cli agent preflight --project <repo> --format json
 where.exe codestory-cli
 codestory-cli --version
 codestory-cli ready --goal local --repair --project <repo> --format json

--- a/plugins/codestory/docs/agent-portability.md
+++ b/plugins/codestory/docs/agent-portability.md
@@ -1,10 +1,17 @@
 # Agent Portability
 
-CodeStory ships one grounding skill and thin host adapters. The skill owns the
-runtime rules; adapters make the rules ambient in hosts that support lifecycle
-hooks or project instruction files. Where the host exposes prompt input, the
-hook attempts request-aware packet grounding before the agent opens source
-files.
+CodeStory ships one grounding skill and thin host adapters. The user-facing
+path is one flow: run agent preflight, install the plugin or adapter, then let
+MCP plus hooks keep CodeStory ambient.
+
+```sh
+codestory-cli agent preflight --project <repo> --format json
+```
+
+The skill owns the runtime rules; adapters make the rules ambient in hosts that
+support lifecycle hooks or project instruction files. Where the host exposes
+prompt input, the hook attempts request-aware packet grounding before the agent
+opens source files.
 
 | Host | Files | Behavior |
 | --- | --- | --- |
@@ -21,4 +28,6 @@ instructions, keep the copied rule text aligned with the root instruction file.
 Every adapter should preserve the same first check: read `codestory://status`
 when MCP is live, then trust only the surfaces allowed by status. Broad
 `packet`, `search`, and `context` use still requires `retrieval_mode=full`.
-Hooks are best-effort startup context, not a blocking dependency.
+Hooks ground on session start, resume, clear, and compact handoff; attempt
+request-aware grounding on user prompts; and fail open with the next CodeStory
+check instead of blocking the host.


### PR DESCRIPTION
## Context
Issue #445 asks the adopter/operator docs to stop spreading the first-run story across diagnostics, retrieval modes, and internals. A new reader should see one agent path first and understand that CodeStory uses plugin hooks.

Closes #445

## What Changed
- Reworked the root README quick start around `codestory-cli agent preflight --project <repo> --format json`, then plugin install, fresh thread, MCP, and hook behavior.
- Updated `docs/usage.md` so the operator journey starts with preflight and describes startup/request-aware/fail-open hooks before the repair lanes.
- Aligned the plugin README and portability doc with the same preflight -> plugin/MCP/hooks path while leaving stale runtime, PATH drift, sidecar repair, and restart guidance in the repair sections.

## How To Review
- Read `README.md#quick-start` first and verify it gives one blessed adopter flow.
- Check `docs/usage.md#operator-journey` for the detailed operator path and trust boundaries.
- Check `plugins/codestory/README.md` and `plugins/codestory/docs/agent-portability.md` for matching plugin/hook wording.

## Verification
- `git diff --check HEAD~1..HEAD` passed.
- `node --test plugins\codestory\tests\plugin-static.test.mjs` passed: 12 tests.
- `cargo run --quiet -p codestory-cli -- agent preflight --project . --format json` exited 0 and returned the documented JSON contract; this worktree reported `repair_index`, so no packet/search readiness was claimed.

## Risk
Docs-only. Main residual risk is wording drift if the active installed binary or plugin-managed runtime changes again before this lands.