### PR TITLE
Fix search quality eval agent profile

### DIFF
--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -355,12 +355,17 @@ fn context_rejects_removed_hybrid_tuning_flags_as_unknown_args() {
 fn search_json_emits_sidecar_primary_results_without_repo_text_fallback() {
     let workspace = tempdir().expect("workspace dir");
     write_retrieval_fixture(workspace.path());
+    let run_id = "search-json-sidecar";
 
     let bootstrap = run_cli(
         workspace.path(),
         &[
             "retrieval",
             "bootstrap",
+            "--profile",
+            "agent",
+            "--run-id",
+            run_id,
             "--wait-secs",
             "30",
             "--format",
@@ -388,6 +393,10 @@ fn search_json_emits_sidecar_primary_results_without_repo_text_fallback() {
         &[
             "retrieval",
             "index",
+            "--profile",
+            "agent",
+            "--run-id",
+            run_id,
             "--refresh",
             "none",
             "--format",
@@ -402,7 +411,16 @@ fn search_json_emits_sidecar_primary_results_without_repo_text_fallback() {
 
     let status = run_cli(
         workspace.path(),
-        &["retrieval", "status", "--format", "json"],
+        &[
+            "retrieval",
+            "status",
+            "--profile",
+            "agent",
+            "--run-id",
+            run_id,
+            "--format",
+            "json",
+        ],
     );
     assert!(
         status.status.success(),
@@ -413,7 +431,12 @@ fn search_json_emits_sidecar_primary_results_without_repo_text_fallback() {
     assert_eq!(
         status_json["retrieval_mode"],
         Value::String("full".to_string()),
-        "live full-sidecar fixture must report retrieval_mode=full: {status_json:#}"
+        "live full-sidecar fixture must report agent retrieval_mode=full: {status_json:#}"
+    );
+    assert_eq!(
+        status_json["ownership"]["profile"],
+        Value::String("agent".to_string()),
+        "live full-sidecar fixture must prepare the agent sidecar profile: {status_json:#}"
     );
 
     let search = run_cli(
@@ -1707,6 +1730,28 @@ fn field_qualified_search_filters_kind_path_name_and_language() {
 fn search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes() {
     let workspace = tempdir().expect("workspace dir");
     write_search_quality_fixture(workspace.path());
+    let run_id = "search-quality-eval";
+
+    let bootstrap = run_cli(
+        workspace.path(),
+        &[
+            "retrieval",
+            "bootstrap",
+            "--profile",
+            "agent",
+            "--run-id",
+            run_id,
+            "--wait-secs",
+            "30",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        bootstrap.status.success(),
+        "retrieval bootstrap failed; search quality eval fixture is blocked: {}",
+        String::from_utf8_lossy(&bootstrap.stderr)
+    );
 
     let index = run_cli(
         workspace.path(),
@@ -1722,6 +1767,10 @@ fn search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes() {
         &[
             "retrieval",
             "index",
+            "--profile",
+            "agent",
+            "--run-id",
+            run_id,
             "--refresh",
             "full",
             "--format",
@@ -1732,6 +1781,35 @@ fn search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes() {
         retrieval_index.status.success(),
         "retrieval index command failed: {}",
         String::from_utf8_lossy(&retrieval_index.stderr)
+    );
+    let status = run_cli(
+        workspace.path(),
+        &[
+            "retrieval",
+            "status",
+            "--profile",
+            "agent",
+            "--run-id",
+            run_id,
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        status.status.success(),
+        "agent retrieval status failed after retrieval index: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    let status_json: Value = serde_json::from_slice(&status.stdout).expect("parse status json");
+    assert_eq!(
+        status_json["retrieval_mode"],
+        Value::String("full".to_string()),
+        "search quality eval must report agent retrieval_mode=full before scoring: {status_json:#}"
+    );
+    assert_eq!(
+        status_json["ownership"]["profile"],
+        Value::String("agent".to_string()),
+        "search quality eval must prepare the agent sidecar profile before scoring: {status_json:#}"
     );
 
     let expectations = [


### PR DESCRIPTION
## Context
Closes #600
Refs #569, #585, #593, #544, #598, #599.

The ignored search quality eval built temp-project sidecars through the default local profile, then exercised agent-facing `search`, which expects agent-profile full retrieval.

## What Changed
- Updated the search quality eval to bootstrap, index, and status-check the agent sidecar profile before scoring.
- Reused a stable `--run-id` across agent-profile bootstrap/index/status so those commands inspect the same sidecar namespace.
- Applied the same agent-profile/run-id audit fix to the earlier ignored full-sidecar search test.
- Asserted `retrieval_mode=full` and `ownership.profile=agent` before invoking agent-facing search.

```mermaid
flowchart LR
    fixture[temp fixture] --> bootstrap[retrieval bootstrap<br/>--profile agent --run-id]
    fixture --> index[index --refresh full]
    bootstrap --> retrieval[retrieval index<br/>--profile agent --run-id]
    index --> retrieval
    retrieval --> status[retrieval status<br/>--profile agent --run-id]
    status --> search[agent-facing search]
```

## How To Review
- Inspect `crates/codestory-cli/tests/search_json_output.rs`.
- Confirm only eval/test setup changed; ranking, fusion, product fail-closed behavior, and storage paths are untouched.

## Verification
- `cargo fmt --check` passed.
- `cargo test -p codestory-cli --test search_json_output search_json_fails_closed_without_full_sidecars -- --nocapture` passed.
- `cargo test -p codestory-cli --test search_json_output search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes -- --ignored --nocapture` passed: `recall=1.000 mrr=0.939 max_latency_ms=2842 anchor_buckets=indexed_symbol_hits=11`.
- `cargo test -p codestory-cli --test search_json_output search_json_emits_sidecar_primary_results_without_repo_text_fallback -- --ignored --nocapture` passed.
- `git diff --check` passed.

## Risk
- Live sidecar tests still depend on Docker/sidecar startup health. This PR does not add cleanup or change product readiness gates.