### PR TITLE
[codex] Cap MCP startup wait

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -520,7 +520,7 @@ function localWaitFreshCommand(projectRoot = process.cwd()) {
 
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
 }
 
 function sidecarRepairTimeoutMs() {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1192,6 +1192,7 @@ test("hook manifest timeouts cover managed bootstrap budget", async () => {
     /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
     "local wait-fresh timeout default",
   );
+  assert.equal(localWaitFreshTimeoutMs, 5000, "local wait-fresh default must stay MCP startup-safe");
   const requiredTimeoutSec = Math.max(
     Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
     Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),


### PR DESCRIPTION
## Context

Closes #674.
Refs #662 and #618.

The installed 0.11.20 plugin cache still runs the MCP adapter with a 120s pre-stdio local wait-fresh default. In the active Codex model context that startup path still closes before `initialize` completes, so `codestory://status` is not model-visible.

```mermaid
flowchart LR
  Host[Codex MCP host] --> Adapter[plugin adapter]
  Adapter --> Wait[local wait-fresh]
  Wait --> Serve[codestory-cli serve --stdio]
  Adapter -->|after this PR: 5s default cap| Serve
```

## What Changed

- Changed the plugin MCP launcher local wait-fresh default from 120000ms to 5000ms.
- Added a plugin static regression assertion so the 5000ms startup-safe default cannot drift silently.
- Kept `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS` as the override for slower local setups.
- Preserved fail-open status behavior so the adapter can still expose diagnostic resources instead of closing transport.

## How To Review

- Review `plugins/codestory/scripts/codestory-mcp.cjs` for the startup timeout default change.
- Review `plugins/codestory/tests/plugin-static.test.mjs` for the explicit default-timeout regression assertion.
- Keep #662 open until an updated installed plugin is refreshed/reloaded and a fresh Codex thread can read `codestory://status` from model-visible MCP resources.

## Verification

- `git diff --check`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 37 passed, 0 failed
- PR source adapter direct JSON-RPC probe against managed CLI: `initialize` + `resources/list` returned 2 responses, 2 resources, exit status 0, elapsed ~5241ms.
- Installed cache adapter without override: no `initialize` response within about 30018ms.
- Installed cache adapter with `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS=5000`: `initialize` + `resources/list` succeeded in about 5259ms.
- Independent review found the missing regression assertion; this branch now includes it and the plugin static suite still passes.

## Risk

- A very slow checkout may initially expose fail-open `repair_setup` status instead of waiting up to 120s before MCP startup. Operators can still override with `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS`.
- This PR proves the source adapter responds within the host-scale handshake window. #662 final acceptance still needs a refreshed/reloaded installed plugin and a fresh Codex thread where `codestory://status` is model-visible.
