### PR TITLE
Harden managed CLI provisioning downloads

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -15,6 +15,9 @@ const fallbackBinaryNames = process.platform === 'win32'
   ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
   : ['codestory-cli'];
 const sharedAgentRunId = 'shared-agent';
+const releaseDownloadTimeoutMs = 60000;
+const releaseDownloadAttempts = 3;
+const releaseDownloadRetryDelaysMs = [1000, 3000];
 
 function readJson(file) {
   try {
@@ -230,12 +233,25 @@ function copyLocalReleaseFile(releaseDir, name, destination) {
   fs.copyFileSync(path.join(releaseDir, name), destination);
 }
 
-function downloadFile(url, destination) {
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function downloadFileOnce(url, destination, options = {}) {
+  const timeoutMs = options.timeoutMs || releaseDownloadTimeoutMs;
+  const redirectsRemaining = options.redirectsRemaining ?? 5;
+  const get = options.get || https.get;
   return new Promise((resolve, reject) => {
-    const request = https.get(url, (response) => {
+    const request = get(url, (response) => {
       if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
         response.resume();
-        downloadFile(response.headers.location, destination).then(resolve, reject);
+        if (!response.headers.location || redirectsRemaining <= 0) {
+          reject(new Error(`download redirect failed: ${url}`));
+          return;
+        }
+        const nextUrl = new URL(response.headers.location, url).toString();
+        downloadFileOnce(nextUrl, destination, { ...options, redirectsRemaining: redirectsRemaining - 1 })
+          .then(resolve, reject);
         return;
       }
       if (response.statusCode !== 200) {
@@ -248,20 +264,58 @@ function downloadFile(url, destination) {
       output.on('finish', () => output.close(resolve));
       output.on('error', reject);
     });
-    request.setTimeout(15000, () => request.destroy(new Error(`download timed out: ${url}`)));
+    request.setTimeout(timeoutMs, () => request.destroy(new Error(`download timed out after ${timeoutMs}ms: ${url}`)));
     request.on('error', reject);
   });
 }
 
+async function downloadFile(url, destination, options = {}) {
+  const attempts = options.attempts || releaseDownloadAttempts;
+  const startedAt = Date.now();
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await downloadFileOnce(url, destination, options);
+      return;
+    } catch (error) {
+      lastError = error;
+      fs.rmSync(destination, { force: true });
+      if (attempt < attempts) {
+        const delayMs = options.retryDelayMs
+          ? options.retryDelayMs(attempt)
+          : releaseDownloadRetryDelaysMs[attempt - 1] ||
+            releaseDownloadRetryDelaysMs[releaseDownloadRetryDelaysMs.length - 1];
+        if (delayMs > 0) await sleep(delayMs);
+      }
+    }
+  }
+  const elapsedMs = Date.now() - startedAt;
+  throw new Error(`download failed after ${attempts} attempts over ${elapsedMs}ms: ${lastError?.message || 'unknown error'}`);
+}
+
+function releaseAssetFetchFailure(name, startedAt, attempts, error) {
+  const elapsedMs = Date.now() - startedAt;
+  return `managed_cli_asset_fetch_failed:${name}:elapsed_ms=${elapsedMs}:attempts=${attempts}:retry=restart_reload_status:last_error=${error.message}`;
+}
+
 async function fetchReleaseFile(version, name, destination) {
+  const startedAt = Date.now();
   if (process.env.CODESTORY_PLUGIN_RELEASE_DIR) {
-    copyLocalReleaseFile(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name, destination);
+    try {
+      copyLocalReleaseFile(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name, destination);
+    } catch (error) {
+      throw new Error(releaseAssetFetchFailure(name, startedAt, 1, error));
+    }
     return `file://${path.join(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name)}`;
   }
   const baseUrl = process.env.CODESTORY_PLUGIN_RELEASE_BASE_URL ||
     `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}`;
   const url = `${baseUrl.replace(/\/$/u, '')}/${name}`;
-  await downloadFile(url, destination);
+  try {
+    await downloadFile(url, destination);
+  } catch (error) {
+    throw new Error(releaseAssetFetchFailure(name, startedAt, releaseDownloadAttempts, error));
+  }
   return url;
 }
 
@@ -375,8 +429,12 @@ async function resolveCli() {
     return { source: 'managed', version, warnings, ...managed };
   }
 
-  warnings.push('managed_cli_unavailable_using_path_fallback');
-  const pathFallback = pathCliCandidates()[0] || 'codestory-cli';
+  const managedProvisionFailure = warnings.find((warning) => warning.startsWith('managed_cli_provision_failed:')) || null;
+  const pathCandidates = pathCliCandidates();
+  warnings.push(pathCandidates.length > 0
+    ? 'managed_cli_unavailable_using_path_fallback'
+    : 'managed_cli_unavailable_no_path_fallback');
+  const pathFallback = pathCandidates[0] || 'codestory-cli';
   return {
     source: 'path_fallback',
     path: pathFallback,
@@ -388,6 +446,7 @@ async function resolveCli() {
     archiveSha256: null,
     archiveUrl: null,
     provisionedAt: null,
+    managedProvisionFailure,
     warnings,
   };
 }
@@ -433,6 +492,9 @@ function probeResolvedCli(resolved) {
 }
 
 function failOpenReasonForProbe(resolved, probe) {
+  if (resolved.managedProvisionFailure && resolved.source === 'path_fallback' && pathCliCandidates().length === 0) {
+    return resolved.managedProvisionFailure;
+  }
   if (probe.error || probe.status !== 0) {
     return `${resolved.source}_cli_unspawnable`;
   }
@@ -585,11 +647,16 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     version: cliVersion(candidate),
     active: samePathText(candidate, resolved.path),
   }));
-  const minimumNext = options.minimumNext || [
+  const managedProvisionFailed = String(reason || '').startsWith('managed_cli_provision_failed:');
+  const managedProvisionNext = [
+    'Restart/reload the Codex host/app and read codestory://status; managed CLI provisioning will retry release asset downloads.',
+    'Refresh or reinstall the CodeStory plugin after GitHub release assets are reachable, then restart/reload the Codex host/app and read codestory://status.',
+  ];
+  const minimumNext = options.minimumNext || (managedProvisionFailed && pathCandidates.length === 0 ? managedProvisionNext : [
     'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
     process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
     'codestory-cli --version',
-  ];
+  ]);
   const fullRepair = options.fullRepair || minimumNext;
   const recommendedNext = options.recommendedNext || fullRepair;
   const sidecarPolicy = readSidecarPolicy();
@@ -987,7 +1054,7 @@ async function main() {
   });
 }
 
-main().catch((error) => {
+function runLauncherError(error) {
   const resolved = {
     source: 'launcher',
     path: 'codestory-cli',
@@ -1008,4 +1075,14 @@ main().catch((error) => {
     stdout: '',
     stderr: '',
   }, 'launcher_error'));
-});
+}
+
+if (require.main === module) {
+  main().catch(runLauncherError);
+} else {
+  module.exports = {
+    _test: {
+      downloadFile,
+    },
+  };
+}

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -937,6 +937,104 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
+test("release asset downloader retries a transient failure", async () => {
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+  const launcher = require(join(pluginRoot, "scripts", "codestory-mcp.cjs"));
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-retry-"));
+  const destination = join(dataDir, "SHA256SUMS.txt");
+  let calls = 0;
+
+  const fakeGet = (_url, onResponse) => {
+    calls += 1;
+    const request = new EventEmitter();
+    request.setTimeout = () => request;
+    request.destroy = (error) => {
+      process.nextTick(() => request.emit("error", error));
+      return request;
+    };
+    process.nextTick(() => {
+      if (calls === 1) {
+        request.emit("error", new Error("synthetic network reset"));
+        return;
+      }
+      const response = new PassThrough();
+      response.statusCode = 200;
+      response.headers = {};
+      onResponse(response);
+      response.end("checksum fixture\n");
+    });
+    return request;
+  };
+
+  try {
+    await launcher._test.downloadFile("https://example.invalid/SHA256SUMS.txt", destination, {
+      attempts: 2,
+      get: fakeGet,
+      retryDelayMs: () => 1,
+      timeoutMs: 100,
+    });
+
+    assert.equal(calls, 2);
+    assert.equal(await readFile(destination, "utf8"), "checksum fixture\n");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher keeps managed provision failures primary without PATH", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-provision-fail-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-empty-release-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: "",
+        CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
+        PLUGIN_DATA: dataDir,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.match(
+      status.degraded_reason,
+      /^managed_cli_provision_failed:managed_cli_asset_fetch_failed:SHA256SUMS\.txt:elapsed_ms=\d+:attempts=1:retry=restart_reload_status:/u,
+    );
+    assert.equal(status.plugin_runtime.cli_source, "path_fallback");
+    assert.deepEqual(status.path_candidates, []);
+    assert.equal(
+      status.plugin_runtime.warnings.includes("managed_cli_unavailable_no_path_fallback"),
+      true,
+    );
+    assert.match(status.readiness[0].minimum_next[0], /^Restart\/reload/u);
+    assert.equal(
+      status.readiness[0].minimum_next.some((step) => {
+        return /where\.exe codestory-cli|command -v codestory-cli|codestory-cli --version/u.test(step);
+      }),
+      false,
+    );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
 test("session-start hooks are thin and host manifests point at them", async () => {
   const hookConfig = JSON.parse(
     await readFile(join(pluginRoot, "hooks", "claude-codex-hooks.json"), "utf8"),


### PR DESCRIPTION
## Context

Closes #659.

The plugin-managed MCP launcher fetched `SHA256SUMS.txt` and the platform archive with a single 15s HTTPS request. A slow GitHub asset response could fail managed provisioning, then drift into PATH fallback even when PATH was intentionally absent.

## What Changed

- Added bounded release-asset download retry behavior in `plugins/codestory/scripts/codestory-mcp.cjs`: 60s per attempt, 3 attempts, short backoff, redirect cap, and partial-file cleanup before retry.
- Kept checksum verification intact: the archive is still verified against the fetched `SHA256SUMS.txt` before extraction and manifest write.
- Wrapped asset fetch failures with the failing asset name, elapsed time, attempt count, and retry guidance.
- When managed provisioning fails and no PATH CLI exists, fail-open status now keeps the managed provisioning failure as the primary repair reason and recommends managed-provision retry/reinstall guidance instead of PATH archaeology.
- Added focused plugin tests for transient download retry and no-PATH managed provisioning failure classification.

## How To Review

1. Review the downloader and managed-failure classification changes in `plugins/codestory/scripts/codestory-mcp.cjs`.
2. Review the new regression tests beside the existing managed release fixture in `plugins/codestory/tests/plugin-static.test.mjs`.
3. Confirm PATH fallback behavior is still covered when a PATH candidate exists.

## Verification

- `node --check plugins/codestory/scripts/codestory-mcp.cjs`
- `node --test --test-name-pattern "release asset downloader|managed provision failures" plugins/codestory/tests/plugin-static.test.mjs` - 2/2 passed
- `node --test --test-name-pattern "only unusable PATH fallback|managed cli probe fails" plugins/codestory/tests/plugin-static.test.mjs` - 2/2 passed
- `node --test plugins/codestory/tests/plugin-static.test.mjs` - 35/35 passed
- `git diff --check`

## Risk

Low. The change is limited to plugin-managed CLI provisioning and fail-open diagnostics. It does not add a PATH shim, does not skip checksum verification, and does not touch sidecar setup, packet/search ranking, Docker, cache cleanup, or Cargo code.
