### PR TITLE
[codex] Add hook lifecycle policy

### DIFF
--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require('child_process');
+const { createHash } = require('crypto');
 const { eventHeader, getCodeStoryInstructions } = require('./codestory-instructions.cjs');
 const {
   classifyMcpRuntime,
@@ -51,8 +52,16 @@ function truncate(text, maxChars = MAX_OUTPUT_CHARS) {
   return `${value.slice(0, maxChars)}\n\n... CodeStory hook output truncated by hook budget.`;
 }
 
+function normalizeText(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function hashText(text) {
+  return createHash('sha256').update(text).digest('hex').slice(0, 16);
+}
+
 function compactKey(text, maxChars = 160) {
-  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, maxChars);
+  return normalizeText(text).slice(0, maxChars);
 }
 
 function hookTaxonomy(input, event) {
@@ -72,7 +81,7 @@ function hookTaxonomy(input, event) {
 function hookPolicy(input, event) {
   const taxonomy = hookTaxonomy(input, event);
   const project = input.cwd || process.cwd();
-  const promptKey = compactKey(input.prompt || '');
+  const promptKey = `prompt:${hashText(normalizeText(input.prompt || ''))}`;
   const dedupeBase = `${taxonomy}:${project}`;
   return {
     taxonomy,
@@ -130,6 +139,46 @@ function runtimeStatusBlock(policy, mcp) {
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
   ].join('\n');
+}
+
+function firstFreshness(value) {
+  if (!value || typeof value !== 'object') return null;
+  for (const [key, nested] of Object.entries(value)) {
+    if ((key === 'freshness' || key === 'index_freshness') && nested && typeof nested === 'object') {
+      return nested;
+    }
+    const found = firstFreshness(nested);
+    if (found) return found;
+  }
+  return null;
+}
+
+function freshnessSummary(value) {
+  const freshness = firstFreshness(value);
+  if (!freshness) return 'not_reported';
+  const status = freshness.status || 'unknown';
+  const changed = freshness.changed_file_count ?? freshness.changed_files ?? 'unknown';
+  const added = freshness.new_file_count ?? freshness.new_files ?? 'unknown';
+  const removed = freshness.removed_file_count ?? freshness.removed_files ?? 'unknown';
+  return `${status} changed=${changed} new=${added} removed=${removed}`;
+}
+
+function readinessEvidence(parsed) {
+  const verdicts = Array.isArray(parsed.verdicts) ? parsed.verdicts : [];
+  const statuses = verdicts
+    .map((verdict) => `${verdict?.goal || 'unknown'}=${verdict?.status || 'unknown'}`)
+    .join(' ') || 'none';
+  const evidence = {
+    statuses,
+    freshness: freshnessSummary(parsed),
+  };
+  return {
+    text: [
+      `agent_readiness_evidence: ${evidence.statuses}`,
+      `freshness_evidence: ${evidence.freshness}`,
+    ].join('\n'),
+    fingerprint: hashText(JSON.stringify(evidence)),
+  };
 }
 
 function rememberEmission(policy, contentKey) {
@@ -207,23 +256,55 @@ function runReadinessProbe(cli, project, cwd) {
     windowsHide: true,
   });
   if (result.status !== 0 || !result.stdout.trim()) {
+    const reason = result.error
+      ? result.error.message
+      : truncate(result.stderr || `agent readiness probe exited with status ${result.status}`);
     return {
       ready: false,
-      reason: result.error
-        ? result.error.message
-        : truncate(result.stderr || `agent readiness probe exited with status ${result.status}`),
+      reason,
+      evidence: [
+        'agent_readiness_evidence: unavailable',
+        'freshness_evidence: unavailable',
+      ].join('\n'),
+      fingerprint: `readiness-unavailable:${hashText(reason)}`,
     };
   }
   try {
     const parsed = JSON.parse(result.stdout);
     const verdicts = Array.isArray(parsed.verdicts) ? parsed.verdicts : [];
+    const evidence = readinessEvidence(parsed);
+    const ready = verdicts.some((verdict) => verdict?.goal === 'agent_packet_search' && verdict?.status === 'ready');
     return {
-      ready: verdicts.some((verdict) => verdict?.goal === 'agent_packet_search' && verdict?.status === 'ready'),
-      reason: 'agent_packet_search readiness is not ready',
+      ready,
+      reason: ready ? null : 'agent_packet_search readiness is not ready',
+      evidence: evidence.text,
+      fingerprint: `readiness:${evidence.fingerprint}`,
     };
   } catch {
-    return { ready: false, reason: 'agent readiness probe returned invalid JSON' };
+    return {
+      ready: false,
+      reason: 'agent readiness probe returned invalid JSON',
+      evidence: [
+        'agent_readiness_evidence: invalid_json',
+        'freshness_evidence: unavailable',
+      ].join('\n'),
+      fingerprint: 'readiness-invalid-json',
+    };
   }
+}
+
+function heartbeatReadinessProbe(mcp, project, cwd) {
+  const cli = process.env.CODESTORY_CLI || mcp.managed_cli_path;
+  if (!cli) {
+    return {
+      evidence: [
+        'agent_readiness_evidence: unavailable',
+        'freshness_evidence: unavailable',
+      ].join('\n'),
+      fingerprint: 'readiness-unavailable:no-cli',
+    };
+  }
+  return runReadinessProbe(cli, project, cwd);
 }
 
 function runCodeStory(input, event, policy, state = {}) {
@@ -236,6 +317,9 @@ function runCodeStory(input, event, policy, state = {}) {
 
   const mcp = classifyMcpRuntime();
   if (policy.runtimeOnly) {
+    const heartbeatProbe = policy.heartbeat
+      ? heartbeatReadinessProbe(mcp, policy.project, input.cwd || process.cwd())
+      : null;
     const output = state.hook?.preflight_failed && mcp.degraded_no_surface
       ? [
         `event_taxonomy: ${policy.taxonomy}`,
@@ -246,8 +330,8 @@ function runCodeStory(input, event, policy, state = {}) {
       : runtimeStatusBlock(policy, mcp);
     return {
       kind: 'runtime truth',
-      output: truncate(output, policy.cap),
-      fingerprint: runtimeFingerprint(mcp),
+      output: truncate([output, heartbeatProbe?.evidence].filter(Boolean).join('\n'), policy.cap),
+      fingerprint: [runtimeFingerprint(mcp), heartbeatProbe?.fingerprint].filter(Boolean).join('|'),
     };
   }
 
@@ -400,7 +484,7 @@ function buildContext(input, event, state = {}) {
 
 function freshInstructionBoundary(event, input = {}) {
   const source = String(input.source || input.trigger || '').toLowerCase();
-  return event === 'SessionStart' && (!source || source === 'startup');
+  return event === 'SessionStart' && (!source || source === 'startup' || source === 'clear');
 }
 
 readHookInput().then((input) => {

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -6,11 +6,24 @@ const {
   classifyMcpRuntime,
   mcpDetectionText,
   readActiveState,
+  readHookState,
   rememberActiveState,
+  writeHookState,
   writeHookOutput,
 } = require('./codestory-runtime.cjs');
 
 const MAX_OUTPUT_CHARS = 4000;
+const EVENT_CAPS = {
+  startup: 4000,
+  clear: 4000,
+  child_worktree_start: 4000,
+  user_prompt: 4000,
+  resume: 2200,
+  compact: 2200,
+  handoff: 2200,
+  goal_heartbeat: 1400,
+  session: 3000,
+};
 const RUNTIME_TIMEOUT_MS = 3500;
 const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
 
@@ -32,10 +45,52 @@ function readHookInput() {
   });
 }
 
-function truncate(text) {
+function truncate(text, maxChars = MAX_OUTPUT_CHARS) {
   const value = String(text || '').trim();
-  if (value.length <= MAX_OUTPUT_CHARS) return value;
-  return `${value.slice(0, MAX_OUTPUT_CHARS)}\n\n... CodeStory hook output truncated by hook budget.`;
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n\n... CodeStory hook output truncated by hook budget.`;
+}
+
+function compactKey(text, maxChars = 160) {
+  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, maxChars);
+}
+
+function hookTaxonomy(input, event) {
+  const source = compactKey(input.source || input.trigger || input.reason || '').toLowerCase();
+  const combined = `${String(event || '').toLowerCase()} ${source}`;
+  if (event === 'UserPromptSubmit') return 'user_prompt';
+  if (/goal|heartbeat/u.test(combined)) return 'goal_heartbeat';
+  if (/compact/u.test(combined)) return 'compact';
+  if (/resume/u.test(combined)) return 'resume';
+  if (/clear/u.test(combined)) return 'clear';
+  if (/handoff/u.test(combined)) return 'handoff';
+  if (/child|worktree/u.test(combined)) return 'child_worktree_start';
+  if (/start|startup/u.test(combined)) return 'startup';
+  return 'session';
+}
+
+function hookPolicy(input, event) {
+  const taxonomy = hookTaxonomy(input, event);
+  const project = input.cwd || process.cwd();
+  const promptKey = compactKey(input.prompt || '');
+  const dedupeBase = `${taxonomy}:${project}`;
+  return {
+    taxonomy,
+    project,
+    cap: EVENT_CAPS[taxonomy] || EVENT_CAPS.session,
+    dedupeKey: taxonomy === 'user_prompt' ? `${dedupeBase}:${promptKey}` : dedupeBase,
+    resetDedupe: taxonomy === 'startup' || taxonomy === 'clear',
+    runtimeOnly: ['resume', 'compact', 'handoff', 'goal_heartbeat'].includes(taxonomy),
+    heartbeat: taxonomy === 'goal_heartbeat',
+  };
+}
+
+function runtimeFingerprint(mcp) {
+  return [
+    mcp.mcp_resource_status,
+    mcp.managed_cli_present ? 'managed' : 'no-managed',
+    mcp.degraded_no_surface ? 'degraded' : 'surface',
+  ].join('|');
 }
 
 function firstRuntimeFailure(mcp) {
@@ -59,16 +114,54 @@ function shortDegradedNotice(mcp, reason, state = {}) {
   return [
     'CodeStory degraded mode: no MCP or managed runtime surface is usable.',
     `First failing layer: ${firstRuntimeFailure(mcp)}.`,
-    reason ? `Reason: ${truncate(reason)}` : null,
+    reason ? `Reason: ${truncate(reason, 600)}` : null,
     hook.preflight_failed ? SOURCE_FALLBACK : 'Run one bounded managed/local-dev preflight if available; otherwise use bounded source reads.',
   ].filter(Boolean).join('\n');
 }
 
-function hookCommand(input, event) {
-  const project = input.cwd || process.cwd();
+function runtimeStatusBlock(policy, mcp) {
+  return [
+    'CODESTORY HOOK RUNTIME TRUTH',
+    `event_taxonomy: ${policy.taxonomy}`,
+    `output_cap_chars: ${policy.cap}`,
+    `dedupe_key: ${policy.dedupeKey}`,
+    mcpDetectionText(mcp),
+    mcp.mcp_resources_exposed
+      ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
+      : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
+  ].join('\n');
+}
+
+function rememberEmission(policy, contentKey) {
+  const state = readHookState();
+  const emitted = state.emitted || {};
+  const previous = policy.resetDedupe ? undefined : emitted[policy.dedupeKey];
+  if (previous === contentKey) {
+    return false;
+  }
+  state.emitted = {
+    ...(policy.resetDedupe ? {} : emitted),
+    [policy.dedupeKey]: contentKey,
+  };
+  writeHookState(state);
+  return true;
+}
+
+function rememberHeartbeat(policy, contentKey) {
+  const state = readHookState();
+  const previous = state.heartbeatKey;
+  writeHookState({
+    ...state,
+    heartbeatKey: contentKey,
+  });
+  return previous ? previous !== contentKey : false;
+}
+
+function hookCommand(input, event, policy) {
+  const project = policy.project;
   if (!project) return null;
 
-  if (event === 'UserPromptSubmit' && String(input.prompt || '').trim()) {
+  if (policy.taxonomy === 'user_prompt' && String(input.prompt || '').trim()) {
     return {
       kind: 'request packet',
       args: [
@@ -83,7 +176,7 @@ function hookCommand(input, event) {
     };
   }
 
-  if (event === 'SessionStart') {
+  if (['startup', 'clear', 'child_worktree_start'].includes(policy.taxonomy)) {
     return {
       kind: 'session ground',
       args: [
@@ -99,7 +192,41 @@ function hookCommand(input, event) {
   return null;
 }
 
-function runCodeStory(input, event, state = {}) {
+function runReadinessProbe(cli, project, cwd) {
+  const result = spawnSync(cli, [
+    'ready',
+    '--goal', 'agent',
+    '--project', project,
+    '--format', 'json',
+  ], {
+    cwd,
+    encoding: 'utf8',
+    timeout: RUNTIME_TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT_CHARS * 4,
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
+    windowsHide: true,
+  });
+  if (result.status !== 0 || !result.stdout.trim()) {
+    return {
+      ready: false,
+      reason: result.error
+        ? result.error.message
+        : truncate(result.stderr || `agent readiness probe exited with status ${result.status}`),
+    };
+  }
+  try {
+    const parsed = JSON.parse(result.stdout);
+    const verdicts = Array.isArray(parsed.verdicts) ? parsed.verdicts : [];
+    return {
+      ready: verdicts.some((verdict) => verdict?.goal === 'agent_packet_search' && verdict?.status === 'ready'),
+      reason: 'agent_packet_search readiness is not ready',
+    };
+  } catch {
+    return { ready: false, reason: 'agent readiness probe returned invalid JSON' };
+  }
+}
+
+function runCodeStory(input, event, policy, state = {}) {
   if (process.env.CODESTORY_HOOK_DISABLE_RUNTIME === '1') {
     return {
       kind: 'disabled',
@@ -107,29 +234,82 @@ function runCodeStory(input, event, state = {}) {
     };
   }
 
-  const command = hookCommand(input, event);
-  if (!command) return null;
   const mcp = classifyMcpRuntime();
+  if (policy.runtimeOnly) {
+    const output = state.hook?.preflight_failed && mcp.degraded_no_surface
+      ? [
+        `event_taxonomy: ${policy.taxonomy}`,
+        `output_cap_chars: ${policy.cap}`,
+        `dedupe_key: ${policy.dedupeKey}`,
+        shortDegradedNotice(mcp, null, state),
+      ].join('\n')
+      : runtimeStatusBlock(policy, mcp);
+    return {
+      kind: 'runtime truth',
+      output: truncate(output, policy.cap),
+      fingerprint: runtimeFingerprint(mcp),
+    };
+  }
+
+  const command = hookCommand(input, event, policy);
+  if (!command) return null;
   if (mcp.mcp_config_installed && mcp.mcp_process_launchable) {
     return {
       kind: 'mcp detection',
-      output: [
+      output: truncate([
+        `event_taxonomy: ${policy.taxonomy}`,
+        `output_cap_chars: ${policy.cap}`,
+        `dedupe_key: ${policy.dedupeKey}`,
         mcpDetectionText(mcp),
         mcp.mcp_resources_exposed
-          ? 'Use codestory://status as the active runtime truth before CLI fallback.'
+          ? 'Use codestory://status as the active runtime truth. Run packet/search/context only when status allows that surface with retrieval_mode=full.'
           : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Reload the host/plugin and read codestory://status; do not add CodeStory to PATH.',
-      ].join('\n'),
+      ].join('\n'), policy.cap),
+      fingerprint: runtimeFingerprint(mcp),
     };
   }
+
   if (!process.env.CODESTORY_CLI && !mcp.managed_cli_present) {
     return {
       degraded: true,
       kind: 'degraded mode',
-      output: shortDegradedNotice(mcp, null, state),
+      output: truncate([
+        `event_taxonomy: ${policy.taxonomy}`,
+        `output_cap_chars: ${policy.cap}`,
+        `dedupe_key: ${policy.dedupeKey}`,
+        shortDegradedNotice(mcp, null, state),
+      ].join('\n'), policy.cap),
+      fingerprint: `${runtimeFingerprint(mcp)}|no-cli`,
     };
   }
 
   const cli = process.env.CODESTORY_CLI || mcp.managed_cli_path;
+  const readiness = policy.taxonomy === 'user_prompt'
+    ? runReadinessProbe(cli, policy.project, input.cwd || process.cwd())
+    : { ready: true, reason: null };
+  if (policy.taxonomy === 'user_prompt' && !readiness.ready) {
+    const failedState = {
+      ...state,
+      hook: {
+        ...(state.hook || {}),
+        preflight_failed: Boolean(readiness.reason),
+      },
+    };
+    return {
+      degraded: true,
+      kind: 'runtime truth',
+      output: truncate([
+        `event_taxonomy: ${policy.taxonomy}`,
+        `output_cap_chars: ${policy.cap}`,
+        `dedupe_key: ${policy.dedupeKey}`,
+        mcp.degraded_no_surface
+          ? shortDegradedNotice(mcp, readiness.reason, failedState)
+          : runtimeStatusBlock(policy, mcp),
+        'Packet skipped: sidecar-backed packet/search readiness is not proven full for this hook invocation.',
+      ].join('\n'), policy.cap),
+      fingerprint: `${runtimeFingerprint(mcp)}|packet-not-ready`,
+    };
+  }
 
   const result = spawnSync(cli, command.args, {
     cwd: input.cwd || process.cwd(),
@@ -143,15 +323,15 @@ function runCodeStory(input, event, state = {}) {
   if (result.status === 0 && result.stdout.trim()) {
     return {
       kind: command.kind,
-      output: truncate(result.stdout),
+      output: truncate(result.stdout, policy.cap),
       next: command.next,
+      fingerprint: `${runtimeFingerprint(mcp)}|${command.kind}`,
     };
   }
 
   const reason = result.error
     ? result.error.message
     : truncate(result.stderr || `codestory-cli exited with status ${result.status}`);
-
   const failedState = {
     ...state,
     hook: {
@@ -164,19 +344,29 @@ function runCodeStory(input, event, state = {}) {
     degraded: mcp.degraded_no_surface,
     preflightFailed: true,
     kind: command.kind,
-    output: mcp.degraded_no_surface
-      ? shortDegradedNotice(mcp, reason, failedState)
+    output: truncate(mcp.degraded_no_surface
+      ? [
+        `event_taxonomy: ${policy.taxonomy}`,
+        `output_cap_chars: ${policy.cap}`,
+        `dedupe_key: ${policy.dedupeKey}`,
+        shortDegradedNotice(mcp, reason, failedState),
+      ].join('\n')
       : [
         mcpDetectionText(mcp),
         `CodeStory hook attempted ${command.kind} but did not receive usable output.`,
         reason ? `Reason: ${reason}` : null,
         command.next,
-      ].filter(Boolean).join('\n'),
+      ].filter(Boolean).join('\n'), policy.cap),
+    fingerprint: `${runtimeFingerprint(mcp)}|${reason}`,
   };
 }
 
 function buildContext(input, event, state = {}) {
-  const runtime = runCodeStory(input, event, state);
+  const policy = hookPolicy(input, event);
+  const runtime = runCodeStory(input, event, policy, state);
+  if (runtime && policy.heartbeat && !rememberHeartbeat(policy, runtime.fingerprint || runtime.output)) {
+    return null;
+  }
   const runtimeBlock = runtime && runtime.output
     ? [
       `CODESTORY HOOK ${runtime.kind.toUpperCase()}`,
@@ -184,13 +374,17 @@ function buildContext(input, event, state = {}) {
       runtime.next ? `Next: ${runtime.next}` : null,
     ].filter(Boolean).join('\n\n')
     : null;
-
-  if (runtime && runtime.kind === 'mcp detection') {
-    return [eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n');
+  const contentKey = runtime?.fingerprint || runtimeBlock || policy.taxonomy;
+  if (runtimeBlock && !rememberEmission(policy, contentKey)) {
+    return null;
   }
 
-  if (runtime && runtime.degraded) {
-    return [eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n');
+  if (runtime && runtime.kind === 'mcp detection') {
+    return truncate([eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n'), policy.cap);
+  }
+
+  if (policy.runtimeOnly || (runtime && runtime.degraded)) {
+    return truncate([eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n'), policy.cap);
   }
 
   const emitted = state.hook && state.hook.instructions_emitted;
@@ -201,7 +395,7 @@ function buildContext(input, event, state = {}) {
     parts.push(runtimeBlock);
   }
 
-  return parts.join('\n\n');
+  return truncate(parts.join('\n\n'), policy.cap);
 }
 
 function freshInstructionBoundary(event, input = {}) {
@@ -224,8 +418,10 @@ readHookInput().then((input) => {
       : state;
     const context = buildContext(input, event, activeState);
     const priorInstructions = (activeState.hook && activeState.hook.instructions_emitted) || {};
-    const emittedFullInstructions = context.includes('CODESTORY BACKGROUND GROUNDING RULES') ||
-      context.includes('CODESTORY BACKGROUND GROUNDING ACTIVE');
+    const emittedFullInstructions = context && (
+      context.includes('CODESTORY BACKGROUND GROUNDING RULES') ||
+      context.includes('CODESTORY BACKGROUND GROUNDING ACTIVE')
+    );
     const instructions = emittedFullInstructions
       ? { ...priorInstructions, [event]: true }
       : priorInstructions;
@@ -239,7 +435,7 @@ readHookInput().then((input) => {
       },
     });
     const nextState = readActiveState() || {};
-    if (/CodeStory is unavailable for this session/u.test(context)) {
+    if (context && /CodeStory is unavailable for this session/u.test(context)) {
       rememberActiveState({ hook: { ...(nextState.hook || {}), preflight_failed: true } });
     }
     writeHookOutput(event, context);

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -5,6 +5,7 @@ const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 const STATE_FILE = '.codestory-active';
+const HOOK_STATE_FILE = '.codestory-hook-output-state.json';
 const MCP_RUNTIME_FILE = '.codestory-mcp-runtime.json';
 
 function pluginDataDir() {
@@ -146,6 +147,27 @@ function rememberActiveState(state) {
   }
 }
 
+function readHookState() {
+  const stateDir = pluginDataDir();
+  if (!stateDir) return {};
+  return readJson(path.join(stateDir, HOOK_STATE_FILE)) || {};
+}
+
+function writeHookState(state) {
+  const stateDir = pluginDataDir();
+  if (!stateDir) return;
+
+  try {
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(path.join(stateDir, HOOK_STATE_FILE), JSON.stringify({
+      ...state,
+      updatedAt: new Date().toISOString(),
+    }));
+  } catch (e) {
+    // Best effort only. Hook state must not block the host session.
+  }
+}
+
 function writeHookOutput(event, context) {
   if (isCopilot) {
     process.stdout.write(JSON.stringify({ additionalContext: context }));
@@ -173,6 +195,8 @@ module.exports = {
   classifyMcpRuntime,
   mcpDetectionText,
   readActiveState,
+  readHookState,
   rememberActiveState,
+  writeHookState,
   writeHookOutput,
 };

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { spawnSync } from "node:child_process";
 import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
@@ -849,6 +850,20 @@ async function writeNodeCli(binDir, source) {
   return cliPath;
 }
 
+function runCodexHook(input, env) {
+  const result = spawnSync(process.execPath, [join(pluginRoot, "hooks", "codestory-activate.cjs")], {
+    env: {
+      ...process.env,
+      COPILOT_PLUGIN_DATA: "",
+      ...env,
+    },
+    input: JSON.stringify(input),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
 test("hook output keeps CodeStory ambient and checks MCP before CLI fallback", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
@@ -1013,7 +1028,7 @@ test("hook failed preflight switches degraded guidance to bounded source fallbac
   }
 });
 
-test("hook dedupes repeated request grounding instructions within plugin state", async () => {
+test("hook dedupes repeated request prompts within plugin state", async () => {
   const { spawnSync } = await import("node:child_process");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-dedupe-"));
   const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-dedupe-bin-"));
@@ -1047,11 +1062,10 @@ test("hook dedupes repeated request grounding instructions within plugin state",
       assert.equal(first.status, 0, first.stderr);
       assert.equal(second.status, 0, second.stderr);
       const firstContext = JSON.parse(first.stdout).hookSpecificOutput.additionalContext;
-      const secondContext = JSON.parse(second.stdout).hookSpecificOutput.additionalContext;
-      assert.match(firstContext, /CODESTORY BACKGROUND GROUNDING ACTIVE/u);
-      assert.doesNotMatch(secondContext, /CODESTORY BACKGROUND GROUNDING ACTIVE/u);
-      assert.match(secondContext, /CODESTORY HOOK REQUEST PACKET/u);
-      assert.match(secondContext, /packet ok/u);
+      const secondOutput = JSON.parse(second.stdout);
+      assert.match(firstContext, /event_taxonomy: user_prompt/u);
+      assert.match(firstContext, /Packet skipped: sidecar-backed packet\/search readiness is not proven full/u);
+      assert.equal(Object.hasOwn(secondOutput, "hookSpecificOutput"), false);
     });
   } finally {
     await rm(dataDir, { recursive: true, force: true });
@@ -1115,6 +1129,102 @@ test("hook resets instruction dedupe on fresh startup session boundary", async (
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(binDir, { recursive: true, force: true });
+  }
+});
+
+test("hook prompt output dedupes repeated prompts", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-prompt-dedupe-"));
+  const env = {
+    PLUGIN_DATA: dataDir,
+    PATH: "",
+  };
+
+  try {
+    const first = runCodexHook({
+      hook_event_name: "UserPromptSubmit",
+      prompt: "Where is RefreshMode defined?",
+      cwd: repoRoot,
+    }, env);
+    const second = runCodexHook({
+      hook_event_name: "UserPromptSubmit",
+      prompt: "Where is RefreshMode defined?",
+      cwd: repoRoot,
+    }, env);
+    const third = runCodexHook({
+      hook_event_name: "UserPromptSubmit",
+      prompt: "Where is strict_sidecar_status defined?",
+      cwd: repoRoot,
+    }, env);
+
+    assert.match(first.hookSpecificOutput.additionalContext, /event_taxonomy: user_prompt/u);
+    assert.equal(Object.hasOwn(second, "hookSpecificOutput"), false);
+    assert.match(third.hookSpecificOutput.additionalContext, /Where is strict_sidecar_status defined\?/u);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("hook resume and compact output use short runtime caps", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-short-events-"));
+  const env = {
+    PLUGIN_DATA: dataDir,
+    PATH: "",
+  };
+
+  try {
+    for (const source of ["resume", "compact"]) {
+      const output = runCodexHook({
+        hook_event_name: "SessionStart",
+        source,
+        cwd: repoRoot,
+      }, env);
+      const context = output.hookSpecificOutput.additionalContext;
+      assert.match(context, new RegExp(`event_taxonomy: ${source}`, "u"));
+      assert.match(context, /output_cap_chars: 2200/u);
+      assert.equal(context.length <= 2200, true, `${source} context length ${context.length}`);
+      assert.doesNotMatch(context, /CODESTORY BACKGROUND GROUNDING RULES/u);
+      assert.doesNotMatch(context, /attempted session ground/u);
+    }
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("hook goal heartbeat is quiet until runtime state changes", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-"));
+  const cliPath = join(dataDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const env = {
+    PLUGIN_DATA: dataDir,
+    PATH: "",
+  };
+
+  try {
+    const first = runCodexHook({
+      hook_event_name: "GoalLoopHeartbeat",
+      cwd: repoRoot,
+    }, env);
+    assert.equal(Object.hasOwn(first, "hookSpecificOutput"), false);
+
+    await writeFile(cliPath, "", "utf8");
+    await writeFile(
+      join(dataDir, ".codestory-mcp-runtime.json"),
+      JSON.stringify({ source: "managed", path: cliPath }),
+      "utf8",
+    );
+    const changed = runCodexHook({
+      hook_event_name: "GoalLoopHeartbeat",
+      cwd: repoRoot,
+    }, env);
+    assert.match(changed.hookSpecificOutput.additionalContext, /event_taxonomy: goal_heartbeat/u);
+    assert.match(changed.hookSpecificOutput.additionalContext, /mcp_resources_exposed: mcp_resources_exposed/u);
+
+    const repeated = runCodexHook({
+      hook_event_name: "GoalLoopHeartbeat",
+      cwd: repoRoot,
+    }, env);
+    assert.equal(Object.hasOwn(repeated, "hookSpecificOutput"), false);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
   }
 });
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1073,6 +1073,59 @@ test("hook dedupes repeated request prompts within plugin state", async () => {
   }
 });
 
+test("hook invokes packet when agent packet search readiness is ready", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-packet-ready-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-packet-ready-bin-"));
+  const logFile = join(dataDir, "calls.jsonl");
+
+  try {
+    const cliPath = await writeNodeCli(
+      binDir,
+      [
+        "const fs = require('fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify(args) + '\\n');",
+        "if (args[0] === 'ready') {",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status: 'ready', index: { freshness: { status: 'fresh', changed_file_count: 0, new_file_count: 0, removed_file_count: 0 } } }] }));",
+        "  process.exit(0);",
+        "}",
+        "if (args[0] === 'packet') { console.log('packet ok'); process.exit(0); }",
+        "process.exit(2);",
+      ].join("\n"),
+    );
+    await withTempHookInstall(async (installRoot) => {
+      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
+      const result = spawnSync(process.execPath, [hookPath], {
+        env: {
+          ...process.env,
+          CODESTORY_CLI: cliPath,
+          COPILOT_PLUGIN_DATA: "",
+          PLUGIN_DATA: dataDir,
+          TEST_LOG: logFile,
+        },
+        input: JSON.stringify({
+          hook_event_name: "UserPromptSubmit",
+          prompt: "Where is RefreshMode defined?",
+          cwd: repoRoot,
+        }),
+        encoding: "utf8",
+      });
+
+      assert.equal(result.status, 0, result.stderr);
+      const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
+      assert.match(context, /packet ok/u);
+      const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+      assert.deepEqual(calls.map((args) => args[0]), ["ready", "packet"]);
+      assert.deepEqual(calls[0].slice(0, 4), ["ready", "--goal", "agent", "--project"]);
+      assert.deepEqual(calls[1].slice(0, 4), ["packet", "--project", repoRoot, "--question"]);
+    });
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  }
+});
+
 test("hook resets instruction dedupe on fresh startup session boundary", async () => {
   const { spawnSync } = await import("node:child_process");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-startup-dedupe-"));
@@ -1098,6 +1151,11 @@ test("hook resets instruction dedupe on fresh startup session boundary", async (
         source: "resume",
         cwd: repoRoot,
       });
+      const clearInput = JSON.stringify({
+        hook_event_name: "SessionStart",
+        source: "clear",
+        cwd: repoRoot,
+      });
       const firstStartup = spawnSync(process.execPath, [hookPath], {
         env,
         input: startupInput,
@@ -1108,6 +1166,11 @@ test("hook resets instruction dedupe on fresh startup session boundary", async (
         input: resumeInput,
         encoding: "utf8",
       });
+      const clear = spawnSync(process.execPath, [hookPath], {
+        env,
+        input: clearInput,
+        encoding: "utf8",
+      });
       const secondStartup = spawnSync(process.execPath, [hookPath], {
         env,
         input: startupInput,
@@ -1116,13 +1179,17 @@ test("hook resets instruction dedupe on fresh startup session boundary", async (
 
       assert.equal(firstStartup.status, 0, firstStartup.stderr);
       assert.equal(resume.status, 0, resume.stderr);
+      assert.equal(clear.status, 0, clear.stderr);
       assert.equal(secondStartup.status, 0, secondStartup.stderr);
       const firstContext = JSON.parse(firstStartup.stdout).hookSpecificOutput.additionalContext;
       const resumeContext = JSON.parse(resume.stdout).hookSpecificOutput.additionalContext;
+      const clearContext = JSON.parse(clear.stdout).hookSpecificOutput.additionalContext;
       const secondContext = JSON.parse(secondStartup.stdout).hookSpecificOutput.additionalContext;
       const fullInstructions = /CODESTORY BACKGROUND GROUNDING (?:ACTIVE|RULES)/u;
       assert.match(firstContext, fullInstructions);
       assert.doesNotMatch(resumeContext, fullInstructions);
+      assert.match(clearContext, fullInstructions);
+      assert.match(clearContext, /ground ok/u);
       assert.match(secondContext, fullInstructions);
       assert.match(secondContext, /ground ok/u);
     });
@@ -1159,6 +1226,13 @@ test("hook prompt output dedupes repeated prompts", async () => {
     assert.match(first.hookSpecificOutput.additionalContext, /event_taxonomy: user_prompt/u);
     assert.equal(Object.hasOwn(second, "hookSpecificOutput"), false);
     assert.match(third.hookSpecificOutput.additionalContext, /Where is strict_sidecar_status defined\?/u);
+    const stateText = await readFile(join(dataDir, ".codestory-hook-output-state.json"), "utf8");
+    const promptHash = createHash("sha256")
+      .update("Where is RefreshMode defined?")
+      .digest("hex")
+      .slice(0, 16);
+    assert.match(stateText, new RegExp(`prompt:${promptHash}`, "u"));
+    assert.doesNotMatch(stateText, /Where is RefreshMode defined/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1190,11 +1264,29 @@ test("hook resume and compact output use short runtime caps", async () => {
   }
 });
 
-test("hook goal heartbeat is quiet until runtime state changes", async () => {
+test("hook goal heartbeat is quiet until readiness or freshness evidence changes", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-"));
-  const cliPath = join(dataDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-bin-"));
+  const cliPath = await writeNodeCli(
+    binDir,
+    [
+      "const status = process.env.TEST_AGENT_STATUS || 'repair_retrieval';",
+      "const freshness = process.env.TEST_FRESHNESS_STATUS || 'stale';",
+      "const changed = Number(process.env.TEST_CHANGED_FILES || 1);",
+      "const args = process.argv.slice(2);",
+      "if (args[0] === 'ready') {",
+      "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status, index: { freshness: { status: freshness, changed_file_count: changed, new_file_count: 0, removed_file_count: 0 } } }] }));",
+      "  process.exit(0);",
+      "}",
+      "process.exit(2);",
+    ].join("\n"),
+  );
   const env = {
     PLUGIN_DATA: dataDir,
+    CODESTORY_CLI: cliPath,
+    TEST_AGENT_STATUS: "repair_retrieval",
+    TEST_FRESHNESS_STATUS: "stale",
+    TEST_CHANGED_FILES: "1",
     PATH: "",
   };
 
@@ -1205,18 +1297,16 @@ test("hook goal heartbeat is quiet until runtime state changes", async () => {
     }, env);
     assert.equal(Object.hasOwn(first, "hookSpecificOutput"), false);
 
-    await writeFile(cliPath, "", "utf8");
-    await writeFile(
-      join(dataDir, ".codestory-mcp-runtime.json"),
-      JSON.stringify({ source: "managed", path: cliPath }),
-      "utf8",
-    );
+    env.TEST_AGENT_STATUS = "ready";
+    env.TEST_FRESHNESS_STATUS = "fresh";
+    env.TEST_CHANGED_FILES = "0";
     const changed = runCodexHook({
       hook_event_name: "GoalLoopHeartbeat",
       cwd: repoRoot,
     }, env);
     assert.match(changed.hookSpecificOutput.additionalContext, /event_taxonomy: goal_heartbeat/u);
-    assert.match(changed.hookSpecificOutput.additionalContext, /mcp_resources_exposed: mcp_resources_exposed/u);
+    assert.match(changed.hookSpecificOutput.additionalContext, /agent_readiness_evidence: agent_packet_search=ready/u);
+    assert.match(changed.hookSpecificOutput.additionalContext, /freshness_evidence: fresh changed=0 new=0 removed=0/u);
 
     const repeated = runCodexHook({
       hook_event_name: "GoalLoopHeartbeat",
@@ -1225,6 +1315,7 @@ test("hook goal heartbeat is quiet until runtime state changes", async () => {
     assert.equal(Object.hasOwn(repeated, "hookSpecificOutput"), false);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Context

Closes #561.

#565 already moved the hook path away from PATH-dependent runtime discovery. This PR keeps that managed-runtime/degraded-notice behavior and adds the lifecycle policy layer for hook noise control.

## What Changed

- Added hook event taxonomy for startup, clear, child/worktree start, user prompt, resume, compact, handoff, and goal heartbeat.
- Added event-specific output caps and persisted dedupe keys in plugin data.
- Made resume/compact emit short runtime truth instead of full grounding packets.
- Made goal heartbeat silent by default and noisy only when runtime readiness/freshness fingerprint changes.
- Gated user-prompt packets behind proven `agent_packet_search` readiness; otherwise the hook emits a short status/degraded hint.
- Covered repeated prompt dedupe, compact/resume caps, heartbeat silence/noise, and MCP-configured-but-not-visible degraded notice in `plugin-static.test.mjs`.

```mermaid
flowchart TD
  A["Hook input"] --> B["Classify taxonomy"]
  B --> C{Runtime-only event?}
  C -->|resume/compact/handoff| D["Short runtime truth"]
  C -->|goal heartbeat| E{"Fingerprint changed?"}
  E -->|no| F["Silent"]
  E -->|yes| D
  C -->|user prompt| G{"agent_packet_search ready?"}
  G -->|yes| H["Tiny packet"]
  G -->|no| I["Short status hint"]
  C -->|startup/clear/child| J["Strict ground or degraded hint"]
  D --> K["Apply cap + dedupe key"]
  H --> K
  I --> K
  J --> K
```

## How To Review

- Start in `plugins/codestory/hooks/codestory-activate.cjs` at the taxonomy/policy helpers, then read `runCodeStory` and `buildContext`.
- Check `plugins/codestory/hooks/codestory-runtime.cjs` for the small persisted hook-state helper.
- Review the added/updated hook tests in `plugins/codestory/tests/plugin-static.test.mjs` around the lifecycle hook cases.

## Verification

- `node --check plugins\\codestory\\hooks\\codestory-activate.cjs`
- `node --check plugins\\codestory\\hooks\\codestory-runtime.cjs`
- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs` - 29 passed, 0 failed
- `git diff --check origin/dev/codestory-next...HEAD`

## Risk

- Hook behavior is intentionally quieter. A host event whose source string does not match the taxonomy falls back to the generic `session` cap/policy.
- User-prompt packets now require proven agent readiness; degraded environments get status hints rather than speculative packet attempts.
