### PR TITLE
Gate packaged agent proof

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import textwrap
+import zipfile
+from pathlib import Path
+
+
+DEFAULT_QUESTION = "Explain how CodeStory validates packaged agent readiness."
+DEFAULT_QUERY = "RuntimeContext"
+STATUS_URI = "codestory://status"
+
+
+class GateFailure(Exception):
+    def __init__(self, layer: str, artifact: Path, message: str):
+        super().__init__(message)
+        self.layer = layer
+        self.artifact = artifact
+        self.message = message
+
+
+def fail(layer: str, artifact: Path, message: str) -> None:
+    raise GateFailure(layer, artifact, message)
+
+
+def ensure_inside(path: Path, root: Path) -> None:
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise ValueError(f"archive member escapes extraction root: {path}")
+
+
+def unpack_archive(archive: Path, destination: Path) -> None:
+    if zipfile.is_zipfile(archive):
+        with zipfile.ZipFile(archive) as handle:
+            for member in handle.infolist():
+                target = destination / member.filename
+                ensure_inside(target, destination)
+            handle.extractall(destination)
+        return
+
+    if tarfile.is_tarfile(archive):
+        with tarfile.open(archive) as handle:
+            for member in handle.getmembers():
+                target = destination / member.name
+                ensure_inside(target, destination)
+            handle.extractall(destination)
+        return
+
+    raise ValueError(f"unsupported archive format: {archive}")
+
+
+def find_cli(unpacked: Path) -> Path:
+    names = {"codestory-cli", "codestory-cli.exe", "codestory-cli.cmd"}
+    matches = [path for path in unpacked.rglob("*") if path.is_file() and path.name in names]
+    if not matches:
+        raise FileNotFoundError(f"archive does not contain codestory-cli under {unpacked}")
+    cli = sorted(matches, key=lambda path: (len(path.parts), str(path)))[0]
+    if cli.suffix != ".cmd":
+        cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
+    return cli
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_json_file(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_command(
+    cli: Path,
+    layer: str,
+    args: list[str],
+    artifact: Path,
+    timeout_secs: int,
+    parse_json: bool = True,
+) -> object | None:
+    stdout_path = artifact.with_suffix(artifact.suffix + ".stdout.txt")
+    stderr_path = artifact.with_suffix(artifact.suffix + ".stderr.txt")
+    command = [str(cli), *args]
+    try:
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_secs,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout_path.write_text(exc.stdout or "", encoding="utf-8")
+        stderr_path.write_text(exc.stderr or "", encoding="utf-8")
+        fail(layer, stdout_path, f"command timed out after {timeout_secs}s: {' '.join(command)}")
+
+    stdout_path.write_text(result.stdout, encoding="utf-8")
+    stderr_path.write_text(result.stderr, encoding="utf-8")
+    if result.returncode != 0:
+        artifact_path = stderr_path if result.stderr.strip() else stdout_path
+        fail(layer, artifact_path, f"command exited {result.returncode}: {' '.join(command)}")
+
+    if not parse_json:
+        artifact.write_text(result.stdout, encoding="utf-8")
+        return None
+
+    if artifact.exists() and artifact.stat().st_size > 0:
+        try:
+            return read_json_file(artifact)
+        except json.JSONDecodeError as exc:
+            fail(layer, artifact, f"output file is not valid JSON: {exc}")
+
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        fail(layer, stdout_path, f"stdout is not valid JSON: {exc}")
+    write_json(artifact, parsed)
+    return parsed
+
+
+def require(value: bool, layer: str, artifact: Path, message: str) -> None:
+    if not value:
+        fail(layer, artifact, message)
+
+
+def require_agent_ready(payload: object, layer: str, artifact: Path) -> None:
+    verdicts = payload.get("verdicts", []) if isinstance(payload, dict) else []
+    agent = next((item for item in verdicts if item.get("goal") == "agent_packet_search"), None)
+    require(agent is not None, layer, artifact, "missing agent_packet_search readiness verdict")
+    require(
+        agent.get("status") == "ready",
+        layer,
+        artifact,
+        f"agent_packet_search status is {agent.get('status')!r}, expected 'ready'",
+    )
+
+
+def require_retrieval_full(payload: object, layer: str, artifact: Path) -> None:
+    mode = payload.get("retrieval_mode") if isinstance(payload, dict) else None
+    if mode is None and isinstance(payload, dict):
+        mode = payload.get("sidecar_retrieval", {}).get("retrieval_mode")
+    require(mode == "full", layer, artifact, f"retrieval_mode is {mode!r}, expected 'full'")
+
+
+def require_search_full(payload: object, artifact: Path) -> None:
+    shadow = payload.get("retrieval_shadow") if isinstance(payload, dict) else None
+    mode = shadow.get("retrieval_mode") if isinstance(shadow, dict) else None
+    require(mode == "full", "search", artifact, f"search retrieval_shadow.retrieval_mode is {mode!r}")
+
+
+def require_packet_ready(payload: object, artifact: Path) -> None:
+    require(isinstance(payload, dict), "packet", artifact, "packet output is not a JSON object")
+    require("sufficiency" in payload, "packet", artifact, "packet output missing sufficiency")
+    require("retrieval_trace_summary" in payload, "packet", artifact, "packet output missing retrieval trace summary")
+
+
+def require_context_ready(payload: object, artifact: Path) -> None:
+    require(isinstance(payload, dict), "context", artifact, "context output is not a JSON object")
+    require("retrieval_trace" in payload, "context", artifact, "context output missing retrieval trace")
+
+
+def stdio_request(process: subprocess.Popen[str], request: dict, layer: str, artifact: Path) -> dict:
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write(json.dumps(request) + "\n")
+    process.stdin.flush()
+    line = process.stdout.readline()
+    if not line:
+        fail(layer, artifact, "serve --stdio closed before responding")
+    try:
+        response = json.loads(line)
+    except json.JSONDecodeError as exc:
+        artifact.write_text(line, encoding="utf-8")
+        fail(layer, artifact, f"serve --stdio emitted invalid JSON: {exc}")
+    return response
+
+
+def stdio_status(cli: Path, project: Path, artifact: Path, timeout_secs: int) -> dict:
+    stderr_path = artifact.with_suffix(artifact.suffix + ".stderr.txt")
+    command = [
+        str(cli),
+        "serve",
+        "--stdio",
+        "--refresh",
+        "none",
+        "--project",
+        str(project),
+    ]
+    process = subprocess.Popen(
+        command,
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        tools = stdio_request(
+            process,
+            {"jsonrpc": "2.0", "id": "tools", "method": "tools/list"},
+            "serve_stdio",
+            artifact,
+        )
+        status_response = stdio_request(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": "status",
+                "method": "resources/read",
+                "params": {"uri": STATUS_URI},
+            },
+            "serve_stdio",
+            artifact,
+        )
+    finally:
+        process.kill()
+        _, stderr = process.communicate(timeout=timeout_secs)
+        stderr_path.write_text(stderr or "", encoding="utf-8")
+
+    payload = {"tools": tools, "status_response": status_response}
+    write_json(artifact, payload)
+    if "error" in tools:
+        fail("serve_stdio", artifact, f"tools/list failed: {tools['error']}")
+    if "error" in status_response:
+        fail("serve_stdio", artifact, f"status resource failed: {status_response['error']}")
+
+    contents = status_response.get("result", {}).get("contents", [])
+    content = next((item for item in contents if item.get("uri") == STATUS_URI), None)
+    require(content is not None, "serve_stdio", artifact, "status response missing codestory://status")
+    status = json.loads(content.get("text", "{}"))
+    payload["status"] = status
+    write_json(artifact, payload)
+    return status
+
+
+def require_stdio_ready(status: dict, artifact: Path) -> None:
+    require(status.get("server_version") is not None, "serve_stdio", artifact, "status missing server_version")
+    surfaces = status.get("allowed_surfaces", {})
+    for name in ["packet", "search", "context"]:
+        allowed = surfaces.get(name, {}).get("allowed")
+        require(allowed is True, "serve_stdio", artifact, f"allowed_surfaces.{name}.allowed is {allowed!r}")
+
+
+def run_gate(args: argparse.Namespace) -> None:
+    archive = Path(args.archive).resolve()
+    project = Path(args.project).resolve()
+    out_dir = Path(args.out_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="codestory-packaged-agent-proof-", dir=out_dir) as temp:
+        unpacked = Path(temp) / "unpacked"
+        unpacked.mkdir()
+        unpack_archive(archive, unpacked)
+        cli = find_cli(unpacked)
+
+        summary = {
+            "archive": str(archive),
+            "cli": str(cli),
+            "project": str(project),
+            "artifacts": {},
+        }
+        write_json(out_dir / "summary.json", summary)
+
+        version_artifact = out_dir / "version.txt"
+        run_command(cli, "version", ["--version"], version_artifact, args.timeout_secs, parse_json=False)
+        summary["artifacts"]["version"] = str(version_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        ready_artifact = out_dir / "ready.json"
+        ready = run_command(
+            cli,
+            "ready",
+            [
+                "ready",
+                "--goal",
+                "agent",
+                "--repair",
+                "--project",
+                str(project),
+                "--format",
+                "json",
+                "--output-file",
+                str(ready_artifact),
+            ],
+            ready_artifact,
+            args.timeout_secs,
+        )
+        require_agent_ready(ready, "ready", ready_artifact)
+        summary["artifacts"]["ready"] = str(ready_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        doctor_artifact = out_dir / "doctor.json"
+        doctor = run_command(
+            cli,
+            "doctor",
+            ["doctor", "--project", str(project), "--format", "json", "--output-file", str(doctor_artifact)],
+            doctor_artifact,
+            args.timeout_secs,
+        )
+        require_retrieval_full(doctor, "doctor", doctor_artifact)
+        summary["artifacts"]["doctor"] = str(doctor_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        status_artifact = out_dir / "retrieval-status.json"
+        status = run_command(
+            cli,
+            "retrieval_status",
+            [
+                "retrieval",
+                "status",
+                "--project",
+                str(project),
+                "--format",
+                "json",
+                "--output-file",
+                str(status_artifact),
+            ],
+            status_artifact,
+            args.timeout_secs,
+        )
+        require_retrieval_full(status, "retrieval_status", status_artifact)
+        summary["artifacts"]["retrieval_status"] = str(status_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        search_artifact = out_dir / "search.json"
+        search = run_command(
+            cli,
+            "search",
+            [
+                "search",
+                "--project",
+                str(project),
+                "--query",
+                args.query,
+                "--why",
+                "--format",
+                "json",
+                "--output-file",
+                str(search_artifact),
+            ],
+            search_artifact,
+            args.timeout_secs,
+        )
+        require_search_full(search, search_artifact)
+        summary["artifacts"]["search"] = str(search_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        context_artifact = out_dir / "context.json"
+        context = run_command(
+            cli,
+            "context",
+            [
+                "context",
+                "--project",
+                str(project),
+                "--query",
+                args.context_query,
+                "--format",
+                "json",
+                "--output-file",
+                str(context_artifact),
+            ],
+            context_artifact,
+            args.timeout_secs,
+        )
+        require_context_ready(context, context_artifact)
+        summary["artifacts"]["context"] = str(context_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        packet_artifact = out_dir / "packet.json"
+        packet = run_command(
+            cli,
+            "packet",
+            [
+                "packet",
+                "--project",
+                str(project),
+                "--question",
+                args.question,
+                "--budget",
+                "tiny",
+                "--format",
+                "json",
+                "--output-file",
+                str(packet_artifact),
+            ],
+            packet_artifact,
+            args.timeout_secs,
+        )
+        require_packet_ready(packet, packet_artifact)
+        summary["artifacts"]["packet"] = str(packet_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        stdio_artifact = out_dir / "serve-stdio-status.json"
+        status = stdio_status(cli, project, stdio_artifact, args.timeout_secs)
+        require_stdio_ready(status, stdio_artifact)
+        summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+    print(f"packaged agent proof passed; artifacts={out_dir}")
+
+
+def write_fake_cli(path: Path) -> None:
+    fake = path / "fake_cli.py"
+    fake.write_text(
+        textwrap.dedent(
+            r'''
+            import json
+            import os
+            import sys
+
+            def emit(value):
+                if "--output-file" in sys.argv:
+                    out = sys.argv[sys.argv.index("--output-file") + 1]
+                    open(out, "w", encoding="utf-8").write(json.dumps(value))
+                else:
+                    print(json.dumps(value))
+
+            fail = os.environ.get("CODESTORY_FAKE_FAIL_LAYER")
+            if "--version" in sys.argv:
+                print("codestory-cli 9.9.9")
+                raise SystemExit(0)
+            layer = sys.argv[1]
+            if layer == "retrieval" and len(sys.argv) > 2:
+                layer = "retrieval_status"
+            if fail == f"{layer}_stderr":
+                print("forced stderr failure", file=sys.stderr)
+                raise SystemExit(3)
+            if fail == layer:
+                print("forced failure")
+                raise SystemExit(2)
+            if layer == "ready":
+                emit({"verdicts": [{"goal": "agent_packet_search", "status": "ready"}]})
+            elif layer == "doctor":
+                emit({"retrieval_mode": "full"})
+            elif layer == "retrieval_status":
+                emit({"retrieval_mode": "full"})
+            elif layer == "search":
+                emit({"retrieval_shadow": {"retrieval_mode": "full"}, "indexed_symbol_hits": [{"node_id": "1"}]})
+            elif layer == "context":
+                emit({"retrieval_trace": {"resolved_profile": "investigate"}})
+            elif layer == "packet":
+                emit({"sufficiency": {"status": "supported"}, "retrieval_trace_summary": {}})
+            elif layer == "serve":
+                for line in sys.stdin:
+                    request = json.loads(line)
+                    if request.get("method") == "tools/list":
+                        result = {"tools": [{"name": "packet"}, {"name": "search"}, {"name": "context"}]}
+                    else:
+                        status = {
+                            "server_version": "9.9.9",
+                            "allowed_surfaces": {
+                                "packet": {"allowed": True},
+                                "search": {"allowed": True},
+                                "context": {"allowed": True},
+                            },
+                        }
+                        result = {"contents": [{"uri": "codestory://status", "mimeType": "application/json", "text": json.dumps(status)}]}
+                    print(json.dumps({"jsonrpc": "2.0", "id": request.get("id"), "result": result}), flush=True)
+            else:
+                raise SystemExit(f"unknown fake layer: {layer}")
+            '''
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    if os.name == "nt":
+        wrapper = path / "codestory-cli.cmd"
+        wrapper.write_text(f'@echo off\r\n"{sys.executable}" "%~dp0fake_cli.py" %*\r\n', encoding="utf-8")
+    else:
+        wrapper = path / "codestory-cli"
+        wrapper.write_text(f"#!{sys.executable}\nimport runpy\nrunpy.run_path({str(fake)!r}, run_name='__main__')\n", encoding="utf-8")
+        wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+
+
+def self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="codestory-packaged-proof-self-test-") as temp:
+        root = Path(temp)
+        stage = root / "pkg" / "codestory-cli-v9.9.9-test"
+        stage.mkdir(parents=True)
+        write_fake_cli(stage)
+        archive = root / "fake.zip"
+        with zipfile.ZipFile(archive, "w") as handle:
+            for path in stage.rglob("*"):
+                handle.write(path, path.relative_to(stage.parent).as_posix())
+        project = root / "repo"
+        project.mkdir()
+        out_dir = root / "out"
+        args = argparse.Namespace(
+            archive=str(archive),
+            project=str(project),
+            out_dir=str(out_dir),
+            query=DEFAULT_QUERY,
+            context_query=DEFAULT_QUERY,
+            question=DEFAULT_QUESTION,
+            timeout_secs=30,
+        )
+        run_gate(args)
+        assert (out_dir / "summary.json").is_file()
+
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "search"
+        try:
+            try:
+                run_gate(args)
+            except GateFailure as exc:
+                assert exc.layer == "search"
+                assert "search.json.stdout.txt" in str(exc.artifact)
+            else:
+                raise AssertionError("forced fake search failure should fail the gate")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "doctor_stderr"
+        try:
+            try:
+                run_gate(args)
+            except GateFailure as exc:
+                assert exc.layer == "doctor"
+                assert "doctor.json.stderr.txt" in str(exc.artifact)
+            else:
+                raise AssertionError("stderr fake failure should point at stderr artifact")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+    print("self-test passed")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gate releases on packaged full-sidecar agent proof.")
+    parser.add_argument("--archive", help="Packaged codestory-cli archive to test.")
+    parser.add_argument("--project", default=".", help="Representative repository to prove against.")
+    parser.add_argument("--out-dir", default="target/packaged-agent-proof", help="Artifact directory.")
+    parser.add_argument("--query", default=DEFAULT_QUERY, help="Search proof query.")
+    parser.add_argument("--context-query", default=DEFAULT_QUERY, help="Context proof target query.")
+    parser.add_argument("--question", default=DEFAULT_QUESTION, help="Packet proof question.")
+    parser.add_argument("--timeout-secs", type=int, default=1800, help="Per-layer timeout.")
+    parser.add_argument("--self-test", action="store_true", help="Run script self-tests.")
+    args = parser.parse_args()
+    if not args.self_test and not args.archive:
+        parser.error("--archive is required unless --self-test is set")
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    if args.self_test:
+        self_test()
+        return
+    try:
+        run_gate(args)
+    except GateFailure as exc:
+        print(f"::error::layer={exc.layer} artifact={exc.artifact} {exc.message}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -153,6 +153,23 @@ def require_retrieval_full(payload: object, layer: str, artifact: Path) -> None:
     require(mode == "full", layer, artifact, f"retrieval_mode is {mode!r}, expected 'full'")
 
 
+def require_version(output: str, expected_version: str, archive: Path, artifact: Path) -> None:
+    actual = output.strip().removeprefix("codestory-cli ").strip()
+    require(
+        actual == expected_version,
+        "version",
+        artifact,
+        f"codestory-cli version is {actual!r}, expected {expected_version!r}",
+    )
+    expected_archive_prefix = f"codestory-cli-v{expected_version}-"
+    require(
+        archive.name.startswith(expected_archive_prefix),
+        "version",
+        artifact,
+        f"archive name {archive.name!r} does not start with {expected_archive_prefix!r}",
+    )
+
+
 def require_retrieval_index_ready(payload: object, layer: str, artifact: Path) -> None:
     require(isinstance(payload, dict), layer, artifact, "retrieval index output is not a JSON object")
     for field in ["zoekt_stubbed", "qdrant_stubbed", "scip_stubbed"]:
@@ -426,6 +443,7 @@ def run_gate(args: argparse.Namespace) -> None:
 
         version_artifact = out_dir / "version.txt"
         run_command(cli, "version", ["--version"], version_artifact, args.timeout_secs, parse_json=False)
+        require_version(version_artifact.read_text(encoding="utf-8"), args.expected_version, archive, version_artifact)
         summary["artifacts"]["version"] = str(version_artifact)
         write_json(out_dir / "summary.json", summary)
 
@@ -744,7 +762,7 @@ def self_test() -> None:
         stage = root / "pkg" / "codestory-cli-v9.9.9-test"
         stage.mkdir(parents=True)
         write_fake_cli(stage)
-        archive = root / "fake.zip"
+        archive = root / "codestory-cli-v9.9.9-test.zip"
         with zipfile.ZipFile(archive, "w") as handle:
             for path in stage.rglob("*"):
                 handle.write(path, path.relative_to(stage.parent).as_posix())
@@ -758,6 +776,7 @@ def self_test() -> None:
             query=DEFAULT_QUERY,
             context_query=DEFAULT_QUERY,
             question=DEFAULT_QUESTION,
+            expected_version="9.9.9",
             timeout_secs=30,
         )
         run_gate(args)
@@ -774,6 +793,16 @@ def self_test() -> None:
                 raise AssertionError("forced fake search failure should fail the gate")
         finally:
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+        mismatch_args = argparse.Namespace(**vars(args))
+        mismatch_args.expected_version = "9.9.8"
+        try:
+            run_gate(mismatch_args)
+        except GateFailure as exc:
+            assert exc.layer == "version"
+            assert "version.txt" in str(exc.artifact)
+        else:
+            raise AssertionError("version mismatch should fail the gate")
 
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "doctor_stderr"
         try:
@@ -848,11 +877,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--query", default=DEFAULT_QUERY, help="Search proof query.")
     parser.add_argument("--context-query", default=DEFAULT_QUERY, help="Context proof target query.")
     parser.add_argument("--question", default=DEFAULT_QUESTION, help="Packet proof question.")
+    parser.add_argument("--expected-version", help="Expected codestory-cli version in the archive.")
     parser.add_argument("--timeout-secs", type=int, default=1800, help="Per-layer timeout.")
     parser.add_argument("--self-test", action="store_true", help="Run script self-tests.")
     args = parser.parse_args()
     if not args.self_test and not args.archive:
         parser.error("--archive is required unless --self-test is set")
+    if not args.self_test and not args.expected_version:
+        parser.error("--expected-version is required unless --self-test is set")
     return args
 
 

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import queue
+import signal
 import stat
 import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
 import textwrap
+import time
 import zipfile
 from pathlib import Path
 
@@ -157,29 +161,88 @@ def require_search_full(payload: object, artifact: Path) -> None:
 
 def require_packet_ready(payload: object, artifact: Path) -> None:
     require(isinstance(payload, dict), "packet", artifact, "packet output is not a JSON object")
-    require("sufficiency" in payload, "packet", artifact, "packet output missing sufficiency")
+    sufficiency = payload.get("sufficiency")
+    require(isinstance(sufficiency, dict), "packet", artifact, "packet output missing sufficiency")
+    status = sufficiency.get("status")
+    require(status == "sufficient", "packet", artifact, f"packet sufficiency.status is {status!r}")
     require("retrieval_trace_summary" in payload, "packet", artifact, "packet output missing retrieval trace summary")
+    answer = payload.get("answer")
+    require(isinstance(answer, dict), "packet", artifact, "packet output missing answer")
+    retrieval_version = answer.get("retrieval_version")
+    require(
+        retrieval_version == "sidecar",
+        "packet",
+        artifact,
+        f"packet answer.retrieval_version is {retrieval_version!r}",
+    )
 
 
 def require_context_ready(payload: object, artifact: Path) -> None:
     require(isinstance(payload, dict), "context", artifact, "context output is not a JSON object")
     require("retrieval_trace" in payload, "context", artifact, "context output missing retrieval trace")
+    retrieval_version = payload.get("retrieval_version")
+    require(retrieval_version == "sidecar", "context", artifact, f"context retrieval_version is {retrieval_version!r}")
 
 
-def stdio_request(process: subprocess.Popen[str], request: dict, layer: str, artifact: Path) -> dict:
-    assert process.stdin is not None
-    assert process.stdout is not None
-    process.stdin.write(json.dumps(request) + "\n")
-    process.stdin.flush()
-    line = process.stdout.readline()
-    if not line:
-        fail(layer, artifact, "serve --stdio closed before responding")
+def write_stdio_artifact(artifact: Path, transcript: list[dict], stdout: str, stderr_path: Path, extra: dict | None = None) -> None:
+    payload = {
+        "transcript": transcript,
+        "stdout": stdout,
+        "stderr_artifact": str(stderr_path),
+    }
+    if extra:
+        payload.update(extra)
+    write_json(artifact, payload)
+
+
+def stream_lines(stream, lines: list[str], line_queue: queue.Queue[str | None] | None = None) -> None:
     try:
-        response = json.loads(line)
-    except json.JSONDecodeError as exc:
-        artifact.write_text(line, encoding="utf-8")
-        fail(layer, artifact, f"serve --stdio emitted invalid JSON: {exc}")
-    return response
+        for line in iter(stream.readline, ""):
+            lines.append(line)
+            if line_queue is not None:
+                line_queue.put(line)
+    finally:
+        if line_queue is not None:
+            line_queue.put(None)
+
+
+def terminate_process_tree(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=1,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if process.poll() is None:
+        process.kill()
+
+
+def read_stdio_line(stdout_queue: queue.Queue[str | None], timeout_secs: int) -> str | None:
+    deadline = time.monotonic() + timeout_secs
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise subprocess.TimeoutExpired("serve --stdio response", timeout_secs)
+        try:
+            line = stdout_queue.get(timeout=remaining)
+        except queue.Empty as exc:
+            raise subprocess.TimeoutExpired("serve --stdio response", timeout_secs) from exc
+        if line is None:
+            return None
+        if line.strip():
+            return line
 
 
 def stdio_status(cli: Path, project: Path, artifact: Path, timeout_secs: int) -> dict:
@@ -199,32 +262,100 @@ def stdio_status(cli: Path, project: Path, artifact: Path, timeout_secs: int) ->
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0,
+        start_new_session=os.name != "nt",
     )
+    requests = [
+        {"jsonrpc": "2.0", "id": "tools", "method": "tools/list"},
+        {
+            "jsonrpc": "2.0",
+            "id": "status",
+            "method": "resources/read",
+            "params": {"uri": STATUS_URI},
+        },
+    ]
+    transcript: list[dict] = []
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+    stdout_queue: queue.Queue[str | None] = queue.Queue()
+    assert process.stdin is not None
+    assert process.stdout is not None
+    assert process.stderr is not None
+    stdout_thread = threading.Thread(target=stream_lines, args=(process.stdout, stdout_lines, stdout_queue), daemon=True)
+    stderr_thread = threading.Thread(target=stream_lines, args=(process.stderr, stderr_lines), daemon=True)
+    stdout_thread.start()
+    stderr_thread.start()
+    responses: list[dict] = []
+    process_terminated = False
     try:
-        tools = stdio_request(
-            process,
-            {"jsonrpc": "2.0", "id": "tools", "method": "tools/list"},
-            "serve_stdio",
-            artifact,
-        )
-        status_response = stdio_request(
-            process,
-            {
-                "jsonrpc": "2.0",
-                "id": "status",
-                "method": "resources/read",
-                "params": {"uri": STATUS_URI},
-            },
-            "serve_stdio",
-            artifact,
-        )
+        for request in requests:
+            entry = {"request": request}
+            transcript.append(entry)
+            process.stdin.write(json.dumps(request) + "\n")
+            process.stdin.flush()
+            try:
+                line = read_stdio_line(stdout_queue, timeout_secs)
+            except subprocess.TimeoutExpired:
+                entry["timed_out"] = True
+                terminate_process_tree(process)
+                process_terminated = True
+                stderr_path.write_text("".join(stderr_lines), encoding="utf-8")
+                write_stdio_artifact(
+                    artifact,
+                    transcript,
+                    "".join(stdout_lines),
+                    stderr_path,
+                    {"timed_out": True, "timeout_secs": timeout_secs},
+                )
+                fail("serve_stdio", artifact, f"serve --stdio timed out after {timeout_secs}s")
+            if line is None:
+                terminate_process_tree(process)
+                process_terminated = True
+                stderr_path.write_text("".join(stderr_lines), encoding="utf-8")
+                write_stdio_artifact(artifact, transcript, "".join(stdout_lines), stderr_path)
+                fail("serve_stdio", artifact, "serve --stdio closed before responding")
+            try:
+                response = json.loads(line)
+            except json.JSONDecodeError as exc:
+                entry["invalid_line"] = line
+                terminate_process_tree(process)
+                process_terminated = True
+                stderr_path.write_text("".join(stderr_lines), encoding="utf-8")
+                write_stdio_artifact(
+                    artifact,
+                    transcript,
+                    "".join(stdout_lines),
+                    stderr_path,
+                    {"invalid_line": line},
+                )
+                fail("serve_stdio", artifact, f"serve --stdio emitted invalid JSON: {exc}")
+            entry["response"] = response
+            responses.append(response)
     finally:
-        process.kill()
-        _, stderr = process.communicate(timeout=timeout_secs)
-        stderr_path.write_text(stderr or "", encoding="utf-8")
+        try:
+            process.stdin.close()
+        except OSError:
+            pass
+        if not process_terminated:
+            try:
+                process.wait(timeout=0.1)
+            except subprocess.TimeoutExpired:
+                terminate_process_tree(process)
+                try:
+                    process.wait(timeout=0.5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+        stdout_thread.join(timeout=0.2)
+        stderr_thread.join(timeout=0.2)
 
-    payload = {"tools": tools, "status_response": status_response}
+    stderr_path.write_text("".join(stderr_lines), encoding="utf-8")
+    responses_by_id = {response.get("id"): response for response in responses if isinstance(response, dict)}
+    tools = responses_by_id.get("tools")
+    status_response = responses_by_id.get("status")
+    payload = {"tools": tools, "status_response": status_response, "transcript": transcript, "stdout": "".join(stdout_lines)}
     write_json(artifact, payload)
+    require(isinstance(tools, dict), "serve_stdio", artifact, "serve --stdio did not return tools/list response")
+    require(isinstance(status_response, dict), "serve_stdio", artifact, "serve --stdio did not return status response")
     if "error" in tools:
         fail("serve_stdio", artifact, f"tools/list failed: {tools['error']}")
     if "error" in status_response:
@@ -414,6 +545,7 @@ def write_fake_cli(path: Path) -> None:
             import json
             import os
             import sys
+            import time
 
             def emit(value):
                 if "--output-file" in sys.argv:
@@ -444,12 +576,21 @@ def write_fake_cli(path: Path) -> None:
             elif layer == "search":
                 emit({"retrieval_shadow": {"retrieval_mode": "full"}, "indexed_symbol_hits": [{"node_id": "1"}]})
             elif layer == "context":
-                emit({"retrieval_trace": {"resolved_profile": "investigate"}})
+                if fail == "context_weak":
+                    emit({"retrieval_trace": {"resolved_profile": "investigate"}})
+                else:
+                    emit({"retrieval_version": "sidecar", "retrieval_trace": {"resolved_profile": "investigate"}})
             elif layer == "packet":
-                emit({"sufficiency": {"status": "supported"}, "retrieval_trace_summary": {}})
+                if fail == "packet_weak":
+                    emit({"sufficiency": {"status": "supported"}, "answer": {"retrieval_version": "fallback"}, "retrieval_trace_summary": {}})
+                else:
+                    emit({"sufficiency": {"status": "sufficient"}, "answer": {"retrieval_version": "sidecar"}, "retrieval_trace_summary": {}})
             elif layer == "serve":
                 for line in sys.stdin:
                     request = json.loads(line)
+                    if fail == "serve_timeout":
+                        time.sleep(60)
+                        continue
                     if request.get("method") == "tools/list":
                         result = {"tools": [{"name": "packet"}, {"name": "search"}, {"name": "context"}]}
                     else:
@@ -524,6 +665,44 @@ def self_test() -> None:
                 assert "doctor.json.stderr.txt" in str(exc.artifact)
             else:
                 raise AssertionError("stderr fake failure should point at stderr artifact")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "packet_weak"
+        try:
+            try:
+                run_gate(args)
+            except GateFailure as exc:
+                assert exc.layer == "packet"
+                assert "packet.json" in str(exc.artifact)
+            else:
+                raise AssertionError("weak fake packet should fail the gate")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "context_weak"
+        try:
+            try:
+                run_gate(args)
+            except GateFailure as exc:
+                assert exc.layer == "context"
+                assert "context.json" in str(exc.artifact)
+            else:
+                raise AssertionError("weak fake context should fail the gate")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "serve_timeout"
+        timeout_args = argparse.Namespace(**vars(args))
+        timeout_args.timeout_secs = 1
+        try:
+            try:
+                run_gate(timeout_args)
+            except GateFailure as exc:
+                assert exc.layer == "serve_stdio"
+                assert "serve-stdio-status.json" in str(exc.artifact)
+            else:
+                raise AssertionError("silent fake stdio server should fail the gate")
         finally:
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
 

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -179,9 +179,28 @@ def require_packet_ready(payload: object, artifact: Path) -> None:
 
 def require_context_ready(payload: object, artifact: Path) -> None:
     require(isinstance(payload, dict), "context", artifact, "context output is not a JSON object")
-    require("retrieval_trace" in payload, "context", artifact, "context output missing retrieval trace")
-    retrieval_version = payload.get("retrieval_version")
-    require(retrieval_version == "sidecar", "context", artifact, f"context retrieval_version is {retrieval_version!r}")
+    context = payload.get("context")
+    require(isinstance(context, dict), "context", artifact, "context output missing context object")
+    retrieval_version = context.get("retrieval_version")
+    require(
+        retrieval_version == "sidecar",
+        "context",
+        artifact,
+        f"context retrieval_version is {retrieval_version!r}",
+    )
+    trace = context.get("retrieval_trace")
+    require(isinstance(trace, dict), "context", artifact, "context output missing context retrieval trace")
+    steps = trace.get("steps")
+    require(
+        isinstance(steps, list) and len(steps) > 0,
+        "context",
+        artifact,
+        "context retrieval trace has no steps",
+    )
+    shadow = trace.get("retrieval_shadow")
+    require(isinstance(shadow, dict), "context", artifact, "context retrieval trace missing retrieval shadow")
+    mode = shadow.get("retrieval_mode")
+    require(mode == "full", "context", artifact, f"context retrieval_shadow.retrieval_mode is {mode!r}")
 
 
 def write_stdio_artifact(artifact: Path, transcript: list[dict], stdout: str, stderr_path: Path, extra: dict | None = None) -> None:
@@ -578,8 +597,27 @@ def write_fake_cli(path: Path) -> None:
             elif layer == "context":
                 if fail == "context_weak":
                     emit({"retrieval_trace": {"resolved_profile": "investigate"}})
+                elif fail == "context_fallback":
+                    emit({
+                        "context": {
+                            "retrieval_version": "sidecar",
+                            "retrieval_trace": {
+                                "steps": [{}],
+                                "retrieval_shadow": {"retrieval_mode": "fallback"},
+                            },
+                        },
+                    })
                 else:
-                    emit({"retrieval_version": "sidecar", "retrieval_trace": {"resolved_profile": "investigate"}})
+                    emit({
+                        "context": {
+                            "retrieval_version": "sidecar",
+                            "retrieval_trace": {
+                                "resolved_profile": "investigate",
+                                "steps": [{}],
+                                "retrieval_shadow": {"retrieval_mode": "full"},
+                            },
+                        },
+                    })
             elif layer == "packet":
                 if fail == "packet_weak":
                     emit({"sufficiency": {"status": "supported"}, "answer": {"retrieval_version": "fallback"}, "retrieval_trace_summary": {}})
@@ -689,6 +727,18 @@ def self_test() -> None:
                 assert "context.json" in str(exc.artifact)
             else:
                 raise AssertionError("weak fake context should fail the gate")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "context_fallback"
+        try:
+            try:
+                run_gate(args)
+            except GateFailure as exc:
+                assert exc.layer == "context"
+                assert "context.json" in str(exc.artifact)
+            else:
+                raise AssertionError("fallback fake context should fail the gate")
         finally:
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
 

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -153,6 +153,13 @@ def require_retrieval_full(payload: object, layer: str, artifact: Path) -> None:
     require(mode == "full", layer, artifact, f"retrieval_mode is {mode!r}, expected 'full'")
 
 
+def require_retrieval_index_ready(payload: object, layer: str, artifact: Path) -> None:
+    require(isinstance(payload, dict), layer, artifact, "retrieval index output is not a JSON object")
+    for field in ["zoekt_stubbed", "qdrant_stubbed", "scip_stubbed"]:
+        value = payload.get(field)
+        require(value is False, layer, artifact, f"{field} is {value!r}, expected False")
+
+
 def require_search_full(payload: object, artifact: Path) -> None:
     shadow = payload.get("retrieval_shadow") if isinstance(payload, dict) else None
     mode = shadow.get("retrieval_mode") if isinstance(shadow, dict) else None
@@ -422,6 +429,76 @@ def run_gate(args: argparse.Namespace) -> None:
         summary["artifacts"]["version"] = str(version_artifact)
         write_json(out_dir / "summary.json", summary)
 
+        local_bootstrap_artifact = out_dir / "local-retrieval-bootstrap.json"
+        run_command(
+            cli,
+            "local_retrieval_bootstrap",
+            [
+                "retrieval",
+                "bootstrap",
+                "--project",
+                str(project),
+                "--profile",
+                "local",
+                "--format",
+                "json",
+                "--output-file",
+                str(local_bootstrap_artifact),
+            ],
+            local_bootstrap_artifact,
+            args.timeout_secs,
+        )
+        summary["artifacts"]["local_retrieval_bootstrap"] = str(local_bootstrap_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        local_index_artifact = out_dir / "local-retrieval-index.json"
+        local_index = run_command(
+            cli,
+            "local_retrieval_index",
+            [
+                "retrieval",
+                "index",
+                "--project",
+                str(project),
+                "--profile",
+                "local",
+                "--refresh",
+                "full",
+                "--format",
+                "json",
+                "--output-file",
+                str(local_index_artifact),
+            ],
+            local_index_artifact,
+            args.timeout_secs,
+        )
+        require_retrieval_index_ready(local_index, "local_retrieval_index", local_index_artifact)
+        summary["artifacts"]["local_retrieval_index"] = str(local_index_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        local_status_artifact = out_dir / "local-retrieval-status.json"
+        local_status = run_command(
+            cli,
+            "local_retrieval_status",
+            [
+                "retrieval",
+                "status",
+                "--project",
+                str(project),
+                "--profile",
+                "local",
+                "--format",
+                "json",
+                "--output-file",
+                str(local_status_artifact),
+            ],
+            local_status_artifact,
+            args.timeout_secs,
+        )
+        require_retrieval_full(local_status, "local_retrieval_status", local_status_artifact)
+        summary["artifacts"]["local_retrieval_status"] = str(local_status_artifact)
+        write_json(out_dir / "summary.json", summary)
+
         ready_artifact = out_dir / "ready.json"
         ready = run_command(
             cli,
@@ -534,7 +611,7 @@ def run_gate(args: argparse.Namespace) -> None:
                 "--question",
                 args.question,
                 "--budget",
-                "tiny",
+                "compact",
                 "--format",
                 "json",
                 "--output-file",
@@ -579,7 +656,7 @@ def write_fake_cli(path: Path) -> None:
                 raise SystemExit(0)
             layer = sys.argv[1]
             if layer == "retrieval" and len(sys.argv) > 2:
-                layer = "retrieval_status"
+                layer = "retrieval_" + sys.argv[2].replace("-", "_")
             if fail == f"{layer}_stderr":
                 print("forced stderr failure", file=sys.stderr)
                 raise SystemExit(3)
@@ -590,6 +667,10 @@ def write_fake_cli(path: Path) -> None:
                 emit({"verdicts": [{"goal": "agent_packet_search", "status": "ready"}]})
             elif layer == "doctor":
                 emit({"retrieval_mode": "full"})
+            elif layer == "retrieval_bootstrap":
+                emit({"project_status": {"retrieval_mode": "unavailable"}})
+            elif layer == "retrieval_index":
+                emit({"zoekt_stubbed": False, "qdrant_stubbed": False, "scip_stubbed": False})
             elif layer == "retrieval_status":
                 emit({"retrieval_mode": "full"})
             elif layer == "search":

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,7 @@ jobs:
         run: |
           python .github/scripts/check-packaged-agent-proof.py \
             --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --expected-version "${{ needs.preflight.outputs.version }}" \
             --project "${{ github.workspace }}" \
             --out-dir target/packaged-agent-proof
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,22 @@ jobs:
             --binary "$bin" \
             --out-dir target/release-dist
 
+      - name: Packaged full-sidecar agent proof
+        if: matrix.asset_target == 'linux-x64'
+        run: |
+          python .github/scripts/check-packaged-agent-proof.py \
+            --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --project "${{ github.workspace }}" \
+            --out-dir target/packaged-agent-proof
+
+      - name: Upload packaged agent proof artifacts
+        if: always() && matrix.asset_target == 'linux-x64'
+        uses: actions/upload-artifact@v5
+        with:
+          name: packaged-agent-proof-${{ matrix.asset_target }}
+          path: target/packaged-agent-proof
+          if-no-files-found: warn
+
       - name: Package release asset on Windows
         if: runner.os == 'Windows'
         shell: pwsh

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1981,11 +1981,13 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     } else {
         RuntimeContext::new_inspect_only(&cmd.project)?
     };
-    if cmd.repair {
-        repair_ready_state(&runtime, cmd.goal)?;
-    }
+    let repaired_sidecar = if cmd.repair {
+        repair_ready_state(&runtime, cmd.goal)?
+    } else {
+        None
+    };
     let summary = runtime.open_project_summary()?;
-    let sidecar = ready_sidecar_status(&runtime, cmd.goal, cmd.repair);
+    let sidecar = ready_sidecar_status(&runtime, repaired_sidecar);
     let mut verdicts = build_summary_readiness(
         &summary.root,
         &summary.stats,
@@ -2024,11 +2026,14 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
 
-fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -> Result<()> {
+fn repair_ready_state(
+    runtime: &RuntimeContext,
+    goal: Option<args::ReadyGoal>,
+) -> Result<Option<codestory_retrieval::SidecarRuntimeConfig>> {
     let opened = runtime.ensure_open(args::RefreshMode::Auto)?;
     ensure_index_ready(&opened, "ready repair")?;
     if !matches!(goal, None | Some(args::ReadyGoal::Agent)) {
-        return Ok(());
+        return Ok(None);
     }
 
     let storage_scope = codestory_retrieval::BootstrapStorageScope::from_parts(
@@ -2065,10 +2070,10 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
     codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
-        sidecar,
+        sidecar.clone(),
     )
     .context("ready repair final retrieval status")?;
-    Ok(())
+    Ok(Some(sidecar))
 }
 
 fn ensure_ready_repair_embed_liveness(
@@ -9490,14 +9495,9 @@ fn doctor_sidecar_status(runtime: &RuntimeContext) -> DoctorSidecarStatusOutput 
 
 fn ready_sidecar_status(
     runtime: &RuntimeContext,
-    goal: Option<args::ReadyGoal>,
-    repaired: bool,
+    repaired_sidecar: Option<codestory_retrieval::SidecarRuntimeConfig>,
 ) -> DoctorSidecarStatusOutput {
-    if repaired && matches!(goal, None | Some(args::ReadyGoal::Agent)) {
-        let sidecar = codestory_retrieval::sidecar_runtime_for_project(
-            &runtime.project_root,
-            codestory_retrieval::SidecarProfile::Agent,
-        );
+    if let Some(sidecar) = repaired_sidecar {
         return doctor_sidecar_status_for_runtime(runtime, sidecar);
     }
     doctor_sidecar_status(runtime)

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -127,20 +127,19 @@ impl SidecarRuntimeConfig {
     }
 
     pub fn for_project_auto(project_root: &Path) -> Self {
+        let explicit_profile = env_profile();
         let env_run_id = env_agent_run_id();
-        let latest_run_id = env_run_id
-            .is_none()
-            .then(|| latest_agent_run_id(project_root))
-            .flatten();
-        let profile = if env_profile() == Some(SidecarProfile::Agent)
-            || latest_run_id.is_some()
-            || running_in_ci_agent()
-        {
-            SidecarProfile::Agent
+        let latest_run_id = if explicit_profile.is_none() && env_run_id.is_none() {
+            latest_agent_run_id(project_root)
         } else {
-            SidecarProfile::Local
+            None
         };
-        let run_id = env_run_id.or(latest_run_id);
+        let (profile, run_id) = auto_runtime_selection(
+            explicit_profile,
+            env_run_id,
+            latest_run_id,
+            running_in_ci_agent(),
+        );
         Self::for_project_profile_with_run_id(Some(project_root), profile, run_id.as_deref())
     }
 
@@ -333,6 +332,22 @@ fn running_in_ci_agent() -> bool {
         || env_flag("CODESTORY_AGENT_RUN", false)
         || env_flag("CI", false)
         || env_flag("GITHUB_ACTIONS", false)
+}
+
+fn auto_runtime_selection(
+    explicit_profile: Option<SidecarProfile>,
+    env_run_id: Option<String>,
+    latest_run_id: Option<String>,
+    ci_agent: bool,
+) -> (SidecarProfile, Option<String>) {
+    match explicit_profile {
+        Some(SidecarProfile::Local) => (SidecarProfile::Local, None),
+        Some(SidecarProfile::Agent) => (SidecarProfile::Agent, env_run_id.or(latest_run_id)),
+        None if env_run_id.is_some() || latest_run_id.is_some() || ci_agent => {
+            (SidecarProfile::Agent, env_run_id.or(latest_run_id))
+        }
+        None => (SidecarProfile::Local, None),
+    }
 }
 
 fn namespace_for(
@@ -639,5 +654,27 @@ mod tests {
         );
         assert!(first.cleanup_command.contains("--profile agent"));
         assert!(first.cleanup_command.contains("--run-id review-fix"));
+    }
+
+    #[test]
+    fn explicit_local_profile_overrides_latest_agent_run() {
+        let (profile, run_id) = auto_runtime_selection(
+            Some(SidecarProfile::Local),
+            None,
+            Some("latest-agent".to_string()),
+            false,
+        );
+
+        assert_eq!(profile, SidecarProfile::Local);
+        assert_eq!(run_id, None);
+    }
+
+    #[test]
+    fn latest_agent_run_selects_agent_without_explicit_profile() {
+        let (profile, run_id) =
+            auto_runtime_selection(None, None, Some("latest-agent".to_string()), false);
+
+        assert_eq!(profile, SidecarProfile::Agent);
+        assert_eq!(run_id.as_deref(), Some("latest-agent"));
     }
 }


### PR DESCRIPTION
## Context

Closes #476.
Closes #528.

Issue #476 asks for a release gate that exercises the packaged CLI, not just the source-built binary. Issue #528 fixed the context proof contract after packaged proof artifacts showed the actual context shape nests `retrieval_trace` under `context`.

This branch now also covers the release-blocking profile handoff found while refreshing #513: the packaged proof must make both local/default retrieval and agent retrieval truthful before accepting `doctor`, packet/search/context, or stdio readiness. A focused review also added release identity proof, so the gate cannot pass against the wrong archive version.

## What Changed

- Added `.github/scripts/check-packaged-agent-proof.py` and wired it into `release.yml` after the packaged archive exists.
- The proof runner unpacks the archive and requires the expected release version to match both `codestory-cli --version` and the archive name.
- The packaged binary is then run through local/default retrieval bootstrap, local retrieval index, local retrieval status, agent `ready --goal agent --repair`, `doctor`, retrieval status, search, context, packet, and `serve --stdio` status.
- The gate requires local/default retrieval index output to be non-stubbed and local status to be `retrieval_mode=full` before agent repair.
- `ready --goal agent --repair` now renders post-repair readiness from the exact agent sidecar runtime it repaired.
- Explicit retrieval profile selection now wins over latest-agent auto-selection, so `--profile local` can repair local/default retrieval even when an agent namespace exists.
- Packet proof uses `--budget compact`; `--budget tiny` truncated answer-critical evidence and produced a correct `partial` sufficiency result.

## How To Review

- Start with `.github/scripts/check-packaged-agent-proof.py` at `run_gate`; confirm the sequence proves release identity, local/default retrieval, agent repair, and each packet/search/context/stdout layer with layer-specific artifacts.
- Check `crates/codestory-retrieval/src/config.rs` for explicit profile precedence in auto runtime selection.
- Check `crates/codestory-cli/src/main.rs` around `run_ready`, `repair_ready_state`, and `ready_sidecar_status` for same-runtime post-repair reporting.
- Confirm `release.yml` passes `needs.preflight.outputs.version` into the packaged proof and preserves failed proof artifacts.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `node .github/scripts/check-workflow-policy.mjs`
- `python -m py_compile .github\scripts\check-packaged-agent-proof.py`
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `cargo test -p codestory-retrieval profile -- --nocapture`
- `cargo test -p codestory-cli --test ready_command ready_command_emits_compact_verdicts_and_filters_goal -- --nocapture`
- `cargo build --release -p codestory-cli`
- `python .github/scripts/package-codestory-release.py --version 0.11.18 --target windows-x64 --binary target/release/codestory-cli.exe --out-dir target/release-dist-pr513-local-default-proof`
- `python .github/scripts/check-packaged-agent-proof.py --archive target/release-dist-pr513-local-default-proof/codestory-cli-v0.11.18-windows-x64.zip --expected-version 0.11.18 --project C:\Users\alber\source\repos\codestory --out-dir target/pr513-packaged-agent-proof-version-guard --timeout-secs 1800`

Passing packaged proof artifact directory:

```text
target/pr513-packaged-agent-proof-version-guard
```

## Risk

Moderate but release-scoped. The gate is stricter than before because it proves archive identity, local/default retrieval, and agent retrieval before accepting `doctor`. The main cost is longer release proof runtime from the local retrieval index step. The proof still depends on release-runner sidecar prerequisites; failures should preserve layer-specific artifacts for diagnosis.