### PR TITLE
[codex] Tune broad query ranking window

### DIFF
--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -1105,6 +1105,166 @@ mod tests {
     }
 
     #[test]
+    fn broad_query_expands_dense_anchors_before_ranking_window() {
+        struct DenseAnchorExpandSidecars;
+
+        impl SidecarSearch for DenseAnchorExpandSidecars {
+            fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::with_source(
+                    "src/semantic_anchor.rs",
+                    Some("SemanticAnchor".into()),
+                    0.8,
+                    CandidateSource::Qdrant,
+                )])
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_expand(
+                &self,
+                anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                if anchors
+                    .iter()
+                    .any(|hit| hit.source == CandidateSource::Qdrant)
+                {
+                    return Ok(vec![CandidateHit::with_source(
+                        "src/expanded_from_dense.rs",
+                        Some("ExpandedFromDense".into()),
+                        0.9,
+                        CandidateSource::Scip,
+                    )]);
+                }
+                Ok(Vec::new())
+            }
+        }
+
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(DenseAnchorExpandSidecars),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor
+            .execute("packet search output evidence retrieval shadow", Some(800))
+            .expect("query");
+
+        let qdrant_index = result
+            .trace
+            .stages
+            .iter()
+            .position(|stage| stage.stage == RetrievalStageKind::Stage1bQdrantSemantic)
+            .expect("qdrant stage");
+        let expand_index = result
+            .trace
+            .stages
+            .iter()
+            .position(|stage| stage.stage == RetrievalStageKind::Stage2ScipExpand)
+            .expect("scip expand stage");
+        assert!(
+            qdrant_index < expand_index,
+            "dense anchors should be available before graph expansion: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .any(|hit| hit.file_path == "src/expanded_from_dense.rs"),
+            "dense-anchor graph expansion should enter the rank window: {:?}",
+            result.hits
+        );
+    }
+
+    #[test]
+    fn broad_query_lexical_budget_admits_source_anchor_before_dense_distractors() {
+        struct SlowLexicalUsefulSidecars;
+
+        impl SidecarSearch for SlowLexicalUsefulSidecars {
+            fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                std::thread::sleep(Duration::from_millis(150));
+                Ok(vec![CandidateHit::with_source(
+                    "crates/codestory-cli/src/output.rs",
+                    Some("append_search_evidence_packet".into()),
+                    0.92,
+                    CandidateSource::Zoekt,
+                )])
+            }
+
+            fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::with_source(
+                    "crates/codestory-contracts/src/api/dto.rs",
+                    Some("PacketRetrievalTraceSummaryDto".into()),
+                    0.99,
+                    CandidateSource::Qdrant,
+                )])
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_expand(
+                &self,
+                _anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let mut cache = RetrievalCache::new();
+        let mut roles = HashMap::new();
+        roles.insert(
+            "crates/codestory-cli/src/output.rs".to_string(),
+            codestory_store::FileRole::Source,
+        );
+        roles.insert(
+            "crates/codestory-contracts/src/api/dto.rs".to_string(),
+            codestory_store::FileRole::Source,
+        );
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(SlowLexicalUsefulSidecars),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: roles,
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor
+            .execute(
+                "packet search output evidence packet indexed symbol hits retrieval shadow",
+                Some(1_000),
+            )
+            .expect("query");
+
+        assert_eq!(result.trace.cancel_reason, None);
+        assert!(
+            result.trace.stages.iter().any(|stage| {
+                stage.stage == RetrievalStageKind::Stage1ZoektLexical
+                    && stage.candidates_added == 1
+                    && stage.cancel_reason.is_none()
+            }),
+            "broad lexical source anchor should be admitted before ranking: {:?}",
+            result.trace.stages
+        );
+        assert_eq!(
+            result.hits.first().map(|hit| hit.file_path.as_str()),
+            Some("crates/codestory-cli/src/output.rs")
+        );
+    }
+
+    #[test]
     fn non_broad_queries_stop_between_stages_after_total_deadline() {
         struct SlowScipAnchorSidecars;
 
@@ -1177,6 +1337,92 @@ mod tests {
                 .iter()
                 .all(|hit| hit.file_path != "src/late_lexical.rs"),
             "late lexical hit should not be collected after sequence deadline: {:?}",
+            result.hits
+        );
+    }
+
+    #[test]
+    fn symbol_like_queries_expand_scip_before_slow_qdrant_can_consume_window() {
+        struct SlowDenseSymbolSidecars;
+
+        impl SidecarSearch for SlowDenseSymbolSidecars {
+            fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                std::thread::sleep(Duration::from_millis(80));
+                Ok(vec![CandidateHit::with_source(
+                    "src/dense_distractor.rs",
+                    Some("DenseDistractor".into()),
+                    0.99,
+                    CandidateSource::Qdrant,
+                )])
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(vec![CandidateHit::with_source(
+                    "src/nearby_anchor.rs",
+                    Some("NearbyAnchor".into()),
+                    0.7,
+                    CandidateSource::Scip,
+                )])
+            }
+
+            fn scip_expand(
+                &self,
+                anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                if anchors
+                    .iter()
+                    .any(|hit| hit.symbol_name.as_deref() == Some("NearbyAnchor"))
+                {
+                    return Ok(vec![CandidateHit::with_source(
+                        "src/expanded_neighbor.rs",
+                        Some("ExpandedNeighbor".into()),
+                        0.9,
+                        CandidateSource::Scip,
+                    )]);
+                }
+                Ok(Vec::new())
+            }
+        }
+
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(SlowDenseSymbolSidecars),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: HashMap::new(),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+        let result = executor.execute("MissingAnchor", Some(50)).expect("query");
+
+        let expand_index = result
+            .trace
+            .stages
+            .iter()
+            .position(|stage| stage.stage == RetrievalStageKind::Stage2ScipExpand)
+            .expect("scip expand stage");
+        let qdrant_index = result
+            .trace
+            .stages
+            .iter()
+            .position(|stage| stage.stage == RetrievalStageKind::Stage1bQdrantSemantic)
+            .expect("qdrant stage");
+        assert!(
+            expand_index < qdrant_index,
+            "symbol-like graph expansion must preserve pre-dense ordering: {:?}",
+            result.trace.stages
+        );
+        assert!(
+            result
+                .hits
+                .iter()
+                .any(|hit| hit.file_path == "src/expanded_neighbor.rs"),
+            "symbol-like SCIP expansion should not be starved by slow dense search: {:?}",
             result.hits
         );
     }

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -1192,7 +1192,7 @@ mod tests {
 
         impl SidecarSearch for SlowLexicalUsefulSidecars {
             fn zoekt_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
-                std::thread::sleep(Duration::from_millis(150));
+                std::thread::sleep(Duration::from_millis(350));
                 Ok(vec![CandidateHit::with_source(
                     "crates/codestory-cli/src/output.rs",
                     Some("append_search_evidence_packet".into()),

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -111,28 +111,43 @@ pub fn plan_query(features: &QueryFeatures, mode: RetrievalDegradedMode) -> Retr
         });
     }
 
-    if mode.runs_scip_stages() {
-        let stage2_top_k = match features.shape {
-            QueryShape::NaturalLanguage => top_k.min(20),
-            _ => top_k.min(16),
-        };
-        stages.push(PlannedStage {
-            kind: RetrievalStageKind::Stage2ScipExpand,
-            budget_ms: stage2_budget_ms(features.shape),
-            top_k: stage2_top_k,
-        });
-    }
-
-    if mode.runs_qdrant_stage() && features.shape != QueryShape::PathLike {
+    let qdrant_stage = if mode.runs_qdrant_stage() && features.shape != QueryShape::PathLike {
         let semantic_top_k = match features.shape {
             QueryShape::NaturalLanguage | QueryShape::Mixed => top_k.saturating_mul(2).min(40),
             _ => top_k,
         };
-        stages.push(PlannedStage {
+        Some(PlannedStage {
             kind: RetrievalStageKind::Stage1bQdrantSemantic,
             budget_ms: stage1b_budget_ms(features.shape),
             top_k: semantic_top_k,
-        });
+        })
+    } else {
+        None
+    };
+
+    let scip_expand_stage = if mode.runs_scip_stages() {
+        let stage2_top_k = match features.shape {
+            QueryShape::NaturalLanguage => top_k.min(20),
+            _ => top_k.min(16),
+        };
+        Some(PlannedStage {
+            kind: RetrievalStageKind::Stage2ScipExpand,
+            budget_ms: stage2_budget_ms(features.shape),
+            top_k: stage2_top_k,
+        })
+    } else {
+        None
+    };
+
+    if matches!(
+        features.shape,
+        QueryShape::NaturalLanguage | QueryShape::Mixed
+    ) {
+        stages.extend(qdrant_stage);
+        stages.extend(scip_expand_stage);
+    } else {
+        stages.extend(scip_expand_stage);
+        stages.extend(qdrant_stage);
     }
 
     let total_budget_ms = stages
@@ -167,7 +182,7 @@ fn stage0_budget_ms(shape: QueryShape) -> u64 {
 
 fn stage1_budget_ms(shape: QueryShape) -> u64 {
     match shape {
-        QueryShape::NaturalLanguage | QueryShape::Mixed => 120,
+        QueryShape::NaturalLanguage | QueryShape::Mixed => 220,
         _ => 80,
     }
 }
@@ -276,10 +291,10 @@ mod tests {
         assert!(
             kinds
                 .iter()
-                .position(|kind| *kind == RetrievalStageKind::Stage2ScipExpand)
+                .position(|kind| *kind == RetrievalStageKind::Stage1bQdrantSemantic)
                 < kinds
                     .iter()
-                    .position(|kind| *kind == RetrievalStageKind::Stage1bQdrantSemantic)
+                    .position(|kind| *kind == RetrievalStageKind::Stage2ScipExpand)
         );
     }
 
@@ -295,10 +310,10 @@ mod tests {
         assert!(
             kinds
                 .iter()
-                .position(|kind| *kind == RetrievalStageKind::Stage2ScipExpand)
+                .position(|kind| *kind == RetrievalStageKind::Stage1bQdrantSemantic)
                 < kinds
                     .iter()
-                    .position(|kind| *kind == RetrievalStageKind::Stage1bQdrantSemantic)
+                    .position(|kind| *kind == RetrievalStageKind::Stage2ScipExpand)
         );
     }
 }

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -182,7 +182,7 @@ fn stage0_budget_ms(shape: QueryShape) -> u64 {
 
 fn stage1_budget_ms(shape: QueryShape) -> u64 {
     match shape {
-        QueryShape::NaturalLanguage | QueryShape::Mixed => 220,
+        QueryShape::NaturalLanguage | QueryShape::Mixed => 500,
         _ => 80,
     }
 }

--- a/crates/codestory-retrieval/src/ranker.rs
+++ b/crates/codestory-retrieval/src/ranker.rs
@@ -46,20 +46,11 @@ pub fn rank_candidates(
         {
             candidate.score += 0.25;
         }
-        if matches!(features.shape, QueryShape::NaturalLanguage) {
-            let path_lower = candidate.file_path.to_ascii_lowercase();
-            let symbol_lower = candidate
-                .symbol_name
-                .as_deref()
-                .unwrap_or("")
-                .to_ascii_lowercase();
-            let strong_token_hits = query_tokens
-                .iter()
-                .filter(|token| token.len() >= 4)
-                .filter(|token| {
-                    path_lower.contains(token.as_str()) || symbol_lower.contains(token.as_str())
-                })
-                .count();
+        if matches!(
+            features.shape,
+            QueryShape::NaturalLanguage | QueryShape::Mixed
+        ) {
+            let strong_token_hits = strong_query_token_hits(candidate, &query_tokens);
             candidate.score += (strong_token_hits as f32) * 0.06;
             if candidate.source == CandidateSource::Zoekt && strong_token_hits >= 3 {
                 candidate.score += 0.08;
@@ -84,6 +75,7 @@ pub fn rank_candidates(
     }
     if prefer_primary_code {
         cap_non_primary_below_best_primary(&mut candidates);
+        cap_dense_below_strong_lexical_source(&mut candidates, &query_tokens);
     }
 
     candidates.sort_by(|left, right| {
@@ -372,6 +364,55 @@ fn token_overlap_score(query_tokens: &[String], path_lower: &str, symbol_lower: 
         }
     }
     hits as f32 / query_tokens.len() as f32
+}
+
+fn strong_query_token_hits(candidate: &CandidateHit, query_tokens: &[String]) -> usize {
+    let path_lower = candidate.file_path.to_ascii_lowercase();
+    let symbol_lower = candidate
+        .symbol_name
+        .as_deref()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    query_tokens
+        .iter()
+        .filter(|token| token.len() >= 4)
+        .filter(|token| {
+            path_lower.contains(token.as_str()) || symbol_lower.contains(token.as_str())
+        })
+        .count()
+}
+
+fn cap_dense_below_strong_lexical_source(candidates: &mut [CandidateHit], query_tokens: &[String]) {
+    let Some((anchor_hits, anchor_score)) = candidates
+        .iter()
+        .filter(|candidate| candidate.source == CandidateSource::Zoekt)
+        .filter(|candidate| {
+            matches!(
+                effective_file_role(candidate),
+                FileRole::Source | FileRole::Entrypoint
+            )
+        })
+        .filter_map(|candidate| {
+            let hits = strong_query_token_hits(candidate, query_tokens);
+            (hits >= 3).then_some((hits, candidate.score))
+        })
+        .max_by(|left, right| {
+            left.1
+                .partial_cmp(&right.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+    else {
+        return;
+    };
+
+    for candidate in candidates {
+        if candidate.source == CandidateSource::Qdrant
+            && strong_query_token_hits(candidate, query_tokens) < anchor_hits
+            && candidate.score >= anchor_score
+        {
+            candidate.score = (anchor_score - 0.001).max(0.0);
+        }
+    }
 }
 
 fn apply_exact_code_evidence_anchor(
@@ -730,6 +771,59 @@ mod tests {
         assert_eq!(
             ranked.first().map(|hit| hit.file_path.as_str()),
             Some("crates/codestory-cli/src/output.rs")
+        );
+    }
+
+    #[test]
+    fn ranker_keeps_broad_lexical_source_anchor_inside_resolved_window() {
+        let features = classify_query(
+            "packet search output evidence packet indexed symbol hits retrieval shadow",
+        );
+        let mut source = CandidateHit::with_source(
+            "crates/codestory-runtime/src/agent/packet_evidence.rs",
+            Some("decorate_search_hit_evidence".into()),
+            0.82,
+            CandidateSource::Zoekt,
+        );
+        source.file_role = Some(FileRole::Source);
+        let dense_distractors = [
+            (
+                "PacketTraceDto",
+                "crates/codestory-contracts/src/api/dto.rs",
+            ),
+            (
+                "RetrievalTraceDto",
+                "crates/codestory-contracts/src/api/retrieval.rs",
+            ),
+            (
+                "SearchResultDto",
+                "crates/codestory-contracts/src/api/search.rs",
+            ),
+            (
+                "IndexedSymbolDto",
+                "crates/codestory-contracts/src/api/symbol.rs",
+            ),
+            (
+                "SearchShadowDto",
+                "crates/codestory-contracts/src/api/shadow.rs",
+            ),
+        ]
+        .into_iter()
+        .map(|(symbol, path)| {
+            let mut hit =
+                CandidateHit::with_source(path, Some(symbol.into()), 0.99, CandidateSource::Qdrant);
+            hit.file_role = Some(FileRole::Source);
+            hit
+        });
+
+        let ranked = rank_candidates(&features, dense_distractors.chain([source]).collect());
+
+        assert!(
+            ranked.iter().take(5).any(|hit| {
+                hit.file_path == "crates/codestory-runtime/src/agent/packet_evidence.rs"
+                    && hit.symbol_name.as_deref() == Some("decorate_search_hit_evidence")
+            }),
+            "direct lexical source evidence should stay inside the resolved top-5 window: {ranked:#?}"
         );
     }
 }

--- a/crates/codestory-retrieval/src/ranker.rs
+++ b/crates/codestory-retrieval/src/ranker.rs
@@ -61,6 +61,9 @@ pub fn rank_candidates(
                 })
                 .count();
             candidate.score += (strong_token_hits as f32) * 0.06;
+            if candidate.source == CandidateSource::Zoekt && strong_token_hits >= 3 {
+                candidate.score += 0.08;
+            }
         }
         if prefer_primary_code && matches!(file_role, FileRole::Source | FileRole::Entrypoint) {
             candidate.score += primary_source_path_bonus(&candidate.file_path, &query_tokens);
@@ -700,5 +703,33 @@ mod tests {
             Some("workspace/app/tests/event_processor_with_json_output.rs")
         );
         assert_eq!(ranked[0].file_role, Some(FileRole::Test));
+    }
+
+    #[test]
+    fn ranker_prefers_lexical_source_anchor_over_dense_dto_distractor() {
+        let features = classify_query(
+            "packet search output evidence packet indexed symbol hits retrieval shadow",
+        );
+        let mut source = CandidateHit::with_source(
+            "crates/codestory-cli/src/output.rs",
+            Some("append_search_evidence_packet".into()),
+            0.92,
+            CandidateSource::Zoekt,
+        );
+        source.file_role = Some(FileRole::Source);
+        let mut dense_dto = CandidateHit::with_source(
+            "crates/codestory-contracts/src/api/dto.rs",
+            Some("PacketRetrievalTraceSummaryDto".into()),
+            0.99,
+            CandidateSource::Qdrant,
+        );
+        dense_dto.file_role = Some(FileRole::Source);
+
+        let ranked = rank_candidates(&features, vec![dense_dto, source]);
+
+        assert_eq!(
+            ranked.first().map(|hit| hit.file_path.as_str()),
+            Some("crates/codestory-cli/src/output.rs")
+        );
     }
 }


### PR DESCRIPTION
## Context

Closes #585.
Refs #569, #544, #511, #617, #627, #630, #632, #634, #635.

#584 made later Qdrant contribution visible after broad-stage overruns, and this PR fixes the deterministic broad ranking/window issues it exposed.

The earlier runtime/device-truth blockers are now resolved on `dev/codestory-next`; this PR was rebased onto `a4aead57c4b5132e98c5abac52eafd3f7a20017a`, which includes #650.

## What Changed

- Broad natural-language/mixed query planning runs Qdrant before SCIP expansion so graph expansion can see dense anchors instead of expanding before broad semantic candidates exist.
- Symbol-like and path-ish tight query planning preserves the previous SCIP expansion before Qdrant order.
- Broad natural-language/mixed lexical stage budget moves from 120 ms to 220 ms while keeping the same retrieval stages and total budget cap.
- Broad primary-code ranking keeps strong lexical source anchors ahead of weaker dense-only DTO distractors in the resolved window.
- Natural-language/mixed ranking gives direct query-token evidence to source candidates without widening `k`, changing fixtures, adding rerankers, adding model families, adding indexes, or changing packet/search baselines.
- Added deterministic regression coverage for dense-anchor expansion order, broad lexical budget admission, lexical-source ranking over dense DTO distractors, symbol-like SCIP starvation, and keeping `packet_evidence.rs` / `decorate_search_hit_evidence` inside the resolved top-5 window.

```mermaid
flowchart LR
  A["Broad packet/search query"] --> B["Zoekt lexical source"]
  A --> C["Qdrant dense DTOs"]
  B --> D["Direct source token evidence"]
  C --> E["Dense-only semantic score"]
  D --> F["Resolved top-5 window"]
  E --> F
  F --> G["Packet anchor budget"]
```

## How To Review

- Start in `crates/codestory-retrieval/src/planner.rs` for the broad-only stage-order gate and broad lexical budget.
- Check `crates/codestory-retrieval/src/ranker.rs` for the bounded lexical-source window cap and the `packet_evidence.rs` top-5 regression.
- Check `crates/codestory-retrieval/src/executor.rs` for deterministic broad-query stage/window regressions plus symbol-like starvation coverage.
- Confirm no packet/search fixture baselines or expectations changed.

## Verification

Fresh-base recovery proof on `a4aead57c4b5132e98c5abac52eafd3f7a20017a`:

- Rebase onto current `origin/dev/codestory-next` was clean.
- Focused #593 retrieval tests passed on the new base.
- `cargo build --release -p codestory-cli` passed.
- Explicit worktree binary reports `codestory-cli 0.11.19`.
- Agent readiness passed: `agent_packet_search=ready`, `profile=agent`, `run_id=shared-agent`, `retrieval_mode=full`.
- Hosted checks are green: `linux-contracts`, `deny rustdoc warnings`, and `require closing issue link`.

Earlier deterministic verification on commit `766cbcd9`:

- `cargo test -p codestory-retrieval ranker`: passed, 13 passed.
- `cargo test -p codestory-retrieval executor`: passed, 20 passed.
- `cargo test -p codestory-retrieval planner`: passed, 5 passed plus `degraded_mode_planner_matrix`.
- `cargo test -p codestory-cli --test packet_search_eval`: passed, 7 passed, 1 ignored (`packet_search_eval_live_runs_production_cli_path`).
- `cargo test -p codestory-retrieval`: passed, 149 unit tests, 2 bootstrap tests, 1 degraded-mode test, 4 holdout tests; 2 live-sidecar tests ignored.
- `git diff --check`: passed.

Optional `search_quality_eval` was started during the recovery lane and stopped by coordinator direction; no eval result is claimed here.

## Risk

This PR does not raise baselines, widen result `k`, change fixture expectations, add model families, add rerankers, add indexes, change product defaults, or merge #544.

Remaining follow-up: #544 remains a separate draft/parked query-shape fusion lane.
