### PR TITLE
[codex] expose packet proof metadata

### DIFF
--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -35,7 +35,7 @@ pub use dto::{
     NodeOccurrencesRequest, OpenContainingFolderRequest, OpenDefinitionRequest, OpenProjectRequest,
     PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetModeDto, PacketBudgetUsageDto,
     PacketClaimDto, PacketCoverageReportDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
-    PacketPlanDto, PacketPlanQueryDto, PacketRetrievalTraceSummaryDto,
+    PacketPlanDto, PacketPlanQueryDto, PacketProofStatusDto, PacketRetrievalTraceSummaryDto,
     PacketSidecarQueryDiagnosticDto, PacketSufficiencyDto, PacketSufficiencyStatusDto,
     PacketTaskClassDto, ProjectSummary, ReadFileTextRequest, ReadFileTextResponse,
     ReadinessGoalDto, ReadinessIndexSnapshotDto, ReadinessSetupSnapshotDto,

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1985,9 +1985,22 @@ pub enum PacketSufficiencyStatusDto {
     Insufficient,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketProofStatusDto {
+    Proven,
+    Likely,
+    Diagnostic,
+    Unsupported,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct PacketClaimDto {
     pub claim: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_status: Option<PacketProofStatusDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_evidence_role: Option<PacketEvidenceTierDto>,
     #[serde(default)]
     pub citations: Vec<AgentCitationDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2311,6 +2324,28 @@ mod packet_tests {
         let legacy: PacketSufficiencyStatusDto =
             serde_json::from_str("\"insufficient\"").expect("deserialize legacy status");
         assert_eq!(legacy, PacketSufficiencyStatusDto::Insufficient);
+    }
+
+    #[test]
+    fn packet_claim_serializes_machine_checkable_proof_metadata() {
+        let value = serde_json::to_value(PacketClaimDto {
+            claim: "Dense hits need backing source proof.".to_string(),
+            proof_status: Some(PacketProofStatusDto::Diagnostic),
+            required_evidence_role: Some(PacketEvidenceTierDto::ExactSource),
+            citations: Vec::new(),
+            coverage_role: Some("source evidence".to_string()),
+            eligible_for_sufficiency: Some(false),
+        })
+        .expect("serialize packet claim");
+
+        assert_eq!(value["proof_status"], "diagnostic");
+        assert_eq!(value["required_evidence_role"], "exact_source");
+
+        let legacy: PacketClaimDto =
+            serde_json::from_str(r#"{"claim":"legacy claim","citations":[]}"#)
+                .expect("deserialize legacy packet claim");
+        assert_eq!(legacy.proof_status, None);
+        assert_eq!(legacy.required_evidence_role, None);
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -9216,6 +9216,8 @@ mod tests {
         let generic = PacketClaimDto {
             claim: "Runtime orchestration is anchored by `RuntimeCoordinator`; inspect it there."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "RuntimeCoordinator",
                 "src/runtime.rs",
@@ -9227,6 +9229,8 @@ mod tests {
         let causal = PacketClaimDto {
             claim: "`RuntimeCoordinator` coordinates runtime state transitions and downstream service calls."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "RuntimeCoordinator",
                 "src/runtime.rs",
@@ -9239,6 +9243,8 @@ mod tests {
             claim:
                 "`Session.send` in `src/requests/sessions.py` ties request, session in this flow to cited definitions and adjacent ownership."
                     .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "Session.send",
                 "src/requests/sessions.py",
@@ -9251,6 +9257,8 @@ mod tests {
             claim:
                 "`PreparedRequest` is defined in cited source `src/requests/models.py` and should be treated as an exact source anchor for this flow."
                     .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "PreparedRequest",
                 "src/requests/models.py",
@@ -9272,6 +9280,8 @@ mod tests {
             PacketClaimDto {
                 claim: "The public useSWR export wraps useSWRHandler with argument normalization."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "useSWRHandler",
                     "src/index/use-swr.ts",
@@ -9282,6 +9292,8 @@ mod tests {
             },
             PacketClaimDto {
                 claim: "useSWRHandler serializes the key before reading cache state.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "serialize",
                     "src/_internal/utils/serialize.ts",
@@ -9294,6 +9306,8 @@ mod tests {
                 claim:
                     "createCacheHelper provides cache get, set, subscribe, and snapshot helpers."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "createCacheHelper",
                     "src/_internal/utils/helper.ts",
@@ -9305,6 +9319,8 @@ mod tests {
             PacketClaimDto {
                 claim: "internalMutate routes mutate behavior through the mutation helper."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "internalMutate",
                     "src/_internal/utils/mutate.ts",
@@ -9348,6 +9364,8 @@ mod tests {
                 claim:
                     "StringUtils.isBlank treats null, empty, and whitespace-only inputs as blank."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "StringUtils.isBlank",
                     "src/main/java/org/apache/commons/lang3/StringUtils.java",
@@ -9359,6 +9377,8 @@ mod tests {
             PacketClaimDto {
                 claim: "StringUtils.isEmpty does not trim whitespace before deciding emptiness."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "StringUtils.isEmpty",
                     "src/main/java/org/apache/commons/lang3/StringUtils.java",
@@ -9370,6 +9390,8 @@ mod tests {
             PacketClaimDto {
                 claim: "Strings delegates region matching work to CharSequenceUtils.regionMatches."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "Strings.regionMatches",
                     "src/main/java/org/apache/commons/lang3/Strings.java",

--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -822,6 +822,8 @@ mod tests {
             covered_claims: vec![PacketClaimDto {
                 claim: "Packet budget ownership is covered by cited runtime and contract anchors."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: answer.citations.clone(),
                 coverage_role: Some("source evidence".to_string()),
                 eligible_for_sufficiency: Some(true),

--- a/crates/codestory-runtime/src/agent/packet_claims.rs
+++ b/crates/codestory-runtime/src/agent/packet_claims.rs
@@ -8,6 +8,9 @@ use crate::agent::packet_claim_profiles::{
     packet_source_derived_claim_for_role, packet_source_derived_claims_for_citation,
 };
 use crate::agent::packet_command_profiles::packet_append_command_flow_template_claims;
+use crate::agent::packet_evidence::{
+    citation_sufficiency_eligible, evidence_resolution_for_citation, evidence_tier_for_citation,
+};
 use crate::agent::packet_evidence_roles::{
     PacketEvidenceRole, packet_claim_key_for_citation, packet_evidence_role,
 };
@@ -18,7 +21,10 @@ use crate::agent::packet_scoring::{
 };
 use crate::agent::packet_terms::{packet_probe_terms, packet_terms_indicate_sql_schema_flow};
 use crate::query_mentions_non_primary_source;
-use codestory_contracts::api::{AgentAnswerDto, AgentCitationDto, PacketClaimDto};
+use codestory_contracts::api::{
+    AgentAnswerDto, AgentCitationDto, PacketClaimDto, PacketEvidenceResolutionDto,
+    PacketEvidenceTierDto, PacketProofStatusDto,
+};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fmt::Write as _;
@@ -56,7 +62,59 @@ pub(crate) fn packet_supported_claims(answer: &AgentAnswerDto) -> Vec<PacketClai
         &mut claims,
         &mut seen_claims,
     );
+    decorate_packet_claims_proof_metadata(&mut claims);
     claims
+}
+
+pub(crate) fn decorate_packet_claims_proof_metadata(claims: &mut [PacketClaimDto]) {
+    for claim in claims {
+        decorate_packet_claim_proof_metadata(claim);
+    }
+}
+
+fn decorate_packet_claim_proof_metadata(claim: &mut PacketClaimDto) {
+    let proven_tier = claim
+        .citations
+        .iter()
+        .find(|citation| citation_sufficiency_eligible(citation))
+        .map(evidence_tier_for_citation);
+    claim.required_evidence_role = Some(proven_tier.unwrap_or(PacketEvidenceTierDto::ExactSource));
+    claim.proof_status = Some(packet_claim_proof_status(claim, proven_tier.is_some()));
+}
+
+fn packet_claim_proof_status(
+    claim: &PacketClaimDto,
+    has_proof_bearing_citation: bool,
+) -> PacketProofStatusDto {
+    if claim.citations.is_empty() {
+        return PacketProofStatusDto::Unsupported;
+    }
+    if has_proof_bearing_citation && claim.eligible_for_sufficiency != Some(false) {
+        return PacketProofStatusDto::Proven;
+    }
+    if claim
+        .citations
+        .iter()
+        .all(packet_citation_is_diagnostic_only)
+    {
+        return PacketProofStatusDto::Diagnostic;
+    }
+    PacketProofStatusDto::Likely
+}
+
+fn packet_citation_is_diagnostic_only(citation: &AgentCitationDto) -> bool {
+    if citation.eligible_for_sufficiency == Some(false) {
+        return true;
+    }
+    matches!(
+        evidence_tier_for_citation(citation),
+        PacketEvidenceTierDto::DenseSemantic
+            | PacketEvidenceTierDto::GeneratedSummary
+            | PacketEvidenceTierDto::SyntheticSourceScan
+    ) || matches!(
+        evidence_resolution_for_citation(citation),
+        PacketEvidenceResolutionDto::DiagnosticOnly
+    )
 }
 
 pub(crate) fn append_flow_template_claims(
@@ -504,6 +562,8 @@ fn packet_push_flow_template_claim_with_citations(
     }
     claims.push(PacketClaimDto {
         claim: claim_text.to_string(),
+        proof_status: None,
+        required_evidence_role: None,
         citations,
         coverage_role: Some("flow template".to_string()),
         eligible_for_sufficiency: Some(true),
@@ -534,6 +594,8 @@ pub(crate) fn append_ranked_citation_claims(
             if seen_claims.insert(key) {
                 claims.push(PacketClaimDto {
                     claim: shaped,
+                    proof_status: None,
+                    required_evidence_role: None,
                     citations: vec![citation.clone()],
                     coverage_role: citation.coverage_role.clone(),
                     eligible_for_sufficiency: Some(false),
@@ -563,6 +625,8 @@ pub(crate) fn append_ranked_citation_claims(
         }
         claims.push(PacketClaimDto {
             claim: packet_claim_for_role(role, citation, prompt, rank_terms),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![citation.clone()],
             coverage_role: Some(role.as_str().to_string()),
             eligible_for_sufficiency: Some(true),
@@ -819,6 +883,8 @@ fn packet_push_claim(
     }
     claims.push(PacketClaimDto {
         claim: claim_text.to_string(),
+        proof_status: None,
+        required_evidence_role: None,
         citations: citation.map(|value| vec![value]).unwrap_or_default(),
         coverage_role: Some("source definition".to_string()),
         eligible_for_sufficiency: Some(false),
@@ -947,7 +1013,7 @@ mod tests {
     use super::*;
     use codestory_contracts::api::{
         AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, NodeId,
-        NodeKind, RetrievalScoreBreakdownDto, SearchHitOrigin,
+        NodeKind, PacketProofStatusDto, RetrievalScoreBreakdownDto, SearchHitOrigin,
     };
 
     fn test_answer(prompt: &str, citations: Vec<AgentCitationDto>) -> AgentAnswerDto {
@@ -1008,6 +1074,53 @@ mod tests {
             coverage_role: None,
             eligible_for_sufficiency: Some(true),
         }
+    }
+
+    #[test]
+    fn generated_summary_and_dense_claims_need_backing_source_proof() {
+        let mut generated = test_citation("generated summary", "target/generated/summary.md", 0.9);
+        generated.evidence_tier = Some(PacketEvidenceTierDto::GeneratedSummary);
+        generated.resolution_status = Some(PacketEvidenceResolutionDto::DiagnosticOnly);
+        generated.eligible_for_sufficiency = None;
+
+        let mut dense = test_citation("dense anchor", "src/runtime.rs", 0.8);
+        dense.evidence_tier = Some(PacketEvidenceTierDto::DenseSemantic);
+        dense.resolution_status = Some(PacketEvidenceResolutionDto::Resolved);
+        dense.eligible_for_sufficiency = None;
+
+        let mut claims = vec![PacketClaimDto {
+            claim: "Runtime dispatch is covered.".to_string(),
+            proof_status: None,
+            required_evidence_role: None,
+            citations: vec![generated, dense],
+            coverage_role: Some("source evidence".to_string()),
+            eligible_for_sufficiency: Some(true),
+        }];
+
+        decorate_packet_claims_proof_metadata(&mut claims);
+
+        assert_eq!(
+            claims[0].proof_status,
+            Some(PacketProofStatusDto::Diagnostic)
+        );
+        assert_eq!(
+            claims[0].required_evidence_role,
+            Some(PacketEvidenceTierDto::ExactSource)
+        );
+
+        let mut exact_source = test_citation("dispatch", "src/runtime.rs", 1.0);
+        exact_source.evidence_tier = Some(PacketEvidenceTierDto::ExactSource);
+        exact_source.resolution_status = Some(PacketEvidenceResolutionDto::SourceRangeOnly);
+        exact_source.eligible_for_sufficiency = Some(true);
+        claims[0].citations.push(exact_source);
+
+        decorate_packet_claims_proof_metadata(&mut claims);
+
+        assert_eq!(claims[0].proof_status, Some(PacketProofStatusDto::Proven));
+        assert_eq!(
+            claims[0].required_evidence_role,
+            Some(PacketEvidenceTierDto::ExactSource)
+        );
     }
 
     fn write_sql_fixture(name: &str) -> std::path::PathBuf {

--- a/crates/codestory-runtime/src/agent/packet_command_profiles.rs
+++ b/crates/codestory-runtime/src/agent/packet_command_profiles.rs
@@ -364,6 +364,8 @@ fn packet_push_flow_template_claim_with_citations(
     }
     claims.push(PacketClaimDto {
         claim: claim_text.to_string(),
+        proof_status: None,
+        required_evidence_role: None,
         citations,
         coverage_role: Some("command profile".to_string()),
         eligible_for_sufficiency: Some(true),

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -199,9 +199,12 @@ pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
     }
 }
 
-fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
+pub(crate) fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
     if citation_is_diagnostic_source_proof(citation) {
         return PacketEvidenceTier::ExactSource;
+    }
+    if let Some(tier) = citation.evidence_tier {
+        return tier;
     }
     if let Some(breakdown) = citation.retrieval_score_breakdown.as_ref() {
         if breakdown.provenance.iter().any(|value| {
@@ -227,13 +230,18 @@ fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier
     }
 }
 
-fn evidence_resolution_for_citation(citation: &AgentCitationDto) -> PacketEvidenceResolution {
+pub(crate) fn evidence_resolution_for_citation(
+    citation: &AgentCitationDto,
+) -> PacketEvidenceResolution {
     if citation_is_diagnostic_source_proof(citation) {
         return if citation.file_path.is_some() && citation.line.is_some() {
             PacketEvidenceResolution::SourceRangeOnly
         } else {
             PacketEvidenceResolution::Unresolved
         };
+    }
+    if let Some(resolution) = citation.resolution_status {
+        return resolution;
     }
     if citation.resolvable {
         PacketEvidenceResolution::Resolved

--- a/crates/codestory-runtime/src/agent/packet_required_probes.rs
+++ b/crates/codestory-runtime/src/agent/packet_required_probes.rs
@@ -2680,6 +2680,8 @@ mod tests {
             PacketClaimDto {
                 claim: "FOREIGN KEY constraints define row references between SQL tables."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2688,6 +2690,8 @@ mod tests {
                 claim:
                     "A CHECK constraint validates a column without describing table relationships."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2708,6 +2712,8 @@ mod tests {
         let non_relationship_claims = vec![PacketClaimDto {
             claim: "A CHECK constraint validates a column without describing table relationships."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2720,6 +2726,8 @@ mod tests {
         let column_reference_claims = vec![PacketClaimDto {
             claim: "A CHECK constraint references the Price column while validating values."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2739,6 +2747,8 @@ mod tests {
             claim:
                 "A CHECK constraint references the Price column and validates values between 0 and 100."
                     .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2760,18 +2770,24 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "app.use registers middleware on the router.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "app.handle delegates request handling to the router.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "res.send prepares and sends the response body.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2791,12 +2807,16 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Logger owns a stack of handlers registered by pushHandler.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "addRecord creates a log record before passing it to handlers.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2804,6 +2824,8 @@ mod tests {
             PacketClaimDto {
                 claim: "AbstractProcessingHandler handles records by processing and writing them."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2829,18 +2851,24 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Top-level HTTP helpers delegate to a Client.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "BaseRequest.finalize prepares the request body for sending.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Response.fromStream builds a streamed response boundary.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2866,6 +2894,8 @@ mod tests {
                 claim:
                     "The form validation examples use native required, pattern, min, and max constraints."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2873,6 +2903,8 @@ mod tests {
             PacketClaimDto {
                 claim: "A custom validation example applies script-driven validity checks before rendering messages."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2880,12 +2912,16 @@ mod tests {
             PacketClaimDto {
                 claim: "Custom error rendering branches on ValidityState fields to choose messages."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Submit handlers prevent submission when the form is invalid.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -1,4 +1,4 @@
-use crate::agent::packet_claims::packet_supported_claims;
+use crate::agent::packet_claims::{decorate_packet_claims_proof_metadata, packet_supported_claims};
 use crate::agent::packet_evidence::citation_sufficiency_eligible;
 use crate::agent::packet_evidence_roles::{PacketEvidenceRole, packet_evidence_role};
 use crate::agent::packet_flow_requirements::{
@@ -87,10 +87,12 @@ fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSuffi
         task_class,
         answer,
         budget,
-        supported_claims,
+        mut supported_claims,
         missing_required_probe_queries,
         targeted_follow_up_queries,
     } = input;
+
+    decorate_packet_claims_proof_metadata(&mut supported_claims);
 
     let has_errors = answer
         .retrieval_trace
@@ -2174,6 +2176,8 @@ mod tests {
     fn claim(text: &str) -> PacketClaimDto {
         PacketClaimDto {
             claim: text.to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2228,6 +2232,8 @@ mod tests {
     ) -> PacketClaimDto {
         PacketClaimDto {
             claim: text.to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![citation],
             coverage_role: coverage_role.map(str::to_string),
             eligible_for_sufficiency,
@@ -3817,12 +3823,16 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Selected callback invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Selected handler invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,
@@ -3873,12 +3883,16 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Selected callback invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Selected handler invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -109,11 +109,15 @@ and may be dense anchors with reason `component_report`.
   to promote answer quality or language quality without packet-runtime or drill
   evidence at the matching proof tier.
 
-Packet citations may expose optional JSON fields: `evidence_tier`,
-`evidence_producer`, `resolution_status`, `coverage_role`, and
-`eligible_for_sufficiency`. Sufficiency is role-bearing: a citation can help
-prove a packet claim only when the evidence tier, resolved/source-range status,
-and coverage role match the claim being covered.
+Packet claims expose `proof_status` and `required_evidence_role`.
+`proof_status` is `proven`, `likely`, `diagnostic`, or `unsupported`.
+`required_evidence_role` reuses the packet evidence tier taxonomy below; dense
+semantic hits and generated summaries stay diagnostic unless another
+proof-bearing citation backs the claim. Packet citations may expose optional
+JSON fields: `evidence_tier`, `evidence_producer`, `resolution_status`,
+`coverage_role`, and `eligible_for_sufficiency`. Sufficiency is role-bearing:
+a citation can help prove a packet claim only when the evidence tier,
+resolved/source-range status, and coverage role match the claim being covered.
 
 | Evidence tier | Proof role | Sufficiency rule |
 | --- | --- | --- |


### PR DESCRIPTION
## Context

Closes #444.

Packet covered claims already depended on citation evidence tiers, resolution state, and sufficiency eligibility, but the claim DTO did not expose a machine-checkable proof decision. That made generated summaries and dense hits too easy to over-read as proof.

## What Changed

- Added `proof_status` to packet claims with `proven`, `likely`, `diagnostic`, and `unsupported` states.
- Added `required_evidence_role` on packet claims using the existing `PacketEvidenceTierDto` taxonomy instead of a parallel role model.
- Decorated packet supported claims and sufficiency-covered claims from existing citation tier/resolution/eligibility metadata.
- Kept generated-summary, dense-semantic, and synthetic-source-only citations diagnostic unless a separate proof-bearing citation backs the claim.
- Added contract coverage for claim metadata JSON and runtime coverage for the generated-summary/dense-hit diagnostic case.
- Updated retrieval design docs to name the new packet-claim fields and the residual proof rule.

## How To Review

1. Start with `crates/codestory-contracts/src/api/dto.rs` for the serialized DTO shape.
2. Review `crates/codestory-runtime/src/agent/packet_claims.rs` for claim proof decoration.
3. Check `crates/codestory-runtime/src/agent/packet_evidence.rs` to confirm explicit citation tier/resolution metadata wins before fallback inference.
4. Skim the constructor-only updates in packet tests/helpers; those are DTO field fallout.

## Verification

- `cargo test -p codestory-runtime generated_summary_and_dense_claims_need_backing_source_proof` - passed.
- `cargo check -p codestory-runtime` - passed.
- `cargo test -p codestory-contracts packet_claim_serializes_machine_checkable_proof_metadata` - passed.
- `git diff --check` - passed before commit; Git emitted CRLF normalization warnings only.

## Risk

Packet/search sidecar proof was not exercised end to end in this environment because CodeStory retrieval was degraded with a missing retrieval manifest. The patch is covered at the DTO and runtime claim-decorator boundary, but full sidecar packet behavior should still be verified once retrieval mode is full.
