### PR TITLE
[codex] document sidecar readiness repair

### DIFF
--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -182,5 +182,5 @@ Promotion requires at least:
 
 Proof tiers, promotion checklist, and north-star SLOs:
 [`retrieval-architecture.md`](../testing/retrieval-architecture.md). Setup,
-version pins, env vars, and CI smoke:
-[`retrieval-sidecars.md`](../ops/retrieval-sidecars.md).
+version pins, agent readiness repair, env vars, and CI smoke:
+[`retrieval-sidecars.md`](../ops/retrieval-sidecars.md#agent-readiness-repair).

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -31,6 +31,65 @@ flowchart LR
     cli --> embed[llama.cpp embedding endpoint]
 ```
 
+## Agent readiness repair
+
+Use this section when an agent tool says `packet`, `search`, or `context` is
+blocked, or when `doctor` reports `agent_packet_search` needs repair. Keep local
+navigation and agent retrieval separate: a ready SQLite graph can support
+`ground`, `files`, and symbol navigation while sidecar packet/search remains
+blocked.
+
+Start with the active runtime surface:
+
+```sh
+codestory-cli agent preflight --project <repo> --format json
+codestory-cli doctor --project <repo> --format markdown
+codestory-cli retrieval status --project <repo> --format json
+```
+
+When plugin MCP is live, read `codestory://status` first and use its
+`allowed_surfaces` values as the tool boundary. Do not infer the active runtime
+from the source checkout, marketplace cache, or PATH when status is available.
+
+| State | Meaning | Operator action |
+|-------|---------|-----------------|
+| `local_navigation=ready`, `agent_packet_search=ready`, `sidecar_mode=full` | Local graph and sidecar packet/search infrastructure are ready | Use packet/search/context as infrastructure-eligible, then prove answer quality with source, packet-runtime, drill, or benchmark evidence |
+| `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; run the repair command from preflight/status before packet/search claims |
+| `local_navigation=repair_local` | Core index or cache is missing or stale | Run `codestory-cli ready --goal local --repair --project <repo> --format json`, then rerun `doctor` |
+| `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Repair the failing sidecar layer, rerun `retrieval index --refresh full`, then rerun `retrieval status` |
+| `doctor` ready but a packet/search command returns `retrieval_unavailable` | Runtime/status disagreement or sidecar process drift | Capture the failing command output, `doctor`, and `retrieval status`; repair the named layer before retrying |
+
+Layer repair should follow the first failing layer, not a broad rebuild:
+
+| Failing layer | Evidence to capture | Small repair |
+|---------------|---------------------|--------------|
+| Active runtime or plugin adapter | `codestory://status` fields, `server_executable`, `cli_version`, `plugin_runtime`, `allowed_surfaces` | Reload or reinstall the active CLI/plugin runtime, then reread status |
+| Core SQLite graph | `doctor` cache/index checks and indexed file counts | `codestory-cli ready --goal local --repair --project <repo> --format json` |
+| Zoekt lexical sidecar | `retrieval status` mode/degraded reason and Zoekt health text | Free port `6070` or rerun bootstrap, then `retrieval index --refresh full` |
+| Qdrant dense sidecar | Qdrant health, collection name, point count, dense-anchor count, backend/dimension fields | Fix Qdrant/model/backend state; move the Qdrant cache aside only if repeated health checks fail |
+| SCIP graph artifacts | `scip_unavailable`, graph artifact hash/path, manifest contract | Rerun `retrieval index --refresh full`; inspect SCIP cache paths if it repeats |
+| Embedding endpoint | `CODESTORY_EMBED_LLAMACPP_URL`, managed embeddings probe, model/backend/dimension fields | Start or reconfigure llama.cpp, then rerun retrieval index/status |
+| Manifest contract | `manifest_contract`, source root, input hash, generation, schema, graph hash, counts, lane provenance | Rerun `retrieval index --project <repo> --refresh full` |
+
+A legacy semantic diagnostic warning against `127.0.0.1:8080` is not by itself a
+packet/search blocker when `doctor` reports `sidecar_retrieval: mode=full` and
+the managed embeddings probe succeeds against the configured endpoint. Keep the
+warning in the evidence bundle; do not treat it as proof that a separate
+runtime fix has landed.
+
+Attach these artifacts to issues or PRs that claim readiness repair:
+
+- `codestory://status` transcript when MCP is live, or the full
+  `agent preflight` JSON when it is not.
+- `doctor --format markdown` or JSON output, including readiness verdicts and
+  legacy/managed embedding diagnostics.
+- `retrieval status --format json`, including `retrieval_mode`,
+  `degraded_reason`, and `manifest_contract`.
+- The exact failing `packet`, `search`, or `context` command output when a
+  ready status disagrees with a tool call.
+- Any cache directory moved aside during reset, plus the status output after the
+  replacement index is healthy.
+
 ## Operator repair path
 
 ### Prerequisites

--- a/docs/testing/retrieval-architecture.md
+++ b/docs/testing/retrieval-architecture.md
@@ -6,8 +6,8 @@ generic symbol/path roles; benchmark-only probe catalogs remain behind test-only
 Sidecar retrieval is mandatory for current evidence; `CODESTORY_RETRIEVAL=0` is treated as a
 configuration error, not a diagnostic route.
 
-**Related:** [`../ops/retrieval-sidecars.md`](../ops/retrieval-sidecars.md) (setup,
-env vars, CI smoke), [`../architecture/retrieval-design.md`](../architecture/retrieval-design.md)
+**Related:** [`../ops/retrieval-sidecars.md`](../ops/retrieval-sidecars.md#agent-readiness-repair) (setup,
+agent readiness repair, env vars, CI smoke), [`../architecture/retrieval-design.md`](../architecture/retrieval-design.md)
 (mode definitions, cost envelopes, promotion guards).
 
 ---
@@ -78,7 +78,7 @@ classified as source-truth follow-up rather than hidden grounding.
 
 Version pins, env vars, bootstrap commands, troubleshooting, and CI smoke
 sequences are owned by
-[`retrieval-sidecars.md`](../ops/retrieval-sidecars.md). AST-first policy gates
+[`retrieval-sidecars.md`](../ops/retrieval-sidecars.md#agent-readiness-repair). AST-first policy gates
 and dense-anchor promotion fields are summarized there and in
 [`retrieval-design.md`](../architecture/retrieval-design.md#ast-first-semantic-contract).
 


### PR DESCRIPTION
## Context

Closes #485.

Operator sidecar readiness repair had setup and status details in the sidecar runbook, but no single repair path tying status states, failing layers, commands, and evidence artifacts together. Nearby architecture and promotion docs already route to the ops surface.

```mermaid
flowchart LR
    status[status or doctor] --> local{local ready?}
    local -- no --> graph[repair local graph]
    local -- yes --> agent{agent full?}
    agent -- no --> sidecar[repair failing sidecar layer]
    agent -- yes --> evidence[capture packet/search evidence]
```

## What Changed

- Added `Agent readiness repair` to `docs/ops/retrieval-sidecars.md` as the canonical operator repair path.
- Documented readiness states, failing layers, minimum repair commands, and evidence artifacts.
- Linked the architecture and promotion docs to that canonical section instead of duplicating the workflow.

## How To Review

1. Start at `docs/ops/retrieval-sidecars.md#agent-readiness-repair`.
2. Confirm the linked architecture/testing docs point to that section cleanly.
3. Confirm the diff stays docs-only and avoids runtime code, release versioning, language-support output, and Qdrant finalize implementation surfaces.

## Verification

- `codestory-cli agent preflight --project C:\Users\alber\source\repos\codestory --format json` -> usable, local graph ready, full retrieval ready.
- `codestory-cli doctor --project C:\Users\alber\source\repos\codestory --format markdown` -> `local_navigation=ready`, `agent_packet_search=ready`, `sidecar_mode=full`; legacy `127.0.0.1:8080` semantic warning still present; managed embeddings probe OK at configured `127.0.0.1:25072`.
- `codestory-cli search --project C:\Users\alber\source\repos\codestory --query "agent sidecar readiness repair docs status states failing layers commands evidence artifacts retrieval sidecars" --why` -> failed with `retrieval_unavailable` / `zoekt_unreachable`; treated as a recovery-evidence scenario, not proof of answer quality.
- `git diff --check` -> passed.
- `rg -n "#agent-readiness-repair|## Agent readiness repair|retrieval_unavailable|legacy semantic diagnostic|agent_packet_search|allowed_surfaces" docs\ops\retrieval-sidecars.md docs\architecture\retrieval-design.md docs\testing\retrieval-architecture.md` -> passed.
- No Cargo run; docs-only lane.

## Risk

Low. This is documentation-only. Main risk is status vocabulary drift if the runtime changes later. The docs do not claim #502 removes the legacy semantic warning.