### PR TITLE
[codex] Remove stale docs concepts references

### DIFF
--- a/docs/contributors/documentation-maintenance-checklist.md
+++ b/docs/contributors/documentation-maintenance-checklist.md
@@ -56,7 +56,7 @@ This checklist provides guidelines for maintaining high-quality, consistent docu
 - **docs/README.md**: True routing document
 - **docs/usage.md**: Operator journey and workflows
 - **docs/architecture/**: System architecture and design
-- **docs/concepts/**: Core concepts and terminology
+- **docs/glossary.md**: Core concepts and terminology
 - **docs/contributors/**: Contributor guidelines and setup
 - **docs/testing/**: Testing procedures and benchmarks
 - **docs/ops/**: Operational procedures and maintenance

--- a/docs/search-index.md
+++ b/docs/search-index.md
@@ -42,8 +42,8 @@ Keyword index for CodeStory documentation. For routing by job, start at
 - **language-support.md**: Language support claims and coverage
 - **subsystems/**: Subsystem-specific documentation
 
-#### docs/concepts/
-- **how-codestory-works.md**: Core concepts and functionality
+#### docs/glossary.md
+- **glossary.md**: Canonical terminology across operator, architecture, and verification docs
 
 #### docs/contributors/
 - **getting-started.md**: Contributor setup and verification


### PR DESCRIPTION
## Context

Closes #484.

Docs inventory/search-index pages referenced `docs/concepts`, but that directory is not present in the repo. The current canonical concepts/terminology surface is `docs/glossary.md`, and architecture routing already lives under `docs/architecture/`.

## What Changed

- Redirected the documentation maintenance checklist structure row from missing `docs/concepts/` to `docs/glossary.md`.
- Replaced the stale `docs/search-index.md` `docs/concepts/` section with the existing glossary surface.

Changed files:
- `docs/contributors/documentation-maintenance-checklist.md`
- `docs/search-index.md`

## How To Review

1. Confirm no `docs/concepts` references remain.
2. Confirm `docs/glossary.md` is the right replacement for core terminology/concepts inventory.
3. Confirm this stays docs-only and does not touch runtime, sidecar repair, or release metadata.

## Verification

- `codestory-cli agent preflight --project "C:\Users\alber\.codex\worktrees\2a10\codestory" --format json` -> local graph initially blocked with `repair_index`; packet/search not trusted.
- `codestory-cli ready --goal local --repair --project "C:\Users\alber\.codex\worktrees\2a10\codestory" --format json` -> `local_navigation` ready, `indexed_file_count: 273`, `error_count: 0`, sidecar retrieval still unavailable with `retrieval_manifest_missing`.
- `codestory-cli ground --project "C:\Users\alber\.codex\worktrees\2a10\codestory" --why` -> grounding snapshot covered 273/273 files and 38981/38981 symbols; used only for orientation, not packet/search proof.
- `Test-Path -LiteralPath 'docs\concepts'` -> `False`.
- Initial `rg -n --hidden --glob '!.git' --glob '!target' 'docs[/\\]concepts'` -> two stale hits in the changed files.
- Repeat `rg -n --hidden --glob '!.git' --glob '!target' 'docs[/\\]concepts'` -> no matches, exit 1.
- `Test-Path -LiteralPath 'docs\glossary.md'` -> `True`.
- `git diff --check` -> pass.
- `rg -n --hidden --glob '!.git' --glob '!target' 'lychee|markdownlint|linkcheck|link-check|broken links|markdown-link|remark|mdbook' .github docs scripts plugins Cargo.toml` -> only checklist text mentions broken links; no concrete repo link-check command found. The repo docs-only lane in `docs/contributors/testing-matrix.md` calls for `git diff --check` and reading changed pages back.

## Risk

Low. This is a docs inventory/path-truth change only. Residual risk is that a future dedicated link checker could prefer a different canonical concepts destination, but no such repo command was present in this checkout.
