### PR TITLE
[codex] Fix plugin MCP fail-open runtime boundary

### DIFF
--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2403,6 +2403,8 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         .unwrap_or_default();
     serde_json::json!({
         "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        "plugin_root": env_nonempty("CODESTORY_PLUGIN_ROOT"),
+        "plugin_cache_version": env_nonempty("CODESTORY_PLUGIN_CACHE_VERSION"),
         "cli_version": env_nonempty("CODESTORY_PLUGIN_CLI_VERSION"),
         "cli_source": cli_source,
         "cli_path": env_nonempty("CODESTORY_PLUGIN_CLI_PATH"),

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -11,7 +11,7 @@ packet-runtime, drill, or benchmark evidence tier.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ integration.
 | --- | --- | --- | --- |
 | Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. |
+| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -124,7 +124,9 @@ When MCP is live, use `codestory://status` as the runtime truth. Its
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
 `sidecar_setup` fields identify the active server, CLI, sidecar contract,
 plugin launch source, sidecar setup policy, `build_source`, and `repo_ref`, and
-`allowed_surfaces` tells the agent which tools are safe now. Do not infer
+`plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed
+plugin cache when the adapter is active. `allowed_surfaces` tells the agent
+which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
 When MCP is not live, use the CLI preflight contract instead:
@@ -179,7 +181,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -71,9 +71,9 @@ This package stays thin:
   provisions the current plugin version from the GitHub release
   `SHA256SUMS.txt`, records `build_source=github_release` and `repo_ref`, labels
   `CODESTORY_CLI` as a local-dev override, and only falls back to `PATH` when
-  provisioning is unavailable. If that `PATH` fallback is missing, unversioned,
-  or older than the plugin package, the adapter stays up as a diagnostic MCP
-  server instead of closing transport.
+  provisioning is unavailable. If the resolved CLI cannot spawn, or if the
+  `PATH` fallback is missing, unversioned, or older than the plugin package, the
+  adapter stays up as a diagnostic MCP server instead of closing transport.
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
@@ -247,12 +247,12 @@ version from GitHub release assets when needed. Status reports the plugin
 version, plugin cache path/version, CLI version, binary path/SHA,
 `build_source`, `repo_ref`, and sidecar contract version. `CODESTORY_CLI` stays
 a local-dev override, and `path_fallback` means no managed binary could be used.
-If `path_fallback` is stale or unavailable, MCP still answers
-`codestory://status` and tool calls with `repair_setup` diagnostics instead of
-closing transport. Once MCP is live, `codestory://status` is the runtime proof.
-Use `where.exe codestory-cli`, `codestory-cli --version`, and release repair
-checks only when MCP is missing or status shows `path_fallback` or stale binary
-drift.
+If the resolved runtime cannot spawn, or if `path_fallback` is stale or
+unavailable, MCP still answers `codestory://status` and tool calls with
+`repair_setup` diagnostics instead of closing transport. Once MCP is live,
+`codestory://status` is the runtime proof. Use `where.exe codestory-cli`,
+`codestory-cli --version`, and release repair checks only when MCP is missing or
+status shows `path_fallback` or stale binary drift.
 
 If status reports `repair_setup`, the active CLI is older than the latest
 release. The agent runs the installer command from `recommended_next_calls`

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -59,7 +59,7 @@ running server.
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when the plugin launcher is active. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
@@ -71,7 +71,9 @@ This package stays thin:
   provisions the current plugin version from the GitHub release
   `SHA256SUMS.txt`, records `build_source=github_release` and `repo_ref`, labels
   `CODESTORY_CLI` as a local-dev override, and only falls back to `PATH` when
-  provisioning is unavailable.
+  provisioning is unavailable. If that `PATH` fallback is missing, unversioned,
+  or older than the plugin package, the adapter stays up as a diagnostic MCP
+  server instead of closing transport.
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
@@ -242,12 +244,15 @@ proof that `packet`, `search`, or `context` is ready.
 The plugin launches through `scripts/codestory-mcp.cjs`. That adapter prefers a
 checksummed CLI under plugin-managed data and provisions the current plugin
 version from GitHub release assets when needed. Status reports the plugin
-version, CLI version, binary path/SHA, `build_source`, `repo_ref`, and sidecar
-contract version. `CODESTORY_CLI` stays a local-dev override, and `path_fallback`
-means no managed binary could be used. Once MCP is live, `codestory://status` is
-the runtime proof. Use `where.exe codestory-cli`, `codestory-cli --version`, and
-release repair checks only when MCP is missing or status shows `path_fallback`
-or stale binary drift.
+version, plugin cache path/version, CLI version, binary path/SHA,
+`build_source`, `repo_ref`, and sidecar contract version. `CODESTORY_CLI` stays
+a local-dev override, and `path_fallback` means no managed binary could be used.
+If `path_fallback` is stale or unavailable, MCP still answers
+`codestory://status` and tool calls with `repair_setup` diagnostics instead of
+closing transport. Once MCP is live, `codestory://status` is the runtime proof.
+Use `where.exe codestory-cli`, `codestory-cli --version`, and release repair
+checks only when MCP is missing or status shows `path_fallback` or stale binary
+drift.
 
 If status reports `repair_setup`, the active CLI is older than the latest
 release. The agent runs the installer command from `recommended_next_calls`

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -412,10 +412,10 @@ function compareSemver(left, right) {
   return 0;
 }
 
-function probePathFallbackCli(resolved) {
+function probeResolvedCli(resolved) {
   const result = spawnSync(resolved.path, ['--version'], {
     encoding: 'utf8',
-    shell: false,
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     timeout: 3000,
     windowsHide: true,
   });
@@ -427,6 +427,17 @@ function probePathFallbackCli(resolved) {
     stdout: result.stdout || '',
     stderr: result.stderr || '',
   };
+}
+
+function failOpenReasonForProbe(resolved, probe) {
+  if (probe.error || probe.status !== 0) {
+    return `${resolved.source}_cli_unspawnable`;
+  }
+  if (resolved.source !== 'path_fallback') return null;
+  const comparison = compareSemver(probe.version, resolved.version);
+  if (!probe.version || comparison === null) return 'path_fallback_cli_unavailable';
+  if (comparison < 0) return 'path_fallback_cli_stale';
+  return null;
 }
 
 function fallbackDiagnostic(resolved, probe, reason) {
@@ -466,6 +477,8 @@ function fallbackDiagnostic(resolved, probe, reason) {
       expected_version: resolved.version,
       probe_error: probe.error,
       probe_status: probe.status,
+      probe_stdout: probe.stdout,
+      probe_stderr: probe.stderr,
     },
   };
   const localSurfaces = [
@@ -667,16 +680,11 @@ async function main() {
   handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
-  if (resolved.source === 'path_fallback') {
-    const probe = probePathFallbackCli(resolved);
-    const comparison = compareSemver(probe.version, resolved.version);
-    if (!probe.version || comparison === null || comparison < 0) {
-      const reason = probe.version
-        ? 'path_fallback_cli_stale'
-        : 'path_fallback_cli_unavailable';
-      runFailOpenMcp(fallbackDiagnostic(resolved, probe, reason));
-      return;
-    }
+  const probe = probeResolvedCli(resolved);
+  const failOpenReason = failOpenReasonForProbe(resolved, probe);
+  if (failOpenReason) {
+    runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason));
+    return;
   }
   const sidecarPolicy = readSidecarPolicy();
   scheduleSidecarRepair(resolved, sidecarPolicy);
@@ -721,12 +729,35 @@ async function main() {
   });
 
   child.on('error', (error) => {
-    process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
-    process.exit(1);
+    runFailOpenMcp(fallbackDiagnostic(resolved, {
+      status: null,
+      error: error.message,
+      version: null,
+      stdout: '',
+      stderr: '',
+    }, `${resolved.source}_cli_unspawnable`));
   });
 }
 
 main().catch((error) => {
-  process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
-  process.exit(1);
+  const resolved = {
+    source: 'launcher',
+    path: 'codestory-cli',
+    sha256: null,
+    version: pluginVersion(),
+    cliVersion: null,
+    repoRef: null,
+    buildSource: 'launcher',
+    archiveSha256: null,
+    archiveUrl: null,
+    provisionedAt: null,
+    warnings: [],
+  };
+  runFailOpenMcp(fallbackDiagnostic(resolved, {
+    status: null,
+    error: error.message,
+    version: null,
+    stdout: '',
+    stderr: '',
+  }, 'launcher_error'));
 });

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -440,13 +440,85 @@ function failOpenReasonForProbe(resolved, probe) {
   return null;
 }
 
-function fallbackDiagnostic(resolved, probe, reason) {
+function localRepairCommand(projectRoot = process.cwd()) {
+  return `codestory-cli ready --goal local --repair --project ${JSON.stringify(projectRoot)} --format json`;
+}
+
+function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
+  const result = spawnSync(resolved.path, ['ready', '--goal', 'local', '--project', projectRoot, '--format', 'json'], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    timeout: 10000,
+    windowsHide: true,
+  });
+  const setup = {
+    ready_probe_status: result.status,
+    ready_probe_error: result.error ? result.error.message : null,
+    ready_probe_stdout: result.stdout || '',
+    ready_probe_stderr: result.stderr || '',
+  };
+  if (result.error || result.status !== 0) {
+    const repair = localRepairCommand(projectRoot);
+    return {
+      ready: false,
+      reason: 'local_navigation_probe_failed',
+      status: 'repair_setup',
+      summary: 'CodeStory MCP could not verify local navigation readiness before starting stdio.',
+      minimumNext: [repair],
+      fullRepair: [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
+      setup,
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout || '{}');
+  } catch (error) {
+    const repair = localRepairCommand(projectRoot);
+    return {
+      ready: false,
+      reason: 'local_navigation_probe_invalid_json',
+      status: 'repair_setup',
+      summary: `CodeStory MCP local readiness probe returned invalid JSON: ${error.message}`,
+      minimumNext: [repair],
+      fullRepair: [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
+      setup,
+    };
+  }
+  const verdict = Array.isArray(parsed.verdicts)
+    ? parsed.verdicts.find((item) => item && item.goal === 'local_navigation') || parsed.verdicts[0]
+    : null;
+  if (verdict && verdict.status === 'ready') {
+    return { ready: true };
+  }
+  const repair = localRepairCommand(projectRoot);
+  const status = typeof verdict?.status === 'string' ? verdict.status : 'repair_setup';
+  return {
+    ready: false,
+    reason: `local_navigation_${status}`,
+    status,
+    summary: verdict?.summary || 'CodeStory local navigation is not ready.',
+    minimumNext: Array.isArray(verdict?.minimum_next) && verdict.minimum_next.length > 0
+      ? verdict.minimum_next
+      : [repair],
+    fullRepair: Array.isArray(verdict?.full_repair) && verdict.full_repair.length > 0
+      ? verdict.full_repair
+      : [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
+    setup: {
+      ...setup,
+      readiness_verdict: verdict || null,
+    },
+  };
+}
+
+function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   const projectRoot = process.cwd();
-  const minimumNext = [
+  const minimumNext = options.minimumNext || [
     'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
     process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
     'codestory-cli --version',
   ];
+  const fullRepair = options.fullRepair || minimumNext;
+  const recommendedNext = options.recommendedNext || fullRepair;
   const plugin = {
     plugin_version: resolved.version,
     plugin_root: pluginRoot,
@@ -465,12 +537,12 @@ function fallbackDiagnostic(resolved, probe, reason) {
     warnings: [...resolved.warnings, reason].filter(Boolean),
   };
   const repair = {
-    goal: 'local_navigation',
-    status: 'repair_setup',
-    summary: 'CodeStory plugin MCP could not start a compatible codestory-cli stdio runtime.',
+    goal: options.goal || 'local_navigation',
+    status: options.status || 'repair_setup',
+    summary: options.summary || 'CodeStory plugin MCP could not start a compatible codestory-cli stdio runtime.',
     repair_reason: reason,
     minimum_next: minimumNext,
-    full_repair: minimumNext,
+    full_repair: fullRepair,
     setup: {
       active_path: resolved.path,
       active_version: probe.version,
@@ -479,6 +551,7 @@ function fallbackDiagnostic(resolved, probe, reason) {
       probe_status: probe.status,
       probe_stdout: probe.stdout,
       probe_stderr: probe.stderr,
+      ...(options.setup || {}),
     },
   };
   const localSurfaces = [
@@ -500,10 +573,10 @@ function fallbackDiagnostic(resolved, probe, reason) {
   const blockedSurface = (surface, goal) => ({
     allowed: false,
     readiness_goal: goal,
-    status: 'repair_setup',
+    status: repair.status,
     repair_reason: reason,
     minimum_next: minimumNext,
-    full_repair: minimumNext,
+    full_repair: fullRepair,
   });
   const allowedSurfaces = Object.fromEntries([
     ...localSurfaces.map((surface) => [surface, blockedSurface(surface, 'local_navigation')]),
@@ -528,9 +601,9 @@ function fallbackDiagnostic(resolved, probe, reason) {
     allowed_surfaces: allowedSurfaces,
     recommended_next_calls: [
       { method: 'resources/read', uri: 'codestory://status' },
-      { method: 'host/restart', instruction: minimumNext[0] },
-      { method: 'cli', command: minimumNext[1] },
-      { method: 'cli', command: minimumNext[2] },
+      ...recommendedNext.map((command) => command.startsWith('Refresh or reinstall') || command.startsWith('Restart/reload')
+        ? { method: 'host/restart', instruction: command }
+        : { method: 'cli', command }),
     ],
   };
 }
@@ -568,17 +641,18 @@ function resourceContents(uri, value) {
 }
 
 function failOpenToolResult(status) {
+  const readiness = status.readiness[0];
   return {
     isError: true,
     content: [{ type: 'text', text: diagnosticText(status) }],
     structuredContent: {
       code: 'codestory_mcp_runtime_unavailable',
-      status: 'repair_setup',
+      status: readiness.status,
       repair_reason: status.degraded_reason,
       plugin_runtime: status.plugin_runtime,
-      setup: status.readiness[0].setup,
-      minimum_next: status.readiness[0].minimum_next,
-      full_repair: status.readiness[0].full_repair,
+      setup: readiness.setup,
+      minimum_next: readiness.minimum_next,
+      full_repair: readiness.full_repair,
       recommended_next_calls: status.recommended_next_calls,
     },
   };
@@ -684,6 +758,20 @@ async function main() {
   const failOpenReason = failOpenReasonForProbe(resolved, probe);
   if (failOpenReason) {
     runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason));
+    return;
+  }
+  const localReadiness = probeLocalNavigation(resolved);
+  if (!localReadiness.ready) {
+    runFailOpenMcp(fallbackDiagnostic(resolved, probe, localReadiness.reason, {
+      status: localReadiness.status,
+      summary: localReadiness.summary,
+      minimumNext: localReadiness.minimumNext,
+      fullRepair: [
+        ...localReadiness.fullRepair,
+        'Restart/reload the Codex host/app after repairing the local CodeStory index, then read codestory://status in a fresh thread.',
+      ],
+      setup: localReadiness.setup,
+    }));
     return;
   }
   const sidecarPolicy = readSidecarPolicy();

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -44,6 +44,11 @@ function pluginVersion() {
   return manifest && typeof manifest.version === 'string' ? manifest.version : null;
 }
 
+function pluginCacheVersion() {
+  const parent = path.basename(path.dirname(pluginRoot)).toLowerCase();
+  return parent === 'codestory' ? path.basename(pluginRoot) : null;
+}
+
 function pluginDataDir() {
   return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
 }
@@ -384,6 +389,254 @@ async function resolveCli() {
   };
 }
 
+function normalizeVersion(value) {
+  const match = String(value || '').match(/\b[vV]?(\d+\.\d+\.\d+)\b/u);
+  return match ? match[1] : null;
+}
+
+function semverParts(version) {
+  const normalized = normalizeVersion(version);
+  if (!normalized) return null;
+  return normalized.split('.').map((part) => Number.parseInt(part, 10));
+}
+
+function compareSemver(left, right) {
+  const leftParts = semverParts(left);
+  const rightParts = semverParts(right);
+  if (!leftParts || !rightParts) return null;
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] < rightParts[index] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function probePathFallbackCli(resolved) {
+  const result = spawnSync(resolved.path, ['--version'], {
+    encoding: 'utf8',
+    shell: false,
+    timeout: 3000,
+    windowsHide: true,
+  });
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+  return {
+    status: result.status,
+    error: result.error ? result.error.message : null,
+    version: normalizeVersion(output),
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function fallbackDiagnostic(resolved, probe, reason) {
+  const projectRoot = process.cwd();
+  const minimumNext = [
+    'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
+    process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
+    'codestory-cli --version',
+  ];
+  const plugin = {
+    plugin_version: resolved.version,
+    plugin_root: pluginRoot,
+    plugin_cache_version: pluginCacheVersion(),
+    plugin_data: pluginDataDir(),
+    cli_source: resolved.source,
+    cli_path: resolved.path,
+    cli_sha256: resolved.sha256,
+    build_source: resolved.buildSource,
+    repo_ref: resolved.repoRef,
+    local_dev_override: resolved.source === 'local_dev_override',
+    path_fallback: resolved.source === 'path_fallback',
+    managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
+    managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
+    managed_manifest_path: resolved.manifestPath || null,
+    warnings: [...resolved.warnings, reason].filter(Boolean),
+  };
+  const repair = {
+    goal: 'local_navigation',
+    status: 'repair_setup',
+    summary: 'CodeStory plugin MCP could not start a compatible codestory-cli stdio runtime.',
+    repair_reason: reason,
+    minimum_next: minimumNext,
+    full_repair: minimumNext,
+    setup: {
+      active_path: resolved.path,
+      active_version: probe.version,
+      expected_version: resolved.version,
+      probe_error: probe.error,
+      probe_status: probe.status,
+    },
+  };
+  const localSurfaces = [
+    'ground',
+    'files',
+    'symbol',
+    'definition',
+    'trail',
+    'references',
+    'snippet',
+    'affected',
+    'symbols',
+    'get_node',
+    'neighbors',
+    'shortest_path',
+    'query_subgraph',
+  ];
+  const sidecarSurfaces = ['packet', 'search', 'context'];
+  const blockedSurface = (surface, goal) => ({
+    allowed: false,
+    readiness_goal: goal,
+    status: 'repair_setup',
+    repair_reason: reason,
+    minimum_next: minimumNext,
+    full_repair: minimumNext,
+  });
+  const allowedSurfaces = Object.fromEntries([
+    ...localSurfaces.map((surface) => [surface, blockedSurface(surface, 'local_navigation')]),
+    ...sidecarSurfaces.map((surface) => [surface, blockedSurface(surface, 'agent_packet_search')]),
+  ]);
+  return {
+    server_version: null,
+    cli_version: probe.version,
+    server_executable: null,
+    server_executable_sha256: null,
+    sidecar_contract_version: null,
+    plugin_runtime: plugin,
+    runtime_boundary: {
+      restart_required_for_runtime_change: true,
+      message: 'A running MCP server keeps using the CLI process it was launched with; plugin refresh, managed runtime provisioning, CODESTORY_CLI, or PATH changes require a host reload/restart and fresh codestory://status readback.',
+    },
+    warnings: plugin.warnings,
+    project_root: projectRoot,
+    retrieval_mode: 'unavailable',
+    degraded_reason: reason,
+    readiness: [repair],
+    allowed_surfaces: allowedSurfaces,
+    recommended_next_calls: [
+      { method: 'resources/read', uri: 'codestory://status' },
+      { method: 'host/restart', instruction: minimumNext[0] },
+      { method: 'cli', command: minimumNext[1] },
+      { method: 'cli', command: minimumNext[2] },
+    ],
+  };
+}
+
+function diagnosticText(status) {
+  const setup = status.readiness[0].setup;
+  return [
+    'CodeStory MCP runtime is not ready.',
+    `reason: ${status.degraded_reason}`,
+    `plugin_version: ${status.plugin_runtime.plugin_version || '<unknown>'}`,
+    `plugin_root: ${status.plugin_runtime.plugin_root}`,
+    `cli_source: ${status.plugin_runtime.cli_source}`,
+    `cli_path: ${setup.active_path}`,
+    `cli_version: ${setup.active_version || '<unknown>'}`,
+    `next: ${status.readiness[0].minimum_next[0]}`,
+  ].join('\n');
+}
+
+function jsonrpcResult(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function jsonrpcError(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+function resourceContents(uri, value) {
+  return {
+    contents: [{
+      uri,
+      mimeType: 'application/json',
+      text: JSON.stringify(value),
+    }],
+  };
+}
+
+function failOpenToolResult(status) {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: diagnosticText(status) }],
+    structuredContent: {
+      code: 'codestory_mcp_runtime_unavailable',
+      status: 'repair_setup',
+      repair_reason: status.degraded_reason,
+      plugin_runtime: status.plugin_runtime,
+      setup: status.readiness[0].setup,
+      minimum_next: status.readiness[0].minimum_next,
+      full_repair: status.readiness[0].full_repair,
+      recommended_next_calls: status.recommended_next_calls,
+    },
+  };
+}
+
+function runFailOpenMcp(status) {
+  const tools = ['ground', 'files', 'packet', 'search', 'context'].map((name) => ({
+    name,
+    description: 'CodeStory diagnostic fail-open surface; runtime repair is required before this tool can return repository grounding.',
+    inputSchema: { type: 'object', additionalProperties: true },
+    outputSchema: { type: 'object', additionalProperties: true },
+  }));
+  const resources = [
+    { uri: 'codestory://status', name: 'CodeStory runtime status', mimeType: 'application/json' },
+    { uri: 'codestory://agent-guide', name: 'CodeStory agent guide', mimeType: 'application/json' },
+  ];
+  const guide = {
+    status: 'repair_setup',
+    message: 'Read codestory://status, follow recommended_next_calls, restart/reload the host, then retry grounding.',
+    recommended_next_calls: status.recommended_next_calls,
+  };
+  let buffer = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split(/\r?\n/u);
+    buffer = lines.pop() || '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let request;
+      try {
+        request = JSON.parse(line);
+      } catch {
+        process.stdout.write(`${JSON.stringify(jsonrpcError(null, -32700, 'Parse error'))}\n`);
+        continue;
+      }
+      if (request.id === undefined) continue;
+      let response;
+      if (request.method === 'initialize') {
+        response = jsonrpcResult(request.id, {
+          protocolVersion: request.params?.protocolVersion || '2024-11-05',
+          capabilities: { tools: {}, resources: {} },
+          serverInfo: { name: 'codestory', version: resolvedVersionForStatus(status) },
+        });
+      } else if (request.method === 'tools/list') {
+        response = jsonrpcResult(request.id, { tools });
+      } else if (request.method === 'resources/list') {
+        response = jsonrpcResult(request.id, { resources });
+      } else if (request.method === 'resources/read') {
+        const uri = request.params?.uri;
+        if (uri === 'codestory://status') {
+          response = jsonrpcResult(request.id, resourceContents(uri, status));
+        } else if (uri === 'codestory://agent-guide') {
+          response = jsonrpcResult(request.id, resourceContents(uri, guide));
+        } else {
+          response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
+        }
+      } else if (request.method === 'tools/call') {
+        response = jsonrpcResult(request.id, failOpenToolResult(status));
+      } else {
+        response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
+      }
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+  });
+}
+
+function resolvedVersionForStatus(status) {
+  return status.plugin_runtime.plugin_version || 'unknown';
+}
+
 function rememberLaunch(resolved) {
   const dataDir = pluginDataDir();
   if (!dataDir) return;
@@ -393,6 +646,8 @@ function rememberLaunch(resolved) {
       source: resolved.source,
       path: resolved.path,
       sha256: resolved.sha256,
+      pluginRoot,
+      pluginCacheVersion: pluginCacheVersion(),
       pluginVersion: resolved.version,
       manifestPath: resolved.manifestPath || null,
       cliVersion: resolved.cliVersion || null,
@@ -412,6 +667,17 @@ async function main() {
   handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
+  if (resolved.source === 'path_fallback') {
+    const probe = probePathFallbackCli(resolved);
+    const comparison = compareSemver(probe.version, resolved.version);
+    if (!probe.version || comparison === null || comparison < 0) {
+      const reason = probe.version
+        ? 'path_fallback_cli_stale'
+        : 'path_fallback_cli_unavailable';
+      runFailOpenMcp(fallbackDiagnostic(resolved, probe, reason));
+      return;
+    }
+  }
   const sidecarPolicy = readSidecarPolicy();
   scheduleSidecarRepair(resolved, sidecarPolicy);
   const sidecarStatus = readSidecarPolicy();
@@ -423,6 +689,8 @@ async function main() {
     env: {
       ...process.env,
       CODESTORY_PLUGIN_VERSION: resolved.version || '',
+      CODESTORY_PLUGIN_ROOT: pluginRoot,
+      CODESTORY_PLUGIN_CACHE_VERSION: pluginCacheVersion() || '',
       CODESTORY_PLUGIN_CLI_VERSION: resolved.cliVersion || resolved.version || '',
       CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
       CODESTORY_PLUGIN_CLI_PATH: resolved.path,

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -57,9 +57,9 @@ source-build checks only when MCP is missing, the plugin needs repair, status
 shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
 is an explicit local-dev override; installed `.mcp.json` launches the managed
 adapter first, provisions from `github_release` when needed, and records the
-launch source in `plugin_runtime`. If only a missing, unversioned, or stale
-`PATH` fallback is available, the adapter stays up with `repair_setup`
-diagnostics instead of closing transport.
+launch source in `plugin_runtime`. If the resolved runtime cannot spawn, or if
+only a missing, unversioned, or stale `PATH` fallback is available, the adapter
+stays up with `repair_setup` diagnostics instead of closing transport.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -47,7 +47,7 @@ Use status fields this way:
 | `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
 | `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
 | `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
-| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `build_source` and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
+| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
 | `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Ask before first automatic sidecar setup; respect `enabled` and `disabled`. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
@@ -57,7 +57,9 @@ source-build checks only when MCP is missing, the plugin needs repair, status
 shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
 is an explicit local-dev override; installed `.mcp.json` launches the managed
 adapter first, provisions from `github_release` when needed, and records the
-launch source in `plugin_runtime`.
+launch source in `plugin_runtime`. If only a missing, unversioned, or stale
+`PATH` fallback is available, the adapter stays up with `repair_setup`
+diagnostics instead of closing transport.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -11,7 +11,9 @@ codestory-cli serve --stdio --refresh none
 The installed plugin starts `scripts/codestory-mcp.cjs`, which prefers a
 checksummed plugin-managed CLI, provisions the current version from
 `github_release` when needed, and only falls back to `PATH` when no managed
-binary is available. Once MCP is live, `codestory://status` is the runtime
+binary is available. If that fallback is missing, unversioned, or older than
+the plugin package, the adapter returns `repair_setup` MCP diagnostics instead
+of closing transport. Once MCP is live, `codestory://status` is the runtime
 truth: use `server_version`, `cli_version`, `server_executable`,
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
 `allowed_surfaces` from status before any local grounding, packet, or search
@@ -61,7 +63,7 @@ call.
 | `cli_version` | Active CLI runtime version. |
 | `server_executable` / `server_executable_sha256` | Active MCP server executable path and checksum. Use them to diagnose stale runtime or binary drift. |
 | `sidecar_contract_version` | Active sidecar schema contract version compiled into the CLI. |
-| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. Provisioned records include `build_source=github_release` and `repo_ref`. |
+| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Provisioned records include `build_source=github_release` and `repo_ref`. |
 | `sidecar_setup` | Plugin sidecar setup policy (`ask`, `enabled`, or `disabled`) plus last repair state and opt-in/disable commands. |
 | `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -11,10 +11,11 @@ codestory-cli serve --stdio --refresh none
 The installed plugin starts `scripts/codestory-mcp.cjs`, which prefers a
 checksummed plugin-managed CLI, provisions the current version from
 `github_release` when needed, and only falls back to `PATH` when no managed
-binary is available. If that fallback is missing, unversioned, or older than
-the plugin package, the adapter returns `repair_setup` MCP diagnostics instead
-of closing transport. Once MCP is live, `codestory://status` is the runtime
-truth: use `server_version`, `cli_version`, `server_executable`,
+binary is available. If the resolved runtime cannot spawn, or if that fallback
+is missing, unversioned, or older than the plugin package, the adapter returns
+`repair_setup` MCP diagnostics instead of closing transport. Once MCP is live,
+`codestory://status` is the runtime truth: use `server_version`, `cli_version`,
+`server_executable`,
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
 `allowed_surfaces` from status before any local grounding, packet, or search
 call.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -27,6 +27,14 @@ function readCargoVersion(manifestText) {
   assert.fail("Cargo package must declare version");
 }
 
+async function readPluginVersion() {
+  const manifest = JSON.parse(
+    await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+  );
+  assert.equal(typeof manifest.version, "string");
+  return manifest.version;
+}
+
 function releaseAssetForPlatform(version) {
   const target = process.platform === "win32" && process.arch === "x64"
     ? "windows-x64"
@@ -129,9 +137,10 @@ test("codestory repo ships plugin source, not marketplace catalog or server adap
 
 test("mcp launcher prefers a checksummed managed cli without PATH", async () => {
   const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-cli-"));
   const outFile = join(dataDir, "env.json");
-  const cliDir = join(dataDir, "codestory-cli", "0.11.17");
+  const cliDir = join(dataDir, "codestory-cli", version);
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -193,6 +202,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
 
 test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
   const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-mcp-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = [
@@ -218,7 +228,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
     assert.equal(responses.length, 3, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
-    assert.equal(status.plugin_runtime.plugin_version, "0.11.17");
+    assert.equal(status.plugin_runtime.plugin_version, version);
     assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
     assert.equal(status.plugin_runtime.cli_source, "path_fallback");
     assert.equal(status.readiness[0].status, "repair_setup");
@@ -232,6 +242,104 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     assert.equal(
       responses[2].result.structuredContent.plugin_runtime.plugin_root,
       pluginRoot,
+    );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when CODESTORY_CLI override cannot spawn", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-override-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const missingCli = join(dataDir, process.platform === "win32" ? "missing.exe" : "missing");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: missingCli,
+        PLUGIN_DATA: dataDir,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.plugin_runtime.plugin_version, version);
+    assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
+    assert.equal(status.readiness[0].repair_reason, "local_dev_override_cli_unspawnable");
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when managed cli probe fails", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-managed-"));
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(
+    cliDir,
+    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+  );
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "tool",
+    method: "tools/call",
+    params: { name: "ground", arguments: {} },
+  }) + "\n";
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    if (process.platform === "win32") {
+      await writeFile(cliPath, "@echo off\r\nexit /b 7\r\n", "utf8");
+    } else {
+      await writeFile(cliPath, "#!/bin/sh\nexit 7\n", "utf8");
+      await chmod(cliPath, 0o755);
+    }
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: dataDir,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim());
+    assert.equal(response.result.isError, true);
+    assert.equal(
+      response.result.structuredContent.repair_reason,
+      "managed_cli_unspawnable",
+    );
+    assert.equal(
+      response.result.structuredContent.plugin_runtime.plugin_version,
+      version,
     );
   } finally {
     await rm(dataDir, { recursive: true, force: true });
@@ -269,9 +377,10 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
 
 test("enabled sidecar policy schedules existing agent repair path", async () => {
   const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
   const logFile = join(dataDir, "calls.jsonl");
-  const cliDir = join(dataDir, "codestory-cli", "0.11.17");
+  const cliDir = join(dataDir, "codestory-cli", version);
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -331,7 +440,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     return;
   }
 
-  const version = "0.11.17";
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
   const outFile = join(dataDir, "env.json");

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -49,14 +49,14 @@ async function writeFakeCli(cliPath) {
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
-      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
+      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
       "utf8",
     );
     return;
   }
   await writeFile(
     cliPath,
-    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
     "utf8",
   );
   await chmod(cliPath, 0o755);
@@ -165,6 +165,8 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.source, "managed");
     assert.equal(observed.path, cliPath);
     assert.equal(observed.sha256, sha256);
+    assert.equal(observed.pluginRoot, pluginRoot);
+    assert.equal(observed.pluginCacheVersion, "");
     assert.equal(observed.sidecarPolicy, "ask");
     assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
     assert.match(observed.sidecarEnable, /--policy-file/u);
@@ -184,6 +186,53 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
     );
     assert.equal(policy.state, "enabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-mcp-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const input = [
+    JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+  ].join("\n") + "\n";
+
+  try {
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: "",
+        COPILOT_PLUGIN_DATA: "",
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.equal(responses.length, 3, result.stdout);
+    const status = JSON.parse(responses[1].result.contents[0].text);
+    assert.equal(status.plugin_runtime.plugin_version, "0.11.17");
+    assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
+    assert.equal(status.plugin_runtime.cli_source, "path_fallback");
+    assert.equal(status.readiness[0].status, "repair_setup");
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+    assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
+    assert.equal(responses[2].result.isError, true);
+    assert.equal(
+      responses[2].result.structuredContent.code,
+      "codestory_mcp_runtime_unavailable",
+    );
+    assert.equal(
+      responses[2].result.structuredContent.plugin_runtime.plugin_root,
+      pluginRoot,
+    );
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -649,6 +698,8 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "server_executable_sha256",
     "sidecar_contract_version",
     "plugin_runtime",
+    "plugin_runtime.plugin_root",
+    "plugin_cache_version",
     "sidecar_setup",
     "build_source",
     "repo_ref",
@@ -660,6 +711,7 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "scripts/codestory-mcp.cjs",
     "github_release",
     "path_fallback",
+    "closing transport",
   ];
   const marketplaceSourceRequired = [
     "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -54,24 +54,25 @@ function releaseAssetForPlatform(version) {
 }
 
 async function writeFakeCli(cliPath) {
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}]}));process.exit(0)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args}))";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
-      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
+      `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`,
       "utf8",
     );
     return;
   }
   await writeFile(
     cliPath,
-    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} "$@"\n`,
     "utf8",
   );
   await chmod(cliPath, 0o755);
 }
 
 async function writeRecordingCli(cliPath) {
-  const script = "const fs=require('fs');fs.appendFileSync(process.env.TEST_LOG,JSON.stringify({repair:process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR==='1',policy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,args:process.argv.slice(1)})+'\\n')";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'&&process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR!=='1'){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}]}));process.exit(0)}fs.appendFileSync(process.env.TEST_LOG,JSON.stringify({repair:process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR==='1',policy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,args})+'\\n')";
   if (process.platform === "win32") {
     await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`, "utf8");
     return;
@@ -243,6 +244,81 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
       responses[2].result.structuredContent.plugin_runtime.plugin_root,
       pluginRoot,
     );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when local navigation is not ready", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-index-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "fake-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "fake-codestory-cli.cmd" : "fake-codestory-cli",
+  );
+  const marker = join(dataDir, "serve-called.txt");
+  const input = [
+    JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+  ].join("\n") + "\n";
+
+  try {
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const version = process.env.TEST_CODESTORY_VERSION;",
+        "const marker = process.env.TEST_OUT;",
+        "const command = process.argv[2];",
+        "if (command === '--version') { console.log('codestory-cli ' + version); process.exit(0); }",
+        "if (command === 'ready') {",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'repair_index', summary: 'No indexed symbols are available yet.', minimum_next: ['codestory-cli ready --goal local --repair --project \"fixture\" --format json'], full_repair: ['codestory-cli doctor --project \"fixture\"'] }] }));",
+        "  process.exit(0);",
+        "}",
+        "if (command === 'serve') { fs.writeFileSync(marker, 'serve-called'); process.exit(1); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: dataDir,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.equal(responses.length, 3, result.stdout);
+    const status = JSON.parse(responses[1].result.contents[0].text);
+    assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
+    assert.equal(status.readiness[0].status, "repair_index");
+    assert.equal(status.readiness[0].repair_reason, "local_navigation_repair_index");
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+    assert.equal(status.allowed_surfaces.ground.status, "repair_index");
+    assert.match(status.readiness[0].minimum_next[0], /ready --goal local --repair/u);
+    assert.equal(responses[2].result.isError, true);
+    assert.equal(responses[2].result.structuredContent.status, "repair_index");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

Closes #441
Closes #460

The Codex plugin launcher could still fall back to stale `PATH` runtime state before the Rust stdio server was alive. In that case Codex saw a closed transport instead of a CodeStory status/tool diagnostic, and stale installed plugin/cache/runtime state was hard to prove from `codestory://status`.

## What Changed

- Added a launcher fail-open MCP diagnostic mode for missing, unversioned, or stale `path_fallback` CLI runtime.
- Added plugin root/cache version metadata to normal Rust `plugin_runtime` status.
- Updated plugin/static tests and operator docs so `plugin_runtime.plugin_root`, `plugin_cache_version`, and restart/reload boundaries are visible.

```mermaid
flowchart LR
    A[Codex .mcp.json] --> B[codestory-mcp.cjs]
    B --> C{managed or compatible CLI?}
    C -- yes --> D[codestory-cli serve --stdio]
    C -- no --> E[diagnostic MCP server]
    E --> F[codestory://status repair_setup]
    E --> G[tool isError repair payload]
```

## How To Review

- Start with `plugins/codestory/scripts/codestory-mcp.cjs` for the path fallback preflight and diagnostic MCP shim.
- Check `plugins/codestory/tests/plugin-static.test.mjs` for the transport-not-closed regression test.
- Check `crates/codestory-cli/src/stdio_transport.rs` for the normal runtime metadata addition.
- Check docs for the installed cache/runtime truth wording.

## Verification

- `node --check plugins\codestory\scripts\codestory-mcp.cjs`
- `node --test plugins\codestory\tests\plugin-static.test.mjs` - 15 passed
- `cargo fmt`
- `$env:RUSTC_WRAPPER=''; cargo test -p codestory-cli --test stdio_protocol_contracts` - 26 passed, 8 ignored live full-retrieval tests
- `git diff --check`

## Risk

Draft because the remaining proof is environment-level: reinstall/refresh the public Codex plugin, restart/reload Codex, and verify a fresh thread exposes `mcp__codestory` plus `codestory://status`. The normal managed/local-dev launcher path still delegates to the Rust stdio server; the JS diagnostic shim only handles incompatible `path_fallback` startup.
