### PR TITLE
Infer Codex plugin data from installed cache

### DIFF
--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -24,8 +24,8 @@
     "privacyPolicyURL": "https://github.com/TheGreenCedar/CodeStory",
     "termsOfServiceURL": "https://github.com/TheGreenCedar/CodeStory",
     "defaultPrompt": [
-      "@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.",
-      "@CodeStory Where is RefreshMode defined, which codestory-cli commands accept --refresh, and what is the call path from index into codestory-store?",
+      "@CodeStory Check local and agent readiness for this checkout before packet/search.",
+      "@CodeStory Find RefreshMode and the index path into codestory-store.",
       "@CodeStory I am editing a file in this repo. What symbols are affected and what tests should I run first?"
     ],
     "brandColor": "#2563EB",

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -54,8 +54,38 @@ function pluginCacheVersion() {
   return parent === 'codestory' ? path.basename(pluginRoot) : null;
 }
 
+function inferredCodexPluginDataDir(root = pluginRoot) {
+  const parts = path.resolve(root).split(/[\\/]+/u);
+  for (let index = 0; index <= parts.length - 6; index += 1) {
+    if (
+      parts[index].toLowerCase() !== '.codex' ||
+      parts[index + 1] !== 'plugins' ||
+      parts[index + 2] !== 'cache' ||
+      parts[index + 4] !== 'codestory'
+    ) {
+      continue;
+    }
+    const codexRoot = parts.slice(0, index + 1).join(path.sep);
+    const dataDir = path.join(codexRoot, 'plugins', 'data', `codestory-${parts[index + 3]}`);
+    if (usablePluginDataDir(dataDir)) return dataDir;
+  }
+  return null;
+}
+
+function usablePluginDataDir(dataDir) {
+  try {
+    if (fs.existsSync(dataDir)) return fs.statSync(dataDir).isDirectory();
+    const dataRoot = path.dirname(dataDir);
+    if (fs.existsSync(dataRoot)) return fs.statSync(dataRoot).isDirectory();
+    fs.accessSync(path.dirname(dataRoot), fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function pluginDataDir() {
-  return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
+  return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || inferredCodexPluginDataDir();
 }
 
 function sidecarPolicyPath(dataDir = pluginDataDir()) {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -364,6 +364,84 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
   }
 });
 
+test("mcp launcher infers Codex managed data from installed cache without env", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const codexHome = await mkdtemp(join(tmpdir(), "codestory-installed-cache-"));
+  const codexRoot = join(codexHome, ".codex");
+  const installRoot = join(codexRoot, "plugins", "cache", "TheGreenCedar", "codestory", version);
+  const dataDir = join(codexRoot, "plugins", "data", "codestory-TheGreenCedar");
+  const outFile = join(dataDir, "env.json");
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const pathDir = await mkdtemp(join(tmpdir(), "codestory-stale-path-"));
+  const staleCli = join(pathDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const launcher = join(installRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    await mkdir(join(installRoot, "scripts"), { recursive: true });
+    await mkdir(join(installRoot, "hooks"), { recursive: true });
+    await mkdir(join(installRoot, ".codex-plugin"), { recursive: true });
+    await mkdir(cliDir, { recursive: true });
+    await writeFile(
+      launcher,
+      await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8"),
+      "utf8",
+    );
+    await writeFile(
+      join(installRoot, "hooks", "codestory-runtime.cjs"),
+      await readFile(join(pluginRoot, "hooks", "codestory-runtime.cjs"), "utf8"),
+      "utf8",
+    );
+    await writeFile(
+      join(installRoot, ".codex-plugin", "plugin.json"),
+      JSON.stringify({ version }),
+      "utf8",
+    );
+    await writeFakeCli(cliPath);
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+    await writeFile(
+      staleCli,
+      process.platform === "win32"
+        ? "@echo off\r\necho codestory-cli 0.0.1\r\n"
+        : "#!/bin/sh\necho codestory-cli 0.0.1\n",
+      "utf8",
+    );
+    await chmod(staleCli, 0o755);
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: "",
+        COPILOT_PLUGIN_DATA: "",
+        TEST_OUT: outFile,
+        PATH: pathDir,
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const observed = JSON.parse(await readFile(outFile, "utf8"));
+    assert.equal(observed.source, "managed");
+    assert.equal(observed.path, cliPath);
+    assert.equal(observed.pluginRoot, installRoot);
+    assert.equal(observed.pluginCacheVersion, version);
+    assert.equal(observed.dirtyMarkerPath, dirtyMarkerPathForProject(repoRoot, dataDir));
+  } finally {
+    await rm(codexHome, { recursive: true, force: true });
+    await rm(pathDir, { recursive: true, force: true });
+  }
+});
+
 test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();


### PR DESCRIPTION
## Context

Refs #618.

Fresh Codex contexts can now see the CodeStory MCP resources, but the installed plugin runtime can still fall back to a stale ambient `codestory-cli` when the host launches the MCP adapter without `PLUGIN_DATA` or `COPILOT_PLUGIN_DATA`. That keeps the model-visible status surface from proving the plugin-managed runtime path for the v0.12 validation gate.

This PR is source work for v0.12. It does not bump the release version.

## What Changed

- Teach the Codex MCP adapter to infer the managed plugin data directory from an installed cache path shaped like `.codex/plugins/cache/<publisher>/codestory/<version>`.
- Keep explicit `PLUGIN_DATA` and `COPILOT_PLUGIN_DATA` as higher-priority inputs.
- Add a regression test that simulates an installed cache, a managed CLI, and a stale PATH CLI, then verifies the adapter chooses the managed runtime.
- Shorten the Codex default prompts so plugin manifest loading no longer warns about overlong prompt entries.

## How To Review

- Start with `plugins/codestory/scripts/codestory-mcp.cjs` and confirm the new inference only applies to the Codex installed-cache layout.
- Review `plugins/codestory/tests/plugin-static.test.mjs` for the installed-cache regression and stale PATH guard.
- Check `plugins/codestory/.codex-plugin/plugin.json` for prompt text only; no version metadata changed.

## Verification

- `node --test --test-name-pattern "mcp launcher" plugins/codestory/tests/plugin-static.test.mjs` -> 11 pass.
- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 38 pass.
- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `git diff --check` -> passed.
- `rg -n '0\.11\.23' CHANGELOG.md Cargo.lock crates plugins/codestory/.codex-plugin/plugin.json plugins/codestory/.claude-plugin/plugin.json plugins/codestory/.github/plugin/plugin.json` -> no matches.

## Risk

The remaining risk is runtime packaging proof: this change needs to ride the 0.12 plugin release/install path before #618 can be closed from a fresh model context. The patch is intentionally source-only and does not create another patch release.
