### PR TITLE
[codex] Use managed embedding endpoint in packaged ready repair

### DIFF
--- a/crates/codestory-cli/src/managed_embeddings.rs
+++ b/crates/codestory-cli/src/managed_embeddings.rs
@@ -24,7 +24,6 @@ const MANAGED_SEMANTIC_DOC_MAX_TOKENS: usize = 512;
 const MANAGED_ONNX_BATCH_TOKENS: usize = 32_768;
 const MANAGED_STORED_VECTOR_ENCODING: &str = "int8";
 const BUNDLED_LLAMACPP_BACKEND_LABEL: &str = "llamacpp";
-const BUNDLED_LLAMACPP_URL: &str = "http://127.0.0.1:8080/v1/embeddings";
 const MANAGED_DIR_NAME: &str = "managed-embeddings";
 const MANAGED_POOLED_ONNX_MODEL_NAME: &str = "model_optimized_cls_pool.onnx";
 const ONNX_SOURCE_OUTPUT_NAME: &str = "last_hidden_state";
@@ -340,10 +339,6 @@ pub(crate) fn prepare_bundled_llamacpp_client_env_defaults() {
             && env_value_is_unset("CODESTORY_EMBED_BACKEND")
         {
             set_env_default_str("CODESTORY_EMBED_BACKEND", BUNDLED_LLAMACPP_BACKEND_LABEL);
-        }
-        if legacy_llamacpp_backend_selected() && env_value_is_unset("CODESTORY_EMBED_LLAMACPP_URL")
-        {
-            set_env_default_str("CODESTORY_EMBED_LLAMACPP_URL", BUNDLED_LLAMACPP_URL);
         }
     }
 }

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -928,7 +928,7 @@ mod tests {
         write_fake_managed_onnx_assets(&cache.join("managed-embeddings"));
 
         RuntimeContext::new_agent_sidecar(&ProjectArgs {
-            project,
+            project: project.clone(),
             cache_dir: Some(cache),
         })
         .expect("runtime context");
@@ -937,10 +937,20 @@ mod tests {
             env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
             Some("llamacpp")
         );
+        assert_eq!(env::var("CODESTORY_EMBED_LLAMACPP_URL").ok(), None);
+        let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+            &project,
+            codestory_retrieval::SidecarProfile::Agent,
+            Some("ready-repair-test"),
+        );
+        let expected_url =
+            codestory_retrieval::SidecarLayout::embed_base_url(sidecar.embed_http_port);
+        sidecar.activate_embed_url_default();
         assert_eq!(
             env::var("CODESTORY_EMBED_LLAMACPP_URL").ok().as_deref(),
-            Some("http://127.0.0.1:8080/v1/embeddings")
+            Some(expected_url.as_str())
         );
+        assert_ne!(expected_url, "http://127.0.0.1:8080/v1/embeddings");
         assert_eq!(env::var("CODESTORY_EMBED_ONNX_MODEL").ok(), None);
         assert_eq!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").ok(), None);
     }


### PR DESCRIPTION
## Context

`ready --goal agent --repair` in a packaged install must use the managed retrieval sidecar embedding endpoint. The previous packaged path could still seed `CODESTORY_EMBED_LLAMACPP_URL` with `http://127.0.0.1:8080/v1/embeddings`, which bypassed the sidecar-assigned endpoint and blocked repair.

Closes #521
Refs #476, #513

## What Changed

- Removed the bundled llama.cpp hard-coded endpoint default from managed embedding env setup.
- Kept the bundled backend default as `llamacpp`.
- Updated the runtime default test to assert the URL is left unset until the sidecar runtime activates its managed embedding endpoint, and that the resulting endpoint is not the old `127.0.0.1:8080` URL.

## How To Review

- Review `crates/codestory-cli/src/managed_embeddings.rs` for the removed hard-coded URL default.
- Review `crates/codestory-cli/src/runtime.rs` for the agent sidecar runtime default expectation.
- Check the packaged proof artifacts at `target\issue-521-packaged-ready-proof`.

## Verification

- `cargo test -p codestory-cli agent_sidecar_runtime_defaults_prevent_managed_onnx_autostart` passed.
- `cargo test -p codestory-cli bundled_llamacpp_defaults_preserve_explicit_user_env` passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.
- `cargo build --release -p codestory-cli` passed.
- `python .github\scripts\package-codestory-release.py --version 0.11.18 --target windows-x64 --binary target\release\codestory-cli.exe --out-dir target\issue-521-packaged-dist` passed.
- Packaged proof: `target\issue-521-packaged-ready-proof\ready-agent-repair.exitcode.txt` is `0`.
- Packaged proof: `target\issue-521-packaged-ready-proof\ready-agent-repair.json` reports `status=ready` and `sidecar.retrieval_mode=full`.
- Packaged proof: `target\issue-521-packaged-ready-proof\ready-agent-repair.stderr.txt` is empty.

## Risk

- Proof used a small disposable fixture repo under the proof artifact directory, not a full CodeStory repo indexing run.
- The proof validates the packaged repair path and managed endpoint selection, but does not make broader retrieval-quality claims beyond `ready` / `retrieval_mode=full` for that fixture.
