### PR TITLE
[codex] Split readiness lane reporting

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -17,7 +17,7 @@ use codestory_contracts::api::{
     TrailCallerScope, TrailContextDto, TrailDirection, TrailMode,
 };
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{collections::BTreeMap, path::PathBuf};
 
 const INDEX_REFRESH_HELP: &str = "Index defaults to `auto`: it chooses `full` for an empty cache and `incremental` once the \
 cache already has indexed files.";
@@ -1529,12 +1529,28 @@ pub(crate) struct AgentPreflightLaneOutput {
     pub(crate) summary: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReadinessLaneOutput {
+    pub(crate) status: ReadinessStatusDto,
+    pub(crate) profile: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) run_id: Option<String>,
+    pub(crate) sidecar_mode: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) degraded_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) next_command: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct AgentPreflightOutput {
     pub(crate) usable: bool,
     pub(crate) mode: String,
     pub(crate) local_graph: AgentPreflightLaneOutput,
     pub(crate) full_retrieval: AgentPreflightLaneOutput,
+    pub(crate) local_default: ReadinessLaneOutput,
+    pub(crate) agent_packet_search: ReadinessLaneOutput,
+    pub(crate) readiness_lanes: BTreeMap<String, ReadinessLaneOutput>,
     pub(crate) sidecar_setup: serde_json::Value,
     pub(crate) safe_surfaces: Vec<String>,
     pub(crate) blocked_surfaces: Vec<String>,
@@ -2321,6 +2337,10 @@ pub(crate) struct DoctorCheckOutput {
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct DoctorSidecarStatusOutput {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) run_id: Option<String>,
     pub(crate) retrieval_mode: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) degraded_reason: Option<String>,
@@ -2358,6 +2378,8 @@ pub(crate) struct DoctorOutput {
     pub(crate) freshness: Option<IndexFreshnessDto>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) readiness: Vec<ReadinessVerdictDto>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) readiness_lanes: BTreeMap<String, ReadinessLaneOutput>,
     pub(crate) checks: Vec<DoctorCheckOutput>,
     pub(crate) next_commands: Vec<String>,
     pub(crate) environment: Vec<DoctorCheckOutput>,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -77,12 +77,12 @@ use args::{
     DrillSummarySourceTruthTargetOutput, DrillSummaryStatsOutput, DrillSummaryVerdictOutput,
     DrillVerificationChecklistItemOutput, FilesCommand, GenerateCompletionsCommand, GroundCommand,
     IndexCommand, IndexDryRunOutput, IndexOutput, PacketCommand, ProjectArgs, QueryCommand,
-    QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadyCommand, ReadyOutput,
-    RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand, SetupAction,
-    SetupCommand, SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile, SnippetCommand,
-    SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, SymbolWorkflowCommand, TaskAction,
-    TaskBriefCommand, TaskCommand,
-    TrailCommand, TrailJsonOutput, VerificationTargetOutput, build_trail_request,
+    QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadinessLaneOutput, ReadyCommand,
+    ReadyOutput, RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand,
+    SetupAction, SetupCommand, SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile,
+    SnippetCommand, SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, SymbolWorkflowCommand,
+    TaskAction, TaskBriefCommand, TaskCommand, TrailCommand, TrailJsonOutput,
+    VerificationTargetOutput, build_trail_request,
 };
 #[cfg(test)]
 use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
@@ -2037,7 +2037,9 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
         summary.freshness.as_ref(),
         &sidecar,
     );
-    let output = build_agent_preflight_output(&readiness, Path::new(&summary.root));
+    let readiness_lanes = build_readiness_lanes_for_runtime(&runtime, &readiness);
+    let output =
+        build_agent_preflight_output(&readiness, Path::new(&summary.root), readiness_lanes);
     let markdown = render_agent_preflight_markdown(&output);
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
@@ -2112,10 +2114,12 @@ const LOCAL_GRAPH_AGENT_SURFACES: &[&str] = &[
     "ground", "files", "symbol", "callers", "callees", "trail", "trace", "snippet", "affected",
 ];
 const FULL_RETRIEVAL_AGENT_SURFACES: &[&str] = &["packet_full", "search_full", "context_full"];
+const AGENT_RUN_MISSING_ID: &str = "agent-run-missing";
 
 fn build_agent_preflight_output(
     readiness: &[codestory_contracts::api::ReadinessVerdictDto],
     project_root: &Path,
+    readiness_lanes: BTreeMap<String, ReadinessLaneOutput>,
 ) -> args::AgentPreflightOutput {
     let local = readiness
         .iter()
@@ -2157,6 +2161,15 @@ fn build_agent_preflight_output(
         mode: mode.to_string(),
         local_graph: agent_preflight_lane(local),
         full_retrieval: agent_preflight_lane(agent),
+        local_default: readiness_lanes
+            .get("local_default")
+            .cloned()
+            .expect("local_default readiness lane"),
+        agent_packet_search: readiness_lanes
+            .get("agent_packet_search")
+            .cloned()
+            .expect("agent_packet_search readiness lane"),
+        readiness_lanes,
         sidecar_setup: stdio_transport::stdio_sidecar_setup_status(project_root),
         safe_surfaces,
         blocked_surfaces,
@@ -9940,6 +9953,7 @@ fn build_doctor_output(
         summary.freshness.as_ref(),
         &sidecar_retrieval,
     );
+    let readiness_lanes = build_readiness_lanes_for_runtime(runtime, &readiness);
     let next_commands = readiness::compatibility_next_commands(&readiness);
     let mut checks = Vec::new();
     checks.push(doctor_check(
@@ -10030,6 +10044,7 @@ fn build_doctor_output(
         retrieval,
         freshness: summary.freshness.clone(),
         readiness,
+        readiness_lanes,
         checks,
         next_commands,
         environment,
@@ -10055,6 +10070,8 @@ fn readiness_sidecar_input(
     sidecar: &DoctorSidecarStatusOutput,
 ) -> readiness::ReadinessSidecarInput<'_> {
     readiness::ReadinessSidecarInput {
+        profile: sidecar.profile.as_deref(),
+        run_id: sidecar.run_id.as_deref(),
         retrieval_mode: sidecar.retrieval_mode.as_str(),
         degraded_reason: sidecar.degraded_reason.as_deref(),
         manifest_generation: sidecar.manifest_generation.as_deref(),
@@ -10063,27 +10080,20 @@ fn readiness_sidecar_input(
 }
 
 fn doctor_sidecar_status(runtime: &RuntimeContext) -> DoctorSidecarStatusOutput {
-    match codestory_retrieval::strict_sidecar_status(
+    let sidecar = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    match codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
+        sidecar.clone(),
     ) {
         Ok(report) => {
-            let status = doctor_sidecar_status_from_report(report);
+            let status = doctor_sidecar_status_from_report(report, Some(&sidecar));
             let handoff_failure = (status.retrieval_mode == "full")
                 .then(|| doctor_sidecar_profile_handoff_failure(runtime))
                 .flatten();
             apply_sidecar_profile_handoff(status, handoff_failure)
         }
-        Err(error) => DoctorSidecarStatusOutput {
-            retrieval_mode: "unavailable".to_string(),
-            degraded_reason: Some(format!("sidecar_status_error: {error}")),
-            manifest_generation: None,
-            manifest_input_hash: None,
-            precise_semantic_import_status: None,
-            precise_semantic_import_reason: None,
-            precise_semantic_import_revision: None,
-            precise_semantic_import_producer: None,
-        },
+        Err(error) => doctor_sidecar_status_error(error, Some(&sidecar)),
     }
 }
 
@@ -10104,24 +10114,16 @@ fn doctor_sidecar_status_for_runtime(
     match codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
-        sidecar,
+        sidecar.clone(),
     ) {
-        Ok(report) => doctor_sidecar_status_from_report(report),
-        Err(error) => DoctorSidecarStatusOutput {
-            retrieval_mode: "unavailable".to_string(),
-            degraded_reason: Some(format!("sidecar_status_error: {error}")),
-            manifest_generation: None,
-            manifest_input_hash: None,
-            precise_semantic_import_status: None,
-            precise_semantic_import_reason: None,
-            precise_semantic_import_revision: None,
-            precise_semantic_import_producer: None,
-        },
+        Ok(report) => doctor_sidecar_status_from_report(report, Some(&sidecar)),
+        Err(error) => doctor_sidecar_status_error(error, Some(&sidecar)),
     }
 }
 
 fn doctor_sidecar_status_from_report(
     report: codestory_retrieval::RetrievalStatusReport,
+    runtime: Option<&codestory_retrieval::SidecarRuntimeConfig>,
 ) -> DoctorSidecarStatusOutput {
     let manifest_generation = report
         .manifest
@@ -10148,6 +10150,15 @@ fn doctor_sidecar_status_from_report(
         .as_ref()
         .and_then(|manifest| manifest.precise_semantic_import_producer.clone());
     DoctorSidecarStatusOutput {
+        profile: runtime
+            .map(|runtime| runtime.profile.as_str().to_string())
+            .or_else(|| {
+                report
+                    .ownership
+                    .as_ref()
+                    .map(|ownership| ownership.profile.clone())
+            }),
+        run_id: runtime.and_then(|runtime| runtime.run_id.clone()),
         retrieval_mode: report.retrieval_mode,
         degraded_reason: report.degraded_reason,
         manifest_generation,
@@ -10157,6 +10168,148 @@ fn doctor_sidecar_status_from_report(
         precise_semantic_import_revision,
         precise_semantic_import_producer,
     }
+}
+
+fn doctor_sidecar_status_error(
+    error: anyhow::Error,
+    runtime: Option<&codestory_retrieval::SidecarRuntimeConfig>,
+) -> DoctorSidecarStatusOutput {
+    DoctorSidecarStatusOutput {
+        profile: runtime.map(|runtime| runtime.profile.as_str().to_string()),
+        run_id: runtime.and_then(|runtime| runtime.run_id.clone()),
+        retrieval_mode: "unavailable".to_string(),
+        degraded_reason: Some(format!("sidecar_status_error: {error}")),
+        manifest_generation: None,
+        manifest_input_hash: None,
+        precise_semantic_import_status: None,
+        precise_semantic_import_reason: None,
+        precise_semantic_import_revision: None,
+        precise_semantic_import_producer: None,
+    }
+}
+
+pub(crate) fn build_readiness_lanes_for_runtime(
+    runtime: &RuntimeContext,
+    readiness: &[codestory_contracts::api::ReadinessVerdictDto],
+) -> BTreeMap<String, ReadinessLaneOutput> {
+    let project = display::clean_path_string(&runtime.project_root.to_string_lossy());
+    let project_arg = display::quote_command_argument_value(&project);
+    let local_runtime = codestory_retrieval::sidecar_runtime_for_project(
+        &runtime.project_root,
+        codestory_retrieval::SidecarProfile::Local,
+    );
+    let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root);
+    let local_status = doctor_sidecar_status_for_runtime(runtime, local_runtime);
+    let agent_status = doctor_sidecar_status_for_runtime(runtime, agent_runtime);
+    let agent_verdict = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::AgentPacketSearch);
+    let mut lanes = BTreeMap::new();
+    lanes.insert(
+        "local_default".to_string(),
+        readiness_lane_output("local_default", &local_status, None, &project_arg),
+    );
+    lanes.insert(
+        "agent_packet_search".to_string(),
+        readiness_lane_output(
+            "agent_packet_search",
+            &agent_status,
+            agent_verdict,
+            &project_arg,
+        ),
+    );
+    lanes
+}
+
+fn agent_readiness_sidecar_runtime(
+    project_root: &Path,
+) -> codestory_retrieval::SidecarRuntimeConfig {
+    let active = codestory_retrieval::sidecar_runtime_auto(project_root);
+    if active.profile == codestory_retrieval::SidecarProfile::Agent {
+        return active;
+    }
+    codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        project_root,
+        codestory_retrieval::SidecarProfile::Agent,
+        Some(AGENT_RUN_MISSING_ID),
+    )
+}
+
+fn readiness_lane_output(
+    lane: &str,
+    sidecar: &DoctorSidecarStatusOutput,
+    verdict: Option<&codestory_contracts::api::ReadinessVerdictDto>,
+    project_arg: &str,
+) -> ReadinessLaneOutput {
+    let status = readiness_lane_status(sidecar, verdict);
+    ReadinessLaneOutput {
+        status,
+        profile: sidecar
+            .profile
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string()),
+        run_id: sidecar.run_id.clone(),
+        sidecar_mode: sidecar.retrieval_mode.clone(),
+        degraded_reason: sidecar.degraded_reason.clone(),
+        next_command: lane_next_command(lane, sidecar, status, verdict, project_arg),
+    }
+}
+
+fn readiness_lane_status(
+    sidecar: &DoctorSidecarStatusOutput,
+    verdict: Option<&codestory_contracts::api::ReadinessVerdictDto>,
+) -> ReadinessStatusDto {
+    let sidecar_status = if sidecar.retrieval_mode == "full" {
+        ReadinessStatusDto::Ready
+    } else {
+        ReadinessStatusDto::RepairRetrieval
+    };
+    match verdict.map(|verdict| verdict.status) {
+        Some(status @ (ReadinessStatusDto::RepairSetup | ReadinessStatusDto::RepairIndex)) => {
+            status
+        }
+        Some(ReadinessStatusDto::CheckIndex) if sidecar_status == ReadinessStatusDto::Ready => {
+            ReadinessStatusDto::CheckIndex
+        }
+        _ => sidecar_status,
+    }
+}
+
+fn lane_next_command(
+    lane: &str,
+    sidecar: &DoctorSidecarStatusOutput,
+    status: ReadinessStatusDto,
+    verdict: Option<&codestory_contracts::api::ReadinessVerdictDto>,
+    project_arg: &str,
+) -> Option<String> {
+    if status == ReadinessStatusDto::Ready {
+        return Some(retrieval_status_command(sidecar, project_arg));
+    }
+    if let Some(command) = verdict.and_then(|verdict| verdict.minimum_next.first()) {
+        return Some(command.clone());
+    }
+    match lane {
+        "agent_packet_search" if sidecar.retrieval_mode != "full" => Some(format!(
+            "codestory-cli ready --goal agent --repair --project {project_arg} --format json"
+        )),
+        "local_default" if sidecar.retrieval_mode != "full" => Some(format!(
+            "codestory-cli retrieval index --project {project_arg} --profile local --refresh full --format json"
+        )),
+        _ => Some(retrieval_status_command(sidecar, project_arg)),
+    }
+}
+
+fn retrieval_status_command(sidecar: &DoctorSidecarStatusOutput, project_arg: &str) -> String {
+    let mut command = format!(
+        "codestory-cli retrieval status --project {project_arg} --profile {}",
+        sidecar.profile.as_deref().unwrap_or("local")
+    );
+    if let Some(run_id) = sidecar.run_id.as_deref() {
+        command.push_str(" --run-id ");
+        command.push_str(&display::quote_command_argument_value(run_id));
+    }
+    command.push_str(" --format json");
+    command
 }
 
 fn apply_sidecar_profile_handoff(
@@ -11634,6 +11787,38 @@ mod tests {
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
 
+    struct EnvVarSnapshot<'a> {
+        values: Vec<(&'a str, Option<std::ffi::OsString>)>,
+    }
+
+    impl<'a> EnvVarSnapshot<'a> {
+        fn clear(names: &'a [&'a str]) -> Self {
+            let values = names
+                .iter()
+                .map(|name| (*name, std::env::var_os(name)))
+                .collect();
+            for name in names {
+                unsafe {
+                    std::env::remove_var(name);
+                }
+            }
+            Self { values }
+        }
+    }
+
+    impl Drop for EnvVarSnapshot<'_> {
+        fn drop(&mut self) {
+            for (name, value) in &self.values {
+                unsafe {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+        }
+    }
+
     fn test_search_hit_defaults() -> SearchHit {
         SearchHit {
             node_id: NodeId(String::new()),
@@ -11680,6 +11865,8 @@ mod tests {
     #[test]
     fn sidecar_profile_handoff_downgrades_full_readiness() {
         let status = DoctorSidecarStatusOutput {
+            profile: Some("agent".to_string()),
+            run_id: Some("run".to_string()),
             retrieval_mode: "full".to_string(),
             degraded_reason: None,
             manifest_generation: Some("generation".to_string()),
@@ -11704,6 +11891,78 @@ mod tests {
             Some(
                 "profile_handoff_mismatch: active profile=agent namespace=run is full but local/default profile is mode=unavailable reason=zoekt_stub"
             )
+        );
+    }
+
+    #[test]
+    fn agent_readiness_runtime_does_not_collapse_to_local_without_agent_run() {
+        let _env_lock = crate::config::config_env_test_lock();
+        let _env_snapshot = EnvVarSnapshot::clear(&[
+            "CODESTORY_RETRIEVAL_PROFILE",
+            "CODESTORY_SIDECAR_PROFILE",
+            "CODESTORY_AGENT_RUN_ID",
+            "CODESTORY_SIDECAR_RUN_ID",
+            "CODESTORY_AGENT",
+            "CODESTORY_AGENT_RUN",
+            "CI",
+            "GITHUB_ACTIONS",
+        ]);
+        let temp = tempdir().expect("temp dir");
+        let project = temp.path().join("repo");
+        fs::create_dir_all(&project).expect("create project");
+
+        let runtime = agent_readiness_sidecar_runtime(&project);
+
+        assert_eq!(runtime.profile, codestory_retrieval::SidecarProfile::Agent);
+        assert_eq!(runtime.run_id.as_deref(), Some(AGENT_RUN_MISSING_ID));
+    }
+
+    #[test]
+    fn readiness_lane_keeps_agent_full_separate_from_local_handoff_mismatch() {
+        let sidecar = DoctorSidecarStatusOutput {
+            profile: Some("agent".to_string()),
+            run_id: Some("run".to_string()),
+            retrieval_mode: "full".to_string(),
+            degraded_reason: None,
+            manifest_generation: Some("generation".to_string()),
+            manifest_input_hash: Some("hash".to_string()),
+            precise_semantic_import_status: None,
+            precise_semantic_import_reason: None,
+            precise_semantic_import_revision: None,
+            precise_semantic_import_producer: None,
+        };
+        let aggregate_verdict = codestory_contracts::api::ReadinessVerdictDto {
+            goal: ReadinessGoalDto::AgentPacketSearch,
+            status: ReadinessStatusDto::RepairRetrieval,
+            summary: "profile_handoff_mismatch: local/default is unavailable".to_string(),
+            minimum_next: vec![
+                "codestory-cli ready --goal agent --repair --project C:/repo --format json"
+                    .to_string(),
+            ],
+            full_repair: Vec::new(),
+            setup: None,
+            index: None,
+            sidecar: None,
+        };
+
+        let lane = readiness_lane_output(
+            "agent_packet_search",
+            &sidecar,
+            Some(&aggregate_verdict),
+            "C:/repo",
+        );
+
+        assert_eq!(lane.status, ReadinessStatusDto::Ready);
+        assert_eq!(lane.sidecar_mode, "full");
+        assert_eq!(lane.profile, "agent");
+        assert_eq!(lane.run_id.as_deref(), Some("run"));
+        assert!(
+            lane.next_command.as_deref().is_some_and(|command| command
+                .contains("retrieval status")
+                && command.contains("--profile agent")
+                && command.contains("--run-id")
+                && command.contains("--format json")),
+            "ready agent lane should point at lane-scoped status proof: {lane:?}"
         );
     }
 

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -3822,6 +3822,8 @@ mod tests {
             retrieval_mode: "full".to_string(),
             degraded_reason: None,
             sidecar_retrieval: crate::args::DoctorSidecarStatusOutput {
+                profile: Some("local".to_string()),
+                run_id: None,
                 retrieval_mode: "full".to_string(),
                 degraded_reason: None,
                 manifest_generation: None,
@@ -3834,6 +3836,7 @@ mod tests {
             retrieval: None,
             freshness: None,
             readiness: Vec::new(),
+            readiness_lanes: std::collections::BTreeMap::new(),
             checks: Vec::new(),
             next_commands: Vec::new(),
             environment: Vec::new(),

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -26,6 +26,8 @@ pub(crate) struct ReadinessSetupInput {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ReadinessSidecarInput<'a> {
+    pub(crate) profile: Option<&'a str>,
+    pub(crate) run_id: Option<&'a str>,
     pub(crate) retrieval_mode: &'a str,
     pub(crate) degraded_reason: Option<&'a str>,
     pub(crate) manifest_generation: Option<&'a str>,
@@ -365,6 +367,8 @@ fn readiness_setup_snapshot(input: &ReadinessSetupInput) -> ReadinessSetupSnapsh
 
 fn readiness_sidecar_snapshot(input: ReadinessSidecarInput<'_>) -> ReadinessSidecarSnapshotDto {
     ReadinessSidecarSnapshotDto {
+        profile: input.profile.map(ToOwned::to_owned),
+        run_id: input.run_id.map(ToOwned::to_owned),
         retrieval_mode: input.retrieval_mode.to_string(),
         degraded_reason: input.degraded_reason.map(ToOwned::to_owned),
         manifest_generation: input.manifest_generation.map(ToOwned::to_owned),
@@ -462,6 +466,8 @@ mod tests {
                 newer_installed_version: None,
             }),
             sidecar: Some(ReadinessSidecarInput {
+                profile: Some("agent"),
+                run_id: Some("run"),
                 retrieval_mode: "full",
                 degraded_reason: None,
                 manifest_generation: Some("generation"),
@@ -509,6 +515,8 @@ mod tests {
                 newer_installed_version: Some("0.11.11".to_string()),
             }),
             sidecar: Some(ReadinessSidecarInput {
+                profile: Some("agent"),
+                run_id: Some("run"),
                 retrieval_mode: "full",
                 degraded_reason: None,
                 manifest_generation: Some("generation"),
@@ -550,6 +558,8 @@ mod tests {
             &stats,
             Some(&freshness),
             Some(ReadinessSidecarInput {
+                profile: Some("local"),
+                run_id: None,
                 retrieval_mode: "full",
                 degraded_reason: None,
                 manifest_generation: Some("generation"),
@@ -629,6 +639,8 @@ mod tests {
                 &stats,
                 Some(&freshness),
                 Some(ReadinessSidecarInput {
+                    profile: Some("agent"),
+                    run_id: Some("run"),
                     retrieval_mode: "full",
                     degraded_reason: None,
                     manifest_generation: Some("generation"),
@@ -668,6 +680,8 @@ mod tests {
                 &stats,
                 Some(&freshness),
                 Some(ReadinessSidecarInput {
+                    profile: Some("agent"),
+                    run_id: Some("run"),
                     retrieval_mode: "no_semantic",
                     degraded_reason: Some("semantic store unavailable"),
                     manifest_generation: Some("generation"),
@@ -723,6 +737,8 @@ mod tests {
         for sidecar in [
             None,
             Some(ReadinessSidecarInput {
+                profile: Some("local"),
+                run_id: None,
                 retrieval_mode: "unavailable",
                 degraded_reason: Some("manifest:<missing>"),
                 manifest_generation: None,
@@ -753,6 +769,8 @@ mod tests {
                 &stats,
                 None,
                 Some(ReadinessSidecarInput {
+                    profile: Some("agent"),
+                    run_id: Some("run"),
                     retrieval_mode: "unavailable",
                     degraded_reason: None,
                     manifest_generation: None,

--- a/crates/codestory-cli/src/report.rs
+++ b/crates/codestory-cli/src/report.rs
@@ -145,6 +145,8 @@ fn attach_report_handoff(
         freshness: summary.freshness.as_ref(),
         setup: None,
         sidecar: Some(crate::readiness::ReadinessSidecarInput {
+            profile: Some("local"),
+            run_id: None,
             retrieval_mode: &sidecar.retrieval_mode,
             degraded_reason: sidecar.degraded_reason.as_deref(),
             manifest_generation: sidecar.manifest_generation.as_deref(),

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2067,10 +2067,12 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
 fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Value> {
     let summary = runtime.open_project_summary()?;
     let retrieval = summary.retrieval.as_ref();
+    let sidecar_runtime = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
     let (sidecar_mode, degraded_reason, manifest_generation, manifest_input_hash, ownership) =
-        match codestory_retrieval::strict_sidecar_status(
+        match codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
             Some(&runtime.storage_path),
+            sidecar_runtime.clone(),
         ) {
             Ok(report) => {
                 let manifest_generation = report
@@ -2117,6 +2119,8 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         freshness: summary.freshness.as_ref(),
         setup: setup_repair.as_ref(),
         sidecar: Some(crate::readiness::ReadinessSidecarInput {
+            profile: Some(sidecar_runtime.profile.as_str()),
+            run_id: sidecar_runtime.run_id.as_deref(),
             retrieval_mode: &sidecar_mode,
             degraded_reason: degraded_reason.as_deref(),
             manifest_generation: manifest_generation.as_deref(),
@@ -2125,6 +2129,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     });
     let sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
     let allowed_surfaces = stdio_allowed_surfaces(&readiness);
+    let readiness_lanes = crate::build_readiness_lanes_for_runtime(runtime, &readiness);
     let recommended_next_calls = stdio_status_recommended_next_calls(&readiness, &sidecar_setup);
     Ok(serde_json::json!({
         "server_version": env!("CARGO_PKG_VERSION"),
@@ -2157,6 +2162,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
         },
         "index_freshness": summary.freshness,
         "readiness": readiness,
+        "readiness_lanes": readiness_lanes,
         "allowed_surfaces": allowed_surfaces,
         "recommended_next_calls": recommended_next_calls
     }))

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -711,6 +711,39 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
         doctor["retrieval_mode"], "full",
         "sidecar repair test needs mandatory sidecar retrieval to be not full: {doctor:#}"
     );
+    assert_eq!(
+        doctor["readiness_lanes"]["local_default"]["profile"], "local",
+        "doctor should expose local/default retrieval as its own lane: {doctor:#}"
+    );
+    assert!(
+        doctor["readiness_lanes"]["local_default"]["sidecar_mode"].is_string(),
+        "local/default lane should expose sidecar mode: {doctor:#}"
+    );
+    assert!(
+        doctor["readiness_lanes"]["local_default"]["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval index")
+                && command.contains("--profile local")),
+        "local/default lane should expose a local-scoped next command: {doctor:#}"
+    );
+    assert_eq!(
+        doctor["readiness_lanes"]["agent_packet_search"]["status"], "repair_retrieval",
+        "doctor should keep agent packet/search readiness separate: {doctor:#}"
+    );
+    assert_eq!(
+        doctor["readiness_lanes"]["agent_packet_search"]["profile"], "agent",
+        "agent lane must not collapse to local when no agent run exists: {doctor:#}"
+    );
+    assert_eq!(
+        doctor["readiness_lanes"]["agent_packet_search"]["run_id"], "agent-run-missing",
+        "agent lane should make the missing-run repair state explicit: {doctor:#}"
+    );
+    assert!(
+        doctor["readiness_lanes"]["agent_packet_search"]["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("ready --goal agent --repair")),
+        "agent lane should expose the agent-scoped repair command: {doctor:#}"
+    );
 
     let next_commands = doctor_next_commands(&doctor);
     let joined = next_commands.join("\n");
@@ -768,6 +801,38 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
     assert_eq!(
         preflight["full_retrieval"]["status"], "repair_retrieval",
         "{preflight:#}"
+    );
+    assert_eq!(
+        preflight["local_default"]["profile"], "local",
+        "preflight should expose local/default retrieval lane: {preflight:#}"
+    );
+    assert!(
+        preflight["local_default"]["sidecar_mode"].is_string(),
+        "local/default lane should expose sidecar mode: {preflight:#}"
+    );
+    assert!(
+        preflight["local_default"]["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile local")),
+        "local/default lane should expose a local-scoped next command: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        "preflight should expose agent packet/search lane: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["agent_packet_search"]["profile"], "agent",
+        "agent preflight lane must not collapse to local when no agent run exists: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["agent_packet_search"]["run_id"], "agent-run-missing",
+        "agent preflight lane should make the missing-run repair state explicit: {preflight:#}"
+    );
+    assert!(
+        preflight["readiness_lanes"]["agent_packet_search"]["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("ready --goal agent --repair")),
+        "agent lane should expose the agent-scoped repair command: {preflight:#}"
     );
     let safe_surfaces = preflight["safe_surfaces"]
         .as_array()

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2150,10 +2150,9 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         json!("agent"),
         "agent lane must not collapse to local when no agent run exists: {status}"
     );
-    assert_eq!(
-        agent_lane["run_id"],
-        json!("agent-run-missing"),
-        "agent lane should make the missing-run repair state explicit: {status}"
+    assert!(
+        agent_lane["run_id"].as_str().is_some_and(|run_id| !run_id.is_empty()),
+        "agent lane should report a non-empty agent run id: {status}"
     );
     assert!(
         agent_lane["next_command"]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2116,6 +2116,51 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     let readiness = status["readiness"]
         .as_array()
         .unwrap_or_else(|| panic!("status should include readiness verdicts: {status}"));
+    let readiness_lanes = status["readiness_lanes"]
+        .as_object()
+        .unwrap_or_else(|| panic!("status should include readiness lanes: {status}"));
+    let local_default = readiness_lanes
+        .get("local_default")
+        .unwrap_or_else(|| panic!("status should include local_default lane: {status}"));
+    assert_eq!(
+        local_default["profile"],
+        json!("local"),
+        "local/default lane should report the local profile: {status}"
+    );
+    assert!(
+        local_default["sidecar_mode"].is_string(),
+        "local/default lane should report sidecar mode: {status}"
+    );
+    assert!(
+        local_default["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--profile local")),
+        "local/default lane should expose a local-scoped next command: {status}"
+    );
+    let agent_lane = readiness_lanes
+        .get("agent_packet_search")
+        .unwrap_or_else(|| panic!("status should include agent_packet_search lane: {status}"));
+    assert_eq!(
+        agent_lane["status"],
+        json!("repair_retrieval"),
+        "agent lane should report blocked packet/search readiness: {status}"
+    );
+    assert_eq!(
+        agent_lane["profile"],
+        json!("agent"),
+        "agent lane must not collapse to local when no agent run exists: {status}"
+    );
+    assert_eq!(
+        agent_lane["run_id"],
+        json!("agent-run-missing"),
+        "agent lane should make the missing-run repair state explicit: {status}"
+    );
+    assert!(
+        agent_lane["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("ready --goal agent --repair")),
+        "agent lane should expose the agent-scoped next command: {status}"
+    );
     for surface in [
         "ground",
         "files",

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -348,6 +348,10 @@ pub struct ReadinessIndexSnapshotDto {
 /// Sidecar state snapshot used inside readiness verdicts.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
 pub struct ReadinessSidecarSnapshotDto {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
     pub retrieval_mode: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,


### PR DESCRIPTION
## Context

Closes #550.

`doctor`, `agent preflight`, and `codestory://status` already had readiness verdicts, but the sidecar truth could still read as one collapsed state when agent packet/search and local/default sidecar readiness diverged.

```mermaid
flowchart LR
    S["sidecar status probes"] --> L["local_default lane"]
    S --> A["agent_packet_search lane"]
    L --> O["doctor / preflight / status JSON"]
    A --> O
```

## What Changed

- Added explicit readiness lane output for `local_default` and `agent_packet_search`.
- Included profile, run id, sidecar mode, degraded reason, status, and lane-scoped next command in lane output.
- Kept existing compatibility fields (`readiness`, `local_graph`, `full_retrieval`, top-level retrieval fields) intact.
- Added profile/run id to sidecar snapshots used by readiness verdicts.
- Covered doctor JSON, agent preflight JSON, stdio status JSON, and the profile-mismatch helper case.

## How To Review

- Inspect `crates/codestory-cli/src/main.rs` around `build_readiness_lanes_for_runtime` and `readiness_lane_status`.
- Confirm `crates/codestory-cli/src/stdio_transport.rs` includes `readiness_lanes` in `codestory://status`.
- Confirm the output structs in `crates/codestory-cli/src/args.rs` preserve existing fields and only add lane fields.

## Verification

- `cargo check -p codestory-cli`
- `cargo fmt`
- `cargo test -p codestory-cli readiness_lane_keeps_agent_full_separate_from_local_handoff_mismatch`
- `cargo test -p codestory-cli --test cli_golden_path doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full`
- `cargo test -p codestory-cli --test cli_golden_path agent_preflight_reports_local_graph_when_retrieval_is_degraded`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls`
- `git diff --check`

## Risk

- This is reporting-only. It does not change retrieval ranking, sidecar storage, or repair execution.
- The compatibility fields remain, so consumers can migrate to `readiness_lanes` without losing old fields.
