### PR TITLE
[codex] Add native Windows AMD embedding launch

### DIFF
--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -1,5 +1,7 @@
 use crate::config::{
-    SidecarLayout, SidecarProfile, SidecarRuntimeConfig, retrieval_compose_profile, user_cache_root,
+    EmbeddingServerLaunchMode, NATIVE_LLAMA_MANAGED_CACHE_REL_PATH,
+    NATIVE_LLAMA_SOURCE_CACHE_REL_PATH, SidecarLayout, SidecarProfile, SidecarRuntimeConfig,
+    embedding_server_launch_mode, retrieval_compose_profile, user_cache_root,
 };
 use crate::health::{InfrastructureHealth, probe_infrastructure_health};
 use crate::qdrant_storage::{
@@ -8,6 +10,8 @@ use crate::qdrant_storage::{
 };
 use crate::sidecar::{SidecarStateFile, sidecar_up_with_runtime};
 use anyhow::{Context, Result, bail};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
@@ -35,6 +39,13 @@ pub struct BootstrapReport {
     pub compose_started: bool,
     pub compose_file: Option<PathBuf>,
     pub storage_repair: QdrantStorageRepairReport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NativeEmbeddingServerLaunch {
+    executable: PathBuf,
+    args: Vec<String>,
+    log_path: PathBuf,
 }
 
 /// Prepare cache dirs, optionally start Docker Compose, write sidecar state, wait for probes.
@@ -87,6 +98,10 @@ pub fn bootstrap_sidecars_with_runtime(
     layout.ensure_data_dirs()?;
     let storage_repair =
         repair_qdrant_storage(&layout, storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?;
+    let launch_mode = embedding_server_launch_mode()?;
+    let native_embedding = (launch_mode == EmbeddingServerLaunchMode::NativeSpawned)
+        .then(|| native_embedding_server_launch(repo_root, runtime))
+        .transpose()?;
 
     let resolved_compose = if skip_compose {
         None
@@ -95,11 +110,14 @@ pub fn bootstrap_sidecars_with_runtime(
     };
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
-        docker_compose_up(path, repo_root, runtime)?;
+        docker_compose_up(path, repo_root, runtime, launch_mode)?;
         true
     } else {
         false
     };
+    if let Some(launch) = native_embedding.as_ref() {
+        spawn_native_embedding_server(launch)?;
+    }
 
     let state = sidecar_up_with_runtime(runtime, resolved_compose.as_deref())?;
     if !wait_timeout.is_zero() {
@@ -210,6 +228,7 @@ fn docker_compose_up(
     compose_file: &Path,
     repo_root: Option<&Path>,
     runtime: &SidecarRuntimeConfig,
+    launch_mode: EmbeddingServerLaunchMode,
 ) -> Result<()> {
     let layout = &runtime.layout;
     if !docker_available() {
@@ -306,6 +325,7 @@ fn docker_compose_up(
             .env_remove("LLAMA_ARG_DEVICE")
             .env_remove("LLAMA_ARG_N_GPU_LAYERS");
     }
+    command.args(docker_compose_services_for_launch_mode(launch_mode));
 
     let output = command.output().context("spawn docker compose")?;
     if !output.status.success() {
@@ -385,6 +405,139 @@ pub fn docker_compose_down_for_state(state: &SidecarStateFile) -> Result<()> {
 
 fn docker_compose_command() -> Result<Command> {
     Ok(Command::new("docker"))
+}
+
+fn docker_compose_services_for_launch_mode(
+    mode: EmbeddingServerLaunchMode,
+) -> &'static [&'static str] {
+    match mode {
+        EmbeddingServerLaunchMode::DockerComposeEmbed => &[],
+        EmbeddingServerLaunchMode::NativeSpawned => &["qdrant", "zoekt"],
+    }
+}
+
+fn native_embedding_server_launch(
+    repo_root: Option<&Path>,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<NativeEmbeddingServerLaunch> {
+    let executable = native_llama_server_path(repo_root)?;
+    let model_path =
+        embed_model_dir(repo_root, &runtime.layout)?.join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF);
+    if !model_path.is_file() {
+        bail!(
+            "native llama.cpp embedding model not found: {}; run `node scripts/setup-retrieval-env.mjs --fetch-embed-model` or set CODESTORY_EMBED_MODEL_DIR",
+            model_path.display()
+        );
+    }
+    Ok(native_embedding_server_launch_from_paths(
+        executable, model_path, runtime,
+    ))
+}
+
+fn native_embedding_server_launch_from_paths(
+    executable: PathBuf,
+    model_path: PathBuf,
+    runtime: &SidecarRuntimeConfig,
+) -> NativeEmbeddingServerLaunch {
+    let mut args = vec![
+        "--embedding".to_string(),
+        "--model".to_string(),
+        model_path.display().to_string(),
+        "--host".to_string(),
+        "127.0.0.1".to_string(),
+        "--port".to_string(),
+        runtime.embed_http_port.to_string(),
+    ];
+    if let Some(request) = crate::embeddings::embedding_accelerator_request() {
+        args.push("--device".to_string());
+        args.push(request.device);
+    }
+    NativeEmbeddingServerLaunch {
+        executable,
+        args,
+        log_path: crate::embeddings::native_embedding_log_path(runtime),
+    }
+}
+
+fn native_llama_server_path(repo_root: Option<&Path>) -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("CODESTORY_EMBED_NATIVE_LLAMA_SERVER") {
+        return validate_explicit_native_llama_server(PathBuf::from(path));
+    }
+    native_llama_server_path_from_candidates(native_llama_server_candidates(repo_root))
+}
+
+fn validate_explicit_native_llama_server(path: PathBuf) -> Result<PathBuf> {
+    if !path.is_absolute() {
+        bail!(
+            "CODESTORY_EMBED_NATIVE_LLAMA_SERVER must be an absolute path to llama-server.exe; ambient PATH lookup is not allowed"
+        );
+    }
+    if !path.is_file() {
+        bail!(
+            "CODESTORY_EMBED_NATIVE_LLAMA_SERVER does not point to a file: {}; install managed llama.cpp assets or set the absolute executable path",
+            path.display()
+        );
+    }
+    Ok(path)
+}
+
+fn native_llama_server_path_from_candidates(candidates: Vec<PathBuf>) -> Result<PathBuf> {
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "native llama-server.exe not found; set CODESTORY_EMBED_NATIVE_LLAMA_SERVER to an absolute path or install managed llama.cpp assets under {}; ambient PATH lookup is not allowed",
+                user_cache_root()
+                    .join(NATIVE_LLAMA_MANAGED_CACHE_REL_PATH)
+                    .display()
+            )
+        })
+}
+
+fn native_llama_server_candidates(repo_root: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = vec![user_cache_root().join(NATIVE_LLAMA_MANAGED_CACHE_REL_PATH)];
+    if let Some(root) = repo_root {
+        candidates.push(root.join(NATIVE_LLAMA_SOURCE_CACHE_REL_PATH));
+        candidates.push(root.join(NATIVE_LLAMA_MANAGED_CACHE_REL_PATH));
+    }
+    candidates
+}
+
+fn spawn_native_embedding_server(launch: &NativeEmbeddingServerLaunch) -> Result<()> {
+    if let Some(parent) = launch.log_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create native llama.cpp log dir {}", parent.display()))?;
+    }
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&launch.log_path)
+        .with_context(|| format!("open native llama.cpp log {}", launch.log_path.display()))?;
+    writeln!(
+        log,
+        "starting native llama.cpp embedding server: {} {}",
+        launch.executable.display(),
+        launch.args.join(" ")
+    )
+    .ok();
+    let stdout = log
+        .try_clone()
+        .context("clone native llama.cpp stdout log")?;
+    let _child = Command::new(&launch.executable)
+        .args(&launch.args)
+        .current_dir(launch.executable.parent().unwrap_or_else(|| Path::new(".")))
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(log))
+        .spawn()
+        .with_context(|| {
+            format!(
+                "spawn native llama.cpp server {}",
+                launch.executable.display()
+            )
+        })?;
+    Ok(())
 }
 
 fn remove_container_if_present(name: &str) -> Result<()> {
@@ -535,7 +688,10 @@ fn wait_for_infrastructure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn embed_model_dir_discovers_repo_models_layout() {
@@ -659,6 +815,108 @@ mod tests {
     }
 
     #[test]
+    fn native_launch_mode_limits_compose_to_qdrant_and_zoekt() {
+        assert_eq!(
+            docker_compose_services_for_launch_mode(EmbeddingServerLaunchMode::NativeSpawned),
+            &["qdrant", "zoekt"]
+        );
+        assert!(
+            docker_compose_services_for_launch_mode(EmbeddingServerLaunchMode::DockerComposeEmbed)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn native_explicit_executable_requires_absolute_file() {
+        let relative = validate_explicit_native_llama_server(PathBuf::from("llama-server.exe"))
+            .expect_err("relative executable must fail closed");
+        assert!(relative.to_string().contains("absolute path"));
+
+        let temp = tempdir().expect("temp");
+        let exe = temp.path().join("llama-server.exe");
+        std::fs::write(&exe, b"fake exe").expect("exe");
+        assert_eq!(
+            validate_explicit_native_llama_server(exe.clone()).expect("absolute file"),
+            exe
+        );
+    }
+
+    #[test]
+    fn native_executable_candidates_do_not_fall_back_to_path() {
+        let error =
+            native_llama_server_path_from_candidates(vec![PathBuf::from("llama-server.exe")])
+                .expect_err("bare executable must not resolve through PATH");
+
+        assert!(
+            error
+                .to_string()
+                .contains("ambient PATH lookup is not allowed")
+        );
+    }
+
+    #[test]
+    fn native_launch_args_use_model_port_and_amd_vulkan_device() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _provider = EnvGuard::set("CODESTORY_EMBED_DEVICE_PROVIDER", "amd");
+        let _name = EnvGuard::set("CODESTORY_EMBED_DEVICE_NAME", "AMD Radeon RX 7900 XT");
+        let _device = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_DEVICE");
+        let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
+
+        let temp = tempdir().expect("temp");
+        let exe = temp.path().join("llama-server.exe");
+        let model = temp.path().join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF);
+        std::fs::write(&exe, b"fake exe").expect("exe");
+        std::fs::write(&model, b"fake model").expect("model");
+        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Local);
+
+        let launch =
+            native_embedding_server_launch_from_paths(exe.clone(), model.clone(), &runtime);
+        let model_arg = model.display().to_string();
+        let port_arg = runtime.embed_http_port.to_string();
+
+        assert_eq!(launch.executable, exe);
+        assert_eq!(launch.args[0], "--embedding");
+        assert!(
+            launch
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--model" && pair[1] == model_arg.as_str())
+        );
+        assert!(
+            launch
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--host" && pair[1] == "127.0.0.1")
+        );
+        assert!(
+            launch
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--port" && pair[1] == port_arg.as_str())
+        );
+        assert!(
+            launch
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--device" && pair[1] == "Vulkan0")
+        );
+    }
+
+    #[test]
+    fn native_launch_missing_model_fails_before_spawn() {
+        let temp = tempdir().expect("temp");
+        let error = embed_model_dir_from_candidates([temp.path().join("embed-models")])
+            .expect_err("missing model should fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains(crate::embeddings::BGE_BASE_EN_V1_5_GGUF)
+        );
+        assert!(error.to_string().contains("fetch-embed-model"));
+    }
+
+    #[test]
     fn repo_compose_file_still_wins_over_bundled_fallback() {
         let project = tempdir().expect("project");
         let compose = project.path().join(DEFAULT_COMPOSE_REL_PATH);
@@ -669,5 +927,39 @@ mod tests {
         let resolved = resolve_compose_file(Some(project.path()), None).expect("resolve compose");
 
         assert_eq!(resolved, compose);
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
     }
 }

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -8,7 +8,7 @@ use crate::qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION, QdrantStorageRepairReport,
     repair_qdrant_storage,
 };
-use crate::sidecar::{SidecarStateFile, sidecar_up_with_runtime};
+use crate::sidecar::{SidecarStateFile, sidecar_up_with_runtime_and_launch_metadata};
 use anyhow::{Context, Result, bail};
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -44,6 +44,7 @@ pub struct BootstrapReport {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NativeEmbeddingServerLaunch {
     executable: PathBuf,
+    model_path: PathBuf,
     args: Vec<String>,
     log_path: PathBuf,
 }
@@ -119,7 +120,13 @@ pub fn bootstrap_sidecars_with_runtime(
         spawn_native_embedding_server(launch)?;
     }
 
-    let state = sidecar_up_with_runtime(runtime, resolved_compose.as_deref())?;
+    let state = sidecar_up_with_runtime_and_launch_metadata(
+        runtime,
+        resolved_compose.as_deref(),
+        native_embedding
+            .as_ref()
+            .map(|launch| embedding_launch_metadata(launch, runtime, repo_root)),
+    )?;
     if !wait_timeout.is_zero() {
         let _ = wait_for_infrastructure(&layout, wait_timeout)?;
     }
@@ -454,9 +461,50 @@ fn native_embedding_server_launch_from_paths(
     }
     NativeEmbeddingServerLaunch {
         executable,
+        model_path,
         args,
         log_path: crate::embeddings::native_embedding_log_path(runtime),
     }
+}
+
+fn embedding_launch_metadata(
+    native_launch: &NativeEmbeddingServerLaunch,
+    runtime: &SidecarRuntimeConfig,
+    repo_root: Option<&Path>,
+) -> crate::health::EmbeddingLaunchMetadata {
+    crate::health::EmbeddingLaunchMetadata {
+        provider: "llamacpp".to_string(),
+        launch_mode: EmbeddingServerLaunchMode::NativeSpawned
+            .as_str()
+            .to_string(),
+        endpoint: SidecarLayout::embed_base_url(runtime.embed_http_port),
+        executable_source: Some(native_llama_executable_source(
+            &native_launch.executable,
+            repo_root,
+        )),
+        executable_path: Some(native_launch.executable.display().to_string()),
+        model_path: Some(native_launch.model_path.display().to_string()),
+        requested_device: crate::embeddings::embedding_accelerator_request()
+            .map(|request| request.device),
+    }
+}
+
+fn native_llama_executable_source(path: &Path, repo_root: Option<&Path>) -> String {
+    if std::env::var("CODESTORY_EMBED_NATIVE_LLAMA_SERVER").is_ok() {
+        return "env:CODESTORY_EMBED_NATIVE_LLAMA_SERVER".to_string();
+    }
+    if path == user_cache_root().join(NATIVE_LLAMA_MANAGED_CACHE_REL_PATH) {
+        return "managed_cache".to_string();
+    }
+    if let Some(root) = repo_root {
+        if path == root.join(NATIVE_LLAMA_SOURCE_CACHE_REL_PATH) {
+            return "source_cache".to_string();
+        }
+        if path == root.join(NATIVE_LLAMA_MANAGED_CACHE_REL_PATH) {
+            return "repo_managed_cache".to_string();
+        }
+    }
+    "resolved_path".to_string()
 }
 
 fn native_llama_server_path(repo_root: Option<&Path>) -> Result<PathBuf> {
@@ -900,6 +948,12 @@ mod tests {
                 .windows(2)
                 .any(|pair| pair[0] == "--device" && pair[1] == "Vulkan0")
         );
+        let metadata = embedding_launch_metadata(&launch, &runtime, Some(temp.path()));
+        assert_eq!(metadata.provider, "llamacpp");
+        assert_eq!(metadata.launch_mode, "native_spawned");
+        assert_eq!(metadata.executable_path, Some(exe.display().to_string()));
+        assert_eq!(metadata.model_path, Some(model.display().to_string()));
+        assert_eq!(metadata.requested_device.as_deref(), Some("Vulkan0"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -59,10 +59,20 @@ impl SidecarProfile {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum EmbeddingServerLaunchMode {
     DockerComposeEmbed,
     NativeSpawned,
+}
+
+impl EmbeddingServerLaunchMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DockerComposeEmbed => "docker_compose_embed",
+            Self::NativeSpawned => "native_spawned",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -25,6 +25,9 @@ pub const DEFAULT_QDRANT_HTTP_PORT: u16 = 6333;
 pub const DEFAULT_QDRANT_GRPC_PORT: u16 = 6334;
 pub const DEFAULT_EMBED_HTTP_PORT: u16 = 8080;
 pub const DEFAULT_AGENT_RUN_ID: &str = "shared-agent";
+pub const NATIVE_LLAMA_MANAGED_CACHE_REL_PATH: &str =
+    "managed-embeddings/llama/b9058/llama-b9058-bin-win-vulkan-x64/llama-server.exe";
+pub const NATIVE_LLAMA_SOURCE_CACHE_REL_PATH: &str = "target/llamacpp/b8840/llama-server.exe";
 
 pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
 pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
@@ -54,6 +57,12 @@ impl SidecarProfile {
             Self::Agent => "agent",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddingServerLaunchMode {
+    DockerComposeEmbed,
+    NativeSpawned,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -560,6 +569,34 @@ pub fn retrieval_compose_profile() -> String {
         .unwrap_or_else(|| "real".to_string())
 }
 
+pub fn embedding_server_launch_mode() -> Result<EmbeddingServerLaunchMode> {
+    if let Some(mode) = std::env::var("CODESTORY_EMBED_SERVER_LAUNCH")
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .and_then(|value| match value.as_str() {
+            "native_spawned" | "native" | "windows_amd_native" => {
+                Some(EmbeddingServerLaunchMode::NativeSpawned)
+            }
+            "docker_compose_embed" | "docker" | "compose" => {
+                Some(EmbeddingServerLaunchMode::DockerComposeEmbed)
+            }
+            _ => None,
+        })
+    {
+        return Ok(mode);
+    }
+    if std::env::var("CODESTORY_EMBED_SERVER_LAUNCH").is_ok() {
+        anyhow::bail!(
+            "CODESTORY_EMBED_SERVER_LAUNCH must be docker_compose_embed or native_spawned"
+        );
+    }
+    if cfg!(target_os = "windows") && crate::embeddings::embedding_accelerator_request().is_some() {
+        Ok(EmbeddingServerLaunchMode::NativeSpawned)
+    } else {
+        Ok(EmbeddingServerLaunchMode::DockerComposeEmbed)
+    }
+}
+
 fn env_port(name: &str, default: u16) -> Option<u16> {
     std::env::var(name)
         .ok()
@@ -597,7 +634,10 @@ pub fn dir_size_bytes(path: &Path) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn agent_profile_default_runtime_reuses_project_shared_run() {
@@ -672,5 +712,54 @@ mod tests {
 
         assert_eq!(profile, SidecarProfile::Agent);
         assert_eq!(run_id.as_deref(), Some("latest-agent"));
+    }
+
+    #[test]
+    fn explicit_embedding_launch_modes_parse() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _mode = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "native_spawned");
+
+        assert_eq!(
+            embedding_server_launch_mode().expect("launch mode"),
+            EmbeddingServerLaunchMode::NativeSpawned
+        );
+    }
+
+    #[test]
+    fn invalid_embedding_launch_mode_fails_closed() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _mode = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "llama-server.exe");
+
+        let error = embedding_server_launch_mode().expect_err("invalid mode");
+
+        assert!(error.to_string().contains(
+            "CODESTORY_EMBED_SERVER_LAUNCH must be docker_compose_embed or native_spawned"
+        ));
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
     }
 }

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
@@ -114,7 +115,7 @@ pub fn embedding_device_readiness_for_runtime(
 }
 
 fn embedding_device_readiness_with_observed_state(
-    sidecar_observed_state: Option<&'static str>,
+    sidecar_observed_state: Option<EmbeddingDeviceObservation>,
 ) -> EmbeddingDeviceReadiness {
     let cpu_allowed = explicit_cpu_allowed();
     let detection = host_embedding_device_detection();
@@ -125,10 +126,6 @@ fn embedding_device_readiness_with_observed_state(
     };
     let accelerator_requested = accelerator_request.is_some();
     let observation = sidecar_observed_state
-        .map(|state| EmbeddingDeviceObservation {
-            state,
-            source: "sidecar_log",
-        })
         .unwrap_or_else(|| observed_embedding_device_state(cpu_allowed, accelerator_requested));
     let observed_state = observation.state;
     let accelerated = observed_state == "accelerated";
@@ -166,7 +163,13 @@ fn embedding_device_readiness_with_observed_state(
 
 fn observe_sidecar_embedding_device_state(
     runtime: &crate::config::SidecarRuntimeConfig,
-) -> Option<&'static str> {
+) -> Option<EmbeddingDeviceObservation> {
+    if crate::config::embedding_server_launch_mode()
+        .ok()
+        .is_some_and(|mode| mode == crate::config::EmbeddingServerLaunchMode::NativeSpawned)
+    {
+        return observe_native_embedding_device_state(runtime);
+    }
     let output = Command::new("docker")
         .args([
             "logs",
@@ -186,8 +189,33 @@ fn observe_sidecar_embedding_device_state(
     );
     match observed_embedding_device_state_from_text(&text) {
         "unknown" => None,
-        state => Some(state),
+        state => Some(EmbeddingDeviceObservation {
+            state,
+            source: "sidecar_log",
+        }),
     }
+}
+
+fn observe_native_embedding_device_state(
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> Option<EmbeddingDeviceObservation> {
+    let text = std::fs::read_to_string(native_embedding_log_path(runtime)).ok()?;
+    match observed_embedding_device_state_from_text(&text) {
+        "unknown" => None,
+        state => Some(EmbeddingDeviceObservation {
+            state,
+            source: "native_log",
+        }),
+    }
+}
+
+pub(crate) fn native_embedding_log_path(runtime: &crate::config::SidecarRuntimeConfig) -> PathBuf {
+    runtime
+        .layout
+        .state_file
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("llama-server-native.log")
 }
 
 pub fn embedding_accelerator_request() -> Option<EmbeddingAcceleratorRequest> {
@@ -340,7 +368,7 @@ fn detect_windows_amd_gpu() -> Option<HostGpuDetection> {
 }
 
 fn windows_video_controller_probe_script() -> &'static str {
-    r#"$job = Start-Job -ScriptBlock { Get-CimInstance Win32_VideoController | ForEach-Object { $_.Name } }; if (Wait-Job $job -Timeout 2) { Receive-Job $job; Remove-Job $job -Force } else { Stop-Job $job; Remove-Job $job -Force; exit 124 }"#
+    r#"$job = Start-Job -ScriptBlock { Get-CimInstance Win32_VideoController | ForEach-Object { "$($_.Name) $($_.AdapterCompatibility)" } }; if (Wait-Job $job -Timeout 2) { Receive-Job $job; Remove-Job $job -Force } else { Stop-Job $job; Remove-Job $job -Force; exit 124 }"#
 }
 
 fn detect_amd_gpu_from_windows_video_controller(output: &str) -> Option<HostGpuDetection> {
@@ -833,10 +861,22 @@ mod tests {
     }
 
     #[test]
+    fn windows_video_controller_parser_skips_virtual_monitor_before_amd() {
+        let detection = detect_amd_gpu_from_windows_video_controller(
+            "Meta Virtual Monitor Meta Platforms\r\nAMD Radeon RX 7900 XT Advanced Micro Devices, Inc.\r\n",
+        )
+        .expect("amd gpu");
+
+        assert_eq!(detection.provider, "amd");
+        assert!(detection.name.contains("AMD Radeon RX 7900 XT"));
+    }
+
+    #[test]
     fn windows_video_controller_probe_script_has_timeout() {
         let script = windows_video_controller_probe_script();
 
         assert!(script.contains("Wait-Job $job -Timeout 2"));
+        assert!(script.contains("AdapterCompatibility"));
         assert!(script.contains("Stop-Job $job"));
         assert!(script.contains("exit 124"));
     }
@@ -902,7 +942,11 @@ mod tests {
         let observed = observed_embedding_device_state_from_text(
             "llama_model_load: offloaded 33/33 layers to GPU\n",
         );
-        let readiness = embedding_device_readiness_with_observed_state(Some(observed));
+        let readiness =
+            embedding_device_readiness_with_observed_state(Some(EmbeddingDeviceObservation {
+                state: observed,
+                source: "sidecar_log",
+            }));
 
         assert_eq!(observed, "accelerated");
         assert_eq!(readiness.requested_policy, "accelerator_required");
@@ -949,6 +993,27 @@ mod tests {
         assert_eq!(readiness.detected_provider.as_deref(), Some("amd"));
         assert!(readiness.accelerator_requested);
         assert!(!readiness.full_retrieval_allowed);
+    }
+
+    #[test]
+    fn native_log_observed_acceleration_uses_native_source() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
+        let _policy = EnvGuard::remove(DEVICE_POLICY_ENV);
+        let _device = EnvGuard::remove(DEVICE_STATE_ENV);
+        let _provider = EnvGuard::set(DEVICE_PROVIDER_ENV, "amd");
+        let _name = EnvGuard::set(DEVICE_NAME_ENV, "AMD Radeon RX 7900 XT");
+        let _host_detect = EnvGuard::remove(DISABLE_HOST_GPU_DETECT_ENV);
+
+        let readiness =
+            embedding_device_readiness_with_observed_state(Some(EmbeddingDeviceObservation {
+                state: "accelerated",
+                source: "native_log",
+            }));
+
+        assert_eq!(readiness.observed_state, "accelerated");
+        assert_eq!(readiness.observation_source, "native_log");
+        assert!(readiness.full_retrieval_allowed);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -70,6 +70,21 @@ pub struct RetrievalRepairHint {
     pub full_repair: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmbeddingLaunchMetadata {
+    pub provider: String,
+    pub launch_mode: String,
+    pub endpoint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_device: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetrievalStatusReport {
     pub retrieval_mode: String,
@@ -104,6 +119,8 @@ pub struct RetrievalStatusReport {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding_accelerator_request_device: Option<String>,
     pub embedding_cpu_allowed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_launch: Option<EmbeddingLaunchMetadata>,
     pub zoekt: ComponentHealth,
     pub qdrant: ComponentHealth,
     pub scip: ComponentHealth,
@@ -380,6 +397,7 @@ pub fn unavailable_status_report_with_embedding_device(
             .clone(),
         embedding_accelerator_request_device: embedding_device.accelerator_request_device.clone(),
         embedding_cpu_allowed: embedding_device.cpu_allowed,
+        embedding_launch: None,
         zoekt: unavailable_component("zoekt", &reason),
         qdrant: unavailable_component("qdrant", &reason),
         scip: unavailable_component("scip", &reason),
@@ -706,6 +724,7 @@ pub fn probe_sidecar_health_with_embedding_device(
             .clone(),
         embedding_accelerator_request_device: embedding_device.accelerator_request_device.clone(),
         embedding_cpu_allowed: embedding_device.cpu_allowed,
+        embedding_launch: None,
         zoekt,
         qdrant,
         scip,
@@ -962,6 +981,7 @@ mod tests {
             embedding_accelerator_request_provider: None,
             embedding_accelerator_request_device: None,
             embedding_cpu_allowed: false,
+            embedding_launch: None,
             zoekt: ComponentHealth {
                 name: "zoekt".into(),
                 status: ComponentStatus::Healthy,

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -868,6 +868,7 @@ mod tests {
             embedding_accelerator_request_provider: None,
             embedding_accelerator_request_device: None,
             embedding_cpu_allowed: false,
+            embedding_launch: None,
             zoekt_data_dir: root.join("zoekt").display().to_string(),
             qdrant_data_dir: root.join("qdrant").display().to_string(),
             scip_artifacts_root: root.join("scip").display().to_string(),

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -64,9 +64,9 @@ pub use embeddings::{
 pub use executor::{QueryExecutor, QueryResult, QueryTrace, StageTrace, cancellation_flag};
 pub use generation::{SIDECAR_SCHEMA_VERSION, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED};
 pub use health::{
-    ComponentHealth, ComponentStatus, InfrastructureHealth, RetrievalManifestContractReport,
-    RetrievalManifestLaneProvenance, RetrievalRepairHint, RetrievalStatusReport,
-    probe_infrastructure_health, probe_sidecar_health,
+    ComponentHealth, ComponentStatus, EmbeddingLaunchMetadata, InfrastructureHealth,
+    RetrievalManifestContractReport, RetrievalManifestLaneProvenance, RetrievalRepairHint,
+    RetrievalStatusReport, probe_infrastructure_health, probe_sidecar_health,
 };
 pub use index::{
     FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, finalize_index_for_runtime,

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -7,7 +7,7 @@ use crate::generation::{
     manifest_staleness_reason, manifest_unavailable_reason,
 };
 use crate::health::{
-    RetrievalStatusReport, attach_manifest_contract, attach_repair_hint,
+    EmbeddingLaunchMetadata, RetrievalStatusReport, attach_manifest_contract, attach_repair_hint,
     probe_sidecar_health_with_embedding_device, unavailable_status_report_with_embedding_device,
 };
 use crate::index::{compute_sidecar_input_fingerprint, sidecar_project_id_for_root};
@@ -61,6 +61,8 @@ pub struct SidecarStateFile {
     pub embedding_accelerator_request_device: Option<String>,
     #[serde(default)]
     pub embedding_cpu_allowed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding_launch: Option<EmbeddingLaunchMetadata>,
     pub zoekt_data_dir: String,
     pub qdrant_data_dir: String,
     pub scip_artifacts_root: String,
@@ -78,6 +80,14 @@ pub fn sidecar_up() -> Result<SidecarStateFile> {
 pub fn sidecar_up_with_runtime(
     runtime: &SidecarRuntimeConfig,
     compose_file: Option<&Path>,
+) -> Result<SidecarStateFile> {
+    sidecar_up_with_runtime_and_launch_metadata(runtime, compose_file, None)
+}
+
+pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
+    runtime: &SidecarRuntimeConfig,
+    compose_file: Option<&Path>,
+    embedding_launch: Option<EmbeddingLaunchMetadata>,
 ) -> Result<SidecarStateFile> {
     let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
@@ -102,6 +112,7 @@ pub fn sidecar_up_with_runtime(
         embedding_accelerator_request_provider: embedding_device.accelerator_request_provider,
         embedding_accelerator_request_device: embedding_device.accelerator_request_device,
         embedding_cpu_allowed: embedding_device.cpu_allowed,
+        embedding_launch,
         zoekt_data_dir: layout.zoekt_data_dir.display().to_string(),
         qdrant_data_dir: layout.qdrant_data_dir.display().to_string(),
         scip_artifacts_root: layout.scip_artifacts_root.display().to_string(),
@@ -299,7 +310,16 @@ fn attach_status_ownership(
     runtime: &SidecarRuntimeConfig,
 ) -> RetrievalStatusReport {
     report.ownership = Some(runtime.ownership());
+    report.embedding_launch = read_sidecar_state(&runtime.layout.state_file)
+        .and_then(|state| state.embedding_launch)
+        .or(report.embedding_launch);
     report
+}
+
+fn read_sidecar_state(path: &Path) -> Option<SidecarStateFile> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str::<SidecarStateFile>(&contents).ok())
 }
 
 fn enrich_status_with_semantic_doc_stats(
@@ -491,7 +511,57 @@ mod tests {
     use crate::index::{compute_sidecar_input_fingerprint, project_id_for_root};
     use crate::test_support::retrieval_manifest_fixture;
     use codestory_store::{FileInfo, FileRole};
+    use std::collections::BTreeMap;
     use tempfile::TempDir;
+
+    fn test_runtime(root: &TempDir) -> SidecarRuntimeConfig {
+        SidecarRuntimeConfig {
+            layout: SidecarLayout {
+                zoekt_http_port: 16070,
+                qdrant_http_port: 16333,
+                qdrant_grpc_port: 16334,
+                zoekt_data_dir: root.path().join("zoekt"),
+                qdrant_data_dir: root.path().join("qdrant"),
+                scip_artifacts_root: root.path().join("scip"),
+                state_file: root.path().join("retrieval-sidecars.json"),
+            },
+            profile: SidecarProfile::Local,
+            run_id: None,
+            namespace: "test".to_string(),
+            compose_project: "test".to_string(),
+            embed_http_port: 18080,
+            cleanup_command: "codestory-cli retrieval down".to_string(),
+            labels: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn status_attaches_embedding_launch_metadata_from_state_file() {
+        let root = TempDir::new().expect("root");
+        let runtime = test_runtime(&root);
+        let launch = EmbeddingLaunchMetadata {
+            provider: "llamacpp".to_string(),
+            launch_mode: "native_spawned".to_string(),
+            endpoint: "http://127.0.0.1:18080/v1/embeddings".to_string(),
+            executable_source: Some("managed_cache".to_string()),
+            executable_path: Some("C:/cache/llama-server.exe".to_string()),
+            model_path: Some("C:/cache/bge-base-en-v1.5.Q8_0.gguf".to_string()),
+            requested_device: Some("Vulkan0".to_string()),
+        };
+        let state =
+            sidecar_up_with_runtime_and_launch_metadata(&runtime, None, Some(launch.clone()))
+                .expect("write state");
+        assert_eq!(state.embedding_launch, Some(launch.clone()));
+
+        let report = unavailable_status_report_with_embedding_device(
+            "missing",
+            None,
+            &crate::embeddings::embedding_device_readiness(),
+        );
+        let report = attach_status_ownership(report, &runtime);
+
+        assert_eq!(report.embedding_launch, Some(launch));
+    }
 
     #[test]
     fn status_rejects_stale_manifest_before_component_probes() {


### PR DESCRIPTION
## Context

Windows AMD detection now works far enough to request `Vulkan0`, but the product retrieval bootstrap still used the Docker `embed` service. On this host that left packet/search readiness fail-closed with `observed_device=unknown` and `observation_source=accelerator_request_unobserved`.

This PR adds the smallest native Windows AMD embedding-server path so CodeStory can launch a trusted local `llama-server.exe` without relying on ambient `PATH`, while preserving the strict readiness rule: host detection/request intent is not enough; full packet/search still requires trusted runtime observation.

Closes #630.

## What Changed

- Added an embedding server launch mode: `docker_compose_embed` or `native_spawned`.
- On Windows with an accelerator request, defaulted product bootstrap toward `native_spawned` unless explicitly overridden.
- Resolved native `llama-server.exe` only from explicit/trusted paths:
  - `CODESTORY_EMBED_NATIVE_LLAMA_SERVER` must be an absolute file path.
  - Managed cache/source artifact candidates are checked directly.
  - Bare `llama-server.exe` / ambient `PATH` lookup is rejected.
- In native mode, Docker Compose starts only `qdrant` and `zoekt`; the `embed` container is not started.
- Native launch validates the GGUF model before spawn and starts `llama-server.exe` with `--embedding`, `--model`, loopback host/port, and `--device Vulkan0` when AMD acceleration is requested.
- Added `native_log` as a trusted observation source and kept CPU/unknown fail-closed behavior.
- Added status metadata for native launch provider, mode, endpoint, executable source/path, model path, and requested device.
- Improved Windows GPU detection so a virtual monitor entry does not mask the AMD adapter.

## How To Review

Start with:

```powershell
git show --stat HEAD
cargo test -p codestory-retrieval native -- --nocapture
cargo test -p codestory-retrieval status_attaches_embedding_launch_metadata_from_state_file -- --nocapture
```

Then review:

- `crates/codestory-retrieval/src/config.rs` for launch-mode parsing/defaulting.
- `crates/codestory-retrieval/src/compose.rs` for native executable/model validation, Compose service selection, launch args, and metadata creation.
- `crates/codestory-retrieval/src/embeddings.rs` for `native_log` observation and Windows adapter detection.
- `crates/codestory-retrieval/src/sidecar.rs` / `health.rs` for state/status metadata plumbing.

## Verification

```text
cargo fmt
cargo test -p codestory-retrieval
179 passed; 0 failed; 1 ignored

git diff --check
passed
```

Coordinator recheck:

```text
cargo test -p codestory-retrieval native -- --nocapture
6 passed

cargo test -p codestory-retrieval embedding_launch -- --nocapture
2 passed

cargo test -p codestory-retrieval status_attaches_embedding_launch_metadata_from_state_file -- --nocapture
1 passed

git diff --check HEAD~1..HEAD
passed
```

Native Windows AMD smoke used explicit cached paths only, not PATH:

```text
executable: C:\Users\alber\AppData\Local\codestory\codestory\cache\managed-embeddings\llama\b9058\llama-b9058-bin-win-vulkan-x64\llama-server.exe
model: C:\Users\alber\AppData\Local\codestory\codestory\cache\embed-models\bge-base-en-v1.5.Q8_0.gguf
args: --embedding --host 127.0.0.1 --port 18081 --device Vulkan0
/v1/embeddings: HTTP 200, dim 768
```

Log evidence included:

```text
loaded Vulkan backend
Vulkan0 (RX 7900 XT)
using device Vulkan0 (AMD Radeon RX 7900 XT)
offloaded 13/13 layers to GPU
```

GitHub checks on head `f9bda696`:

```text
linux-contracts: passed
deny rustdoc warnings: passed
require closing issue link: passed
windows-manifest-missing: skipped
```

## Risk

This proves the native llama.cpp AMD path and status contract. It does not claim the broader #593 packet/search eval has passed yet; that proof should rerun after this lands on `dev/codestory-next`.

The PR intentionally does not add ranking/fusion changes, model-family changes, Docker cleanup, cache deletion, or CPU-backed proof.
