### PR TITLE
Fix release package docs path

### DIFF
--- a/.github/scripts/package-codestory-release.py
+++ b/.github/scripts/package-codestory-release.py
@@ -79,7 +79,8 @@ def main() -> None:
 
         copy_required_file(root, "README.md", stage_root)
         copy_required_file(root, "LICENSE", stage_root)
-        copy_required_file(root, "docs/usage.md", stage_root)
+        copy_required_file(root, "docs/glossary.md", stage_root)
+        copy_required_dir(root, "docs/users", stage_root)
         copy_required_dir(root, "plugins/codestory/skills/codestory-grounding", stage_root)
 
         if archive_ext == ".zip":


### PR DESCRIPTION
## Context

Closes #684
Refs #694

Auto Release for `0.12.2` failed before publishing because the release packager still required the removed `docs/usage.md` file. The current user docs live under `docs/users/`, with `docs/glossary.md` as a linked shared reference.

## What Changed

- Updated `.github/scripts/package-codestory-release.py` to package `docs/users/` and `docs/glossary.md` instead of the stale `docs/usage.md`.

## How To Review

- Confirm the packaged docs match the current user-docs layout from #682.
- Confirm the packager still includes root `README.md`, `LICENSE`, and the CodeStory grounding skill.

## Verification

- `python .github/scripts/package-codestory-release.py --version 0.12.2 --target windows-x64 --binary target/release/codestory-cli.exe --out-dir target/release-dist-repair`
- Archive content check confirmed:
  - `docs/users/README.md`
  - `docs/glossary.md`
  - `plugins/codestory/skills/codestory-grounding/SKILL.md`
- `python .github/scripts/check-codestory-release.py --version 0.12.2`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

## Risk

- This is packaging-only. The previous Auto Release run built and smoked `codestory-cli 0.12.2` before failing at packaging.
- After this lands on `main`, Auto Release will skip because the version did not change from the previous failed release commit; manually dispatch `release.yml` for `0.12.2`.
