### PR TITLE
[codex] add local wait-fresh ready contract

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -584,6 +584,11 @@ pub(crate) struct ReadyCommand {
         help = "Repair readiness before reporting it. Local repairs refresh the index; agent repairs also bootstrap and rebuild retrieval sidecars."
     )]
     pub(crate) repair: bool,
+    #[arg(
+        long,
+        help = "For local graph freshness, no-op when fresh and run at most one incremental refresh when stale or unchecked."
+    )]
+    pub(crate) wait_fresh: bool,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
     pub(crate) format: OutputFormat,
     #[arg(
@@ -1519,6 +1524,8 @@ pub(crate) struct IndexOutput<'a> {
 #[derive(Debug, Serialize)]
 pub(crate) struct ReadyOutput {
     pub(crate) verdicts: Vec<ReadinessVerdictDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) local_refresh: Option<crate::readiness::LocalRefreshOutput>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -22,7 +22,7 @@ use codestory_contracts::api::{
     EvidenceSourceLocationDto, EvidenceTypeDto, FrameworkRouteCoverageDto, GraphArtifactDto,
     GroundingBudgetDto, IndexFreshnessDto, IndexFreshnessStatusDto, IndexMode, IndexedFilesRequest,
     NodeId, NodeKind, NodeOccurrencesRequest, PacketBudgetModeDto, PacketSufficiencyStatusDto,
-    PacketTaskClassDto, ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto,
+    PacketTaskClassDto, ProjectSummary, ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto,
     RetrievalFallbackReasonDto, RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit,
     SearchMatchQualityDto, SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest,
     SourceOccurrenceDto, SourceTruthCheckDto, TrailCallerScope, TrailConfigDto, TrailContextDto,
@@ -1994,6 +1994,8 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         } else {
             RuntimeContext::new(&cmd.project)?
         }
+    } else if cmd.wait_fresh {
+        RuntimeContext::new(&cmd.project)?
     } else {
         RuntimeContext::new_inspect_only(&cmd.project)?
     };
@@ -2002,7 +2004,11 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     } else {
         None
     };
-    let summary = runtime.open_project_summary()?;
+    let (summary, local_refresh) = if cmd.wait_fresh && !cmd.repair {
+        wait_for_local_freshness(&runtime)?
+    } else {
+        (runtime.open_project_summary()?, None)
+    };
     let sidecar = ready_sidecar_status(&runtime, repaired_sidecar);
     let mut verdicts = build_summary_readiness(
         &summary.root,
@@ -2014,9 +2020,83 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         let goal = goal.as_dto();
         verdicts.retain(|verdict| verdict.goal == goal);
     }
-    let output = ReadyOutput { verdicts };
+    let output = ReadyOutput {
+        verdicts,
+        local_refresh,
+    };
     let markdown = render_ready_markdown(&output);
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
+fn wait_for_local_freshness(
+    runtime: &RuntimeContext,
+) -> Result<(ProjectSummary, Option<readiness::LocalRefreshOutput>)> {
+    let summary = runtime.open_project_summary()?;
+    if !local_freshness_needs_refresh(&summary) {
+        let mut output = local_refresh_output_from_summary(&summary);
+        if output.state == readiness::LocalRefreshState::Fresh {
+            output.reason = Some("already_fresh".to_string());
+        }
+        return Ok((summary, Some(output)));
+    }
+
+    match runtime.ensure_open_from_summary(args::RefreshMode::Incremental, summary.clone()) {
+        Ok(opened) => {
+            let mut output = local_refresh_output_from_summary(&opened.summary);
+            if output.state == readiness::LocalRefreshState::Fresh {
+                output.reason = Some("refreshed".to_string());
+            } else {
+                output.state = readiness::LocalRefreshState::Failed;
+                output.blocks_local_surfaces = true;
+                output.reason = Some("refresh_did_not_reach_fresh".to_string());
+            }
+            Ok((opened.summary, Some(output)))
+        }
+        Err(error) => {
+            let mut output = local_refresh_output_from_summary(&summary);
+            output.state = classify_local_refresh_failure_state(&error);
+            output.blocks_local_surfaces = true;
+            output.readiness_status = ReadinessStatusDto::RepairIndex;
+            output.reason = Some(error.to_string());
+            Ok((summary, Some(output)))
+        }
+    }
+}
+
+fn local_freshness_needs_refresh(summary: &ProjectSummary) -> bool {
+    summary.freshness.as_ref().is_some_and(|freshness| {
+        matches!(
+            freshness.status,
+            IndexFreshnessStatusDto::Stale | IndexFreshnessStatusDto::NotChecked
+        )
+    })
+}
+
+fn local_refresh_output_from_summary(summary: &ProjectSummary) -> readiness::LocalRefreshOutput {
+    let verdict = readiness::build_readiness_verdict(
+        ReadinessGoalDto::LocalNavigation,
+        readiness::ReadinessInputs {
+            project: &summary.root,
+            stats: &summary.stats,
+            freshness: summary.freshness.as_ref(),
+            setup: None,
+            sidecar: None,
+        },
+    );
+    readiness::local_refresh_output(&verdict)
+}
+
+fn classify_local_refresh_failure_state(error: &anyhow::Error) -> readiness::LocalRefreshState {
+    let message = format!("{error:#}").to_ascii_lowercase();
+    if message.contains("cache_busy")
+        || message.contains("database is locked")
+        || message.contains("database table is locked")
+        || message.contains("cache is busy")
+    {
+        readiness::LocalRefreshState::SkippedLocked
+    } else {
+        readiness::LocalRefreshState::Failed
+    }
 }
 
 fn run_agent(cmd: args::AgentCommand) -> Result<()> {
@@ -11823,6 +11903,21 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn classify_local_refresh_failure_state_detects_lock_contention() {
+        let locked = anyhow::anyhow!("cache_busy: database is locked");
+        assert_eq!(
+            classify_local_refresh_failure_state(&locked),
+            readiness::LocalRefreshState::SkippedLocked
+        );
+
+        let failed = anyhow::anyhow!("index refresh failed");
+        assert_eq!(
+            classify_local_refresh_failure_state(&failed),
+            readiness::LocalRefreshState::Failed
+        );
     }
 
     fn test_search_hit_defaults() -> SearchHit {

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -1994,8 +1994,6 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         } else {
             RuntimeContext::new(&cmd.project)?
         }
-    } else if cmd.wait_fresh {
-        RuntimeContext::new(&cmd.project)?
     } else {
         RuntimeContext::new_inspect_only(&cmd.project)?
     };
@@ -2005,7 +2003,7 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         None
     };
     let (summary, local_refresh) = if cmd.wait_fresh && !cmd.repair {
-        wait_for_local_freshness(&runtime)?
+        wait_for_local_freshness(&cmd.project, &runtime)?
     } else {
         (runtime.open_project_summary()?, None)
     };
@@ -2029,9 +2027,10 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
 }
 
 fn wait_for_local_freshness(
-    runtime: &RuntimeContext,
+    project: &ProjectArgs,
+    inspect_runtime: &RuntimeContext,
 ) -> Result<(ProjectSummary, Option<readiness::LocalRefreshOutput>)> {
-    let summary = runtime.open_project_summary()?;
+    let summary = inspect_runtime.open_project_summary()?;
     if !local_freshness_needs_refresh(&summary) {
         let mut output = local_refresh_output_from_summary(&summary);
         if output.state == readiness::LocalRefreshState::Fresh {
@@ -2040,7 +2039,8 @@ fn wait_for_local_freshness(
         return Ok((summary, Some(output)));
     }
 
-    match runtime.ensure_open_from_summary(args::RefreshMode::Incremental, summary.clone()) {
+    let index_runtime = RuntimeContext::new(project)?;
+    match index_runtime.ensure_open(args::RefreshMode::Incremental) {
         Ok(opened) => {
             let mut output = local_refresh_output_from_summary(&opened.summary);
             if output.state == readiness::LocalRefreshState::Fresh {

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -160,6 +160,16 @@ pub(crate) fn render_index_markdown(output: &IndexOutput<'_>) -> String {
 pub(crate) fn render_ready_markdown(output: &ReadyOutput) -> String {
     let mut markdown = String::new();
     let _ = writeln!(markdown, "# Readiness");
+    if let Some(refresh) = output.local_refresh.as_ref() {
+        let _ = writeln!(
+            markdown,
+            "local_refresh: `{}`",
+            crate::readiness::local_refresh_state_label(refresh.state)
+        );
+        if let Some(reason) = refresh.reason.as_deref() {
+            let _ = writeln!(markdown, "local_refresh_reason: {reason}");
+        }
+    }
     append_readiness_verdicts(&mut markdown, &output.verdicts, true);
     markdown
 }

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -41,6 +41,7 @@ pub(crate) enum LocalRefreshState {
     Fresh,
     Stale,
     NotChecked,
+    SkippedLocked,
     Failed,
 }
 
@@ -156,6 +157,7 @@ pub(crate) fn local_refresh_state_label(state: LocalRefreshState) -> &'static st
         LocalRefreshState::Fresh => "fresh",
         LocalRefreshState::Stale => "stale",
         LocalRefreshState::NotChecked => "not_checked",
+        LocalRefreshState::SkippedLocked => "skipped_locked",
         LocalRefreshState::Failed => "failed",
     }
 }
@@ -178,6 +180,7 @@ pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefres
         LocalRefreshState::Fresh => None,
         LocalRefreshState::Stale => Some("index_changed".to_string()),
         LocalRefreshState::NotChecked => Some("freshness_not_checked".to_string()),
+        LocalRefreshState::SkippedLocked => Some("index_locked".to_string()),
         LocalRefreshState::Failed => Some(verdict.summary.clone()),
     };
 

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -50,6 +50,31 @@ fn ready_command_emits_compact_verdicts_and_filters_goal() {
         .expect("local ready verdicts");
     assert_eq!(local_verdicts.len(), 1);
     assert_eq!(local_verdicts[0]["goal"], "local_navigation");
+    assert!(
+        local_json["local_refresh"].is_null(),
+        "plain ready should not report a wait-fresh action: {local_json_text}"
+    );
+
+    let wait_json_text = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "ready",
+            "--goal",
+            "local",
+            "--wait-fresh",
+            "--format",
+            "json",
+        ],
+    );
+    let wait_json: Value = serde_json::from_str(&wait_json_text).expect("ready wait json");
+    assert_eq!(wait_json["verdicts"][0]["status"], "ready");
+    assert_eq!(wait_json["local_refresh"]["state"], "fresh");
+    assert_eq!(wait_json["local_refresh"]["reason"], "already_fresh");
+    assert_eq!(
+        wait_json["verdicts"][0]["sidecar"]["degraded_reason"], "retrieval_manifest_missing",
+        "local wait-fresh must not bootstrap retrieval sidecars: {wait_json_text}"
+    );
 
     let markdown = run_cli(
         workspace.path(),
@@ -129,6 +154,69 @@ fn ready_repair_indexes_fresh_workspace_for_local_navigation() {
             .expect("minimum next command")
             .contains("codestory-cli ground --project"),
         "repaired local readiness should point at grounding, not another index repair: {json_text}"
+    );
+}
+
+#[test]
+fn ready_wait_fresh_refreshes_stale_local_graph_once() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+    run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+    fs::write(
+        workspace.path().join("src").join("lib.rs"),
+        r#"pub fn entry_point() -> String {
+    helper("ready")
+}
+
+pub fn added_after_index() -> String {
+    helper("fresh")
+}
+
+fn helper(value: &str) -> String {
+    format!("ready:{value}")
+}
+"#,
+    )
+    .expect("make index stale");
+
+    let stale_json_text = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &["ready", "--goal", "local", "--format", "json"],
+    );
+    let stale_json: Value = serde_json::from_str(&stale_json_text).expect("stale ready json");
+    assert_eq!(stale_json["verdicts"][0]["status"], "repair_index");
+    assert_eq!(stale_json["verdicts"][0]["index"]["status"], "stale");
+
+    let wait_json_text = run_cli(
+        workspace.path(),
+        cache_dir.path(),
+        &[
+            "ready",
+            "--goal",
+            "local",
+            "--wait-fresh",
+            "--format",
+            "json",
+        ],
+    );
+    let wait_json: Value = serde_json::from_str(&wait_json_text).expect("wait fresh json");
+    assert_eq!(wait_json["verdicts"][0]["status"], "ready");
+    assert_eq!(wait_json["verdicts"][0]["index"]["status"], "fresh");
+    assert_eq!(wait_json["local_refresh"]["state"], "fresh");
+    assert_eq!(wait_json["local_refresh"]["reason"], "refreshed");
+    assert_eq!(
+        wait_json["verdicts"][0]["sidecar"]["retrieval_mode"],
+        "unavailable"
+    );
+    assert_eq!(
+        wait_json["verdicts"][0]["sidecar"]["degraded_reason"], "retrieval_manifest_missing",
+        "wait-fresh should leave packet/search sidecars separately gated: {wait_json_text}"
     );
 }
 


### PR DESCRIPTION
## Context

Closes #575.
Refs #566.

Agents still need a reusable local graph freshness command before broader MCP/status wiring can stop handing them stale-index setup steps. This PR adds the local-only contract first and leaves packet/search sidecar startup out of scope.

## What Changed

- Added `ready --wait-fresh` for local graph freshness.
- When the index is already fresh, `--wait-fresh` opens inspect-only, reports `local_refresh.state=fresh` with `reason=already_fresh`, and does not initialize the indexing or managed embedding runtime.
- When freshness is stale or unchecked, it opens the indexing runtime only for one incremental local refresh through the existing runtime/indexing path, then reports the refreshed readiness result.
- Added `local_refresh` output to `ready` JSON/Markdown for wait-fresh runs, including `fresh`, `failed`, and `skipped_locked` states.
- Kept packet/search/context sidecars separately gated; `--wait-fresh` does not bootstrap retrieval sidecars.

## How To Review

- Start in `crates/codestory-cli/src/main.rs` at `run_ready` and `wait_for_local_freshness`.
- Then check `crates/codestory-cli/src/args.rs` and `crates/codestory-cli/src/output.rs` for the CLI/output shape.
- Finish in `crates/codestory-cli/tests/ready_command.rs` for fresh no-op and stale-to-fresh CLI coverage.

## Verification

- CodeStory grounding: `cargo run -p codestory-cli -- agent preflight --project "C:\Users\alber\.codex\worktrees\issue-566-wait-fresh-contract\codestory" --format json` reported local graph ready, safe local surfaces, and packet/search/context blocked by missing retrieval sidecars.
- `cargo test -p codestory-cli --test ready_command -- --nocapture` passed 3 tests.
- `cargo test -p codestory-cli classify_local_refresh_failure_state_detects_lock_contention -- --nocapture` passed.
- `cargo check -p codestory-cli -p codestory-runtime` passed.
- `git diff --check` passed.

## Risk

- This is PR 1 of the contract: it does not add timeout budgeting, large-change skip policy, MCP startup/status auto-wiring, daemon/watch behavior, or packet/search sidecar startup.
- Lock contention is classified when surfaced by the existing refresh path; no flaky live SQLite lock race was added.