### PR TITLE
Bootstrap managed plugin runtime

### DIFF
--- a/plugins/codestory/hooks/claude-codex-hooks.json
+++ b/plugins/codestory/hooks/claude-codex-hooks.json
@@ -8,7 +8,7 @@
             "type": "command",
             "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.cjs\" || exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.cjs\" }",
-            "timeout": 5,
+            "timeout": 300,
             "statusMessage": "Loading CodeStory grounding..."
           }
         ]
@@ -21,7 +21,7 @@
             "type": "command",
             "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.cjs\" || exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.cjs\" }",
-            "timeout": 5,
+            "timeout": 300,
             "statusMessage": "Preparing CodeStory packet..."
           }
         ]

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -4,6 +4,7 @@ const { spawnSync } = require('child_process');
 const { createHash } = require('crypto');
 const { eventHeader, getCodeStoryInstructions } = require('./codestory-instructions.cjs');
 const {
+  bootstrapManagedRuntime,
   classifyMcpRuntime,
   dirtyMarkerPathForProject,
   mcpDetectionText,
@@ -29,6 +30,7 @@ const EVENT_CAPS = {
 };
 const RUNTIME_TIMEOUT_MS = 3500;
 const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
+const BOOTSTRAP_TAXONOMIES = new Set(['startup', 'clear', 'child_worktree_start', 'session']);
 
 function readHookInput() {
   return new Promise((resolve) => {
@@ -172,6 +174,27 @@ function runtimeStatusBlock(policy, mcp) {
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
   ].join('\n');
+}
+
+function shouldBootstrapManagedRuntime(policy, mcp) {
+  if (process.env.CODESTORY_CLI) return false;
+  if (!BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) return false;
+  return Boolean(policy.project && mcp.mcp_process_launchable && !mcp.mcp_resources_exposed);
+}
+
+function bootstrapText(bootstrap) {
+  if (!bootstrap || !bootstrap.attempted) return null;
+  const status = bootstrap.parsed || {};
+  const plugin = status.plugin_runtime || {};
+  const localRefresh = status.local_refresh || status.readiness?.[0]?.local_refresh || {};
+  const reason = status.degraded_reason || status.readiness?.[0]?.repair_reason || bootstrap.error || bootstrap.stderr;
+  return [
+    `managed_bootstrap: ${bootstrap.ready ? 'ready' : 'blocked'}`,
+    `managed_bootstrap_cli_source: ${plugin.cli_source || '<unknown>'}`,
+    plugin.managed_binary_path ? `managed_bootstrap_cli_path: ${plugin.managed_binary_path}` : null,
+    `managed_bootstrap_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
+    reason ? `managed_bootstrap_reason: ${truncate(reason, 500)}` : null,
+  ].filter(Boolean).join('\n');
 }
 
 function firstFreshness(value) {
@@ -348,7 +371,14 @@ function runCodeStory(input, event, policy, state = {}) {
     };
   }
 
-  const mcp = classifyMcpRuntime();
+  let mcp = classifyMcpRuntime();
+  const bootstrap = shouldBootstrapManagedRuntime(policy, mcp)
+    ? bootstrapManagedRuntime({ projectRoot: policy.project })
+    : null;
+  if (bootstrap?.attempted) {
+    mcp = classifyMcpRuntime();
+  }
+  const bootstrapBlock = bootstrapText(bootstrap);
   if (policy.runtimeOnly) {
     const heartbeatProbe = policy.heartbeat
       ? heartbeatReadinessProbe(mcp, policy.project, input.cwd || process.cwd())
@@ -377,12 +407,13 @@ function runCodeStory(input, event, policy, state = {}) {
         `event_taxonomy: ${policy.taxonomy}`,
         `output_cap_chars: ${policy.cap}`,
         `dedupe_key: ${policy.dedupeKey}`,
+        bootstrapBlock,
         mcpDetectionText(mcp),
         mcp.mcp_resources_exposed
           ? 'Use codestory://status as the active runtime truth. Run packet/search/context only when status allows that surface with retrieval_mode=full.'
           : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Reload the host/plugin and read codestory://status; do not add CodeStory to PATH.',
       ].join('\n'), policy.cap),
-      fingerprint: runtimeFingerprint(mcp),
+      fingerprint: `${runtimeFingerprint(mcp)}|${bootstrapBlock || 'no-bootstrap'}`,
     };
   }
 

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const { createHash } = require('crypto');
 
 const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
@@ -79,6 +80,16 @@ function mcpScriptExists(root, args) {
   return fs.existsSync(path.resolve(root, scriptArg));
 }
 
+function mcpScriptPath(root, args) {
+  const scriptArg = args.find((arg) => typeof arg === 'string' && /codestory-mcp\.cjs$/u.test(arg));
+  return scriptArg ? path.resolve(root, scriptArg) : null;
+}
+
+function bootstrapTimeoutMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_BOOTSTRAP_TIMEOUT_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 240000;
+}
+
 function managedCliInfo(dataDir = pluginDataDir(), version = pluginVersion()) {
   if (!dataDir) return { present: false, path: null, source: null };
   const runtime = readJson(path.join(dataDir, MCP_RUNTIME_FILE));
@@ -128,6 +139,44 @@ function classifyMcpRuntime(options = {}) {
     managed_cli_path: managed.path,
     managed_cli_source: managed.source,
     degraded_no_surface: !resourcesExposed && !managed.present,
+  };
+}
+
+function bootstrapManagedRuntime(options = {}) {
+  const root = options.pluginRoot || pluginRoot();
+  const dataDir = options.pluginDataDir === undefined ? pluginDataDir() : options.pluginDataDir;
+  const projectRoot = normalizeProjectRoot(options.projectRoot || process.cwd());
+  const mcp = configuredMcp(root);
+  const scriptPath = mcpScriptPath(root, mcp.args);
+  if (!dataDir) return { attempted: false, reason: 'plugin_data_required' };
+  if (!mcp.installed || mcp.command !== 'node' || !scriptPath || !fs.existsSync(scriptPath)) {
+    return { attempted: false, reason: 'mcp_launcher_unavailable' };
+  }
+
+  const result = spawnSync(process.execPath, [scriptPath, 'bootstrap-status', '--project', projectRoot], {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: bootstrapTimeoutMs(),
+    maxBuffer: 20000,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      PLUGIN_DATA: dataDir,
+    },
+  });
+  let status = null;
+  try {
+    status = JSON.parse(result.stdout || '{}');
+  } catch (error) {
+    status = { ready: false, degraded_reason: `bootstrap_status_invalid_json:${error.message}` };
+  }
+  return {
+    attempted: true,
+    status: result.status,
+    error: result.error ? result.error.message : null,
+    stderr: result.stderr || '',
+    ready: status?.ready === true,
+    parsed: status,
   };
 }
 
@@ -421,6 +470,7 @@ function writeHookOutput(event, context) {
 }
 
 module.exports = {
+  bootstrapManagedRuntime,
   classifyMcpRuntime,
   dirtyMarkerPathForProject,
   dirtyHookStatus,

--- a/plugins/codestory/hooks/copilot-hooks.json
+++ b/plugins/codestory/hooks/copilot-hooks.json
@@ -6,7 +6,7 @@
         "type": "command",
         "bash": "node \"${PLUGIN_ROOT}/hooks/codestory-activate.cjs\"",
         "powershell": "node \"${PLUGIN_ROOT}\\hooks\\codestory-activate.cjs\"",
-        "timeoutSec": 5
+        "timeoutSec": 300
       }
     ]
   }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -128,6 +128,11 @@ function repairCommandForProject(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
 
+function optionValue(argv, name) {
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : null;
+}
+
 function dirtyMarkerEnv(projectRoot = process.cwd()) {
   const markerPath = dirtyMarkerPathForProject(projectRoot, pluginDataDir());
   const normalizedRoot = (() => {
@@ -624,7 +629,12 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
     );
   }
   if (parsedProbe.ok) {
-    return { ready: true };
+    return {
+      ready: true,
+      setup,
+      verdict: parsedProbe.verdict || null,
+      localRefresh: parsedProbe.localRefresh || null,
+    };
   }
   const verdict = parsedProbe.verdict || null;
   const status = typeof verdict?.status === 'string' ? verdict.status : 'repair_setup';
@@ -640,8 +650,28 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
   );
 }
 
+function pluginRuntimeForResolved(resolved) {
+  return {
+    plugin_version: resolved.version,
+    plugin_root: pluginRoot,
+    plugin_cache_version: pluginCacheVersion(),
+    plugin_data: pluginDataDir(),
+    cli_source: resolved.source,
+    cli_path: resolved.path,
+    cli_sha256: resolved.sha256,
+    build_source: resolved.buildSource,
+    repo_ref: resolved.repoRef,
+    local_dev_override: resolved.source === 'local_dev_override',
+    path_fallback: resolved.source === 'path_fallback',
+    managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
+    managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
+    managed_manifest_path: resolved.manifestPath || null,
+    warnings: resolved.warnings.filter(Boolean),
+  };
+}
+
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {
-  const projectRoot = process.cwd();
+  const projectRoot = options.projectRoot || process.cwd();
   const pathCandidates = pathCliCandidates().map((candidate) => ({
     path: candidate,
     version: cliVersion(candidate),
@@ -660,23 +690,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   const fullRepair = options.fullRepair || minimumNext;
   const recommendedNext = options.recommendedNext || fullRepair;
   const sidecarPolicy = readSidecarPolicy();
-  const plugin = {
-    plugin_version: resolved.version,
-    plugin_root: pluginRoot,
-    plugin_cache_version: pluginCacheVersion(),
-    plugin_data: pluginDataDir(),
-    cli_source: resolved.source,
-    cli_path: resolved.path,
-    cli_sha256: resolved.sha256,
-    build_source: resolved.buildSource,
-    repo_ref: resolved.repoRef,
-    local_dev_override: resolved.source === 'local_dev_override',
-    path_fallback: resolved.source === 'path_fallback',
-    managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
-    managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
-    managed_manifest_path: resolved.manifestPath || null,
-    warnings: [...resolved.warnings, reason].filter(Boolean),
-  };
+  const plugin = pluginRuntimeForResolved({ ...resolved, warnings: [...resolved.warnings, reason] });
   const repair = {
     goal: options.goal || 'local_navigation',
     status: options.status || 'repair_setup',
@@ -759,6 +773,85 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
         : { method: 'cli', command }),
     ],
   };
+}
+
+async function bootstrapStatus(projectRoot = process.cwd()) {
+  const resolved = await resolveCli();
+  rememberLaunch(resolved);
+  const probe = probeResolvedCli(resolved);
+  const failOpenReason = failOpenReasonForProbe(resolved, probe);
+  if (failOpenReason) {
+    return {
+      ready: false,
+      ...fallbackDiagnostic(resolved, probe, failOpenReason, { projectRoot }),
+    };
+  }
+
+  const localReadiness = probeLocalNavigation(resolved, projectRoot);
+  if (!localReadiness.ready) {
+    return {
+      ready: false,
+      ...fallbackDiagnostic(resolved, probe, localReadiness.reason, {
+        projectRoot,
+        status: localReadiness.status,
+        summary: localReadiness.summary,
+        minimumNext: localReadiness.minimumNext,
+        fullRepair: localReadiness.fullRepair,
+        localRefresh: localReadiness.localRefresh,
+        setup: localReadiness.setup,
+      }),
+    };
+  }
+
+  const sidecarPolicy = readSidecarPolicy();
+  const plugin = pluginRuntimeForResolved(resolved);
+  const localRefresh = localReadiness.localRefresh || {
+    state: 'fresh',
+    blocks_local_surfaces: false,
+    readiness_status: 'ready',
+  };
+  const repair = {
+    goal: 'local_navigation',
+    status: 'ready',
+    summary: localReadiness.verdict?.summary || 'CodeStory local navigation is ready.',
+    repair_reason: null,
+    local_refresh: localRefresh,
+    minimum_next: [{ method: 'resources/read', uri: 'codestory://status' }],
+    full_repair: [],
+    setup: {
+      ...localReadiness.setup,
+      readiness_verdict: localReadiness.verdict,
+    },
+  };
+  return {
+    ready: true,
+    project_root: projectRoot,
+    server_version: resolved.version,
+    cli_version: probe.version,
+    plugin_runtime: plugin,
+    runtime_truth: runtimeTruthStatus(plugin, repair, {
+      sidecarPolicy: sidecarPolicy.state || 'unavailable',
+      localRefresh,
+    }),
+    local_refresh: localRefresh,
+    readiness: [repair],
+    recommended_next_calls: [{ method: 'resources/read', uri: 'codestory://status' }],
+  };
+}
+
+async function handleBootstrapStatusCommand(argv) {
+  if (argv[2] !== 'bootstrap-status') return false;
+  const projectRoot = optionValue(argv, '--project') || process.cwd();
+  try {
+    process.stdout.write(`${JSON.stringify(await bootstrapStatus(projectRoot))}\n`);
+  } catch (error) {
+    process.stdout.write(`${JSON.stringify({
+      ready: false,
+      degraded_reason: `launcher_error:${error.message}`,
+      project_root: projectRoot,
+    })}\n`);
+  }
+  process.exit(0);
 }
 
 function pathCliCandidates() {
@@ -976,6 +1069,7 @@ function rememberLaunch(resolved) {
 }
 
 async function main() {
+  if (await handleBootstrapStatusCommand(process.argv)) return;
   handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1136,6 +1136,60 @@ test("session-start hooks are thin and host manifests point at them", async () =
   assert.equal(manifest.hooks, "./hooks/claude-codex-hooks.json");
 });
 
+test("hook manifest timeouts cover managed bootstrap budget", async () => {
+  const hookConfig = JSON.parse(
+    await readFile(join(pluginRoot, "hooks", "claude-codex-hooks.json"), "utf8"),
+  );
+  const copilotHookConfig = JSON.parse(
+    await readFile(join(pluginRoot, "hooks", "copilot-hooks.json"), "utf8"),
+  );
+  const runtimeSource = await readFile(join(pluginRoot, "hooks", "codestory-runtime.cjs"), "utf8");
+  const mcpSource = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8");
+  const numberFrom = (text, pattern, label) => {
+    const match = text.match(pattern);
+    assert.ok(match, `missing ${label}`);
+    return Number.parseInt(match[1], 10);
+  };
+
+  const bootstrapTimeoutMs = numberFrom(
+    runtimeSource,
+    /function bootstrapTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
+    "bootstrap timeout default",
+  );
+  const releaseDownloadTimeoutMs = numberFrom(
+    mcpSource,
+    /const releaseDownloadTimeoutMs = (\d+);/u,
+    "release download timeout",
+  );
+  const releaseDownloadAttempts = numberFrom(
+    mcpSource,
+    /const releaseDownloadAttempts = (\d+);/u,
+    "release download attempts",
+  );
+  const localWaitFreshTimeoutMs = numberFrom(
+    mcpSource,
+    /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
+    "local wait-fresh timeout default",
+  );
+  const requiredTimeoutSec = Math.max(
+    Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
+    Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),
+  );
+  const claudeTimeouts = Object.values(hookConfig.hooks)
+    .flat()
+    .flatMap((entry) => entry.hooks)
+    .map((hook) => hook.timeout);
+  const copilotTimeouts = copilotHookConfig.hooks.sessionStart.map((hook) => hook.timeoutSec);
+
+  for (const timeoutSec of [...claudeTimeouts, ...copilotTimeouts]) {
+    assert.equal(typeof timeoutSec, "number");
+    assert.ok(
+      timeoutSec >= requiredTimeoutSec,
+      `hook timeout ${timeoutSec}s must cover managed bootstrap budget ${requiredTimeoutSec}s`,
+    );
+  }
+});
+
 async function withFakeCodeStoryCli(callback) {
   const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-test-"));
   const shPath = join(binDir, "codestory-cli");

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -937,6 +937,74 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
+test("startup hook bootstraps managed cli before reporting MCP visibility", async (t) => {
+  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
+  if (tarProbe.status !== 0) {
+    t.skip("tar unavailable for archive fixture");
+    return;
+  }
+
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-bootstrap-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-hook-release-"));
+  const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
+  const { archiveBase, archiveName } = releaseAssetForPlatform(version);
+  const stageDir = join(releaseDir, archiveBase);
+  const cliPath = join(stageDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const archivePath = join(releaseDir, archiveName);
+
+  try {
+    await mkdir(stageDir, { recursive: true });
+    await writeFakeCli(cliPath);
+    const packArgs = archiveName.endsWith(".zip")
+      ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
+      : ["-czf", archivePath, "-C", releaseDir, archiveBase];
+    const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
+    assert.equal(pack.status, 0, pack.stderr);
+    const archiveSha256 = createHash("sha256")
+      .update(await readFile(archivePath))
+      .digest("hex");
+    await writeFile(join(releaseDir, "SHA256SUMS.txt"), `${archiveSha256}  ${archiveName}\n`, "utf8");
+
+    const result = spawnSync(process.execPath, [hookPath], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: "",
+        CODESTORY_MCP_RESOURCES_EXPOSED: "",
+        CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
+        COPILOT_PLUGIN_DATA: "",
+        PLUGIN_DATA: dataDir,
+      },
+      input: JSON.stringify({
+        hook_event_name: "SessionStart",
+        source: "startup",
+        cwd: repoRoot,
+      }),
+      encoding: "utf8",
+      timeout: 30000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
+    assert.match(context, /managed_bootstrap: ready/u);
+    assert.match(context, /managed_bootstrap_cli_source: managed/u);
+    assert.match(context, /managed_bootstrap_local_refresh: fresh/u);
+    assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+    assert.match(context, /managed_cli_present: yes/u);
+    assert.doesNotMatch(context, /where\.exe codestory-cli|command -v codestory-cli|adding CodeStory to PATH/u);
+
+    const manifest = JSON.parse(
+      await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
+    );
+    assert.equal(manifest.version, version);
+    assert.equal(manifest.build_source, "github_release");
+    assert.equal(manifest.archive_sha256, archiveSha256);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
 test("release asset downloader retries a transient failure", async () => {
   const { EventEmitter } = await import("node:events");
   const { PassThrough } = await import("node:stream");


### PR DESCRIPTION
## Context

Closes #658
Refs #618, #662

Fresh plugin installs can reach a state where `.mcp.json` is launchable but the active Codex model context still does not expose `codestory://status`. Before this change, the lifecycle hook only classified that state. If no managed CLI manifest/runtime state existed yet, the hook reported `managed_cli_present: no` and left the user to manually launch the packaged MCP path.

#662 remains the owner for host/model-context MCP resource injection. This PR only fixes the CodeStory-controlled bootstrap path before that boundary.

## What Changed

- Added a `bootstrap-status` mode to `plugins/codestory/scripts/codestory-mcp.cjs` that reuses the existing managed CLI provisioner and local `ready --goal local --wait-fresh` check, then exits with compact JSON instead of starting stdio serve.
- Added a lifecycle-hook bootstrap helper in `codestory-runtime.cjs` and invoked it from repo-scoped startup/session hooks when MCP is launchable but resources are not model-visible.
- Raised shipped Claude/Codex and Copilot hook manifest timeouts to cover the managed bootstrap budget instead of letting the host kill the hook at 5s.
- Kept no-PATH behavior: the hook does not require `CODESTORY_CLI` or recommend adding `codestory-cli` to PATH.
- Added plugin static regressions for fresh-install managed bootstrap and for the manifest-timeout/bootstrap-budget contract.

```mermaid
flowchart TD
  A[Repo-scoped startup hook] --> B{MCP launchable?}
  B -->|no| C[existing degraded notice]
  B -->|yes| D{resources model-visible?}
  D -->|yes| E[read codestory://status]
  D -->|no| F[run launcher bootstrap-status]
  F --> G[provision managed CLI]
  G --> H[ready --goal local --wait-fresh]
  H --> I[hook reports managed path and local refresh]
  I --> J[#662 still owns model visibility]
```

## How To Review

Start with the new launcher mode in `plugins/codestory/scripts/codestory-mcp.cjs`, then the hook call site in `plugins/codestory/hooks/codestory-activate.cjs`. For the review follow-up, check the hook manifest timeout values and the `hook manifest timeouts cover managed bootstrap budget` test in `plugins/codestory/tests/plugin-static.test.mjs`.

## Verification

- `node --test --test-name-pattern "hook manifest timeouts|startup hook bootstraps" plugins\codestory\tests\plugin-static.test.mjs` -> 2/2 pass
- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> 37/37 pass
- `git diff --check` -> pass
- CodeStory affected analysis -> matched `plugin-static.test.mjs`; static JSON hook manifests were unmatched by the graph but are read directly by the new regression

## Risk

The first repo-scoped startup/session hook can now spend bounded time provisioning release assets and running local wait-fresh. The shipped hook manifests now allow 300s so the hook can return the managed bootstrap result instead of being killed by the host at 5s. This PR does not make `codestory://status` model-visible when the host does not inject MCP resources; that remains #662.
