### PR TITLE
Keep agent full-repair status proof lane-scoped

### DIFF
--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -408,8 +408,15 @@ fn agent_packet_search_repair_commands(project_arg: &str, run_id: Option<&str>) 
         project_arg,
         run_id,
     ));
+    let mut status_command = format!(
+        "codestory-cli retrieval status --project {project_arg} --profile agent --format json"
+    );
+    if let Some(run_id) = run_id {
+        status_command.push_str(" --run-id ");
+        status_command.push_str(&quote_command_argument_value(run_id));
+    }
     commands.extend([
-        format!("codestory-cli retrieval status --project {project_arg} --format json"),
+        status_command,
         format!("codestory-cli doctor --project {project_arg} --format markdown"),
     ]);
     commands

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -177,6 +177,20 @@ fn ready_command_emits_compact_verdicts_and_filters_goal() {
             ),
         "explicit run id should stay in agent repair guidance: {explicit_agent_json_text}"
     );
+    assert!(
+        explicit_agent_json["verdicts"][0]["full_repair"]
+            .as_array()
+            .is_some_and(
+                |commands| commands
+                    .iter()
+                    .any(|command| command.as_str().is_some_and(|text| text
+                        .contains("retrieval status")
+                        && text.contains("--profile agent")
+                        && text.contains("--run-id")
+                        && text.contains("isolated-proof")))
+            ),
+        "explicit run id should stay in agent status proof guidance: {explicit_agent_json_text}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Context

Agent packet/search repair already preserved an explicit `--run-id` on the repair command, but the follow-up `full_repair` proof command used plain default-lane retrieval status. For isolated agent runs, that could inspect the wrong sidecar lane after telling the reviewer/operator to repair the agent lane.

Closes #654
Refs #651

## What Changed

- Updated `agent_packet_search_repair_commands()` so the `full_repair` status proof uses `codestory-cli retrieval status --profile agent`.
- Preserved `--run-id <id>` on that status proof when the agent lane has an explicit run id.
- Added a `ready_command` regression for the `isolated-proof` run id.

```mermaid
flowchart LR
    A[ready agent] --> B[ready --goal agent --repair]
    B --> C[retrieval status --profile agent]
    C --> D[--run-id when present]
```

## How To Review

1. Inspect `crates/codestory-cli/src/readiness.rs` and confirm only the status proof command changed lane scope.
2. Inspect `crates/codestory-cli/tests/ready_command.rs` and confirm the regression asserts `--profile agent --run-id isolated-proof` in `full_repair`.
3. Confirm no sidecar setup, Docker, storage, release metadata, or broad repair behavior changed.

## Verification

- `cargo test -p codestory-cli --test ready_command ready_command_emits_compact_verdicts_and_filters_goal`
- `cargo test -p codestory-cli --test ready_command`
- `cargo test -p codestory-cli readiness::tests::non_full_sidecars_report_retrieval_layer_and_one_canonical_repair`
- `cargo fmt --check`
- `git diff --check`

## Risk

Low. This only changes generated guidance text for the agent packet/search repair proof path. It does not start repairs, change sidecar selection logic, or alter retrieval/storage behavior.
