### PR TITLE
Auto repair approved sidecars

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -18,6 +18,7 @@ const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
 const releaseDownloadRetryDelaysMs = [1000, 3000];
+const sidecarRepairRecentMs = 30000;
 
 function readJson(file) {
   try {
@@ -128,6 +129,89 @@ function repairCommandForProject(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
 
+function repairArgsForProject(projectRoot = process.cwd()) {
+  return ['ready', '--goal', 'agent', '--repair', '--project', projectRoot, '--format', 'json', '--run-id', sharedAgentRunId];
+}
+
+function normalizeProjectRoot(projectRoot = process.cwd()) {
+  const resolved = path.resolve(projectRoot);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function comparableProjectRoot(projectRoot = process.cwd()) {
+  return normalizeProjectRoot(projectRoot).replace(/[\\/]+$/u, '').toLowerCase();
+}
+
+function sameProjectRoot(left, right) {
+  return comparableProjectRoot(left) === comparableProjectRoot(right);
+}
+
+function recentAutomaticRepair(policy, projectRoot = process.cwd()) {
+  const last = policy?.lastRepair;
+  if (!last?.project_root || !sameProjectRoot(last.project_root, projectRoot)) return false;
+  if (last.state === 'completed' || last.state === 'blocked') return true;
+  if (last.state !== 'repairing') return false;
+  const updatedAt = Date.parse(last.updated_at || '');
+  return Number.isFinite(updatedAt) && Date.now() - updatedAt < sidecarRepairRecentMs;
+}
+
+function writeSidecarRepairState(policy, state, projectRoot, patch = {}) {
+  if (!policy?.path) return null;
+  return writeSidecarPolicy('enabled', {
+    last_repair: {
+      state,
+      updated_at: new Date().toISOString(),
+      project_root: normalizeProjectRoot(projectRoot),
+      command: repairCommandForProject(projectRoot),
+      ...patch,
+    },
+  }, policy.path);
+}
+
+function maybeStartAutomaticSidecarRepair(resolved, projectRoot = process.cwd(), policy = readSidecarPolicy()) {
+  if (policy.state !== 'enabled' || !policy.path) {
+    return { attempted: false, state: policy.state };
+  }
+  if (recentAutomaticRepair(policy, projectRoot)) {
+    return { attempted: false, state: policy.lastRepair?.state || policy.state };
+  }
+
+  try {
+    const child = spawn(resolved.path, repairArgsForProject(projectRoot), {
+      cwd: projectRoot,
+      detached: true,
+      stdio: 'ignore',
+      shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+      windowsHide: true,
+      env: {
+        ...process.env,
+        CODESTORY_PLUGIN_SIDECAR_REPAIR: '1',
+        CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: policy.state,
+        CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: policy.path || '',
+      },
+    });
+    writeSidecarRepairState(policy, 'repairing', projectRoot, { pid: child.pid || null });
+    child.on('exit', (code, signal) => {
+      writeSidecarRepairState(policy, code === 0 ? 'completed' : 'blocked', projectRoot, {
+        exit_status: code,
+        signal: signal || null,
+      });
+    });
+    child.on('error', (error) => {
+      writeSidecarRepairState(policy, 'blocked', projectRoot, { error: error.message });
+    });
+    child.unref();
+    return { attempted: true, state: 'repairing', pid: child.pid || null };
+  } catch (error) {
+    writeSidecarRepairState(policy, 'blocked', projectRoot, { error: error.message });
+    return { attempted: true, state: 'blocked', error: error.message };
+  }
+}
+
 function optionValue(argv, name) {
   const index = argv.indexOf(name);
   return index >= 0 ? argv[index + 1] : null;
@@ -135,13 +219,7 @@ function optionValue(argv, name) {
 
 function dirtyMarkerEnv(projectRoot = process.cwd()) {
   const markerPath = dirtyMarkerPathForProject(projectRoot, pluginDataDir());
-  const normalizedRoot = (() => {
-    try {
-      return fs.realpathSync(path.resolve(projectRoot));
-    } catch {
-      return path.resolve(projectRoot);
-    }
-  })();
+  const normalizedRoot = normalizeProjectRoot(projectRoot);
   return {
     path: markerPath || '',
     projectRoot: markerPath ? normalizedRoot : '',
@@ -803,7 +881,9 @@ async function bootstrapStatus(projectRoot = process.cwd()) {
     };
   }
 
-  const sidecarPolicy = readSidecarPolicy();
+  const initialSidecarPolicy = readSidecarPolicy();
+  maybeStartAutomaticSidecarRepair(resolved, projectRoot, initialSidecarPolicy);
+  const sidecarPolicy = readSidecarPolicy(initialSidecarPolicy.path);
   const plugin = pluginRuntimeForResolved(resolved);
   const localRefresh = localReadiness.localRefresh || {
     state: 'fresh',
@@ -1094,7 +1174,9 @@ async function main() {
     }));
     return;
   }
-  const sidecarStatus = readSidecarPolicy();
+  const initialSidecarStatus = readSidecarPolicy();
+  maybeStartAutomaticSidecarRepair(resolved, process.cwd(), initialSidecarStatus);
+  const sidecarStatus = readSidecarPolicy(initialSidecarStatus.path);
   const dirtyMarker = dirtyMarkerEnv(process.cwd());
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -436,7 +436,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
   }
 });
 
-test("mcp launcher waits for fresh local navigation without agent repair", async () => {
+test("mcp launcher waits for fresh local navigation without unapproved agent repair", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-repair-index-"));
@@ -485,7 +485,7 @@ test("mcp launcher waits for fresh local navigation without agent repair", async
         ...process.env,
         CODESTORY_CLI: cliPath,
         PLUGIN_DATA: dataDir,
-        CODESTORY_PLUGIN_SIDECAR_POLICY: "enabled",
+        CODESTORY_PLUGIN_SIDECAR_POLICY: "disabled",
         TEST_CODESTORY_VERSION: version,
         TEST_LOG: logFile,
         TEST_OUT: marker,
@@ -809,7 +809,7 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
   }
 });
 
-test("enabled sidecar policy does not schedule agent repair at MCP startup", async () => {
+test("enabled sidecar policy schedules agent repair at MCP startup", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
@@ -849,14 +849,38 @@ test("enabled sidecar policy does not schedule agent repair at MCP startup", asy
     });
     assert.equal(result.status, 0, result.stderr);
 
-    const text = await readFile(logFile, "utf8");
-    const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+    let text = "";
+    let calls = [];
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      text = await readFile(logFile, "utf8");
+      calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+      if (calls.some((call) => call.repair)) break;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
     assert.ok(calls.some((call) => {
       return JSON.stringify(call.args) === JSON.stringify(["serve", "--stdio", "--refresh", "none"]);
     }), text);
-    assert.equal(calls.some((call) => call.repair), false);
-    assert.equal(calls.some((call) => call.args.includes("agent")), false);
-    assert.equal(calls.some((call) => call.args.includes("--repair")), false);
+    const repair = calls.find((call) => call.repair);
+    assert.ok(repair, text);
+    assert.deepEqual(repair.args, [
+      "ready",
+      "--goal",
+      "agent",
+      "--repair",
+      "--project",
+      repoRoot,
+      "--format",
+      "json",
+      "--run-id",
+      "shared-agent",
+    ]);
+    assert.equal(repair.policy, "enabled");
+    const policy = JSON.parse(
+      await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
+    );
+    assert.equal(policy.last_repair.project_root, repoRoot);
+    assert.match(policy.last_repair.command, /ready --goal agent --repair/u);
+    assert.ok(["repairing", "completed"].includes(policy.last_repair.state));
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

Closes #660
Refs #618, #658, #661, #662

Issue #660 tracks the remaining first-run sidecar onboarding gap after managed CLI provisioning and local freshness repair landed. The launcher already exposes sidecar policy/status, but an approved install still required hand-running `ready --goal agent --repair` before packet/search could become ready. This keeps #662 separate; it does not change model-visible MCP resource injection.

## What Changed

- Added a policy-gated launcher repair path in `plugins/codestory/scripts/codestory-mcp.cjs`.
- When sidecar setup policy is `enabled` and a policy file exists, bootstrap/launch starts one background `ready --goal agent --repair --project <repo> --format json --run-id shared-agent` using the already resolved managed/local-dev CLI path.
- Persists `last_repair` metadata in `sidecar-setup-policy.json` so status can expose the current approved repair state.
- Preserves ask/disabled/no-policy behavior: no sidecar repair is started without approval.
- Updated the existing plugin static test coverage for approved repair and non-approved no-repair behavior.

```mermaid
flowchart LR
  A[Plugin launcher] --> B[Resolve managed or local-dev CLI]
  B --> C[Local wait-fresh]
  C --> D{sidecar policy}
  D -->|enabled + policy file| E[start one agent repair]
  D -->|ask/disabled/no file| F[do not start sidecars]
  E --> G[serve stdio]
  F --> G
```

## How To Review

- Review `maybeStartAutomaticSidecarRepair` in `plugins/codestory/scripts/codestory-mcp.cjs` for policy gating, resolved-CLI usage, and one-shot repair marker behavior.
- Review `plugins/codestory/tests/plugin-static.test.mjs` for the two core contracts: disabled policy does not repair, enabled persisted policy schedules `ready --goal agent --repair --run-id shared-agent`.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` - 37 passed.
- `git diff --check` - passed.

## Risk

- No live Docker/full sidecar repair was run; this is the launcher/static contract slice.
- A failed sidecar setup still has to surface through status/readiness rather than retrying in a loop.
