### PR TITLE
[codex] release 0.11.16

### DIFF
--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -82,6 +82,12 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
@@ -91,8 +97,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
             ${{ runner.os }}-cargo-stable-
 
       - name: Runtime sidecar and packet contract tests
@@ -136,6 +143,12 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        run: |
+          $release = rustc -Vv | Select-String '^release: ' | ForEach-Object { $_.ToString().Substring(9) }
+          "version=$release" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
@@ -145,8 +158,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
             ${{ runner.os }}-cargo-stable-
 
       - name: Retrieval bootstrap manifest-missing contract

--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -28,6 +28,34 @@ on:
       - docs/testing/retrieval-architecture.md
       - docker/retrieval-compose.yml
       - .github/workflows/retrieval-sidecar-smoke.yml
+  # Base-branch runs seed caches that sibling PRs are allowed to restore.
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - crates/codestory-retrieval/**
+      - crates/codestory-contracts/**
+      - crates/codestory-store/Cargo.toml
+      - crates/codestory-store/src/**
+      - crates/codestory-cli/src/retrieval.rs
+      - crates/codestory-cli/src/main.rs
+      - crates/codestory-cli/src/args.rs
+      - crates/codestory-cli/src/runtime.rs
+      - crates/codestory-cli/src/stdio_*.rs
+      - crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+      - crates/codestory-cli/tests/search_json_output.rs
+      - crates/codestory-cli/tests/stdio_protocol_contracts.rs
+      - crates/codestory-runtime/src/**
+      - crates/codestory-indexer/Cargo.toml
+      - crates/codestory-indexer/src/lib.rs
+      - scripts/lint-retrieval-generalization.mjs
+      - scripts/**retrieval**
+      - docs/ops/retrieval-sidecars.md
+      - docs/architecture/retrieval-*.md
+      - docs/testing/retrieval-architecture.md
+      - docker/retrieval-compose.yml
+      - .github/workflows/retrieval-sidecar-smoke.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -43,6 +43,12 @@ jobs:
           rustup toolchain install stable --profile minimal
           rustup default stable
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
@@ -52,8 +58,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-rustdoc-stable-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-
             ${{ runner.os }}-rustdoc-stable-
 
       - name: Deny rustdoc warnings

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -9,6 +9,18 @@ on:
       - docs/contributors/getting-started.md
       - docs/contributors/testing-matrix.md
       - .github/workflows/rustdoc.yml
+  # Base-branch runs seed caches that sibling PRs are allowed to restore.
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - docs/contributors/getting-started.md
+      - docs/contributors/testing-matrix.md
+      - .github/workflows/rustdoc.yml
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.11.16
+
+CodeStory 0.11.16 promotes the current `dev/codestory-next` release slice:
+agent preflight JSON output, Rust release-aware Cargo cache keys,
+plugin-managed versioned CLI provisioning with `codestory://status` runtime
+metadata, and the golden agent path docs for explicit hook behavior.
+
+This release is a promotion and metadata sync only. It does not add new backlog
+features or claim new packet/search readiness beyond the existing sidecar
+evidence tiers.
+
 ## 0.11.15
 
 CodeStory 0.11.15 fixes installed hook execution in Codex plugin caches that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/README.md
+++ b/README.md
@@ -27,24 +27,37 @@ Per-task medians, ranges, reproduction commands, and boundary notes:
 
 ## Quick start
 
-The normal path is an **agent plugin** backed by the local stdio server. The
-CLI is for setup, repair, debugging, and transcripts.
+The golden path is: preflight the repo, install the **agent plugin**, then let
+the plugin's MCP server and hooks keep CodeStory ambient. The CLI is for
+preflight, repair, debugging, and transcripts.
 
 For Codex:
 
-1. Open Codex in the repository you want to ground.
-2. Run `/plugins`, then install **TheGreenCedar → codestory**.
+1. In the repository you want to ground, run:
+
+   ```sh
+   codestory-cli agent preflight --project <repo> --format json
+   ```
+
+   Use `safe_surfaces`, `blocked_surfaces`, and `repair_command` as the
+   handoff. If local graph surfaces are blocked, run the repair command first.
+   If only `packet`, `search`, or `context` is blocked, local navigation can
+   still proceed while sidecars are repaired later.
+
+2. Open Codex in that repository, run `/plugins`, then install
+   **TheGreenCedar → codestory**.
 3. Start a fresh thread and ask:
 
-```text
-@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
-```
+   ```text
+   @CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+   ```
 
 Claude Code, GitHub Copilot, and Cursor adapters can load the same
 status-first grounding rules automatically when their host supports hooks or
-project instructions. Hook-enabled hosts keep CodeStory ambient and can attempt
-strict startup grounding plus request-aware packets before the agent opens
-source files. Codex uses the plugin's MCP server plus the
+project instructions. Hook-enabled hosts keep CodeStory ambient: they ground on
+session start, try request-aware grounding on user prompts, carry guidance
+through resume/clear/compact handoffs, and fail open with the next CodeStory
+check to run. Codex uses the plugin's MCP server plus the
 `@CodeStory` skill.
 
 The plugin launches a managed MCP adapter that starts
@@ -56,7 +69,7 @@ directly. Install details, binary bootstrap, and uninstall notes live in the
 **Verify without the agent:**
 
 ```sh
-codestory-cli doctor --project <repo>
+codestory-cli agent preflight --project <repo> --format json
 ```
 
 **If install or MCP fails:** marketplace registration, CLI bootstrap, and host restart notes live in the [plugin README](plugins/codestory/README.md).

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ strict startup grounding plus request-aware packets before the agent opens
 source files. Codex uses the plugin's MCP server plus the
 `@CodeStory` skill.
 
-The plugin launches `codestory-cli serve --stdio --refresh none` on your
-machine. It does not edit your repository. Other local MCP-style clients can
-run the same stdio surface directly. Install details, binary bootstrap, and
-uninstall notes live in the [plugin README](plugins/codestory/README.md).
+The plugin launches a managed MCP adapter that starts
+`codestory-cli serve --stdio --refresh none` on your machine. It does not edit
+your repository. Other local MCP-style clients can run the same stdio surface
+directly. Install details, binary bootstrap, and uninstall notes live in the
+[plugin README](plugins/codestory/README.md).
 
 **Verify without the agent:**
 

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -11,8 +11,8 @@ use codestory_contracts::api::{
     BookmarkCategoryDto, BookmarkDto, ClaimReadinessDto, EvidencePacketDto, GroundingBudgetDto,
     IndexDryRunDto, IndexFreshnessDto, IndexedFileRoleDto, IndexingPhaseTimings, LayoutDirection,
     NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto, ProjectSummary, ReadinessGoalDto,
-    ReadinessVerdictDto, RepoTextScanStatsDto, RetrievalScoreBreakdownDto, RetrievalShadowDto,
-    RetrievalStateDto, SearchHitOrigin, SearchMatchQualityDto, SearchPlanDto,
+    ReadinessStatusDto, ReadinessVerdictDto, RepoTextScanStatsDto, RetrievalScoreBreakdownDto,
+    RetrievalShadowDto, RetrievalStateDto, SearchHitOrigin, SearchMatchQualityDto, SearchPlanDto,
     SearchQueryAssessmentDto, SnippetContextDto, SummaryGenerationDto, SymbolContextDto,
     TrailCallerScope, TrailContextDto, TrailDirection, TrailMode,
 };
@@ -67,6 +67,8 @@ pub(crate) enum Command {
     Doctor(DoctorCommand),
     #[command(about = "Print compact readiness verdicts for local navigation or agent search.")]
     Ready(ReadyCommand),
+    #[command(about = "Agent-facing readiness and repair helpers.")]
+    Agent(AgentCommand),
     #[command(about = "Install or check local setup assets.")]
     Setup(SetupCommand),
     #[command(about = "Prepare or inspect local cache artifacts.")]
@@ -487,6 +489,32 @@ pub(crate) struct ReadyCommand {
     )]
     pub(crate) repair: bool,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct AgentCommand {
+    #[command(subcommand)]
+    pub(crate) action: AgentAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum AgentAction {
+    #[command(about = "Print one JSON contract for safe agent CodeStory surfaces.")]
+    Preflight(AgentPreflightCommand),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct AgentPreflightCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(
         long,
@@ -1296,6 +1324,25 @@ pub(crate) struct IndexOutput<'a> {
 #[derive(Debug, Serialize)]
 pub(crate) struct ReadyOutput {
     pub(crate) verdicts: Vec<ReadinessVerdictDto>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentPreflightLaneOutput {
+    pub(crate) ready: bool,
+    pub(crate) status: ReadinessStatusDto,
+    pub(crate) summary: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentPreflightOutput {
+    pub(crate) usable: bool,
+    pub(crate) mode: String,
+    pub(crate) local_graph: AgentPreflightLaneOutput,
+    pub(crate) full_retrieval: AgentPreflightLaneOutput,
+    pub(crate) safe_surfaces: Vec<String>,
+    pub(crate) blocked_surfaces: Vec<String>,
+    pub(crate) repair_command: Option<String>,
+    pub(crate) human_summary: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -22,10 +22,11 @@ use codestory_contracts::api::{
     EvidenceSourceLocationDto, EvidenceTypeDto, FrameworkRouteCoverageDto, GraphArtifactDto,
     IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode, IndexedFilesRequest, NodeId, NodeKind,
     NodeOccurrencesRequest, PacketBudgetModeDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
-    RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalScoreBreakdownDto,
-    RetrievalShadowDto, SearchHit, SearchMatchQualityDto, SearchQueryAssessmentDto,
-    SearchRepoTextMode, SearchRequest, SourceOccurrenceDto, SourceTruthCheckDto, TrailCallerScope,
-    TrailConfigDto, TrailContextDto, TrailDirection, TrailMode,
+    ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto, RetrievalFallbackReasonDto,
+    RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit, SearchMatchQualityDto,
+    SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest, SourceOccurrenceDto,
+    SourceTruthCheckDto, TrailCallerScope, TrailConfigDto, TrailContextDto, TrailDirection,
+    TrailMode,
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -182,6 +183,7 @@ fn main() -> Result<()> {
         Command::Packet(cmd) => run_packet(cmd),
         Command::Doctor(cmd) => run_doctor(cmd),
         Command::Ready(cmd) => run_ready(cmd),
+        Command::Agent(cmd) => run_agent(cmd),
         Command::Setup(cmd) => run_setup(cmd),
         Command::Cache(cmd) => run_cache(cmd),
         Command::Search(cmd) => run_search(cmd),
@@ -1266,6 +1268,29 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
 
+fn run_agent(cmd: args::AgentCommand) -> Result<()> {
+    match cmd.action {
+        args::AgentAction::Preflight(cmd) => run_agent_preflight(cmd),
+    }
+}
+
+fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, "agent preflight")?;
+    preflight_output_file(cmd.output_file.as_deref())?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let summary = runtime.open_project_summary()?;
+    let sidecar = doctor_sidecar_status(&runtime);
+    let readiness = build_summary_readiness(
+        &summary.root,
+        &summary.stats,
+        summary.freshness.as_ref(),
+        &sidecar,
+    );
+    let output = build_agent_preflight_output(&readiness);
+    let markdown = render_agent_preflight_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
 fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -> Result<()> {
     let opened = runtime.ensure_open(args::RefreshMode::Auto)?;
     ensure_index_ready(&opened, "ready repair")?;
@@ -1301,6 +1326,114 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
     codestory_retrieval::strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
         .context("ready repair final retrieval status")?;
     Ok(())
+}
+
+const LOCAL_GRAPH_AGENT_SURFACES: &[&str] =
+    &["ground", "files", "symbol", "trail", "snippet", "affected"];
+const FULL_RETRIEVAL_AGENT_SURFACES: &[&str] = &["packet_full", "search_full", "context_full"];
+
+fn build_agent_preflight_output(
+    readiness: &[codestory_contracts::api::ReadinessVerdictDto],
+) -> args::AgentPreflightOutput {
+    let local = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation)
+        .expect("local_navigation readiness verdict");
+    let agent = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::AgentPacketSearch)
+        .expect("agent_packet_search readiness verdict");
+    let local_ready = local.status == ReadinessStatusDto::Ready;
+    let full_ready = agent.status == ReadinessStatusDto::Ready;
+    let mut safe_surfaces = Vec::new();
+    let mut blocked_surfaces = Vec::new();
+
+    if local_ready {
+        safe_surfaces.extend(surface_strings(LOCAL_GRAPH_AGENT_SURFACES));
+    } else {
+        blocked_surfaces.extend(surface_strings(LOCAL_GRAPH_AGENT_SURFACES));
+    }
+    if full_ready {
+        safe_surfaces.extend(surface_strings(FULL_RETRIEVAL_AGENT_SURFACES));
+    } else {
+        blocked_surfaces.extend(surface_strings(FULL_RETRIEVAL_AGENT_SURFACES));
+    }
+
+    let mode = if full_ready {
+        "full_retrieval"
+    } else if local_ready {
+        "local_graph"
+    } else {
+        "blocked"
+    };
+    let repair_command = readiness::primary_non_ready(readiness)
+        .and_then(|verdict| verdict.full_repair.first().cloned());
+    let human_summary = agent_preflight_summary(local_ready, full_ready, local);
+
+    args::AgentPreflightOutput {
+        usable: local_ready || full_ready,
+        mode: mode.to_string(),
+        local_graph: agent_preflight_lane(local),
+        full_retrieval: agent_preflight_lane(agent),
+        safe_surfaces,
+        blocked_surfaces,
+        repair_command,
+        human_summary,
+    }
+}
+
+fn surface_strings(surfaces: &[&str]) -> Vec<String> {
+    surfaces
+        .iter()
+        .map(|surface| (*surface).to_string())
+        .collect()
+}
+
+fn agent_preflight_lane(
+    verdict: &codestory_contracts::api::ReadinessVerdictDto,
+) -> args::AgentPreflightLaneOutput {
+    args::AgentPreflightLaneOutput {
+        ready: verdict.status == ReadinessStatusDto::Ready,
+        status: verdict.status,
+        summary: verdict.summary.clone(),
+    }
+}
+
+fn agent_preflight_summary(
+    local_ready: bool,
+    full_ready: bool,
+    local: &codestory_contracts::api::ReadinessVerdictDto,
+) -> String {
+    match (local_ready, full_ready) {
+        (_, true) => "Local graph and full retrieval are ready.".to_string(),
+        (true, false) => "Local graph is ready. Full retrieval needs sidecar repair.".to_string(),
+        (false, _) => format!(
+            "Local graph is not ready: {} Full retrieval is also unavailable for agent packet/search.",
+            local.summary
+        ),
+    }
+}
+
+fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(markdown, "# Agent Preflight");
+    let _ = writeln!(markdown, "usable: `{}`", output.usable);
+    let _ = writeln!(markdown, "mode: `{}`", output.mode);
+    let _ = writeln!(
+        markdown,
+        "local_graph: {}",
+        readiness::status_label(output.local_graph.status)
+    );
+    let _ = writeln!(
+        markdown,
+        "full_retrieval: {}",
+        readiness::status_label(output.full_retrieval.status)
+    );
+    let _ = writeln!(markdown, "human_summary: {}", output.human_summary);
+    if let Some(command) = output.repair_command.as_deref() {
+        let _ = writeln!(markdown, "repair_command: `{command}`");
+    }
+    markdown
 }
 
 fn run_search(cmd: SearchCommand) -> Result<()> {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -16,6 +16,8 @@ use codestory_contracts::api::{
     TrailCallerScope, TrailDirection, TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
+use sha2::{Digest, Sha256};
+use std::fs::File;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -2001,10 +2003,13 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     let sidecar = serde_json::json!({
         "retrieval_mode": sidecar_mode.clone(),
         "degraded_reason": degraded_reason.clone(),
+        "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "manifest_generation": manifest_generation.clone(),
         "manifest_input_hash": manifest_input_hash.clone(),
     });
-    let (server_executable, server_warnings) = stdio_server_executable_status();
+    let (server_executable, server_executable_sha256, server_warnings) =
+        stdio_server_executable_status();
+    let plugin_runtime = stdio_plugin_runtime_status();
     let setup_repair = stdio_setup_repair_input(server_executable.as_deref());
     let readiness = crate::readiness::build_readiness_verdicts(crate::readiness::ReadinessInputs {
         project: &summary.root,
@@ -2022,7 +2027,15 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     let recommended_next_calls = stdio_status_recommended_next_calls(&readiness);
     Ok(serde_json::json!({
         "server_version": env!("CARGO_PKG_VERSION"),
+        "cli_version": env!("CARGO_PKG_VERSION"),
         "server_executable": server_executable,
+        "server_executable_sha256": server_executable_sha256,
+        "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
+        "plugin_runtime": plugin_runtime,
+        "runtime_boundary": {
+            "restart_required_for_runtime_change": true,
+            "message": "A running MCP server keeps using the CLI process it was launched with; install, override, or PATH changes require a host reload/restart and a fresh codestory://status readback."
+        },
         "warnings": server_warnings,
         "project_root": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
         "storage_path": crate::display::clean_path_string(&runtime.storage_path.to_string_lossy()),
@@ -2297,17 +2310,71 @@ fn stdio_recommended_next_call(command: &str) -> serde_json::Value {
     })
 }
 
-fn stdio_server_executable_status() -> (Option<String>, Vec<String>) {
+fn stdio_server_executable_status() -> (Option<String>, Option<String>, Vec<String>) {
     match std::env::current_exe() {
-        Ok(path) => (
-            Some(crate::display::clean_path_string(&path.to_string_lossy())),
-            Vec::new(),
-        ),
+        Ok(path) => {
+            let display = crate::display::clean_path_string(&path.to_string_lossy());
+            match sha256_file(&path) {
+                Ok(sha256) => (Some(display), Some(sha256), Vec::new()),
+                Err(error) => (
+                    Some(display),
+                    None,
+                    vec![format!("server_executable_checksum_unavailable: {error}")],
+                ),
+            }
+        }
         Err(error) => (
+            None,
             None,
             vec![format!("server_executable_unavailable: {error}")],
         ),
     }
+}
+
+fn stdio_plugin_runtime_status() -> serde_json::Value {
+    let cli_source = env_nonempty("CODESTORY_PLUGIN_CLI_SOURCE")
+        .unwrap_or_else(|| "direct_cli_launch".to_string());
+    let warnings = env_nonempty("CODESTORY_PLUGIN_CLI_WARNINGS")
+        .map(|value| {
+            value
+                .split(';')
+                .filter(|item| !item.trim().is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    serde_json::json!({
+        "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        "cli_version": env_nonempty("CODESTORY_PLUGIN_CLI_VERSION"),
+        "cli_source": cli_source,
+        "cli_path": env_nonempty("CODESTORY_PLUGIN_CLI_PATH"),
+        "cli_sha256": env_nonempty("CODESTORY_PLUGIN_CLI_SHA256"),
+        "build_source": env_nonempty("CODESTORY_PLUGIN_CLI_BUILD_SOURCE"),
+        "repo_ref": env_nonempty("CODESTORY_PLUGIN_CLI_REPO_REF"),
+        "archive_sha256": env_nonempty("CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256"),
+        "archive_url": env_nonempty("CODESTORY_PLUGIN_CLI_ARCHIVE_URL"),
+        "provisioned_at": env_nonempty("CODESTORY_PLUGIN_CLI_PROVISIONED_AT"),
+        "local_dev_override": cli_source == "local_dev_override",
+        "path_fallback": cli_source == "path_fallback",
+        "managed_binary_path": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_PATH") } else { None },
+        "managed_binary_sha256": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_SHA256") } else { None },
+        "managed_manifest_path": env_nonempty("CODESTORY_PLUGIN_CLI_MANIFEST_PATH"),
+        "warnings": warnings
+    })
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher).with_context(|| format!("hash {}", path.display()))?;
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn stdio_allowed_surfaces(readiness: &[ReadinessVerdictDto]) -> serde_json::Value {

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -733,6 +733,61 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
 }
 
 #[test]
+fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+
+    let preflight = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["agent", "preflight", "--format", "json"],
+    );
+
+    assert_eq!(preflight["usable"], true, "{preflight:#}");
+    assert_eq!(preflight["mode"], "local_graph", "{preflight:#}");
+    assert_eq!(preflight["local_graph"]["ready"], true, "{preflight:#}");
+    assert_eq!(
+        preflight["full_retrieval"]["status"], "repair_retrieval",
+        "{preflight:#}"
+    );
+    assert!(
+        preflight["safe_surfaces"]
+            .as_array()
+            .expect("safe surfaces")
+            .iter()
+            .any(|surface| surface == "ground"),
+        "local graph surfaces should be safe: {preflight:#}"
+    );
+    assert!(
+        preflight["blocked_surfaces"]
+            .as_array()
+            .expect("blocked surfaces")
+            .iter()
+            .any(|surface| surface == "packet_full"),
+        "full retrieval surfaces should be blocked: {preflight:#}"
+    );
+    assert!(
+        preflight["repair_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("ready --goal agent --repair")),
+        "preflight should point at the existing agent repair path: {preflight:#}"
+    );
+    assert!(
+        preflight["human_summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("Local graph is ready")),
+        "preflight should include a human summary: {preflight:#}"
+    );
+}
+
+#[test]
 fn doctor_reports_current_and_stored_semantic_doc_embedding_contract() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1967,6 +1967,19 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         json!(env!("CARGO_PKG_VERSION")),
         "status should identify the serving package version: {status}"
     );
+    assert_eq!(
+        status["cli_version"],
+        json!(env!("CARGO_PKG_VERSION")),
+        "status should identify the active CLI version: {status}"
+    );
+    assert!(
+        status["sidecar_contract_version"].is_number(),
+        "status should expose the sidecar contract version: {status}"
+    );
+    assert!(
+        status["sidecar_retrieval"]["sidecar_contract_version"].is_number(),
+        "sidecar status should expose the sidecar contract version: {status}"
+    );
     assert!(
         status["server_executable"]
             .as_str()
@@ -1975,6 +1988,22 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
                 .as_array()
                 .is_some_and(|warnings| !warnings.is_empty()),
         "status should expose server_executable or an explicit warning: {status}"
+    );
+    assert!(
+        status["server_executable_sha256"]
+            .as_str()
+            .is_some_and(|sha256| sha256.len() == 64),
+        "status should expose the active server executable checksum: {status}"
+    );
+    assert_eq!(
+        status["runtime_boundary"]["restart_required_for_runtime_change"],
+        json!(true),
+        "status should make the MCP restart boundary explicit: {status}"
+    );
+    assert_eq!(
+        status["plugin_runtime"]["cli_source"],
+        json!("direct_cli_launch"),
+        "direct cargo stdio tests should label the non-plugin launch boundary: {status}"
     );
     assert!(
         status

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2024"
 
 [dependencies]

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -11,7 +11,7 @@ packet-runtime, drill, or benchmark evidence tier.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current MCP `server_version`, `server_executable`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,8 +13,8 @@ debugging, transcripts, and direct stdio integration.
 
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
-| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `server_executable`, and `allowed_surfaces`. |
+| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
+| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -101,7 +101,10 @@ codestory-cli ground --project <target-workspace> --why
 **Key guidance:**
 
 When MCP is live, use `codestory://status` as the runtime truth. Its
-`server_version` and `server_executable` fields identify the active server, and
+`server_version`, `cli_version`, `server_executable`,
+`server_executable_sha256`, `sidecar_contract_version`, and `plugin_runtime`
+fields identify the active server, CLI, sidecar contract, plugin launch source,
+`build_source`, and `repo_ref`, and
 `allowed_surfaces` tells the agent which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
@@ -157,7 +160,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `server_executable`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,17 +6,19 @@ last turn. CodeStory indexes once and serves evidence from that map so the agent
 can answer from citations instead of re-exploring the tree.
 
 Start with the human task, then run the smallest path that proves the state you
-need. The agent plugin is the normal path. The CLI is for setup, repair,
-debugging, transcripts, and direct stdio integration.
+need. The golden path is CLI preflight first, then the agent plugin/MCP/hooks
+path. The CLI is otherwise for repair, debugging, transcripts, and direct stdio
+integration.
 
 ## Operator Journey
 
 | Stage | Human action | Agent/CLI action | Trust check |
 | --- | --- | --- | --- |
+| Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Ask the agent to check readiness and ground the repo. | Read `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
+| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
-| Broad discovery | Ask a repo-wide question. | Use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
+| Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
 
 Packet/search output from degraded retrieval, missing sidecars, stale manifests,
@@ -25,6 +27,11 @@ or any non-`full` retrieval mode is navigation help only. It is not proof.
 Most humans should start from the plugin flow in
 [README - Quick start](../README.md#quick-start). Use the CLI when you need the
 exact setup, repair, or debug record.
+
+Hook-enabled hosts keep CodeStory ambient. Hooks attempt strict grounding on
+session start, resume, clear, and compact handoff; they attempt request-aware
+packet grounding on each user prompt; and they fail open with the next
+CodeStory check instead of blocking the host.
 
 ### Example prompts
 
@@ -72,8 +79,19 @@ environment variables with `$env:NAME = "value"`.
 
 ## Install And Ground A Repo
 
-Install the CodeStory plugin once, then start a fresh agent thread for the
-workspace you want to ground. The canonical skill package lives at
+Run the CLI preflight in the workspace first:
+
+```sh
+codestory-cli agent preflight --project <target-workspace> --format json
+```
+
+Use its `safe_surfaces`, `blocked_surfaces`, and `repair_command` fields as the
+agent handoff. If local graph surfaces are blocked, run the repair command
+before source work. If only `packet`, `search`, or `context` is blocked, local
+navigation can continue while sidecars are repaired later.
+
+Install the CodeStory plugin once, then start a fresh agent thread for that
+workspace. The canonical skill package lives at
 [../plugins/codestory/skills/codestory-grounding/SKILL.md](../plugins/codestory/skills/codestory-grounding/SKILL.md).
 
 **Codex plugin installation flow:**
@@ -89,6 +107,7 @@ workspace you want to ground. The canonical skill package lives at
 **Direct CLI transcript (for setup, repair, or debugging):**
 
 ```sh
+codestory-cli agent preflight --project <target-workspace> --format json
 codestory-cli ready --goal local --repair --project <target-workspace> --format json
 codestory-cli ground --project <target-workspace> --why
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,6 +105,15 @@ When MCP is live, use `codestory://status` as the runtime truth. Its
 `allowed_surfaces` tells the agent which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
+When MCP is not live, use the CLI preflight contract instead:
+
+```sh
+codestory-cli agent preflight --project <target-workspace> --format json
+```
+
+Use its `safe_surfaces`, `blocked_surfaces`, and `repair_command` fields as the
+agent handoff.
+
 **Next steps after installation:**
 
 If the agent reports that local graph surfaces are allowed but `packet`,

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/.mcp.json
+++ b/plugins/codestory/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "codestory": {
-      "command": "codestory-cli",
-      "args": ["serve", "--stdio", "--refresh", "none"],
+      "command": "node",
+      "args": ["./scripts/codestory-mcp.cjs"],
       "tool_timeout_sec": 300
     }
   }

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -41,23 +41,28 @@ or non-code folders.
 
 The status resource is the contract. When MCP is live, read
 `codestory://status` first and obey `allowed_surfaces`. Treat
-`server_version` and `server_executable` from status as the active runtime
-evidence; source docs, marketplace cache contents, and local build outputs can
-all differ from the running server.
+`server_version`, `server_executable`, `server_executable_sha256`, and
+`plugin_runtime` from status as the active runtime evidence; source docs,
+marketplace cache contents, and local build outputs can all differ from the
+running server.
 
 | Status lane | Allows | Does not allow |
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `server_executable`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
 This package stays thin:
 
 - `.codex-plugin/plugin.json` describes the Codex plugin package.
-- `.mcp.json` launches `codestory-cli serve --stdio --refresh none` from the
-  agent host `PATH`.
+- `.mcp.json` launches `scripts/codestory-mcp.cjs`, which prefers a
+  checksummed plugin-managed CLI from plugin data. If none exists, the adapter
+  provisions the current plugin version from the GitHub release
+  `SHA256SUMS.txt`, records `build_source=github_release` and `repo_ref`, labels
+  `CODESTORY_CLI` as a local-dev override, and only falls back to `PATH` when
+  provisioning is unavailable.
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
@@ -99,7 +104,8 @@ rather than the terminal. Use the UI path when the CLI marketplace command is
 unavailable.
 
 Start a new Codex thread after installation or refresh. The installed package
-launches `codestory-cli serve --stdio --refresh none` from `PATH`.
+launches the managed MCP adapter, which then starts
+`codestory-cli serve --stdio --refresh none`.
 
 ### After install
 
@@ -118,8 +124,9 @@ If the host does not expose lifecycle hooks yet, use the explicit prompt:
 
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
 live through MCP by reading `codestory://status`. If MCP is live, the agent uses
-`server_version`, `server_executable`, and `allowed_surfaces` from status
-instead of rechecking PATH or release metadata.
+`server_version`, `cli_version`, `server_executable`,
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
+`allowed_surfaces` from status instead of rechecking PATH or release metadata.
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
 missing, status reports a suspect runtime, or you are debugging/repairing the
@@ -211,21 +218,22 @@ proof that `packet`, `search`, or `context` is ready.
 
 ### Agent runtime repair
 
-The plugin does not bundle the binary. The installed MCP runtime launches
-`codestory-cli serve --stdio --refresh none` from the agent host `PATH`. Once
-MCP is live, `codestory://status` is the runtime proof. Use
-`where.exe codestory-cli`, `codestory-cli --version`, and release repair checks
-only when MCP is missing or the status fields show stale binary drift.
+The plugin launches through `scripts/codestory-mcp.cjs`. That adapter prefers a
+checksummed CLI under plugin-managed data and provisions the current plugin
+version from GitHub release assets when needed. Status reports the plugin
+version, CLI version, binary path/SHA, `build_source`, `repo_ref`, and sidecar
+contract version. `CODESTORY_CLI` stays a local-dev override, and `path_fallback`
+means no managed binary could be used. Once MCP is live, `codestory://status` is
+the runtime proof. Use `where.exe codestory-cli`, `codestory-cli --version`, and
+release repair checks only when MCP is missing or status shows `path_fallback`
+or stale binary drift.
 
 If status reports `repair_setup`, the active CLI is older than the latest
 release. The agent runs the installer command from `recommended_next_calls`
 before using local navigation, packet, search, or context.
 If a running `codestory-cli serve --stdio --refresh none` process locks the old
-binary, install the current release into a versioned directory and put that
-directory before stale entries on `PATH`; verify the command that MCP will
-launch with `codestory-cli --version`. If `PATH` changed, mention restart only
-after the current binary is installed and verified; a Codex host/app restart may
-be needed before a fresh agent thread sees the new `PATH`.
+binary, let the plugin provision the current release into versioned managed
+storage or install a versioned directory before stale `PATH` entries. Codex host/app restart may be needed before a fresh agent thread sees the new launch choice; confirm with a fresh `codestory://status` readback.
 
 Use source fallback only when no release asset fits the host:
 
@@ -233,9 +241,9 @@ Use source fallback only when no release asset fits the host:
 cargo build --release -p codestory-cli
 ```
 
-Then put `target/release` on the agent host `PATH` for installed MCP runtime
-use. Set `CODESTORY_CLI` only for manual CLI fallback commands or source-build
-debugging; `.mcp.json` does not launch through that variable.
+Then set `CODESTORY_CLI` to the source-built binary for local-dev MCP testing or
+manual CLI fallback commands. Status labels this as `local_dev_override`; do
+not treat it as the installed managed runtime.
 
 Source docs, marketplace source checkout/cache, and the active installed MCP
 runtime can differ. Before claiming an installed behavior is live, verify the

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -8,14 +8,23 @@ CodeStory gives a coding agent a local, read-only grounding surface before it
 plans, reviews, or edits a repository. Index once; answer from evidence with
 citations instead of re-exploring the tree on every prompt.
 
-The human job is simple: install the plugin and start a fresh thread in the
-repo. Hosts with lifecycle-hook adapters keep CodeStory ambient: on session
-start, resume, clear, and compact, the hook injects CodeStory-first grounding
-rules and attempts a strict `ground` snapshot from the session cwd; on each user
-prompt, it attempts a tiny `packet` using that exact prompt. The agent should
-use CodeStory before source files whenever it needs to verify repository facts,
-plan edits, choose tests, or review changes. The CLI is still there, but it is
-the escape hatch and repair surface, not the main user experience.
+The human job is simple: run agent preflight in the repo, install the plugin,
+and start a fresh thread there.
+
+```sh
+codestory-cli agent preflight --project <repo> --format json
+```
+
+Use `safe_surfaces`, `blocked_surfaces`, and `repair_command` as the handoff.
+Then let the plugin path take over.
+Hosts with lifecycle-hook adapters keep CodeStory ambient. On session start,
+resume, clear, and compact, the hook
+injects CodeStory-first grounding rules and attempts a strict `ground` snapshot
+from the session cwd; on each user prompt, it attempts a tiny `packet` using
+that exact prompt. The agent should use CodeStory before source files whenever
+it needs to verify repository facts, plan edits, choose tests, or review
+changes. The CLI is still there, but it is the escape hatch and repair surface,
+not the main user experience.
 
 This is strict startup grounding plus request-aware packets, not a random
 repository summary. Hooks fail open. Missing `node`, missing `codestory-cli`, missing MCP, degraded
@@ -75,8 +84,18 @@ CLI/MCP runtime.
 
 ## Install For Agent Use
 
-For normal Codex use, install the plugin through the Codex plugin flow for your
-workspace. Open Codex in the repo you want to ground, then use:
+For normal Codex use, first preflight the repo:
+
+```bash
+codestory-cli agent preflight --project <repo> --format json
+```
+
+If local graph surfaces are blocked, run the emitted `repair_command` before
+source work. If only `packet`, `search`, or `context` is blocked, local
+navigation can continue while sidecars are repaired later.
+
+Then install the plugin through the Codex plugin flow for your workspace. Open
+Codex in the repo you want to ground, then use:
 
 ```text
 /plugins
@@ -192,6 +211,7 @@ Use the CLI when the agent needs to repair setup, produce a transcript, or debug
 why the MCP server is not ready:
 
 ```console
+codestory-cli agent preflight --project <repo> --format json
 where.exe codestory-cli
 codestory-cli --version
 codestory-cli ready --goal local --repair --project <repo> --format json

--- a/plugins/codestory/docs/agent-portability.md
+++ b/plugins/codestory/docs/agent-portability.md
@@ -1,10 +1,17 @@
 # Agent Portability
 
-CodeStory ships one grounding skill and thin host adapters. The skill owns the
-runtime rules; adapters make the rules ambient in hosts that support lifecycle
-hooks or project instruction files. Where the host exposes prompt input, the
-hook attempts request-aware packet grounding before the agent opens source
-files.
+CodeStory ships one grounding skill and thin host adapters. The user-facing
+path is one flow: run agent preflight, install the plugin or adapter, then let
+MCP plus hooks keep CodeStory ambient.
+
+```sh
+codestory-cli agent preflight --project <repo> --format json
+```
+
+The skill owns the runtime rules; adapters make the rules ambient in hosts that
+support lifecycle hooks or project instruction files. Where the host exposes
+prompt input, the hook attempts request-aware packet grounding before the agent
+opens source files.
 
 | Host | Files | Behavior |
 | --- | --- | --- |
@@ -21,4 +28,6 @@ instructions, keep the copied rule text aligned with the root instruction file.
 Every adapter should preserve the same first check: read `codestory://status`
 when MCP is live, then trust only the surfaces allowed by status. Broad
 `packet`, `search`, and `context` use still requires `retrieval_mode=full`.
-Hooks are best-effort startup context, not a blocking dependency.
+Hooks ground on session start, resume, clear, and compact handoff; attempt
+request-aware grounding on user prompts; and fail open with the next CodeStory
+check instead of blocking the host.

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -9,11 +9,11 @@ const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, read codestory://status first.
+2. If the CodeStory MCP server is live, read codestory://status first; otherwise run codestory-cli agent preflight --project <repo> --format json.
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
-6. If MCP is missing, use codestory-cli ready --goal local --repair as an incremental-by-default setup/repair fallback; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
+6. If MCP is missing, use the preflight repair_command as the setup/repair fallback; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
 
 Do this without waiting for the user to mention CodeStory.`;
 
@@ -59,11 +59,11 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live, then use the allowed CodeStory surface that fits the task.
+Before manually opening source files, first read codestory://status when MCP is live; when it is not, run codestory-cli agent preflight --project <repo> --format json and use the reported safe_surfaces.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.
-Use incremental ready repair as the default setup path once a repository target is known.
+Use the preflight repair_command as the default setup path once a repository target is known.
 
 ${body}`;
 }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const { spawnSync } = require('child_process');
+const { createHash } = require('crypto');
+const fs = require('fs');
+const https = require('https');
+const os = require('os');
+const path = require('path');
+
+const pluginRoot = path.dirname(__dirname);
+const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codestory-cli';
+const fallbackBinaryNames = process.platform === 'win32'
+  ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
+  : ['codestory-cli'];
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function fileSha256(file) {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function findFile(root, names) {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isFile() && names.includes(entry.name)) return fullPath;
+    if (entry.isDirectory()) {
+      const found = findFile(fullPath, names);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function pluginVersion() {
+  const manifest = readJson(path.join(pluginRoot, '.codex-plugin', 'plugin.json'));
+  return manifest && typeof manifest.version === 'string' ? manifest.version : null;
+}
+
+function pluginDataDir() {
+  return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
+}
+
+function resolveManifest(manifestPath) {
+  const manifest = readJson(manifestPath);
+  if (!manifest) return null;
+  const executable = manifest.executable_path || manifest.executablePath || manifest.path;
+  if (!executable) return null;
+  const cliPath = path.resolve(path.dirname(manifestPath), executable);
+  if (!fs.existsSync(cliPath)) return null;
+  const sha256 = fileSha256(cliPath);
+  const expected = manifest.sha256 || manifest.executable_sha256 || manifest.executableSha256;
+  if (expected && expected.toLowerCase() !== sha256) {
+    return { warning: `managed_cli_checksum_mismatch:${manifestPath}` };
+  }
+  return {
+    path: cliPath,
+    sha256,
+    manifestPath,
+    cliVersion: manifest.version || manifest.cli_version || null,
+    repoRef: manifest.repo_ref || null,
+    buildSource: manifest.build_source || manifest.source || null,
+    archiveSha256: manifest.archive_sha256 || null,
+    archiveUrl: manifest.archive_url || null,
+    provisionedAt: manifest.provisioned_at || null,
+  };
+}
+
+function assetTarget() {
+  const platform = process.platform;
+  const arch = process.arch;
+  if (platform === 'win32' && arch === 'x64') return 'windows-x64';
+  if (platform === 'win32' && arch === 'arm64') return 'windows-arm64';
+  if (platform === 'linux' && arch === 'x64') return 'linux-x64';
+  if (platform === 'linux' && arch === 'arm64') return 'linux-arm64';
+  if (platform === 'darwin' && arch === 'arm64') return 'macos-arm64';
+  return null;
+}
+
+function archiveName(version, target = assetTarget()) {
+  if (!target) return null;
+  const extension = target.startsWith('windows-') ? 'zip' : 'tar.gz';
+  return `codestory-cli-v${version}-${target}.${extension}`;
+}
+
+function expectedArchiveHash(sumsText, name) {
+  for (const line of sumsText.split(/\r?\n/u)) {
+    const match = line.match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/u);
+    if (match && match[2].trim() === name) return match[1].toLowerCase();
+  }
+  throw new Error(`SHA256SUMS.txt did not contain ${name}`);
+}
+
+function copyLocalReleaseFile(releaseDir, name, destination) {
+  fs.copyFileSync(path.join(releaseDir, name), destination);
+}
+
+function downloadFile(url, destination) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+        response.resume();
+        downloadFile(response.headers.location, destination).then(resolve, reject);
+        return;
+      }
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`download failed ${response.statusCode}: ${url}`));
+        return;
+      }
+      const output = fs.createWriteStream(destination);
+      response.pipe(output);
+      output.on('finish', () => output.close(resolve));
+      output.on('error', reject);
+    });
+    request.setTimeout(15000, () => request.destroy(new Error(`download timed out: ${url}`)));
+    request.on('error', reject);
+  });
+}
+
+async function fetchReleaseFile(version, name, destination) {
+  if (process.env.CODESTORY_PLUGIN_RELEASE_DIR) {
+    copyLocalReleaseFile(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name, destination);
+    return `file://${path.join(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name)}`;
+  }
+  const baseUrl = process.env.CODESTORY_PLUGIN_RELEASE_BASE_URL ||
+    `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}`;
+  const url = `${baseUrl.replace(/\/$/u, '')}/${name}`;
+  await downloadFile(url, destination);
+  return url;
+}
+
+function extractArchive(archivePath, destination) {
+  fs.mkdirSync(destination, { recursive: true });
+  const result = spawnSync('tar', ['-xf', archivePath, '-C', destination], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.status !== 0) {
+    throw new Error(`tar extract failed: ${result.stderr || result.error?.message || result.status}`);
+  }
+}
+
+async function provisionManagedCli(dataDir, version) {
+  if (!dataDir || !version || process.env.CODESTORY_PLUGIN_DISABLE_PROVISION === '1') return null;
+  const target = assetTarget();
+  const asset = archiveName(version, target);
+  if (!target || !asset) throw new Error(`unsupported_release_target:${process.platform}-${process.arch}`);
+
+  const versionDir = path.join(dataDir, 'codestory-cli', version);
+  const binDir = path.join(versionDir, 'bin');
+  const manifestPath = path.join(versionDir, 'manifest.json');
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codestory-plugin-cli-'));
+  const sumsPath = path.join(tempRoot, 'SHA256SUMS.txt');
+  const archivePath = path.join(tempRoot, asset);
+  const extractDir = path.join(tempRoot, 'extract');
+  try {
+    await fetchReleaseFile(version, 'SHA256SUMS.txt', sumsPath);
+    const archiveUrl = await fetchReleaseFile(version, asset, archivePath);
+    const expected = expectedArchiveHash(fs.readFileSync(sumsPath, 'utf8'), asset);
+    const actual = fileSha256(archivePath);
+    if (actual !== expected) {
+      throw new Error(`archive_checksum_mismatch:${asset}`);
+    }
+    extractArchive(archivePath, extractDir);
+    const extracted = findFile(extractDir, fallbackBinaryNames);
+    if (!extracted) throw new Error(`archive_missing_cli:${asset}`);
+
+    fs.mkdirSync(binDir, { recursive: true });
+    const destination = path.join(binDir, path.basename(extracted));
+    fs.copyFileSync(extracted, destination);
+    if (process.platform !== 'win32') fs.chmodSync(destination, 0o755);
+    const binarySha256 = fileSha256(destination);
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      path: path.relative(versionDir, destination).replace(/\\/gu, '/'),
+      sha256: binarySha256,
+      version,
+      build_source: 'github_release',
+      repo_ref: `v${version}`,
+      archive: asset,
+      archive_url: archiveUrl,
+      archive_sha256: actual,
+      target,
+      provisioned_at: new Date().toISOString(),
+    }, null, 2));
+    return resolveManifest(manifestPath);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function resolveManagedCli(dataDir, version, warnings) {
+  if (!dataDir || !version) return null;
+  for (const manifestPath of [
+    path.join(dataDir, 'codestory-cli', version, 'manifest.json'),
+    path.join(dataDir, 'codestory-cli', 'manifest.json'),
+  ]) {
+    const resolved = resolveManifest(manifestPath);
+    if (resolved) return resolved;
+  }
+
+  for (const cliPath of [
+    path.join(dataDir, 'codestory-cli', version, binaryName),
+    path.join(dataDir, 'codestory-cli', version, 'bin', binaryName),
+  ]) {
+    if (fs.existsSync(cliPath)) {
+      return { path: cliPath, sha256: fileSha256(cliPath), manifestPath: null };
+    }
+  }
+  try {
+    return await provisionManagedCli(dataDir, version);
+  } catch (error) {
+    warnings.push(`managed_cli_provision_failed:${error.message}`);
+  }
+  return null;
+}
+
+async function resolveCli() {
+  const version = pluginVersion();
+  const warnings = [];
+  if (process.env.CODESTORY_CLI) {
+    return {
+      source: 'local_dev_override',
+      path: process.env.CODESTORY_CLI,
+      sha256: fs.existsSync(process.env.CODESTORY_CLI) ? fileSha256(process.env.CODESTORY_CLI) : null,
+      version,
+      cliVersion: null,
+      repoRef: null,
+      buildSource: 'local_dev_override',
+      archiveSha256: null,
+      archiveUrl: null,
+      provisionedAt: null,
+      warnings,
+    };
+  }
+
+  const managed = await resolveManagedCli(pluginDataDir(), version, warnings);
+  if (managed && managed.warning) warnings.push(managed.warning);
+  if (managed && managed.path) {
+    return { source: 'managed', version, warnings, ...managed };
+  }
+
+  warnings.push('managed_cli_unavailable_using_path_fallback');
+  return {
+    source: 'path_fallback',
+    path: 'codestory-cli',
+    sha256: null,
+    version,
+    cliVersion: null,
+    repoRef: null,
+    buildSource: 'path_fallback',
+    archiveSha256: null,
+    archiveUrl: null,
+    provisionedAt: null,
+    warnings,
+  };
+}
+
+function rememberLaunch(resolved) {
+  const dataDir = pluginDataDir();
+  if (!dataDir) return;
+  try {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, '.codestory-mcp-runtime.json'), JSON.stringify({
+      source: resolved.source,
+      path: resolved.path,
+      sha256: resolved.sha256,
+      pluginVersion: resolved.version,
+      manifestPath: resolved.manifestPath || null,
+      cliVersion: resolved.cliVersion || null,
+      repoRef: resolved.repoRef || null,
+      buildSource: resolved.buildSource || null,
+      archiveSha256: resolved.archiveSha256 || null,
+      archiveUrl: resolved.archiveUrl || null,
+      provisionedAt: resolved.provisionedAt || null,
+      updatedAt: new Date().toISOString(),
+    }, null, 2));
+  } catch {
+    // Best effort only. Launch metadata must not block MCP startup.
+  }
+}
+
+async function main() {
+  const resolved = await resolveCli();
+  rememberLaunch(resolved);
+
+  const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    windowsHide: true,
+    env: {
+      ...process.env,
+      CODESTORY_PLUGIN_VERSION: resolved.version || '',
+      CODESTORY_PLUGIN_CLI_VERSION: resolved.cliVersion || resolved.version || '',
+      CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
+      CODESTORY_PLUGIN_CLI_PATH: resolved.path,
+      CODESTORY_PLUGIN_CLI_SHA256: resolved.sha256 || '',
+      CODESTORY_PLUGIN_CLI_MANIFEST_PATH: resolved.manifestPath || '',
+      CODESTORY_PLUGIN_CLI_BUILD_SOURCE: resolved.buildSource || '',
+      CODESTORY_PLUGIN_CLI_REPO_REF: resolved.repoRef || '',
+      CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256: resolved.archiveSha256 || '',
+      CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
+      CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
+      CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+    },
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    process.exit(code || 0);
+  });
+
+  child.on('error', (error) => {
+    process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
+    process.exit(1);
+  });
+}
+
+main().catch((error) => {
+  process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
+  process.exit(1);
+});

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -43,15 +43,20 @@ Use status fields this way:
 | Status field | Meaning | Agent action |
 | --- | --- | --- |
 | `server_version` | Version of the active MCP server binary. | Use as active runtime evidence once MCP is live. |
+| `cli_version` | Version reported by the active CLI runtime. | Use as the active CLI version, not the source checkout version. |
 | `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
+| `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
+| `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
+| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `build_source` and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 
 Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
-source-build checks only when MCP is missing, the plugin needs repair, or the
-user asks for a CLI transcript. `CODESTORY_CLI` is for manual CLI/source
-fallback commands; `.mcp.json` launches `codestory-cli` from the agent host
-`PATH`.
+source-build checks only when MCP is missing, the plugin needs repair, status
+shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
+is an explicit local-dev override; installed `.mcp.json` launches the managed
+adapter first, provisions from `github_release` when needed, and records the
+launch source in `plugin_runtime`.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -2,16 +2,20 @@
 
 Serves the indexed project over either a small HTTP JSON API or an MCP-style JSON-lines stdio protocol. It is for local browser/editor integrations after the cache is ready.
 
-For the installed plugin, `.mcp.json` starts:
+For direct MCP-style clients:
 
 ```text
 codestory-cli serve --stdio --refresh none
 ```
 
-The process resolves `codestory-cli` from the agent host `PATH`. Once MCP is
-live, `codestory://status` is the runtime truth: use `server_version`,
-`server_executable`, and `allowed_surfaces` from status before any local
-grounding, packet, or search call.
+The installed plugin starts `scripts/codestory-mcp.cjs`, which prefers a
+checksummed plugin-managed CLI, provisions the current version from
+`github_release` when needed, and only falls back to `PATH` when no managed
+binary is available. Once MCP is live, `codestory://status` is the runtime
+truth: use `server_version`, `cli_version`, `server_executable`,
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
+`allowed_surfaces` from status before any local grounding, packet, or search
+call.
 
 ## Usage
 
@@ -54,13 +58,18 @@ grounding, packet, or search call.
 | Status field | Use |
 |--------------|-----|
 | `server_version` | Active MCP server version. Prefer this over source checkout or package version once MCP is live. |
-| `server_executable` | Active MCP server executable path. Use it to diagnose stale PATH or binary drift. |
+| `cli_version` | Active CLI runtime version. |
+| `server_executable` / `server_executable_sha256` | Active MCP server executable path and checksum. Use them to diagnose stale runtime or binary drift. |
+| `sidecar_contract_version` | Active sidecar schema contract version compiled into the CLI. |
+| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. Provisioned records include `build_source=github_release` and `repo_ref`. |
+| `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Allows `packet`, `search`, and `context` only when the surface bit is true and `retrieval_mode=full`. |
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is not
-registered, status is unavailable, or the status executable/version indicates a
-stale binary. If PATH changes during repair, start a fresh Codex host/app session before checking status again.
+registered, status is unavailable, status reports `path_fallback`, or the status
+executable/version indicates a stale binary. If launch inputs change during
+repair, start a fresh Codex host/app session before checking status again.
 
 ## Notes
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -121,7 +121,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
   const { spawnSync } = await import("node:child_process");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-cli-"));
   const outFile = join(dataDir, "env.json");
-  const cliDir = join(dataDir, "codestory-cli", "0.11.15");
+  const cliDir = join(dataDir, "codestory-cli", "0.11.16");
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -169,7 +169,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     return;
   }
 
-  const version = "0.11.15";
+  const version = "0.11.16";
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
   const outFile = join(dataDir, "env.json");
@@ -215,7 +215,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     assert.equal(observed.repoRef, `v${version}`);
     assert.equal(observed.buildSource, "github_release");
     assert.equal(observed.archiveSha256, archiveSha256);
-    assert.match(observed.path, /codestory-cli[\\/]+0\.11\.15[\\/]bin[\\/]codestory-cli/u);
+    assert.match(observed.path, /codestory-cli[\\/]+0\.11\.16[\\/]bin[\\/]codestory-cli/u);
     assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
 
     const manifest = JSON.parse(

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { access, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { dirname, join, delimiter } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -26,6 +27,41 @@ function readCargoVersion(manifestText) {
   assert.fail("Cargo package must declare version");
 }
 
+function releaseAssetForPlatform(version) {
+  const target = process.platform === "win32" && process.arch === "x64"
+    ? "windows-x64"
+    : process.platform === "win32" && process.arch === "arm64"
+      ? "windows-arm64"
+      : process.platform === "linux" && process.arch === "x64"
+        ? "linux-x64"
+        : process.platform === "linux" && process.arch === "arm64"
+          ? "linux-arm64"
+          : process.platform === "darwin" && process.arch === "arm64"
+            ? "macos-arm64"
+            : null;
+  assert.ok(target, `unsupported test platform: ${process.platform}-${process.arch}`);
+  const archiveBase = `codestory-cli-v${version}-${target}`;
+  const archiveName = `${archiveBase}.${target.startsWith("windows-") ? "zip" : "tar.gz"}`;
+  return { archiveBase, archiveName };
+}
+
+async function writeFakeCli(cliPath) {
+  if (process.platform === "win32") {
+    await writeFile(
+      cliPath,
+      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))" %*\r\n`,
+      "utf8",
+    );
+    return;
+  }
+  await writeFile(
+    cliPath,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))' "$@"\n`,
+    "utf8",
+  );
+  await chmod(cliPath, 0o755);
+}
+
 test("plugin metadata maps skill and direct stdio server", async () => {
   const manifest = JSON.parse(
     await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
@@ -41,12 +77,9 @@ test("plugin metadata maps skill and direct stdio server", async () => {
     manifest.interface.capabilities.includes("Lifecycle hooks"),
     true,
   );
-  assert.equal(mcp.mcpServers.codestory.command, "codestory-cli");
+  assert.equal(mcp.mcpServers.codestory.command, "node");
   assert.deepEqual(mcp.mcpServers.codestory.args, [
-    "serve",
-    "--stdio",
-    "--refresh",
-    "none",
+    "./scripts/codestory-mcp.cjs",
   ]);
   assert.equal(Object.hasOwn(mcp.mcpServers.codestory, "cwd"), false);
 });
@@ -81,9 +114,123 @@ test("codestory repo ships plugin source, not marketplace catalog or server adap
       join(repoRoot, ".agents", "skills", "codestory-grounding", "SKILL.md"),
     ),
   );
-  await assert.rejects(
-    access(join(pluginRoot, "scripts", "codestory-mcp.mjs")),
+  await access(join(pluginRoot, "scripts", "codestory-mcp.cjs"));
+});
+
+test("mcp launcher prefers a checksummed managed cli without PATH", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-cli-"));
+  const outFile = join(dataDir, "env.json");
+  const cliDir = join(dataDir, "codestory-cli", "0.11.15");
+  const cliPath = join(
+    cliDir,
+    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
   );
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    await writeFakeCli(cliPath);
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: dataDir,
+        TEST_OUT: outFile,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const observed = JSON.parse(await readFile(outFile, "utf8"));
+    assert.equal(observed.source, "managed");
+    assert.equal(observed.path, cliPath);
+    assert.equal(observed.sha256, sha256);
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher provisions a checksummed release asset into plugin data", async (t) => {
+  const { spawnSync } = await import("node:child_process");
+  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
+  if (tarProbe.status !== 0) {
+    t.skip("tar unavailable for archive fixture");
+    return;
+  }
+
+  const version = "0.11.15";
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
+  const outFile = join(dataDir, "env.json");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const { archiveBase, archiveName } = releaseAssetForPlatform(version);
+  const stageDir = join(releaseDir, archiveBase);
+  const cliName = process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli";
+  const cliPath = join(stageDir, cliName);
+  const archivePath = join(releaseDir, archiveName);
+
+  try {
+    await mkdir(stageDir, { recursive: true });
+    await writeFakeCli(cliPath);
+    const packArgs = archiveName.endsWith(".zip")
+      ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
+      : ["-czf", archivePath, "-C", releaseDir, archiveBase];
+    const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
+    assert.equal(pack.status, 0, pack.stderr);
+    const archiveSha256 = createHash("sha256")
+      .update(await readFile(archivePath))
+      .digest("hex");
+    await writeFile(
+      join(releaseDir, "SHA256SUMS.txt"),
+      `${archiveSha256}  ${archiveName}\n`,
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: "",
+        CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
+        PLUGIN_DATA: dataDir,
+        TEST_OUT: outFile,
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const observed = JSON.parse(await readFile(outFile, "utf8"));
+    assert.equal(observed.source, "managed");
+    assert.equal(observed.version, version);
+    assert.equal(observed.repoRef, `v${version}`);
+    assert.equal(observed.buildSource, "github_release");
+    assert.equal(observed.archiveSha256, archiveSha256);
+    assert.match(observed.path, /codestory-cli[\\/]+0\.11\.15[\\/]bin[\\/]codestory-cli/u);
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+
+    const manifest = JSON.parse(
+      await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
+    );
+    assert.equal(manifest.version, version);
+    assert.equal(manifest.repo_ref, `v${version}`);
+    assert.equal(manifest.build_source, "github_release");
+    assert.equal(manifest.archive, archiveName);
+    assert.equal(manifest.archive_sha256, archiveSha256);
+    assert.equal(typeof manifest.sha256, "string");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
 });
 
 test("session-start hooks are thin and host manifests point at them", async () => {
@@ -381,13 +528,21 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
   const statusRuntimeRequired = [
     "codestory://status",
     "server_version",
+    "cli_version",
     "server_executable",
+    "server_executable_sha256",
+    "sidecar_contract_version",
+    "plugin_runtime",
+    "build_source",
+    "repo_ref",
     "allowed_surfaces",
   ];
   const cliRepairRequired = ["where.exe codestory-cli", "codestory-cli --version"];
   const stdioLaunchRequired = [
     "codestory-cli serve --stdio --refresh none",
-    "agent host `PATH`",
+    "scripts/codestory-mcp.cjs",
+    "github_release",
+    "path_fallback",
   ];
   const marketplaceSourceRequired = [
     "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",
@@ -470,6 +625,7 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "Install details, binary bootstrap",
     "[plugin README](plugins/codestory/README.md)",
     "`codestory-cli serve --stdio --refresh none`",
+    "managed MCP adapter",
     "Codex uses the plugin's MCP server plus the\n`@CodeStory` skill",
   ];
   for (const text of [readme, skill]) {


### PR DESCRIPTION
## Context

Closes #455.

This promotes the current `dev/codestory-next` release slice to `main` as CodeStory 0.11.16. The branch starts from `origin/dev/codestory-next` at `e31bf18020446bcef8fc822d5853ab8e213ddbc7` and adds only the release/version metadata commit.

Latest public release before this PR is `v0.11.15`. This PR does not create or push a `v*` tag; the `main` release workflow owns tags, GitHub release assets, and checksums after merge.

## What Changed

- Bumped all eight `codestory-*` workspace crate versions and `Cargo.lock` from `0.11.15` to `0.11.16`.
- Bumped Codex, Claude, and GitHub plugin package manifests to `0.11.16`.
- Updated plugin static test fixtures for the versioned managed CLI path and release provisioning metadata.
- Added the 0.11.16 changelog entry covering:
  - #443 / PR #451: `codestory-cli agent preflight --project <repo> --format json`.
  - #450 / PR #452: Rust release-aware Cargo cache keys.
  - #442 / PR #449: plugin-managed versioned CLI provisioning and `codestory://status` runtime metadata.
  - #445 / PR #454: golden agent path docs and explicit hook behavior.

## How To Review

- Confirm the release bump commit is metadata-only on top of `dev/codestory-next`.
- Check `crates/codestory-cli/Cargo.toml`, the other workspace crate manifests, `Cargo.lock`, and plugin manifests all read `0.11.16`.
- Review the changelog entry for accurate release notes and explicit non-claims.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.16` -> passed; 8 workspace crates, `Cargo.lock`, and the codestory plugin are synchronized.
- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> passed; 12 tests.
- `cargo check -p codestory-cli --locked` -> passed in 2m 15s.
- `git diff --check` -> passed.

## Risk

- Draft until CI confirms the promoted dev delta and release workflow expectations.
- This PR does not claim fresh packet/search sidecar readiness; local release-lane doctor in this worktree reported missing index/sidecar manifest, so proof here is direct source, git, and release checks.
- Release tags/assets are intentionally left to the `main` release workflow after merge.