### PR TITLE
[codex] add handoff proof target status

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -138,6 +138,35 @@ codestory-cli agent preflight --project <target-workspace> --format json
 Use its `safe_surfaces`, `blocked_surfaces`, and `repair_command` fields as the
 agent handoff.
 
+## Delegated Worktree Proof Target
+
+Before a delegated CodeStory lane spends time on cache repair, readiness, or
+sidecar proof, verify the Git target. `scripts/codex-worktree-setup.ps1` prints
+this handoff surface first:
+
+```text
+intended_base_ref
+resolved_base_commit
+child_start_head
+child_branch_or_detached
+proof_target
+pr_head_ref
+pr_head_commit
+remote_tip_verification.<target>.command
+remote_tip_verification.<target>.result
+```
+
+Defaults are intentionally narrow: `intended_base_ref` is
+`origin/dev/codestory-next`, and a PR lane with `CODESTORY_PR_HEAD_REF` or
+`-PrHeadRef` proves `base:origin/dev/codestory-next + pr-head:<ref>`. Use
+`-BranchHeadProof` or `CODESTORY_BRANCH_HEAD_PROOF=1` only when the lane is
+explicitly proving the branch head by itself.
+
+The setup script reports stale `main`, stale local `dev/codestory-next`, stale
+PR heads, unresolved refs, and the exact `git ls-remote origin ...` result
+before it runs index, retrieval, or doctor handoff work. Treat those warnings as
+Git proof-target blockers, not packet/search readiness blockers.
+
 **Next steps after installation:**
 
 If the agent reports that local graph surfaces are allowed but `packet`,

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -119,6 +119,17 @@ CLI directly:
 
 Always pass `--project <target-workspace>` explicitly.
 
+For delegated CodeStory child worktrees, check the Git proof target before
+cache, readiness, or sidecar proof work. `scripts/codex-worktree-setup.ps1`
+prints `intended_base_ref`, `resolved_base_commit`, `child_start_head`,
+`child_branch_or_detached`, `proof_target`, `pr_head_ref`, `pr_head_commit`, and
+the exact `git ls-remote origin ...` command/result when a remote branch is
+applicable. PR lanes default to proving current `origin/dev/codestory-next` plus
+the PR head (`CODESTORY_PR_HEAD_REF` or `-PrHeadRef`); use branch-head proof
+only when explicitly requested. Stale `main`, stale local
+`dev/codestory-next`, stale PR head, unresolved refs, or the wrong proof target
+are Git blockers to fix before expensive readiness evidence.
+
 For binary repair details, use [serve](references/serve.md) for MCP/PATH
 behavior and [doctor](references/doctor.md) for health and repair evidence.
 

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -154,6 +154,9 @@ function Get-RemoteHeadRefName {
     if ($Ref -match "^refs/heads/(.+)$") {
         return $Ref
     }
+    if ($Ref -notmatch "^refs/" -and $Ref -notmatch "^[0-9a-fA-F]{40}$") {
+        return "refs/heads/$Ref"
+    }
 
     return $null
 }
@@ -523,6 +526,7 @@ function Invoke-SelfTest {
         $resolvedCli = Find-CodeStoryCli $projectRoot
         Assert-SelfTest (Same-Path $resolvedCli $currentCli) "stale default install should be rejected and versioned current install should be used"
         Assert-SelfTest ((Get-RemoteHeadRefName "origin/dev/codestory-next") -eq "refs/heads/dev/codestory-next") "origin branch refs should map to ls-remote heads"
+        Assert-SelfTest ((Get-RemoteHeadRefName "codex/issue-670-handoff-proof-target") -eq "refs/heads/codex/issue-670-handoff-proof-target") "plain branch refs should map to ls-remote heads"
         Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $false) -eq "base:origin/dev/codestory-next + pr-head:origin/pr-branch") "PR proof target should default to base plus PR head"
         Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $true) -eq "branch-head:origin/pr-branch") "branch-head proof should be explicit"
     } finally {

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -1,6 +1,9 @@
 [CmdletBinding()]
 param(
     [string]$Project = ".",
+    [string]$IntendedBaseRef = $(if ($env:CODESTORY_INTENDED_BASE_REF) { $env:CODESTORY_INTENDED_BASE_REF } else { "origin/dev/codestory-next" }),
+    [string]$PrHeadRef = $env:CODESTORY_PR_HEAD_REF,
+    [switch]$BranchHeadProof,
     [switch]$ResolveCliOnly,
     [switch]$SelfTest
 )
@@ -97,6 +100,179 @@ function Invoke-DoctorJson {
     }
 
     return ($json | ConvertFrom-Json)
+}
+
+function Invoke-GitText {
+    param([string[]]$Arguments)
+
+    $output = (& git @Arguments 2>$null | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    return $output
+}
+
+function Get-GitCommit {
+    param([string]$Ref)
+
+    if (-not $Ref) {
+        return $null
+    }
+
+    $commit = Invoke-GitText @("rev-parse", "--verify", "$Ref^{commit}")
+    if (-not $commit) {
+        return $null
+    }
+
+    return ($commit -split "\r?\n")[0]
+}
+
+function Get-CurrentBranchOrDetached {
+    $branch = Invoke-GitText @("symbolic-ref", "--quiet", "--short", "HEAD")
+    if ($branch) {
+        return $branch
+    }
+
+    $head = Get-GitCommit "HEAD"
+    if ($head) {
+        return "detached:$head"
+    }
+
+    return "unknown"
+}
+
+function Get-RemoteHeadRefName {
+    param([string]$Ref)
+
+    if (-not $Ref) {
+        return $null
+    }
+    if ($Ref -match "^origin/(.+)$") {
+        return "refs/heads/$($Matches[1])"
+    }
+    if ($Ref -match "^refs/heads/(.+)$") {
+        return $Ref
+    }
+
+    return $null
+}
+
+function Get-RemoteHeadVerification {
+    param([string]$Ref)
+
+    $remoteRef = Get-RemoteHeadRefName $Ref
+    if (-not $remoteRef) {
+        return $null
+    }
+
+    $command = "git ls-remote origin $remoteRef"
+    $result = Invoke-GitText @("ls-remote", "origin", $remoteRef)
+    $commit = $null
+    if ($result) {
+        $commit = (($result -split "\s+") | Select-Object -First 1)
+    }
+
+    return [pscustomobject]@{
+        Command = $command
+        Result = $(if ($result) { $result } else { "<no remote tip>" })
+        Commit = $commit
+    }
+}
+
+function Get-ProofTarget {
+    param(
+        [string]$BaseRef,
+        [string]$HeadRef,
+        [bool]$UseBranchHeadProof
+    )
+
+    if ($HeadRef) {
+        if ($UseBranchHeadProof) {
+            return "branch-head:$HeadRef"
+        }
+        return "base:$BaseRef + pr-head:$HeadRef"
+    }
+
+    return $BaseRef
+}
+
+function Add-StaleRefWarning {
+    param(
+        [string[]]$Warnings,
+        [string]$Label,
+        [string]$LocalCommit,
+        $Remote
+    )
+
+    if ($LocalCommit -and $Remote -and $Remote.Commit -and $LocalCommit -ne $Remote.Commit) {
+        return @($Warnings + "$Label stale: local=$LocalCommit remote=$($Remote.Commit)")
+    }
+
+    return $Warnings
+}
+
+function Write-HandoffProofTargetSummary {
+    param(
+        [string]$BaseRef,
+        [string]$HeadRef,
+        [bool]$UseBranchHeadProof
+    )
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Warning "Git is unavailable; skipping CodeStory handoff proof-target status."
+        return
+    }
+
+    $childHead = Get-GitCommit "HEAD"
+    if (-not $childHead) {
+        Write-Warning "Current directory is not a Git worktree; skipping CodeStory handoff proof-target status."
+        return
+    }
+
+    $baseCommit = Get-GitCommit $BaseRef
+    $headCommit = Get-GitCommit $HeadRef
+    $baseRemote = Get-RemoteHeadVerification $BaseRef
+    $headRemote = Get-RemoteHeadVerification $HeadRef
+    $mainRemote = Get-RemoteHeadVerification "origin/main"
+    $devRemote = Get-RemoteHeadVerification "origin/dev/codestory-next"
+    $warnings = @()
+
+    if (-not $baseCommit) {
+        $warnings += "intended_base_ref unresolved: $BaseRef"
+    }
+    $warnings = Add-StaleRefWarning $warnings "intended_base_ref" $baseCommit $baseRemote
+    $warnings = Add-StaleRefWarning $warnings "main" (Get-GitCommit "main") $mainRemote
+    $warnings = Add-StaleRefWarning $warnings "dev/codestory-next" (Get-GitCommit "dev/codestory-next") $devRemote
+    if ($HeadRef) {
+        if (-not $headCommit) {
+            $warnings += "pr_head_ref unresolved: $HeadRef"
+        }
+        $warnings = Add-StaleRefWarning $warnings "pr_head_ref" $headCommit $headRemote
+        if ($UseBranchHeadProof) {
+            $warnings += "branch-head proof requested; default PR proof is current base plus PR head."
+        }
+    }
+
+    Write-Host "CodeStory handoff proof target"
+    Write-Host ("  intended_base_ref: {0}" -f $BaseRef)
+    Write-Host ("  resolved_base_commit: {0}" -f $(if ($baseCommit) { $baseCommit } else { "unresolved" }))
+    Write-Host ("  child_start_head: {0}" -f $childHead)
+    Write-Host ("  child_branch_or_detached: {0}" -f (Get-CurrentBranchOrDetached))
+    Write-Host ("  proof_target: {0}" -f (Get-ProofTarget $BaseRef $HeadRef $UseBranchHeadProof))
+    Write-Host ("  pr_head_ref: {0}" -f $(if ($HeadRef) { $HeadRef } else { "none" }))
+    Write-Host ("  pr_head_commit: {0}" -f $(if ($headCommit) { $headCommit } else { "none" }))
+    if ($baseRemote) {
+        Write-Host ("  remote_tip_verification.intended_base.command: {0}" -f $baseRemote.Command)
+        Write-Host ("  remote_tip_verification.intended_base.result: {0}" -f $baseRemote.Result)
+    }
+    if ($headRemote) {
+        Write-Host ("  remote_tip_verification.pr_head.command: {0}" -f $headRemote.Command)
+        Write-Host ("  remote_tip_verification.pr_head.result: {0}" -f $headRemote.Result)
+    }
+    foreach ($warning in $warnings) {
+        Write-Warning "CodeStory handoff proof target: $warning"
+    }
 }
 
 function Write-DoctorReadinessSummary {
@@ -346,6 +522,9 @@ function Invoke-SelfTest {
 
         $resolvedCli = Find-CodeStoryCli $projectRoot
         Assert-SelfTest (Same-Path $resolvedCli $currentCli) "stale default install should be rejected and versioned current install should be used"
+        Assert-SelfTest ((Get-RemoteHeadRefName "origin/dev/codestory-next") -eq "refs/heads/dev/codestory-next") "origin branch refs should map to ls-remote heads"
+        Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $false) -eq "base:origin/dev/codestory-next + pr-head:origin/pr-branch") "PR proof target should default to base plus PR head"
+        Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $true) -eq "branch-head:origin/pr-branch") "branch-head proof should be explicit"
     } finally {
         $env:CODESTORY_HOME = $oldCodeStoryHome
         $env:CODESTORY_CLI = $oldCodeStoryCli
@@ -401,6 +580,9 @@ $projectPath = (Resolve-Path -LiteralPath $Project).Path
 
 Push-Location $projectPath
 try {
+    $branchHeadProofEnabled = $BranchHeadProof.IsPresent -or ($env:CODESTORY_BRANCH_HEAD_PROOF -match "^(1|true|yes)$")
+    Write-HandoffProofTargetSummary $IntendedBaseRef $PrHeadRef $branchHeadProofEnabled
+
     $sccache = Join-Path $env:USERPROFILE ".cargo\bin\sccache.exe"
     if (Test-Path -LiteralPath $sccache) {
         $env:RUSTC_WRAPPER = $sccache


### PR DESCRIPTION
## Context

Closes #670.

Delegated CodeStory lanes need a Git proof-target check before cache repair, readiness handoff, or sidecar proof work. The issue evidence showed runtime readiness can be fresh while a child is proving stale `main`, stale local `dev/codestory-next`, or a branch head when the intended PR proof target is current base plus PR head.

## What Changed

- Added an early `CodeStory handoff proof target` block to `scripts/codex-worktree-setup.ps1`, before CLI resolution, cache rehydrate, index refresh, retrieval bootstrap, or doctor handoff.
- The block reports `intended_base_ref`, `resolved_base_commit`, `child_start_head`, `child_branch_or_detached`, `proof_target`, `pr_head_ref`, `pr_head_commit`, and exact `git ls-remote origin ...` command/results when the refs map to remote branch heads.
- PR lanes can pass `-PrHeadRef` or `CODESTORY_PR_HEAD_REF`; the default proof target becomes `base:<base> + pr-head:<head>`. `-BranchHeadProof` or `CODESTORY_BRANCH_HEAD_PROOF=1` makes branch-head proof explicit.
- Added warnings for unresolved refs, stale `main`, stale local `dev/codestory-next`, stale PR head, and explicit branch-head proof.
- Documented the contract in `docs/usage.md` and the shipped `codestory-grounding` skill.

No sidecar ranking, packet/search, Docker, cache, MCP exposure, or `main` mutation logic changed.

## How To Review

1. Read `Write-HandoffProofTargetSummary` in `scripts/codex-worktree-setup.ps1` and confirm it runs before setup work.
2. Check the two supported PR proof modes: default base plus PR head, and explicit branch-head proof.
3. Check the docs/skill wording for the future coordinator handoff contract.

## Verification

- `git rev-parse origin/dev/codestory-next` -> `340672f90fec9db6560351dc1effee34b92e8353`.
- `git ls-remote origin refs/heads/dev/codestory-next` -> `340672f90fec9db6560351dc1effee34b92e8353 refs/heads/dev/codestory-next`.
- Managed CodeStory CLI fallback: `codestory-cli 0.11.20`; MCP resources were not model-visible in this session, so source mapping used direct repo reads. `doctor --format json` reported no indexed files and `retrieval_mode=unavailable`, so I did not run cache or sidecar repair.
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\codex-worktree-setup.ps1 -SelfTest` -> `codex-worktree-setup self-test: ok`.
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\codex-worktree-setup.ps1 -Project . -ResolveCliOnly` -> printed the required handoff fields and detected stale local `dev/codestory-next` before CLI resolution. This exercised the existing current-release installer fallback because no ready repo/sibling CLI candidate was present; it did not run index or sidecar work.
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\codex-worktree-setup.ps1 -Project . -ResolveCliOnly -PrHeadRef origin/dev/codestory-next` -> printed `proof_target: base:origin/dev/codestory-next + pr-head:origin/dev/codestory-next` and exact remote-tip checks for both refs.
- `git diff --check` -> passed.
- `git diff --cached --check` -> passed before commit.

## Risk

The new surface is PowerShell-only because the existing Codex worktree setup path is PowerShell-only. It reports stale Git targets but does not stop the setup script; coordinators should treat warnings as proof-target blockers before doing expensive proof work.
