### PR TITLE
[codex] Refresh active stdio status freshness

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2026,7 +2026,7 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
 
-fn wait_for_local_freshness(
+pub(crate) fn wait_for_local_freshness(
     project: &ProjectArgs,
     inspect_runtime: &RuntimeContext,
 ) -> Result<(ProjectSummary, Option<readiness::LocalRefreshOutput>)> {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -12,8 +12,8 @@ use codestory_contracts::api::{
     AgentRetrievalProfileSelectionDto, ApiError, GraphResponse, GroundingBudgetDto,
     IndexedFileRoleDto, IndexedFilesRequest, ListChildrenSymbolsRequest, ListRootSymbolsRequest,
     NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto,
-    ReadinessGoalDto, ReadinessStatusDto, ReadinessVerdictDto, SearchRepoTextMode, SearchRequest,
-    TrailCallerScope, TrailDirection, TrailMode,
+    ProjectSummary, ReadinessGoalDto, ReadinessStatusDto, ReadinessVerdictDto, SearchRepoTextMode,
+    SearchRequest, TrailCallerScope, TrailDirection, TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
 use sha2::{Digest, Sha256};
@@ -43,6 +43,7 @@ use std::time::{Duration, Instant};
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
+const STDIO_SOURCE_FINGERPRINT_FILE_CAP: usize = 25_000;
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
 const STDIO_CLI_VERSION_TIMEOUT: Duration = Duration::from_secs(3);
 const STDIO_CLI_VERSION_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -2033,14 +2034,25 @@ fn read_stdio_status_resource_cached(
         return Ok(cached.value.clone());
     }
 
-    let value = read_stdio_status_resource(runtime)?;
-    // ponytail: short stdio snapshot cache; storage/sidecar fingerprints bust it when runtime state changes.
+    let project = stdio_project_args(runtime);
+    let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
+    let (summary, local_refresh) = crate::wait_for_local_freshness(&project, &inspect_runtime)?;
+    let key = stdio_status_cache_key(runtime);
+    let value = read_stdio_status_resource(runtime, summary, local_refresh)?;
+    // ponytail: short stdio snapshot cache; source/storage/sidecar fingerprints bust it when state changes.
     state.status_cache = Some(StdioStatusCacheEntry {
         key,
         value: value.clone(),
         cached_at: Instant::now(),
     });
     Ok(value)
+}
+
+fn stdio_project_args(runtime: &RuntimeContext) -> args::ProjectArgs {
+    args::ProjectArgs {
+        project: runtime.project_root.clone(),
+        cache_dir: Some(runtime.cache_root.clone()),
+    }
 }
 
 fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
@@ -2050,11 +2062,15 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
         format!("storage:{}", runtime.storage_path.display()),
         format!(
             "storage_state:{}",
-            stdio_storage_fingerprint(&runtime.storage_path)
+            stdio_path_fingerprint(&runtime.storage_path)
         ),
         format!(
             "sidecar_state:{}",
             stdio_path_fingerprint(&layout.state_file)
+        ),
+        format!(
+            "source_state:{}",
+            stdio_source_fingerprint(&runtime.project_root)
         ),
         format!(
             "active_embedding_backend:{}",
@@ -2064,8 +2080,75 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
     .join("|")
 }
 
-fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Value> {
-    let summary = runtime.open_project_summary()?;
+fn stdio_source_fingerprint(project_root: &Path) -> String {
+    let mut stack = vec![project_root.to_path_buf()];
+    let mut files = Vec::new();
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(error) => return format!("read_dir_error:{}:{error}", dir.display()),
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => return format!("dir_entry_error:{error}"),
+            };
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) => return format!("file_type_error:{}:{error}", path.display()),
+            };
+            if file_type.is_dir() {
+                if !stdio_source_fingerprint_skip_dir(&path) {
+                    stack.push(path);
+                }
+            } else if file_type.is_file() {
+                files.push(path);
+                if files.len() > STDIO_SOURCE_FINGERPRINT_FILE_CAP {
+                    return "source_files:too_many".to_string();
+                }
+            }
+        }
+    }
+    files.sort();
+    let mut hasher = Sha256::new();
+    hasher.update(files.len().to_string().as_bytes());
+    for path in files {
+        hasher.update(b"\0path:");
+        hasher.update(path.to_string_lossy().as_bytes());
+        match std::fs::metadata(&path) {
+            Ok(metadata) => {
+                hasher.update(b"\0len:");
+                hasher.update(metadata.len().to_string().as_bytes());
+                hasher.update(b"\0mtime:");
+                let modified_ms = metadata
+                    .modified()
+                    .ok()
+                    .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_millis())
+                    .unwrap_or_default();
+                hasher.update(modified_ms.to_string().as_bytes());
+            }
+            Err(error) => {
+                hasher.update(b"\0metadata_error:");
+                hasher.update(error.to_string().as_bytes());
+            }
+        }
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+fn stdio_source_fingerprint_skip_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| matches!(name, ".git" | "target" | "node_modules" | "dist"))
+}
+
+fn read_stdio_status_resource(
+    runtime: &RuntimeContext,
+    summary: ProjectSummary,
+    local_refresh: Option<crate::readiness::LocalRefreshOutput>,
+) -> Result<serde_json::Value> {
     let retrieval = summary.retrieval.as_ref();
     let sidecar_runtime = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
     let (sidecar_mode, degraded_reason, manifest_generation, manifest_input_hash, ownership) =
@@ -2165,7 +2248,7 @@ fn read_stdio_status_resource(runtime: &RuntimeContext) -> Result<serde_json::Va
             "diagnostic_only": true
         },
         "index_freshness": summary.freshness,
-        "local_refresh": crate::readiness::local_refresh_output(local),
+        "local_refresh": local_refresh.unwrap_or_else(|| crate::readiness::local_refresh_output(local)),
         "readiness": readiness,
         "readiness_lanes": readiness_lanes,
         "allowed_surfaces": allowed_surfaces,

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -521,41 +521,6 @@ fn freshness_count(value: &Value, aliases: &[&str]) -> Option<u64> {
         .find_map(|alias| value.get(*alias).and_then(Value::as_u64))
 }
 
-fn assert_stale_freshness_counts(value: &Value, context: &str) {
-    let freshness = find_index_freshness(value)
-        .unwrap_or_else(|| panic!("{context} should include an index freshness signal: {value:#}"));
-    assert_eq!(
-        freshness_count(
-            freshness,
-            &["changed_file_count", "changed_count", "changed"]
-        ),
-        Some(1),
-        "{context} freshness should report one changed file: {freshness:#}"
-    );
-    assert_eq!(
-        freshness_count(
-            freshness,
-            &["new_file_count", "new_count", "new", "added_count", "added"]
-        ),
-        Some(1),
-        "{context} freshness should report one new file: {freshness:#}"
-    );
-    assert_eq!(
-        freshness_count(
-            freshness,
-            &[
-                "removed_file_count",
-                "removed_count",
-                "removed",
-                "deleted_count",
-                "deleted"
-            ]
-        ),
-        Some(1),
-        "{context} freshness should report one removed file: {freshness:#}"
-    );
-}
-
 fn assert_fresh_freshness_counts(value: &Value, context: &str) {
     let freshness = find_index_freshness(value)
         .unwrap_or_else(|| panic!("{context} should include an index freshness signal: {value:#}"));
@@ -2437,8 +2402,22 @@ fn tool_calls_block_all_surfaces_when_active_cli_is_stale() {
 }
 
 #[test]
-fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
+fn resources_read_status_refreshes_long_lived_stale_index_with_bounded_latency() {
     let fixture = indexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+    let warmup = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-freshness-warmup",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let warmup_result = assert_success_envelope(&warmup, json!("status-freshness-warmup"));
+    let warmup_status = json_resource_content(warmup_result, "codestory://status");
+    assert_fresh_freshness_counts(&warmup_status, "warm codestory://status");
+
     thread::sleep(Duration::from_millis(25));
     fs::write(
         fixture.workspace.path().join("src").join("runtime.rs"),
@@ -2460,20 +2439,48 @@ fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
     fs::remove_file(fixture.workspace.path().join("src").join("alpha.rs"))
         .expect("remove indexed file after indexing");
 
-    let mut server = spawn_stdio_server(&fixture);
-    let warmup = send_json(
+    let refreshed = send_json(
         &mut server,
         json!({
             "jsonrpc": "2.0",
-            "id": "status-freshness-warmup",
+            "id": "status-freshness-after-mutation",
             "method": "resources/read",
             "params": {"uri": "codestory://status"}
         }),
     );
-    assert_success_envelope(&warmup, json!("status-freshness-warmup"));
+    let refreshed_result =
+        assert_success_envelope(&refreshed, json!("status-freshness-after-mutation"));
+    let refreshed_status = json_resource_content(refreshed_result, "codestory://status");
+    assert_fresh_freshness_counts(&refreshed_status, "codestory://status after mutation");
+    assert_eq!(
+        refreshed_status["local_refresh"]["reason"],
+        json!("refreshed"),
+        "long-lived status must not return the cached warm freshness result after source mutation: {refreshed_status}"
+    );
+    assert_eq!(
+        refreshed_status["local_refresh"]["blocks_local_surfaces"],
+        json!(false),
+        "successful local refresh should keep local graph surfaces usable: {refreshed_status}"
+    );
+    assert_eq!(
+        refreshed_status["allowed_surfaces"]["ground"]["allowed"],
+        json!(true),
+        "fresh local graph should allow local graph surfaces: {refreshed_status}"
+    );
+    assert_eq!(
+        refreshed_status["allowed_surfaces"]["packet"]["status"],
+        json!("repair_retrieval"),
+        "packet/search should stay gated by the agent retrieval lane after local refresh: {refreshed_status}"
+    );
+    let status_next_call_text = refreshed_status["recommended_next_calls"].to_string();
+    assert!(
+        !status_next_call_text.contains("\"tool\":\"packet\"")
+            && !status_next_call_text.contains("\"tool\":\"search\""),
+        "local freshness repair should not recommend packet/search calls while sidecars are unavailable: {refreshed_status}"
+    );
 
     let mut elapsed = Vec::new();
-    let mut last_status = Value::Null;
+    let mut last_status = refreshed_status;
     for index in 0..12 {
         let started = Instant::now();
         let response = send_json(
@@ -2490,37 +2497,13 @@ fn resources_read_status_reports_stale_index_freshness_with_bounded_latency() {
         last_status = json_resource_content(result, "codestory://status");
     }
 
-    assert_stale_freshness_counts(&last_status, "codestory://status");
-    assert_eq!(
-        last_status["local_refresh"]["state"],
-        json!("stale"),
-        "stale local graph state should be compactly exposed: {last_status}"
-    );
-    assert_eq!(
-        last_status["local_refresh"]["blocks_local_surfaces"],
-        json!(true),
-        "stale local graph state should block only local graph surfaces: {last_status}"
-    );
-    assert_eq!(
-        last_status["allowed_surfaces"]["ground"]["allowed"],
-        json!(false),
-        "stale local graph should block local graph surfaces: {last_status}"
-    );
-    assert_eq!(
-        last_status["allowed_surfaces"]["packet"]["status"],
-        json!("repair_retrieval"),
-        "packet/search should stay gated by the agent retrieval lane while local graph is stale: {last_status}"
-    );
-    let status_next_call_text = last_status["recommended_next_calls"].to_string();
+    assert_fresh_freshness_counts(&last_status, "cached codestory://status after refresh");
     assert!(
-        !status_next_call_text.contains("\"tool\":\"packet\"")
-            && !status_next_call_text.contains("\"tool\":\"search\""),
-        "stale index readiness should recommend repair, not packet/search calls: {last_status}"
-    );
-    assert!(
-        status_next_call_text.contains("codestory-cli ready --goal local --repair")
-            && status_next_call_text.contains("codestory://status"),
-        "stale index readiness should recommend index repair and a status recheck: {last_status}"
+        matches!(
+            last_status["local_refresh"]["reason"].as_str(),
+            Some("refreshed" | "already_fresh")
+        ),
+        "status should stay fresh without stale cache masking after the bounded refresh: {last_status}"
     );
     elapsed.sort_unstable();
     let median = elapsed[elapsed.len() / 2];


### PR DESCRIPTION
## Context

Closes #581
Refs #566, #577

Long-lived `serve --stdio --refresh none` could keep returning cached `codestory://status` JSON after source changed, so agents could see stale local graph readiness until the status cache expired. This PR keeps the fix scoped to active stdio status/resource freshness after startup; pre-tool local graph gates are left for the follow-up child issue.

```mermaid
flowchart LR
    A[status read] --> B[source fingerprint]
    B -->|same| C[status cache]
    B -->|changed| D[local wait-fresh]
    D --> E[status JSON]
    E --> F[local_refresh]
    E --> G[agent sidecar lane unchanged]
```

## What Changed

- Added a bounded source metadata fingerprint to the stdio status cache key so post-startup source mutations bust cached status responses.
- Routed cache misses for `codestory://status` through the existing local wait-fresh helper, using local-only incremental refresh and returning compact `local_refresh` state.
- Kept packet/search sidecar readiness separate; no packet/search sidecars are started and no local graph tool pre-call gates were added.
- Updated the stdio protocol regression so the server starts, reads fresh status, mutates source, reads status again, and proves the warm status cache does not mask the mutation.

## How To Review

- Start in `crates/codestory-cli/src/stdio_transport.rs` at the `codestory://status` cache path.
- Confirm the only widened helper is `wait_for_local_freshness` in `crates/codestory-cli/src/main.rs`.
- Review `resources_read_status_refreshes_long_lived_stale_index_with_bounded_latency` for the post-startup mutation contract.

## Verification

- `cargo fmt --check`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_refreshes_long_lived_stale_index_with_bounded_latency -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls -- --nocapture`
- `git diff --check`

## Risk

The source fingerprint is a bounded metadata scan and intentionally only decides whether to reuse cached status. The authoritative freshness and refresh behavior remains the existing local wait-fresh path. Large workspaces over the fingerprint cap may still rely on compact degraded/local freshness output rather than aggressive repeated refresh work.