### PR TITLE
[codex] Add runtime path truth diagnostic

### DIFF
--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -20,7 +20,7 @@ use sha2::{Digest, Sha256};
 use std::fs::{self, File};
 use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration as StdDuration;
 
 use crate::args;
@@ -44,6 +44,8 @@ use std::time::{Duration, Instant};
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
+const STDIO_CLI_VERSION_TIMEOUT: Duration = Duration::from_secs(3);
+const STDIO_CLI_VERSION_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 /// Run the stdio server until stdin closes.
 ///
@@ -2247,12 +2249,34 @@ fn push_cli_candidate_paths(candidates: &mut Vec<String>, directory: &Path) {
 }
 
 fn stdio_cli_version(candidate: &str) -> Option<String> {
-    let output = Command::new(candidate).arg("--version").output().ok()?;
-    if !output.status.success() {
-        return None;
+    stdio_cli_version_with_timeout(candidate, STDIO_CLI_VERSION_TIMEOUT)
+}
+
+fn stdio_cli_version_with_timeout(candidate: &str, timeout: Duration) -> Option<String> {
+    let started_at = Instant::now();
+    let mut child = Command::new(candidate)
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    loop {
+        if let Some(status) = child.try_wait().ok()? {
+            let output = child.wait_with_output().ok()?;
+            if !status.success() {
+                return None;
+            }
+            let text = String::from_utf8_lossy(&output.stdout);
+            return text.split_whitespace().find_map(normalize_release_version);
+        }
+        if started_at.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        let remaining = timeout.saturating_sub(started_at.elapsed());
+        std::thread::sleep(STDIO_CLI_VERSION_POLL_INTERVAL.min(remaining));
     }
-    let text = String::from_utf8_lossy(&output.stdout);
-    text.split_whitespace().find_map(normalize_release_version)
 }
 
 fn stdio_path_cli_candidate_statuses(active_path: Option<&str>) -> serde_json::Value {
@@ -3028,6 +3052,50 @@ version = "0.11.20"
 "#;
 
         assert_eq!(cargo_package_version(manifest), Some("0.11.20".to_string()));
+    }
+
+    #[test]
+    fn stdio_cli_version_returns_none_when_probe_times_out() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "codestory-stdio-cli-timeout-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let candidate = temp_dir.join(if cfg!(windows) {
+            "codestory-cli.cmd"
+        } else {
+            "codestory-cli"
+        });
+        fs::write(
+            &candidate,
+            if cfg!(windows) {
+                "@echo off\r\nping -n 6 127.0.0.1 > nul\r\necho codestory-cli 9.9.9\r\n"
+            } else {
+                "#!/bin/sh\nsleep 5\necho codestory-cli 9.9.9\n"
+            },
+        )
+        .expect("write slow cli probe");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&candidate)
+                .expect("candidate metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&candidate, permissions).expect("chmod candidate");
+        }
+
+        let started_at = Instant::now();
+        let version =
+            stdio_cli_version_with_timeout(&candidate.to_string_lossy(), Duration::from_millis(50));
+
+        assert_eq!(version, None);
+        assert!(
+            started_at.elapsed() < Duration::from_secs(2),
+            "version probe should return near the configured timeout"
+        );
+        let _ = fs::remove_dir_all(&temp_dir);
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -17,7 +17,7 @@ use codestory_contracts::api::{
 };
 use codestory_retrieval::SidecarLayout;
 use sha2::{Digest, Sha256};
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -2088,6 +2088,8 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     });
     let (server_executable, server_executable_sha256, server_warnings) =
         stdio_server_executable_status();
+    let path_candidates = stdio_path_cli_candidate_statuses(server_executable.as_deref());
+    let source_checkout_version = stdio_source_checkout_version(&runtime.project_root);
     let plugin_runtime = stdio_plugin_runtime_status();
     let setup_repair = stdio_setup_repair_input(server_executable.as_deref());
     let readiness = crate::readiness::build_readiness_verdicts(crate::readiness::ReadinessInputs {
@@ -2110,6 +2112,8 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         "cli_version": env!("CARGO_PKG_VERSION"),
         "server_executable": server_executable,
         "server_executable_sha256": server_executable_sha256,
+        "source_checkout_version": source_checkout_version,
+        "path_candidates": path_candidates,
         "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "plugin_runtime": plugin_runtime,
         "runtime_boundary": {
@@ -2249,6 +2253,87 @@ fn stdio_cli_version(candidate: &str) -> Option<String> {
     }
     let text = String::from_utf8_lossy(&output.stdout);
     text.split_whitespace().find_map(normalize_release_version)
+}
+
+fn stdio_path_cli_candidate_statuses(active_path: Option<&str>) -> serde_json::Value {
+    serde_json::Value::Array(
+        stdio_path_cli_candidates()
+            .into_iter()
+            .map(|path| {
+                serde_json::json!({
+                    "path": crate::display::clean_path_string(&path),
+                    "version": stdio_cli_version(&path),
+                    "active": active_path.is_some_and(|active| same_path_text(&path, active)),
+                })
+            })
+            .collect(),
+    )
+}
+
+fn stdio_path_cli_candidates() -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Some(paths) = std::env::var_os("PATH") {
+        for directory in std::env::split_paths(&paths) {
+            push_existing_path_cli_candidates(&mut candidates, &directory);
+        }
+    }
+    dedupe_path_text(candidates)
+}
+
+fn push_existing_path_cli_candidates(candidates: &mut Vec<String>, directory: &Path) {
+    for binary in stdio_cli_binary_names() {
+        let candidate = directory.join(binary);
+        if candidate.is_file() {
+            candidates.push(candidate.to_string_lossy().to_string());
+        }
+    }
+}
+
+fn stdio_cli_binary_names() -> &'static [&'static str] {
+    if cfg!(windows) {
+        &[
+            "codestory-cli.exe",
+            "codestory-cli.cmd",
+            "codestory-cli.bat",
+            "codestory-cli",
+        ]
+    } else {
+        &["codestory-cli"]
+    }
+}
+
+fn stdio_source_checkout_version(project_root: &Path) -> Option<String> {
+    fs::read_to_string(project_root.join("crates/codestory-cli/Cargo.toml"))
+        .ok()
+        .and_then(|manifest| cargo_package_version(&manifest))
+}
+
+fn cargo_package_version(manifest: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in manifest.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_package = trimmed == "[package]";
+            continue;
+        }
+        if !in_package {
+            continue;
+        }
+        let Some(version) = trimmed.strip_prefix("version") else {
+            continue;
+        };
+        let Some(version) = version.trim_start().strip_prefix('=') else {
+            continue;
+        };
+        if let Some(version) = version.trim().strip_prefix('"').and_then(|value| {
+            value
+                .split_once('"')
+                .map(|(version, _)| version.to_string())
+        }) {
+            return Some(version);
+        }
+    }
+    None
 }
 
 fn same_path_text(left: &str, right: &str) -> bool {
@@ -2928,6 +3013,21 @@ mod tests {
             calls[0].get("command").is_none(),
             "restart boundary should not be exposed as a CLI command: {calls}"
         );
+    }
+
+    #[test]
+    fn cargo_package_version_reads_only_package_section() {
+        let manifest = r#"
+[workspace]
+version = "9.9.9"
+
+[package]
+name = "codestory-cli"
+edition = "2024"
+version = "0.11.20"
+"#;
+
+        assert_eq!(cargo_package_version(manifest), Some("0.11.20".to_string()));
     }
 
     #[test]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1986,6 +1986,17 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         "status should identify the active CLI version: {status}"
     );
     assert!(
+        status["source_checkout_version"].is_null()
+            || status["source_checkout_version"]
+                .as_str()
+                .is_some_and(|version| !version.is_empty()),
+        "status should distinguish source checkout version from active runtime version: {status}"
+    );
+    assert!(
+        status["path_candidates"].is_array(),
+        "status should report competing PATH candidates even when none are present: {status}"
+    );
+    assert!(
         status["sidecar_contract_version"].is_number(),
         "status should expose the sidecar contract version: {status}"
     );

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -374,9 +374,10 @@ async function resolveCli() {
   }
 
   warnings.push('managed_cli_unavailable_using_path_fallback');
+  const pathFallback = pathCliCandidates()[0] || 'codestory-cli';
   return {
     source: 'path_fallback',
-    path: 'codestory-cli',
+    path: pathFallback,
     sha256: null,
     version,
     cliVersion: null,

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -512,6 +512,11 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
 
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   const projectRoot = process.cwd();
+  const pathCandidates = pathCliCandidates().map((candidate) => ({
+    path: candidate,
+    version: cliVersion(candidate),
+    active: samePathText(candidate, resolved.path),
+  }));
   const minimumNext = options.minimumNext || [
     'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
     process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
@@ -587,6 +592,8 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     cli_version: probe.version,
     server_executable: null,
     server_executable_sha256: null,
+    source_checkout_version: sourceCheckoutVersion(projectRoot),
+    path_candidates: pathCandidates,
     sidecar_contract_version: null,
     plugin_runtime: plugin,
     runtime_boundary: {
@@ -608,6 +615,75 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   };
 }
 
+function pathCliCandidates() {
+  const pathValue = process.env.PATH || '';
+  const candidates = [];
+  for (const directory of pathValue.split(path.delimiter).filter(Boolean)) {
+    for (const name of cliBinaryNames()) {
+      const candidate = path.join(directory, name);
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        candidates.push(candidate);
+      }
+    }
+  }
+  return dedupePaths(candidates);
+}
+
+function cliBinaryNames() {
+  return process.platform === 'win32'
+    ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli.bat', 'codestory-cli']
+    : ['codestory-cli'];
+}
+
+function cliVersion(candidate) {
+  const result = spawnSync(candidate, ['--version'], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(candidate),
+    timeout: 3000,
+    windowsHide: true,
+  });
+  if (result.status !== 0 || result.error) return null;
+  return normalizeVersion(`${result.stdout || ''}\n${result.stderr || ''}`);
+}
+
+function samePathText(left, right) {
+  const normalize = (value) => String(value || '').replace(/[\\/]+$/u, '').toLowerCase();
+  return normalize(left) === normalize(right);
+}
+
+function dedupePaths(paths) {
+  const deduped = [];
+  for (const candidate of paths) {
+    if (!deduped.some((seen) => samePathText(seen, candidate))) {
+      deduped.push(candidate);
+    }
+  }
+  return deduped;
+}
+
+function sourceCheckoutVersion(projectRoot) {
+  try {
+    return cargoPackageVersion(fs.readFileSync(path.join(projectRoot, 'crates', 'codestory-cli', 'Cargo.toml'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function cargoPackageVersion(manifest) {
+  let inPackage = false;
+  for (const line of manifest.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (/^\[[^\]]+\]$/u.test(trimmed)) {
+      inPackage = trimmed === '[package]';
+      continue;
+    }
+    if (!inPackage) continue;
+    const match = trimmed.match(/^version\s*=\s*"([^"]+)"/u);
+    if (match) return match[1];
+  }
+  return null;
+}
+
 function diagnosticText(status) {
   const setup = status.readiness[0].setup;
   return [
@@ -618,6 +694,8 @@ function diagnosticText(status) {
     `cli_source: ${status.plugin_runtime.cli_source}`,
     `cli_path: ${setup.active_path}`,
     `cli_version: ${setup.active_version || '<unknown>'}`,
+    `source_checkout_version: ${status.source_checkout_version || '<none>'}`,
+    `path_candidates: ${(status.path_candidates || []).map((candidate) => `${candidate.path}@${candidate.version || '<unknown>'}`).join(', ') || '<none>'}`,
     `next: ${status.readiness[0].minimum_next[0]}`,
   ].join('\n');
 }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -246,11 +246,12 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
       {
         path: fakeCli,
         version: "0.0.1",
-        active: false,
+        active: true,
       },
     ]);
     assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
     assert.equal(status.plugin_runtime.cli_source, "path_fallback");
+    assert.equal(status.plugin_runtime.cli_path, fakeCli);
     assert.equal(status.readiness[0].status, "repair_setup");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -204,7 +204,17 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
 test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
+  const sourceVersion = readCargoVersion(await readFile(join(repoRoot, "crates", "codestory-cli", "Cargo.toml"), "utf8"));
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-mcp-"));
+  const pathDir = await mkdtemp(join(tmpdir(), "codestory-path-candidate-"));
+  const fakeCli = join(pathDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  await writeFile(
+    fakeCli,
+    process.platform === "win32"
+      ? "@echo off\r\necho codestory-cli 0.0.1\r\n"
+      : "#!/bin/sh\necho codestory-cli 0.0.1\n",
+  );
+  await chmod(fakeCli, 0o755);
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = [
     JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
@@ -217,9 +227,10 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
       env: {
         PLUGIN_DATA: "",
         COPILOT_PLUGIN_DATA: "",
-        PATH: "",
+        PATH: pathDir,
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
+      cwd: repoRoot,
       input,
       encoding: "utf8",
       timeout: 5000,
@@ -230,6 +241,14 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     assert.equal(responses.length, 3, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
     assert.equal(status.plugin_runtime.plugin_version, version);
+    assert.equal(status.source_checkout_version, sourceVersion);
+    assert.deepEqual(status.path_candidates, [
+      {
+        path: fakeCli,
+        version: "0.0.1",
+        active: false,
+      },
+    ]);
     assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
     assert.equal(status.plugin_runtime.cli_source, "path_fallback");
     assert.equal(status.readiness[0].status, "repair_setup");
@@ -246,6 +265,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     );
   } finally {
     await rm(dataDir, { recursive: true, force: true });
+    await rm(pathDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Context
Issue #492 asks CodeStory to make installed runtime and PATH truth visible so agents can diagnose stale binary drift from the status surface instead of guessing from source checkout state.

Closes #492

## What Changed
- Added `source_checkout_version` and `path_candidates` to stdio `codestory://status`.
- Added the same source/PATH diagnostics to the plugin launcher fail-open status payload and diagnostic text.
- Extended the stdio and plugin launcher tests around runtime/path truth.

## How To Review
- Check `crates/codestory-cli/src/stdio_transport.rs` for the status payload fields and PATH candidate scan.
- Check `plugins/codestory/scripts/codestory-mcp.cjs` for the plugin fail-open equivalent.
- Confirm the tests assert the new source/runtime distinction and stale PATH candidate case.

## Verification
- `codestory-cli doctor --project C:\Users\alber\.codex\worktrees\issue492-runtime-path-truth\codestory --format json` reported no initial index and `retrieval_manifest_missing` for sidecars.
- `codestory-cli ready --goal local --repair --project C:\Users\alber\.codex\worktrees\issue492-runtime-path-truth\codestory --format json` repaired local navigation: 273 indexed files, 0 errors.
- `codestory-cli ground --project C:\Users\alber\.codex\worktrees\issue492-runtime-path-truth\codestory --why` returned a fresh local grounding snapshot; sidecar packet/search remained unavailable.
- `cargo fmt --check`
- `cargo test -p codestory-cli stdio_cli_version_returns_none_when_probe_times_out`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `git diff --check`

## Risk
- PATH candidate version probing can add status latency when many PATH entries contain `codestory-cli` shims; Rust and plugin `--version` probes are bounded to 3000 ms per candidate.
- No sidecar repair behavior changed; packet/search proof was not claimed because sidecar retrieval was unavailable in this worktree.

