### PR TITLE
[codex] Share agent runtime construction

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -205,6 +205,10 @@ fn main() -> Result<()> {
     }
 }
 
+fn new_agent_surface_runtime(project: &ProjectArgs) -> Result<RuntimeContext> {
+    RuntimeContext::new_agent_sidecar(project)
+}
+
 fn run_cache(cmd: CacheCommand) -> Result<()> {
     match cmd.action {
         CacheAction::Identity(cmd) => run_cache_identity(cmd),
@@ -1002,7 +1006,7 @@ struct ResolvedContextTarget {
 fn run_context(cmd: ContextCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "context")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "context")?;
 
@@ -1049,7 +1053,7 @@ fn run_context(cmd: ContextCommand) -> Result<()> {
 fn run_packet(cmd: PacketCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "packet")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "packet")?;
 
@@ -1580,7 +1584,7 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     preflight_output_file(cmd.output_file.as_deref())?;
     let runtime = if cmd.repair {
         if matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
-            RuntimeContext::new_agent_sidecar(&cmd.project)?
+            new_agent_surface_runtime(&cmd.project)?
         } else {
             RuntimeContext::new(&cmd.project)?
         }
@@ -1788,7 +1792,7 @@ fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> Strin
 fn run_search(cmd: SearchCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "search")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "search")?;
     let search_results = runtime
@@ -8636,7 +8640,7 @@ fn render_affected_footer(
 }
 
 fn run_serve(cmd: ServeCommand) -> Result<()> {
-    let runtime = RuntimeContext::new_agent_sidecar(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "serve")?;
     if cmd.stdio {

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -75,6 +75,35 @@ fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
 }
 
 #[test]
+fn direct_cli_and_stdio_agent_surfaces_share_runtime_constructor() {
+    let main = read("crates/codestory-cli/src/main.rs");
+    let helper = source_between(&main, "fn new_agent_surface_runtime", "fn run_cache");
+    assert!(
+        helper.contains("RuntimeContext::new_agent_sidecar(project)"),
+        "shared agent surface runtime must keep ready/direct CLI/stdio on the agent-sidecar constructor"
+    );
+
+    for (start, end, surface) in [
+        ("fn run_context", "fn run_packet", "context"),
+        ("fn run_packet", "fn render_packet_markdown", "packet"),
+        ("fn run_search", "fn search_request_from_command", "search"),
+        ("fn run_serve", "fn run_generate_completions", "stdio/serve"),
+    ] {
+        let body = source_between(&main, start, end);
+        assert!(
+            body.contains("new_agent_surface_runtime(&cmd.project)?"),
+            "{surface} must use the same agent-sidecar runtime constructor as stdio status/ready"
+        );
+    }
+
+    let ready = source_between(&main, "fn run_ready", "fn run_agent");
+    assert!(
+        ready.contains("new_agent_surface_runtime(&cmd.project)?"),
+        "ready --goal agent --repair must stay on the shared agent-sidecar runtime constructor"
+    );
+}
+
+#[test]
 fn workspace_crate_stays_decoupled_from_store_and_runtime() {
     let dependencies = dependency_names("crates/codestory-workspace/Cargo.toml");
     assert!(


### PR DESCRIPTION
## Context
Closes #479.

Direct CLI `packet`, `search`, and `context` were constructing runtime through the inspect-only path while `ready --goal agent --repair` and `serve --stdio` used the agent-sidecar constructor. That left agent-facing surfaces able to disagree about sidecar defaults before they reached the same readiness contract.

```mermaid
flowchart LR
  Direct["direct packet/search/context"] --> Shared["new_agent_surface_runtime"]
  Ready["ready --goal agent --repair"] --> Shared
  Stdio["serve --stdio status/tools"] --> Shared
  Shared --> Agent["RuntimeContext::new_agent_sidecar"]
  Agent --> Readiness["agent_packet_search readiness"]
```

## What Changed
- Added `new_agent_surface_runtime` as the CLI boundary helper for agent-facing runtime construction.
- Routed direct CLI `context`, `packet`, and `search` through the same helper as `ready --goal agent --repair` and `serve --stdio`.
- Added an architecture-contract regression pinning direct CLI, ready, and stdio/serve to the same agent-sidecar constructor.

## How To Review
- Start in `crates/codestory-cli/src/main.rs` and confirm the direct agent surfaces no longer use `RuntimeContext::new_inspect_only`.
- Check `crates/codestory-cli/tests/architecture_contracts.rs` for the drift guard.
- The intended behavior change is constructor alignment only; blocked-command wording, files output, release evidence, and sidecar repair docs are untouched.

## Verification
- `cargo test -p codestory-cli --test architecture_contracts direct_cli_and_stdio_agent_surfaces_share_runtime_constructor` passed.
- `cargo test -p codestory-cli agent_sidecar_runtime_defaults_prevent_managed_onnx_autostart` passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls` passed.
- `target/debug/codestory-cli.exe ready --goal local --repair --project ... --format json` reported local navigation `ready`, 273 indexed files, 0 changed/new/removed.
- `target/debug/codestory-cli.exe ready --goal agent --project ... --format json` reported `repair_retrieval`, `retrieval_mode=unavailable`, `degraded_reason=retrieval_manifest_missing`.
- Direct `packet`, `search`, and `context` commands all failed closed with `retrieval_unavailable`, expected `mode=full`, reason `retrieval_manifest_missing`.
- Raw stdio `resources/read` for `codestory://status` reported local surfaces allowed and `packet/search/context` blocked with `status=repair_retrieval`, `repair_reason=retrieval_manifest_missing`.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk
Low code risk: this only changes runtime construction for already agent-facing direct CLI commands. Full sidecar success was not proven in this worktree because sidecar retrieval is unavailable due `retrieval_manifest_missing`; the verified behavior is fail-closed agreement across direct CLI and stdio status.