### PR TITLE
Release 0.12.1 plugin MCP setup flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/README.md
+++ b/README.md
@@ -27,30 +27,24 @@ Per-task medians, ranges, reproduction commands, and boundary notes:
 
 ## Quick start
 
-The golden path is: preflight the repo, install the **agent plugin**, then let
-the plugin's MCP server and hooks keep CodeStory ambient. The CLI is for
-preflight, repair, debugging, and transcripts.
+The golden path is: install the **agent plugin**, open the repository you want
+to ground, and let the plugin's MCP server and hooks keep CodeStory ambient.
+The plugin provisions and runs the managed CLI behind MCP; normal users should
+not run `codestory-cli` directly.
 
 For Codex:
 
-1. In the repository you want to ground, run:
-
-   ```sh
-   codestory-cli agent preflight --project <repo> --format json
-   ```
-
-   Use `safe_surfaces`, `blocked_surfaces`, and `repair_command` as the
-   handoff. If local graph surfaces are blocked, run the repair command first.
-   If only `packet`, `search`, or `context` is blocked, local navigation can
-   still proceed while sidecars are repaired later.
-
-2. Open Codex in that repository, run `/plugins`, then install
+1. Open Codex in the repository you want to ground, run `/plugins`, then install
    **TheGreenCedar → codestory**.
-3. Start a fresh thread and ask:
+2. Start a fresh thread and ask:
 
    ```text
-   @CodeStory check local_navigation and agent_packet_search on this checkout, ground the repo, and tell me whether sidecars need repair before I use packet.
+   @CodeStory read codestory://status, ground this checkout if allowed, and tell me which CodeStory surfaces are ready before I edit.
    ```
+
+   The first check should happen through MCP. If setup or repair is needed, the
+   agent should report the MCP status and the next repair action instead of
+   making you guess which binary is installed.
 
 Claude Code, GitHub Copilot, and Cursor adapters can load the same
 status-first grounding rules automatically when their host supports hooks or
@@ -60,17 +54,9 @@ through resume/clear/compact handoffs, and fail open with the next CodeStory
 check to run. Codex uses the plugin's MCP server plus the
 `@CodeStory` skill.
 
-The plugin launches a managed MCP adapter that starts
-`codestory-cli serve --stdio --refresh none` on your machine. It does not edit
-your repository. Other local MCP-style clients can run the same stdio surface
-directly. Install details, binary bootstrap, and uninstall notes live in the
-[plugin README](plugins/codestory/README.md).
-
-**Verify without the agent:**
-
-```sh
-codestory-cli agent preflight --project <repo> --format json
-```
+The plugin launches a managed MCP adapter that provisions and starts the
+CodeStory runtime on your machine. It does not edit your repository. Other
+local MCP-style clients can run the same stdio surface directly. Install details, binary bootstrap, and uninstall notes live in the [plugin README](plugins/codestory/README.md).
 
 **If install or MCP fails:** marketplace registration, CLI bootstrap, and host restart notes live in the [plugin README](plugins/codestory/README.md).
 

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -11,10 +11,10 @@ use serde_json::{Map, Value, json};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Side-effect class advertised for a stdio tool.
 ///
-/// The current stdio surface is read-only and local-only; adding a new effect
-/// requires updating both safety metadata and tool annotations.
+/// Adding a new effect requires updating both safety metadata and tool annotations.
 pub(crate) enum ToolEffect {
     Read,
+    LocalConfigWrite,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -30,6 +30,12 @@ impl SafetyMetadata {
         }
     }
 
+    pub(crate) const fn local_config_write() -> Self {
+        Self {
+            effect: ToolEffect::LocalConfigWrite,
+        }
+    }
+
     fn to_json(self) -> Value {
         match self.effect {
             ToolEffect::Read => json!({
@@ -38,6 +44,13 @@ impl SafetyMetadata {
                 "localOnly": true,
                 "openWorld": false
             }),
+            ToolEffect::LocalConfigWrite => json!({
+                "readOnly": false,
+                "sideEffects": true,
+                "localOnly": true,
+                "openWorld": false,
+                "mutation": "local_plugin_configuration"
+            }),
         }
     }
 
@@ -45,6 +58,12 @@ impl SafetyMetadata {
         match self.effect {
             ToolEffect::Read => json!({
                 "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": false
+            }),
+            ToolEffect::LocalConfigWrite => json!({
+                "readOnlyHint": false,
                 "destructiveHint": false,
                 "idempotentHint": true,
                 "openWorldHint": false
@@ -1266,7 +1285,22 @@ static PACKET_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     &["question"],
 );
 
+static SIDECAR_SETUP_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Configure the plugin-local sidecar setup policy.",
+    &[SchemaProperty::string("action", "Policy action.")
+        .with_enum(&["status", "enable", "disable", "ask", "repair"])
+        .with_default(ValueLiteral::String("status"))],
+    &[],
+);
+
 static TOOLS: &[ToolSpec] = &[
+    ToolSpec {
+        name: "sidecar_setup",
+        description: "Read or change the plugin-local sidecar setup policy through MCP; use this instead of asking the user to run shell commands.",
+        input_schema: SIDECAR_SETUP_INPUT_SCHEMA,
+        output_schema: Some(SchemaSpec::Object(GENERIC_OBJECT_SCHEMA)),
+        safety: SafetyMetadata::local_config_write(),
+    },
     ToolSpec {
         name: "packet",
         description: "Answer broad structural questions with graph/sidecar evidence, sufficiency, truncation, and follow-up commands before source snippets.",
@@ -1478,7 +1512,6 @@ pub(crate) fn is_tool_name(name: &str) -> bool {
 
 /// Build the `tools/list` response.
 pub(crate) fn tools_list_json() -> Value {
-    debug_assert_read_only_catalog();
     json!({
         "result": {
             "tools": TOOLS.iter().map(|tool| tool.to_json()).collect::<Vec<_>>()
@@ -1523,13 +1556,4 @@ pub(crate) fn prompt_get_json(name: &str) -> Result<Value> {
         .find(|prompt| prompt.name == name)
         .map(|prompt| prompt.get_json())
         .ok_or_else(|| anyhow::anyhow!("Unknown prompt: {name}"))
-}
-
-fn debug_assert_read_only_catalog() {
-    debug_assert!(
-        TOOLS
-            .iter()
-            .all(|tool| matches!(tool.safety.effect, ToolEffect::Read)),
-        "stdio catalog may only expose read-only tools"
-    );
 }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -24,7 +24,7 @@ use std::fs::{self, File};
 use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::Duration as StdDuration;
+use std::time::{Duration as StdDuration, SystemTime, UNIX_EPOCH};
 
 use crate::args;
 use crate::http_transport::{
@@ -416,11 +416,31 @@ fn stdio_tool_blocked_error(
         "status": surface.get("status").cloned().unwrap_or(serde_json::Value::Null),
         "failed_layer": surface.get("failed_layer").cloned().unwrap_or(serde_json::Value::Null),
         "repair_reason": surface.get("repair_reason").cloned().unwrap_or(serde_json::Value::Null),
-        "minimum_next": surface.get("minimum_next").cloned().unwrap_or_else(|| serde_json::json!([])),
-        "full_repair": surface.get("full_repair").cloned().unwrap_or_else(|| serde_json::json!([])),
+        "minimum_next": stdio_repair_calls_from_value(surface.get("minimum_next")),
+        "full_repair": stdio_repair_calls_from_value(surface.get("full_repair")),
         "setup": verdict.and_then(|verdict| verdict.get("setup")).cloned().unwrap_or(serde_json::Value::Null),
         "sidecar": verdict.and_then(|verdict| verdict.get("sidecar")).cloned().unwrap_or(serde_json::Value::Null),
     })))
+}
+
+fn stdio_repair_calls_from_value(value: Option<&serde_json::Value>) -> serde_json::Value {
+    let Some(commands) = value.and_then(serde_json::Value::as_array) else {
+        return serde_json::json!([]);
+    };
+    serde_json::Value::Array(
+        commands
+            .iter()
+            .filter_map(|command| {
+                if let Some(command) = command.as_str() {
+                    Some(stdio_recommended_next_call(command))
+                } else if command.is_object() {
+                    Some(command.clone())
+                } else {
+                    None
+                }
+            })
+            .collect(),
+    )
 }
 
 fn stdio_jsonrpc_tool_call_from_legacy(
@@ -823,6 +843,7 @@ fn handle_stdio_tool_call(
         "symbols" => handle_stdio_symbols(runtime, request),
         "snippet" => handle_stdio_snippet(runtime, request),
         "context" => handle_stdio_context(runtime, request),
+        "sidecar_setup" => handle_stdio_sidecar_setup(runtime, state, request),
         _ => serde_json::json!({"error": "unknown tool"}),
     }
 }
@@ -3069,12 +3090,16 @@ fn stdio_status_recommended_next_calls(
                             "instruction": sidecar_setup["prompt"]
                         },
                         {
-                            "method": "cli",
-                            "command": sidecar_setup["enable_command"]
+                            "method": "tools/call",
+                            "tool": "sidecar_setup",
+                            "arguments": {"action": "enable"},
+                            "debug_command": sidecar_setup["enable_command"]
                         },
                         {
-                            "method": "cli",
-                            "command": sidecar_setup["disable_command"]
+                            "method": "tools/call",
+                            "tool": "sidecar_setup",
+                            "arguments": {"action": "disable"},
+                            "debug_command": sidecar_setup["disable_command"]
                         },
                         {
                             "method": "resources/read",
@@ -3093,8 +3118,10 @@ fn stdio_status_recommended_next_calls(
                             "instruction": "Automatic sidecar setup is disabled for this plugin install."
                         },
                         {
-                            "method": "cli",
-                            "command": sidecar_setup["enable_command"]
+                            "method": "tools/call",
+                            "tool": "sidecar_setup",
+                            "arguments": {"action": "enable"},
+                            "debug_command": sidecar_setup["enable_command"]
                         },
                         {
                             "method": "resources/read",
@@ -3190,9 +3217,26 @@ fn stdio_recommended_next_call(command: &str) -> serde_json::Value {
             "instruction": command
         });
     }
+    if command.contains("ready --goal agent --repair") {
+        return serde_json::json!({
+            "method": "tools/call",
+            "tool": "sidecar_setup",
+            "arguments": {"action": "repair"},
+            "debug_command": command
+        });
+    }
+    if command.contains("ready --goal local") || command.contains("codestory-cli doctor") {
+        return serde_json::json!({
+            "method": "resources/read",
+            "uri": "codestory://status",
+            "instruction": "Read status again after the MCP-managed local freshness check. Use the debug_command only for maintainer transcripts.",
+            "debug_command": command
+        });
+    }
     serde_json::json!({
-        "method": "cli",
-        "command": command
+        "method": "host/instruction",
+        "instruction": "Follow MCP status and agent-guide before falling back to CLI diagnostics.",
+        "debug_command": command
     })
 }
 
@@ -3252,7 +3296,14 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
 }
 
 pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Value {
-    let state = match env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE").as_deref() {
+    let policy = stdio_sidecar_policy_file();
+    let env_state = env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE");
+    let state = match policy
+        .as_ref()
+        .and_then(|policy| policy.get("state"))
+        .and_then(serde_json::Value::as_str)
+        .or(env_state.as_deref())
+    {
         Some("enabled") => "enabled",
         Some("disabled") => "disabled",
         Some(_) => "ask",
@@ -3272,11 +3323,23 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
         "auto_repair": auto_repair,
         "prompt_required": prompt_required,
         "prompt": if prompt_required { Some("CodeStory packet/search needs retrieval sidecars. Enable automatic sidecar setup for this plugin install?") } else { None },
+        "mcp_control": {
+            "status": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "status"}},
+            "enable": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "enable"}},
+            "disable": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "disable"}},
+            "ask": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "ask"}},
+            "repair": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "repair"}}
+        },
         "enable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND"),
         "disable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND"),
         "next_repair_command": next_repair_command,
         "policy_path": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH"),
-        "policy_updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT"),
+        "policy_updated_at": policy
+            .as_ref()
+            .and_then(|policy| policy.get("updated_at"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .or_else(|| env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT")),
         "last_repair": {
             "state": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE"),
             "updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT"),
@@ -3284,6 +3347,115 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
             "command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND")
         }
     })
+}
+
+fn stdio_sidecar_policy_file() -> Option<serde_json::Value> {
+    let policy_path =
+        std::env::var_os("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH").map(PathBuf::from)?;
+    fs::read_to_string(policy_path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+}
+
+fn handle_stdio_sidecar_setup(
+    runtime: &RuntimeContext,
+    state: &mut StdioServerState,
+    request: &serde_json::Value,
+) -> serde_json::Value {
+    let action = request
+        .pointer("/params/arguments/action")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("status");
+    match action {
+        "status" => {
+            serde_json::json!({"result": stdio_sidecar_setup_status(&runtime.project_root)})
+        }
+        "enable" | "disable" | "ask" => match stdio_write_sidecar_policy(action) {
+            Ok(()) => {
+                state.status_cache = None;
+                serde_json::json!({"result": stdio_sidecar_setup_status(&runtime.project_root)})
+            }
+            Err(error) => serde_json::json!({"error": error.to_string()}),
+        },
+        "repair" => {
+            state.status_cache = None;
+            handle_stdio_sidecar_repair(runtime)
+        }
+        _ => {
+            serde_json::json!({"error": "sidecar_setup.action must be status, enable, disable, ask, or repair"})
+        }
+    }
+}
+
+fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
+    let state = match action {
+        "enable" => "enabled",
+        "disable" => "disabled",
+        "ask" => "ask",
+        _ => bail!("unsupported sidecar setup action: {action}"),
+    };
+    let policy_path = std::env::var_os("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH")
+        .map(PathBuf::from)
+        .context("CodeStory plugin data is unavailable; restart from an installed plugin before changing sidecar setup policy")?;
+    if let Some(parent) = policy_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!("create sidecar setup policy directory {}", parent.display())
+        })?;
+    }
+    let current = fs::read_to_string(&policy_path)
+        .ok()
+        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    let mut next = current.as_object().cloned().unwrap_or_default();
+    next.insert("state".to_string(), serde_json::json!(state));
+    let updated_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| format!("unix:{}", duration.as_secs()))
+        .unwrap_or_else(|_| "unix:0".to_string());
+    next.insert("updated_at".to_string(), serde_json::json!(updated_at));
+    fs::write(
+        &policy_path,
+        serde_json::to_string_pretty(&serde_json::Value::Object(next))?,
+    )
+    .with_context(|| format!("write sidecar setup policy {}", policy_path.display()))?;
+    Ok(())
+}
+
+fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(error) => return serde_json::json!({"error": error.to_string()}),
+    };
+    let output = Command::new(exe)
+        .arg("ready")
+        .arg("--goal")
+        .arg("agent")
+        .arg("--repair")
+        .arg("--project")
+        .arg(&runtime.project_root)
+        .arg("--format")
+        .arg("json")
+        .arg("--run-id")
+        .arg(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+        .env("CODESTORY_PLUGIN_SIDECAR_REPAIR", "1")
+        .output();
+    match output {
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let parsed = serde_json::from_str::<serde_json::Value>(&stdout).ok();
+            serde_json::json!({
+                "result": {
+                    "status": if output.status.success() { "completed" } else { "failed" },
+                    "exit_code": output.status.code(),
+                    "stdout": stdout,
+                    "stderr": String::from_utf8_lossy(&output.stderr),
+                    "parsed": parsed,
+                    "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
+                }
+            })
+        }
+        Err(error) => serde_json::json!({"error": error.to_string()}),
+    }
 }
 
 fn env_nonempty(name: &str) -> Option<String> {
@@ -3515,7 +3687,7 @@ fn read_stdio_agent_guide_resource() -> serde_json::Value {
             }
         ],
         "safety_notes": [
-            "All stdio tools are read-only, non-destructive, idempotent, local-only, and closed-world.",
+            "Browser stdio tools are read-only, non-destructive, idempotent, local-only, and closed-world; sidecar_setup is the local plugin-configuration exception.",
             "Read codestory://status first and branch on allowed_surfaces before choosing tools.",
             "Use ground for compact repository orientation after status when local_navigation is ready.",
             "Use packet for broad task questions only when packet/search status is allowed; use context only when allowed_surfaces.context.allowed is true.",

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -273,6 +273,10 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
     if let Some(state) = &fixture.sidecar_policy_state {
         command.env("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE", state);
         command.env(
+            "CODESTORY_PLUGIN_SIDECAR_POLICY_PATH",
+            fixture.cache_dir.path().join("plugin-sidecar-policy.json"),
+        );
+        command.env(
             "CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND",
             "node codestory-mcp.cjs sidecar-policy enable",
         );
@@ -807,6 +811,42 @@ fn assert_read_only_tool_metadata(tool: &Value) {
     );
 }
 
+fn assert_sidecar_setup_tool_metadata(tool: &Value) {
+    let annotations = tool
+        .get("annotations")
+        .unwrap_or_else(|| panic!("sidecar_setup should include MCP-style annotations: {tool}"));
+    let safety = tool
+        .get("safety")
+        .or_else(|| tool.get("metadata"))
+        .unwrap_or_else(|| panic!("sidecar_setup should include safety metadata: {tool}"));
+
+    assert_eq!(
+        annotations.get("readOnlyHint").and_then(Value::as_bool),
+        Some(false),
+        "sidecar_setup should declare local config writes: {tool}"
+    );
+    assert_eq!(
+        annotations.get("destructiveHint").and_then(Value::as_bool),
+        Some(false),
+        "sidecar_setup should declare non-destructive behavior: {tool}"
+    );
+    assert_eq!(
+        annotations.get("idempotentHint").and_then(Value::as_bool),
+        Some(true),
+        "sidecar_setup should declare idempotent behavior: {tool}"
+    );
+    assert!(
+        contains_bool_recursive(safety, &["localOnly", "local_only"], true)
+            && contains_bool_recursive(safety, &["openWorld", "open_world"], false),
+        "sidecar_setup should declare local-only closed-world behavior: {tool}"
+    );
+    assert_eq!(
+        safety.get("mutation").and_then(Value::as_str),
+        Some("local_plugin_configuration"),
+        "sidecar_setup should label the plugin-local mutation: {tool}"
+    );
+}
+
 #[test]
 fn initialize_preserves_id_and_reports_server_info_and_capabilities() {
     let fixture = indexed_fixture();
@@ -886,7 +926,7 @@ fn notification_messages_do_not_produce_responses() {
 }
 
 #[test]
-fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
+fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);
 
@@ -917,13 +957,14 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
             "references",
             "search",
             "shortest_path",
+            "sidecar_setup",
             "snippet",
             "symbol",
             "symbols",
             "trace",
             "trail",
         ],
-        "stdio browser tool names should stay stable and read-only: {tools}"
+        "stdio browser/setup tool names should stay stable: {tools}"
     );
     assert!(
         !tool_names.iter().any(|name| name.starts_with("codestory_")),
@@ -987,9 +1028,12 @@ fn tool_catalog_keeps_stable_read_only_browser_tool_names() {
     );
 
     for tool in tools["tools"].as_array().expect("tools array") {
-        assert_read_only_tool_metadata(tool);
-
         let name = tool["name"].as_str().expect("tool name");
+        if name == "sidecar_setup" {
+            assert_sidecar_setup_tool_metadata(tool);
+        } else {
+            assert_read_only_tool_metadata(tool);
+        }
         let looks_like_write_or_system_tool = [
             "write", "edit", "delete", "remove", "create", "update", "patch", "open_", "launch",
             "shell", "exec", "system", "fs.",
@@ -1100,6 +1144,18 @@ fn tool_catalog_input_schemas_capture_stable_arguments() {
         schema_property(packet, "include_evidence").get("default"),
         Some(&json!(true)),
         "packet.include_evidence should document the stdio default: {packet}"
+    );
+
+    let sidecar_setup = tool_input_schema(&tools, "sidecar_setup");
+    assert_schema_enum_values(
+        sidecar_setup,
+        "/properties/action/enum",
+        &["status", "enable", "disable", "ask", "repair"],
+    );
+    assert_eq!(
+        schema_property(sidecar_setup, "action").get("default"),
+        Some(&json!("status")),
+        "sidecar_setup.action should default to the cheap status probe: {sidecar_setup}"
     );
 
     let ground = tool_input_schema(&tools, "ground");
@@ -2328,11 +2384,17 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         !next_call_text.contains("codestory-cli index --project")
             && !next_call_text.contains("retrieval bootstrap")
             && !next_call_text.contains("retrieval index")
-            && next_call_text.contains("codestory-cli ready --goal agent --repair")
+            && next_call_text.contains("\"tool\":\"sidecar_setup\"")
+            && next_call_text.contains("\"action\":\"repair\"")
+            && next_call_text.contains("\"debug_command\"")
             && next_call_text.contains("retrieval status")
             && next_call_text.contains("codestory://status")
             && next_call_text.contains("codestory://agent-guide"),
-        "status should recommend sidecar repair without repeating a fresh core index when mode is not full: {status}"
+        "status should recommend MCP-managed sidecar repair without repeating a fresh core index when mode is not full: {status}"
+    );
+    assert!(
+        !next_call_text.contains("\"method\":\"cli\""),
+        "status should not expose CLI as the normal user-facing repair method: {status}"
     );
     assert!(
         status
@@ -2425,10 +2487,22 @@ fn resources_read_status_prompts_before_sidecar_repair_when_policy_is_ask() {
     assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
     let next_call_text = status["recommended_next_calls"].to_string();
     assert!(next_call_text.contains("host/confirm"), "{status}");
-    assert!(next_call_text.contains("sidecar-policy enable"), "{status}");
+    assert!(
+        next_call_text.contains("\"tool\":\"sidecar_setup\""),
+        "{status}"
+    );
+    assert!(next_call_text.contains("\"action\":\"enable\""), "{status}");
+    assert!(
+        next_call_text.contains("\"action\":\"disable\""),
+        "{status}"
+    );
     assert!(
         !next_call_text.contains("ready --goal agent --repair"),
         "ask policy should not recommend heavy sidecar repair before consent: {status}"
+    );
+    assert!(
+        !next_call_text.contains("\"method\":\"cli\""),
+        "ask policy should not expose CLI as the normal consent path: {status}"
     );
 }
 
@@ -2462,12 +2536,18 @@ fn resources_read_status_recommends_sidecar_repair_when_policy_enabled() {
     );
     let next_call_text = status["recommended_next_calls"].to_string();
     assert!(
-        next_call_text.contains("codestory-cli ready --goal agent --repair"),
-        "enabled policy should keep the existing agent repair path visible: {status}"
+        next_call_text.contains("\"tool\":\"sidecar_setup\"")
+            && next_call_text.contains("\"action\":\"repair\"")
+            && next_call_text.contains("\"debug_command\""),
+        "enabled policy should route agent repair through the MCP sidecar_setup tool: {status}"
     );
     assert!(
         next_call_text.contains("--run-id") && next_call_text.contains("shared-agent"),
         "enabled policy should point at the shared agent run id: {status}"
+    );
+    assert!(
+        !next_call_text.contains("\"method\":\"cli\""),
+        "enabled policy should not expose CLI as the normal repair path: {status}"
     );
 }
 
@@ -2496,10 +2576,86 @@ fn resources_read_status_suppresses_auto_repair_when_policy_disabled() {
         next_call_text.contains("Automatic sidecar setup is disabled"),
         "{status}"
     );
-    assert!(next_call_text.contains("sidecar-policy enable"), "{status}");
+    assert!(
+        next_call_text.contains("\"tool\":\"sidecar_setup\""),
+        "{status}"
+    );
+    assert!(next_call_text.contains("\"action\":\"enable\""), "{status}");
     assert!(
         !next_call_text.contains("ready --goal agent --repair"),
         "disabled policy should not recommend automatic sidecar repair: {status}"
+    );
+    assert!(
+        !next_call_text.contains("\"method\":\"cli\""),
+        "disabled policy should not expose CLI as the normal recovery path: {status}"
+    );
+}
+
+#[test]
+fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("ask".to_string());
+    let policy_path = fixture.cache_dir.path().join("plugin-sidecar-policy.json");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-enable",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "enable"}
+            }
+        }),
+    );
+    let setup = assert_tool_success(&response, json!("sidecar-setup-enable"));
+    assert_eq!(
+        setup["state"],
+        json!("enabled"),
+        "sidecar_setup enable should report the updated policy state immediately: {setup}"
+    );
+    assert_eq!(
+        setup["mcp_control"]["repair"],
+        json!({"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "repair"}}),
+        "sidecar_setup should expose the MCP repair call, not a user CLI step: {setup}"
+    );
+
+    let policy: Value = serde_json::from_str(
+        &fs::read_to_string(&policy_path)
+            .unwrap_or_else(|error| panic!("read sidecar policy {policy_path:?}: {error}")),
+    )
+    .unwrap_or_else(|error| panic!("sidecar policy should be json: {error}"));
+    assert_eq!(policy["state"], json!("enabled"), "{policy}");
+    assert!(
+        policy["updated_at"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("unix:")),
+        "sidecar policy should record an update timestamp: {policy}"
+    );
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-status",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&status_response, json!("sidecar-setup-status"));
+    let status = json_resource_content(result, "codestory://status");
+    assert_eq!(
+        status["sidecar_setup"]["state"],
+        json!("enabled"),
+        "{status}"
+    );
+    assert!(
+        status["recommended_next_calls"]
+            .to_string()
+            .contains("\"tool\":\"sidecar_setup\""),
+        "status should keep recovery on MCP tooling after sidecar_setup enable: {status}"
     );
 }
 
@@ -2849,16 +3005,27 @@ fn tool_calls_block_all_surfaces_when_active_cli_is_stale() {
             .unwrap_or_else(|| panic!("blocked stale CLI tool should include setup: {response}"));
         assert_eq!(setup["active_version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(setup["latest_version"], "999.0.0");
+        let minimum_next = error
+            .pointer("/minimum_next")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| {
+                panic!("blocked stale CLI tool should include minimum_next: {response}")
+            });
         assert!(
-            error
-                .pointer("/minimum_next")
-                .and_then(Value::as_array)
-                .is_some_and(|commands| commands.iter().any(|command| command
-                    .as_str()
-                    .is_some_and(
-                        |text| text.contains("install-codestory.ps1") && text.contains("999.0.0")
-                    ))),
-            "blocked stale CLI tool should expose installer repair command: {response}"
+            minimum_next.iter().all(|call| call
+                .get("method")
+                .and_then(Value::as_str)
+                .is_some_and(|method| method != "cli")),
+            "blocked stale CLI tool should not expose CLI as the normal repair method: {response}"
+        );
+        assert!(
+            minimum_next.iter().any(|call| call
+                .get("debug_command")
+                .and_then(Value::as_str)
+                .is_some_and(
+                    |text| text.contains("install-codestory.ps1") && text.contains("999.0.0")
+                )),
+            "blocked stale CLI tool should keep installer detail as debug metadata: {response}"
         );
     }
 }
@@ -3639,26 +3806,37 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
         "stdio search readiness error should expose exactly one canonical minimum repair: {response}"
     );
     assert!(
-        minimum_next.iter().any(|command| command
-            .as_str()
-            .is_some_and(|text| text.contains("codestory-cli ready --goal agent --repair"))),
-        "stdio search readiness error should point at agent-owned repair: {response}"
+        minimum_next.iter().any(|call| call
+            .get("tool")
+            .and_then(Value::as_str)
+            .is_some_and(|tool| tool == "sidecar_setup")
+            && call
+                .pointer("/arguments/action")
+                .and_then(Value::as_str)
+                .is_some_and(|action| action == "repair")
+            && call.get("debug_command").and_then(Value::as_str).is_some()),
+        "stdio search readiness error should point at MCP-managed agent repair: {response}"
     );
     let full_repair = error["full_repair"]
         .as_array()
         .unwrap_or_else(|| panic!("stdio search error should include full_repair: {response}"));
     assert!(
-        full_repair.iter().all(|command| command
-            .as_str()
-            .is_some_and(|text| !text.contains("codestory-cli index"))),
+        full_repair.iter().all(
+            |call| call.to_string().contains("\"method\":\"cli\"") == false
+                && call
+                    .get("debug_command")
+                    .and_then(Value::as_str)
+                    .is_none_or(|text| !text.contains("codestory-cli index"))
+        ),
         "stdio search sidecar errors should not repeat core index repair commands: {response}"
     );
     assert!(
-        full_repair.iter().any(|command| command
-            .as_str()
+        full_repair.iter().any(|call| call
+            .get("debug_command")
+            .and_then(Value::as_str)
             .is_some_and(|text| text.contains("codestory-cli retrieval status")
                 && text.contains("--format json"))),
-        "stdio search error should include sidecar status proof command: {response}"
+        "stdio search error should include sidecar status proof debug command: {response}"
     );
 }
 

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 
 [dependencies]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,28 +5,27 @@ trace, repeat. That costs wall time and context on work you already did in the
 last turn. CodeStory indexes once and serves evidence from that map so the agent
 can answer from citations instead of re-exploring the tree.
 
-Start with the human task, then run the smallest path that proves the state you
-need. The golden path is CLI preflight first, then the agent plugin/MCP/hooks
-path. The CLI is otherwise for repair, debugging, transcripts, and direct stdio
+Start with the human task, then use the plugin path. The golden path is plugin
+install first, then MCP status, grounding, and repair guidance through the
+agent. The CLI is for maintainers, debugging, transcripts, and direct stdio
 integration.
 
 ## Operator Journey
 
-| Stage | Human action | Agent/CLI action | Trust check |
+| Stage | Human action | Agent/MCP action | Trust check |
 | --- | --- | --- | --- |
-| Preflight | Run `codestory-cli agent preflight --project <target-workspace> --format json`. | Reports local graph readiness, full retrieval readiness, safe/blocked surfaces, and repair command. | Local graph surfaces are safe before source work; sidecar surfaces require `retrieval_mode=full`. |
-| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter, then `codestory-cli serve --stdio --refresh none`. | Fresh thread sees the active MCP runtime. |
+| Install | Install the `codestory` agent plugin from `TheGreenCedar`. | Plugin starts its managed MCP adapter and provisions the runtime behind MCP. | Fresh thread sees the active MCP runtime. |
 | First grounding | Start a fresh thread in the repo. | Hooks attempt startup grounding; the agent reads `codestory://status`, then `codestory://grounding` or `ground`. | Status reports `server_version`, `cli_version`, `server_executable`, `server_executable_sha256`, `sidecar_contract_version`, `plugin_runtime`, `runtime_truth`, `sidecar_setup`, `dirty_marker`, and `allowed_surfaces`. `plugin_runtime.plugin_root` and `plugin_cache_version` identify the installed package cache when launched by the plugin adapter. |
 | Source work | Ask for a plan, review, or code path. | Use allowed local graph surfaces such as `files`, `symbol`, `callers`, `callees`, `trail`, `trace`, `snippet`, `symbols`, `get_node`, `neighbors`, `shortest_path`, `query_subgraph`, and `affected`. | Claims cite concrete files, node ids, snippets, or trails. |
 | Broad discovery | Ask a repo-wide question. | Hooks may attempt request-aware packets; the agent may use `packet`, `search`, or `context`. | Trust only when that surface is allowed and `retrieval_mode=full`. |
-| Repair | Ask for a transcript or run CLI directly. | Use `ready --goal local --repair` or `ready --goal agent --repair`. | Repeat readiness checks after repair. |
+| Repair | Ask `@CodeStory` what is blocked. | Use `codestory://status`, `codestory://agent-guide`, and `sidecar_setup` before falling back to CLI diagnostics. | Repeat MCP status checks after repair. |
 
 Packet/search output from degraded retrieval, missing sidecars, stale manifests,
 or any non-`full` retrieval mode is navigation help only. It is not proof.
 
 Most humans should start from the plugin flow in
-[README - Quick start](../README.md#quick-start). Use the CLI when you need the
-exact setup, repair, or debug record.
+[README - Quick start](../README.md#quick-start). Use the CLI only when MCP is
+missing or you need an exact setup, repair, or debug record.
 
 Hook-enabled hosts keep CodeStory ambient. Hooks attempt strict grounding on
 session start, resume, clear, and compact handoff; they attempt request-aware
@@ -79,17 +78,6 @@ environment variables with `$env:NAME = "value"`.
 
 ## Install And Ground A Repo
 
-Run the CLI preflight in the workspace first:
-
-```sh
-codestory-cli agent preflight --project <target-workspace> --format json
-```
-
-Use its `safe_surfaces`, `blocked_surfaces`, and `repair_command` fields as the
-agent handoff. If local graph surfaces are blocked, run the repair command
-before source work. If only `packet`, `search`, or `context` is blocked, local
-navigation can continue while sidecars are repaired later.
-
 Install the CodeStory plugin once, then start a fresh agent thread for that
 workspace. The canonical skill package lives at
 [../plugins/codestory/skills/codestory-grounding/SKILL.md](../plugins/codestory/skills/codestory-grounding/SKILL.md).
@@ -104,7 +92,7 @@ workspace. The canonical skill package lives at
 @CodeStory read codestory://status, report allowed_surfaces for this checkout, ground the repo if allowed, and tell me whether packet/search/context need sidecar repair before I use them.
 ```
 
-**Direct CLI transcript (for setup, repair, or debugging):**
+**Direct CLI transcript (maintainer/debug fallback only):**
 
 ```sh
 codestory-cli agent preflight --project <target-workspace> --format json

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -8,15 +8,10 @@ CodeStory gives a coding agent a local, read-only grounding surface before it
 plans, reviews, or edits a repository. Index once; answer from evidence with
 citations instead of re-exploring the tree on every prompt.
 
-The human job is simple: run agent preflight in the repo, install the plugin,
-and start a fresh thread there.
-
-```sh
-codestory-cli agent preflight --project <repo> --format json
-```
-
-Use `safe_surfaces`, `blocked_surfaces`, and `repair_command` as the handoff.
-Then let the plugin path take over.
+The human job is simple: install the plugin, open the repository, and start a
+fresh thread there. The plugin owns runtime bootstrap through MCP. If the user
+has to find or install `codestory-cli` before installing the plugin, the product
+flow is wrong.
 Hosts with lifecycle-hook adapters keep CodeStory ambient. On session start,
 resume, clear, and compact, the hook
 injects CodeStory-first grounding rules and attempts a strict `ground` snapshot
@@ -27,12 +22,12 @@ changes. The CLI is still there, but it is the escape hatch and repair surface,
 not the main user experience.
 
 This is strict startup grounding plus request-aware packets, not a random
-repository summary. Hooks fail open. Missing `node`, missing `codestory-cli`, missing MCP, degraded
+repository summary. Hooks fail open. Missing `node`, missing MCP, degraded
 sidecars, timeouts, non-repo folders, and empty output must not block the host
 session. If the hook cannot produce useful grounding, it leaves the agent with
-the next CodeStory check to run: usually `codestory://status`, an allowed
-`packet`/`search`/`context` call, or incremental
-`ready --goal local --repair`. Agents still skip no-op ground output in huge
+the next CodeStory check to run through MCP: usually `codestory://status`,
+`codestory://agent-guide`, or an allowed `packet`/`search`/`context` call.
+Agents still skip no-op ground output in huge
 or non-code folders.
 
 ## What The Agent Gets
@@ -41,6 +36,7 @@ or non-code folders.
 | --- | --- | --- |
 | Is this repo indexed and safe to use? | `codestory://status` | Read first; status is the runtime truth. |
 | What should I do next? | `codestory://agent-guide` | Let the skill route normal setup and repair. |
+| Enable or repair packet/search sidecars. | `sidecar_setup` tool | Use MCP, not a shell command. |
 | Give me a compact repo map. | `codestory://grounding` | Start from current local files. |
 | Inspect indexed file inventory and coverage. | `files` tool | Use for scope, language mix, and missing coverage. |
 | Map changed files to likely impact. | `affected` tool | Use for review planning and focused test choice. |
@@ -89,18 +85,8 @@ CLI/MCP runtime.
 
 ## Install For Agent Use
 
-For normal Codex use, first preflight the repo:
-
-```bash
-codestory-cli agent preflight --project <repo> --format json
-```
-
-If local graph surfaces are blocked, run the emitted `repair_command` before
-source work. If only `packet`, `search`, or `context` is blocked, local
-navigation can continue while sidecars are repaired later.
-
-Then install the plugin through the Codex plugin flow for your workspace. Open
-Codex in the repo you want to ground, then use:
+For normal Codex use, install the plugin through the Codex plugin flow for your
+workspace. Open Codex in the repo you want to ground, then use:
 
 ```text
 /plugins
@@ -128,8 +114,8 @@ rather than the terminal. Use the UI path when the CLI marketplace command is
 unavailable.
 
 Start a new Codex thread after installation or refresh. The installed package
-launches the managed MCP adapter, which then starts
-`codestory-cli serve --stdio --refresh none`.
+launches the managed MCP adapter, which provisions and starts the runtime behind
+MCP.
 
 ### After install
 
@@ -157,6 +143,10 @@ Use `where.exe codestory-cli` and `codestory-cli --version` only when MCP is
 missing, status reports a suspect runtime, or you are debugging/repairing the
 installed CLI. If PATH changed during repair, start a fresh Codex host/app
 session before treating a new MCP runtime as live.
+
+When `codestory://status` reports sidecar setup is needed, the agent should call
+`sidecar_setup` with `{"action":"enable"}` or `{"action":"repair"}`. Do not ask
+the user to install or run `codestory-cli`; the plugin owns that path.
 
 ### Optional dirty-marker Git hooks
 

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -548,6 +548,26 @@ function localWaitFreshCommand(projectRoot = process.cwd()) {
   return `codestory-cli ready --goal local --wait-fresh --project ${JSON.stringify(projectRoot)} --format json`;
 }
 
+function mcpNextCallForCommand(command) {
+  if (command.startsWith('Restart/reload') || command.startsWith('Refresh or reinstall')) {
+    return { method: 'host/restart', instruction: command };
+  }
+  if (command.includes('ready --goal agent --repair')) {
+    return {
+      method: 'tools/call',
+      tool: 'sidecar_setup',
+      arguments: { action: 'repair' },
+      debug_command: command,
+    };
+  }
+  return {
+    method: 'resources/read',
+    uri: 'codestory://status',
+    instruction: 'Use MCP status and agent-guide first; debug_command is for maintainer transcripts only.',
+    debug_command: command,
+  };
+}
+
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
@@ -755,8 +775,6 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   ];
   const minimumNext = options.minimumNext || (managedProvisionFailed && pathCandidates.length === 0 ? managedProvisionNext : [
     'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
-    process.platform === 'win32' ? 'where.exe codestory-cli' : 'command -v codestory-cli',
-    'codestory-cli --version',
   ]);
   const fullRepair = options.fullRepair || minimumNext;
   const recommendedNext = options.recommendedNext || fullRepair;
@@ -839,9 +857,8 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     allowed_surfaces: allowedSurfaces,
     recommended_next_calls: [
       { method: 'resources/read', uri: 'codestory://status' },
-      ...recommendedNext.map((command) => command.startsWith('Refresh or reinstall') || command.startsWith('Restart/reload')
-        ? { method: 'host/restart', instruction: command }
-        : { method: 'cli', command }),
+      { method: 'resources/read', uri: 'codestory://agent-guide' },
+      ...recommendedNext.map((command) => mcpNextCallForCommand(command)),
     ],
   };
 }
@@ -996,6 +1013,7 @@ function cargoPackageVersion(manifest) {
 
 function diagnosticText(status) {
   const setup = status.readiness[0].setup;
+  const next = status.recommended_next_calls?.[0] || status.readiness[0].minimum_next?.[0] || null;
   return [
     'CodeStory MCP runtime is not ready.',
     `reason: ${status.degraded_reason}`,
@@ -1006,7 +1024,7 @@ function diagnosticText(status) {
     `cli_version: ${setup.active_version || '<unknown>'}`,
     `source_checkout_version: ${status.source_checkout_version || '<none>'}`,
     `path_candidates: ${(status.path_candidates || []).map((candidate) => `${candidate.path}@${candidate.version || '<unknown>'}`).join(', ') || '<none>'}`,
-    `next: ${status.readiness[0].minimum_next[0]}`,
+    `next: ${next ? JSON.stringify(next) : 'read codestory://status'}`,
   ].join('\n');
 }
 
@@ -1047,6 +1065,30 @@ function failOpenToolResult(status) {
   };
 }
 
+function failOpenSidecarSetupResult(request) {
+  const action = request.params?.arguments?.action || 'status';
+  if (!['status', 'enable', 'disable', 'ask'].includes(action)) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: 'sidecar_setup.action must be status, enable, disable, or ask while the runtime is in diagnostic mode.' }],
+      structuredContent: { code: 'invalid_sidecar_setup_action', action },
+    };
+  }
+  if (action !== 'status') {
+    writeSidecarPolicy(action === 'enable' ? 'enabled' : action === 'disable' ? 'disabled' : 'ask');
+  }
+  const policy = readSidecarPolicy();
+  return {
+    content: [{ type: 'text', text: JSON.stringify(policy) }],
+    structuredContent: {
+      state: policy.state,
+      path: policy.path,
+      updated_at: policy.updatedAt,
+      last_repair: policy.lastRepair,
+    },
+  };
+}
+
 function runFailOpenMcp(status) {
   const tools = ['ground', 'files', 'packet', 'search', 'context'].map((name) => ({
     name,
@@ -1054,6 +1096,31 @@ function runFailOpenMcp(status) {
     inputSchema: { type: 'object', additionalProperties: true },
     outputSchema: { type: 'object', additionalProperties: true },
   }));
+  tools.unshift({
+    name: 'sidecar_setup',
+    description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['status', 'enable', 'disable', 'ask'], default: 'status' },
+      },
+      additionalProperties: false,
+    },
+    outputSchema: { type: 'object', additionalProperties: true },
+    safety: {
+      readOnly: false,
+      sideEffects: true,
+      localOnly: true,
+      openWorld: false,
+      mutation: 'local_plugin_configuration',
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  });
   const resources = [
     { uri: 'codestory://status', name: 'CodeStory runtime status', mimeType: 'application/json' },
     { uri: 'codestory://agent-guide', name: 'CodeStory agent guide', mimeType: 'application/json' },
@@ -1100,7 +1167,12 @@ function runFailOpenMcp(status) {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
       } else if (request.method === 'tools/call') {
-        response = jsonrpcResult(request.id, failOpenToolResult(status));
+        response = jsonrpcResult(
+          request.id,
+          request.params?.name === 'sidecar_setup'
+            ? failOpenSidecarSetupResult(request)
+            : failOpenToolResult(status),
+        );
       } else {
         response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
       }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -2096,8 +2096,8 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
   ];
   const cliRepairRequired = ["where.exe codestory-cli", "codestory-cli --version"];
   const stdioLaunchRequired = [
-    "codestory-cli serve --stdio --refresh none",
     "scripts/codestory-mcp.cjs",
+    "sidecar_setup",
     "github_release",
     "path_fallback",
     "closing transport",
@@ -2185,8 +2185,8 @@ test("plugin docs are agent-first, status-first, and marketplace-aware", async (
   const rootReadmeRequired = [
     "Install details, binary bootstrap",
     "[plugin README](plugins/codestory/README.md)",
-    "`codestory-cli serve --stdio --refresh none`",
     "managed MCP adapter",
+    "normal users should\nnot run `codestory-cli` directly",
     "Codex uses the plugin's MCP server plus the\n`@CodeStory` skill",
   ];
   for (const text of [readme, skill]) {


### PR DESCRIPTION
## Context

The plugin install path was still leaking CLI-first recovery instructions. A normal user should install CodeStory through the plugin and let MCP own runtime bootstrap, sidecar setup, status, and repair. This PR makes that path real in code and bumps the release to `0.12.1`.

## What Changed

- Added a `sidecar_setup` MCP tool for plugin-local sidecar policy/status/repair actions.
- Changed `codestory://status` and blocked-tool repair payloads to recommend MCP calls first, with old shell commands retained only as `debug_command` metadata.
- Made sidecar policy writes visible immediately by reading the plugin policy file and invalidating the stdio status cache after setup changes.
- Updated the fail-open plugin launcher to expose the same `sidecar_setup` tool and MCP-shaped recommendations.
- Rewrote root/plugin usage docs so normal install starts with the plugin/MCP flow, not preinstalled CLI commands.
- Bumped all workspace crates, `Cargo.lock`, and plugin manifests to `0.12.1`.

## How To Review

1. Inspect the new stdio catalog entry and handler in `crates/codestory-cli/src/stdio_catalog.rs` and `crates/codestory-cli/src/stdio_transport.rs`.
2. Check the protocol tests around `sidecar_setup`, recommended calls, and blocked-tool errors in `crates/codestory-cli/tests/stdio_protocol_contracts.rs`.
3. Check the docs for the intended user flow in `README.md`, `plugins/codestory/README.md`, and `docs/usage.md`.

## Verification

- `cargo check -p codestory-cli`
- `python .github/scripts/check-codestory-release.py --version 0.12.1`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test plugins\codestory\tests\plugin-static.test.mjs`
- `cargo test -p codestory-cli --test stdio_protocol_contracts -- --nocapture` (`34 passed; 9 ignored` live-sidecar contracts)
- `cargo test -p codestory-cli --test architecture_contracts stdio_tool_catalog_stays_aligned_with_read_only_browser_service_operations -- --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_agent_guide_describes_default_browser_loop_and_safety -- --nocapture`
- `git diff --check`

## Risk

`sidecar_setup repair` shells out to the current executable for the existing heavy `ready --goal agent --repair` path. That keeps repair behavior consistent, but live sidecar readiness still depends on the host/container environment and the ignored full-retrieval contracts.
