### PR TITLE
Accept sidecar repair setup action

### DIFF
--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -105,6 +105,12 @@ function normalizeSidecarPolicyState(value) {
   return 'ask';
 }
 
+function sidecarPolicyStateForAction(action) {
+  if (action === 'enable' || action === 'repair') return 'enabled';
+  if (action === 'disable') return 'disabled';
+  return 'ask';
+}
+
 function readSidecarPolicy(file = sidecarPolicyPath()) {
   const policy = file ? readJson(file) : null;
   const state = normalizeSidecarPolicyState(process.env.CODESTORY_PLUGIN_SIDECAR_POLICY || policy?.state);
@@ -135,8 +141,8 @@ function handleSidecarPolicyCommand(argv) {
   const action = argv[3] || 'status';
   const policyFileFlag = argv.indexOf('--policy-file');
   const policyFile = policyFileFlag >= 0 ? argv[policyFileFlag + 1] : sidecarPolicyPath();
-  if (!['enable', 'disable', 'ask', 'status'].includes(action)) {
-    process.stderr.write('usage: codestory-mcp.cjs sidecar-policy [enable|disable|ask|status] [--policy-file PATH]\n');
+  if (!['enable', 'disable', 'ask', 'repair', 'status'].includes(action)) {
+    process.stderr.write('usage: codestory-mcp.cjs sidecar-policy [enable|disable|ask|repair|status] [--policy-file PATH]\n');
     process.exit(2);
   }
   if (policyFileFlag >= 0 && !policyFile) {
@@ -148,7 +154,7 @@ function handleSidecarPolicyCommand(argv) {
       process.stderr.write('sidecar-policy needs PLUGIN_DATA or --policy-file to remember the setting\n');
       process.exit(2);
     }
-    writeSidecarPolicy(action === 'enable' ? 'enabled' : action === 'disable' ? 'disabled' : 'ask', {}, policyFile);
+    writeSidecarPolicy(sidecarPolicyStateForAction(action), {}, policyFile);
   }
   process.stdout.write(`${JSON.stringify(readSidecarPolicy(policyFile), null, 2)}\n`);
   process.exit(0);
@@ -1067,15 +1073,15 @@ function failOpenToolResult(status) {
 
 function failOpenSidecarSetupResult(request) {
   const action = request.params?.arguments?.action || 'status';
-  if (!['status', 'enable', 'disable', 'ask'].includes(action)) {
+  if (!['status', 'enable', 'disable', 'ask', 'repair'].includes(action)) {
     return {
       isError: true,
-      content: [{ type: 'text', text: 'sidecar_setup.action must be status, enable, disable, or ask while the runtime is in diagnostic mode.' }],
+      content: [{ type: 'text', text: 'sidecar_setup.action must be status, enable, disable, ask, or repair while the runtime is in diagnostic mode.' }],
       structuredContent: { code: 'invalid_sidecar_setup_action', action },
     };
   }
   if (action !== 'status') {
-    writeSidecarPolicy(action === 'enable' ? 'enabled' : action === 'disable' ? 'disabled' : 'ask');
+    writeSidecarPolicy(sidecarPolicyStateForAction(action));
   }
   const policy = readSidecarPolicy();
   return {
@@ -1102,7 +1108,7 @@ function runFailOpenMcp(status) {
     inputSchema: {
       type: 'object',
       properties: {
-        action: { type: 'string', enum: ['status', 'enable', 'disable', 'ask'], default: 'status' },
+        action: { type: 'string', enum: ['status', 'enable', 'disable', 'ask', 'repair'], default: 'status' },
       },
       additionalProperties: false,
     },

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -609,6 +609,7 @@ test("mcp launcher fails open when wait-fresh skips local refresh", async () => 
     JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "sidecar_setup", arguments: { action: "repair" } } }),
   ].join("\n") + "\n";
 
   try {
@@ -654,7 +655,7 @@ test("mcp launcher fails open when wait-fresh skips local refresh", async () => 
     assert.equal(result.status, 0, result.stderr);
     await assert.rejects(access(marker));
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 3, result.stdout);
+    assert.equal(responses.length, 4, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
     assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
     assert.equal(status.runtime_truth.runtime_source, "local_dev_override");
@@ -680,6 +681,9 @@ test("mcp launcher fails open when wait-fresh skips local refresh", async () => 
     assert.equal(responses[2].result.structuredContent.local_refresh.reason, "index_locked");
     assert.equal(responses[2].result.structuredContent.local_refresh.changed_file_count, 1);
     assert.equal(responses[2].result.structuredContent.local_refresh.fatal_error_count, 0);
+    assert.equal(responses[3].result.structuredContent.state, "enabled");
+    const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
+    assert.equal(policy.state, "enabled");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -882,10 +886,17 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
     assert.equal(disable.status, 0, disable.stderr);
     assert.equal(JSON.parse(disable.stdout).state, "disabled");
 
+    const repair = spawnSync(process.execPath, [launcher, "sidecar-policy", "repair"], {
+      env: { PLUGIN_DATA: dataDir },
+      encoding: "utf8",
+    });
+    assert.equal(repair.status, 0, repair.stderr);
+    assert.equal(JSON.parse(repair.stdout).state, "enabled");
+
     const policy = JSON.parse(
       await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
     );
-    assert.equal(policy.state, "disabled");
+    assert.equal(policy.state, "enabled");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

#687 found that the fail-open MCP status could recommend `sidecar_setup` with `action: "repair"`, while the tool schema and handler rejected `repair`. That made the advertised self-healing MCP call impossible to execute.

Closes #687
Refs #683

## What Changed

- Accept `repair` in the fail-open `sidecar_setup` MCP tool schema and handler.
- Treat `repair` as the same local sidecar policy state as `enable`, reusing the existing startup repair path instead of adding a second repair runner.
- Accept `repair` in the companion `sidecar-policy` CLI command for parity.
- Added plugin-static coverage that calls `sidecar_setup` with `repair` and proves the policy becomes enabled.

## How To Review

```mermaid
flowchart LR
  A[status recommends repair] --> B[sidecar_setup action repair]
  B --> C[policy enabled]
  C --> D[next MCP startup runs existing agent repair]
```

Focus on `plugins/codestory/scripts/codestory-mcp.cjs`: the new helper only maps accepted setup actions to the existing persisted policy states.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 38 passed
- `git diff --check` -> passed
- `node .github/scripts/check-workflow-policy.mjs` -> passed

## Risk

Low. This does not change the sidecar repair command itself or claim retrieval is healthy; it only makes the already-recommended MCP action executable and keeps the existing `enable` behavior as the repair path.
