### PR TITLE
Fail ready repair on embed liveness

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1646,7 +1646,7 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    codestory_retrieval::bootstrap_sidecars_with_profile(
+    let bootstrap = codestory_retrieval::bootstrap_sidecars_with_profile(
         Some(runtime.project_root.as_path()),
         &storage_scope,
         None,
@@ -1655,6 +1655,7 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
         codestory_retrieval::SidecarProfile::Agent,
     )
     .context("ready repair retrieval bootstrap")?;
+    ensure_ready_repair_embed_liveness(&bootstrap.infrastructure)?;
     codestory_retrieval::repair_project_qdrant_collection(
         &runtime.project_root,
         &runtime.storage_path,
@@ -1670,6 +1671,22 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
     codestory_retrieval::strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
         .context("ready repair final retrieval status")?;
     Ok(())
+}
+
+fn ensure_ready_repair_embed_liveness(
+    infrastructure: &codestory_retrieval::InfrastructureHealth,
+) -> Result<()> {
+    if infrastructure.embed_reachable {
+        return Ok(());
+    }
+    bail!(
+        "ready repair embedding sidecar liveness failed before mandatory Qdrant semantic smoke: {}; zoekt_reachable={} ({}); qdrant_reachable={} ({})",
+        infrastructure.embed_detail,
+        infrastructure.zoekt_reachable,
+        infrastructure.zoekt_detail,
+        infrastructure.qdrant_reachable,
+        infrastructure.qdrant_detail
+    )
 }
 
 const LOCAL_GRAPH_AGENT_SURFACES: &[&str] =
@@ -10534,6 +10551,28 @@ mod tests {
             eligible_for_sufficiency: None,
             score_breakdown: None,
         }
+    }
+
+    #[test]
+    fn ready_repair_embed_liveness_blocks_before_semantic_smoke() {
+        let infrastructure = codestory_retrieval::InfrastructureHealth {
+            zoekt_reachable: true,
+            qdrant_reachable: true,
+            embed_reachable: false,
+            zoekt_detail: "http 200".into(),
+            qdrant_detail: "http 200".into(),
+            embed_detail:
+                "llama.cpp embeddings unavailable: http://127.0.0.1:55280/v1/embeddings: Connection Failed"
+                    .into(),
+        };
+
+        let error = ensure_ready_repair_embed_liveness(&infrastructure)
+            .expect_err("unreachable embedding endpoint must stop ready repair");
+        let message = format!("{error:#}");
+
+        assert!(message.contains("embedding sidecar liveness failed"));
+        assert!(message.contains("before mandatory Qdrant semantic smoke"));
+        assert!(message.contains("http://127.0.0.1:55280/v1/embeddings"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #523.
Refs #476, #513.

Issue #523 covers the packaged ready repair path that selected a dynamic managed embedding URL, then reached mandatory Qdrant semantic smoke before the embedding endpoint was live. The shared checkout now has healthy installed sidecars, so this is scoped to managed packaged-run liveness rather than missing sidecar installation.

## What Changed

- `ready --goal agent --repair` now checks the waited bootstrap infrastructure report before Qdrant repair, full indexing, or retrieval finalize.
- If the embedding endpoint is still unreachable after bootstrap waits, ready fails with an embed-sidecar liveness error that preserves the embed, Zoekt, and Qdrant health details.
- Added a focused unit test proving the liveness gate stops before mandatory semantic smoke.

## How To Review

- Start in `crates/codestory-cli/src/main.rs` at `repair_ready_state`.
- Confirm the existing bootstrap wait result is reused instead of adding a second sidecar wait path.
- Confirm explicit `CODESTORY_EMBED_LLAMACPP_URL` behavior is unchanged; this patch only reads the health result produced after the existing runtime setup.

## Verification

- `cargo test -p codestory-cli ready_repair_embed_liveness_blocks_before_semantic_smoke` passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

No packaged #513 proof was run from this branch because this branch only contains the runtime fix and does not include the draft packaged-proof harness from #513. The expected follow-up proof is to refresh #513 or run its packaged gate after this PR lands/overlays it; the previous dynamic-port connection-refused failure should become a precise ready-layer embed liveness failure if the endpoint still is not reachable.