### PR TITLE
[codex] Align search evals with agent retrieval profile

### DIFF
--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -143,6 +143,75 @@ fn run_cli(workspace: &Path, args: &[&str]) -> std::process::Output {
     command.output().expect("run codestory-cli")
 }
 
+fn prepare_agent_retrieval(workspace: &Path) -> Value {
+    let bootstrap = run_cli(
+        workspace,
+        &[
+            "retrieval",
+            "bootstrap",
+            "--profile",
+            "agent",
+            "--wait-secs",
+            "30",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        bootstrap.status.success(),
+        "agent retrieval bootstrap failed; live full-sidecar fixture is blocked: {}",
+        String::from_utf8_lossy(&bootstrap.stderr)
+    );
+
+    let index = run_cli(
+        workspace,
+        &[
+            "retrieval",
+            "index",
+            "--profile",
+            "agent",
+            "--refresh",
+            "full",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        index.status.success(),
+        "agent retrieval index failed; live full-sidecar fixture is blocked: {}",
+        String::from_utf8_lossy(&index.stderr)
+    );
+
+    let status = run_cli(
+        workspace,
+        &[
+            "retrieval",
+            "status",
+            "--profile",
+            "agent",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        status.status.success(),
+        "agent retrieval status failed after agent-profile index: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status_json: Value = serde_json::from_slice(&status.stdout).expect("parse status json");
+    assert_eq!(
+        status_json["ownership"]["profile"].as_str(),
+        Some("agent"),
+        "agent-facing search evals must prepare agent-profile sidecars: {status_json:#}"
+    );
+    assert_eq!(
+        status_json["retrieval_mode"].as_str(),
+        Some("full"),
+        "agent-facing search evals require full agent sidecar retrieval: {status_json:#}"
+    );
+    status_json
+}
+
 fn assert_framework_route_metadata(framework: &Value) -> String {
     let route = &framework["symbol"]["node"]["route_endpoint"];
     assert_eq!(route["kind"], "framework_route");
@@ -356,23 +425,6 @@ fn search_json_emits_sidecar_primary_results_without_repo_text_fallback() {
     let workspace = tempdir().expect("workspace dir");
     write_retrieval_fixture(workspace.path());
 
-    let bootstrap = run_cli(
-        workspace.path(),
-        &[
-            "retrieval",
-            "bootstrap",
-            "--wait-secs",
-            "30",
-            "--format",
-            "json",
-        ],
-    );
-    assert!(
-        bootstrap.status.success(),
-        "retrieval bootstrap failed; live full-sidecar fixture is blocked: {}",
-        String::from_utf8_lossy(&bootstrap.stderr)
-    );
-
     let index = run_cli(
         workspace.path(),
         &["index", "--refresh", "full", "--format", "json"],
@@ -383,38 +435,7 @@ fn search_json_emits_sidecar_primary_results_without_repo_text_fallback() {
         String::from_utf8_lossy(&index.stderr)
     );
 
-    let retrieval_index = run_cli(
-        workspace.path(),
-        &[
-            "retrieval",
-            "index",
-            "--refresh",
-            "none",
-            "--format",
-            "json",
-        ],
-    );
-    assert!(
-        retrieval_index.status.success(),
-        "retrieval index failed; live full-sidecar fixture is blocked: {}",
-        String::from_utf8_lossy(&retrieval_index.stderr)
-    );
-
-    let status = run_cli(
-        workspace.path(),
-        &["retrieval", "status", "--format", "json"],
-    );
-    assert!(
-        status.status.success(),
-        "retrieval status failed after retrieval index: {}",
-        String::from_utf8_lossy(&status.stderr)
-    );
-    let status_json: Value = serde_json::from_slice(&status.stdout).expect("parse status json");
-    assert_eq!(
-        status_json["retrieval_mode"],
-        Value::String("full".to_string()),
-        "live full-sidecar fixture must report retrieval_mode=full: {status_json:#}"
-    );
+    prepare_agent_retrieval(workspace.path());
 
     let search = run_cli(
         workspace.path(),
@@ -1717,22 +1738,7 @@ fn search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes() {
         "index command failed: {}",
         String::from_utf8_lossy(&index.stderr)
     );
-    let retrieval_index = run_cli(
-        workspace.path(),
-        &[
-            "retrieval",
-            "index",
-            "--refresh",
-            "full",
-            "--format",
-            "json",
-        ],
-    );
-    assert!(
-        retrieval_index.status.success(),
-        "retrieval index command failed: {}",
-        String::from_utf8_lossy(&retrieval_index.stderr)
-    );
+    prepare_agent_retrieval(workspace.path());
 
     let expectations = [
         ("exact_symbol_anchor", "exact_symbol_anchor", "off"),


### PR DESCRIPTION
## Context
Closes #600

Agent-facing search now requires full retrieval from the agent sidecar profile. The ignored temp-project search evals still prepared the default local profile, so the eval could fail at the product boundary with a local-vs-agent profile mismatch before proving search quality.

## What Changed
- Added a shared ignored-test helper that prepares retrieval with `retrieval bootstrap --profile agent`, `retrieval index --profile agent`, and `retrieval status --profile agent`.
- The helper asserts `ownership.profile == "agent"` and `retrieval_mode == "full"` before any agent-facing `search` scoring runs.
- Updated both `search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes` and the earlier full-sidecar search JSON test to use the same agent-profile readiness path.

## How To Review
- Review `crates/codestory-cli/tests/search_json_output.rs` only.
- Confirm the changed setup is test-harness-only and does not alter ranking, fusion, storage, or product fail-closed behavior.
- The old unprofiled `retrieval index` calls are gone from the ignored temp-project search paths.

## Verification
- `cargo fmt --check` passed.
- `cargo test -p codestory-cli --test search_json_output search_json_fails_closed_without_full_sidecars -- --nocapture` passed.
- `git diff --check` passed.
- `cargo test -p codestory-cli --test search_json_output search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes -- --ignored --exact --nocapture` did not reproduce the local-vs-agent profile mismatch. It is still blocked by live sidecar service health during `retrieval index --profile agent`: `Zoekt sidecar is mandatory and must be reachable ... Connection refused`.

## Risk
The ignored live eval still depends on healthy sidecar services. This PR keeps the product fail-closed gate intact and only changes the eval setup to prove agent-profile readiness before search.
