### PR TITLE
[codex] detect packaged MCP before CLI fallback

### DIFF
--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require('child_process');
-const { getCodeStoryInstructions } = require('./codestory-instructions.cjs');
-const { rememberActiveState, writeHookOutput } = require('./codestory-runtime.cjs');
+const { eventHeader, getCodeStoryInstructions } = require('./codestory-instructions.cjs');
+const {
+  classifyMcpRuntime,
+  mcpDetectionText,
+  rememberActiveState,
+  writeHookOutput,
+} = require('./codestory-runtime.cjs');
 
 const MAX_OUTPUT_CHARS = 12000;
 const RUNTIME_TIMEOUT_MS = 3500;
@@ -76,6 +81,18 @@ function runCodeStory(input, event) {
 
   const command = hookCommand(input, event);
   if (!command) return null;
+  const mcp = classifyMcpRuntime();
+  if (mcp.mcp_config_installed && mcp.mcp_process_launchable) {
+    return {
+      kind: 'mcp detection',
+      output: [
+        mcpDetectionText(mcp),
+        mcp.mcp_resources_exposed
+          ? 'Use codestory://status as the active runtime truth before CLI fallback.'
+          : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Reload the host/plugin and read codestory://status; do not add CodeStory to PATH.',
+      ].join('\n'),
+    };
+  }
   const cli = process.env.CODESTORY_CLI || 'codestory-cli';
 
   const result = spawnSync(cli, command.args, {
@@ -102,6 +119,7 @@ function runCodeStory(input, event) {
   return {
     kind: command.kind,
     output: [
+      mcpDetectionText(mcp),
       `CodeStory hook attempted ${command.kind} but did not receive usable output.`,
       reason ? `Reason: ${reason}` : null,
       command.next,
@@ -111,14 +129,22 @@ function runCodeStory(input, event) {
 
 function buildContext(input, event) {
   const runtime = runCodeStory(input, event);
-  const parts = [getCodeStoryInstructions(event, input)];
-
-  if (runtime && runtime.output) {
-    parts.push([
+  const runtimeBlock = runtime && runtime.output
+    ? [
       `CODESTORY HOOK ${runtime.kind.toUpperCase()}`,
       runtime.output,
       runtime.next ? `Next: ${runtime.next}` : null,
-    ].filter(Boolean).join('\n\n'));
+    ].filter(Boolean).join('\n\n')
+    : null;
+
+  if (runtime && runtime.kind === 'mcp detection') {
+    return [eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n');
+  }
+
+  const parts = [getCodeStoryInstructions(event, input)];
+
+  if (runtimeBlock) {
+    parts.push(runtimeBlock);
   }
 
   return parts.join('\n\n');

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -9,11 +9,11 @@ const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, read codestory://status first; otherwise run codestory-cli agent preflight --project <repo> --format json.
+2. If the CodeStory MCP server is live, read codestory://status first. If MCP is configured but resources are not model-visible, reload the host/plugin instead of adding CodeStory to PATH.
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
-6. If MCP is missing, use the preflight repair_command as the setup/repair fallback; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
+6. If MCP is truly unavailable, use managed CLI or local-dev CODESTORY_CLI preflight as the setup/repair fallback. PATH checks are diagnostics only; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
 
 Do this without waiting for the user to mention CodeStory.`;
 
@@ -59,11 +59,11 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live; when it is not, run codestory-cli agent preflight --project <repo> --format json and use the reported safe_surfaces.
+Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, say that and reload the host/plugin instead of asking for PATH setup. When MCP is truly unavailable, use managed CLI or local-dev CODESTORY_CLI preflight and use the reported safe_surfaces.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.
-Use the preflight repair_command as the default setup path once a repository target is known.
+Use the managed/runtime preflight repair_command as the default setup path once a repository target is known; keep PATH checks diagnostic.
 
 ${body}`;
 }
@@ -71,5 +71,6 @@ ${body}`;
 module.exports = {
   FALLBACK,
   compactPrompt,
+  eventHeader,
   getCodeStoryInstructions,
 };

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -5,11 +5,114 @@ const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 const STATE_FILE = '.codestory-active';
+const MCP_RUNTIME_FILE = '.codestory-mcp-runtime.json';
 
 function pluginDataDir() {
   if (isCodex) return process.env.PLUGIN_DATA;
   if (isCopilot) return process.env.COPILOT_PLUGIN_DATA;
   return null;
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function pluginRoot() {
+  return path.dirname(__dirname);
+}
+
+function pluginVersion(root = pluginRoot()) {
+  const manifest = readJson(path.join(root, '.codex-plugin', 'plugin.json'));
+  return manifest && typeof manifest.version === 'string' ? manifest.version : null;
+}
+
+function configuredMcp(root = pluginRoot()) {
+  const configPath = path.join(root, '.mcp.json');
+  const config = readJson(configPath);
+  const server = config?.mcpServers?.codestory;
+  if (!server) {
+    return { installed: false, configPath, command: null, args: [] };
+  }
+  return {
+    installed: true,
+    configPath,
+    command: server.command || null,
+    args: Array.isArray(server.args) ? server.args : [],
+  };
+}
+
+function mcpScriptExists(root, args) {
+  const scriptArg = args.find((arg) => typeof arg === 'string' && /codestory-mcp\.cjs$/u.test(arg));
+  if (!scriptArg) return false;
+  return fs.existsSync(path.resolve(root, scriptArg));
+}
+
+function managedCliInfo(dataDir = pluginDataDir(), version = pluginVersion()) {
+  if (!dataDir) return { present: false, path: null, source: null };
+  const runtime = readJson(path.join(dataDir, MCP_RUNTIME_FILE));
+  if (runtime?.source === 'managed' && runtime.path) {
+    return { present: fs.existsSync(runtime.path), path: runtime.path, source: 'runtime_state' };
+  }
+
+  const manifestPath = version
+    ? path.join(dataDir, 'codestory-cli', version, 'manifest.json')
+    : path.join(dataDir, 'codestory-cli', 'manifest.json');
+  const manifest = readJson(manifestPath);
+  const manifestCli = manifest?.path
+    ? path.resolve(path.dirname(manifestPath), manifest.path)
+    : null;
+  if (manifestCli) {
+    return { present: fs.existsSync(manifestCli), path: manifestCli, source: 'manifest' };
+  }
+  return { present: false, path: null, source: null };
+}
+
+function classifyMcpRuntime(options = {}) {
+  const root = options.pluginRoot || pluginRoot();
+  const dataDir = options.pluginDataDir === undefined ? pluginDataDir() : options.pluginDataDir;
+  const mcp = configuredMcp(root);
+  const runtimePath = dataDir ? path.join(dataDir, MCP_RUNTIME_FILE) : null;
+  const runtime = runtimePath ? readJson(runtimePath) : null;
+  const managed = managedCliInfo(dataDir, pluginVersion(root));
+  const launchable = mcp.installed && mcp.command === 'node' && mcpScriptExists(root, mcp.args);
+  const resourcesExposed = process.env.CODESTORY_MCP_RESOURCES_EXPOSED === '1' ||
+    Boolean(runtime?.source && runtime?.path && fs.existsSync(runtime.path));
+  const resourceStatus = resourcesExposed
+    ? 'mcp_resources_exposed'
+    : launchable
+      ? 'mcp_resources_not_model_visible'
+      : 'mcp_resources_unavailable';
+
+  return {
+    mcp_config_installed: mcp.installed,
+    mcp_config_path: mcp.configPath,
+    mcp_command: mcp.command,
+    mcp_args: mcp.args,
+    mcp_process_launchable: launchable,
+    mcp_resources_exposed: resourcesExposed,
+    mcp_resource_status: resourceStatus,
+    mcp_runtime_state_path: runtimePath,
+    mcp_runtime_state_present: Boolean(runtime),
+    managed_cli_present: managed.present,
+    managed_cli_path: managed.path,
+    managed_cli_source: managed.source,
+    degraded_no_surface: !resourcesExposed && !managed.present,
+  };
+}
+
+function mcpDetectionText(status) {
+  return [
+    'CODESTORY MCP RUNTIME DETECTION',
+    `mcp_config_installed: ${status.mcp_config_installed ? 'yes' : 'no'}${status.mcp_config_installed ? ` (${status.mcp_config_path})` : ''}`,
+    `mcp_process_launchable: ${status.mcp_process_launchable ? 'yes' : 'no'}`,
+    `mcp_resources_exposed: ${status.mcp_resource_status}`,
+    `managed_cli_present: ${status.managed_cli_present ? 'yes' : 'no'}${status.managed_cli_path ? ` (${status.managed_cli_path})` : ''}`,
+    `degraded_no_surface: ${status.degraded_no_surface ? 'yes' : 'no'}`,
+  ].join('\n');
 }
 
 function rememberActiveState(state) {
@@ -51,6 +154,8 @@ function writeHookOutput(event, context) {
 }
 
 module.exports = {
+  classifyMcpRuntime,
+  mcpDetectionText,
   rememberActiveState,
   writeHookOutput,
 };

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
-import { dirname, join, delimiter } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
+const require = createRequire(import.meta.url);
+const { classifyMcpRuntime } = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
 
 function readCargoVersion(manifestText) {
   let inPackage = false;
@@ -512,7 +515,7 @@ test("enabled sidecar policy schedules existing agent repair path", async () => 
     });
     assert.equal(result.status, 0, result.stderr);
 
-    for (let attempt = 0; attempt < 20; attempt += 1) {
+    for (let attempt = 0; attempt < 80; attempt += 1) {
       const text = await readFile(logFile, "utf8").catch(() => "");
       const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
       if (calls.some((call) => call.repair)) {
@@ -661,74 +664,135 @@ async function withFakeCodeStoryCli(callback) {
   }
 }
 
-test("hook output keeps CodeStory ambient and attempts request-aware grounding", async () => {
+test("hook output keeps CodeStory ambient and checks MCP before CLI fallback", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-mcp-first-"));
 
-  await withFakeCodeStoryCli(async (binDir) => {
-    const fakeCli = process.platform === "win32"
-      ? join(binDir, "codestory-cli.cmd")
-      : join(binDir, "codestory-cli");
-    const env = {
-      ...process.env,
-      CODESTORY_CLI: fakeCli,
-      COPILOT_PLUGIN_DATA: "",
-      PLUGIN_DATA: join(repoRoot, ".tmp-plugin-data"),
-      PATH: `${binDir}${delimiter}${process.env.PATH || ""}`,
-    };
+  try {
+    await withFakeCodeStoryCli(async (binDir) => {
+      const fakeCli = process.platform === "win32"
+        ? join(binDir, "codestory-cli.cmd")
+        : join(binDir, "codestory-cli");
+      const env = {
+        ...process.env,
+        CODESTORY_CLI: fakeCli,
+        COPILOT_PLUGIN_DATA: "",
+        PLUGIN_DATA: dataDir,
+      };
 
-    const sessionResult = spawnSync(process.execPath, [hookPath], {
-      env,
-      input: JSON.stringify({
-        hook_event_name: "SessionStart",
-        source: "startup",
-        cwd: repoRoot,
-      }),
-      encoding: "utf8",
+      const sessionResult = spawnSync(process.execPath, [hookPath], {
+        env,
+        input: JSON.stringify({
+          hook_event_name: "SessionStart",
+          source: "startup",
+          cwd: repoRoot,
+        }),
+        encoding: "utf8",
+      });
+
+      assert.equal(sessionResult.status, 0, sessionResult.stderr);
+      const sessionOutput = JSON.parse(sessionResult.stdout);
+      const sessionContext = sessionOutput.hookSpecificOutput.additionalContext;
+      assert.equal(sessionOutput.systemMessage, "CODESTORY:BACKGROUND");
+      assert.match(sessionContext, /^CODESTORY SESSION GROUNDING ACTIVE \(startup\)/u);
+      assert.match(sessionContext, /CODESTORY MCP RUNTIME DETECTION/u);
+      assert.match(sessionContext, /mcp_config_installed: yes/u);
+      assert.match(sessionContext, /mcp_process_launchable: yes/u);
+      assert.match(sessionContext, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+      assert.match(sessionContext, /do not add CodeStory to PATH/u);
+      assert.doesNotMatch(sessionContext, /FAKE_CODESTORY_CLI/u);
+      assert.doesNotMatch(sessionContext, /## Runtime Truth/u);
+
+      const promptResult = spawnSync(process.execPath, [hookPath], {
+        env,
+        input: JSON.stringify({
+          hook_event_name: "UserPromptSubmit",
+          prompt: "Where is RefreshMode defined?",
+          cwd: repoRoot,
+        }),
+        encoding: "utf8",
+      });
+
+      assert.equal(promptResult.status, 0, promptResult.stderr);
+      const promptOutput = JSON.parse(promptResult.stdout);
+      const promptContext = promptOutput.hookSpecificOutput.additionalContext;
+      assert.equal(promptOutput.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+      assert.match(promptContext, /Prompt: Where is RefreshMode defined\?/u);
+      assert.match(promptContext, /CODESTORY MCP RUNTIME DETECTION/u);
+      assert.doesNotMatch(promptContext, /FAKE_CODESTORY_CLI/u);
+      assert.doesNotMatch(promptContext, /attempted request packet/u);
     });
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
 
-    assert.equal(sessionResult.status, 0, sessionResult.stderr);
-    const sessionOutput = JSON.parse(sessionResult.stdout);
-    assert.equal(sessionOutput.systemMessage, "CODESTORY:BACKGROUND");
-    assert.match(
-      sessionOutput.hookSpecificOutput.additionalContext,
-      /CODESTORY SESSION GROUNDING ACTIVE \(startup\)/u,
-    );
-    assert.match(
-      sessionOutput.hookSpecificOutput.additionalContext,
-      /Before manually opening source files/u,
-    );
-    assert.match(
-      sessionOutput.hookSpecificOutput.additionalContext,
-      /FAKE_CODESTORY_CLI ground --project/u,
-    );
+test("hook MCP classifier distinguishes configured launchable and model-visible states", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-classify-"));
+  const version = await readPluginVersion();
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
 
-    const promptResult = spawnSync(process.execPath, [hookPath], {
-      env,
-      input: JSON.stringify({
-        hook_event_name: "UserPromptSubmit",
-        prompt: "Where is RefreshMode defined?",
-        cwd: repoRoot,
-      }),
-      encoding: "utf8",
-    });
+  try {
+    const configured = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
+    assert.equal(configured.mcp_config_installed, true);
+    assert.equal(configured.mcp_process_launchable, true);
+    assert.equal(configured.mcp_resources_exposed, false);
+    assert.equal(configured.mcp_resource_status, "mcp_resources_not_model_visible");
+    assert.equal(configured.managed_cli_present, false);
 
-    assert.equal(promptResult.status, 0, promptResult.stderr);
-    const promptOutput = JSON.parse(promptResult.stdout);
-    assert.equal(promptOutput.hookSpecificOutput.hookEventName, "UserPromptSubmit");
-    assert.match(
-      promptOutput.hookSpecificOutput.additionalContext,
-      /Prompt: Where is RefreshMode defined\?/u,
+    await mkdir(cliDir, { recursive: true });
+    await writeFakeCli(cliPath);
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
+      "utf8",
     );
-    assert.match(
-      promptOutput.hookSpecificOutput.additionalContext,
-      /FAKE_CODESTORY_CLI packet --project/u,
+    const managed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
+    assert.equal(managed.managed_cli_present, true);
+    assert.equal(managed.managed_cli_path, cliPath);
+    assert.equal(managed.degraded_no_surface, false);
+
+    await writeFile(
+      join(dataDir, ".codestory-mcp-runtime.json"),
+      JSON.stringify({ source: "managed", path: cliPath }),
+      "utf8",
     );
-    assert.match(
-      promptOutput.hookSpecificOutput.additionalContext,
-      /--question Where is RefreshMode defined\?/u,
+    const exposed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
+    assert.equal(exposed.mcp_resources_exposed, true);
+    assert.equal(exposed.mcp_resource_status, "mcp_resources_exposed");
+    assert.equal(exposed.degraded_no_surface, false);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("hook MCP classifier distinguishes launch failure and no runtime", async () => {
+  const brokenRoot = await mkdtemp(join(tmpdir(), "codestory-broken-mcp-"));
+  const emptyRoot = await mkdtemp(join(tmpdir(), "codestory-no-mcp-"));
+
+  try {
+    await writeFile(
+      join(brokenRoot, ".mcp.json"),
+      JSON.stringify({ mcpServers: { codestory: { command: "node", args: ["./missing.cjs"] } } }),
+      "utf8",
     );
-  });
+    const broken = classifyMcpRuntime({ pluginRoot: brokenRoot, pluginDataDir: null });
+    assert.equal(broken.mcp_config_installed, true);
+    assert.equal(broken.mcp_process_launchable, false);
+    assert.equal(broken.mcp_resource_status, "mcp_resources_unavailable");
+    assert.equal(broken.managed_cli_present, false);
+
+    const none = classifyMcpRuntime({ pluginRoot: emptyRoot, pluginDataDir: null });
+    assert.equal(none.mcp_config_installed, false);
+    assert.equal(none.mcp_process_launchable, false);
+    assert.equal(none.managed_cli_present, false);
+    assert.equal(none.degraded_no_surface, true);
+  } finally {
+    await rm(brokenRoot, { recursive: true, force: true });
+    await rm(emptyRoot, { recursive: true, force: true });
+  }
 });
 
 test("hook script executes under Codex home module scope", async () => {
@@ -790,14 +854,15 @@ test("hook script executes under Codex home module scope", async () => {
   }
 });
 
-test("hook output fails open when runtime grounding is unavailable", async () => {
+test("hook output reports model-invisible MCP instead of PATH setup guidance", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-no-resources-"));
   const result = spawnSync(process.execPath, [hookPath], {
     env: {
       ...process.env,
       COPILOT_PLUGIN_DATA: "",
-      PLUGIN_DATA: join(repoRoot, ".tmp-plugin-data"),
+      PLUGIN_DATA: dataDir,
       PATH: "",
     },
     input: JSON.stringify({
@@ -810,14 +875,14 @@ test("hook output fails open when runtime grounding is unavailable", async () =>
 
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
-  assert.match(
-    output.hookSpecificOutput.additionalContext,
-    /attempted request packet but did not receive usable output/u,
-  );
-  assert.match(
-    output.hookSpecificOutput.additionalContext,
-    /codestory:\/\/status/u,
-  );
+  const context = output.hookSpecificOutput.additionalContext;
+  assert.match(context, /mcp_config_installed: yes/u);
+  assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+  assert.match(context, /MCP resources are not visible/u);
+  assert.doesNotMatch(context, /codestory-cli ENOENT/u);
+  assert.doesNotMatch(context, /attempted request packet/u);
+  assert.doesNotMatch(context, /adding CodeStory to PATH/u);
+  await rm(dataDir, { recursive: true, force: true });
 });
 
 test("portable agent adapters are present", async () => {


### PR DESCRIPTION
## Context

Closes #549.

CodeStory plugin hooks were still trying `CODESTORY_CLI || codestory-cli` before classifying the packaged MCP surface. That made a configured plugin/MCP install look like PATH setup archaeology when the real failure was MCP resources not being visible to the current agent context.

```mermaid
flowchart LR
    A[Hook event] --> B[Classify packaged MCP]
    B -->|configured and launchable| C[Report MCP resource visibility]
    C -->|not model-visible| D[Short degraded notice]
    C -->|visible| E[Read codestory://status]
    B -->|MCP unavailable| F[CLI fallback]
```

## What Changed

- Added a hook-side MCP classifier for `mcp_config_installed`, `mcp_process_launchable`, `mcp_resources_exposed`, `managed_cli_present`, and `degraded_no_surface`.
- Changed activation output so configured/launchable MCP stops before CLI fallback and emits a short model-invisible-resource notice.
- Kept PATH as diagnostic/local-dev wording only; no hook path now suggests adding CodeStory to PATH.
- Added focused static coverage for configured MCP without model-visible resources, launch failure, exposed runtime state, managed CLI with no PATH, and no runtime.

## How To Review

- Start with `plugins/codestory/hooks/codestory-activate.cjs` to see the MCP-first branch before CLI spawn.
- Review `plugins/codestory/hooks/codestory-runtime.cjs` for the classifier and output labels.
- Review the hook tests in `plugins/codestory/tests/plugin-static.test.mjs` for the acceptance-state coverage.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 20 passed.
- Focused hook smoke with empty `PATH` and fresh `PLUGIN_DATA` -> emitted `CODESTORY HOOK MCP DETECTION`, `mcp_config_installed: yes`, `mcp_process_launchable: yes`, `mcp_resources_exposed: mcp_resources_not_model_visible`, and `do not add CodeStory to PATH`; no `codestory-cli ENOENT` fallback.
- `git diff --check` -> passed.

## Risk

The hook can only infer model-visible MCP resources from host/runtime state available to the plugin hook. If a host exposes resources without writing `.codestory-mcp-runtime.json`, the hook reports the conservative model-invisible state and asks for a host/plugin reload plus `codestory://status` readback.
