### PR TITLE
[codex] Normalize blocked command repair guidance

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1407,6 +1407,7 @@ pub(crate) struct ReadyOutput {
 pub(crate) struct AgentPreflightLaneOutput {
     pub(crate) ready: bool,
     pub(crate) status: ReadinessStatusDto,
+    pub(crate) failed_layer: Option<&'static str>,
     pub(crate) summary: String,
 }
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1741,6 +1741,7 @@ fn agent_preflight_lane(
     args::AgentPreflightLaneOutput {
         ready: verdict.status == ReadinessStatusDto::Ready,
         status: verdict.status,
+        failed_layer: readiness::failed_layer(verdict),
         summary: verdict.summary.clone(),
     }
 }
@@ -1770,11 +1771,17 @@ fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> Strin
         "local_graph: {}",
         readiness::status_label(output.local_graph.status)
     );
+    if let Some(layer) = output.local_graph.failed_layer {
+        let _ = writeln!(markdown, "local_graph_failed_layer: `{layer}`");
+    }
     let _ = writeln!(
         markdown,
         "full_retrieval: {}",
         readiness::status_label(output.full_retrieval.status)
     );
+    if let Some(layer) = output.full_retrieval.failed_layer {
+        let _ = writeln!(markdown, "full_retrieval_failed_layer: `{layer}`");
+    }
     if let Some(state) = output
         .sidecar_setup
         .get("state")

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -101,6 +101,16 @@ pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
     }
 }
 
+pub(crate) fn failed_layer(verdict: &ReadinessVerdictDto) -> Option<&'static str> {
+    match verdict.status {
+        ReadinessStatusDto::Ready => None,
+        ReadinessStatusDto::RepairSetup => Some("runtime_setup"),
+        ReadinessStatusDto::RepairIndex => Some("local_index"),
+        ReadinessStatusDto::CheckIndex => Some("index_freshness"),
+        ReadinessStatusDto::RepairRetrieval => Some("retrieval_sidecar"),
+    }
+}
+
 pub(crate) fn goal_label(goal: ReadinessGoalDto) -> &'static str {
     match goal {
         ReadinessGoalDto::LocalNavigation => "local_navigation",
@@ -217,7 +227,7 @@ fn verdict_state(
                     Some(IndexFreshnessStatusDto::Fresh)
                 ),
             );
-            let minimum_next = full_repair.iter().take(2).cloned().collect();
+            let minimum_next = full_repair.iter().take(1).cloned().collect();
             return (
                 ReadinessStatusDto::RepairRetrieval,
                 format!(
@@ -700,10 +710,38 @@ mod tests {
             degraded
                 .full_repair
                 .iter()
-                .take(2)
+                .take(1)
                 .cloned()
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn non_full_sidecars_report_retrieval_layer_and_one_canonical_repair() {
+        let stats = stats(3);
+        let freshness = freshness(IndexFreshnessStatusDto::Fresh);
+        for sidecar in [
+            None,
+            Some(ReadinessSidecarInput {
+                retrieval_mode: "unavailable",
+                degraded_reason: Some("manifest:<missing>"),
+                manifest_generation: None,
+                manifest_input_hash: None,
+            }),
+        ] {
+            let verdict = build_readiness_verdict(
+                ReadinessGoalDto::AgentPacketSearch,
+                inputs(&stats, Some(&freshness), sidecar),
+            );
+
+            assert_eq!(verdict.status, ReadinessStatusDto::RepairRetrieval);
+            assert_eq!(failed_layer(&verdict), Some("retrieval_sidecar"));
+            assert_eq!(verdict.minimum_next.len(), 1);
+            assert!(
+                verdict.minimum_next[0].contains("ready --goal agent --repair"),
+                "sidecar repair should expose one canonical repair command: {verdict:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -310,6 +310,7 @@ fn stdio_tool_blocked_error(
         "tool": name,
         "readiness_goal": surface.get("readiness_goal").cloned().unwrap_or(serde_json::Value::Null),
         "status": surface.get("status").cloned().unwrap_or(serde_json::Value::Null),
+        "failed_layer": surface.get("failed_layer").cloned().unwrap_or(serde_json::Value::Null),
         "repair_reason": surface.get("repair_reason").cloned().unwrap_or(serde_json::Value::Null),
         "minimum_next": surface.get("minimum_next").cloned().unwrap_or_else(|| serde_json::json!([])),
         "full_repair": surface.get("full_repair").cloned().unwrap_or_else(|| serde_json::json!([])),
@@ -2513,6 +2514,7 @@ fn stdio_allowed_surface(verdict: Option<&ReadinessVerdictDto>) -> serde_json::V
                 "allowed": allowed,
                 "readiness_goal": crate::readiness::goal_label(verdict.goal),
                 "status": crate::readiness::status_label(verdict.status),
+                "failed_layer": crate::readiness::failed_layer(verdict),
                 "summary": verdict.summary,
                 "repair_reason": stdio_repair_reason(verdict),
                 "blocked_reason": if allowed { None } else { Some(verdict.summary.as_str()) },
@@ -2524,6 +2526,7 @@ fn stdio_allowed_surface(verdict: Option<&ReadinessVerdictDto>) -> serde_json::V
             "allowed": false,
             "readiness_goal": null,
             "status": "unknown",
+            "failed_layer": null,
             "summary": "Readiness verdict was not available for this surface.",
             "repair_reason": null,
             "blocked_reason": "Readiness verdict was not available for this surface.",
@@ -2849,6 +2852,43 @@ mod tests {
         assert!(
             calls[0].get("command").is_none(),
             "restart boundary should not be exposed as a CLI command: {calls}"
+        );
+    }
+
+    #[test]
+    fn stdio_blocked_agent_surfaces_name_retrieval_layer_and_canonical_repair() {
+        let repair =
+            "codestory-cli ready --goal agent --repair --project \"C:/repo/example\" --format json"
+                .to_string();
+        let readiness = vec![ReadinessVerdictDto {
+            goal: ReadinessGoalDto::AgentPacketSearch,
+            status: ReadinessStatusDto::RepairRetrieval,
+            summary:
+                "Agent packet/search needs full sidecar retrieval; current mode is `unavailable`."
+                    .to_string(),
+            minimum_next: vec![repair.clone()],
+            full_repair: vec![
+                repair.clone(),
+                "codestory-cli retrieval status --project \"C:/repo/example\" --format json"
+                    .to_string(),
+                "codestory-cli doctor --project \"C:/repo/example\" --format markdown".to_string(),
+            ],
+            setup: None,
+            index: None,
+            sidecar: None,
+        }];
+
+        let surfaces = stdio_allowed_surfaces(&readiness);
+        let packet = &surfaces["packet"];
+
+        assert_eq!(packet["allowed"], json!(false));
+        assert_eq!(packet["failed_layer"], json!("retrieval_sidecar"));
+        assert_eq!(packet["minimum_next"], json!([repair]));
+        assert!(
+            packet["full_repair"]
+                .as_array()
+                .is_some_and(|commands| commands.len() == 3),
+            "full repair should keep proof commands behind the canonical minimum repair: {packet}"
         );
     }
 

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -691,7 +691,7 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
     let index_next_commands_joined = index_next_commands.join("\n");
     assert!(
         index_next_commands_joined.contains("codestory-cli retrieval status")
-            && index_next_commands_joined.contains("codestory-cli retrieval index"),
+            && index_next_commands_joined.contains("codestory-cli ready --goal agent --repair"),
         "index output should recommend sidecar repair when sidecar retrieval is not full: {index:#}"
     );
     assert_no_agent_proof_commands(&index_next_commands, "index output");
@@ -716,8 +716,7 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
     let joined = next_commands.join("\n");
     assert!(
         joined.contains("codestory-cli retrieval status")
-            && joined.contains("codestory-cli retrieval index")
-            && joined.contains("--refresh full")
+            && joined.contains("codestory-cli ready --goal agent --repair")
             && joined.contains("codestory-cli doctor"),
         "doctor should recommend retrieval repair before packet/search: {doctor:#}"
     );
@@ -872,9 +871,9 @@ fn doctor_reports_current_and_stored_semantic_doc_embedding_contract() {
         .join("\n");
     assert!(
         first_next_commands.contains("retrieval status")
-            && first_next_commands.contains("retrieval index")
+            && first_next_commands.contains("ready --goal agent --repair")
             && !first_next_commands.contains("packet"),
-        "doctor should recommend sidecar status/index repair before packet/search when mode is not full: {doctor:#}"
+        "doctor should recommend canonical sidecar repair before packet/search when mode is not full: {doctor:#}"
     );
 }
 

--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -287,9 +287,8 @@ fn search_json_fails_closed_without_full_sidecars() {
     assert!(
         stderr.contains("Minimum next:")
             && stderr.contains("Full repair:")
-            && stderr.contains("codestory-cli retrieval index")
-            && stderr.contains("--refresh full")
-            && stderr.contains("codestory-cli retrieval bootstrap")
+            && stderr.contains("codestory-cli ready --goal agent --repair")
+            && stderr.contains("codestory-cli retrieval status")
             && stderr.contains("codestory-cli doctor"),
         "search should include retrieval repair commands: {stderr}"
     );

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2780,6 +2780,10 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
         Some("repair_retrieval")
     );
     assert_eq!(
+        error.pointer("/failed_layer").and_then(Value::as_str),
+        Some("retrieval_sidecar")
+    );
+    assert_eq!(
         error.pointer("/repair_reason").and_then(Value::as_str),
         Some("retrieval_manifest_missing")
     );
@@ -2792,6 +2796,11 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
     let minimum_next = error["minimum_next"]
         .as_array()
         .unwrap_or_else(|| panic!("stdio search error should include minimum_next: {response}"));
+    assert_eq!(
+        minimum_next.len(),
+        1,
+        "stdio search readiness error should expose exactly one canonical minimum repair: {response}"
+    );
     assert!(
         minimum_next.iter().any(|command| command
             .as_str()

--- a/crates/codestory-contracts/src/api/errors.rs
+++ b/crates/codestory-contracts/src/api/errors.rs
@@ -29,7 +29,7 @@ pub struct ApiErrorDetails {
 
 impl ApiErrorDetails {
     pub fn retrieval_unavailable(project: impl Into<String>, next_commands: Vec<String>) -> Self {
-        let minimum_next = next_commands.iter().take(2).cloned().collect::<Vec<_>>();
+        let minimum_next = next_commands.iter().take(1).cloned().collect::<Vec<_>>();
         Self {
             failed_layer: Some("retrieval_sidecar".to_string()),
             project: Some(project.into()),
@@ -111,12 +111,11 @@ mod tests {
             "sidecar retrieval primary is unavailable or degraded",
             "C:/repo/example",
             vec![
-                "codestory-cli retrieval bootstrap --project \"C:/repo/example\" --format json"
-                    .to_string(),
-                "codestory-cli retrieval index --project \"C:/repo/example\" --refresh full --format json"
+                "codestory-cli ready --goal agent --repair --project \"C:/repo/example\" --format json"
                     .to_string(),
                 "codestory-cli retrieval status --project \"C:/repo/example\" --format json"
                     .to_string(),
+                "codestory-cli doctor --project \"C:/repo/example\" --format markdown".to_string(),
             ],
         );
 
@@ -127,15 +126,15 @@ mod tests {
         assert_eq!(value["details"]["project"], "C:/repo/example");
         assert_eq!(
             value["details"]["next_commands"][0],
-            "codestory-cli retrieval bootstrap --project \"C:/repo/example\" --format json"
+            "codestory-cli ready --goal agent --repair --project \"C:/repo/example\" --format json"
         );
         assert_eq!(
             value["details"]["minimum_next"][0],
-            "codestory-cli retrieval bootstrap --project \"C:/repo/example\" --format json"
+            "codestory-cli ready --goal agent --repair --project \"C:/repo/example\" --format json"
         );
         assert_eq!(
             value["details"]["full_repair"][1],
-            "codestory-cli retrieval index --project \"C:/repo/example\" --refresh full --format json"
+            "codestory-cli retrieval status --project \"C:/repo/example\" --format json"
         );
     }
 }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -135,8 +135,7 @@ pub(crate) fn sidecar_retrieval_unavailable_error(
 fn sidecar_retrieval_recovery_commands(project: &str) -> Vec<String> {
     let project = quote_cli_arg(project);
     vec![
-        format!("codestory-cli retrieval bootstrap --project {project} --format json"),
-        format!("codestory-cli retrieval index --project {project} --refresh full --format json"),
+        format!("codestory-cli ready --goal agent --repair --project {project} --format json"),
         format!("codestory-cli retrieval status --project {project} --format json"),
         format!("codestory-cli doctor --project {project} --format markdown"),
     ]
@@ -1963,8 +1962,8 @@ mod tests {
         assert!(
             commands
                 .first()
-                .is_some_and(|command| command.contains("retrieval bootstrap")),
-            "sidecar recovery should start with the sidecar bootstrap, not repeat a core index: {commands:?}"
+                .is_some_and(|command| command.contains("ready --goal agent --repair")),
+            "sidecar recovery should start with the canonical agent repair command: {commands:?}"
         );
         assert!(
             commands

--- a/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
+++ b/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
@@ -296,16 +296,16 @@ fn assert_mandatory_sidecar_unavailable(error: &ApiError) {
         details
             .next_commands
             .iter()
-            .any(|command| command.contains("codestory-cli retrieval bootstrap")),
-        "retrieval error should include bootstrap recovery command: {error:?}"
+            .next()
+            .is_some_and(|command| command.contains("codestory-cli ready --goal agent --repair")),
+        "retrieval error should start with the canonical agent repair command: {error:?}"
     );
     assert!(
         details
             .next_commands
             .iter()
-            .any(|command| command.contains("codestory-cli retrieval index")
-                && command.contains("--refresh full")),
-        "retrieval error should include sidecar index recovery command: {error:?}"
+            .all(|command| !command.contains("codestory-cli retrieval index")),
+        "retrieval error should not expose a separate sidecar index command before ready repair: {error:?}"
     );
     assert!(
         details

--- a/crates/codestory-runtime/tests/retrieval_eval.rs
+++ b/crates/codestory-runtime/tests/retrieval_eval.rs
@@ -177,24 +177,23 @@ fn retrieval_eval_search_fails_closed_without_full_retrieval_sidecars() {
         details
             .next_commands
             .iter()
-            .any(|command| command.contains("codestory-cli index")
-                && command.contains("--refresh full")),
-        "retrieval error should include index recovery command: {error:?}"
+            .all(|command| !command.contains("codestory-cli index")),
+        "retrieval error should not repeat core index repair commands: {error:?}"
     );
     assert!(
         details
             .next_commands
             .iter()
-            .any(|command| command.contains("codestory-cli retrieval bootstrap")),
-        "retrieval error should include bootstrap recovery command: {error:?}"
+            .next()
+            .is_some_and(|command| command.contains("codestory-cli ready --goal agent --repair")),
+        "retrieval error should start with the canonical agent repair command: {error:?}"
     );
     assert!(
         details
             .next_commands
             .iter()
-            .any(|command| command.contains("codestory-cli retrieval index")
-                && command.contains("--refresh full")),
-        "retrieval error should include sidecar index recovery command: {error:?}"
+            .all(|command| !command.contains("codestory-cli retrieval index")),
+        "retrieval error should not expose a separate sidecar index command before ready repair: {error:?}"
     );
 }
 


### PR DESCRIPTION
## Context
Closes #480.

Blocked packet/search/context paths were using different recovery vocabularies: readiness/preflight/status pointed at `ready --goal agent --repair`, while direct sidecar-unavailable API errors still surfaced separate retrieval bootstrap/index commands. Operators saw different next steps for the same `retrieval_sidecar` failure.

## What Changed
- Added a shared readiness failed-layer label so preflight lanes and stdio blocked-tool surfaces name `retrieval_sidecar`, `local_index`, `index_freshness`, or `runtime_setup` consistently.
- Normalized non-full sidecar repair guidance to one canonical minimum command: `codestory-cli ready --goal agent --repair --project ... --format json`.
- Kept `retrieval status --format json` and markdown `doctor` as full-repair/proof follow-ups instead of first-step recovery commands.
- Updated direct runtime retrieval-unavailable API errors and stdio blocked-tool payloads to match the readiness/preflight vocabulary.

## How To Review
1. Start in `crates/codestory-cli/src/readiness.rs`; this is the shared command/layer formatter.
2. Check the consumers in `crates/codestory-cli/src/main.rs`, `crates/codestory-cli/src/stdio_transport.rs`, `crates/codestory-contracts/src/api/errors.rs`, and `crates/codestory-runtime/src/agent/retrieval_primary.rs`.
3. Review the focused tests for manifest-missing and sidecar-unavailable blocked output.

## Verification
- `cargo fmt --check` passed.
- `git diff --check` passed.
- `cargo test -p codestory-cli non_full_sidecars_report_retrieval_layer_and_one_canonical_repair` passed.
- `cargo test -p codestory-cli stdio_blocked_agent_surfaces_name_retrieval_layer_and_canonical_repair` passed.
- `cargo test -p codestory-contracts retrieval_unavailable_error_serializes_repair_details` passed.
- `cargo test -p codestory-cli --test search_json_output search_json_fails_closed_without_full_sidecars` passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts search_tool_fails_closed_without_full_retrieval_sidecars` passed.
- `cargo test -p codestory-cli --test cli_golden_path doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full` passed.
- `cargo test -p codestory-cli --test cli_golden_path agent_preflight_reports_local_graph_when_retrieval_is_degraded` passed.
- `cargo test -p codestory-runtime recovery_commands_quote_shell_sensitive_project_paths` passed.
- Practical proof on an isolated tiny repo/cache: `index` produced fresh local navigation plus `agent_packet_search` repair with one `minimum_next` command; `agent preflight --format json` reported `full_retrieval.failed_layer = "retrieval_sidecar"`; blocked `search --repo-text off --format json` failed with one `Minimum next` command: `codestory-cli ready --goal agent --repair --project ... --format json`.

## Risk
- The full `cargo test -p codestory-runtime --test retrieval_eval retrieval_eval_search_fails_closed_without_full_retrieval_sidecars` run was interrupted after several minutes with no test output beyond "running 1 test". The same direct recovery helper is covered by the runtime unit test and the CLI blocked-search command proof above.
- This does not attempt packaged proof gates (#476), release evidence (#477), follow-up hints (#481), files output (#483), or v0.12 work.
