### PR TITLE
Release CodeStory 0.11.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,25 @@ jobs:
           rustup default stable
           rustup target add "${{ matrix.rust_target }}"
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Cargo registry, git sources, and build output
+        id: cargo-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-release-stable-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-release-stable-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-
+
       - name: Build codestory-cli
         run: cargo build --release -p codestory-cli --target "${{ matrix.rust_target }}"
 
@@ -162,7 +181,7 @@ jobs:
             --out-dir target/release-dist
 
       - name: Upload release asset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: codestory-cli-${{ matrix.asset_target }}
           path: |
@@ -170,6 +189,17 @@ jobs:
             target/release-dist/*.zip
             target/release-dist/*.sha256
           if-no-files-found: error
+
+      - name: Save Cargo registry, git sources, and build output
+        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}
 
   publish:
     name: Publish GitHub release
@@ -187,7 +217,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: target/release-assets
           pattern: codestory-cli-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,9 @@ jobs:
           & $bin --version
           & $bin --help
 
+      - name: Clear release asset output
+        run: python -c "import shutil; shutil.rmtree('target/release-dist', ignore_errors=True)"
+
       - name: Package release asset
         if: runner.os != 'Windows'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.11.17
+
+CodeStory 0.11.17 promotes the current `dev/codestory-next` release slice:
+release workflow artifact actions are upgraded to v5, the release matrix now
+restores and saves Cargo cache entries, and stale `target/release-dist` output
+is cleared before packaging.
+
+The CodeStory plugin now carries the sidecar setup policy surfaces from the
+0.11.17 development slice: `ask`, `enabled`, and `disabled` policy modes,
+`sidecar_setup` status and preflight exposure, background
+`ready --goal agent --repair` scheduling when setup is enabled, disabled-policy
+suppression, and enable/disable commands that persist through `--policy-file`
+outside `PLUGIN_DATA`.
+
+Operator note: Refs #460. Issue #460 required no source change. Public source
+and release metadata were already correct; local operator recovery came from
+refreshing the installed plugin cache with `codex.cmd plugin add
+codestory@TheGreenCedar --json`. Fresh host/plugin `codestory://status` proof
+remains outside this release PR.
+
 ## 0.11.16
 
 CodeStory 0.11.16 promotes the current `dev/codestory-next` release slice:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1339,6 +1339,7 @@ pub(crate) struct AgentPreflightOutput {
     pub(crate) mode: String,
     pub(crate) local_graph: AgentPreflightLaneOutput,
     pub(crate) full_retrieval: AgentPreflightLaneOutput,
+    pub(crate) sidecar_setup: serde_json::Value,
     pub(crate) safe_surfaces: Vec<String>,
     pub(crate) blocked_surfaces: Vec<String>,
     pub(crate) repair_command: Option<String>,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -34,6 +34,7 @@ use std::{
     fs,
     io::{IsTerminal, Read},
     net::TcpListener,
+    path::Path,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -1286,7 +1287,7 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
         summary.freshness.as_ref(),
         &sidecar,
     );
-    let output = build_agent_preflight_output(&readiness);
+    let output = build_agent_preflight_output(&readiness, Path::new(&summary.root));
     let markdown = render_agent_preflight_markdown(&output);
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
@@ -1334,6 +1335,7 @@ const FULL_RETRIEVAL_AGENT_SURFACES: &[&str] = &["packet_full", "search_full", "
 
 fn build_agent_preflight_output(
     readiness: &[codestory_contracts::api::ReadinessVerdictDto],
+    project_root: &Path,
 ) -> args::AgentPreflightOutput {
     let local = readiness
         .iter()
@@ -1375,6 +1377,7 @@ fn build_agent_preflight_output(
         mode: mode.to_string(),
         local_graph: agent_preflight_lane(local),
         full_retrieval: agent_preflight_lane(agent),
+        sidecar_setup: stdio_transport::stdio_sidecar_setup_status(project_root),
         safe_surfaces,
         blocked_surfaces,
         repair_command,
@@ -1429,6 +1432,13 @@ fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> Strin
         "full_retrieval: {}",
         readiness::status_label(output.full_retrieval.status)
     );
+    if let Some(state) = output
+        .sidecar_setup
+        .get("state")
+        .and_then(|value| value.as_str())
+    {
+        let _ = writeln!(markdown, "sidecar_setup: `{state}`");
+    }
     let _ = writeln!(markdown, "human_summary: {}", output.human_summary);
     if let Some(command) = output.repair_command.as_deref() {
         let _ = writeln!(markdown, "repair_command: `{command}`");

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2023,8 +2023,9 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
             manifest_input_hash: manifest_input_hash.as_deref(),
         }),
     });
+    let sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
     let allowed_surfaces = stdio_allowed_surfaces(&readiness);
-    let recommended_next_calls = stdio_status_recommended_next_calls(&readiness);
+    let recommended_next_calls = stdio_status_recommended_next_calls(&readiness, &sidecar_setup);
     Ok(serde_json::json!({
         "server_version": env!("CARGO_PKG_VERSION"),
         "cli_version": env!("CARGO_PKG_VERSION"),
@@ -2043,6 +2044,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         "retrieval_mode": sidecar_mode,
         "degraded_reason": degraded_reason,
         "sidecar_retrieval": sidecar,
+        "sidecar_setup": sidecar_setup,
         "legacy_semantic_diagnostics": {
             "mode": retrieval.map(|state| state.mode),
             "semantic_ready": retrieval.is_some_and(|state| state.semantic_ready),
@@ -2234,8 +2236,64 @@ fn semver_triplet(version: &str) -> Option<(u64, u64, u64)> {
     parts.next().is_none().then_some((major, minor, patch))
 }
 
-fn stdio_status_recommended_next_calls(readiness: &[ReadinessVerdictDto]) -> serde_json::Value {
+fn stdio_status_recommended_next_calls(
+    readiness: &[ReadinessVerdictDto],
+    sidecar_setup: &serde_json::Value,
+) -> serde_json::Value {
     if let Some(non_ready) = crate::readiness::primary_non_ready(readiness) {
+        if non_ready.goal == ReadinessGoalDto::AgentPacketSearch {
+            match sidecar_setup
+                .get("state")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("ask")
+            {
+                "ask" => {
+                    return serde_json::json!([
+                        {
+                            "method": "host/confirm",
+                            "instruction": sidecar_setup["prompt"]
+                        },
+                        {
+                            "method": "cli",
+                            "command": sidecar_setup["enable_command"]
+                        },
+                        {
+                            "method": "cli",
+                            "command": sidecar_setup["disable_command"]
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://status"
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://agent-guide"
+                        }
+                    ]);
+                }
+                "disabled" => {
+                    return serde_json::json!([
+                        {
+                            "method": "host/instruction",
+                            "instruction": "Automatic sidecar setup is disabled for this plugin install."
+                        },
+                        {
+                            "method": "cli",
+                            "command": sidecar_setup["enable_command"]
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://status"
+                        },
+                        {
+                            "method": "resources/read",
+                            "uri": "codestory://agent-guide"
+                        }
+                    ]);
+                }
+                _ => {}
+            }
+        }
         return serde_json::Value::Array(
             non_ready
                 .full_repair
@@ -2360,6 +2418,39 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         "managed_binary_sha256": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_SHA256") } else { None },
         "managed_manifest_path": env_nonempty("CODESTORY_PLUGIN_CLI_MANIFEST_PATH"),
         "warnings": warnings
+    })
+}
+
+pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Value {
+    let state = match env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE").as_deref() {
+        Some("enabled") => "enabled",
+        Some("disabled") => "disabled",
+        Some(_) => "ask",
+        None => "unmanaged",
+    };
+    let prompt_required = matches!(state, "ask");
+    let auto_repair = matches!(state, "enabled");
+    let project = crate::display::clean_path_string(&project_root.to_string_lossy());
+    let default_repair =
+        format!("codestory-cli ready --goal agent --repair --project \"{project}\" --format json");
+    let next_repair_command =
+        env_nonempty("CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND").unwrap_or(default_repair);
+    serde_json::json!({
+        "state": state,
+        "auto_repair": auto_repair,
+        "prompt_required": prompt_required,
+        "prompt": if prompt_required { Some("CodeStory packet/search needs retrieval sidecars. Enable automatic sidecar setup for this plugin install?") } else { None },
+        "enable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND"),
+        "disable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND"),
+        "next_repair_command": next_repair_command,
+        "policy_path": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH"),
+        "policy_updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT"),
+        "last_repair": {
+            "state": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE"),
+            "updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT"),
+            "project_root": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT"),
+            "command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND")
+        }
     })
 }
 
@@ -2733,17 +2824,20 @@ mod tests {
         let restart =
             "Restart/reload the Codex host/app so MCP relaunches codestory-cli 0.11.11 from C:/Users/alber/AppData/Local/CodeStory/bin/codestory-cli.exe; then open a fresh agent thread and read codestory://status."
                 .to_string();
-        let calls = stdio_status_recommended_next_calls(&[ReadinessVerdictDto {
-            goal: ReadinessGoalDto::LocalNavigation,
-            status: ReadinessStatusDto::RepairSetup,
-            summary: "A newer installed codestory-cli exists outside the active process."
-                .to_string(),
-            minimum_next: vec![restart.clone()],
-            full_repair: vec![restart.clone()],
-            setup: None,
-            index: None,
-            sidecar: None,
-        }]);
+        let calls = stdio_status_recommended_next_calls(
+            &[ReadinessVerdictDto {
+                goal: ReadinessGoalDto::LocalNavigation,
+                status: ReadinessStatusDto::RepairSetup,
+                summary: "A newer installed codestory-cli exists outside the active process."
+                    .to_string(),
+                minimum_next: vec![restart.clone()],
+                full_repair: vec![restart.clone()],
+                setup: None,
+                index: None,
+                sidecar: None,
+            }],
+            &json!({"state": "enabled"}),
+        );
 
         assert_eq!(calls[0]["method"], json!("host/restart"));
         assert_eq!(calls[0]["instruction"], json!(restart));

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -14,6 +14,7 @@ struct StdioFixture {
     hash_embeddings: bool,
     latest_release_version: String,
     disable_installed_cli_probe: bool,
+    sidecar_policy_state: Option<String>,
 }
 
 struct StdioServer {
@@ -134,6 +135,7 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
         hash_embeddings,
         latest_release_version: env!("CARGO_PKG_VERSION").to_string(),
         disable_installed_cli_probe: false,
+        sidecar_policy_state: None,
     }
 }
 
@@ -226,6 +228,17 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
     );
     if fixture.disable_installed_cli_probe {
         command.env("CODESTORY_DISABLE_INSTALLED_CLI_PROBE", "1");
+    }
+    if let Some(state) = &fixture.sidecar_policy_state {
+        command.env("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE", state);
+        command.env(
+            "CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND",
+            "node codestory-mcp.cjs sidecar-policy enable",
+        );
+        command.env(
+            "CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND",
+            "node codestory-mcp.cjs sidecar-policy disable",
+        );
     }
     let mut child = command.spawn().expect("spawn stdio server");
 
@@ -2125,6 +2138,95 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
             .and_then(Value::as_array)
             .is_some_and(|calls| !calls.is_empty()),
         "status should include recommended next calls: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_prompts_before_sidecar_repair_when_policy_is_ask() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("ask".to_string());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-sidecar-ask",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-sidecar-ask"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["sidecar_setup"]["state"], json!("ask"));
+    assert_eq!(status["sidecar_setup"]["prompt_required"], json!(true));
+    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
+    let next_call_text = status["recommended_next_calls"].to_string();
+    assert!(next_call_text.contains("host/confirm"), "{status}");
+    assert!(next_call_text.contains("sidecar-policy enable"), "{status}");
+    assert!(
+        !next_call_text.contains("ready --goal agent --repair"),
+        "ask policy should not recommend heavy sidecar repair before consent: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_recommends_sidecar_repair_when_policy_enabled() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("enabled".to_string());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-sidecar-enabled",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-sidecar-enabled"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["sidecar_setup"]["state"], json!("enabled"));
+    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(true));
+    let next_call_text = status["recommended_next_calls"].to_string();
+    assert!(
+        next_call_text.contains("codestory-cli ready --goal agent --repair"),
+        "enabled policy should keep the existing agent repair path visible: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_suppresses_auto_repair_when_policy_disabled() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("disabled".to_string());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-sidecar-disabled",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-sidecar-disabled"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["sidecar_setup"]["state"], json!("disabled"));
+    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
+    let next_call_text = status["recommended_next_calls"].to_string();
+    assert!(
+        next_call_text.contains("Automatic sidecar setup is disabled"),
+        "{status}"
+    );
+    assert!(next_call_text.contains("sidecar-policy enable"), "{status}");
+    assert!(
+        !next_call_text.contains("ready --goal agent --repair"),
+        "disabled policy should not recommend automatic sidecar repair: {status}"
     );
 }
 

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.16"
+version = "0.11.17"
 edition = "2024"
 
 [dependencies]

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -11,7 +11,7 @@ packet-runtime, drill, or benchmark evidence tier.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ integration.
 | --- | --- | --- | --- |
 | Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. |
+| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -121,9 +121,9 @@ codestory-cli ground --project <target-workspace> --why
 
 When MCP is live, use `codestory://status` as the runtime truth. Its
 `server_version`, `cli_version`, `server_executable`,
-`server_executable_sha256`, `sidecar_contract_version`, and `plugin_runtime`
-fields identify the active server, CLI, sidecar contract, plugin launch source,
-`build_source`, and `repo_ref`, and
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
+`sidecar_setup` fields identify the active server, CLI, sidecar contract,
+plugin launch source, sidecar setup policy, `build_source`, and `repo_ref`, and
 `allowed_surfaces` tells the agent which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
@@ -179,7 +179,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -59,7 +59,7 @@ running server.
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
@@ -144,8 +144,9 @@ If the host does not expose lifecycle hooks yet, use the explicit prompt:
 The first run should be agent-owned. The skill checks whether `codestory-cli` is
 live through MCP by reading `codestory://status`. If MCP is live, the agent uses
 `server_version`, `cli_version`, `server_executable`,
-`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
-`allowed_surfaces` from status instead of rechecking PATH or release metadata.
+`server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`,
+`sidecar_setup`, and `allowed_surfaces` from status instead of rechecking PATH
+or release metadata.
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
 missing, status reports a suspect runtime, or you are debugging/repairing the

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -48,6 +48,127 @@ function pluginDataDir() {
   return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
 }
 
+function sidecarPolicyPath(dataDir = pluginDataDir()) {
+  return dataDir ? path.join(dataDir, 'sidecar-setup-policy.json') : null;
+}
+
+function sidecarPolicyCommand(action, policyFile = sidecarPolicyPath()) {
+  const policyArg = policyFile ? ` --policy-file ${JSON.stringify(policyFile)}` : '';
+  return `node ${JSON.stringify(__filename)} sidecar-policy ${action}${policyArg}`;
+}
+
+function normalizeSidecarPolicyState(value) {
+  const state = String(value || '').trim().toLowerCase();
+  if (state === 'enabled' || state === 'disabled' || state === 'ask' || state === 'unknown') {
+    return state === 'unknown' ? 'ask' : state;
+  }
+  return 'ask';
+}
+
+function readSidecarPolicy(file = sidecarPolicyPath()) {
+  const policy = file ? readJson(file) : null;
+  const state = normalizeSidecarPolicyState(process.env.CODESTORY_PLUGIN_SIDECAR_POLICY || policy?.state);
+  return {
+    state,
+    path: file,
+    updatedAt: policy?.updated_at || null,
+    lastRepair: policy?.last_repair || null,
+  };
+}
+
+function writeSidecarPolicy(state, patch = {}, file = sidecarPolicyPath()) {
+  if (!file) return null;
+  const current = readJson(file) || {};
+  const next = {
+    ...current,
+    ...patch,
+    state: normalizeSidecarPolicyState(state),
+    updated_at: new Date().toISOString(),
+  };
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(next, null, 2));
+  return next;
+}
+
+function handleSidecarPolicyCommand(argv) {
+  if (argv[2] !== 'sidecar-policy') return;
+  const action = argv[3] || 'status';
+  const policyFileFlag = argv.indexOf('--policy-file');
+  const policyFile = policyFileFlag >= 0 ? argv[policyFileFlag + 1] : sidecarPolicyPath();
+  if (!['enable', 'disable', 'ask', 'status'].includes(action)) {
+    process.stderr.write('usage: codestory-mcp.cjs sidecar-policy [enable|disable|ask|status] [--policy-file PATH]\n');
+    process.exit(2);
+  }
+  if (policyFileFlag >= 0 && !policyFile) {
+    process.stderr.write('sidecar-policy --policy-file requires a path\n');
+    process.exit(2);
+  }
+  if (action !== 'status') {
+    if (!policyFile) {
+      process.stderr.write('sidecar-policy needs PLUGIN_DATA or --policy-file to remember the setting\n');
+      process.exit(2);
+    }
+    writeSidecarPolicy(action === 'enable' ? 'enabled' : action === 'disable' ? 'disabled' : 'ask', {}, policyFile);
+  }
+  process.stdout.write(`${JSON.stringify(readSidecarPolicy(policyFile), null, 2)}\n`);
+  process.exit(0);
+}
+
+function repairCommandForProject(projectRoot = process.cwd()) {
+  return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json`;
+}
+
+function recordSidecarRepair(state, patch = {}) {
+  const policy = readSidecarPolicy();
+  if (policy.state !== 'enabled') return;
+  writeSidecarPolicy('enabled', {
+    last_repair: {
+      ...(policy.lastRepair || {}),
+      ...patch,
+      state,
+      updated_at: new Date().toISOString(),
+    },
+  });
+}
+
+function scheduleSidecarRepair(resolved, policy) {
+  if (policy.state !== 'enabled') return;
+  const projectRoot = process.cwd();
+  const args = ['ready', '--goal', 'agent', '--repair', '--project', projectRoot, '--format', 'json'];
+  recordSidecarRepair('scheduled', {
+    project_root: projectRoot,
+    command: repairCommandForProject(projectRoot),
+    started_at: new Date().toISOString(),
+  });
+  try {
+    const repair = spawn(resolved.path, args, {
+      stdio: 'ignore',
+      shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+      windowsHide: true,
+      env: { ...process.env, CODESTORY_PLUGIN_SIDECAR_REPAIR: '1' },
+    });
+    repair.on('exit', (code, signal) => {
+      recordSidecarRepair(code === 0 ? 'completed' : 'failed', {
+        exit_code: code,
+        signal: signal || null,
+        finished_at: new Date().toISOString(),
+      });
+    });
+    repair.on('error', (error) => {
+      recordSidecarRepair('spawn_failed', {
+        error: error.message,
+        finished_at: new Date().toISOString(),
+      });
+    });
+    repair.unref();
+  } catch (error) {
+    recordSidecarRepair('spawn_failed', {
+      error: error.message,
+      finished_at: new Date().toISOString(),
+    });
+  }
+}
+
 function resolveManifest(manifestPath) {
   const manifest = readJson(manifestPath);
   if (!manifest) return null;
@@ -288,8 +409,12 @@ function rememberLaunch(resolved) {
 }
 
 async function main() {
+  handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
+  const sidecarPolicy = readSidecarPolicy();
+  scheduleSidecarRepair(resolved, sidecarPolicy);
+  const sidecarStatus = readSidecarPolicy();
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
     stdio: 'inherit',
@@ -309,6 +434,16 @@ async function main() {
       CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
       CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
       CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+      CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
+      CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
+      CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
+      CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
+      CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
+      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: repairCommandForProject(process.cwd()),
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
+      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND: sidecarStatus.lastRepair?.command || '',
     },
   });
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -48,6 +48,7 @@ Use status fields this way:
 | `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
 | `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
 | `plugin_runtime` | Plugin launch source and managed CLI metadata, including `build_source` and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
+| `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Ask before first automatic sidecar setup; respect `enabled` and `disabled`. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -62,6 +62,7 @@ call.
 | `server_executable` / `server_executable_sha256` | Active MCP server executable path and checksum. Use them to diagnose stale runtime or binary drift. |
 | `sidecar_contract_version` | Active sidecar schema contract version compiled into the CLI. |
 | `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. Provisioned records include `build_source=github_release` and `repo_ref`. |
+| `sidecar_setup` | Plugin sidecar setup policy (`ask`, `enabled`, or `disabled`) plus last repair state and opt-in/disable commands. |
 | `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Allows `packet`, `search`, and `context` only when the surface bit is true and `retrieval_mode=full`. |

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -131,7 +131,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
   const { spawnSync } = await import("node:child_process");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-cli-"));
   const outFile = join(dataDir, "env.json");
-  const cliDir = join(dataDir, "codestory-cli", "0.11.16");
+  const cliDir = join(dataDir, "codestory-cli", "0.11.17");
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -222,7 +222,7 @@ test("enabled sidecar policy schedules existing agent repair path", async () => 
   const { spawnSync } = await import("node:child_process");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
   const logFile = join(dataDir, "calls.jsonl");
-  const cliDir = join(dataDir, "codestory-cli", "0.11.15");
+  const cliDir = join(dataDir, "codestory-cli", "0.11.17");
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -282,7 +282,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     return;
   }
 
-  const version = "0.11.16";
+  const version = "0.11.17";
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
   const outFile = join(dataDir, "env.json");
@@ -328,7 +328,10 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     assert.equal(observed.repoRef, `v${version}`);
     assert.equal(observed.buildSource, "github_release");
     assert.equal(observed.archiveSha256, archiveSha256);
-    assert.match(observed.path, /codestory-cli[\\/]+0\.11\.16[\\/]bin[\\/]codestory-cli/u);
+    assert.match(
+      observed.path,
+      new RegExp(String.raw`codestory-cli[\\/]+${version.replaceAll(".", String.raw`\.`)}[\\/]bin[\\/]codestory-cli`, "u"),
+    );
     assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
 
     const manifest = JSON.parse(

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -49,16 +49,26 @@ async function writeFakeCli(cliPath) {
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
-      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))" %*\r\n`,
+      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
       "utf8",
     );
     return;
   }
   await writeFile(
     cliPath,
-    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,args:process.argv.slice(1)}))' "$@"\n`,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
     "utf8",
   );
+  await chmod(cliPath, 0o755);
+}
+
+async function writeRecordingCli(cliPath) {
+  const script = "const fs=require('fs');fs.appendFileSync(process.env.TEST_LOG,JSON.stringify({repair:process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR==='1',policy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,args:process.argv.slice(1)})+'\\n')";
+  if (process.platform === "win32") {
+    await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`, "utf8");
+    return;
+  }
+  await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} "$@"\n`, "utf8");
   await chmod(cliPath, 0o755);
 }
 
@@ -155,7 +165,110 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.source, "managed");
     assert.equal(observed.path, cliPath);
     assert.equal(observed.sha256, sha256);
+    assert.equal(observed.sidecarPolicy, "ask");
+    assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
+    assert.match(observed.sidecarEnable, /--policy-file/u);
     assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+
+    const enable = spawnSync(observed.sidecarEnable, {
+      shell: true,
+      env: {
+        ...process.env,
+        PLUGIN_DATA: "",
+        COPILOT_PLUGIN_DATA: "",
+      },
+      encoding: "utf8",
+    });
+    assert.equal(enable.status, 0, enable.stderr);
+    const policy = JSON.parse(
+      await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
+    );
+    assert.equal(policy.state, "enabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher persists sidecar setup policy in plugin data", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-policy-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    const enable = spawnSync(process.execPath, [launcher, "sidecar-policy", "enable"], {
+      env: { PLUGIN_DATA: dataDir },
+      encoding: "utf8",
+    });
+    assert.equal(enable.status, 0, enable.stderr);
+    assert.equal(JSON.parse(enable.stdout).state, "enabled");
+
+    const disable = spawnSync(process.execPath, [launcher, "sidecar-policy", "disable"], {
+      env: { PLUGIN_DATA: dataDir },
+      encoding: "utf8",
+    });
+    assert.equal(disable.status, 0, disable.stderr);
+    assert.equal(JSON.parse(disable.stdout).state, "disabled");
+
+    const policy = JSON.parse(
+      await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
+    );
+    assert.equal(policy.state, "disabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("enabled sidecar policy schedules existing agent repair path", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
+  const logFile = join(dataDir, "calls.jsonl");
+  const cliDir = join(dataDir, "codestory-cli", "0.11.15");
+  const cliPath = join(
+    cliDir,
+    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+  );
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    await writeRecordingCli(cliPath);
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+    await writeFile(
+      join(dataDir, "sidecar-setup-policy.json"),
+      JSON.stringify({ state: "enabled" }),
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: dataDir,
+        TEST_LOG: logFile,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const text = await readFile(logFile, "utf8").catch(() => "");
+      const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+      if (calls.some((call) => call.repair)) {
+        assert.ok(calls.some((call) => call.args.includes("serve")), text);
+        const repair = calls.find((call) => call.repair);
+        assert.deepEqual(repair.args.slice(0, 4), ["ready", "--goal", "agent", "--repair"]);
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.fail(`repair call was not recorded:\n${await readFile(logFile, "utf8").catch(() => "")}`);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -533,6 +646,7 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "server_executable_sha256",
     "sidecar_contract_version",
     "plugin_runtime",
+    "sidecar_setup",
     "build_source",
     "repo_ref",
     "allowed_surfaces",


### PR DESCRIPTION
## Context

Closes #461

Promotes the current `dev/codestory-next` release slice to `main` as CodeStory `0.11.17`. The latest public release is `v0.11.16`; this PR does not create or push a `v*` tag manually.

Local runtime note: this worktree's PATH resolved `codestory-cli 0.11.11`, so installed packet/search output was not used as release proof. Verification below is from direct source/git checks and release gates.

## What Changed

- Bumped all `codestory-*` workspace crate versions and `Cargo.lock` to `0.11.17`.
- Bumped the Codex, Claude, and GitHub plugin package manifests to `0.11.17`.
- Updated plugin static release-version test fixtures and removed one stale hard-coded release regex by deriving it from the test version.
- Added `CHANGELOG.md` notes for `0.11.17` while preserving the already-public `0.11.16` notes from `main`.

Release contents promoted from `dev/codestory-next`:

- #457 / PR #458: release workflow artifact actions upgraded to v5, release matrix Cargo cache restore/save added, and stale `target/release-dist` output cleared before packaging.
- #453 / PR #459: plugin sidecar setup policy modes (`ask`, `enabled`, `disabled`), `sidecar_setup` status/preflight exposure, background `ready --goal agent --repair` scheduling when enabled, disabled policy suppression, and enable/disable commands carrying `--policy-file` so policy persists outside `PLUGIN_DATA`.
- Refs #460 as an operator note only: no source diff was needed; public source/release metadata was already correct, and local operator recovery came from refreshing the plugin cache with `codex.cmd plugin add codestory@TheGreenCedar --json`. #460 still needs fresh host/plugin `codestory://status` proof in its own lane.

```mermaid
flowchart LR
  dev[dev/codestory-next] --> pr[0.11.17 release PR]
  pr --> main[main]
  main --> actions[release workflow]
  actions --> tag[v0.11.17 tag and assets]
```

## How To Review

- Confirm the PR is a release/promotion slice only: version surfaces, changelog, release workflow changes from PR #458, and sidecar policy changes from PR #459.
- Check `crates/codestory-cli/Cargo.toml` as the release version source, then confirm Cargo/plugin mirrors match.
- Confirm the PR body closes #461 and keeps #460 open.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.17` - passed; versions synchronized across 8 workspace crates, `Cargo.lock`, and plugin manifests.
- `node .github/scripts/check-workflow-policy.mjs` - passed.
- `node --test plugins/codestory/tests/plugin-static.test.mjs` - passed; 14/14 tests.
- `cargo check --workspace` - passed.
- `git diff --check` - passed.
- GitHub checks passed: issue-link guard, `deny rustdoc warnings`, and `linux-contracts`; `windows-manifest-missing` skipped as expected.

## Risk

- Release automation must create the `v0.11.17` tag/assets after merge to `main`; no tag was created manually.
- #460 still needs separate fresh host/plugin `codestory://status` proof before closure.