### PR TITLE
Prototype query-shape fusion

### DIFF
--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -546,6 +546,12 @@ fn merge_candidates(acc: &mut Vec<CandidateHit>, incoming: Vec<CandidateHit>) ->
             if existing.start_line.is_none() {
                 existing.start_line = hit.start_line;
             }
+            if existing.file_role.is_none() {
+                existing.file_role = hit.file_role;
+            }
+            if existing.scip_hop_distance.is_none() {
+                existing.scip_hop_distance = hit.scip_hop_distance;
+            }
             for label in hit.provenance {
                 existing.add_provenance(label);
             }
@@ -1485,6 +1491,13 @@ mod tests {
     #[test]
     fn executor_merges_duplicate_candidate_provenance() {
         let query = "how extension service starts";
+        let mut graph_hit = CandidateHit::with_source(
+            "src/service.rs",
+            Some("ExtensionService".into()),
+            0.75,
+            CandidateSource::Scip,
+        );
+        graph_hit.scip_hop_distance = Some(1);
         let mock = MockSidecarSearch {
             zoekt: Mutex::new(HashMap::from([(
                 query.into(),
@@ -1504,12 +1517,7 @@ mod tests {
                     CandidateSource::Qdrant,
                 )],
             )])),
-            scip_expand: Mutex::new(vec![CandidateHit::with_source(
-                "src/service.rs",
-                Some("ExtensionService".into()),
-                0.75,
-                CandidateSource::Scip,
-            )]),
+            scip_expand: Mutex::new(vec![graph_hit]),
             ..Default::default()
         };
         let mut cache = RetrievalCache::new();
@@ -1531,8 +1539,13 @@ mod tests {
             hit.score > 0.70,
             "merged candidate should keep ranker-adjusted score above lexical-only input: {hit:?}"
         );
+        assert!(hit.provenance.iter().any(|label| label == "lexical_source"));
         assert!(hit.provenance.iter().any(|label| label == "graph_neighbor"));
         assert!(hit.provenance.iter().any(|label| label == "dense_anchor"));
+        let rank_features = hit.rank_features.as_ref().expect("rank features");
+        assert!(rank_features.lexical >= 0.85);
+        assert!(rank_features.semantic >= 0.85);
+        assert_eq!(rank_features.scip_distance, 0.5);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -31,7 +31,7 @@ impl RetrievalStageKind {
     pub fn provenance_label(self) -> Option<&'static str> {
         match self {
             RetrievalStageKind::Stage0ScipAnchor => Some("exact"),
-            RetrievalStageKind::Stage1ZoektLexical => None,
+            RetrievalStageKind::Stage1ZoektLexical => Some("lexical_source"),
             RetrievalStageKind::Stage1bQdrantSemantic => Some("dense_anchor"),
             RetrievalStageKind::Stage2ScipExpand => Some("graph_neighbor"),
             RetrievalStageKind::Stage3RepoTextFallback => None,
@@ -232,7 +232,11 @@ mod tests {
     fn stage_kind_metadata_matches_sidecar_stage_contract() {
         let cases = [
             (RetrievalStageKind::Stage0ScipAnchor, Some("exact"), true),
-            (RetrievalStageKind::Stage1ZoektLexical, None, true),
+            (
+                RetrievalStageKind::Stage1ZoektLexical,
+                Some("lexical_source"),
+                true,
+            ),
             (
                 RetrievalStageKind::Stage1bQdrantSemantic,
                 Some("dense_anchor"),

--- a/crates/codestory-retrieval/src/ranker.rs
+++ b/crates/codestory-retrieval/src/ranker.rs
@@ -62,7 +62,7 @@ pub fn rank_candidates(
         if prefer_primary_code && symbol_name_looks_test_like(candidate.symbol_name.as_deref()) {
             candidate.score *= 0.55;
         }
-        candidate.rank_features = Some(rank_features);
+        candidate.rank_features = Some(export_rank_features(candidate, rank_features));
     }
 
     apply_exact_code_evidence_anchor(features, &query_tokens, &mut candidates);
@@ -156,9 +156,7 @@ fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> Ran
     let has_semantic = matches!(candidate.source, CandidateSource::Qdrant)
         || candidate_has_provenance(candidate, "dense_anchor")
         || candidate_has_provenance(candidate, "component_report");
-    let has_graph = matches!(candidate.source, CandidateSource::Scip)
-        || candidate_has_provenance(candidate, "graph_neighbor")
-        || candidate_has_provenance(candidate, "exact");
+    let has_graph = candidate_has_graph_provenance(candidate);
 
     let lexical = if matches!(candidate.source, CandidateSource::Legacy) {
         candidate.score * 0.5
@@ -198,6 +196,13 @@ fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> Ran
     }
 }
 
+fn export_rank_features(candidate: &CandidateHit, mut features: RankFeatures) -> RankFeatures {
+    if !candidate_has_graph_provenance(candidate) {
+        features.scip_distance = 0.0;
+    }
+    features
+}
+
 fn score_features(features: &RankFeatures, weights: RankWeights) -> f32 {
     weights.lexical * features.lexical
         + weights.semantic * features.semantic
@@ -205,6 +210,12 @@ fn score_features(features: &RankFeatures, weights: RankWeights) -> f32 {
         + weights.file_role_prior * features.file_role_prior
         + weights.definition_quality * features.definition_quality
         + weights.token_overlap * features.token_overlap
+}
+
+fn candidate_has_graph_provenance(candidate: &CandidateHit) -> bool {
+    matches!(candidate.source, CandidateSource::Scip)
+        || candidate_has_provenance(candidate, "graph_neighbor")
+        || candidate_has_provenance(candidate, "exact")
 }
 
 fn candidate_has_provenance(candidate: &CandidateHit, label: &str) -> bool {
@@ -590,6 +601,33 @@ mod tests {
         let ranked = rank_candidates(&features, vec![hit]);
         let rf = ranked[0].rank_features.as_ref().expect("features");
         assert!(rf.file_role_prior > 0.0);
+    }
+
+    #[test]
+    fn ranker_exports_zero_graph_feature_without_graph_provenance() {
+        let features = classify_query("explain service startup");
+        let lexical = CandidateHit::lexical_stub("src/service.rs", 0.8);
+        let dense = CandidateHit::with_source(
+            "src/search.rs",
+            Some("SearchService".into()),
+            0.9,
+            CandidateSource::Qdrant,
+        );
+
+        let ranked = rank_candidates(&features, vec![lexical, dense]);
+
+        for candidate in ranked {
+            assert_eq!(
+                candidate
+                    .rank_features
+                    .as_ref()
+                    .expect("rank features")
+                    .scip_distance,
+                0.0,
+                "{} should not export graph evidence",
+                candidate.file_path
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/ranker.rs
+++ b/crates/codestory-retrieval/src/ranker.rs
@@ -151,19 +151,30 @@ fn build_rank_features(candidate: &CandidateHit, query_tokens: &[String]) -> Ran
         .unwrap_or("")
         .to_ascii_lowercase();
 
-    let lexical = match candidate.source {
-        CandidateSource::Zoekt => candidate.score.max(0.35),
-        CandidateSource::Legacy => candidate.score * 0.5,
-        _ => candidate.score * 0.6,
+    let has_lexical = matches!(candidate.source, CandidateSource::Zoekt)
+        || candidate_has_provenance(candidate, "lexical_source");
+    let has_semantic = matches!(candidate.source, CandidateSource::Qdrant)
+        || candidate_has_provenance(candidate, "dense_anchor")
+        || candidate_has_provenance(candidate, "component_report");
+    let has_graph = matches!(candidate.source, CandidateSource::Scip)
+        || candidate_has_provenance(candidate, "graph_neighbor")
+        || candidate_has_provenance(candidate, "exact");
+
+    let lexical = if matches!(candidate.source, CandidateSource::Legacy) {
+        candidate.score * 0.5
+    } else if has_lexical {
+        candidate.score.max(0.35)
+    } else {
+        candidate.score * 0.6
     };
 
-    let semantic = if candidate.source == CandidateSource::Qdrant {
+    let semantic = if has_semantic {
         candidate.score.max(0.4)
     } else {
         candidate.score * 0.25
     };
 
-    let scip_distance = if candidate.source == CandidateSource::Scip {
+    let scip_distance = if has_graph {
         1.0 / (1.0 + candidate.scip_hop_distance.unwrap_or(0) as f32)
     } else {
         0.2
@@ -194,6 +205,13 @@ fn score_features(features: &RankFeatures, weights: RankWeights) -> f32 {
         + weights.file_role_prior * features.file_role_prior
         + weights.definition_quality * features.definition_quality
         + weights.token_overlap * features.token_overlap
+}
+
+fn candidate_has_provenance(candidate: &CandidateHit, label: &str) -> bool {
+    candidate
+        .provenance
+        .iter()
+        .any(|candidate_label| candidate_label == label)
 }
 
 fn file_role_prior(file_role: FileRole) -> f32 {
@@ -825,5 +843,29 @@ mod tests {
             }),
             "direct lexical source evidence should stay inside the resolved top-5 window: {ranked:#?}"
         );
+    }
+
+    #[test]
+    fn ranker_fuses_duplicate_lane_provenance_into_rank_features() {
+        let features = classify_query("how does service startup flow");
+        let mut fused = CandidateHit::with_source(
+            "src/service.rs",
+            Some("ExtensionService".into()),
+            0.85,
+            CandidateSource::Zoekt,
+        );
+        fused.provenance = vec![
+            "lexical_source".into(),
+            "dense_anchor".into(),
+            "graph_neighbor".into(),
+        ];
+        fused.scip_hop_distance = Some(1);
+
+        let ranked = rank_candidates(&features, vec![fused]);
+        let rank_features = ranked[0].rank_features.as_ref().expect("rank features");
+
+        assert_eq!(rank_features.lexical, 0.85);
+        assert_eq!(rank_features.semantic, 0.85);
+        assert_eq!(rank_features.scip_distance, 0.5);
     }
 }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1431,12 +1431,16 @@ fn resolve_sidecar_candidates_with_stats(
 
 fn score_breakdown_for_candidate(candidate: &CandidateHit) -> RetrievalScoreBreakdownDto {
     let provenance = candidate_provenance_labels(candidate);
-    let (lexical, semantic, graph) = match candidate.source {
-        CandidateSource::Zoekt => (candidate.score, 0.0, 0.0),
-        CandidateSource::Qdrant => (0.0, candidate.score, 0.0),
-        CandidateSource::Scip => (0.0, 0.0, candidate.score),
-        CandidateSource::Legacy => (candidate.score, 0.0, 0.0),
-    };
+    let (lexical, semantic, graph) = candidate
+        .rank_features
+        .as_ref()
+        .map(|features| (features.lexical, features.semantic, features.scip_distance))
+        .unwrap_or_else(|| match candidate.source {
+            CandidateSource::Zoekt => (candidate.score, 0.0, 0.0),
+            CandidateSource::Qdrant => (0.0, candidate.score, 0.0),
+            CandidateSource::Scip => (0.0, 0.0, candidate.score),
+            CandidateSource::Legacy => (candidate.score, 0.0, 0.0),
+        });
     RetrievalScoreBreakdownDto {
         lexical,
         semantic,
@@ -1723,6 +1727,43 @@ mod tests {
         assert_eq!(shadow.stage_timings[0].stage, "stage1_zoekt_lexical");
         assert_eq!(shadow.candidates.len(), 2);
         assert_eq!(shadow.would_rank, vec!["src/a.rs", "src/b.rs"]);
+    }
+
+    #[test]
+    fn score_breakdown_reports_fused_rank_features_and_provenance() {
+        let mut candidate = CandidateHit::with_source(
+            "src/service.rs",
+            Some("ExtensionService".into()),
+            0.91,
+            CandidateSource::Zoekt,
+        );
+        candidate.provenance = vec![
+            "lexical_source".into(),
+            "dense_anchor".into(),
+            "graph_neighbor".into(),
+        ];
+        candidate.rank_features = Some(codestory_retrieval::RankFeatures {
+            lexical: 0.91,
+            semantic: 0.82,
+            scip_distance: 0.5,
+            file_role_prior: 0.72,
+            definition_quality: 0.85,
+            token_overlap: 0.25,
+        });
+
+        let breakdown = score_breakdown_for_candidate(&candidate);
+
+        assert_eq!(breakdown.lexical, 0.91);
+        assert_eq!(breakdown.semantic, 0.82);
+        assert_eq!(breakdown.graph, 0.5);
+        assert_eq!(
+            breakdown.provenance,
+            vec![
+                "lexical_source".to_string(),
+                "dense_anchor".to_string(),
+                "graph_neighbor".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1470,13 +1470,39 @@ fn candidate_provenance_labels(candidate: &CandidateHit) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::packet_evidence::PacketEvidenceTier;
+    use codestory_contracts::api::{NodeId, NodeKind as ApiNodeKind, SearchHitOrigin};
     use codestory_retrieval::{
         CandidateHit, QueryTrace, RetrievalStageKind, StageTrace, classify_query,
-        project_id_for_root, test_support::retrieval_manifest_fixture,
+        project_id_for_root, rank_candidates, test_support::retrieval_manifest_fixture,
     };
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
         crate::process_env_test_lock()
+    }
+
+    fn search_hit_for_candidate(candidate: &CandidateHit) -> SearchHit {
+        SearchHit {
+            node_id: NodeId("candidate".to_string()),
+            display_name: candidate
+                .symbol_name
+                .clone()
+                .unwrap_or_else(|| candidate.file_path.clone()),
+            kind: ApiNodeKind::FUNCTION,
+            file_path: Some(candidate.file_path.clone()),
+            line: candidate.start_line,
+            score: candidate.score,
+            origin: SearchHitOrigin::IndexedSymbol,
+            match_quality: None,
+            resolvable: true,
+            evidence_tier: None,
+            evidence_producer: None,
+            resolution_status: None,
+            loss_reason: None,
+            coverage_role: None,
+            eligible_for_sufficiency: None,
+            score_breakdown: Some(score_breakdown_for_candidate(candidate)),
+        }
     }
 
     #[test]
@@ -1764,6 +1790,46 @@ mod tests {
                 "graph_neighbor".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn score_breakdown_does_not_export_graph_for_pure_lexical_candidate() {
+        let mut candidate = CandidateHit::with_source(
+            "src/service.rs",
+            Some("Service".into()),
+            0.78,
+            CandidateSource::Zoekt,
+        );
+        candidate.provenance = vec!["lexical_source".into()];
+        let ranked = rank_candidates(&classify_query("explain service startup"), vec![candidate]);
+        let candidate = ranked.first().expect("ranked candidate");
+
+        let breakdown = score_breakdown_for_candidate(candidate);
+        let mut hit = search_hit_for_candidate(candidate);
+        decorate_search_hit_evidence(&mut hit);
+
+        assert_eq!(breakdown.graph, 0.0);
+        assert_eq!(hit.evidence_tier, Some(PacketEvidenceTier::LexicalSource));
+    }
+
+    #[test]
+    fn score_breakdown_does_not_export_graph_for_pure_dense_candidate() {
+        let mut candidate = CandidateHit::with_source(
+            "src/search.rs",
+            Some("SearchService".into()),
+            0.86,
+            CandidateSource::Qdrant,
+        );
+        candidate.provenance = vec!["dense_anchor".into()];
+        let ranked = rank_candidates(&classify_query("explain search service"), vec![candidate]);
+        let candidate = ranked.first().expect("ranked candidate");
+
+        let breakdown = score_breakdown_for_candidate(candidate);
+        let mut hit = search_hit_for_candidate(candidate);
+        decorate_search_hit_evidence(&mut hit);
+
+        assert_eq!(breakdown.graph, 0.0);
+        assert_ne!(hit.evidence_tier, Some(PacketEvidenceTier::ResolvedGraph));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #511.
Refs #569, #593.

PR #593 is now merged into `dev/codestory-next`; this PR has been replayed onto `origin/dev/codestory-next` at `85bdc714384f769208af285b74ca2ae26534e10f` and is clean/mergeable on GitHub at head `c19b7fc00c25e6ab2f59aa34b7ad9f256a02c71a`.

This stays inside the existing sidecar retrieval path. It does not touch `main`, release metadata, model families, rerankers, alternate lexical indexes, product defaults, sidecar setup, Docker, cache deletion, or live packet/search evals.

## What Changed

- Added deterministic lexical provenance for the Zoekt stage via the existing `RetrievalStageKind::provenance_label` contract.
- Preserved duplicate-candidate metadata during union: file role, SCIP hop distance, and all lane provenance labels now survive when lexical/dense/graph stages identify the same file/symbol.
- Updated rank feature fusion to read existing provenance labels (`lexical_source`, `dense_anchor`, `component_report`, `graph_neighbor`, `exact`) instead of treating the retained candidate source as the only lane signal.
- Updated packet/search score breakdown reporting to expose fused rank features when the ranker populated them.
- Fixed the review blocker where non-graph rank features could export `graph > 0.0` for pure lexical/dense candidates; exported graph score is now nonzero only with graph source/provenance.
- Added focused regressions for candidate union, rank fusion, score breakdown provenance, graph-evidence export, stage metadata, and coexistence with the #593 lexical-source ranking tests.

```mermaid
flowchart LR
  A["Zoekt / Qdrant / SCIP stages"] --> B["merge_candidates"]
  B --> C["provenance-preserving candidate"]
  C --> D["rank_candidates"]
  D --> E["rank_features"]
  E --> F["packet/search score breakdown"]
```

## How To Review

- Start in `crates/codestory-retrieval/src/executor.rs` at `merge_candidates` to see duplicate candidate metadata/provenance union.
- Then read `crates/codestory-retrieval/src/ranker.rs` at `build_rank_features` and `export_rank_features` to see provenance-based fusion and graph export gating.
- Finish in `crates/codestory-runtime/src/agent/retrieval_primary.rs` at `score_breakdown_for_candidate` to confirm packet/search diagnostics report fused rank features without over-tiering pure lexical/dense candidates as graph evidence.

## Verification

- Fresh worktree: `C:\Users\alber\.codex\worktrees\issue-544-final-after-593\codestory`.
- Required preflight: `git fetch --prune origin` passed; requested worktree path was not registered before creation; `origin/dev/codestory-next` is `85bdc714384f769208af285b74ca2ae26534e10f`; `85bdc714384f769208af285b74ca2ae26534e10f` is an ancestor of the base ref.
- Source version preflight: all `crates/codestory-*` manifests are `0.11.19`; plugin manifests at `.codex-plugin`, `.claude-plugin`, and `.github/plugin` are `0.11.19`.
- Replayed the two existing PR commits from old head `2112f4a48e9c6c546de123ff79b0b923347c09ef` onto the current base. Commit 2 was patch-equivalent by `git range-diff`; commit 1 required one `ranker.rs` test-tail conflict resolution because #593 added ranker tests in the same area. Resolution kept the #593 tests and the #544 fused-provenance regression; no new ranking work was added.
- `cargo test -p codestory-retrieval ranker_` passed 15.
- `cargo test -p codestory-retrieval executor_merges_duplicate_candidate_provenance` passed 1.
- `cargo test -p codestory-retrieval stage_kind_metadata_matches_sidecar_stage_contract` passed 1.
- `cargo test -p codestory-runtime score_breakdown` passed 3.
- `git diff --check` passed.
- Hosted checks on head `c19b7fc00c25e6ab2f59aa34b7ad9f256a02c71a`: `require closing issue link` passed. No rustdoc or retrieval-sidecar-smoke run was reported on this new head at the time of this update; prior rustdoc/retrieval smoke checks belonged to old head `2112f4a48e9c6c546de123ff79b0b923347c09ef`.

## Risk

- Ready to leave draft and merge to `dev/codestory-next` from the code/test/mergeability evidence above.
- No live sidecar setup, Docker, cache deletion, broad cargo build, or packet/search eval was run in this final assessment, per scope. This PR still does not claim live packet/search quality proof.
- Residual risk is limited to live sidecar behavior not exercised here; the unit-level retrieval/runtime surface and GitHub mergeability are green.
