### PR TITLE
Fix files support tier metadata

### DIFF
--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -71,6 +71,19 @@ pub fn schedule_index(project_path: &str) -> usize {
     .expect("write runtime.rs");
 }
 
+fn write_docker_compose_fixture(root: &Path) {
+    let docker = root.join("docker");
+    fs::create_dir_all(&docker).expect("create docker dir");
+    fs::write(
+        docker.join("app-compose.yml"),
+        r#"services:
+  app:
+    image: tiny-browser-fixture:latest
+"#,
+    )
+    .expect("write docker compose");
+}
+
 fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> std::process::Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
     command
@@ -1221,6 +1234,40 @@ fn app_controller_opens_project() {
     );
 
     search_dir_snapshot.assert_unchanged();
+}
+
+#[test]
+fn files_json_reports_structural_support_tiers_for_cargo_and_compose() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+    write_docker_compose_fixture(workspace.path());
+    index_tiny_workspace_for_browser_loop(workspace.path(), cache_dir.path());
+
+    let files = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["files", "--refresh", "none", "--format", "json"],
+    );
+
+    assert!(
+        files["summary"]["language_counts"]
+            .as_array()
+            .is_some_and(|items| {
+                items.iter().any(|item| {
+                    item["language"] == "cargo_manifest"
+                        && item["support_mode"] == "structural_collector"
+                        && item["evidence_tier"] == "structural_only"
+                        && item["claim_label"] == "structural collector only"
+                }) && items.iter().any(|item| {
+                    item["language"] == "docker_compose"
+                        && item["support_mode"] == "structural_collector"
+                        && item["evidence_tier"] == "structural_only"
+                        && item["claim_label"] == "structural collector only"
+                })
+            }),
+        "files JSON should expose path-scoped structural support tiers for manifests and Compose: {files:#}"
+    );
 }
 
 struct SearchDirSnapshot {

--- a/crates/codestory-contracts/src/language_support.rs
+++ b/crates/codestory-contracts/src/language_support.rs
@@ -280,6 +280,8 @@ pub const LANGUAGE_SUPPORT_PROFILES: &[LanguageSupportProfile] = &[
     structural_profile("html", &["html", "htm"]),
     structural_profile("css", &["css"]),
     structural_profile("sql", &["sql"]),
+    structural_profile("docker_compose", &[]),
+    structural_profile("cargo_manifest", &[]),
 ];
 
 const fn parser_profile(
@@ -711,6 +713,14 @@ mod tests {
         assert!(!is_docker_compose_file_path("openapi.yaml"));
         assert!(!is_docker_compose_file_path("docs/service.yml"));
         assert!(language_support_profile_for_ext("yaml").is_none());
+        let profile = language_support_profile_for_language_name("docker_compose")
+            .expect("docker compose structural profile");
+        assert_eq!(
+            profile.support_mode,
+            LanguageSupportMode::StructuralCollector
+        );
+        assert_eq!(profile.evidence_tier, LanguageEvidenceTier::StructuralOnly);
+        assert!(profile.extensions.is_empty());
     }
 
     #[test]
@@ -723,5 +733,13 @@ mod tests {
         assert!(!is_cargo_manifest_file_path(".cargo/config.toml"));
         assert!(!is_cargo_manifest_file_path("Cargo.lock"));
         assert!(language_support_profile_for_ext("toml").is_none());
+        let profile = language_support_profile_for_language_name("cargo_manifest")
+            .expect("cargo manifest structural profile");
+        assert_eq!(
+            profile.support_mode,
+            LanguageSupportMode::StructuralCollector
+        );
+        assert_eq!(profile.evidence_tier, LanguageEvidenceTier::StructuralOnly);
+        assert!(profile.extensions.is_empty());
     }
 }


### PR DESCRIPTION
## Context
Closes #482.

`codestory-cli files --format json` already indexed Cargo manifests and Docker Compose files, but the language-count summary reported `support_mode=unknown` and `evidence_tier=unknown` for `cargo_manifest` and `docker_compose`. The structural collector contract in `language_support.rs` already defines these as exact-source structural proof surfaces; the files summary was falling through because those path-scoped language names were not present in the public support profile table.

## What Changed
- Added empty-extension structural profiles for `docker_compose` and `cargo_manifest`, preserving the existing no-generic-TOML/YAML routing boundary.
- Added contract assertions that both language names resolve to `structural_collector` / `structural_only` while keeping `.toml` and `.yaml` unsupported by extension alone.
- Added a focused CLI files-output fixture that indexes Cargo plus Docker Compose and asserts both language-count rows expose structural support tier metadata.

## How To Review
- Check `crates/codestory-contracts/src/language_support.rs` for the profile-table addition and path-scoped tests.
- Check `crates/codestory-cli/tests/cli_golden_path.rs` for the dedicated files JSON fixture.
- Confirm no sidecar finalize, docs inventory, release versioning, or broad language-support redesign surfaces changed.

## Verification
- `cargo test -p codestory-contracts language_support -- --nocapture` passed: 7 passed.
- `cargo test -p codestory-cli --test cli_golden_path files_json_reports_structural_support_tiers_for_cargo_and_compose -- --nocapture` passed: 1 passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- `target/debug/codestory-cli.exe ready --goal local --repair --project C:\Users\alber\.codex\worktrees\8de3\codestory --format json` passed with `indexed_file_count=273`, `error_count=0`.
- `target/debug/codestory-cli.exe files --project C:\Users\alber\.codex\worktrees\8de3\codestory --format json` showed `cargo_manifest` and `docker_compose` as `structural_collector` / `structural_only`.

## Risk
- I also ran `cargo test -p codestory-cli --test cli_golden_path tiny_workspace_browser_loop_works_from_existing_cache -- --nocapture`; it failed on a pre-existing/current-base readiness-message mismatch where stdio `context` reports stale index repair before the expected sidecar wording. The new #482 fixture passes and does not modify that browser-loop fixture.