### PR TITLE
Enable sidecar onboarding repair

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -128,6 +128,10 @@ function repairCommandForProject(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
 
+function resolvedRepairCommandForProject(resolved, projectRoot = process.cwd()) {
+  return `${JSON.stringify(resolved.path)} ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
+}
+
 function optionValue(argv, name) {
   const index = argv.indexOf(name);
   return index >= 0 ? argv[index + 1] : null;
@@ -519,6 +523,11 @@ function localWaitFreshTimeoutMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
 }
 
+function sidecarRepairTimeoutMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR_TIMEOUT_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+}
+
 function runLocalNavigationWaitFresh(resolved, projectRoot) {
   const args = ['ready', '--goal', 'local', '--wait-fresh'];
   args.push('--project', projectRoot, '--format', 'json');
@@ -529,6 +538,38 @@ function runLocalNavigationWaitFresh(resolved, projectRoot) {
     windowsHide: true,
   });
   return { args, result };
+}
+
+function runSidecarStartupRepair(resolved, sidecarStatus, projectRoot = process.cwd()) {
+  if (sidecarStatus.state !== 'enabled') return sidecarStatus;
+  if (resolved.source !== 'managed' && resolved.source !== 'local_dev_override') return sidecarStatus;
+  const args = ['ready', '--goal', 'agent', '--repair'];
+  args.push('--project', projectRoot, '--format', 'json', '--run-id', sharedAgentRunId);
+  const result = spawnSync(resolved.path, args, {
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    timeout: sidecarRepairTimeoutMs(),
+    windowsHide: true,
+    env: {
+      ...process.env,
+      CODESTORY_PLUGIN_SIDECAR_REPAIR: '1',
+      CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
+    },
+  });
+  const lastRepair = {
+    state: result.error?.code === 'ETIMEDOUT' ? 'timeout' : result.status === 0 ? 'completed' : 'failed',
+    updated_at: new Date().toISOString(),
+    project_root: projectRoot,
+    command: resolvedRepairCommandForProject(resolved, projectRoot),
+  };
+  if (sidecarStatus.path) {
+    writeSidecarPolicy(sidecarStatus.state, { last_repair: lastRepair }, sidecarStatus.path);
+    return readSidecarPolicy(sidecarStatus.path);
+  }
+  return {
+    ...sidecarStatus,
+    lastRepair,
+  };
 }
 
 function localReadySetup(prefix, args, result) {
@@ -1094,7 +1135,7 @@ async function main() {
     }));
     return;
   }
-  const sidecarStatus = readSidecarPolicy();
+  const sidecarStatus = runSidecarStartupRepair(resolved, readSidecarPolicy(), process.cwd());
   const dirtyMarker = dirtyMarkerEnv(process.cwd());
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -1163,7 +1163,7 @@ async function main() {
       CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
       CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
       CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
-      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: repairCommandForProject(process.cwd()),
+      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, process.cwd()),
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -335,6 +335,10 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.sidecarPolicy, "ask");
     assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
     assert.match(observed.sidecarEnable, /--policy-file/u);
+    assert.equal(
+      observed.sidecarRepair.startsWith(`${JSON.stringify(cliPath)} ready --goal agent --repair`),
+      true,
+    );
     assert.match(observed.sidecarRepair, /ready --goal agent --repair/u);
     assert.match(observed.sidecarRepair, /--run-id shared-agent/u);
     assert.equal(observed.dirtyMarkerRoot, await realpath(repoRoot));

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -485,7 +485,7 @@ test("mcp launcher waits for fresh local navigation without agent repair", async
         ...process.env,
         CODESTORY_CLI: cliPath,
         PLUGIN_DATA: dataDir,
-        CODESTORY_PLUGIN_SIDECAR_POLICY: "enabled",
+        CODESTORY_PLUGIN_SIDECAR_POLICY: "ask",
         TEST_CODESTORY_VERSION: version,
         TEST_LOG: logFile,
         TEST_OUT: marker,
@@ -809,7 +809,7 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
   }
 });
 
-test("enabled sidecar policy does not schedule agent repair at MCP startup", async () => {
+test("enabled sidecar policy runs one agent repair at MCP startup", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
@@ -851,12 +851,29 @@ test("enabled sidecar policy does not schedule agent repair at MCP startup", asy
 
     const text = await readFile(logFile, "utf8");
     const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+    const repairCalls = calls.filter((call) => call.repair);
+    assert.equal(repairCalls.length, 1, text);
+    assert.equal(repairCalls[0].policy, "enabled");
+    assert.deepEqual(repairCalls[0].args, [
+      "ready",
+      "--goal",
+      "agent",
+      "--repair",
+      "--project",
+      repoRoot,
+      "--format",
+      "json",
+      "--run-id",
+      "shared-agent",
+    ]);
     assert.ok(calls.some((call) => {
       return JSON.stringify(call.args) === JSON.stringify(["serve", "--stdio", "--refresh", "none"]);
     }), text);
-    assert.equal(calls.some((call) => call.repair), false);
-    assert.equal(calls.some((call) => call.args.includes("agent")), false);
-    assert.equal(calls.some((call) => call.args.includes("--repair")), false);
+    const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
+    assert.equal(policy.last_repair.state, "completed");
+    assert.equal(policy.last_repair.project_root, repoRoot);
+    assert.match(policy.last_repair.command, /ready --goal agent --repair/u);
+    assert.match(policy.last_repair.command, /--run-id shared-agent/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context
Closes #660
Refs #618, #658, #661, #662

First plugin install/onboarding can now use the existing approved sidecar setup policy instead of requiring a second hidden manual `ready --goal agent --repair` step. #662 remains separate: this does not change host/model-context MCP resource visibility.

## What Changed
- Added one policy-gated MCP launcher repair step before `serve --stdio`: when sidecar policy is `enabled` and the resolved CLI source is `managed` or `local_dev_override`, the launcher runs `ready --goal agent --repair --run-id shared-agent` with the resolved CLI path.
- Skips startup sidecar repair for `ask`, `disabled`, missing policy, and PATH fallback states.
- Records the startup repair result in the existing sidecar policy `last_repair` field so status can report what happened.
- Updated plugin static tests for the enabled repair path and the non-enabled no-repair path.

```mermaid
flowchart LR
  A["MCP launcher start"] --> B["resolve managed/local CLI"]
  B --> C["local wait-fresh"]
  C --> D{"sidecar policy"}
  D -->|"enabled"| E["ready agent repair shared-agent"]
  D -->|"ask/disabled/missing"| F["no sidecar repair"]
  E --> G["serve stdio"]
  F --> G
```

## How To Review
- Start with `plugins/codestory/scripts/codestory-mcp.cjs`: `runSidecarStartupRepair` is the only new launcher behavior.
- Then review `plugins/codestory/tests/plugin-static.test.mjs`: the old enabled-policy no-repair expectation is inverted, and the local wait-fresh test now proves `ask` does not repair.

## Verification
- `node --test --test-name-pattern 'mcp launcher prefers a checksummed managed cli without PATH|mcp launcher waits for fresh local navigation without agent repair|mcp launcher persists sidecar setup policy in plugin data|enabled sidecar policy runs one agent repair at MCP startup' plugins\codestory\tests\plugin-static.test.mjs`
- `node --test plugins\codestory\tests\plugin-static.test.mjs`
- `git diff --check`

## Risk
- The enabled-policy repair is synchronous and bounded by `CODESTORY_PLUGIN_SIDECAR_REPAIR_TIMEOUT_MS` or 120s by default; startup can spend that time only after local wait-fresh succeeds and policy is already enabled.
- If sidecar repair fails or times out, the launcher records `last_repair` and still starts stdio so existing status/readiness surfaces remain honest.
- No workaround for #662 is included; MCP resource injection/model visibility still needs its own fix.
