### PR TITLE
Support Windows ARM64 installer downloads

### DIFF
--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -185,13 +185,24 @@ function Find-ExistingCli {
     return $null
 }
 
-function Test-WindowsX64 {
-    $hostIsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
-        [System.Runtime.InteropServices.OSPlatform]::Windows
+function Get-WindowsReleaseTarget {
+    param(
+        [bool]$HostIsWindows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+            [System.Runtime.InteropServices.OSPlatform]::Windows
+        ),
+        [System.Runtime.InteropServices.Architecture]$Architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
     )
-    $isX64 = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq `
-        [System.Runtime.InteropServices.Architecture]::X64
-    return ($hostIsWindows -and $isX64)
+
+    if (-not $HostIsWindows) {
+        return $null
+    }
+    if ($Architecture -eq [System.Runtime.InteropServices.Architecture]::X64) {
+        return "windows-x64"
+    }
+    if ($Architecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
+        return "windows-arm64"
+    }
+    return $null
 }
 
 function Normalize-PathListEntry {
@@ -358,11 +369,12 @@ function Install-ReleaseCli {
         [string]$ReleaseVersion
     )
 
-    if (-not (Test-WindowsX64)) {
-        throw "Automatic download currently supports Windows x64 only. Pass -CodestoryCli or set CODESTORY_CLI to reuse an existing $script:RequiredVersion binary."
+    $releaseTarget = Get-WindowsReleaseTarget
+    if (-not $releaseTarget) {
+        throw "Automatic download currently supports Windows x64 and Windows ARM64 only. Pass -CodestoryCli or set CODESTORY_CLI to reuse an existing $script:RequiredVersion binary."
     }
 
-    $archiveName = "codestory-cli-v$ReleaseVersion-windows-x64.zip"
+    $archiveName = "codestory-cli-v$ReleaseVersion-$releaseTarget.zip"
     $baseUrl = "https://github.com/TheGreenCedar/CodeStory/releases/download/v$ReleaseVersion"
     $archiveUrl = "$baseUrl/$archiveName"
     $sumsUrl = "$baseUrl/SHA256SUMS.txt"
@@ -532,7 +544,9 @@ function Assert-SelfTest {
 
 function Invoke-SelfTest {
     Set-RequiredVersion "v0.11.4"
-    Test-WindowsX64 | Out-Null
+    Assert-SelfTest ((Get-WindowsReleaseTarget $true ([System.Runtime.InteropServices.Architecture]::X64)) -eq "windows-x64") "Windows x64 should map to windows-x64 release assets"
+    Assert-SelfTest ((Get-WindowsReleaseTarget $true ([System.Runtime.InteropServices.Architecture]::Arm64)) -eq "windows-arm64") "Windows ARM64 should map to windows-arm64 release assets"
+    Assert-SelfTest (-not (Get-WindowsReleaseTarget $false ([System.Runtime.InteropServices.Architecture]::X64))) "non-Windows hosts should not auto-download Windows assets"
     Assert-SelfTest (Test-PathListContains "C:\Tools;C:\CodeStory\bin\" "C:\CodeStory\bin") "path-list check should ignore trailing slash"
     Assert-SelfTest (-not (Test-PathListContains "C:\Tools" "C:\CodeStory\bin")) "path-list check should reject missing directory"
     Assert-SelfTest ((Set-PathListDirectoryFirst "C:\Old;C:\CodeStory\bin" "C:\CodeStory\bin") -eq "C:\CodeStory\bin;C:\Old") "path ordering should put current install first"
@@ -714,7 +728,7 @@ Set-RequiredVersion $Version
 $cliInfo = Find-ExistingCli $CodestoryCli $InstallDir
 if (-not $cliInfo) {
     if ($NoDownload) {
-        throw "No existing codestory-cli $script:RequiredVersion found. Pass -CodestoryCli, set CODESTORY_CLI, add codestory-cli to PATH, or rerun without -NoDownload on Windows x64."
+        throw "No existing codestory-cli $script:RequiredVersion found. Pass -CodestoryCli, set CODESTORY_CLI, add codestory-cli to PATH, or rerun without -NoDownload on Windows x64 or Windows ARM64."
     }
     $cliInfo = Install-ReleaseCli $InstallDir $Version
 }


### PR DESCRIPTION
## Context

Windows ARM64 release assets are already built by the release workflow, but the PowerShell installer only selected the Windows x64 archive. That made ARM64 Windows users hit an unsupported auto-download path even though CodeStory publishes a matching runtime asset.

Closes #490

## What Changed

- Replaced the installer's x64-only predicate with a Windows release target resolver.
- Mapped Windows x64 to `windows-x64` and Windows ARM64 to `windows-arm64`.
- Kept non-Windows and other Windows architectures on the explicit existing-binary path.
- Updated installer self-test coverage for x64, ARM64, and unsupported OS mapping.

## How To Review

- Read `scripts/install-codestory.ps1` around `Get-WindowsReleaseTarget` and `Install-ReleaseCli`.
- Confirm the archive name now follows the same asset labels as `.github/workflows/release.yml`.
- Confirm unsupported platforms still get directed to `-CodestoryCli` or `CODESTORY_CLI` instead of a speculative download.

## Verification

- `codestory-cli agent preflight --project 'C:\Users\alber\.codex\worktrees\issue490-windows-arm64-installer\codestory' --format json` -> initially blocked; local graph needed repair and packet/search sidecars were unavailable.
- `codestory-cli ready --goal local --repair --project 'C:\Users\alber\.codex\worktrees\issue490-windows-arm64-installer\codestory' --format json` -> local navigation ready, 273 indexed files, 0 errors; sidecar retrieval still unavailable.
- `codestory-cli ground --project 'C:\Users\alber\.codex\worktrees\issue490-windows-arm64-installer\codestory' --why` -> grounding snapshot available for local navigation.
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-codestory.ps1 -SelfTest` -> `install-codestory self-test: ok`.
- `git diff --check` -> clean.

## Risk

Draft because this was smoked through the installer self-test on this Windows workstation, not on physical Windows ARM64 hardware and not against a live ARM64 release download. The remaining risk is a host-specific ARM64 PowerShell/.NET runtime mismatch, but the resolver uses `RuntimeInformation.OSArchitecture`, matching the installer architecture decision already used by the plugin-managed runtime path.