### PR TITLE
Surface fail-open local refresh

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -747,6 +747,7 @@ function failOpenToolResult(status) {
       code: 'codestory_mcp_runtime_unavailable',
       status: readiness.status,
       repair_reason: status.degraded_reason,
+      local_refresh: status.local_refresh || null,
       plugin_runtime: status.plugin_runtime,
       setup: readiness.setup,
       minimum_next: readiness.minimum_next,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -429,6 +429,10 @@ test("mcp launcher fails open when wait-fresh skips local refresh", async () => 
     ]);
     assert.equal(responses[2].result.isError, true);
     assert.equal(responses[2].result.structuredContent.status, "repair_index");
+    assert.equal(responses[2].result.structuredContent.local_refresh.state, "skipped_locked");
+    assert.equal(responses[2].result.structuredContent.local_refresh.reason, "index_locked");
+    assert.equal(responses[2].result.structuredContent.local_refresh.changed_file_count, 1);
+    assert.equal(responses[2].result.structuredContent.local_refresh.fatal_error_count, 0);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context
Issue #577 was reopened after PR #580 because fail-open `tools/call` responses still hid the compact `local_refresh` truth. The diagnostic status/readiness object already carried that data, but `failOpenToolResult` only returned status, repair reason, runtime, setup, repair commands, and recommendations.

Closes #577
Refs #580, #566

## What Changed
- Added `structuredContent.local_refresh` to fail-open MCP tool results, using the existing `status.local_refresh || null` shape.
- Extended the skipped-locked wait-fresh static test so the `tools/call` response proves `local_refresh.state`, `reason`, and counts are preserved.

## How To Review
- Start with `plugins/codestory/scripts/codestory-mcp.cjs` and confirm `failOpenToolResult` now mirrors the status-level local refresh summary.
- Then read the existing skipped-locked fail-open test in `plugins/codestory/tests/plugin-static.test.mjs`; it exercises `resources/read` and `tools/call` after wait-fresh reports `skipped_locked`.

## Verification
- `node --check plugins/codestory/scripts/codestory-mcp.cjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `git diff --check`

## Risk
Low. This only adds an already-computed diagnostic field to fail-open structured content and tightens the existing static test. The runtime behavior remains fail-open when local refresh is locked or skipped.