### PR TITLE
[codex] fix qdrant smoke finalize retry

### DIFF
--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -20,6 +20,7 @@ use codestory_store::{FileRole, LlmSymbolDoc, RetrievalIndexManifest, Store, Sym
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
+use std::time::Duration;
 use tracing::{info, warn};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -63,6 +64,8 @@ struct SidecarStubFlags {
 }
 
 const SIDECAR_INPUT_BATCH_SIZE: usize = QDRANT_INDEX_UPSERT_BATCH_SIZE * 8;
+const QDRANT_SEMANTIC_SMOKE_RETRY_ATTEMPTS: usize = 2;
+const QDRANT_SEMANTIC_SMOKE_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 pub fn project_id_for_root(project_root: &Path) -> String {
     let canonical = project_root
@@ -487,10 +490,60 @@ fn ensure_qdrant_collection(
             "Qdrant collection ensured and populated"
         );
     }
-    if !qdrant_client.semantic_search_smoke(collection) {
-        bail!("mandatory Qdrant semantic smoke failed for {project_id} collection {collection}");
-    }
+    ensure_qdrant_semantic_smoke(project_id, collection, qdrant_client)?;
     Ok(qdrant_ready_points.unwrap_or_default())
+}
+
+fn ensure_qdrant_semantic_smoke(
+    project_id: &str,
+    collection: &str,
+    qdrant_client: &QdrantClient,
+) -> Result<()> {
+    ensure_qdrant_semantic_smoke_with(
+        project_id,
+        collection,
+        || qdrant_client.semantic_search_smoke_result(collection),
+        QDRANT_SEMANTIC_SMOKE_RETRY_ATTEMPTS,
+        QDRANT_SEMANTIC_SMOKE_RETRY_DELAY,
+        std::thread::sleep,
+    )
+}
+
+fn ensure_qdrant_semantic_smoke_with<F, S>(
+    project_id: &str,
+    collection: &str,
+    mut smoke: F,
+    retry_attempts: usize,
+    retry_delay: Duration,
+    mut sleep: S,
+) -> Result<()>
+where
+    F: FnMut() -> Result<()>,
+    S: FnMut(Duration),
+{
+    let total_attempts = retry_attempts + 1;
+    for attempt in 1..=total_attempts {
+        match smoke() {
+            Ok(()) => return Ok(()),
+            Err(error) if attempt < total_attempts => {
+                warn!(
+                    project_id = %project_id,
+                    collection = %collection,
+                    attempt,
+                    total_attempts,
+                    error = %error,
+                    "Qdrant semantic smoke failed; retrying before finalize"
+                );
+                sleep(retry_delay);
+            }
+            Err(error) => {
+                bail!(
+                    "mandatory Qdrant semantic smoke failed for {project_id} collection {collection} after {attempt} attempt(s): {error:#}"
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 fn ensure_scip_artifacts(
@@ -1095,6 +1148,71 @@ mod tests {
             error.to_string().contains("mandatory"),
             "expected mandatory-sidecar error, got {error:#}"
         );
+    }
+
+    #[test]
+    fn qdrant_semantic_smoke_gate_succeeds_first_attempt() {
+        let mut calls = 0usize;
+        ensure_qdrant_semantic_smoke_with(
+            "proj",
+            "collection",
+            || {
+                calls += 1;
+                Ok(())
+            },
+            2,
+            Duration::from_millis(1),
+            |_| panic!("sleep should not run after first-pass success"),
+        )
+        .expect("smoke succeeds");
+
+        assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn qdrant_semantic_smoke_gate_retries_transient_failure() {
+        let mut calls = 0usize;
+        let mut sleeps = 0usize;
+        ensure_qdrant_semantic_smoke_with(
+            "proj",
+            "collection",
+            || {
+                calls += 1;
+                if calls == 1 {
+                    anyhow::bail!("qdrant semantic smoke search failed: qdrant query warming");
+                }
+                Ok(())
+            },
+            2,
+            Duration::from_millis(1),
+            |_| sleeps += 1,
+        )
+        .expect("retry succeeds");
+
+        assert_eq!(calls, 2);
+        assert_eq!(sleeps, 1);
+    }
+
+    #[test]
+    fn qdrant_semantic_smoke_gate_fails_closed_with_sublayer_detail() {
+        let mut calls = 0usize;
+        let error = ensure_qdrant_semantic_smoke_with(
+            "proj",
+            "collection",
+            || {
+                calls += 1;
+                anyhow::bail!("qdrant semantic smoke search failed: embedding endpoint refused")
+            },
+            2,
+            Duration::from_millis(1),
+            |_| {},
+        )
+        .expect_err("hard smoke failure must fail finalize");
+
+        let message = format!("{error:#}");
+        assert_eq!(calls, 3);
+        assert!(message.contains("mandatory Qdrant semantic smoke failed"));
+        assert!(message.contains("embedding endpoint refused"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/qdrant_client.rs
+++ b/crates/codestory-retrieval/src/qdrant_client.rs
@@ -390,17 +390,26 @@ impl QdrantClient {
 
     /// Smoke semantic search used by health probes (requires indexed collection).
     pub fn semantic_search_smoke(&self, collection: &str) -> bool {
+        self.semantic_search_smoke_result(collection).is_ok()
+    }
+
+    /// Smoke semantic search used by finalize paths when failure detail matters.
+    pub fn semantic_search_smoke_result(&self, collection: &str) -> Result<()> {
         if !qdrant_semantic_vectors_enabled() {
-            return false;
+            bail!("qdrant semantic vectors are disabled");
         }
         match self.search(collection, "function", 3) {
-            Ok(hits) => hits.iter().any(|hit| {
-                let path = hit.file_path.trim();
-                !path.is_empty()
-                    && !path.contains(':')
-                    && (path.contains('/') || path.contains('\\') || path.contains('.'))
-            }),
-            Err(_) => false,
+            Ok(hits) => {
+                if hits.iter().any(hit_has_repo_relative_payload_path) {
+                    Ok(())
+                } else {
+                    bail!(
+                        "qdrant semantic smoke returned {} hit(s) without a repo-relative payload path",
+                        hits.len()
+                    );
+                }
+            }
+            Err(error) => Err(error).context("qdrant semantic smoke search failed"),
         }
     }
 
@@ -437,6 +446,13 @@ impl QdrantClient {
         Self::stub_marker_path(qdrant_data_dir, collection).is_file()
             || Self::legacy_stub_marker_path(qdrant_data_dir, collection).is_file()
     }
+}
+
+fn hit_has_repo_relative_payload_path(hit: &super::CandidateHit) -> bool {
+    let path = hit.file_path.trim();
+    !path.is_empty()
+        && !path.contains(':')
+        && (path.contains('/') || path.contains('\\') || path.contains('.'))
 }
 
 fn parse_collection_names(body: &str) -> Result<Vec<String>> {


### PR DESCRIPTION
## Context

Closes #502.

A completed Qdrant collection could fail the final semantic smoke before `persist_finalized_manifest`, leaving the collection populated but sidecar readiness stuck at `retrieval_manifest_missing`. The failing smoke path also collapsed every sublayer into `mandatory Qdrant semantic smoke failed`, so the operator could not tell whether the miss came from embedding, Qdrant query, payload shape, or disabled vectors.

```mermaid
flowchart LR
  A[Qdrant collection ready] --> B[semantic smoke]
  B -->|transient miss| C[short retry]
  C -->|passes| D[persist finalized manifest]
  C -->|still fails| E[fail closed with sublayer detail]
```

## What Changed

- Added `QdrantClient::semantic_search_smoke_result` so finalize can preserve smoke failure detail while existing health probes keep the bool wrapper.
- Added a small finalize-only retry gate around the mandatory Qdrant semantic smoke.
- Added focused unit coverage for first-pass success, retry success, and hard failure with sublayer detail.

## How To Review

- Start in `crates/codestory-retrieval/src/index.rs` at `ensure_qdrant_collection` and `ensure_qdrant_semantic_smoke_with`.
- Then check `crates/codestory-retrieval/src/qdrant_client.rs` for the diagnostic smoke result and repo-relative payload validation.
- Confirm the retry stays fail-closed: manifest persistence is still downstream of a passing smoke.

## Verification

- `git fetch origin dev/codestory-next`; integrated docs-only commit `f8bda8cc` before commit.
- `cargo test -p codestory-retrieval qdrant_semantic_smoke_gate --lib` - passed, 3 tests.
- `cargo fmt --check` - passed.
- `git diff --check` - passed.
- `codestory-cli ready --goal local --repair --project C:\Users\alber\.codex\worktrees\2198\codestory --format json` - local navigation ready, fresh index, 273 files.
- `codestory-cli retrieval status --project C:\Users\alber\.codex\worktrees\2198\codestory --format json` - fail-closed as expected: `retrieval_mode=unavailable`, `degraded_reason=retrieval_manifest_missing`.
- `codestory-cli doctor --project C:\Users\alber\.codex\worktrees\2198\codestory --format json` - local navigation ready; agent packet/search remains `repair_retrieval` until sidecar manifest exists.

## Risk

- The retry adds up to 500ms only when the finalize semantic smoke fails.
- This lane did not run a live full sidecar finalize because the local worktree has no finalized retrieval manifest and the llama.cpp endpoint is unavailable.
