### PR TITLE
Add sidecar inventory dry run

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -715,6 +715,8 @@ pub(crate) enum RetrievalAction {
     Down(RetrievalSidecarStateCommand),
     /// Probe Zoekt, Qdrant, and SCIP availability for the project.
     Status(RetrievalStatusCommand),
+    /// List owned sidecar namespaces and dry-run cleanup eligibility.
+    Inventory(RetrievalInventoryCommand),
     /// Run workspace index then persist retrieval_index_manifest sidecar metadata.
     Index(RetrievalIndexCommand),
     /// Execute a standalone sidecar retrieval query against indexed sidecar metadata.
@@ -823,6 +825,16 @@ pub(crate) struct RetrievalStatusCommand {
 }
 
 #[derive(Args, Debug)]
+pub(crate) struct RetrievalInventoryCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
+    pub(crate) format: OutputFormat,
+    #[arg(long, value_name = "PATH")]
+    pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
 pub(crate) struct SidecarCommand {
     #[command(subcommand)]
     pub(crate) action: SidecarAction,
@@ -832,6 +844,8 @@ pub(crate) struct SidecarCommand {
 pub(crate) enum SidecarAction {
     /// Alias for `retrieval status`.
     Status(RetrievalStatusCommand),
+    /// Alias for `retrieval inventory`.
+    Inventory(RetrievalInventoryCommand),
     #[command(external_subcommand)]
     Unknown(Vec<String>),
 }

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -217,10 +217,13 @@ fn main() -> Result<()> {
 fn run_sidecar(cmd: SidecarCommand) -> Result<()> {
     match cmd.action {
         SidecarAction::Status(status_cmd) => retrieval::run_retrieval_status(status_cmd),
+        SidecarAction::Inventory(inventory_cmd) => {
+            retrieval::run_retrieval_inventory(inventory_cmd)
+        }
         SidecarAction::Unknown(args) => {
             let subcommand = args.first().map(String::as_str).unwrap_or("<unknown>");
             bail!(
-                "unknown sidecar subcommand `{subcommand}`; use `codestory-cli sidecar status` or `codestory-cli retrieval status`"
+                "unknown sidecar subcommand `{subcommand}`; use `codestory-cli sidecar status`, `codestory-cli sidecar inventory`, or `codestory-cli retrieval status`"
             )
         }
     }

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -12,8 +12,8 @@ use codestory_retrieval::{
 
 use crate::args::{
     CliSidecarProfile, OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand,
-    RetrievalCommand, RetrievalIndexCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
-    RetrievalStatusCommand,
+    RetrievalCommand, RetrievalIndexCommand, RetrievalInventoryCommand, RetrievalQueryCommand,
+    RetrievalSidecarStateCommand, RetrievalStatusCommand,
 };
 use crate::output::{emit, validate_output_file_parent};
 use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_refresh_request};
@@ -24,6 +24,7 @@ pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
         RetrievalAction::Up(up_cmd) => run_retrieval_up(up_cmd),
         RetrievalAction::Down(down_cmd) => run_retrieval_down(down_cmd),
         RetrievalAction::Status(status_cmd) => run_retrieval_status(status_cmd),
+        RetrievalAction::Inventory(inventory_cmd) => run_retrieval_inventory(inventory_cmd),
         RetrievalAction::Index(index_cmd) => run_retrieval_index(index_cmd),
         RetrievalAction::Query(query_cmd) => run_retrieval_query(query_cmd),
     }
@@ -119,6 +120,14 @@ pub(crate) fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
     }
     .context("retrieval status")?;
     emit_retrieval_status(cmd.format, &report, cmd.output_file.as_deref())
+}
+
+pub(crate) fn run_retrieval_inventory(cmd: RetrievalInventoryCommand) -> Result<()> {
+    preflight_output(cmd.output_file.as_deref())?;
+    let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
+    let report = codestory_retrieval::sidecar_inventory(&runtime.project_root)
+        .context("retrieval inventory")?;
+    emit_retrieval_inventory(cmd.format, &report, cmd.output_file.as_deref())
 }
 
 fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
@@ -550,6 +559,61 @@ fn emit_retrieval_status(
         report.scip.detail,
         report.scip.capabilities.graph,
     );
+    emit(format, report, markdown, output_file)
+}
+
+fn emit_retrieval_inventory(
+    format: OutputFormat,
+    report: &codestory_retrieval::SidecarInventoryReport,
+    output_file: Option<&std::path::Path>,
+) -> Result<()> {
+    let mut markdown = format!(
+        "# Retrieval sidecar inventory\n\n- dry_run: {}\n- docker_available: {}\n- cache_root: `{}`\n",
+        report.dry_run, report.docker_available, report.cache_root
+    );
+    if let Some(error) = report.docker_error.as_deref() {
+        markdown.push_str(&format!("- docker_error: `{error}`\n"));
+    }
+    if report.namespaces.is_empty() {
+        markdown.push_str("\nNo sidecar namespaces found.\n");
+    }
+    for namespace in &report.namespaces {
+        let ports = namespace
+            .containers
+            .iter()
+            .filter_map(|container| container.ports.as_deref())
+            .collect::<Vec<_>>()
+            .join("; ");
+        markdown.push_str(&format!(
+            "\n## {}\n\n- state: `{:?}`\n- owner/profile: `{}` / `{}`\n- state_path: `{}`\n- cleanup_command: `{}`\n- age_ms: `{}`\n- compose_project: `{}`\n- containers: {}\n- networks: {}\n- ports: `{}`\n- model_dir: `{}` required_gguf=`{}` present={}\n",
+            namespace.namespace,
+            namespace.state,
+            namespace.owner.as_deref().unwrap_or("<unknown>"),
+            namespace.profile.as_deref().unwrap_or("<unknown>"),
+            namespace.state_path,
+            namespace.cleanup_command.as_deref().unwrap_or("<none>"),
+            namespace
+                .age_ms
+                .map(|age| age.to_string())
+                .unwrap_or_else(|| "<unknown>".to_string()),
+            namespace.compose_project.as_deref().unwrap_or("<unknown>"),
+            namespace.containers.len(),
+            namespace.networks.len(),
+            if ports.is_empty() { "<none>" } else { &ports },
+            namespace.model.model_dir.as_deref().unwrap_or("<none>"),
+            namespace.model.required_gguf,
+            namespace.model.required_gguf_present,
+        ));
+        if !namespace.reasons.is_empty() {
+            markdown.push_str(&format!("- reasons: `{}`\n", namespace.reasons.join("; ")));
+        }
+        if let Some(reason) = namespace.safe_candidate_reason.as_deref() {
+            markdown.push_str(&format!("- safe_candidate_reason: `{reason}`\n"));
+        }
+        if let Some(reason) = namespace.blocking_reason.as_deref() {
+            markdown.push_str(&format!("- blocking_reason: `{reason}`\n"));
+        }
+    }
     emit(format, report, markdown, output_file)
 }
 

--- a/crates/codestory-cli/tests/sidecar_status_cli.rs
+++ b/crates/codestory-cli/tests/sidecar_status_cli.rs
@@ -79,6 +79,45 @@ fn sidecar_status_uses_retrieval_status_human_output() {
 }
 
 #[test]
+fn sidecar_inventory_reports_read_only_dry_run_json() {
+    let project = tempdir().expect("project");
+    let cache_dir = tempdir().expect("cache");
+    write_tiny_project(project.path());
+
+    let output = run_cli(
+        project.path(),
+        cache_dir.path(),
+        &["sidecar", "inventory", "--format", "json"],
+    );
+    assert_success(&output, "sidecar inventory failed");
+
+    let json = stdout_json(&output);
+    assert_eq!(json["dry_run"].as_bool(), Some(true));
+    assert!(json["namespaces"].is_array());
+}
+
+#[test]
+fn retrieval_inventory_has_human_output() {
+    let project = tempdir().expect("project");
+    let cache_dir = tempdir().expect("cache");
+    write_tiny_project(project.path());
+
+    let output = run_cli(
+        project.path(),
+        cache_dir.path(),
+        &["retrieval", "inventory", "--format", "markdown"],
+    );
+    assert_success(&output, "retrieval inventory failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("# Retrieval sidecar inventory"),
+        "inventory should have a human-readable heading:\n{stdout}"
+    );
+    assert!(stdout.contains("dry_run"));
+}
+
+#[test]
 fn unknown_sidecar_subcommand_suggests_status_without_runtime_side_effects() {
     let project = tempdir().expect("project");
     let cache_dir = tempdir().expect("cache");
@@ -99,6 +138,7 @@ fn unknown_sidecar_subcommand_suggests_status_without_runtime_side_effects() {
     );
     assert!(combined.contains("unknown sidecar subcommand `frobnicate`"));
     assert!(combined.contains("codestory-cli sidecar status"));
+    assert!(combined.contains("codestory-cli sidecar inventory"));
     assert!(combined.contains("codestory-cli retrieval status"));
     assert!(
         !cache_dir.path().join("codestory.db").exists(),

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -17,6 +17,14 @@ use std::time::{Duration, Instant};
 pub const DEFAULT_COMPOSE_REL_PATH: &str = "docker/retrieval-compose.yml";
 const BUNDLED_RETRIEVAL_COMPOSE: &str = include_str!("../../../docker/retrieval-compose.yml");
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct EmbedModelInventory {
+    pub model_dir: Option<String>,
+    pub required_gguf: String,
+    pub required_gguf_present: bool,
+    pub candidate_dirs: Vec<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct BootstrapReport {
     pub state: SidecarStateFile,
@@ -355,15 +363,53 @@ fn docker_bind_path(path: &Path) -> String {
 }
 
 fn embed_model_dir(repo_root: Option<&Path>, layout: &SidecarLayout) -> Result<PathBuf> {
-    if let Ok(path) = std::env::var("CODESTORY_EMBED_MODEL_DIR") {
-        let path = PathBuf::from(path);
-        if embed_model_dir_ready(&path) {
-            return Ok(path);
-        }
-        bail!(
+    let inventory = embed_model_inventory(repo_root, layout);
+    if let Some(model_dir) = inventory
+        .required_gguf_present
+        .then(|| inventory.model_dir.as_ref())
+        .flatten()
+    {
+        return Ok(PathBuf::from(model_dir));
+    }
+    if std::env::var("CODESTORY_EMBED_MODEL_DIR").is_ok() {
+        anyhow::bail!(
             "CODESTORY_EMBED_MODEL_DIR does not contain {}; run `node scripts/setup-retrieval-env.mjs --fetch-embed-model` or set CODESTORY_EMBED_MODEL_DIR",
             crate::embeddings::BGE_BASE_EN_V1_5_GGUF
         );
+    }
+    anyhow::bail!(
+        "No llama.cpp embedding model directory contains {}; run `node scripts/setup-retrieval-env.mjs --fetch-embed-model` or set CODESTORY_EMBED_MODEL_DIR",
+        crate::embeddings::BGE_BASE_EN_V1_5_GGUF
+    )
+}
+
+pub fn embed_model_inventory(
+    repo_root: Option<&Path>,
+    layout: &SidecarLayout,
+) -> EmbedModelInventory {
+    let candidates = embed_model_candidates(repo_root, layout);
+    let model_dir = candidates
+        .iter()
+        .find(|candidate| embed_model_dir_ready(candidate))
+        .or_else(|| candidates.first())
+        .map(|path| path.display().to_string());
+    let required_gguf_present = model_dir
+        .as_ref()
+        .is_some_and(|path| embed_model_dir_ready(Path::new(path)));
+    EmbedModelInventory {
+        model_dir,
+        required_gguf: crate::embeddings::BGE_BASE_EN_V1_5_GGUF.to_string(),
+        required_gguf_present,
+        candidate_dirs: candidates
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect(),
+    }
+}
+
+fn embed_model_candidates(repo_root: Option<&Path>, layout: &SidecarLayout) -> Vec<PathBuf> {
+    if let Ok(path) = std::env::var("CODESTORY_EMBED_MODEL_DIR") {
+        return vec![PathBuf::from(path)];
     }
     let workdir = repo_root
         .or_else(|| Some(Path::new(".")))
@@ -373,14 +419,21 @@ fn embed_model_dir(repo_root: Option<&Path>, layout: &SidecarLayout) -> Result<P
         .parent()
         .map(|parent| parent.join("embed-models"))
         .unwrap_or_else(|| layout.qdrant_data_dir.join("embed-models"));
-    embed_model_dir_from_candidates([
+    let mut candidates = Vec::new();
+    for candidate in [
         workdir.join("target").join("retrieval-models"),
         workdir.join("models").join("gguf").join("bge-base-en-v1.5"),
         user_cache_root().join("embed-models"),
         fallback,
-    ])
+    ] {
+        if !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
+    }
+    candidates
 }
 
+#[cfg(test)]
 fn embed_model_dir_from_candidates(
     candidates: impl IntoIterator<Item = PathBuf>,
 ) -> Result<PathBuf> {

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -1,0 +1,909 @@
+use crate::compose::{EmbedModelInventory, embed_model_inventory};
+use crate::config::{SidecarRuntimeConfig, user_cache_root};
+use crate::sidecar::SidecarStateFile;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const STALE_AFTER_MS: i64 = 24 * 60 * 60 * 1000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SidecarInventoryState {
+    Live,
+    Stale,
+    Orphaned,
+    Incomplete,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SidecarDockerResourceKind {
+    Container,
+    Network,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SidecarDockerResource {
+    pub kind: SidecarDockerResourceKind,
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ports: Option<String>,
+    pub labels: BTreeMap<String, String>,
+    pub match_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SidecarInventoryEntry {
+    pub namespace: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    pub state_path: String,
+    pub state_exists: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup_command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub age_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compose_project: Option<String>,
+    pub containers: Vec<SidecarDockerResource>,
+    pub networks: Vec<SidecarDockerResource>,
+    pub model: EmbedModelInventory,
+    pub state: SidecarInventoryState,
+    pub reasons: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safe_candidate_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocking_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SidecarInventoryReport {
+    pub dry_run: bool,
+    pub docker_available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docker_error: Option<String>,
+    pub cache_root: String,
+    pub namespaces: Vec<SidecarInventoryEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct StateCandidate {
+    namespace: String,
+    state_path: PathBuf,
+    state: Option<SidecarStateFile>,
+    read_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct DockerInventory {
+    available: bool,
+    error: Option<String>,
+    containers: Vec<SidecarDockerResource>,
+    networks: Vec<SidecarDockerResource>,
+}
+
+pub fn sidecar_inventory(project_root: &Path) -> Result<SidecarInventoryReport> {
+    sidecar_inventory_with_cache_root(project_root, &user_cache_root())
+}
+
+pub fn sidecar_inventory_with_cache_root(
+    project_root: &Path,
+    cache_root: &Path,
+) -> Result<SidecarInventoryReport> {
+    let docker = read_docker_inventory();
+    Ok(build_inventory(
+        project_root,
+        cache_root,
+        chrono::Utc::now().timestamp_millis(),
+        docker,
+    ))
+}
+
+fn build_inventory(
+    project_root: &Path,
+    cache_root: &Path,
+    now_ms: i64,
+    docker: DockerInventory,
+) -> SidecarInventoryReport {
+    build_inventory_with_model(project_root, cache_root, now_ms, docker, None)
+}
+
+fn build_inventory_with_model(
+    project_root: &Path,
+    cache_root: &Path,
+    now_ms: i64,
+    docker: DockerInventory,
+    model_override: Option<EmbedModelInventory>,
+) -> SidecarInventoryReport {
+    let mut states = discover_state_candidates(cache_root);
+    add_resource_only_candidates(&mut states, cache_root, &docker);
+    let mut compose_projects = BTreeSet::new();
+    for state in &states {
+        if let Some(compose_project) = state
+            .state
+            .as_ref()
+            .and_then(|state| owned_state(state).then(|| state.compose_project.clone()))
+        {
+            compose_projects.insert(compose_project);
+        }
+    }
+
+    let layout = SidecarRuntimeConfig::for_project_auto(project_root).layout;
+    let model =
+        model_override.unwrap_or_else(|| embed_model_inventory(Some(project_root), &layout));
+    let mut entries = states
+        .into_iter()
+        .map(|candidate| {
+            let resources = matching_resources(&candidate, &docker, &compose_projects);
+            inventory_entry(
+                now_ms,
+                candidate,
+                resources,
+                docker.available,
+                model.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|a, b| a.namespace.cmp(&b.namespace));
+
+    SidecarInventoryReport {
+        dry_run: true,
+        docker_available: docker.available,
+        docker_error: docker.error,
+        cache_root: cache_root.display().to_string(),
+        namespaces: entries,
+    }
+}
+
+fn discover_state_candidates(cache_root: &Path) -> Vec<StateCandidate> {
+    let mut candidates = Vec::new();
+    let local = cache_root.join("retrieval-sidecars.json");
+    if local.exists() {
+        candidates.push(read_state_candidate("codestory".to_string(), local));
+    }
+    let sidecars_root = cache_root.join("sidecars");
+    if let Ok(entries) = std::fs::read_dir(&sidecars_root) {
+        for entry in entries.flatten() {
+            if !entry.file_type().map(|kind| kind.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let namespace = entry.file_name().to_string_lossy().to_string();
+            if !namespace.starts_with("codestory-") {
+                continue;
+            }
+            let state_path = entry.path().join("retrieval-sidecars.json");
+            candidates.push(if state_path.exists() {
+                read_state_candidate(namespace, state_path)
+            } else {
+                StateCandidate {
+                    namespace,
+                    state_path,
+                    state: None,
+                    read_error: Some("state file missing".to_string()),
+                }
+            });
+        }
+    }
+    candidates
+}
+
+fn read_state_candidate(namespace: String, state_path: PathBuf) -> StateCandidate {
+    let parsed = std::fs::read_to_string(&state_path)
+        .with_context(|| format!("read {}", state_path.display()))
+        .and_then(|contents| {
+            serde_json::from_str::<SidecarStateFile>(&contents)
+                .with_context(|| format!("parse {}", state_path.display()))
+        });
+    match parsed {
+        Ok(state) => StateCandidate {
+            namespace: state.namespace.clone(),
+            state_path,
+            state: Some(state),
+            read_error: None,
+        },
+        Err(error) => StateCandidate {
+            namespace,
+            state_path,
+            state: None,
+            read_error: Some(error.to_string()),
+        },
+    }
+}
+
+fn add_resource_only_candidates(
+    states: &mut Vec<StateCandidate>,
+    cache_root: &Path,
+    docker: &DockerInventory,
+) {
+    let mut known = states
+        .iter()
+        .map(|state| state.namespace.clone())
+        .collect::<BTreeSet<_>>();
+    for resource in docker.containers.iter().chain(docker.networks.iter()) {
+        let Some(namespace) = resource_namespace(resource) else {
+            continue;
+        };
+        if !known.insert(namespace.clone()) {
+            continue;
+        }
+        states.push(StateCandidate {
+            state_path: cache_root
+                .join("sidecars")
+                .join(&namespace)
+                .join("retrieval-sidecars.json"),
+            namespace,
+            state: None,
+            read_error: Some("no state file for matching Docker resource".to_string()),
+        });
+    }
+}
+
+fn matching_resources(
+    candidate: &StateCandidate,
+    docker: &DockerInventory,
+    owned_compose_projects: &BTreeSet<String>,
+) -> (Vec<SidecarDockerResource>, Vec<SidecarDockerResource>) {
+    let containers = docker
+        .containers
+        .iter()
+        .filter_map(|resource| match_resource(candidate, resource, owned_compose_projects))
+        .collect();
+    let networks = docker
+        .networks
+        .iter()
+        .filter_map(|resource| match_resource(candidate, resource, owned_compose_projects))
+        .collect();
+    (containers, networks)
+}
+
+fn match_resource(
+    candidate: &StateCandidate,
+    resource: &SidecarDockerResource,
+    owned_compose_projects: &BTreeSet<String>,
+) -> Option<SidecarDockerResource> {
+    if resource_namespace(resource).as_deref() == Some(candidate.namespace.as_str()) {
+        let mut resource = resource.clone();
+        resource.match_reason = "matched codestory namespace label".to_string();
+        return Some(resource);
+    }
+    let compose_project = compose_project(resource);
+    if let Some(state) = candidate.state.as_ref()
+        && owned_state(state)
+        && compose_project.as_deref() == Some(state.compose_project.as_str())
+    {
+        let mut resource = resource.clone();
+        resource.match_reason = "matched compose project from owned state".to_string();
+        return Some(resource);
+    }
+    if resource.kind == SidecarDockerResourceKind::Network
+        && resource.labels.get("dev.codestory.owner").is_none()
+        && compose_project
+            .as_ref()
+            .is_some_and(|project| owned_compose_projects.contains(project))
+        && candidate
+            .state
+            .as_ref()
+            .is_some_and(|state| state.compose_project == compose_project.unwrap())
+    {
+        let mut resource = resource.clone();
+        resource.match_reason = "matched unlabeled compose network via owned state".to_string();
+        return Some(resource);
+    }
+    None
+}
+
+fn inventory_entry(
+    now_ms: i64,
+    candidate: StateCandidate,
+    resources: (Vec<SidecarDockerResource>, Vec<SidecarDockerResource>),
+    docker_available: bool,
+    model: EmbedModelInventory,
+) -> SidecarInventoryEntry {
+    let (containers, networks) = resources;
+    let state_exists = candidate.state.is_some();
+    let state = candidate.state.as_ref();
+    let owner = state.map(|state| state.owner.clone());
+    let profile = state.map(|state| state.profile.clone());
+    let cleanup_command = state
+        .map(|state| state.cleanup_command.clone())
+        .filter(|command| !command.trim().is_empty());
+    let compose_project = state.map(|state| state.compose_project.clone());
+    let age_ms = state.map(|state| now_ms.saturating_sub(state.started_at_epoch_ms).max(0));
+
+    let mut reasons = Vec::new();
+    if let Some(error) = candidate.read_error.as_ref() {
+        reasons.push(error.clone());
+    }
+    if state.is_some_and(|state| !owned_state(state)) {
+        reasons.push("state owner is not codestory".to_string());
+    }
+    if state.is_some() && !model.required_gguf_present {
+        reasons.push(format!("missing required GGUF {}", model.required_gguf));
+    }
+    if state.is_some_and(|state| {
+        !Path::new(&state.zoekt_data_dir).exists()
+            || !Path::new(&state.qdrant_data_dir).exists()
+            || !Path::new(&state.scip_artifacts_root).exists()
+    }) {
+        reasons.push("one or more sidecar data directories are missing".to_string());
+    }
+    let live_container = containers.iter().any(resource_running);
+    let status = classify_entry(
+        state,
+        state_exists,
+        live_container,
+        docker_available,
+        age_ms,
+        model.required_gguf_present,
+        &containers,
+        &networks,
+    );
+    let (safe_candidate_reason, blocking_reason) = candidate_reasons(status, &reasons);
+
+    SidecarInventoryEntry {
+        namespace: candidate.namespace,
+        owner,
+        profile,
+        state_path: candidate.state_path.display().to_string(),
+        state_exists,
+        cleanup_command,
+        age_ms,
+        compose_project,
+        containers,
+        networks,
+        model,
+        state: status,
+        reasons,
+        safe_candidate_reason,
+        blocking_reason,
+    }
+}
+
+fn classify_entry(
+    state: Option<&SidecarStateFile>,
+    state_exists: bool,
+    live_container: bool,
+    docker_available: bool,
+    age_ms: Option<i64>,
+    model_ready: bool,
+    containers: &[SidecarDockerResource],
+    networks: &[SidecarDockerResource],
+) -> SidecarInventoryState {
+    if state.is_some_and(|state| !owned_state(state))
+        || (!state_exists
+            && containers
+                .iter()
+                .chain(networks.iter())
+                .any(|resource| resource_owner(resource).as_deref() != Some("codestory")))
+    {
+        return SidecarInventoryState::Unknown;
+    }
+    if !state_exists {
+        return if containers.is_empty() && networks.is_empty() {
+            SidecarInventoryState::Incomplete
+        } else {
+            SidecarInventoryState::Orphaned
+        };
+    }
+    if state.is_some_and(|_| !model_ready) {
+        return SidecarInventoryState::Incomplete;
+    }
+    if live_container {
+        return SidecarInventoryState::Live;
+    }
+    if !docker_available {
+        return SidecarInventoryState::Unknown;
+    }
+    if age_ms.is_some_and(|age| age >= STALE_AFTER_MS) {
+        return SidecarInventoryState::Stale;
+    }
+    if containers.is_empty() && networks.is_empty() {
+        return SidecarInventoryState::Orphaned;
+    }
+    SidecarInventoryState::Stale
+}
+
+fn candidate_reasons(
+    status: SidecarInventoryState,
+    reasons: &[String],
+) -> (Option<String>, Option<String>) {
+    match status {
+        SidecarInventoryState::Stale => (
+            Some("owned state/resources are stale; dry-run only".to_string()),
+            None,
+        ),
+        SidecarInventoryState::Orphaned => (
+            Some("owned state/resources have no live match; dry-run only".to_string()),
+            None,
+        ),
+        SidecarInventoryState::Live => (
+            None,
+            Some("matching running containers block cleanup".to_string()),
+        ),
+        SidecarInventoryState::Incomplete => (
+            None,
+            Some(
+                reasons
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "inventory is incomplete".to_string()),
+            ),
+        ),
+        SidecarInventoryState::Unknown => (
+            None,
+            Some(
+                reasons
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "ownership is unknown".to_string()),
+            ),
+        ),
+    }
+}
+
+fn owned_state(state: &SidecarStateFile) -> bool {
+    state.owner == "codestory"
+}
+
+fn resource_namespace(resource: &SidecarDockerResource) -> Option<String> {
+    resource.labels.get("dev.codestory.namespace").cloned()
+}
+
+fn resource_owner(resource: &SidecarDockerResource) -> Option<String> {
+    resource.labels.get("dev.codestory.owner").cloned()
+}
+
+fn compose_project(resource: &SidecarDockerResource) -> Option<String> {
+    resource
+        .labels
+        .get("com.docker.compose.project")
+        .cloned()
+        .or_else(|| resource.name.strip_suffix("_default").map(str::to_string))
+}
+
+fn resource_running(resource: &SidecarDockerResource) -> bool {
+    resource
+        .state
+        .as_deref()
+        .is_some_and(|state| state.eq_ignore_ascii_case("running"))
+        || resource
+            .status
+            .as_deref()
+            .is_some_and(|status| status.to_ascii_lowercase().starts_with("up "))
+}
+
+fn read_docker_inventory() -> DockerInventory {
+    let containers = read_docker_resources(
+        SidecarDockerResourceKind::Container,
+        &["container", "ls", "-a", "--format", "{{json .}}"],
+    );
+    let networks = read_docker_resources(
+        SidecarDockerResourceKind::Network,
+        &["network", "ls", "--format", "{{json .}}"],
+    );
+    match (containers, networks) {
+        (Ok(containers), Ok(networks)) => DockerInventory {
+            available: true,
+            error: None,
+            containers,
+            networks,
+        },
+        (Err(error), Ok(networks)) => DockerInventory {
+            available: false,
+            error: Some(error.to_string()),
+            containers: Vec::new(),
+            networks,
+        },
+        (Ok(containers), Err(error)) => DockerInventory {
+            available: false,
+            error: Some(error.to_string()),
+            containers,
+            networks: Vec::new(),
+        },
+        (Err(left), Err(right)) => DockerInventory {
+            available: false,
+            error: Some(format!("{left}; {right}")),
+            containers: Vec::new(),
+            networks: Vec::new(),
+        },
+    }
+}
+
+fn read_docker_resources(
+    kind: SidecarDockerResourceKind,
+    args: &[&str],
+) -> Result<Vec<SidecarDockerResource>> {
+    let output = Command::new("docker")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("spawn docker")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "docker {:?} failed: {}{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| docker_resource_from_json_line(kind.clone(), line))
+        .collect())
+}
+
+fn docker_resource_from_json_line(
+    kind: SidecarDockerResourceKind,
+    line: &str,
+) -> Option<SidecarDockerResource> {
+    let value = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    Some(SidecarDockerResource {
+        kind,
+        id: string_field(&value, &["ID"]).unwrap_or_default(),
+        name: string_field(&value, &["Names", "Name"]).unwrap_or_default(),
+        state: string_field(&value, &["State"]),
+        status: string_field(&value, &["Status"]),
+        ports: string_field(&value, &["Ports"]).filter(|value| !value.trim().is_empty()),
+        labels: labels_from_value(value.get("Labels")),
+        match_reason: String::new(),
+    })
+}
+
+fn string_field(value: &serde_json::Value, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|name| value.get(*name).and_then(|value| value.as_str()))
+        .map(str::to_string)
+}
+
+fn labels_from_value(value: Option<&serde_json::Value>) -> BTreeMap<String, String> {
+    match value {
+        Some(serde_json::Value::Object(object)) => object
+            .iter()
+            .filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string())))
+            .collect(),
+        Some(serde_json::Value::String(labels)) => labels
+            .split(',')
+            .filter_map(|label| label.split_once('='))
+            .map(|(key, value)| (key.trim().to_string(), value.trim().to_string()))
+            .collect(),
+        _ => BTreeMap::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_state(path: &Path, state: &SidecarStateFile) {
+        std::fs::create_dir_all(path.parent().expect("state parent")).expect("state parent");
+        std::fs::write(
+            path,
+            serde_json::to_string_pretty(state).expect("state json"),
+        )
+        .expect("write state");
+    }
+
+    fn state(namespace: &str, root: &Path, started_at_epoch_ms: i64) -> SidecarStateFile {
+        SidecarStateFile {
+            owner: "codestory".to_string(),
+            profile: "agent".to_string(),
+            namespace: namespace.to_string(),
+            compose_project: namespace.to_string(),
+            run_id: Some("test".to_string()),
+            zoekt_http_port: 21001,
+            qdrant_http_port: 21002,
+            qdrant_grpc_port: 21003,
+            embed_http_port: 21004,
+            embed_url: "http://127.0.0.1:21004/v1/embeddings".to_string(),
+            zoekt_data_dir: root.join("zoekt").display().to_string(),
+            qdrant_data_dir: root.join("qdrant").display().to_string(),
+            scip_artifacts_root: root.join("scip").display().to_string(),
+            compose_file: None,
+            cleanup_command: format!(
+                "codestory-cli retrieval down --project C:/repo --profile agent --run-id {}",
+                namespace
+            ),
+            started_at_epoch_ms,
+        }
+    }
+
+    fn create_state_dirs(state: &SidecarStateFile) {
+        std::fs::create_dir_all(&state.zoekt_data_dir).expect("zoekt dir");
+        std::fs::create_dir_all(&state.qdrant_data_dir).expect("qdrant dir");
+        std::fs::create_dir_all(&state.scip_artifacts_root).expect("scip dir");
+    }
+
+    fn test_model(project: &Path, present: bool) -> EmbedModelInventory {
+        let dir = project.join("models").join("gguf").join("bge-base-en-v1.5");
+        EmbedModelInventory {
+            model_dir: Some(dir.display().to_string()),
+            required_gguf: crate::embeddings::BGE_BASE_EN_V1_5_GGUF.to_string(),
+            required_gguf_present: present,
+            candidate_dirs: vec![dir.display().to_string()],
+        }
+    }
+
+    fn test_inventory(
+        project: &Path,
+        cache: &Path,
+        now_ms: i64,
+        docker: DockerInventory,
+        model_ready: bool,
+    ) -> SidecarInventoryReport {
+        build_inventory_with_model(
+            project,
+            cache,
+            now_ms,
+            docker,
+            Some(test_model(project, model_ready)),
+        )
+    }
+
+    fn container(namespace: &str, running: bool) -> SidecarDockerResource {
+        let mut labels = BTreeMap::new();
+        labels.insert("dev.codestory.owner".to_string(), "codestory".to_string());
+        labels.insert("dev.codestory.namespace".to_string(), namespace.to_string());
+        labels.insert(
+            "com.docker.compose.project".to_string(),
+            namespace.to_string(),
+        );
+        SidecarDockerResource {
+            kind: SidecarDockerResourceKind::Container,
+            id: "container-id".to_string(),
+            name: format!("{namespace}-qdrant"),
+            state: Some(if running { "running" } else { "exited" }.to_string()),
+            status: Some(if running { "Up 1 minute" } else { "Exited" }.to_string()),
+            ports: Some("127.0.0.1:21002->6333/tcp".to_string()),
+            labels,
+            match_reason: String::new(),
+        }
+    }
+
+    fn unlabeled_compose_network(compose_project: &str) -> SidecarDockerResource {
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            "com.docker.compose.project".to_string(),
+            compose_project.to_string(),
+        );
+        SidecarDockerResource {
+            kind: SidecarDockerResourceKind::Network,
+            id: "network-id".to_string(),
+            name: format!("{compose_project}_default"),
+            state: None,
+            status: None,
+            ports: None,
+            labels,
+            match_reason: String::new(),
+        }
+    }
+
+    #[test]
+    fn stale_state_dirs_are_safe_dry_run_candidates() {
+        let project = tempdir().expect("project");
+        let cache = tempdir().expect("cache");
+        let namespace = "codestory-agent-stale-test";
+        let root = cache.path().join("sidecars").join(namespace);
+        let state = state(namespace, &root, 0);
+        create_state_dirs(&state);
+        write_state(&root.join("retrieval-sidecars.json"), &state);
+
+        let report = test_inventory(
+            project.path(),
+            cache.path(),
+            STALE_AFTER_MS + 1,
+            DockerInventory {
+                available: true,
+                ..DockerInventory::default()
+            },
+            true,
+        );
+
+        let entry = &report.namespaces[0];
+        assert!(report.dry_run);
+        assert_eq!(entry.state, SidecarInventoryState::Stale);
+        assert!(entry.safe_candidate_reason.is_some());
+        assert!(
+            entry
+                .cleanup_command
+                .as_deref()
+                .unwrap()
+                .contains("retrieval down")
+        );
+    }
+
+    #[test]
+    fn live_matching_resources_block_cleanup_and_report_ports() {
+        let project = tempdir().expect("project");
+        let cache = tempdir().expect("cache");
+        let namespace = "codestory-agent-live-test";
+        let root = cache.path().join("sidecars").join(namespace);
+        let state = state(namespace, &root, 100);
+        create_state_dirs(&state);
+        write_state(&root.join("retrieval-sidecars.json"), &state);
+
+        let report = test_inventory(
+            project.path(),
+            cache.path(),
+            200,
+            DockerInventory {
+                available: true,
+                containers: vec![container(namespace, true)],
+                networks: Vec::new(),
+                error: None,
+            },
+            true,
+        );
+
+        let entry = &report.namespaces[0];
+        assert_eq!(entry.state, SidecarInventoryState::Live);
+        assert!(
+            entry
+                .blocking_reason
+                .as_deref()
+                .unwrap()
+                .contains("running")
+        );
+        assert_eq!(
+            entry.containers[0].ports.as_deref(),
+            Some("127.0.0.1:21002->6333/tcp")
+        );
+    }
+
+    #[test]
+    fn missing_model_file_marks_inventory_incomplete() {
+        let project = tempdir().expect("project");
+        let cache = tempdir().expect("cache");
+        let namespace = "codestory-agent-missing-model";
+        let root = cache.path().join("sidecars").join(namespace);
+        let state = state(namespace, &root, 100);
+        create_state_dirs(&state);
+        write_state(&root.join("retrieval-sidecars.json"), &state);
+
+        let report = test_inventory(
+            project.path(),
+            cache.path(),
+            200,
+            DockerInventory {
+                available: true,
+                ..DockerInventory::default()
+            },
+            false,
+        );
+
+        let entry = &report.namespaces[0];
+        assert_eq!(entry.state, SidecarInventoryState::Incomplete);
+        assert!(!entry.model.required_gguf_present);
+        assert!(
+            entry
+                .blocking_reason
+                .as_deref()
+                .unwrap()
+                .contains(crate::embeddings::BGE_BASE_EN_V1_5_GGUF)
+        );
+    }
+
+    #[test]
+    fn resource_without_state_is_orphaned_when_owned_by_codestory() {
+        let project = tempdir().expect("project");
+        let cache = tempdir().expect("cache");
+        let namespace = "codestory-agent-resource-only";
+
+        let report = test_inventory(
+            project.path(),
+            cache.path(),
+            200,
+            DockerInventory {
+                available: true,
+                containers: vec![container(namespace, false)],
+                networks: Vec::new(),
+                error: None,
+            },
+            true,
+        );
+
+        let entry = &report.namespaces[0];
+        assert_eq!(entry.namespace, namespace);
+        assert_eq!(entry.state, SidecarInventoryState::Orphaned);
+        assert!(entry.safe_candidate_reason.is_some());
+    }
+
+    #[test]
+    fn unlabeled_compose_network_matches_only_through_owned_state() {
+        let project = tempdir().expect("project");
+        let cache = tempdir().expect("cache");
+        let namespace = "codestory-agent-compose-network";
+        let root = cache.path().join("sidecars").join(namespace);
+        let state = state(namespace, &root, 100);
+        create_state_dirs(&state);
+        write_state(&root.join("retrieval-sidecars.json"), &state);
+
+        let report = test_inventory(
+            project.path(),
+            cache.path(),
+            200,
+            DockerInventory {
+                available: true,
+                containers: Vec::new(),
+                networks: vec![unlabeled_compose_network(namespace)],
+                error: None,
+            },
+            true,
+        );
+
+        let entry = &report.namespaces[0];
+        assert_eq!(entry.networks.len(), 1);
+        assert_eq!(
+            entry.networks[0].match_reason,
+            "matched compose project from owned state"
+        );
+        assert!(entry.safe_candidate_reason.is_some());
+    }
+
+    #[test]
+    fn unknown_ownership_is_not_a_cleanup_candidate() {
+        let project = tempdir().expect("project");
+        let cache = tempdir().expect("cache");
+        let namespace = "codestory-agent-unknown-owner";
+        let root = cache.path().join("sidecars").join(namespace);
+        let mut state = state(namespace, &root, 100);
+        state.owner = "someone-else".to_string();
+        create_state_dirs(&state);
+        write_state(&root.join("retrieval-sidecars.json"), &state);
+
+        let report = test_inventory(
+            project.path(),
+            cache.path(),
+            200,
+            DockerInventory {
+                available: true,
+                ..DockerInventory::default()
+            },
+            true,
+        );
+
+        let entry = &report.namespaces[0];
+        assert_eq!(entry.state, SidecarInventoryState::Unknown);
+        assert!(entry.safe_candidate_reason.is_none());
+        assert!(entry.blocking_reason.as_deref().unwrap().contains("owner"));
+    }
+
+    #[test]
+    fn dry_run_inventory_does_not_delete_state_files() {
+        let project = tempdir().expect("project");
+        let cache = tempdir().expect("cache");
+        let namespace = "codestory-agent-no-delete";
+        let root = cache.path().join("sidecars").join(namespace);
+        let state_path = root.join("retrieval-sidecars.json");
+        let state = state(namespace, &root, 0);
+        create_state_dirs(&state);
+        write_state(&state_path, &state);
+
+        let report = test_inventory(
+            project.path(),
+            cache.path(),
+            STALE_AFTER_MS + 1,
+            DockerInventory {
+                available: true,
+                ..DockerInventory::default()
+            },
+            true,
+        );
+
+        assert!(report.dry_run);
+        assert!(state_path.exists(), "inventory must not remove state files");
+    }
+}

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -19,6 +19,7 @@ mod executor;
 mod generation;
 mod health;
 mod index;
+mod inventory;
 mod mode;
 mod planner;
 mod qdrant_client;
@@ -43,8 +44,9 @@ pub use capabilities::SidecarCapabilities;
 #[allow(deprecated)]
 pub use compose::bootstrap_sidecars_without_storage_scope;
 pub use compose::{
-    BootstrapReport, DEFAULT_COMPOSE_REL_PATH, bootstrap_sidecars, bootstrap_sidecars_with_profile,
-    bootstrap_sidecars_with_runtime, docker_available, resolve_compose_file,
+    BootstrapReport, DEFAULT_COMPOSE_REL_PATH, EmbedModelInventory, bootstrap_sidecars,
+    bootstrap_sidecars_with_profile, bootstrap_sidecars_with_runtime, docker_available,
+    embed_model_inventory, resolve_compose_file,
 };
 pub use config::{
     DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT, DEFAULT_QDRANT_HTTP_PORT,
@@ -68,6 +70,10 @@ pub use health::{
 pub use index::{
     FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, finalize_index_for_runtime,
     project_id_for_root, repair_project_qdrant_collection, sidecar_project_id_for_root,
+};
+pub use inventory::{
+    SidecarDockerResource, SidecarDockerResourceKind, SidecarInventoryEntry,
+    SidecarInventoryReport, SidecarInventoryState, sidecar_inventory,
 };
 pub use mode::RetrievalDegradedMode;
 pub use mode::derive_degraded_mode;

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -206,6 +206,21 @@ not an answer-quality claim and not a product packet/search success.
 Generated sidecar artifacts are disposable local cache state. To recover from a
 bad setup:
 
+Start with the read-only inventory dry-run:
+
+```powershell
+codestory-cli retrieval inventory --project <repo> --format markdown
+codestory-cli retrieval inventory --project <repo> --format json
+```
+
+The inventory lists CodeStory-owned sidecar namespaces, state paths, cleanup
+commands, Compose projects, matching containers/networks, visible ports, and
+the required `bge-base-en-v1.5.Q8_0.gguf` model check. It classifies namespaces
+as `live`, `stale`, `orphaned`, `incomplete`, or `unknown` with safe-candidate
+and blocking reasons. It is a dry-run status surface only: it does not run
+Docker prune, remove containers, delete networks, or clear state files, and it
+works even when packet/search readiness is unavailable.
+
 1. Stop the relevant Docker/sidecar services.
 2. Move the affected CodeStory-owned Qdrant, Zoekt, or SCIP cache directory
    aside under the cache root.


### PR DESCRIPTION
## Context

Closes #582
Refs #487, #496, #579

Operators need a packet/search-independent way to inspect CodeStory-owned sidecar namespaces before any cleanup work. This PR adds a read-only inventory and GC dry-run surface only; it does not remove Docker resources, clear state, or start packet/search sidecars.

## What Changed

- Added `codestory-cli retrieval inventory` and `codestory-cli sidecar inventory` with JSON and markdown output.
- Added a retrieval inventory contract that reads CodeStory sidecar state files, read-only Docker container/network metadata, visible ports, cleanup command text, namespace/profile ownership, age, Compose project, and the required `bge-base-en-v1.5.Q8_0.gguf` model check.
- Classifies namespaces as `live`, `stale`, `orphaned`, `incomplete`, or `unknown`, with safe-candidate and blocking reasons.
- Reused the existing sidecar/model layout logic and documented the new dry-run command in the sidecar ops runbook.

## How To Review

- Start with `crates/codestory-retrieval/src/inventory.rs` for the read-only inventory contract and classification rules.
- Check `crates/codestory-cli/src/retrieval.rs` and `crates/codestory-cli/src/args.rs` for the command surface.
- Confirm no path calls Docker prune/remove/delete or `retrieval down`; Docker access is inventory-only.

## Verification

- `cargo test -p codestory-retrieval inventory::tests -- --nocapture` - passed
- `cargo test -p codestory-cli --test sidecar_status_cli -- --nocapture` - passed
- `cargo fmt --check` - passed
- `git diff --check origin/dev/codestory-next...HEAD` - passed
- `./target/debug/codestory-cli.exe retrieval inventory --project . --format json` via compact smoke - passed (`dry_run=True`, `namespaces=72`, `docker_available=True`)

## Risk

- Docker CLI JSON fields can vary by Docker version; missing fields are tolerated and Docker command failures become `docker_error` instead of blocking the command.
- Inventory reports existing workstation sidecar state across namespaces, so local namespace counts are environment-specific.
- This is intentionally dry-run only. Actual cleanup behavior remains out of scope.
