### PR TITLE
[codex] Add dirty marker freshness bridge

### DIFF
--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -10,12 +10,15 @@ use codestory_contracts::api::{
     AffectedAnalysisRequest, AffectedChangeKindDto, AffectedChangeRecordDto, AgentAskRequest,
     AgentPacketRequestDto, AgentResponseModeDto, AgentRetrievalPresetDto,
     AgentRetrievalProfileSelectionDto, ApiError, GraphResponse, GroundingBudgetDto,
-    IndexedFileRoleDto, IndexedFilesRequest, ListChildrenSymbolsRequest, ListRootSymbolsRequest,
-    NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, PacketBudgetModeDto, PacketTaskClassDto,
-    ProjectSummary, ReadinessGoalDto, ReadinessStatusDto, ReadinessVerdictDto, SearchRepoTextMode,
-    SearchRequest, TrailCallerScope, TrailDirection, TrailMode,
+    IndexFreshnessChangeKindDto, IndexFreshnessDto, IndexFreshnessSampleDto,
+    IndexFreshnessStatusDto, IndexedFileRoleDto, IndexedFilesRequest, ListChildrenSymbolsRequest,
+    ListRootSymbolsRequest, NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind,
+    PacketBudgetModeDto, PacketTaskClassDto, ProjectSummary, ReadinessGoalDto, ReadinessStatusDto,
+    ReadinessVerdictDto, SearchRepoTextMode, SearchRequest, TrailCallerScope, TrailDirection,
+    TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File};
 use std::io::{BufRead, Read, Write};
@@ -49,6 +52,7 @@ const STDIO_SOURCE_FINGERPRINT_FILE_CAP: usize = 25_000;
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
 const STDIO_CLI_VERSION_TIMEOUT: Duration = Duration::from_secs(3);
 const STDIO_CLI_VERSION_POLL_INTERVAL: Duration = Duration::from_millis(25);
+const DIRTY_MARKER_SCHEMA_VERSION: u32 = 1;
 
 /// Run the stdio server until stdin closes.
 ///
@@ -168,6 +172,26 @@ struct StdioStatusCacheEntry {
     key: String,
     value: serde_json::Value,
     cached_at: Instant,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct StdioDirtyMarker {
+    schema_version: u32,
+    project_root: String,
+    dirty: bool,
+    updated_at: String,
+    source: String,
+    #[serde(default)]
+    path_sample: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct StdioDirtyMarkerStatus {
+    path: Option<PathBuf>,
+    marker: Option<StdioDirtyMarker>,
+    status: &'static str,
+    blocks_local_surfaces: bool,
+    reason: Option<String>,
 }
 
 fn handle_stdio_message(
@@ -2097,6 +2121,7 @@ fn stdio_project_args(runtime: &RuntimeContext) -> args::ProjectArgs {
 
 fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
     let layout = SidecarLayout::from_env_for_project(&runtime.project_root);
+    let marker_path = stdio_dirty_marker_env_path(&runtime.project_root);
     [
         format!("project:{}", runtime.project_root.display()),
         format!("storage:{}", runtime.storage_path.display()),
@@ -2111,6 +2136,13 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
         format!(
             "source_state:{}",
             stdio_source_fingerprint(&runtime.project_root)
+        ),
+        format!(
+            "dirty_marker:{}",
+            marker_path
+                .as_ref()
+                .map(|path| stdio_path_fingerprint(path))
+                .unwrap_or_else(|| "not_configured".to_string())
         ),
         format!(
             "active_embedding_backend:{}",
@@ -2184,6 +2216,180 @@ fn stdio_source_fingerprint_skip_dir(path: &Path) -> bool {
         .is_some_and(|name| matches!(name, ".git" | "target" | "node_modules" | "dist"))
 }
 
+fn stdio_dirty_marker_env_path(project_root: &Path) -> Option<PathBuf> {
+    let path = std::env::var_os("CODESTORY_PLUGIN_DIRTY_MARKER_PATH").map(PathBuf::from)?;
+    let env_root = std::env::var_os("CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| project_root.to_path_buf());
+    if !stdio_same_path_text(&env_root, project_root) {
+        return None;
+    }
+    Some(path)
+}
+
+fn stdio_dirty_marker_status(project_root: &Path, storage_path: &Path) -> StdioDirtyMarkerStatus {
+    let Some(path) = stdio_dirty_marker_env_path(project_root) else {
+        return StdioDirtyMarkerStatus {
+            path: None,
+            marker: None,
+            status: "not_configured",
+            blocks_local_surfaces: false,
+            reason: None,
+        };
+    };
+    let text = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return StdioDirtyMarkerStatus {
+                path: Some(path),
+                marker: None,
+                status: "missing",
+                blocks_local_surfaces: false,
+                reason: None,
+            };
+        }
+        Err(error) => {
+            return StdioDirtyMarkerStatus {
+                path: Some(path),
+                marker: None,
+                status: "unknown",
+                blocks_local_surfaces: false,
+                reason: Some(format!("marker_read_error:{error}")),
+            };
+        }
+    };
+    let marker: StdioDirtyMarker = match serde_json::from_str(&text) {
+        Ok(marker) => marker,
+        Err(error) => {
+            return StdioDirtyMarkerStatus {
+                path: Some(path),
+                marker: None,
+                status: "unknown",
+                blocks_local_surfaces: false,
+                reason: Some(format!("marker_json_error:{error}")),
+            };
+        }
+    };
+    if marker.schema_version != DIRTY_MARKER_SCHEMA_VERSION {
+        return StdioDirtyMarkerStatus {
+            path: Some(path),
+            marker: Some(marker),
+            status: "unknown",
+            blocks_local_surfaces: false,
+            reason: Some("schema_version_unsupported".to_string()),
+        };
+    }
+    if !stdio_same_path_text(Path::new(&marker.project_root), project_root) {
+        return StdioDirtyMarkerStatus {
+            path: Some(path),
+            marker: Some(marker),
+            status: "unknown",
+            blocks_local_surfaces: false,
+            reason: Some("project_root_mismatch".to_string()),
+        };
+    }
+    if !marker.dirty {
+        return StdioDirtyMarkerStatus {
+            path: Some(path),
+            marker: Some(marker),
+            status: "clean",
+            blocks_local_surfaces: false,
+            reason: None,
+        };
+    }
+    let marker_modified = fs::metadata(&path).and_then(|metadata| metadata.modified());
+    let storage_modified = fs::metadata(storage_path).and_then(|metadata| metadata.modified());
+    match (marker_modified, storage_modified) {
+        (Ok(marker_modified), Ok(storage_modified)) if marker_modified > storage_modified => {
+            StdioDirtyMarkerStatus {
+                path: Some(path),
+                marker: Some(marker),
+                status: "dirty_stale",
+                blocks_local_surfaces: true,
+                reason: Some("dirty_marker_newer_than_index".to_string()),
+            }
+        }
+        (Ok(_), Ok(_)) => StdioDirtyMarkerStatus {
+            path: Some(path),
+            marker: Some(marker),
+            status: "dirty_indexed",
+            blocks_local_surfaces: false,
+            reason: None,
+        },
+        (_, _) => StdioDirtyMarkerStatus {
+            path: Some(path),
+            marker: Some(marker),
+            status: "dirty_unknown",
+            blocks_local_surfaces: false,
+            reason: Some("marker_or_storage_mtime_unavailable".to_string()),
+        },
+    }
+}
+
+fn stdio_same_path_text(left: &Path, right: &Path) -> bool {
+    let clean = |path: &Path| {
+        let path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        path.to_string_lossy()
+            .trim_start_matches(r"\\?\")
+            .replace('\\', "/")
+            .trim_end_matches('/')
+            .to_ascii_lowercase()
+    };
+    clean(left) == clean(right)
+}
+
+fn stdio_effective_freshness(
+    freshness: Option<&IndexFreshnessDto>,
+    marker: &StdioDirtyMarkerStatus,
+) -> Option<IndexFreshnessDto> {
+    if !marker.blocks_local_surfaces {
+        return freshness.cloned();
+    }
+    let mut effective = freshness.cloned().unwrap_or(IndexFreshnessDto {
+        status: IndexFreshnessStatusDto::NotChecked,
+        changed_file_count: 0,
+        new_file_count: 0,
+        removed_file_count: 0,
+        checked_file_count: 0,
+        indexed_file_count: 0,
+        duration_ms: 0,
+        reason: None,
+        samples: Vec::new(),
+    });
+    effective.status = IndexFreshnessStatusDto::Stale;
+    effective.changed_file_count = effective.changed_file_count.max(1);
+    effective.reason = marker.reason.clone();
+    if effective.samples.is_empty()
+        && let Some(marker) = marker.marker.as_ref()
+    {
+        effective.samples = marker
+            .path_sample
+            .iter()
+            .take(5)
+            .map(|path| IndexFreshnessSampleDto {
+                kind: IndexFreshnessChangeKindDto::Changed,
+                path: path.clone(),
+            })
+            .collect();
+    }
+    Some(effective)
+}
+
+fn stdio_dirty_marker_json(marker: &StdioDirtyMarkerStatus) -> serde_json::Value {
+    serde_json::json!({
+        "status": marker.status,
+        "blocks_local_surfaces": marker.blocks_local_surfaces,
+        "reason": marker.reason,
+        "path": marker.path.as_ref().map(|path| crate::display::clean_path_string(&path.to_string_lossy())),
+        "schema_version": marker.marker.as_ref().map(|marker| marker.schema_version),
+        "project_root": marker.marker.as_ref().map(|marker| marker.project_root.as_str()),
+        "dirty": marker.marker.as_ref().map(|marker| marker.dirty),
+        "updated_at": marker.marker.as_ref().map(|marker| marker.updated_at.as_str()),
+        "source": marker.marker.as_ref().map(|marker| marker.source.as_str()),
+        "path_sample": marker.marker.as_ref().map(|marker| marker.path_sample.clone()).unwrap_or_default(),
+    })
+}
+
 fn read_stdio_status_resource(
     runtime: &RuntimeContext,
     summary: ProjectSummary,
@@ -2236,10 +2442,12 @@ fn read_stdio_status_resource(
     let source_checkout_version = stdio_source_checkout_version(&runtime.project_root);
     let plugin_runtime = stdio_plugin_runtime_status();
     let setup_repair = stdio_setup_repair_input(server_executable.as_deref());
+    let dirty_marker = stdio_dirty_marker_status(&runtime.project_root, &runtime.storage_path);
+    let effective_freshness = stdio_effective_freshness(summary.freshness.as_ref(), &dirty_marker);
     let readiness = crate::readiness::build_readiness_verdicts(crate::readiness::ReadinessInputs {
         project: &summary.root,
         stats: &summary.stats,
-        freshness: summary.freshness.as_ref(),
+        freshness: effective_freshness.as_ref(),
         setup: setup_repair.as_ref(),
         sidecar: Some(crate::readiness::ReadinessSidecarInput {
             profile: Some(sidecar_runtime.profile.as_str()),
@@ -2260,8 +2468,12 @@ fn read_stdio_status_resource(
         .iter()
         .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation)
         .expect("local_navigation readiness verdict");
-    let local_refresh_status =
+    let mut local_refresh_status =
         local_refresh.unwrap_or_else(|| crate::readiness::local_refresh_output(local));
+    if dirty_marker.blocks_local_surfaces {
+        local_refresh_status = crate::readiness::local_refresh_output(local);
+        local_refresh_status.reason = dirty_marker.reason.clone();
+    }
     let local_refresh_json =
         serde_json::to_value(&local_refresh_status).expect("serialize local refresh");
     let runtime_truth = stdio_runtime_truth_status(
@@ -2294,6 +2506,7 @@ fn read_stdio_status_resource(
         "degraded_reason": degraded_reason,
         "sidecar_retrieval": sidecar,
         "sidecar_setup": sidecar_setup,
+        "dirty_marker": stdio_dirty_marker_json(&dirty_marker),
         "legacy_semantic_diagnostics": {
             "mode": retrieval.map(|state| state.mode),
             "semantic_ready": retrieval.is_some_and(|state| state.semantic_ready),
@@ -2303,6 +2516,7 @@ fn read_stdio_status_resource(
             "diagnostic_only": true
         },
         "index_freshness": summary.freshness,
+        "effective_index_freshness": effective_freshness,
         "local_refresh": local_refresh_json,
         "readiness": readiness,
         "readiness_lanes": readiness_lanes_json,

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -1245,6 +1245,24 @@ fn stdio_storage_fingerprint(storage_path: &std::path::Path) -> String {
     parts.join("|")
 }
 
+fn stdio_storage_modified(
+    storage_path: &std::path::Path,
+) -> std::io::Result<std::time::SystemTime> {
+    let paths = [
+        storage_path.to_path_buf(),
+        storage_path.with_extension("db-wal"),
+        storage_path.with_extension("db-shm"),
+    ];
+    let mut newest: Option<std::time::SystemTime> = None;
+    for path in paths {
+        let Ok(modified) = fs::metadata(path).and_then(|metadata| metadata.modified()) else {
+            continue;
+        };
+        newest = Some(newest.map_or(modified, |current| current.max(modified)));
+    }
+    newest.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "storage state missing"))
+}
+
 fn stdio_mandatory_sidecar_fingerprint(
     project_root: &std::path::Path,
     storage_path: &std::path::Path,
@@ -2298,7 +2316,7 @@ fn stdio_dirty_marker_status(project_root: &Path, storage_path: &Path) -> StdioD
         };
     }
     let marker_modified = fs::metadata(&path).and_then(|metadata| metadata.modified());
-    let storage_modified = fs::metadata(storage_path).and_then(|metadata| metadata.modified());
+    let storage_modified = stdio_storage_modified(storage_path);
     match (marker_modified, storage_modified) {
         (Ok(marker_modified), Ok(storage_modified)) if marker_modified > storage_modified => {
             StdioDirtyMarkerStatus {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2,7 +2,7 @@ use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -15,6 +15,8 @@ struct StdioFixture {
     latest_release_version: String,
     disable_installed_cli_probe: bool,
     sidecar_policy_state: Option<String>,
+    dirty_marker_path: Option<PathBuf>,
+    dirty_marker_project_root: Option<PathBuf>,
 }
 
 struct StdioServer {
@@ -136,6 +138,8 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
         latest_release_version: env!("CARGO_PKG_VERSION").to_string(),
         disable_installed_cli_probe: false,
         sidecar_policy_state: None,
+        dirty_marker_path: None,
+        dirty_marker_project_root: None,
     }
 }
 
@@ -239,6 +243,12 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
             "CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND",
             "node codestory-mcp.cjs sidecar-policy disable",
         );
+    }
+    if let Some(path) = &fixture.dirty_marker_path {
+        command.env("CODESTORY_PLUGIN_DIRTY_MARKER_PATH", path);
+    }
+    if let Some(root) = &fixture.dirty_marker_project_root {
+        command.env("CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT", root);
     }
     let mut child = command.spawn().expect("spawn stdio server");
 
@@ -2332,6 +2342,114 @@ fn resources_read_status_suppresses_auto_repair_when_policy_disabled() {
     assert!(
         !next_call_text.contains("ready --goal agent --repair"),
         "disabled policy should not recommend automatic sidecar repair: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
+    let mut fixture = indexed_fixture();
+    let marker_path = fixture.cache_dir.path().join("dirty-marker.json");
+    thread::sleep(Duration::from_millis(25));
+    fs::write(
+        &marker_path,
+        json!({
+            "schema_version": 1,
+            "project_root": fixture.workspace.path().to_string_lossy(),
+            "dirty": true,
+            "updated_at": "2026-06-25T00:00:00.000Z",
+            "source": "test-hook",
+            "path_sample": ["src/runtime.rs"]
+        })
+        .to_string(),
+    )
+    .expect("write dirty marker");
+    fixture.dirty_marker_path = Some(marker_path.clone());
+    fixture.dirty_marker_project_root = Some(fixture.workspace.path().to_path_buf());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-dirty-marker",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-dirty-marker"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["dirty_marker"]["status"], json!("dirty_stale"));
+    assert_eq!(status["dirty_marker"]["dirty"], json!(true));
+    assert_eq!(
+        status["dirty_marker"]["reason"],
+        json!("dirty_marker_newer_than_index")
+    );
+    assert_eq!(
+        status["index_freshness"]["status"],
+        json!("fresh"),
+        "computed inventory freshness should remain visible: {status}"
+    );
+    assert_eq!(
+        status["effective_index_freshness"]["status"],
+        json!("stale")
+    );
+    assert_eq!(status["local_refresh"]["state"], json!("stale"));
+    assert_eq!(
+        status["local_refresh"]["blocks_local_surfaces"],
+        json!(true)
+    );
+    assert_eq!(status["readiness"][0]["status"], json!("repair_index"));
+    assert_allowed_surface(&status, "ground", false, "local_navigation", "repair_index");
+    assert_allowed_surface(
+        &status,
+        "packet",
+        false,
+        "agent_packet_search",
+        "repair_retrieval",
+    );
+}
+
+#[test]
+fn resources_read_status_reports_unknown_dirty_marker_without_blocking_local_index() {
+    let mut fixture = indexed_fixture();
+    let marker_path = fixture.cache_dir.path().join("dirty-marker-invalid.json");
+    fs::write(&marker_path, "{not-json").expect("write invalid marker");
+    fixture.dirty_marker_path = Some(marker_path);
+    fixture.dirty_marker_project_root = Some(fixture.workspace.path().to_path_buf());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-unknown-marker",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-unknown-marker"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["dirty_marker"]["status"], json!("unknown"));
+    assert_eq!(
+        status["dirty_marker"]["blocks_local_surfaces"],
+        json!(false)
+    );
+    assert!(
+        status["dirty_marker"]["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("marker_json_error")),
+        "unknown marker should explain the parse failure: {status}"
+    );
+    assert_fresh_freshness_counts(&status, "status with unknown dirty marker");
+    assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
+    assert_allowed_surface(
+        &status,
+        "packet",
+        false,
+        "agent_packet_search",
+        "repair_retrieval",
     );
 }
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -106,6 +106,35 @@ fn indexed_fixture() -> StdioFixture {
     indexed_fixture_with_embedding_mode(true)
 }
 
+fn write_dirty_marker_fixture(fixture: &StdioFixture, name: &str, marker: Value) -> PathBuf {
+    let marker_path = fixture.cache_dir.path().join(name);
+    thread::sleep(Duration::from_millis(25));
+    fs::write(&marker_path, marker.to_string()).expect("write dirty marker");
+    marker_path
+}
+
+fn refresh_fixture_index(fixture: &StdioFixture) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    command
+        .arg("index")
+        .arg("--refresh")
+        .arg("incremental")
+        .arg("--format")
+        .arg("json")
+        .arg("--project")
+        .arg(fixture.workspace.path())
+        .arg("--cache-dir")
+        .arg(fixture.cache_dir.path());
+    apply_fixture_embedding_env(&mut command, fixture.hash_embeddings);
+    let output = command.output().expect("run index refresh");
+    assert!(
+        output.status.success(),
+        "index refresh failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
     let workspace = tempfile::tempdir().expect("workspace dir");
     let cache_dir = tempfile::tempdir().expect("cache dir");
@@ -2348,10 +2377,9 @@ fn resources_read_status_suppresses_auto_repair_when_policy_disabled() {
 #[test]
 fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
     let mut fixture = indexed_fixture();
-    let marker_path = fixture.cache_dir.path().join("dirty-marker.json");
-    thread::sleep(Duration::from_millis(25));
-    fs::write(
-        &marker_path,
+    let marker_path = write_dirty_marker_fixture(
+        &fixture,
+        "dirty-marker.json",
         json!({
             "schema_version": 1,
             "project_root": fixture.workspace.path().to_string_lossy(),
@@ -2359,10 +2387,8 @@ fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
             "updated_at": "2026-06-25T00:00:00.000Z",
             "source": "test-hook",
             "path_sample": ["src/runtime.rs"]
-        })
-        .to_string(),
-    )
-    .expect("write dirty marker");
+        }),
+    );
     fixture.dirty_marker_path = Some(marker_path.clone());
     fixture.dirty_marker_project_root = Some(fixture.workspace.path().to_path_buf());
     let mut server = spawn_stdio_server(&fixture);
@@ -2401,6 +2427,56 @@ fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
     );
     assert_eq!(status["readiness"][0]["status"], json!("repair_index"));
     assert_allowed_surface(&status, "ground", false, "local_navigation", "repair_index");
+    assert_allowed_surface(
+        &status,
+        "packet",
+        false,
+        "agent_packet_search",
+        "repair_retrieval",
+    );
+}
+
+#[test]
+fn resources_read_status_uses_full_storage_state_for_dirty_marker_freshness() {
+    let mut fixture = indexed_fixture();
+    let marker_path = write_dirty_marker_fixture(
+        &fixture,
+        "dirty-marker-wal-indexed.json",
+        json!({
+            "schema_version": 1,
+            "project_root": fixture.workspace.path().to_string_lossy(),
+            "dirty": true,
+            "updated_at": "2026-06-25T00:00:00.000Z",
+            "source": "test-hook",
+            "path_sample": ["src/runtime.rs"]
+        }),
+    );
+    thread::sleep(Duration::from_millis(1200));
+    refresh_fixture_index(&fixture);
+    fixture.dirty_marker_path = Some(marker_path.clone());
+    fixture.dirty_marker_project_root = Some(fixture.workspace.path().to_path_buf());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-dirty-marker-indexed",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-dirty-marker-indexed"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["dirty_marker"]["status"], json!("dirty_indexed"));
+    assert_eq!(status["dirty_marker"]["dirty"], json!(true));
+    assert_eq!(
+        status["dirty_marker"]["blocks_local_surfaces"],
+        json!(false)
+    );
+    assert_fresh_freshness_counts(&status, "dirty marker older than full storage state");
+    assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
     assert_allowed_surface(
         &status,
         "packet",
@@ -2451,6 +2527,110 @@ fn resources_read_status_reports_unknown_dirty_marker_without_blocking_local_ind
         "agent_packet_search",
         "repair_retrieval",
     );
+}
+
+#[test]
+fn resources_read_status_dirty_marker_fail_open_matrix() {
+    let cases = [
+        ("missing", None, json!("missing"), None, None),
+        (
+            "schema",
+            Some(json!({
+                "schema_version": 99,
+                "project_root": "__PROJECT_ROOT__",
+                "dirty": true,
+                "updated_at": "2026-06-25T00:00:00.000Z",
+                "source": "test-hook",
+                "path_sample": []
+            })),
+            json!("unknown"),
+            Some(json!("schema_version_unsupported")),
+            None,
+        ),
+        (
+            "root",
+            Some(json!({
+                "schema_version": 1,
+                "project_root": "C:/different/project",
+                "dirty": true,
+                "updated_at": "2026-06-25T00:00:00.000Z",
+                "source": "test-hook",
+                "path_sample": []
+            })),
+            json!("unknown"),
+            Some(json!("project_root_mismatch")),
+            None,
+        ),
+        (
+            "clean",
+            Some(json!({
+                "schema_version": 1,
+                "project_root": "__PROJECT_ROOT__",
+                "dirty": false,
+                "updated_at": "2026-06-25T00:00:00.000Z",
+                "source": "test-hook",
+                "path_sample": []
+            })),
+            json!("clean"),
+            None,
+            Some(json!(false)),
+        ),
+    ];
+
+    for (name, marker, expected_status, expected_reason, expected_dirty) in cases {
+        let mut fixture = indexed_fixture();
+        let marker_path = fixture
+            .cache_dir
+            .path()
+            .join(format!("dirty-marker-{name}.json"));
+        if let Some(mut marker) = marker {
+            if marker["project_root"] == json!("__PROJECT_ROOT__") {
+                marker["project_root"] = json!(fixture.workspace.path().to_string_lossy());
+            }
+            fs::write(&marker_path, marker.to_string()).expect("write marker");
+        }
+        fixture.dirty_marker_path = Some(marker_path);
+        fixture.dirty_marker_project_root = Some(fixture.workspace.path().to_path_buf());
+        let mut server = spawn_stdio_server(&fixture);
+
+        let response = send_json(
+            &mut server,
+            json!({
+                "jsonrpc": "2.0",
+                "id": format!("status-dirty-marker-{name}"),
+                "method": "resources/read",
+                "params": {"uri": "codestory://status"}
+            }),
+        );
+        let result =
+            assert_success_envelope(&response, json!(format!("status-dirty-marker-{name}")));
+        let status = json_resource_content(result, "codestory://status");
+
+        assert_eq!(
+            status["dirty_marker"]["status"], expected_status,
+            "{name}: {status}"
+        );
+        assert_eq!(
+            status["dirty_marker"]["blocks_local_surfaces"],
+            json!(false),
+            "{name}: {status}"
+        );
+        if let Some(reason) = expected_reason {
+            assert_eq!(status["dirty_marker"]["reason"], reason, "{name}: {status}");
+        }
+        if let Some(dirty) = expected_dirty {
+            assert_eq!(status["dirty_marker"]["dirty"], dirty, "{name}: {status}");
+        }
+        assert_fresh_freshness_counts(&status, name);
+        assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
+        assert_allowed_surface(
+            &status,
+            "packet",
+            false,
+            "agent_packet_search",
+            "repair_retrieval",
+        );
+    }
 }
 
 #[test]
@@ -3093,6 +3273,51 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
             }),
         "agent guide should include safety notes: {guide}"
     );
+}
+
+#[test]
+#[ignore = "live full-retrieval stdio success contract; set CODESTORY_STDIO_FULL_RETRIEVAL_TESTS=1 after preparing real sidecars"]
+fn resources_read_status_keeps_dirty_marker_separate_from_full_sidecar_readiness() {
+    let Some(mut fixture) = full_retrieval_fixture().unwrap_or_else(|error| panic!("{error}"))
+    else {
+        return;
+    };
+    let marker_path = write_dirty_marker_fixture(
+        &fixture,
+        "dirty-marker-full-sidecar.json",
+        json!({
+            "schema_version": 1,
+            "project_root": fixture.workspace.path().to_string_lossy(),
+            "dirty": true,
+            "updated_at": "2026-06-25T00:00:00.000Z",
+            "source": "test-hook",
+            "path_sample": ["src/runtime.rs"]
+        }),
+    );
+    fixture.dirty_marker_path = Some(marker_path);
+    fixture.dirty_marker_project_root = Some(fixture.workspace.path().to_path_buf());
+    let mut server = spawn_stdio_server(&fixture);
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "full-retrieval-dirty-marker-status",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let status_result = assert_success_envelope(
+        &status_response,
+        json!("full-retrieval-dirty-marker-status"),
+    );
+    let status = json_resource_content(status_result, "codestory://status");
+
+    assert_eq!(status["dirty_marker"]["status"], json!("dirty_stale"));
+    assert_allowed_surface(&status, "ground", false, "local_navigation", "repair_index");
+    for surface in ["packet", "search", "context"] {
+        assert_allowed_surface(&status, surface, true, "agent_packet_search", "ready");
+    }
 }
 
 #[test]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ integration.
 | --- | --- | --- | --- |
 | Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
 | Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
-| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `runtime_truth`, `sidecar_setup`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. |
+| First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `runtime_truth`, `sidecar_setup`, `dirty_marker`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `callers`, `callees`, `trail`, `trace`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
 | Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
@@ -122,7 +122,7 @@ codestory-cli ground --project <target-workspace> --why
 When MCP is live, use `codestory://status` as the runtime truth. Its
 `server_version`, `cli_version`, `server_executable`,
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`,
-`runtime_truth`, and `sidecar_setup` fields identify the active server, CLI, sidecar contract,
+`runtime_truth`, `sidecar_setup`, and `dirty_marker` fields identify the active server, CLI, sidecar contract,
 plugin launch source, sidecar setup policy, `build_source`, and `repo_ref`, and
 `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed
 plugin cache when the adapter is active. `allowed_surfaces` tells the agent
@@ -181,7 +181,7 @@ explicit ref, setup fetches and builds the remote default branch.
 
 | Runtime truth | Allows | Blocks |
 | --- | --- | --- |
-| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `runtime_truth`, `sidecar_setup`, `build_source`, `repo_ref`, and `allowed_surfaces`; `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
+| `codestory://status` | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `runtime_truth`, `sidecar_setup`, `dirty_marker`, `build_source`, `repo_ref`, and `allowed_surfaces`; `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Use this first when MCP is live. | Guessing active runtime from source checkout, marketplace cache, or `PATH` alone. |
 | `allowed_surfaces.<surface>.allowed` for `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trail`, `trace`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` | The named MCP local graph surface only; check each surface's own `.allowed` bit before calling it. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, and `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, and `context` for broad candidate discovery and bounded evidence packets. | Answer-quality claims without matching packet-runtime, drill, benchmark, or source evidence. |
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -59,7 +59,7 @@ running server.
 | --- | --- | --- |
 | `allowed_surfaces.<surface>.allowed` for local graph surfaces | The named local surface only: `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trail`, `trace`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`. | Other local surfaces, `packet`, `search`, or `context`. |
 | `allowed_surfaces.packet.allowed`, `allowed_surfaces.search.allowed`, or `allowed_surfaces.context.allowed` with `retrieval_mode=full` | `packet`, `search`, or `context` for broad candidate discovery and evidence packets. | Answer-quality claims without packet-runtime, drill, benchmark, or source evidence. |
-| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `runtime_truth`, `sidecar_setup`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when the plugin launcher is active. | Guessing active runtime from source checkout or PATH alone. |
+| `codestory://status` fields | Current `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `runtime_truth`, `sidecar_setup`, `dirty_marker`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when the plugin launcher is active. | Guessing active runtime from source checkout or PATH alone. |
 
 ## How It Runs
 
@@ -147,7 +147,7 @@ The first run should be agent-owned. The skill checks whether `codestory-cli` is
 live through MCP by reading `codestory://status`. If MCP is live, the agent uses
 `server_version`, `cli_version`, `server_executable`,
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`,
-`runtime_truth`, `sidecar_setup`, and `allowed_surfaces` from status instead of rechecking PATH
+`runtime_truth`, `sidecar_setup`, `dirty_marker`, and `allowed_surfaces` from status instead of rechecking PATH
 or release metadata.
 
 Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -5,10 +5,12 @@ const { createHash } = require('crypto');
 const { eventHeader, getCodeStoryInstructions } = require('./codestory-instructions.cjs');
 const {
   classifyMcpRuntime,
+  dirtyMarkerPathForProject,
   mcpDetectionText,
   readActiveState,
   readHookState,
   rememberActiveState,
+  writeDirtyMarker,
   writeHookState,
   writeHookOutput,
 } = require('./codestory-runtime.cjs');
@@ -92,6 +94,37 @@ function hookPolicy(input, event) {
     runtimeOnly: ['resume', 'compact', 'handoff', 'goal_heartbeat'].includes(taxonomy),
     heartbeat: taxonomy === 'goal_heartbeat',
   };
+}
+
+function gitDirtyState(project) {
+  if (!project) return null;
+  const result = spawnSync('git', ['-C', project, 'status', '--porcelain'], {
+    encoding: 'utf8',
+    timeout: 1000,
+    maxBuffer: 20_000,
+    windowsHide: true,
+  });
+  if (result.status !== 0 || result.error) return null;
+  const paths = result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean)
+    .slice(0, 20);
+  return {
+    dirty: paths.length > 0,
+    pathSample: paths,
+  };
+}
+
+function writeProjectDirtyMarker(policy) {
+  if (!dirtyMarkerPathForProject(policy.project)) return;
+  const state = gitDirtyState(policy.project);
+  if (!state) return;
+  writeDirtyMarker(policy.project, {
+    dirty: state.dirty,
+    pathSample: state.pathSample,
+    source: `codestory-hook:${policy.taxonomy}`,
+  });
 }
 
 function runtimeFingerprint(mcp) {
@@ -447,6 +480,7 @@ function runCodeStory(input, event, policy, state = {}) {
 
 function buildContext(input, event, state = {}) {
   const policy = hookPolicy(input, event);
+  writeProjectDirtyMarker(policy);
   const runtime = runCodeStory(input, event, policy, state);
   if (runtime && policy.heartbeat && !rememberHeartbeat(policy, runtime.fingerprint || runtime.output)) {
     return null;

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { createHash } = require('crypto');
 
 const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
@@ -7,6 +8,8 @@ const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 const STATE_FILE = '.codestory-active';
 const HOOK_STATE_FILE = '.codestory-hook-output-state.json';
 const MCP_RUNTIME_FILE = '.codestory-mcp-runtime.json';
+const DIRTY_MARKER_SCHEMA_VERSION = 1;
+const DIRTY_MARKER_SAMPLE_LIMIT = 20;
 
 function pluginDataDir() {
   if (isCodex) return process.env.PLUGIN_DATA;
@@ -29,6 +32,22 @@ function readJson(file) {
 
 function pluginRoot() {
   return path.dirname(__dirname);
+}
+
+function normalizeProjectRoot(projectRoot) {
+  const resolved = path.resolve(projectRoot || process.cwd());
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function dirtyMarkerPathForProject(projectRoot, dataDir = pluginDataDir()) {
+  if (!dataDir || !projectRoot) return null;
+  const normalizedRoot = normalizeProjectRoot(projectRoot);
+  const key = createHash('sha256').update(normalizedRoot).digest('hex').slice(0, 32);
+  return path.join(dataDir, 'dirty-markers', `${key}.json`);
 }
 
 function pluginVersion(root = pluginRoot()) {
@@ -168,6 +187,35 @@ function writeHookState(state) {
   }
 }
 
+function writeDirtyMarker(projectRoot, options = {}) {
+  const markerPath = dirtyMarkerPathForProject(projectRoot, options.pluginDataDir);
+  if (!markerPath) return null;
+  const normalizedRoot = normalizeProjectRoot(projectRoot);
+  const pathSample = Array.isArray(options.pathSample)
+    ? options.pathSample
+      .filter((item) => typeof item === 'string' && item.trim())
+      .slice(0, DIRTY_MARKER_SAMPLE_LIMIT)
+    : [];
+  const marker = {
+    schema_version: DIRTY_MARKER_SCHEMA_VERSION,
+    project_root: normalizedRoot,
+    dirty: Boolean(options.dirty),
+    updated_at: new Date().toISOString(),
+    source: String(options.source || 'codestory-hook'),
+  };
+  if (pathSample.length > 0) {
+    marker.path_sample = pathSample;
+  }
+
+  try {
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, JSON.stringify(marker, null, 2));
+    return { path: markerPath, marker };
+  } catch {
+    return null;
+  }
+}
+
 function writeHookOutput(event, context) {
   if (isCopilot) {
     process.stdout.write(JSON.stringify({ additionalContext: context }));
@@ -193,10 +241,12 @@ function writeHookOutput(event, context) {
 
 module.exports = {
   classifyMcpRuntime,
+  dirtyMarkerPathForProject,
   mcpDetectionText,
   readActiveState,
   readHookState,
   rememberActiveState,
+  writeDirtyMarker,
   writeHookState,
   writeHookOutput,
 };

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -209,6 +209,17 @@ function writeDirtyMarker(projectRoot, options = {}) {
 
   try {
     fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    const existing = readJson(markerPath);
+    const existingSample = Array.isArray(existing?.path_sample) ? existing.path_sample : [];
+    if (
+      existing?.schema_version === marker.schema_version
+      && existing?.project_root === marker.project_root
+      && existing?.dirty === marker.dirty
+      && existing?.source === marker.source
+      && JSON.stringify(existingSample) === JSON.stringify(pathSample)
+    ) {
+      return { path: markerPath, marker: existing, unchanged: true };
+    }
     fs.writeFileSync(markerPath, JSON.stringify(marker, null, 2));
     return { path: markerPath, marker };
   } catch {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -7,6 +7,7 @@ const fs = require('fs');
 const https = require('https');
 const os = require('os');
 const path = require('path');
+const { dirtyMarkerPathForProject } = require('../hooks/codestory-runtime.cjs');
 
 const pluginRoot = path.dirname(__dirname);
 const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codestory-cli';
@@ -121,6 +122,21 @@ function handleSidecarPolicyCommand(argv) {
 
 function repairCommandForProject(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json`;
+}
+
+function dirtyMarkerEnv(projectRoot = process.cwd()) {
+  const markerPath = dirtyMarkerPathForProject(projectRoot, pluginDataDir());
+  const normalizedRoot = (() => {
+    try {
+      return fs.realpathSync(path.resolve(projectRoot));
+    } catch {
+      return path.resolve(projectRoot);
+    }
+  })();
+  return {
+    path: markerPath || '',
+    projectRoot: markerPath ? normalizedRoot : '',
+  };
 }
 
 function runtimeTruthStatus(plugin, repair, options = {}) {
@@ -917,6 +933,7 @@ async function main() {
     return;
   }
   const sidecarStatus = readSidecarPolicy();
+  const dirtyMarker = dirtyMarkerEnv(process.cwd());
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
     stdio: 'inherit',
@@ -948,6 +965,8 @@ async function main() {
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND: sidecarStatus.lastRepair?.command || '',
+      CODESTORY_PLUGIN_DIRTY_MARKER_PATH: dirtyMarker.path,
+      CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT: dirtyMarker.projectRoot,
     },
   });
 

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -17,8 +17,8 @@ is missing, unversioned, or older than the plugin package, the adapter returns
 `codestory://status` is the runtime truth: use `server_version`, `cli_version`,
 `server_executable`,
 `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`,
-`runtime_truth`, and `allowed_surfaces` from status before any local grounding,
-packet, or search call.
+`runtime_truth`, `dirty_marker`, and `allowed_surfaces` from status before any
+local grounding, packet, or search call.
 
 ## Usage
 
@@ -67,6 +67,7 @@ packet, or search call.
 | `plugin_runtime` | Plugin launch source. `managed` is the installed plugin path, `local_dev_override` means `CODESTORY_CLI`, and `path_fallback` means no managed binary was available. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. Provisioned records include `build_source=github_release` and `repo_ref`. |
 | `runtime_truth` | Grouped runtime source, plugin root, managed CLI path, launcher source, sidecar policy/status, and local/agent readiness lanes. |
 | `sidecar_setup` | Plugin sidecar setup policy (`ask`, `enabled`, or `disabled`) plus last repair state and opt-in/disable commands. |
+| `dirty_marker` | Optional plugin hook freshness marker. `dirty_stale` means local graph surfaces report `repair_index` until the index is refreshed; packet/search/context readiness remains sidecar-gated. |
 | `runtime_boundary` | Restart/reload reminder for changes to the managed binary, override, or PATH. |
 | `allowed_surfaces.<surface>.allowed` | Allows that concrete MCP surface. Local graph surfaces include `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trail`, `trace`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Allows `packet`, `search`, and `context` only when the surface bit is true and `retrieval_mode=full`. |

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -11,7 +11,11 @@ import { fileURLToPath } from "node:url";
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
 const require = createRequire(import.meta.url);
-const { classifyMcpRuntime } = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
+const {
+  classifyMcpRuntime,
+  dirtyMarkerPathForProject,
+  writeDirtyMarker,
+} = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
 
 function readCargoVersion(manifestText) {
   let inPackage = false;
@@ -58,7 +62,7 @@ function releaseAssetForPlatform(version) {
 }
 
 async function writeFakeCli(cliPath) {
-  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,args}))";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
@@ -140,6 +144,40 @@ test("codestory repo ships plugin source, not marketplace catalog or server adap
   await access(join(pluginRoot, "scripts", "codestory-mcp.cjs"));
 });
 
+test("dirty marker writer stores one project-keyed marker under plugin data", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-dirty-marker-"));
+  const projectRoot = await mkdtemp(join(tmpdir(), "codestory-dirty-project-"));
+
+  try {
+    const realProjectRoot = await realpath(projectRoot);
+    const first = writeDirtyMarker(projectRoot, {
+      pluginDataDir: dataDir,
+      dirty: true,
+      source: "test-hook",
+      pathSample: ["src/lib.rs", "src/changed.rs", ""],
+    });
+    const second = writeDirtyMarker(projectRoot, {
+      pluginDataDir: dataDir,
+      dirty: false,
+      source: "test-hook",
+    });
+
+    assert.ok(first);
+    assert.ok(second);
+    assert.equal(first.path, second.path);
+    assert.equal(first.path, dirtyMarkerPathForProject(projectRoot, dataDir));
+    const marker = JSON.parse(await readFile(second.path, "utf8"));
+    assert.equal(marker.schema_version, 1);
+    assert.equal(marker.project_root, realProjectRoot);
+    assert.equal(marker.dirty, false);
+    assert.equal(marker.source, "test-hook");
+    assert.equal(typeof marker.updated_at, "string");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
 test("mcp launcher prefers a checksummed managed cli without PATH", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
@@ -184,6 +222,8 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.sidecarPolicy, "ask");
     assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
     assert.match(observed.sidecarEnable, /--policy-file/u);
+    assert.equal(observed.dirtyMarkerRoot, await realpath(repoRoot));
+    assert.equal(observed.dirtyMarkerPath, dirtyMarkerPathForProject(repoRoot, dataDir));
     assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
 
     const enable = spawnSync(observed.sidecarEnable, {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -156,6 +156,14 @@ test("dirty marker writer stores one project-keyed marker under plugin data", as
       source: "test-hook",
       pathSample: ["src/lib.rs", "src/changed.rs", ""],
     });
+    const firstStat = await stat(first.path);
+    const repeat = writeDirtyMarker(projectRoot, {
+      pluginDataDir: dataDir,
+      dirty: true,
+      source: "test-hook",
+      pathSample: ["src/lib.rs", "src/changed.rs", ""],
+    });
+    const repeatStat = await stat(first.path);
     const second = writeDirtyMarker(projectRoot, {
       pluginDataDir: dataDir,
       dirty: false,
@@ -163,8 +171,11 @@ test("dirty marker writer stores one project-keyed marker under plugin data", as
     });
 
     assert.ok(first);
+    assert.ok(repeat);
     assert.ok(second);
+    assert.equal(repeat.unchanged, true);
     assert.equal(first.path, second.path);
+    assert.equal(repeatStat.mtimeMs, firstStat.mtimeMs);
     assert.equal(first.path, dirtyMarkerPathForProject(projectRoot, dataDir));
     const marker = JSON.parse(await readFile(second.path, "utf8"));
     assert.equal(marker.schema_version, 1);


### PR DESCRIPTION
## Context
Closes #607.

#607 needs the smallest bridge from opt-in hook freshness into active stdio readiness. Dependency #605 is closed, so this PR implements the bridge instead of adding hook installation or sidecar behavior.

## What Changed
- Added a hook-side dirty marker writer under plugin data, keyed by normalized project root.
- Made unchanged dirty marker writes idempotent so repeated hooks do not refresh marker mtime and re-block an already-refreshed local index.
- Passed the marker path/root from the plugin MCP adapter into `codestory-cli serve --stdio` through env, with no PATH dependency.
- Taught `codestory://status` to report `dirty_marker`, preserve computed `index_freshness`, and use `effective_index_freshness` for local readiness when a dirty marker is newer than the full indexed storage state (`codestory.db`, WAL, or SHM).
- Kept packet/search/context readiness on the existing full sidecar gate.
- Documented the new status field in the existing status-field references.

```mermaid
flowchart LR
  Hook[Lifecycle hook] --> Marker[plugin data dirty marker]
  Adapter[MCP adapter] --> Env[marker path/root env]
  Env --> Status[serve --stdio codestory://status]
  Marker --> Status
  Status --> Local{dirty marker newer than index storage?}
  Local -- yes --> Repair[local graph repair_index]
  Local -- no --> Inventory[computed inventory freshness]
  Status --> Sidecar[packet/search/context sidecar readiness unchanged]
```

## How To Review
- Start with `plugins/codestory/hooks/codestory-runtime.cjs` and `plugins/codestory/hooks/codestory-activate.cjs` for marker write/idempotence.
- Then check `plugins/codestory/scripts/codestory-mcp.cjs` for the stdio env bridge.
- Finish in `crates/codestory-cli/src/stdio_transport.rs`, especially `dirty_marker`, `index_freshness`, `effective_index_freshness`, and `allowed_surfaces` behavior.

## Verification
- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs` - pass, 31 tests.
- `cargo test -p codestory-cli --test stdio_protocol_contracts dirty_marker -- --nocapture` - pass, 4 tests / 1 ignored full-sidecar contract.
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls -- --exact --nocapture` - pass, 1 test.
- `cargo fmt --check` - pass.
- `git diff --check` - pass.
- GitHub checks on `c6a4d679`: rustdoc pass, linux-contracts pass, issue-link guard pass, windows manifest skipped.

## Risk
Live host/plugin reload behavior is not exercised here; local tests cover the adapter env contract and stdio status behavior. Invalid, missing, or mismatched markers report `unknown`/`missing` and do not block local graph surfaces. No retrieval manifest or sidecar auto-start behavior changes.