### PR TITLE
[codex] Finalize retrieval manifest after native AMD launch

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2195,12 +2195,13 @@ fn repair_ready_state(
             )
         },
     )?;
-    codestory_retrieval::strict_sidecar_status_for_runtime(
+    let final_status = codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
         sidecar.clone(),
     )
     .context("ready repair final retrieval status")?;
+    ensure_ready_repair_full_sidecar(&final_status)?;
     Ok(Some(sidecar))
 }
 
@@ -2226,6 +2227,40 @@ fn ensure_ready_repair_embed_liveness(
         infrastructure.zoekt_detail,
         infrastructure.qdrant_reachable,
         infrastructure.qdrant_detail
+    )
+}
+
+fn ensure_ready_repair_full_sidecar(
+    report: &codestory_retrieval::RetrievalStatusReport,
+) -> Result<()> {
+    if report.retrieval_mode == "full" {
+        return Ok(());
+    }
+    let reason = report.degraded_reason.as_deref().unwrap_or("unknown");
+    let manifest_note = if reason == "retrieval_manifest_missing" {
+        " after finalize; retrieval manifest was not persisted"
+    } else {
+        ""
+    };
+    bail!(
+        "ready repair final retrieval status did not reach full mode{manifest_note}: mode={} degraded_reason={} embedding_device_state={} observation_source={} {}; {}; {}",
+        report.retrieval_mode,
+        reason,
+        report.embedding_device_state,
+        report.embedding_device_observation_source,
+        ready_repair_component_detail(&report.zoekt),
+        ready_repair_component_detail(&report.qdrant),
+        ready_repair_component_detail(&report.scip)
+    )
+}
+
+fn ready_repair_component_detail(component: &codestory_retrieval::ComponentHealth) -> String {
+    format!(
+        "{}={:?} reason={} detail={}",
+        component.name,
+        component.status,
+        component.degraded_reason.as_deref().unwrap_or("none"),
+        component.detail
     )
 }
 
@@ -12150,6 +12185,90 @@ mod tests {
             eligible_for_sufficiency: None,
             score_breakdown: None,
         }
+    }
+
+    fn ready_repair_test_component(
+        name: &str,
+        status: codestory_retrieval::ComponentStatus,
+        reason: &str,
+    ) -> codestory_retrieval::ComponentHealth {
+        codestory_retrieval::ComponentHealth {
+            name: name.into(),
+            status,
+            latency_ms: None,
+            detail: reason.into(),
+            degraded_reason: Some(reason.into()),
+            capabilities: codestory_retrieval::SidecarCapabilities::NONE,
+        }
+    }
+
+    fn ready_repair_test_report(
+        mode: &str,
+        reason: Option<&str>,
+    ) -> codestory_retrieval::RetrievalStatusReport {
+        codestory_retrieval::RetrievalStatusReport {
+            retrieval_mode: mode.into(),
+            ownership: None,
+            degraded_reason: reason.map(str::to_string),
+            repair: None,
+            query_embedding_backend: "llamacpp:bge-base-en-v1.5".into(),
+            manifest_vector_embedding_backend: None,
+            manifest_vector_embedding_dim: None,
+            stored_doc_vector_producer_backend: None,
+            stored_doc_vector_dim: None,
+            stored_doc_vector_mixed_backends: None,
+            embedding_device_policy: "accelerator_required".into(),
+            embedding_device_state: "accelerated".into(),
+            embedding_device_observation_source: "native_log".into(),
+            embedding_detected_provider: Some("amd".into()),
+            embedding_detected_gpu: Some("Vulkan0".into()),
+            embedding_accelerator_requested: true,
+            embedding_accelerator_request_provider: Some("vulkan".into()),
+            embedding_accelerator_request_device: Some("Vulkan0".into()),
+            embedding_cpu_allowed: false,
+            embedding_launch: None,
+            zoekt: ready_repair_test_component(
+                "zoekt",
+                codestory_retrieval::ComponentStatus::Unavailable,
+                "retrieval_manifest_missing",
+            ),
+            qdrant: ready_repair_test_component(
+                "qdrant",
+                codestory_retrieval::ComponentStatus::Unavailable,
+                "retrieval_manifest_missing",
+            ),
+            scip: ready_repair_test_component(
+                "scip",
+                codestory_retrieval::ComponentStatus::Unavailable,
+                "retrieval_manifest_missing",
+            ),
+            manifest_contract: None,
+            manifest: None,
+        }
+    }
+
+    #[test]
+    fn ready_repair_final_status_accepts_full_mode() {
+        let report = ready_repair_test_report("full", None);
+
+        ensure_ready_repair_full_sidecar(&report).expect("full mode should pass");
+    }
+
+    #[test]
+    fn ready_repair_final_status_blocks_missing_manifest_after_finalize() {
+        let report = ready_repair_test_report("unavailable", Some("retrieval_manifest_missing"));
+
+        let error = ensure_ready_repair_full_sidecar(&report)
+            .expect_err("missing manifest after finalize must fail repair");
+        let message = format!("{error:#}");
+
+        assert!(message.contains("did not reach full mode after finalize"));
+        assert!(message.contains("retrieval manifest was not persisted"));
+        assert!(message.contains("embedding_device_state=accelerated"));
+        assert!(message.contains("observation_source=native_log"));
+        assert!(message.contains("zoekt=Unavailable"));
+        assert!(message.contains("qdrant=Unavailable"));
+        assert!(message.contains("scip=Unavailable"));
     }
 
     #[test]


### PR DESCRIPTION
## Context

Closes #632

Post-#631 proof showed native Windows AMD embedding launch reached `embedding_device_state=accelerated` from `native_log`, but packet/search still ended at `retrieval_manifest_missing`. The `shared-agent` run-id selection is correct, so this PR keeps the fix at the repair/finalization boundary.

## What Changed

- `ready --goal agent --repair` now requires the final strict sidecar status to be `retrieval_mode=full` after bootstrap, liveness, full index refresh, and retrieval finalize.
- If final strict status is still degraded, repair fails with the mode, degraded reason, embedding observation, and Zoekt/Qdrant/SCIP status/detail.
- Added focused unit coverage for full-mode acceptance and manifest-missing-after-finalize blocker wording.

```mermaid
flowchart LR
    A["ready repair"] --> B["bootstrap + embed liveness"]
    B --> C["full index + finalize"]
    C --> D["strict sidecar status"]
    D -->|"full"| E["repair succeeds"]
    D -->|"not full"| F["repair fails with blocker detail"]
```

## How To Review

- Start in `crates/codestory-cli/src/main.rs` at `repair_ready_state`.
- Confirm the change only adds a final full-mode assertion and does not alter bootstrap, native launch, CPU fallback, ranking, model family, embedding dimension, or sidecar cleanup behavior.

## Verification

- `cargo test -p codestory-cli ready_repair_final_status -- --nocapture` passed: 2 tests ran.
- `cargo test -p codestory-cli ready_repair -- --nocapture` passed: 5 actual tests ran, including the ready-command local repair integration test.
- `git diff --check` passed.
- `cargo fmt --check` passed.

## Risk

Low. This makes an existing repair path fail closed when final strict retrieval is not full. It does not start extra repair loops, delete caches, prune Docker, or change retrieval scoring/model policy.