### PR TITLE
[codex] Refresh active stdio status freshness

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2026,7 +2026,7 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
 
-fn wait_for_local_freshness(
+pub(crate) fn wait_for_local_freshness(
     project: &ProjectArgs,
     inspect_runtime: &RuntimeContext,
 ) -> Result<(ProjectSummary, Option<readiness::LocalRefreshOutput>)> {
@@ -2063,7 +2063,7 @@ fn wait_for_local_freshness(
     }
 }
 
-fn local_freshness_needs_refresh(summary: &ProjectSummary) -> bool {
+pub(crate) fn local_freshness_needs_refresh(summary: &ProjectSummary) -> bool {
     summary.freshness.as_ref().is_some_and(|freshness| {
         matches!(
             freshness.status,
@@ -2072,7 +2072,9 @@ fn local_freshness_needs_refresh(summary: &ProjectSummary) -> bool {
     })
 }
 
-fn local_refresh_output_from_summary(summary: &ProjectSummary) -> readiness::LocalRefreshOutput {
+pub(crate) fn local_refresh_output_from_summary(
+    summary: &ProjectSummary,
+) -> readiness::LocalRefreshOutput {
     let verdict = readiness::build_readiness_verdict(
         ReadinessGoalDto::LocalNavigation,
         readiness::ReadinessInputs {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -12,8 +12,8 @@ use codestory_contracts::api::{
     AgentRetrievalProfileSelectionDto, ApiError, GraphResponse, GroundingBudgetDto,
     IndexedFileRoleDto, IndexedFilesRequest, ListChildrenSymbolsRequest, ListRootSymbolsRequest,
     NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto,
-    ReadinessGoalDto, ReadinessStatusDto, ReadinessVerdictDto, SearchRepoTextMode, SearchRequest,
-    TrailCallerScope, TrailDirection, TrailMode,
+    ProjectSummary, ReadinessGoalDto, ReadinessStatusDto, ReadinessVerdictDto, SearchRepoTextMode,
+    SearchRequest, TrailCallerScope, TrailDirection, TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
 use sha2::{Digest, Sha256};
@@ -42,7 +42,6 @@ use crate::{
 use std::time::{Duration, Instant};
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
-const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
 const STDIO_CLI_VERSION_TIMEOUT: Duration = Duration::from_secs(3);
 const STDIO_CLI_VERSION_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -157,14 +156,13 @@ fn write_stdio_response<W: Write>(stdout: &mut W, response: &serde_json::Value) 
 struct StdioServerState {
     packet_cache: StdioPacketCache,
     search_cache: StdioSearchFragmentCache,
-    status_cache: Option<StdioStatusCacheEntry>,
+    local_refresh_attempt: Option<StdioLocalRefreshAttempt>,
 }
 
 #[derive(Clone)]
-struct StdioStatusCacheEntry {
-    key: String,
-    value: serde_json::Value,
-    cached_at: Instant,
+struct StdioLocalRefreshAttempt {
+    signature: String,
+    output: crate::readiness::LocalRefreshOutput,
 }
 
 fn handle_stdio_message(
@@ -351,7 +349,7 @@ fn stdio_tool_blocked_error(
     state: &mut StdioServerState,
     name: &str,
 ) -> Result<Option<serde_json::Value>> {
-    let status = read_stdio_status_resource_cached(runtime, state)?;
+    let status = read_stdio_status_resource_fresh(runtime, state)?;
     let Some(surface) = status.pointer(&format!("/allowed_surfaces/{name}")) else {
         return Ok(None);
     };
@@ -1997,7 +1995,7 @@ fn read_stdio_resource(
     uri: &str,
 ) -> serde_json::Value {
     let result = match uri {
-        "codestory://status" => read_stdio_status_resource_cached(runtime, state),
+        "codestory://status" => read_stdio_status_resource_fresh(runtime, state),
         "codestory://agent-guide" => Ok(read_stdio_agent_guide_resource()),
         "codestory://project" => runtime
             .open_project_summary()
@@ -2021,51 +2019,80 @@ fn read_stdio_resource(
         .unwrap_or_else(|error| serde_json::json!({"error": error.to_string()}))
 }
 
-fn read_stdio_status_resource_cached(
+fn read_stdio_status_resource_fresh(
     runtime: &RuntimeContext,
     state: &mut StdioServerState,
 ) -> Result<serde_json::Value> {
-    let key = stdio_status_cache_key(runtime);
-    if let Some(cached) = state.status_cache.as_ref()
-        && cached.key == key
-        && cached.cached_at.elapsed() < STDIO_STATUS_CACHE_TTL
-    {
-        return Ok(cached.value.clone());
-    }
+    let project = args::ProjectArgs {
+        project: runtime.project_root.clone(),
+        cache_dir: Some(runtime.cache_root.clone()),
+    };
+    let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
+    let summary = inspect_runtime.open_project_summary()?;
+    let signature = stdio_local_freshness_signature(&summary);
 
-    let value = read_stdio_status_resource(runtime)?;
-    // ponytail: short stdio snapshot cache; storage/sidecar fingerprints bust it when runtime state changes.
-    state.status_cache = Some(StdioStatusCacheEntry {
-        key,
-        value: value.clone(),
-        cached_at: Instant::now(),
-    });
-    Ok(value)
+    let (summary, local_refresh) = if crate::local_freshness_needs_refresh(&summary) {
+        if let Some(signature) = signature.as_ref()
+            && let Some(attempt) = state.local_refresh_attempt.as_ref()
+            && attempt.signature == *signature
+        {
+            (summary, Some(attempt.output.clone()))
+        } else {
+            let (summary, output) = crate::wait_for_local_freshness(&project, &inspect_runtime)?;
+            if let (Some(signature), Some(output)) = (signature, output.as_ref()) {
+                state.local_refresh_attempt = Some(StdioLocalRefreshAttempt {
+                    signature,
+                    output: output.clone(),
+                });
+            }
+            (summary, output)
+        }
+    } else {
+        let mut output = crate::local_refresh_output_from_summary(&summary);
+        if output.state == crate::readiness::LocalRefreshState::Fresh {
+            output.reason = Some("already_fresh".to_string());
+        }
+        (summary, Some(output))
+    };
+
+    read_stdio_status_resource(runtime, summary, local_refresh)
 }
 
-fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
-    let layout = SidecarLayout::from_env_for_project(&runtime.project_root);
-    [
-        format!("project:{}", runtime.project_root.display()),
-        format!("storage:{}", runtime.storage_path.display()),
-        format!(
-            "storage_state:{}",
-            stdio_storage_fingerprint(&runtime.storage_path)
-        ),
-        format!(
-            "sidecar_state:{}",
-            stdio_path_fingerprint(&layout.state_file)
-        ),
-        format!(
-            "active_embedding_backend:{}",
-            codestory_retrieval::embedding_runtime_id()
-        ),
-    ]
-    .join("|")
+fn stdio_local_freshness_signature(summary: &ProjectSummary) -> Option<String> {
+    let freshness = summary.freshness.as_ref()?;
+    let root = Path::new(&summary.root);
+    let samples = freshness
+        .samples
+        .iter()
+        .map(|sample| {
+            let path = root.join(&sample.path);
+            format!(
+                "{:?}:{}:{}",
+                sample.kind,
+                sample.path,
+                stdio_path_fingerprint(&path)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    Some(format!(
+        "status:{:?}|changed:{}|new:{}|removed:{}|checked:{}|indexed:{}|fatal:{}|samples:{}",
+        freshness.status,
+        freshness.changed_file_count,
+        freshness.new_file_count,
+        freshness.removed_file_count,
+        freshness.checked_file_count,
+        freshness.indexed_file_count,
+        summary.stats.fatal_error_count,
+        samples
+    ))
 }
 
-fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Value> {
-    let summary = runtime.open_project_summary()?;
+fn read_stdio_status_resource(
+    runtime: &RuntimeContext,
+    summary: ProjectSummary,
+    local_refresh: Option<crate::readiness::LocalRefreshOutput>,
+) -> Result<serde_json::Value> {
     let retrieval = summary.retrieval.as_ref();
     let sidecar_runtime = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
     let (sidecar_mode, degraded_reason, manifest_generation, manifest_input_hash, ownership) =
@@ -2165,7 +2192,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
             "diagnostic_only": true
         },
         "index_freshness": summary.freshness,
-        "local_refresh": crate::readiness::local_refresh_output(local),
+        "local_refresh": local_refresh.unwrap_or_else(|| crate::readiness::local_refresh_output(local)),
         "readiness": readiness,
         "readiness_lanes": readiness_lanes,
         "allowed_surfaces": allowed_surfaces,

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -521,41 +521,6 @@ fn freshness_count(value: &Value, aliases: &[&str]) -> Option<u64> {
         .find_map(|alias| value.get(*alias).and_then(Value::as_u64))
 }
 
-fn assert_stale_freshness_counts(value: &Value, context: &str) {
-    let freshness = find_index_freshness(value)
-        .unwrap_or_else(|| panic!("{context} should include an index freshness signal: {value:#}"));
-    assert_eq!(
-        freshness_count(
-            freshness,
-            &["changed_file_count", "changed_count", "changed"]
-        ),
-        Some(1),
-        "{context} freshness should report one changed file: {freshness:#}"
-    );
-    assert_eq!(
-        freshness_count(
-            freshness,
-            &["new_file_count", "new_count", "new", "added_count", "added"]
-        ),
-        Some(1),
-        "{context} freshness should report one new file: {freshness:#}"
-    );
-    assert_eq!(
-        freshness_count(
-            freshness,
-            &[
-                "removed_file_count",
-                "removed_count",
-                "removed",
-                "deleted_count",
-                "deleted"
-            ]
-        ),
-        Some(1),
-        "{context} freshness should report one removed file: {freshness:#}"
-    );
-}
-
 fn assert_fresh_freshness_counts(value: &Value, context: &str) {
     let freshness = find_index_freshness(value)
         .unwrap_or_else(|| panic!("{context} should include an index freshness signal: {value:#}"));
@@ -2437,7 +2402,7 @@ fn tool_calls_block_all_surfaces_when_active_cli_is_stale() {
 }
 
 #[test]
-fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
+fn resources_read_status_waits_fresh_with_bounded_latency() {
     let fixture = indexed_fixture();
     thread::sleep(Duration::from_millis(25));
     fs::write(
@@ -2490,48 +2455,47 @@ fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
         last_status = json_resource_content(result, "codestory://status");
     }
 
-    assert_stale_freshness_counts(&last_status, "codestory://status");
+    assert_fresh_freshness_counts(&last_status, "codestory://status");
     assert_eq!(
         last_status["local_refresh"]["state"],
-        json!("stale"),
-        "stale local graph state should be compactly exposed: {last_status}"
+        json!("fresh"),
+        "status should report the post-refresh local graph state: {last_status}"
     );
     assert_eq!(
         last_status["local_refresh"]["blocks_local_surfaces"],
-        json!(true),
-        "stale local graph state should block only local graph surfaces: {last_status}"
+        json!(false),
+        "fresh local graph state should allow local graph surfaces: {last_status}"
     );
     assert_eq!(
         last_status["allowed_surfaces"]["ground"]["allowed"],
-        json!(false),
-        "stale local graph should block local graph surfaces: {last_status}"
+        json!(true),
+        "fresh local graph should allow local graph surfaces: {last_status}"
     );
     assert_eq!(
         last_status["allowed_surfaces"]["packet"]["status"],
         json!("repair_retrieval"),
-        "packet/search should stay gated by the agent retrieval lane while local graph is stale: {last_status}"
+        "packet/search should stay gated by the agent retrieval lane after local refresh: {last_status}"
     );
     let status_next_call_text = last_status["recommended_next_calls"].to_string();
     assert!(
         !status_next_call_text.contains("\"tool\":\"packet\"")
             && !status_next_call_text.contains("\"tool\":\"search\""),
-        "stale index readiness should recommend repair, not packet/search calls: {last_status}"
+        "missing retrieval readiness should recommend repair, not packet/search calls: {last_status}"
     );
     assert!(
-        status_next_call_text.contains("codestory-cli ready --goal local --repair")
-            && status_next_call_text.contains("codestory://status"),
-        "stale index readiness should recommend index repair and a status recheck: {last_status}"
+        !status_next_call_text.contains("codestory-cli ready --goal local --repair"),
+        "fresh local readiness should not ask the agent for manual local repair: {last_status}"
     );
     elapsed.sort_unstable();
     let median = elapsed[elapsed.len() / 2];
     let p95 = elapsed[(elapsed.len() * 95).div_ceil(100) - 1];
     assert!(
-        median < Duration::from_millis(250),
-        "warm status freshness check median should stay under 250ms for a small repo, got median={median:?}, p95={p95:?}"
+        median < Duration::from_millis(750),
+        "warm status freshness check median should stay under 750ms for a small repo, got median={median:?}, p95={p95:?}"
     );
     assert!(
-        p95 < Duration::from_secs(1),
-        "warm status freshness check p95 should stay under 1s for a small repo, got median={median:?}, p95={p95:?}"
+        p95 < Duration::from_secs(2),
+        "warm status freshness check p95 should stay under 2s for a small repo, got median={median:?}, p95={p95:?}"
     );
 
     let mut index_command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
@@ -2568,6 +2532,73 @@ fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
     let result = assert_success_envelope(&refreshed, json!("status-freshness-after-reindex"));
     let refreshed_status = json_resource_content(result, "codestory://status");
     assert_fresh_freshness_counts(&refreshed_status, "codestory://status after reindex");
+}
+
+#[test]
+fn resources_read_status_waits_fresh_after_live_source_mutation() {
+    let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let initial = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-before-live-mutation",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&initial, json!("status-before-live-mutation"));
+    let initial_status = json_resource_content(result, "codestory://status");
+    assert_fresh_freshness_counts(&initial_status, "initial codestory://status");
+    assert_eq!(
+        initial_status["local_refresh"]["reason"],
+        json!("already_fresh"),
+        "initial status should prove the runtime started from a fresh cache: {initial_status}"
+    );
+
+    thread::sleep(Duration::from_millis(25));
+    fs::write(
+        fixture.workspace.path().join("src").join("runtime.rs"),
+        r#"pub fn normalize_project(project_name: &str) -> String {
+    format!("live:{project_name}")
+}
+"#,
+    )
+    .expect("modify indexed file while stdio server is running");
+
+    let after_mutation = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-after-live-mutation",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&after_mutation, json!("status-after-live-mutation"));
+    let status = json_resource_content(result, "codestory://status");
+    assert_fresh_freshness_counts(&status, "codestory://status after live mutation");
+    assert_eq!(
+        status["local_refresh"]["state"],
+        json!("fresh"),
+        "live source mutation should be repaired or reported, not hidden by the status cache: {status}"
+    );
+    assert_eq!(
+        status["local_refresh"]["reason"],
+        json!("refreshed"),
+        "live source mutation should trigger the bounded local wait-fresh path: {status}"
+    );
+    assert_eq!(
+        status["allowed_surfaces"]["ground"]["allowed"],
+        json!(true),
+        "fresh local graph after live mutation should keep local surfaces available: {status}"
+    );
+    assert_eq!(
+        status["allowed_surfaces"]["packet"]["status"],
+        json!("repair_retrieval"),
+        "local wait-fresh must stay separate from packet/search sidecar readiness: {status}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Context
Closes #581
Refs #566, #577

Long-lived `serve --stdio --refresh none` sessions could keep answering `codestory://status` from a short status snapshot even after source files changed. That made agents manually repair local graph freshness while an MCP/server runtime was already alive.

This slice stays on the local freshness path only: no plugin files, no retrieval sidecar inventory, no packet/search sidecar startup, and no daemon/watch behavior.

## What Changed
- Route stdio status and tool-block readiness checks through a fresh inspect runtime before rendering `codestory://status`.
- Reuse the existing local `wait_fresh` helper so stale/not-checked local graph state gets one bounded incremental refresh attempt per freshness signature.
- Keep local graph freshness separate from agent packet/search sidecar readiness in status and allowed-surface output.
- Add a stdio contract test that starts a long-lived server, reads status, mutates source, reads status again, and proves the live mutation goes through the bounded refresh path instead of a cached fresh snapshot.

## How To Review
- Start with `crates/codestory-cli/src/stdio_transport.rs` around `read_stdio_status_resource_fresh`.
- Check `crates/codestory-cli/src/main.rs` for the existing wait-fresh helper exposure only.
- Review `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the live-mutation regression and bounded status freshness contract.

## Verification
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_waits_fresh_after_live_source_mutation -- --nocapture` -> passed
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_waits_fresh_with_bounded_latency -- --nocapture` -> passed
- `cargo test -p codestory-cli --test stdio_protocol_contracts -- --nocapture` -> passed, 28 passed / 8 ignored full-retrieval tests
- `cargo fmt --check` -> passed
- `git diff --check` -> passed
- `target/debug/codestory-cli.exe ready --goal local --repair --project . --format json` -> local_navigation ready, freshness fresh, retrieval_manifest_missing for local profile

## Risk
- Status reads now favor truthful local freshness over the previous short status snapshot cache, so repeated `codestory://status` reads do more local freshness work. The bounded contract now allows sub-second median behavior on the tiny fixture.
- Full packet/search sidecar readiness was intentionally not exercised or started for this issue.