### PR TITLE
[codex] publish graph schema and evidence examples

### DIFF
--- a/docs/testing/retrieval-architecture.md
+++ b/docs/testing/retrieval-architecture.md
@@ -34,6 +34,118 @@ counts, degraded modes, and lane provenance. It is readiness/freshness evidence
 only. Packet-quality promotion still needs role-bearing packet sufficiency plus
 the matching drill or benchmark tier.
 
+## Published Schema and Evidence Examples
+
+These are the safe public surfaces for agents, docs, and PR evidence. Prefer
+these DTOs and status fields over internal SQL tables, cache paths, sidecar
+payloads, dense vectors, or generated summaries.
+
+| Need | Safe surface | Owner boundary |
+|------|--------------|----------------|
+| Local graph shape | `NodeId`, `EdgeId`, `NodeKind`, `EdgeKind`, `ResolutionCertainty` in `crates/codestory-contracts/src/graph.rs`; route DTOs in `crates/codestory-contracts/src/api/dto.rs` | Store-local ids and extracted graph facts. `NodeId` is not a cross-repo identity; use `canonical_id`, file path, or qualified name for durable references. |
+| Project/index readiness | `ProjectSummary`, `StorageStatsDto`, `IndexFreshnessDto`, `ReadinessVerdictDto`, `ReadinessSidecarSnapshotDto` | Runtime truth for this workspace and this invocation. A fresh local graph does not imply packet/search readiness. |
+| Support tier | `IndexedFileLanguageCountDto` plus `LANGUAGE_SUPPORT_PROFILES` in `language_support.rs` | Language claim tier only: parser-backed graph or structural source-proof. It does not claim typed semantic edges or packet answer quality. |
+| Search and packet evidence | `SearchHit`, `AgentCitationDto`, `PacketEvidenceTierDto`, `PacketEvidenceResolutionDto`, `coverage_role`, `eligible_for_sufficiency` | Role-bearing evidence for packet sufficiency. Ranking fields explain why a hit appeared; they do not prove sufficiency alone. |
+| Sidecar freshness | `retrieval status --format json` `retrieval_mode`, `degraded_reason`, and `manifest_contract`; persisted source is `RetrievalIndexManifest` | Full sidecar retrieval requires a current manifest contract for the same source root, input hash, schema, generation, graph hash, and counts. |
+| Blocked retrieval | `agent preflight` `safe_surfaces`, `blocked_surfaces`, `repair_command`; API error `retrieval_unavailable` with recovery commands | Fail closed for `packet`, `search`, and `context`; continue only with allowed local graph surfaces. |
+
+Local graph evidence example:
+
+```json
+{
+  "node_id": "2754485059345548338",
+  "node_ref": "crates/codestory-contracts/src/api/dto.rs:43:ProjectSummary",
+  "display_name": "ProjectSummary",
+  "kind": "STRUCT",
+  "evidence_tier": "resolved_graph",
+  "resolution_status": "resolved",
+  "eligible_for_sufficiency": true
+}
+```
+
+Support tier example:
+
+```json
+{
+  "language": "rust",
+  "file_count": 118,
+  "support_mode": "parser_backed_graph",
+  "evidence_tier": "graph_fidelity",
+  "claim_label": "parser-backed graph, fidelity-gated"
+}
+```
+
+Sidecar manifest example:
+
+```json
+{
+  "retrieval_mode": "full",
+  "degraded_reason": null,
+  "manifest_contract": {
+    "source_root": "/repo",
+    "project_id": "1a2b3c",
+    "input_hash": "sha256:...",
+    "generation": "project-input",
+    "schema_version": 3,
+    "graph_hash": "sha256:...",
+    "symbol_doc_count": 2213,
+    "dense_anchor_count": 0,
+    "degraded_modes": [],
+    "retrieval_mode": "full",
+    "degraded_reason": null,
+    "lanes": [
+      { "lane": "graph", "status": "ready", "count": 2213 }
+    ]
+  }
+}
+```
+
+Packet evidence example:
+
+```json
+{
+  "display_name": "sidecar_retrieval_primary_enabled",
+  "file_path": "crates/codestory-runtime/src/agent/retrieval_primary.rs",
+  "line": 74,
+  "evidence_tier": "resolved_graph",
+  "evidence_producer": "route_endpoint",
+  "resolution_status": "resolved",
+  "coverage_role": "runtime_orchestration",
+  "eligible_for_sufficiency": true
+}
+```
+
+Blocked retrieval example:
+
+```json
+{
+  "usable": false,
+  "local_graph": { "ready": true, "status": "ready" },
+  "full_retrieval": {
+    "ready": false,
+    "status": "repair_retrieval",
+    "summary": "Full retrieval is unavailable for agent packet/search."
+  },
+  "safe_surfaces": ["ground", "files", "symbol", "trail", "snippet", "affected"],
+  "blocked_surfaces": ["packet_full", "search_full", "context_full"],
+  "repair_command": "codestory-cli ready --goal agent --repair --project \"<repo>\" --format json"
+}
+```
+
+Non-claims:
+
+- `semantic_suggestion`, `dense_semantic`, repo-text, generated summary, and
+  synthetic source-scan evidence can help navigation, but they are not source
+  truth without an exact source or resolved graph follow-up.
+- `retrieval_mode=full` proves infrastructure eligibility only. It is not
+  answer-quality, agent-usefulness, language-support, or public savings proof.
+- A support tier row proves the named language/profile boundary only. It does
+  not upgrade structural collectors to parser-backed graphs or parser-backed
+  graphs to typed semantic edge coverage.
+- A blocked `packet`, `search`, or `context` surface must not be worked around
+  by treating legacy semantic fallback or local graph readiness as sidecar
+  packet/search evidence.
+
 ## Implemented Stack
 
 | Layer | Location | Role |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -308,22 +308,22 @@ summary endpoints/models or embedding endpoints in trusted environment
 variables such as `CODESTORY_SUMMARY_ENDPOINT`, `CODESTORY_SUMMARY_MODEL`, or
 `CODESTORY_EMBED_LLAMACPP_URL`.
 
-## Command Cheat Sheet
+## Command By Situation
 
-| Command | Use |
-| --- | --- |
-| `doctor` | Read-only health check for project, cache, index, retrieval, and environment readiness. |
-| `index` | Build or refresh the SQLite graph and derived local read models. |
-| `ground` | Broad repo-level orientation snapshot. |
-| `report` | Derived Markdown repo report or JSON graph export from the current SQLite store. |
-| `files` | Indexed file inventory, language counts, roles, and coverage notes. |
-| `symbol`, `trail`, `snippet`, `explore` | Cache-local exact-target source inspection once you have a node id or target. |
-| `context --id`, `context --query <exact target>`, `context --bookmark` | Target-first Investigate context packet; target selection is local/index-first, answer/evidence retrieval needs full sidecar primary. |
-| `affected` | Changed-file impact hints for review planning. |
-| `packet`, `search` | Broad sidecar-backed discovery; trust only with `retrieval_mode=full`. |
-| `retrieval bootstrap`, `retrieval index`, `retrieval status` | Sidecar setup, indexing, and readiness checks. |
-| `serve --stdio` | Persistent local read surface for repeated agent queries. |
-| `generate-completions` | Shell completions from the command model. |
+Use the command that matches where the agent is stuck. Do not run a generic
+inventory sweep when one status field or one graph target will answer the
+question.
+
+| Stuck situation | First command | Use next when |
+| --- | --- | --- |
+| Orientation: "What is in this checkout?" | `codestory-cli ground --project <repo> --why` | Use `files --project <repo>` when the question is about language mix, generated/vendor files, or incomplete coverage. |
+| Implementation start: "Where do I edit?" | `codestory-cli symbol --project <repo> --query "<feature-or-type>"` | Use `trail --story --hide-speculative` after choosing a concrete node. |
+| Symbol impact: "What might this change touch?" | `git diff --name-only HEAD | codestory-cli affected --project <repo> --stdin --format json` | Use the output to choose focused tests; it is not a test result. |
+| Test choice: "Which verification is smallest?" | `codestory-cli affected --project <repo> --format markdown` | Use repo docs or touched test names to pick one narrow test before broader lanes. |
+| Source snippet: "Show me the relevant code." | `codestory-cli snippet --project <repo> --id <node-id> --function-body --lines 80` | If snippet truncates, follow its truncation guidance or read the source file directly. |
+| Readiness: "Can I trust CodeStory now?" | `codestory-cli agent preflight --project <repo> --format json` | Use `codestory://status` instead when MCP is live; branch on `allowed_surfaces`. |
+| Repair: "A surface is blocked." | `codestory-cli ready --goal local --repair --project <repo> --format json` for local graph, or `codestory-cli ready --goal agent --repair --project <repo> --format json` for packet/search/context | Rerun `agent preflight`, `doctor`, or `retrieval status` after repair; do not retry a failed live surface until the failing layer changes. |
+| Broad evidence: "I need a packet/search answer." | `codestory-cli retrieval status --project <repo> --format json` | Run `packet`, `search`, or `context` only after `retrieval_mode` is `full` and the matching surface is allowed. |
 
 ## Verification
 

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -142,18 +142,21 @@ behavior and [doctor](references/doctor.md) for health and repair evidence.
 
 ## Command Routing
 
-| Need | Route |
+Route by the situation where the agent is stuck. Do not run a generic command
+inventory when one status field or one graph target will answer the question.
+
+| Stuck situation | Route |
 | --- | --- |
-| Setup and health | `setup embeddings`, `doctor`, `ready`, `index`, `cache` |
-| Agent orientation | MCP `ground` / `codestory://grounding` or CLI `ground` |
-| Broad task packet | MCP/CLI `packet` |
-| Candidate discovery | MCP/CLI `search --why` |
-| Focused source view | `symbol`, `trail`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, `explore` |
-| Sidecar-backed evidence packet | `packet`, `search`, `context` |
-| Coverage and impact | MCP/CLI `files`, `affected` |
-| Reusable targets | `bookmark` |
-| Structured evaluation | `drill`, `drill-suite` |
-| Local integration surface | `serve --stdio` |
+| Orientation: "What is in this checkout?" | MCP `ground` / `codestory://grounding` or CLI `ground`; use `files` for language mix or incomplete coverage. |
+| Implementation start: "Where do I edit?" | `symbol` for a concrete feature/type, then `trail --story --hide-speculative` after a node is selected. |
+| Symbol impact: "What might this change touch?" | `affected` with changed files from git; treat output as review/test planning, not proof. |
+| Test choice: "Which verification is smallest?" | `affected`, nearby repo docs, and touched test names before broader test lanes. |
+| Source snippet: "Show me the relevant code." | `snippet --id <node-id> --function-body --lines <n>`; follow truncation guidance or read source directly if capped. |
+| Readiness: "Can I trust CodeStory now?" | `codestory://status` when MCP is live; CLI `agent preflight --project <target-workspace> --format json` when MCP is unavailable. |
+| Repair: "A surface is blocked." | `ready --goal local --repair` for local graph; `ready --goal agent --repair` for `packet`, `search`, or `context`; use `doctor` and `retrieval status` as proof after repair. |
+| Broad evidence: "I need a packet/search answer." | `packet`, `search`, or `context` only when that surface is allowed and `retrieval_mode=full`. |
+| Reusable target or structured evaluation | `bookmark` for repeated targets; `drill` / `drill-suite` for evaluation lanes. |
+| Local integration surface | `serve --stdio`. |
 
 Load the matching reference only when detailed flags, examples, or
 troubleshooting rules are needed:


### PR DESCRIPTION
## Context

Closes #495.

Issue #495 asks for a publishable graph schema and evidence guide plus command guidance organized by the situation where an agent is stuck. This is docs-only and targets the existing CodeStory evidence/runbook surfaces.

## What Changed

- Added safe DTO/schema surfaces and concrete evidence examples to `docs/testing/retrieval-architecture.md` for local graph evidence, language support tier rows, sidecar `manifest_contract`, packet evidence, and blocked retrieval states.
- Added explicit non-claims for semantic suggestions, fallback modes, `retrieval_mode=full`, support tiers, and blocked packet/search/context surfaces.
- Replaced generic command inventory wording in `docs/usage.md` and the shipped `codestory-grounding` skill with situation-based command routing for orientation, implementation start, symbol impact, test choice, source snippets, readiness, repair, and broad evidence.

## How To Review

1. Read `docs/testing/retrieval-architecture.md#published-schema-and-evidence-examples` for the published schema/evidence boundary.
2. Read `docs/usage.md#command-by-situation` for the public operator path.
3. Read `plugins/codestory/skills/codestory-grounding/SKILL.md#command-routing` for the agent-facing routing path.

## Verification

- `codestory-cli ready --goal local --repair --project "C:/Users/alber/.codex/worktrees/issue495-schema-evidence-docs/codestory" --format json` - local graph ready, 273 indexed files, sidecar retrieval unavailable.
- `codestory-cli ground --project "C:/Users/alber/.codex/worktrees/issue495-schema-evidence-docs/codestory" --why` - graph snapshot available for direct source/doc grounding.
- `codestory-cli agent preflight --project "C:/Users/alber/.codex/worktrees/issue495-schema-evidence-docs/codestory" --format json` - local graph safe surfaces ready; packet/search/context blocked pending sidecar repair.
- `git diff --check` - passed.
- `node --test plugins/codestory/tests/plugin-static.test.mjs` - passed, 18/18.

## Risk

Low. Docs-only, no runtime behavior changes. The examples are intentionally minimal and use DTO/status shapes from the current code; they are not full sample command transcripts.