### PR TITLE
[codex] Fix sidecar search layout probe

### DIFF
--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -175,9 +175,13 @@ impl<'a> QueryExecutor<'a> {
             return (mode, None);
         }
         if let Some(manifest) = self.manifest.as_ref() {
-            let layout = crate::config::SidecarLayout::from_env();
-            let report =
-                probe_sidecar_health(&layout, &manifest.project_id, Some(manifest.clone()));
+            let Some(layout) = self.sidecars.layout() else {
+                return (
+                    RetrievalDegradedMode::Unavailable,
+                    Some("sidecar_layout_missing".into()),
+                );
+            };
+            let report = probe_sidecar_health(layout, &manifest.project_id, Some(manifest.clone()));
             return derive_degraded_mode(&report.zoekt, &report.qdrant, &report.scip);
         }
         (
@@ -470,10 +474,14 @@ mod tests {
     use super::*;
     use crate::cache::RetrievalCache;
     use crate::candidate::{CandidateHit, CandidateSource};
-    use crate::sidecar_search::mock::MockSidecarSearch;
+    use crate::config::SidecarLayout;
+    use crate::sidecar_search::{SidecarSearch, mock::MockSidecarSearch};
+    use crate::test_support::retrieval_manifest_fixture;
     use codestory_store::RetrievalIndexManifest;
     use std::collections::HashMap;
+    use std::net::TcpListener;
     use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
 
     fn sample_manifest() -> RetrievalIndexManifest {
         RetrievalIndexManifest {
@@ -689,6 +697,32 @@ mod tests {
             .execute("ExtensionService", Some(800))
             .expect_err("non-full modes must fail closed");
         assert!(error.to_string().contains("retrieval sidecar is mandatory"));
+    }
+
+    #[test]
+    fn executor_resolve_mode_probes_live_sidecar_layout_instead_of_env_default() {
+        let mut layout = SidecarLayout::from_env();
+        layout.zoekt_http_port = unused_local_port();
+        let manifest = retrieval_manifest_fixture("testproj", "cafebabedeadbeef");
+        let sidecars = TrackingSidecars {
+            layout,
+            layout_calls: AtomicUsize::new(0),
+        };
+        let mut cache = RetrievalCache::new();
+        let executor = QueryExecutor {
+            sidecars: &sidecars,
+            cache: &mut cache,
+            manifest: Some(manifest),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: None,
+        };
+
+        let (mode, reason) = executor.resolve_mode();
+
+        assert_eq!(sidecars.layout_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(mode, RetrievalDegradedMode::Unavailable);
+        assert_eq!(reason.as_deref(), Some("zoekt_unreachable"));
     }
 
     #[test]
@@ -963,6 +997,43 @@ mod tests {
             result.hits.first().and_then(|hit| hit.file_role),
             Some(codestory_store::FileRole::Generated)
         );
+    }
+
+    struct TrackingSidecars {
+        layout: SidecarLayout,
+        layout_calls: AtomicUsize,
+    }
+
+    impl SidecarSearch for TrackingSidecars {
+        fn layout(&self) -> Option<&SidecarLayout> {
+            self.layout_calls.fetch_add(1, Ordering::Relaxed);
+            Some(&self.layout)
+        }
+
+        fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+
+        fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+
+        fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+
+        fn scip_expand(
+            &self,
+            _anchors: &[CandidateHit],
+            _limit: usize,
+        ) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn unused_local_port() -> u16 {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind free port");
+        listener.local_addr().expect("local addr").port()
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/sidecar_search.rs
+++ b/crates/codestory-retrieval/src/sidecar_search.rs
@@ -7,6 +7,10 @@ use anyhow::Result;
 use codestory_store::RetrievalIndexManifest;
 /// Sidecar search surface used by the executor (mockable in unit tests).
 pub trait SidecarSearch: Send + Sync {
+    fn layout(&self) -> Option<&SidecarLayout> {
+        None
+    }
+
     fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
     fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
     fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
@@ -61,6 +65,10 @@ impl LiveSidecarSearch {
 }
 
 impl SidecarSearch for LiveSidecarSearch {
+    fn layout(&self) -> Option<&SidecarLayout> {
+        Some(&self.layout)
+    }
+
     fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
         self.zoekt
             .search(&self.layout, &self.sidecar_generation, query, limit)


### PR DESCRIPTION
## Context

Closes #519.
Refs #476.

Search mode resolution was probing a fresh local/default sidecar layout even after query context had resolved the project/agent layout. That could let status report full while search failed against a different runtime.

## What Changed

- Added an optional layout accessor to the sidecar search surface.
- Made `QueryExecutor::resolve_mode()` probe the sidecar-provided layout instead of constructing a fresh local/default layout.
- Added a no-env regression that proves mode resolution asks the sidecar for its non-default layout before probing.

## How To Review

- Start with `crates/codestory-retrieval/src/sidecar_search.rs` for the layout handoff.
- Then review `crates/codestory-retrieval/src/executor.rs` for the probe behavior and regression.

## Verification

- `cargo fmt`
- `cargo test -p codestory-retrieval executor_resolve_mode_probes_live_sidecar_layout_instead_of_env_default -- --nocapture`
- `cargo test -p codestory-retrieval`
- `cargo check -p codestory-cli`
- `git diff --check`

## Risk

No changes to `crates/codestory-retrieval/src/health.rs`. The remaining #476 proof gap is packaged full-sidecar proof: a managed agent run still needs to show `retrieval status` and `search --why` using the same full sidecar runtime end to end.