### PR TITLE
[codex] fix v0.11.19 packaged proof model setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,10 @@ jobs:
             --binary "$bin" \
             --out-dir target/release-dist
 
+      - name: Fetch retrieval embedding model
+        if: matrix.asset_target == 'linux-x64'
+        run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
+
       - name: Packaged full-sidecar agent proof
         if: matrix.asset_target == 'linux-x64'
         run: |

--- a/scripts/setup-retrieval-env.mjs
+++ b/scripts/setup-retrieval-env.mjs
@@ -29,6 +29,7 @@ Options:
   --skip-status             Skip final "retrieval status"
   --with-holdout-clone      Clone holdout-retrieval OSS repos (network; large)
   --fetch-embed-model       Download bge-base-en-v1.5.Q8_0.gguf into target/retrieval-models
+  --fetch-only              With --fetch-embed-model, fetch/verify the model and exit
   --release                 Build and use release CLI (default: debug for speed)
   --project <path>          Project root for status (default: repo root)
   --wait-secs <n>           Bootstrap wait timeout (default: 90)
@@ -48,6 +49,7 @@ function parseArgs(argv) {
     skipStatus: false,
     withHoldoutClone: false,
     fetchEmbedModel: false,
+    fetchOnly: false,
     release: false,
     project: repoRoot,
     waitSecs: 90,
@@ -82,6 +84,10 @@ function parseArgs(argv) {
       opts.fetchEmbedModel = true;
       continue;
     }
+    if (arg === "--fetch-only") {
+      opts.fetchOnly = true;
+      continue;
+    }
     if (arg === "--release") {
       opts.release = true;
       continue;
@@ -98,6 +104,9 @@ function parseArgs(argv) {
   }
   if (!Number.isInteger(opts.waitSecs) || opts.waitSecs < 0) {
     throw new Error("--wait-secs must be a non-negative integer");
+  }
+  if (opts.fetchOnly && !opts.fetchEmbedModel) {
+    throw new Error("--fetch-only requires --fetch-embed-model");
   }
   return opts;
 }
@@ -151,16 +160,22 @@ function printPrereqReport(opts) {
   const cacheRoot = codestoryCacheRoot();
   const checks = [
     ["node", commandExists("node"), "required"],
-    ["cargo", commandExists("cargo"), opts.skipBuild ? "optional (--skip-build)" : "required"],
+    [
+      "cargo",
+      commandExists("cargo"),
+      opts.skipBuild || opts.fetchOnly ? "optional" : "required",
+    ],
     [
       "docker",
       commandExists("docker"),
-      opts.skipCompose ? "optional (--skip-compose)" : "required for live Qdrant",
+      opts.skipCompose || opts.fetchOnly ? "optional" : "required for live Qdrant",
     ],
     [
       `compose file (${composeFile})`,
       fs.existsSync(composeFile),
-      "required unless CODESTORY_RETRIEVAL_COMPOSE_FILE points elsewhere",
+      opts.fetchOnly
+        ? "optional"
+        : "required unless CODESTORY_RETRIEVAL_COMPOSE_FILE points elsewhere",
     ],
   ];
 
@@ -301,6 +316,10 @@ async function main() {
 
   if (opts.fetchEmbedModel) {
     await fetchEmbedModel();
+    if (opts.fetchOnly) {
+      console.log("\nFetch-only setup complete.");
+      return;
+    }
   }
 
   const bootstrapArgs = [


### PR DESCRIPTION
## Context
Auto Release for v0.11.19 failed on `main` at `c0d49031beed9a390a1609aee1f89345c36a5b5d` in `Release / Build linux-x64`.

The packaged CLI built and archived successfully, then `.github/scripts/check-packaged-agent-proof.py` failed at `layer=local_retrieval_bootstrap`. The uploaded proof artifact stderr says bootstrap could not find `bge-base-en-v1.5.Q8_0.gguf` and suggested `node scripts/setup-retrieval-env.mjs --fetch-embed-model`.

Latest release is still `v0.11.18`; `v0.11.19` release and tag are absent.

Closes #545
Refs #501

```mermaid
flowchart LR
  package[Package linux-x64 archive] --> model[Fetch verified GGUF model]
  model --> proof[Packaged full-sidecar proof]
  proof --> publish[Publish release]
```

## What Changed
- Added `--fetch-only` to `scripts/setup-retrieval-env.mjs` so CI can reuse the existing pinned model download and SHA-256 verification without also running bootstrap/status through the repo-local CLI.
- Added a linux-x64 release step before packaged proof: `node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only`.

## How To Review
- Check that `--fetch-only` requires `--fetch-embed-model` and exits immediately after the model is verified.
- Check that the release workflow only runs the new step for `matrix.asset_target == 'linux-x64'`, matching the existing packaged proof gate.

## Verification
- `node scripts\setup-retrieval-env.mjs --fetch-only` failed as expected with `--fetch-only requires --fetch-embed-model`.
- `node scripts\setup-retrieval-env.mjs --fetch-embed-model --fetch-only` downloaded/verified `117974304` bytes with SHA-256 `ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c`, then exited before bootstrap.
- `python .github\scripts\check-packaged-agent-proof.py --self-test` passed.
- `node .github\scripts\check-workflow-policy.mjs` passed.
- `git diff --check` passed.

## Risk
Full CI reproduction is still the release workflow itself: this Windows lane did not rebuild the linux-x64 archive or start Linux Docker sidecars. The fix covers the observed failing precondition before bootstrap.
