### PR TITLE
Fix zero dense sidecar health

### DIFF
--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -506,12 +506,17 @@ pub fn probe_sidecar_health(
     let qdrant = if dense_anchor_count == 0 {
         ComponentHealth {
             name: "qdrant".into(),
-            status: ComponentStatus::Degraded,
+            status: ComponentStatus::Healthy,
             latency_ms: None,
-            detail: "graph_first_v1 selected zero dense anchors; semantic retrieval is unavailable"
-                .into(),
-            degraded_reason: Some("semantic_dense_projection_count_zero".into()),
-            capabilities: SidecarCapabilities::NONE,
+            detail:
+                "graph_first_v1 selected zero dense anchors; semantic retrieval skipped by policy"
+                    .into(),
+            degraded_reason: None,
+            capabilities: SidecarCapabilities {
+                lexical: false,
+                semantic: true,
+                graph: false,
+            },
         }
     } else {
         let collection = manifest.qdrant_collection.clone();
@@ -727,7 +732,7 @@ mod tests {
     }
 
     #[test]
-    fn zero_dense_manifest_degrades_semantic_lane() {
+    fn zero_dense_manifest_skips_semantic_lane_without_degrading() {
         let layout = SidecarLayout::from_env();
         let project_id = "testproject";
         let input_hash = "ba5eba11cafebeef";
@@ -760,13 +765,13 @@ mod tests {
 
         let report = probe_sidecar_health(&layout, project_id, Some(manifest));
 
-        assert_eq!(report.qdrant.status, ComponentStatus::Degraded);
-        assert_eq!(
-            report.qdrant.degraded_reason.as_deref(),
+        assert_eq!(report.qdrant.status, ComponentStatus::Healthy);
+        assert_eq!(report.qdrant.degraded_reason, None);
+        assert!(report.qdrant.capabilities.semantic);
+        assert_ne!(
+            report.degraded_reason.as_deref(),
             Some("semantic_dense_projection_count_zero")
         );
-        assert!(!report.qdrant.capabilities.semantic);
-        assert_ne!(report.retrieval_mode, "full");
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #518.
Refs #476.

Packaged agent readiness must fail closed on real sidecar health, but `graph_first_v1` can legitimately select zero dense anchors. In that policy case, Qdrant should be reported as skipped by policy instead of degrading the whole sidecar health report with `semantic_dense_projection_count_zero`.

## What Changed

- Treat zero dense-anchor manifests as a healthy Qdrant policy skip in retrieval health.
- Update the focused health test to assert the zero-dense path no longer reports `semantic_dense_projection_count_zero`.

## How To Review

- Start with `crates/codestory-retrieval/src/health.rs` in the zero dense-anchor branch of `probe_sidecar_health`.
- Confirm the updated unit test covers only the health classification change.

## Verification

- `cargo test -p codestory-retrieval zero_dense_manifest_skips_semantic_lane_without_degrading` passed.
- `cargo build -p codestory-cli` passed.
- `git diff --check` passed.

## Risk

This is a partial readiness fix. It fixes zero-dense health classification only; it does not prove full packaged search readiness because the remaining Zoekt search split-brain is still unresolved.