### PR TITLE
[codex] Shorten degraded grounding hooks

### DIFF
--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -5,12 +5,14 @@ const { eventHeader, getCodeStoryInstructions } = require('./codestory-instructi
 const {
   classifyMcpRuntime,
   mcpDetectionText,
+  readActiveState,
   rememberActiveState,
   writeHookOutput,
 } = require('./codestory-runtime.cjs');
 
-const MAX_OUTPUT_CHARS = 12000;
+const MAX_OUTPUT_CHARS = 4000;
 const RUNTIME_TIMEOUT_MS = 3500;
+const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
 
 function readHookInput() {
   return new Promise((resolve) => {
@@ -36,6 +38,32 @@ function truncate(text) {
   return `${value.slice(0, MAX_OUTPUT_CHARS)}\n\n... CodeStory hook output truncated by hook budget.`;
 }
 
+function firstRuntimeFailure(mcp) {
+  if (!mcp.mcp_config_installed) {
+    return `MCP: no codestory server configured at ${mcp.mcp_config_path}`;
+  }
+  if (!mcp.mcp_process_launchable) {
+    return 'MCP: configured codestory server is not launchable from the plugin root';
+  }
+  if (!mcp.mcp_resources_exposed) {
+    return `MCP: ${mcp.mcp_resource_status}`;
+  }
+  if (!mcp.managed_cli_present) {
+    return 'managed runtime: no managed CLI manifest or runtime state was found';
+  }
+  return 'runtime: no usable grounding surface was found';
+}
+
+function shortDegradedNotice(mcp, reason, state = {}) {
+  const hook = state.hook || {};
+  return [
+    'CodeStory degraded mode: no MCP or managed runtime surface is usable.',
+    `First failing layer: ${firstRuntimeFailure(mcp)}.`,
+    reason ? `Reason: ${truncate(reason)}` : null,
+    hook.preflight_failed ? SOURCE_FALLBACK : 'Run one bounded managed/local-dev preflight if available; otherwise use bounded source reads.',
+  ].filter(Boolean).join('\n');
+}
+
 function hookCommand(input, event) {
   const project = input.cwd || process.cwd();
   if (!project) return null;
@@ -51,7 +79,7 @@ function hookCommand(input, event) {
         '--refresh', 'none',
         '--latency-budget-ms', '1500',
       ],
-      next: 'If the packet is partial or unavailable, read codestory://status and run the packet/search/context follow-up that status allows before opening source files.',
+      next: 'If CodeStory is unavailable, use bounded source reads in the target repo instead of repeated repair attempts.',
     };
   }
 
@@ -64,14 +92,14 @@ function hookCommand(input, event) {
         '--budget', 'strict',
         '--refresh', 'none',
       ],
-      next: 'If the ground snapshot is unavailable, read codestory://status and run ready --goal local --repair for the target repo before source reads.',
+      next: 'If CodeStory is unavailable, use bounded source reads in the target repo instead of repeated repair attempts.',
     };
   }
 
   return null;
 }
 
-function runCodeStory(input, event) {
+function runCodeStory(input, event, state = {}) {
   if (process.env.CODESTORY_HOOK_DISABLE_RUNTIME === '1') {
     return {
       kind: 'disabled',
@@ -93,7 +121,15 @@ function runCodeStory(input, event) {
       ].join('\n'),
     };
   }
-  const cli = process.env.CODESTORY_CLI || 'codestory-cli';
+  if (!process.env.CODESTORY_CLI && !mcp.managed_cli_present) {
+    return {
+      degraded: true,
+      kind: 'degraded mode',
+      output: shortDegradedNotice(mcp, null, state),
+    };
+  }
+
+  const cli = process.env.CODESTORY_CLI || mcp.managed_cli_path;
 
   const result = spawnSync(cli, command.args, {
     cwd: input.cwd || process.cwd(),
@@ -116,19 +152,31 @@ function runCodeStory(input, event) {
     ? result.error.message
     : truncate(result.stderr || `codestory-cli exited with status ${result.status}`);
 
+  const failedState = {
+    ...state,
+    hook: {
+      ...(state.hook || {}),
+      preflight_failed: true,
+    },
+  };
+
   return {
+    degraded: mcp.degraded_no_surface,
+    preflightFailed: true,
     kind: command.kind,
-    output: [
-      mcpDetectionText(mcp),
-      `CodeStory hook attempted ${command.kind} but did not receive usable output.`,
-      reason ? `Reason: ${reason}` : null,
-      command.next,
-    ].filter(Boolean).join('\n'),
+    output: mcp.degraded_no_surface
+      ? shortDegradedNotice(mcp, reason, failedState)
+      : [
+        mcpDetectionText(mcp),
+        `CodeStory hook attempted ${command.kind} but did not receive usable output.`,
+        reason ? `Reason: ${reason}` : null,
+        command.next,
+      ].filter(Boolean).join('\n'),
   };
 }
 
-function buildContext(input, event) {
-  const runtime = runCodeStory(input, event);
+function buildContext(input, event, state = {}) {
+  const runtime = runCodeStory(input, event, state);
   const runtimeBlock = runtime && runtime.output
     ? [
       `CODESTORY HOOK ${runtime.kind.toUpperCase()}`,
@@ -141,7 +189,13 @@ function buildContext(input, event) {
     return [eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n');
   }
 
-  const parts = [getCodeStoryInstructions(event, input)];
+  if (runtime && runtime.degraded) {
+    return [eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n');
+  }
+
+  const emitted = state.hook && state.hook.instructions_emitted;
+  const alreadyEmitted = emitted && emitted[event];
+  const parts = [alreadyEmitted ? eventHeader(event, input).trim() : getCodeStoryInstructions(event, input)];
 
   if (runtimeBlock) {
     parts.push(runtimeBlock);
@@ -153,12 +207,28 @@ function buildContext(input, event) {
 readHookInput().then((input) => {
   const event = input.hook_event_name || 'SessionStart';
   try {
+    const state = readActiveState() || {};
+    const context = buildContext(input, event, state);
+    const priorInstructions = (state.hook && state.hook.instructions_emitted) || {};
+    const emittedFullInstructions = context.includes('CODESTORY BACKGROUND GROUNDING RULES') ||
+      context.includes('CODESTORY BACKGROUND GROUNDING ACTIVE');
+    const instructions = emittedFullInstructions
+      ? { ...priorInstructions, [event]: true }
+      : priorInstructions;
     rememberActiveState({
       event,
       cwd: input.cwd || process.cwd(),
       source: input.source || input.trigger || null,
+      hook: {
+        instructions_emitted: instructions,
+        preflight_failed: state.hook && state.hook.preflight_failed,
+      },
     });
-    writeHookOutput(event, buildContext(input, event));
+    const nextState = readActiveState() || {};
+    if (/CodeStory is unavailable for this session/u.test(context)) {
+      rememberActiveState({ hook: { ...(nextState.hook || {}), preflight_failed: true } });
+    }
+    writeHookOutput(event, context);
   } catch (e) {
     // Best effort only. A hook failure must not block the agent session.
   }

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -204,12 +204,26 @@ function buildContext(input, event, state = {}) {
   return parts.join('\n\n');
 }
 
+function freshInstructionBoundary(event, input = {}) {
+  const source = String(input.source || input.trigger || '').toLowerCase();
+  return event === 'SessionStart' && (!source || source === 'startup');
+}
+
 readHookInput().then((input) => {
   const event = input.hook_event_name || 'SessionStart';
   try {
     const state = readActiveState() || {};
-    const context = buildContext(input, event, state);
-    const priorInstructions = (state.hook && state.hook.instructions_emitted) || {};
+    const activeState = freshInstructionBoundary(event, input)
+      ? {
+        ...state,
+        hook: {
+          ...(state.hook || {}),
+          instructions_emitted: {},
+        },
+      }
+      : state;
+    const context = buildContext(input, event, activeState);
+    const priorInstructions = (activeState.hook && activeState.hook.instructions_emitted) || {};
     const emittedFullInstructions = context.includes('CODESTORY BACKGROUND GROUNDING RULES') ||
       context.includes('CODESTORY BACKGROUND GROUNDING ACTIVE');
     const instructions = emittedFullInstructions

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -13,6 +13,11 @@ function pluginDataDir() {
   return null;
 }
 
+function stateFilePath() {
+  const stateDir = pluginDataDir();
+  return stateDir ? path.join(stateDir, STATE_FILE) : null;
+}
+
 function readJson(file) {
   try {
     return JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -115,14 +120,25 @@ function mcpDetectionText(status) {
   ].join('\n');
 }
 
+function readActiveState() {
+  const file = stateFilePath();
+  return file ? readJson(file) : null;
+}
+
 function rememberActiveState(state) {
-  const stateDir = pluginDataDir();
-  if (!stateDir) return;
+  const file = stateFilePath();
+  if (!file) return;
 
   try {
-    fs.mkdirSync(stateDir, { recursive: true });
-    fs.writeFileSync(path.join(stateDir, STATE_FILE), JSON.stringify({
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const previous = readActiveState() || {};
+    fs.writeFileSync(file, JSON.stringify({
+      ...previous,
       ...state,
+      hook: {
+        ...(previous.hook || {}),
+        ...(state.hook || {}),
+      },
       updatedAt: new Date().toISOString(),
     }));
   } catch (e) {
@@ -156,6 +172,7 @@ function writeHookOutput(event, context) {
 module.exports = {
   classifyMcpRuntime,
   mcpDetectionText,
+  readActiveState,
   rememberActiveState,
   writeHookOutput,
 };

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -820,6 +820,35 @@ async function withFakeCodeStoryCli(callback) {
   }
 }
 
+async function withTempHookInstall(callback) {
+  const { cp } = await import("node:fs/promises");
+  const installRoot = await mkdtemp(join(tmpdir(), "codestory-hook-install-"));
+  try {
+    await cp(join(pluginRoot, "hooks"), join(installRoot, "hooks"), {
+      recursive: true,
+    });
+    await callback(installRoot);
+  } finally {
+    await rm(installRoot, { recursive: true, force: true });
+  }
+}
+
+async function writeNodeCli(binDir, source) {
+  const scriptPath = join(binDir, "fake-codestory-cli.cjs");
+  const cliPath = join(
+    binDir,
+    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+  );
+  await writeFile(scriptPath, source, "utf8");
+  if (process.platform === "win32") {
+    await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`, "utf8");
+    return cliPath;
+  }
+  await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} "$@"\n`, "utf8");
+  await chmod(cliPath, 0o755);
+  return cliPath;
+}
+
 test("hook output keeps CodeStory ambient and checks MCP before CLI fallback", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
@@ -881,6 +910,152 @@ test("hook output keeps CodeStory ambient and checks MCP before CLI fallback", a
     });
   } finally {
     await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("hook degraded output is short when no MCP or managed runtime is usable", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-degraded-"));
+  const pathDir = await mkdtemp(join(tmpdir(), "codestory-hook-path-"));
+
+  try {
+    await writeNodeCli(pathDir, "console.log('FAKE_CODESTORY_CLI');");
+    await withTempHookInstall(async (installRoot) => {
+      const result = spawnSync(process.execPath, [join(installRoot, "hooks", "codestory-activate.cjs")], {
+        env: {
+          ...process.env,
+          COPILOT_PLUGIN_DATA: "",
+          PLUGIN_DATA: dataDir,
+          PATH: pathDir,
+          ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+        },
+        input: JSON.stringify({
+          hook_event_name: "UserPromptSubmit",
+          prompt: "Find the hook failure.",
+          cwd: repoRoot,
+        }),
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
+      assert.match(context, /CodeStory degraded mode: no MCP or managed runtime surface is usable/u);
+      assert.match(context, /First failing layer: MCP: no codestory server configured/u);
+      assert.doesNotMatch(context, /CODESTORY BACKGROUND GROUNDING/u);
+      assert.doesNotMatch(context, /FAKE_CODESTORY_CLI/u);
+      assert.ok(context.length < 1600, context);
+    });
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(pathDir, { recursive: true, force: true });
+  }
+});
+
+test("hook failed preflight switches degraded guidance to bounded source fallback", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-bin-"));
+
+  try {
+    const cliPath = await writeNodeCli(
+      binDir,
+      "process.stderr.write('first preflight failed\\n' + 'x'.repeat(8000));process.exit(2);",
+    );
+    await withTempHookInstall(async (installRoot) => {
+      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
+      const first = spawnSync(process.execPath, [hookPath], {
+        env: {
+          ...process.env,
+          CODESTORY_CLI: cliPath,
+          COPILOT_PLUGIN_DATA: "",
+          PLUGIN_DATA: dataDir,
+        },
+        input: JSON.stringify({
+          hook_event_name: "UserPromptSubmit",
+          prompt: "Find the hook failure.",
+          cwd: repoRoot,
+        }),
+        encoding: "utf8",
+      });
+
+      assert.equal(first.status, 0, first.stderr);
+      const firstContext = JSON.parse(first.stdout).hookSpecificOutput.additionalContext;
+      assert.match(firstContext, /Reason: first preflight failed/u);
+      assert.match(firstContext, /CodeStory is unavailable for this session/u);
+      assert.match(firstContext, /hook output truncated by hook budget/u);
+      assert.doesNotMatch(firstContext, /CODESTORY BACKGROUND GROUNDING/u);
+      assert.ok(firstContext.length < 5600, firstContext);
+
+      const second = spawnSync(process.execPath, [hookPath], {
+        env: {
+          ...process.env,
+          CODESTORY_CLI: "",
+          COPILOT_PLUGIN_DATA: "",
+          PLUGIN_DATA: dataDir,
+        },
+        input: JSON.stringify({
+          hook_event_name: "SessionStart",
+          source: "resume",
+          cwd: repoRoot,
+        }),
+        encoding: "utf8",
+      });
+
+      assert.equal(second.status, 0, second.stderr);
+      const secondContext = JSON.parse(second.stdout).hookSpecificOutput.additionalContext;
+      assert.match(secondContext, /CodeStory is unavailable for this session/u);
+      assert.match(secondContext, /bounded source reads/u);
+      assert.doesNotMatch(secondContext, /repair archaeology/u);
+    });
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  }
+});
+
+test("hook dedupes repeated request grounding instructions within plugin state", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-dedupe-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-dedupe-bin-"));
+
+  try {
+    const cliPath = await writeNodeCli(binDir, "console.log('packet ok');");
+    await withTempHookInstall(async (installRoot) => {
+      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
+      const env = {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        COPILOT_PLUGIN_DATA: "",
+        PLUGIN_DATA: dataDir,
+      };
+      const input = JSON.stringify({
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Where is RefreshMode defined?",
+        cwd: repoRoot,
+      });
+      const first = spawnSync(process.execPath, [hookPath], {
+        env,
+        input,
+        encoding: "utf8",
+      });
+      const second = spawnSync(process.execPath, [hookPath], {
+        env,
+        input,
+        encoding: "utf8",
+      });
+
+      assert.equal(first.status, 0, first.stderr);
+      assert.equal(second.status, 0, second.stderr);
+      const firstContext = JSON.parse(first.stdout).hookSpecificOutput.additionalContext;
+      const secondContext = JSON.parse(second.stdout).hookSpecificOutput.additionalContext;
+      assert.match(firstContext, /CODESTORY BACKGROUND GROUNDING ACTIVE/u);
+      assert.doesNotMatch(secondContext, /CODESTORY BACKGROUND GROUNDING ACTIVE/u);
+      assert.match(secondContext, /CODESTORY HOOK REQUEST PACKET/u);
+      assert.match(secondContext, /packet ok/u);
+    });
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
   }
 });
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1059,6 +1059,65 @@ test("hook dedupes repeated request grounding instructions within plugin state",
   }
 });
 
+test("hook resets instruction dedupe on fresh startup session boundary", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-startup-dedupe-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-startup-dedupe-bin-"));
+
+  try {
+    const cliPath = await writeNodeCli(binDir, "console.log('ground ok');");
+    await withTempHookInstall(async (installRoot) => {
+      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
+      const env = {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        COPILOT_PLUGIN_DATA: "",
+        PLUGIN_DATA: dataDir,
+      };
+      const startupInput = JSON.stringify({
+        hook_event_name: "SessionStart",
+        source: "startup",
+        cwd: repoRoot,
+      });
+      const resumeInput = JSON.stringify({
+        hook_event_name: "SessionStart",
+        source: "resume",
+        cwd: repoRoot,
+      });
+      const firstStartup = spawnSync(process.execPath, [hookPath], {
+        env,
+        input: startupInput,
+        encoding: "utf8",
+      });
+      const resume = spawnSync(process.execPath, [hookPath], {
+        env,
+        input: resumeInput,
+        encoding: "utf8",
+      });
+      const secondStartup = spawnSync(process.execPath, [hookPath], {
+        env,
+        input: startupInput,
+        encoding: "utf8",
+      });
+
+      assert.equal(firstStartup.status, 0, firstStartup.stderr);
+      assert.equal(resume.status, 0, resume.stderr);
+      assert.equal(secondStartup.status, 0, secondStartup.stderr);
+      const firstContext = JSON.parse(firstStartup.stdout).hookSpecificOutput.additionalContext;
+      const resumeContext = JSON.parse(resume.stdout).hookSpecificOutput.additionalContext;
+      const secondContext = JSON.parse(secondStartup.stdout).hookSpecificOutput.additionalContext;
+      const fullInstructions = /CODESTORY BACKGROUND GROUNDING (?:ACTIVE|RULES)/u;
+      assert.match(firstContext, fullInstructions);
+      assert.doesNotMatch(resumeContext, fullInstructions);
+      assert.match(secondContext, fullInstructions);
+      assert.match(secondContext, /ground ok/u);
+    });
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  }
+});
+
 test("hook MCP classifier distinguishes configured launchable and model-visible states", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-classify-"));
   const version = await readPluginVersion();


### PR DESCRIPTION
## Context
Closes #551.

Ambient CodeStory hooks were noisy when MCP and managed runtime surfaces were unavailable. The first actionable failure could be buried behind repeated grounding playbook text, and failed preflight guidance could send agents back into setup archaeology.

## What Changed
- Added short degraded-mode hook notices for missing MCP/managed runtime surfaces and failed explicit preflights.
- Avoided implicit PATH fallback from hooks; they now use MCP detection, managed runtime state, or explicit `CODESTORY_CLI` only.
- Reused the existing plugin-data state file to dedupe repeated full instruction injection and remember a failed preflight.
- Lowered the hook output cap and added static regressions for no-runtime, failed-preflight, dedupe, and oversized output behavior.

## How To Review
- Review `plugins/codestory/hooks/codestory-activate.cjs` for the degraded-mode branch and output shape.
- Review `plugins/codestory/hooks/codestory-runtime.cjs` for the state merge/read helper.
- Review `plugins/codestory/tests/plugin-static.test.mjs` for the temp hook install regressions.

## Verification
- `node --test plugins/codestory/tests/plugin-static.test.mjs` (25 passed)

## Risk
- Hook state remains best-effort and plugin-data scoped; hosts without plugin data stay stateless.
- This does not touch `plugins/codestory/scripts/codestory-mcp.cjs` or retrieval ranking.