### PR TITLE
[codex] limit stdio frame size

### DIFF
--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -18,7 +18,7 @@ use codestory_contracts::api::{
 use codestory_retrieval::SidecarLayout;
 use sha2::{Digest, Sha256};
 use std::fs::File;
-use std::io::{BufRead, Write};
+use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration as StdDuration;
@@ -43,6 +43,7 @@ use std::time::{Duration, Instant};
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
+const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
 
 /// Run the stdio server until stdin closes.
 ///
@@ -50,29 +51,103 @@ const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
 /// telemetry on stderr so stdout remains a newline-delimited JSON stream.
 pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
     let stdin = std::io::stdin();
+    let mut stdin = stdin.lock();
     let mut stdout = std::io::stdout();
     let mut state = StdioServerState::default();
-    for line in stdin.lock().lines() {
-        let line = line?;
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        let bytes_read = (&mut stdin)
+            .take((STDIO_MAX_FRAME_BYTES + 1) as u64)
+            .read_until(b'\n', &mut line)?;
+        if bytes_read == 0 {
+            break;
+        }
+        if line.len() > STDIO_MAX_FRAME_BYTES {
+            let tail_bytes = if line.ends_with(b"\n") {
+                0
+            } else {
+                discard_stdio_frame_tail(&mut stdin)?
+            };
+            let response = stdio_frame_too_large_error(line.len() + tail_bytes);
+            write_stdio_response(&mut stdout, &response)?;
+            continue;
+        }
+        let line = match std::str::from_utf8(&line) {
+            Ok(line) => line.trim_end_matches(&['\r', '\n']),
+            Err(error) => {
+                let response = stdio_jsonrpc_error(
+                    serde_json::Value::Null,
+                    -32700,
+                    format!("Parse error: {error}"),
+                );
+                write_stdio_response(&mut stdout, &response)?;
+                continue;
+            }
+        };
         if line.trim().is_empty() {
             continue;
         }
-        if let Some(response) = handle_stdio_message(&runtime, &mut state, &line) {
-            let response_id = stdio_response_id_label(&response);
-            let serialize_started = Instant::now();
-            serde_json::to_writer(&mut stdout, &response)?;
-            let serialization_ms = stdio_elapsed_ms(serialize_started);
-            let newline_started = Instant::now();
-            stdout.write_all(b"\n")?;
-            let newline_write_ms = stdio_elapsed_ms(newline_started);
-            let flush_started = Instant::now();
-            stdout.flush()?;
-            let flush_ms = stdio_elapsed_ms(flush_started);
-            report_stdio_server_phase(&response_id, "response_serialization", serialization_ms);
-            report_stdio_server_phase(&response_id, "newline_write", newline_write_ms);
-            report_stdio_server_phase(&response_id, "flush", flush_ms);
+        if let Some(response) = handle_stdio_message(&runtime, &mut state, line) {
+            write_stdio_response(&mut stdout, &response)?;
         }
     }
+    Ok(())
+}
+
+fn discard_stdio_frame_tail<R: BufRead>(reader: &mut R) -> Result<usize> {
+    let mut discarded = 0;
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(discarded);
+        }
+        if let Some(index) = available.iter().position(|byte| *byte == b'\n') {
+            reader.consume(index + 1);
+            return Ok(discarded + index + 1);
+        }
+        let len = available.len();
+        reader.consume(len);
+        discarded += len;
+    }
+}
+
+fn stdio_frame_too_large_error(line_bytes: usize) -> serde_json::Value {
+    let mut response = stdio_jsonrpc_error(
+        serde_json::Value::Null,
+        -32700,
+        format!("Parse error: stdio frame exceeded {STDIO_MAX_FRAME_BYTES} byte limit"),
+    );
+    if let Some(error) = response
+        .get_mut("error")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        error.insert(
+            "data".to_string(),
+            serde_json::json!({
+                "code": "stdio_frame_too_large",
+                "max_frame_bytes": STDIO_MAX_FRAME_BYTES,
+                "line_bytes": line_bytes,
+            }),
+        );
+    }
+    response
+}
+
+fn write_stdio_response<W: Write>(stdout: &mut W, response: &serde_json::Value) -> Result<()> {
+    let response_id = stdio_response_id_label(response);
+    let serialize_started = Instant::now();
+    serde_json::to_writer(&mut *stdout, response)?;
+    let serialization_ms = stdio_elapsed_ms(serialize_started);
+    let newline_started = Instant::now();
+    stdout.write_all(b"\n")?;
+    let newline_write_ms = stdio_elapsed_ms(newline_started);
+    let flush_started = Instant::now();
+    stdout.flush()?;
+    let flush_ms = stdio_elapsed_ms(flush_started);
+    report_stdio_server_phase(&response_id, "response_serialization", serialization_ms);
+    report_stdio_server_phase(&response_id, "newline_write", newline_write_ms);
+    report_stdio_server_phase(&response_id, "flush", flush_ms);
     Ok(())
 }
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -3312,6 +3312,43 @@ fn invalid_json_returns_parse_error_with_null_id() {
 }
 
 #[test]
+fn oversized_stdio_frame_returns_structured_protocol_error() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+    let oversized = "x".repeat(1024 * 1024 + 1);
+
+    let response = send_line(&mut server, &oversized);
+
+    let error = assert_error_envelope(&response, Value::Null);
+    assert_error_code(error, -32700);
+    assert_eq!(
+        error.pointer("/data/code").and_then(Value::as_str),
+        Some("stdio_frame_too_large"),
+        "oversized frame should use a structured protocol error: {response}"
+    );
+    assert_eq!(
+        error
+            .pointer("/data/max_frame_bytes")
+            .and_then(Value::as_u64),
+        Some(1024 * 1024),
+        "oversized frame error should report the configured byte limit: {response}"
+    );
+    assert!(
+        error
+            .pointer("/data/line_bytes")
+            .and_then(Value::as_u64)
+            .is_some_and(|bytes| bytes > 1024 * 1024),
+        "oversized frame error should report observed line bytes: {response}"
+    );
+
+    let follow_up = send_json(
+        &mut server,
+        json!({"jsonrpc": "2.0", "id": "after-oversized", "method": "initialize"}),
+    );
+    assert_success_envelope(&follow_up, json!("after-oversized"));
+}
+
+#[test]
 fn bad_tool_call_args_return_jsonrpc_error() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);


### PR DESCRIPTION
## Context
Closes #486.
Refs #472.

`serve --stdio` reads JSONL requests from local clients. Before this change, the reader could allocate an unbounded line before JSON parsing rejected it.

## What Changed
- Added a 1 MiB stdio JSONL frame limit before `serde_json` parsing.
- Return a JSON-RPC parse-error envelope with structured `error.data` when the frame is too large.
- Drain the rest of an oversized line so the stdio server can continue serving the next request.
- Added a regression test for oversized-line failure and post-error recovery.

## How To Review
- Start in `crates/codestory-cli/src/stdio_transport.rs` at the stdio read loop.
- Check `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the oversized-frame contract.

## Verification
- `cargo test -p codestory-cli --test stdio_protocol_contracts oversized_stdio_frame_returns_structured_protocol_error -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts`
- `cargo fmt --check`
- `git diff --check`
- Reviewer reran the focused and full stdio protocol tests, `cargo fmt --check`, and `git diff --check`.

## Risk
The limit is a fixed 1 MiB protocol guard, including the JSONL line delimiter read by `read_until`. If a real stdio client needs larger frames, that should be a deliberate follow-up protocol change rather than an implicit unbounded reader.