### PR TITLE
[codex] Add dirty marker hook management

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,6 +148,26 @@ the sidecar lane only when the task needs those sidecar-backed surfaces:
 codestory-cli ready --goal agent --repair --project <target-workspace> --format json
 ```
 
+Optional dirty-marker Git hooks can mark local graph freshness dirty after Git
+checkout, merge, or rewrite operations. Install them only when you want that
+repo-level signal:
+
+```sh
+node plugins/codestory/hooks/codestory-dirty-hook.cjs install --project <target-workspace> --plugin-data <plugin-data-dir>
+node plugins/codestory/hooks/codestory-dirty-hook.cjs status --project <target-workspace> --plugin-data <plugin-data-dir>
+```
+
+Uninstall is safe and removes only CodeStory-managed hook blocks:
+
+```sh
+node plugins/codestory/hooks/codestory-dirty-hook.cjs uninstall --project <target-workspace> --plugin-data <plugin-data-dir>
+```
+
+`foreign_hook_present` means existing hook content was preserved.
+`uninstall_required` means an older CodeStory-managed block should be removed
+before reinstalling. Dirty markers affect local graph freshness only; packet,
+search, and context remain gated on full sidecar readiness.
+
 **Common next steps:**
 
 - If `packet`, `search`, or `context` is not allowed: Keep local browse work local; repair retrieval sidecars only when the task needs those surfaces

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -77,6 +77,9 @@ This package stays thin:
 - `hooks/` keeps CodeStory ambient for host adapters that support lifecycle
   hooks: `SessionStart` attempts strict startup grounding and
   `UserPromptSubmit` attempts request-aware packet grounding.
+- `hooks/codestory-dirty-hook.cjs` is the explicit opt-in Git hook manager for
+  local graph freshness. It installs CodeStory-managed blocks only, preserves
+  existing hook content, and uninstalls only those managed blocks.
 - `skills/codestory-grounding` is the single canonical CodeStory grounding
   skill shipped by this repository.
 
@@ -154,6 +157,28 @@ Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
 missing, status reports a suspect runtime, or you are debugging/repairing the
 installed CLI. If PATH changed during repair, start a fresh Codex host/app
 session before treating a new MCP runtime as live.
+
+### Optional dirty-marker Git hooks
+
+The plugin status path can consume dirty markers written under plugin data. To
+mark a repo dirty after Git checkout/merge/rewrite operations, install the
+optional hook blocks explicitly:
+
+```bash
+node plugins/codestory/hooks/codestory-dirty-hook.cjs install --project <repo> --plugin-data <plugin-data-dir>
+node plugins/codestory/hooks/codestory-dirty-hook.cjs status --project <repo> --plugin-data <plugin-data-dir>
+```
+
+Uninstall removes only the CodeStory-managed blocks:
+
+```bash
+node plugins/codestory/hooks/codestory-dirty-hook.cjs uninstall --project <repo> --plugin-data <plugin-data-dir>
+```
+
+If status reports `foreign_hook_present`, existing hook content was preserved.
+If it reports `uninstall_required`, uninstall the old managed block before
+installing again. Dirty markers affect local graph freshness only; packet,
+search, and context remain gated on full sidecar readiness.
 
 ## What To Ask
 

--- a/plugins/codestory/hooks/codestory-dirty-hook.cjs
+++ b/plugins/codestory/hooks/codestory-dirty-hook.cjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+const {
+  dirtyHookStatus,
+  installDirtyHooks,
+  uninstallDirtyHooks,
+  writeDirtyMarker,
+} = require('./codestory-runtime.cjs');
+
+function argValue(args, name) {
+  const index = args.indexOf(name);
+  return index === -1 ? null : args[index + 1] || null;
+}
+
+function usage() {
+  return [
+    'Usage: codestory-dirty-hook.cjs <install|uninstall|status|mark> --project <repo> [--plugin-data <dir>]',
+    '',
+    'Installs or removes CodeStory-managed Git hook blocks that write the dirty marker.',
+  ].join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const action = args[0];
+  const project = argValue(args, '--project') || process.cwd();
+  const pluginDataDir = argValue(args, '--plugin-data') || process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA;
+  const options = { pluginDataDir };
+
+  if (!['install', 'uninstall', 'status', 'mark'].includes(action)) {
+    console.error(usage());
+    process.exit(2);
+  }
+
+  let result;
+  if (action === 'install') {
+    result = installDirtyHooks(project, options);
+  } else if (action === 'uninstall') {
+    result = uninstallDirtyHooks(project, options);
+  } else if (action === 'status') {
+    result = dirtyHookStatus(project, options);
+  } else {
+    result = writeDirtyMarker(project, {
+      ...options,
+      dirty: true,
+      source: argValue(args, '--source') || 'codestory-git-hook',
+    }) || { status: 'plugin_data_required' };
+  }
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+}

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -10,6 +10,9 @@ const HOOK_STATE_FILE = '.codestory-hook-output-state.json';
 const MCP_RUNTIME_FILE = '.codestory-mcp-runtime.json';
 const DIRTY_MARKER_SCHEMA_VERSION = 1;
 const DIRTY_MARKER_SAMPLE_LIMIT = 20;
+const DIRTY_HOOK_NAMES = ['post-checkout', 'post-merge', 'post-rewrite'];
+const DIRTY_HOOK_START = '# >>> codestory dirty marker >>>';
+const DIRTY_HOOK_END = '# <<< codestory dirty marker <<<';
 
 function pluginDataDir() {
   if (isCodex) return process.env.PLUGIN_DATA;
@@ -227,6 +230,174 @@ function writeDirtyMarker(projectRoot, options = {}) {
   }
 }
 
+function shellQuote(value) {
+  return `'${String(value).replace(/\\/g, '/').replace(/'/g, `'\\''`)}'`;
+}
+
+function gitDirForProject(projectRoot) {
+  const dotGit = path.join(normalizeProjectRoot(projectRoot), '.git');
+  try {
+    const stat = fs.statSync(dotGit);
+    if (stat.isDirectory()) return dotGit;
+    if (stat.isFile()) {
+      const text = fs.readFileSync(dotGit, 'utf8').trim();
+      const match = text.match(/^gitdir:\s*(.+)$/iu);
+      if (!match) return null;
+      return path.resolve(path.dirname(dotGit), match[1]);
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function hookManagerPaths(projectRoot, options = {}) {
+  const dataDir = options.pluginDataDir || pluginDataDir();
+  const gitDir = gitDirForProject(projectRoot);
+  const scriptPath = path.join(__dirname, 'codestory-dirty-hook.cjs');
+  return {
+    dataDir,
+    gitDir,
+    hooksDir: gitDir ? path.join(gitDir, 'hooks') : null,
+    nodePath: process.execPath,
+    projectRoot: normalizeProjectRoot(projectRoot),
+    scriptPath,
+  };
+}
+
+function dirtyHookBlock(paths, hookName) {
+  const command = [
+    shellQuote(paths.nodePath),
+    shellQuote(paths.scriptPath),
+    'mark',
+    '--project',
+    shellQuote(paths.projectRoot),
+    '--plugin-data',
+    shellQuote(paths.dataDir),
+    '--source',
+    shellQuote(`git-hook:${hookName}`),
+    '|| true',
+  ].join(' ');
+  return `${DIRTY_HOOK_START}\n${command}\n${DIRTY_HOOK_END}`;
+}
+
+function splitDirtyHookBlock(text) {
+  const start = text.indexOf(DIRTY_HOOK_START);
+  const end = text.indexOf(DIRTY_HOOK_END);
+  if (start === -1 || end === -1 || end < start) {
+    return { before: text, block: null, after: '' };
+  }
+  const afterStart = end + DIRTY_HOOK_END.length;
+  return {
+    before: text.slice(0, start).replace(/[ \t]*\r?\n?$/u, ''),
+    block: text.slice(start, afterStart),
+    after: text.slice(afterStart).replace(/^\r?\n/u, ''),
+  };
+}
+
+function dirtyHookState(hookPath, expectedBlock) {
+  if (!fs.existsSync(hookPath)) {
+    return { state: 'not_installed', path: hookPath };
+  }
+  const text = fs.readFileSync(hookPath, 'utf8');
+  const parts = splitDirtyHookBlock(text);
+  if (!parts.block) {
+    return { state: 'foreign_hook_present', path: hookPath };
+  }
+  return {
+    state: parts.block === expectedBlock ? 'installed' : 'uninstall_required',
+    path: hookPath,
+  };
+}
+
+function dirtyHookSummary(results) {
+  const states = results.map((result) => result.state);
+  if (states.every((state) => state === 'installed')) return 'installed';
+  if (states.every((state) => state === 'not_installed')) return 'not_installed';
+  if (states.some((state) => state === 'uninstall_required')) return 'uninstall_required';
+  if (states.some((state) => state === 'installed')) return 'partially_installed';
+  if (states.some((state) => state === 'foreign_hook_present')) return 'foreign_hook_present';
+  return 'unknown';
+}
+
+function dirtyHookStatus(projectRoot, options = {}) {
+  const paths = hookManagerPaths(projectRoot, options);
+  if (!paths.dataDir || !paths.hooksDir) {
+    return {
+      status: !paths.dataDir ? 'plugin_data_required' : 'not_a_git_repository',
+      project_root: paths.projectRoot,
+      hooks: [],
+    };
+  }
+  const hooks = DIRTY_HOOK_NAMES.map((hookName) => {
+    return {
+      hook: hookName,
+      ...dirtyHookState(path.join(paths.hooksDir, hookName), dirtyHookBlock(paths, hookName)),
+    };
+  });
+  return {
+    status: dirtyHookSummary(hooks),
+    project_root: paths.projectRoot,
+    plugin_data: paths.dataDir,
+    hooks,
+  };
+}
+
+function installDirtyHooks(projectRoot, options = {}) {
+  const paths = hookManagerPaths(projectRoot, options);
+  if (!paths.dataDir) throw new Error('plugin data path is required');
+  if (!paths.hooksDir) throw new Error('project is not a git repository');
+  fs.mkdirSync(paths.hooksDir, { recursive: true });
+  const hooks = DIRTY_HOOK_NAMES.map((hookName) => {
+    const hookPath = path.join(paths.hooksDir, hookName);
+    const expectedBlock = dirtyHookBlock(paths, hookName);
+    const state = dirtyHookState(hookPath, expectedBlock);
+    if (state.state === 'installed') return { hook: hookName, ...state, changed: false };
+    if (state.state === 'uninstall_required') {
+      return { hook: hookName, ...state, changed: false };
+    }
+    const existing = fs.existsSync(hookPath) ? fs.readFileSync(hookPath, 'utf8').trimEnd() : '#!/bin/sh';
+    const next = `${existing}\n\n${expectedBlock}\n`;
+    fs.writeFileSync(hookPath, next, { mode: 0o755 });
+    return { hook: hookName, ...dirtyHookState(hookPath, expectedBlock), changed: true };
+  });
+  return {
+    status: dirtyHookSummary(hooks),
+    project_root: paths.projectRoot,
+    plugin_data: paths.dataDir,
+    hooks,
+  };
+}
+
+function uninstallDirtyHooks(projectRoot, options = {}) {
+  const paths = hookManagerPaths(projectRoot, options);
+  if (!paths.hooksDir) throw new Error('project is not a git repository');
+  const hooks = DIRTY_HOOK_NAMES.map((hookName) => {
+    const hookPath = path.join(paths.hooksDir, hookName);
+    if (!fs.existsSync(hookPath)) {
+      return { hook: hookName, state: 'not_installed', path: hookPath, changed: false };
+    }
+    const text = fs.readFileSync(hookPath, 'utf8');
+    const parts = splitDirtyHookBlock(text);
+    if (!parts.block) {
+      return { hook: hookName, state: 'foreign_hook_present', path: hookPath, changed: false };
+    }
+    const next = [parts.before, parts.after].filter(Boolean).join('\n').trimEnd();
+    if (next && next.trim() !== '#!/bin/sh') {
+      fs.writeFileSync(hookPath, `${next}\n`, { mode: 0o755 });
+    } else {
+      fs.rmSync(hookPath, { force: true });
+    }
+    return { hook: hookName, ...dirtyHookState(hookPath, dirtyHookBlock(paths, hookName)), changed: true };
+  });
+  return {
+    status: dirtyHookSummary(hooks),
+    project_root: paths.projectRoot,
+    plugin_data: paths.dataDir,
+    hooks,
+  };
+}
+
 function writeHookOutput(event, context) {
   if (isCopilot) {
     process.stdout.write(JSON.stringify({ additionalContext: context }));
@@ -253,10 +424,13 @@ function writeHookOutput(event, context) {
 module.exports = {
   classifyMcpRuntime,
   dirtyMarkerPathForProject,
+  dirtyHookStatus,
+  installDirtyHooks,
   mcpDetectionText,
   readActiveState,
   readHookState,
   rememberActiveState,
+  uninstallDirtyHooks,
   writeDirtyMarker,
   writeHookState,
   writeHookOutput,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -14,6 +14,9 @@ const require = createRequire(import.meta.url);
 const {
   classifyMcpRuntime,
   dirtyMarkerPathForProject,
+  dirtyHookStatus,
+  installDirtyHooks,
+  uninstallDirtyHooks,
   writeDirtyMarker,
 } = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
 
@@ -183,6 +186,105 @@ test("dirty marker writer stores one project-keyed marker under plugin data", as
     assert.equal(marker.dirty, false);
     assert.equal(marker.source, "test-hook");
     assert.equal(typeof marker.updated_at, "string");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("dirty marker hook manager installs idempotently and preserves foreign hook content", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-dirty-hook-data-"));
+  const projectRoot = await mkdtemp(join(tmpdir(), "codestory-dirty-hook-project-"));
+
+  try {
+    await mkdir(join(projectRoot, ".git", "hooks"), { recursive: true });
+    const postMerge = join(projectRoot, ".git", "hooks", "post-merge");
+    await writeFile(postMerge, "#!/bin/sh\necho foreign\n", "utf8");
+
+    const before = dirtyHookStatus(projectRoot, { pluginDataDir: dataDir });
+    assert.equal(before.status, "foreign_hook_present");
+
+    const installed = installDirtyHooks(projectRoot, { pluginDataDir: dataDir });
+    assert.equal(installed.status, "installed");
+    assert.equal(installed.hooks.every((hook) => hook.state === "installed"), true);
+    assert.equal(installed.hooks.every((hook) => hook.changed === true), true);
+    const firstPostMerge = await readFile(postMerge, "utf8");
+    assert.match(firstPostMerge, /echo foreign/u);
+    assert.match(firstPostMerge, /codestory dirty marker/u);
+
+    const repeated = installDirtyHooks(projectRoot, { pluginDataDir: dataDir });
+    assert.equal(repeated.status, "installed");
+    assert.equal(repeated.hooks.every((hook) => hook.changed === false), true);
+    assert.equal(await readFile(postMerge, "utf8"), firstPostMerge);
+
+    const uninstalled = uninstallDirtyHooks(projectRoot, { pluginDataDir: dataDir });
+    assert.equal(uninstalled.status, "foreign_hook_present");
+    assert.equal(await readFile(postMerge, "utf8"), "#!/bin/sh\necho foreign\n");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("dirty marker hook command reports uninstall-required stale managed blocks", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-dirty-hook-cli-data-"));
+  const projectRoot = await mkdtemp(join(tmpdir(), "codestory-dirty-hook-cli-project-"));
+  const script = join(pluginRoot, "hooks", "codestory-dirty-hook.cjs");
+
+  try {
+    await mkdir(join(projectRoot, ".git", "hooks"), { recursive: true });
+    const hookPath = join(projectRoot, ".git", "hooks", "post-checkout");
+    await writeFile(
+      hookPath,
+      [
+        "#!/bin/sh",
+        "# >>> codestory dirty marker >>>",
+        "node old-script.cjs mark --project old --plugin-data old || true",
+        "# <<< codestory dirty marker <<<",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const install = spawnSync(process.execPath, [
+      script,
+      "install",
+      "--project",
+      projectRoot,
+      "--plugin-data",
+      dataDir,
+    ], { encoding: "utf8" });
+    assert.equal(install.status, 0, install.stderr);
+    const installed = JSON.parse(install.stdout);
+    assert.equal(installed.status, "uninstall_required");
+    assert.equal(installed.hooks.find((hook) => hook.hook === "post-checkout").state, "uninstall_required");
+
+    const uninstall = spawnSync(process.execPath, [
+      script,
+      "uninstall",
+      "--project",
+      projectRoot,
+      "--plugin-data",
+      dataDir,
+    ], { encoding: "utf8" });
+    assert.equal(uninstall.status, 0, uninstall.stderr);
+    assert.equal(JSON.parse(uninstall.stdout).status, "not_installed");
+
+    const mark = spawnSync(process.execPath, [
+      script,
+      "mark",
+      "--project",
+      projectRoot,
+      "--plugin-data",
+      dataDir,
+      "--source",
+      "test-command",
+    ], { encoding: "utf8" });
+    assert.equal(mark.status, 0, mark.stderr);
+    const markerResult = JSON.parse(mark.stdout);
+    const marker = JSON.parse(await readFile(markerResult.path, "utf8"));
+    assert.equal(marker.dirty, true);
+    assert.equal(marker.source, "test-command");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(projectRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Context
Closes #612.

#607 added the dirty-marker bridge, but repo hook management stayed out of scope. This PR adds the explicit opt-in install/uninstall path for CodeStory-managed dirty-marker Git hook blocks without changing packet/search sidecar readiness.

## What Changed
- Added `plugins/codestory/hooks/codestory-dirty-hook.cjs` with `install`, `status`, `uninstall`, and `mark` actions.
- Reused the existing dirty marker writer and plugin-data marker contract.
- Installed managed blocks into `post-checkout`, `post-merge`, and `post-rewrite` only when explicitly requested.
- Preserved foreign hook content, made reinstall idempotent, and reports `foreign_hook_present` / `uninstall_required` states.
- Documented the safe operator sequence in plugin and usage docs.

```mermaid
flowchart LR
  Operator["operator opts in"] --> Install["dirty-hook install"]
  Install --> GitHooks["managed Git hook blocks"]
  GitHooks --> Mark["dirty-hook mark"]
  Mark --> Marker["plugin-data dirty marker"]
  Marker --> Status["codestory://status local freshness"]
  Status --> Local["local graph gate"]
  Status --> Sidecar["packet/search sidecar gate unchanged"]
```

## How To Review
- Start in `plugins/codestory/hooks/codestory-runtime.cjs` at the dirty hook manager helpers.
- Check `plugins/codestory/hooks/codestory-dirty-hook.cjs` for the operator command surface.
- Read the two new plugin static tests for install/idempotence/uninstall/foreign-hook behavior.
- Check `plugins/codestory/README.md` and `docs/usage.md` for the operator sequence.

## Verification
- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs` - pass, 33 tests.
- `cargo fmt --check` - pass.
- `git diff --check` - pass.
- `git diff --cached --check` - pass before commit.

## Risk
The hook manager is opt-in and only edits Git hook files when the operator runs the install command. It preserves foreign hook content and removes only CodeStory-managed blocks, but live host/plugin reload behavior was not exercised here.