### PR TITLE
[codex] optimize release ci cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,25 @@ jobs:
           rustup default stable
           rustup target add "${{ matrix.rust_target }}"
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Cargo registry, git sources, and build output
+        id: cargo-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-release-stable-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-release-stable-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-
+
       - name: Build codestory-cli
         run: cargo build --release -p codestory-cli --target "${{ matrix.rust_target }}"
 
@@ -162,7 +181,7 @@ jobs:
             --out-dir target/release-dist
 
       - name: Upload release asset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: codestory-cli-${{ matrix.asset_target }}
           path: |
@@ -170,6 +189,17 @@ jobs:
             target/release-dist/*.zip
             target/release-dist/*.sha256
           if-no-files-found: error
+
+      - name: Save Cargo registry, git sources, and build output
+        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}
 
   publish:
     name: Publish GitHub release
@@ -187,7 +217,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: target/release-assets
           pattern: codestory-cli-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,9 @@ jobs:
           & $bin --version
           & $bin --help
 
+      - name: Clear release asset output
+        run: python -c "import shutil; shutil.rmtree('target/release-dist', ignore_errors=True)"
+
       - name: Package release asset
         if: runner.os != 'Windows'
         run: |


### PR DESCRIPTION
## Context

Release `v0.11.16` shipped successfully, but the Auto Release run emitted Node 20 deprecation annotations from artifact actions and each release matrix build rebuilt Cargo state cold.

Closes #457

## What Changed

- Upgraded release artifact upload/download actions from `v4` to `v5`.
- Added release matrix Cargo cache restore/save using `actions/cache/restore@v5` and `actions/cache/save@v5`.
- Keyed release build caches by runner OS, Rust release, matrix Rust target triple, and `Cargo.lock`.
- Added a same-OS/Rust/target restore prefix so older `Cargo.lock` caches can seed future release builds without crossing target triples.
- Clear `target/release-dist` after cache restore/smoke and before packaging so cached `target` state cannot upload stale archives or checksums.

## How To Review

- Inspect `.github/workflows/release.yml` only.
- Confirm the cache restore runs after Rust stable and the matrix target are installed, before `cargo build --release -p codestory-cli --target ...`.
- Confirm `target/release-dist` is removed before both packaging paths run.
- Confirm smoke, packaging, checksum verification, tag refusal, and release refusal behavior remain intact.

## Verification

- `node .github/scripts/check-workflow-policy.mjs` -> passed: `Workflow policy passed: third-party actions and saga issue-link guard are valid.`
- `node -e ...` focused YAML/action assertion -> passed: `release workflow static checks passed`.
- `git diff --check` -> passed.

No Cargo build was run; this is workflow YAML only.

## Risk

First run per OS/Rust/target/Cargo.lock cache key will still be cold. Cache save is best-effort and `continue-on-error`, so release correctness should not depend on cache availability.
