### PR TITLE
[codex] Repair local graph before MCP serve

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -539,7 +539,7 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
     );
   }
   if (parsedProbe.ok) {
-    return { ready: true };
+    return { ready: true, repaired: false };
   }
 
   const repair = runLocalNavigationReady(resolved, projectRoot, true);
@@ -572,7 +572,7 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
     );
   }
   if (parsedRepair.ok) {
-    return { ready: true };
+    return { ready: true, repaired: true };
   }
   const verdict = parsedRepair.verdict || parsedProbe.verdict || null;
   const status = typeof verdict?.status === 'string' ? verdict.status : 'repair_setup';
@@ -932,7 +932,9 @@ async function main() {
     return;
   }
   const sidecarPolicy = readSidecarPolicy();
-  scheduleSidecarRepair(resolved, sidecarPolicy);
+  if (!localReadiness.repaired) {
+    scheduleSidecarRepair(resolved, sidecarPolicy);
+  }
   const sidecarStatus = readSidecarPolicy();
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -445,59 +445,62 @@ function localRepairCommand(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal local --repair --project ${JSON.stringify(projectRoot)} --format json`;
 }
 
-function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
-  const result = spawnSync(resolved.path, ['ready', '--goal', 'local', '--project', projectRoot, '--format', 'json'], {
+function localRepairTimeoutMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+}
+
+function runLocalNavigationReady(resolved, projectRoot, repair) {
+  const args = ['ready', '--goal', 'local'];
+  if (repair) args.push('--repair');
+  args.push('--project', projectRoot, '--format', 'json');
+  const result = spawnSync(resolved.path, args, {
     encoding: 'utf8',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
-    timeout: 10000,
+    timeout: repair ? localRepairTimeoutMs() : 10000,
     windowsHide: true,
   });
-  const setup = {
-    ready_probe_status: result.status,
-    ready_probe_error: result.error ? result.error.message : null,
-    ready_probe_stdout: result.stdout || '',
-    ready_probe_stderr: result.stderr || '',
+  return { args, result };
+}
+
+function localReadySetup(prefix, args, result) {
+  return {
+    [`${prefix}_args`]: args,
+    [`${prefix}_status`]: result.status,
+    [`${prefix}_error`]: result.error ? result.error.message : null,
+    [`${prefix}_stdout`]: result.stdout || '',
+    [`${prefix}_stderr`]: result.stderr || '',
   };
-  if (result.error || result.status !== 0) {
-    const repair = localRepairCommand(projectRoot);
-    return {
-      ready: false,
-      reason: 'local_navigation_probe_failed',
-      status: 'repair_setup',
-      summary: 'CodeStory MCP could not verify local navigation readiness before starting stdio.',
-      minimumNext: [repair],
-      fullRepair: [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
-      setup,
-    };
-  }
+}
+
+function parseLocalReadyResult(result) {
   let parsed;
   try {
     parsed = JSON.parse(result.stdout || '{}');
   } catch (error) {
-    const repair = localRepairCommand(projectRoot);
     return {
-      ready: false,
-      reason: 'local_navigation_probe_invalid_json',
-      status: 'repair_setup',
-      summary: `CodeStory MCP local readiness probe returned invalid JSON: ${error.message}`,
-      minimumNext: [repair],
-      fullRepair: [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
-      setup,
+      ok: false,
+      invalidJson: error.message,
+      verdict: null,
     };
   }
   const verdict = Array.isArray(parsed.verdicts)
     ? parsed.verdicts.find((item) => item && item.goal === 'local_navigation') || parsed.verdicts[0]
     : null;
-  if (verdict && verdict.status === 'ready') {
-    return { ready: true };
-  }
+  return {
+    ok: Boolean(verdict && verdict.status === 'ready'),
+    invalidJson: null,
+    verdict,
+  };
+}
+
+function localNavigationFailure(projectRoot, reason, status, summary, setup, verdict = null) {
   const repair = localRepairCommand(projectRoot);
-  const status = typeof verdict?.status === 'string' ? verdict.status : 'repair_setup';
   return {
     ready: false,
-    reason: `local_navigation_${status}`,
+    reason,
     status,
-    summary: verdict?.summary || 'CodeStory local navigation is not ready.',
+    summary,
     minimumNext: Array.isArray(verdict?.minimum_next) && verdict.minimum_next.length > 0
       ? verdict.minimum_next
       : [repair],
@@ -506,9 +509,81 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
       : [repair, `codestory-cli doctor --project ${JSON.stringify(projectRoot)}`],
     setup: {
       ...setup,
-      readiness_verdict: verdict || null,
+      readiness_verdict: verdict,
     },
   };
+}
+
+function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
+  const probe = runLocalNavigationReady(resolved, projectRoot, false);
+  const setup = {
+    ...localReadySetup('ready_probe', probe.args, probe.result),
+  };
+  if (probe.result.error || probe.result.status !== 0) {
+    return localNavigationFailure(
+      projectRoot,
+      'local_navigation_probe_failed',
+      'repair_setup',
+      'CodeStory MCP could not verify local navigation readiness before starting stdio.',
+      setup,
+    );
+  }
+  const parsedProbe = parseLocalReadyResult(probe.result);
+  if (parsedProbe.invalidJson) {
+    return localNavigationFailure(
+      projectRoot,
+      'local_navigation_probe_invalid_json',
+      'repair_setup',
+      `CodeStory MCP local readiness probe returned invalid JSON: ${parsedProbe.invalidJson}`,
+      setup,
+    );
+  }
+  if (parsedProbe.ok) {
+    return { ready: true };
+  }
+
+  const repair = runLocalNavigationReady(resolved, projectRoot, true);
+  const repairSetup = {
+    ...setup,
+    ...localReadySetup('local_repair', repair.args, repair.result),
+  };
+  if (repair.result.error || repair.result.status !== 0) {
+    const timeout = repair.result.error && repair.result.error.code === 'ETIMEDOUT';
+    return localNavigationFailure(
+      projectRoot,
+      timeout ? 'local_navigation_repair_timeout' : 'local_navigation_repair_failed',
+      'repair_setup',
+      timeout
+        ? 'CodeStory MCP timed out while refreshing local navigation before starting stdio.'
+        : 'CodeStory MCP could not refresh local navigation before starting stdio.',
+      repairSetup,
+      parsedProbe.verdict || null,
+    );
+  }
+  const parsedRepair = parseLocalReadyResult(repair.result);
+  if (parsedRepair.invalidJson) {
+    return localNavigationFailure(
+      projectRoot,
+      'local_navigation_repair_invalid_json',
+      'repair_setup',
+      `CodeStory MCP local repair returned invalid JSON: ${parsedRepair.invalidJson}`,
+      repairSetup,
+      parsedProbe.verdict || null,
+    );
+  }
+  if (parsedRepair.ok) {
+    return { ready: true };
+  }
+  const verdict = parsedRepair.verdict || parsedProbe.verdict || null;
+  const status = typeof verdict?.status === 'string' ? verdict.status : 'repair_setup';
+  return localNavigationFailure(
+    projectRoot,
+    `local_navigation_${status}`,
+    status,
+    verdict?.summary || 'CodeStory local navigation is not ready after one bounded repair.',
+    repairSetup,
+    verdict,
+  );
 }
 
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -273,7 +273,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
   }
 });
 
-test("mcp launcher repairs stale local navigation once before serving", async () => {
+test("mcp launcher repairs stale local navigation without agent repair under enabled sidecar policy", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-repair-index-"));
@@ -322,6 +322,7 @@ test("mcp launcher repairs stale local navigation once before serving", async ()
         ...process.env,
         CODESTORY_CLI: cliPath,
         PLUGIN_DATA: dataDir,
+        CODESTORY_PLUGIN_SIDECAR_POLICY: "enabled",
         TEST_CODESTORY_VERSION: version,
         TEST_LOG: logFile,
         TEST_OUT: marker,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -273,6 +273,79 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
   }
 });
 
+test("mcp launcher repairs stale local navigation once before serving", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-repair-index-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "fake-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "fake-codestory-cli.cmd" : "fake-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+
+  try {
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const version = process.env.TEST_CODESTORY_VERSION;",
+        "const logFile = process.env.TEST_LOG;",
+        "const marker = process.env.TEST_OUT;",
+        "const args = process.argv.slice(2);",
+        "const command = args[0];",
+        "fs.appendFileSync(logFile, JSON.stringify({ args, sidecarRepair: process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR === '1' }) + '\\n');",
+        "if (command === '--version') { console.log('codestory-cli ' + version); process.exit(0); }",
+        "if (command === 'ready') {",
+        "  const ready = args.includes('--repair');",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: ready ? 'ready' : 'repair_index', summary: ready ? 'ready' : 'stale local graph', minimum_next: [], full_repair: [] }] }));",
+        "  process.exit(0);",
+        "}",
+        "if (command === 'serve') { fs.writeFileSync(marker, 'serve-called'); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: dataDir,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      encoding: "utf8",
+      timeout: 15000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(await readFile(marker, "utf8"), "serve-called");
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    const readyCalls = calls.filter((call) => call.args[0] === "ready");
+    assert.deepEqual(readyCalls.map((call) => call.args.slice(0, 4)), [
+      ["ready", "--goal", "local", "--project"],
+      ["ready", "--goal", "local", "--repair"],
+    ]);
+    assert.equal(calls.some((call) => call.args.includes("agent")), false);
+    assert.equal(calls.some((call) => call.sidecarRepair), false);
+    assert.equal(calls.some((call) => call.args[0] === "serve"), true);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("mcp launcher fails open when local navigation is not ready", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
@@ -327,7 +400,7 @@ test("mcp launcher fails open when local navigation is not ready", async () => {
       },
       input,
       encoding: "utf8",
-      timeout: 5000,
+      timeout: 15000,
     });
 
     assert.equal(result.status, 0, result.stderr);
@@ -341,9 +414,91 @@ test("mcp launcher fails open when local navigation is not ready", async () => {
     assert.equal(status.allowed_surfaces.ground.allowed, false);
     assert.equal(status.allowed_surfaces.ground.status, "repair_index");
     assert.match(status.readiness[0].minimum_next[0], /ready --goal local --repair/u);
+    assert.deepEqual(status.readiness[0].setup.local_repair_args.slice(0, 4), [
+      "ready",
+      "--goal",
+      "local",
+      "--repair",
+    ]);
     assert.equal(responses[2].result.isError, true);
     assert.equal(responses[2].result.structuredContent.status, "repair_index");
   } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher fails open when local navigation repair times out", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-repair-timeout-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "fake-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "fake-codestory-cli.cmd" : "fake-codestory-cli",
+  );
+  const marker = join(dataDir, "serve-called.txt");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const version = process.env.TEST_CODESTORY_VERSION;",
+        "const marker = process.env.TEST_OUT;",
+        "const args = process.argv.slice(2);",
+        "const command = args[0];",
+        "if (command === '--version') { console.log('codestory-cli ' + version); process.exit(0); }",
+        "if (command === 'ready' && args.includes('--repair')) { const end = Date.now() + 200; while (Date.now() < end) {} process.exit(0); }",
+        "if (command === 'ready') { console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'repair_index', summary: 'stale local graph', minimum_next: [], full_repair: [] }] })); process.exit(0); }",
+        "if (command === 'serve') { fs.writeFileSync(marker, 'serve-called'); process.exit(1); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: dataDir,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS: "50",
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.readiness[0].repair_reason, "local_navigation_repair_timeout");
+    assert.deepEqual(status.readiness[0].setup.local_repair_args.slice(0, 4), [
+      "ready",
+      "--goal",
+      "local",
+      "--repair",
+    ]);
+    assert.equal(status.allowed_surfaces.ground.allowed, false);
+  } finally {
+    await new Promise((resolve) => setTimeout(resolve, 300));
     await rm(dataDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Context

Closes #560

Packaged MCP startup should not hand agents setup archaeology when only the local graph is stale. It can make one bounded local-only repair attempt, then either serve from a fresh graph or keep the existing diagnostic fail-open surface.

## What Changed
- Added one bounded local-only `ready --goal local --repair` attempt in the packaged MCP launcher when the initial local navigation probe is stale.
- Preserved fail-open MCP diagnostics on repair failure, invalid JSON, or timeout; diagnostics now include probe and repair command/setup evidence.
- Added plugin static coverage for successful local repair before serve, still-stale fail-open behavior, timeout fail-open behavior, and no agent sidecar repair during the local repair path.

## How To Review
- Start with `plugins/codestory/scripts/codestory-mcp.cjs` around `probeLocalNavigation`.
- Then review `plugins/codestory/tests/plugin-static.test.mjs` local navigation launcher tests.

## Verification
- `node --test --test-name-pattern "local navigation|repairs stale" plugins/codestory/tests/plugin-static.test.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `git diff --check`
- `.\target\debug\codestory-cli.exe ready --goal local --repair --project "C:\Users\alber\.codex\worktrees\2c54\codestory" --format json` -> local_navigation ready, 274/274 indexed, retrieval_manifest_missing unchanged.

## Risk
- Local repair timeout defaults to 120s; it is intentionally local-only and does not invoke `ready --goal agent` or packet/search sidecar startup.
- Cargo/Rust was not touched, so `cargo fmt` was not run.