### PR TITLE
Report active agent repair status

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1603,6 +1603,14 @@ pub(crate) struct ReadinessLaneOutput {
     pub(crate) profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) namespace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) compose_project: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) repair_updated_at_epoch_ms: Option<i64>,
     pub(crate) sidecar_mode: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) degraded_reason: Option<String>,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -34,7 +34,7 @@ use std::{
     fs,
     io::{IsTerminal, Read},
     net::TcpListener,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -52,6 +52,7 @@ mod managed_embeddings;
 mod output;
 mod query_resolution;
 mod readiness;
+mod ready_repair_status;
 mod report;
 mod retrieval;
 mod runtime;
@@ -635,24 +636,40 @@ struct ReadyRepairProgress {
     profile: &'static str,
     run_id: String,
     namespace: String,
+    project_root: PathBuf,
     phase: Arc<Mutex<&'static str>>,
     done: Arc<AtomicBool>,
     start: Instant,
+    started_at_epoch_ms: i64,
+    pid: u32,
+    sidecar: codestory_retrieval::SidecarRuntimeConfig,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl ReadyRepairProgress {
-    fn start(sidecar: &codestory_retrieval::SidecarRuntimeConfig) -> Self {
+    fn start(sidecar: &codestory_retrieval::SidecarRuntimeConfig, project_root: &Path) -> Self {
         let phase = Arc::new(Mutex::new("starting"));
         let done = Arc::new(AtomicBool::new(false));
         let start = Instant::now();
+        let started_at_epoch_ms = ready_repair_status::now_epoch_ms();
+        let pid = std::process::id();
         let profile = sidecar.profile.as_str();
         let run_id = sidecar.run_id.as_deref().unwrap_or("none").to_string();
         let namespace = sidecar.namespace.clone();
+        let project_root = project_root.to_path_buf();
+        let sidecar_for_worker = sidecar.clone();
         let worker_phase = Arc::clone(&phase);
         let worker_done = Arc::clone(&done);
         let worker_run_id = run_id.clone();
         let worker_namespace = namespace.clone();
+        let worker_project_root = project_root.clone();
+        let _ = ready_repair_status::write_ready_repair_status(
+            sidecar,
+            &project_root,
+            "starting",
+            started_at_epoch_ms,
+            pid,
+        );
         let handle = std::thread::spawn(move || {
             while !worker_done.load(Ordering::SeqCst) {
                 std::thread::sleep(Duration::from_millis(100));
@@ -675,6 +692,13 @@ impl ReadyRepairProgress {
                         "active"
                     )
                 );
+                let _ = ready_repair_status::write_ready_repair_status(
+                    &sidecar_for_worker,
+                    &worker_project_root,
+                    phase,
+                    started_at_epoch_ms,
+                    pid,
+                );
                 std::thread::sleep(Duration::from_secs(1));
             }
         });
@@ -682,9 +706,13 @@ impl ReadyRepairProgress {
             profile,
             run_id,
             namespace,
+            project_root,
             phase,
             done,
             start,
+            started_at_epoch_ms,
+            pid,
+            sidecar: sidecar.clone(),
             handle: Some(handle),
         }
     }
@@ -702,6 +730,13 @@ impl ReadyRepairProgress {
                 "started"
             )
         );
+        let _ = ready_repair_status::write_ready_repair_status(
+            &self.sidecar,
+            &self.project_root,
+            phase,
+            self.started_at_epoch_ms,
+            self.pid,
+        );
     }
 }
 
@@ -711,6 +746,11 @@ impl Drop for ReadyRepairProgress {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
+        ready_repair_status::clear_ready_repair_status(
+            &self.sidecar,
+            self.started_at_epoch_ms,
+            self.pid,
+        );
     }
 }
 
@@ -2292,7 +2332,7 @@ fn repair_ready_state(
         sidecar.namespace,
         sidecar.compose_project
     );
-    let progress = ReadyRepairProgress::start(&sidecar);
+    let progress = ReadyRepairProgress::start(&sidecar, &runtime.project_root);
     let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime_progress(
         &sidecar,
         Some(runtime.project_root.as_path()),
@@ -10722,6 +10762,12 @@ pub(crate) fn build_readiness_lanes_for_runtime(
             &project_arg,
         ),
     );
+    apply_ready_repair_status_overlay(
+        &mut lanes,
+        &runtime.project_root,
+        agent_run_id,
+        &project_arg,
+    );
     lanes
 }
 
@@ -10750,10 +10796,40 @@ fn readiness_lane_output(
             .clone()
             .unwrap_or_else(|| "unknown".to_string()),
         run_id: sidecar.run_id.clone(),
+        namespace: None,
+        compose_project: None,
+        phase: None,
+        repair_updated_at_epoch_ms: None,
         sidecar_mode: sidecar.retrieval_mode.clone(),
         degraded_reason: sidecar.degraded_reason.clone(),
         next_command: lane_next_command(lane, sidecar, status, verdict, project_arg),
     }
+}
+
+fn apply_ready_repair_status_overlay(
+    lanes: &mut BTreeMap<String, ReadinessLaneOutput>,
+    project_root: &Path,
+    agent_run_id: Option<&str>,
+    project_arg: &str,
+) {
+    let Some(status) = ready_repair_status::active_ready_repair_status(project_root, agent_run_id)
+    else {
+        return;
+    };
+    let Some(lane) = lanes.get_mut("agent_packet_search") else {
+        return;
+    };
+    lane.status = ReadinessStatusDto::Repairing;
+    lane.profile = status.profile;
+    lane.run_id = status.run_id.clone();
+    lane.namespace = Some(status.namespace);
+    lane.compose_project = Some(status.compose_project);
+    lane.phase = Some(status.phase);
+    lane.repair_updated_at_epoch_ms = Some(status.updated_at_epoch_ms);
+    lane.next_command = Some(retrieval_status_command_for_agent(
+        project_arg,
+        status.run_id.as_deref(),
+    ));
 }
 
 fn readiness_lane_status(
@@ -10807,6 +10883,17 @@ fn agent_ready_repair_command(project_arg: &str, run_id: Option<&str>) -> String
         command.push_str(" --run-id ");
         command.push_str(&display::quote_command_argument_value(run_id));
     }
+    command
+}
+
+fn retrieval_status_command_for_agent(project_arg: &str, run_id: Option<&str>) -> String {
+    let mut command =
+        format!("codestory-cli retrieval status --project {project_arg} --profile agent");
+    if let Some(run_id) = run_id {
+        command.push_str(" --run-id ");
+        command.push_str(&display::quote_command_argument_value(run_id));
+    }
+    command.push_str(" --format json");
     command
 }
 

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -137,6 +137,7 @@ pub(crate) fn primary_non_ready(verdicts: &[ReadinessVerdictDto]) -> Option<&Rea
 pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
     match status {
         ReadinessStatusDto::Ready => "ready",
+        ReadinessStatusDto::Repairing => "repairing",
         ReadinessStatusDto::RepairSetup => "repair_setup",
         ReadinessStatusDto::RepairIndex => "repair_index",
         ReadinessStatusDto::CheckIndex => "check_index",
@@ -147,6 +148,7 @@ pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
 pub(crate) fn failed_layer(verdict: &ReadinessVerdictDto) -> Option<&'static str> {
     match verdict.status {
         ReadinessStatusDto::Ready => None,
+        ReadinessStatusDto::Repairing => Some("retrieval_sidecar"),
         ReadinessStatusDto::RepairSetup => Some("runtime_setup"),
         ReadinessStatusDto::RepairIndex => Some("local_index"),
         ReadinessStatusDto::CheckIndex => Some("index_freshness"),
@@ -174,7 +176,9 @@ pub(crate) fn local_refresh_state_label(state: LocalRefreshState) -> &'static st
 pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefreshOutput {
     let index = verdict.index.as_ref();
     let state = match verdict.status {
-        ReadinessStatusDto::Ready | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Fresh,
+        ReadinessStatusDto::Ready
+        | ReadinessStatusDto::Repairing
+        | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Fresh,
         ReadinessStatusDto::CheckIndex => LocalRefreshState::NotChecked,
         ReadinessStatusDto::RepairSetup => LocalRefreshState::Failed,
         ReadinessStatusDto::RepairIndex => {

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -1,0 +1,290 @@
+use anyhow::Result;
+use codestory_retrieval::{
+    DEFAULT_AGENT_RUN_ID, SidecarProfile, SidecarRuntimeConfig,
+    sidecar_runtime_for_project_with_run_id,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const READY_REPAIR_STATUS_FILE: &str = "ready-repair-status.json";
+const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
+const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ReadyRepairStatus {
+    pub(crate) schema_version: u32,
+    pub(crate) status: String,
+    pub(crate) project_root: String,
+    pub(crate) profile: String,
+    pub(crate) run_id: Option<String>,
+    pub(crate) namespace: String,
+    pub(crate) compose_project: String,
+    pub(crate) phase: String,
+    pub(crate) pid: u32,
+    pub(crate) started_at_epoch_ms: i64,
+    pub(crate) updated_at_epoch_ms: i64,
+}
+
+pub(crate) fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
+pub(crate) fn write_ready_repair_status(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+    phase: &str,
+    started_at_epoch_ms: i64,
+    pid: u32,
+) -> Result<()> {
+    let path = ready_repair_status_path(sidecar);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let status = ReadyRepairStatus {
+        schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+        status: "repairing".to_string(),
+        project_root: clean_path_text(project_root),
+        profile: sidecar.profile.as_str().to_string(),
+        run_id: sidecar.run_id.clone(),
+        namespace: sidecar.namespace.clone(),
+        compose_project: sidecar.compose_project.clone(),
+        phase: phase.to_string(),
+        pid,
+        started_at_epoch_ms,
+        updated_at_epoch_ms: now_epoch_ms(),
+    };
+    let json = serde_json::to_string_pretty(&status)?;
+    Ok(fs::write(path, json)?)
+}
+
+pub(crate) fn clear_ready_repair_status(
+    sidecar: &SidecarRuntimeConfig,
+    started_at_epoch_ms: i64,
+    pid: u32,
+) {
+    let path = ready_repair_status_path(sidecar);
+    let Some(status) = read_ready_repair_status_file(&path) else {
+        return;
+    };
+    if status.pid == pid && status.started_at_epoch_ms == started_at_epoch_ms {
+        let _ = fs::remove_file(path);
+    }
+}
+
+pub(crate) fn active_ready_repair_status(
+    project_root: &Path,
+    run_id: Option<&str>,
+) -> Option<ReadyRepairStatus> {
+    let now = now_epoch_ms();
+    ready_repair_status_paths(project_root, run_id)
+        .into_iter()
+        .filter_map(|path| read_ready_repair_status(&path, project_root, now))
+        .max_by_key(|status| status.updated_at_epoch_ms)
+}
+
+pub(crate) fn ready_repair_status_cache_fingerprint(project_root: &Path) -> String {
+    ready_repair_status_paths(project_root, None)
+        .into_iter()
+        .map(|path| path_fingerprint(&path))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+fn ready_repair_status_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
+    sidecar
+        .layout
+        .state_file
+        .with_file_name(READY_REPAIR_STATUS_FILE)
+}
+
+fn read_ready_repair_status(
+    path: &Path,
+    project_root: &Path,
+    now_epoch_ms: i64,
+) -> Option<ReadyRepairStatus> {
+    let status = read_ready_repair_status_file(path)?;
+    if status.schema_version != READY_REPAIR_STATUS_SCHEMA_VERSION
+        || status.status != "repairing"
+        || status.profile != SidecarProfile::Agent.as_str()
+        || !same_path_text(Path::new(&status.project_root), project_root)
+    {
+        return None;
+    }
+    let age_ms = now_epoch_ms.saturating_sub(status.updated_at_epoch_ms);
+    if age_ms > READY_REPAIR_STATUS_TTL.as_millis() as i64 {
+        return None;
+    }
+    Some(status)
+}
+
+fn read_ready_repair_status_file(path: &Path) -> Option<ReadyRepairStatus> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+}
+
+fn ready_repair_status_paths(project_root: &Path, run_id: Option<&str>) -> Vec<PathBuf> {
+    let mut paths = BTreeSet::new();
+    if let Some(run_id) = run_id {
+        let sidecar = sidecar_runtime_for_project_with_run_id(
+            project_root,
+            SidecarProfile::Agent,
+            Some(run_id),
+        );
+        paths.insert(ready_repair_status_path(&sidecar));
+        return paths.into_iter().collect();
+    }
+
+    let default_sidecar = sidecar_runtime_for_project_with_run_id(
+        project_root,
+        SidecarProfile::Agent,
+        Some(DEFAULT_AGENT_RUN_ID),
+    );
+    paths.insert(ready_repair_status_path(&default_sidecar));
+
+    if let Some((sidecars_root, namespace_prefix)) = agent_sidecars_scan_root(&default_sidecar)
+        && let Ok(entries) = fs::read_dir(sidecars_root)
+    {
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let namespace = entry.file_name().to_string_lossy().to_string();
+            if namespace.starts_with(&namespace_prefix) {
+                paths.insert(entry.path().join(READY_REPAIR_STATUS_FILE));
+            }
+        }
+    }
+
+    paths.into_iter().collect()
+}
+
+fn agent_sidecars_scan_root(sidecar: &SidecarRuntimeConfig) -> Option<(PathBuf, String)> {
+    let namespace_prefix = sidecar.namespace.strip_suffix(DEFAULT_AGENT_RUN_ID)?;
+    let namespace_dir = sidecar.layout.state_file.parent()?;
+    let sidecars_root = namespace_dir.parent()?;
+    Some((sidecars_root.to_path_buf(), namespace_prefix.to_string()))
+}
+
+fn clean_path_text(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+fn same_path_text(left: &Path, right: &Path) -> bool {
+    clean_path_text(left) == clean_path_text(right)
+}
+
+fn path_fingerprint(path: &Path) -> String {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            let modified_ms = metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_millis())
+                .unwrap_or_default();
+            format!("{}:{}:{}", path.display(), metadata.len(), modified_ms)
+        }
+        Err(_) => format!("{}:missing", path.display()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_retrieval::SidecarLayout;
+
+    fn test_sidecar(root: &Path) -> SidecarRuntimeConfig {
+        let namespace = "codestory-agent-test-proof".to_string();
+        SidecarRuntimeConfig {
+            layout: SidecarLayout {
+                zoekt_http_port: 6070,
+                qdrant_http_port: 6333,
+                qdrant_grpc_port: 6334,
+                zoekt_data_dir: root.join("zoekt"),
+                qdrant_data_dir: root.join("qdrant"),
+                scip_artifacts_root: root.join("scip"),
+                state_file: root.join("retrieval-sidecars.json"),
+            },
+            profile: SidecarProfile::Agent,
+            run_id: Some("test-proof".to_string()),
+            namespace: namespace.clone(),
+            compose_project: namespace,
+            embed_http_port: 8080,
+            cleanup_command: "codestory-cli retrieval down".to_string(),
+            labels: Default::default(),
+        }
+    }
+
+    #[test]
+    fn repair_status_file_round_trips_current_phase_and_clears() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let started_at = now_epoch_ms();
+        let pid = 4242;
+
+        write_ready_repair_status(&sidecar, project.path(), "Qdrant finalize", started_at, pid)
+            .expect("write repair status");
+        let path = ready_repair_status_path(&sidecar);
+        let status = read_ready_repair_status(&path, project.path(), now_epoch_ms())
+            .expect("active repair status");
+
+        assert_eq!(status.status, "repairing");
+        assert_eq!(status.phase, "Qdrant finalize");
+        assert_eq!(status.run_id.as_deref(), Some("test-proof"));
+        assert_eq!(status.namespace, "codestory-agent-test-proof");
+
+        clear_ready_repair_status(&sidecar, started_at, pid);
+        assert!(
+            !path.exists(),
+            "drop cleanup should remove the matching repair state file"
+        );
+    }
+
+    #[test]
+    fn stale_repair_status_expires() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let path = ready_repair_status_path(&sidecar);
+        fs::create_dir_all(path.parent().expect("repair status parent")).expect("state dir");
+        let now = now_epoch_ms();
+        let stale = ReadyRepairStatus {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            status: "repairing".to_string(),
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: Some("test-proof".to_string()),
+            namespace: "codestory-agent-test-proof".to_string(),
+            compose_project: "codestory-agent-test-proof".to_string(),
+            phase: "embeddings".to_string(),
+            pid: 4242,
+            started_at_epoch_ms: now - 60_000,
+            updated_at_epoch_ms: now - READY_REPAIR_STATUS_TTL.as_millis() as i64 - 1,
+        };
+        fs::write(&path, serde_json::to_string(&stale).expect("status json"))
+            .expect("write stale status");
+
+        assert_eq!(
+            read_ready_repair_status(&path, project.path(), now),
+            None,
+            "stale repair state must not mask final readiness"
+        );
+    }
+}

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2210,6 +2210,12 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
             stdio_path_fingerprint(&layout.state_file)
         ),
         format!(
+            "repair_state:{}",
+            crate::ready_repair_status::ready_repair_status_cache_fingerprint(
+                &runtime.project_root
+            )
+        ),
+        format!(
             "source_state:{}",
             stdio_source_fingerprint(&runtime.project_root)
         ),
@@ -2704,6 +2710,14 @@ fn stdio_runtime_truth_status(
                 .get("degraded_reason")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null),
+            "namespace": readiness_lanes
+                .pointer("/agent_packet_search/namespace")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+            "phase": readiness_lanes
+                .pointer("/agent_packet_search/phase")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
         },
         "readiness_lanes": {
             "local_graph": {
@@ -2740,6 +2754,16 @@ fn stdio_runtime_truth_sidecar_lane(lane: &serde_json::Value) -> serde_json::Val
             .cloned()
             .unwrap_or_else(|| serde_json::json!("unavailable")),
         "run_id": lane.get("run_id").cloned().unwrap_or(serde_json::Value::Null),
+        "namespace": lane.get("namespace").cloned().unwrap_or(serde_json::Value::Null),
+        "compose_project": lane
+            .get("compose_project")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        "phase": lane.get("phase").cloned().unwrap_or(serde_json::Value::Null),
+        "repair_updated_at_epoch_ms": lane
+            .get("repair_updated_at_epoch_ms")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
         "sidecar_mode": lane
             .get("sidecar_mode")
             .cloned()

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -5,7 +5,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 
 struct StdioFixture {
@@ -23,6 +23,14 @@ struct StdioServer {
     child: Child,
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
+}
+
+struct RemoveDirOnDrop(PathBuf);
+
+impl Drop for RemoveDirOnDrop {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
 }
 
 impl Drop for StdioServer {
@@ -682,6 +690,58 @@ fn json_resource_content(result: &Value, uri: &str) -> Value {
         .unwrap_or_else(|| panic!("resource {uri} content should include JSON text: {content}"));
     serde_json::from_str(text)
         .unwrap_or_else(|error| panic!("resource {uri} should be parseable JSON: {error}\n{text}"))
+}
+
+fn write_active_repair_status_fixture(
+    fixture: &StdioFixture,
+    run_id: &str,
+    phase: &str,
+) -> (PathBuf, RemoveDirOnDrop) {
+    let canonical_root =
+        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &canonical_root,
+        codestory_retrieval::SidecarProfile::Agent,
+        Some(run_id),
+    );
+    let status_path = sidecar
+        .layout
+        .state_file
+        .with_file_name("ready-repair-status.json");
+    let status_dir = status_path
+        .parent()
+        .expect("repair status parent")
+        .to_path_buf();
+    fs::create_dir_all(&status_dir).expect("create repair status dir");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_millis() as i64;
+    let project_root = canonical_root
+        .to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase();
+    fs::write(
+        &status_path,
+        json!({
+            "schema_version": 1,
+            "status": "repairing",
+            "project_root": project_root,
+            "profile": "agent",
+            "run_id": run_id,
+            "namespace": sidecar.namespace,
+            "compose_project": sidecar.compose_project,
+            "phase": phase,
+            "pid": 4242,
+            "started_at_epoch_ms": now,
+            "updated_at_epoch_ms": now
+        })
+        .to_string(),
+    )
+    .expect("write repair status fixture");
+    (status_path, RemoveDirOnDrop(status_dir))
 }
 
 fn continuation_uris_for(node_id: &str) -> Vec<String> {
@@ -2282,6 +2342,63 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
             .and_then(Value::as_array)
             .is_some_and(|calls| !calls.is_empty()),
         "status should include recommended next calls: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_reports_active_agent_repair_phase() {
+    let fixture = indexed_fixture();
+    let (status_path, _cleanup) =
+        write_active_repair_status_fixture(&fixture, "issue-661-proof", "Qdrant finalize");
+    assert!(status_path.exists(), "repair status fixture should exist");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-repairing",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+
+    let result = assert_success_envelope(&response, json!("status-repairing"));
+    let status = json_resource_content(result, "codestory://status");
+    let agent_lane = &status["readiness_lanes"]["agent_packet_search"];
+    assert_eq!(agent_lane["status"], json!("repairing"), "{status}");
+    assert_eq!(agent_lane["profile"], json!("agent"), "{status}");
+    assert_eq!(agent_lane["run_id"], json!("issue-661-proof"), "{status}");
+    assert_eq!(agent_lane["phase"], json!("Qdrant finalize"), "{status}");
+    assert!(
+        agent_lane["namespace"]
+            .as_str()
+            .is_some_and(|namespace| namespace.contains("issue-661-proof")),
+        "repairing status should include the active namespace: {status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["readiness_lanes"]["agent_packet_search"]["status"],
+        json!("repairing"),
+        "{status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["readiness_lanes"]["agent_packet_search"]["phase"],
+        json!("Qdrant finalize"),
+        "{status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["sidecar_status"]["phase"],
+        json!("Qdrant finalize"),
+        "{status}"
+    );
+    assert!(
+        agent_lane["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval status")
+                && command.contains("--profile agent")
+                && command.contains("--run-id")
+                && command.contains("issue-661-proof")),
+        "repairing lane should point at status proof, not a second repair: {status}"
     );
 }
 

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -311,6 +311,7 @@ pub enum ReadinessGoalDto {
 #[serde(rename_all = "snake_case")]
 pub enum ReadinessStatusDto {
     Ready,
+    Repairing,
     RepairSetup,
     RepairIndex,
     CheckIndex,

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -54,6 +54,7 @@ from the source checkout, marketplace cache, or PATH when status is available.
 | State | Meaning | Operator action |
 |-------|---------|-----------------|
 | `local_navigation=ready`, `agent_packet_search=ready`, `sidecar_mode=full` | Local graph and sidecar packet/search infrastructure are ready | Use packet/search/context as infrastructure-eligible, then prove answer quality with source, packet-runtime, drill, or benchmark evidence |
+| `local_navigation=ready`, `agent_packet_search=repairing` | Agent sidecar repair is active and status should include the current `phase`, `profile`, `run_id`, and `namespace` | Wait or reread `codestory://status`; do not start a second agent repair for the same run |
 | `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; run the repair command from preflight/status before packet/search claims |
 | `local_navigation=repair_local` | Core index or cache is missing or stale | Run `codestory-cli ready --goal local --repair --project <repo> --format json`, then rerun `doctor` |
 | `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Repair the failing sidecar layer, rerun `retrieval index --refresh full`, then rerun `retrieval status` |


### PR DESCRIPTION
## Context

Closes #661
Refs #665

PR #664 made `ready --goal agent --repair` emit truthful stderr phase progress while preserving final JSON stdout. The remaining acceptance was the MCP/status side: while repair is still active, `codestory://status` should show `agent_packet_search.status=repairing` with the current phase instead of only stale unavailable/ready snapshots.

```mermaid
flowchart LR
  repair["ready --goal agent --repair"] --> state["ready-repair-status.json\nphase/profile/run_id/namespace"]
  state --> status["codestory://status"]
  status --> lane["agent_packet_search.status=repairing"]
  repair --> cleanup["complete/fail/drop clears state"]
  state --> expiry["30s expiry masks crashes"]
```

## What Changed

- Added an ephemeral ready-repair status file beside the agent sidecar namespace state, written on repair start, phase changes, and heartbeat updates.
- Added `repairing` to `ReadinessStatusDto` and overlaid active repair state onto the shared readiness-lane builder.
- Extended status lane JSON with optional `namespace`, `compose_project`, `phase`, and `repair_updated_at_epoch_ms` fields.
- Included repair-state fingerprinting in the stdio status cache key so long-lived MCP status can see phase changes.
- Updated `runtime_truth` and the sidecar ops doc to describe the active-repair status.

## How To Review

1. Start in `crates/codestory-cli/src/ready_repair_status.rs` for the file shape, expiry, and cleanup rules.
2. Check `ReadyRepairProgress` in `crates/codestory-cli/src/main.rs` to confirm CLI stderr progress and final JSON stdout are preserved.
3. Check `build_readiness_lanes_for_runtime` and `stdio_transport.rs` to see how the overlay reaches `codestory://status` without making packet/search available before full retrieval readiness.
4. Check `resources_read_status_reports_active_agent_repair_phase` for the MCP-facing contract.

## Verification

- `cargo test -p codestory-cli ready_repair_status -- --nocapture` passed: 2 passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_active_agent_repair_phase -- --nocapture` passed: 1 passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls -- --nocapture` passed: 1 passed.
- `cargo test -p codestory-cli --test ready_command ready_command_emits_compact_verdicts_and_filters_goal -- --nocapture` passed: 1 passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

- This is a file-based status overlay, not a service redesign. If a repair process is killed before cleanup, status expires the overlay after 30 seconds.
- The overlay changes the status lane only; packet/search remain blocked until the existing full sidecar manifest/readiness checks pass.
