### PR TITLE
release 0.11.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -641,6 +641,12 @@ pub(crate) struct RetrievalSidecarStateCommand {
     pub(crate) project: ProjectArgs,
     #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
     pub(crate) profile: CliSidecarProfile,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to reuse for status or cleanup. If omitted, agent profile creates a fresh run namespace."
+    )]
+    pub(crate) run_id: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -667,6 +673,12 @@ pub(crate) struct RetrievalBootstrapCommand {
     pub(crate) project: ProjectArgs,
     #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
     pub(crate) profile: CliSidecarProfile,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to reuse for status or cleanup. If omitted, agent profile creates a fresh run namespace."
+    )]
+    pub(crate) run_id: Option<String>,
     #[arg(
         long,
         help = "Skip docker compose even when Docker is installed (dirs + state file only)."
@@ -697,6 +709,12 @@ pub(crate) struct RetrievalStatusCommand {
     pub(crate) project: ProjectArgs,
     #[arg(long, value_enum)]
     pub(crate) profile: Option<CliSidecarProfile>,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to inspect. If omitted, agent profile creates a fresh status namespace."
+    )]
+    pub(crate) run_id: Option<String>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(long, value_name = "PATH")]
@@ -707,6 +725,14 @@ pub(crate) struct RetrievalStatusCommand {
 pub(crate) struct RetrievalIndexCommand {
     #[command(flatten)]
     pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum)]
+    pub(crate) profile: Option<CliSidecarProfile>,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to reuse while finalizing sidecar artifacts."
+    )]
+    pub(crate) run_id: Option<String>,
     #[arg(long, value_enum, default_value_t = RefreshMode::Auto, help = INDEX_REFRESH_HELP)]
     pub(crate) refresh: RefreshMode,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -67,6 +67,8 @@ pub(crate) enum Command {
     Doctor(DoctorCommand),
     #[command(about = "Print compact readiness verdicts for local navigation or agent search.")]
     Ready(ReadyCommand),
+    #[command(about = "Run a machine-readable smoke profile for CI and agent images.")]
+    Smoke(SmokeCommand),
     #[command(about = "Agent-facing readiness and repair helpers.")]
     Agent(AgentCommand),
     #[command(about = "Install or check local setup assets.")]
@@ -316,6 +318,28 @@ pub(crate) struct GroundCommand {
         help = "Explain retrieval mode, coverage, and query hints in the Markdown output."
     )]
     pub(crate) why: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum SmokeProfile {
+    #[value(name = "ci-agent")]
+    CiAgent,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct SmokeCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum, default_value_t = SmokeProfile::CiAgent)]
+    pub(crate) profile: SmokeProfile,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -609,15 +609,38 @@ pub(crate) enum RetrievalAction {
     /// Start Docker Compose sidecars (when available), prepare cache dirs, and wait for health.
     Bootstrap(RetrievalBootstrapCommand),
     /// Prepare local sidecar data directories and write sidecar state (does not start Docker).
-    Up,
+    Up(RetrievalSidecarStateCommand),
     /// Remove local sidecar state file (does not stop external processes).
-    Down,
+    Down(RetrievalSidecarStateCommand),
     /// Probe Zoekt, Qdrant, and SCIP availability for the project.
     Status(RetrievalStatusCommand),
     /// Run workspace index then persist retrieval_index_manifest sidecar metadata.
     Index(RetrievalIndexCommand),
     /// Execute a standalone sidecar retrieval query against indexed sidecar metadata.
     Query(RetrievalQueryCommand),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum CliSidecarProfile {
+    Local,
+    Agent,
+}
+
+impl From<CliSidecarProfile> for codestory_retrieval::SidecarProfile {
+    fn from(value: CliSidecarProfile) -> Self {
+        match value {
+            CliSidecarProfile::Local => Self::Local,
+            CliSidecarProfile::Agent => Self::Agent,
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct RetrievalSidecarStateCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
+    pub(crate) profile: CliSidecarProfile,
 }
 
 #[derive(Args, Debug)]
@@ -642,6 +665,8 @@ pub(crate) struct RetrievalQueryCommand {
 pub(crate) struct RetrievalBootstrapCommand {
     #[command(flatten)]
     pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum, default_value_t = CliSidecarProfile::Local)]
+    pub(crate) profile: CliSidecarProfile,
     #[arg(
         long,
         help = "Skip docker compose even when Docker is installed (dirs + state file only)."
@@ -670,6 +695,8 @@ pub(crate) struct RetrievalBootstrapCommand {
 pub(crate) struct RetrievalStatusCommand {
     #[command(flatten)]
     pub(crate) project: ProjectArgs,
+    #[arg(long, value_enum)]
+    pub(crate) profile: Option<CliSidecarProfile>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(long, value_name = "PATH")]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -20,13 +20,13 @@ use codestory_contracts::api::{
     AppEventPayload, BookmarkCategoryDto, BookmarkDto, ClaimReadinessDto,
     CreateBookmarkCategoryRequest, CreateBookmarkRequest, EvidenceItemDto, EvidencePacketDto,
     EvidenceSourceLocationDto, EvidenceTypeDto, FrameworkRouteCoverageDto, GraphArtifactDto,
-    IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode, IndexedFilesRequest, NodeId, NodeKind,
-    NodeOccurrencesRequest, PacketBudgetModeDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
-    ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto, RetrievalFallbackReasonDto,
-    RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit, SearchMatchQualityDto,
-    SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest, SourceOccurrenceDto,
-    SourceTruthCheckDto, TrailCallerScope, TrailConfigDto, TrailContextDto, TrailDirection,
-    TrailMode,
+    GroundingBudgetDto, IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode, IndexedFilesRequest,
+    NodeId, NodeKind, NodeOccurrencesRequest, PacketBudgetModeDto, PacketSufficiencyStatusDto,
+    PacketTaskClassDto, ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto,
+    RetrievalFallbackReasonDto, RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit,
+    SearchMatchQualityDto, SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest,
+    SourceOccurrenceDto, SourceTruthCheckDto, TrailCallerScope, TrailConfigDto, TrailContextDto,
+    TrailDirection, TrailMode,
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -79,8 +79,8 @@ use args::{
     IndexCommand, IndexDryRunOutput, IndexOutput, PacketCommand, ProjectArgs, QueryCommand,
     QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadyCommand, ReadyOutput,
     RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand, SetupAction,
-    SetupCommand, SnippetCommand, SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, TrailCommand,
-    TrailJsonOutput, VerificationTargetOutput, build_trail_request,
+    SetupCommand, SmokeCommand, SmokeProfile, SnippetCommand, SnippetJsonOutput, SymbolCommand,
+    SymbolJsonOutput, TrailCommand, TrailJsonOutput, VerificationTargetOutput, build_trail_request,
 };
 #[cfg(test)]
 use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
@@ -184,6 +184,7 @@ fn main() -> Result<()> {
         Command::Packet(cmd) => run_packet(cmd),
         Command::Doctor(cmd) => run_doctor(cmd),
         Command::Ready(cmd) => run_ready(cmd),
+        Command::Smoke(cmd) => run_smoke(cmd),
         Command::Agent(cmd) => run_agent(cmd),
         Command::Setup(cmd) => run_setup(cmd),
         Command::Cache(cmd) => run_cache(cmd),
@@ -637,6 +638,343 @@ fn run_ground(cmd: GroundCommand) -> Result<()> {
         .map_err(map_api_error)?;
     let markdown = render_ground_markdown(&runtime.project_root, &snapshot, cmd.why);
     emit(cmd.format, &snapshot, markdown, cmd.output_file.as_deref())
+}
+
+#[derive(serde::Serialize)]
+struct SmokeOutput {
+    profile: &'static str,
+    status: &'static str,
+    project: String,
+    checked_surfaces: Vec<SmokeSurfaceOutput>,
+    skipped_optional_surfaces: Vec<SmokeSkippedSurfaceOutput>,
+    repair_hints: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct SmokeSurfaceOutput {
+    surface: &'static str,
+    status: &'static str,
+    duration_ms: u64,
+    detail: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    repair_hints: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct SmokeSkippedSurfaceOutput {
+    surface: &'static str,
+    reason: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    repair_hints: Vec<String>,
+}
+
+fn run_smoke(cmd: SmokeCommand) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, "smoke")?;
+    preflight_output_file(cmd.output_file.as_deref())?;
+
+    let output = match cmd.profile {
+        SmokeProfile::CiAgent => run_ci_agent_smoke(&cmd.project),
+    };
+    let failed = output.status == "fail";
+    let markdown = render_smoke_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())?;
+    if failed {
+        bail!("smoke profile {} failed", output.profile);
+    }
+    Ok(())
+}
+
+fn run_ci_agent_smoke(project: &ProjectArgs) -> SmokeOutput {
+    let requested_project = display::clean_path_string(&project.project.to_string_lossy());
+    let mut output = SmokeOutput {
+        profile: "ci-agent",
+        status: "pass",
+        project: requested_project,
+        checked_surfaces: Vec::new(),
+        skipped_optional_surfaces: Vec::new(),
+        repair_hints: Vec::new(),
+    };
+
+    let runtime = match RuntimeContext::new(project) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "project",
+                0,
+                format!("failed to open project: {error:#}"),
+                vec!["pass a valid --project repository root".to_string()],
+            );
+            return output;
+        }
+    };
+
+    output.project = display::clean_path_string(&runtime.project_root.to_string_lossy());
+    let project_arg = quote_command_path(&runtime.project_root);
+
+    let start = Instant::now();
+    let opened = match runtime.ensure_open(args::RefreshMode::Auto) {
+        Ok(opened) => match ensure_index_ready(&opened, "smoke index") {
+            Ok(()) => {
+                smoke_pass(
+                    &mut output,
+                    "index",
+                    start,
+                    format!(
+                        "refresh={} files={} errors={}",
+                        refresh_label(args::RefreshMode::Auto, opened.refresh_mode),
+                        opened.summary.stats.file_count,
+                        opened.summary.stats.error_count
+                    ),
+                );
+                opened
+            }
+            Err(error) => {
+                smoke_fail(
+                    &mut output,
+                    "index",
+                    elapsed_ms(start),
+                    format!("index not ready: {error:#}"),
+                    vec![format!(
+                        "codestory-cli index --project {project_arg} --refresh full --format json"
+                    )],
+                );
+                return output;
+            }
+        },
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "index",
+                elapsed_ms(start),
+                format!("index failed: {error:#}"),
+                vec![format!(
+                    "codestory-cli index --project {project_arg} --refresh full --format json"
+                )],
+            );
+            return output;
+        }
+    };
+
+    let start = Instant::now();
+    let snapshot = match runtime
+        .grounding
+        .grounding_snapshot(GroundingBudgetDto::Strict)
+        .map_err(map_api_error)
+    {
+        Ok(snapshot) => {
+            smoke_pass(
+                &mut output,
+                "ground",
+                start,
+                format!(
+                    "represented_files={}/{} represented_symbols={}/{}",
+                    snapshot.coverage.represented_files,
+                    snapshot.coverage.total_files,
+                    snapshot.coverage.represented_symbols,
+                    snapshot.coverage.total_symbols
+                ),
+            );
+            snapshot
+        }
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "ground",
+                elapsed_ms(start),
+                format!("ground failed: {error:#}"),
+                vec![format!(
+                    "codestory-cli ground --project {project_arg} --refresh none --format json"
+                )],
+            );
+            return output;
+        }
+    };
+
+    let Some(symbol) = snapshot.root_symbols.first() else {
+        smoke_fail(
+            &mut output,
+            "symbol",
+            0,
+            "ground snapshot returned no root symbols".to_string(),
+            vec![format!(
+                "codestory-cli index --project {project_arg} --refresh full --format json"
+            )],
+        );
+        return output;
+    };
+
+    let start = Instant::now();
+    match runtime.browser.symbol_context(symbol.id.clone()) {
+        Ok(context) => smoke_pass(
+            &mut output,
+            "symbol",
+            start,
+            format!(
+                "resolved={} kind={:?} file={}",
+                context.node.display_name,
+                context.node.kind,
+                context.node.file_path.as_deref().unwrap_or("unavailable")
+            ),
+        ),
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "symbol",
+                elapsed_ms(start),
+                format!("symbol resolution failed: {}", map_api_error(error)),
+                vec![format!(
+                    "codestory-cli symbol --project {project_arg} --id {} --format json",
+                    symbol.id.0
+                )],
+            );
+            return output;
+        }
+    }
+
+    let start = Instant::now();
+    let fake_path = "__codestory_smoke_fake_change__.rs";
+    match runtime.browser.affected_analysis(AffectedAnalysisRequest {
+        changed_paths: vec![fake_path.to_string()],
+        change_records: vec![affected_path_record(
+            fake_path,
+            AffectedChangeKindDto::Unknown,
+            "smoke",
+        )],
+        depth: Some(1),
+        filter: None,
+    }) {
+        Ok(affected) => smoke_pass(
+            &mut output,
+            "affected",
+            start,
+            format!(
+                "fake_path={} changed_files={} impacted_symbols={}",
+                fake_path,
+                affected.changed_paths.len(),
+                affected.impacted_symbols.len()
+            ),
+        ),
+        Err(error) => {
+            smoke_fail(
+                &mut output,
+                "affected",
+                elapsed_ms(start),
+                format!("affected failed: {}", map_api_error(error)),
+                vec![format!(
+                    "codestory-cli affected --project {project_arg} {fake_path} --format json"
+                )],
+            );
+            return output;
+        }
+    }
+
+    let start = Instant::now();
+    let sidecar = doctor_sidecar_status(&runtime);
+    if sidecar.retrieval_mode == "full" {
+        smoke_pass(
+            &mut output,
+            "sidecar_full_mode",
+            start,
+            "retrieval_mode=full".to_string(),
+        );
+    } else {
+        smoke_skip(
+            &mut output,
+            "sidecar_full_mode",
+            format!(
+                "retrieval_mode={}{}",
+                sidecar.retrieval_mode,
+                sidecar
+                    .degraded_reason
+                    .as_deref()
+                    .map(|reason| format!(" reason={reason}"))
+                    .unwrap_or_default()
+            ),
+            vec![
+                format!(
+                    "codestory-cli retrieval index --project {project_arg} --refresh full --format json"
+                ),
+                format!("codestory-cli retrieval status --project {project_arg} --format json"),
+            ],
+        );
+    }
+
+    let _ = opened;
+    output
+}
+
+fn smoke_pass(output: &mut SmokeOutput, surface: &'static str, start: Instant, detail: String) {
+    output.checked_surfaces.push(SmokeSurfaceOutput {
+        surface,
+        status: "pass",
+        duration_ms: elapsed_ms(start),
+        detail,
+        repair_hints: Vec::new(),
+    });
+}
+
+fn smoke_fail(
+    output: &mut SmokeOutput,
+    surface: &'static str,
+    duration_ms: u64,
+    detail: String,
+    repair_hints: Vec<String>,
+) {
+    output.status = "fail";
+    output.repair_hints.extend(repair_hints.clone());
+    output.checked_surfaces.push(SmokeSurfaceOutput {
+        surface,
+        status: "fail",
+        duration_ms,
+        detail,
+        repair_hints,
+    });
+}
+
+fn smoke_skip(
+    output: &mut SmokeOutput,
+    surface: &'static str,
+    reason: String,
+    repair_hints: Vec<String>,
+) {
+    output.repair_hints.extend(repair_hints.clone());
+    output
+        .skipped_optional_surfaces
+        .push(SmokeSkippedSurfaceOutput {
+            surface,
+            reason,
+            repair_hints,
+        });
+}
+
+fn render_smoke_markdown(output: &SmokeOutput) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(markdown, "# Smoke");
+    let _ = writeln!(markdown, "profile: `{}`", output.profile);
+    let _ = writeln!(markdown, "status: `{}`", output.status);
+    let _ = writeln!(markdown, "project: `{}`", output.project);
+    let _ = writeln!(markdown, "\n## Checked Surfaces");
+    for surface in &output.checked_surfaces {
+        let _ = writeln!(
+            markdown,
+            "- {} [{}] {} ({} ms)",
+            surface.surface, surface.status, surface.detail, surface.duration_ms
+        );
+    }
+    if !output.skipped_optional_surfaces.is_empty() {
+        let _ = writeln!(markdown, "\n## Skipped Optional Surfaces");
+        for surface in &output.skipped_optional_surfaces {
+            let _ = writeln!(markdown, "- {}: {}", surface.surface, surface.reason);
+        }
+    }
+    if !output.repair_hints.is_empty() {
+        let _ = writeln!(markdown, "\n## Repair Hints");
+        for hint in &output.repair_hints {
+            let _ = writeln!(markdown, "- `{hint}`");
+        }
+    }
+    markdown
 }
 
 #[derive(serde::Serialize)]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1304,12 +1304,13 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    codestory_retrieval::bootstrap_sidecars(
+    codestory_retrieval::bootstrap_sidecars_with_profile(
         Some(runtime.project_root.as_path()),
         &storage_scope,
         None,
         false,
         Duration::from_secs(90),
+        codestory_retrieval::SidecarProfile::Agent,
     )
     .context("ready repair retrieval bootstrap")?;
     codestory_retrieval::repair_project_qdrant_collection(

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -10,8 +10,8 @@ use codestory_retrieval::{
 };
 
 use crate::args::{
-    OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand, RetrievalCommand,
-    RetrievalIndexCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
+    CliSidecarProfile, OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand,
+    RetrievalCommand, RetrievalIndexCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
     RetrievalStatusCommand,
 };
 use crate::output::{emit, validate_output_file_parent};
@@ -99,7 +99,10 @@ fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
 fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let report = if let Some(profile) = cmd.profile {
+    let profile = cmd
+        .profile
+        .or_else(|| cmd.run_id.as_ref().map(|_| CliSidecarProfile::Agent));
+    let report = if let Some(profile) = profile {
         let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
             &runtime.project_root,
             profile.into(),

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -5,12 +5,14 @@ use std::time::Duration;
 use codestory_retrieval::{
     BootstrapStorageScope, FinalizeIndexOutcome, ProjectQdrantRepairOutcome, QueryRequest,
     RetrievalIndexManifest, RetrievalStatusReport, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    bootstrap_sidecars, execute_retrieval_query, sidecar_down, sidecar_up, strict_sidecar_status,
+    bootstrap_sidecars_with_profile, execute_retrieval_query, sidecar_down_for_project,
+    sidecar_up_with_runtime, strict_sidecar_status,
 };
 
 use crate::args::{
     OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand, RetrievalCommand,
-    RetrievalIndexCommand, RetrievalQueryCommand, RetrievalStatusCommand,
+    RetrievalIndexCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
+    RetrievalStatusCommand,
 };
 use crate::output::{emit, validate_output_file_parent};
 use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_refresh_request};
@@ -18,8 +20,8 @@ use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_
 pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
     match cmd.action {
         RetrievalAction::Bootstrap(bootstrap_cmd) => run_retrieval_bootstrap(bootstrap_cmd),
-        RetrievalAction::Up => run_retrieval_up(),
-        RetrievalAction::Down => run_retrieval_down(),
+        RetrievalAction::Up(up_cmd) => run_retrieval_up(up_cmd),
+        RetrievalAction::Down(down_cmd) => run_retrieval_down(down_cmd),
         RetrievalAction::Status(status_cmd) => run_retrieval_status(status_cmd),
         RetrievalAction::Index(index_cmd) => run_retrieval_index(index_cmd),
         RetrievalAction::Query(query_cmd) => run_retrieval_query(query_cmd),
@@ -34,12 +36,13 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    let report = bootstrap_sidecars(
+    let report = bootstrap_sidecars_with_profile(
         Some(&runtime.project_root),
         &storage_scope,
         cmd.compose_file.as_deref(),
         cmd.skip_compose,
         Duration::from_secs(cmd.wait_secs),
+        cmd.profile.into(),
     )
     .context("retrieval bootstrap")?;
     let project_qdrant_repair = codestory_retrieval::repair_project_qdrant_collection(
@@ -58,14 +61,19 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
     )
 }
 
-fn run_retrieval_up() -> Result<()> {
-    let state = sidecar_up().context("retrieval up")?;
+fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let sidecar =
+        codestory_retrieval::sidecar_runtime_for_project(&runtime.project_root, cmd.profile.into());
+    let state = sidecar_up_with_runtime(&sidecar, None).context("retrieval up")?;
     println!("{}", serde_json::to_string_pretty(&state)?);
     Ok(())
 }
 
-fn run_retrieval_down() -> Result<()> {
-    sidecar_down().context("retrieval down")?;
+fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    sidecar_down_for_project(&runtime.project_root, cmd.profile.into())
+        .context("retrieval down")?;
     println!("retrieval sidecar state cleared");
     Ok(())
 }
@@ -73,8 +81,16 @@ fn run_retrieval_down() -> Result<()> {
 fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let report = strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
-        .context("retrieval status")?;
+    let report = if let Some(profile) = cmd.profile {
+        codestory_retrieval::strict_sidecar_status_for_profile(
+            &runtime.project_root,
+            Some(&runtime.storage_path),
+            profile.into(),
+        )
+    } else {
+        strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
+    }
+    .context("retrieval status")?;
     emit_retrieval_status(cmd.format, &report, cmd.output_file.as_deref())
 }
 
@@ -362,8 +378,25 @@ fn emit_retrieval_status(
             )
         })
         .unwrap_or_default();
+    let ownership_note = report
+        .ownership
+        .as_ref()
+        .map(|ownership| {
+            format!(
+                "- ownership: owner=`{}` profile=`{}` namespace=`{}` cleanup=`{}` ports=zoekt:{} qdrant:{} grpc:{} embed:{}\n",
+                ownership.owner,
+                ownership.profile,
+                ownership.namespace,
+                ownership.cleanup_command,
+                ownership.ports.zoekt_http,
+                ownership.ports.qdrant_http,
+                ownership.ports.qdrant_grpc,
+                ownership.ports.embed_http,
+            )
+        })
+        .unwrap_or_default();
     let markdown = format!(
-        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
+        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
         report.retrieval_mode,
         report.degraded_reason,
         report.query_embedding_backend,
@@ -374,6 +407,7 @@ fn emit_retrieval_status(
         report.stored_doc_vector_mixed_backends,
         manifest_contract_note,
         repair_note,
+        ownership_note,
         report.zoekt.status,
         report.zoekt.detail,
         report.zoekt.capabilities.lexical,

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use codestory_retrieval::{
     BootstrapStorageScope, FinalizeIndexOutcome, ProjectQdrantRepairOutcome, QueryRequest,
     RetrievalIndexManifest, RetrievalStatusReport, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    bootstrap_sidecars_with_profile, execute_retrieval_query, sidecar_down_for_project,
-    sidecar_up_with_runtime, strict_sidecar_status,
+    bootstrap_sidecars_with_runtime, execute_retrieval_query, sidecar_down_for_runtime,
+    sidecar_up_with_runtime, strict_sidecar_status, strict_sidecar_status_for_runtime,
 };
 
 use crate::args::{
@@ -36,22 +36,33 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    let report = bootstrap_sidecars_with_profile(
+    let sidecar_profile = cmd.profile;
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &runtime.project_root,
+        sidecar_profile.into(),
+        cmd.run_id.as_deref(),
+    );
+    let report = bootstrap_sidecars_with_runtime(
+        &sidecar,
         Some(&runtime.project_root),
         &storage_scope,
         cmd.compose_file.as_deref(),
         cmd.skip_compose,
         Duration::from_secs(cmd.wait_secs),
-        cmd.profile.into(),
     )
     .context("retrieval bootstrap")?;
+    activate_retrieval_profile_env(Some(sidecar_profile), sidecar.run_id.as_deref());
     let project_qdrant_repair = codestory_retrieval::repair_project_qdrant_collection(
         &runtime.project_root,
         &runtime.storage_path,
     )
     .context("retrieval project qdrant repair")?;
-    let status = strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
-        .context("retrieval status after bootstrap")?;
+    let status = strict_sidecar_status_for_runtime(
+        &runtime.project_root,
+        Some(&runtime.storage_path),
+        sidecar,
+    )
+    .context("retrieval status after bootstrap")?;
     emit_retrieval_bootstrap(
         cmd.format,
         &report,
@@ -63,8 +74,11 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
 
 fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let sidecar =
-        codestory_retrieval::sidecar_runtime_for_project(&runtime.project_root, cmd.profile.into());
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &runtime.project_root,
+        cmd.profile.into(),
+        cmd.run_id.as_deref(),
+    );
     let state = sidecar_up_with_runtime(&sidecar, None).context("retrieval up")?;
     println!("{}", serde_json::to_string_pretty(&state)?);
     Ok(())
@@ -72,8 +86,12 @@ fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
 
 fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    sidecar_down_for_project(&runtime.project_root, cmd.profile.into())
-        .context("retrieval down")?;
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &runtime.project_root,
+        cmd.profile.into(),
+        cmd.run_id.as_deref(),
+    );
+    sidecar_down_for_runtime(&sidecar).context("retrieval down")?;
     println!("retrieval sidecar state cleared");
     Ok(())
 }
@@ -82,10 +100,15 @@ fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let report = if let Some(profile) = cmd.profile {
-        codestory_retrieval::strict_sidecar_status_for_profile(
+        let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+            &runtime.project_root,
+            profile.into(),
+            cmd.run_id.as_deref(),
+        );
+        codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
             Some(&runtime.storage_path),
-            profile.into(),
+            sidecar,
         )
     } else {
         strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
@@ -110,6 +133,7 @@ fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
 
 fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
+    activate_retrieval_profile_env(cmd.profile, cmd.run_id.as_deref());
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let summary = runtime.open_project_summary()?;
     let refresh_mode = resolve_refresh_request(cmd.refresh, &summary);
@@ -126,6 +150,29 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
             .context("retrieval index finalize after semantic-doc contract repair")
     })?;
     emit_retrieval_index(cmd.format, &outcome, cmd.output_file.as_deref())
+}
+
+fn activate_retrieval_profile_env(
+    profile: Option<crate::args::CliSidecarProfile>,
+    run_id: Option<&str>,
+) {
+    if let Some(profile) = profile {
+        let profile = match profile {
+            crate::args::CliSidecarProfile::Local => "local",
+            crate::args::CliSidecarProfile::Agent => "agent",
+        };
+        // SAFETY: retrieval CLI commands are short-lived processes and set this before sidecar
+        // layout resolution or worker threads are started.
+        unsafe {
+            std::env::set_var("CODESTORY_RETRIEVAL_PROFILE", profile);
+        }
+    }
+    if let Some(run_id) = run_id {
+        // SAFETY: see the profile environment setup above.
+        unsafe {
+            std::env::set_var("CODESTORY_SIDECAR_RUN_ID", run_id);
+        }
+    }
 }
 
 fn run_retrieval_index_refresh(

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2403,6 +2403,8 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         .unwrap_or_default();
     serde_json::json!({
         "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        "plugin_root": env_nonempty("CODESTORY_PLUGIN_ROOT"),
+        "plugin_cache_version": env_nonempty("CODESTORY_PLUGIN_CACHE_VERSION"),
         "cli_version": env_nonempty("CODESTORY_PLUGIN_CLI_VERSION"),
         "cli_source": cli_source,
         "cli_path": env_nonempty("CODESTORY_PLUGIN_CLI_PATH"),

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1089,7 +1089,7 @@ fn stdio_mandatory_sidecar_fingerprint(
     project_root: &std::path::Path,
     storage_path: &std::path::Path,
 ) -> String {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     let status = codestory_retrieval::strict_sidecar_status(project_root, Some(storage_path)).map(
         |report| StdioSidecarStatusFingerprint {
             retrieval_mode: report.retrieval_mode,
@@ -1949,7 +1949,7 @@ fn read_stdio_status_resource_cached(
 }
 
 fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(&runtime.project_root);
     [
         format!("project:{}", runtime.project_root.display()),
         format!("storage:{}", runtime.storage_path.display()),
@@ -1972,7 +1972,7 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
 fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Value> {
     let summary = runtime.open_project_summary()?;
     let retrieval = summary.retrieval.as_ref();
-    let (sidecar_mode, degraded_reason, manifest_generation, manifest_input_hash) =
+    let (sidecar_mode, degraded_reason, manifest_generation, manifest_input_hash, ownership) =
         match codestory_retrieval::strict_sidecar_status(
             &runtime.project_root,
             Some(&runtime.storage_path),
@@ -1991,11 +1991,13 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
                     report.degraded_reason,
                     manifest_generation,
                     manifest_input_hash,
+                    report.ownership,
                 )
             }
             Err(error) => (
                 "unavailable".to_string(),
                 Some(format!("sidecar_status_error: {error}")),
+                None,
                 None,
                 None,
             ),
@@ -2006,6 +2008,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "manifest_generation": manifest_generation.clone(),
         "manifest_input_hash": manifest_input_hash.clone(),
+        "ownership": ownership,
     });
     let (server_executable, server_executable_sha256, server_warnings) =
         stdio_server_executable_status();
@@ -2403,6 +2406,8 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         .unwrap_or_default();
     serde_json::json!({
         "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
+        "plugin_root": env_nonempty("CODESTORY_PLUGIN_ROOT"),
+        "plugin_cache_version": env_nonempty("CODESTORY_PLUGIN_CACHE_VERSION"),
         "cli_version": env_nonempty("CODESTORY_PLUGIN_CLI_VERSION"),
         "cli_source": cli_source,
         "cli_path": env_nonempty("CODESTORY_PLUGIN_CLI_PATH"),

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -280,6 +280,10 @@ fn top_level_help_names_command_purposes() {
             "Answer a broad repository question with evidence.",
         ),
         ("doctor", "Check cache, index, and retrieval health."),
+        (
+            "smoke",
+            "Run a machine-readable smoke profile for CI and agent images.",
+        ),
         ("setup", "Install or check local setup assets."),
         ("cache", "Prepare or inspect local cache artifacts."),
         ("symbol", "Inspect a symbol by query or id."),
@@ -295,6 +299,83 @@ fn top_level_help_names_command_purposes() {
             "top-level help should show {command:?} purpose {purpose:?}, not only command names:\n{help_text}"
         );
     }
+}
+
+#[test]
+fn smoke_ci_agent_json_runs_tiny_repo_profile() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    let output = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &["smoke", "--profile", "ci-agent", "--format", "json"],
+    );
+    assert_success(&output, "smoke ci-agent failed");
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse smoke json");
+    assert_eq!(json_string(&json, "/profile"), "ci-agent");
+    assert_eq!(json_string(&json, "/status"), "pass");
+
+    let checked = json["checked_surfaces"]
+        .as_array()
+        .expect("checked surfaces array");
+    for surface in ["index", "ground", "symbol", "affected"] {
+        assert!(
+            checked
+                .iter()
+                .any(|item| item["surface"] == surface && item["status"] == "pass"),
+            "smoke should pass required surface {surface}: {json:#}"
+        );
+    }
+    assert!(
+        checked
+            .iter()
+            .any(|item| item["surface"] == "sidecar_full_mode")
+            || json["skipped_optional_surfaces"]
+                .as_array()
+                .is_some_and(|items| items
+                    .iter()
+                    .any(|item| item["surface"] == "sidecar_full_mode")),
+        "sidecar full mode should be checked or explicitly skipped: {json:#}"
+    );
+}
+
+#[test]
+fn smoke_ci_agent_invalid_project_emits_json_failure() {
+    let workspace = tempdir().expect("workspace dir");
+    let missing = workspace.path().join("missing");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+        .args([
+            "smoke",
+            "--profile",
+            "ci-agent",
+            "--format",
+            "json",
+            "--project",
+        ])
+        .arg(&missing)
+        .output()
+        .expect("run codestory-cli");
+    assert!(
+        !output.status.success(),
+        "invalid project smoke should fail, stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("parse smoke json");
+    assert_eq!(json_string(&json, "/profile"), "ci-agent");
+    assert_eq!(json_string(&json, "/status"), "fail");
+    assert_eq!(json_string(&json, "/checked_surfaces/0/surface"), "project");
+    assert!(
+        json["repair_hints"]
+            .as_array()
+            .is_some_and(|hints| !hints.is_empty()),
+        "failure JSON should include repair hints: {json:#}"
+    );
 }
 
 #[test]

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -33,6 +33,19 @@ fn run_status(project: &std::path::Path, extra_args: &[&str]) -> Value {
     serde_json::from_slice(&output.stdout).expect("parse status json")
 }
 
+fn run_down(project: &std::path::Path, extra_args: &[&str]) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    command.args(["retrieval", "down", "--project"]);
+    command.arg(project);
+    command.args(extra_args);
+    let output = command.output().expect("run retrieval down");
+    assert!(
+        output.status.success(),
+        "down failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn create_valid_cache_with_cli(project: &std::path::Path, cache: &std::path::Path) {
     let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
         .args(["index", "--project"])
@@ -163,6 +176,94 @@ fn bootstrap_then_status_reports_manifest_missing_before_indexing() {
                             && text.contains("--refresh full")))
             ),
         "manifest-missing status should include full sidecar rebuild guidance: {status}"
+    );
+}
+
+#[test]
+fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
+    let project = tempdir().expect("project");
+    fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");
+    let cache = tempdir().expect("cache");
+    let cache_arg = cache.path().to_str().expect("utf8 cache");
+
+    let bootstrap = run_bootstrap(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--skip-compose",
+            "--wait-secs",
+            "0",
+            "--format",
+            "json",
+        ],
+    );
+    let state = &bootstrap["sidecar_state"];
+    assert_eq!(state["owner"].as_str(), Some("codestory"));
+    assert_eq!(state["profile"].as_str(), Some("agent"));
+    let namespace = state["namespace"].as_str().expect("namespace");
+    assert!(namespace.starts_with("codestory-agent-"));
+    assert!(
+        state["zoekt_http_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert!(
+        state["qdrant_http_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert!(
+        state["qdrant_grpc_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert!(
+        state["embed_http_port"]
+            .as_u64()
+            .is_some_and(|port| port > 0)
+    );
+    assert_ne!(state["zoekt_http_port"].as_u64(), Some(6070));
+    assert_ne!(state["qdrant_http_port"].as_u64(), Some(6333));
+    assert_ne!(state["qdrant_grpc_port"].as_u64(), Some(6334));
+    assert_ne!(state["embed_http_port"].as_u64(), Some(8080));
+    assert!(
+        state["cleanup_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile agent")),
+        "agent state should name the cleanup path: {state}"
+    );
+    let status = run_status(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--format",
+            "json",
+        ],
+    );
+    let ownership = &status["ownership"];
+    assert_eq!(ownership["profile"].as_str(), Some("agent"));
+    assert_eq!(ownership["namespace"].as_str(), Some(namespace));
+    assert_eq!(
+        ownership["ports"]["zoekt_http"].as_u64(),
+        state["zoekt_http_port"].as_u64()
+    );
+    let state_path =
+        std::path::PathBuf::from(ownership["state_file"].as_str().expect("state file"));
+    assert!(state_path.is_file(), "state file should exist before down");
+
+    run_down(
+        project.path(),
+        &["--cache-dir", cache_arg, "--profile", "agent"],
+    );
+    assert!(
+        !state_path.exists(),
+        "down should remove only the owned state file"
     );
 }
 

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -193,6 +193,8 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
             cache_arg,
             "--profile",
             "agent",
+            "--run-id",
+            "contract-a",
             "--skip-compose",
             "--wait-secs",
             "0",
@@ -205,6 +207,11 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
     assert_eq!(state["profile"].as_str(), Some("agent"));
     let namespace = state["namespace"].as_str().expect("namespace");
     assert!(namespace.starts_with("codestory-agent-"));
+    assert!(
+        namespace.ends_with("-contract-a"),
+        "agent namespace should carry the run id: {namespace}"
+    );
+    assert_eq!(state["run_id"].as_str(), Some("contract-a"));
     assert!(
         state["zoekt_http_port"]
             .as_u64()
@@ -242,6 +249,8 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
             cache_arg,
             "--profile",
             "agent",
+            "--run-id",
+            "contract-a",
             "--format",
             "json",
         ],
@@ -259,11 +268,64 @@ fn agent_profile_bootstrap_status_and_down_are_project_isolated() {
 
     run_down(
         project.path(),
-        &["--cache-dir", cache_arg, "--profile", "agent"],
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--run-id",
+            "contract-a",
+        ],
     );
     assert!(
         !state_path.exists(),
         "down should remove only the owned state file"
+    );
+}
+
+#[test]
+fn agent_profile_status_repair_hints_are_profile_aware() {
+    let project = tempdir().expect("project");
+    fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");
+    let cache = tempdir().expect("cache");
+    let cache_arg = cache.path().to_str().expect("utf8 cache");
+
+    let status = run_status(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--profile",
+            "agent",
+            "--run-id",
+            "repair-a",
+            "--format",
+            "json",
+        ],
+    );
+
+    let repair = &status["repair"];
+    assert_eq!(
+        repair["reason"].as_str(),
+        Some("retrieval_manifest_missing")
+    );
+    assert!(
+        repair["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile agent")
+                && command.contains("--run-id repair-a")),
+        "agent status repair command should keep the profile/run id: {status}"
+    );
+    let full_repair = repair["full_repair"]
+        .as_array()
+        .expect("full repair commands");
+    assert!(
+        full_repair
+            .iter()
+            .all(|command| command.as_str().is_some_and(
+                |text| text.contains("--profile agent") && text.contains("--run-id repair-a")
+            )),
+        "agent full repair commands should keep the profile/run id: {status}"
     );
 }
 

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -330,6 +330,43 @@ fn agent_profile_status_repair_hints_are_profile_aware() {
 }
 
 #[test]
+fn run_id_status_implies_agent_profile() {
+    let project = tempdir().expect("project");
+    fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");
+    let cache = tempdir().expect("cache");
+    let cache_arg = cache.path().to_str().expect("utf8 cache");
+
+    let status = run_status(
+        project.path(),
+        &[
+            "--cache-dir",
+            cache_arg,
+            "--run-id",
+            "implicit-agent",
+            "--format",
+            "json",
+        ],
+    );
+
+    let ownership = &status["ownership"];
+    assert_eq!(ownership["profile"].as_str(), Some("agent"));
+    assert!(
+        ownership["namespace"]
+            .as_str()
+            .is_some_and(|namespace| namespace.ends_with("-implicit-agent")),
+        "status --run-id should inspect the named agent namespace: {status}"
+    );
+    let repair = &status["repair"];
+    assert!(
+        repair["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile agent")
+                && command.contains("--run-id implicit-agent")),
+        "status --run-id repair command should keep the inferred agent run id: {status}"
+    );
+}
+
+#[test]
 fn bootstrap_json_surfaces_prune_suppressed_reason_on_scan_errors() {
     let project = tempdir().expect("project");
     fs::write(project.path().join("lib.rs"), "pub fn main() {}\n").expect("source");

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-contracts/src/api.rs
+++ b/crates/codestory-contracts/src/api.rs
@@ -35,7 +35,7 @@ pub use dto::{
     NodeOccurrencesRequest, OpenContainingFolderRequest, OpenDefinitionRequest, OpenProjectRequest,
     PacketBudgetDto, PacketBudgetLimitsDto, PacketBudgetModeDto, PacketBudgetUsageDto,
     PacketClaimDto, PacketCoverageReportDto, PacketEvidenceResolutionDto, PacketEvidenceTierDto,
-    PacketPlanDto, PacketPlanQueryDto, PacketRetrievalTraceSummaryDto,
+    PacketPlanDto, PacketPlanQueryDto, PacketProofStatusDto, PacketRetrievalTraceSummaryDto,
     PacketSidecarQueryDiagnosticDto, PacketSufficiencyDto, PacketSufficiencyStatusDto,
     PacketTaskClassDto, ProjectSummary, ReadFileTextRequest, ReadFileTextResponse,
     ReadinessGoalDto, ReadinessIndexSnapshotDto, ReadinessSetupSnapshotDto,

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1985,9 +1985,22 @@ pub enum PacketSufficiencyStatusDto {
     Insufficient,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PacketProofStatusDto {
+    Proven,
+    Likely,
+    Diagnostic,
+    Unsupported,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct PacketClaimDto {
     pub claim: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof_status: Option<PacketProofStatusDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_evidence_role: Option<PacketEvidenceTierDto>,
     #[serde(default)]
     pub citations: Vec<AgentCitationDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2311,6 +2324,28 @@ mod packet_tests {
         let legacy: PacketSufficiencyStatusDto =
             serde_json::from_str("\"insufficient\"").expect("deserialize legacy status");
         assert_eq!(legacy, PacketSufficiencyStatusDto::Insufficient);
+    }
+
+    #[test]
+    fn packet_claim_serializes_machine_checkable_proof_metadata() {
+        let value = serde_json::to_value(PacketClaimDto {
+            claim: "Dense hits need backing source proof.".to_string(),
+            proof_status: Some(PacketProofStatusDto::Diagnostic),
+            required_evidence_role: Some(PacketEvidenceTierDto::ExactSource),
+            citations: Vec::new(),
+            coverage_role: Some("source evidence".to_string()),
+            eligible_for_sufficiency: Some(false),
+        })
+        .expect("serialize packet claim");
+
+        assert_eq!(value["proof_status"], "diagnostic");
+        assert_eq!(value["required_evidence_role"], "exact_source");
+
+        let legacy: PacketClaimDto =
+            serde_json::from_str(r#"{"claim":"legacy claim","citations":[]}"#)
+                .expect("deserialize legacy packet claim");
+        assert_eq!(legacy.proof_status, None);
+        assert_eq!(legacy.required_evidence_role, None);
     }
 
     #[test]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -1,10 +1,12 @@
-use crate::config::{SidecarLayout, retrieval_compose_profile, user_cache_root};
+use crate::config::{
+    SidecarLayout, SidecarProfile, SidecarRuntimeConfig, retrieval_compose_profile, user_cache_root,
+};
 use crate::health::{InfrastructureHealth, probe_infrastructure_health};
 use crate::qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION, QdrantStorageRepairReport,
     repair_qdrant_storage,
 };
-use crate::sidecar::{SidecarStateFile, sidecar_up};
+use crate::sidecar::{SidecarStateFile, sidecar_up_with_runtime};
 use anyhow::{Context, Result, bail};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -32,7 +34,27 @@ pub fn bootstrap_sidecars(
     skip_compose: bool,
     wait_timeout: Duration,
 ) -> Result<BootstrapReport> {
-    let layout = SidecarLayout::from_env();
+    bootstrap_sidecars_with_profile(
+        repo_root,
+        storage_scope,
+        compose_file,
+        skip_compose,
+        wait_timeout,
+        SidecarProfile::Local,
+    )
+}
+
+pub fn bootstrap_sidecars_with_profile(
+    repo_root: Option<&Path>,
+    storage_scope: &BootstrapStorageScope,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+    profile: SidecarProfile,
+) -> Result<BootstrapReport> {
+    let runtime = SidecarRuntimeConfig::for_project_profile(repo_root, profile);
+    let layout = runtime.layout.clone();
+    runtime.activate_embed_url_default();
     layout.ensure_data_dirs()?;
     let storage_repair =
         repair_qdrant_storage(&layout, storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?;
@@ -44,13 +66,13 @@ pub fn bootstrap_sidecars(
     };
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
-        docker_compose_up(path, repo_root, &layout)?;
+        docker_compose_up(path, repo_root, &runtime)?;
         true
     } else {
         false
     };
 
-    let state = sidecar_up()?;
+    let state = sidecar_up_with_runtime(&runtime, resolved_compose.as_deref())?;
     let infrastructure = if wait_timeout.is_zero() {
         probe_infrastructure_health(&layout)
     } else {
@@ -155,8 +177,9 @@ pub fn docker_available() -> bool {
 fn docker_compose_up(
     compose_file: &Path,
     repo_root: Option<&Path>,
-    layout: &SidecarLayout,
+    runtime: &SidecarRuntimeConfig,
 ) -> Result<()> {
+    let layout = &runtime.layout;
     if !docker_available() {
         bail!(
             "docker is not available on PATH. Install Docker Desktop (Windows) or Docker Engine, \
@@ -190,6 +213,8 @@ fn docker_compose_up(
     remove_container_if_present("codestory-zoekt-stub")?;
     command
         .arg("compose")
+        .arg("-p")
+        .arg(&runtime.compose_project)
         .arg("-f")
         .arg(compose_file)
         .arg("up")
@@ -216,6 +241,14 @@ fn docker_compose_up(
             "CODESTORY_EMBED_MODEL_DIR",
             docker_bind_path(&embed_model_dir(repo_root, layout)),
         )
+        .env("CODESTORY_EMBED_PORT", runtime.embed_http_port.to_string())
+        .env(
+            "CODESTORY_EMBED_LLAMACPP_URL",
+            SidecarLayout::embed_base_url(runtime.embed_http_port),
+        )
+        .env("CODESTORY_SIDECAR_NAMESPACE", &runtime.namespace)
+        .env("CODESTORY_SIDECAR_PROFILE", runtime.profile.as_str())
+        .env("CODESTORY_SIDECAR_OWNER", "codestory")
         .env("COMPOSE_PROFILES", compose_profile);
 
     let output = command.output().context("spawn docker compose")?;
@@ -224,6 +257,38 @@ fn docker_compose_up(
         let stdout = String::from_utf8_lossy(&output.stdout);
         bail!(
             "docker compose up failed (exit {:?}):\n{stdout}{stderr}",
+            output.status.code()
+        );
+    }
+    Ok(())
+}
+
+pub fn docker_compose_down_for_state(state: &SidecarStateFile) -> Result<()> {
+    if state.owner != "codestory" || state.profile != SidecarProfile::Agent.as_str() {
+        return Ok(());
+    }
+    let Some(compose_file) = state.compose_file.as_ref().map(PathBuf::from) else {
+        return Ok(());
+    };
+    if !compose_file.is_file() || !docker_available() {
+        return Ok(());
+    }
+    let output = docker_compose_command()?
+        .arg("compose")
+        .arg("-p")
+        .arg(&state.compose_project)
+        .arg("-f")
+        .arg(&compose_file)
+        .arg("down")
+        .arg("--remove-orphans")
+        .output()
+        .context("spawn docker compose down")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "docker compose down failed for owned sidecar namespace {} (exit {:?}):\n{stdout}{stderr}",
+            state.namespace,
             output.status.code()
         );
     }
@@ -355,7 +420,7 @@ mod tests {
 
         assert_eq!(path, cache.path().join("retrieval-compose.yml"));
         let contents = std::fs::read_to_string(path).expect("read bundled compose");
-        assert!(contents.contains("name: codestory-retrieval"));
+        assert!(contents.contains("name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}"));
         assert!(contents.contains("qdrant/qdrant:v1.12.5"));
     }
 

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -53,6 +53,24 @@ pub fn bootstrap_sidecars_with_profile(
     profile: SidecarProfile,
 ) -> Result<BootstrapReport> {
     let runtime = SidecarRuntimeConfig::for_project_profile(repo_root, profile);
+    bootstrap_sidecars_with_runtime(
+        &runtime,
+        repo_root,
+        storage_scope,
+        compose_file,
+        skip_compose,
+        wait_timeout,
+    )
+}
+
+pub fn bootstrap_sidecars_with_runtime(
+    runtime: &SidecarRuntimeConfig,
+    repo_root: Option<&Path>,
+    storage_scope: &BootstrapStorageScope,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+) -> Result<BootstrapReport> {
     let layout = runtime.layout.clone();
     runtime.activate_embed_url_default();
     layout.ensure_data_dirs()?;
@@ -66,13 +84,13 @@ pub fn bootstrap_sidecars_with_profile(
     };
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
-        docker_compose_up(path, repo_root, &runtime)?;
+        docker_compose_up(path, repo_root, runtime)?;
         true
     } else {
         false
     };
 
-    let state = sidecar_up_with_runtime(&runtime, resolved_compose.as_deref())?;
+    let state = sidecar_up_with_runtime(runtime, resolved_compose.as_deref())?;
     let infrastructure = if wait_timeout.is_zero() {
         probe_infrastructure_health(&layout)
     } else {

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -1,5 +1,8 @@
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -20,6 +23,7 @@ pub const LLAMACPP_SERVER_IMAGE_PIN: &str = "ghcr.io/ggml-org/llama.cpp:server";
 pub const DEFAULT_ZOEKT_HTTP_PORT: u16 = 6070;
 pub const DEFAULT_QDRANT_HTTP_PORT: u16 = 6333;
 pub const DEFAULT_QDRANT_GRPC_PORT: u16 = 6334;
+pub const DEFAULT_EMBED_HTTP_PORT: u16 = 8080;
 
 pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
 pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
@@ -35,20 +39,220 @@ pub struct SidecarLayout {
     pub state_file: PathBuf,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SidecarProfile {
+    Local,
+    Agent,
+}
+
+impl SidecarProfile {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Agent => "agent",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarPorts {
+    pub zoekt_http: u16,
+    pub qdrant_http: u16,
+    pub qdrant_grpc: u16,
+    pub embed_http: u16,
+    pub embed_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SidecarOwnership {
+    pub owner: String,
+    pub profile: String,
+    pub namespace: String,
+    pub compose_project: String,
+    pub state_file: String,
+    pub cleanup_command: String,
+    pub ports: SidecarPorts,
+    pub labels: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SidecarRuntimeConfig {
+    pub layout: SidecarLayout,
+    pub profile: SidecarProfile,
+    pub namespace: String,
+    pub compose_project: String,
+    pub embed_http_port: u16,
+    pub cleanup_command: String,
+    pub labels: BTreeMap<String, String>,
+}
+
 impl SidecarLayout {
     pub fn from_env() -> Self {
+        Self::from_env_for_profile(None, SidecarProfile::Local)
+    }
+
+    pub fn from_env_for_project(project_root: &Path) -> Self {
+        let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
+        runtime.activate_embed_url_default();
+        runtime.layout
+    }
+
+    fn from_env_for_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
+        SidecarRuntimeConfig::for_project_profile(project_root, profile).layout
+    }
+
+    pub fn from_env_agent(project_root: &Path) -> Self {
+        let runtime =
+            SidecarRuntimeConfig::for_project_profile(Some(project_root), SidecarProfile::Agent);
+        runtime.activate_embed_url_default();
+        runtime.layout
+    }
+
+    pub fn from_env_local(project_root: Option<&Path>) -> Self {
+        Self::from_env_for_profile(project_root, SidecarProfile::Local)
+    }
+
+    pub fn embed_base_url(embed_http_port: u16) -> String {
+        format!("http://127.0.0.1:{embed_http_port}/v1/embeddings")
+    }
+}
+
+impl SidecarRuntimeConfig {
+    pub fn local() -> Self {
+        Self::for_project_profile(None, SidecarProfile::Local)
+    }
+
+    pub fn for_project_auto(project_root: &Path) -> Self {
+        let profile = if env_profile() == Some(SidecarProfile::Agent)
+            || agent_state_file(project_root).is_file()
+            || running_in_ci_agent()
+        {
+            SidecarProfile::Agent
+        } else {
+            SidecarProfile::Local
+        };
+        Self::for_project_profile(Some(project_root), profile)
+    }
+
+    pub fn for_project_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
         let base = user_cache_root();
+        let namespace = namespace_for(project_root, profile);
+        let state_file = match profile {
+            SidecarProfile::Local => base.join("retrieval-sidecars.json"),
+            SidecarProfile::Agent => base
+                .join("sidecars")
+                .join(&namespace)
+                .join("retrieval-sidecars.json"),
+        };
+        let stored = read_ports_from_state(&state_file);
+        let dynamic = profile == SidecarProfile::Agent && stored.is_none();
+        let zoekt_http_port = env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.zoekt_http))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_ZOEKT_HTTP_PORT
+                }
+            });
+        let qdrant_http_port = env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.qdrant_http))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_QDRANT_HTTP_PORT
+                }
+            });
+        let qdrant_grpc_port = env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.qdrant_grpc))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_QDRANT_GRPC_PORT
+                }
+            });
+        let embed_http_port = env_port("CODESTORY_EMBED_PORT", DEFAULT_EMBED_HTTP_PORT)
+            .or_else(|| stored.as_ref().map(|ports| ports.embed_http))
+            .unwrap_or_else(|| {
+                if dynamic {
+                    free_local_port()
+                } else {
+                    DEFAULT_EMBED_HTTP_PORT
+                }
+            });
+        let root = match profile {
+            SidecarProfile::Local => base.clone(),
+            SidecarProfile::Agent => base.join("sidecars").join(&namespace),
+        };
+        let layout = SidecarLayout {
+            zoekt_http_port,
+            qdrant_http_port,
+            qdrant_grpc_port,
+            zoekt_data_dir: root.join("zoekt"),
+            qdrant_data_dir: root.join("qdrant"),
+            scip_artifacts_root: root.join("scip"),
+            state_file: state_file.clone(),
+        };
+        let cleanup_command = project_root
+            .map(|path| {
+                format!(
+                    "codestory-cli retrieval down --project {} --profile {}",
+                    quote_command_path(path),
+                    profile.as_str()
+                )
+            })
+            .unwrap_or_else(|| "codestory-cli retrieval down".to_string());
+        let mut labels = BTreeMap::new();
+        labels.insert("dev.codestory.owner".into(), "codestory".into());
+        labels.insert("dev.codestory.profile".into(), profile.as_str().into());
+        labels.insert("dev.codestory.namespace".into(), namespace.clone());
         Self {
-            zoekt_http_port: env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT),
-            qdrant_http_port: env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT),
-            qdrant_grpc_port: env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT),
-            zoekt_data_dir: base.join("zoekt"),
-            qdrant_data_dir: base.join("qdrant"),
-            scip_artifacts_root: base.join("scip"),
-            state_file: base.join("retrieval-sidecars.json"),
+            layout,
+            profile,
+            namespace: namespace.clone(),
+            compose_project: namespace,
+            embed_http_port,
+            cleanup_command,
+            labels,
         }
     }
 
+    pub fn ownership(&self) -> SidecarOwnership {
+        SidecarOwnership {
+            owner: "codestory".into(),
+            profile: self.profile.as_str().into(),
+            namespace: self.namespace.clone(),
+            compose_project: self.compose_project.clone(),
+            state_file: self.layout.state_file.display().to_string(),
+            cleanup_command: self.cleanup_command.clone(),
+            ports: SidecarPorts {
+                zoekt_http: self.layout.zoekt_http_port,
+                qdrant_http: self.layout.qdrant_http_port,
+                qdrant_grpc: self.layout.qdrant_grpc_port,
+                embed_http: self.embed_http_port,
+                embed_url: SidecarLayout::embed_base_url(self.embed_http_port),
+            },
+            labels: self.labels.clone(),
+        }
+    }
+
+    pub fn activate_embed_url_default(&self) {
+        if std::env::var("CODESTORY_EMBED_LLAMACPP_URL").is_err() {
+            // SAFETY: this is command-local setup before sidecar probes/query embedding calls.
+            unsafe {
+                std::env::set_var(
+                    "CODESTORY_EMBED_LLAMACPP_URL",
+                    SidecarLayout::embed_base_url(self.embed_http_port),
+                );
+            }
+        }
+    }
+}
+
+impl SidecarLayout {
     pub fn zoekt_base_url(&self) -> String {
         format!("http://127.0.0.1:{}", self.zoekt_http_port)
     }
@@ -72,6 +276,95 @@ impl SidecarLayout {
         }
         Ok(())
     }
+}
+
+pub fn sidecar_runtime_for_project(
+    project_root: &Path,
+    profile: SidecarProfile,
+) -> SidecarRuntimeConfig {
+    SidecarRuntimeConfig::for_project_profile(Some(project_root), profile)
+}
+
+pub fn sidecar_runtime_auto(project_root: &Path) -> SidecarRuntimeConfig {
+    SidecarRuntimeConfig::for_project_auto(project_root)
+}
+
+fn env_profile() -> Option<SidecarProfile> {
+    std::env::var("CODESTORY_RETRIEVAL_PROFILE")
+        .ok()
+        .or_else(|| std::env::var("CODESTORY_SIDECAR_PROFILE").ok())
+        .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "agent" | "ci" => Some(SidecarProfile::Agent),
+            "local" | "dev" => Some(SidecarProfile::Local),
+            _ => None,
+        })
+}
+
+fn running_in_ci_agent() -> bool {
+    env_flag("CODESTORY_AGENT", false)
+        || env_flag("CODESTORY_AGENT_RUN", false)
+        || env_flag("CI", false)
+        || env_flag("GITHUB_ACTIONS", false)
+}
+
+fn namespace_for(project_root: Option<&Path>, profile: SidecarProfile) -> String {
+    match (profile, project_root) {
+        (SidecarProfile::Local, _) => "codestory".into(),
+        (SidecarProfile::Agent, Some(path)) => {
+            format!(
+                "codestory-agent-{}",
+                fnv1a_hex(path.to_string_lossy().as_bytes())
+            )
+        }
+        (SidecarProfile::Agent, None) => format!("codestory-agent-{}", std::process::id()),
+    }
+}
+
+fn agent_state_file(project_root: &Path) -> PathBuf {
+    user_cache_root()
+        .join("sidecars")
+        .join(namespace_for(Some(project_root), SidecarProfile::Agent))
+        .join("retrieval-sidecars.json")
+}
+
+fn read_ports_from_state(path: &Path) -> Option<SidecarPorts> {
+    let value =
+        serde_json::from_str::<serde_json::Value>(&std::fs::read_to_string(path).ok()?).ok()?;
+    Some(SidecarPorts {
+        zoekt_http: value.get("zoekt_http_port")?.as_u64()?.try_into().ok()?,
+        qdrant_http: value.get("qdrant_http_port")?.as_u64()?.try_into().ok()?,
+        qdrant_grpc: value.get("qdrant_grpc_port")?.as_u64()?.try_into().ok()?,
+        embed_http: value
+            .get("embed_http_port")
+            .and_then(|value| value.as_u64())
+            .and_then(|value| value.try_into().ok())
+            .unwrap_or(DEFAULT_EMBED_HTTP_PORT),
+        embed_url: value
+            .get("embed_url")
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| SidecarLayout::embed_base_url(DEFAULT_EMBED_HTTP_PORT)),
+    })
+}
+
+fn free_local_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .and_then(|listener| listener.local_addr())
+        .map(|addr| addr.port())
+        .unwrap_or(0)
+}
+
+fn fnv1a_hex(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn quote_command_path(path: &Path) -> String {
+    format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
 }
 
 pub fn user_cache_root() -> PathBuf {
@@ -102,11 +395,12 @@ pub fn retrieval_compose_profile() -> String {
         .unwrap_or_else(|| "real".to_string())
 }
 
-fn env_port(name: &str, default: u16) -> u16 {
+fn env_port(name: &str, default: u16) -> Option<u16> {
     std::env::var(name)
         .ok()
         .and_then(|value| value.parse().ok())
-        .unwrap_or(default)
+        .filter(|port| *port != 0)
+        .or(Some(default).filter(|_| std::env::var(name).is_ok()))
 }
 
 fn env_flag(name: &str, default: bool) -> bool {

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Phase 2 lexical shard pin (local index + optional Zoekt webserver).
 pub const ZOEKT_REAL_VERSION_PIN: &str = "zoekt-20250506123554";
@@ -27,6 +28,7 @@ pub const DEFAULT_EMBED_HTTP_PORT: u16 = 8080;
 
 pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
 pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
+static AGENT_RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct SidecarLayout {
@@ -80,6 +82,7 @@ pub struct SidecarOwnership {
 pub struct SidecarRuntimeConfig {
     pub layout: SidecarLayout,
     pub profile: SidecarProfile,
+    pub run_id: Option<String>,
     pub namespace: String,
     pub compose_project: String,
     pub embed_http_port: u16,
@@ -124,20 +127,35 @@ impl SidecarRuntimeConfig {
     }
 
     pub fn for_project_auto(project_root: &Path) -> Self {
+        let env_run_id = env_agent_run_id();
+        let latest_run_id = env_run_id
+            .is_none()
+            .then(|| latest_agent_run_id(project_root))
+            .flatten();
         let profile = if env_profile() == Some(SidecarProfile::Agent)
-            || agent_state_file(project_root).is_file()
+            || latest_run_id.is_some()
             || running_in_ci_agent()
         {
             SidecarProfile::Agent
         } else {
             SidecarProfile::Local
         };
-        Self::for_project_profile(Some(project_root), profile)
+        let run_id = env_run_id.or(latest_run_id);
+        Self::for_project_profile_with_run_id(Some(project_root), profile, run_id.as_deref())
     }
 
     pub fn for_project_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
+        Self::for_project_profile_with_run_id(project_root, profile, None)
+    }
+
+    pub fn for_project_profile_with_run_id(
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+    ) -> Self {
         let base = user_cache_root();
-        let namespace = namespace_for(project_root, profile);
+        let run_id = (profile == SidecarProfile::Agent).then(|| agent_run_id(run_id));
+        let namespace = namespace_for(project_root, profile, run_id.as_deref());
         let state_file = match profile {
             SidecarProfile::Local => base.join("retrieval-sidecars.json"),
             SidecarProfile::Agent => base
@@ -151,7 +169,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.zoekt_http))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "zoekt")
                 } else {
                     DEFAULT_ZOEKT_HTTP_PORT
                 }
@@ -160,7 +178,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.qdrant_http))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "qdrant-http")
                 } else {
                     DEFAULT_QDRANT_HTTP_PORT
                 }
@@ -169,7 +187,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.qdrant_grpc))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "qdrant-grpc")
                 } else {
                     DEFAULT_QDRANT_GRPC_PORT
                 }
@@ -178,7 +196,7 @@ impl SidecarRuntimeConfig {
             .or_else(|| stored.as_ref().map(|ports| ports.embed_http))
             .unwrap_or_else(|| {
                 if dynamic {
-                    free_local_port()
+                    dynamic_agent_port(&namespace, "embed")
                 } else {
                     DEFAULT_EMBED_HTTP_PORT
                 }
@@ -197,13 +215,7 @@ impl SidecarRuntimeConfig {
             state_file: state_file.clone(),
         };
         let cleanup_command = project_root
-            .map(|path| {
-                format!(
-                    "codestory-cli retrieval down --project {} --profile {}",
-                    quote_command_path(path),
-                    profile.as_str()
-                )
-            })
+            .map(|path| retrieval_command("down", path, profile, run_id.as_deref(), None))
             .unwrap_or_else(|| "codestory-cli retrieval down".to_string());
         let mut labels = BTreeMap::new();
         labels.insert("dev.codestory.owner".into(), "codestory".into());
@@ -212,6 +224,7 @@ impl SidecarRuntimeConfig {
         Self {
             layout,
             profile,
+            run_id,
             namespace: namespace.clone(),
             compose_project: namespace,
             embed_http_port,
@@ -285,6 +298,14 @@ pub fn sidecar_runtime_for_project(
     SidecarRuntimeConfig::for_project_profile(Some(project_root), profile)
 }
 
+pub fn sidecar_runtime_for_project_with_run_id(
+    project_root: &Path,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+) -> SidecarRuntimeConfig {
+    SidecarRuntimeConfig::for_project_profile_with_run_id(Some(project_root), profile, run_id)
+}
+
 pub fn sidecar_runtime_auto(project_root: &Path) -> SidecarRuntimeConfig {
     SidecarRuntimeConfig::for_project_auto(project_root)
 }
@@ -300,6 +321,13 @@ fn env_profile() -> Option<SidecarProfile> {
         })
 }
 
+fn env_agent_run_id() -> Option<String> {
+    std::env::var("CODESTORY_SIDECAR_RUN_ID")
+        .ok()
+        .or_else(|| std::env::var("CODESTORY_AGENT_RUN_ID").ok())
+        .and_then(|value| normalized_label_component(&value))
+}
+
 fn running_in_ci_agent() -> bool {
     env_flag("CODESTORY_AGENT", false)
         || env_flag("CODESTORY_AGENT_RUN", false)
@@ -307,24 +335,110 @@ fn running_in_ci_agent() -> bool {
         || env_flag("GITHUB_ACTIONS", false)
 }
 
-fn namespace_for(project_root: Option<&Path>, profile: SidecarProfile) -> String {
+fn namespace_for(
+    project_root: Option<&Path>,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+) -> String {
     match (profile, project_root) {
         (SidecarProfile::Local, _) => "codestory".into(),
         (SidecarProfile::Agent, Some(path)) => {
             format!(
-                "codestory-agent-{}",
-                fnv1a_hex(path.to_string_lossy().as_bytes())
+                "codestory-agent-{}-{}",
+                project_hash(path),
+                run_id.unwrap_or("run")
             )
         }
-        (SidecarProfile::Agent, None) => format!("codestory-agent-{}", std::process::id()),
+        (SidecarProfile::Agent, None) => format!(
+            "codestory-agent-{}-{}",
+            std::process::id(),
+            run_id.unwrap_or("run")
+        ),
     }
 }
 
-fn agent_state_file(project_root: &Path) -> PathBuf {
-    user_cache_root()
-        .join("sidecars")
-        .join(namespace_for(Some(project_root), SidecarProfile::Agent))
-        .join("retrieval-sidecars.json")
+fn project_hash(project_root: &Path) -> String {
+    fnv1a_hex(project_root.to_string_lossy().as_bytes())
+}
+
+fn agent_namespace_prefix(project_root: &Path) -> String {
+    format!("codestory-agent-{}-", project_hash(project_root))
+}
+
+fn latest_agent_run_id(project_root: &Path) -> Option<String> {
+    let prefix = agent_namespace_prefix(project_root);
+    let sidecars_root = user_cache_root().join("sidecars");
+    let entries = std::fs::read_dir(sidecars_root).ok()?;
+    let mut newest: Option<(std::time::SystemTime, String)> = None;
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let namespace = entry.file_name().to_string_lossy().to_string();
+        let Some(run_id) = namespace
+            .strip_prefix(&prefix)
+            .and_then(normalized_label_component)
+        else {
+            continue;
+        };
+        let state_file = entry.path().join("retrieval-sidecars.json");
+        if !state_file.is_file() {
+            continue;
+        }
+        let modified = state_file
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        if newest
+            .as_ref()
+            .is_none_or(|(current, _)| modified > *current)
+        {
+            newest = Some((modified, run_id));
+        }
+    }
+    newest.map(|(_, run_id)| run_id)
+}
+
+fn agent_run_id(explicit: Option<&str>) -> String {
+    explicit
+        .and_then(normalized_label_component)
+        .or_else(env_agent_run_id)
+        .unwrap_or_else(default_agent_run_id)
+}
+
+fn default_agent_run_id() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let counter = AGENT_RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{}-{nanos:x}-{counter:x}", std::process::id())
+}
+
+fn normalized_label_component(value: &str) -> Option<String> {
+    let mut normalized = String::with_capacity(value.len());
+    let mut previous_dash = false;
+    for ch in value.trim().chars() {
+        let next = if ch.is_ascii_alphanumeric() {
+            ch.to_ascii_lowercase()
+        } else {
+            '-'
+        };
+        if next == '-' {
+            if previous_dash {
+                continue;
+            }
+            previous_dash = true;
+        } else {
+            previous_dash = false;
+        }
+        normalized.push(next);
+    }
+    let normalized = normalized.trim_matches('-').to_string();
+    (!normalized.is_empty()).then_some(normalized)
 }
 
 fn read_ports_from_state(path: &Path) -> Option<SidecarPorts> {
@@ -347,6 +461,23 @@ fn read_ports_from_state(path: &Path) -> Option<SidecarPorts> {
     })
 }
 
+fn dynamic_agent_port(namespace: &str, salt: &str) -> u16 {
+    let seed = fnv1a_hex(format!("{namespace}:{salt}").as_bytes());
+    let parsed = u64::from_str_radix(&seed, 16).unwrap_or(0);
+    let base = 20_000 + u16::try_from(parsed % 40_000).unwrap_or(0);
+    for offset in 0..1000 {
+        let port = 20_000 + ((u32::from(base - 20_000) + offset) % 40_000) as u16;
+        if local_port_available(port) {
+            return port;
+        }
+    }
+    free_local_port()
+}
+
+fn local_port_available(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
 fn free_local_port() -> u16 {
     TcpListener::bind(("127.0.0.1", 0))
         .and_then(|listener| listener.local_addr())
@@ -365,6 +496,31 @@ fn fnv1a_hex(bytes: &[u8]) -> String {
 
 fn quote_command_path(path: &Path) -> String {
     format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
+}
+
+pub fn retrieval_command(
+    action: &str,
+    project_root: &Path,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+    extra_args: Option<&str>,
+) -> String {
+    let mut command = format!(
+        "codestory-cli retrieval {action} --project {}",
+        quote_command_path(project_root)
+    );
+    if profile == SidecarProfile::Agent {
+        command.push_str(" --profile agent");
+        if let Some(run_id) = run_id.and_then(normalized_label_component) {
+            command.push_str(" --run-id ");
+            command.push_str(&run_id);
+        }
+    }
+    if let Some(extra_args) = extra_args {
+        command.push(' ');
+        command.push_str(extra_args);
+    }
+    command
 }
 
 pub fn user_cache_root() -> PathBuf {
@@ -427,4 +583,61 @@ pub fn dir_size_bytes(path: &Path) -> u64 {
         }
     }
     total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn agent_profile_default_runtime_isolates_same_project_runs() {
+        let project = tempdir().expect("project");
+
+        let first =
+            SidecarRuntimeConfig::for_project_profile(Some(project.path()), SidecarProfile::Agent);
+        let second =
+            SidecarRuntimeConfig::for_project_profile(Some(project.path()), SidecarProfile::Agent);
+
+        assert_ne!(first.run_id, second.run_id);
+        assert_ne!(first.namespace, second.namespace);
+        assert_ne!(first.layout.state_file, second.layout.state_file);
+        assert_ne!(first.layout.zoekt_http_port, second.layout.zoekt_http_port);
+        assert_ne!(
+            first.layout.qdrant_http_port,
+            second.layout.qdrant_http_port
+        );
+        assert_ne!(
+            first.layout.qdrant_grpc_port,
+            second.layout.qdrant_grpc_port
+        );
+        assert_ne!(first.embed_http_port, second.embed_http_port);
+    }
+
+    #[test]
+    fn agent_profile_run_id_reuses_namespace_state_and_ports() {
+        let project = tempdir().expect("project");
+
+        let first = SidecarRuntimeConfig::for_project_profile_with_run_id(
+            Some(project.path()),
+            SidecarProfile::Agent,
+            Some("review-fix"),
+        );
+        let second = SidecarRuntimeConfig::for_project_profile_with_run_id(
+            Some(project.path()),
+            SidecarProfile::Agent,
+            Some("review-fix"),
+        );
+
+        assert_eq!(first.run_id.as_deref(), Some("review-fix"));
+        assert_eq!(first.namespace, second.namespace);
+        assert_eq!(first.layout.state_file, second.layout.state_file);
+        assert_eq!(first.layout.zoekt_http_port, second.layout.zoekt_http_port);
+        assert_eq!(
+            first.layout.qdrant_http_port,
+            second.layout.qdrant_http_port
+        );
+        assert!(first.cleanup_command.contains("--profile agent"));
+        assert!(first.cleanup_command.contains("--run-id review-fix"));
+    }
 }

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,6 +1,7 @@
 use crate::capabilities::SidecarCapabilities;
 use crate::config::{
-    QDRANT_HEALTH_BUDGET, SidecarLayout, ZOEKT_HEALTH_BUDGET, qdrant_semantic_vectors_enabled,
+    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, ZOEKT_HEALTH_BUDGET,
+    qdrant_semantic_vectors_enabled,
 };
 use crate::embeddings::manifest_embedding_backend_is_product;
 use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
@@ -72,6 +73,8 @@ pub struct RetrievalRepairHint {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetrievalStatusReport {
     pub retrieval_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ownership: Option<SidecarOwnership>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -301,6 +304,7 @@ pub fn unavailable_status_report(
         .and_then(|manifest| manifest.embedding_dim);
     RetrievalStatusReport {
         retrieval_mode: "unavailable".into(),
+        ownership: None,
         degraded_reason: Some(reason.clone()),
         repair: None,
         query_embedding_backend: crate::embeddings::embedding_runtime_id(),
@@ -575,6 +579,7 @@ pub fn probe_sidecar_health(
 
     RetrievalStatusReport {
         retrieval_mode: mode.as_str().into(),
+        ownership: None,
         degraded_reason,
         repair: None,
         query_embedding_backend: current_embedding_backend,
@@ -789,6 +794,7 @@ mod tests {
         };
         let report = RetrievalStatusReport {
             retrieval_mode: "full".into(),
+            ownership: None,
             degraded_reason: None,
             query_embedding_backend: "llamacpp:bge-base-en-v1.5".into(),
             manifest_vector_embedding_backend: manifest.embedding_backend.clone(),

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,7 +1,7 @@
 use crate::capabilities::SidecarCapabilities;
 use crate::config::{
-    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, ZOEKT_HEALTH_BUDGET,
-    qdrant_semantic_vectors_enabled,
+    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, SidecarProfile, SidecarRuntimeConfig,
+    ZOEKT_HEALTH_BUDGET, qdrant_semantic_vectors_enabled, retrieval_command,
 };
 use crate::embeddings::manifest_embedding_backend_is_product;
 use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
@@ -113,6 +113,7 @@ pub fn attach_manifest_contract(
 pub fn attach_repair_hint(
     mut report: RetrievalStatusReport,
     project_root: &Path,
+    runtime: Option<&SidecarRuntimeConfig>,
 ) -> RetrievalStatusReport {
     if report.retrieval_mode == "full" {
         return report;
@@ -123,11 +124,32 @@ pub fn attach_repair_hint(
             .as_deref()
             .unwrap_or("sidecar_retrieval_not_full"),
     );
-    let project = quote_command_path(project_root);
+    let profile = runtime
+        .map(|runtime| runtime.profile)
+        .unwrap_or(SidecarProfile::Local);
+    let run_id = runtime.and_then(|runtime| runtime.run_id.as_deref());
     let full_repair = vec![
-        format!("codestory-cli retrieval bootstrap --project {project} --format json"),
-        format!("codestory-cli retrieval index --project {project} --refresh full --format json"),
-        format!("codestory-cli retrieval status --project {project} --format json"),
+        retrieval_command(
+            "bootstrap",
+            project_root,
+            profile,
+            run_id,
+            Some("--format json"),
+        ),
+        retrieval_command(
+            "index",
+            project_root,
+            profile,
+            run_id,
+            Some("--refresh full --format json"),
+        ),
+        retrieval_command(
+            "status",
+            project_root,
+            profile,
+            run_id,
+            Some("--format json"),
+        ),
     ];
     report.repair = Some(RetrievalRepairHint {
         reason,
@@ -145,10 +167,6 @@ fn repair_reason_code(degraded_reason: &str) -> String {
         return "sidecar_manifest_stale".into();
     }
     degraded_reason.to_string()
-}
-
-fn quote_command_path(path: &Path) -> String {
-    format!("\"{}\"", path.display().to_string().replace('"', "\\\""))
 }
 
 fn manifest_contract_report(
@@ -606,6 +624,7 @@ mod tests {
         let report = attach_repair_hint(
             unavailable_status_report("retrieval_manifest_missing", None),
             Path::new("C:/repo with spaces"),
+            None,
         );
         let repair = report.repair.expect("repair hint");
 
@@ -634,6 +653,7 @@ mod tests {
         let report = attach_repair_hint(
             unavailable_status_report(detailed, None),
             Path::new("C:/repo"),
+            None,
         );
         let repair = report.repair.expect("repair hint");
 

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -115,7 +115,7 @@ pub fn repair_project_qdrant_collection(
         }));
     }
 
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     layout.ensure_data_dirs()?;
     let qdrant_client = QdrantClient::new(&layout);
     let probe = qdrant_client.health_probe(&manifest.qdrant_collection);
@@ -179,7 +179,7 @@ pub fn repair_project_qdrant_collection(
 }
 
 pub fn finalize_index(project_root: &Path, storage_path: &Path) -> Result<FinalizeIndexOutcome> {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     layout.ensure_data_dirs()?;
 
     let project_id = sidecar_project_id_for_root(project_root);

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -43,12 +43,14 @@ pub use capabilities::SidecarCapabilities;
 #[allow(deprecated)]
 pub use compose::bootstrap_sidecars_without_storage_scope;
 pub use compose::{
-    BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, docker_available,
-    resolve_compose_file,
+    BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, bootstrap_sidecars_with_profile,
+    docker_available, resolve_compose_file,
 };
 pub use config::{
-    DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN,
-    SidecarLayout, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
+    DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT,
+    DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarLayout, SidecarOwnership, SidecarPorts,
+    SidecarProfile, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
+    sidecar_runtime_auto, sidecar_runtime_for_project,
 };
 pub use config::{qdrant_enabled, qdrant_semantic_vectors_enabled};
 pub use embeddings::qdrant_vector_dim;
@@ -86,7 +88,8 @@ pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
 pub use scip_client::ScipClient;
 pub use sidecar::{
-    SidecarStateFile, sidecar_down, sidecar_status, sidecar_up, strict_sidecar_status,
+    SidecarStateFile, sidecar_down, sidecar_down_for_project, sidecar_status, sidecar_up,
+    sidecar_up_with_runtime, strict_sidecar_status, strict_sidecar_status_for_profile,
 };
 pub use sidecar_search::{LiveSidecarSearch, SidecarSearch};
 pub use zoekt_client::ZoektClient;

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -44,13 +44,13 @@ pub use capabilities::SidecarCapabilities;
 pub use compose::bootstrap_sidecars_without_storage_scope;
 pub use compose::{
     BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, bootstrap_sidecars_with_profile,
-    docker_available, resolve_compose_file,
+    bootstrap_sidecars_with_runtime, docker_available, resolve_compose_file,
 };
 pub use config::{
     DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT,
     DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarLayout, SidecarOwnership, SidecarPorts,
     SidecarProfile, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
-    sidecar_runtime_auto, sidecar_runtime_for_project,
+    sidecar_runtime_auto, sidecar_runtime_for_project, sidecar_runtime_for_project_with_run_id,
 };
 pub use config::{qdrant_enabled, qdrant_semantic_vectors_enabled};
 pub use embeddings::qdrant_vector_dim;
@@ -88,8 +88,9 @@ pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
 pub use scip_client::ScipClient;
 pub use sidecar::{
-    SidecarStateFile, sidecar_down, sidecar_down_for_project, sidecar_status, sidecar_up,
-    sidecar_up_with_runtime, strict_sidecar_status, strict_sidecar_status_for_profile,
+    SidecarStateFile, sidecar_down, sidecar_down_for_project, sidecar_down_for_runtime,
+    sidecar_status, sidecar_up, sidecar_up_with_runtime, strict_sidecar_status,
+    strict_sidecar_status_for_profile, strict_sidecar_status_for_runtime,
 };
 pub use sidecar_search::{LiveSidecarSearch, SidecarSearch};
 pub use zoekt_client::ZoektClient;

--- a/crates/codestory-retrieval/src/qdrant_storage.rs
+++ b/crates/codestory-retrieval/src/qdrant_storage.rs
@@ -114,6 +114,7 @@ pub fn repair_qdrant_storage(
             &protected,
             &scan.recency_by_collection,
             max_keep,
+            &mut scan.scan_errors,
         )?
     };
 
@@ -473,6 +474,7 @@ fn execute_retention_on_disk(
     protected: &HashSet<String>,
     recency_by_collection: &HashMap<String, i64>,
     max_keep: usize,
+    repair_errors: &mut Vec<String>,
 ) -> Result<(usize, usize, usize, bool)> {
     let all = list_on_disk_codestory_collections(qdrant_data_dir, recency_by_collection)?;
     let collections_seen = all.len();
@@ -482,14 +484,22 @@ fn execute_retention_on_disk(
     for name in plan.to_prune {
         let path = qdrant_data_dir.join("collections").join(&name);
         if path.is_dir() {
-            std::fs::remove_dir_all(&path).with_context(|| {
-                format!(
-                    "remove stale qdrant collection dir beyond retention {}",
-                    path.display()
-                )
-            })?;
-            QdrantClient::clear_stub_marker_files(qdrant_data_dir, &name);
-            removed += 1;
+            match std::fs::remove_dir_all(&path) {
+                Ok(()) => {
+                    QdrantClient::clear_stub_marker_files(qdrant_data_dir, &name);
+                    removed += 1;
+                }
+                Err(error) => {
+                    warn!(
+                        collection = %name,
+                        %error,
+                        "failed to prune stale Qdrant collection dir; continuing bootstrap repair"
+                    );
+                    repair_errors.push(format!(
+                        "remove stale qdrant collection dir {name}: {error}"
+                    ));
+                }
+            }
         }
     }
     Ok((
@@ -612,8 +622,14 @@ mod tests {
             }
             thread::sleep(Duration::from_millis(5));
         }
-        let (pruned, seen, _, overflow) =
-            execute_retention_on_disk(root.path(), &protected, &HashMap::new(), 64).expect("prune");
+        let (pruned, seen, _, overflow) = execute_retention_on_disk(
+            root.path(),
+            &protected,
+            &HashMap::new(),
+            64,
+            &mut Vec::new(),
+        )
+        .expect("prune");
         assert!(pruned > 0);
         assert_eq!(seen, 65);
         assert!(!overflow);

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -240,7 +240,7 @@ struct QueryContext {
 }
 
 fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryContext> {
-    let layout = SidecarLayout::from_env();
+    let layout = SidecarLayout::from_env_for_project(project_root);
     let project_id = sidecar_project_id_for_root(project_root);
     let (manifest, file_roles) = if storage_path.exists() {
         let storage = Store::open(storage_path).context("open storage for query")?;

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1,4 +1,7 @@
-use crate::config::SidecarLayout;
+use crate::config::{
+    SidecarLayout, SidecarProfile, SidecarRuntimeConfig, sidecar_runtime_auto,
+    sidecar_runtime_for_project,
+};
 use crate::generation::{
     SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
     manifest_staleness_reason, manifest_unavailable_reason,
@@ -22,25 +25,56 @@ use std::path::Path;
 /// The file records local sidecar endpoints and data roots only. It is not a readiness manifest;
 /// callers must use `sidecar_status` or `strict_sidecar_status` before trusting retrieval output.
 pub struct SidecarStateFile {
+    #[serde(default = "default_sidecar_owner")]
+    pub owner: String,
+    #[serde(default = "default_sidecar_profile")]
+    pub profile: String,
+    #[serde(default = "default_sidecar_namespace")]
+    pub namespace: String,
+    #[serde(default = "default_sidecar_namespace")]
+    pub compose_project: String,
     pub zoekt_http_port: u16,
     pub qdrant_http_port: u16,
     pub qdrant_grpc_port: u16,
+    #[serde(default = "default_embed_http_port")]
+    pub embed_http_port: u16,
+    #[serde(default = "default_embed_url")]
+    pub embed_url: String,
     pub zoekt_data_dir: String,
     pub qdrant_data_dir: String,
     pub scip_artifacts_root: String,
+    #[serde(default)]
+    pub compose_file: Option<String>,
+    #[serde(default)]
+    pub cleanup_command: String,
     pub started_at_epoch_ms: i64,
 }
 
 pub fn sidecar_up() -> Result<SidecarStateFile> {
-    let layout = SidecarLayout::from_env();
+    sidecar_up_with_runtime(&SidecarRuntimeConfig::local(), None)
+}
+
+pub fn sidecar_up_with_runtime(
+    runtime: &SidecarRuntimeConfig,
+    compose_file: Option<&Path>,
+) -> Result<SidecarStateFile> {
+    let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
     let state = SidecarStateFile {
+        owner: "codestory".into(),
+        profile: runtime.profile.as_str().into(),
+        namespace: runtime.namespace.clone(),
+        compose_project: runtime.compose_project.clone(),
         zoekt_http_port: layout.zoekt_http_port,
         qdrant_http_port: layout.qdrant_http_port,
         qdrant_grpc_port: layout.qdrant_grpc_port,
+        embed_http_port: runtime.embed_http_port,
+        embed_url: SidecarLayout::embed_base_url(runtime.embed_http_port),
         zoekt_data_dir: layout.zoekt_data_dir.display().to_string(),
         qdrant_data_dir: layout.qdrant_data_dir.display().to_string(),
         scip_artifacts_root: layout.scip_artifacts_root.display().to_string(),
+        compose_file: compose_file.map(|path| path.display().to_string()),
+        cleanup_command: runtime.cleanup_command.clone(),
         started_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
     };
     let json = serde_json::to_string_pretty(&state).context("serialize sidecar state")?;
@@ -49,8 +83,25 @@ pub fn sidecar_up() -> Result<SidecarStateFile> {
 }
 
 pub fn sidecar_down() -> Result<()> {
-    let layout = SidecarLayout::from_env();
+    sidecar_down_for_runtime(&SidecarRuntimeConfig::local())
+}
+
+pub fn sidecar_down_for_project(project_root: &Path, profile: SidecarProfile) -> Result<()> {
+    sidecar_down_for_runtime(&sidecar_runtime_for_project(project_root, profile))
+}
+
+pub fn sidecar_down_for_runtime(runtime: &SidecarRuntimeConfig) -> Result<()> {
+    let layout = &runtime.layout;
     if layout.state_file.exists() {
+        if runtime.profile == SidecarProfile::Agent
+            && let Some(state) = std::fs::read_to_string(&layout.state_file)
+                .ok()
+                .and_then(|contents| serde_json::from_str::<SidecarStateFile>(&contents).ok())
+            && state.owner == "codestory"
+            && state.namespace == runtime.namespace
+        {
+            crate::compose::docker_compose_down_for_state(&state)?;
+        }
         std::fs::remove_file(&layout.state_file).context("remove retrieval-sidecars.json")?;
     }
     Ok(())
@@ -77,12 +128,36 @@ pub fn strict_sidecar_status(
     sidecar_status_inner(project_root, storage_path, true)
 }
 
+pub fn strict_sidecar_status_for_profile(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    profile: SidecarProfile,
+) -> Result<RetrievalStatusReport> {
+    sidecar_status_inner_with_runtime(
+        project_root,
+        storage_path,
+        true,
+        sidecar_runtime_for_project(project_root, profile),
+    )
+}
+
 fn sidecar_status_inner(
     project_root: &Path,
     storage_path: Option<&Path>,
     strict: bool,
 ) -> Result<RetrievalStatusReport> {
-    let layout = SidecarLayout::from_env();
+    let runtime = sidecar_runtime_auto(project_root);
+    sidecar_status_inner_with_runtime(project_root, storage_path, strict, runtime)
+}
+
+fn sidecar_status_inner_with_runtime(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    strict: bool,
+    runtime: SidecarRuntimeConfig,
+) -> Result<RetrievalStatusReport> {
+    runtime.activate_embed_url_default();
+    let layout = runtime.layout.clone();
     let project_id = sidecar_project_id_for_root(project_root);
     let manifest = if let Some(path) = storage_path.filter(|path| path.exists()) {
         let storage = Store::open(path).context("open storage for manifest")?;
@@ -100,49 +175,72 @@ fn sidecar_status_inner(
             )
             .context("check strict sidecar readiness")?
         {
-            return Ok(enrich_status_with_semantic_doc_stats(
-                attach_repair_hint(
-                    attach_manifest_contract(
-                        crate::health::unavailable_status_report(
-                            format!("sidecar_manifest_stale: {reason}"),
-                            Some(manifest.clone()),
+            return Ok(attach_status_ownership(
+                enrich_status_with_semantic_doc_stats(
+                    attach_repair_hint(
+                        attach_manifest_contract(
+                            crate::health::unavailable_status_report(
+                                format!("sidecar_manifest_stale: {reason}"),
+                                Some(manifest.clone()),
+                            ),
+                            project_root,
                         ),
                         project_root,
                     ),
-                    project_root,
+                    &storage,
                 ),
-                &storage,
+                &runtime,
             ));
         }
         if let Some(manifest) = manifest.as_ref()
             && let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest)
         {
-            return Ok(enrich_status_with_semantic_doc_stats(
-                attach_repair_hint(
-                    attach_manifest_contract(
-                        crate::health::unavailable_status_report(reason, Some(manifest.clone())),
+            return Ok(attach_status_ownership(
+                enrich_status_with_semantic_doc_stats(
+                    attach_repair_hint(
+                        attach_manifest_contract(
+                            crate::health::unavailable_status_report(
+                                reason,
+                                Some(manifest.clone()),
+                            ),
+                            project_root,
+                        ),
                         project_root,
                     ),
-                    project_root,
+                    &storage,
                 ),
-                &storage,
+                &runtime,
             ));
         }
         let report = probe_sidecar_health(&layout, &project_id, manifest);
-        return Ok(enrich_status_with_semantic_doc_stats(
-            attach_repair_hint(attach_manifest_contract(report, project_root), project_root),
-            &storage,
+        return Ok(attach_status_ownership(
+            enrich_status_with_semantic_doc_stats(
+                attach_repair_hint(attach_manifest_contract(report, project_root), project_root),
+                &storage,
+            ),
+            &runtime,
         ));
     } else {
         None
     };
-    Ok(attach_repair_hint(
-        attach_manifest_contract(
-            probe_sidecar_health(&layout, &project_id, manifest),
+    Ok(attach_status_ownership(
+        attach_repair_hint(
+            attach_manifest_contract(
+                probe_sidecar_health(&layout, &project_id, manifest),
+                project_root,
+            ),
             project_root,
         ),
-        project_root,
+        &runtime,
     ))
+}
+
+fn attach_status_ownership(
+    mut report: RetrievalStatusReport,
+    runtime: &SidecarRuntimeConfig,
+) -> RetrievalStatusReport {
+    report.ownership = Some(runtime.ownership());
+    report
 }
 
 fn enrich_status_with_semantic_doc_stats(
@@ -291,6 +389,26 @@ fn manifest_contract_drift_should_win(reason: &str) -> bool {
     reason.contains("sidecar_embedding_backend_changed")
         || reason.contains("sidecar_embedding_dim_changed")
         || reason == SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED
+}
+
+fn default_sidecar_owner() -> String {
+    "codestory".into()
+}
+
+fn default_sidecar_profile() -> String {
+    "local".into()
+}
+
+fn default_sidecar_namespace() -> String {
+    "codestory".into()
+}
+
+fn default_embed_http_port() -> u16 {
+    crate::config::DEFAULT_EMBED_HTTP_PORT
+}
+
+fn default_embed_url() -> String {
+    SidecarLayout::embed_base_url(crate::config::DEFAULT_EMBED_HTTP_PORT)
 }
 
 #[cfg(test)]

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -33,6 +33,8 @@ pub struct SidecarStateFile {
     pub namespace: String,
     #[serde(default = "default_sidecar_namespace")]
     pub compose_project: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
     pub zoekt_http_port: u16,
     pub qdrant_http_port: u16,
     pub qdrant_grpc_port: u16,
@@ -65,6 +67,7 @@ pub fn sidecar_up_with_runtime(
         profile: runtime.profile.as_str().into(),
         namespace: runtime.namespace.clone(),
         compose_project: runtime.compose_project.clone(),
+        run_id: runtime.run_id.clone(),
         zoekt_http_port: layout.zoekt_http_port,
         qdrant_http_port: layout.qdrant_http_port,
         qdrant_grpc_port: layout.qdrant_grpc_port,
@@ -133,12 +136,19 @@ pub fn strict_sidecar_status_for_profile(
     storage_path: Option<&Path>,
     profile: SidecarProfile,
 ) -> Result<RetrievalStatusReport> {
-    sidecar_status_inner_with_runtime(
+    strict_sidecar_status_for_runtime(
         project_root,
         storage_path,
-        true,
         sidecar_runtime_for_project(project_root, profile),
     )
+}
+
+pub fn strict_sidecar_status_for_runtime(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    runtime: SidecarRuntimeConfig,
+) -> Result<RetrievalStatusReport> {
+    sidecar_status_inner_with_runtime(project_root, storage_path, true, runtime)
 }
 
 fn sidecar_status_inner(
@@ -186,6 +196,7 @@ fn sidecar_status_inner_with_runtime(
                             project_root,
                         ),
                         project_root,
+                        Some(&runtime),
                     ),
                     &storage,
                 ),
@@ -206,6 +217,7 @@ fn sidecar_status_inner_with_runtime(
                             project_root,
                         ),
                         project_root,
+                        Some(&runtime),
                     ),
                     &storage,
                 ),
@@ -215,7 +227,11 @@ fn sidecar_status_inner_with_runtime(
         let report = probe_sidecar_health(&layout, &project_id, manifest);
         return Ok(attach_status_ownership(
             enrich_status_with_semantic_doc_stats(
-                attach_repair_hint(attach_manifest_contract(report, project_root), project_root),
+                attach_repair_hint(
+                    attach_manifest_contract(report, project_root),
+                    project_root,
+                    Some(&runtime),
+                ),
                 &storage,
             ),
             &runtime,
@@ -230,6 +246,7 @@ fn sidecar_status_inner_with_runtime(
                 project_root,
             ),
             project_root,
+            Some(&runtime),
         ),
         &runtime,
     ))

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -9216,6 +9216,8 @@ mod tests {
         let generic = PacketClaimDto {
             claim: "Runtime orchestration is anchored by `RuntimeCoordinator`; inspect it there."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "RuntimeCoordinator",
                 "src/runtime.rs",
@@ -9227,6 +9229,8 @@ mod tests {
         let causal = PacketClaimDto {
             claim: "`RuntimeCoordinator` coordinates runtime state transitions and downstream service calls."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "RuntimeCoordinator",
                 "src/runtime.rs",
@@ -9239,6 +9243,8 @@ mod tests {
             claim:
                 "`Session.send` in `src/requests/sessions.py` ties request, session in this flow to cited definitions and adjacent ownership."
                     .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "Session.send",
                 "src/requests/sessions.py",
@@ -9251,6 +9257,8 @@ mod tests {
             claim:
                 "`PreparedRequest` is defined in cited source `src/requests/models.py` and should be treated as an exact source anchor for this flow."
                     .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![test_packet_citation(
                 "PreparedRequest",
                 "src/requests/models.py",
@@ -9272,6 +9280,8 @@ mod tests {
             PacketClaimDto {
                 claim: "The public useSWR export wraps useSWRHandler with argument normalization."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "useSWRHandler",
                     "src/index/use-swr.ts",
@@ -9282,6 +9292,8 @@ mod tests {
             },
             PacketClaimDto {
                 claim: "useSWRHandler serializes the key before reading cache state.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "serialize",
                     "src/_internal/utils/serialize.ts",
@@ -9294,6 +9306,8 @@ mod tests {
                 claim:
                     "createCacheHelper provides cache get, set, subscribe, and snapshot helpers."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "createCacheHelper",
                     "src/_internal/utils/helper.ts",
@@ -9305,6 +9319,8 @@ mod tests {
             PacketClaimDto {
                 claim: "internalMutate routes mutate behavior through the mutation helper."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "internalMutate",
                     "src/_internal/utils/mutate.ts",
@@ -9348,6 +9364,8 @@ mod tests {
                 claim:
                     "StringUtils.isBlank treats null, empty, and whitespace-only inputs as blank."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "StringUtils.isBlank",
                     "src/main/java/org/apache/commons/lang3/StringUtils.java",
@@ -9359,6 +9377,8 @@ mod tests {
             PacketClaimDto {
                 claim: "StringUtils.isEmpty does not trim whitespace before deciding emptiness."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "StringUtils.isEmpty",
                     "src/main/java/org/apache/commons/lang3/StringUtils.java",
@@ -9370,6 +9390,8 @@ mod tests {
             PacketClaimDto {
                 claim: "Strings delegates region matching work to CharSequenceUtils.regionMatches."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: vec![test_packet_citation(
                     "Strings.regionMatches",
                     "src/main/java/org/apache/commons/lang3/Strings.java",

--- a/crates/codestory-runtime/src/agent/packet_budget.rs
+++ b/crates/codestory-runtime/src/agent/packet_budget.rs
@@ -822,6 +822,8 @@ mod tests {
             covered_claims: vec![PacketClaimDto {
                 claim: "Packet budget ownership is covered by cited runtime and contract anchors."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: answer.citations.clone(),
                 coverage_role: Some("source evidence".to_string()),
                 eligible_for_sufficiency: Some(true),

--- a/crates/codestory-runtime/src/agent/packet_claims.rs
+++ b/crates/codestory-runtime/src/agent/packet_claims.rs
@@ -8,6 +8,9 @@ use crate::agent::packet_claim_profiles::{
     packet_source_derived_claim_for_role, packet_source_derived_claims_for_citation,
 };
 use crate::agent::packet_command_profiles::packet_append_command_flow_template_claims;
+use crate::agent::packet_evidence::{
+    citation_sufficiency_eligible, evidence_resolution_for_citation, evidence_tier_for_citation,
+};
 use crate::agent::packet_evidence_roles::{
     PacketEvidenceRole, packet_claim_key_for_citation, packet_evidence_role,
 };
@@ -18,7 +21,10 @@ use crate::agent::packet_scoring::{
 };
 use crate::agent::packet_terms::{packet_probe_terms, packet_terms_indicate_sql_schema_flow};
 use crate::query_mentions_non_primary_source;
-use codestory_contracts::api::{AgentAnswerDto, AgentCitationDto, PacketClaimDto};
+use codestory_contracts::api::{
+    AgentAnswerDto, AgentCitationDto, PacketClaimDto, PacketEvidenceResolutionDto,
+    PacketEvidenceTierDto, PacketProofStatusDto,
+};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::fmt::Write as _;
@@ -56,7 +62,59 @@ pub(crate) fn packet_supported_claims(answer: &AgentAnswerDto) -> Vec<PacketClai
         &mut claims,
         &mut seen_claims,
     );
+    decorate_packet_claims_proof_metadata(&mut claims);
     claims
+}
+
+pub(crate) fn decorate_packet_claims_proof_metadata(claims: &mut [PacketClaimDto]) {
+    for claim in claims {
+        decorate_packet_claim_proof_metadata(claim);
+    }
+}
+
+fn decorate_packet_claim_proof_metadata(claim: &mut PacketClaimDto) {
+    let proven_tier = claim
+        .citations
+        .iter()
+        .find(|citation| citation_sufficiency_eligible(citation))
+        .map(evidence_tier_for_citation);
+    claim.required_evidence_role = Some(proven_tier.unwrap_or(PacketEvidenceTierDto::ExactSource));
+    claim.proof_status = Some(packet_claim_proof_status(claim, proven_tier.is_some()));
+}
+
+fn packet_claim_proof_status(
+    claim: &PacketClaimDto,
+    has_proof_bearing_citation: bool,
+) -> PacketProofStatusDto {
+    if claim.citations.is_empty() {
+        return PacketProofStatusDto::Unsupported;
+    }
+    if has_proof_bearing_citation && claim.eligible_for_sufficiency != Some(false) {
+        return PacketProofStatusDto::Proven;
+    }
+    if claim
+        .citations
+        .iter()
+        .all(packet_citation_is_diagnostic_only)
+    {
+        return PacketProofStatusDto::Diagnostic;
+    }
+    PacketProofStatusDto::Likely
+}
+
+fn packet_citation_is_diagnostic_only(citation: &AgentCitationDto) -> bool {
+    if citation.eligible_for_sufficiency == Some(false) {
+        return true;
+    }
+    matches!(
+        evidence_tier_for_citation(citation),
+        PacketEvidenceTierDto::DenseSemantic
+            | PacketEvidenceTierDto::GeneratedSummary
+            | PacketEvidenceTierDto::SyntheticSourceScan
+    ) || matches!(
+        evidence_resolution_for_citation(citation),
+        PacketEvidenceResolutionDto::DiagnosticOnly
+    )
 }
 
 pub(crate) fn append_flow_template_claims(
@@ -504,6 +562,8 @@ fn packet_push_flow_template_claim_with_citations(
     }
     claims.push(PacketClaimDto {
         claim: claim_text.to_string(),
+        proof_status: None,
+        required_evidence_role: None,
         citations,
         coverage_role: Some("flow template".to_string()),
         eligible_for_sufficiency: Some(true),
@@ -534,6 +594,8 @@ pub(crate) fn append_ranked_citation_claims(
             if seen_claims.insert(key) {
                 claims.push(PacketClaimDto {
                     claim: shaped,
+                    proof_status: None,
+                    required_evidence_role: None,
                     citations: vec![citation.clone()],
                     coverage_role: citation.coverage_role.clone(),
                     eligible_for_sufficiency: Some(false),
@@ -563,6 +625,8 @@ pub(crate) fn append_ranked_citation_claims(
         }
         claims.push(PacketClaimDto {
             claim: packet_claim_for_role(role, citation, prompt, rank_terms),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![citation.clone()],
             coverage_role: Some(role.as_str().to_string()),
             eligible_for_sufficiency: Some(true),
@@ -819,6 +883,8 @@ fn packet_push_claim(
     }
     claims.push(PacketClaimDto {
         claim: claim_text.to_string(),
+        proof_status: None,
+        required_evidence_role: None,
         citations: citation.map(|value| vec![value]).unwrap_or_default(),
         coverage_role: Some("source definition".to_string()),
         eligible_for_sufficiency: Some(false),
@@ -947,7 +1013,7 @@ mod tests {
     use super::*;
     use codestory_contracts::api::{
         AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto, AgentRetrievalTraceDto, NodeId,
-        NodeKind, RetrievalScoreBreakdownDto, SearchHitOrigin,
+        NodeKind, PacketProofStatusDto, RetrievalScoreBreakdownDto, SearchHitOrigin,
     };
 
     fn test_answer(prompt: &str, citations: Vec<AgentCitationDto>) -> AgentAnswerDto {
@@ -1008,6 +1074,53 @@ mod tests {
             coverage_role: None,
             eligible_for_sufficiency: Some(true),
         }
+    }
+
+    #[test]
+    fn generated_summary_and_dense_claims_need_backing_source_proof() {
+        let mut generated = test_citation("generated summary", "target/generated/summary.md", 0.9);
+        generated.evidence_tier = Some(PacketEvidenceTierDto::GeneratedSummary);
+        generated.resolution_status = Some(PacketEvidenceResolutionDto::DiagnosticOnly);
+        generated.eligible_for_sufficiency = None;
+
+        let mut dense = test_citation("dense anchor", "src/runtime.rs", 0.8);
+        dense.evidence_tier = Some(PacketEvidenceTierDto::DenseSemantic);
+        dense.resolution_status = Some(PacketEvidenceResolutionDto::Resolved);
+        dense.eligible_for_sufficiency = None;
+
+        let mut claims = vec![PacketClaimDto {
+            claim: "Runtime dispatch is covered.".to_string(),
+            proof_status: None,
+            required_evidence_role: None,
+            citations: vec![generated, dense],
+            coverage_role: Some("source evidence".to_string()),
+            eligible_for_sufficiency: Some(true),
+        }];
+
+        decorate_packet_claims_proof_metadata(&mut claims);
+
+        assert_eq!(
+            claims[0].proof_status,
+            Some(PacketProofStatusDto::Diagnostic)
+        );
+        assert_eq!(
+            claims[0].required_evidence_role,
+            Some(PacketEvidenceTierDto::ExactSource)
+        );
+
+        let mut exact_source = test_citation("dispatch", "src/runtime.rs", 1.0);
+        exact_source.evidence_tier = Some(PacketEvidenceTierDto::ExactSource);
+        exact_source.resolution_status = Some(PacketEvidenceResolutionDto::SourceRangeOnly);
+        exact_source.eligible_for_sufficiency = Some(true);
+        claims[0].citations.push(exact_source);
+
+        decorate_packet_claims_proof_metadata(&mut claims);
+
+        assert_eq!(claims[0].proof_status, Some(PacketProofStatusDto::Proven));
+        assert_eq!(
+            claims[0].required_evidence_role,
+            Some(PacketEvidenceTierDto::ExactSource)
+        );
     }
 
     fn write_sql_fixture(name: &str) -> std::path::PathBuf {

--- a/crates/codestory-runtime/src/agent/packet_command_profiles.rs
+++ b/crates/codestory-runtime/src/agent/packet_command_profiles.rs
@@ -364,6 +364,8 @@ fn packet_push_flow_template_claim_with_citations(
     }
     claims.push(PacketClaimDto {
         claim: claim_text.to_string(),
+        proof_status: None,
+        required_evidence_role: None,
         citations,
         coverage_role: Some("command profile".to_string()),
         eligible_for_sufficiency: Some(true),

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -199,9 +199,12 @@ pub(crate) fn evidence_producer_for_hit(hit: &SearchHit) -> String {
     }
 }
 
-fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
+pub(crate) fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier {
     if citation_is_diagnostic_source_proof(citation) {
         return PacketEvidenceTier::ExactSource;
+    }
+    if let Some(tier) = citation.evidence_tier {
+        return tier;
     }
     if let Some(breakdown) = citation.retrieval_score_breakdown.as_ref() {
         if breakdown.provenance.iter().any(|value| {
@@ -227,13 +230,18 @@ fn evidence_tier_for_citation(citation: &AgentCitationDto) -> PacketEvidenceTier
     }
 }
 
-fn evidence_resolution_for_citation(citation: &AgentCitationDto) -> PacketEvidenceResolution {
+pub(crate) fn evidence_resolution_for_citation(
+    citation: &AgentCitationDto,
+) -> PacketEvidenceResolution {
     if citation_is_diagnostic_source_proof(citation) {
         return if citation.file_path.is_some() && citation.line.is_some() {
             PacketEvidenceResolution::SourceRangeOnly
         } else {
             PacketEvidenceResolution::Unresolved
         };
+    }
+    if let Some(resolution) = citation.resolution_status {
+        return resolution;
     }
     if citation.resolvable {
         PacketEvidenceResolution::Resolved

--- a/crates/codestory-runtime/src/agent/packet_required_probes.rs
+++ b/crates/codestory-runtime/src/agent/packet_required_probes.rs
@@ -2680,6 +2680,8 @@ mod tests {
             PacketClaimDto {
                 claim: "FOREIGN KEY constraints define row references between SQL tables."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2688,6 +2690,8 @@ mod tests {
                 claim:
                     "A CHECK constraint validates a column without describing table relationships."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2708,6 +2712,8 @@ mod tests {
         let non_relationship_claims = vec![PacketClaimDto {
             claim: "A CHECK constraint validates a column without describing table relationships."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2720,6 +2726,8 @@ mod tests {
         let column_reference_claims = vec![PacketClaimDto {
             claim: "A CHECK constraint references the Price column while validating values."
                 .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2739,6 +2747,8 @@ mod tests {
             claim:
                 "A CHECK constraint references the Price column and validates values between 0 and 100."
                     .to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2760,18 +2770,24 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "app.use registers middleware on the router.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "app.handle delegates request handling to the router.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "res.send prepares and sends the response body.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2791,12 +2807,16 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Logger owns a stack of handlers registered by pushHandler.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "addRecord creates a log record before passing it to handlers.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2804,6 +2824,8 @@ mod tests {
             PacketClaimDto {
                 claim: "AbstractProcessingHandler handles records by processing and writing them."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2829,18 +2851,24 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Top-level HTTP helpers delegate to a Client.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "BaseRequest.finalize prepares the request body for sending.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Response.fromStream builds a streamed response boundary.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2866,6 +2894,8 @@ mod tests {
                 claim:
                     "The form validation examples use native required, pattern, min, and max constraints."
                         .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2873,6 +2903,8 @@ mod tests {
             PacketClaimDto {
                 claim: "A custom validation example applies script-driven validity checks before rendering messages."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
@@ -2880,12 +2912,16 @@ mod tests {
             PacketClaimDto {
                 claim: "Custom error rendering branches on ValidityState fields to choose messages."
                     .to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Submit handlers prevent submission when the form is invalid.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: None,
                 eligible_for_sufficiency: None,

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -1,4 +1,4 @@
-use crate::agent::packet_claims::packet_supported_claims;
+use crate::agent::packet_claims::{decorate_packet_claims_proof_metadata, packet_supported_claims};
 use crate::agent::packet_evidence::citation_sufficiency_eligible;
 use crate::agent::packet_evidence_roles::{PacketEvidenceRole, packet_evidence_role};
 use crate::agent::packet_flow_requirements::{
@@ -87,10 +87,12 @@ fn assemble_packet_sufficiency(input: PacketSufficiencyInput<'_>) -> PacketSuffi
         task_class,
         answer,
         budget,
-        supported_claims,
+        mut supported_claims,
         missing_required_probe_queries,
         targeted_follow_up_queries,
     } = input;
+
+    decorate_packet_claims_proof_metadata(&mut supported_claims);
 
     let has_errors = answer
         .retrieval_trace
@@ -2174,6 +2176,8 @@ mod tests {
     fn claim(text: &str) -> PacketClaimDto {
         PacketClaimDto {
             claim: text.to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: Vec::new(),
             coverage_role: None,
             eligible_for_sufficiency: None,
@@ -2228,6 +2232,8 @@ mod tests {
     ) -> PacketClaimDto {
         PacketClaimDto {
             claim: text.to_string(),
+            proof_status: None,
+            required_evidence_role: None,
             citations: vec![citation],
             coverage_role: coverage_role.map(str::to_string),
             eligible_for_sufficiency,
@@ -3817,12 +3823,16 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Selected callback invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Selected handler invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,
@@ -3873,12 +3883,16 @@ mod tests {
         let claims = vec![
             PacketClaimDto {
                 claim: "Selected callback invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,
             },
             PacketClaimDto {
                 claim: "Selected handler invocation happens.".to_string(),
+                proof_status: None,
+                required_evidence_role: None,
                 citations: Vec::new(),
                 coverage_role: Some("dispatch".to_string()),
                 eligible_for_sufficiency: None,

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2024"
 
 [dependencies]

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -6,13 +6,17 @@
 # or:
 #   cargo run -p codestory-cli -- retrieval bootstrap
 
-name: codestory-retrieval
+name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}
 
 services:
   qdrant:
     image: qdrant/qdrant:v1.12.5
-    container_name: codestory-qdrant
+    container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-qdrant
     restart: unless-stopped
+    labels:
+      dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}
+      dev.codestory.profile: ${CODESTORY_SIDECAR_PROFILE:-local}
+      dev.codestory.namespace: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}
     ports:
       - "127.0.0.1:${CODESTORY_QDRANT_HTTP_PORT:-6333}:6333"
       - "127.0.0.1:${CODESTORY_QDRANT_GRPC_PORT:-6334}:6334"
@@ -24,8 +28,12 @@ services:
   # Zoekt webserver (mount index dir populated by `retrieval index`).
   zoekt:
     image: sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4
-    container_name: codestory-zoekt
+    container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-zoekt
     restart: unless-stopped
+    labels:
+      dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}
+      dev.codestory.profile: ${CODESTORY_SIDECAR_PROFILE:-local}
+      dev.codestory.namespace: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}
     ports:
       - "127.0.0.1:${CODESTORY_ZOEKT_PORT:-6070}:6070"
     volumes:
@@ -37,8 +45,12 @@ services:
   # Model GGUF must exist under CODESTORY_EMBED_MODEL_DIR (see setup-retrieval-env.mjs).
   embed:
     image: ghcr.io/ggml-org/llama.cpp:server
-    container_name: codestory-embed
+    container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-embed
     restart: unless-stopped
+    labels:
+      dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}
+      dev.codestory.profile: ${CODESTORY_SIDECAR_PROFILE:-local}
+      dev.codestory.namespace: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}
     ports:
       - "127.0.0.1:${CODESTORY_EMBED_PORT:-8080}:8080"
     volumes:

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -109,11 +109,15 @@ and may be dense anchors with reason `component_report`.
   to promote answer quality or language quality without packet-runtime or drill
   evidence at the matching proof tier.
 
-Packet citations may expose optional JSON fields: `evidence_tier`,
-`evidence_producer`, `resolution_status`, `coverage_role`, and
-`eligible_for_sufficiency`. Sufficiency is role-bearing: a citation can help
-prove a packet claim only when the evidence tier, resolved/source-range status,
-and coverage role match the claim being covered.
+Packet claims expose `proof_status` and `required_evidence_role`.
+`proof_status` is `proven`, `likely`, `diagnostic`, or `unsupported`.
+`required_evidence_role` reuses the packet evidence tier taxonomy below; dense
+semantic hits and generated summaries stay diagnostic unless another
+proof-bearing citation backs the claim. Packet citations may expose optional
+JSON fields: `evidence_tier`, `evidence_producer`, `resolution_status`,
+`coverage_role`, and `eligible_for_sufficiency`. Sufficiency is role-bearing:
+a citation can help prove a packet claim only when the evidence tier,
+resolved/source-range status, and coverage role match the claim being covered.
 
 | Evidence tier | Proof role | Sufficiency rule |
 | --- | --- | --- |

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -220,6 +220,18 @@ cargo test -p codestory-cli
 
 Prefer this lane before `cargo test` for the whole workspace when the change is isolated to CLI args, rendering, or contract envelopes.
 
+For CI agents or container images that need a single machine-readable local
+readiness check, run:
+
+```sh
+codestory-cli smoke --project <repo> --profile ci-agent --format json
+```
+
+The profile indexes the local graph, grounds the repo, resolves one indexed
+symbol, runs `affected` on a fake changed path, and reports sidecar full mode
+only when the existing sidecar status already proves it. Non-full sidecars are
+listed under `skipped_optional_surfaces` with repair hints.
+
 Runtime-backed CLI fixture flows are a separate heavier lane:
 
 ```sh

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -11,7 +11,7 @@ packet-runtime, drill, or benchmark evidence tier.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
+| `codestory://status` | Current MCP `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Use this first when plugin MCP is live. | Guessing the active runtime from source checkout, marketplace cache, or PATH alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ integration.
 | --- | --- | --- | --- |
 | Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. |
+| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -124,7 +124,9 @@ When MCP is live, use `codestory://status` as the runtime truth. Its
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
 `sidecar_setup` fields identify the active server, CLI, sidecar contract,
 plugin launch source, sidecar setup policy, `build_source`, and `repo_ref`, and
-`allowed_surfaces` tells the agent which tools are safe now. Do not infer
+`plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed
+plugin cache when the adapter is active. `allowed_surfaces` tells the agent
+which tools are safe now. Do not infer
 packet/search readiness from a successful local grounding command.
 
 When MCP is not live, use the CLI preflight contract instead:
@@ -179,7 +181,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.17",
+  "version": "0.11.18",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -71,9 +71,9 @@ This package stays thin:
   provisions the current plugin version from the GitHub release
   `SHA256SUMS.txt`, records `build_source=github_release` and `repo_ref`, labels
   `CODESTORY_CLI` as a local-dev override, and only falls back to `PATH` when
-  provisioning is unavailable. If that `PATH` fallback is missing, unversioned,
-  or older than the plugin package, the adapter stays up as a diagnostic MCP
-  server instead of closing transport.
+  provisioning is unavailable. If the resolved CLI cannot spawn, or if the
+  `PATH` fallback is missing, unversioned, or older than the plugin package, the
+  adapter stays up as a diagnostic MCP server instead of closing transport.
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
@@ -247,12 +247,12 @@ version from GitHub release assets when needed. Status reports the plugin
 version, plugin cache path/version, CLI version, binary path/SHA,
 `build_source`, `repo_ref`, and sidecar contract version. `CODESTORY_CLI` stays
 a local-dev override, and `path_fallback` means no managed binary could be used.
-If `path_fallback` is stale or unavailable, MCP still answers
-`codestory://status` and tool calls with `repair_setup` diagnostics instead of
-closing transport. Once MCP is live, `codestory://status` is the runtime proof.
-Use `where.exe codestory-cli`, `codestory-cli --version`, and release repair
-checks only when MCP is missing or status shows `path_fallback` or stale binary
-drift.
+If the resolved runtime cannot spawn, or if `path_fallback` is stale or
+unavailable, MCP still answers `codestory://status` and tool calls with
+`repair_setup` diagnostics instead of closing transport. Once MCP is live,
+`codestory://status` is the runtime proof. Use `where.exe codestory-cli`,
+`codestory-cli --version`, and release repair checks only when MCP is missing or
+status shows `path_fallback` or stale binary drift.
 
 If status reports `repair_setup`, the active CLI is older than the latest
 release. The agent runs the installer command from `recommended_next_calls`

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -59,7 +59,7 @@ running server.
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `sidecar_setup`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when the plugin launcher is active. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
@@ -71,7 +71,9 @@ This package stays thin:
   provisions the current plugin version from the GitHub release
   `SHA256SUMS.txt`, records `build_source=github_release` and `repo_ref`, labels
   `CODESTORY_CLI` as a local-dev override, and only falls back to `PATH` when
-  provisioning is unavailable.
+  provisioning is unavailable. If that `PATH` fallback is missing, unversioned,
+  or older than the plugin package, the adapter stays up as a diagnostic MCP
+  server instead of closing transport.
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
@@ -242,12 +244,15 @@ proof that `packet`, `search`, or `context` is ready.
 The plugin launches through `scripts/codestory-mcp.cjs`. That adapter prefers a
 checksummed CLI under plugin-managed data and provisions the current plugin
 version from GitHub release assets when needed. Status reports the plugin
-version, CLI version, binary path/SHA, `build_source`, `repo_ref`, and sidecar
-contract version. `CODESTORY_CLI` stays a local-dev override, and `path_fallback`
-means no managed binary could be used. Once MCP is live, `codestory://status` is
-the runtime proof. Use `where.exe codestory-cli`, `codestory-cli --version`, and
-release repair checks only when MCP is missing or status shows `path_fallback`
-or stale binary drift.
+version, plugin cache path/version, CLI version, binary path/SHA,
+`build_source`, `repo_ref`, and sidecar contract version. `CODESTORY_CLI` stays
+a local-dev override, and `path_fallback` means no managed binary could be used.
+If `path_fallback` is stale or unavailable, MCP still answers
+`codestory://status` and tool calls with `repair_setup` diagnostics instead of
+closing transport. Once MCP is live, `codestory://status` is the runtime proof.
+Use `where.exe codestory-cli`, `codestory-cli --version`, and release repair
+checks only when MCP is missing or status shows `path_fallback` or stale binary
+drift.
 
 If status reports `repair_setup`, the active CLI is older than the latest
 release. The agent runs the installer command from `recommended_next_calls`

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -412,10 +412,10 @@ function compareSemver(left, right) {
   return 0;
 }
 
-function probePathFallbackCli(resolved) {
+function probeResolvedCli(resolved) {
   const result = spawnSync(resolved.path, ['--version'], {
     encoding: 'utf8',
-    shell: false,
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     timeout: 3000,
     windowsHide: true,
   });
@@ -427,6 +427,17 @@ function probePathFallbackCli(resolved) {
     stdout: result.stdout || '',
     stderr: result.stderr || '',
   };
+}
+
+function failOpenReasonForProbe(resolved, probe) {
+  if (probe.error || probe.status !== 0) {
+    return `${resolved.source}_cli_unspawnable`;
+  }
+  if (resolved.source !== 'path_fallback') return null;
+  const comparison = compareSemver(probe.version, resolved.version);
+  if (!probe.version || comparison === null) return 'path_fallback_cli_unavailable';
+  if (comparison < 0) return 'path_fallback_cli_stale';
+  return null;
 }
 
 function fallbackDiagnostic(resolved, probe, reason) {
@@ -466,6 +477,8 @@ function fallbackDiagnostic(resolved, probe, reason) {
       expected_version: resolved.version,
       probe_error: probe.error,
       probe_status: probe.status,
+      probe_stdout: probe.stdout,
+      probe_stderr: probe.stderr,
     },
   };
   const localSurfaces = [
@@ -667,16 +680,11 @@ async function main() {
   handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
-  if (resolved.source === 'path_fallback') {
-    const probe = probePathFallbackCli(resolved);
-    const comparison = compareSemver(probe.version, resolved.version);
-    if (!probe.version || comparison === null || comparison < 0) {
-      const reason = probe.version
-        ? 'path_fallback_cli_stale'
-        : 'path_fallback_cli_unavailable';
-      runFailOpenMcp(fallbackDiagnostic(resolved, probe, reason));
-      return;
-    }
+  const probe = probeResolvedCli(resolved);
+  const failOpenReason = failOpenReasonForProbe(resolved, probe);
+  if (failOpenReason) {
+    runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason));
+    return;
   }
   const sidecarPolicy = readSidecarPolicy();
   scheduleSidecarRepair(resolved, sidecarPolicy);
@@ -721,12 +729,35 @@ async function main() {
   });
 
   child.on('error', (error) => {
-    process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
-    process.exit(1);
+    runFailOpenMcp(fallbackDiagnostic(resolved, {
+      status: null,
+      error: error.message,
+      version: null,
+      stdout: '',
+      stderr: '',
+    }, `${resolved.source}_cli_unspawnable`));
   });
 }
 
 main().catch((error) => {
-  process.stderr.write(`codestory mcp launch failed: ${error.message}\n`);
-  process.exit(1);
+  const resolved = {
+    source: 'launcher',
+    path: 'codestory-cli',
+    sha256: null,
+    version: pluginVersion(),
+    cliVersion: null,
+    repoRef: null,
+    buildSource: 'launcher',
+    archiveSha256: null,
+    archiveUrl: null,
+    provisionedAt: null,
+    warnings: [],
+  };
+  runFailOpenMcp(fallbackDiagnostic(resolved, {
+    status: null,
+    error: error.message,
+    version: null,
+    stdout: '',
+    stderr: '',
+  }, 'launcher_error'));
 });

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -440,13 +440,85 @@ function failOpenReasonForProbe(resolved, probe) {
   return null;
 }
 
-function fallbackDiagnostic(resolved, probe, reason) {
+function localRepairCommand(projectRoot = process.cwd()) {
+  return `codestory-cli ready --goal local --repair --project ${JSON.stringify(projectRoot)} --format json`;
+}
+
+function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
+  const result = spawnSync(resolved.path, ['ready', '--goal', 'local', '--project', projectRoot, '--format', 'json'], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    timeout: 10000,
+    windowsHide: true,
+  });
+  const setup = {
+    ready_probe_status: result.status,
+    ready_probe_error: result.error ? result.error.message : null,
+    ready_probe_stdout: result.stdout || '',
+    ready_probe_stderr: result.stderr || '',
+  };
+  if (result.error || result.status !== 0) {
+    const repair = localRepairCommand(projectRoot);
+    return {
+      ready: false,
+      reason: 'local_navigation_probe_failed',
+      status: 'repair_setup',
+      summary: 'CodeStory MCP could not verify local navigation readiness before starting stdio.',
+      minimumNext: [repair],
+      fullRepair: [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
+      setup,
+    };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout || '{}');
+  } catch (error) {
+    const repair = localRepairCommand(projectRoot);
+    return {
+      ready: false,
+      reason: 'local_navigation_probe_invalid_json',
+      status: 'repair_setup',
+      summary: `CodeStory MCP local readiness probe returned invalid JSON: ${error.message}`,
+      minimumNext: [repair],
+      fullRepair: [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
+      setup,
+    };
+  }
+  const verdict = Array.isArray(parsed.verdicts)
+    ? parsed.verdicts.find((item) => item && item.goal === 'local_navigation') || parsed.verdicts[0]
+    : null;
+  if (verdict && verdict.status === 'ready') {
+    return { ready: true };
+  }
+  const repair = localRepairCommand(projectRoot);
+  const status = typeof verdict?.status === 'string' ? verdict.status : 'repair_setup';
+  return {
+    ready: false,
+    reason: `local_navigation_${status}`,
+    status,
+    summary: verdict?.summary || 'CodeStory local navigation is not ready.',
+    minimumNext: Array.isArray(verdict?.minimum_next) && verdict.minimum_next.length > 0
+      ? verdict.minimum_next
+      : [repair],
+    fullRepair: Array.isArray(verdict?.full_repair) && verdict.full_repair.length > 0
+      ? verdict.full_repair
+      : [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
+    setup: {
+      ...setup,
+      readiness_verdict: verdict || null,
+    },
+  };
+}
+
+function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   const projectRoot = process.cwd();
-  const minimumNext = [
+  const minimumNext = options.minimumNext || [
     'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
     process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
     'codestory-cli --version',
   ];
+  const fullRepair = options.fullRepair || minimumNext;
+  const recommendedNext = options.recommendedNext || fullRepair;
   const plugin = {
     plugin_version: resolved.version,
     plugin_root: pluginRoot,
@@ -465,12 +537,12 @@ function fallbackDiagnostic(resolved, probe, reason) {
     warnings: [...resolved.warnings, reason].filter(Boolean),
   };
   const repair = {
-    goal: 'local_navigation',
-    status: 'repair_setup',
-    summary: 'CodeStory plugin MCP could not start a compatible codestory-cli stdio runtime.',
+    goal: options.goal || 'local_navigation',
+    status: options.status || 'repair_setup',
+    summary: options.summary || 'CodeStory plugin MCP could not start a compatible codestory-cli stdio runtime.',
     repair_reason: reason,
     minimum_next: minimumNext,
-    full_repair: minimumNext,
+    full_repair: fullRepair,
     setup: {
       active_path: resolved.path,
       active_version: probe.version,
@@ -479,6 +551,7 @@ function fallbackDiagnostic(resolved, probe, reason) {
       probe_status: probe.status,
       probe_stdout: probe.stdout,
       probe_stderr: probe.stderr,
+      ...(options.setup || {}),
     },
   };
   const localSurfaces = [
@@ -500,10 +573,10 @@ function fallbackDiagnostic(resolved, probe, reason) {
   const blockedSurface = (surface, goal) => ({
     allowed: false,
     readiness_goal: goal,
-    status: 'repair_setup',
+    status: repair.status,
     repair_reason: reason,
     minimum_next: minimumNext,
-    full_repair: minimumNext,
+    full_repair: fullRepair,
   });
   const allowedSurfaces = Object.fromEntries([
     ...localSurfaces.map((surface) => [surface, blockedSurface(surface, 'local_navigation')]),
@@ -528,9 +601,9 @@ function fallbackDiagnostic(resolved, probe, reason) {
     allowed_surfaces: allowedSurfaces,
     recommended_next_calls: [
       { method: 'resources/read', uri: 'codestory://status' },
-      { method: 'host/restart', instruction: minimumNext[0] },
-      { method: 'cli', command: minimumNext[1] },
-      { method: 'cli', command: minimumNext[2] },
+      ...recommendedNext.map((command) => command.startsWith('Refresh or reinstall') || command.startsWith('Restart/reload')
+        ? { method: 'host/restart', instruction: command }
+        : { method: 'cli', command }),
     ],
   };
 }
@@ -568,17 +641,18 @@ function resourceContents(uri, value) {
 }
 
 function failOpenToolResult(status) {
+  const readiness = status.readiness[0];
   return {
     isError: true,
     content: [{ type: 'text', text: diagnosticText(status) }],
     structuredContent: {
       code: 'codestory_mcp_runtime_unavailable',
-      status: 'repair_setup',
+      status: readiness.status,
       repair_reason: status.degraded_reason,
       plugin_runtime: status.plugin_runtime,
-      setup: status.readiness[0].setup,
-      minimum_next: status.readiness[0].minimum_next,
-      full_repair: status.readiness[0].full_repair,
+      setup: readiness.setup,
+      minimum_next: readiness.minimum_next,
+      full_repair: readiness.full_repair,
       recommended_next_calls: status.recommended_next_calls,
     },
   };
@@ -684,6 +758,20 @@ async function main() {
   const failOpenReason = failOpenReasonForProbe(resolved, probe);
   if (failOpenReason) {
     runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason));
+    return;
+  }
+  const localReadiness = probeLocalNavigation(resolved);
+  if (!localReadiness.ready) {
+    runFailOpenMcp(fallbackDiagnostic(resolved, probe, localReadiness.reason, {
+      status: localReadiness.status,
+      summary: localReadiness.summary,
+      minimumNext: localReadiness.minimumNext,
+      fullRepair: [
+        ...localReadiness.fullRepair,
+        'Restart/reload the Codex host/app after repairing the local CodeStory index, then read codestory://status in a fresh thread.',
+      ],
+      setup: localReadiness.setup,
+    }));
     return;
   }
   const sidecarPolicy = readSidecarPolicy();

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -44,6 +44,11 @@ function pluginVersion() {
   return manifest && typeof manifest.version === 'string' ? manifest.version : null;
 }
 
+function pluginCacheVersion() {
+  const parent = path.basename(path.dirname(pluginRoot)).toLowerCase();
+  return parent === 'codestory' ? path.basename(pluginRoot) : null;
+}
+
 function pluginDataDir() {
   return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
 }
@@ -384,6 +389,254 @@ async function resolveCli() {
   };
 }
 
+function normalizeVersion(value) {
+  const match = String(value || '').match(/\b[vV]?(\d+\.\d+\.\d+)\b/u);
+  return match ? match[1] : null;
+}
+
+function semverParts(version) {
+  const normalized = normalizeVersion(version);
+  if (!normalized) return null;
+  return normalized.split('.').map((part) => Number.parseInt(part, 10));
+}
+
+function compareSemver(left, right) {
+  const leftParts = semverParts(left);
+  const rightParts = semverParts(right);
+  if (!leftParts || !rightParts) return null;
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] < rightParts[index] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function probePathFallbackCli(resolved) {
+  const result = spawnSync(resolved.path, ['--version'], {
+    encoding: 'utf8',
+    shell: false,
+    timeout: 3000,
+    windowsHide: true,
+  });
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+  return {
+    status: result.status,
+    error: result.error ? result.error.message : null,
+    version: normalizeVersion(output),
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+function fallbackDiagnostic(resolved, probe, reason) {
+  const projectRoot = process.cwd();
+  const minimumNext = [
+    'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
+    process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
+    'codestory-cli --version',
+  ];
+  const plugin = {
+    plugin_version: resolved.version,
+    plugin_root: pluginRoot,
+    plugin_cache_version: pluginCacheVersion(),
+    plugin_data: pluginDataDir(),
+    cli_source: resolved.source,
+    cli_path: resolved.path,
+    cli_sha256: resolved.sha256,
+    build_source: resolved.buildSource,
+    repo_ref: resolved.repoRef,
+    local_dev_override: resolved.source === 'local_dev_override',
+    path_fallback: resolved.source === 'path_fallback',
+    managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
+    managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
+    managed_manifest_path: resolved.manifestPath || null,
+    warnings: [...resolved.warnings, reason].filter(Boolean),
+  };
+  const repair = {
+    goal: 'local_navigation',
+    status: 'repair_setup',
+    summary: 'CodeStory plugin MCP could not start a compatible codestory-cli stdio runtime.',
+    repair_reason: reason,
+    minimum_next: minimumNext,
+    full_repair: minimumNext,
+    setup: {
+      active_path: resolved.path,
+      active_version: probe.version,
+      expected_version: resolved.version,
+      probe_error: probe.error,
+      probe_status: probe.status,
+    },
+  };
+  const localSurfaces = [
+    'ground',
+    'files',
+    'symbol',
+    'definition',
+    'trail',
+    'references',
+    'snippet',
+    'affected',
+    'symbols',
+    'get_node',
+    'neighbors',
+    'shortest_path',
+    'query_subgraph',
+  ];
+  const sidecarSurfaces = ['packet', 'search', 'context'];
+  const blockedSurface = (surface, goal) => ({
+    allowed: false,
+    readiness_goal: goal,
+    status: 'repair_setup',
+    repair_reason: reason,
+    minimum_next: minimumNext,
+    full_repair: minimumNext,
+  });
+  const allowedSurfaces = Object.fromEntries([
+    ...localSurfaces.map((surface) => [surface, blockedSurface(surface, 'local_navigation')]),
+    ...sidecarSurfaces.map((surface) => [surface, blockedSurface(surface, 'agent_packet_search')]),
+  ]);
+  return {
+    server_version: null,
+    cli_version: probe.version,
+    server_executable: null,
+    server_executable_sha256: null,
+    sidecar_contract_version: null,
+    plugin_runtime: plugin,
+    runtime_boundary: {
+      restart_required_for_runtime_change: true,
+      message: 'A running MCP server keeps using the CLI process it was launched with; plugin refresh, managed runtime provisioning, CODESTORY_CLI, or PATH changes require a host reload/restart and fresh codestory://status readback.',
+    },
+    warnings: plugin.warnings,
+    project_root: projectRoot,
+    retrieval_mode: 'unavailable',
+    degraded_reason: reason,
+    readiness: [repair],
+    allowed_surfaces: allowedSurfaces,
+    recommended_next_calls: [
+      { method: 'resources/read', uri: 'codestory://status' },
+      { method: 'host/restart', instruction: minimumNext[0] },
+      { method: 'cli', command: minimumNext[1] },
+      { method: 'cli', command: minimumNext[2] },
+    ],
+  };
+}
+
+function diagnosticText(status) {
+  const setup = status.readiness[0].setup;
+  return [
+    'CodeStory MCP runtime is not ready.',
+    `reason: ${status.degraded_reason}`,
+    `plugin_version: ${status.plugin_runtime.plugin_version || '<unknown>'}`,
+    `plugin_root: ${status.plugin_runtime.plugin_root}`,
+    `cli_source: ${status.plugin_runtime.cli_source}`,
+    `cli_path: ${setup.active_path}`,
+    `cli_version: ${setup.active_version || '<unknown>'}`,
+    `next: ${status.readiness[0].minimum_next[0]}`,
+  ].join('\n');
+}
+
+function jsonrpcResult(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function jsonrpcError(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+function resourceContents(uri, value) {
+  return {
+    contents: [{
+      uri,
+      mimeType: 'application/json',
+      text: JSON.stringify(value),
+    }],
+  };
+}
+
+function failOpenToolResult(status) {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: diagnosticText(status) }],
+    structuredContent: {
+      code: 'codestory_mcp_runtime_unavailable',
+      status: 'repair_setup',
+      repair_reason: status.degraded_reason,
+      plugin_runtime: status.plugin_runtime,
+      setup: status.readiness[0].setup,
+      minimum_next: status.readiness[0].minimum_next,
+      full_repair: status.readiness[0].full_repair,
+      recommended_next_calls: status.recommended_next_calls,
+    },
+  };
+}
+
+function runFailOpenMcp(status) {
+  const tools = ['ground', 'files', 'packet', 'search', 'context'].map((name) => ({
+    name,
+    description: 'CodeStory diagnostic fail-open surface; runtime repair is required before this tool can return repository grounding.',
+    inputSchema: { type: 'object', additionalProperties: true },
+    outputSchema: { type: 'object', additionalProperties: true },
+  }));
+  const resources = [
+    { uri: 'codestory://status', name: 'CodeStory runtime status', mimeType: 'application/json' },
+    { uri: 'codestory://agent-guide', name: 'CodeStory agent guide', mimeType: 'application/json' },
+  ];
+  const guide = {
+    status: 'repair_setup',
+    message: 'Read codestory://status, follow recommended_next_calls, restart/reload the host, then retry grounding.',
+    recommended_next_calls: status.recommended_next_calls,
+  };
+  let buffer = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split(/\r?\n/u);
+    buffer = lines.pop() || '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let request;
+      try {
+        request = JSON.parse(line);
+      } catch {
+        process.stdout.write(`${JSON.stringify(jsonrpcError(null, -32700, 'Parse error'))}\n`);
+        continue;
+      }
+      if (request.id === undefined) continue;
+      let response;
+      if (request.method === 'initialize') {
+        response = jsonrpcResult(request.id, {
+          protocolVersion: request.params?.protocolVersion || '2024-11-05',
+          capabilities: { tools: {}, resources: {} },
+          serverInfo: { name: 'codestory', version: resolvedVersionForStatus(status) },
+        });
+      } else if (request.method === 'tools/list') {
+        response = jsonrpcResult(request.id, { tools });
+      } else if (request.method === 'resources/list') {
+        response = jsonrpcResult(request.id, { resources });
+      } else if (request.method === 'resources/read') {
+        const uri = request.params?.uri;
+        if (uri === 'codestory://status') {
+          response = jsonrpcResult(request.id, resourceContents(uri, status));
+        } else if (uri === 'codestory://agent-guide') {
+          response = jsonrpcResult(request.id, resourceContents(uri, guide));
+        } else {
+          response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
+        }
+      } else if (request.method === 'tools/call') {
+        response = jsonrpcResult(request.id, failOpenToolResult(status));
+      } else {
+        response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
+      }
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+  });
+}
+
+function resolvedVersionForStatus(status) {
+  return status.plugin_runtime.plugin_version || 'unknown';
+}
+
 function rememberLaunch(resolved) {
   const dataDir = pluginDataDir();
   if (!dataDir) return;
@@ -393,6 +646,8 @@ function rememberLaunch(resolved) {
       source: resolved.source,
       path: resolved.path,
       sha256: resolved.sha256,
+      pluginRoot,
+      pluginCacheVersion: pluginCacheVersion(),
       pluginVersion: resolved.version,
       manifestPath: resolved.manifestPath || null,
       cliVersion: resolved.cliVersion || null,
@@ -412,6 +667,17 @@ async function main() {
   handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
+  if (resolved.source === 'path_fallback') {
+    const probe = probePathFallbackCli(resolved);
+    const comparison = compareSemver(probe.version, resolved.version);
+    if (!probe.version || comparison === null || comparison < 0) {
+      const reason = probe.version
+        ? 'path_fallback_cli_stale'
+        : 'path_fallback_cli_unavailable';
+      runFailOpenMcp(fallbackDiagnostic(resolved, probe, reason));
+      return;
+    }
+  }
   const sidecarPolicy = readSidecarPolicy();
   scheduleSidecarRepair(resolved, sidecarPolicy);
   const sidecarStatus = readSidecarPolicy();
@@ -423,6 +689,8 @@ async function main() {
     env: {
       ...process.env,
       CODESTORY_PLUGIN_VERSION: resolved.version || '',
+      CODESTORY_PLUGIN_ROOT: pluginRoot,
+      CODESTORY_PLUGIN_CACHE_VERSION: pluginCacheVersion() || '',
       CODESTORY_PLUGIN_CLI_VERSION: resolved.cliVersion || resolved.version || '',
       CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
       CODESTORY_PLUGIN_CLI_PATH: resolved.path,

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -57,9 +57,9 @@ source-build checks only when MCP is missing, the plugin needs repair, status
 shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
 is an explicit local-dev override; installed `.mcp.json` launches the managed
 adapter first, provisions from `github_release` when needed, and records the
-launch source in `plugin_runtime`. If only a missing, unversioned, or stale
-`PATH` fallback is available, the adapter stays up with `repair_setup`
-diagnostics instead of closing transport.
+launch source in `plugin_runtime`. If the resolved runtime cannot spawn, or if
+only a missing, unversioned, or stale `PATH` fallback is available, the adapter
+stays up with `repair_setup` diagnostics instead of closing transport.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -47,7 +47,7 @@ Use status fields this way:
 | `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
 | `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
 | `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
-| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `build_source` and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
+| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
 | `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Ask before first automatic sidecar setup; respect `enabled` and `disabled`. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
@@ -57,7 +57,9 @@ source-build checks only when MCP is missing, the plugin needs repair, status
 shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
 is an explicit local-dev override; installed `.mcp.json` launches the managed
 adapter first, provisions from `github_release` when needed, and records the
-launch source in `plugin_runtime`.
+launch source in `plugin_runtime`. If only a missing, unversioned, or stale
+`PATH` fallback is available, the adapter stays up with `repair_setup`
+diagnostics instead of closing transport.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -11,7 +11,9 @@ codestory-cli serve --stdio --refresh none
 The installed plugin starts `scripts/codestory-mcp.cjs`, which prefers a
 checksummed plugin-managed CLI, provisions the current version from
 `github_release` when needed, and only falls back to `PATH` when no managed
-binary is available. Once MCP is live, `codestory://status` is the runtime
+binary is available. If that fallback is missing, unversioned, or older than
+the plugin package, the adapter returns `repair_setup` MCP diagnostics instead
+of closing transport. Once MCP is live, `codestory://status` is the runtime
 truth: use `server_version`, `cli_version`, `server_executable`,
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
 `allowed_surfaces` from status before any local grounding, packet, or search
@@ -61,7 +63,7 @@ call.
 | `cli_version` | Active CLI runtime version. |
 | `server_executable` / `server_executable_sha256` | Active MCP server executable path and checksum. Use them to diagnose stale runtime or binary drift. |
 | `sidecar_contract_version` | Active sidecar schema contract version compiled into the CLI. |
-| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. Provisioned records include `build_source=github_release` and `repo_ref`. |
+| `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Provisioned records include `build_source=github_release` and `repo_ref`. |
 | `sidecar_setup` | Plugin sidecar setup policy (`ask`, `enabled`, or `disabled`) plus last repair state and opt-in/disable commands. |
 | `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -11,10 +11,11 @@ codestory-cli serve --stdio --refresh none
 The installed plugin starts `scripts/codestory-mcp.cjs`, which prefers a
 checksummed plugin-managed CLI, provisions the current version from
 `github_release` when needed, and only falls back to `PATH` when no managed
-binary is available. If that fallback is missing, unversioned, or older than
-the plugin package, the adapter returns `repair_setup` MCP diagnostics instead
-of closing transport. Once MCP is live, `codestory://status` is the runtime
-truth: use `server_version`, `cli_version`, `server_executable`,
+binary is available. If the resolved runtime cannot spawn, or if that fallback
+is missing, unversioned, or older than the plugin package, the adapter returns
+`repair_setup` MCP diagnostics instead of closing transport. Once MCP is live,
+`codestory://status` is the runtime truth: use `server_version`, `cli_version`,
+`server_executable`,
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, and
 `allowed_surfaces` from status before any local grounding, packet, or search
 call.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -27,6 +27,14 @@ function readCargoVersion(manifestText) {
   assert.fail("Cargo package must declare version");
 }
 
+async function readPluginVersion() {
+  const manifest = JSON.parse(
+    await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+  );
+  assert.equal(typeof manifest.version, "string");
+  return manifest.version;
+}
+
 function releaseAssetForPlatform(version) {
   const target = process.platform === "win32" && process.arch === "x64"
     ? "windows-x64"
@@ -129,9 +137,10 @@ test("codestory repo ships plugin source, not marketplace catalog or server adap
 
 test("mcp launcher prefers a checksummed managed cli without PATH", async () => {
   const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-cli-"));
   const outFile = join(dataDir, "env.json");
-  const cliDir = join(dataDir, "codestory-cli", "0.11.17");
+  const cliDir = join(dataDir, "codestory-cli", version);
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -193,6 +202,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
 
 test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
   const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-mcp-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = [
@@ -218,7 +228,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
     assert.equal(responses.length, 3, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
-    assert.equal(status.plugin_runtime.plugin_version, "0.11.17");
+    assert.equal(status.plugin_runtime.plugin_version, version);
     assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
     assert.equal(status.plugin_runtime.cli_source, "path_fallback");
     assert.equal(status.readiness[0].status, "repair_setup");
@@ -232,6 +242,104 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     assert.equal(
       responses[2].result.structuredContent.plugin_runtime.plugin_root,
       pluginRoot,
+    );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when CODESTORY_CLI override cannot spawn", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-override-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const missingCli = join(dataDir, process.platform === "win32" ? "missing.exe" : "missing");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: missingCli,
+        PLUGIN_DATA: dataDir,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.plugin_runtime.plugin_version, version);
+    assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
+    assert.equal(status.readiness[0].repair_reason, "local_dev_override_cli_unspawnable");
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when managed cli probe fails", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-managed-"));
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(
+    cliDir,
+    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+  );
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "tool",
+    method: "tools/call",
+    params: { name: "ground", arguments: {} },
+  }) + "\n";
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    if (process.platform === "win32") {
+      await writeFile(cliPath, "@echo off\r\nexit /b 7\r\n", "utf8");
+    } else {
+      await writeFile(cliPath, "#!/bin/sh\nexit 7\n", "utf8");
+      await chmod(cliPath, 0o755);
+    }
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: dataDir,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim());
+    assert.equal(response.result.isError, true);
+    assert.equal(
+      response.result.structuredContent.repair_reason,
+      "managed_cli_unspawnable",
+    );
+    assert.equal(
+      response.result.structuredContent.plugin_runtime.plugin_version,
+      version,
     );
   } finally {
     await rm(dataDir, { recursive: true, force: true });
@@ -269,9 +377,10 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
 
 test("enabled sidecar policy schedules existing agent repair path", async () => {
   const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
   const logFile = join(dataDir, "calls.jsonl");
-  const cliDir = join(dataDir, "codestory-cli", "0.11.17");
+  const cliDir = join(dataDir, "codestory-cli", version);
   const cliPath = join(
     cliDir,
     process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
@@ -331,7 +440,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     return;
   }
 
-  const version = "0.11.17";
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
   const outFile = join(dataDir, "env.json");

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -49,14 +49,14 @@ async function writeFakeCli(cliPath) {
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
-      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
+      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
       "utf8",
     );
     return;
   }
   await writeFile(
     cliPath,
-    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
     "utf8",
   );
   await chmod(cliPath, 0o755);
@@ -165,6 +165,8 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.source, "managed");
     assert.equal(observed.path, cliPath);
     assert.equal(observed.sha256, sha256);
+    assert.equal(observed.pluginRoot, pluginRoot);
+    assert.equal(observed.pluginCacheVersion, "");
     assert.equal(observed.sidecarPolicy, "ask");
     assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
     assert.match(observed.sidecarEnable, /--policy-file/u);
@@ -184,6 +186,53 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
     );
     assert.equal(policy.state, "enabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-mcp-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const input = [
+    JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+  ].join("\n") + "\n";
+
+  try {
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: "",
+        COPILOT_PLUGIN_DATA: "",
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.equal(responses.length, 3, result.stdout);
+    const status = JSON.parse(responses[1].result.contents[0].text);
+    assert.equal(status.plugin_runtime.plugin_version, "0.11.17");
+    assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
+    assert.equal(status.plugin_runtime.cli_source, "path_fallback");
+    assert.equal(status.readiness[0].status, "repair_setup");
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+    assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
+    assert.equal(responses[2].result.isError, true);
+    assert.equal(
+      responses[2].result.structuredContent.code,
+      "codestory_mcp_runtime_unavailable",
+    );
+    assert.equal(
+      responses[2].result.structuredContent.plugin_runtime.plugin_root,
+      pluginRoot,
+    );
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -649,6 +698,8 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "server_executable_sha256",
     "sidecar_contract_version",
     "plugin_runtime",
+    "plugin_runtime.plugin_root",
+    "plugin_cache_version",
     "sidecar_setup",
     "build_source",
     "repo_ref",
@@ -660,6 +711,7 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
     "scripts/codestory-mcp.cjs",
     "github_release",
     "path_fallback",
+    "closing transport",
   ];
   const marketplaceSourceRequired = [
     "The marketplace catalog repo is `TheGreenCedar/AgentPluginMarketplace`",

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -54,24 +54,25 @@ function releaseAssetForPlatform(version) {
 }
 
 async function writeFakeCli(cliPath) {
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}]}));process.exit(0)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args}))";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
-      `@echo off\r\n"${process.execPath}" -e "require('fs').writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))" %*\r\n`,
+      `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`,
       "utf8",
     );
     return;
   }
   await writeFile(
     cliPath,
-    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e 'require("fs").writeFileSync(process.env.TEST_OUT, JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args:process.argv.slice(1)}))' "$@"\n`,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} "$@"\n`,
     "utf8",
   );
   await chmod(cliPath, 0o755);
 }
 
 async function writeRecordingCli(cliPath) {
-  const script = "const fs=require('fs');fs.appendFileSync(process.env.TEST_LOG,JSON.stringify({repair:process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR==='1',policy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,args:process.argv.slice(1)})+'\\n')";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'&&process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR!=='1'){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}]}));process.exit(0)}fs.appendFileSync(process.env.TEST_LOG,JSON.stringify({repair:process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR==='1',policy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,args})+'\\n')";
   if (process.platform === "win32") {
     await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`, "utf8");
     return;
@@ -243,6 +244,81 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
       responses[2].result.structuredContent.plugin_runtime.plugin_root,
       pluginRoot,
     );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when local navigation is not ready", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-index-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "fake-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "fake-codestory-cli.cmd" : "fake-codestory-cli",
+  );
+  const marker = join(dataDir, "serve-called.txt");
+  const input = [
+    JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+  ].join("\n") + "\n";
+
+  try {
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const version = process.env.TEST_CODESTORY_VERSION;",
+        "const marker = process.env.TEST_OUT;",
+        "const command = process.argv[2];",
+        "if (command === '--version') { console.log('codestory-cli ' + version); process.exit(0); }",
+        "if (command === 'ready') {",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'repair_index', summary: 'No indexed symbols are available yet.', minimum_next: ['codestory-cli ready --goal local --repair --project \"fixture\" --format json'], full_repair: ['codestory-cli doctor --project \"fixture\"'] }] }));",
+        "  process.exit(0);",
+        "}",
+        "if (command === 'serve') { fs.writeFileSync(marker, 'serve-called'); process.exit(1); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: dataDir,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.equal(responses.length, 3, result.stdout);
+    const status = JSON.parse(responses[1].result.contents[0].text);
+    assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
+    assert.equal(status.readiness[0].status, "repair_index");
+    assert.equal(status.readiness[0].repair_reason, "local_navigation_repair_index");
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+    assert.equal(status.allowed_surfaces.ground.status, "repair_index");
+    assert.match(status.readiness[0].minimum_next[0], /ready --goal local --repair/u);
+    assert.equal(responses[2].result.isError, true);
+    assert.equal(responses[2].result.structuredContent.status, "repair_index");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

This patch release promotes the reviewed CodeStory plugin/runtime fixes from `dev/codestory-next` to `main` so they can be published and dogfooded as a public plugin/runtime version.

The release includes the merged lanes for #441, #444, #446, #447, and the runtime visibility work needed to finish #460 after public install proof.

Closes #468.

## What Changed

- Bumped all 8 CodeStory workspace crates from `0.11.17` to `0.11.18`.
- Bumped the Codex, Claude, and GitHub plugin manifests to `0.11.18`.
- Updated `Cargo.lock` only for the local CodeStory package versions.

## How To Review

1. Confirm the diff is release metadata only.
2. Confirm `crates/codestory-cli/Cargo.toml`, all workspace crate manifests, plugin manifests, and `Cargo.lock` agree on `0.11.18`.
3. Confirm this PR targets `main`; the main merge triggers the release workflow and binary assets.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.18`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `cargo check -p codestory-cli`
- `cargo fmt --check`
- `git diff --check`

## Risk

The version bump itself is metadata-only. The release risk is in the already-merged runtime changes; those passed the final integration review and targeted verification before this branch was cut.