### PR TITLE
[codex] Add sidecar status alias

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -111,6 +111,8 @@ pub(crate) enum Command {
     GenerateCompletions(GenerateCompletionsCommand),
     #[command(about = "Manage retrieval sidecar data.")]
     Retrieval(RetrievalCommand),
+    #[command(about = "Show retrieval sidecar status.")]
+    Sidecar(SidecarCommand),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -809,6 +811,20 @@ pub(crate) struct RetrievalStatusCommand {
     pub(crate) format: OutputFormat,
     #[arg(long, value_name = "PATH")]
     pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct SidecarCommand {
+    #[command(subcommand)]
+    pub(crate) action: SidecarAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum SidecarAction {
+    /// Alias for `retrieval status`.
+    Status(RetrievalStatusCommand),
+    #[command(external_subcommand)]
+    Unknown(Vec<String>),
 }
 
 #[derive(Args, Debug)]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -79,9 +79,9 @@ use args::{
     IndexCommand, IndexDryRunOutput, IndexOutput, PacketCommand, ProjectArgs, QueryCommand,
     QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadyCommand, ReadyOutput,
     RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand, SetupAction,
-    SetupCommand, SmokeCommand, SmokeProfile, SnippetCommand, SnippetJsonOutput, SymbolCommand,
-    SymbolJsonOutput, TaskAction, TaskBriefCommand, TaskCommand, TrailCommand, TrailJsonOutput,
-    VerificationTargetOutput, build_trail_request,
+    SetupCommand, SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile, SnippetCommand,
+    SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, TaskAction, TaskBriefCommand, TaskCommand,
+    TrailCommand, TrailJsonOutput, VerificationTargetOutput, build_trail_request,
 };
 #[cfg(test)]
 use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
@@ -207,6 +207,19 @@ fn main() -> Result<()> {
         Command::Serve(cmd) => run_serve(cmd),
         Command::GenerateCompletions(cmd) => run_generate_completions(cmd),
         Command::Retrieval(cmd) => retrieval::run_retrieval(cmd),
+        Command::Sidecar(cmd) => run_sidecar(cmd),
+    }
+}
+
+fn run_sidecar(cmd: SidecarCommand) -> Result<()> {
+    match cmd.action {
+        SidecarAction::Status(status_cmd) => retrieval::run_retrieval_status(status_cmd),
+        SidecarAction::Unknown(args) => {
+            let subcommand = args.first().map(String::as_str).unwrap_or("<unknown>");
+            bail!(
+                "unknown sidecar subcommand `{subcommand}`; use `codestory-cli sidecar status` or `codestory-cli retrieval status`"
+            )
+        }
     }
 }
 

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -97,7 +97,7 @@ fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
     Ok(())
 }
 
-fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
+pub(crate) fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let profile = cmd

--- a/crates/codestory-cli/tests/sidecar_status_cli.rs
+++ b/crates/codestory-cli/tests/sidecar_status_cli.rs
@@ -1,0 +1,107 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+use tempfile::tempdir;
+
+fn write_tiny_project(root: &Path) {
+    fs::write(root.join("lib.rs"), "pub fn main() {}\n").expect("write tiny project");
+}
+
+fn run_cli(project: &Path, cache_dir: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    command.args(args);
+    command.arg("--project").arg(project);
+    command.arg("--cache-dir").arg(cache_dir);
+    command.output().expect("run codestory-cli")
+}
+
+fn assert_success(output: &Output, context: &str) {
+    assert!(
+        output.status.success(),
+        "{context}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn stdout_json(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout should be JSON: {error}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[test]
+fn sidecar_status_aliases_retrieval_status_json() {
+    let project = tempdir().expect("project");
+    let cache_dir = tempdir().expect("cache");
+    write_tiny_project(project.path());
+
+    let retrieval = run_cli(
+        project.path(),
+        cache_dir.path(),
+        &["retrieval", "status", "--format", "json"],
+    );
+    assert_success(&retrieval, "retrieval status failed");
+
+    let sidecar = run_cli(
+        project.path(),
+        cache_dir.path(),
+        &["sidecar", "status", "--format", "json"],
+    );
+    assert_success(&sidecar, "sidecar status failed");
+
+    assert_eq!(stdout_json(&sidecar), stdout_json(&retrieval));
+}
+
+#[test]
+fn sidecar_status_uses_retrieval_status_human_output() {
+    let project = tempdir().expect("project");
+    let cache_dir = tempdir().expect("cache");
+    write_tiny_project(project.path());
+
+    let output = run_cli(
+        project.path(),
+        cache_dir.path(),
+        &["sidecar", "status", "--format", "markdown"],
+    );
+    assert_success(&output, "sidecar status failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("# Retrieval status"),
+        "sidecar status should reuse retrieval status output:\n{stdout}"
+    );
+}
+
+#[test]
+fn unknown_sidecar_subcommand_suggests_status_without_runtime_side_effects() {
+    let project = tempdir().expect("project");
+    let cache_dir = tempdir().expect("cache");
+    write_tiny_project(project.path());
+
+    let output = run_cli(project.path(), cache_dir.path(), &["sidecar", "frobnicate"]);
+    assert!(
+        !output.status.success(),
+        "unknown sidecar subcommand should fail\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(combined.contains("unknown sidecar subcommand `frobnicate`"));
+    assert!(combined.contains("codestory-cli sidecar status"));
+    assert!(combined.contains("codestory-cli retrieval status"));
+    assert!(
+        !cache_dir.path().join("codestory.db").exists(),
+        "unknown sidecar subcommand should fail before runtime cache creation"
+    );
+}


### PR DESCRIPTION
## Context

Closes #552.

`codestory-cli sidecar status` is a predictable operator command, but only `retrieval status` existed. This keeps the sidecar spelling as a status-only alias and leaves other sidecar commands unsupported.

## What Changed

```mermaid
flowchart LR
  A["sidecar status"] --> C["retrieval status handler"]
  B["sidecar <x>"] --> D["targeted suggestion"]
```

- Added top-level `sidecar status` parser path that calls the existing retrieval status handler.
- Added targeted `sidecar <unknown>` error text pointing at `codestory-cli sidecar status` and `codestory-cli retrieval status`.
- Added focused integration tests for JSON alias parity, markdown output, and the unknown-subcommand guard.

## How To Review

- Start in `crates/codestory-cli/src/args.rs` for parser shape.
- Check `crates/codestory-cli/src/main.rs` to confirm only status aliases into retrieval.
- Review `crates/codestory-cli/tests/sidecar_status_cli.rs` for the acceptance coverage.

## Verification

- `cargo fmt`
- `cargo test -p codestory-cli --test sidecar_status_cli`
- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts bootstrap_then_status_reports_manifest_missing_before_indexing`
- `git diff --check`

## Risk

Low. This is CLI parsing and dispatch only; it does not change sidecar storage, readiness, or retrieval ranking.