### PR TITLE
Release CodeStory 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.12.0
+
+CodeStory 0.12.0 promotes the managed plugin runtime path for Codex. The
+plugin MCP can expose `codestory://status` in fresh contexts, provision and
+report managed CLI state, repair sidecar onboarding when allowed, and avoid
+falling back to stale ambient PATH binaries when Codex launches the installed
+adapter without plugin data environment variables.
+
+This release also removes the ONNX product embedding runtime, tightens agent
+repair progress/status reporting, adds handoff proof-target status, and trims
+Codex starter prompts so installed plugin manifests load without overlong
+default-prompt warnings.
+
+Supporting PRs: #671, #672, #673, #678.
+
+## 0.11.22
+
+CodeStory 0.11.22 fixes the plugin-bundled MCP launch directory. The plugin
+now sets the MCP server `cwd` to the installed plugin root so Codex resolves
+`./scripts/codestory-mcp.cjs` inside the plugin cache instead of the active
+repo/session directory.
+
+Supporting PRs: #677.
+
+## 0.11.21
+
+CodeStory 0.11.21 is a patch hotfix for the main-served plugin package. It
+ships the MCP adapter startup wait cap from #675 through a synchronized release
+version bump so an official plugin refresh installs new package metadata instead
+of relying on same-version cache replacement.
+
+The adapter now waits up to five seconds for local freshness repair during MCP
+startup before failing open to diagnostic status. Operators can still override
+the cap with `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS`. This release does not
+claim fresh installed-plugin or model-visible MCP resource proof; those remain
+runtime checks after publication and host/plugin refresh.
+
+Supporting PRs: #675.
+
 ## 0.11.20
 
 CodeStory 0.11.20 is the agent-readiness stabilization release. It makes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.11.20"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -908,24 +908,24 @@ pub(crate) struct SetupEmbeddingsCommand {
         long,
         value_enum,
         default_value_t = CliEmbeddingQuant::Q8_0,
-        help = "Legacy GGUF quant selector retained for CLI compatibility; managed setup now installs the pinned ONNX model."
+        help = "Legacy compatibility selector; setup embeddings now installs diagnostic ONNX assets only."
     )]
     pub(crate) quant: CliEmbeddingQuant,
     #[arg(
         long,
         value_enum,
         default_value_t = CliLlamaVariant::Vulkan,
-        help = "Legacy llama.cpp variant selector retained for CLI compatibility; managed setup now uses ONNX Runtime."
+        help = "Legacy compatibility selector; product embeddings use the llama.cpp retrieval sidecar."
     )]
     pub(crate) variant: CliLlamaVariant,
     #[arg(
         long,
-        help = "Show the managed ONNX asset plan without downloading anything."
+        help = "Show the diagnostic ONNX asset plan without downloading anything."
     )]
     pub(crate) dry_run: bool,
     #[arg(
         long,
-        help = "Compatibility flag; managed ONNX setup never starts a server."
+        help = "Compatibility flag; diagnostic ONNX setup never starts a server."
     )]
     pub(crate) no_start: bool,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1603,6 +1603,14 @@ pub(crate) struct ReadinessLaneOutput {
     pub(crate) profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) namespace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) compose_project: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) repair_updated_at_epoch_ms: Option<i64>,
     pub(crate) sidecar_mode: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) degraded_reason: Option<String>,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -118,6 +118,7 @@ const CONTEXT_BUNDLE_OUTPUT_BYTE_CAP: usize = 5 * 1024 * 1024;
 const CONTEXT_BUNDLE_MARKDOWN_SOFT_CAP: usize = 2 * 1024 * 1024;
 const CONTEXT_BUNDLE_TRUNCATION_SUFFIX: &str =
     "\n\n... bundle content truncated by context bundle byte cap\n";
+const READY_REPAIR_PROGRESS_INTERVAL: Duration = Duration::from_secs(10);
 const READY_REPAIR_EMBED_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(10);
 const READY_REPAIR_EMBED_OBSERVATION_POLL: Duration = Duration::from_millis(250);
 const MAX_DRILL_JOBS: usize = 8;
@@ -627,6 +628,102 @@ fn format_progress_bar(current: u32, total: u32) -> String {
         "[{}{}]",
         "#".repeat(filled as usize),
         "-".repeat(WIDTH.saturating_sub(filled) as usize)
+    )
+}
+
+struct ReadyRepairProgress {
+    profile: &'static str,
+    run_id: String,
+    namespace: String,
+    phase: Arc<Mutex<&'static str>>,
+    done: Arc<AtomicBool>,
+    start: Instant,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ReadyRepairProgress {
+    fn start(sidecar: &codestory_retrieval::SidecarRuntimeConfig) -> Self {
+        let phase = Arc::new(Mutex::new("starting"));
+        let done = Arc::new(AtomicBool::new(false));
+        let start = Instant::now();
+        let profile = sidecar.profile.as_str();
+        let run_id = sidecar.run_id.as_deref().unwrap_or("none").to_string();
+        let namespace = sidecar.namespace.clone();
+        let worker_phase = Arc::clone(&phase);
+        let worker_done = Arc::clone(&done);
+        let worker_run_id = run_id.clone();
+        let worker_namespace = namespace.clone();
+        let handle = std::thread::spawn(move || {
+            while !worker_done.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(100));
+                if start.elapsed() < READY_REPAIR_PROGRESS_INTERVAL {
+                    continue;
+                }
+                let elapsed = start.elapsed().as_secs();
+                if elapsed % READY_REPAIR_PROGRESS_INTERVAL.as_secs() != 0 {
+                    continue;
+                }
+                let phase = *worker_phase.lock().expect("ready repair phase lock");
+                eprintln!(
+                    "{}",
+                    ready_repair_progress_line(
+                        phase,
+                        profile,
+                        &worker_run_id,
+                        &worker_namespace,
+                        elapsed,
+                        "active"
+                    )
+                );
+                std::thread::sleep(Duration::from_secs(1));
+            }
+        });
+        Self {
+            profile,
+            run_id,
+            namespace,
+            phase,
+            done,
+            start,
+            handle: Some(handle),
+        }
+    }
+
+    fn set_phase(&self, phase: &'static str) {
+        *self.phase.lock().expect("ready repair phase lock") = phase;
+        eprintln!(
+            "{}",
+            ready_repair_progress_line(
+                phase,
+                self.profile,
+                &self.run_id,
+                &self.namespace,
+                self.start.elapsed().as_secs(),
+                "started"
+            )
+        );
+    }
+}
+
+impl Drop for ReadyRepairProgress {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn ready_repair_progress_line(
+    phase: &str,
+    profile: &str,
+    run_id: &str,
+    namespace: &str,
+    elapsed_s: u64,
+    status: &str,
+) -> String {
+    format!(
+        "[ready-repair] phase=\"{phase}\" profile={profile} run_id={run_id} namespace={namespace} elapsed_s={elapsed_s} status={status}"
     )
 }
 
@@ -2195,13 +2292,15 @@ fn repair_ready_state(
         sidecar.namespace,
         sidecar.compose_project
     );
-    let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime(
+    let progress = ReadyRepairProgress::start(&sidecar);
+    let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime_progress(
         &sidecar,
         Some(runtime.project_root.as_path()),
         &storage_scope,
         None,
         false,
         Duration::from_secs(90),
+        |phase| progress.set_phase(phase),
     )
     .context("ready repair retrieval bootstrap")?;
     let infrastructure = ready_repair_infrastructure_with_runtime_observation(
@@ -2211,24 +2310,31 @@ fn repair_ready_state(
         &sidecar,
     );
     ensure_ready_repair_embed_liveness(&infrastructure)?;
+    progress.set_phase("Qdrant finalize");
     codestory_retrieval::repair_project_qdrant_collection(
         &runtime.project_root,
         &runtime.storage_path,
     )
     .context("ready repair project qdrant repair")?;
+    progress.set_phase("graph artifact");
     runtime
         .index
         .run_indexing_blocking(IndexMode::Full)
         .map_err(map_api_error)
         .context("ready repair retrieval index refresh")?;
-    retrieval::finalize_retrieval_index_for_sidecar_runtime(runtime, &sidecar).with_context(
-        || {
-            format!(
-                "ready repair retrieval index finalize using {}",
-                retrieval::format_sidecar_runtime(&sidecar)
-            )
-        },
-    )?;
+    codestory_retrieval::finalize_index_for_runtime_with_progress(
+        &runtime.project_root,
+        &runtime.storage_path,
+        &sidecar,
+        |phase| progress.set_phase(phase),
+    )
+    .with_context(|| {
+        format!(
+            "ready repair retrieval index finalize using {}",
+            retrieval::format_sidecar_runtime(&sidecar)
+        )
+    })?;
+    progress.set_phase("readiness check");
     let final_status = codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
@@ -12369,6 +12475,26 @@ mod tests {
         let mut unknown_full = ready_repair_test_report("full", None);
         unknown_full.embedding_device_state = "unknown".into();
         assert!(!ready_repair_existing_sidecar_is_reusable(&unknown_full));
+    }
+
+    #[test]
+    fn ready_repair_progress_line_names_phase_identity_and_status() {
+        let line = ready_repair_progress_line(
+            "Qdrant finalize",
+            "agent",
+            "shared-agent",
+            "codestory-agent",
+            10,
+            "active",
+        );
+
+        assert!(line.starts_with("[ready-repair] "));
+        assert!(line.contains("phase=\"Qdrant finalize\""));
+        assert!(line.contains("profile=agent"));
+        assert!(line.contains("run_id=shared-agent"));
+        assert!(line.contains("namespace=codestory-agent"));
+        assert!(line.contains("elapsed_s=10"));
+        assert!(line.contains("status=active"));
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -34,7 +34,7 @@ use std::{
     fs,
     io::{IsTerminal, Read},
     net::TcpListener,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -52,6 +52,7 @@ mod managed_embeddings;
 mod output;
 mod query_resolution;
 mod readiness;
+mod ready_repair_status;
 mod report;
 mod retrieval;
 mod runtime;
@@ -635,24 +636,40 @@ struct ReadyRepairProgress {
     profile: &'static str,
     run_id: String,
     namespace: String,
+    project_root: PathBuf,
     phase: Arc<Mutex<&'static str>>,
     done: Arc<AtomicBool>,
     start: Instant,
+    started_at_epoch_ms: i64,
+    pid: u32,
+    sidecar: codestory_retrieval::SidecarRuntimeConfig,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl ReadyRepairProgress {
-    fn start(sidecar: &codestory_retrieval::SidecarRuntimeConfig) -> Self {
+    fn start(sidecar: &codestory_retrieval::SidecarRuntimeConfig, project_root: &Path) -> Self {
         let phase = Arc::new(Mutex::new("starting"));
         let done = Arc::new(AtomicBool::new(false));
         let start = Instant::now();
+        let started_at_epoch_ms = ready_repair_status::now_epoch_ms();
+        let pid = std::process::id();
         let profile = sidecar.profile.as_str();
         let run_id = sidecar.run_id.as_deref().unwrap_or("none").to_string();
         let namespace = sidecar.namespace.clone();
+        let project_root = project_root.to_path_buf();
+        let sidecar_for_worker = sidecar.clone();
         let worker_phase = Arc::clone(&phase);
         let worker_done = Arc::clone(&done);
         let worker_run_id = run_id.clone();
         let worker_namespace = namespace.clone();
+        let worker_project_root = project_root.clone();
+        let _ = ready_repair_status::write_ready_repair_status(
+            sidecar,
+            &project_root,
+            "starting",
+            started_at_epoch_ms,
+            pid,
+        );
         let handle = std::thread::spawn(move || {
             while !worker_done.load(Ordering::SeqCst) {
                 std::thread::sleep(Duration::from_millis(100));
@@ -675,6 +692,13 @@ impl ReadyRepairProgress {
                         "active"
                     )
                 );
+                let _ = ready_repair_status::write_ready_repair_status(
+                    &sidecar_for_worker,
+                    &worker_project_root,
+                    phase,
+                    started_at_epoch_ms,
+                    pid,
+                );
                 std::thread::sleep(Duration::from_secs(1));
             }
         });
@@ -682,9 +706,13 @@ impl ReadyRepairProgress {
             profile,
             run_id,
             namespace,
+            project_root,
             phase,
             done,
             start,
+            started_at_epoch_ms,
+            pid,
+            sidecar: sidecar.clone(),
             handle: Some(handle),
         }
     }
@@ -702,6 +730,13 @@ impl ReadyRepairProgress {
                 "started"
             )
         );
+        let _ = ready_repair_status::write_ready_repair_status(
+            &self.sidecar,
+            &self.project_root,
+            phase,
+            self.started_at_epoch_ms,
+            self.pid,
+        );
     }
 }
 
@@ -711,6 +746,11 @@ impl Drop for ReadyRepairProgress {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
+        ready_repair_status::clear_ready_repair_status(
+            &self.sidecar,
+            self.started_at_epoch_ms,
+            self.pid,
+        );
     }
 }
 
@@ -2292,7 +2332,7 @@ fn repair_ready_state(
         sidecar.namespace,
         sidecar.compose_project
     );
-    let progress = ReadyRepairProgress::start(&sidecar);
+    let progress = ReadyRepairProgress::start(&sidecar, &runtime.project_root);
     let bootstrap = codestory_retrieval::bootstrap_sidecars_with_runtime_progress(
         &sidecar,
         Some(runtime.project_root.as_path()),
@@ -10722,6 +10762,12 @@ pub(crate) fn build_readiness_lanes_for_runtime(
             &project_arg,
         ),
     );
+    apply_ready_repair_status_overlay(
+        &mut lanes,
+        &runtime.project_root,
+        agent_run_id,
+        &project_arg,
+    );
     lanes
 }
 
@@ -10750,10 +10796,40 @@ fn readiness_lane_output(
             .clone()
             .unwrap_or_else(|| "unknown".to_string()),
         run_id: sidecar.run_id.clone(),
+        namespace: None,
+        compose_project: None,
+        phase: None,
+        repair_updated_at_epoch_ms: None,
         sidecar_mode: sidecar.retrieval_mode.clone(),
         degraded_reason: sidecar.degraded_reason.clone(),
         next_command: lane_next_command(lane, sidecar, status, verdict, project_arg),
     }
+}
+
+fn apply_ready_repair_status_overlay(
+    lanes: &mut BTreeMap<String, ReadinessLaneOutput>,
+    project_root: &Path,
+    agent_run_id: Option<&str>,
+    project_arg: &str,
+) {
+    let Some(status) = ready_repair_status::active_ready_repair_status(project_root, agent_run_id)
+    else {
+        return;
+    };
+    let Some(lane) = lanes.get_mut("agent_packet_search") else {
+        return;
+    };
+    lane.status = ReadinessStatusDto::Repairing;
+    lane.profile = status.profile;
+    lane.run_id = status.run_id.clone();
+    lane.namespace = Some(status.namespace);
+    lane.compose_project = Some(status.compose_project);
+    lane.phase = Some(status.phase);
+    lane.repair_updated_at_epoch_ms = Some(status.updated_at_epoch_ms);
+    lane.next_command = Some(retrieval_status_command_for_agent(
+        project_arg,
+        status.run_id.as_deref(),
+    ));
 }
 
 fn readiness_lane_status(
@@ -10807,6 +10883,17 @@ fn agent_ready_repair_command(project_arg: &str, run_id: Option<&str>) -> String
         command.push_str(" --run-id ");
         command.push_str(&display::quote_command_argument_value(run_id));
     }
+    command
+}
+
+fn retrieval_status_command_for_agent(project_arg: &str, run_id: Option<&str>) -> String {
+    let mut command =
+        format!("codestory-cli retrieval status --project {project_arg} --profile agent");
+    if let Some(run_id) = run_id {
+        command.push_str(" --run-id ");
+        command.push_str(&display::quote_command_argument_value(run_id));
+    }
+    command.push_str(" --format json");
     command
 }
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -421,7 +421,8 @@ fn setup_embeddings_next_commands(
     }
     vec![
         format!("codestory-cli doctor{args}"),
-        format!("codestory-cli index{args} --refresh full"),
+        format!("codestory-cli retrieval bootstrap{args}"),
+        format!("codestory-cli retrieval index{args} --refresh full"),
     ]
 }
 
@@ -4009,9 +4010,9 @@ fn drill_suite_retrieval_blockers(
         .into_iter()
         .map(|(status, repos)| {
             let next_action = if status.contains("MissingEmbeddingRuntime") {
-                "run `codestory-cli setup embeddings --project <repo>`, then rebuild with `codestory-cli retrieval index --project <repo> --refresh full` before trusting packet/search evidence".to_string()
+                "run `codestory-cli retrieval bootstrap --project <repo>`, then rebuild with `codestory-cli retrieval index --project <repo> --refresh full` before trusting packet/search evidence".to_string()
             } else if status.contains("MissingSemanticDocs") {
-                "rerun `codestory-cli retrieval index --project <repo> --refresh full` after semantic setup before trusting packet/search evidence".to_string()
+                "rerun `codestory-cli retrieval index --project <repo> --refresh full` after sidecar setup before trusting packet/search evidence".to_string()
             } else {
                 "inspect doctor/retrieval status and repair to retrieval_mode=full before treating broad search quality as repo-specific".to_string()
             };
@@ -11160,7 +11161,7 @@ fn semantic_contract_check(
             "semantic_contract",
             "info",
             format!(
-                "semantic stale: {}. Resolve the embedding runtime first with `codestory-cli setup embeddings`; then run `codestory-cli retrieval index --refresh full` before trusting packet/search evidence.",
+                "semantic stale: {}. Resolve the product embedding sidecar first with `codestory-cli retrieval bootstrap`; then run `codestory-cli retrieval index --refresh full` before trusting packet/search evidence.",
                 gaps.join("; ")
             ),
         )
@@ -11305,7 +11306,10 @@ fn index_next_commands(
         && retrieval.fallback_reason == Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime)
     {
         commands.push(format!(
-            "codestory-cli setup embeddings --project {project}"
+            "codestory-cli retrieval bootstrap --project {project}"
+        ));
+        commands.push(format!(
+            "codestory-cli retrieval index --project {project} --refresh full"
         ));
     }
     commands.push(format!("codestory-cli ground --project {project}"));
@@ -13212,6 +13216,62 @@ mod tests {
                 "not-checked freshness should stop before `{blocked}` proof/navigation commands: {joined}"
             );
         }
+    }
+
+    #[test]
+    fn index_next_commands_use_sidecar_repair_for_missing_embedding_runtime() {
+        let mut retrieval = sample_retrieval();
+        retrieval.semantic_ready = false;
+        retrieval.fallback_reason = Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime);
+
+        let commands = index_next_commands("C:/repo", Some(&retrieval), None, true);
+        let joined = commands.join("\n");
+
+        assert!(joined.contains("codestory-cli retrieval bootstrap --project"));
+        assert!(
+            joined.contains("codestory-cli retrieval index --project")
+                && joined.contains("--refresh full")
+        );
+        assert!(!joined.contains("setup embeddings"));
+    }
+
+    #[test]
+    fn semantic_contract_check_uses_sidecar_repair_for_missing_embedding_runtime() {
+        let mut retrieval = sample_retrieval();
+        retrieval.semantic_ready = false;
+        retrieval.fallback_reason = Some(RetrievalFallbackReasonDto::MissingEmbeddingRuntime);
+        retrieval.current_embedding = Some(codestory_contracts::api::EmbeddingProfileContractDto {
+            profile: "bge-base-en-v1.5".to_string(),
+            backend: "llamacpp".to_string(),
+            model_id: "BAAI/bge-base-en-v1.5-local".to_string(),
+            cache_key: "current".to_string(),
+            dimension: Some(768),
+            doc_shape: "current-shape".to_string(),
+        });
+        retrieval.stored_embedding =
+            Some(codestory_contracts::api::StoredSemanticDocsContractDto {
+                doc_count: 1,
+                embedding_profile: Some("bge-base-en-v1.5".to_string()),
+                embedding_backend: Some("onnx".to_string()),
+                cache_key: Some("old".to_string()),
+                dimension: Some(768),
+                doc_version: Some(5),
+                mixed_embedding_profiles: false,
+                mixed_embedding_models: false,
+                mixed_embedding_backends: false,
+                mixed_dimensions: false,
+                mixed_doc_versions: false,
+                mixed_doc_shapes: false,
+                doc_shape: Some("old-shape".to_string()),
+                semantic_policy_version: Some("graph_first_v1".to_string()),
+                mixed_semantic_policy_versions: false,
+            });
+
+        let check = semantic_contract_check(&retrieval);
+
+        assert!(check.message.contains("retrieval bootstrap"));
+        assert!(check.message.contains("retrieval index --refresh full"));
+        assert!(!check.message.contains("setup embeddings"));
     }
 
     #[test]
@@ -16196,7 +16256,8 @@ mod tests {
         );
         assert_eq!(blocker.repo_count, 2);
         assert_eq!(blocker.repos, vec!["alpha", "gamma"]);
-        assert!(blocker.next_action.contains("setup embeddings"));
+        assert!(blocker.next_action.contains("retrieval bootstrap"));
+        assert!(!blocker.next_action.contains("setup embeddings"));
 
         let markdown = render_drill_suite_markdown(&output);
         assert!(markdown.contains("## Retrieval Blockers"));

--- a/crates/codestory-cli/src/managed_embeddings.rs
+++ b/crates/codestory-cli/src/managed_embeddings.rs
@@ -19,10 +19,6 @@ const MANAGED_ONNX_PROVIDER: &str = if cfg!(target_os = "windows") {
 } else {
     "cpu"
 };
-const MANAGED_DOC_EMBED_BATCH_SIZE: usize = 2048;
-const MANAGED_SEMANTIC_DOC_MAX_TOKENS: usize = 512;
-const MANAGED_ONNX_BATCH_TOKENS: usize = 32_768;
-const MANAGED_STORED_VECTOR_ENCODING: &str = "int8";
 const BUNDLED_LLAMACPP_BACKEND_LABEL: &str = "llamacpp";
 const MANAGED_DIR_NAME: &str = "managed-embeddings";
 const MANAGED_POOLED_ONNX_MODEL_NAME: &str = "model_optimized_cls_pool.onnx";
@@ -264,7 +260,7 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
         return ManagedEmbeddingsStatus {
             state: "disabled_by_config".to_string(),
             message:
-                "Managed ONNX is skipped because embedding env config selects legacy llama.cpp."
+                "Diagnostic ONNX setup is skipped because embedding env config selects llama.cpp."
                     .to_string(),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
@@ -275,9 +271,8 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
     if disabled_by_embedding_env() {
         return ManagedEmbeddingsStatus {
             state: "disabled_by_config".to_string(),
-            message:
-                "Managed ONNX is skipped because embedding env config selects another backend."
-                    .to_string(),
+            message: "Diagnostic ONNX setup is skipped because embedding env config selects another backend."
+                .to_string(),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
             model: None,
@@ -289,7 +284,7 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
     if model.is_none() || tokenizer.is_none() {
         return ManagedEmbeddingsStatus {
             state: "missing_managed_assets".to_string(),
-            message: "Managed ONNX assets are not installed. Run `codestory-cli setup embeddings`."
+            message: "Diagnostic ONNX assets are not installed. Product packet/search uses the llama.cpp retrieval sidecar; run `codestory-cli retrieval bootstrap` and `codestory-cli retrieval index --refresh full` for product readiness."
                 .to_string(),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
@@ -303,7 +298,7 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
         return ManagedEmbeddingsStatus {
             state: "managed_onnx_unusable".to_string(),
             message: format!(
-                "Managed ONNX assets are installed but failed runtime verification: {error}"
+                "Diagnostic ONNX assets are installed but failed runtime verification: {error}"
             ),
             root: clean_path(root),
             endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
@@ -314,22 +309,13 @@ pub(crate) fn inspect_status(root: &Path) -> ManagedEmbeddingsStatus {
     ManagedEmbeddingsStatus {
         state: "managed_onnx_ready".to_string(),
         message: format!(
-            "Managed ONNX embeddings are installed with model `{}` and tokenizer `{}`.",
+            "Diagnostic ONNX embeddings are installed with model `{}` and tokenizer `{}`. Product packet/search still requires llama.cpp sidecar retrieval.",
             clean_path(&model),
             clean_path(&tokenizer)
         ),
         root: clean_path(root),
         endpoint: MANAGED_ONNX_BACKEND_LABEL.to_string(),
         model: Some(clean_path(&model)),
-    }
-}
-
-pub(crate) fn prepare_runtime_if_installed(root: &Path) {
-    if disabled_by_embedding_env() || legacy_llamacpp_backend_selected() {
-        return;
-    }
-    if managed_endpoint_assets_available(root) {
-        set_managed_endpoint_env(root);
     }
 }
 
@@ -1010,48 +996,6 @@ fn explicit_llama_url() -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-}
-
-fn set_managed_endpoint_env(root: &Path) {
-    let Some(model_path) = default_onnx_model_path(root) else {
-        return;
-    };
-    let Some(tokenizer_path) = default_onnx_tokenizer_path(root) else {
-        return;
-    };
-    unsafe {
-        set_env_default_str("CODESTORY_EMBED_BACKEND", MANAGED_ONNX_BACKEND_LABEL);
-        set_env_default_str("CODESTORY_EMBED_ONNX_MODEL", &clean_path(&model_path));
-        set_env_default_str(
-            "CODESTORY_EMBED_ONNX_TOKENIZER",
-            &clean_path(&tokenizer_path),
-        );
-        set_env_default_str("CODESTORY_EMBED_ONNX_PROVIDER", MANAGED_ONNX_PROVIDER);
-        set_env_default(
-            "CODESTORY_EMBED_ONNX_BATCH_TOKENS",
-            MANAGED_ONNX_BATCH_TOKENS,
-        );
-        set_env_default(
-            "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE",
-            MANAGED_DOC_EMBED_BATCH_SIZE,
-        );
-        set_env_default(
-            "CODESTORY_SEMANTIC_DOC_MAX_TOKENS",
-            MANAGED_SEMANTIC_DOC_MAX_TOKENS,
-        );
-        set_env_default_str(
-            "CODESTORY_STORED_VECTOR_ENCODING",
-            MANAGED_STORED_VECTOR_ENCODING,
-        );
-    }
-}
-
-unsafe fn set_env_default(key: &str, value: usize) {
-    if std::env::var_os(key).is_none() {
-        unsafe {
-            std::env::set_var(key, value.to_string());
-        }
-    }
 }
 
 unsafe fn set_env_default_str(key: &str, value: &str) {

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -137,6 +137,7 @@ pub(crate) fn primary_non_ready(verdicts: &[ReadinessVerdictDto]) -> Option<&Rea
 pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
     match status {
         ReadinessStatusDto::Ready => "ready",
+        ReadinessStatusDto::Repairing => "repairing",
         ReadinessStatusDto::RepairSetup => "repair_setup",
         ReadinessStatusDto::RepairIndex => "repair_index",
         ReadinessStatusDto::CheckIndex => "check_index",
@@ -147,6 +148,7 @@ pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
 pub(crate) fn failed_layer(verdict: &ReadinessVerdictDto) -> Option<&'static str> {
     match verdict.status {
         ReadinessStatusDto::Ready => None,
+        ReadinessStatusDto::Repairing => Some("retrieval_sidecar"),
         ReadinessStatusDto::RepairSetup => Some("runtime_setup"),
         ReadinessStatusDto::RepairIndex => Some("local_index"),
         ReadinessStatusDto::CheckIndex => Some("index_freshness"),
@@ -174,7 +176,9 @@ pub(crate) fn local_refresh_state_label(state: LocalRefreshState) -> &'static st
 pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefreshOutput {
     let index = verdict.index.as_ref();
     let state = match verdict.status {
-        ReadinessStatusDto::Ready | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Fresh,
+        ReadinessStatusDto::Ready
+        | ReadinessStatusDto::Repairing
+        | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Fresh,
         ReadinessStatusDto::CheckIndex => LocalRefreshState::NotChecked,
         ReadinessStatusDto::RepairSetup => LocalRefreshState::Failed,
         ReadinessStatusDto::RepairIndex => {

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -1,0 +1,290 @@
+use anyhow::Result;
+use codestory_retrieval::{
+    DEFAULT_AGENT_RUN_ID, SidecarProfile, SidecarRuntimeConfig,
+    sidecar_runtime_for_project_with_run_id,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const READY_REPAIR_STATUS_FILE: &str = "ready-repair-status.json";
+const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
+const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ReadyRepairStatus {
+    pub(crate) schema_version: u32,
+    pub(crate) status: String,
+    pub(crate) project_root: String,
+    pub(crate) profile: String,
+    pub(crate) run_id: Option<String>,
+    pub(crate) namespace: String,
+    pub(crate) compose_project: String,
+    pub(crate) phase: String,
+    pub(crate) pid: u32,
+    pub(crate) started_at_epoch_ms: i64,
+    pub(crate) updated_at_epoch_ms: i64,
+}
+
+pub(crate) fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
+pub(crate) fn write_ready_repair_status(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+    phase: &str,
+    started_at_epoch_ms: i64,
+    pid: u32,
+) -> Result<()> {
+    let path = ready_repair_status_path(sidecar);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let status = ReadyRepairStatus {
+        schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+        status: "repairing".to_string(),
+        project_root: clean_path_text(project_root),
+        profile: sidecar.profile.as_str().to_string(),
+        run_id: sidecar.run_id.clone(),
+        namespace: sidecar.namespace.clone(),
+        compose_project: sidecar.compose_project.clone(),
+        phase: phase.to_string(),
+        pid,
+        started_at_epoch_ms,
+        updated_at_epoch_ms: now_epoch_ms(),
+    };
+    let json = serde_json::to_string_pretty(&status)?;
+    Ok(fs::write(path, json)?)
+}
+
+pub(crate) fn clear_ready_repair_status(
+    sidecar: &SidecarRuntimeConfig,
+    started_at_epoch_ms: i64,
+    pid: u32,
+) {
+    let path = ready_repair_status_path(sidecar);
+    let Some(status) = read_ready_repair_status_file(&path) else {
+        return;
+    };
+    if status.pid == pid && status.started_at_epoch_ms == started_at_epoch_ms {
+        let _ = fs::remove_file(path);
+    }
+}
+
+pub(crate) fn active_ready_repair_status(
+    project_root: &Path,
+    run_id: Option<&str>,
+) -> Option<ReadyRepairStatus> {
+    let now = now_epoch_ms();
+    ready_repair_status_paths(project_root, run_id)
+        .into_iter()
+        .filter_map(|path| read_ready_repair_status(&path, project_root, now))
+        .max_by_key(|status| status.updated_at_epoch_ms)
+}
+
+pub(crate) fn ready_repair_status_cache_fingerprint(project_root: &Path) -> String {
+    ready_repair_status_paths(project_root, None)
+        .into_iter()
+        .map(|path| path_fingerprint(&path))
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+fn ready_repair_status_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
+    sidecar
+        .layout
+        .state_file
+        .with_file_name(READY_REPAIR_STATUS_FILE)
+}
+
+fn read_ready_repair_status(
+    path: &Path,
+    project_root: &Path,
+    now_epoch_ms: i64,
+) -> Option<ReadyRepairStatus> {
+    let status = read_ready_repair_status_file(path)?;
+    if status.schema_version != READY_REPAIR_STATUS_SCHEMA_VERSION
+        || status.status != "repairing"
+        || status.profile != SidecarProfile::Agent.as_str()
+        || !same_path_text(Path::new(&status.project_root), project_root)
+    {
+        return None;
+    }
+    let age_ms = now_epoch_ms.saturating_sub(status.updated_at_epoch_ms);
+    if age_ms > READY_REPAIR_STATUS_TTL.as_millis() as i64 {
+        return None;
+    }
+    Some(status)
+}
+
+fn read_ready_repair_status_file(path: &Path) -> Option<ReadyRepairStatus> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+}
+
+fn ready_repair_status_paths(project_root: &Path, run_id: Option<&str>) -> Vec<PathBuf> {
+    let mut paths = BTreeSet::new();
+    if let Some(run_id) = run_id {
+        let sidecar = sidecar_runtime_for_project_with_run_id(
+            project_root,
+            SidecarProfile::Agent,
+            Some(run_id),
+        );
+        paths.insert(ready_repair_status_path(&sidecar));
+        return paths.into_iter().collect();
+    }
+
+    let default_sidecar = sidecar_runtime_for_project_with_run_id(
+        project_root,
+        SidecarProfile::Agent,
+        Some(DEFAULT_AGENT_RUN_ID),
+    );
+    paths.insert(ready_repair_status_path(&default_sidecar));
+
+    if let Some((sidecars_root, namespace_prefix)) = agent_sidecars_scan_root(&default_sidecar)
+        && let Ok(entries) = fs::read_dir(sidecars_root)
+    {
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let namespace = entry.file_name().to_string_lossy().to_string();
+            if namespace.starts_with(&namespace_prefix) {
+                paths.insert(entry.path().join(READY_REPAIR_STATUS_FILE));
+            }
+        }
+    }
+
+    paths.into_iter().collect()
+}
+
+fn agent_sidecars_scan_root(sidecar: &SidecarRuntimeConfig) -> Option<(PathBuf, String)> {
+    let namespace_prefix = sidecar.namespace.strip_suffix(DEFAULT_AGENT_RUN_ID)?;
+    let namespace_dir = sidecar.layout.state_file.parent()?;
+    let sidecars_root = namespace_dir.parent()?;
+    Some((sidecars_root.to_path_buf(), namespace_prefix.to_string()))
+}
+
+fn clean_path_text(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+fn same_path_text(left: &Path, right: &Path) -> bool {
+    clean_path_text(left) == clean_path_text(right)
+}
+
+fn path_fingerprint(path: &Path) -> String {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            let modified_ms = metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_millis())
+                .unwrap_or_default();
+            format!("{}:{}:{}", path.display(), metadata.len(), modified_ms)
+        }
+        Err(_) => format!("{}:missing", path.display()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_retrieval::SidecarLayout;
+
+    fn test_sidecar(root: &Path) -> SidecarRuntimeConfig {
+        let namespace = "codestory-agent-test-proof".to_string();
+        SidecarRuntimeConfig {
+            layout: SidecarLayout {
+                zoekt_http_port: 6070,
+                qdrant_http_port: 6333,
+                qdrant_grpc_port: 6334,
+                zoekt_data_dir: root.join("zoekt"),
+                qdrant_data_dir: root.join("qdrant"),
+                scip_artifacts_root: root.join("scip"),
+                state_file: root.join("retrieval-sidecars.json"),
+            },
+            profile: SidecarProfile::Agent,
+            run_id: Some("test-proof".to_string()),
+            namespace: namespace.clone(),
+            compose_project: namespace,
+            embed_http_port: 8080,
+            cleanup_command: "codestory-cli retrieval down".to_string(),
+            labels: Default::default(),
+        }
+    }
+
+    #[test]
+    fn repair_status_file_round_trips_current_phase_and_clears() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let started_at = now_epoch_ms();
+        let pid = 4242;
+
+        write_ready_repair_status(&sidecar, project.path(), "Qdrant finalize", started_at, pid)
+            .expect("write repair status");
+        let path = ready_repair_status_path(&sidecar);
+        let status = read_ready_repair_status(&path, project.path(), now_epoch_ms())
+            .expect("active repair status");
+
+        assert_eq!(status.status, "repairing");
+        assert_eq!(status.phase, "Qdrant finalize");
+        assert_eq!(status.run_id.as_deref(), Some("test-proof"));
+        assert_eq!(status.namespace, "codestory-agent-test-proof");
+
+        clear_ready_repair_status(&sidecar, started_at, pid);
+        assert!(
+            !path.exists(),
+            "drop cleanup should remove the matching repair state file"
+        );
+    }
+
+    #[test]
+    fn stale_repair_status_expires() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let path = ready_repair_status_path(&sidecar);
+        fs::create_dir_all(path.parent().expect("repair status parent")).expect("state dir");
+        let now = now_epoch_ms();
+        let stale = ReadyRepairStatus {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            status: "repairing".to_string(),
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: Some("test-proof".to_string()),
+            namespace: "codestory-agent-test-proof".to_string(),
+            compose_project: "codestory-agent-test-proof".to_string(),
+            phase: "embeddings".to_string(),
+            pid: 4242,
+            started_at_epoch_ms: now - 60_000,
+            updated_at_epoch_ms: now - READY_REPAIR_STATUS_TTL.as_millis() as i64 - 1,
+        };
+        fs::write(&path, serde_json::to_string(&stale).expect("status json"))
+            .expect("write stale status");
+
+        assert_eq!(
+            read_ready_repair_status(&path, project.path(), now),
+            None,
+            "stale repair state must not mask final readiness"
+        );
+    }
+}

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -41,9 +41,9 @@ pub(crate) struct OpenedProject {
 
 /// Shared service handles and filesystem roots for a CLI command.
 ///
-/// `RuntimeContext::new` may start installed managed embeddings before runtime
-/// access; use `new_inspect_only` for health and cache commands that should not
-/// mutate or start background dependencies.
+/// Runtime construction never promotes installed managed embedding assets into
+/// product defaults. Product packet/search paths set llama.cpp sidecar defaults
+/// explicitly before opening the runtime.
 pub(crate) struct RuntimeContext {
     pub(crate) project: ProjectService,
     pub(crate) index: IndexService,
@@ -61,13 +61,6 @@ pub(crate) struct RuntimeContext {
 struct ResolutionCandidateRank {
     file_filter_match: u8,
     resolution: ResolutionRank,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-/// Managed embedding startup behavior for runtime construction.
-pub(crate) enum ManagedEmbeddingStartup {
-    AutostartIfInstalled,
-    InspectOnly,
 }
 
 #[derive(Debug, Clone)]
@@ -106,7 +99,7 @@ impl std::error::Error for AmbiguousTargetError {}
 impl RuntimeContext {
     /// Open runtime services for a command that may use managed embeddings.
     pub(crate) fn new(args: &ProjectArgs) -> Result<Self> {
-        Self::new_with_startup(args, ManagedEmbeddingStartup::AutostartIfInstalled)
+        Self::new_with_startup(args)
     }
 
     /// Open runtime services for agent-facing packet/search commands.
@@ -117,18 +110,15 @@ impl RuntimeContext {
 
     /// Open runtime services without starting managed embedding processes.
     pub(crate) fn new_inspect_only(args: &ProjectArgs) -> Result<Self> {
-        Self::new_with_startup(args, ManagedEmbeddingStartup::InspectOnly)
+        Self::new_with_startup(args)
     }
 
-    fn new_with_startup(args: &ProjectArgs, startup: ManagedEmbeddingStartup) -> Result<Self> {
+    fn new_with_startup(args: &ProjectArgs) -> Result<Self> {
         let project_root = canonicalize_project_root(&args.project)?;
         let cache_override = trusted_cache_override(&project_root, args.cache_dir.as_deref())?;
         let cache_root = cache_root_for_project(&project_root, cache_override.as_deref())?;
         let managed_embeddings_root =
             crate::managed_embeddings::runtime_managed_root(cache_override.as_deref())?;
-        if startup == ManagedEmbeddingStartup::AutostartIfInstalled {
-            crate::managed_embeddings::prepare_runtime_if_installed(&managed_embeddings_root);
-        }
         let storage_path = cache_root.join("codestory.db");
         let runtime = Runtime::new();
         let events = runtime.events();
@@ -978,7 +968,7 @@ mod tests {
     }
 
     #[test]
-    fn autostart_runtime_sets_managed_onnx_defaults_when_assets_exist() {
+    fn default_runtime_does_not_promote_managed_onnx_assets() {
         let _env_lock = crate::config::config_env_test_lock();
         let _env_snapshot = EnvSnapshot::clear(MANAGED_ENV_VARS);
         let temp = tempdir().expect("temp dir");
@@ -993,12 +983,9 @@ mod tests {
         })
         .expect("runtime context");
 
-        assert_eq!(
-            env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
-            Some("onnx")
-        );
-        assert!(env::var("CODESTORY_EMBED_ONNX_MODEL").is_ok());
-        assert!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").is_ok());
+        assert_eq!(env::var("CODESTORY_EMBED_BACKEND").ok(), None);
+        assert_eq!(env::var("CODESTORY_EMBED_ONNX_MODEL").ok(), None);
+        assert_eq!(env::var("CODESTORY_EMBED_ONNX_TOKENIZER").ok(), None);
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2210,6 +2210,12 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
             stdio_path_fingerprint(&layout.state_file)
         ),
         format!(
+            "repair_state:{}",
+            crate::ready_repair_status::ready_repair_status_cache_fingerprint(
+                &runtime.project_root
+            )
+        ),
+        format!(
             "source_state:{}",
             stdio_source_fingerprint(&runtime.project_root)
         ),
@@ -2704,6 +2710,14 @@ fn stdio_runtime_truth_status(
                 .get("degraded_reason")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null),
+            "namespace": readiness_lanes
+                .pointer("/agent_packet_search/namespace")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+            "phase": readiness_lanes
+                .pointer("/agent_packet_search/phase")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
         },
         "readiness_lanes": {
             "local_graph": {
@@ -2740,6 +2754,16 @@ fn stdio_runtime_truth_sidecar_lane(lane: &serde_json::Value) -> serde_json::Val
             .cloned()
             .unwrap_or_else(|| serde_json::json!("unavailable")),
         "run_id": lane.get("run_id").cloned().unwrap_or(serde_json::Value::Null),
+        "namespace": lane.get("namespace").cloned().unwrap_or(serde_json::Value::Null),
+        "compose_project": lane
+            .get("compose_project")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        "phase": lane.get("phase").cloned().unwrap_or(serde_json::Value::Null),
+        "repair_updated_at_epoch_ms": lane
+            .get("repair_updated_at_epoch_ms")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
         "sidecar_mode": lane
             .get("sidecar_mode")
             .cloned()

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1098,7 +1098,13 @@ fn setup_embeddings_dry_run_reports_pinned_managed_assets() {
     );
     assert_eq!(
         setup["backend"], "onnx",
-        "setup should select ONNX: {setup:#}"
+        "setup should report the diagnostic ONNX backend: {setup:#}"
+    );
+    assert!(
+        setup["status"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("Diagnostic ONNX assets are not installed")),
+        "setup should label ONNX as diagnostic: {setup:#}"
     );
     assert!(
         setup["model"]["url"]
@@ -1143,7 +1149,12 @@ fn setup_embeddings_dry_run_reports_pinned_managed_assets() {
                 clean_test_path(cache_dir.path())
             ),
             format!(
-                "codestory-cli index --project \"{}\" --cache-dir \"{}\" --refresh full",
+                "codestory-cli retrieval bootstrap --project \"{}\" --cache-dir \"{}\"",
+                clean_test_path(workspace.path()),
+                clean_test_path(cache_dir.path())
+            ),
+            format!(
+                "codestory-cli retrieval index --project \"{}\" --cache-dir \"{}\" --refresh full",
                 clean_test_path(workspace.path()),
                 clean_test_path(cache_dir.path())
             ),
@@ -1170,14 +1181,20 @@ fn doctor_reports_managed_embedding_setup_state() {
     let message = managed["message"].as_str().expect("managed message");
     match status {
         "info" => assert!(
-            message.contains("setup embeddings"),
-            "doctor should name the setup command when managed assets are missing: {doctor:#}"
+            message.contains("Diagnostic ONNX") && message.contains("retrieval bootstrap"),
+            "doctor should label missing ONNX assets as diagnostic and name product sidecar repair: {doctor:#}"
         ),
         "ok" => assert!(
-            message.contains("Managed ONNX embeddings are installed"),
-            "doctor should report globally available managed assets for isolated cache dirs: {doctor:#}"
+            message.contains("Diagnostic ONNX embeddings are installed"),
+            "doctor should label globally available ONNX assets as diagnostic: {doctor:#}"
         ),
-        _ => panic!("managed setup state should be informational or installed: {doctor:#}"),
+        "warn" => assert!(
+            message.contains("External llama.cpp endpoint"),
+            "doctor should report product llama.cpp endpoint warnings separately from ONNX setup: {doctor:#}"
+        ),
+        _ => panic!(
+            "managed setup state should be informational, installed, or endpoint warning: {doctor:#}"
+        ),
     }
 }
 
@@ -1198,14 +1215,30 @@ fn doctor_does_not_autostart_installed_managed_embeddings() {
     let managed = check_with_name(&doctor, "managed_embeddings");
     assert_eq!(
         managed["status"], "warn",
-        "installed but invalid managed assets should fail runtime verification: {doctor:#}"
+        "unreachable product llama.cpp endpoint should warn without promoting ONNX assets: {doctor:#}"
     );
     assert!(
         managed["message"]
             .as_str()
-            .is_some_and(|message| message.contains("failed runtime verification")),
-        "managed status should explain that installed assets did not pass runtime verification: {doctor:#}"
+            .is_some_and(|message| message.contains("External llama.cpp endpoint")),
+        "managed status should report the product endpoint warning: {doctor:#}"
     );
+    for name in [
+        "CODESTORY_EMBED_ONNX_MODEL",
+        "CODESTORY_EMBED_ONNX_TOKENIZER",
+        "CODESTORY_EMBED_ONNX_PROVIDER",
+    ] {
+        let env_row = doctor["environment"]
+            .as_array()
+            .expect("doctor environment")
+            .iter()
+            .find(|row| row["name"] == name)
+            .unwrap_or_else(|| panic!("missing env row {name}: {doctor:#}"));
+        assert_eq!(
+            env_row["message"], "not set; using runtime defaults",
+            "doctor must not set {name} from installed diagnostic assets: {env_row:#}"
+        );
+    }
     assert!(
         !cache_dir
             .path()

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -5,7 +5,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 
 struct StdioFixture {
@@ -23,6 +23,14 @@ struct StdioServer {
     child: Child,
     stdin: ChildStdin,
     stdout: BufReader<ChildStdout>,
+}
+
+struct RemoveDirOnDrop(PathBuf);
+
+impl Drop for RemoveDirOnDrop {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
 }
 
 impl Drop for StdioServer {
@@ -682,6 +690,58 @@ fn json_resource_content(result: &Value, uri: &str) -> Value {
         .unwrap_or_else(|| panic!("resource {uri} content should include JSON text: {content}"));
     serde_json::from_str(text)
         .unwrap_or_else(|error| panic!("resource {uri} should be parseable JSON: {error}\n{text}"))
+}
+
+fn write_active_repair_status_fixture(
+    fixture: &StdioFixture,
+    run_id: &str,
+    phase: &str,
+) -> (PathBuf, RemoveDirOnDrop) {
+    let canonical_root =
+        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
+    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &canonical_root,
+        codestory_retrieval::SidecarProfile::Agent,
+        Some(run_id),
+    );
+    let status_path = sidecar
+        .layout
+        .state_file
+        .with_file_name("ready-repair-status.json");
+    let status_dir = status_path
+        .parent()
+        .expect("repair status parent")
+        .to_path_buf();
+    fs::create_dir_all(&status_dir).expect("create repair status dir");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_millis() as i64;
+    let project_root = canonical_root
+        .to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase();
+    fs::write(
+        &status_path,
+        json!({
+            "schema_version": 1,
+            "status": "repairing",
+            "project_root": project_root,
+            "profile": "agent",
+            "run_id": run_id,
+            "namespace": sidecar.namespace,
+            "compose_project": sidecar.compose_project,
+            "phase": phase,
+            "pid": 4242,
+            "started_at_epoch_ms": now,
+            "updated_at_epoch_ms": now
+        })
+        .to_string(),
+    )
+    .expect("write repair status fixture");
+    (status_path, RemoveDirOnDrop(status_dir))
 }
 
 fn continuation_uris_for(node_id: &str) -> Vec<String> {
@@ -2282,6 +2342,63 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
             .and_then(Value::as_array)
             .is_some_and(|calls| !calls.is_empty()),
         "status should include recommended next calls: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_reports_active_agent_repair_phase() {
+    let fixture = indexed_fixture();
+    let (status_path, _cleanup) =
+        write_active_repair_status_fixture(&fixture, "issue-661-proof", "Qdrant finalize");
+    assert!(status_path.exists(), "repair status fixture should exist");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-repairing",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+
+    let result = assert_success_envelope(&response, json!("status-repairing"));
+    let status = json_resource_content(result, "codestory://status");
+    let agent_lane = &status["readiness_lanes"]["agent_packet_search"];
+    assert_eq!(agent_lane["status"], json!("repairing"), "{status}");
+    assert_eq!(agent_lane["profile"], json!("agent"), "{status}");
+    assert_eq!(agent_lane["run_id"], json!("issue-661-proof"), "{status}");
+    assert_eq!(agent_lane["phase"], json!("Qdrant finalize"), "{status}");
+    assert!(
+        agent_lane["namespace"]
+            .as_str()
+            .is_some_and(|namespace| namespace.contains("issue-661-proof")),
+        "repairing status should include the active namespace: {status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["readiness_lanes"]["agent_packet_search"]["status"],
+        json!("repairing"),
+        "{status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["readiness_lanes"]["agent_packet_search"]["phase"],
+        json!("Qdrant finalize"),
+        "{status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["sidecar_status"]["phase"],
+        json!("Qdrant finalize"),
+        "{status}"
+    );
+    assert!(
+        agent_lane["next_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval status")
+                && command.contains("--profile agent")
+                && command.contains("--run-id")
+                && command.contains("issue-661-proof")),
+        "repairing lane should point at status proof, not a second repair: {status}"
     );
 }
 

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -311,6 +311,7 @@ pub enum ReadinessGoalDto {
 #[serde(rename_all = "snake_case")]
 pub enum ReadinessStatusDto {
     Ready,
+    Repairing,
     RepairSetup,
     RepairIndex,
     CheckIndex,

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -94,6 +94,26 @@ pub fn bootstrap_sidecars_with_runtime(
     skip_compose: bool,
     wait_timeout: Duration,
 ) -> Result<BootstrapReport> {
+    bootstrap_sidecars_with_runtime_progress(
+        runtime,
+        repo_root,
+        storage_scope,
+        compose_file,
+        skip_compose,
+        wait_timeout,
+        |_| {},
+    )
+}
+
+pub fn bootstrap_sidecars_with_runtime_progress(
+    runtime: &SidecarRuntimeConfig,
+    repo_root: Option<&Path>,
+    storage_scope: &BootstrapStorageScope,
+    compose_file: Option<&Path>,
+    skip_compose: bool,
+    wait_timeout: Duration,
+    mut progress: impl FnMut(&'static str),
+) -> Result<BootstrapReport> {
     let layout = runtime.layout.clone();
     runtime.activate_embed_url_default();
     layout.ensure_data_dirs()?;
@@ -111,13 +131,17 @@ pub fn bootstrap_sidecars_with_runtime(
     };
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
-        docker_compose_up(path, repo_root, runtime, launch_mode)?;
+        with_bootstrap_progress(&mut progress, "container startup", || {
+            docker_compose_up(path, repo_root, runtime, launch_mode)
+        })?;
         true
     } else {
         false
     };
     if let Some(launch) = native_embedding.as_ref() {
-        spawn_native_embedding_server(launch)?;
+        with_bootstrap_progress(&mut progress, "model/bootstrap", || {
+            spawn_native_embedding_server(launch)
+        })?;
     }
 
     let state = sidecar_up_with_runtime_and_launch_metadata(
@@ -128,7 +152,9 @@ pub fn bootstrap_sidecars_with_runtime(
             .map(|launch| embedding_launch_metadata(launch, runtime, repo_root)),
     )?;
     if !wait_timeout.is_zero() {
-        let _ = wait_for_infrastructure(&layout, wait_timeout)?;
+        let _ = with_bootstrap_progress(&mut progress, "model/bootstrap", || {
+            wait_for_infrastructure(&layout, wait_timeout)
+        })?;
     }
     let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
     let infrastructure = crate::health::probe_infrastructure_health_with_embedding_device(
@@ -143,6 +169,15 @@ pub fn bootstrap_sidecars_with_runtime(
         compose_file: resolved_compose,
         storage_repair,
     })
+}
+
+fn with_bootstrap_progress<T>(
+    progress: &mut impl FnMut(&'static str),
+    phase: &'static str,
+    action: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    progress(phase);
+    action()
 }
 
 /// Deprecated: pass [`BootstrapStorageScope::from_parts`] as the second argument to [`bootstrap_sidecars`].
@@ -872,6 +907,25 @@ mod tests {
             docker_compose_services_for_launch_mode(EmbeddingServerLaunchMode::DockerComposeEmbed)
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn bootstrap_progress_is_emitted_before_blocking_work() {
+        let phases = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let progress_phases = std::rc::Rc::clone(&phases);
+        let action_phases = std::rc::Rc::clone(&phases);
+
+        with_bootstrap_progress(
+            &mut |phase| progress_phases.borrow_mut().push(phase),
+            "model/bootstrap",
+            || {
+                assert_eq!(&*action_phases.borrow(), &["model/bootstrap"]);
+                Ok(())
+            },
+        )
+        .expect("progress wrapper should return action result");
+
+        assert_eq!(&*phases.borrow(), &["model/bootstrap"]);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/generation.rs
+++ b/crates/codestory-retrieval/src/generation.rs
@@ -404,17 +404,18 @@ mod tests {
     }
 
     #[test]
-    fn manifest_staleness_rejects_embedding_contract_drift() {
+    fn manifest_staleness_rejects_old_onnx_embedding_contract() {
         let project = TempDir::new().expect("project");
         let storage_path = project.path().join("codestory.db");
         let storage = Store::open(&storage_path).expect("open store");
         let mut manifest = manifest("proj", "deadbeefcafebabe1234");
-        manifest.embedding_backend = Some("other-backend:768".into());
+        manifest.embedding_backend = Some("onnx:bge".into());
 
         let reason = manifest_staleness_reason(&storage, &manifest)
             .expect("embedding backend drift should stale manifest");
 
         assert!(reason.contains("sidecar_embedding_backend_changed"));
+        assert!(reason.contains("manifest=onnx:bge"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -191,6 +191,15 @@ pub fn finalize_index_for_runtime(
     storage_path: &Path,
     runtime: &SidecarRuntimeConfig,
 ) -> Result<FinalizeIndexOutcome> {
+    finalize_index_for_runtime_with_progress(project_root, storage_path, runtime, |_| {})
+}
+
+pub fn finalize_index_for_runtime_with_progress(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+    mut progress: impl FnMut(&'static str),
+) -> Result<FinalizeIndexOutcome> {
     runtime.activate_embed_url_default();
     let layout = runtime.layout.clone();
     layout.ensure_data_dirs()?;
@@ -371,15 +380,17 @@ pub fn finalize_index_for_runtime(
         }
     }
 
-    let zoekt_version = ensure_zoekt_generation(
-        project_root,
-        storage_path,
-        &layout,
-        &project_id,
-        &generation,
-        zoekt_probe.reachable,
-        zoekt_ready,
-    )?;
+    let zoekt_version = with_finalize_progress(&mut progress, "lexical sidecar", || {
+        ensure_zoekt_generation(
+            project_root,
+            storage_path,
+            &layout,
+            &project_id,
+            &generation,
+            zoekt_probe.reachable,
+            zoekt_ready,
+        )
+    })?;
 
     let _qdrant_point_count = ensure_qdrant_collection(
         storage_path,
@@ -389,38 +400,52 @@ pub fn finalize_index_for_runtime(
         &collection,
         sidecar_input.projection_count,
         qdrant_ready_points,
+        &mut progress,
     )?;
 
-    ensure_scip_artifacts(
-        storage_path,
-        &scip_dir,
-        &project_id,
-        &generation,
-        scip_ready,
-        &mut manifest,
-    )?;
+    with_finalize_progress(&mut progress, "graph artifact", || {
+        ensure_scip_artifacts(
+            storage_path,
+            &scip_dir,
+            &project_id,
+            &generation,
+            scip_ready,
+            &mut manifest,
+        )
+    })?;
     update_precise_semantic_import_status(&scip_dir, &mut manifest)?;
 
     manifest.zoekt_version = zoekt_version;
     manifest.scip_revision = read_scip_revision(&scip_dir).or(manifest.scip_revision);
     manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
 
-    finalize_manifest_after_health_check(
-        storage_path,
-        &layout,
-        &qdrant_client,
-        project_id,
-        &collection,
-        &sidecar_input,
-        manifest,
-        degraded_modes,
-        SidecarStubFlags {
-            zoekt_stubbed,
-            qdrant_stubbed,
-            scip_stubbed,
-        },
-        &embedding_device,
-    )
+    with_finalize_progress(&mut progress, "manifest write", || {
+        finalize_manifest_after_health_check(
+            storage_path,
+            &layout,
+            &qdrant_client,
+            project_id,
+            &collection,
+            &sidecar_input,
+            manifest,
+            degraded_modes,
+            SidecarStubFlags {
+                zoekt_stubbed,
+                qdrant_stubbed,
+                scip_stubbed,
+            },
+            &embedding_device,
+        )
+    })
+}
+
+fn with_finalize_progress<T>(
+    progress: &mut impl FnMut(&'static str),
+    phase: &'static str,
+    action: impl FnOnce() -> Result<T>,
+) -> Result<T> {
+    progress(phase);
+    action()
 }
 
 fn ensure_zoekt_generation(
@@ -467,6 +492,7 @@ fn ensure_qdrant_collection(
     collection: &str,
     projection_count: i64,
     mut qdrant_ready_points: Option<u64>,
+    progress: &mut impl FnMut(&'static str),
 ) -> Result<u64> {
     if projection_count == 0 {
         info!(
@@ -491,8 +517,9 @@ fn ensure_qdrant_collection(
             "Qdrant generated collection reused"
         );
     } else {
-        let count =
-            upsert_qdrant_points_from_store(storage_path, project_root, qdrant_client, collection)?;
+        let count = with_finalize_progress(progress, "embeddings", || {
+            upsert_qdrant_points_from_store(storage_path, project_root, qdrant_client, collection)
+        })?;
         if count == 0 {
             bail!(
                 "mandatory Qdrant semantic collection has no indexed symbol points for {project_id}"
@@ -517,7 +544,9 @@ fn ensure_qdrant_collection(
             "Qdrant collection ensured and populated"
         );
     }
-    ensure_qdrant_semantic_smoke(project_id, collection, qdrant_client)?;
+    with_finalize_progress(progress, "Qdrant finalize", || {
+        ensure_qdrant_semantic_smoke(project_id, collection, qdrant_client)
+    })?;
     Ok(qdrant_ready_points.unwrap_or_default())
 }
 
@@ -1181,6 +1210,25 @@ mod tests {
             error.to_string().contains("mandatory"),
             "expected mandatory-sidecar error, got {error:#}"
         );
+    }
+
+    #[test]
+    fn finalize_progress_is_emitted_before_blocking_work() {
+        let phases = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let progress_phases = std::rc::Rc::clone(&phases);
+        let action_phases = std::rc::Rc::clone(&phases);
+
+        with_finalize_progress(
+            &mut |phase| progress_phases.borrow_mut().push(phase),
+            "lexical sidecar",
+            || {
+                assert_eq!(&*action_phases.borrow(), &["lexical sidecar"]);
+                Ok(())
+            },
+        )
+        .expect("progress wrapper should return action result");
+
+        assert_eq!(&*phases.borrow(), &["lexical sidecar"]);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -45,8 +45,9 @@ pub use capabilities::SidecarCapabilities;
 pub use compose::bootstrap_sidecars_without_storage_scope;
 pub use compose::{
     BootstrapReport, DEFAULT_COMPOSE_REL_PATH, EmbedModelInventory, bootstrap_sidecars,
-    bootstrap_sidecars_with_profile, bootstrap_sidecars_with_runtime, docker_available,
-    embed_model_inventory, resolve_compose_file,
+    bootstrap_sidecars_with_profile, bootstrap_sidecars_with_runtime,
+    bootstrap_sidecars_with_runtime_progress, docker_available, embed_model_inventory,
+    resolve_compose_file,
 };
 pub use config::{
     DEFAULT_AGENT_RUN_ID, DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT,
@@ -71,7 +72,8 @@ pub use health::{
 };
 pub use index::{
     FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, finalize_index_for_runtime,
-    project_id_for_root, repair_project_qdrant_collection, sidecar_project_id_for_root,
+    finalize_index_for_runtime_with_progress, project_id_for_root,
+    repair_project_qdrant_collection, sidecar_project_id_for_root,
 };
 pub use inventory::{
     SidecarDockerResource, SidecarDockerResourceKind, SidecarGcNamespaceResult, SidecarGcReport,

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -5734,7 +5734,7 @@ fn sync_llm_symbol_projection(
         })?),
         Err(error) => {
             tracing::warn!(
-                "embedding runtime unavailable ({error}); graph-native symbol docs will still be refreshed, but dense anchor retrieval will be unavailable until managed ONNX assets are installed with `codestory-cli setup embeddings` or embedding env points at a reachable runtime. Agent-facing retrieval must be repaired to full sidecar readiness before packet/search evidence is trusted."
+                "embedding runtime unavailable ({error}); graph-native symbol docs will still be refreshed, but dense anchor retrieval will be unavailable until the llama.cpp embedding sidecar is reachable or embedding env points at an explicit diagnostic runtime. Agent-facing retrieval must be repaired to full sidecar readiness before packet/search evidence is trusted."
             );
             None
         }

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -507,7 +507,7 @@ impl OnnxModelPaths {
 fn required_path_env(key: &str) -> Result<PathBuf> {
     let raw = std::env::var(key).with_context(|| {
         format!(
-            "{key} is not set; run `codestory-cli setup embeddings` or set {ONNX_MODEL_PATH_ENV} and {ONNX_TOKENIZER_PATH_ENV}"
+            "{key} is not set; ONNX is diagnostic-only, so set {ONNX_MODEL_PATH_ENV} and {ONNX_TOKENIZER_PATH_ENV} explicitly or use product llama.cpp sidecar retrieval"
         )
     })?;
     let path = PathBuf::from(raw.trim());

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.11.20"
+version = "0.12.0"
 edition = "2024"
 
 [dependencies]

--- a/docs/architecture/subsystems/runtime.md
+++ b/docs/architecture/subsystems/runtime.md
@@ -49,11 +49,10 @@ Important tuning surfaces:
 
 Product packet/search evidence is served through mandatory sidecars. The live
 query sidecar must use `llamacpp:bge-base-en-v1.5`, and health must report
-`retrieval_mode=full`. Stored product-compatible BGE-base dense docs may have
-ONNX or llama.cpp producer metadata when the dimension/backend contract matches
-the retrieval manifest; hash and other in-process embedding paths remain
-diagnostic unless a future spec promotes them with fresh sidecar-quality
-evidence. Current benchmark findings live in
+`retrieval_mode=full`. Stored ONNX, hash, or other diagnostic producer metadata
+must fail closed when it does not match the current llama.cpp product manifest;
+hash and other in-process embedding paths remain diagnostic unless a future spec
+promotes them with fresh sidecar-quality evidence. Current benchmark findings live in
 [embedding-backend-benchmarks.md](../../testing/embedding-backend-benchmarks.md).
 
 The CLI owns managed embedding setup. `codestory-cli retrieval bootstrap` starts

--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -100,9 +100,12 @@ Recovery order:
    `codestory-cli retrieval index --project . --refresh full`.
 5. Require `codestory-cli retrieval status --project . --format json` to report
    `retrieval_mode: "full"` before trusting packet/search evidence.
-6. If `doctor` reports `missing_managed_assets`, use `codestory-cli setup embeddings --project .`
-   only for managed ONNX/local semantic diagnostics. Managed setup installs ONNX assets and should
-   not start a server or create the product retrieval manifest.
+6. If `doctor` reports missing or unreachable embeddings, repair the llama.cpp
+   sidecar path with `codestory-cli retrieval bootstrap` and
+   `codestory-cli retrieval index --project . --refresh full`. Use
+   `codestory-cli setup embeddings --project .` only for explicit ONNX
+   diagnostics; it does not start sidecars or create the product retrieval
+   manifest.
 7. If semantic retrieval is still the only failing part, inspect the reported degraded-state reason before touching lexical ranking or CLI rendering.
 
 ## If Cold Indexing Is Slow

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -124,7 +124,7 @@ cargo build --release -p codestory-cli
 
 On Windows PowerShell, use `.\target\release\codestory-cli.exe`.
 
-This loop proves the local CLI and managed ONNX diagnostic path are wired, but
+This loop proves the local CLI and diagnostic ONNX asset path are wired, but
 it is not product packet/search sidecar setup. Treat `setup embeddings
 --dry-run` as an asset-plan check only. It should not start an embedding server,
 write a product retrieval manifest, or make agent-facing retrieval evidence

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -271,8 +271,9 @@ Default Windows cache locations:
 Downloaded model artifacts under `CODESTORY_EMBED_MODEL_DIR` or
 `target/retrieval-models` are accepted only after pinned size and SHA-256
 verification by the setup wrapper. Remove that model directory to uninstall the
-downloaded GGUF. Managed ONNX assets from `setup embeddings` are separate and do
-not substitute for llama.cpp sidecar retrieval.
+downloaded GGUF. Diagnostic ONNX assets from `setup embeddings` are separate,
+are not promoted into product runtime defaults, and do not substitute for
+llama.cpp sidecar retrieval.
 
 ## Operator troubleshooting
 
@@ -357,7 +358,7 @@ sidecars, and partial sidecars are diagnostic only and cannot produce
 
 Qdrant document vectors are copied from managed local `llm_symbol_doc`
 dense-anchor rows when the stored embedding contract is product BGE base profile:
-`bge-base-en-v1.5`, `768` dimensions, ONNX or llama.cpp backend. Query vectors
+`bge-base-en-v1.5`, `768` dimensions, and the llama.cpp product backend. Query vectors
 come from the local llama.cpp sidecar so retrieval remains sidecar-backed and
 can smoke-test the live collection. Wrong model dimensions fail loudly.
 

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -54,6 +54,7 @@ from the source checkout, marketplace cache, or PATH when status is available.
 | State | Meaning | Operator action |
 |-------|---------|-----------------|
 | `local_navigation=ready`, `agent_packet_search=ready`, `sidecar_mode=full` | Local graph and sidecar packet/search infrastructure are ready | Use packet/search/context as infrastructure-eligible, then prove answer quality with source, packet-runtime, drill, or benchmark evidence |
+| `local_navigation=ready`, `agent_packet_search=repairing` | Agent sidecar repair is active and status should include the current `phase`, `profile`, `run_id`, and `namespace` | Wait or reread `codestory://status`; do not start a second agent repair for the same run |
 | `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; run the repair command from preflight/status before packet/search claims |
 | `local_navigation=repair_local` | Core index or cache is missing or stale | Run `codestory-cli ready --goal local --repair --project <repo> --format json`, then rerun `doctor` |
 | `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Repair the failing sidecar layer, rerun `retrieval index --refresh full`, then rerun `retrieval status` |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -138,6 +138,35 @@ codestory-cli agent preflight --project <target-workspace> --format json
 Use its `safe_surfaces`, `blocked_surfaces`, and `repair_command` fields as the
 agent handoff.
 
+## Delegated Worktree Proof Target
+
+Before a delegated CodeStory lane spends time on cache repair, readiness, or
+sidecar proof, verify the Git target. `scripts/codex-worktree-setup.ps1` prints
+this handoff surface first:
+
+```text
+intended_base_ref
+resolved_base_commit
+child_start_head
+child_branch_or_detached
+proof_target
+pr_head_ref
+pr_head_commit
+remote_tip_verification.<target>.command
+remote_tip_verification.<target>.result
+```
+
+Defaults are intentionally narrow: `intended_base_ref` is
+`origin/dev/codestory-next`, and a PR lane with `CODESTORY_PR_HEAD_REF` or
+`-PrHeadRef` proves `base:origin/dev/codestory-next + pr-head:<ref>`. Use
+`-BranchHeadProof` or `CODESTORY_BRANCH_HEAD_PROOF=1` only when the lane is
+explicitly proving the branch head by itself.
+
+The setup script reports stale `main`, stale local `dev/codestory-next`, stale
+PR heads, unresolved refs, and the exact `git ls-remote origin ...` result
+before it runs index, retrieval, or doctor handoff work. Treat those warnings as
+Git proof-target blockers, not packet/search readiness blockers.
+
 **Next steps after installation:**
 
 If the agent reports that local graph surfaces are allowed but `packet`,

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.20",
+  "version": "0.12.0",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -24,8 +24,8 @@
     "privacyPolicyURL": "https://github.com/TheGreenCedar/CodeStory",
     "termsOfServiceURL": "https://github.com/TheGreenCedar/CodeStory",
     "defaultPrompt": [
-      "@CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.",
-      "@CodeStory Where is RefreshMode defined, which codestory-cli commands accept --refresh, and what is the call path from index into codestory-store?",
+      "@CodeStory Check local and agent readiness for this checkout before packet/search.",
+      "@CodeStory Find RefreshMode and the index path into codestory-store.",
       "@CodeStory I am editing a file in this repo. What symbols are affected and what tests should I run first?"
     ],
     "brandColor": "#2563EB",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.11.20",
+  "version": "0.12.0",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.11.20",
+  "version": "0.12.0",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/claude-codex-hooks.json
+++ b/plugins/codestory/hooks/claude-codex-hooks.json
@@ -8,7 +8,7 @@
             "type": "command",
             "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.cjs\" || exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.cjs\" }",
-            "timeout": 5,
+            "timeout": 300,
             "statusMessage": "Loading CodeStory grounding..."
           }
         ]
@@ -21,7 +21,7 @@
             "type": "command",
             "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.cjs\" || exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.cjs\" }",
-            "timeout": 5,
+            "timeout": 300,
             "statusMessage": "Preparing CodeStory packet..."
           }
         ]

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -4,6 +4,7 @@ const { spawnSync } = require('child_process');
 const { createHash } = require('crypto');
 const { eventHeader, getCodeStoryInstructions } = require('./codestory-instructions.cjs');
 const {
+  bootstrapManagedRuntime,
   classifyMcpRuntime,
   dirtyMarkerPathForProject,
   mcpDetectionText,
@@ -29,6 +30,7 @@ const EVENT_CAPS = {
 };
 const RUNTIME_TIMEOUT_MS = 3500;
 const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
+const BOOTSTRAP_TAXONOMIES = new Set(['startup', 'clear', 'child_worktree_start', 'session']);
 
 function readHookInput() {
   return new Promise((resolve) => {
@@ -172,6 +174,27 @@ function runtimeStatusBlock(policy, mcp) {
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
   ].join('\n');
+}
+
+function shouldBootstrapManagedRuntime(policy, mcp) {
+  if (process.env.CODESTORY_CLI) return false;
+  if (!BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) return false;
+  return Boolean(policy.project && mcp.mcp_process_launchable && !mcp.mcp_resources_exposed);
+}
+
+function bootstrapText(bootstrap) {
+  if (!bootstrap || !bootstrap.attempted) return null;
+  const status = bootstrap.parsed || {};
+  const plugin = status.plugin_runtime || {};
+  const localRefresh = status.local_refresh || status.readiness?.[0]?.local_refresh || {};
+  const reason = status.degraded_reason || status.readiness?.[0]?.repair_reason || bootstrap.error || bootstrap.stderr;
+  return [
+    `managed_bootstrap: ${bootstrap.ready ? 'ready' : 'blocked'}`,
+    `managed_bootstrap_cli_source: ${plugin.cli_source || '<unknown>'}`,
+    plugin.managed_binary_path ? `managed_bootstrap_cli_path: ${plugin.managed_binary_path}` : null,
+    `managed_bootstrap_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
+    reason ? `managed_bootstrap_reason: ${truncate(reason, 500)}` : null,
+  ].filter(Boolean).join('\n');
 }
 
 function firstFreshness(value) {
@@ -348,7 +371,14 @@ function runCodeStory(input, event, policy, state = {}) {
     };
   }
 
-  const mcp = classifyMcpRuntime();
+  let mcp = classifyMcpRuntime();
+  const bootstrap = shouldBootstrapManagedRuntime(policy, mcp)
+    ? bootstrapManagedRuntime({ projectRoot: policy.project })
+    : null;
+  if (bootstrap?.attempted) {
+    mcp = classifyMcpRuntime();
+  }
+  const bootstrapBlock = bootstrapText(bootstrap);
   if (policy.runtimeOnly) {
     const heartbeatProbe = policy.heartbeat
       ? heartbeatReadinessProbe(mcp, policy.project, input.cwd || process.cwd())
@@ -377,12 +407,13 @@ function runCodeStory(input, event, policy, state = {}) {
         `event_taxonomy: ${policy.taxonomy}`,
         `output_cap_chars: ${policy.cap}`,
         `dedupe_key: ${policy.dedupeKey}`,
+        bootstrapBlock,
         mcpDetectionText(mcp),
         mcp.mcp_resources_exposed
           ? 'Use codestory://status as the active runtime truth. Run packet/search/context only when status allows that surface with retrieval_mode=full.'
           : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Reload the host/plugin and read codestory://status; do not add CodeStory to PATH.',
       ].join('\n'), policy.cap),
-      fingerprint: runtimeFingerprint(mcp),
+      fingerprint: `${runtimeFingerprint(mcp)}|${bootstrapBlock || 'no-bootstrap'}`,
     };
   }
 

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const { createHash } = require('crypto');
 
 const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
@@ -79,6 +80,16 @@ function mcpScriptExists(root, args) {
   return fs.existsSync(path.resolve(root, scriptArg));
 }
 
+function mcpScriptPath(root, args) {
+  const scriptArg = args.find((arg) => typeof arg === 'string' && /codestory-mcp\.cjs$/u.test(arg));
+  return scriptArg ? path.resolve(root, scriptArg) : null;
+}
+
+function bootstrapTimeoutMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_BOOTSTRAP_TIMEOUT_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 240000;
+}
+
 function managedCliInfo(dataDir = pluginDataDir(), version = pluginVersion()) {
   if (!dataDir) return { present: false, path: null, source: null };
   const runtime = readJson(path.join(dataDir, MCP_RUNTIME_FILE));
@@ -128,6 +139,44 @@ function classifyMcpRuntime(options = {}) {
     managed_cli_path: managed.path,
     managed_cli_source: managed.source,
     degraded_no_surface: !resourcesExposed && !managed.present,
+  };
+}
+
+function bootstrapManagedRuntime(options = {}) {
+  const root = options.pluginRoot || pluginRoot();
+  const dataDir = options.pluginDataDir === undefined ? pluginDataDir() : options.pluginDataDir;
+  const projectRoot = normalizeProjectRoot(options.projectRoot || process.cwd());
+  const mcp = configuredMcp(root);
+  const scriptPath = mcpScriptPath(root, mcp.args);
+  if (!dataDir) return { attempted: false, reason: 'plugin_data_required' };
+  if (!mcp.installed || mcp.command !== 'node' || !scriptPath || !fs.existsSync(scriptPath)) {
+    return { attempted: false, reason: 'mcp_launcher_unavailable' };
+  }
+
+  const result = spawnSync(process.execPath, [scriptPath, 'bootstrap-status', '--project', projectRoot], {
+    cwd: root,
+    encoding: 'utf8',
+    timeout: bootstrapTimeoutMs(),
+    maxBuffer: 20000,
+    windowsHide: true,
+    env: {
+      ...process.env,
+      PLUGIN_DATA: dataDir,
+    },
+  });
+  let status = null;
+  try {
+    status = JSON.parse(result.stdout || '{}');
+  } catch (error) {
+    status = { ready: false, degraded_reason: `bootstrap_status_invalid_json:${error.message}` };
+  }
+  return {
+    attempted: true,
+    status: result.status,
+    error: result.error ? result.error.message : null,
+    stderr: result.stderr || '',
+    ready: status?.ready === true,
+    parsed: status,
   };
 }
 
@@ -421,6 +470,7 @@ function writeHookOutput(event, context) {
 }
 
 module.exports = {
+  bootstrapManagedRuntime,
   classifyMcpRuntime,
   dirtyMarkerPathForProject,
   dirtyHookStatus,

--- a/plugins/codestory/hooks/copilot-hooks.json
+++ b/plugins/codestory/hooks/copilot-hooks.json
@@ -6,7 +6,7 @@
         "type": "command",
         "bash": "node \"${PLUGIN_ROOT}/hooks/codestory-activate.cjs\"",
         "powershell": "node \"${PLUGIN_ROOT}\\hooks\\codestory-activate.cjs\"",
-        "timeoutSec": 5
+        "timeoutSec": 300
       }
     ]
   }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -15,6 +15,9 @@ const fallbackBinaryNames = process.platform === 'win32'
   ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
   : ['codestory-cli'];
 const sharedAgentRunId = 'shared-agent';
+const releaseDownloadTimeoutMs = 60000;
+const releaseDownloadAttempts = 3;
+const releaseDownloadRetryDelaysMs = [1000, 3000];
 
 function readJson(file) {
   try {
@@ -230,12 +233,25 @@ function copyLocalReleaseFile(releaseDir, name, destination) {
   fs.copyFileSync(path.join(releaseDir, name), destination);
 }
 
-function downloadFile(url, destination) {
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function downloadFileOnce(url, destination, options = {}) {
+  const timeoutMs = options.timeoutMs || releaseDownloadTimeoutMs;
+  const redirectsRemaining = options.redirectsRemaining ?? 5;
+  const get = options.get || https.get;
   return new Promise((resolve, reject) => {
-    const request = https.get(url, (response) => {
+    const request = get(url, (response) => {
       if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
         response.resume();
-        downloadFile(response.headers.location, destination).then(resolve, reject);
+        if (!response.headers.location || redirectsRemaining <= 0) {
+          reject(new Error(`download redirect failed: ${url}`));
+          return;
+        }
+        const nextUrl = new URL(response.headers.location, url).toString();
+        downloadFileOnce(nextUrl, destination, { ...options, redirectsRemaining: redirectsRemaining - 1 })
+          .then(resolve, reject);
         return;
       }
       if (response.statusCode !== 200) {
@@ -248,20 +264,58 @@ function downloadFile(url, destination) {
       output.on('finish', () => output.close(resolve));
       output.on('error', reject);
     });
-    request.setTimeout(15000, () => request.destroy(new Error(`download timed out: ${url}`)));
+    request.setTimeout(timeoutMs, () => request.destroy(new Error(`download timed out after ${timeoutMs}ms: ${url}`)));
     request.on('error', reject);
   });
 }
 
+async function downloadFile(url, destination, options = {}) {
+  const attempts = options.attempts || releaseDownloadAttempts;
+  const startedAt = Date.now();
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await downloadFileOnce(url, destination, options);
+      return;
+    } catch (error) {
+      lastError = error;
+      fs.rmSync(destination, { force: true });
+      if (attempt < attempts) {
+        const delayMs = options.retryDelayMs
+          ? options.retryDelayMs(attempt)
+          : releaseDownloadRetryDelaysMs[attempt - 1] ||
+            releaseDownloadRetryDelaysMs[releaseDownloadRetryDelaysMs.length - 1];
+        if (delayMs > 0) await sleep(delayMs);
+      }
+    }
+  }
+  const elapsedMs = Date.now() - startedAt;
+  throw new Error(`download failed after ${attempts} attempts over ${elapsedMs}ms: ${lastError?.message || 'unknown error'}`);
+}
+
+function releaseAssetFetchFailure(name, startedAt, attempts, error) {
+  const elapsedMs = Date.now() - startedAt;
+  return `managed_cli_asset_fetch_failed:${name}:elapsed_ms=${elapsedMs}:attempts=${attempts}:retry=restart_reload_status:last_error=${error.message}`;
+}
+
 async function fetchReleaseFile(version, name, destination) {
+  const startedAt = Date.now();
   if (process.env.CODESTORY_PLUGIN_RELEASE_DIR) {
-    copyLocalReleaseFile(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name, destination);
+    try {
+      copyLocalReleaseFile(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name, destination);
+    } catch (error) {
+      throw new Error(releaseAssetFetchFailure(name, startedAt, 1, error));
+    }
     return `file://${path.join(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name)}`;
   }
   const baseUrl = process.env.CODESTORY_PLUGIN_RELEASE_BASE_URL ||
     `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}`;
   const url = `${baseUrl.replace(/\/$/u, '')}/${name}`;
-  await downloadFile(url, destination);
+  try {
+    await downloadFile(url, destination);
+  } catch (error) {
+    throw new Error(releaseAssetFetchFailure(name, startedAt, releaseDownloadAttempts, error));
+  }
   return url;
 }
 
@@ -375,8 +429,12 @@ async function resolveCli() {
     return { source: 'managed', version, warnings, ...managed };
   }
 
-  warnings.push('managed_cli_unavailable_using_path_fallback');
-  const pathFallback = pathCliCandidates()[0] || 'codestory-cli';
+  const managedProvisionFailure = warnings.find((warning) => warning.startsWith('managed_cli_provision_failed:')) || null;
+  const pathCandidates = pathCliCandidates();
+  warnings.push(pathCandidates.length > 0
+    ? 'managed_cli_unavailable_using_path_fallback'
+    : 'managed_cli_unavailable_no_path_fallback');
+  const pathFallback = pathCandidates[0] || 'codestory-cli';
   return {
     source: 'path_fallback',
     path: pathFallback,
@@ -388,6 +446,7 @@ async function resolveCli() {
     archiveSha256: null,
     archiveUrl: null,
     provisionedAt: null,
+    managedProvisionFailure,
     warnings,
   };
 }
@@ -433,6 +492,9 @@ function probeResolvedCli(resolved) {
 }
 
 function failOpenReasonForProbe(resolved, probe) {
+  if (resolved.managedProvisionFailure && resolved.source === 'path_fallback' && pathCliCandidates().length === 0) {
+    return resolved.managedProvisionFailure;
+  }
   if (probe.error || probe.status !== 0) {
     return `${resolved.source}_cli_unspawnable`;
   }
@@ -585,11 +647,16 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     version: cliVersion(candidate),
     active: samePathText(candidate, resolved.path),
   }));
-  const minimumNext = options.minimumNext || [
+  const managedProvisionFailed = String(reason || '').startsWith('managed_cli_provision_failed:');
+  const managedProvisionNext = [
+    'Restart/reload the Codex host/app and read codestory://status; managed CLI provisioning will retry release asset downloads.',
+    'Refresh or reinstall the CodeStory plugin after GitHub release assets are reachable, then restart/reload the Codex host/app and read codestory://status.',
+  ];
+  const minimumNext = options.minimumNext || (managedProvisionFailed && pathCandidates.length === 0 ? managedProvisionNext : [
     'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
     process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
     'codestory-cli --version',
-  ];
+  ]);
   const fullRepair = options.fullRepair || minimumNext;
   const recommendedNext = options.recommendedNext || fullRepair;
   const sidecarPolicy = readSidecarPolicy();
@@ -987,7 +1054,7 @@ async function main() {
   });
 }
 
-main().catch((error) => {
+function runLauncherError(error) {
   const resolved = {
     source: 'launcher',
     path: 'codestory-cli',
@@ -1008,4 +1075,14 @@ main().catch((error) => {
     stdout: '',
     stderr: '',
   }, 'launcher_error'));
-});
+}
+
+if (require.main === module) {
+  main().catch(runLauncherError);
+} else {
+  module.exports = {
+    _test: {
+      downloadFile,
+    },
+  };
+}

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -54,8 +54,38 @@ function pluginCacheVersion() {
   return parent === 'codestory' ? path.basename(pluginRoot) : null;
 }
 
+function inferredCodexPluginDataDir(root = pluginRoot) {
+  const parts = path.resolve(root).split(/[\\/]+/u);
+  for (let index = 0; index <= parts.length - 6; index += 1) {
+    if (
+      parts[index].toLowerCase() !== '.codex' ||
+      parts[index + 1] !== 'plugins' ||
+      parts[index + 2] !== 'cache' ||
+      parts[index + 4] !== 'codestory'
+    ) {
+      continue;
+    }
+    const codexRoot = parts.slice(0, index + 1).join(path.sep);
+    const dataDir = path.join(codexRoot, 'plugins', 'data', `codestory-${parts[index + 3]}`);
+    if (usablePluginDataDir(dataDir)) return dataDir;
+  }
+  return null;
+}
+
+function usablePluginDataDir(dataDir) {
+  try {
+    if (fs.existsSync(dataDir)) return fs.statSync(dataDir).isDirectory();
+    const dataRoot = path.dirname(dataDir);
+    if (fs.existsSync(dataRoot)) return fs.statSync(dataRoot).isDirectory();
+    fs.accessSync(path.dirname(dataRoot), fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function pluginDataDir() {
-  return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || null;
+  return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || inferredCodexPluginDataDir();
 }
 
 function sidecarPolicyPath(dataDir = pluginDataDir()) {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -520,7 +520,7 @@ function localWaitFreshCommand(projectRoot = process.cwd()) {
 
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
 }
 
 function sidecarRepairTimeoutMs() {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -128,6 +128,10 @@ function repairCommandForProject(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
 
+function resolvedRepairCommandForProject(resolved, projectRoot = process.cwd()) {
+  return `${JSON.stringify(resolved.path)} ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
+}
+
 function optionValue(argv, name) {
   const index = argv.indexOf(name);
   return index >= 0 ? argv[index + 1] : null;
@@ -519,6 +523,11 @@ function localWaitFreshTimeoutMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
 }
 
+function sidecarRepairTimeoutMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR_TIMEOUT_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
+}
+
 function runLocalNavigationWaitFresh(resolved, projectRoot) {
   const args = ['ready', '--goal', 'local', '--wait-fresh'];
   args.push('--project', projectRoot, '--format', 'json');
@@ -529,6 +538,38 @@ function runLocalNavigationWaitFresh(resolved, projectRoot) {
     windowsHide: true,
   });
   return { args, result };
+}
+
+function runSidecarStartupRepair(resolved, sidecarStatus, projectRoot = process.cwd()) {
+  if (sidecarStatus.state !== 'enabled') return sidecarStatus;
+  if (resolved.source !== 'managed' && resolved.source !== 'local_dev_override') return sidecarStatus;
+  const args = ['ready', '--goal', 'agent', '--repair'];
+  args.push('--project', projectRoot, '--format', 'json', '--run-id', sharedAgentRunId);
+  const result = spawnSync(resolved.path, args, {
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    timeout: sidecarRepairTimeoutMs(),
+    windowsHide: true,
+    env: {
+      ...process.env,
+      CODESTORY_PLUGIN_SIDECAR_REPAIR: '1',
+      CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
+    },
+  });
+  const lastRepair = {
+    state: result.error?.code === 'ETIMEDOUT' ? 'timeout' : result.status === 0 ? 'completed' : 'failed',
+    updated_at: new Date().toISOString(),
+    project_root: projectRoot,
+    command: resolvedRepairCommandForProject(resolved, projectRoot),
+  };
+  if (sidecarStatus.path) {
+    writeSidecarPolicy(sidecarStatus.state, { last_repair: lastRepair }, sidecarStatus.path);
+    return readSidecarPolicy(sidecarStatus.path);
+  }
+  return {
+    ...sidecarStatus,
+    lastRepair,
+  };
 }
 
 function localReadySetup(prefix, args, result) {
@@ -1094,7 +1135,7 @@ async function main() {
     }));
     return;
   }
-  const sidecarStatus = readSidecarPolicy();
+  const sidecarStatus = runSidecarStartupRepair(resolved, readSidecarPolicy(), process.cwd());
   const dirtyMarker = dirtyMarkerEnv(process.cwd());
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
@@ -1122,7 +1163,7 @@ async function main() {
       CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
       CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
       CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
-      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: repairCommandForProject(process.cwd()),
+      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, process.cwd()),
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -128,6 +128,11 @@ function repairCommandForProject(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
 
+function optionValue(argv, name) {
+  const index = argv.indexOf(name);
+  return index >= 0 ? argv[index + 1] : null;
+}
+
 function dirtyMarkerEnv(projectRoot = process.cwd()) {
   const markerPath = dirtyMarkerPathForProject(projectRoot, pluginDataDir());
   const normalizedRoot = (() => {
@@ -624,7 +629,12 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
     );
   }
   if (parsedProbe.ok) {
-    return { ready: true };
+    return {
+      ready: true,
+      setup,
+      verdict: parsedProbe.verdict || null,
+      localRefresh: parsedProbe.localRefresh || null,
+    };
   }
   const verdict = parsedProbe.verdict || null;
   const status = typeof verdict?.status === 'string' ? verdict.status : 'repair_setup';
@@ -640,8 +650,28 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
   );
 }
 
+function pluginRuntimeForResolved(resolved) {
+  return {
+    plugin_version: resolved.version,
+    plugin_root: pluginRoot,
+    plugin_cache_version: pluginCacheVersion(),
+    plugin_data: pluginDataDir(),
+    cli_source: resolved.source,
+    cli_path: resolved.path,
+    cli_sha256: resolved.sha256,
+    build_source: resolved.buildSource,
+    repo_ref: resolved.repoRef,
+    local_dev_override: resolved.source === 'local_dev_override',
+    path_fallback: resolved.source === 'path_fallback',
+    managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
+    managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
+    managed_manifest_path: resolved.manifestPath || null,
+    warnings: resolved.warnings.filter(Boolean),
+  };
+}
+
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {
-  const projectRoot = process.cwd();
+  const projectRoot = options.projectRoot || process.cwd();
   const pathCandidates = pathCliCandidates().map((candidate) => ({
     path: candidate,
     version: cliVersion(candidate),
@@ -660,23 +690,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   const fullRepair = options.fullRepair || minimumNext;
   const recommendedNext = options.recommendedNext || fullRepair;
   const sidecarPolicy = readSidecarPolicy();
-  const plugin = {
-    plugin_version: resolved.version,
-    plugin_root: pluginRoot,
-    plugin_cache_version: pluginCacheVersion(),
-    plugin_data: pluginDataDir(),
-    cli_source: resolved.source,
-    cli_path: resolved.path,
-    cli_sha256: resolved.sha256,
-    build_source: resolved.buildSource,
-    repo_ref: resolved.repoRef,
-    local_dev_override: resolved.source === 'local_dev_override',
-    path_fallback: resolved.source === 'path_fallback',
-    managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
-    managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
-    managed_manifest_path: resolved.manifestPath || null,
-    warnings: [...resolved.warnings, reason].filter(Boolean),
-  };
+  const plugin = pluginRuntimeForResolved({ ...resolved, warnings: [...resolved.warnings, reason] });
   const repair = {
     goal: options.goal || 'local_navigation',
     status: options.status || 'repair_setup',
@@ -759,6 +773,85 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
         : { method: 'cli', command }),
     ],
   };
+}
+
+async function bootstrapStatus(projectRoot = process.cwd()) {
+  const resolved = await resolveCli();
+  rememberLaunch(resolved);
+  const probe = probeResolvedCli(resolved);
+  const failOpenReason = failOpenReasonForProbe(resolved, probe);
+  if (failOpenReason) {
+    return {
+      ready: false,
+      ...fallbackDiagnostic(resolved, probe, failOpenReason, { projectRoot }),
+    };
+  }
+
+  const localReadiness = probeLocalNavigation(resolved, projectRoot);
+  if (!localReadiness.ready) {
+    return {
+      ready: false,
+      ...fallbackDiagnostic(resolved, probe, localReadiness.reason, {
+        projectRoot,
+        status: localReadiness.status,
+        summary: localReadiness.summary,
+        minimumNext: localReadiness.minimumNext,
+        fullRepair: localReadiness.fullRepair,
+        localRefresh: localReadiness.localRefresh,
+        setup: localReadiness.setup,
+      }),
+    };
+  }
+
+  const sidecarPolicy = readSidecarPolicy();
+  const plugin = pluginRuntimeForResolved(resolved);
+  const localRefresh = localReadiness.localRefresh || {
+    state: 'fresh',
+    blocks_local_surfaces: false,
+    readiness_status: 'ready',
+  };
+  const repair = {
+    goal: 'local_navigation',
+    status: 'ready',
+    summary: localReadiness.verdict?.summary || 'CodeStory local navigation is ready.',
+    repair_reason: null,
+    local_refresh: localRefresh,
+    minimum_next: [{ method: 'resources/read', uri: 'codestory://status' }],
+    full_repair: [],
+    setup: {
+      ...localReadiness.setup,
+      readiness_verdict: localReadiness.verdict,
+    },
+  };
+  return {
+    ready: true,
+    project_root: projectRoot,
+    server_version: resolved.version,
+    cli_version: probe.version,
+    plugin_runtime: plugin,
+    runtime_truth: runtimeTruthStatus(plugin, repair, {
+      sidecarPolicy: sidecarPolicy.state || 'unavailable',
+      localRefresh,
+    }),
+    local_refresh: localRefresh,
+    readiness: [repair],
+    recommended_next_calls: [{ method: 'resources/read', uri: 'codestory://status' }],
+  };
+}
+
+async function handleBootstrapStatusCommand(argv) {
+  if (argv[2] !== 'bootstrap-status') return false;
+  const projectRoot = optionValue(argv, '--project') || process.cwd();
+  try {
+    process.stdout.write(`${JSON.stringify(await bootstrapStatus(projectRoot))}\n`);
+  } catch (error) {
+    process.stdout.write(`${JSON.stringify({
+      ready: false,
+      degraded_reason: `launcher_error:${error.message}`,
+      project_root: projectRoot,
+    })}\n`);
+  }
+  process.exit(0);
 }
 
 function pathCliCandidates() {
@@ -976,6 +1069,7 @@ function rememberLaunch(resolved) {
 }
 
 async function main() {
+  if (await handleBootstrapStatusCommand(process.argv)) return;
   handleSidecarPolicyCommand(process.argv);
   const resolved = await resolveCli();
   rememberLaunch(resolved);

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -119,6 +119,17 @@ CLI directly:
 
 Always pass `--project <target-workspace>` explicitly.
 
+For delegated CodeStory child worktrees, check the Git proof target before
+cache, readiness, or sidecar proof work. `scripts/codex-worktree-setup.ps1`
+prints `intended_base_ref`, `resolved_base_commit`, `child_start_head`,
+`child_branch_or_detached`, `proof_target`, `pr_head_ref`, `pr_head_commit`, and
+the exact `git ls-remote origin ...` command/result when a remote branch is
+applicable. PR lanes default to proving current `origin/dev/codestory-next` plus
+the PR head (`CODESTORY_PR_HEAD_REF` or `-PrHeadRef`); use branch-head proof
+only when explicitly requested. Stale `main`, stale local
+`dev/codestory-next`, stale PR head, unresolved refs, or the wrong proof target
+are Git blockers to fix before expensive readiness evidence.
+
 For binary repair details, use [serve](references/serve.md) for MCP/PATH
 behavior and [doctor](references/doctor.md) for health and repair evidence.
 

--- a/plugins/codestory/skills/codestory-grounding/references/context.md
+++ b/plugins/codestory/skills/codestory-grounding/references/context.md
@@ -29,7 +29,7 @@ Builds target context around one concrete retrieval target. Target selection is 
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> context --project <target-workspace> --query AppController` | Markdown context packet with resolution metadata, retrieval trace, citations, gaps, and next commands when sidecar-primary retrieval is full. |
-| Failure path | If the target is ambiguous or missing, run `search --project <target-workspace> --query "<target>" --why`, choose a concrete `node_id`, then rerun `context --id <node_id>`. If local navigation readiness is weak, run `doctor --project <target-workspace>`, `setup embeddings --project <target-workspace>` when needed, and `index --project <target-workspace> --refresh full`. | Keeps target context tied to a resolvable target and avoids treating stale retrieval as strong evidence. |
+| Failure path | If the target is ambiguous or missing, run `search --project <target-workspace> --query "<target>" --why`, choose a concrete `node_id`, then rerun `context --id <node_id>`. If sidecar-primary retrieval readiness is weak, run `doctor --project <target-workspace>`, `retrieval bootstrap --project <target-workspace>` when needed, and `retrieval index --project <target-workspace> --refresh full`. | Keeps target context tied to a resolvable target and avoids treating stale retrieval as strong evidence. |
 | Integration edge | Use `search --why`, `explore`, or `bookmark list` first, then pass the selected node via `--id <node_id>` or `--bookmark <bookmark_id>`; use `--bundle out/context-AppController` for reviewer handoff. | Converts candidate discovery into a deeper, shareable evidence packet. |
 
 ## Notes

--- a/plugins/codestory/skills/codestory-grounding/references/index.md
+++ b/plugins/codestory/skills/codestory-grounding/references/index.md
@@ -52,9 +52,9 @@ unstructured docs. On a fresh machine, check the setup plan first:
 <codestory-cli> setup embeddings --project <target-workspace> --dry-run --format json
 ```
 
-Then install assets with `setup embeddings --project <target-workspace>` if the
-plan is acceptable, and rerun `index --project <target-workspace>` unless the
-setup plan explicitly asks for a full refresh.
+Then install assets with `setup embeddings --project <target-workspace>` only
+for explicit ONNX diagnostics. Product packet/search readiness uses the
+llama.cpp retrieval sidecar path.
 
 High-signal environment toggles:
 

--- a/plugins/codestory/skills/codestory-grounding/references/setup.md
+++ b/plugins/codestory/skills/codestory-grounding/references/setup.md
@@ -16,7 +16,7 @@ surprise-download. Agent-facing packet/search evidence still requires
 |--------|---------|-----|
 | `--project <path>` | `.` | Target workspace used to resolve cache configuration. Always pass it explicitly. |
 | `--cache-dir <path>` | auto | Use an isolated cache root, useful for tests and repros. |
-| `--quant <q8_0|q4_k_m>` | `q8_0` | Legacy compatibility selector. Managed `setup embeddings` installs pinned ONNX assets for the local semantic runtime; GGUF llama.cpp sidecar model setup is handled by the retrieval sidecar setup path. |
+| `--quant <q8_0|q4_k_m>` | `q8_0` | Legacy compatibility selector. `setup embeddings` installs diagnostic ONNX assets only; GGUF llama.cpp sidecar model setup is handled by the retrieval sidecar setup path. |
 | `--variant <cpu|vulkan>` | `vulkan` | Compatibility selector for older setup flows; product sidecar use is governed by `retrieval bootstrap`. |
 | `--dry-run` | off | Show the asset plan without downloading anything. |
 | `--no-start` | off | Compatibility flag; product setup is handled by retrieval sidecar bootstrap. |
@@ -28,7 +28,7 @@ surprise-download. Agent-facing packet/search evidence still requires
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Product packet/search setup | Follow `docs/ops/retrieval-sidecars.md`, then run `retrieval bootstrap`, `retrieval index`, and `retrieval status` for the target workspace. | Product search/packet paths are usable only when status reports `retrieval_mode=full`. |
-| Legacy managed assets | `setup embeddings --project <target-workspace> --dry-run --format json`, then `setup embeddings --project <target-workspace>` if the plan is expected. | Installs local managed ONNX assets for semantic diagnostics; it does not start sidecars or prove packet/search readiness. |
+| Legacy diagnostic assets | `setup embeddings --project <target-workspace> --dry-run --format json`, then `setup embeddings --project <target-workspace>` if the plan is expected. | Installs local ONNX assets for semantic diagnostics; it does not start sidecars, set product defaults, or prove packet/search readiness. |
 | Failure path | Use the sidecar runbook for llama.cpp/GGUF/manifest failures; use `setup embeddings --dry-run --format json` only for legacy managed asset diagnosis. | Keeps product sidecar setup separate from legacy asset setup. |
 
 ## Notes

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -937,6 +937,74 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
+test("startup hook bootstraps managed cli before reporting MCP visibility", async (t) => {
+  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
+  if (tarProbe.status !== 0) {
+    t.skip("tar unavailable for archive fixture");
+    return;
+  }
+
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-bootstrap-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-hook-release-"));
+  const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
+  const { archiveBase, archiveName } = releaseAssetForPlatform(version);
+  const stageDir = join(releaseDir, archiveBase);
+  const cliPath = join(stageDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const archivePath = join(releaseDir, archiveName);
+
+  try {
+    await mkdir(stageDir, { recursive: true });
+    await writeFakeCli(cliPath);
+    const packArgs = archiveName.endsWith(".zip")
+      ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
+      : ["-czf", archivePath, "-C", releaseDir, archiveBase];
+    const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
+    assert.equal(pack.status, 0, pack.stderr);
+    const archiveSha256 = createHash("sha256")
+      .update(await readFile(archivePath))
+      .digest("hex");
+    await writeFile(join(releaseDir, "SHA256SUMS.txt"), `${archiveSha256}  ${archiveName}\n`, "utf8");
+
+    const result = spawnSync(process.execPath, [hookPath], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: "",
+        CODESTORY_MCP_RESOURCES_EXPOSED: "",
+        CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
+        COPILOT_PLUGIN_DATA: "",
+        PLUGIN_DATA: dataDir,
+      },
+      input: JSON.stringify({
+        hook_event_name: "SessionStart",
+        source: "startup",
+        cwd: repoRoot,
+      }),
+      encoding: "utf8",
+      timeout: 30000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
+    assert.match(context, /managed_bootstrap: ready/u);
+    assert.match(context, /managed_bootstrap_cli_source: managed/u);
+    assert.match(context, /managed_bootstrap_local_refresh: fresh/u);
+    assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+    assert.match(context, /managed_cli_present: yes/u);
+    assert.doesNotMatch(context, /where\.exe codestory-cli|command -v codestory-cli|adding CodeStory to PATH/u);
+
+    const manifest = JSON.parse(
+      await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
+    );
+    assert.equal(manifest.version, version);
+    assert.equal(manifest.build_source, "github_release");
+    assert.equal(manifest.archive_sha256, archiveSha256);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
 test("release asset downloader retries a transient failure", async () => {
   const { EventEmitter } = await import("node:events");
   const { PassThrough } = await import("node:stream");
@@ -1066,6 +1134,60 @@ test("session-start hooks are thin and host manifests point at them", async () =
 
   const manifest = JSON.parse(await readFile(hostManifest, "utf8"));
   assert.equal(manifest.hooks, "./hooks/claude-codex-hooks.json");
+});
+
+test("hook manifest timeouts cover managed bootstrap budget", async () => {
+  const hookConfig = JSON.parse(
+    await readFile(join(pluginRoot, "hooks", "claude-codex-hooks.json"), "utf8"),
+  );
+  const copilotHookConfig = JSON.parse(
+    await readFile(join(pluginRoot, "hooks", "copilot-hooks.json"), "utf8"),
+  );
+  const runtimeSource = await readFile(join(pluginRoot, "hooks", "codestory-runtime.cjs"), "utf8");
+  const mcpSource = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8");
+  const numberFrom = (text, pattern, label) => {
+    const match = text.match(pattern);
+    assert.ok(match, `missing ${label}`);
+    return Number.parseInt(match[1], 10);
+  };
+
+  const bootstrapTimeoutMs = numberFrom(
+    runtimeSource,
+    /function bootstrapTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
+    "bootstrap timeout default",
+  );
+  const releaseDownloadTimeoutMs = numberFrom(
+    mcpSource,
+    /const releaseDownloadTimeoutMs = (\d+);/u,
+    "release download timeout",
+  );
+  const releaseDownloadAttempts = numberFrom(
+    mcpSource,
+    /const releaseDownloadAttempts = (\d+);/u,
+    "release download attempts",
+  );
+  const localWaitFreshTimeoutMs = numberFrom(
+    mcpSource,
+    /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
+    "local wait-fresh timeout default",
+  );
+  const requiredTimeoutSec = Math.max(
+    Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
+    Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),
+  );
+  const claudeTimeouts = Object.values(hookConfig.hooks)
+    .flat()
+    .flatMap((entry) => entry.hooks)
+    .map((hook) => hook.timeout);
+  const copilotTimeouts = copilotHookConfig.hooks.sessionStart.map((hook) => hook.timeoutSec);
+
+  for (const timeoutSec of [...claudeTimeouts, ...copilotTimeouts]) {
+    assert.equal(typeof timeoutSec, "number");
+    assert.ok(
+      timeoutSec >= requiredTimeoutSec,
+      `hook timeout ${timeoutSec}s must cover managed bootstrap budget ${requiredTimeoutSec}s`,
+    );
+  }
 });
 
 async function withFakeCodeStoryCli(callback) {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -364,6 +364,84 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
   }
 });
 
+test("mcp launcher infers Codex managed data from installed cache without env", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const codexHome = await mkdtemp(join(tmpdir(), "codestory-installed-cache-"));
+  const codexRoot = join(codexHome, ".codex");
+  const installRoot = join(codexRoot, "plugins", "cache", "TheGreenCedar", "codestory", version);
+  const dataDir = join(codexRoot, "plugins", "data", "codestory-TheGreenCedar");
+  const outFile = join(dataDir, "env.json");
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const pathDir = await mkdtemp(join(tmpdir(), "codestory-stale-path-"));
+  const staleCli = join(pathDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const launcher = join(installRoot, "scripts", "codestory-mcp.cjs");
+
+  try {
+    await mkdir(join(installRoot, "scripts"), { recursive: true });
+    await mkdir(join(installRoot, "hooks"), { recursive: true });
+    await mkdir(join(installRoot, ".codex-plugin"), { recursive: true });
+    await mkdir(cliDir, { recursive: true });
+    await writeFile(
+      launcher,
+      await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8"),
+      "utf8",
+    );
+    await writeFile(
+      join(installRoot, "hooks", "codestory-runtime.cjs"),
+      await readFile(join(pluginRoot, "hooks", "codestory-runtime.cjs"), "utf8"),
+      "utf8",
+    );
+    await writeFile(
+      join(installRoot, ".codex-plugin", "plugin.json"),
+      JSON.stringify({ version }),
+      "utf8",
+    );
+    await writeFakeCli(cliPath);
+    const sha256 = createHash("sha256")
+      .update(await readFile(cliPath))
+      .digest("hex");
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      "utf8",
+    );
+    await writeFile(
+      staleCli,
+      process.platform === "win32"
+        ? "@echo off\r\necho codestory-cli 0.0.1\r\n"
+        : "#!/bin/sh\necho codestory-cli 0.0.1\n",
+      "utf8",
+    );
+    await chmod(staleCli, 0o755);
+
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        PLUGIN_DATA: "",
+        COPILOT_PLUGIN_DATA: "",
+        TEST_OUT: outFile,
+        PATH: pathDir,
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const observed = JSON.parse(await readFile(outFile, "utf8"));
+    assert.equal(observed.source, "managed");
+    assert.equal(observed.path, cliPath);
+    assert.equal(observed.pluginRoot, installRoot);
+    assert.equal(observed.pluginCacheVersion, version);
+    assert.equal(observed.dirtyMarkerPath, dirtyMarkerPathForProject(repoRoot, dataDir));
+  } finally {
+    await rm(codexHome, { recursive: true, force: true });
+    await rm(pathDir, { recursive: true, force: true });
+  }
+});
+
 test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -937,6 +937,104 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
+test("release asset downloader retries a transient failure", async () => {
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+  const launcher = require(join(pluginRoot, "scripts", "codestory-mcp.cjs"));
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-retry-"));
+  const destination = join(dataDir, "SHA256SUMS.txt");
+  let calls = 0;
+
+  const fakeGet = (_url, onResponse) => {
+    calls += 1;
+    const request = new EventEmitter();
+    request.setTimeout = () => request;
+    request.destroy = (error) => {
+      process.nextTick(() => request.emit("error", error));
+      return request;
+    };
+    process.nextTick(() => {
+      if (calls === 1) {
+        request.emit("error", new Error("synthetic network reset"));
+        return;
+      }
+      const response = new PassThrough();
+      response.statusCode = 200;
+      response.headers = {};
+      onResponse(response);
+      response.end("checksum fixture\n");
+    });
+    return request;
+  };
+
+  try {
+    await launcher._test.downloadFile("https://example.invalid/SHA256SUMS.txt", destination, {
+      attempts: 2,
+      get: fakeGet,
+      retryDelayMs: () => 1,
+      timeoutMs: 100,
+    });
+
+    assert.equal(calls, 2);
+    assert.equal(await readFile(destination, "utf8"), "checksum fixture\n");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher keeps managed provision failures primary without PATH", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-provision-fail-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-empty-release-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    const result = spawnSync(process.execPath, [launcher], {
+      env: {
+        ...process.env,
+        CODESTORY_CLI: "",
+        CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
+        PLUGIN_DATA: dataDir,
+        PATH: "",
+        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.match(
+      status.degraded_reason,
+      /^managed_cli_provision_failed:managed_cli_asset_fetch_failed:SHA256SUMS\.txt:elapsed_ms=\d+:attempts=1:retry=restart_reload_status:/u,
+    );
+    assert.equal(status.plugin_runtime.cli_source, "path_fallback");
+    assert.deepEqual(status.path_candidates, []);
+    assert.equal(
+      status.plugin_runtime.warnings.includes("managed_cli_unavailable_no_path_fallback"),
+      true,
+    );
+    assert.match(status.readiness[0].minimum_next[0], /^Restart\/reload/u);
+    assert.equal(
+      status.readiness[0].minimum_next.some((step) => {
+        return /where\.exe codestory-cli|command -v codestory-cli|codestory-cli --version/u.test(step);
+      }),
+      false,
+    );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
 test("session-start hooks are thin and host manifests point at them", async () => {
   const hookConfig = JSON.parse(
     await readFile(join(pluginRoot, "hooks", "claude-codex-hooks.json"), "utf8"),

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -335,6 +335,10 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.sidecarPolicy, "ask");
     assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
     assert.match(observed.sidecarEnable, /--policy-file/u);
+    assert.equal(
+      observed.sidecarRepair.startsWith(`${JSON.stringify(cliPath)} ready --goal agent --repair`),
+      true,
+    );
     assert.match(observed.sidecarRepair, /ready --goal agent --repair/u);
     assert.match(observed.sidecarRepair, /--run-id shared-agent/u);
     assert.equal(observed.dirtyMarkerRoot, await realpath(repoRoot));
@@ -485,7 +489,7 @@ test("mcp launcher waits for fresh local navigation without agent repair", async
         ...process.env,
         CODESTORY_CLI: cliPath,
         PLUGIN_DATA: dataDir,
-        CODESTORY_PLUGIN_SIDECAR_POLICY: "enabled",
+        CODESTORY_PLUGIN_SIDECAR_POLICY: "ask",
         TEST_CODESTORY_VERSION: version,
         TEST_LOG: logFile,
         TEST_OUT: marker,
@@ -809,7 +813,7 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
   }
 });
 
-test("enabled sidecar policy does not schedule agent repair at MCP startup", async () => {
+test("enabled sidecar policy runs one agent repair at MCP startup", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
@@ -851,12 +855,29 @@ test("enabled sidecar policy does not schedule agent repair at MCP startup", asy
 
     const text = await readFile(logFile, "utf8");
     const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+    const repairCalls = calls.filter((call) => call.repair);
+    assert.equal(repairCalls.length, 1, text);
+    assert.equal(repairCalls[0].policy, "enabled");
+    assert.deepEqual(repairCalls[0].args, [
+      "ready",
+      "--goal",
+      "agent",
+      "--repair",
+      "--project",
+      repoRoot,
+      "--format",
+      "json",
+      "--run-id",
+      "shared-agent",
+    ]);
     assert.ok(calls.some((call) => {
       return JSON.stringify(call.args) === JSON.stringify(["serve", "--stdio", "--refresh", "none"]);
     }), text);
-    assert.equal(calls.some((call) => call.repair), false);
-    assert.equal(calls.some((call) => call.args.includes("agent")), false);
-    assert.equal(calls.some((call) => call.args.includes("--repair")), false);
+    const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
+    assert.equal(policy.last_repair.state, "completed");
+    assert.equal(policy.last_repair.project_root, repoRoot);
+    assert.match(policy.last_repair.command, /ready --goal agent --repair/u);
+    assert.match(policy.last_repair.command, /--run-id shared-agent/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1192,6 +1192,7 @@ test("hook manifest timeouts cover managed bootstrap budget", async () => {
     /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
     "local wait-fresh timeout default",
   );
+  assert.equal(localWaitFreshTimeoutMs, 5000, "local wait-fresh default must stay MCP startup-safe");
   const requiredTimeoutSec = Math.max(
     Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
     Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -154,6 +154,9 @@ function Get-RemoteHeadRefName {
     if ($Ref -match "^refs/heads/(.+)$") {
         return $Ref
     }
+    if ($Ref -notmatch "^refs/" -and $Ref -notmatch "^[0-9a-fA-F]{40}$") {
+        return "refs/heads/$Ref"
+    }
 
     return $null
 }
@@ -523,6 +526,7 @@ function Invoke-SelfTest {
         $resolvedCli = Find-CodeStoryCli $projectRoot
         Assert-SelfTest (Same-Path $resolvedCli $currentCli) "stale default install should be rejected and versioned current install should be used"
         Assert-SelfTest ((Get-RemoteHeadRefName "origin/dev/codestory-next") -eq "refs/heads/dev/codestory-next") "origin branch refs should map to ls-remote heads"
+        Assert-SelfTest ((Get-RemoteHeadRefName "codex/issue-670-handoff-proof-target") -eq "refs/heads/codex/issue-670-handoff-proof-target") "plain branch refs should map to ls-remote heads"
         Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $false) -eq "base:origin/dev/codestory-next + pr-head:origin/pr-branch") "PR proof target should default to base plus PR head"
         Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $true) -eq "branch-head:origin/pr-branch") "branch-head proof should be explicit"
     } finally {

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -1,6 +1,9 @@
 [CmdletBinding()]
 param(
     [string]$Project = ".",
+    [string]$IntendedBaseRef = $(if ($env:CODESTORY_INTENDED_BASE_REF) { $env:CODESTORY_INTENDED_BASE_REF } else { "origin/dev/codestory-next" }),
+    [string]$PrHeadRef = $env:CODESTORY_PR_HEAD_REF,
+    [switch]$BranchHeadProof,
     [switch]$ResolveCliOnly,
     [switch]$SelfTest
 )
@@ -97,6 +100,179 @@ function Invoke-DoctorJson {
     }
 
     return ($json | ConvertFrom-Json)
+}
+
+function Invoke-GitText {
+    param([string[]]$Arguments)
+
+    $output = (& git @Arguments 2>$null | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    return $output
+}
+
+function Get-GitCommit {
+    param([string]$Ref)
+
+    if (-not $Ref) {
+        return $null
+    }
+
+    $commit = Invoke-GitText @("rev-parse", "--verify", "$Ref^{commit}")
+    if (-not $commit) {
+        return $null
+    }
+
+    return ($commit -split "\r?\n")[0]
+}
+
+function Get-CurrentBranchOrDetached {
+    $branch = Invoke-GitText @("symbolic-ref", "--quiet", "--short", "HEAD")
+    if ($branch) {
+        return $branch
+    }
+
+    $head = Get-GitCommit "HEAD"
+    if ($head) {
+        return "detached:$head"
+    }
+
+    return "unknown"
+}
+
+function Get-RemoteHeadRefName {
+    param([string]$Ref)
+
+    if (-not $Ref) {
+        return $null
+    }
+    if ($Ref -match "^origin/(.+)$") {
+        return "refs/heads/$($Matches[1])"
+    }
+    if ($Ref -match "^refs/heads/(.+)$") {
+        return $Ref
+    }
+
+    return $null
+}
+
+function Get-RemoteHeadVerification {
+    param([string]$Ref)
+
+    $remoteRef = Get-RemoteHeadRefName $Ref
+    if (-not $remoteRef) {
+        return $null
+    }
+
+    $command = "git ls-remote origin $remoteRef"
+    $result = Invoke-GitText @("ls-remote", "origin", $remoteRef)
+    $commit = $null
+    if ($result) {
+        $commit = (($result -split "\s+") | Select-Object -First 1)
+    }
+
+    return [pscustomobject]@{
+        Command = $command
+        Result = $(if ($result) { $result } else { "<no remote tip>" })
+        Commit = $commit
+    }
+}
+
+function Get-ProofTarget {
+    param(
+        [string]$BaseRef,
+        [string]$HeadRef,
+        [bool]$UseBranchHeadProof
+    )
+
+    if ($HeadRef) {
+        if ($UseBranchHeadProof) {
+            return "branch-head:$HeadRef"
+        }
+        return "base:$BaseRef + pr-head:$HeadRef"
+    }
+
+    return $BaseRef
+}
+
+function Add-StaleRefWarning {
+    param(
+        [string[]]$Warnings,
+        [string]$Label,
+        [string]$LocalCommit,
+        $Remote
+    )
+
+    if ($LocalCommit -and $Remote -and $Remote.Commit -and $LocalCommit -ne $Remote.Commit) {
+        return @($Warnings + "$Label stale: local=$LocalCommit remote=$($Remote.Commit)")
+    }
+
+    return $Warnings
+}
+
+function Write-HandoffProofTargetSummary {
+    param(
+        [string]$BaseRef,
+        [string]$HeadRef,
+        [bool]$UseBranchHeadProof
+    )
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Warning "Git is unavailable; skipping CodeStory handoff proof-target status."
+        return
+    }
+
+    $childHead = Get-GitCommit "HEAD"
+    if (-not $childHead) {
+        Write-Warning "Current directory is not a Git worktree; skipping CodeStory handoff proof-target status."
+        return
+    }
+
+    $baseCommit = Get-GitCommit $BaseRef
+    $headCommit = Get-GitCommit $HeadRef
+    $baseRemote = Get-RemoteHeadVerification $BaseRef
+    $headRemote = Get-RemoteHeadVerification $HeadRef
+    $mainRemote = Get-RemoteHeadVerification "origin/main"
+    $devRemote = Get-RemoteHeadVerification "origin/dev/codestory-next"
+    $warnings = @()
+
+    if (-not $baseCommit) {
+        $warnings += "intended_base_ref unresolved: $BaseRef"
+    }
+    $warnings = Add-StaleRefWarning $warnings "intended_base_ref" $baseCommit $baseRemote
+    $warnings = Add-StaleRefWarning $warnings "main" (Get-GitCommit "main") $mainRemote
+    $warnings = Add-StaleRefWarning $warnings "dev/codestory-next" (Get-GitCommit "dev/codestory-next") $devRemote
+    if ($HeadRef) {
+        if (-not $headCommit) {
+            $warnings += "pr_head_ref unresolved: $HeadRef"
+        }
+        $warnings = Add-StaleRefWarning $warnings "pr_head_ref" $headCommit $headRemote
+        if ($UseBranchHeadProof) {
+            $warnings += "branch-head proof requested; default PR proof is current base plus PR head."
+        }
+    }
+
+    Write-Host "CodeStory handoff proof target"
+    Write-Host ("  intended_base_ref: {0}" -f $BaseRef)
+    Write-Host ("  resolved_base_commit: {0}" -f $(if ($baseCommit) { $baseCommit } else { "unresolved" }))
+    Write-Host ("  child_start_head: {0}" -f $childHead)
+    Write-Host ("  child_branch_or_detached: {0}" -f (Get-CurrentBranchOrDetached))
+    Write-Host ("  proof_target: {0}" -f (Get-ProofTarget $BaseRef $HeadRef $UseBranchHeadProof))
+    Write-Host ("  pr_head_ref: {0}" -f $(if ($HeadRef) { $HeadRef } else { "none" }))
+    Write-Host ("  pr_head_commit: {0}" -f $(if ($headCommit) { $headCommit } else { "none" }))
+    if ($baseRemote) {
+        Write-Host ("  remote_tip_verification.intended_base.command: {0}" -f $baseRemote.Command)
+        Write-Host ("  remote_tip_verification.intended_base.result: {0}" -f $baseRemote.Result)
+    }
+    if ($headRemote) {
+        Write-Host ("  remote_tip_verification.pr_head.command: {0}" -f $headRemote.Command)
+        Write-Host ("  remote_tip_verification.pr_head.result: {0}" -f $headRemote.Result)
+    }
+    foreach ($warning in $warnings) {
+        Write-Warning "CodeStory handoff proof target: $warning"
+    }
 }
 
 function Write-DoctorReadinessSummary {
@@ -346,6 +522,9 @@ function Invoke-SelfTest {
 
         $resolvedCli = Find-CodeStoryCli $projectRoot
         Assert-SelfTest (Same-Path $resolvedCli $currentCli) "stale default install should be rejected and versioned current install should be used"
+        Assert-SelfTest ((Get-RemoteHeadRefName "origin/dev/codestory-next") -eq "refs/heads/dev/codestory-next") "origin branch refs should map to ls-remote heads"
+        Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $false) -eq "base:origin/dev/codestory-next + pr-head:origin/pr-branch") "PR proof target should default to base plus PR head"
+        Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $true) -eq "branch-head:origin/pr-branch") "branch-head proof should be explicit"
     } finally {
         $env:CODESTORY_HOME = $oldCodeStoryHome
         $env:CODESTORY_CLI = $oldCodeStoryCli
@@ -401,6 +580,9 @@ $projectPath = (Resolve-Path -LiteralPath $Project).Path
 
 Push-Location $projectPath
 try {
+    $branchHeadProofEnabled = $BranchHeadProof.IsPresent -or ($env:CODESTORY_BRANCH_HEAD_PROOF -match "^(1|true|yes)$")
+    Write-HandoffProofTargetSummary $IntendedBaseRef $PrHeadRef $branchHeadProofEnabled
+
     $sccache = Join-Path $env:USERPROFILE ".cargo\bin\sccache.exe"
     if (Test-Path -LiteralPath $sccache) {
         $env:RUSTC_WRAPPER = $sccache


### PR DESCRIPTION
## Context

Refs #618.

This is the direct 0.12.0 release-candidate promotion. It intentionally does not create another 0.11.x patch bump. The branch carries the current `dev/codestory-next` runtime/plugin work to `main` and synchronizes release metadata to `0.12.0` so the official plugin/package path can carry PR #678.

## What Changed

- Bumped all CodeStory workspace crate versions to `0.12.0`.
- Bumped Cargo.lock CodeStory package entries to `0.12.0`.
- Bumped Codex, Claude, and GitHub plugin manifest versions to `0.12.0`.
- Added the `0.12.0` changelog entry while preserving the existing `0.11.21` and `0.11.22` entries from `main`.

## How To Review

- Review the final PR diff against `main`; the release metadata change is the last commit, `29f2ba12`.
- Confirm `CHANGELOG.md` adds `0.12.0` above `0.11.22` without dropping patch-release history.
- Confirm version surfaces all say `0.12.0`.
- Treat #618 as a post-release installed-plugin proof gate, not something this PR closes on merge.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.12.0` -> passed.
- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 38 pass.
- `git diff --check` -> passed.
- `rg -n '0\.11\.23' CHANGELOG.md Cargo.lock crates plugins/codestory/.codex-plugin/plugin.json plugins/codestory/.claude-plugin/plugin.json plugins/codestory/.github/plugin/plugin.json` -> no matches.

## Risk

The remaining risk is the #618 runtime acceptance proof after release: install/reload the 0.12 plugin package, then read `codestory://status` in a fresh model context and verify `cli_source=managed`, `path_fallback=false`, and version/path alignment under plugin data. This PR prepares that package path; it does not claim installed-runtime acceptance by itself.
