### PR TITLE
[codex] add sidecar setup policy

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1339,6 +1339,7 @@ pub(crate) struct AgentPreflightOutput {
     pub(crate) mode: String,
     pub(crate) local_graph: AgentPreflightLaneOutput,
     pub(crate) full_retrieval: AgentPreflightLaneOutput,
+    pub(crate) sidecar_setup: serde_json::Value,
     pub(crate) safe_surfaces: Vec<String>,
     pub(crate) blocked_surfaces: Vec<String>,
     pub(crate) repair_command: Option<String>,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -34,6 +34,7 @@ use std::{
     fs,
     io::{IsTerminal, Read},
     net::TcpListener,
+    path::Path,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -1286,7 +1287,7 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
         summary.freshness.as_ref(),
         &sidecar,
     );
-    let output = build_agent_preflight_output(&readiness);
+    let output = build_agent_preflight_output(&readiness, Path::new(&summary.root));
     let markdown = render_agent_preflight_markdown(&output);
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
@@ -1334,6 +1335,7 @@ const FULL_RETRIEVAL_AGENT_SURFACES: &[&str] = &["packet_full", "search_full", "
 
 fn build_agent_preflight_output(
     readiness: &[codestory_contracts::api::ReadinessVerdictDto],
+    project_root: &Path,
 ) -> args::AgentPreflightOutput {
     let local = readiness
         .iter()
@@ -1375,6 +1377,7 @@ fn build_agent_preflight_output(
         mode: mode.to_string(),
         local_graph: agent_preflight_lane(local),
         full_retrieval: agent_preflight_lane(agent),
+        sidecar_setup: stdio_transport::stdio_sidecar_setup_status(project_root),
         safe_surfaces,
         blocked_surfaces,
         repair_command,
@@ -1429,6 +1432,13 @@ fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> Strin
         "full_retrieval: {}",
         readiness::status_label(output.full_retrieval.status)
     );
+    if let Some(state) = output
+        .sidecar_setup
+        .get("state")
+        .and_then(|value| value.as_str())
+    {
+        let _ = writeln!(markdown, "sidecar_setup: `{state}`");
+    }
     let _ = writeln!(markdown, "human_summary: {}", output.human_summary);
     if let Some(command) = output.repair_command.as_deref() {
         let _ = writeln!(markdown, "repair_command: `{command}`");

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2023,8 +2023,9 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
             manifest_input_hash: manifest_input_hash.as_deref(),
         }),
     });
+    let sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
     let allowed_surfaces = stdio_allowed_surfaces(&readiness);
-    let recommended_next_calls = stdio_status_recommended_next_calls(&readiness);
+    let recommended_next_calls = stdio_status_recommended_next_calls(&readiness, &sidecar_setup);
     Ok(serde_json::json!({
         "server_version": env!("CARGO_PKG_VERSION"),
         "cli_version": env!("CARGO_PKG_VERSION"),
@@ -2043,6 +2044,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         "retrieval_mode": sidecar_mode,
         "degraded_reason": degraded_reason,
         "sidecar_retrieval": sidecar,
+        "sidecar_setup": sidecar_setup,
         "legacy_semantic_diagnostics": {
             "mode": retrieval.map(|state| state.mode),
             "semantic_ready": retrieval.is_some_and(|state| state.semantic_ready),
@@ -2234,8 +2236,64 @@ fn semver_triplet(version: &str) -> Option<(u64, u64, u64)> {
     parts.next().is_none().then_some((major, minor, patch))
 }
 
-fn stdio_status_recommended_next_calls(readiness: &[ReadinessVerdictDto]) -> serde_json::Value {
+fn stdio_status_recommended_next_calls(
+    readiness: &[ReadinessVerdictDto],
+    sidecar_setup: &serde_json::Value,
+) -> serde_json::Value {
     if let Some(non_ready) = crate::readiness::primary_non_ready(readiness) {
+        if non_ready.goal == ReadinessGoalDto::AgentPacketSearch {
+            match sidecar_setup
+                .get("state")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("ask")
+            {
+                "ask" => {
+                    return serde_json::json!([
+                        {
+                            "method": "host/confirm",
+                            "instruction": sidecar_setup["prompt"]
+                        },
+                        {
+                            "method": "cli",
+                            "command": sidecar_setup["enable_command"]
+                        },
+                        {
+                            "method": "cli",
+                            "command": sidecar_setup["disable_command"]
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://status"
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://agent-guide"
+                        }
+                    ]);
+                }
+                "disabled" => {
+                    return serde_json::json!([
+                        {
+                            "method": "host/instruction",
+                            "instruction": "Automatic sidecar setup is disabled for this plugin install."
+                        },
+                        {
+                            "method": "cli",
+                            "command": sidecar_setup["enable_command"]
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://status"
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://agent-guide"
+                        }
+                    ]);
+                }
+                _ => {}
+            }
+        }
         return serde_json::Value::Array(
             non_ready
                 .full_repair
@@ -2360,6 +2418,39 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         "managed_binary_sha256": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_SHA256") } else { None },
         "managed_manifest_path": env_nonempty("CODESTORY_PLUGIN_CLI_MANIFEST_PATH"),
         "warnings": warnings
+    })
+}
+
+pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Value {
+    let state = match env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE").as_deref() {
+        Some("enabled") => "enabled",
+        Some("disabled") => "disabled",
+        Some(_) => "ask",
+        None => "unmanaged",
+    };
+    let prompt_required = matches!(state, "ask");
+    let auto_repair = matches!(state, "enabled");
+    let project = crate::display::clean_path_string(&project_root.to_string_lossy());
+    let default_repair =
+        format!("codestory-cli ready --goal agent --repair --project \"{project}\" --format json");
+    let next_repair_command =
+        env_nonempty("CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND").unwrap_or(default_repair);
+    serde_json::json!({
+        "state": state,
+        "auto_repair": auto_repair,
+        "prompt_required": prompt_required,
+        "prompt": if prompt_required { Some("CodeStory packet/search needs retrieval sidecars. Enable automatic sidecar setup for this plugin install?") } else { None },
+        "enable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND"),
+        "disable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND"),
+        "next_repair_command": next_repair_command,
+        "policy_path": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH"),
+        "policy_updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT"),
+        "last_repair": {
+            "state": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE"),
+            "updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT"),
+            "project_root": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT"),
+            "command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND")
+        }
     })
 }
 
@@ -2733,17 +2824,20 @@ mod tests {
         let restart =
             "Restart/reload the Codex host/app so MCP relaunches codestory-cli 0.11.11 from C:/Users/alber/AppData/Local/CodeStory/bin/codestory-cli.exe; then open a fresh agent thread and read codestory://status."
                 .to_string();
-        let calls = stdio_status_recommended_next_calls(&[ReadinessVerdictDto {
-            goal: ReadinessGoalDto::LocalNavigation,
-            status: ReadinessStatusDto::RepairSetup,
-            summary: "A newer installed codestory-cli exists outside the active process."
-                .to_string(),
-            minimum_next: vec![restart.clone()],
-            full_repair: vec![restart.clone()],
-            setup: None,
-            index: None,
-            sidecar: None,
-        }]);
+        let calls = stdio_status_recommended_next_calls(
+            &[ReadinessVerdictDto {
+                goal: ReadinessGoalDto::LocalNavigation,
+                status: ReadinessStatusDto::RepairSetup,
+                summary: "A newer installed codestory-cli exists outside the active process."
+                    .to_string(),
+                minimum_next: vec![restart.clone()],
+                full_repair: vec![restart.clone()],
+                setup: None,
+                index: None,
+                sidecar: None,
+            }],
+            &json!({"state": "enabled"}),
+        );
 
         assert_eq!(calls[0]["method"], json!("host/restart"));
         assert_eq!(calls[0]["instruction"], json!(restart));

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -14,6 +14,7 @@ struct StdioFixture {
     hash_embeddings: bool,
     latest_release_version: String,
     disable_installed_cli_probe: bool,
+    sidecar_policy_state: Option<String>,
 }
 
 struct StdioServer {
@@ -134,6 +135,7 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
         hash_embeddings,
         latest_release_version: env!("CARGO_PKG_VERSION").to_string(),
         disable_installed_cli_probe: false,
+        sidecar_policy_state: None,
     }
 }
 
@@ -226,6 +228,17 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
     );
     if fixture.disable_installed_cli_probe {
         command.env("CODESTORY_DISABLE_INSTALLED_CLI_PROBE", "1");
+    }
+    if let Some(state) = &fixture.sidecar_policy_state {
+        command.env("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE", state);
+        command.env(
+            "CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND",
+            "node codestory-mcp.cjs sidecar-policy enable",
+        );
+        command.env(
+            "CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND",
+            "node codestory-mcp.cjs sidecar-policy disable",
+        );
     }
     let mut child = command.spawn().expect("spawn stdio server");
 
@@ -2125,6 +2138,95 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
             .and_then(Value::as_array)
             .is_some_and(|calls| !calls.is_empty()),
         "status should include recommended next calls: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_prompts_before_sidecar_repair_when_policy_is_ask() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("ask".to_string());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-sidecar-ask",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-sidecar-ask"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["sidecar_setup"]["state"], json!("ask"));
+    assert_eq!(status["sidecar_setup"]["prompt_required"], json!(true));
+    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
+    let next_call_text = status["recommended_next_calls"].to_string();
+    assert!(next_call_text.contains("host/confirm"), "{status}");
+    assert!(next_call_text.contains("sidecar-policy enable"), "{status}");
+    assert!(
+        !next_call_text.contains("ready --goal agent --repair"),
+        "ask policy should not recommend heavy sidecar repair before consent: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_recommends_sidecar_repair_when_policy_enabled() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("enabled".to_string());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-sidecar-enabled",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-sidecar-enabled"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["sidecar_setup"]["state"], json!("enabled"));
+    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(true));
+    let next_call_text = status["recommended_next_calls"].to_string();
+    assert!(
+        next_call_text.contains("codestory-cli ready --goal agent --repair"),
+        "enabled policy should keep the existing agent repair path visible: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_suppresses_auto_repair_when_policy_disabled() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("disabled".to_string());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-sidecar-disabled",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-sidecar-disabled"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["sidecar_setup"]["state"], json!("disabled"));
+    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
+    let next_call_text = status["recommended_next_calls"].to_string();
+    assert!(
+        next_call_text.contains("Automatic sidecar setup is disabled"),
+        "{status}"
+    );
+    assert!(next_call_text.contains("sidecar-policy enable"), "{status}");
+    assert!(
+        !next_call_text.contains("ready --goal agent --repair"),
+        "disabled policy should not recommend automatic sidecar repair: {status}"
     );
 }
 

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -11,7 +11,7 @@ packet-runtime, drill, or benchmark evidence tier.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ integration.
 | --- | --- | --- | --- |
 | Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
+| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -121,9 +121,9 @@ codestory-cli ground --project <target-workspace> --why
 
 When MCP is live, use `codestory://status` as the runtime truth. Its
 `server_version`, `cli_version`, `server_executable`,
-`server_executable_sha256`, `sidecar_contract_version`, and `plugin_runtime`
-fields identify the active server, CLI, sidecar contract, plugin launch source,
-`build_source`, and `repo_ref`, and
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
+`sidecar_setup` fields identify the active server, CLI, sidecar contract,
+plugin launch source, sidecar setup policy, `build_source`, and `repo_ref`, and
 `allowed_surfaces` tells the agent which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
@@ -179,7 +179,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -59,7 +59,7 @@ running server.
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
@@ -144,8 +144,9 @@ If the host does not expose lifecycle hooks yet, use the explicit prompt:
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
 live through MCP by reading `codestory://status`. If MCP is live, the agent uses
 `server_version`, `cli_version`, `server_executable`,
-`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
-`allowed_surfaces` from status instead of rechecking PATH or release metadata.
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`,
+`sidecar_setup`, and `allowed_surfaces` from status instead of rechecking PATH
+or release metadata.
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
 missing, status reports a suspect runtime, or you are debugging/repairing the

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -48,6 +48,127 @@ function pluginDataDir() {
   return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
 }
 
+function sidecarPolicyPath(dataDir = pluginDataDir()) {
+  return dataDir ? path.join(dataDir, 'sidecar-setup-policy.json') : null;
+}
+
+function sidecarPolicyCommand(action, policyFile = sidecarPolicyPath()) {
+  const policyArg = policyFile ? ` --policy-file ${JSON.stringify(policyFile)}` : '';
+  return `node ${JSON.stringify(__filename)} sidecar-policy ${action}${policyArg}`;
+}
+
+function normalizeSidecarPolicyState(value) {
+  const state = String(value || '').trim().toLowerCase();
+  if (state === 'enabled' || state === 'disabled' || state === 'ask' || state === 'unknown') {
+    return state === 'unknown' ? 'ask' : state;
+  }
+  return 'ask';
+}
+
+function readSidecarPolicy(file = sidecarPolicyPath()) {
+  const policy = file ? readJson(file) : null;
+  const state = normalizeSidecarPolicyState(process.env.CODESTORY_PLUGIN_SIDECAR_POLICY || policy?.state);
+  return {
+    state,
+    path: file,
+    updatedAt: policy?.updated_at || null,
+    lastRepair: policy?.last_repair || null,
+  };
+}
+
+function writeSidecarPolicy(state, patch = {}, file = sidecarPolicyPath()) {
+  if (!file) return null;
+  const current = readJson(file) || {};
+  const next = {
+    ...current,
+    ...patch,
+    state: normalizeSidecarPolicyState(state),
+    updated_at: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(next, null, 2));
+  return next;
+}
+
+function handleSidecarPolicyCommand(argv) {
+  if (argv[2] !== 'sidecar-policy') return;
+  const action = argv[3] || 'status';
+  const policyFileFlag = argv.indexOf('--policy-file');
+  const policyFile = policyFileFlag >= 0 ? argv[policyFileFlag + 1] : sidecarPolicyPath();
+  if (!['enable', 'disable', 'ask', 'status'].includes(action)) {
+    process.stderr.write('usage: codestory-mcp.cjs sidecar-policy [enable|disable|ask|status] [--policy-file PATH]\n');
+    process.exit(2);
+  }
+  if (policyFileFlag >= 0 && !policyFile) {
+    process.stderr.write('sidecar-policy --policy-file requires a path\n');
+    process.exit(2);
+  }
+  if (action !== 'status') {
+    if (!policyFile) {
+      process.stderr.write('sidecar-policy needs PLUGIN_DATA or --policy-file to remember the setting\n');
+      process.exit(2);
+    }
+    writeSidecarPolicy(action === 'enable' ? 'enabled' : action === 'disable' ? 'disabled' : 'ask', {}, policyFile);
+  }
+  process.stdout.write(`${JSON.stringify(readSidecarPolicy(policyFile), null, 2)}\n`);
+  process.exit(0);
+}
+
+function repairCommandForProject(projectRoot = process.cwd()) {
+  return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json`;
+}
+
+function recordSidecarRepair(state, patch = {}) {
+  const policy = readSidecarPolicy();
+  if (policy.state !== 'enabled') return;
+  writeSidecarPolicy('enabled', {
+    last_repair: {
+      ...(policy.lastRepair || {}),
+      ...patch,
+      state,
+      updated_at: new Date().toISOString(),
+    },
+  });
+}
+
+function scheduleSidecarRepair(resolved, policy) {
+  if (policy.state !== 'enabled') return;
+  const projectRoot = process.cwd();
+  const args = ['ready', '--goal', 'agent', '--repair', '--project', projectRoot, '--format', 'json'];
+  recordSidecarRepair('scheduled', {
+    project_root: projectRoot,
+    command: repairCommandForProject(projectRoot),
+    started_at: new Date().toISOString(),
+  });
+  try {
+    const repair = spawn(resolved.path, args, {
+      stdio: 'ignore',
+      shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+      windowsHide: true,
+      env: { ...process.env, CODESTORY_PLUGIN_SIDECAR_REPAIR: '1' },
+    });
+    repair.on('exit', (code, signal) => {
+      recordSidecarRepair(code === 0 ? 'completed' : 'failed', {
+        exit_code: code,
+        signal: signal || null,
+        finished_at: new Date().toISOString(),
+      });
+    });
+    repair.on('error', (error) => {
+      recordSidecarRepair('spawn_failed', {
+        error: error.message,
+        finished_at: new Date().toISOString(),
+      });
+    });
+    repair.unref();
+  } catch (error) {
+    recordSidecarRepair('spawn_failed', {
+      error: error.message,
+      finished_at: new Date().toISOString(),
+    });
+  }
+}
+
 function resolveManifest(manifestPath) {
   const manifest = readJson(manifestPath);
   if (!manifest) return null;
@@ -288,8 +409,12 @@ function rememberLaunch(resolved) {
 }
 
 async function main() {
+  handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
+  const sidecarPolicy = readSidecarPolicy();
+  scheduleSidecarRepair(resolved, sidecarPolicy);
+  const sidecarStatus = readSidecarPolicy();
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
     stdio: 'inherit',
@@ -309,6 +434,16 @@ async function main() {
       CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
       CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
       CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+      CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
+      CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
+      CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
+      CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
+      CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
+      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: repairCommandForProject(process.cwd()),
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND: sidecarStatus.lastRepair?.command || '',
     },
   });
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -48,6 +48,7 @@ Use status fields this way:
 | `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
 | `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
 | `plugin_runtime` | Plugin launch source and managed CLI metadata, including `build_source` and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
+| `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Ask before first automatic sidecar setup; respect `enabled` and `disabled`. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -62,6 +62,7 @@ call.
 | `server_executable` / `server_executable_sha256` | Active MCP server executable path and checksum. Use them to diagnose stale runtime or binary drift. |
 | `sidecar_contract_version` | Active sidecar schema contract version compiled into the CLI. |
 | `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. Provisioned records include `build_source=github_release` and `repo_ref`. |
+| `sidecar_setup` | Plugin sidecar setup policy (`ask`, `enabled`, or `disabled`) plus last repair state and opt-in/disable commands. |
 | `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Allows `packet`, `search`, and `context` only when the surface bit is true and `retrieval_mode=full`. |

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -49,16 +49,26 @@ async function writeFakeCli(cliPath) {
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
-      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))" %*\r\n`,
+      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
       "utf8",
     );
     return;
   }
   await writeFile(
     cliPath,
-    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))' "$@"\n`,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
     "utf8",
   );
+  await chmod(cliPath, 0o755);
+}
+
+async function writeRecordingCli(cliPath) {
+  const script = "const fs=require('fs');fs.appendFileSync(process.env.TEST_LOG,JSON.stringify({repair:process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR==='1',policy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,args:process.argv.slice(1)})+'\\n')";
+  if (process.platform === "win32") {
+    await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`, "utf8");
+    return;
+  }
+  await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} "$@"\n`, "utf8");
   await chmod(cliPath, 0o755);
 }
 
@@ -155,7 +165,110 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.source, "managed");
     assert.equal(observed.path, cliPath);
     assert.equal(observed.sha256, sha256);
+    assert.equal(observed.sidecarPolicy, "ask");
+    assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
+    assert.match(observed.sidecarEnable, /--policy-file/u);
     assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+
+    const enable = spawnSync(observed.sidecarEnable, {
+      shell: true,
+      env: {
+        ...process.env,
+        PLUGIN_DATA: "",
+        COPILOT_PLUGIN_DATA: "",
+      },
+      encoding: "utf8",
+    });
+    assert.equal(enable.status, 0, enable.stderr);
+    const policy = JSON.parse(
+      await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
+    );
+    assert.equal(policy.state, "enabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher persists sidecar setup policy in plugin data", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-policy-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    const enable = spawnSync(process.execPath, [launcher, "sidecar-policy", "enable"], {
+      env: { PLUGIN_DATA: dataDir },
+      encoding: "utf8",
+    });
+    assert.equal(enable.status, 0, enable.stderr);
+    assert.equal(JSON.parse(enable.stdout).state, "enabled");
+
+    const disable = spawnSync(process.execPath, [launcher, "sidecar-policy", "disable"], {
+      env: { PLUGIN_DATA: dataDir },
+      encoding: "utf8",
+    });
+    assert.equal(disable.status, 0, disable.stderr);
+    assert.equal(JSON.parse(disable.stdout).state, "disabled");
+
+    const policy = JSON.parse(
+      await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
+    );
+    assert.equal(policy.state, "disabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("enabled sidecar policy schedules existing agent repair path", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
+  const logFile = join(dataDir, "calls.jsonl");
+  const cliDir = join(dataDir, "codestory-cli", "0.11.15");
+  const cliPath = join(
+    cliDir,
+    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+  );
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    await writeRecordingCli(cliPath);
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+    await writeFile(
+      join(dataDir, "sidecar-setup-policy.json"),
+      JSON.stringify({ state: "enabled" }),
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: dataDir,
+        TEST_LOG: logFile,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const text = await readFile(logFile, "utf8").catch(() => "");
+      const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+      if (calls.some((call) => call.repair)) {
+        assert.ok(calls.some((call) => call.args.includes("serve")), text);
+        const repair = calls.find((call) => call.repair);
+        assert.deepEqual(repair.args.slice(0, 4), ["ready", "--goal", "agent", "--repair"]);
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.fail(`repair call was not recorded:\n${await readFile(logFile, "utf8").catch(() => "")}`);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -533,6 +646,7 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "server_executable_sha256",
     "sidecar_contract_version",
     "plugin_runtime",
+    "sidecar_setup",
     "build_source",
     "repo_ref",
     "allowed_surfaces",


### PR DESCRIPTION
## Context

Closes #453.

The Codex plugin adapter managed the CLI binary but had no remembered policy for retrieval sidecar setup. First plugin launches kept reporting packet/search repair without a consent path, and later launches could not distinguish ask/enabled/disabled sidecar setup behavior.

Fresh public install/cache dogfood is not claimed clean here. The local stale install evidence is tracked separately in #460.

## What Changed

- Added plugin-data sidecar setup policy persistence in `plugins/codestory/scripts/codestory-mcp.cjs` with `ask`, `enabled`, and `disabled` states.
- Added `sidecar-policy enable|disable|ask|status` adapter commands for the opt-in/stop path.
- Made the emitted enable/disable commands self-contained by carrying `--policy-file <plugin-data>/sidecar-setup-policy.json`, so they still persist when run from a normal shell without `PLUGIN_DATA`.
- On `enabled`, plugin startup schedules the existing `codestory-cli ready --goal agent --repair --project <repo> --format json` path in the background and records last repair state.
- On `ask`, startup does not run repair and status recommends a plain consent action plus enable/disable commands.
- On `disabled`, startup suppresses auto-repair and status says automatic sidecar setup is disabled.
- Exposed `sidecar_setup` in `codestory://status` and CLI agent preflight output; updated the nearby status docs/skill reference.

## How To Review

- Start with `plugins/codestory/scripts/codestory-mcp.cjs` for persistence, self-contained policy commands, and background repair scheduling.
- Check `crates/codestory-cli/src/stdio_transport.rs` for `codestory://status` and recommended next-call behavior.
- Check `plugins/codestory/tests/plugin-static.test.mjs` for the emitted enable command running without `PLUGIN_DATA` and writing the intended policy file.
- Check `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for ask/enabled/disabled status coverage.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` passed: 14 tests, including the emitted enable command without `PLUGIN_DATA` writing `sidecar-setup-policy.json`.
- `cargo test -p codestory-cli --test stdio_protocol_contracts -- --nocapture` passed earlier in this PR: 26 passed, 8 ignored live full-sidecar tests.
- `cargo fmt --check` passed earlier in this PR.
- `git diff --check` passed after the blocker fix.

## Risk

The enabled path schedules the existing repair command in the background; this PR does not prove live full-sidecar readiness or change the sidecar isolation work tracked in #446. Live packet/search readiness still requires `retrieval_mode=full` evidence after repair.

Adjacent runtime freshness risk: #460 tracks stale public Codex plugin/cache install evidence (`codestory/0.11.15` cache and `codestory-cli 0.11.11` on PATH after restart/reinstall). This PR exposes policy state once the adapter is active, but it does not prove the public fresh-install path selects the newest plugin cache/runtime.