### PR TITLE
Add ci-agent smoke profile

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -67,6 +67,8 @@ pub(crate) enum Command {
     Doctor(DoctorCommand),
     #[command(about = "Print compact readiness verdicts for local navigation or agent search.")]
     Ready(ReadyCommand),
+    #[command(about = "Run a machine-readable smoke profile for CI and agent images.")]
+    Smoke(SmokeCommand),
     #[command(about = "Agent-facing readiness and repair helpers.")]
     Agent(AgentCommand),
     #[command(about = "Install or check local setup assets.")]
@@ -316,6 +318,28 @@ pub(crate) struct GroundCommand {
         help = "Explain retrieval mode, coverage, and query hints in the Markdown output."
     )]
     pub(crate) why: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum SmokeProfile {
+    #[value(name = "ci-agent")]
+    CiAgent,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct SmokeCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum, default_value_t = SmokeProfile::CiAgent)]
+    pub(crate) profile: SmokeProfile,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -20,13 +20,13 @@ use codestory_contracts::api::{
     AppEventPayload, BookmarkCategoryDto, BookmarkDto, ClaimReadinessDto,
     CreateBookmarkCategoryRequest, CreateBookmarkRequest, EvidenceItemDto, EvidencePacketDto,
     EvidenceSourceLocationDto, EvidenceTypeDto, FrameworkRouteCoverageDto, GraphArtifactDto,
-    IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode, IndexedFilesRequest, NodeId, NodeKind,
-    NodeOccurrencesRequest, PacketBudgetModeDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
-    ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto, RetrievalFallbackReasonDto,
-    RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit, SearchMatchQualityDto,
-    SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest, SourceOccurrenceDto,
-    SourceTruthCheckDto, TrailCallerScope, TrailConfigDto, TrailContextDto, TrailDirection,
-    TrailMode,
+    GroundingBudgetDto, IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode, IndexedFilesRequest,
+    NodeId, NodeKind, NodeOccurrencesRequest, PacketBudgetModeDto, PacketSufficiencyStatusDto,
+    PacketTaskClassDto, ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto,
+    RetrievalFallbackReasonDto, RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit,
+    SearchMatchQualityDto, SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest,
+    SourceOccurrenceDto, SourceTruthCheckDto, TrailCallerScope, TrailConfigDto, TrailContextDto,
+    TrailDirection, TrailMode,
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -79,8 +79,8 @@ use args::{
     IndexCommand, IndexDryRunOutput, IndexOutput, PacketCommand, ProjectArgs, QueryCommand,
     QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadyCommand, ReadyOutput,
     RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand, SetupAction,
-    SetupCommand, SnippetCommand, SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, TrailCommand,
-    TrailJsonOutput, VerificationTargetOutput, build_trail_request,
+    SetupCommand, SmokeCommand, SmokeProfile, SnippetCommand, SnippetJsonOutput, SymbolCommand,
+    SymbolJsonOutput, TrailCommand, TrailJsonOutput, VerificationTargetOutput, build_trail_request,
 };
 #[cfg(test)]
 use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
@@ -184,6 +184,7 @@ fn main() -> Result<()> {
         Command::Packet(cmd) => run_packet(cmd),
         Command::Doctor(cmd) => run_doctor(cmd),
         Command::Ready(cmd) => run_ready(cmd),
+        Command::Smoke(cmd) => run_smoke(cmd),
         Command::Agent(cmd) => run_agent(cmd),
         Command::Setup(cmd) => run_setup(cmd),
         Command::Cache(cmd) => run_cache(cmd),
@@ -637,6 +638,343 @@ fn run_ground(cmd: GroundCommand) -> Result<()> {
         .map_err(map_api_error)?;
     let markdown = render_ground_markdown(&runtime.project_root, &snapshot, cmd.why);
     emit(cmd.format, &snapshot, markdown, cmd.output_file.as_deref())
+}
+
+#[derive(serde::Serialize)]
+struct SmokeOutput {
+    profile: &'static str,
+    status: &'static str,
+    project: String,
+    checked_surfaces: Vec<SmokeSurfaceOutput>,
+    skipped_optional_surfaces: Vec<SmokeSkippedSurfaceOutput>,
+    repair_hints: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct SmokeSurfaceOutput {
+    surface: &'static str,
+    status: &'static str,
+    duration_ms: u64,
+    detail: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    repair_hints: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct SmokeSkippedSurfaceOutput {
+    surface: &'static str,
+    reason: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    repair_hints: Vec<String>,
+}
+
+fn run_smoke(cmd: SmokeCommand) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, "smoke")?;
+    preflight_output_file(cmd.output_file.as_deref())?;
+
+    let output = match cmd.profile {
+        SmokeProfile::CiAgent => run_ci_agent_smoke(&cmd.project),
+    };
+    let failed = output.status == "fail";
+    let markdown = render_smoke_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())?;
+    if failed {
+        bail!("smoke profile {} failed", output.profile);
+    }
+    Ok(())
+}
+
+fn run_ci_agent_smoke(project: &ProjectArgs) -> SmokeOutput {
+    let requested_project = display::clean_path_string(&project.project.to_string_lossy());
+    let mut output = SmokeOutput {
+        profile: "ci-agent",
+        status: "pass",
+        project: requested_project,
+        checked_surfaces: Vec::new(),
+        skipped_optional_surfaces: Vec::new(),
+        repair_hints: Vec::new(),
+    };
+
+    let runtime = match RuntimeContext::new(project) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "project",
+                0,
+                format!("failed to open project: {error:#}"),
+                vec!["pass a valid --project repository root".to_string()],
+            );
+            return output;
+        }
+    };
+
+    output.project = display::clean_path_string(&runtime.project_root.to_string_lossy());
+    let project_arg = quote_command_path(&runtime.project_root);
+
+    let start = Instant::now();
+    let opened = match runtime.ensure_open(args::RefreshMode::Auto) {
+        Ok(opened) => match ensure_index_ready(&opened, "smoke index") {
+            Ok(()) => {
+                smoke_pass(
+                    &mut output,
+                    "index",
+                    start,
+                    format!(
+                        "refresh={} files={} errors={}",
+                        refresh_label(args::RefreshMode::Auto, opened.refresh_mode),
+                        opened.summary.stats.file_count,
+                        opened.summary.stats.error_count
+                    ),
+                );
+                opened
+            }
+            Err(error) => {
+                smoke_fail(
+                    &mut output,
+                    "index",
+                    elapsed_ms(start),
+                    format!("index not ready: {error:#}"),
+                    vec![format!(
+                        "codestory-cli index --project {project_arg} --refresh full --format json"
+                    )],
+                );
+                return output;
+            }
+        },
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "index",
+                elapsed_ms(start),
+                format!("index failed: {error:#}"),
+                vec![format!(
+                    "codestory-cli index --project {project_arg} --refresh full --format json"
+                )],
+            );
+            return output;
+        }
+    };
+
+    let start = Instant::now();
+    let snapshot = match runtime
+        .grounding
+        .grounding_snapshot(GroundingBudgetDto::Strict)
+        .map_err(map_api_error)
+    {
+        Ok(snapshot) => {
+            smoke_pass(
+                &mut output,
+                "ground",
+                start,
+                format!(
+                    "represented_files={}/{} represented_symbols={}/{}",
+                    snapshot.coverage.represented_files,
+                    snapshot.coverage.total_files,
+                    snapshot.coverage.represented_symbols,
+                    snapshot.coverage.total_symbols
+                ),
+            );
+            snapshot
+        }
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "ground",
+                elapsed_ms(start),
+                format!("ground failed: {error:#}"),
+                vec![format!(
+                    "codestory-cli ground --project {project_arg} --refresh none --format json"
+                )],
+            );
+            return output;
+        }
+    };
+
+    let Some(symbol) = snapshot.root_symbols.first() else {
+        smoke_fail(
+            &mut output,
+            "symbol",
+            0,
+            "ground snapshot returned no root symbols".to_string(),
+            vec![format!(
+                "codestory-cli index --project {project_arg} --refresh full --format json"
+            )],
+        );
+        return output;
+    };
+
+    let start = Instant::now();
+    match runtime.browser.symbol_context(symbol.id.clone()) {
+        Ok(context) => smoke_pass(
+            &mut output,
+            "symbol",
+            start,
+            format!(
+                "resolved={} kind={:?} file={}",
+                context.node.display_name,
+                context.node.kind,
+                context.node.file_path.as_deref().unwrap_or("unavailable")
+            ),
+        ),
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "symbol",
+                elapsed_ms(start),
+                format!("symbol resolution failed: {}", map_api_error(error)),
+                vec![format!(
+                    "codestory-cli symbol --project {project_arg} --id {} --format json",
+                    symbol.id.0
+                )],
+            );
+            return output;
+        }
+    }
+
+    let start = Instant::now();
+    let fake_path = "__codestory_smoke_fake_change__.rs";
+    match runtime.browser.affected_analysis(AffectedAnalysisRequest {
+        changed_paths: vec![fake_path.to_string()],
+        change_records: vec![affected_path_record(
+            fake_path,
+            AffectedChangeKindDto::Unknown,
+            "smoke",
+        )],
+        depth: Some(1),
+        filter: None,
+    }) {
+        Ok(affected) => smoke_pass(
+            &mut output,
+            "affected",
+            start,
+            format!(
+                "fake_path={} changed_files={} impacted_symbols={}",
+                fake_path,
+                affected.changed_paths.len(),
+                affected.impacted_symbols.len()
+            ),
+        ),
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "affected",
+                elapsed_ms(start),
+                format!("affected failed: {}", map_api_error(error)),
+                vec![format!(
+                    "codestory-cli affected --project {project_arg} {fake_path} --format json"
+                )],
+            );
+            return output;
+        }
+    }
+
+    let start = Instant::now();
+    let sidecar = doctor_sidecar_status(&runtime);
+    if sidecar.retrieval_mode == "full" {
+        smoke_pass(
+            &mut output,
+            "sidecar_full_mode",
+            start,
+            "retrieval_mode=full".to_string(),
+        );
+    } else {
+        smoke_skip(
+            &mut output,
+            "sidecar_full_mode",
+            format!(
+                "retrieval_mode={}{}",
+                sidecar.retrieval_mode,
+                sidecar
+                    .degraded_reason
+                    .as_deref()
+                    .map(|reason| format!(" reason={reason}"))
+                    .unwrap_or_default()
+            ),
+            vec![
+                format!(
+                    "codestory-cli retrieval index --project {project_arg} --refresh full --format json"
+                ),
+                format!("codestory-cli retrieval status --project {project_arg} --format json"),
+            ],
+        );
+    }
+
+    let _ = opened;
+    output
+}
+
+fn smoke_pass(output: &mut SmokeOutput, surface: &'static str, start: Instant, detail: String) {
+    output.checked_surfaces.push(SmokeSurfaceOutput {
+        surface,
+        status: "pass",
+        duration_ms: elapsed_ms(start),
+        detail,
+        repair_hints: Vec::new(),
+    });
+}
+
+fn smoke_fail(
+    output: &mut SmokeOutput,
+    surface: &'static str,
+    duration_ms: u64,
+    detail: String,
+    repair_hints: Vec<String>,
+) {
+    output.status = "fail";
+    output.repair_hints.extend(repair_hints.clone());
+    output.checked_surfaces.push(SmokeSurfaceOutput {
+        surface,
+        status: "fail",
+        duration_ms,
+        detail,
+        repair_hints,
+    });
+}
+
+fn smoke_skip(
+    output: &mut SmokeOutput,
+    surface: &'static str,
+    reason: String,
+    repair_hints: Vec<String>,
+) {
+    output.repair_hints.extend(repair_hints.clone());
+    output
+        .skipped_optional_surfaces
+        .push(SmokeSkippedSurfaceOutput {
+            surface,
+            reason,
+            repair_hints,
+        });
+}
+
+fn render_smoke_markdown(output: &SmokeOutput) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(markdown, "# Smoke");
+    let _ = writeln!(markdown, "profile: `{}`", output.profile);
+    let _ = writeln!(markdown, "status: `{}`", output.status);
+    let _ = writeln!(markdown, "project: `{}`", output.project);
+    let _ = writeln!(markdown, "\n## Checked Surfaces");
+    for surface in &output.checked_surfaces {
+        let _ = writeln!(
+            markdown,
+            "- {} [{}] {} ({} ms)",
+            surface.surface, surface.status, surface.detail, surface.duration_ms
+        );
+    }
+    if !output.skipped_optional_surfaces.is_empty() {
+        let _ = writeln!(markdown, "\n## Skipped Optional Surfaces");
+        for surface in &output.skipped_optional_surfaces {
+            let _ = writeln!(markdown, "- {}: {}", surface.surface, surface.reason);
+        }
+    }
+    if !output.repair_hints.is_empty() {
+        let _ = writeln!(markdown, "\n## Repair Hints");
+        for hint in &output.repair_hints {
+            let _ = writeln!(markdown, "- `{hint}`");
+        }
+    }
+    markdown
 }
 
 #[derive(serde::Serialize)]

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -280,6 +280,10 @@ fn top_level_help_names_command_purposes() {
             "Answer a broad repository question with evidence.",
         ),
         ("doctor", "Check cache, index, and retrieval health."),
+        (
+            "smoke",
+            "Run a machine-readable smoke profile for CI and agent images.",
+        ),
         ("setup", "Install or check local setup assets."),
         ("cache", "Prepare or inspect local cache artifacts."),
         ("symbol", "Inspect a symbol by query or id."),
@@ -295,6 +299,83 @@ fn top_level_help_names_command_purposes() {
             "top-level help should show {command:?} purpose {purpose:?}, not only command names:\n{help_text}"
         );
     }
+}
+
+#[test]
+fn smoke_ci_agent_json_runs_tiny_repo_profile() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    let output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &["smoke", "--profile", "ci-agent", "--format", "json"],
+    );
+    assert_success(&output, "smoke ci-agent failed");
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse smoke json");
+    assert_eq!(json_string(&json, "/profile"), "ci-agent");
+    assert_eq!(json_string(&json, "/status"), "pass");
+
+    let checked = json["checked_surfaces"]
+        .as_array()
+        .expect("checked surfaces array");
+    for surface in ["index", "ground", "symbol", "affected"] {
+        assert!(
+            checked
+                .iter()
+                .any(|item| item["surface"] == surface && item["status"] == "pass"),
+            "smoke should pass required surface {surface}: {json:#}"
+        );
+    }
+    assert!(
+        checked
+            .iter()
+            .any(|item| item["surface"] == "sidecar_full_mode")
+            || json["skipped_optional_surfaces"]
+                .as_array()
+                .is_some_and(|items| items
+                    .iter()
+                    .any(|item| item["surface"] == "sidecar_full_mode")),
+        "sidecar full mode should be checked or explicitly skipped: {json:#}"
+    );
+}
+
+#[test]
+fn smoke_ci_agent_invalid_project_emits_json_failure() {
+    let workspace = tempdir().expect("workspace dir");
+    let missing = workspace.path().join("missing");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+        .args([
+            "smoke",
+            "--profile",
+            "ci-agent",
+            "--format",
+            "json",
+            "--project",
+        ])
+        .arg(&missing)
+        .output()
+        .expect("run codestory-cli");
+    assert!(
+        !output.status.success(),
+        "invalid project smoke should fail, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse smoke json");
+    assert_eq!(json_string(&json, "/profile"), "ci-agent");
+    assert_eq!(json_string(&json, "/status"), "fail");
+    assert_eq!(json_string(&json, "/checked_surfaces/0/surface"), "project");
+    assert!(
+        json["repair_hints"]
+            .as_array()
+            .is_some_and(|hints| !hints.is_empty()),
+        "failure JSON should include repair hints: {json:#}"
+    );
 }
 
 #[test]

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -220,6 +220,18 @@ cargo test -p codestory-cli
 
 Prefer this lane before `cargo test` for the whole workspace when the change is isolated to CLI args, rendering, or contract envelopes.
 
+For CI agents or container images that need a single machine-readable local
+readiness check, run:
+
+```sh
+codestory-cli smoke --project <repo> --profile ci-agent --format json
+```
+
+The profile indexes the local graph, grounds the repo, resolves one indexed
+symbol, runs `affected` on a fake changed path, and reports sidecar full mode
+only when the existing sidecar status already proves it. Non-full sidecars are
+listed under `skipped_optional_surfaces` with repair hints.
+
 Runtime-backed CLI fixture flows are a separate heavier lane:
 
 ```sh


### PR DESCRIPTION
## Context

Issue #447 needs a single machine-readable smoke profile that CI agents and agent images can run without interpreting multiple commands.

Closes #447

## What Changed

- Added `codestory-cli smoke --project <repo> --profile ci-agent --format json`.
- The profile indexes the local graph, grounds the repo, resolves one symbol, runs affected analysis on a fake path, and reads sidecar full-mode status as optional evidence.
- Added JSON failure/skip envelopes plus focused CLI contract tests and testing-matrix docs.

## How To Review

- Review the new `SmokeCommand` args and `run_ci_agent_smoke` flow.
- Confirm the diff is limited to CLI smoke command wiring, tests, and docs.
- Confirm sidecar full mode is optional status only; this does not include #446 sidecar isolation/profile lifecycle work, #444 packet proof metadata, or #441 plugin/MCP transport changes.

## Verification

- `cargo test -p codestory-cli --test cli_error_contracts smoke_ci_agent -- --nocapture`
- `cargo test -p codestory-cli --test cli_error_contracts top_level_help_names_command_purposes -- --nocapture`
- `target\debug\codestory-cli.exe smoke --project . --profile ci-agent --format json`
- `cargo check -p codestory-cli`
- `git diff --check`

## Risk

- Sidecar full mode remains optional and is skipped with repair hints when `retrieval_mode` is not `full`.
- The local smoke run skipped optional sidecar full mode because this clean worktree has no retrieval manifest.
