### PR TITLE
Show agent repair progress

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -118,6 +118,7 @@ const CONTEXT_BUNDLE_OUTPUT_BYTE_CAP: usize = 5 * 1024 * 1024;
 const CONTEXT_BUNDLE_MARKDOWN_SOFT_CAP: usize = 2 * 1024 * 1024;
 const CONTEXT_BUNDLE_TRUNCATION_SUFFIX: &str =
     "\n\n... bundle content truncated by context bundle byte cap\n";
+const READY_REPAIR_PROGRESS_INTERVAL: Duration = Duration::from_secs(10);
 const READY_REPAIR_EMBED_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(10);
 const READY_REPAIR_EMBED_OBSERVATION_POLL: Duration = Duration::from_millis(250);
 const MAX_DRILL_JOBS: usize = 8;
@@ -627,6 +628,102 @@ fn format_progress_bar(current: u32, total: u32) -> String {
         "[{}{}]",
         "#".repeat(filled as usize),
         "-".repeat(WIDTH.saturating_sub(filled) as usize)
+    )
+}
+
+struct ReadyRepairProgress {
+    profile: &'static str,
+    run_id: String,
+    namespace: String,
+    phase: Arc<Mutex<&'static str>>,
+    done: Arc<AtomicBool>,
+    start: Instant,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ReadyRepairProgress {
+    fn start(sidecar: &codestory_retrieval::SidecarRuntimeConfig) -> Self {
+        let phase = Arc::new(Mutex::new("starting"));
+        let done = Arc::new(AtomicBool::new(false));
+        let start = Instant::now();
+        let profile = sidecar.profile.as_str();
+        let run_id = sidecar.run_id.as_deref().unwrap_or("none").to_string();
+        let namespace = sidecar.namespace.clone();
+        let worker_phase = Arc::clone(&phase);
+        let worker_done = Arc::clone(&done);
+        let worker_run_id = run_id.clone();
+        let worker_namespace = namespace.clone();
+        let handle = std::thread::spawn(move || {
+            while !worker_done.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(100));
+                if start.elapsed() < READY_REPAIR_PROGRESS_INTERVAL {
+                    continue;
+                }
+                let elapsed = start.elapsed().as_secs();
+                if elapsed % READY_REPAIR_PROGRESS_INTERVAL.as_secs() != 0 {
+                    continue;
+                }
+                let phase = *worker_phase.lock().expect("ready repair phase lock");
+                eprintln!(
+                    "{}",
+                    ready_repair_progress_line(
+                        phase,
+                        profile,
+                        &worker_run_id,
+                        &worker_namespace,
+                        elapsed,
+                        "active"
+                    )
+                );
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        });
+        Self {
+            profile,
+            run_id,
+            namespace,
+            phase,
+            done,
+            start,
+            handle: Some(handle),
+        }
+    }
+
+    fn set_phase(&self, phase: &'static str) {
+        *self.phase.lock().expect("ready repair phase lock") = phase;
+        eprintln!(
+            "{}",
+            ready_repair_progress_line(
+                phase,
+                self.profile,
+                &self.run_id,
+                &self.namespace,
+                self.start.elapsed().as_secs(),
+                "started"
+            )
+        );
+    }
+}
+
+impl Drop for ReadyRepairProgress {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn ready_repair_progress_line(
+    phase: &str,
+    profile: &str,
+    run_id: &str,
+    namespace: &str,
+    elapsed_s: u64,
+    status: &str,
+) -> String {
+    format!(
+        "[ready-repair] phase=\"{phase}\" profile={profile} run_id={run_id} namespace={namespace} elapsed_s={elapsed_s} status={status}"
     )
 }
 
@@ -2195,6 +2292,8 @@ fn repair_ready_state(
         sidecar.namespace,
         sidecar.compose_project
     );
+    let progress = ReadyRepairProgress::start(&sidecar);
+    progress.set_phase("container startup");
     let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime(
         &sidecar,
         Some(runtime.project_root.as_path()),
@@ -2204,6 +2303,7 @@ fn repair_ready_state(
         Duration::from_secs(90),
     )
     .context("ready repair retrieval bootstrap")?;
+    progress.set_phase("model/bootstrap");
     let infrastructure = ready_repair_infrastructure_with_runtime_observation(
         &bootstrap.infrastructure,
         &runtime.project_root,
@@ -2211,24 +2311,31 @@ fn repair_ready_state(
         &sidecar,
     );
     ensure_ready_repair_embed_liveness(&infrastructure)?;
+    progress.set_phase("Qdrant finalize");
     codestory_retrieval::repair_project_qdrant_collection(
         &runtime.project_root,
         &runtime.storage_path,
     )
     .context("ready repair project qdrant repair")?;
+    progress.set_phase("graph artifact");
     runtime
         .index
         .run_indexing_blocking(IndexMode::Full)
         .map_err(map_api_error)
         .context("ready repair retrieval index refresh")?;
-    retrieval::finalize_retrieval_index_for_sidecar_runtime(runtime, &sidecar).with_context(
-        || {
-            format!(
-                "ready repair retrieval index finalize using {}",
-                retrieval::format_sidecar_runtime(&sidecar)
-            )
-        },
-    )?;
+    codestory_retrieval::finalize_index_for_runtime_with_progress(
+        &runtime.project_root,
+        &runtime.storage_path,
+        &sidecar,
+        |phase| progress.set_phase(phase),
+    )
+    .with_context(|| {
+        format!(
+            "ready repair retrieval index finalize using {}",
+            retrieval::format_sidecar_runtime(&sidecar)
+        )
+    })?;
+    progress.set_phase("readiness check");
     let final_status = codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
@@ -12369,6 +12476,26 @@ mod tests {
         let mut unknown_full = ready_repair_test_report("full", None);
         unknown_full.embedding_device_state = "unknown".into();
         assert!(!ready_repair_existing_sidecar_is_reusable(&unknown_full));
+    }
+
+    #[test]
+    fn ready_repair_progress_line_names_phase_identity_and_status() {
+        let line = ready_repair_progress_line(
+            "Qdrant finalize",
+            "agent",
+            "shared-agent",
+            "codestory-agent",
+            10,
+            "active",
+        );
+
+        assert!(line.starts_with("[ready-repair] "));
+        assert!(line.contains("phase=\"Qdrant finalize\""));
+        assert!(line.contains("profile=agent"));
+        assert!(line.contains("run_id=shared-agent"));
+        assert!(line.contains("namespace=codestory-agent"));
+        assert!(line.contains("elapsed_s=10"));
+        assert!(line.contains("status=active"));
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2293,17 +2293,16 @@ fn repair_ready_state(
         sidecar.compose_project
     );
     let progress = ReadyRepairProgress::start(&sidecar);
-    progress.set_phase("container startup");
-    let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime(
+    let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime_progress(
         &sidecar,
         Some(runtime.project_root.as_path()),
         &storage_scope,
         None,
         false,
         Duration::from_secs(90),
+        |phase| progress.set_phase(phase),
     )
     .context("ready repair retrieval bootstrap")?;
-    progress.set_phase("model/bootstrap");
     let infrastructure = ready_repair_infrastructure_with_runtime_observation(
         &bootstrap.infrastructure,
         &runtime.project_root,

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -94,6 +94,26 @@ pub fn bootstrap_sidecars_with_runtime(
     skip_compose: bool,
     wait_timeout: Duration,
 ) -> Result<BootstrapReport> {
+    bootstrap_sidecars_with_runtime_progress(
+        runtime,
+        repo_root,
+        storage_scope,
+        compose_file,
+        skip_compose,
+        wait_timeout,
+        |_| {},
+    )
+}
+
+pub fn bootstrap_sidecars_with_runtime_progress(
+    runtime: &SidecarRuntimeConfig,
+    repo_root: Option<&Path>,
+    storage_scope: &BootstrapStorageScope,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+    mut progress: impl FnMut(&'static str),
+) -> Result<BootstrapReport> {
     let layout = runtime.layout.clone();
     runtime.activate_embed_url_default();
     layout.ensure_data_dirs()?;
@@ -111,13 +131,17 @@ pub fn bootstrap_sidecars_with_runtime(
     };
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
-        docker_compose_up(path, repo_root, runtime, launch_mode)?;
+        with_bootstrap_progress(&mut progress, "container startup", || {
+            docker_compose_up(path, repo_root, runtime, launch_mode)
+        })?;
         true
     } else {
         false
     };
     if let Some(launch) = native_embedding.as_ref() {
-        spawn_native_embedding_server(launch)?;
+        with_bootstrap_progress(&mut progress, "model/bootstrap", || {
+            spawn_native_embedding_server(launch)
+        })?;
     }
 
     let state = sidecar_up_with_runtime_and_launch_metadata(
@@ -128,7 +152,9 @@ pub fn bootstrap_sidecars_with_runtime(
             .map(|launch| embedding_launch_metadata(launch, runtime, repo_root)),
     )?;
     if !wait_timeout.is_zero() {
-        let _ = wait_for_infrastructure(&layout, wait_timeout)?;
+        let _ = with_bootstrap_progress(&mut progress, "model/bootstrap", || {
+            wait_for_infrastructure(&layout, wait_timeout)
+        })?;
     }
     let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
     let infrastructure = crate::health::probe_infrastructure_health_with_embedding_device(
@@ -143,6 +169,15 @@ pub fn bootstrap_sidecars_with_runtime(
         compose_file: resolved_compose,
         storage_repair,
     })
+}
+
+fn with_bootstrap_progress<T>(
+    progress: &mut impl FnMut(&'static str),
+    phase: &'static str,
+    action: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    progress(phase);
+    action()
 }
 
 /// Deprecated: pass [`BootstrapStorageScope::from_parts`] as the second argument to [`bootstrap_sidecars`].
@@ -872,6 +907,25 @@ mod tests {
             docker_compose_services_for_launch_mode(EmbeddingServerLaunchMode::DockerComposeEmbed)
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn bootstrap_progress_is_emitted_before_blocking_work() {
+        let phases = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let progress_phases = std::rc::Rc::clone(&phases);
+        let action_phases = std::rc::Rc::clone(&phases);
+
+        with_bootstrap_progress(
+            &mut |phase| progress_phases.borrow_mut().push(phase),
+            "model/bootstrap",
+            || {
+                assert_eq!(&*action_phases.borrow(), &["model/bootstrap"]);
+                Ok(())
+            },
+        )
+        .expect("progress wrapper should return action result");
+
+        assert_eq!(&*phases.borrow(), &["model/bootstrap"]);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -380,16 +380,17 @@ pub fn finalize_index_for_runtime_with_progress(
         }
     }
 
-    progress("lexical sidecar");
-    let zoekt_version = ensure_zoekt_generation(
-        project_root,
-        storage_path,
-        &layout,
-        &project_id,
-        &generation,
-        zoekt_probe.reachable,
-        zoekt_ready,
-    )?;
+    let zoekt_version = with_finalize_progress(&mut progress, "lexical sidecar", || {
+        ensure_zoekt_generation(
+            project_root,
+            storage_path,
+            &layout,
+            &project_id,
+            &generation,
+            zoekt_probe.reachable,
+            zoekt_ready,
+        )
+    })?;
 
     let _qdrant_point_count = ensure_qdrant_collection(
         storage_path,
@@ -402,38 +403,49 @@ pub fn finalize_index_for_runtime_with_progress(
         &mut progress,
     )?;
 
-    progress("graph artifact");
-    ensure_scip_artifacts(
-        storage_path,
-        &scip_dir,
-        &project_id,
-        &generation,
-        scip_ready,
-        &mut manifest,
-    )?;
+    with_finalize_progress(&mut progress, "graph artifact", || {
+        ensure_scip_artifacts(
+            storage_path,
+            &scip_dir,
+            &project_id,
+            &generation,
+            scip_ready,
+            &mut manifest,
+        )
+    })?;
     update_precise_semantic_import_status(&scip_dir, &mut manifest)?;
 
     manifest.zoekt_version = zoekt_version;
     manifest.scip_revision = read_scip_revision(&scip_dir).or(manifest.scip_revision);
     manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
 
-    progress("manifest write");
-    finalize_manifest_after_health_check(
-        storage_path,
-        &layout,
-        &qdrant_client,
-        project_id,
-        &collection,
-        &sidecar_input,
-        manifest,
-        degraded_modes,
-        SidecarStubFlags {
-            zoekt_stubbed,
-            qdrant_stubbed,
-            scip_stubbed,
-        },
-        &embedding_device,
-    )
+    with_finalize_progress(&mut progress, "manifest write", || {
+        finalize_manifest_after_health_check(
+            storage_path,
+            &layout,
+            &qdrant_client,
+            project_id,
+            &collection,
+            &sidecar_input,
+            manifest,
+            degraded_modes,
+            SidecarStubFlags {
+                zoekt_stubbed,
+                qdrant_stubbed,
+                scip_stubbed,
+            },
+            &embedding_device,
+        )
+    })
+}
+
+fn with_finalize_progress<T>(
+    progress: &mut impl FnMut(&'static str),
+    phase: &'static str,
+    action: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    progress(phase);
+    action()
 }
 
 fn ensure_zoekt_generation(
@@ -505,9 +517,9 @@ fn ensure_qdrant_collection(
             "Qdrant generated collection reused"
         );
     } else {
-        progress("embeddings");
-        let count =
-            upsert_qdrant_points_from_store(storage_path, project_root, qdrant_client, collection)?;
+        let count = with_finalize_progress(progress, "embeddings", || {
+            upsert_qdrant_points_from_store(storage_path, project_root, qdrant_client, collection)
+        })?;
         if count == 0 {
             bail!(
                 "mandatory Qdrant semantic collection has no indexed symbol points for {project_id}"
@@ -532,8 +544,9 @@ fn ensure_qdrant_collection(
             "Qdrant collection ensured and populated"
         );
     }
-    progress("Qdrant finalize");
-    ensure_qdrant_semantic_smoke(project_id, collection, qdrant_client)?;
+    with_finalize_progress(progress, "Qdrant finalize", || {
+        ensure_qdrant_semantic_smoke(project_id, collection, qdrant_client)
+    })?;
     Ok(qdrant_ready_points.unwrap_or_default())
 }
 
@@ -1197,6 +1210,25 @@ mod tests {
             error.to_string().contains("mandatory"),
             "expected mandatory-sidecar error, got {error:#}"
         );
+    }
+
+    #[test]
+    fn finalize_progress_is_emitted_before_blocking_work() {
+        let phases = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let progress_phases = std::rc::Rc::clone(&phases);
+        let action_phases = std::rc::Rc::clone(&phases);
+
+        with_finalize_progress(
+            &mut |phase| progress_phases.borrow_mut().push(phase),
+            "lexical sidecar",
+            || {
+                assert_eq!(&*action_phases.borrow(), &["lexical sidecar"]);
+                Ok(())
+            },
+        )
+        .expect("progress wrapper should return action result");
+
+        assert_eq!(&*phases.borrow(), &["lexical sidecar"]);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -191,6 +191,15 @@ pub fn finalize_index_for_runtime(
     storage_path: &Path,
     runtime: &SidecarRuntimeConfig,
 ) -> Result<FinalizeIndexOutcome> {
+    finalize_index_for_runtime_with_progress(project_root, storage_path, runtime, |_| {})
+}
+
+pub fn finalize_index_for_runtime_with_progress(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+    mut progress: impl FnMut(&'static str),
+) -> Result<FinalizeIndexOutcome> {
     runtime.activate_embed_url_default();
     let layout = runtime.layout.clone();
     layout.ensure_data_dirs()?;
@@ -371,6 +380,7 @@ pub fn finalize_index_for_runtime(
         }
     }
 
+    progress("lexical sidecar");
     let zoekt_version = ensure_zoekt_generation(
         project_root,
         storage_path,
@@ -389,8 +399,10 @@ pub fn finalize_index_for_runtime(
         &collection,
         sidecar_input.projection_count,
         qdrant_ready_points,
+        &mut progress,
     )?;
 
+    progress("graph artifact");
     ensure_scip_artifacts(
         storage_path,
         &scip_dir,
@@ -405,6 +417,7 @@ pub fn finalize_index_for_runtime(
     manifest.scip_revision = read_scip_revision(&scip_dir).or(manifest.scip_revision);
     manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
 
+    progress("manifest write");
     finalize_manifest_after_health_check(
         storage_path,
         &layout,
@@ -467,6 +480,7 @@ fn ensure_qdrant_collection(
     collection: &str,
     projection_count: i64,
     mut qdrant_ready_points: Option<u64>,
+    progress: &mut impl FnMut(&'static str),
 ) -> Result<u64> {
     if projection_count == 0 {
         info!(
@@ -491,6 +505,7 @@ fn ensure_qdrant_collection(
             "Qdrant generated collection reused"
         );
     } else {
+        progress("embeddings");
         let count =
             upsert_qdrant_points_from_store(storage_path, project_root, qdrant_client, collection)?;
         if count == 0 {
@@ -517,6 +532,7 @@ fn ensure_qdrant_collection(
             "Qdrant collection ensured and populated"
         );
     }
+    progress("Qdrant finalize");
     ensure_qdrant_semantic_smoke(project_id, collection, qdrant_client)?;
     Ok(qdrant_ready_points.unwrap_or_default())
 }

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -71,7 +71,8 @@ pub use health::{
 };
 pub use index::{
     FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, finalize_index_for_runtime,
-    project_id_for_root, repair_project_qdrant_collection, sidecar_project_id_for_root,
+    finalize_index_for_runtime_with_progress, project_id_for_root,
+    repair_project_qdrant_collection, sidecar_project_id_for_root,
 };
 pub use inventory::{
     SidecarDockerResource, SidecarDockerResourceKind, SidecarGcNamespaceResult, SidecarGcReport,

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -45,8 +45,9 @@ pub use capabilities::SidecarCapabilities;
 pub use compose::bootstrap_sidecars_without_storage_scope;
 pub use compose::{
     BootstrapReport, DEFAULT_COMPOSE_REL_PATH, EmbedModelInventory, bootstrap_sidecars,
-    bootstrap_sidecars_with_profile, bootstrap_sidecars_with_runtime, docker_available,
-    embed_model_inventory, resolve_compose_file,
+    bootstrap_sidecars_with_profile, bootstrap_sidecars_with_runtime,
+    bootstrap_sidecars_with_runtime_progress, docker_available, embed_model_inventory,
+    resolve_compose_file,
 };
 pub use config::{
     DEFAULT_AGENT_RUN_ID, DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT,


### PR DESCRIPTION
## Context

Closes #665.
Refs #661.

`ready --goal agent --repair` can spend a long time bootstrapping and finalizing agent sidecar retrieval while stdout stays reserved for final JSON. The issue evidence from June 26 showed a successful repair that reached full agent packet/search readiness, but looked opaque because it printed only the initial sidecar line until completion.

This PR is the CLI-side progress slice. It does not close the parent #661 MCP/status acceptance; #661 remains open for `codestory://status` reporting `agent_packet_search.status=repairing` with current phase from shared repair state.

## What Changed

- Added a `ready --goal agent --repair` stderr progress heartbeat that emits the active phase immediately and repeats it every 10 seconds while repair work is active.
- Included the required repair identity fields on each progress line: `phase`, `profile`, `run_id`, `namespace`, elapsed seconds, and status.
- Added phase callbacks before blocking bootstrap work for container startup, native/model bootstrap, and infrastructure readiness wait.
- Added phase callbacks before retrieval finalization work at existing CodeStory-controlled boundaries: lexical sidecar, embeddings, Qdrant finalize, graph artifact, and manifest write.
- Kept final command output on stdout unchanged, so `--format json` remains machine-readable.

## How To Review

1. Start in `crates/codestory-cli/src/main.rs` at the `ReadyRepairProgress` helper and `repair_ready_state` phase calls.
2. Check `crates/codestory-retrieval/src/compose.rs` for bootstrap progress emitted before Docker/native/wait work.
3. Check `crates/codestory-retrieval/src/index.rs` for no-op-by-default finalization callbacks emitted before each finalization phase.
4. Confirm the callback APIs are only exported from `crates/codestory-retrieval/src/lib.rs` for CLI repair progress.

## Verification

- `cargo fmt --check`
- `cargo test -p codestory-cli ready_repair_`
- `cargo test -p codestory-retrieval progress_is_emitted_before_blocking_work` (2 selected tests)
- `git diff --check`

## Risk

The progress surface is intentionally CLI-scoped and writes to stderr. `codestory://status` does not yet report `agent_packet_search.status=repairing`; doing that truthfully needs a shared in-progress repair state visible to the MCP/status process and remains on #661.
