### PR TITLE
Bound sidecar stage overruns

### DIFF
--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -12,8 +12,8 @@ use codestory_store::RetrievalIndexManifest;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,7 +74,7 @@ pub struct QueryResult {
 /// The executor is fail-closed: live degraded modes return an error instead of serving partial
 /// results. Tests may use `mode_override`, but product callers should rely on live health probes.
 pub struct QueryExecutor<'a> {
-    pub sidecars: &'a dyn SidecarSearch,
+    pub sidecars: Arc<dyn SidecarSearch>,
     pub cache: &'a mut RetrievalCache,
     pub manifest: Option<RetrievalIndexManifest>,
     pub file_roles: HashMap<String, codestory_store::FileRole>,
@@ -122,12 +122,15 @@ impl<'a> QueryExecutor<'a> {
         }
 
         let mut plan = crate::planner::plan_query(&features, mode);
+        let planned_budget_ms = plan.stages.iter().map(|stage| stage.budget_ms).sum::<u64>();
         if let Some(budget) = total_budget_ms {
+            if is_broad_query(features.shape) && budget < planned_budget_ms {
+                scale_stage_budgets(&mut plan.stages, budget);
+            }
             plan.total_budget_ms = budget;
         }
 
         let started = Instant::now();
-        let deadline = started + Duration::from_millis(plan.total_budget_ms);
         let mut candidates = Vec::new();
         let mut stage_traces = Vec::new();
 
@@ -136,7 +139,6 @@ impl<'a> QueryExecutor<'a> {
             &plan.stages,
             &mut candidates,
             &mut stage_traces,
-            deadline,
             StageSequenceOptions {
                 stop_marginal_gain_threshold: Some(plan.stop_marginal_gain_threshold),
                 stop_after_low_gain_streak: plan.stop_after_low_gain_streak,
@@ -191,23 +193,51 @@ impl<'a> QueryExecutor<'a> {
     }
 
     fn run_stage(
-        &self,
+        sidecars: &dyn SidecarSearch,
         stage: &PlannedStage,
         features: &QueryFeatures,
         anchors: &[CandidateHit],
     ) -> Result<Vec<CandidateHit>> {
         let query = &features.raw_query;
         match stage.kind {
-            RetrievalStageKind::Stage0ScipAnchor => self.sidecars.scip_anchor(query, stage.top_k),
-            RetrievalStageKind::Stage1ZoektLexical => {
-                self.sidecars.zoekt_search(query, stage.top_k)
-            }
-            RetrievalStageKind::Stage1bQdrantSemantic => {
-                self.sidecars.qdrant_search(query, stage.top_k)
-            }
-            RetrievalStageKind::Stage2ScipExpand => self.sidecars.scip_expand(anchors, stage.top_k),
+            RetrievalStageKind::Stage0ScipAnchor => sidecars.scip_anchor(query, stage.top_k),
+            RetrievalStageKind::Stage1ZoektLexical => sidecars.zoekt_search(query, stage.top_k),
+            RetrievalStageKind::Stage1bQdrantSemantic => sidecars.qdrant_search(query, stage.top_k),
+            RetrievalStageKind::Stage2ScipExpand => sidecars.scip_expand(anchors, stage.top_k),
             RetrievalStageKind::Stage3RepoTextFallback => {
                 bail!("repo-text diagnostic stage is unsupported in mandatory sidecar retrieval")
+            }
+        }
+    }
+
+    fn run_stage_bounded(
+        &self,
+        stage: &PlannedStage,
+        features: &QueryFeatures,
+        anchors: &[CandidateHit],
+    ) -> Result<StageRun> {
+        if !is_broad_query(features.shape) {
+            return Self::run_stage(self.sidecars.as_ref(), stage, features, anchors)
+                .map(StageRun::Completed);
+        }
+
+        let stage = stage.clone();
+        let timeout_ms = stage.budget_ms.max(1);
+        let features = features.clone();
+        let anchors = anchors.to_vec();
+        let sidecars = Arc::clone(&self.sidecars);
+        let (sender, receiver) = mpsc::channel();
+        // ponytail: timed-out sidecar work is left to finish; use a shared worker pool if timeout volume matters.
+        std::thread::spawn(move || {
+            let result = Self::run_stage(sidecars.as_ref(), &stage, &features, &anchors);
+            let _ = sender.send(result);
+        });
+
+        match receiver.recv_timeout(Duration::from_millis(timeout_ms)) {
+            Ok(result) => result.map(StageRun::Completed),
+            Err(mpsc::RecvTimeoutError::Timeout) => Ok(StageRun::TimedOut),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                bail!("sidecar stage worker disconnected")
             }
         }
     }
@@ -218,16 +248,13 @@ impl<'a> QueryExecutor<'a> {
         stages: &[PlannedStage],
         candidates: &mut Vec<CandidateHit>,
         stage_traces: &mut Vec<StageTrace>,
-        deadline: Instant,
         options: StageSequenceOptions,
     ) -> Result<Option<String>> {
         let mut low_gain_streak = 0u32;
+        let mut cancel_reason = None;
         for stage in stages {
             if self.cancelled.load(Ordering::Relaxed) {
                 return Ok(Some("cancelled".into()));
-            }
-            if Instant::now() >= deadline {
-                return Ok(Some("deadline".into()));
             }
 
             if should_skip_after_exact_symbol_anchor(stage, features, candidates) {
@@ -257,7 +284,22 @@ impl<'a> QueryExecutor<'a> {
 
             let stage_started = Instant::now();
             let before_score = candidate_mass(candidates);
-            let mut stage_hits = self.run_stage(stage, features, candidates)?;
+            let mut stage_hits = match self.run_stage_bounded(stage, features, candidates)? {
+                StageRun::Completed(hits) => hits,
+                StageRun::TimedOut => {
+                    stage_traces.push(stage_trace(
+                        stage,
+                        stage.budget_ms,
+                        0,
+                        0.0,
+                        Some("stage_deadline".into()),
+                        false,
+                        None,
+                    ));
+                    cancel_reason.get_or_insert_with(|| "stage_deadline".into());
+                    continue;
+                }
+            };
             annotate_stage_provenance(stage, &mut stage_hits);
             let (stub_reason, stage_degraded) = stage_stub_metadata(&stage_hits);
             let added = merge_candidates(candidates, stage_hits);
@@ -289,14 +331,48 @@ impl<'a> QueryExecutor<'a> {
                 }
             }
         }
-        Ok(None)
+        Ok(cancel_reason)
     }
+}
+
+enum StageRun {
+    Completed(Vec<CandidateHit>),
+    TimedOut,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct StageSequenceOptions {
     stop_marginal_gain_threshold: Option<f32>,
     stop_after_low_gain_streak: u32,
+}
+
+fn is_broad_query(shape: crate::query_features::QueryShape) -> bool {
+    matches!(
+        shape,
+        crate::query_features::QueryShape::NaturalLanguage
+            | crate::query_features::QueryShape::Mixed
+    )
+}
+
+fn scale_stage_budgets(stages: &mut [PlannedStage], total_budget_ms: u64) {
+    let planned_total = stages.iter().map(|stage| stage.budget_ms).sum::<u64>();
+    if stages.is_empty() || planned_total == 0 {
+        return;
+    }
+
+    let mut remaining = total_budget_ms.max(stages.len() as u64);
+    let last = stages.len() - 1;
+    for (index, stage) in stages.iter_mut().enumerate() {
+        if index == last {
+            stage.budget_ms = remaining.max(1);
+            break;
+        }
+        let stages_left = (last - index) as u64;
+        let scaled = stage.budget_ms.saturating_mul(total_budget_ms) / planned_total;
+        let budget = scaled.max(1).min(remaining.saturating_sub(stages_left));
+        stage.budget_ms = budget;
+        remaining = remaining.saturating_sub(budget);
+    }
 }
 
 fn stage_trace(
@@ -480,8 +556,9 @@ mod tests {
     use codestory_store::RetrievalIndexManifest;
     use std::collections::HashMap;
     use std::net::TcpListener;
-    use std::sync::Mutex;
     use std::sync::atomic::AtomicUsize;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
 
     fn sample_manifest() -> RetrievalIndexManifest {
         RetrievalIndexManifest {
@@ -536,7 +613,7 @@ mod tests {
         };
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),
@@ -560,7 +637,7 @@ mod tests {
         cache.insert(key, vec![CandidateHit::lexical_stub("cached.rs", 1.0)]);
 
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(manifest),
             file_roles: HashMap::new(),
@@ -574,7 +651,7 @@ mod tests {
 
     #[test]
     fn executor_caches_only_complete_query_results() {
-        let mock = MockSidecarSearch {
+        let mock = Arc::new(MockSidecarSearch {
             zoekt: Mutex::new(HashMap::from([(
                 "startup".into(),
                 vec![CandidateHit::with_source(
@@ -585,12 +662,12 @@ mod tests {
                 )],
             )])),
             ..Default::default()
-        };
+        });
         let mut cache = RetrievalCache::new();
         let manifest = sample_manifest();
         {
             let mut executor = QueryExecutor {
-                sidecars: &mock,
+                sidecars: mock.clone(),
                 cache: &mut cache,
                 manifest: Some(manifest.clone()),
                 file_roles: HashMap::new(),
@@ -607,7 +684,7 @@ mod tests {
         let cancelled = cancellation_flag();
         cancelled.store(true, Ordering::Relaxed);
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: mock.clone(),
             cache: &mut cancelled_cache,
             manifest: Some(manifest.clone()),
             file_roles: HashMap::new(),
@@ -650,7 +727,7 @@ mod tests {
         };
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),
@@ -686,7 +763,7 @@ mod tests {
         let mock = MockSidecarSearch::default();
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),
@@ -704,13 +781,13 @@ mod tests {
         let mut layout = SidecarLayout::from_env();
         layout.zoekt_http_port = unused_local_port();
         let manifest = retrieval_manifest_fixture("testproj", "cafebabedeadbeef");
-        let sidecars = TrackingSidecars {
+        let sidecars = Arc::new(TrackingSidecars {
             layout,
             layout_calls: AtomicUsize::new(0),
-        };
+        });
         let mut cache = RetrievalCache::new();
         let executor = QueryExecutor {
-            sidecars: &sidecars,
+            sidecars: sidecars.clone(),
             cache: &mut cache,
             manifest: Some(manifest),
             file_roles: HashMap::new(),
@@ -734,7 +811,7 @@ mod tests {
         cache.insert(key, vec![CandidateHit::lexical_stub("cached.rs", 1.0)]);
 
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(manifest),
             file_roles: HashMap::new(),
@@ -763,7 +840,7 @@ mod tests {
         };
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),
@@ -788,6 +865,103 @@ mod tests {
                 .iter()
                 .any(|hit| hit.file_path == "src/semantic.rs"),
             "expected semantic hit after empty lexical stages: {:?}",
+            result.hits
+        );
+    }
+
+    #[test]
+    fn broad_query_stage_deadline_preserves_later_sidecar_contribution() {
+        struct SlowZoektSidecars;
+
+        impl SidecarSearch for SlowZoektSidecars {
+            fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                std::thread::sleep(Duration::from_millis(200));
+                Ok(vec![CandidateHit::with_source(
+                    "src/slow_lexical.rs",
+                    Some("SlowLexical".into()),
+                    0.99,
+                    CandidateSource::Zoekt,
+                )])
+            }
+
+            fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::with_source(
+                    "src/semantic.rs",
+                    Some("SemanticAnchor".into()),
+                    0.8,
+                    CandidateSource::Qdrant,
+                )])
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_expand(
+                &self,
+                _anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(SlowZoektSidecars),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let started = Instant::now();
+        let result = executor
+            .execute(
+                "LiveSidecarSearch qdrant_search retrieval_mode full sidecar unavailable",
+                Some(120),
+            )
+            .expect("query");
+
+        assert!(
+            started.elapsed() < Duration::from_millis(190),
+            "slow Zoekt must not consume the whole broad-query path: {:?}",
+            result.trace.stages
+        );
+        assert_eq!(
+            result.trace.cancel_reason.as_deref(),
+            Some("stage_deadline")
+        );
+        assert!(
+            result.trace.stages.iter().any(|stage| {
+                stage.stage == RetrievalStageKind::Stage1ZoektLexical
+                    && stage.cancel_reason.as_deref() == Some("stage_deadline")
+            }),
+            "Zoekt overrun should be explicit in stage provenance: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result.trace.stages.iter().any(|stage| {
+                stage.stage == RetrievalStageKind::Stage1bQdrantSemantic
+                    && stage.candidates_added > 0
+            }),
+            "Qdrant must still contribute after Zoekt overrun: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .any(|hit| hit.file_path == "src/semantic.rs"),
+            "semantic fallback should be rankable after lexical overrun: {:?}",
+            result.hits
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .all(|hit| hit.file_path != "src/slow_lexical.rs"),
+            "timed-out Zoekt hits must not merge late into this query: {:?}",
             result.hits
         );
     }
@@ -820,7 +994,7 @@ mod tests {
         manifest.dense_projection_count = Some(0);
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(manifest),
             file_roles: HashMap::new(),
@@ -879,7 +1053,7 @@ mod tests {
         };
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),
@@ -907,7 +1081,7 @@ mod tests {
         let cancelled = cancellation_flag();
         cancelled.store(true, Ordering::Relaxed);
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),
@@ -946,7 +1120,7 @@ mod tests {
             codestory_store::FileRole::Test,
         );
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: roles,
@@ -985,7 +1159,7 @@ mod tests {
         };
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),
@@ -1052,7 +1226,7 @@ mod tests {
         };
         let mut cache = RetrievalCache::new();
         let mut executor = QueryExecutor {
-            sidecars: &mock,
+            sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
             file_roles: HashMap::new(),

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -12,9 +12,12 @@ use codestory_store::RetrievalIndexManifest;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant};
+
+const BROAD_STAGE_WORKER_LIMIT: usize = 16;
+static BROAD_STAGE_WORKERS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Trace for one retrieval stage.
@@ -131,6 +134,7 @@ impl<'a> QueryExecutor<'a> {
         }
 
         let started = Instant::now();
+        let deadline = started + Duration::from_millis(plan.total_budget_ms);
         let mut candidates = Vec::new();
         let mut stage_traces = Vec::new();
 
@@ -139,6 +143,7 @@ impl<'a> QueryExecutor<'a> {
             &plan.stages,
             &mut candidates,
             &mut stage_traces,
+            deadline,
             StageSequenceOptions {
                 stop_marginal_gain_threshold: Some(plan.stop_marginal_gain_threshold),
                 stop_after_low_gain_streak: plan.stop_after_low_gain_streak,
@@ -227,15 +232,19 @@ impl<'a> QueryExecutor<'a> {
         let anchors = anchors.to_vec();
         let sidecars = Arc::clone(&self.sidecars);
         let (sender, receiver) = mpsc::channel();
-        // ponytail: timed-out sidecar work is left to finish; use a shared worker pool if timeout volume matters.
+        let Some(permit) = BroadStageWorkerPermit::try_acquire() else {
+            return Ok(StageRun::TimedOut("stage_worker_limit"));
+        };
+        // ponytail: global cap; use a worker pool if broad-stage timeout volume matters.
         std::thread::spawn(move || {
+            let _permit = permit;
             let result = Self::run_stage(sidecars.as_ref(), &stage, &features, &anchors);
             let _ = sender.send(result);
         });
 
         match receiver.recv_timeout(Duration::from_millis(timeout_ms)) {
             Ok(result) => result.map(StageRun::Completed),
-            Err(mpsc::RecvTimeoutError::Timeout) => Ok(StageRun::TimedOut),
+            Err(mpsc::RecvTimeoutError::Timeout) => Ok(StageRun::TimedOut("stage_deadline")),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 bail!("sidecar stage worker disconnected")
             }
@@ -248,6 +257,7 @@ impl<'a> QueryExecutor<'a> {
         stages: &[PlannedStage],
         candidates: &mut Vec<CandidateHit>,
         stage_traces: &mut Vec<StageTrace>,
+        deadline: Instant,
         options: StageSequenceOptions,
     ) -> Result<Option<String>> {
         let mut low_gain_streak = 0u32;
@@ -255,6 +265,9 @@ impl<'a> QueryExecutor<'a> {
         for stage in stages {
             if self.cancelled.load(Ordering::Relaxed) {
                 return Ok(Some("cancelled".into()));
+            }
+            if !is_broad_query(features.shape) && Instant::now() >= deadline {
+                return Ok(Some("deadline".into()));
             }
 
             if should_skip_after_exact_symbol_anchor(stage, features, candidates) {
@@ -286,17 +299,17 @@ impl<'a> QueryExecutor<'a> {
             let before_score = candidate_mass(candidates);
             let mut stage_hits = match self.run_stage_bounded(stage, features, candidates)? {
                 StageRun::Completed(hits) => hits,
-                StageRun::TimedOut => {
+                StageRun::TimedOut(reason) => {
                     stage_traces.push(stage_trace(
                         stage,
                         stage.budget_ms,
                         0,
                         0.0,
-                        Some("stage_deadline".into()),
+                        Some(reason.into()),
                         false,
                         None,
                     ));
-                    cancel_reason.get_or_insert_with(|| "stage_deadline".into());
+                    cancel_reason.get_or_insert_with(|| reason.into());
                     continue;
                 }
             };
@@ -337,7 +350,26 @@ impl<'a> QueryExecutor<'a> {
 
 enum StageRun {
     Completed(Vec<CandidateHit>),
-    TimedOut,
+    TimedOut(&'static str),
+}
+
+struct BroadStageWorkerPermit;
+
+impl BroadStageWorkerPermit {
+    fn try_acquire() -> Option<Self> {
+        BROAD_STAGE_WORKERS_IN_FLIGHT
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                (current < BROAD_STAGE_WORKER_LIMIT).then_some(current + 1)
+            })
+            .ok()
+            .map(|_| Self)
+    }
+}
+
+impl Drop for BroadStageWorkerPermit {
+    fn drop(&mut self) {
+        BROAD_STAGE_WORKERS_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -962,6 +994,179 @@ mod tests {
                 .iter()
                 .all(|hit| hit.file_path != "src/slow_lexical.rs"),
             "timed-out Zoekt hits must not merge late into this query: {:?}",
+            result.hits
+        );
+    }
+
+    #[test]
+    fn broad_query_slow_scip_expand_still_allows_qdrant_contribution() {
+        struct SlowScipExpandSidecars;
+
+        impl SidecarSearch for SlowScipExpandSidecars {
+            fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::with_source(
+                    "src/lexical.rs",
+                    Some("LexicalAnchor".into()),
+                    0.7,
+                    CandidateSource::Zoekt,
+                )])
+            }
+
+            fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::with_source(
+                    "src/semantic.rs",
+                    Some("SemanticAnchor".into()),
+                    0.8,
+                    CandidateSource::Qdrant,
+                )])
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_expand(
+                &self,
+                _anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                std::thread::sleep(Duration::from_millis(200));
+                Ok(vec![CandidateHit::with_source(
+                    "src/slow_graph.rs",
+                    Some("SlowGraph".into()),
+                    0.95,
+                    CandidateSource::Scip,
+                )])
+            }
+        }
+
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(SlowScipExpandSidecars),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor
+            .execute(
+                "LiveSidecarSearch qdrant_search retrieval_mode full sidecar unavailable",
+                Some(120),
+            )
+            .expect("query");
+
+        assert_eq!(
+            result.trace.cancel_reason.as_deref(),
+            Some("stage_deadline")
+        );
+        assert!(
+            result.trace.stages.iter().any(|stage| {
+                stage.stage == RetrievalStageKind::Stage2ScipExpand
+                    && stage.cancel_reason.as_deref() == Some("stage_deadline")
+            }),
+            "SCIP expand overrun should be explicit in stage provenance: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result.trace.stages.iter().any(|stage| {
+                stage.stage == RetrievalStageKind::Stage1bQdrantSemantic
+                    && stage.candidates_added > 0
+            }),
+            "Qdrant must still contribute after SCIP expand overrun: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .any(|hit| hit.file_path == "src/semantic.rs"),
+            "semantic fallback should be rankable after graph overrun: {:?}",
+            result.hits
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .all(|hit| hit.file_path != "src/slow_graph.rs"),
+            "timed-out graph hits must not merge late into this query: {:?}",
+            result.hits
+        );
+    }
+
+    #[test]
+    fn non_broad_queries_stop_between_stages_after_total_deadline() {
+        struct SlowScipAnchorSidecars;
+
+        impl SidecarSearch for SlowScipAnchorSidecars {
+            fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::with_source(
+                    "src/late_lexical.rs",
+                    Some("LateLexical".into()),
+                    0.99,
+                    CandidateSource::Zoekt,
+                )])
+            }
+
+            fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                std::thread::sleep(Duration::from_millis(30));
+                Ok(vec![CandidateHit::with_source(
+                    "src/anchor.rs",
+                    Some("OtherAnchor".into()),
+                    0.7,
+                    CandidateSource::Scip,
+                )])
+            }
+
+            fn scip_expand(
+                &self,
+                _anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(SlowScipAnchorSidecars),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor.execute("EventProcessor", Some(1)).expect("query");
+
+        assert_eq!(result.trace.cancel_reason.as_deref(), Some("deadline"));
+        assert!(
+            result
+                .trace
+                .stages
+                .iter()
+                .any(|stage| stage.stage == RetrievalStageKind::Stage0ScipAnchor),
+            "first non-broad stage should complete before sequence deadline check: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result
+                .trace
+                .stages
+                .iter()
+                .all(|stage| stage.stage != RetrievalStageKind::Stage1ZoektLexical),
+            "later non-broad stages must not start after total budget is spent: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .all(|hit| hit.file_path != "src/late_lexical.rs"),
+            "late lexical hit should not be collected after sequence deadline: {:?}",
             result.hits
         );
     }

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -57,10 +57,14 @@ pub fn execute_retrieval_query_with_cache(
         manifest,
         file_roles,
     } = load_query_context(request.project_root, request.storage_path)?;
-    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
+    let sidecars = Arc::new(LiveSidecarSearch::new(
+        layout,
+        project_id,
+        manifest.as_ref(),
+    ));
     let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
     let mut executor = QueryExecutor {
-        sidecars: &sidecars,
+        sidecars,
         cache,
         manifest,
         file_roles,
@@ -83,9 +87,13 @@ pub fn execute_strict_retrieval_query_batch_with_cache(
         manifest,
         file_roles,
     } = load_query_context(request.project_root, request.storage_path)?;
-    let sidecars = LiveSidecarSearch::new(layout, project_id, manifest.as_ref());
+    let sidecars = Arc::new(LiveSidecarSearch::new(
+        layout,
+        project_id,
+        manifest.as_ref(),
+    ));
     let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
-    let (mode, degraded_reason) = resolve_batch_mode(&sidecars, manifest.as_ref());
+    let (mode, degraded_reason) = resolve_batch_mode(sidecars.as_ref(), manifest.as_ref());
     if mode != RetrievalDegradedMode::Full {
         bail!(
             "retrieval sidecar is mandatory; project is not in full mode (mode={}, reason={})",
@@ -94,7 +102,7 @@ pub fn execute_strict_retrieval_query_batch_with_cache(
         );
     }
     execute_strict_retrieval_query_batch_against_sidecars(
-        &sidecars,
+        sidecars,
         manifest,
         file_roles,
         cancelled,
@@ -107,7 +115,7 @@ pub fn execute_strict_retrieval_query_batch_with_cache(
 
 #[allow(clippy::too_many_arguments)]
 fn execute_strict_retrieval_query_batch_against_sidecars(
-    sidecars: &dyn SidecarSearch,
+    sidecars: Arc<dyn SidecarSearch>,
     manifest: Option<RetrievalIndexManifest>,
     file_roles: HashMap<String, FileRole>,
     cancelled: Arc<AtomicBool>,
@@ -140,6 +148,7 @@ fn execute_strict_retrieval_query_batch_against_sidecars(
                 let manifest = manifest.clone();
                 let file_roles = file_roles.clone();
                 let cancelled = Arc::clone(&cancelled);
+                let sidecars = Arc::clone(&sidecars);
                 handles.push(scope.spawn(move || {
                     let mut worker_cache = RetrievalCache::new();
                     let mut executor = QueryExecutor {
@@ -288,15 +297,17 @@ fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryC
 }
 
 fn resolve_batch_mode(
-    sidecars: &LiveSidecarSearch,
+    sidecars: &dyn SidecarSearch,
     manifest: Option<&RetrievalIndexManifest>,
 ) -> (RetrievalDegradedMode, Option<String>) {
     if let Some(manifest) = manifest {
-        let report = probe_sidecar_health(
-            sidecars.layout(),
-            &manifest.project_id,
-            Some(manifest.clone()),
-        );
+        let Some(layout) = sidecars.layout() else {
+            return (
+                RetrievalDegradedMode::Unavailable,
+                Some("sidecar_layout_missing".into()),
+            );
+        };
+        let report = probe_sidecar_health(layout, &manifest.project_id, Some(manifest.clone()));
         return derive_degraded_mode(&report.zoekt, &report.qdrant, &report.scip);
     }
     (
@@ -396,10 +407,10 @@ mod tests {
             }
         }
 
-        let sidecars = CountingSidecars {
+        let sidecars = Arc::new(CountingSidecars {
             active: AtomicUsize::new(0),
             max_active: AtomicUsize::new(0),
-        };
+        });
         let mut cache = RetrievalCache::new();
         let manifest = manifest_for("testproj", "cafebabedeadbeef", 3);
         let queries = [
@@ -418,7 +429,7 @@ mod tests {
         ];
 
         let results = execute_strict_retrieval_query_batch_against_sidecars(
-            &sidecars,
+            sidecars.clone(),
             Some(manifest),
             HashMap::new(),
             cancellation_flag(),
@@ -454,7 +465,7 @@ mod tests {
         }];
 
         let error = execute_strict_retrieval_query_batch_against_sidecars(
-            &sidecars,
+            Arc::new(sidecars),
             Some(manifest),
             HashMap::new(),
             cancellation_flag(),


### PR DESCRIPTION
## Context

Closes #578
Refs #569, #544, #511, #585

#569 reproduced the live #544 packet/search miss: exact-symbol search resolves `LiveSidecarSearch::qdrant_search`, but broad readiness searches could spend the sidecar path in early stages and never get useful later-stage contribution.

This PR keeps the fixture contract and eval baseline unchanged. It bounds broad-query sidecar stages and records the remaining live blocker under #585.

## What Changed

- `QueryExecutor` owns an `Arc<dyn SidecarSearch>` so broad-query stages can run through a timed worker instead of blocking the whole query path.
- Broad query stage budgets are proportionally scaled when the caller supplies a smaller live budget.
- Broad-stage workers are capped by a small global in-flight guard so timed-out sidecar calls cannot accumulate without bound.
- Timed-out broad stages now record `cancel_reason: "stage_deadline"`; worker-cap misses record `stage_worker_limit`; later stages still run deterministically when a stage overruns.
- Exact/path queries keep the direct execution path and the previous between-stage sequence deadline behavior, so they stop starting later stages after `total_budget_ms` is spent.
- Strict batch query execution shares the same sidecar handle shape.

```mermaid
flowchart LR
  A["Broad query"] --> B["Acquire worker slot"]
  B -->|"slot available"| C["Timed stage worker"]
  B -->|"cap reached"| D["stage_worker_limit trace"]
  C -->|"stage overruns"| E["stage_deadline trace"]
  D --> F["Later stages still considered"]
  E --> F
  F --> G["Qdrant/SCIP candidates can contribute"]
```

## How To Review

- Start in `crates/codestory-retrieval/src/executor.rs`.
- Check that `run_stage_bounded` only applies timed workers to broad query shapes.
- Check `BroadStageWorkerPermit` for the bounded in-flight guard.
- Check `non_broad_queries_stop_between_stages_after_total_deadline` for restored exact/path deadline behavior.
- Check `broad_query_stage_deadline_preserves_later_sidecar_contribution` and `broad_query_slow_scip_expand_still_allows_qdrant_contribution` for the #578 overrun cases.
- Check `crates/codestory-retrieval/src/query.rs` for the minimal `Arc<dyn SidecarSearch>` follow-through in single and strict batch query paths.

## Verification

Review follow-up at `4ae066fe90220ad916a4a5755e8f04daeaf76194`:

- `cargo fmt`
  - passed
- `cargo test -p codestory-retrieval executor`
  - passed: 17 passed
- `cargo test -p codestory-retrieval strict_batch`
  - passed: 2 passed
- `git diff --check`
  - passed

Earlier #584 verification before the review follow-up:

- `powershell -ExecutionPolicy Bypass -File scripts\codex-worktree-setup.ps1`
  - local graph ready: `files=275`, `nodes=116865`, `edges=98039`, `errors=0`
  - sidecar retrieval ready after index refresh: `retrieval_mode=full`
- `cargo test -p codestory-cli --test packet_search_eval`
  - passed: 7 passed, 1 ignored
- Exact-symbol control:
  - `target\debug\codestory-cli.exe search --query "LiveSidecarSearch::qdrant_search" --limit 10 --refresh none --why --format json`
  - `LiveSidecarSearch::qdrant_search` resolved at rank 1
- Broad readiness diagnostic after stage bounding:
  - full retrieval, `cancel_reason=stage_deadline`
  - `stage1_zoekt_lexical`: `deadline_ms=120`, `elapsed_ms=120`, `cancel_reason=stage_deadline`, `candidates_added=0`
  - `stage2_scip_expand`: `deadline_ms=180`, `elapsed_ms=180`, `cancel_reason=stage_deadline`, `candidates_added=0`
  - `stage1b_qdrant_semantic`: `elapsed_ms=37`, `candidates_added=40`
- Live production eval remained failing before this review follow-up:
  - `cargo test -p codestory-cli --test packet_search_eval -- --ignored --nocapture packet_search_eval_live_runs_production_cli_path`
  - failed after 184.27s: `recall_at_k regressed: actual=0.500 expected=1.000 tolerance=0.000`

## Risk

Draft because #544 is not ready. This removes the broad-query starvation mode and fixes the review blockers around detached worker accumulation and non-broad sequence deadlines, but the live eval miss remains parked on #585.

This PR does not raise baselines, widen `k`, change fixture expectations, add retrieval machinery, add model families/rerankers/indexes, or merge #544.
