### PR TITLE
Release 0.11.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.11.22
+
+CodeStory 0.11.22 fixes the plugin-bundled MCP launch directory. The plugin
+now sets the MCP server `cwd` to the installed plugin root so Codex resolves
+`./scripts/codestory-mcp.cjs` inside the plugin cache instead of the active
+repo/session directory.
+
+Supporting PRs: #677.
+
 ## 0.11.21
 
 CodeStory 0.11.21 is a patch hotfix for the main-served plugin package. It

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.21"
+version = "0.11.22"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.21"
+version = "0.11.22"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.21",
+  "version": "0.11.22",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.21",
+  "version": "0.11.22",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.21",
+  "version": "0.11.22",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/.mcp.json
+++ b/plugins/codestory/.mcp.json
@@ -3,6 +3,7 @@
     "codestory": {
       "command": "node",
       "args": ["./scripts/codestory-mcp.cjs"],
+      "cwd": ".",
       "tool_timeout_sec": 300
     }
   }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -111,7 +111,7 @@ test("plugin metadata maps skill and direct stdio server", async () => {
   assert.deepEqual(mcp.mcpServers.codestory.args, [
     "./scripts/codestory-mcp.cjs",
   ]);
-  assert.equal(Object.hasOwn(mcp.mcpServers.codestory, "cwd"), false);
+  assert.equal(mcp.mcpServers.codestory.cwd, ".");
 });
 
 test("plugin package version tracks the codestory-cli release version", async () => {


### PR DESCRIPTION
## Context

CodeStory 0.11.21 installed correctly, but Codex resolved the plugin-bundled MCP server with `cwd = null`. Because the server command uses `./scripts/codestory-mcp.cjs`, Codex could try to launch it from the active session directory instead of the installed plugin cache, closing transport during MCP initialize.

Fixes #662.
Refs #618.

## What Changed

- Set the CodeStory plugin MCP server `cwd` to `.` so Codex resolves it to the installed plugin root.
- Updated the plugin static test to require the bundled MCP cwd.
- Bumped synchronized release metadata to `0.11.22` across the workspace crates, Cargo.lock, and plugin manifests.
- Added the `0.11.22` changelog entry.

## How To Review

- Check `plugins/codestory/.mcp.json` and the matching static test assertion first.
- Check the version-only surfaces after that.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.11.22`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `git diff --check`

## Risk

Existing running Codex threads may still need a host reload or fresh thread to pick up the corrected plugin MCP launch config. The release needs the normal main-merge publication flow before marketplace reinstall proof can close #618.