### PR TITLE
[codex] Wire indexing cancellation

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1103,6 +1103,11 @@ impl WorkspaceIndexer {
                 .saturating_add(duration_ms_u64(cleanup_started.elapsed()));
         }
 
+        if Self::is_cancelled(cancel_token) {
+            event_bus.publish(Event::IndexingComplete { duration_ms: 0 });
+            return Ok(stats);
+        }
+
         // 3.5 Resolve call/import edges post-pass
         if had_edges {
             let resolver = resolution::ResolutionPass::new();
@@ -19689,6 +19694,77 @@ public:
         // Each file should contribute at least one file node and one symbol node.
         let nodes = storage.get_nodes()?;
         assert!(nodes.len() >= 24);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_incremental_indexing_cancel_after_flush_skips_resolution() -> Result<()> {
+        use codestory_store::Store as Storage;
+        use codestory_workspace::RefreshInfo;
+        use std::fs;
+        use std::time::Duration;
+        use tempfile::tempdir;
+
+        let dir = tempdir()?;
+        let mut files = Vec::new();
+        for index in 0..64 {
+            let path = dir.path().join(format!("module_{index}.rs"));
+            fs::write(
+                &path,
+                format!("fn caller_{index}() {{ callee_{index}(); }}\nfn callee_{index}() {{}}\n"),
+            )?;
+            files.push(path);
+        }
+
+        let mut storage = Storage::new_in_memory().unwrap();
+        let bus = EventBus::new();
+        let rx = bus.receiver();
+        let cancel_token = CancellationToken::new();
+        let cancel_from_progress = cancel_token.clone();
+        let canceller = std::thread::spawn(move || {
+            while let Ok(event) = rx.recv_timeout(Duration::from_secs(2)) {
+                if let Event::IndexingProgress { current, total } = event
+                    && current == total
+                {
+                    cancel_from_progress.cancel();
+                    return;
+                }
+            }
+        });
+        let indexer = WorkspaceIndexer::new(dir.path().to_path_buf()).with_batch_config(
+            IncrementalIndexingConfig {
+                file_batch_size: 64,
+                node_batch_size: usize::MAX,
+                edge_batch_size: usize::MAX,
+                occurrence_batch_size: usize::MAX,
+                error_batch_size: 128,
+            },
+        );
+
+        let refresh_info = RefreshInfo {
+            mode: codestory_workspace::BuildMode::Incremental,
+            files_to_index: files,
+            files_to_remove: vec![],
+            existing_file_ids: std::collections::HashMap::new(),
+        };
+
+        let stats =
+            indexer.run_incremental(&mut storage, &refresh_info, &bus, Some(&cancel_token))?;
+        canceller.join().expect("progress canceller should finish");
+
+        assert!(
+            cancel_token.is_cancelled(),
+            "expected progress to cancel token"
+        );
+        assert!(
+            !stats.resolution_ran,
+            "cancellation after indexing flush should skip resolution"
+        );
+        assert!(
+            !storage.get_edges()?.is_empty(),
+            "indexing should flush edges"
+        );
 
         Ok(())
     }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1141,7 +1141,7 @@ impl WorkspaceIndexer {
             });
             let resolution_started = Instant::now();
             let resolution_stats = resolver
-                .run_with_scope(storage, resolution_scope)
+                .run_with_scope_with_cancel(storage, resolution_scope, cancel_token)
                 .map_err(|e| anyhow!("Resolution error: {:?}", e))?;
             stats.edge_resolution_ms = stats
                 .edge_resolution_ms

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -6,6 +6,7 @@
 //! fallback. It records telemetry and candidate evidence without changing which
 //! files are fresh.
 
+use crate::CancellationToken;
 use crate::semantic::{
     SemanticCandidateIndex, SemanticCandidateNodeSnapshot, SemanticResolutionCandidate,
     SemanticResolutionRequest, SemanticResolverRegistry,
@@ -636,48 +637,76 @@ impl ResolutionPass {
         storage: &mut Storage,
         caller_scope_file_ids: Option<&HashSet<i64>>,
     ) -> Result<ResolutionStats> {
+        self.run_with_scope_with_cancel(storage, caller_scope_file_ids, None)
+    }
+
+    pub fn run_with_scope_with_cancel(
+        &self,
+        storage: &mut Storage,
+        caller_scope_file_ids: Option<&HashSet<i64>>,
+        cancel_token: Option<&CancellationToken>,
+    ) -> Result<ResolutionStats> {
+        Self::check_cancelled(cancel_token)?;
         let conn = storage.get_connection();
         run_in_immediate_transaction(conn, |conn| {
             let mut telemetry = ResolutionPhaseTelemetry::default();
+            Self::check_cancelled(cancel_token)?;
             let scope_started = Instant::now();
             let scope_context = ScopeCallerContext::prepare(conn, caller_scope_file_ids)?;
             telemetry.scope_prepare_ms = duration_ms_u64(scope_started.elapsed());
 
+            Self::check_cancelled(cancel_token)?;
             let counts_started = Instant::now();
             let unresolved_calls_before =
                 Self::count_unresolved_on_conn(conn, EdgeKind::CALL, &scope_context)?;
+            Self::check_cancelled(cancel_token)?;
             let unresolved_imports_before =
                 Self::count_unresolved_on_conn(conn, EdgeKind::IMPORT, &scope_context)?;
             telemetry.unresolved_count_start_ms = duration_ms_u64(counts_started.elapsed());
+            Self::check_cancelled(cancel_token)?;
             let override_count_started = Instant::now();
             let _unresolved_overrides_before =
                 Self::count_unresolved_on_conn(conn, EdgeKind::OVERRIDE, &scope_context)?;
             telemetry.unresolved_override_count_ms =
                 duration_ms_u64(override_count_started.elapsed());
 
+            Self::check_cancelled(cancel_token)?;
             let prepared = PreparedResolutionState::load(storage, self.flags, &mut telemetry)?;
+            Self::check_cancelled(cancel_token)?;
 
             let mut strategy_counters = ResolutionStrategyCounters::default();
+            Self::check_cancelled(cancel_token)?;
             let resolved_calls = self.resolve_calls_on_conn(
                 conn,
                 &scope_context,
                 &prepared,
                 &mut telemetry,
                 &mut strategy_counters,
+                cancel_token,
             )?;
+            Self::check_cancelled(cancel_token)?;
             let resolved_imports = self.resolve_imports_on_conn(
                 conn,
                 &scope_context,
                 &prepared,
                 &mut telemetry,
                 &mut strategy_counters,
+                cancel_token,
             )?;
-            let _resolved_overrides =
-                self.resolve_overrides_on_conn(conn, &scope_context, &prepared, &mut telemetry)?;
+            Self::check_cancelled(cancel_token)?;
+            let _resolved_overrides = self.resolve_overrides_on_conn(
+                conn,
+                &scope_context,
+                &prepared,
+                &mut telemetry,
+                cancel_token,
+            )?;
+            Self::check_cancelled(cancel_token)?;
 
             let counts_finished = Instant::now();
             let unresolved_calls =
                 Self::count_unresolved_on_conn(conn, EdgeKind::CALL, &scope_context)?;
+            Self::check_cancelled(cancel_token)?;
             let unresolved_imports =
                 Self::count_unresolved_on_conn(conn, EdgeKind::IMPORT, &scope_context)?;
             telemetry.unresolved_count_end_ms = duration_ms_u64(counts_finished.elapsed());
@@ -693,6 +722,13 @@ impl ResolutionPass {
                 strategy_counters,
             })
         })
+    }
+
+    fn check_cancelled(cancel_token: Option<&CancellationToken>) -> Result<()> {
+        if cancel_token.is_some_and(CancellationToken::is_cancelled) {
+            anyhow::bail!("resolution cancelled");
+        }
+        Ok(())
     }
 
     pub fn unresolved_counts(&self, storage: &Storage) -> Result<(usize, usize)> {
@@ -765,6 +801,7 @@ impl ResolutionPass {
             &prepared,
             &mut telemetry,
             &mut strategy_counters,
+            None,
         )
     }
 
@@ -775,6 +812,7 @@ impl ResolutionPass {
         prepared: &PreparedResolutionState,
         telemetry: &mut ResolutionPhaseTelemetry,
         strategy_counters: &mut ResolutionStrategyCounters,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<usize> {
         pipeline::resolve_calls_on_conn(
             self,
@@ -783,6 +821,7 @@ impl ResolutionPass {
             prepared,
             telemetry,
             strategy_counters,
+            cancel_token,
         )
     }
 
@@ -806,6 +845,7 @@ impl ResolutionPass {
             &prepared,
             &mut telemetry,
             &mut strategy_counters,
+            None,
         )
     }
 
@@ -816,6 +856,7 @@ impl ResolutionPass {
         prepared: &PreparedResolutionState,
         telemetry: &mut ResolutionPhaseTelemetry,
         strategy_counters: &mut ResolutionStrategyCounters,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<usize> {
         pipeline::resolve_imports_on_conn(
             self,
@@ -824,6 +865,7 @@ impl ResolutionPass {
             prepared,
             telemetry,
             strategy_counters,
+            cancel_token,
         )
     }
 
@@ -833,8 +875,16 @@ impl ResolutionPass {
         scope_context: &ScopeCallerContext,
         prepared: &PreparedResolutionState,
         telemetry: &mut ResolutionPhaseTelemetry,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<usize> {
-        pipeline::resolve_overrides_on_conn(self, conn, scope_context, prepared, telemetry)
+        pipeline::resolve_overrides_on_conn(
+            self,
+            conn,
+            scope_context,
+            prepared,
+            telemetry,
+            cancel_token,
+        )
     }
 
     fn compute_call_resolution(

--- a/crates/codestory-indexer/src/resolution/pipeline.rs
+++ b/crates/codestory-indexer/src/resolution/pipeline.rs
@@ -17,11 +17,14 @@ pub(super) fn resolve_calls_on_conn(
     prepared: &PreparedResolutionState,
     telemetry: &mut ResolutionPhaseTelemetry,
     strategy_counters: &mut ResolutionStrategyCounters,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<usize> {
+    ResolutionPass::check_cancelled(cancel_token)?;
     if scope_context.is_empty() {
         return Ok(0);
     }
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let prepare_started = Instant::now();
     let mut prepare_query = String::from(
         "UPDATE edge SET resolved_source_node_id = source_node_id
@@ -37,6 +40,7 @@ pub(super) fn resolve_calls_on_conn(
         .call_prepare_ms
         .saturating_add(duration_ms_u64(prepare_started.elapsed()));
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let cleanup_started = Instant::now();
     sql::cleanup_stale_call_resolutions(conn, pass.flags, pass.policy, scope_context)?;
     telemetry.call_cleanup_ms = telemetry
@@ -60,6 +64,7 @@ pub(super) fn resolve_calls_on_conn(
             strategy_counters,
         },
         ResolutionPass::compute_call_resolution,
+        cancel_token,
     )?;
     telemetry.record_semantic_request_stats(EdgeKind::CALL, semantic_request_stats);
     Ok(resolved)
@@ -72,11 +77,14 @@ pub(super) fn resolve_imports_on_conn(
     prepared: &PreparedResolutionState,
     telemetry: &mut ResolutionPhaseTelemetry,
     strategy_counters: &mut ResolutionStrategyCounters,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<usize> {
+    ResolutionPass::check_cancelled(cancel_token)?;
     if scope_context.is_empty() {
         return Ok(0);
     }
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let prepare_started = Instant::now();
     let mut prepare_query = String::from(
         "UPDATE edge SET resolved_source_node_id = source_node_id
@@ -92,6 +100,7 @@ pub(super) fn resolve_imports_on_conn(
         .import_prepare_ms
         .saturating_add(duration_ms_u64(prepare_started.elapsed()));
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let mut semantic_request_stats = SemanticRequestStats::default();
     let resolved = resolve_edges_after_prepare(
         pass,
@@ -109,6 +118,7 @@ pub(super) fn resolve_imports_on_conn(
             strategy_counters,
         },
         ResolutionPass::compute_import_resolution,
+        cancel_token,
     )?;
     telemetry.record_semantic_request_stats(EdgeKind::IMPORT, semantic_request_stats);
     Ok(resolved)
@@ -120,11 +130,14 @@ pub(super) fn resolve_overrides_on_conn(
     scope_context: &ScopeCallerContext,
     prepared: &PreparedResolutionState,
     telemetry: &mut ResolutionPhaseTelemetry,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<usize> {
+    ResolutionPass::check_cancelled(cancel_token)?;
     if scope_context.is_empty() {
         return Ok(0);
     }
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let override_started = Instant::now();
     let mut prepare_query = String::from(
         "UPDATE edge
@@ -142,6 +155,7 @@ pub(super) fn resolve_overrides_on_conn(
     }
     conn.execute(&prepare_query, params![EdgeKind::OVERRIDE as i32])?;
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let rows = unresolved_override_edges(conn, scope_context)?;
     if rows.is_empty() {
         return Ok(0);
@@ -157,6 +171,7 @@ pub(super) fn resolve_overrides_on_conn(
     let mut updates = Vec::with_capacity(rows.len());
 
     for (edge_id, source_id, source_name) in rows {
+        ResolutionPass::check_cancelled(cancel_token)?;
         let method_name = short_member_name(&source_name);
         if let Some(owner_name) = owner_name_from_member_name(&source_name) {
             let mut candidate_ids = collect_override_candidates_by_owner_name(
@@ -253,6 +268,7 @@ pub(super) fn resolve_overrides_on_conn(
         )?);
     }
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     sql::apply_resolution_updates(conn, &updates)?;
     telemetry.override_resolution_ms = telemetry
         .override_resolution_ms
@@ -268,6 +284,7 @@ fn resolve_edges_after_prepare<F>(
     semantic_index: &SemanticCandidateIndex,
     job: PreparedResolutionJob<'_>,
     compute: F,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<usize>
 where
     F: Fn(
@@ -278,6 +295,7 @@ where
         ) -> Result<ComputedResolution>
         + Sync,
 {
+    ResolutionPass::check_cancelled(cancel_token)?;
     let rows_started = Instant::now();
     let rows = sql::unresolved_edges(conn, job.edge_kind, scope_context)?;
     *job.unresolved_load_ms = job
@@ -287,6 +305,7 @@ where
         return Ok(0);
     }
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let semantic_candidates_started = Instant::now();
     let (semantic_candidates_by_row, semantic_request_stats) =
         pass.semantic_candidates_for_rows(semantic_index, &rows, job.edge_kind)?;
@@ -295,6 +314,7 @@ where
         .semantic_candidates_ms
         .saturating_add(duration_ms_u64(semantic_candidates_started.elapsed()));
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let compute_started = Instant::now();
     let computed_results: Vec<Result<ComputedResolution>> =
         if pass.flags.parallel_compute && rows.len() > 1 {
@@ -316,6 +336,7 @@ where
         .compute_ms
         .saturating_add(duration_ms_u64(compute_started.elapsed()));
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let mut resolved = 0usize;
     let mut updates = Vec::with_capacity(rows.len());
     for computed in computed_results {
@@ -327,6 +348,7 @@ where
         updates.push(computed.update);
     }
 
+    ResolutionPass::check_cancelled(cancel_token)?;
     let apply_started = Instant::now();
     sql::apply_resolution_updates(conn, &updates)?;
     *job.apply_ms = job
@@ -481,6 +503,116 @@ fn collect_override_candidates(
     }
 
     candidates.into_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{Connection, params};
+
+    #[test]
+    fn cancellation_after_compute_stops_before_apply() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE node (
+                id INTEGER PRIMARY KEY,
+                kind INTEGER NOT NULL,
+                serialized_name TEXT NOT NULL,
+                qualified_name TEXT,
+                canonical_id TEXT,
+                file_node_id INTEGER,
+                start_line INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE edge (
+                id INTEGER PRIMARY KEY,
+                kind INTEGER NOT NULL,
+                source_node_id INTEGER NOT NULL,
+                target_node_id INTEGER NOT NULL,
+                file_node_id INTEGER,
+                resolved_source_node_id INTEGER,
+                resolved_target_node_id INTEGER,
+                confidence REAL,
+                certainty TEXT,
+                candidate_target_node_ids TEXT,
+                callsite_identity TEXT
+            );",
+        )?;
+        conn.execute(
+            "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+            params![
+                1_i64,
+                NodeKind::FUNCTION as i32,
+                "caller",
+                "pkg::caller",
+                10_i64
+            ],
+        )?;
+        conn.execute(
+            "INSERT INTO node (id, kind, serialized_name, qualified_name, file_node_id, start_line)
+             VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+            params![
+                2_i64,
+                NodeKind::FUNCTION as i32,
+                "target",
+                "pkg::target",
+                10_i64
+            ],
+        )?;
+        conn.execute(
+            "INSERT INTO edge (id, kind, source_node_id, target_node_id, file_node_id, resolved_target_node_id, confidence, certainty, callsite_identity)
+             VALUES (?1, ?2, ?3, ?4, ?5, NULL, NULL, NULL, NULL)",
+            params![100_i64, EdgeKind::CALL as i32, 1_i64, 2_i64, 10_i64],
+        )?;
+
+        let pass = ResolutionPass::new();
+        let scope_context = ScopeCallerContext::prepare(&conn, None)?;
+        let cancel_token = CancellationToken::new();
+        let cancel_from_compute = cancel_token.clone();
+        let mut semantic_request_stats = SemanticRequestStats::default();
+        let mut unresolved_load_ms = 0;
+        let mut semantic_candidates_ms = 0;
+        let mut compute_ms = 0;
+        let mut apply_ms = 0;
+        let mut strategy_counters = ResolutionStrategyCounters::default();
+
+        let result = resolve_edges_after_prepare(
+            &pass,
+            &conn,
+            &scope_context,
+            &CandidateIndex::default(),
+            &SemanticCandidateIndex::default(),
+            PreparedResolutionJob {
+                edge_kind: EdgeKind::CALL,
+                semantic_request_stats: &mut semantic_request_stats,
+                unresolved_load_ms: &mut unresolved_load_ms,
+                semantic_candidates_ms: &mut semantic_candidates_ms,
+                compute_ms: &mut compute_ms,
+                apply_ms: &mut apply_ms,
+                strategy_counters: &mut strategy_counters,
+            },
+            move |_pass, _candidate_index, row, _semantic_candidates| {
+                cancel_from_compute.cancel();
+                Ok(ComputedResolution {
+                    update: build_resolved_edge_update(row.0, Some((2_i64, 1.0_f32)), &[])?,
+                    strategy: Some(ResolutionStrategy::CallGlobalUnique),
+                })
+            },
+            Some(&cancel_token),
+        );
+
+        assert!(result.is_err(), "cancelled resolution should stop");
+        assert!(cancel_token.is_cancelled());
+        assert_eq!(apply_ms, 0, "apply phase should not run after cancellation");
+        let resolved_target: Option<i64> = conn.query_row(
+            "SELECT resolved_target_node_id FROM edge WHERE id = ?1",
+            params![100_i64],
+            |row| row.get(0),
+        )?;
+        assert_eq!(resolved_target, None);
+
+        Ok(())
+    }
 }
 
 fn collect_override_candidates_by_owner_name(

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -10473,6 +10473,10 @@ fn index_full(
             return Err(indexing_cancelled_error());
         }
         Ok(stats) => stats,
+        Err(_) if is_indexing_cancelled(cancel_token) => {
+            let _ = staged.discard();
+            return Err(indexing_cancelled_error());
+        }
         Err(err) => {
             let _ = staged.discard();
             return Err(ApiError::internal(format!("Indexing failed: {err}")));
@@ -10705,6 +10709,7 @@ where
     let index_stats = match result {
         Ok(_) if is_indexing_cancelled(cancel_token) => return Err(indexing_cancelled_error()),
         Ok(stats) => stats,
+        Err(_) if is_indexing_cancelled(cancel_token) => return Err(indexing_cancelled_error()),
         Err(e) => return Err(ApiError::internal(format!("Indexing failed: {e}"))),
     };
     let snapshot_refresh_stats = store.snapshots().refresh_all_with_stats().map_err(|e| {

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -39,8 +39,9 @@ use codestory_contracts::language_support::{
     LanguageSupportProfile, language_support_profile_for_ext,
     language_support_profile_for_language_name,
 };
-use codestory_indexer::IncrementalIndexingStats;
-use codestory_indexer::WorkspaceIndexer as V2WorkspaceIndexer;
+use codestory_indexer::{
+    CancellationToken, IncrementalIndexingStats, WorkspaceIndexer as V2WorkspaceIndexer,
+};
 use codestory_store::{
     FileInfo, GroundingEdgeKindCount, GroundingNodeRecord, LlmSymbolDoc, LlmSymbolDocReuseMetadata,
     LlmSymbolDocStats, SearchSymbolProjection, SnapshotStore, Store, SymbolSearchDoc,
@@ -8002,8 +8003,8 @@ impl AppController {
         std::thread::spawn(move || {
             let indexing_started = std::time::Instant::now();
             let result = match req.mode {
-                IndexMode::Full => index_full(&root, &storage_path, &events_tx),
-                IndexMode::Incremental => index_incremental(&root, &storage_path, &events_tx),
+                IndexMode::Full => index_full(&root, &storage_path, &events_tx, None),
+                IndexMode::Incremental => index_incremental(&root, &storage_path, &events_tx, None),
             };
 
             match result {
@@ -8030,6 +8031,7 @@ impl AppController {
         &self,
         mode: IndexMode,
         refresh_runtime_caches: bool,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<IndexingPhaseTimings, ApiError> {
         let (root, storage_path) = {
             let mut s = self.state.lock();
@@ -8048,8 +8050,10 @@ impl AppController {
         };
 
         let result = match mode {
-            IndexMode::Full => index_full(&root, &storage_path, &self.events_tx),
-            IndexMode::Incremental => index_incremental(&root, &storage_path, &self.events_tx),
+            IndexMode::Full => index_full(&root, &storage_path, &self.events_tx, cancel_token),
+            IndexMode::Incremental => {
+                index_incremental(&root, &storage_path, &self.events_tx, cancel_token)
+            }
         };
 
         match result {
@@ -8125,14 +8129,30 @@ impl AppController {
     }
 
     pub fn run_indexing_blocking(&self, mode: IndexMode) -> Result<IndexingPhaseTimings, ApiError> {
-        self.run_indexing_blocking_inner(mode, true)
+        self.run_indexing_blocking_inner(mode, true, None)
+    }
+
+    pub fn run_indexing_blocking_with_cancel(
+        &self,
+        mode: IndexMode,
+        cancel_token: &CancellationToken,
+    ) -> Result<IndexingPhaseTimings, ApiError> {
+        self.run_indexing_blocking_inner(mode, true, Some(cancel_token))
     }
 
     pub fn run_indexing_blocking_without_runtime_refresh(
         &self,
         mode: IndexMode,
     ) -> Result<IndexingPhaseTimings, ApiError> {
-        self.run_indexing_blocking_inner(mode, false)
+        self.run_indexing_blocking_inner(mode, false, None)
+    }
+
+    pub fn run_indexing_blocking_without_runtime_refresh_with_cancel(
+        &self,
+        mode: IndexMode,
+        cancel_token: &CancellationToken,
+    ) -> Result<IndexingPhaseTimings, ApiError> {
+        self.run_indexing_blocking_inner(mode, false, Some(cancel_token))
     }
 
     pub fn dry_run_index(&self, mode: IndexMode) -> Result<IndexDryRunDto, ApiError> {
@@ -10422,6 +10442,7 @@ fn index_full(
     root: &Path,
     storage_path: &Path,
     events_tx: &Sender<AppEventPayload>,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<IndexingRunSummary, ApiError> {
     let workspace = Workspace::open(root.to_path_buf())
         .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
@@ -10441,12 +10462,16 @@ fn index_full(
     let bus = EventBus::new();
     let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
     let indexer = V2WorkspaceIndexer::new(root.to_path_buf());
-    let result = indexer.run(staged.store_mut(), &execution_plan, &bus, None);
+    let result = indexer.run(staged.store_mut(), &execution_plan, &bus, cancel_token);
 
     drop(bus);
     let _ = forwarder.join();
 
     let index_stats = match result {
+        Ok(_) if is_indexing_cancelled(cancel_token) => {
+            let _ = staged.discard();
+            return Err(indexing_cancelled_error());
+        }
         Ok(stats) => stats,
         Err(err) => {
             let _ = staged.discard();
@@ -10606,12 +10631,19 @@ fn index_incremental(
     root: &Path,
     storage_path: &Path,
     events_tx: &Sender<AppEventPayload>,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<IndexingRunSummary, ApiError> {
-    run_incremental_indexing_common(root, storage_path, events_tx, |workspace, inputs| {
-        workspace
-            .build_execution_plan(inputs)
-            .map_err(|e| ApiError::internal(format!("Failed to generate refresh info: {e}")))
-    })
+    run_incremental_indexing_common(
+        root,
+        storage_path,
+        events_tx,
+        cancel_token,
+        |workspace, inputs| {
+            workspace
+                .build_execution_plan(inputs)
+                .map_err(|e| ApiError::internal(format!("Failed to generate refresh info: {e}")))
+        },
+    )
 }
 
 fn spawn_progress_forwarder(
@@ -10640,6 +10672,7 @@ fn run_incremental_indexing_common<F>(
     root: &Path,
     storage_path: &Path,
     events_tx: &Sender<AppEventPayload>,
+    cancel_token: Option<&CancellationToken>,
     refresh_builder: F,
 ) -> Result<IndexingRunSummary, ApiError>
 where
@@ -10663,13 +10696,17 @@ where
     let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
 
     let indexer = V2WorkspaceIndexer::new(root.to_path_buf());
-    let result = indexer.run(&mut store, &execution_plan, &bus, None);
+    let result = indexer.run(&mut store, &execution_plan, &bus, cancel_token);
 
     // Drop bus so forwarder unblocks.
     drop(bus);
     let _ = forwarder.join();
 
-    let index_stats = result.map_err(|e| ApiError::internal(format!("Indexing failed: {e}")))?;
+    let index_stats = match result {
+        Ok(_) if is_indexing_cancelled(cancel_token) => return Err(indexing_cancelled_error()),
+        Ok(stats) => stats,
+        Err(e) => return Err(ApiError::internal(format!("Indexing failed: {e}"))),
+    };
     let snapshot_refresh_stats = store.snapshots().refresh_all_with_stats().map_err(|e| {
         ApiError::internal(format!("Failed to refresh live grounding snapshots: {e}"))
     })?;
@@ -10785,6 +10822,16 @@ where
         },
         llm_refresh_scope: Some(llm_refresh_scope),
     })
+}
+
+fn is_indexing_cancelled(cancel_token: Option<&CancellationToken>) -> bool {
+    cancel_token
+        .map(CancellationToken::is_cancelled)
+        .unwrap_or(false)
+}
+
+fn indexing_cancelled_error() -> ApiError {
+    ApiError::new("cancelled", "Indexing cancelled.")
 }
 
 fn workspace_refresh_inputs(store: &Store) -> Result<RefreshInputs, ApiError> {
@@ -16319,6 +16366,30 @@ fn build_llm_symbol_doc_text() -> String {
             .expect_err("missing project should error");
 
         assert_eq!(error.code, "invalid_argument");
+        assert!(!controller.state.lock().is_indexing);
+    }
+
+    #[test]
+    fn cancelled_blocking_index_is_user_visible_and_clears_indexing_state() {
+        let workspace = copy_tictactoe_workspace();
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(workspace.path().to_path_buf(), storage_path)
+            .expect("open project summary");
+
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh_with_cancel(
+                IndexMode::Full,
+                &cancel_token,
+            )
+            .expect_err("cancelled indexing should be visible");
+
+        assert_eq!(error.code, "cancelled");
+        assert!(error.message.contains("cancelled"));
         assert!(!controller.state.lock().is_indexing);
     }
 

--- a/crates/codestory-runtime/src/services.rs
+++ b/crates/codestory-runtime/src/services.rs
@@ -11,6 +11,7 @@ use codestory_contracts::api::{
 };
 
 use crate::AppController;
+use codestory_indexer::CancellationToken;
 
 #[derive(Clone)]
 pub struct ProjectService {
@@ -87,12 +88,30 @@ impl IndexService {
         self.controller.run_indexing_blocking(mode)
     }
 
+    pub fn run_indexing_blocking_with_cancel(
+        &self,
+        mode: IndexMode,
+        cancel_token: &CancellationToken,
+    ) -> Result<IndexingPhaseTimings, ApiError> {
+        self.controller
+            .run_indexing_blocking_with_cancel(mode, cancel_token)
+    }
+
     pub fn run_indexing_blocking_without_runtime_refresh(
         &self,
         mode: IndexMode,
     ) -> Result<IndexingPhaseTimings, ApiError> {
         self.controller
             .run_indexing_blocking_without_runtime_refresh(mode)
+    }
+
+    pub fn run_indexing_blocking_without_runtime_refresh_with_cancel(
+        &self,
+        mode: IndexMode,
+        cancel_token: &CancellationToken,
+    ) -> Result<IndexingPhaseTimings, ApiError> {
+        self.controller
+            .run_indexing_blocking_without_runtime_refresh_with_cancel(mode, cancel_token)
     }
 
     pub fn dry_run_index(&self, mode: IndexMode) -> Result<IndexDryRunDto, ApiError> {


### PR DESCRIPTION
## Context
Issue #559 tracks one PR-sized cancellation path from the #498 spike. The concrete gap was indexing cancellation after file work but before the long resolution pass, plus runtime callers passing no cancellation token into indexer work.

Closes #559

## What Changed
- Threaded the existing `CancellationToken` through blocking runtime indexing helpers into full and incremental indexer runs.
- Added token-aware `IndexService` methods while preserving existing `None` behavior for current callers.
- Added cooperative cancellation checks before the indexer resolution pass and inside `ResolutionPass` before/between unresolved counts, prepared-state load, call/import/override phases, and before applying resolution updates.
- Added regressions for cancellation after indexing progress reaches the end, runtime-visible cancellation clearing `is_indexing`, and cancellation after resolver compute stopping before live resolution apply.

## How To Review
- Start with `crates/codestory-indexer/src/resolution/mod.rs` for the token-aware `run_with_scope_with_cancel` wrapper.
- Review `crates/codestory-indexer/src/resolution/pipeline.rs` for the phase/apply cancellation guards and focused regression.
- Then check `crates/codestory-indexer/src/lib.rs` and `crates/codestory-runtime/src/lib.rs` for token plumbing and user-visible cancellation mapping.

## Verification
- `cargo test -p codestory-indexer cancellation_after_compute_stops_before_apply --lib`
- `cargo test -p codestory-indexer test_incremental_indexing_cancel_after_flush_skips_resolution --lib`
- `cargo test -p codestory-runtime cancelled_blocking_index_is_user_visible_and_clears_indexing_state --lib`
- `cargo check -p codestory-indexer -p codestory-runtime`
- `git diff --check`
- `git diff --cached --check`

## Risk
- This does not add terminal Ctrl+C signal handling. It wires and proves the existing token path; current callers without a token keep existing behavior.