### PR TITLE
[codex] Finalize accelerated native repair readiness

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -118,6 +118,8 @@ const CONTEXT_BUNDLE_OUTPUT_BYTE_CAP: usize = 5 * 1024 * 1024;
 const CONTEXT_BUNDLE_MARKDOWN_SOFT_CAP: usize = 2 * 1024 * 1024;
 const CONTEXT_BUNDLE_TRUNCATION_SUFFIX: &str =
     "\n\n... bundle content truncated by context bundle byte cap\n";
+const READY_REPAIR_EMBED_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(10);
+const READY_REPAIR_EMBED_OBSERVATION_POLL: Duration = Duration::from_millis(250);
 const MAX_DRILL_JOBS: usize = 8;
 
 fn to_api_repo_text_mode(mode: RepoTextMode) -> SearchRepoTextMode {
@@ -2176,7 +2178,13 @@ fn repair_ready_state(
         Duration::from_secs(90),
     )
     .context("ready repair retrieval bootstrap")?;
-    ensure_ready_repair_embed_liveness(&bootstrap.infrastructure)?;
+    let infrastructure = ready_repair_infrastructure_with_runtime_observation(
+        &bootstrap.infrastructure,
+        &runtime.project_root,
+        &runtime.storage_path,
+        &sidecar,
+    );
+    ensure_ready_repair_embed_liveness(&infrastructure)?;
     codestory_retrieval::repair_project_qdrant_collection(
         &runtime.project_root,
         &runtime.storage_path,
@@ -2228,6 +2236,64 @@ fn ensure_ready_repair_embed_liveness(
         infrastructure.qdrant_reachable,
         infrastructure.qdrant_detail
     )
+}
+
+fn ready_repair_infrastructure_with_runtime_observation(
+    infrastructure: &codestory_retrieval::InfrastructureHealth,
+    project_root: &Path,
+    storage_path: &Path,
+    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
+) -> codestory_retrieval::InfrastructureHealth {
+    if infrastructure.embedding_cpu_allowed
+        || infrastructure.embedding_device_state == "accelerated"
+    {
+        return infrastructure.clone();
+    }
+    let deadline = Instant::now() + READY_REPAIR_EMBED_OBSERVATION_TIMEOUT;
+    loop {
+        if let Some(refreshed) = ready_repair_observed_infrastructure(
+            infrastructure,
+            project_root,
+            storage_path,
+            sidecar,
+        ) {
+            return refreshed;
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return infrastructure.clone();
+        }
+        std::thread::sleep((deadline - now).min(READY_REPAIR_EMBED_OBSERVATION_POLL));
+    }
+}
+
+fn ready_repair_observed_infrastructure(
+    infrastructure: &codestory_retrieval::InfrastructureHealth,
+    project_root: &Path,
+    storage_path: &Path,
+    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
+) -> Option<codestory_retrieval::InfrastructureHealth> {
+    let report = codestory_retrieval::strict_sidecar_status_for_runtime(
+        project_root,
+        Some(storage_path),
+        sidecar.clone(),
+    )
+    .ok()?;
+    if !report.embedding_cpu_allowed && report.embedding_device_state != "accelerated" {
+        return None;
+    }
+    let mut refreshed = infrastructure.clone();
+    refreshed.embedding_device_policy = report.embedding_device_policy;
+    refreshed.embedding_device_state = report.embedding_device_state;
+    refreshed.embedding_device_observation_source = report.embedding_device_observation_source;
+    refreshed.embedding_detected_provider = report.embedding_detected_provider;
+    refreshed.embedding_detected_gpu = report.embedding_detected_gpu;
+    refreshed.embedding_accelerator_requested = report.embedding_accelerator_requested;
+    refreshed.embedding_accelerator_request_provider =
+        report.embedding_accelerator_request_provider;
+    refreshed.embedding_accelerator_request_device = report.embedding_accelerator_request_device;
+    refreshed.embedding_cpu_allowed = report.embedding_cpu_allowed;
+    Some(refreshed)
 }
 
 fn ensure_ready_repair_full_sidecar(
@@ -12329,6 +12395,83 @@ mod tests {
         assert!(message.contains("embedding device policy failed before long semantic indexing"));
         assert!(message.contains("requested_policy=accelerator_required"));
         assert!(message.contains("observed_device=unknown"));
+    }
+
+    #[test]
+    fn ready_repair_waits_for_native_log_before_liveness_failure() {
+        let _env = EnvVarSnapshot::clear(&[
+            "CODESTORY_EMBED_SERVER_LAUNCH",
+            "CODESTORY_EMBED_ALLOW_CPU",
+            "CODESTORY_EMBED_DEVICE_POLICY",
+            "CODESTORY_EMBED_DEVICE_STATE",
+            "CODESTORY_EMBED_DISABLE_HOST_GPU_DETECT",
+        ]);
+        unsafe {
+            std::env::set_var("CODESTORY_EMBED_SERVER_LAUNCH", "native_spawned");
+            std::env::set_var("CODESTORY_EMBED_DISABLE_HOST_GPU_DETECT", "1");
+        }
+        let root = tempdir().expect("temp dir");
+        let sidecar = codestory_retrieval::SidecarRuntimeConfig {
+            layout: codestory_retrieval::SidecarLayout {
+                zoekt_http_port: 16070,
+                qdrant_http_port: 16333,
+                qdrant_grpc_port: 16334,
+                zoekt_data_dir: root.path().join("zoekt"),
+                qdrant_data_dir: root.path().join("qdrant"),
+                scip_artifacts_root: root.path().join("scip"),
+                state_file: root.path().join("state").join("retrieval-sidecars.json"),
+            },
+            profile: codestory_retrieval::SidecarProfile::Agent,
+            run_id: Some("shared-agent".into()),
+            namespace: "agent-shared-agent".into(),
+            compose_project: "codestory-agent-shared-agent".into(),
+            embed_http_port: 18080,
+            cleanup_command: "codestory-cli retrieval down".into(),
+            labels: BTreeMap::new(),
+        };
+        let state_dir = sidecar.layout.state_file.parent().expect("state parent");
+        fs::create_dir_all(state_dir).expect("create state dir");
+        let log_path = state_dir.join("llama-server-native.log");
+        let stale = codestory_retrieval::InfrastructureHealth {
+            zoekt_reachable: true,
+            qdrant_reachable: true,
+            embed_reachable: true,
+            embedding_device_policy: "accelerator_required".into(),
+            embedding_device_state: "unknown".into(),
+            embedding_device_observation_source: "sidecar_state".into(),
+            embedding_detected_provider: None,
+            embedding_detected_gpu: None,
+            embedding_accelerator_requested: false,
+            embedding_accelerator_request_provider: None,
+            embedding_accelerator_request_device: None,
+            embedding_cpu_allowed: false,
+            zoekt_detail: "http 200".into(),
+            qdrant_detail: "http 200".into(),
+            embed_detail: "llama.cpp embeddings reachable dim=768".into(),
+        };
+        ensure_ready_repair_embed_liveness(&stale)
+            .expect_err("stale bootstrap observation should fail before re-observation");
+
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            fs::write(
+                log_path,
+                "using device Vulkan0\noffloaded 13/13 layers to GPU\n",
+            )
+            .expect("write native log");
+        });
+        let refreshed = ready_repair_infrastructure_with_runtime_observation(
+            &stale,
+            root.path(),
+            &root.path().join("missing.db"),
+            &sidecar,
+        );
+        writer.join().expect("native log writer");
+
+        assert_eq!(refreshed.embedding_device_state, "accelerated");
+        assert_eq!(refreshed.embedding_device_observation_source, "native_log");
+        ensure_ready_repair_embed_liveness(&refreshed)
+            .expect("native log observation should allow repair to continue");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -12,7 +12,7 @@ use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// bge-base-en-v1.5 vector width (must match Qdrant collection and llama.cpp model).
 pub const RETRIEVAL_EMBEDDING_DIM: usize = 768;
@@ -40,6 +40,9 @@ const DISABLE_HOST_GPU_DETECT_ENV: &str = "CODESTORY_EMBED_DISABLE_HOST_GPU_DETE
 const LLAMACPP_DEVICE_ENV: &str = "CODESTORY_EMBED_LLAMACPP_DEVICE";
 const LLAMACPP_N_GPU_LAYERS_ENV: &str = "CODESTORY_EMBED_LLAMACPP_N_GPU_LAYERS";
 const ALLOW_CPU_ENV: &str = "CODESTORY_EMBED_ALLOW_CPU";
+const NATIVE_LLAMA_LOG_START_MARKER: &str = "starting native llama.cpp embedding server:";
+const RUNTIME_EMBED_DEVICE_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(10);
+const RUNTIME_EMBED_DEVICE_OBSERVATION_POLL: Duration = Duration::from_millis(250);
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(120);
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
@@ -89,6 +92,37 @@ pub fn manifest_embedding_backend_is_product(backend: Option<&str>) -> bool {
 }
 
 pub fn ensure_product_embedding_backend() -> Result<()> {
+    ensure_product_embedding_backend_with_device(embedding_device_readiness())
+}
+
+pub fn ensure_product_embedding_backend_for_runtime(
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> Result<()> {
+    ensure_product_embedding_backend_static()?;
+    let deadline = Instant::now() + RUNTIME_EMBED_DEVICE_OBSERVATION_TIMEOUT;
+    let mut device = embedding_device_readiness_for_runtime(runtime);
+    loop {
+        if device.full_retrieval_allowed {
+            return Ok(());
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            bail!("{}", device.degraded_reason.expect("device policy reason"));
+        }
+        thread::sleep((deadline - now).min(RUNTIME_EMBED_DEVICE_OBSERVATION_POLL));
+        device = embedding_device_readiness_for_runtime(runtime);
+    }
+}
+
+fn ensure_product_embedding_backend_with_device(device: EmbeddingDeviceReadiness) -> Result<()> {
+    ensure_product_embedding_backend_static()?;
+    if !device.full_retrieval_allowed {
+        bail!("{}", device.degraded_reason.expect("device policy reason"));
+    }
+    Ok(())
+}
+
+fn ensure_product_embedding_backend_static() -> Result<()> {
     if !super::config::qdrant_semantic_vectors_enabled() {
         bail!("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS=0 is unsupported for product sidecar indexing");
     }
@@ -96,10 +130,6 @@ pub fn ensure_product_embedding_backend() -> Result<()> {
         bail!(
             "llama.cpp embedding sidecar is mandatory; set CODESTORY_EMBED_BACKEND=llamacpp and CODESTORY_EMBED_LLAMACPP_URL"
         );
-    }
-    let device = embedding_device_readiness();
-    if !device.full_retrieval_allowed {
-        bail!("{}", device.degraded_reason.expect("device policy reason"));
     }
     Ok(())
 }
@@ -200,7 +230,7 @@ fn observe_native_embedding_device_state(
     runtime: &crate::config::SidecarRuntimeConfig,
 ) -> Option<EmbeddingDeviceObservation> {
     let text = std::fs::read_to_string(native_embedding_log_path(runtime)).ok()?;
-    match observed_embedding_device_state_from_text(&text) {
+    match observed_embedding_device_state_from_text(native_embedding_log_current_launch(&text)) {
         "unknown" => None,
         state => Some(EmbeddingDeviceObservation {
             state,
@@ -216,6 +246,12 @@ pub(crate) fn native_embedding_log_path(runtime: &crate::config::SidecarRuntimeC
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("llama-server-native.log")
+}
+
+fn native_embedding_log_current_launch(text: &str) -> &str {
+    text.rfind(NATIVE_LLAMA_LOG_START_MARKER)
+        .map(|offset| &text[offset..])
+        .unwrap_or(text)
 }
 
 pub fn embedding_accelerator_request() -> Option<EmbeddingAcceleratorRequest> {
@@ -733,6 +769,8 @@ pub fn qdrant_vector_dim() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{SidecarLayout, SidecarProfile, SidecarRuntimeConfig};
+    use std::collections::BTreeMap;
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -1017,6 +1055,24 @@ mod tests {
     }
 
     #[test]
+    fn native_log_current_launch_ignores_stale_acceleration() {
+        let text = concat!(
+            "starting native llama.cpp embedding server: old --device Vulkan0\n",
+            "using device Vulkan0\n",
+            "offloaded 33/33 layers to GPU\n",
+            "starting native llama.cpp embedding server: current --device Vulkan0\n",
+            "server listening on 0.0.0.0\n",
+            "n_gpu_layers = 0\n",
+        );
+
+        let current = native_embedding_log_current_launch(text);
+
+        assert!(current.contains("current --device Vulkan0"));
+        assert!(!current.contains("old --device Vulkan0"));
+        assert_eq!(observed_embedding_device_state_from_text(current), "cpu");
+    }
+
+    #[test]
     fn explicit_unknown_device_still_fails_closed_on_amd_host() {
         let _lock = ENV_LOCK.lock().expect("env lock");
         let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
@@ -1084,6 +1140,101 @@ mod tests {
             error.to_string().contains("embedding_device_unverified"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn product_embedding_backend_uses_runtime_native_log_observation() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _backend = EnvGuard::set(EMBEDDING_BACKEND_ENV, "llamacpp");
+        let _real = EnvGuard::set("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
+        let _launch = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "native_spawned");
+        let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
+        let _policy = EnvGuard::remove(DEVICE_POLICY_ENV);
+        let _device = EnvGuard::remove(DEVICE_STATE_ENV);
+        let _host_detect = EnvGuard::set(DISABLE_HOST_GPU_DETECT_ENV, "1");
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let runtime = SidecarRuntimeConfig {
+            layout: SidecarLayout {
+                zoekt_http_port: 16070,
+                qdrant_http_port: 16333,
+                qdrant_grpc_port: 16334,
+                zoekt_data_dir: root.path().join("zoekt"),
+                qdrant_data_dir: root.path().join("qdrant"),
+                scip_artifacts_root: root.path().join("scip"),
+                state_file: root.path().join("state").join("retrieval-sidecars.json"),
+            },
+            profile: SidecarProfile::Agent,
+            run_id: Some("shared-agent".into()),
+            namespace: "agent-shared-agent".into(),
+            compose_project: "codestory-agent-shared-agent".into(),
+            embed_http_port: 18080,
+            cleanup_command: "codestory-cli retrieval down".into(),
+            labels: BTreeMap::new(),
+        };
+        std::fs::create_dir_all(runtime.layout.state_file.parent().expect("state parent"))
+            .expect("create state dir");
+        std::fs::write(
+            native_embedding_log_path(&runtime),
+            "llama_model_load: offloaded 33/33 layers to GPU\n",
+        )
+        .expect("write native log");
+
+        let generic_error = ensure_product_embedding_backend()
+            .expect_err("generic check should not see the runtime native log");
+        assert!(
+            generic_error
+                .to_string()
+                .contains("embedding_device_unverified")
+        );
+
+        ensure_product_embedding_backend_for_runtime(&runtime)
+            .expect("runtime native log should satisfy accelerator policy");
+    }
+
+    #[test]
+    fn product_embedding_backend_for_runtime_waits_for_native_log_observation() {
+        let _lock = ENV_LOCK.lock().expect("env lock");
+        let _backend = EnvGuard::set(EMBEDDING_BACKEND_ENV, "llamacpp");
+        let _real = EnvGuard::set("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
+        let _launch = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "native_spawned");
+        let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
+        let _policy = EnvGuard::remove(DEVICE_POLICY_ENV);
+        let _device = EnvGuard::remove(DEVICE_STATE_ENV);
+        let _host_detect = EnvGuard::set(DISABLE_HOST_GPU_DETECT_ENV, "1");
+        let root = tempfile::TempDir::new().expect("temp dir");
+        let runtime = SidecarRuntimeConfig {
+            layout: SidecarLayout {
+                zoekt_http_port: 16070,
+                qdrant_http_port: 16333,
+                qdrant_grpc_port: 16334,
+                zoekt_data_dir: root.path().join("zoekt"),
+                qdrant_data_dir: root.path().join("qdrant"),
+                scip_artifacts_root: root.path().join("scip"),
+                state_file: root.path().join("state").join("retrieval-sidecars.json"),
+            },
+            profile: SidecarProfile::Agent,
+            run_id: Some("shared-agent".into()),
+            namespace: "agent-shared-agent".into(),
+            compose_project: "codestory-agent-shared-agent".into(),
+            embed_http_port: 18080,
+            cleanup_command: "codestory-cli retrieval down".into(),
+            labels: BTreeMap::new(),
+        };
+        std::fs::create_dir_all(runtime.layout.state_file.parent().expect("state parent"))
+            .expect("create state dir");
+        let log_path = native_embedding_log_path(&runtime);
+        let writer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(50));
+            std::fs::write(
+                log_path,
+                "starting native llama.cpp embedding server: test --device Vulkan0\nload_tensors: offloaded 13/13 layers to GPU\n",
+            )
+            .expect("write native log");
+        });
+
+        ensure_product_embedding_backend_for_runtime(&runtime)
+            .expect("runtime helper should wait for native log acceleration");
+        writer.join().expect("native log writer");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -6,7 +6,7 @@ use crate::generation::{
     SIDECAR_SCHEMA_VERSION, manifest_has_current_sidecar_contract, manifest_unavailable_reason,
     sidecar_generation_id,
 };
-use crate::health::probe_sidecar_health;
+use crate::health::probe_sidecar_health_with_embedding_device;
 use crate::qdrant_client::{QDRANT_INDEX_UPSERT_BATCH_SIZE, QdrantClient, QdrantUpsertPoint};
 use crate::scip_index::{
     SCIP_PRECISE_SEMANTIC_IMPORT_DIR, emit_scip_artifacts_from_store,
@@ -221,7 +221,8 @@ pub fn finalize_index_for_runtime(
     if !qdrant_enabled() {
         bail!("Qdrant sidecar is mandatory; CODESTORY_QDRANT_ENABLED=false is unsupported");
     }
-    crate::embeddings::ensure_product_embedding_backend()?;
+    crate::embeddings::ensure_product_embedding_backend_for_runtime(runtime)?;
+    let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
 
     let mut storage =
         Store::open(storage_path).context("open storage for retrieval sidecar input")?;
@@ -255,7 +256,12 @@ pub fn finalize_index_for_runtime(
             &embedding_backend,
             embedding_dim,
         ) {
-            let status = probe_sidecar_health(&layout, &project_id, Some(previous.clone()));
+            let status = probe_sidecar_health_with_embedding_device(
+                &layout,
+                &project_id,
+                Some(previous.clone()),
+                &embedding_device,
+            );
             let qdrant_point_count = qdrant_ready_point_count(
                 &qdrant_client,
                 &previous.qdrant_collection,
@@ -317,7 +323,12 @@ pub fn finalize_index_for_runtime(
     );
     manifest.scip_revision = read_scip_revision(&scip_dir);
 
-    let existing_status = probe_sidecar_health(&layout, &project_id, Some(manifest.clone()));
+    let existing_status = probe_sidecar_health_with_embedding_device(
+        &layout,
+        &project_id,
+        Some(manifest.clone()),
+        &embedding_device,
+    );
     let zoekt_ready = existing_status.zoekt.capabilities.lexical
         && crate::zoekt_index::shard_matches_lexical_input(
             &layout.zoekt_data_dir,
@@ -335,7 +346,12 @@ pub fn finalize_index_for_runtime(
     if zoekt_ready && qdrant_ready_points.is_some() && scip_ready {
         update_precise_semantic_import_status(&scip_dir, &mut manifest)?;
         manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
-        let status = probe_sidecar_health(&layout, &project_id, Some(manifest.clone()));
+        let status = probe_sidecar_health_with_embedding_device(
+            &layout,
+            &project_id,
+            Some(manifest.clone()),
+            &embedding_device,
+        );
         if status.retrieval_mode == "full" {
             info!(
                 project_id = %project_id,
@@ -403,6 +419,7 @@ pub fn finalize_index_for_runtime(
             qdrant_stubbed,
             scip_stubbed,
         },
+        &embedding_device,
     )
 }
 
@@ -612,8 +629,14 @@ fn finalize_manifest_after_health_check(
     manifest: RetrievalIndexManifest,
     degraded_modes: Vec<String>,
     stub_flags: SidecarStubFlags,
+    embedding_device: &crate::embeddings::EmbeddingDeviceReadiness,
 ) -> Result<FinalizeIndexOutcome> {
-    let status = probe_sidecar_health(layout, &project_id, Some(manifest.clone()));
+    let status = probe_sidecar_health_with_embedding_device(
+        layout,
+        &project_id,
+        Some(manifest.clone()),
+        embedding_device,
+    );
     if status.retrieval_mode != "full" {
         bail!(
             "mandatory sidecar generation did not reach full mode for {project_id}: {} {:?}",

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -60,6 +60,7 @@ pub use embeddings::qdrant_vector_dim;
 pub use embeddings::{
     BGE_BASE_EN_V1_5_GGUF, BGE_QUERY_PREFIX_DEFAULT, RETRIEVAL_EMBEDDING_DIM,
     embedding_backend_label, embedding_runtime_id, ensure_product_embedding_backend,
+    ensure_product_embedding_backend_for_runtime,
 };
 pub use executor::{QueryExecutor, QueryResult, QueryTrace, StageTrace, cancellation_flag};
 pub use generation::{SIDECAR_SCHEMA_VERSION, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED};


### PR DESCRIPTION
## Context

Closes #634.

`ready --goal agent --repair` could fail on Windows before trusting the native llama.cpp evidence that an AMD GPU was actually used. Bootstrap could see the embedding service as reachable while the native log still had not emitted the Vulkan/offload lines, and finalization could also re-check sidecar health through a generic device path. The repair stopped with `embedding_device_unverified` and never persisted the finalized retrieval manifest.

## What Changed

- Added a bounded repair-time re-observation window before the embedding liveness gate: up to 10 seconds, polling every 250ms, using the agent sidecar runtime status/native log.
- Added a bounded runtime-aware product embedding backend check for retrieval finalization, so finalization waits for native-log device proof instead of racing startup output.
- Threaded runtime-aware embedding device evidence through finalization health checks, including the final manifest gate.
- Scoped native-log parsing to the latest native launch marker when the log has multiple appended launches, preventing stale accelerated lines from proving a later run.
- Added focused tests for stale bootstrap state becoming accelerated from native-log evidence, runtime-native finalization policy, delayed native-log proof, stale native-log acceleration, and AMD/Vulkan readiness behavior.

## How To Review

- Start in `crates/codestory-cli/src/main.rs`: `repair_ready_state` now re-observes runtime device evidence before `ensure_ready_repair_embed_liveness`, while preserving the final strict full-mode status gate.
- Then read `crates/codestory-retrieval/src/embeddings.rs`: generic product checks remain generic; runtime-aware checks read the sidecar runtime native log, wait boundedly for proof, and only trust the latest launch segment.
- Check `crates/codestory-retrieval/src/index.rs`: runtime finalization uses runtime-aware device evidence for product backend checks and sidecar health decisions.

## Verification

- `cargo test -p codestory-cli ready_repair -- --nocapture`
- `cargo test -p codestory-cli ready_repair_final_status -- --nocapture`
- `cargo test -p codestory-retrieval product_embedding_backend_uses_runtime_native_log_observation -- --nocapture`
- `cargo test -p codestory-retrieval product_embedding_backend_for_runtime_waits_for_native_log_observation -- --nocapture`
- `cargo test -p codestory-retrieval native_log_current_launch_ignores_stale_acceleration -- --nocapture`
- `cargo test -p codestory-retrieval amd -- --nocapture --test-threads=1`
- `cargo fmt --check`
- `git diff --check`
- `cargo build --release -p codestory-cli`
- Live Windows AMD proof: `target\release\codestory-cli.exe ready --goal agent --repair --project . --format json --run-id shared-agent`

Live proof result:
- `agent_packet_search.status=ready`
- `sidecar.retrieval_mode=full`
- `embedding_device_policy=accelerator_required`
- `embedding_device_state=accelerated`
- `embedding_device_observation_source=native_log`
- `embedding_cpu_allowed=false`
- `embedding_detected_provider=amd`
- `embedding_detected_gpu=AMD Radeon RX 7900 XT Advanced Micro Devices, Inc.`
- `embedding_accelerator_requested=true`
- `embedding_accelerator_request_device=Vulkan0`
- `manifest_generation=41307bfab5429e31-c382c72dca19932d`

## Risk

The live proof was run against this PR worktree and shared-agent run id on the Windows AMD workstation. The local-default lane remains separate and still reports local retrieval repair needed; this PR only claims the agent packet/search lane for the target runtime reached full mode.