### PR TITLE
[codex] Remove ONNX product embedding runtime

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -908,24 +908,24 @@ pub(crate) struct SetupEmbeddingsCommand {
         long,
         value_enum,
         default_value_t = CliEmbeddingQuant::Q8_0,
-        help = "Legacy GGUF quant selector retained for CLI compatibility; managed setup now installs the pinned ONNX model."
+        help = "Legacy compatibility selector; setup embeddings now installs diagnostic ONNX assets only."
     )]
     pub(crate) quant: CliEmbeddingQuant,
     #[arg(
         long,
         value_enum,
         default_value_t = CliLlamaVariant::Vulkan,
-        help = "Legacy llama.cpp variant selector retained for CLI compatibility; managed setup now uses ONNX Runtime."
+        help = "Legacy compatibility selector; product embeddings use the llama.cpp retrieval sidecar."
     )]
     pub(crate) variant: CliLlamaVariant,
     #[arg(
         long,
-        help = "Show the managed ONNX asset plan without downloading anything."
+        help = "Show the diagnostic ONNX asset plan without downloading anything."
     )]
     pub(crate) dry_run: bool,
     #[arg(
         long,
-        help = "Compatibility flag; managed ONNX setup never starts a server."
+        help = "Compatibility flag; diagnostic ONNX setup never starts a server."
     )]
     pub(crate) no_start: bool,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -421,7 +421,8 @@ fn setup_embeddings_next_commands(
     }
     vec![
         format!("codestory-cli doctor{args}"),
-        format!("codestory-cli index{args} --refresh full"),
+        format!("codestory-cli retrieval bootstrap{args}"),
+        format!("codestory-cli retrieval index{args} --refresh full"),
     ]
 }
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -4010,9 +4010,9 @@ fn drill_suite_retrieval_blockers(
         .into_iter()
         .map(|(status, repos)| {
             let next_action = if status.contains("MissingEmbeddingRuntime") {
-                "run `codestory-cli setup embeddings --project <repo>`, then rebuild with `codestory-cli retrieval index --project <repo> --refresh full` before trusting packet/search evidence".to_string()
+                "run `codestory-cli retrieval bootstrap --project <repo>`, then rebuild with `codestory-cli retrieval index --project <repo> --refresh full` before trusting packet/search evidence".to_string()
             } else if status.contains("MissingSemanticDocs") {
-                "rerun `codestory-cli retrieval index --project <repo> --refresh full` after semantic setup before trusting packet/search evidence".to_string()
+                "rerun `codestory-cli retrieval index --project <repo> --refresh full` after sidecar setup before trusting packet/search evidence".to_string()
             } else {
                 "inspect doctor/retrieval status and repair to retrieval_mode=full before treating broad search quality as repo-specific".to_string()
             };
@@ -11161,7 +11161,7 @@ fn semantic_contract_check(
             "semantic_contract",
             "info",
             format!(
-                "semantic stale: {}. Resolve the embedding runtime first with `codestory-cli setup embeddings`; then run `codestory-cli retrieval index --refresh full` before trusting packet/search evidence.",
+                "semantic stale: {}. Resolve the product embedding sidecar first with `codestory-cli retrieval bootstrap`; then run `codestory-cli retrieval index --refresh full` before trusting packet/search evidence.",
                 gaps.join("; ")
             ),
         )
@@ -11306,7 +11306,10 @@ fn index_next_commands(
         && retrieval.fallback_reason == Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime)
     {
         commands.push(format!(
-            "codestory-cli setup embeddings --project {project}"
+            "codestory-cli retrieval bootstrap --project {project}"
+        ));
+        commands.push(format!(
+            "codestory-cli retrieval index --project {project} --refresh full"
         ));
     }
     commands.push(format!("codestory-cli ground --project {project}"));
@@ -13213,6 +13216,62 @@ mod tests {
                 "not-checked freshness should stop before `{blocked}` proof/navigation commands: {joined}"
             );
         }
+    }
+
+    #[test]
+    fn index_next_commands_use_sidecar_repair_for_missing_embedding_runtime() {
+        let mut retrieval = sample_retrieval();
+        retrieval.semantic_ready = false;
+        retrieval.fallback_reason = Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime);
+
+        let commands = index_next_commands("C:/repo", Some(&retrieval), None, true);
+        let joined = commands.join("\n");
+
+        assert!(joined.contains("codestory-cli retrieval bootstrap --project"));
+        assert!(
+            joined.contains("codestory-cli retrieval index --project")
+                && joined.contains("--refresh full")
+        );
+        assert!(!joined.contains("setup embeddings"));
+    }
+
+    #[test]
+    fn semantic_contract_check_uses_sidecar_repair_for_missing_embedding_runtime() {
+        let mut retrieval = sample_retrieval();
+        retrieval.semantic_ready = false;
+        retrieval.fallback_reason = Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime);
+        retrieval.current_embedding = Some(codestory_contracts::api::EmbeddingProfileContractDto {
+            profile: "bge-base-en-v1.5".to_string(),
+            backend: "llamacpp".to_string(),
+            model_id: "BAAI/bge-base-en-v1.5-local".to_string(),
+            cache_key: "current".to_string(),
+            dimension: Some(768),
+            doc_shape: "current-shape".to_string(),
+        });
+        retrieval.stored_embedding =
+            Some(codestory_contracts::api::StoredSemanticDocsContractDto {
+                doc_count: 1,
+                embedding_profile: Some("bge-base-en-v1.5".to_string()),
+                embedding_backend: Some("onnx".to_string()),
+                cache_key: Some("old".to_string()),
+                dimension: Some(768),
+                doc_version: Some(5),
+                mixed_embedding_profiles: false,
+                mixed_embedding_models: false,
+                mixed_embedding_backends: false,
+                mixed_dimensions: false,
+                mixed_doc_versions: false,
+                mixed_doc_shapes: false,
+                doc_shape: Some("old-shape".to_string()),
+                semantic_policy_version: Some("graph_first_v1".to_string()),
+                mixed_semantic_policy_versions: false,
+            });
+
+        let check = semantic_contract_check(&retrieval);
+
+        assert!(check.message.contains("retrieval bootstrap"));
+        assert!(check.message.contains("retrieval index --refresh full"));
+        assert!(!check.message.contains("setup embeddings"));
     }
 
     #[test]
@@ -16197,7 +16256,8 @@ mod tests {
         );
         assert_eq!(blocker.repo_count, 2);
         assert_eq!(blocker.repos, vec!["alpha", "gamma"]);
-        assert!(blocker.next_action.contains("setup embeddings"));
+        assert!(blocker.next_action.contains("retrieval bootstrap"));
+        assert!(!blocker.next_action.contains("setup embeddings"));
 
         let markdown = render_drill_suite_markdown(&output);
         assert!(markdown.contains("## Retrieval Blockers"));

--- a/crates/codestory-cli/src/managed_embeddings.rs
+++ b/crates/codestory-cli/src/managed_embeddings.rs
@@ -19,10 +19,6 @@ const MANAGED_ONNX_PROVIDER: &str = if cfg!(target_os = "windows") {
 } else {
     "cpu"
 };
-const MANAGED_DOC_EMBED_BATCH_SIZE: usize = 2048;
-const MANAGED_SEMANTIC_DOC_MAX_TOKENS: usize = 512;
-const MANAGED_ONNX_BATCH_TOKENS: usize = 32_768;
-const MANAGED_STORED_VECTOR_ENCODING: &str = "int8";
 const BUNDLED_LLAMACPP_BACKEND_LABEL: &str = "llamacpp";
 const MANAGED_DIR_NAME: &str = "managed-embeddings";
 const MANAGED_POOLED_ONNX_MODEL_NAME: &str = "model_optimized_cls_pool.onnx";
@@ -264,7 +260,7 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
         return ManagedEmbeddingsStatus {
             state: "disabled_by_config".to_string(),
             message:
-                "Managed ONNX is skipped because embedding env config selects legacy llama.cpp."
+                "Diagnostic ONNX setup is skipped because embedding env config selects llama.cpp."
                     .to_string(),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
@@ -275,9 +271,8 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
     if disabled_by_embedding_env() {
         return ManagedEmbeddingsStatus {
             state: "disabled_by_config".to_string(),
-            message:
-                "Managed ONNX is skipped because embedding env config selects another backend."
-                    .to_string(),
+            message: "Diagnostic ONNX setup is skipped because embedding env config selects another backend."
+                .to_string(),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
             model: None,
@@ -289,7 +284,7 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
     if model.is_none() || tokenizer.is_none() {
         return ManagedEmbeddingsStatus {
             state: "missing_managed_assets".to_string(),
-            message: "Managed ONNX assets are not installed. Run `codestory-cli setup embeddings`."
+            message: "Diagnostic ONNX assets are not installed. Product packet/search uses the llama.cpp retrieval sidecar; run `codestory-cli retrieval bootstrap` and `codestory-cli retrieval index --refresh full` for product readiness."
                 .to_string(),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
@@ -303,7 +298,7 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
         return ManagedEmbeddingsStatus {
             state: "managed_onnx_unusable".to_string(),
             message: format!(
-                "Managed ONNX assets are installed but failed runtime verification: {error}"
+                "Diagnostic ONNX assets are installed but failed runtime verification: {error}"
             ),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
@@ -314,22 +309,13 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
     ManagedEmbeddingsStatus {
         state: "managed_onnx_ready".to_string(),
         message: format!(
-            "Managed ONNX embeddings are installed with model `{}` and tokenizer `{}`.",
+            "Diagnostic ONNX embeddings are installed with model `{}` and tokenizer `{}`. Product packet/search still requires llama.cpp sidecar retrieval.",
             clean_path(&model),
             clean_path(&tokenizer)
         ),
         root: clean_path(root),
         endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
         model: Some(clean_path(&model)),
-    }
-}
-
-pub(crate) fn prepare_runtime_if_installed(root: &Path) {
-    if disabled_by_embedding_env() || legacy_llamacpp_backend_selected() {
-        return;
-    }
-    if managed_endpoint_assets_available(root) {
-        set_managed_endpoint_env(root);
     }
 }
 
@@ -1010,48 +996,6 @@ fn explicit_llama_url() -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-}
-
-fn set_managed_endpoint_env(root: &Path) {
-    let Some(model_path) = default_onnx_model_path(root) else {
-        return;
-    };
-    let Some(tokenizer_path) = default_onnx_tokenizer_path(root) else {
-        return;
-    };
-    unsafe {
-        set_env_default_str("CODESTORY_EMBED_BACKEND", MANAGED_ONNX_BACKEND_LABEL);
-        set_env_default_str("CODESTORY_EMBED_ONNX_MODEL", &clean_path(&model_path));
-        set_env_default_str(
-            "CODESTORY_EMBED_ONNX_TOKENIZER",
-            &clean_path(&tokenizer_path),
-        );
-        set_env_default_str("CODESTORY_EMBED_ONNX_PROVIDER", MANAGED_ONNX_PROVIDER);
-        set_env_default(
-            "CODESTORY_EMBED_ONNX_BATCH_TOKENS",
-            MANAGED_ONNX_BATCH_TOKENS,
-        );
-        set_env_default(
-            "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE",
-            MANAGED_DOC_EMBED_BATCH_SIZE,
-        );
-        set_env_default(
-            "CODESTORY_SEMANTIC_DOC_MAX_TOKENS",
-            MANAGED_SEMANTIC_DOC_MAX_TOKENS,
-        );
-        set_env_default_str(
-            "CODESTORY_STORED_VECTOR_ENCODING",
-            MANAGED_STORED_VECTOR_ENCODING,
-        );
-    }
-}
-
-unsafe fn set_env_default(key: &str, value: usize) {
-    if std::env::var_os(key).is_none() {
-        unsafe {
-            std::env::set_var(key, value.to_string());
-        }
-    }
 }
 
 unsafe fn set_env_default_str(key: &str, value: &str) {

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -41,9 +41,9 @@ pub(crate) struct OpenedProject {
 
 /// Shared service handles and filesystem roots for a CLI command.
 ///
-/// `RuntimeContext::new` may start installed managed embeddings before runtime
-/// access; use `new_inspect_only` for health and cache commands that should not
-/// mutate or start background dependencies.
+/// Runtime construction never promotes installed managed embedding assets into
+/// product defaults. Product packet/search paths set llama.cpp sidecar defaults
+/// explicitly before opening the runtime.
 pub(crate) struct RuntimeContext {
     pub(crate) project: ProjectService,
     pub(crate) index: IndexService,
@@ -61,13 +61,6 @@ pub(crate) struct RuntimeContext {
 struct ResolutionCandidateRank {
     file_filter_match: u8,
     resolution: ResolutionRank,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-/// Managed embedding startup behavior for runtime construction.
-pub(crate) enum ManagedEmbeddingStartup {
-    AutostartIfInstalled,
-    InspectOnly,
 }
 
 #[derive(Debug, Clone)]
@@ -106,7 +99,7 @@ impl std::error::Error for AmbiguousTargetError {}
 impl RuntimeContext {
     /// Open runtime services for a command that may use managed embeddings.
     pub(crate) fn new(args: &ProjectArgs) -> Result<Self> {
-        Self::new_with_startup(args, ManagedEmbeddingStartup::AutostartIfInstalled)
+        Self::new_with_startup(args)
     }
 
     /// Open runtime services for agent-facing packet/search commands.
@@ -117,18 +110,15 @@ impl RuntimeContext {
 
     /// Open runtime services without starting managed embedding processes.
     pub(crate) fn new_inspect_only(args: &ProjectArgs) -> Result<Self> {
-        Self::new_with_startup(args, ManagedEmbeddingStartup::InspectOnly)
+        Self::new_with_startup(args)
     }
 
-    fn new_with_startup(args: &ProjectArgs, startup: ManagedEmbeddingStartup) -> Result<Self> {
+    fn new_with_startup(args: &ProjectArgs) -> Result<Self> {
         let project_root = canonicalize_project_root(&args.project)?;
         let cache_override = trusted_cache_override(&project_root, args.cache_dir.as_deref())?;
         let cache_root = cache_root_for_project(&project_root, cache_override.as_deref())?;
         let managed_embeddings_root =
             crate::managed_embeddings::runtime_managed_root(cache_override.as_deref())?;
-        if startup == ManagedEmbeddingStartup::AutostartIfInstalled {
-            crate::managed_embeddings::prepare_runtime_if_installed(&managed_embeddings_root);
-        }
         let storage_path = cache_root.join("codestory.db");
         let runtime = Runtime::new();
         let events = runtime.events();
@@ -978,7 +968,7 @@ mod tests {
     }
 
     #[test]
-    fn autostart_runtime_sets_managed_onnx_defaults_when_assets_exist() {
+    fn default_runtime_does_not_promote_managed_onnx_assets() {
         let _env_lock = crate::config::config_env_test_lock();
         let _env_snapshot = EnvSnapshot::clear(MANAGED_ENV_VARS);
         let temp = tempdir().expect("temp dir");
@@ -993,12 +983,9 @@ mod tests {
         })
         .expect("runtime context");
 
-        assert_eq!(
-            env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
-            Some("onnx")
-        );
-        assert!(env::var("CODESTORY_EMBED_ONNX_MODEL").is_ok());
-        assert!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").is_ok());
+        assert_eq!(env::var("CODESTORY_EMBED_BACKEND").ok(), None);
+        assert_eq!(env::var("CODESTORY_EMBED_ONNX_MODEL").ok(), None);
+        assert_eq!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").ok(), None);
     }
 
     #[test]

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1098,7 +1098,13 @@ fn setup_embeddings_dry_run_reports_pinned_managed_assets() {
     );
     assert_eq!(
         setup["backend"], "onnx",
-        "setup should select ONNX: {setup:#}"
+        "setup should report the diagnostic ONNX backend: {setup:#}"
+    );
+    assert!(
+        setup["status"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Diagnostic ONNX assets are not installed")),
+        "setup should label ONNX as diagnostic: {setup:#}"
     );
     assert!(
         setup["model"]["url"]
@@ -1143,7 +1149,12 @@ fn setup_embeddings_dry_run_reports_pinned_managed_assets() {
                 clean_test_path(cache_dir.path())
             ),
             format!(
-                "codestory-cli index --project \"{}\" --cache-dir \"{}\" --refresh full",
+                "codestory-cli retrieval bootstrap --project \"{}\" --cache-dir \"{}\"",
+                clean_test_path(workspace.path()),
+                clean_test_path(cache_dir.path())
+            ),
+            format!(
+                "codestory-cli retrieval index --project \"{}\" --cache-dir \"{}\" --refresh full",
                 clean_test_path(workspace.path()),
                 clean_test_path(cache_dir.path())
             ),
@@ -1170,14 +1181,20 @@ fn doctor_reports_managed_embedding_setup_state() {
     let message = managed["message"].as_str().expect("managed message");
     match status {
         "info" => assert!(
-            message.contains("setup embeddings"),
-            "doctor should name the setup command when managed assets are missing: {doctor:#}"
+            message.contains("Diagnostic ONNX") && message.contains("retrieval bootstrap"),
+            "doctor should label missing ONNX assets as diagnostic and name product sidecar repair: {doctor:#}"
         ),
         "ok" => assert!(
-            message.contains("Managed ONNX embeddings are installed"),
-            "doctor should report globally available managed assets for isolated cache dirs: {doctor:#}"
+            message.contains("Diagnostic ONNX embeddings are installed"),
+            "doctor should label globally available ONNX assets as diagnostic: {doctor:#}"
         ),
-        _ => panic!("managed setup state should be informational or installed: {doctor:#}"),
+        "warn" => assert!(
+            message.contains("External llama.cpp endpoint"),
+            "doctor should report product llama.cpp endpoint warnings separately from ONNX setup: {doctor:#}"
+        ),
+        _ => panic!(
+            "managed setup state should be informational, installed, or endpoint warning: {doctor:#}"
+        ),
     }
 }
 
@@ -1198,14 +1215,30 @@ fn doctor_does_not_autostart_installed_managed_embeddings() {
     let managed = check_with_name(&doctor, "managed_embeddings");
     assert_eq!(
         managed["status"], "warn",
-        "installed but invalid managed assets should fail runtime verification: {doctor:#}"
+        "unreachable product llama.cpp endpoint should warn without promoting ONNX assets: {doctor:#}"
     );
     assert!(
         managed["message"]
             .as_str()
-            .is_some_and(|message| message.contains("failed runtime verification")),
-        "managed status should explain that installed assets did not pass runtime verification: {doctor:#}"
+            .is_some_and(|message| message.contains("External llama.cpp endpoint")),
+        "managed status should report the product endpoint warning: {doctor:#}"
     );
+    for name in [
+        "CODESTORY_EMBED_ONNX_MODEL",
+        "CODESTORY_EMBED_ONNX_TOKENIZER",
+        "CODESTORY_EMBED_ONNX_PROVIDER",
+    ] {
+        let env_row = doctor["environment"]
+            .as_array()
+            .expect("doctor environment")
+            .iter()
+            .find(|row| row["name"] == name)
+            .unwrap_or_else(|| panic!("missing env row {name}: {doctor:#}"));
+        assert_eq!(
+            env_row["message"], "not set; using runtime defaults",
+            "doctor must not set {name} from installed diagnostic assets: {env_row:#}"
+        );
+    }
     assert!(
         !cache_dir
             .path()

--- a/crates/codestory-retrieval/src/generation.rs
+++ b/crates/codestory-retrieval/src/generation.rs
@@ -404,17 +404,18 @@ mod tests {
     }
 
     #[test]
-    fn manifest_staleness_rejects_embedding_contract_drift() {
+    fn manifest_staleness_rejects_old_onnx_embedding_contract() {
         let project = TempDir::new().expect("project");
         let storage_path = project.path().join("codestory.db");
         let storage = Store::open(&storage_path).expect("open store");
         let mut manifest = manifest("proj", "deadbeefcafebabe1234");
-        manifest.embedding_backend = Some("other-backend:768".into());
+        manifest.embedding_backend = Some("onnx:bge".into());
 
         let reason = manifest_staleness_reason(&storage, &manifest)
             .expect("embedding backend drift should stale manifest");
 
         assert!(reason.contains("sidecar_embedding_backend_changed"));
+        assert!(reason.contains("manifest=onnx:bge"));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -5734,7 +5734,7 @@ fn sync_llm_symbol_projection(
         })?),
         Err(error) => {
             tracing::warn!(
-                "embedding runtime unavailable ({error}); graph-native symbol docs will still be refreshed, but dense anchor retrieval will be unavailable until managed ONNX assets are installed with `codestory-cli setup embeddings` or embedding env points at a reachable runtime. Agent-facing retrieval must be repaired to full sidecar readiness before packet/search evidence is trusted."
+                "embedding runtime unavailable ({error}); graph-native symbol docs will still be refreshed, but dense anchor retrieval will be unavailable until the llama.cpp embedding sidecar is reachable or embedding env points at an explicit diagnostic runtime. Agent-facing retrieval must be repaired to full sidecar readiness before packet/search evidence is trusted."
             );
             None
         }

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -507,7 +507,7 @@ impl OnnxModelPaths {
 fn required_path_env(key: &str) -> Result<PathBuf> {
     let raw = std::env::var(key).with_context(|| {
         format!(
-            "{key} is not set; run `codestory-cli setup embeddings` or set {ONNX_MODEL_PATH_ENV} and {ONNX_TOKENIZER_PATH_ENV}"
+            "{key} is not set; ONNX is diagnostic-only, so set {ONNX_MODEL_PATH_ENV} and {ONNX_TOKENIZER_PATH_ENV} explicitly or use product llama.cpp sidecar retrieval"
         )
     })?;
     let path = PathBuf::from(raw.trim());

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -49,11 +49,10 @@ Important tuning surfaces:
 
 Product packet/search evidence is served through mandatory sidecars. The live
 query sidecar must use `llamacpp:bge-base-en-v1.5`, and health must report
-`retrieval_mode=full`. Stored product-compatible BGE-base dense docs may have
-ONNX or llama.cpp producer metadata when the dimension/backend contract matches
-the retrieval manifest; hash and other in-process embedding paths remain
-diagnostic unless a future spec promotes them with fresh sidecar-quality
-evidence. Current benchmark findings live in
+`retrieval_mode=full`. Stored ONNX, hash, or other diagnostic producer metadata
+must fail closed when it does not match the current llama.cpp product manifest;
+hash and other in-process embedding paths remain diagnostic unless a future spec
+promotes them with fresh sidecar-quality evidence. Current benchmark findings live in
 [embedding-backend-benchmarks.md](../../testing/embedding-backend-benchmarks.md).
 
 The CLI owns managed embedding setup. `codestory-cli retrieval bootstrap` starts

--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -100,9 +100,12 @@ Recovery order:
    `codestory-cli retrieval index --project . --refresh full`.
 5. Require `codestory-cli retrieval status --project . --format json` to report
    `retrieval_mode: "full"` before trusting packet/search evidence.
-6. If `doctor` reports `missing_managed_assets`, use `codestory-cli setup embeddings --project .`
-   only for managed ONNX/local semantic diagnostics. Managed setup installs ONNX assets and should
-   not start a server or create the product retrieval manifest.
+6. If `doctor` reports missing or unreachable embeddings, repair the llama.cpp
+   sidecar path with `codestory-cli retrieval bootstrap` and
+   `codestory-cli retrieval index --project . --refresh full`. Use
+   `codestory-cli setup embeddings --project .` only for explicit ONNX
+   diagnostics; it does not start sidecars or create the product retrieval
+   manifest.
 7. If semantic retrieval is still the only failing part, inspect the reported degraded-state reason before touching lexical ranking or CLI rendering.
 
 ## If Cold Indexing Is Slow

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -124,7 +124,7 @@ cargo build --release -p codestory-cli
 
 On Windows PowerShell, use `.\target\release\codestory-cli.exe`.
 
-This loop proves the local CLI and managed ONNX diagnostic path are wired, but
+This loop proves the local CLI and diagnostic ONNX asset path are wired, but
 it is not product packet/search sidecar setup. Treat `setup embeddings
 --dry-run` as an asset-plan check only. It should not start an embedding server,
 write a product retrieval manifest, or make agent-facing retrieval evidence

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -271,8 +271,9 @@ Default Windows cache locations:
 Downloaded model artifacts under `CODESTORY_EMBED_MODEL_DIR` or
 `target/retrieval-models` are accepted only after pinned size and SHA-256
 verification by the setup wrapper. Remove that model directory to uninstall the
-downloaded GGUF. Managed ONNX assets from `setup embeddings` are separate and do
-not substitute for llama.cpp sidecar retrieval.
+downloaded GGUF. Diagnostic ONNX assets from `setup embeddings` are separate,
+are not promoted into product runtime defaults, and do not substitute for
+llama.cpp sidecar retrieval.
 
 ## Operator troubleshooting
 
@@ -357,7 +358,7 @@ sidecars, and partial sidecars are diagnostic only and cannot produce
 
 Qdrant document vectors are copied from managed local `llm_symbol_doc`
 dense-anchor rows when the stored embedding contract is product BGE base profile:
-`bge-base-en-v1.5`, `768` dimensions, ONNX or llama.cpp backend. Query vectors
+`bge-base-en-v1.5`, `768` dimensions, and the llama.cpp product backend. Query vectors
 come from the local llama.cpp sidecar so retrieval remains sidecar-backed and
 can smoke-test the live collection. Wrong model dimensions fail loudly.
 

--- a/plugins/codestory/skills/codestory-grounding/references/context.md
+++ b/plugins/codestory/skills/codestory-grounding/references/context.md
@@ -29,7 +29,7 @@ Builds target context around one concrete retrieval target. Target selection is 
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> context --project <target-workspace> --query AppController` | Markdown context packet with resolution metadata, retrieval trace, citations, gaps, and next commands when sidecar-primary retrieval is full. |
-| Failure path | If the target is ambiguous or missing, run `search --project <target-workspace> --query "<target>" --why`, choose a concrete `node_id`, then rerun `context --id <node_id>`. If local navigation readiness is weak, run `doctor --project <target-workspace>`, `setup embeddings --project <target-workspace>` when needed, and `index --project <target-workspace> --refresh full`. | Keeps target context tied to a resolvable target and avoids treating stale retrieval as strong evidence. |
+| Failure path | If the target is ambiguous or missing, run `search --project <target-workspace> --query "<target>" --why`, choose a concrete `node_id`, then rerun `context --id <node_id>`. If local navigation readiness is weak, run `doctor --project <target-workspace>`, `retrieval bootstrap --project <target-workspace>` when needed, and `retrieval index --project <target-workspace> --refresh full`. | Keeps target context tied to a resolvable target and avoids treating stale retrieval as strong evidence. |
 | Integration edge | Use `search --why`, `explore`, or `bookmark list` first, then pass the selected node via `--id <node_id>` or `--bookmark <bookmark_id>`; use `--bundle out/context-AppController` for reviewer handoff. | Converts candidate discovery into a deeper, shareable evidence packet. |
 
 ## Notes

--- a/plugins/codestory/skills/codestory-grounding/references/context.md
+++ b/plugins/codestory/skills/codestory-grounding/references/context.md
@@ -29,7 +29,7 @@ Builds target context around one concrete retrieval target. Target selection is 
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> context --project <target-workspace> --query AppController` | Markdown context packet with resolution metadata, retrieval trace, citations, gaps, and next commands when sidecar-primary retrieval is full. |
-| Failure path | If the target is ambiguous or missing, run `search --project <target-workspace> --query "<target>" --why`, choose a concrete `node_id`, then rerun `context --id <node_id>`. If local navigation readiness is weak, run `doctor --project <target-workspace>`, `retrieval bootstrap --project <target-workspace>` when needed, and `retrieval index --project <target-workspace> --refresh full`. | Keeps target context tied to a resolvable target and avoids treating stale retrieval as strong evidence. |
+| Failure path | If the target is ambiguous or missing, run `search --project <target-workspace> --query "<target>" --why`, choose a concrete `node_id`, then rerun `context --id <node_id>`. If sidecar-primary retrieval readiness is weak, run `doctor --project <target-workspace>`, `retrieval bootstrap --project <target-workspace>` when needed, and `retrieval index --project <target-workspace> --refresh full`. | Keeps target context tied to a resolvable target and avoids treating stale retrieval as strong evidence. |
 | Integration edge | Use `search --why`, `explore`, or `bookmark list` first, then pass the selected node via `--id <node_id>` or `--bookmark <bookmark_id>`; use `--bundle out/context-AppController` for reviewer handoff. | Converts candidate discovery into a deeper, shareable evidence packet. |
 
 ## Notes

--- a/plugins/codestory/skills/codestory-grounding/references/index.md
+++ b/plugins/codestory/skills/codestory-grounding/references/index.md
@@ -52,9 +52,9 @@ unstructured docs. On a fresh machine, check the setup plan first:
 <codestory-cli> setup embeddings --project <target-workspace> --dry-run --format json
 ```
 
-Then install assets with `setup embeddings --project <target-workspace>` if the
-plan is acceptable, and rerun `index --project <target-workspace>` unless the
-setup plan explicitly asks for a full refresh.
+Then install assets with `setup embeddings --project <target-workspace>` only
+for explicit ONNX diagnostics. Product packet/search readiness uses the
+llama.cpp retrieval sidecar path.
 
 High-signal environment toggles:
 

--- a/plugins/codestory/skills/codestory-grounding/references/setup.md
+++ b/plugins/codestory/skills/codestory-grounding/references/setup.md
@@ -16,7 +16,7 @@ surprise-download. Agent-facing packet/search evidence still requires
 |--------|---------|-----|
 | `--project <path>` | `.` | Target workspace used to resolve cache configuration. Always pass it explicitly. |
 | `--cache-dir <path>` | auto | Use an isolated cache root, useful for tests and repros. |
-| `--quant <q8_0|q4_k_m>` | `q8_0` | Legacy compatibility selector. Managed `setup embeddings` installs pinned ONNX assets for the local semantic runtime; GGUF llama.cpp sidecar model setup is handled by the retrieval sidecar setup path. |
+| `--quant <q8_0|q4_k_m>` | `q8_0` | Legacy compatibility selector. `setup embeddings` installs diagnostic ONNX assets only; GGUF llama.cpp sidecar model setup is handled by the retrieval sidecar setup path. |
 | `--variant <cpu|vulkan>` | `vulkan` | Compatibility selector for older setup flows; product sidecar use is governed by `retrieval bootstrap`. |
 | `--dry-run` | off | Show the asset plan without downloading anything. |
 | `--no-start` | off | Compatibility flag; product setup is handled by retrieval sidecar bootstrap. |
@@ -28,7 +28,7 @@ surprise-download. Agent-facing packet/search evidence still requires
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Product packet/search setup | Follow `docs/ops/retrieval-sidecars.md`, then run `retrieval bootstrap`, `retrieval index`, and `retrieval status` for the target workspace. | Product search/packet paths are usable only when status reports `retrieval_mode=full`. |
-| Legacy managed assets | `setup embeddings --project <target-workspace> --dry-run --format json`, then `setup embeddings --project <target-workspace>` if the plan is expected. | Installs local managed ONNX assets for semantic diagnostics; it does not start sidecars or prove packet/search readiness. |
+| Legacy diagnostic assets | `setup embeddings --project <target-workspace> --dry-run --format json`, then `setup embeddings --project <target-workspace>` if the plan is expected. | Installs local ONNX assets for semantic diagnostics; it does not start sidecars, set product defaults, or prove packet/search readiness. |
 | Failure path | Use the sidecar runbook for llama.cpp/GGUF/manifest failures; use `setup embeddings --dry-run --format json` only for legacy managed asset diagnosis. | Keeps product sidecar setup separate from legacy asset setup. |
 
 ## Notes


### PR DESCRIPTION
## Context

Closes #638.

CodeStory now treats llama.cpp sidecar embeddings as the single product packet/search path. The pre-edit inventory found these ONNX-owned surfaces:

| Path | Decision |
|---|---|
| `crates/codestory-cli/src/managed_embeddings.rs` | diagnostic setup/status path; keep asset install/probe, remove product autostart promotion |
| `crates/codestory-cli/src/runtime.rs` | product/runtime flow; remove implicit installed-ONNX env defaults from `RuntimeContext::new` |
| `crates/codestory-cli/src/main.rs`, `crates/codestory-cli/src/args.rs` | setup/help surface; point next steps/help at llama.cpp retrieval sidecars |
| `crates/codestory-runtime/src/search/engine.rs` | explicit ONNX diagnostic runtime; keep only when env paths are provided |
| `crates/codestory-runtime/src/lib.rs` | runtime warning text; stop telling operators to repair product readiness with setup embeddings |
| `crates/codestory-retrieval/src/generation.rs`, `crates/codestory-retrieval/src/sidecar.rs`, `crates/codestory-retrieval/src/index.rs` | cache/manifest compatibility; keep fail-closed checks, add old ONNX manifest regression |
| `docs/*` and `plugins/codestory/skills/codestory-grounding/references/*` | operator guidance; label ONNX as diagnostic-only and llama.cpp as product path |
| `scripts/codestory-embedding-runtime-compare.mjs`, benchmark docs | diagnostic/historical path; left intact |

```mermaid
flowchart LR
    A[CLI runtime open] --> B[No implicit ONNX env]
    B --> C[Product packet/search]
    C --> D[llama.cpp retrieval sidecar]
    B --> E[Explicit ONNX env]
    E --> F[diagnostic runtime only]
    D --> G[full retrieval manifest]
    F --> H[not product-compatible]
```

## What Changed

- Removed the shared runtime autostart path that promoted installed managed ONNX assets into `CODESTORY_EMBED_*` defaults.
- Kept ONNX setup/runtime code as explicit diagnostics, with status/help text that says it is not product packet/search readiness.
- Changed `setup embeddings` next commands from plain `index --refresh full` to retrieval sidecar bootstrap/index guidance.
- Added/updated regressions for no ONNX env promotion, setup/status wording, stored ONNX semantic-doc mismatch, and old ONNX retrieval manifests.
- Updated nearby docs and the bundled grounding skill references so operators see llama.cpp sidecar retrieval as the product path.

## How To Review

- Start in `crates/codestory-cli/src/runtime.rs`: `RuntimeContext::new` no longer has an autostart branch.
- Then review `crates/codestory-cli/src/managed_embeddings.rs`: ONNX setup/status remains, but text and env promotion changed to diagnostic-only.
- Check `crates/codestory-retrieval/src/generation.rs` for old ONNX manifest fail-closed coverage.
- Skim docs/help updates for operator wording consistency.

## Verification

- `cargo test -p codestory-cli managed_onnx`
- `cargo test -p codestory-cli --test cli_golden_path setup_embeddings_dry_run_reports_pinned_managed_assets -- --nocapture`
- `cargo test -p codestory-cli --test cli_golden_path doctor_reports_managed_embedding_setup_state -- --nocapture`
- `cargo test -p codestory-cli --test cli_golden_path doctor_does_not_autostart_installed_managed_embeddings -- --nocapture`
- `cargo test -p codestory-cli --test cli_golden_path index_dry_run_does_not_autostart_installed_managed_embeddings -- --nocapture`
- `cargo test -p codestory-retrieval manifest_staleness_rejects_old_onnx_embedding_contract`
- `cargo test -p codestory-retrieval strict_readiness_rejects_stored_doc_backend_mismatch`
- `cargo fmt --check`
- `git diff --check`

CodeStory grounding boundary: MCP resources were not model-visible in this delegated worktree. Managed CLI `doctor` was available but reported an empty local index and `retrieval_manifest_missing`; I did not run index/repair because the handoff forbade repair loops.

## Risk

This intentionally does not delete the ONNX engine or dependency; explicit ONNX diagnostics and historical benchmark tooling remain. The main behavior change is that installed managed ONNX assets no longer silently influence product runtime defaults.