### PR TITLE
[codex] Expose local refresh status

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1547,6 +1547,7 @@ pub(crate) struct AgentPreflightOutput {
     pub(crate) usable: bool,
     pub(crate) mode: String,
     pub(crate) local_graph: AgentPreflightLaneOutput,
+    pub(crate) local_refresh: crate::readiness::LocalRefreshOutput,
     pub(crate) full_retrieval: AgentPreflightLaneOutput,
     pub(crate) local_default: ReadinessLaneOutput,
     pub(crate) agent_packet_search: ReadinessLaneOutput,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2160,6 +2160,7 @@ fn build_agent_preflight_output(
         usable: local_ready || full_ready,
         mode: mode.to_string(),
         local_graph: agent_preflight_lane(local),
+        local_refresh: readiness::local_refresh_output(local),
         full_retrieval: agent_preflight_lane(agent),
         local_default: readiness_lanes
             .get("local_default")
@@ -2220,6 +2221,11 @@ fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> Strin
         markdown,
         "local_graph: {}",
         readiness::status_label(output.local_graph.status)
+    );
+    let _ = writeln!(
+        markdown,
+        "local_refresh: {}",
+        readiness::local_refresh_state_label(output.local_refresh.state)
     );
     if let Some(layer) = output.local_graph.failed_layer {
         let _ = writeln!(markdown, "local_graph_failed_layer: `{layer}`");

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -299,16 +299,18 @@ fn verdict_state(
     }
 
     if goal == ReadinessGoalDto::AgentPacketSearch {
+        let sidecar_profile = sidecar.and_then(|sidecar| sidecar.profile);
         let sidecar_mode = sidecar
             .map(|sidecar| sidecar.retrieval_mode)
             .unwrap_or("unavailable");
-        if sidecar_mode != "full" {
+        if sidecar_mode != "full" || sidecar_profile != Some("agent") {
             let full_repair = agent_packet_search_repair_commands(project_arg);
             let minimum_next = full_repair.iter().take(1).cloned().collect();
             return (
                 ReadinessStatusDto::RepairRetrieval,
                 format!(
-                    "Agent packet/search needs full sidecar retrieval; current mode is `{sidecar_mode}`."
+                    "Agent packet/search needs full agent sidecar retrieval; current profile is `{}` and mode is `{sidecar_mode}`.",
+                    sidecar_profile.unwrap_or("unknown")
                 ),
                 minimum_next,
                 full_repair,
@@ -630,8 +632,8 @@ mod tests {
             &stats,
             Some(&freshness),
             Some(ReadinessSidecarInput {
-                profile: Some("local"),
-                run_id: None,
+                profile: Some("agent"),
+                run_id: Some("run"),
                 retrieval_mode: "full",
                 degraded_reason: None,
                 manifest_generation: Some("generation"),
@@ -763,7 +765,7 @@ mod tests {
         assert!(
             unavailable
                 .summary
-                .contains("current mode is `unavailable`")
+                .contains("current profile is `unknown` and mode is `unavailable`")
         );
         assert!(unavailable.sidecar.is_none());
 
@@ -774,6 +776,28 @@ mod tests {
         let refresh = local_refresh_output(&local);
         assert_eq!(refresh.state, LocalRefreshState::Fresh);
         assert!(!refresh.blocks_local_surfaces);
+
+        let local_full = build_readiness_verdict(
+            ReadinessGoalDto::AgentPacketSearch,
+            inputs(
+                &stats,
+                Some(&freshness),
+                Some(ReadinessSidecarInput {
+                    profile: Some("local"),
+                    run_id: None,
+                    retrieval_mode: "full",
+                    degraded_reason: None,
+                    manifest_generation: Some("generation"),
+                    manifest_input_hash: Some("hash"),
+                }),
+            ),
+        );
+
+        assert_eq!(local_full.status, ReadinessStatusDto::RepairRetrieval);
+        assert!(
+            local_full.summary.contains("current profile is `local`"),
+            "local/default full retrieval must not unlock agent packet/search: {local_full:?}"
+        );
 
         let degraded = build_readiness_verdict(
             ReadinessGoalDto::AgentPacketSearch,

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -3,6 +3,7 @@ use codestory_contracts::api::{
     ReadinessSetupSnapshotDto, ReadinessSidecarSnapshotDto, ReadinessStatusDto,
     ReadinessVerdictDto, StorageStatsDto,
 };
+use serde::Serialize;
 
 use crate::display::{clean_path_string, quote_command_argument_value};
 
@@ -32,6 +33,36 @@ pub(crate) struct ReadinessSidecarInput<'a> {
     pub(crate) degraded_reason: Option<&'a str>,
     pub(crate) manifest_generation: Option<&'a str>,
     pub(crate) manifest_input_hash: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LocalRefreshState {
+    Fresh,
+    Stale,
+    NotChecked,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct LocalRefreshOutput {
+    pub(crate) state: LocalRefreshState,
+    pub(crate) blocks_local_surfaces: bool,
+    pub(crate) readiness_status: ReadinessStatusDto,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reason: Option<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub(crate) changed_file_count: u32,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub(crate) new_file_count: u32,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub(crate) removed_file_count: u32,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub(crate) fatal_error_count: u32,
+}
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 pub(crate) fn build_readiness_verdicts(inputs: ReadinessInputs<'_>) -> Vec<ReadinessVerdictDto> {
@@ -120,6 +151,54 @@ pub(crate) fn goal_label(goal: ReadinessGoalDto) -> &'static str {
     }
 }
 
+pub(crate) fn local_refresh_state_label(state: LocalRefreshState) -> &'static str {
+    match state {
+        LocalRefreshState::Fresh => "fresh",
+        LocalRefreshState::Stale => "stale",
+        LocalRefreshState::NotChecked => "not_checked",
+        LocalRefreshState::Failed => "failed",
+    }
+}
+
+pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefreshOutput {
+    let index = verdict.index.as_ref();
+    let state = match verdict.status {
+        ReadinessStatusDto::Ready | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Fresh,
+        ReadinessStatusDto::CheckIndex => LocalRefreshState::NotChecked,
+        ReadinessStatusDto::RepairSetup => LocalRefreshState::Failed,
+        ReadinessStatusDto::RepairIndex => {
+            if index.and_then(|index| index.status) == Some(IndexFreshnessStatusDto::Stale) {
+                LocalRefreshState::Stale
+            } else {
+                LocalRefreshState::Failed
+            }
+        }
+    };
+    let reason = match state {
+        LocalRefreshState::Fresh => None,
+        LocalRefreshState::Stale => Some("index_changed".to_string()),
+        LocalRefreshState::NotChecked => Some("freshness_not_checked".to_string()),
+        LocalRefreshState::Failed => Some(verdict.summary.clone()),
+    };
+
+    LocalRefreshOutput {
+        state,
+        blocks_local_surfaces: verdict.status != ReadinessStatusDto::Ready,
+        readiness_status: verdict.status,
+        reason,
+        changed_file_count: index
+            .map(|index| index.changed_file_count)
+            .unwrap_or_default(),
+        new_file_count: index.map(|index| index.new_file_count).unwrap_or_default(),
+        removed_file_count: index
+            .map(|index| index.removed_file_count)
+            .unwrap_or_default(),
+        fatal_error_count: index
+            .map(|index| index.fatal_error_count)
+            .unwrap_or_default(),
+    }
+}
+
 fn verdict_state(
     goal: ReadinessGoalDto,
     setup: Option<&ReadinessSetupInput>,
@@ -173,48 +252,50 @@ fn verdict_state(
         );
     }
 
-    if stats.node_count == 0 {
-        return index_repair_state(goal, "No indexed symbols are available yet.", project_arg);
-    }
+    if goal == ReadinessGoalDto::LocalNavigation {
+        if stats.node_count == 0 {
+            return index_repair_state(goal, "No indexed symbols are available yet.", project_arg);
+        }
 
-    if stats.fatal_error_count > 0 {
-        let plural = if stats.fatal_error_count == 1 {
-            ""
-        } else {
-            "s"
-        };
-        return index_repair_state(
-            goal,
-            &format!(
-                "The index recorded {} fatal indexing error{plural}.",
-                stats.fatal_error_count
-            ),
-            project_arg,
-        );
-    }
-
-    match freshness.map(|freshness| freshness.status) {
-        Some(IndexFreshnessStatusDto::Stale) => {
+        if stats.fatal_error_count > 0 {
+            let plural = if stats.fatal_error_count == 1 {
+                ""
+            } else {
+                "s"
+            };
             return index_repair_state(
                 goal,
-                "The index has changed, new, or removed files.",
+                &format!(
+                    "The index recorded {} fatal indexing error{plural}.",
+                    stats.fatal_error_count
+                ),
                 project_arg,
             );
         }
-        Some(IndexFreshnessStatusDto::NotChecked) => {
-            let command =
-                format!("codestory-cli index --project {project_arg} --refresh incremental");
-            return (
-                ReadinessStatusDto::CheckIndex,
-                "Index drift was not checked for this cache view.".to_string(),
-                vec![command.clone()],
-                vec![
-                    command,
-                    format!("codestory-cli doctor --project {project_arg}"),
-                ],
-            );
+
+        match freshness.map(|freshness| freshness.status) {
+            Some(IndexFreshnessStatusDto::Stale) => {
+                return index_repair_state(
+                    goal,
+                    "The index has changed, new, or removed files.",
+                    project_arg,
+                );
+            }
+            Some(IndexFreshnessStatusDto::NotChecked) => {
+                let command =
+                    format!("codestory-cli index --project {project_arg} --refresh incremental");
+                return (
+                    ReadinessStatusDto::CheckIndex,
+                    "Index drift was not checked for this cache view.".to_string(),
+                    vec![command.clone()],
+                    vec![
+                        command,
+                        format!("codestory-cli doctor --project {project_arg}"),
+                    ],
+                );
+            }
+            Some(IndexFreshnessStatusDto::Fresh) | None => {}
         }
-        Some(IndexFreshnessStatusDto::Fresh) | None => {}
     }
 
     if goal == ReadinessGoalDto::AgentPacketSearch {
@@ -222,13 +303,7 @@ fn verdict_state(
             .map(|sidecar| sidecar.retrieval_mode)
             .unwrap_or("unavailable");
         if sidecar_mode != "full" {
-            let full_repair = agent_packet_search_repair_commands(
-                project_arg,
-                !matches!(
-                    freshness.map(|freshness| freshness.status),
-                    Some(IndexFreshnessStatusDto::Fresh)
-                ),
-            );
+            let full_repair = agent_packet_search_repair_commands(project_arg);
             let minimum_next = full_repair.iter().take(1).cloned().collect();
             return (
                 ReadinessStatusDto::RepairRetrieval,
@@ -278,15 +353,12 @@ fn ready_summary_with_errors(base: &str, stats: &StorageStatsDto) -> String {
     }
 }
 
-fn agent_packet_search_repair_commands(project_arg: &str, include_core_index: bool) -> Vec<String> {
+fn agent_packet_search_repair_commands(project_arg: &str) -> Vec<String> {
     let mut commands = Vec::new();
     commands.push(ready_repair_command(
         ReadinessGoalDto::AgentPacketSearch,
         project_arg,
     ));
-    if include_core_index {
-        commands.push(format!("codestory-cli doctor --project {project_arg}"));
-    }
     commands.extend([
         format!("codestory-cli retrieval status --project {project_arg} --format json"),
         format!("codestory-cli doctor --project {project_arg} --format markdown"),
@@ -433,16 +505,16 @@ mod tests {
     }
 
     #[test]
-    fn missing_index_requires_index_repair_for_all_goals() {
+    fn missing_index_blocks_local_graph_only() {
         let stats = stats(0);
         let verdicts = build_readiness_verdicts(inputs(&stats, None, None));
 
         assert_eq!(verdicts.len(), 2);
-        assert!(
-            verdicts
-                .iter()
-                .all(|verdict| verdict.status == ReadinessStatusDto::RepairIndex),
-            "missing index should block all readiness goals: {verdicts:?}"
+        assert_eq!(verdicts[0].status, ReadinessStatusDto::RepairIndex);
+        assert_eq!(
+            verdicts[1].status,
+            ReadinessStatusDto::RepairRetrieval,
+            "missing local index should not collapse agent retrieval readiness: {verdicts:?}"
         );
         assert!(
             verdicts[0].minimum_next[0].contains("ready --goal local --repair"),
@@ -567,24 +639,24 @@ mod tests {
             }),
         ));
 
-        assert!(
-            verdicts
-                .iter()
-                .all(|verdict| verdict.status == ReadinessStatusDto::RepairIndex),
-            "fatal index errors should block all readiness goals: {verdicts:?}"
+        assert_eq!(verdicts[0].status, ReadinessStatusDto::RepairIndex);
+        assert_eq!(
+            verdicts[1].status,
+            ReadinessStatusDto::Ready,
+            "fatal local index errors should not block full sidecar retrieval readiness: {verdicts:?}"
         );
         assert!(
-            verdicts
-                .iter()
-                .all(|verdict| verdict.summary.contains("2 fatal indexing errors")),
-            "readiness should explain the recorded fatal index errors: {verdicts:?}"
+            verdicts[0].summary.contains("2 fatal indexing errors"),
+            "local readiness should explain the recorded fatal index errors: {verdicts:?}"
         );
         assert!(
-            verdicts
-                .iter()
-                .all(|verdict| verdict.minimum_next[0].contains("ready --goal")),
+            verdicts[0].minimum_next[0].contains("ready --goal"),
             "error-bearing indexes should request a full refresh repair: {verdicts:?}"
         );
+        let refresh = local_refresh_output(&verdicts[0]);
+        assert_eq!(refresh.state, LocalRefreshState::Failed);
+        assert!(refresh.blocks_local_surfaces);
+        assert_eq!(refresh.fatal_error_count, 2);
     }
 
     #[test]
@@ -598,6 +670,10 @@ mod tests {
         );
 
         assert_eq!(verdict.status, ReadinessStatusDto::Ready);
+        assert_eq!(
+            local_refresh_output(&verdict).state,
+            LocalRefreshState::Fresh
+        );
         assert!(
             verdict.summary.contains("2 nonfatal indexing errors"),
             "nonfatal errors should be visible without blocking local navigation: {verdict:?}"
@@ -622,6 +698,9 @@ mod tests {
         );
 
         assert_eq!(verdict.status, ReadinessStatusDto::CheckIndex);
+        let refresh = local_refresh_output(&verdict);
+        assert_eq!(refresh.state, LocalRefreshState::NotChecked);
+        assert!(refresh.blocks_local_surfaces);
         assert_eq!(
             verdict.index.as_ref().and_then(|index| index.status),
             Some(IndexFreshnessStatusDto::NotChecked)
@@ -634,6 +713,22 @@ mod tests {
         let stats = stats(3);
         let freshness = freshness(IndexFreshnessStatusDto::Stale);
         let verdict = build_readiness_verdict(
+            ReadinessGoalDto::LocalNavigation,
+            inputs(&stats, Some(&freshness), None),
+        );
+
+        assert_eq!(verdict.status, ReadinessStatusDto::RepairIndex);
+        let refresh = local_refresh_output(&verdict);
+        assert_eq!(refresh.state, LocalRefreshState::Stale);
+        assert!(refresh.blocks_local_surfaces);
+        assert_eq!(refresh.changed_file_count, 1);
+        assert!(
+            verdict.minimum_next[0].contains("ready --goal local --repair"),
+            "stale index repair should point at the one-command repair path: {verdict:?}"
+        );
+        assert!(verdict.summary.contains("changed, new, or removed files"));
+
+        let agent = build_readiness_verdict(
             ReadinessGoalDto::AgentPacketSearch,
             inputs(
                 &stats,
@@ -648,13 +743,11 @@ mod tests {
                 }),
             ),
         );
-
-        assert_eq!(verdict.status, ReadinessStatusDto::RepairIndex);
-        assert!(
-            verdict.minimum_next[0].contains("ready --goal agent --repair"),
-            "stale index repair should point at the one-command repair path: {verdict:?}"
+        assert_eq!(
+            agent.status,
+            ReadinessStatusDto::Ready,
+            "stale local graph should not block full sidecar packet/search readiness: {agent:?}"
         );
-        assert!(verdict.summary.contains("changed, new, or removed files"));
     }
 
     #[test]
@@ -673,6 +766,14 @@ mod tests {
                 .contains("current mode is `unavailable`")
         );
         assert!(unavailable.sidecar.is_none());
+
+        let local = build_readiness_verdict(
+            ReadinessGoalDto::LocalNavigation,
+            inputs(&stats, Some(&freshness), None),
+        );
+        let refresh = local_refresh_output(&local);
+        assert_eq!(refresh.state, LocalRefreshState::Fresh);
+        assert!(!refresh.blocks_local_surfaces);
 
         let degraded = build_readiness_verdict(
             ReadinessGoalDto::AgentPacketSearch,
@@ -761,7 +862,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_readiness_keeps_core_index_repair_when_freshness_is_unknown() {
+    fn agent_readiness_uses_sidecar_gate_when_freshness_is_unknown() {
         let stats = stats(3);
         let verdict = build_readiness_verdict(
             ReadinessGoalDto::AgentPacketSearch,
@@ -785,7 +886,14 @@ mod tests {
                 .full_repair
                 .first()
                 .is_some_and(|command| command.contains("ready --goal agent --repair")),
-            "unknown freshness should keep the conservative agent repair path: {verdict:?}"
+            "agent readiness should keep the agent sidecar repair path: {verdict:?}"
+        );
+        assert!(
+            !verdict
+                .full_repair
+                .iter()
+                .any(|command| command == "codestory-cli doctor --project C:/workspace/project"),
+            "unknown local freshness should not inject local graph repair into agent readiness: {verdict:?}"
         );
     }
 }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2131,6 +2131,10 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
     let allowed_surfaces = stdio_allowed_surfaces(&readiness);
     let readiness_lanes = crate::build_readiness_lanes_for_runtime(runtime, &readiness);
     let recommended_next_calls = stdio_status_recommended_next_calls(&readiness, &sidecar_setup);
+    let local = readiness
+        .iter()
+        .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation)
+        .expect("local_navigation readiness verdict");
     Ok(serde_json::json!({
         "server_version": env!("CARGO_PKG_VERSION"),
         "cli_version": env!("CARGO_PKG_VERSION"),
@@ -2161,6 +2165,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
             "diagnostic_only": true
         },
         "index_freshness": summary.freshness,
+        "local_refresh": crate::readiness::local_refresh_output(local),
         "readiness": readiness,
         "readiness_lanes": readiness_lanes,
         "allowed_surfaces": allowed_surfaces,

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3167,6 +3167,49 @@ version = "0.11.20"
     }
 
     #[test]
+    fn stdio_blocks_agent_surfaces_when_only_local_sidecar_is_full() {
+        let stats = codestory_contracts::api::StorageStatsDto {
+            file_count: 1,
+            node_count: 1,
+            edge_count: 0,
+            error_count: 0,
+            fatal_error_count: 0,
+        };
+        let readiness =
+            crate::readiness::build_readiness_verdicts(crate::readiness::ReadinessInputs {
+                project: "C:/repo/example",
+                stats: &stats,
+                freshness: None,
+                setup: None,
+                sidecar: Some(crate::readiness::ReadinessSidecarInput {
+                    profile: Some("local"),
+                    run_id: None,
+                    retrieval_mode: "full",
+                    degraded_reason: None,
+                    manifest_generation: Some("generation"),
+                    manifest_input_hash: Some("hash"),
+                }),
+            });
+
+        let surfaces = stdio_allowed_surfaces(&readiness);
+
+        assert_eq!(surfaces["ground"]["allowed"], json!(true));
+        assert_eq!(surfaces["files"]["allowed"], json!(true));
+        for surface in ["packet", "search", "context"] {
+            assert_eq!(
+                surfaces[surface]["allowed"],
+                json!(false),
+                "local/default full sidecar must not unlock {surface}: {surfaces}"
+            );
+            assert_eq!(
+                surfaces[surface]["status"],
+                json!("repair_retrieval"),
+                "blocked agent surface should stay on the agent retrieval lane: {surfaces}"
+            );
+        }
+    }
+
+    #[test]
     fn stdio_tool_call_success_keeps_packet_timing_out_of_structured_content() {
         let mut packet = json!({
             "packet_id": "packet-1",

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -646,14 +646,15 @@ fn doctor_next_commands_stop_at_index_repair_when_inventory_is_stale() {
     let next_commands = doctor_next_commands(&doctor);
     let joined = next_commands.join("\n");
     assert!(
-        joined.contains("codestory-cli index")
-            && joined.contains("--refresh incremental")
+        joined.contains("codestory-cli ready --goal local --repair")
             && joined.contains("codestory-cli doctor"),
-        "stale doctor should recommend index repair then doctor recheck: {doctor:#}"
+        "stale doctor should recommend local graph repair then doctor recheck: {doctor:#}"
     );
     assert!(
-        !joined.contains("retrieval status") && !joined.contains("retrieval index"),
-        "stale doctor should stop before retrieval repair commands: {doctor:#}"
+        !joined.contains("ready --goal agent --repair")
+            && !joined.contains("retrieval status")
+            && !joined.contains("retrieval index"),
+        "stale doctor next_commands should stop before agent retrieval repair commands: {doctor:#}"
     );
     assert_no_agent_proof_commands(&next_commands, "stale doctor");
 
@@ -670,9 +671,10 @@ fn doctor_next_commands_stop_at_index_repair_when_inventory_is_stale() {
     );
     let markdown = String::from_utf8_lossy(&markdown.stdout);
     assert!(
-        markdown
-            .contains("readiness: local_navigation=repair_index agent_packet_search=repair_index"),
-        "doctor markdown should show split readiness with index repair first:\n{markdown}"
+        markdown.contains(
+            "readiness: local_navigation=repair_index agent_packet_search=repair_retrieval"
+        ),
+        "doctor markdown should show local index repair without collapsing agent retrieval readiness:\n{markdown}"
     );
 }
 
@@ -798,6 +800,14 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
     assert_eq!(preflight["usable"], true, "{preflight:#}");
     assert_eq!(preflight["mode"], "local_graph", "{preflight:#}");
     assert_eq!(preflight["local_graph"]["ready"], true, "{preflight:#}");
+    assert_eq!(
+        preflight["local_refresh"]["state"], "fresh",
+        "{preflight:#}"
+    );
+    assert_eq!(
+        preflight["local_refresh"]["blocks_local_surfaces"], false,
+        "{preflight:#}"
+    );
     assert_eq!(
         preflight["full_retrieval"]["status"], "repair_retrieval",
         "{preflight:#}"

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1470,7 +1470,7 @@ fn assert_sidecar_failure_output(output: std::process::Output) {
     );
     assert!(
         failure.contains("sidecar retrieval")
-            && (failure.contains("expected mode=full")
+            && (failure.contains("expected profile=agent mode=full")
                 || failure.contains("retrieval_manifest_missing")),
         "command should explain the mandatory sidecar gate, got: {failure}"
     );

--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -281,8 +281,8 @@ fn search_json_fails_closed_without_full_sidecars() {
     assert!(
         stderr.contains(
             "retrieval_unavailable: sidecar retrieval primary is unavailable or degraded"
-        ) && stderr.contains("expected mode=full"),
-        "search should report mandatory sidecar full-mode boundary: {stderr}"
+        ) && stderr.contains("expected profile=agent mode=full"),
+        "search should report mandatory agent sidecar full-mode boundary: {stderr}"
     );
     assert!(
         stderr.contains("Minimum next:")

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2088,6 +2088,16 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         status["retrieval_mode"], "full",
         "hash-mode indexed fixture must not report mandatory sidecar retrieval as full: {status}"
     );
+    assert_eq!(
+        status["local_refresh"]["state"],
+        json!("fresh"),
+        "fresh local graph state should be explicit even when sidecar retrieval is unavailable: {status}"
+    );
+    assert_eq!(
+        status["local_refresh"]["blocks_local_surfaces"],
+        json!(false),
+        "fresh local graph state should not block local graph surfaces: {status}"
+    );
     assert!(
         status["sidecar_retrieval"]["retrieval_mode"].is_string(),
         "status should expose sidecar retrieval diagnostics: {status}"
@@ -2151,7 +2161,9 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         "agent lane must not collapse to local when no agent run exists: {status}"
     );
     assert!(
-        agent_lane["run_id"].as_str().is_some_and(|run_id| !run_id.is_empty()),
+        agent_lane["run_id"]
+            .as_str()
+            .is_some_and(|run_id| !run_id.is_empty()),
         "agent lane should report a non-empty agent run id: {status}"
     );
     assert!(
@@ -2479,6 +2491,26 @@ fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
     }
 
     assert_stale_freshness_counts(&last_status, "codestory://status");
+    assert_eq!(
+        last_status["local_refresh"]["state"],
+        json!("stale"),
+        "stale local graph state should be compactly exposed: {last_status}"
+    );
+    assert_eq!(
+        last_status["local_refresh"]["blocks_local_surfaces"],
+        json!(true),
+        "stale local graph state should block only local graph surfaces: {last_status}"
+    );
+    assert_eq!(
+        last_status["allowed_surfaces"]["ground"]["allowed"],
+        json!(false),
+        "stale local graph should block local graph surfaces: {last_status}"
+    );
+    assert_eq!(
+        last_status["allowed_surfaces"]["packet"]["status"],
+        json!("repair_retrieval"),
+        "packet/search should stay gated by the agent retrieval lane while local graph is stale: {last_status}"
+    );
     let status_next_call_text = last_status["recommended_next_calls"].to_string();
     assert!(
         !status_next_call_text.contains("\"tool\":\"packet\"")

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -68,9 +68,9 @@ fn shadow_env_enabled() -> Option<bool> {
 
 /// Whether sidecar retrieval should serve packet/agent results.
 ///
-/// - `CODESTORY_RETRIEVAL=1` forces a sidecar-primary attempt when live mode is `full`.
+/// - `CODESTORY_RETRIEVAL=1` forces a sidecar-primary attempt when the agent sidecar is `full`.
 /// - `CODESTORY_RETRIEVAL=0` is unsupported; packet paths fail closed.
-/// - Unset: sidecar primary when the manifest exists and all sidecars are healthy.
+/// - Unset: sidecar primary when the manifest exists and the agent sidecar is healthy.
 pub(crate) fn sidecar_retrieval_primary_enabled(controller: &AppController) -> bool {
     match retrieval_env_override() {
         Some(false) => {
@@ -81,11 +81,13 @@ pub(crate) fn sidecar_retrieval_primary_enabled(controller: &AppController) -> b
             sidecar_retrieval_eligible(controller) && sidecar_mode_is_required_full(controller)
         }
         None => {
-            // Default product path: sidecar primary when live local state is strong enough to serve.
+            // Default product path: sidecar primary only from full agent-scoped retrieval.
             let auto_on =
                 sidecar_retrieval_eligible(controller) && sidecar_mode_is_required_full(controller);
             if auto_on {
-                tracing::info!("retrieval primary auto-on (unset CODESTORY_RETRIEVAL; mode full)");
+                tracing::info!(
+                    "retrieval primary auto-on (unset CODESTORY_RETRIEVAL; agent sidecar full)"
+                );
             }
             auto_on
         }
@@ -110,8 +112,9 @@ pub(crate) fn sidecar_retrieval_unavailable_reason(controller: &AppController) -
         .degraded_reason
         .map(|reason| format!("; reason={reason}"))
         .unwrap_or_default();
+    let profile = status.profile.as_deref().unwrap_or("unknown");
     Some(format!(
-        "sidecar retrieval primary is unavailable or degraded (mode={}); expected mode=full{reason}",
+        "sidecar retrieval primary is unavailable or degraded (profile={profile} mode={}); expected profile=agent mode=full{reason}",
         status.mode
     ))
 }
@@ -219,17 +222,23 @@ fn sidecar_mode_is_required_full(controller: &AppController) -> bool {
     let Ok(storage_path) = controller.require_storage_path() else {
         return false;
     };
-    sidecar_mode_can_serve_primary(
-        &sidecar_mode_status_for_project(&project_root, &storage_path).mode,
-    )
+    sidecar_status_can_serve_primary(&sidecar_mode_status_for_project(
+        &project_root,
+        &storage_path,
+    ))
 }
 
 fn sidecar_mode_can_serve_primary(mode: &str) -> bool {
     mode == "full"
 }
 
+fn sidecar_status_can_serve_primary(status: &SidecarModeStatus) -> bool {
+    status.profile.as_deref() == Some("agent") && sidecar_mode_can_serve_primary(&status.mode)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SidecarModeStatus {
+    profile: Option<String>,
     mode: String,
     degraded_reason: Option<String>,
 }
@@ -237,10 +246,15 @@ struct SidecarModeStatus {
 fn sidecar_mode_status_for_project(project_root: &Path, storage_path: &Path) -> SidecarModeStatus {
     match strict_sidecar_status(project_root, Some(storage_path)) {
         Ok(report) => SidecarModeStatus {
+            profile: report
+                .ownership
+                .as_ref()
+                .map(|ownership| ownership.profile.clone()),
             mode: report.retrieval_mode,
             degraded_reason: report.degraded_reason,
         },
         Err(error) => SidecarModeStatus {
+            profile: None,
             mode: "unavailable".into(),
             degraded_reason: Some(format!("sidecar_status_error: {error}")),
         },
@@ -1980,6 +1994,32 @@ mod tests {
         assert!(!sidecar_mode_can_serve_primary("no_semantic"));
         assert!(!sidecar_mode_can_serve_primary("lexical_only"));
         assert!(!sidecar_mode_can_serve_primary("unavailable"));
+    }
+
+    #[test]
+    fn sidecar_primary_requires_agent_profile_even_when_local_mode_is_full() {
+        let local_full = SidecarModeStatus {
+            profile: Some("local".into()),
+            mode: "full".into(),
+            degraded_reason: None,
+        };
+        let agent_full = SidecarModeStatus {
+            profile: Some("agent".into()),
+            mode: "full".into(),
+            degraded_reason: None,
+        };
+        let missing_profile_full = SidecarModeStatus {
+            profile: None,
+            mode: "full".into(),
+            degraded_reason: None,
+        };
+
+        assert!(
+            !sidecar_status_can_serve_primary(&local_full),
+            "local/default full sidecar must not serve packet/search/context primary retrieval"
+        );
+        assert!(sidecar_status_can_serve_primary(&agent_full));
+        assert!(!sidecar_status_can_serve_primary(&missing_profile_full));
     }
 
     #[test]

--- a/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
+++ b/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
@@ -280,8 +280,8 @@ fn assert_mandatory_sidecar_unavailable(error: &ApiError) {
         "error should name mandatory sidecar unavailability: {error:?}"
     );
     assert!(
-        error.message.contains("expected mode=full"),
-        "error should name the full-mode requirement: {error:?}"
+        error.message.contains("expected profile=agent mode=full"),
+        "error should name the agent full-mode requirement: {error:?}"
     );
     let details = error.details.as_ref().expect("retrieval error details");
     assert_eq!(details.failed_layer.as_deref(), Some("retrieval_sidecar"));

--- a/crates/codestory-runtime/tests/retrieval_eval.rs
+++ b/crates/codestory-runtime/tests/retrieval_eval.rs
@@ -167,7 +167,7 @@ fn retrieval_eval_search_fails_closed_without_full_retrieval_sidecars() {
         error.message
     );
     assert!(
-        error.message.contains("expected mode=full"),
+        error.message.contains("expected profile=agent mode=full"),
         "{}",
         error.message
     );


### PR DESCRIPTION
## Context

Closes #562.

`codestory://status` exposed readiness verdicts and allowed surfaces, but local graph refresh state was implicit. Stale or failed local graph state could also collapse agent packet/search readiness into local index repair.

```mermaid
flowchart LR
    Freshness[local index freshness] --> Local[local_refresh + local graph surfaces]
    Sidecar[agent full sidecar readiness] --> Agent[packet/search/context surfaces]
    Freshness -. no longer gates .-> Agent
```

## What Changed

- Added compact `local_refresh` output to `codestory://status` and `agent preflight` with `fresh`, `stale`, `not_checked`, and `failed` states.
- Kept stale/not-checked/failed local graph state scoped to local navigation readiness.
- Kept packet/search/context readiness gated by the agent full-sidecar lane, including retrieval-unavailable states.
- Extended focused readiness, preflight, doctor, and stdio status tests for fresh, stale, not-checked/failed, and retrieval-unavailable-with-local-ready cases.

## How To Review

- Start in `crates/codestory-cli/src/readiness.rs` for the readiness split and `local_refresh` derivation.
- Check `crates/codestory-cli/src/stdio_transport.rs` and `crates/codestory-cli/src/main.rs` for the two exposed output surfaces.
- Review the stale status assertions in `crates/codestory-cli/tests/stdio_protocol_contracts.rs` and `crates/codestory-cli/tests/cli_golden_path.rs`.

## Verification

- `cargo fmt`
- `cargo test -p codestory-cli readiness`
- `cargo test -p codestory-cli --test cli_golden_path doctor_next_commands_stop_at_index_repair_when_inventory_is_stale`
- `cargo test -p codestory-cli --test cli_golden_path doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full`
- `cargo test -p codestory-cli --test cli_golden_path agent_preflight_reports_local_graph_when_retrieval_is_degraded`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_stale_index_freshness_with_bounded_latency`
- `cargo check -p codestory-cli`
- `git diff --check`

## Risk

- `local_refresh.not_checked` uses the existing readiness `check_index` state; there is no new live refresh-progress tracker in this slice.
- Full repo-scale e2e stats were not run because this PR only changes status/readiness output contracts.
