### PR TITLE
Fix retrieval profile handoff

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2033,13 +2033,17 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
         Some(runtime.storage_path.as_path()),
         Some(runtime.cache_root.as_path()),
     );
-    let bootstrap = codestory_retrieval::bootstrap_sidecars_with_profile(
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project(
+        &runtime.project_root,
+        codestory_retrieval::SidecarProfile::Agent,
+    );
+    let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime(
+        &sidecar,
         Some(runtime.project_root.as_path()),
         &storage_scope,
         None,
         false,
         Duration::from_secs(90),
-        codestory_retrieval::SidecarProfile::Agent,
     )
     .context("ready repair retrieval bootstrap")?;
     ensure_ready_repair_embed_liveness(&bootstrap.infrastructure)?;
@@ -2053,10 +2057,14 @@ fn repair_ready_state(runtime: &RuntimeContext, goal: Option<args::ReadyGoal>) -
         .run_indexing_blocking(IndexMode::Full)
         .map_err(map_api_error)
         .context("ready repair retrieval index refresh")?;
-    retrieval::finalize_retrieval_index_for_runtime(runtime)
+    retrieval::finalize_retrieval_index_for_sidecar_runtime(runtime, &sidecar)
         .context("ready repair retrieval index finalize")?;
-    codestory_retrieval::strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
-        .context("ready repair final retrieval status")?;
+    codestory_retrieval::strict_sidecar_status_for_runtime(
+        &runtime.project_root,
+        Some(&runtime.storage_path),
+        sidecar,
+    )
+    .context("ready repair final retrieval status")?;
     Ok(())
 }
 
@@ -9462,7 +9470,7 @@ fn doctor_sidecar_status(runtime: &RuntimeContext) -> DoctorSidecarStatusOutput 
                 .manifest
                 .as_ref()
                 .and_then(|manifest| manifest.precise_semantic_import_producer.clone());
-            DoctorSidecarStatusOutput {
+            let status = DoctorSidecarStatusOutput {
                 retrieval_mode: report.retrieval_mode,
                 degraded_reason: report.degraded_reason,
                 manifest_generation,
@@ -9471,7 +9479,11 @@ fn doctor_sidecar_status(runtime: &RuntimeContext) -> DoctorSidecarStatusOutput 
                 precise_semantic_import_reason,
                 precise_semantic_import_revision,
                 precise_semantic_import_producer,
-            }
+            };
+            let handoff_failure = (status.retrieval_mode == "full")
+                .then(|| doctor_sidecar_profile_handoff_failure(runtime))
+                .flatten();
+            apply_sidecar_profile_handoff(status, handoff_failure)
         }
         Err(error) => DoctorSidecarStatusOutput {
             retrieval_mode: "unavailable".to_string(),
@@ -9483,6 +9495,46 @@ fn doctor_sidecar_status(runtime: &RuntimeContext) -> DoctorSidecarStatusOutput 
             precise_semantic_import_revision: None,
             precise_semantic_import_producer: None,
         },
+    }
+}
+
+fn apply_sidecar_profile_handoff(
+    mut status: DoctorSidecarStatusOutput,
+    handoff_failure: Option<String>,
+) -> DoctorSidecarStatusOutput {
+    if status.retrieval_mode == "full"
+        && let Some(reason) = handoff_failure
+    {
+        status.retrieval_mode = "unavailable".to_string();
+        status.degraded_reason = Some(reason);
+    }
+    status
+}
+
+fn doctor_sidecar_profile_handoff_failure(runtime: &RuntimeContext) -> Option<String> {
+    let active = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    if active.profile == codestory_retrieval::SidecarProfile::Local {
+        return None;
+    }
+    let local = codestory_retrieval::strict_sidecar_status_for_profile(
+        &runtime.project_root,
+        Some(&runtime.storage_path),
+        codestory_retrieval::SidecarProfile::Local,
+    );
+    match local {
+        Ok(report) if report.retrieval_mode == "full" => None,
+        Ok(report) => Some(format!(
+            "profile_handoff_mismatch: active profile={} namespace={} is full but local/default profile is mode={} reason={}",
+            active.profile.as_str(),
+            active.namespace,
+            report.retrieval_mode,
+            report.degraded_reason.as_deref().unwrap_or("unknown")
+        )),
+        Err(error) => Some(format!(
+            "profile_handoff_mismatch: active profile={} namespace={} is full but local/default status failed: {error}",
+            active.profile.as_str(),
+            active.namespace
+        )),
     }
 }
 
@@ -10962,6 +11014,36 @@ mod tests {
         assert!(message.contains("embedding sidecar liveness failed"));
         assert!(message.contains("before mandatory Qdrant semantic smoke"));
         assert!(message.contains("http://127.0.0.1:55280/v1/embeddings"));
+    }
+
+    #[test]
+    fn sidecar_profile_handoff_downgrades_full_readiness() {
+        let status = DoctorSidecarStatusOutput {
+            retrieval_mode: "full".to_string(),
+            degraded_reason: None,
+            manifest_generation: Some("generation".to_string()),
+            manifest_input_hash: Some("hash".to_string()),
+            precise_semantic_import_status: None,
+            precise_semantic_import_reason: None,
+            precise_semantic_import_revision: None,
+            precise_semantic_import_producer: None,
+        };
+
+        let downgraded = apply_sidecar_profile_handoff(
+            status,
+            Some(
+                "profile_handoff_mismatch: active profile=agent namespace=run is full but local/default profile is mode=unavailable reason=zoekt_stub"
+                    .to_string(),
+            ),
+        );
+
+        assert_eq!(downgraded.retrieval_mode, "unavailable");
+        assert_eq!(
+            downgraded.degraded_reason.as_deref(),
+            Some(
+                "profile_handoff_mismatch: active profile=agent namespace=run is full but local/default profile is mode=unavailable reason=zoekt_stub"
+            )
+        );
     }
 
     #[test]

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -5,8 +5,9 @@ use std::time::Duration;
 use codestory_retrieval::{
     BootstrapStorageScope, FinalizeIndexOutcome, ProjectQdrantRepairOutcome, QueryRequest,
     RetrievalIndexManifest, RetrievalStatusReport, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    bootstrap_sidecars_with_runtime, execute_retrieval_query, sidecar_down_for_runtime,
-    sidecar_up_with_runtime, strict_sidecar_status, strict_sidecar_status_for_runtime,
+    SidecarProfile, SidecarRuntimeConfig, bootstrap_sidecars_with_runtime, execute_retrieval_query,
+    sidecar_down_for_runtime, sidecar_up_with_runtime, strict_sidecar_status,
+    strict_sidecar_status_for_runtime,
 };
 
 use crate::args::{
@@ -136,22 +137,30 @@ fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
 
 fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
-    activate_retrieval_profile_env(cmd.profile, cmd.run_id.as_deref());
+    let sidecar_profile = cmd.profile.unwrap_or(CliSidecarProfile::Local);
+    activate_retrieval_profile_env(Some(sidecar_profile), cmd.run_id.as_deref());
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &runtime.project_root,
+        sidecar_profile.into(),
+        cmd.run_id.as_deref(),
+    );
     let summary = runtime.open_project_summary()?;
     let refresh_mode = resolve_refresh_request(cmd.refresh, &summary);
     run_retrieval_index_refresh(&runtime, cmd.refresh, refresh_mode)?;
-    let outcome = finalize_retrieval_index_for_runtime(&runtime).or_else(|error| {
-        if !retrieval_index_should_retry_full_refresh(cmd.refresh, &error) {
-            return Err(error);
-        }
-        runtime
-            .index
-            .run_indexing_blocking(IndexMode::Full)
-            .map_err(map_api_error)?;
-        finalize_retrieval_index_for_runtime(&runtime)
-            .context("retrieval index finalize after semantic-doc contract repair")
-    })?;
+    let outcome =
+        finalize_retrieval_index_for_sidecar_runtime(&runtime, &sidecar).or_else(|error| {
+            if !retrieval_index_should_retry_full_refresh(cmd.refresh, &error) {
+                return Err(error);
+            }
+            runtime
+                .index
+                .run_indexing_blocking(IndexMode::Full)
+                .map_err(map_api_error)?;
+            finalize_retrieval_index_for_sidecar_runtime(&runtime, &sidecar)
+                .context("retrieval index finalize after semantic-doc contract repair")
+        })?;
+    ensure_local_profile_handoff(&runtime, &sidecar, &outcome)?;
     emit_retrieval_index(cmd.format, &outcome, cmd.output_file.as_deref())
 }
 
@@ -207,10 +216,83 @@ fn run_retrieval_index_refresh(
 pub(crate) fn finalize_retrieval_index_for_runtime(
     runtime: &RuntimeContext,
 ) -> Result<FinalizeIndexOutcome> {
+    let sidecar = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    finalize_retrieval_index_for_sidecar_runtime(runtime, &sidecar)
+}
+
+pub(crate) fn finalize_retrieval_index_for_sidecar_runtime(
+    runtime: &RuntimeContext,
+    sidecar: &SidecarRuntimeConfig,
+) -> Result<FinalizeIndexOutcome> {
     let opened = runtime.ensure_open(crate::args::RefreshMode::None)?;
     ensure_index_ready(&opened, "retrieval index")?;
-    codestory_retrieval::finalize_index(&runtime.project_root, &runtime.storage_path)
-        .context("retrieval index finalize")
+    codestory_retrieval::finalize_index_for_runtime(
+        &runtime.project_root,
+        &runtime.storage_path,
+        sidecar,
+    )
+    .context("retrieval index finalize")
+}
+
+fn ensure_local_profile_handoff(
+    runtime: &RuntimeContext,
+    indexed_sidecar: &SidecarRuntimeConfig,
+    outcome: &FinalizeIndexOutcome,
+) -> Result<()> {
+    if indexed_sidecar.profile != SidecarProfile::Local {
+        return Ok(());
+    }
+    let default_sidecar = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    if let Some(mismatch) = sidecar_runtime_mismatch(indexed_sidecar, &default_sidecar) {
+        anyhow::bail!("{mismatch}");
+    }
+    let status = strict_sidecar_status_for_runtime(
+        &runtime.project_root,
+        Some(&runtime.storage_path),
+        default_sidecar,
+    )
+    .context("retrieval local/default status after index")?;
+    if status.retrieval_mode != "full" {
+        anyhow::bail!(
+            "retrieval profile handoff failed: local/default status after index is mode={} reason={}; indexed_project_id={} sidecar={}",
+            status.retrieval_mode,
+            status.degraded_reason.as_deref().unwrap_or("unknown"),
+            outcome.project_id,
+            format_sidecar_runtime(indexed_sidecar)
+        );
+    }
+    Ok(())
+}
+
+fn sidecar_runtime_mismatch(
+    indexed: &SidecarRuntimeConfig,
+    default: &SidecarRuntimeConfig,
+) -> Option<String> {
+    let same_paths = indexed.profile == default.profile
+        && indexed.namespace == default.namespace
+        && indexed.layout.zoekt_data_dir == default.layout.zoekt_data_dir
+        && indexed.layout.qdrant_data_dir == default.layout.qdrant_data_dir
+        && indexed.layout.scip_artifacts_root == default.layout.scip_artifacts_root
+        && indexed.layout.state_file == default.layout.state_file;
+    (!same_paths).then(|| {
+        format!(
+            "retrieval profile handoff mismatch: indexed local artifacts use {}; default bare retrieval resolves to {}; retrieval index must not report success until local/default namespace and paths match",
+            format_sidecar_runtime(indexed),
+            format_sidecar_runtime(default)
+        )
+    })
+}
+
+fn format_sidecar_runtime(runtime: &SidecarRuntimeConfig) -> String {
+    format!(
+        "profile={} namespace={} state={} zoekt={} qdrant={} scip={}",
+        runtime.profile.as_str(),
+        runtime.namespace,
+        runtime.layout.state_file.display(),
+        runtime.layout.zoekt_data_dir.display(),
+        runtime.layout.qdrant_data_dir.display(),
+        runtime.layout.scip_artifacts_root.display()
+    )
 }
 
 fn retrieval_index_should_retry_full_refresh(
@@ -504,5 +586,26 @@ mod tests {
             RefreshMode::Auto,
             &error
         ));
+    }
+
+    #[test]
+    fn local_profile_handoff_reports_default_namespace_path_mismatch() {
+        let project = tempfile::TempDir::new().expect("project");
+        let local =
+            codestory_retrieval::sidecar_runtime_for_project(project.path(), SidecarProfile::Local);
+        let agent = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+            project.path(),
+            SidecarProfile::Agent,
+            Some("issue-534"),
+        );
+
+        let message = sidecar_runtime_mismatch(&local, &agent).expect("mismatch");
+
+        assert!(message.contains("retrieval profile handoff mismatch"));
+        assert!(message.contains("profile=local"));
+        assert!(message.contains("profile=agent"));
+        assert!(message.contains("namespace=codestory-agent"));
+        assert!(message.contains("zoekt="));
+        assert!(sidecar_runtime_mismatch(&local, &local).is_none());
     }
 }

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1,5 +1,5 @@
 use crate::config::{
-    SidecarLayout, ZOEKT_REAL_VERSION_PIN, dir_size_bytes, qdrant_enabled,
+    SidecarLayout, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, dir_size_bytes, qdrant_enabled,
     qdrant_semantic_vectors_enabled, zoekt_enabled,
 };
 use crate::generation::{
@@ -182,7 +182,17 @@ pub fn repair_project_qdrant_collection(
 }
 
 pub fn finalize_index(project_root: &Path, storage_path: &Path) -> Result<FinalizeIndexOutcome> {
-    let layout = SidecarLayout::from_env_for_project(project_root);
+    let runtime = crate::config::sidecar_runtime_auto(project_root);
+    finalize_index_for_runtime(project_root, storage_path, &runtime)
+}
+
+pub fn finalize_index_for_runtime(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<FinalizeIndexOutcome> {
+    runtime.activate_embed_url_default();
+    let layout = runtime.layout.clone();
     layout.ensure_data_dirs()?;
 
     let project_id = sidecar_project_id_for_root(project_root);

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -66,8 +66,8 @@ pub use health::{
     probe_infrastructure_health, probe_sidecar_health,
 };
 pub use index::{
-    FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, project_id_for_root,
-    repair_project_qdrant_collection, sidecar_project_id_for_root,
+    FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, finalize_index_for_runtime,
+    project_id_for_root, repair_project_qdrant_collection, sidecar_project_id_for_root,
 };
 pub use mode::RetrievalDegradedMode;
 pub use mode::derive_degraded_mode;


### PR DESCRIPTION
## Context

Closes https://github.com/TheGreenCedar/CodeStory/issues/534.

`retrieval index --profile local` could finalize artifacts under one sidecar runtime while status/search/query later inspected another runtime namespace. Separately, `doctor` and `agent preflight` could report packet/search ready from an agent namespace even when the local/default profile was degraded, which made readiness disagree with the bare CLI surface.

## What Changed

- Thread retrieval index finalization through the selected `SidecarRuntimeConfig` instead of re-resolving sidecar paths later.
- Reuse the same agent sidecar runtime across `ready --goal agent --repair` bootstrap, finalization, and final status.
- Add a local/default handoff guard after local profile indexing; if default bare retrieval resolves to a different namespace/path, index now fails with the mismatch instead of reporting success.
- Make doctor/preflight fail closed for packet/search when a full active agent namespace masks a degraded local/default profile.

## How To Review

- Start in `crates/codestory-cli/src/retrieval.rs` for the index finalization boundary and handoff guard.
- Then check `crates/codestory-cli/src/main.rs` for ready repair runtime reuse and readiness downgrade behavior.
- `crates/codestory-retrieval/src/index.rs` exposes the runtime-aware finalizer used by the CLI.

## Verification

- `cargo test -p codestory-cli sidecar_profile_handoff_downgrades_full_readiness`
- `cargo test -p codestory-cli local_profile_handoff_reports_default_namespace_path_mismatch`
- `cargo test -p codestory-retrieval finalize_index_fails_without_mandatory_sidecar_artifacts`
- `cargo fmt --check`
- `git diff --check`
- Reproduced old installed 0.11.18 mismatch on shared checkout: `agent preflight` reported `full_retrieval`, then bare `search RuntimeContext` failed `mode=unavailable, reason=zoekt_stub`.
- With the built CLI from this branch, shared checkout `agent preflight` now reports `mode=local_graph`, blocks `packet_full/search_full/context_full`, and `doctor` reports packet/search repair instead of ready.

## Risk

Readiness is intentionally conservative when local/default retrieval is degraded but an agent namespace has full artifacts. That may block packet/search until local/default handoff is repaired, but it prevents the specific false-ready state from #534.
