### PR TITLE
[codex] Bump CodeStory release metadata to v0.11.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Changelog
 
-## 0.11.19
+## 0.11.20
 
-CodeStory 0.11.19 promotes the current `dev/codestory-next` release slice:
-agent readiness now keeps repair guidance tied to the active runtime, packaged
-agent proof carries version-guard evidence, and the release evidence log records
-full-sidecar packet/search readiness with no warnings for the repo-scale stats
-run.
+CodeStory 0.11.20 promotes the current `dev/codestory-next` release slice:
+the query-shape fusion work has landed, packet/search ranking keeps graph,
+lexical, and dense evidence distinct, and the release lane is ready for the
+final branch-vs-main review gate before promotion.
 
-This release is a metadata sync for the completed v0.11.19 readiness evidence.
+This release is a metadata sync for the completed v0.11.20 readiness evidence.
 It does not start v0.12 work, merge development history into `main` locally, or
 claim readiness beyond the packaged sidecar proof and recorded release gates.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.19"
+version = "0.11.20"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.19"
+version = "0.11.20"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.19",
+  "version": "0.11.20",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.19",
+  "version": "0.11.20",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.19",
+  "version": "0.11.20",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context
Issue #651 tracks the full v0.11.20 release promotion, including the version bump, final dev-vs-main review, code-simplifier gate, and main promotion.
This PR is only the first slice: synchronized release metadata for v0.11.20 on `dev/codestory-next`.
Closes #652
Refs #651

## What Changed
- Bumped all eight `codestory-*` workspace crate package versions from `0.11.19` to `0.11.20`.
- Updated `Cargo.lock` package entries for those workspace crates.
- Bumped CodeStory plugin manifests under `.codex-plugin`, `.claude-plugin`, and `.github/plugin` to `0.11.20`.
- Updated the changelog top entry for the v0.11.20 release slice.

## How To Review
- Confirm the diff is limited to release/version metadata and the generated lockfile entries.
- Confirm #651 remains open for final review, code-simplifier, and main promotion.
- Confirm #652 is the narrow child issue closed by this PR.

## Verification
- `cargo metadata --locked --format-version 1 --no-deps`
- `python .github/scripts/check-codestory-release.py --version 0.11.20`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

## Risk
Low. This PR does not change runtime behavior, but it does not complete #651 by itself. Remaining gates are the final dev/codestory-next versus main review, code-simplifier pass, and main promotion path.
