### PR TITLE
[codex] Fix MCP visibility reporting without PATH CLI

### DIFF
--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -107,8 +107,7 @@ function classifyMcpRuntime(options = {}) {
   const runtime = runtimePath ? readJson(runtimePath) : null;
   const managed = managedCliInfo(dataDir, pluginVersion(root));
   const launchable = mcp.installed && mcp.command === 'node' && mcpScriptExists(root, mcp.args);
-  const resourcesExposed = process.env.CODESTORY_MCP_RESOURCES_EXPOSED === '1' ||
-    Boolean(runtime?.source && runtime?.path && fs.existsSync(runtime.path));
+  const resourcesExposed = process.env.CODESTORY_MCP_RESOURCES_EXPOSED === '1';
   const resourceStatus = resourcesExposed
     ? 'mcp_resources_exposed'
     : launchable

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1523,10 +1523,26 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
       JSON.stringify({ source: "managed", path: cliPath }),
       "utf8",
     );
-    const exposed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
-    assert.equal(exposed.mcp_resources_exposed, true);
-    assert.equal(exposed.mcp_resource_status, "mcp_resources_exposed");
-    assert.equal(exposed.degraded_no_surface, false);
+    const runtimeStateOnly = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
+    assert.equal(runtimeStateOnly.mcp_runtime_state_present, true);
+    assert.equal(runtimeStateOnly.mcp_resources_exposed, false);
+    assert.equal(runtimeStateOnly.mcp_resource_status, "mcp_resources_not_model_visible");
+    assert.equal(runtimeStateOnly.degraded_no_surface, false);
+
+    const previous = process.env.CODESTORY_MCP_RESOURCES_EXPOSED;
+    try {
+      process.env.CODESTORY_MCP_RESOURCES_EXPOSED = "1";
+      const exposed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
+      assert.equal(exposed.mcp_resources_exposed, true);
+      assert.equal(exposed.mcp_resource_status, "mcp_resources_exposed");
+      assert.equal(exposed.degraded_no_surface, false);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CODESTORY_MCP_RESOURCES_EXPOSED;
+      } else {
+        process.env.CODESTORY_MCP_RESOURCES_EXPOSED = previous;
+      }
+    }
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1622,9 +1638,25 @@ test("hook output reports model-invisible MCP instead of PATH setup guidance", a
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-no-resources-"));
+  const version = await readPluginVersion();
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  await mkdir(cliDir, { recursive: true });
+  await writeFakeCli(cliPath);
+  await writeFile(
+    join(cliDir, "manifest.json"),
+    JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
+    "utf8",
+  );
+  await writeFile(
+    join(dataDir, ".codestory-mcp-runtime.json"),
+    JSON.stringify({ source: "managed", path: cliPath }),
+    "utf8",
+  );
   const result = spawnSync(process.execPath, [hookPath], {
     env: {
       ...process.env,
+      CODESTORY_MCP_RESOURCES_EXPOSED: "",
       COPILOT_PLUGIN_DATA: "",
       PLUGIN_DATA: dataDir,
       PATH: "",
@@ -1642,6 +1674,7 @@ test("hook output reports model-invisible MCP instead of PATH setup guidance", a
   const context = output.hookSpecificOutput.additionalContext;
   assert.match(context, /mcp_config_installed: yes/u);
   assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+  assert.match(context, /managed_cli_present: yes/u);
   assert.match(context, /MCP resources are not visible/u);
   assert.doesNotMatch(context, /codestory-cli ENOENT/u);
   assert.doesNotMatch(context, /attempted request packet/u);


### PR DESCRIPTION
## Context

Installed CodeStory can have `.mcp.json` and a managed CLI runtime while the active host/model surface still does not expose `codestory://status` or CodeStory MCP tools. That state must not collapse into `codestory-cli` PATH guidance, and runtime state from a previous MCP launch is not proof that resources are model-visible in this session.

Closes #647

## What Changed

- Treat `CODESTORY_MCP_RESOURCES_EXPOSED=1` as the only hook-side proof that MCP resources are model-visible.
- Keep managed CLI manifest/runtime state as launch/runtime evidence, but report it separately from model-visible resources.
- Extend the plugin static regression so same-version managed runtime state plus empty `PATH` reports `mcp_resources_not_model_visible` and avoids `codestory-cli ENOENT` guidance.

```mermaid
flowchart LR
  A[Plugin MCP config] --> B[Launchable adapter]
  B --> C[Managed CLI present]
  C --> D{Host exposed MCP resources?}
  D -- yes --> E[Use codestory://status]
  D -- no --> F[Report model-invisible MCP]
```

## How To Review

- Start in `plugins/codestory/hooks/codestory-runtime.cjs` and confirm `classifyMcpRuntime` no longer treats `.codestory-mcp-runtime.json` as resource visibility proof.
- Then review `plugins/codestory/tests/plugin-static.test.mjs` for the no-PATH managed-runtime regression.

## Verification

- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> 33 pass.
- Manual source-hook transcript with `PATH=''`, real managed CLI data, and `CODESTORY_MCP_RESOURCES_EXPOSED=''` reported:
  - `mcp_config_installed: yes`
  - `mcp_process_launchable: yes`
  - `mcp_resources_exposed: mcp_resources_not_model_visible`
  - `managed_cli_present: yes (...\codestory-cli\0.11.19\bin\codestory-cli.exe)`
  - no `codestory-cli ENOENT` guidance.

## Risk

Low. This changes hook-side classification only. A host that really exposes MCP resources needs to set/pass the explicit exposure signal; otherwise the hook now fails closed with operator-facing visibility guidance instead of overclaiming status access.
