### PR TITLE
[codex] Isolate agent sidecars

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -641,6 +641,12 @@ pub(crate) struct RetrievalSidecarStateCommand {
     pub(crate) project: ProjectArgs,
     #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
     pub(crate) profile: CliSidecarProfile,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to reuse for status or cleanup. If omitted, agent profile creates a fresh run namespace."
+    )]
+    pub(crate) run_id: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -667,6 +673,12 @@ pub(crate) struct RetrievalBootstrapCommand {
     pub(crate) project: ProjectArgs,
     #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
     pub(crate) profile: CliSidecarProfile,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to reuse for status or cleanup. If omitted, agent profile creates a fresh run namespace."
+    )]
+    pub(crate) run_id: Option<String>,
     #[arg(
         long,
         help = "Skip docker compose even when Docker is installed (dirs + state file only)."
@@ -697,6 +709,12 @@ pub(crate) struct RetrievalStatusCommand {
     pub(crate) project: ProjectArgs,
     #[arg(long, value_enum)]
     pub(crate) profile: Option<CliSidecarProfile>,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to inspect. If omitted, agent profile creates a fresh status namespace."
+    )]
+    pub(crate) run_id: Option<String>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(long, value_name = "PATH")]
@@ -707,6 +725,14 @@ pub(crate) struct RetrievalStatusCommand {
 pub(crate) struct RetrievalIndexCommand {
     #[command(flatten)]
     pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum)]
+    pub(crate) profile: Option<CliSidecarProfile>,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to reuse while finalizing sidecar artifacts."
+    )]
+    pub(crate) run_id: Option<String>,
     #[arg(long, value_enum, default_value_t = RefreshMode::Auto, help = INDEX_REFRESH_HELP)]
     pub(crate) refresh: RefreshMode,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -609,15 +609,38 @@ pub(crate) enum RetrievalAction {
     /// Start Docker Compose sidecars (when available), prepare cache dirs, and wait for health.
     Bootstrap(RetrievalBootstrapCommand),
     /// Prepare local sidecar data directories and write sidecar state (does not start Docker).
-    Up,
+    Up(RetrievalSidecarStateCommand),
     /// Remove local sidecar state file (does not stop external processes).
-    Down,
+    Down(RetrievalSidecarStateCommand),
     /// Probe Zoekt, Qdrant, and SCIP availability for the project.
     Status(RetrievalStatusCommand),
     /// Run workspace index then persist retrieval_index_manifest sidecar metadata.
     Index(RetrievalIndexCommand),
     /// Execute a standalone sidecar retrieval query against indexed sidecar metadata.
     Query(RetrievalQueryCommand),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliSidecarProfile {
+    Local,
+    Agent,
+}
+
+impl From<CliSidecarProfile> for codestory_retrieval::SidecarProfile {
+    fn from(value: CliSidecarProfile) -> Self {
+        match value {
+            CliSidecarProfile::Local => Self::Local,
+            CliSidecarProfile::Agent => Self::Agent,
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct RetrievalSidecarStateCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
+    pub(crate) profile: CliSidecarProfile,
 }
 
 #[derive(Args, Debug)]
@@ -642,6 +665,8 @@ pub(crate) struct RetrievalQueryCommand {
 pub(crate) struct RetrievalBootstrapCommand {
     #[command(flatten)]
     pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
+    pub(crate) profile: CliSidecarProfile,
     #[arg(
         long,
         help = "Skip docker compose even when Docker is installed (dirs + state file only)."
@@ -670,6 +695,8 @@ pub(crate) struct RetrievalBootstrapCommand {
 pub(crate) struct RetrievalStatusCommand {
     #[command(flatten)]
     pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum)]
+    pub(crate) profile: Option<CliSidecarProfile>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(long, value_name = "PATH")]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1304,12 +1304,13 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    codestory_retrieval::bootstrap_sidecars(
+    codestory_retrieval::bootstrap_sidecars_with_profile(
         Some(runtime.project_root.as_path()),
         &storage_scope,
         None,
         false,
         Duration::from_secs(90),
+        codestory_retrieval::SidecarProfile::Agent,
     )
     .context("ready repair retrieval bootstrap")?;
     codestory_retrieval::repair_project_qdrant_collection(

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -10,8 +10,8 @@ use codestory_retrieval::{
 };
 
 use crate::args::{
-    OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand, RetrievalCommand,
-    RetrievalIndexCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
+    CliSidecarProfile, OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand,
+    RetrievalCommand, RetrievalIndexCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
     RetrievalStatusCommand,
 };
 use crate::output::{emit, validate_output_file_parent};
@@ -99,7 +99,10 @@ fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
 fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let report = if let Some(profile) = cmd.profile {
+    let profile = cmd
+        .profile
+        .or_else(|| cmd.run_id.as_ref().map(|_| CliSidecarProfile::Agent));
+    let report = if let Some(profile) = profile {
         let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
             &runtime.project_root,
             profile.into(),

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -5,12 +5,14 @@ use std::time::Duration;
 use codestory_retrieval::{
     BootstrapStorageScope, FinalizeIndexOutcome, ProjectQdrantRepairOutcome, QueryRequest,
     RetrievalIndexManifest, RetrievalStatusReport, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    bootstrap_sidecars, execute_retrieval_query, sidecar_down, sidecar_up, strict_sidecar_status,
+    bootstrap_sidecars_with_profile, execute_retrieval_query, sidecar_down_for_project,
+    sidecar_up_with_runtime, strict_sidecar_status,
 };
 
 use crate::args::{
     OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand, RetrievalCommand,
-    RetrievalIndexCommand, RetrievalQueryCommand, RetrievalStatusCommand,
+    RetrievalIndexCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
+    RetrievalStatusCommand,
 };
 use crate::output::{emit, validate_output_file_parent};
 use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_refresh_request};
@@ -18,8 +20,8 @@ use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_
 pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
     match cmd.action {
         RetrievalAction::Bootstrap(bootstrap_cmd) => run_retrieval_bootstrap(bootstrap_cmd),
-        RetrievalAction::Up => run_retrieval_up(),
-        RetrievalAction::Down => run_retrieval_down(),
+        RetrievalAction::Up(up_cmd) => run_retrieval_up(up_cmd),
+        RetrievalAction::Down(down_cmd) => run_retrieval_down(down_cmd),
         RetrievalAction::Status(status_cmd) => run_retrieval_status(status_cmd),
         RetrievalAction::Index(index_cmd) => run_retrieval_index(index_cmd),
         RetrievalAction::Query(query_cmd) => run_retrieval_query(query_cmd),
@@ -34,12 +36,13 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    let report = bootstrap_sidecars(
+    let report = bootstrap_sidecars_with_profile(
         Some(&runtime.project_root),
         &storage_scope,
         cmd.compose_file.as_deref(),
         cmd.skip_compose,
         Duration::from_secs(cmd.wait_secs),
+        cmd.profile.into(),
     )
     .context("retrieval bootstrap")?;
     let project_qdrant_repair = codestory_retrieval::repair_project_qdrant_collection(
@@ -58,14 +61,19 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
     )
 }
 
-fn run_retrieval_up() -> Result<()> {
-    let state = sidecar_up().context("retrieval up")?;
+fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let sidecar =
+        codestory_retrieval::sidecar_runtime_for_project(&runtime.project_root, cmd.profile.into());
+    let state = sidecar_up_with_runtime(&sidecar, None).context("retrieval up")?;
     println!("{}", serde_json::to_string_pretty(&state)?);
     Ok(())
 }
 
-fn run_retrieval_down() -> Result<()> {
-    sidecar_down().context("retrieval down")?;
+fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    sidecar_down_for_project(&runtime.project_root, cmd.profile.into())
+        .context("retrieval down")?;
     println!("retrieval sidecar state cleared");
     Ok(())
 }
@@ -73,8 +81,16 @@ fn run_retrieval_down() -> Result<()> {
 fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let report = strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
-        .context("retrieval status")?;
+    let report = if let Some(profile) = cmd.profile {
+        codestory_retrieval::strict_sidecar_status_for_profile(
+            &runtime.project_root,
+            Some(&runtime.storage_path),
+            profile.into(),
+        )
+    } else {
+        strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
+    }
+    .context("retrieval status")?;
     emit_retrieval_status(cmd.format, &report, cmd.output_file.as_deref())
 }
 
@@ -362,8 +378,25 @@ fn emit_retrieval_status(
             )
         })
         .unwrap_or_default();
+    let ownership_note = report
+        .ownership
+        .as_ref()
+        .map(|ownership| {
+            format!(
+                "- ownership: owner=`{}` profile=`{}` namespace=`{}` cleanup=`{}` ports=zoekt:{} qdrant:{} grpc:{} embed:{}\n",
+                ownership.owner,
+                ownership.profile,
+                ownership.namespace,
+                ownership.cleanup_command,
+                ownership.ports.zoekt_http,
+                ownership.ports.qdrant_http,
+                ownership.ports.qdrant_grpc,
+                ownership.ports.embed_http,
+            )
+        })
+        .unwrap_or_default();
     let markdown = format!(
-        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
+        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
         report.retrieval_mode,
         report.degraded_reason,
         report.query_embedding_backend,
@@ -374,6 +407,7 @@ fn emit_retrieval_status(
         report.stored_doc_vector_mixed_backends,
         manifest_contract_note,
         repair_note,
+        ownership_note,
         report.zoekt.status,
         report.zoekt.detail,
         report.zoekt.capabilities.lexical,

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use codestory_retrieval::{
     BootstrapStorageScope, FinalizeIndexOutcome, ProjectQdrantRepairOutcome, QueryRequest,
     RetrievalIndexManifest, RetrievalStatusReport, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    bootstrap_sidecars_with_profile, execute_retrieval_query, sidecar_down_for_project,
-    sidecar_up_with_runtime, strict_sidecar_status,
+    bootstrap_sidecars_with_runtime, execute_retrieval_query, sidecar_down_for_runtime,
+    sidecar_up_with_runtime, strict_sidecar_status, strict_sidecar_status_for_runtime,
 };
 
 use crate::args::{
@@ -36,22 +36,33 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    let report = bootstrap_sidecars_with_profile(
+    let sidecar_profile = cmd.profile;
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &runtime.project_root,
+        sidecar_profile.into(),
+        cmd.run_id.as_deref(),
+    );
+    let report = bootstrap_sidecars_with_runtime(
+        &sidecar,
         Some(&runtime.project_root),
         &storage_scope,
         cmd.compose_file.as_deref(),
         cmd.skip_compose,
         Duration::from_secs(cmd.wait_secs),
-        cmd.profile.into(),
     )
     .context("retrieval bootstrap")?;
+    activate_retrieval_profile_env(Some(sidecar_profile), sidecar.run_id.as_deref());
     let project_qdrant_repair = codestory_retrieval::repair_project_qdrant_collection(
         &runtime.project_root,
         &runtime.storage_path,
     )
     .context("retrieval project qdrant repair")?;
-    let status = strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
-        .context("retrieval status after bootstrap")?;
+    let status = strict_sidecar_status_for_runtime(
+        &runtime.project_root,
+        Some(&runtime.storage_path),
+        sidecar,
+    )
+    .context("retrieval status after bootstrap")?;
     emit_retrieval_bootstrap(
         cmd.format,
         &report,
@@ -63,8 +74,11 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
 
 fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let sidecar =
-        codestory_retrieval::sidecar_runtime_for_project(&runtime.project_root, cmd.profile.into());
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &runtime.project_root,
+        cmd.profile.into(),
+        cmd.run_id.as_deref(),
+    );
     let state = sidecar_up_with_runtime(&sidecar, None).context("retrieval up")?;
     println!("{}", serde_json::to_string_pretty(&state)?);
     Ok(())
@@ -72,8 +86,12 @@ fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
 
 fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    sidecar_down_for_project(&runtime.project_root, cmd.profile.into())
-        .context("retrieval down")?;
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &runtime.project_root,
+        cmd.profile.into(),
+        cmd.run_id.as_deref(),
+    );
+    sidecar_down_for_runtime(&sidecar).context("retrieval down")?;
     println!("retrieval sidecar state cleared");
     Ok(())
 }
@@ -82,10 +100,15 @@ fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let report = if let Some(profile) = cmd.profile {
-        codestory_retrieval::strict_sidecar_status_for_profile(
+        let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+            &runtime.project_root,
+            profile.into(),
+            cmd.run_id.as_deref(),
+        );
+        codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
             Some(&runtime.storage_path),
-            profile.into(),
+            sidecar,
         )
     } else {
         strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
@@ -110,6 +133,7 @@ fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
 
 fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
+    activate_retrieval_profile_env(cmd.profile, cmd.run_id.as_deref());
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let summary = runtime.open_project_summary()?;
     let refresh_mode = resolve_refresh_request(cmd.refresh, &summary);
@@ -126,6 +150,29 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
             .context("retrieval index finalize after semantic-doc contract repair")
     })?;
     emit_retrieval_index(cmd.format, &outcome, cmd.output_file.as_deref())
+}
+
+fn activate_retrieval_profile_env(
+    profile: Option<crate::args::CliSidecarProfile>,
+    run_id: Option<&str>,
+) {
+    if let Some(profile) = profile {
+        let profile = match profile {
+            crate::args::CliSidecarProfile::Local => "local",
+            crate::args::CliSidecarProfile::Agent => "agent",
+        };
+        // SAFETY: retrieval CLI commands are short-lived processes and set this before sidecar
+        // layout resolution or worker threads are started.
+        unsafe {
+            std::env::set_var("CODESTORY_RETRIEVAL_PROFILE", profile);
+        }
+    }
+    if let Some(run_id) = run_id {
+        // SAFETY: see the profile environment setup above.
+        unsafe {
+            std::env::set_var("CODESTORY_SIDECAR_RUN_ID", run_id);
+        }
+    }
 }
 
 fn run_retrieval_index_refresh(

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1089,7 +1089,7 @@ fn stdio_mandatory_sidecar_fingerprint(
     project_root: &std::path::Path,
     storage_path: &std::path::Path,
 ) -> String {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     let status = codestory_retrieval::strict_sidecar_status(project_root, Some(storage_path)).map(
         |report| StdioSidecarStatusFingerprint {
             retrieval_mode: report.retrieval_mode,
@@ -1949,7 +1949,7 @@ fn read_stdio_status_resource_cached(
 }
 
 fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(&runtime.project_root);
     [
         format!("project:{}", runtime.project_root.display()),
         format!("storage:{}", runtime.storage_path.display()),
@@ -1972,7 +1972,7 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
 fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Value> {
     let summary = runtime.open_project_summary()?;
     let retrieval = summary.retrieval.as_ref();
-    let (sidecar_mode, degraded_reason, manifest_generation, manifest_input_hash) =
+    let (sidecar_mode, degraded_reason, manifest_generation, manifest_input_hash, ownership) =
         match codestory_retrieval::strict_sidecar_status(
             &runtime.project_root,
             Some(&runtime.storage_path),
@@ -1991,11 +1991,13 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
                     report.degraded_reason,
                     manifest_generation,
                     manifest_input_hash,
+                    report.ownership,
                 )
             }
             Err(error) => (
                 "unavailable".to_string(),
                 Some(format!("sidecar_status_error: {error}")),
+                None,
                 None,
                 None,
             ),
@@ -2006,6 +2008,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "manifest_generation": manifest_generation.clone(),
         "manifest_input_hash": manifest_input_hash.clone(),
+        "ownership": ownership,
     });
     let (server_executable, server_executable_sha256, server_warnings) =
         stdio_server_executable_status();
@@ -2403,6 +2406,8 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         .unwrap_or_default();
     serde_json::json!({
         "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        "plugin_root": env_nonempty("CODESTORY_PLUGIN_ROOT"),
+        "plugin_cache_version": env_nonempty("CODESTORY_PLUGIN_CACHE_VERSION"),
         "cli_version": env_nonempty("CODESTORY_PLUGIN_CLI_VERSION"),
         "cli_source": cli_source,
         "cli_path": env_nonempty("CODESTORY_PLUGIN_CLI_PATH"),

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -33,6 +33,19 @@ fn run_status(project: &std::path::Path, extra_args: &[&str]) -> Value {
     serde_json::from_slice(&output.stdout).expect("parse status json")
 }
 
+fn run_down(project: &std::path::Path, extra_args: &[&str]) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    command.args(["retrieval", "down", "--project"]);
+    command.arg(project);
+    command.args(extra_args);
+    let output = command.output().expect("run retrieval down");
+    assert!(
+        output.status.success(),
+        "down failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn create_valid_cache_with_cli(project: &std::path::Path, cache: &std::path::Path) {
     let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
         .args(["index", "--project"])
@@ -163,6 +176,94 @@ fn bootstrap_then_status_reports_manifest_missing_before_indexing() {
                             && text.contains("--refresh full")))
             ),
         "manifest-missing status should include full sidecar rebuild guidance: {status}"
+    );
+}
+
+#[test]
+fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
+    let project = tempdir().expect("project");
+    fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");
+    let cache = tempdir().expect("cache");
+    let cache_arg = cache.path().to_str().expect("utf8 cache");
+
+    let bootstrap = run_bootstrap(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--skip-compose",
+            "--wait-secs",
+            "0",
+            "--format",
+            "json",
+        ],
+    );
+    let state = &bootstrap["sidecar_state"];
+    assert_eq!(state["owner"].as_str(), Some("codestory"));
+    assert_eq!(state["profile"].as_str(), Some("agent"));
+    let namespace = state["namespace"].as_str().expect("namespace");
+    assert!(namespace.starts_with("codestory-agent-"));
+    assert!(
+        state["zoekt_http_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert!(
+        state["qdrant_http_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert!(
+        state["qdrant_grpc_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert!(
+        state["embed_http_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert_ne!(state["zoekt_http_port"].as_u64(), Some(6070));
+    assert_ne!(state["qdrant_http_port"].as_u64(), Some(6333));
+    assert_ne!(state["qdrant_grpc_port"].as_u64(), Some(6334));
+    assert_ne!(state["embed_http_port"].as_u64(), Some(8080));
+    assert!(
+        state["cleanup_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile agent")),
+        "agent state should name the cleanup path: {state}"
+    );
+    let status = run_status(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--format",
+            "json",
+        ],
+    );
+    let ownership = &status["ownership"];
+    assert_eq!(ownership["profile"].as_str(), Some("agent"));
+    assert_eq!(ownership["namespace"].as_str(), Some(namespace));
+    assert_eq!(
+        ownership["ports"]["zoekt_http"].as_u64(),
+        state["zoekt_http_port"].as_u64()
+    );
+    let state_path =
+        std::path::PathBuf::from(ownership["state_file"].as_str().expect("state file"));
+    assert!(state_path.is_file(), "state file should exist before down");
+
+    run_down(
+        project.path(),
+        &["--cache-dir", cache_arg, "--profile", "agent"],
+    );
+    assert!(
+        !state_path.exists(),
+        "down should remove only the owned state file"
     );
 }
 

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -193,6 +193,8 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
             cache_arg,
             "--profile",
             "agent",
+            "--run-id",
+            "contract-a",
             "--skip-compose",
             "--wait-secs",
             "0",
@@ -205,6 +207,11 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
     assert_eq!(state["profile"].as_str(), Some("agent"));
     let namespace = state["namespace"].as_str().expect("namespace");
     assert!(namespace.starts_with("codestory-agent-"));
+    assert!(
+        namespace.ends_with("-contract-a"),
+        "agent namespace should carry the run id: {namespace}"
+    );
+    assert_eq!(state["run_id"].as_str(), Some("contract-a"));
     assert!(
         state["zoekt_http_port"]
             .as_u64()
@@ -242,6 +249,8 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
             cache_arg,
             "--profile",
             "agent",
+            "--run-id",
+            "contract-a",
             "--format",
             "json",
         ],
@@ -259,11 +268,64 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
 
     run_down(
         project.path(),
-        &["--cache-dir", cache_arg, "--profile", "agent"],
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--run-id",
+            "contract-a",
+        ],
     );
     assert!(
         !state_path.exists(),
         "down should remove only the owned state file"
+    );
+}
+
+#[test]
+fn agent_profile_status_repair_hints_are_profile_aware() {
+    let project = tempdir().expect("project");
+    fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");
+    let cache = tempdir().expect("cache");
+    let cache_arg = cache.path().to_str().expect("utf8 cache");
+
+    let status = run_status(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--run-id",
+            "repair-a",
+            "--format",
+            "json",
+        ],
+    );
+
+    let repair = &status["repair"];
+    assert_eq!(
+        repair["reason"].as_str(),
+        Some("retrieval_manifest_missing")
+    );
+    assert!(
+        repair["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile agent")
+                && command.contains("--run-id repair-a")),
+        "agent status repair command should keep the profile/run id: {status}"
+    );
+    let full_repair = repair["full_repair"]
+        .as_array()
+        .expect("full repair commands");
+    assert!(
+        full_repair
+            .iter()
+            .all(|command| command.as_str().is_some_and(
+                |text| text.contains("--profile agent") && text.contains("--run-id repair-a")
+            )),
+        "agent full repair commands should keep the profile/run id: {status}"
     );
 }
 

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -330,6 +330,43 @@ fn agent_profile_status_repair_hints_are_profile_aware() {
 }
 
 #[test]
+fn run_id_status_implies_agent_profile() {
+    let project = tempdir().expect("project");
+    fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");
+    let cache = tempdir().expect("cache");
+    let cache_arg = cache.path().to_str().expect("utf8 cache");
+
+    let status = run_status(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--run-id",
+            "implicit-agent",
+            "--format",
+            "json",
+        ],
+    );
+
+    let ownership = &status["ownership"];
+    assert_eq!(ownership["profile"].as_str(), Some("agent"));
+    assert!(
+        ownership["namespace"]
+            .as_str()
+            .is_some_and(|namespace| namespace.ends_with("-implicit-agent")),
+        "status --run-id should inspect the named agent namespace: {status}"
+    );
+    let repair = &status["repair"];
+    assert!(
+        repair["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile agent")
+                && command.contains("--run-id implicit-agent")),
+        "status --run-id repair command should keep the inferred agent run id: {status}"
+    );
+}
+
+#[test]
 fn bootstrap_json_surfaces_prune_suppressed_reason_on_scan_errors() {
     let project = tempdir().expect("project");
     fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -1,10 +1,12 @@
-use crate::config::{SidecarLayout, retrieval_compose_profile, user_cache_root};
+use crate::config::{
+    SidecarLayout, SidecarProfile, SidecarRuntimeConfig, retrieval_compose_profile, user_cache_root,
+};
 use crate::health::{InfrastructureHealth, probe_infrastructure_health};
 use crate::qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION, QdrantStorageRepairReport,
     repair_qdrant_storage,
 };
-use crate::sidecar::{SidecarStateFile, sidecar_up};
+use crate::sidecar::{SidecarStateFile, sidecar_up_with_runtime};
 use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -32,7 +34,27 @@ pub fn bootstrap_sidecars(
     skip_compose: bool,
     wait_timeout: Duration,
 ) -> Result<BootstrapReport> {
-    let layout = SidecarLayout::from_env();
+    bootstrap_sidecars_with_profile(
+        repo_root,
+        storage_scope,
+        compose_file,
+        skip_compose,
+        wait_timeout,
+        SidecarProfile::Local,
+    )
+}
+
+pub fn bootstrap_sidecars_with_profile(
+    repo_root: Option<&Path>,
+    storage_scope: &BootstrapStorageScope,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+    profile: SidecarProfile,
+) -> Result<BootstrapReport> {
+    let runtime = SidecarRuntimeConfig::for_project_profile(repo_root, profile);
+    let layout = runtime.layout.clone();
+    runtime.activate_embed_url_default();
     layout.ensure_data_dirs()?;
     let storage_repair =
         repair_qdrant_storage(&layout, storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?;
@@ -44,13 +66,13 @@ pub fn bootstrap_sidecars(
     };
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
-        docker_compose_up(path, repo_root, &layout)?;
+        docker_compose_up(path, repo_root, &runtime)?;
         true
     } else {
         false
     };
 
-    let state = sidecar_up()?;
+    let state = sidecar_up_with_runtime(&runtime, resolved_compose.as_deref())?;
     let infrastructure = if wait_timeout.is_zero() {
         probe_infrastructure_health(&layout)
     } else {
@@ -155,8 +177,9 @@ pub fn docker_available() -> bool {
 fn docker_compose_up(
     compose_file: &Path,
     repo_root: Option<&Path>,
-    layout: &SidecarLayout,
+    runtime: &SidecarRuntimeConfig,
 ) -> Result<()> {
+    let layout = &runtime.layout;
     if !docker_available() {
         bail!(
             "docker is not available on PATH. Install Docker Desktop (Windows) or Docker Engine, \
@@ -190,6 +213,8 @@ fn docker_compose_up(
     remove_container_if_present("codestory-zoekt-stub")?;
     command
         .arg("compose")
+        .arg("-p")
+        .arg(&runtime.compose_project)
         .arg("-f")
         .arg(compose_file)
         .arg("up")
@@ -216,6 +241,14 @@ fn docker_compose_up(
             "CODESTORY_EMBED_MODEL_DIR",
             docker_bind_path(&embed_model_dir(repo_root, layout)),
         )
+        .env("CODESTORY_EMBED_PORT", runtime.embed_http_port.to_string())
+        .env(
+            "CODESTORY_EMBED_LLAMACPP_URL",
+            SidecarLayout::embed_base_url(runtime.embed_http_port),
+        )
+        .env("CODESTORY_SIDECAR_NAMESPACE", &runtime.namespace)
+        .env("CODESTORY_SIDECAR_PROFILE", runtime.profile.as_str())
+        .env("CODESTORY_SIDECAR_OWNER", "codestory")
         .env("COMPOSE_PROFILES", compose_profile);
 
     let output = command.output().context("spawn docker compose")?;
@@ -224,6 +257,38 @@ fn docker_compose_up(
         let stdout = String::from_utf8_lossy(&output.stdout);
         bail!(
             "docker compose up failed (exit {:?}):\n{stdout}{stderr}",
+            output.status.code()
+        );
+    }
+    Ok(())
+}
+
+pub fn docker_compose_down_for_state(state: &SidecarStateFile) -> Result<()> {
+    if state.owner != "codestory" || state.profile != SidecarProfile::Agent.as_str() {
+        return Ok(());
+    }
+    let Some(compose_file) = state.compose_file.as_ref().map(PathBuf::from) else {
+        return Ok(());
+    };
+    if !compose_file.is_file() || !docker_available() {
+        return Ok(());
+    }
+    let output = docker_compose_command()?
+        .arg("compose")
+        .arg("-p")
+        .arg(&state.compose_project)
+        .arg("-f")
+        .arg(&compose_file)
+        .arg("down")
+        .arg("--remove-orphans")
+        .output()
+        .context("spawn docker compose down")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "docker compose down failed for owned sidecar namespace {} (exit {:?}):\n{stdout}{stderr}",
+            state.namespace,
             output.status.code()
         );
     }
@@ -355,7 +420,7 @@ mod tests {
 
         assert_eq!(path, cache.path().join("retrieval-compose.yml"));
         let contents = std::fs::read_to_string(path).expect("read bundled compose");
-        assert!(contents.contains("name: codestory-retrieval"));
+        assert!(contents.contains("name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}"));
         assert!(contents.contains("qdrant/qdrant:v1.12.5"));
     }
 

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -53,6 +53,24 @@ pub fn bootstrap_sidecars_with_profile(
     profile: SidecarProfile,
 ) -> Result<BootstrapReport> {
     let runtime = SidecarRuntimeConfig::for_project_profile(repo_root, profile);
+    bootstrap_sidecars_with_runtime(
+        &runtime,
+        repo_root,
+        storage_scope,
+        compose_file,
+        skip_compose,
+        wait_timeout,
+    )
+}
+
+pub fn bootstrap_sidecars_with_runtime(
+    runtime: &SidecarRuntimeConfig,
+    repo_root: Option<&Path>,
+    storage_scope: &BootstrapStorageScope,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+) -> Result<BootstrapReport> {
     let layout = runtime.layout.clone();
     runtime.activate_embed_url_default();
     layout.ensure_data_dirs()?;
@@ -66,13 +84,13 @@ pub fn bootstrap_sidecars_with_profile(
     };
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
-        docker_compose_up(path, repo_root, &runtime)?;
+        docker_compose_up(path, repo_root, runtime)?;
         true
     } else {
         false
     };
 
-    let state = sidecar_up_with_runtime(&runtime, resolved_compose.as_deref())?;
+    let state = sidecar_up_with_runtime(runtime, resolved_compose.as_deref())?;
     let infrastructure = if wait_timeout.is_zero() {
         probe_infrastructure_health(&layout)
     } else {

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -1,5 +1,8 @@
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -20,6 +23,7 @@ pub const LLAMACPP_SERVER_IMAGE_PIN: &str = "ghcr.io/ggml-org/llama.cpp:server";
 pub const DEFAULT_ZOEKT_HTTP_PORT: u16 = 6070;
 pub const DEFAULT_QDRANT_HTTP_PORT: u16 = 6333;
 pub const DEFAULT_QDRANT_GRPC_PORT: u16 = 6334;
+pub const DEFAULT_EMBED_HTTP_PORT: u16 = 8080;
 
 pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
 pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
@@ -35,20 +39,220 @@ pub struct SidecarLayout {
     pub state_file: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SidecarProfile {
+    Local,
+    Agent,
+}
+
+impl SidecarProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Agent => "agent",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarPorts {
+    pub zoekt_http: u16,
+    pub qdrant_http: u16,
+    pub qdrant_grpc: u16,
+    pub embed_http: u16,
+    pub embed_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarOwnership {
+    pub owner: String,
+    pub profile: String,
+    pub namespace: String,
+    pub compose_project: String,
+    pub state_file: String,
+    pub cleanup_command: String,
+    pub ports: SidecarPorts,
+    pub labels: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SidecarRuntimeConfig {
+    pub layout: SidecarLayout,
+    pub profile: SidecarProfile,
+    pub namespace: String,
+    pub compose_project: String,
+    pub embed_http_port: u16,
+    pub cleanup_command: String,
+    pub labels: BTreeMap<String, String>,
+}
+
 impl SidecarLayout {
     pub fn from_env() -> Self {
+        Self::from_env_for_profile(None, SidecarProfile::Local)
+    }
+
+    pub fn from_env_for_project(project_root: &Path) -> Self {
+        let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
+        runtime.activate_embed_url_default();
+        runtime.layout
+    }
+
+    fn from_env_for_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
+        SidecarRuntimeConfig::for_project_profile(project_root, profile).layout
+    }
+
+    pub fn from_env_agent(project_root: &Path) -> Self {
+        let runtime =
+            SidecarRuntimeConfig::for_project_profile(Some(project_root), SidecarProfile::Agent);
+        runtime.activate_embed_url_default();
+        runtime.layout
+    }
+
+    pub fn from_env_local(project_root: Option<&Path>) -> Self {
+        Self::from_env_for_profile(project_root, SidecarProfile::Local)
+    }
+
+    pub fn embed_base_url(embed_http_port: u16) -> String {
+        format!("http://127.0.0.1:{embed_http_port}/v1/embeddings")
+    }
+}
+
+impl SidecarRuntimeConfig {
+    pub fn local() -> Self {
+        Self::for_project_profile(None, SidecarProfile::Local)
+    }
+
+    pub fn for_project_auto(project_root: &Path) -> Self {
+        let profile = if env_profile() == Some(SidecarProfile::Agent)
+            || agent_state_file(project_root).is_file()
+            || running_in_ci_agent()
+        {
+            SidecarProfile::Agent
+        } else {
+            SidecarProfile::Local
+        };
+        Self::for_project_profile(Some(project_root), profile)
+    }
+
+    pub fn for_project_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
         let base = user_cache_root();
+        let namespace = namespace_for(project_root, profile);
+        let state_file = match profile {
+            SidecarProfile::Local => base.join("retrieval-sidecars.json"),
+            SidecarProfile::Agent => base
+                .join("sidecars")
+                .join(&namespace)
+                .join("retrieval-sidecars.json"),
+        };
+        let stored = read_ports_from_state(&state_file);
+        let dynamic = profile == SidecarProfile::Agent && stored.is_none();
+        let zoekt_http_port = env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.zoekt_http))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_ZOEKT_HTTP_PORT
+                }
+            });
+        let qdrant_http_port = env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.qdrant_http))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_QDRANT_HTTP_PORT
+                }
+            });
+        let qdrant_grpc_port = env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.qdrant_grpc))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_QDRANT_GRPC_PORT
+                }
+            });
+        let embed_http_port = env_port("CODESTORY_EMBED_PORT", DEFAULT_EMBED_HTTP_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.embed_http))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_EMBED_HTTP_PORT
+                }
+            });
+        let root = match profile {
+            SidecarProfile::Local => base.clone(),
+            SidecarProfile::Agent => base.join("sidecars").join(&namespace),
+        };
+        let layout = SidecarLayout {
+            zoekt_http_port,
+            qdrant_http_port,
+            qdrant_grpc_port,
+            zoekt_data_dir: root.join("zoekt"),
+            qdrant_data_dir: root.join("qdrant"),
+            scip_artifacts_root: root.join("scip"),
+            state_file: state_file.clone(),
+        };
+        let cleanup_command = project_root
+            .map(|path| {
+                format!(
+                    "codestory-cli retrieval down --project {} --profile {}",
+                    quote_command_path(path),
+                    profile.as_str()
+                )
+            })
+            .unwrap_or_else(|| "codestory-cli retrieval down".to_string());
+        let mut labels = BTreeMap::new();
+        labels.insert("dev.codestory.owner".into(), "codestory".into());
+        labels.insert("dev.codestory.profile".into(), profile.as_str().into());
+        labels.insert("dev.codestory.namespace".into(), namespace.clone());
         Self {
-            zoekt_http_port: env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT),
-            qdrant_http_port: env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT),
-            qdrant_grpc_port: env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT),
-            zoekt_data_dir: base.join("zoekt"),
-            qdrant_data_dir: base.join("qdrant"),
-            scip_artifacts_root: base.join("scip"),
-            state_file: base.join("retrieval-sidecars.json"),
+            layout,
+            profile,
+            namespace: namespace.clone(),
+            compose_project: namespace,
+            embed_http_port,
+            cleanup_command,
+            labels,
         }
     }
 
+    pub fn ownership(&self) -> SidecarOwnership {
+        SidecarOwnership {
+            owner: "codestory".into(),
+            profile: self.profile.as_str().into(),
+            namespace: self.namespace.clone(),
+            compose_project: self.compose_project.clone(),
+            state_file: self.layout.state_file.display().to_string(),
+            cleanup_command: self.cleanup_command.clone(),
+            ports: SidecarPorts {
+                zoekt_http: self.layout.zoekt_http_port,
+                qdrant_http: self.layout.qdrant_http_port,
+                qdrant_grpc: self.layout.qdrant_grpc_port,
+                embed_http: self.embed_http_port,
+                embed_url: SidecarLayout::embed_base_url(self.embed_http_port),
+            },
+            labels: self.labels.clone(),
+        }
+    }
+
+    pub fn activate_embed_url_default(&self) {
+        if std::env::var("CODESTORY_EMBED_LLAMACPP_URL").is_err() {
+            // SAFETY: this is command-local setup before sidecar probes/query embedding calls.
+            unsafe {
+                std::env::set_var(
+                    "CODESTORY_EMBED_LLAMACPP_URL",
+                    SidecarLayout::embed_base_url(self.embed_http_port),
+                );
+            }
+        }
+    }
+}
+
+impl SidecarLayout {
     pub fn zoekt_base_url(&self) -> String {
         format!("http://127.0.0.1:{}", self.zoekt_http_port)
     }
@@ -72,6 +276,95 @@ impl SidecarLayout {
         }
         Ok(())
     }
+}
+
+pub fn sidecar_runtime_for_project(
+    project_root: &Path,
+    profile: SidecarProfile,
+) -> SidecarRuntimeConfig {
+    SidecarRuntimeConfig::for_project_profile(Some(project_root), profile)
+}
+
+pub fn sidecar_runtime_auto(project_root: &Path) -> SidecarRuntimeConfig {
+    SidecarRuntimeConfig::for_project_auto(project_root)
+}
+
+fn env_profile() -> Option<SidecarProfile> {
+    std::env::var("CODESTORY_RETRIEVAL_PROFILE")
+        .ok()
+        .or_else(|| std::env::var("CODESTORY_SIDECAR_PROFILE").ok())
+        .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "agent" | "ci" => Some(SidecarProfile::Agent),
+            "local" | "dev" => Some(SidecarProfile::Local),
+            _ => None,
+        })
+}
+
+fn running_in_ci_agent() -> bool {
+    env_flag("CODESTORY_AGENT", false)
+        || env_flag("CODESTORY_AGENT_RUN", false)
+        || env_flag("CI", false)
+        || env_flag("GITHUB_ACTIONS", false)
+}
+
+fn namespace_for(project_root: Option<&Path>, profile: SidecarProfile) -> String {
+    match (profile, project_root) {
+        (SidecarProfile::Local, _) => "codestory".into(),
+        (SidecarProfile::Agent, Some(path)) => {
+            format!(
+                "codestory-agent-{}",
+                fnv1a_hex(path.to_string_lossy().as_bytes())
+            )
+        }
+        (SidecarProfile::Agent, None) => format!("codestory-agent-{}", std::process::id()),
+    }
+}
+
+fn agent_state_file(project_root: &Path) -> PathBuf {
+    user_cache_root()
+        .join("sidecars")
+        .join(namespace_for(Some(project_root), SidecarProfile::Agent))
+        .join("retrieval-sidecars.json")
+}
+
+fn read_ports_from_state(path: &Path) -> Option<SidecarPorts> {
+    let value =
+        serde_json::from_str::<serde_json::Value>(&std::fs::read_to_string(path).ok()?).ok()?;
+    Some(SidecarPorts {
+        zoekt_http: value.get("zoekt_http_port")?.as_u64()?.try_into().ok()?,
+        qdrant_http: value.get("qdrant_http_port")?.as_u64()?.try_into().ok()?,
+        qdrant_grpc: value.get("qdrant_grpc_port")?.as_u64()?.try_into().ok()?,
+        embed_http: value
+            .get("embed_http_port")
+            .and_then(|value| value.as_u64())
+            .and_then(|value| value.try_into().ok())
+            .unwrap_or(DEFAULT_EMBED_HTTP_PORT),
+        embed_url: value
+            .get("embed_url")
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| SidecarLayout::embed_base_url(DEFAULT_EMBED_HTTP_PORT)),
+    })
+}
+
+fn free_local_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .and_then(|listener| listener.local_addr())
+        .map(|addr| addr.port())
+        .unwrap_or(0)
+}
+
+fn fnv1a_hex(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn quote_command_path(path: &Path) -> String {
+    format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
 }
 
 pub fn user_cache_root() -> PathBuf {
@@ -102,11 +395,12 @@ pub fn retrieval_compose_profile() -> String {
         .unwrap_or_else(|| "real".to_string())
 }
 
-fn env_port(name: &str, default: u16) -> u16 {
+fn env_port(name: &str, default: u16) -> Option<u16> {
     std::env::var(name)
         .ok()
         .and_then(|value| value.parse().ok())
-        .unwrap_or(default)
+        .filter(|port| *port != 0)
+        .or(Some(default).filter(|_| std::env::var(name).is_ok()))
 }
 
 fn env_flag(name: &str, default: bool) -> bool {

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Phase 2 lexical shard pin (local index + optional Zoekt webserver).
 pub const ZOEKT_REAL_VERSION_PIN: &str = "zoekt-20250506123554";
@@ -27,6 +28,7 @@ pub const DEFAULT_EMBED_HTTP_PORT: u16 = 8080;
 
 pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
 pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
+static AGENT_RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct SidecarLayout {
@@ -80,6 +82,7 @@ pub struct SidecarOwnership {
 pub struct SidecarRuntimeConfig {
     pub layout: SidecarLayout,
     pub profile: SidecarProfile,
+    pub run_id: Option<String>,
     pub namespace: String,
     pub compose_project: String,
     pub embed_http_port: u16,
@@ -124,20 +127,35 @@ impl SidecarRuntimeConfig {
     }
 
     pub fn for_project_auto(project_root: &Path) -> Self {
+        let env_run_id = env_agent_run_id();
+        let latest_run_id = env_run_id
+            .is_none()
+            .then(|| latest_agent_run_id(project_root))
+            .flatten();
         let profile = if env_profile() == Some(SidecarProfile::Agent)
-            || agent_state_file(project_root).is_file()
+            || latest_run_id.is_some()
             || running_in_ci_agent()
         {
             SidecarProfile::Agent
         } else {
             SidecarProfile::Local
         };
-        Self::for_project_profile(Some(project_root), profile)
+        let run_id = env_run_id.or(latest_run_id);
+        Self::for_project_profile_with_run_id(Some(project_root), profile, run_id.as_deref())
     }
 
     pub fn for_project_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
+        Self::for_project_profile_with_run_id(project_root, profile, None)
+    }
+
+    pub fn for_project_profile_with_run_id(
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+    ) -> Self {
         let base = user_cache_root();
-        let namespace = namespace_for(project_root, profile);
+        let run_id = (profile == SidecarProfile::Agent).then(|| agent_run_id(run_id));
+        let namespace = namespace_for(project_root, profile, run_id.as_deref());
         let state_file = match profile {
             SidecarProfile::Local => base.join("retrieval-sidecars.json"),
             SidecarProfile::Agent => base
@@ -151,7 +169,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.zoekt_http))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "zoekt")
                 } else {
                     DEFAULT_ZOEKT_HTTP_PORT
                 }
@@ -160,7 +178,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.qdrant_http))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "qdrant-http")
                 } else {
                     DEFAULT_QDRANT_HTTP_PORT
                 }
@@ -169,7 +187,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.qdrant_grpc))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "qdrant-grpc")
                 } else {
                     DEFAULT_QDRANT_GRPC_PORT
                 }
@@ -178,7 +196,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.embed_http))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "embed")
                 } else {
                     DEFAULT_EMBED_HTTP_PORT
                 }
@@ -197,13 +215,7 @@ impl SidecarRuntimeConfig {
             state_file: state_file.clone(),
         };
         let cleanup_command = project_root
-            .map(|path| {
-                format!(
-                    "codestory-cli retrieval down --project {} --profile {}",
-                    quote_command_path(path),
-                    profile.as_str()
-                )
-            })
+            .map(|path| retrieval_command("down", path, profile, run_id.as_deref(), None))
             .unwrap_or_else(|| "codestory-cli retrieval down".to_string());
         let mut labels = BTreeMap::new();
         labels.insert("dev.codestory.owner".into(), "codestory".into());
@@ -212,6 +224,7 @@ impl SidecarRuntimeConfig {
         Self {
             layout,
             profile,
+            run_id,
             namespace: namespace.clone(),
             compose_project: namespace,
             embed_http_port,
@@ -285,6 +298,14 @@ pub fn sidecar_runtime_for_project(
     SidecarRuntimeConfig::for_project_profile(Some(project_root), profile)
 }
 
+pub fn sidecar_runtime_for_project_with_run_id(
+    project_root: &Path,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+) -> SidecarRuntimeConfig {
+    SidecarRuntimeConfig::for_project_profile_with_run_id(Some(project_root), profile, run_id)
+}
+
 pub fn sidecar_runtime_auto(project_root: &Path) -> SidecarRuntimeConfig {
     SidecarRuntimeConfig::for_project_auto(project_root)
 }
@@ -300,6 +321,13 @@ fn env_profile() -> Option<SidecarProfile> {
         })
 }
 
+fn env_agent_run_id() -> Option<String> {
+    std::env::var("CODESTORY_SIDECAR_RUN_ID")
+        .ok()
+        .or_else(|| std::env::var("CODESTORY_AGENT_RUN_ID").ok())
+        .and_then(|value| normalized_label_component(&value))
+}
+
 fn running_in_ci_agent() -> bool {
     env_flag("CODESTORY_AGENT", false)
         || env_flag("CODESTORY_AGENT_RUN", false)
@@ -307,24 +335,110 @@ fn running_in_ci_agent() -> bool {
         || env_flag("GITHUB_ACTIONS", false)
 }
 
-fn namespace_for(project_root: Option<&Path>, profile: SidecarProfile) -> String {
+fn namespace_for(
+    project_root: Option<&Path>,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+) -> String {
     match (profile, project_root) {
         (SidecarProfile::Local, _) => "codestory".into(),
         (SidecarProfile::Agent, Some(path)) => {
             format!(
-                "codestory-agent-{}",
-                fnv1a_hex(path.to_string_lossy().as_bytes())
+                "codestory-agent-{}-{}",
+                project_hash(path),
+                run_id.unwrap_or("run")
             )
         }
-        (SidecarProfile::Agent, None) => format!("codestory-agent-{}", std::process::id()),
+        (SidecarProfile::Agent, None) => format!(
+            "codestory-agent-{}-{}",
+            std::process::id(),
+            run_id.unwrap_or("run")
+        ),
     }
 }
 
-fn agent_state_file(project_root: &Path) -> PathBuf {
-    user_cache_root()
-        .join("sidecars")
-        .join(namespace_for(Some(project_root), SidecarProfile::Agent))
-        .join("retrieval-sidecars.json")
+fn project_hash(project_root: &Path) -> String {
+    fnv1a_hex(project_root.to_string_lossy().as_bytes())
+}
+
+fn agent_namespace_prefix(project_root: &Path) -> String {
+    format!("codestory-agent-{}-", project_hash(project_root))
+}
+
+fn latest_agent_run_id(project_root: &Path) -> Option<String> {
+    let prefix = agent_namespace_prefix(project_root);
+    let sidecars_root = user_cache_root().join("sidecars");
+    let entries = std::fs::read_dir(sidecars_root).ok()?;
+    let mut newest: Option<(std::time::SystemTime, String)> = None;
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let namespace = entry.file_name().to_string_lossy().to_string();
+        let Some(run_id) = namespace
+            .strip_prefix(&prefix)
+            .and_then(normalized_label_component)
+        else {
+            continue;
+        };
+        let state_file = entry.path().join("retrieval-sidecars.json");
+        if !state_file.is_file() {
+            continue;
+        }
+        let modified = state_file
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        if newest
+            .as_ref()
+            .is_none_or(|(current, _)| modified > *current)
+        {
+            newest = Some((modified, run_id));
+        }
+    }
+    newest.map(|(_, run_id)| run_id)
+}
+
+fn agent_run_id(explicit: Option<&str>) -> String {
+    explicit
+        .and_then(normalized_label_component)
+        .or_else(env_agent_run_id)
+        .unwrap_or_else(default_agent_run_id)
+}
+
+fn default_agent_run_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let counter = AGENT_RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{}-{nanos:x}-{counter:x}", std::process::id())
+}
+
+fn normalized_label_component(value: &str) -> Option<String> {
+    let mut normalized = String::with_capacity(value.len());
+    let mut previous_dash = false;
+    for ch in value.trim().chars() {
+        let next = if ch.is_ascii_alphanumeric() {
+            ch.to_ascii_lowercase()
+        } else {
+            '-'
+        };
+        if next == '-' {
+            if previous_dash {
+                continue;
+            }
+            previous_dash = true;
+        } else {
+            previous_dash = false;
+        }
+        normalized.push(next);
+    }
+    let normalized = normalized.trim_matches('-').to_string();
+    (!normalized.is_empty()).then_some(normalized)
 }
 
 fn read_ports_from_state(path: &Path) -> Option<SidecarPorts> {
@@ -347,6 +461,23 @@ fn read_ports_from_state(path: &Path) -> Option<SidecarPorts> {
     })
 }
 
+fn dynamic_agent_port(namespace: &str, salt: &str) -> u16 {
+    let seed = fnv1a_hex(format!("{namespace}:{salt}").as_bytes());
+    let parsed = u64::from_str_radix(&seed, 16).unwrap_or(0);
+    let base = 20_000 + u16::try_from(parsed % 40_000).unwrap_or(0);
+    for offset in 0..1000 {
+        let port = 20_000 + ((u32::from(base - 20_000) + offset) % 40_000) as u16;
+        if local_port_available(port) {
+            return port;
+        }
+    }
+    free_local_port()
+}
+
+fn local_port_available(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
 fn free_local_port() -> u16 {
     TcpListener::bind(("127.0.0.1", 0))
         .and_then(|listener| listener.local_addr())
@@ -365,6 +496,31 @@ fn fnv1a_hex(bytes: &[u8]) -> String {
 
 fn quote_command_path(path: &Path) -> String {
     format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
+}
+
+pub fn retrieval_command(
+    action: &str,
+    project_root: &Path,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+    extra_args: Option<&str>,
+) -> String {
+    let mut command = format!(
+        "codestory-cli retrieval {action} --project {}",
+        quote_command_path(project_root)
+    );
+    if profile == SidecarProfile::Agent {
+        command.push_str(" --profile agent");
+        if let Some(run_id) = run_id.and_then(normalized_label_component) {
+            command.push_str(" --run-id ");
+            command.push_str(&run_id);
+        }
+    }
+    if let Some(extra_args) = extra_args {
+        command.push(' ');
+        command.push_str(extra_args);
+    }
+    command
 }
 
 pub fn user_cache_root() -> PathBuf {
@@ -427,4 +583,61 @@ pub fn dir_size_bytes(path: &Path) -> u64 {
         }
     }
     total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn agent_profile_default_runtime_isolates_same_project_runs() {
+        let project = tempdir().expect("project");
+
+        let first =
+            SidecarRuntimeConfig::for_project_profile(Some(project.path()), SidecarProfile::Agent);
+        let second =
+            SidecarRuntimeConfig::for_project_profile(Some(project.path()), SidecarProfile::Agent);
+
+        assert_ne!(first.run_id, second.run_id);
+        assert_ne!(first.namespace, second.namespace);
+        assert_ne!(first.layout.state_file, second.layout.state_file);
+        assert_ne!(first.layout.zoekt_http_port, second.layout.zoekt_http_port);
+        assert_ne!(
+            first.layout.qdrant_http_port,
+            second.layout.qdrant_http_port
+        );
+        assert_ne!(
+            first.layout.qdrant_grpc_port,
+            second.layout.qdrant_grpc_port
+        );
+        assert_ne!(first.embed_http_port, second.embed_http_port);
+    }
+
+    #[test]
+    fn agent_profile_run_id_reuses_namespace_state_and_ports() {
+        let project = tempdir().expect("project");
+
+        let first = SidecarRuntimeConfig::for_project_profile_with_run_id(
+            Some(project.path()),
+            SidecarProfile::Agent,
+            Some("review-fix"),
+        );
+        let second = SidecarRuntimeConfig::for_project_profile_with_run_id(
+            Some(project.path()),
+            SidecarProfile::Agent,
+            Some("review-fix"),
+        );
+
+        assert_eq!(first.run_id.as_deref(), Some("review-fix"));
+        assert_eq!(first.namespace, second.namespace);
+        assert_eq!(first.layout.state_file, second.layout.state_file);
+        assert_eq!(first.layout.zoekt_http_port, second.layout.zoekt_http_port);
+        assert_eq!(
+            first.layout.qdrant_http_port,
+            second.layout.qdrant_http_port
+        );
+        assert!(first.cleanup_command.contains("--profile agent"));
+        assert!(first.cleanup_command.contains("--run-id review-fix"));
+    }
 }

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,6 +1,7 @@
 use crate::capabilities::SidecarCapabilities;
 use crate::config::{
-    QDRANT_HEALTH_BUDGET, SidecarLayout, ZOEKT_HEALTH_BUDGET, qdrant_semantic_vectors_enabled,
+    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, ZOEKT_HEALTH_BUDGET,
+    qdrant_semantic_vectors_enabled,
 };
 use crate::embeddings::manifest_embedding_backend_is_product;
 use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
@@ -72,6 +73,8 @@ pub struct RetrievalRepairHint {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetrievalStatusReport {
     pub retrieval_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ownership: Option<SidecarOwnership>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -301,6 +304,7 @@ pub fn unavailable_status_report(
         .and_then(|manifest| manifest.embedding_dim);
     RetrievalStatusReport {
         retrieval_mode: "unavailable".into(),
+        ownership: None,
         degraded_reason: Some(reason.clone()),
         repair: None,
         query_embedding_backend: crate::embeddings::embedding_runtime_id(),
@@ -575,6 +579,7 @@ pub fn probe_sidecar_health(
 
     RetrievalStatusReport {
         retrieval_mode: mode.as_str().into(),
+        ownership: None,
         degraded_reason,
         repair: None,
         query_embedding_backend: current_embedding_backend,
@@ -789,6 +794,7 @@ mod tests {
         };
         let report = RetrievalStatusReport {
             retrieval_mode: "full".into(),
+            ownership: None,
             degraded_reason: None,
             query_embedding_backend: "llamacpp:bge-base-en-v1.5".into(),
             manifest_vector_embedding_backend: manifest.embedding_backend.clone(),

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,7 +1,7 @@
 use crate::capabilities::SidecarCapabilities;
 use crate::config::{
-    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, ZOEKT_HEALTH_BUDGET,
-    qdrant_semantic_vectors_enabled,
+    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, SidecarProfile, SidecarRuntimeConfig,
+    ZOEKT_HEALTH_BUDGET, qdrant_semantic_vectors_enabled, retrieval_command,
 };
 use crate::embeddings::manifest_embedding_backend_is_product;
 use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
@@ -113,6 +113,7 @@ pub fn attach_manifest_contract(
 pub fn attach_repair_hint(
     mut report: RetrievalStatusReport,
     project_root: &Path,
+    runtime: Option<&SidecarRuntimeConfig>,
 ) -> RetrievalStatusReport {
     if report.retrieval_mode == "full" {
         return report;
@@ -123,11 +124,32 @@ pub fn attach_repair_hint(
             .as_deref()
             .unwrap_or("sidecar_retrieval_not_full"),
     );
-    let project = quote_command_path(project_root);
+    let profile = runtime
+        .map(|runtime| runtime.profile)
+        .unwrap_or(SidecarProfile::Local);
+    let run_id = runtime.and_then(|runtime| runtime.run_id.as_deref());
     let full_repair = vec![
-        format!("codestory-cli retrieval bootstrap --project {project} --format json"),
-        format!("codestory-cli retrieval index --project {project} --refresh full --format json"),
-        format!("codestory-cli retrieval status --project {project} --format json"),
+        retrieval_command(
+            "bootstrap",
+            project_root,
+            profile,
+            run_id,
+            Some("--format json"),
+        ),
+        retrieval_command(
+            "index",
+            project_root,
+            profile,
+            run_id,
+            Some("--refresh full --format json"),
+        ),
+        retrieval_command(
+            "status",
+            project_root,
+            profile,
+            run_id,
+            Some("--format json"),
+        ),
     ];
     report.repair = Some(RetrievalRepairHint {
         reason,
@@ -145,10 +167,6 @@ fn repair_reason_code(degraded_reason: &str) -> String {
         return "sidecar_manifest_stale".into();
     }
     degraded_reason.to_string()
-}
-
-fn quote_command_path(path: &Path) -> String {
-    format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
 }
 
 fn manifest_contract_report(
@@ -606,6 +624,7 @@ mod tests {
         let report = attach_repair_hint(
             unavailable_status_report("retrieval_manifest_missing", None),
             Path::new("C:/repo with spaces"),
+            None,
         );
         let repair = report.repair.expect("repair hint");
 
@@ -634,6 +653,7 @@ mod tests {
         let report = attach_repair_hint(
             unavailable_status_report(detailed, None),
             Path::new("C:/repo"),
+            None,
         );
         let repair = report.repair.expect("repair hint");
 

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -115,7 +115,7 @@ pub fn repair_project_qdrant_collection(
         }));
     }
 
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     layout.ensure_data_dirs()?;
     let qdrant_client = QdrantClient::new(&layout);
     let probe = qdrant_client.health_probe(&manifest.qdrant_collection);
@@ -179,7 +179,7 @@ pub fn repair_project_qdrant_collection(
 }
 
 pub fn finalize_index(project_root: &Path, storage_path: &Path) -> Result<FinalizeIndexOutcome> {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     layout.ensure_data_dirs()?;
 
     let project_id = sidecar_project_id_for_root(project_root);

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -43,12 +43,14 @@ pub use capabilities::SidecarCapabilities;
 #[allow(deprecated)]
 pub use compose::bootstrap_sidecars_without_storage_scope;
 pub use compose::{
-    BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, docker_available,
-    resolve_compose_file,
+    BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, bootstrap_sidecars_with_profile,
+    docker_available, resolve_compose_file,
 };
 pub use config::{
-    DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN,
-    SidecarLayout, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
+    DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT,
+    DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarLayout, SidecarOwnership, SidecarPorts,
+    SidecarProfile, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
+    sidecar_runtime_auto, sidecar_runtime_for_project,
 };
 pub use config::{qdrant_enabled, qdrant_semantic_vectors_enabled};
 pub use embeddings::qdrant_vector_dim;
@@ -86,7 +88,8 @@ pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
 pub use scip_client::ScipClient;
 pub use sidecar::{
-    SidecarStateFile, sidecar_down, sidecar_status, sidecar_up, strict_sidecar_status,
+    SidecarStateFile, sidecar_down, sidecar_down_for_project, sidecar_status, sidecar_up,
+    sidecar_up_with_runtime, strict_sidecar_status, strict_sidecar_status_for_profile,
 };
 pub use sidecar_search::{LiveSidecarSearch, SidecarSearch};
 pub use zoekt_client::ZoektClient;

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -44,13 +44,13 @@ pub use capabilities::SidecarCapabilities;
 pub use compose::bootstrap_sidecars_without_storage_scope;
 pub use compose::{
     BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, bootstrap_sidecars_with_profile,
-    docker_available, resolve_compose_file,
+    bootstrap_sidecars_with_runtime, docker_available, resolve_compose_file,
 };
 pub use config::{
     DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT,
     DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarLayout, SidecarOwnership, SidecarPorts,
     SidecarProfile, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
-    sidecar_runtime_auto, sidecar_runtime_for_project,
+    sidecar_runtime_auto, sidecar_runtime_for_project, sidecar_runtime_for_project_with_run_id,
 };
 pub use config::{qdrant_enabled, qdrant_semantic_vectors_enabled};
 pub use embeddings::qdrant_vector_dim;
@@ -88,8 +88,9 @@ pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
 pub use scip_client::ScipClient;
 pub use sidecar::{
-    SidecarStateFile, sidecar_down, sidecar_down_for_project, sidecar_status, sidecar_up,
-    sidecar_up_with_runtime, strict_sidecar_status, strict_sidecar_status_for_profile,
+    SidecarStateFile, sidecar_down, sidecar_down_for_project, sidecar_down_for_runtime,
+    sidecar_status, sidecar_up, sidecar_up_with_runtime, strict_sidecar_status,
+    strict_sidecar_status_for_profile, strict_sidecar_status_for_runtime,
 };
 pub use sidecar_search::{LiveSidecarSearch, SidecarSearch};
 pub use zoekt_client::ZoektClient;

--- a/crates/codestory-retrieval/src/qdrant_storage.rs
+++ b/crates/codestory-retrieval/src/qdrant_storage.rs
@@ -114,6 +114,7 @@ pub fn repair_qdrant_storage(
             &protected,
             &scan.recency_by_collection,
             max_keep,
+            &mut scan.scan_errors,
         )?
     };
 
@@ -473,6 +474,7 @@ fn execute_retention_on_disk(
     protected: &HashSet<String>,
     recency_by_collection: &HashMap<String, i64>,
     max_keep: usize,
+    repair_errors: &mut Vec<String>,
 ) -> Result<(usize, usize, usize, bool)> {
     let all = list_on_disk_codestory_collections(qdrant_data_dir, recency_by_collection)?;
     let collections_seen = all.len();
@@ -482,14 +484,22 @@ fn execute_retention_on_disk(
     for name in plan.to_prune {
         let path = qdrant_data_dir.join("collections").join(&name);
         if path.is_dir() {
-            std::fs::remove_dir_all(&path).with_context(|| {
-                format!(
-                    "remove stale qdrant collection dir beyond retention {}",
-                    path.display()
-                )
-            })?;
-            QdrantClient::clear_stub_marker_files(qdrant_data_dir, &name);
-            removed += 1;
+            match std::fs::remove_dir_all(&path) {
+                Ok(()) => {
+                    QdrantClient::clear_stub_marker_files(qdrant_data_dir, &name);
+                    removed += 1;
+                }
+                Err(error) => {
+                    warn!(
+                        collection = %name,
+                        %error,
+                        "failed to prune stale Qdrant collection dir; continuing bootstrap repair"
+                    );
+                    repair_errors.push(format!(
+                        "remove stale qdrant collection dir {name}: {error}"
+                    ));
+                }
+            }
         }
     }
     Ok((
@@ -612,8 +622,14 @@ mod tests {
             }
             thread::sleep(Duration::from_millis(5));
         }
-        let (pruned, seen, _, overflow) =
-            execute_retention_on_disk(root.path(), &protected, &HashMap::new(), 64).expect("prune");
+        let (pruned, seen, _, overflow) = execute_retention_on_disk(
+            root.path(),
+            &protected,
+            &HashMap::new(),
+            64,
+            &mut Vec::new(),
+        )
+        .expect("prune");
         assert!(pruned > 0);
         assert_eq!(seen, 65);
         assert!(!overflow);

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -240,7 +240,7 @@ struct QueryContext {
 }
 
 fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryContext> {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     let project_id = sidecar_project_id_for_root(project_root);
     let (manifest, file_roles) = if storage_path.exists() {
         let storage = Store::open(storage_path).context("open storage for query")?;

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1,4 +1,7 @@
-use crate::config::SidecarLayout;
+use crate::config::{
+    SidecarLayout, SidecarProfile, SidecarRuntimeConfig, sidecar_runtime_auto,
+    sidecar_runtime_for_project,
+};
 use crate::generation::{
     SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
     manifest_staleness_reason, manifest_unavailable_reason,
@@ -22,25 +25,56 @@ use std::path::Path;
 /// The file records local sidecar endpoints and data roots only. It is not a readiness manifest;
 /// callers must use `sidecar_status` or `strict_sidecar_status` before trusting retrieval output.
 pub struct SidecarStateFile {
+    #[serde(default = "default_sidecar_owner")]
+    pub owner: String,
+    #[serde(default = "default_sidecar_profile")]
+    pub profile: String,
+    #[serde(default = "default_sidecar_namespace")]
+    pub namespace: String,
+    #[serde(default = "default_sidecar_namespace")]
+    pub compose_project: String,
     pub zoekt_http_port: u16,
     pub qdrant_http_port: u16,
     pub qdrant_grpc_port: u16,
+    #[serde(default = "default_embed_http_port")]
+    pub embed_http_port: u16,
+    #[serde(default = "default_embed_url")]
+    pub embed_url: String,
     pub zoekt_data_dir: String,
     pub qdrant_data_dir: String,
     pub scip_artifacts_root: String,
+    #[serde(default)]
+    pub compose_file: Option<String>,
+    #[serde(default)]
+    pub cleanup_command: String,
     pub started_at_epoch_ms: i64,
 }
 
 pub fn sidecar_up() -> Result<SidecarStateFile> {
-    let layout = SidecarLayout::from_env();
+    sidecar_up_with_runtime(&SidecarRuntimeConfig::local(), None)
+}
+
+pub fn sidecar_up_with_runtime(
+    runtime: &SidecarRuntimeConfig,
+    compose_file: Option<&Path>,
+) -> Result<SidecarStateFile> {
+    let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
     let state = SidecarStateFile {
+        owner: "codestory".into(),
+        profile: runtime.profile.as_str().into(),
+        namespace: runtime.namespace.clone(),
+        compose_project: runtime.compose_project.clone(),
         zoekt_http_port: layout.zoekt_http_port,
         qdrant_http_port: layout.qdrant_http_port,
         qdrant_grpc_port: layout.qdrant_grpc_port,
+        embed_http_port: runtime.embed_http_port,
+        embed_url: SidecarLayout::embed_base_url(runtime.embed_http_port),
         zoekt_data_dir: layout.zoekt_data_dir.display().to_string(),
         qdrant_data_dir: layout.qdrant_data_dir.display().to_string(),
         scip_artifacts_root: layout.scip_artifacts_root.display().to_string(),
+        compose_file: compose_file.map(|path| path.display().to_string()),
+        cleanup_command: runtime.cleanup_command.clone(),
         started_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
     };
     let json = serde_json::to_string_pretty(&state).context("serialize sidecar state")?;
@@ -49,8 +83,25 @@ pub fn sidecar_up() -> Result<SidecarStateFile> {
 }
 
 pub fn sidecar_down() -> Result<()> {
-    let layout = SidecarLayout::from_env();
+    sidecar_down_for_runtime(&SidecarRuntimeConfig::local())
+}
+
+pub fn sidecar_down_for_project(project_root: &Path, profile: SidecarProfile) -> Result<()> {
+    sidecar_down_for_runtime(&sidecar_runtime_for_project(project_root, profile))
+}
+
+pub fn sidecar_down_for_runtime(runtime: &SidecarRuntimeConfig) -> Result<()> {
+    let layout = &runtime.layout;
     if layout.state_file.exists() {
+        if runtime.profile == SidecarProfile::Agent
+            && let Some(state) = std::fs::read_to_string(&layout.state_file)
+                .ok()
+                .and_then(|contents| serde_json::from_str::<SidecarStateFile>(&contents).ok())
+            && state.owner == "codestory"
+            && state.namespace == runtime.namespace
+        {
+            crate::compose::docker_compose_down_for_state(&state)?;
+        }
         std::fs::remove_file(&layout.state_file).context("remove retrieval-sidecars.json")?;
     }
     Ok(())
@@ -77,12 +128,36 @@ pub fn strict_sidecar_status(
     sidecar_status_inner(project_root, storage_path, true)
 }
 
+pub fn strict_sidecar_status_for_profile(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    profile: SidecarProfile,
+) -> Result<RetrievalStatusReport> {
+    sidecar_status_inner_with_runtime(
+        project_root,
+        storage_path,
+        true,
+        sidecar_runtime_for_project(project_root, profile),
+    )
+}
+
 fn sidecar_status_inner(
     project_root: &Path,
     storage_path: Option<&Path>,
     strict: bool,
 ) -> Result<RetrievalStatusReport> {
-    let layout = SidecarLayout::from_env();
+    let runtime = sidecar_runtime_auto(project_root);
+    sidecar_status_inner_with_runtime(project_root, storage_path, strict, runtime)
+}
+
+fn sidecar_status_inner_with_runtime(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    strict: bool,
+    runtime: SidecarRuntimeConfig,
+) -> Result<RetrievalStatusReport> {
+    runtime.activate_embed_url_default();
+    let layout = runtime.layout.clone();
     let project_id = sidecar_project_id_for_root(project_root);
     let manifest = if let Some(path) = storage_path.filter(|path| path.exists()) {
         let storage = Store::open(path).context("open storage for manifest")?;
@@ -100,49 +175,72 @@ fn sidecar_status_inner(
             )
             .context("check strict sidecar readiness")?
         {
-            return Ok(enrich_status_with_semantic_doc_stats(
-                attach_repair_hint(
-                    attach_manifest_contract(
-                        crate::health::unavailable_status_report(
-                            format!("sidecar_manifest_stale: {reason}"),
-                            Some(manifest.clone()),
+            return Ok(attach_status_ownership(
+                enrich_status_with_semantic_doc_stats(
+                    attach_repair_hint(
+                        attach_manifest_contract(
+                            crate::health::unavailable_status_report(
+                                format!("sidecar_manifest_stale: {reason}"),
+                                Some(manifest.clone()),
+                            ),
+                            project_root,
                         ),
                         project_root,
                     ),
-                    project_root,
+                    &storage,
                 ),
-                &storage,
+                &runtime,
             ));
         }
         if let Some(manifest) = manifest.as_ref()
             && let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest)
         {
-            return Ok(enrich_status_with_semantic_doc_stats(
-                attach_repair_hint(
-                    attach_manifest_contract(
-                        crate::health::unavailable_status_report(reason, Some(manifest.clone())),
+            return Ok(attach_status_ownership(
+                enrich_status_with_semantic_doc_stats(
+                    attach_repair_hint(
+                        attach_manifest_contract(
+                            crate::health::unavailable_status_report(
+                                reason,
+                                Some(manifest.clone()),
+                            ),
+                            project_root,
+                        ),
                         project_root,
                     ),
-                    project_root,
+                    &storage,
                 ),
-                &storage,
+                &runtime,
             ));
         }
         let report = probe_sidecar_health(&layout, &project_id, manifest);
-        return Ok(enrich_status_with_semantic_doc_stats(
-            attach_repair_hint(attach_manifest_contract(report, project_root), project_root),
-            &storage,
+        return Ok(attach_status_ownership(
+            enrich_status_with_semantic_doc_stats(
+                attach_repair_hint(attach_manifest_contract(report, project_root), project_root),
+                &storage,
+            ),
+            &runtime,
         ));
     } else {
         None
     };
-    Ok(attach_repair_hint(
-        attach_manifest_contract(
-            probe_sidecar_health(&layout, &project_id, manifest),
+    Ok(attach_status_ownership(
+        attach_repair_hint(
+            attach_manifest_contract(
+                probe_sidecar_health(&layout, &project_id, manifest),
+                project_root,
+            ),
             project_root,
         ),
-        project_root,
+        &runtime,
     ))
+}
+
+fn attach_status_ownership(
+    mut report: RetrievalStatusReport,
+    runtime: &SidecarRuntimeConfig,
+) -> RetrievalStatusReport {
+    report.ownership = Some(runtime.ownership());
+    report
 }
 
 fn enrich_status_with_semantic_doc_stats(
@@ -291,6 +389,26 @@ fn manifest_contract_drift_should_win(reason: &str) -> bool {
     reason.contains("sidecar_embedding_backend_changed")
         || reason.contains("sidecar_embedding_dim_changed")
         || reason == SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED
+}
+
+fn default_sidecar_owner() -> String {
+    "codestory".into()
+}
+
+fn default_sidecar_profile() -> String {
+    "local".into()
+}
+
+fn default_sidecar_namespace() -> String {
+    "codestory".into()
+}
+
+fn default_embed_http_port() -> u16 {
+    crate::config::DEFAULT_EMBED_HTTP_PORT
+}
+
+fn default_embed_url() -> String {
+    SidecarLayout::embed_base_url(crate::config::DEFAULT_EMBED_HTTP_PORT)
 }
 
 #[cfg(test)]

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -33,6 +33,8 @@ pub struct SidecarStateFile {
     pub namespace: String,
     #[serde(default = "default_sidecar_namespace")]
     pub compose_project: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
     pub zoekt_http_port: u16,
     pub qdrant_http_port: u16,
     pub qdrant_grpc_port: u16,
@@ -65,6 +67,7 @@ pub fn sidecar_up_with_runtime(
         profile: runtime.profile.as_str().into(),
         namespace: runtime.namespace.clone(),
         compose_project: runtime.compose_project.clone(),
+        run_id: runtime.run_id.clone(),
         zoekt_http_port: layout.zoekt_http_port,
         qdrant_http_port: layout.qdrant_http_port,
         qdrant_grpc_port: layout.qdrant_grpc_port,
@@ -133,12 +136,19 @@ pub fn strict_sidecar_status_for_profile(
     storage_path: Option<&Path>,
     profile: SidecarProfile,
 ) -> Result<RetrievalStatusReport> {
-    sidecar_status_inner_with_runtime(
+    strict_sidecar_status_for_runtime(
         project_root,
         storage_path,
-        true,
         sidecar_runtime_for_project(project_root, profile),
     )
+}
+
+pub fn strict_sidecar_status_for_runtime(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    runtime: SidecarRuntimeConfig,
+) -> Result<RetrievalStatusReport> {
+    sidecar_status_inner_with_runtime(project_root, storage_path, true, runtime)
 }
 
 fn sidecar_status_inner(
@@ -186,6 +196,7 @@ fn sidecar_status_inner_with_runtime(
                             project_root,
                         ),
                         project_root,
+                        Some(&runtime),
                     ),
                     &storage,
                 ),
@@ -206,6 +217,7 @@ fn sidecar_status_inner_with_runtime(
                             project_root,
                         ),
                         project_root,
+                        Some(&runtime),
                     ),
                     &storage,
                 ),
@@ -215,7 +227,11 @@ fn sidecar_status_inner_with_runtime(
         let report = probe_sidecar_health(&layout, &project_id, manifest);
         return Ok(attach_status_ownership(
             enrich_status_with_semantic_doc_stats(
-                attach_repair_hint(attach_manifest_contract(report, project_root), project_root),
+                attach_repair_hint(
+                    attach_manifest_contract(report, project_root),
+                    project_root,
+                    Some(&runtime),
+                ),
                 &storage,
             ),
             &runtime,
@@ -230,6 +246,7 @@ fn sidecar_status_inner_with_runtime(
                 project_root,
             ),
             project_root,
+            Some(&runtime),
         ),
         &runtime,
     ))

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -6,13 +6,17 @@
 # or:
 #   cargo run -p codestory-cli -- retrieval bootstrap
 
-name: codestory-retrieval
+name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}
 
 services:
   qdrant:
     image: qdrant/qdrant:v1.12.5
-    container_name: codestory-qdrant
+    container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-qdrant
     restart: unless-stopped
+    labels:
+      dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}
+      dev.codestory.profile: ${CODESTORY_SIDECAR_PROFILE:-local}
+      dev.codestory.namespace: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}
     ports:
       - "127.0.0.1:${CODESTORY_QDRANT_HTTP_PORT:-6333}:6333"
       - "127.0.0.1:${CODESTORY_QDRANT_GRPC_PORT:-6334}:6334"
@@ -24,8 +28,12 @@ services:
   # Zoekt webserver (mount index dir populated by `retrieval index`).
   zoekt:
     image: sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4
-    container_name: codestory-zoekt
+    container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-zoekt
     restart: unless-stopped
+    labels:
+      dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}
+      dev.codestory.profile: ${CODESTORY_SIDECAR_PROFILE:-local}
+      dev.codestory.namespace: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}
     ports:
       - "127.0.0.1:${CODESTORY_ZOEKT_PORT:-6070}:6070"
     volumes:
@@ -37,8 +45,12 @@ services:
   # Model GGUF must exist under CODESTORY_EMBED_MODEL_DIR (see setup-retrieval-env.mjs).
   embed:
     image: ghcr.io/ggml-org/llama.cpp:server
-    container_name: codestory-embed
+    container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-embed
     restart: unless-stopped
+    labels:
+      dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}
+      dev.codestory.profile: ${CODESTORY_SIDECAR_PROFILE:-local}
+      dev.codestory.namespace: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}
     ports:
       - "127.0.0.1:${CODESTORY_EMBED_PORT:-8080}:8080"
     volumes:


### PR DESCRIPTION
## Context

Closes #446.

Agent and CI runners need sidecar setup that does not assume one global localhost namespace. Local developer defaults can remain simple, but agent-oriented bootstrap/status paths need explicit ownership, namespace, ports, and cleanup evidence.

## What Changed

- Added sidecar profile handling for local versus agent-oriented sidecar state.
- Added per-project/profile sidecar state/status details, including ownership metadata, namespace-oriented compose output, ports, cleanup hints, and safe labels.
- Updated retrieval CLI/bootstrap/status plumbing and stdio status output to carry the profile-aware sidecar contract.
- Updated compose generation and retrieval clients to use profile-derived layout values instead of only fixed global defaults.
- Added focused bootstrap/status contract coverage for profile and cleanup behavior.

## How To Review

1. Start with `crates/codestory-retrieval/src/config.rs` for the profile/layout model.
2. Review `crates/codestory-retrieval/src/compose.rs` and `docker/retrieval-compose.yml` for namespace/label/port behavior.
3. Review CLI plumbing in `crates/codestory-cli/src/retrieval.rs`, `args.rs`, and `stdio_transport.rs`.
4. Check `crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs` for the intended agent contract.

## Verification

- `cargo test -p codestory-retrieval`
- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts -- --nocapture`
- `cargo test -p codestory-retrieval --test bootstrap_repair_contracts -- --nocapture`
- `cargo fmt --check`
- `git diff --check`

All passed in `C:\Users\alber\.codex\worktrees\issue-446-sidecar-isolation\codestory`.

## Risk

Live Docker sidecar startup/teardown was not exercised in this environment. The tests cover profile/status/state/cleanup contracts without starting real global sidecars.