### PR TITLE
[codex] Release 0.11.21 MCP startup cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.11.21
+
+CodeStory 0.11.21 is a patch hotfix for the main-served plugin package. It
+ships the MCP adapter startup wait cap from #675 through a synchronized release
+version bump so an official plugin refresh installs new package metadata instead
+of relying on same-version cache replacement.
+
+The adapter now waits up to five seconds for local freshness repair during MCP
+startup before failing open to diagnostic status. Operators can still override
+the cap with `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS`. This release does not
+claim fresh installed-plugin or model-visible MCP resource proof; those remain
+runtime checks after publication and host/plugin refresh.
+
+Supporting PRs: #675.
+
 ## 0.11.20
 
 CodeStory 0.11.20 is the agent-readiness stabilization release. It makes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.20"
+version = "0.11.21"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.20",
+  "version": "0.11.21",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.20",
+  "version": "0.11.21",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.20",
+  "version": "0.11.21",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -449,7 +449,7 @@ function localWaitFreshCommand(projectRoot = process.cwd()) {
 
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
 }
 
 function runLocalNavigationWaitFresh(resolved, projectRoot) {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -970,6 +970,16 @@ test("session-start hooks are thin and host manifests point at them", async () =
   assert.equal(manifest.hooks, "./hooks/claude-codex-hooks.json");
 });
 
+test("mcp launcher local wait-fresh default stays startup-safe", async () => {
+  const mcpSource = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8");
+  const match = mcpSource.match(
+    /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
+  );
+  assert.ok(match, "missing local wait-fresh timeout default");
+  const localWaitFreshTimeoutMs = Number.parseInt(match[1], 10);
+  assert.equal(localWaitFreshTimeoutMs, 5000, "local wait-fresh default must stay MCP startup-safe");
+});
+
 async function withFakeCodeStoryCli(callback) {
   const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-test-"));
   const shPath = join(binDir, "codestory-cli");


### PR DESCRIPTION
## Context

Closes #676.
Refs #662.
Refs #618.

#673 is merged on `dev/codestory-next`, but the installed plugin will not reliably refresh from a same-version `0.11.20` source change. This PR carries the MCP startup wait cap as a synchronized `0.11.21` patch release on `main` so the official release/plugin refresh path has new package metadata to install.

Current release/tag is `v0.11.20`. The larger `0.12.0` lane remains open; this is the minimal patch release needed to unblock the promoted plugin/runtime proof.

```mermaid
flowchart LR
  Main[`main` source] --> Version[`0.11.21`]
  Version --> Release[auto-release]
  Release --> Refresh[plugin refresh/reload]
  Refresh --> Status[codestory://status proof]
```

## What Changed

- Changed the plugin MCP adapter local wait-fresh default from `120000ms` to `5000ms`.
- Added a focused static regression for the `5000ms` default.
- Bumped CodeStory release metadata to `0.11.21` across workspace crates, `Cargo.lock`, and shipped plugin manifests.
- Added the `0.11.21` changelog entry.

## How To Review

- Confirm the behavior change is limited to `plugins/codestory/scripts/codestory-mcp.cjs` and the static regression.
- Confirm the timeout override remains `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS`.
- Confirm `0.11.21` is synchronized across Cargo manifests, `Cargo.lock`, and plugin manifests.
- Treat merge as the patch release trigger; final #662/#618 acceptance still needs official plugin refresh/reload and fresh-thread model-visible `codestory://status` proof.

## Verification

- `python .github\scripts\check-codestory-release.py --version 0.11.21` -> passed
- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> 34 passed, 0 failed
- `git diff --check` -> passed

## Risk

Very slow local navigation freshness repair now fails open sooner during MCP startup, exposing diagnostic status instead of waiting up to 120 seconds before stdio serve. Operators can still override with `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS`.

Release risk is explicit: binary/package evidence is not final runtime proof. After publication, #662/#618 still require plugin refresh plus fresh-thread model-visible MCP status.
