### PR TITLE
[codex] prevent escaped status comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ evidence instead of rediscovering the checkout on every question.
 - Release version checks: `python .github/scripts/check-codestory-release.py --version <version>` and `node .github/scripts/check-workflow-policy.mjs`.
 - On Windows, the Codex npm shim should be invoked as `codex.cmd` (typically under `%APPDATA%\\npm`); using the extensionless `codex` shim can fail with `os error 193`.
 - In this PowerShell environment, large parallel file reads can truncate output; when investigating a single large file, prefer one direct read command (for example `Get-Content` or `cmd /c type`) before parallelizing.
+- Public GitHub status comments should go through `node scripts/github-status-comment.mjs --issue <n> --body-file <file>` or stdin; the helper rejects literal `\\n` text before posting.
 
 ## Coding Style & Naming Conventions
 - Rust edition is `2024` across workspace crates.

--- a/scripts/github-status-comment.mjs
+++ b/scripts/github-status-comment.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function parseArgs(argv) {
+  const opts = { dryRun: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--dry-run") {
+      opts.dryRun = true;
+      continue;
+    }
+    if (arg === "--issue" || arg === "--pr" || arg === "--repo" || arg === "--body-file" || arg === "--body") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a value`);
+      }
+      opts[arg.slice(2).replace("-", "_")] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  if (Boolean(opts.issue) === Boolean(opts.pr)) {
+    throw new Error("pass exactly one of --issue or --pr");
+  }
+  if (opts.body && opts.body_file) {
+    throw new Error("pass only one of --body or --body-file");
+  }
+  return opts;
+}
+
+function commentBody(opts, stdin = process.stdin) {
+  if (opts.body_file) {
+    return readFileSync(opts.body_file, "utf8");
+  }
+  if (opts.body) {
+    return opts.body;
+  }
+  return readFileSync(stdin.fd, "utf8");
+}
+
+function validateCommentBody(body) {
+  if (!body.trim()) {
+    throw new Error("comment body is empty");
+  }
+  if (body.includes("\\n")) {
+    throw new Error("comment body contains literal \\\\n; use real newlines via stdin or --body-file");
+  }
+}
+
+function ghArgs(opts, bodyFile) {
+  const command = opts.issue ? ["issue", "comment", opts.issue] : ["pr", "comment", opts.pr];
+  if (opts.repo) {
+    command.push("--repo", opts.repo);
+  }
+  command.push("--body-file", bodyFile);
+  return command;
+}
+
+function postComment(opts, body) {
+  if (opts.dryRun) {
+    process.stdout.write(body);
+    if (!body.endsWith("\n")) {
+      process.stdout.write("\n");
+    }
+    return;
+  }
+  const dir = mkdtempSync(path.join(tmpdir(), "codestory-comment-"));
+  const bodyFile = path.join(dir, "body.md");
+  try {
+    writeFileSync(bodyFile, body, "utf8");
+    execFileSync("gh", ghArgs(opts, bodyFile), { stdio: "inherit" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  const body = commentBody(opts);
+  validateCommentBody(body);
+  postComment(opts, body);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+
+export { ghArgs, parseArgs, validateCommentBody };

--- a/scripts/tests/github-status-comment.test.mjs
+++ b/scripts/tests/github-status-comment.test.mjs
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ghArgs, parseArgs, validateCommentBody } from "../github-status-comment.mjs";
+
+test("comment validation accepts real newlines", () => {
+  assert.doesNotThrow(() => validateCommentBody("Status:\n- ready\n"));
+});
+
+test("comment validation rejects literal newline escapes", () => {
+  assert.throws(
+    () => validateCommentBody("Status:\\n- not rendered"),
+    /literal \\\\n/,
+  );
+});
+
+test("comment helper posts through body files", () => {
+  const opts = parseArgs(["--issue", "641", "--repo", "TheGreenCedar/CodeStory", "--body-file", "body.md"]);
+
+  assert.deepEqual(ghArgs(opts, "body.md"), [
+    "issue",
+    "comment",
+    "641",
+    "--repo",
+    "TheGreenCedar/CodeStory",
+    "--body-file",
+    "body.md",
+  ]);
+});


### PR DESCRIPTION
## Context

Closes #641.

Public status comments are part of CodeStory's coordinator trail. When comment bodies are assembled with escaped newline text, GitHub renders literal `\n` sequences instead of Markdown line breaks.

## What Changed

- Added `scripts/github-status-comment.mjs`, a tiny issue/PR comment helper that accepts stdin, `--body-file`, or `--body` and rejects literal `\n` text before posting.
- Routed real posts through a temporary body file and `gh ... --body-file`, avoiding shell-escaped inline comment bodies.
- Documented the helper in `AGENTS.md` for future coordinator/status-comment lanes.
- Added a focused Node regression proving real newlines pass and literal newline escapes fail.

## How To Review

- Check `validateCommentBody` in `scripts/github-status-comment.mjs`.
- Check that `ghArgs` always uses `--body-file` for GitHub writes.
- Check `scripts/tests/github-status-comment.test.mjs` for the real-newline versus escaped-newline distinction.

## Verification

- `node --test scripts\tests\github-status-comment.test.mjs`
- `@('Status:', '- ready') | node scripts\github-status-comment.mjs --issue 641 --dry-run`
- `'Status:\n- broken' | node scripts\github-status-comment.mjs --issue 641 --dry-run` failed before posting with the literal-newline guard.
- `git diff --check`

## Risk

This does not rewrite historical comments and only prevents future coordinator/status comments that use the helper. It does not touch #593/#544 ranking/eval code or sidecar/runtime readiness paths.
