### PR TITLE
Normalize Windows projection identity

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -860,15 +860,26 @@ impl WorkspaceIndexer {
         let processed_count = Arc::new(AtomicUsize::new(0));
         let cancelled = Arc::new(AtomicBool::new(false));
         let root = self.root.clone();
-        let existing_projection_ids = plan.existing_file_ids.clone();
         let existing_projection_setup_started = Instant::now();
+        let existing_projection_ids = plan.existing_file_ids.clone();
+        let existing_projection_file_ids = Self::existing_projection_file_ids(
+            storage,
+            &root,
+            &plan.files_to_index,
+            &existing_projection_ids,
+        )?;
         stats.setup_existing_projection_ids_ms =
             duration_ms_u64(existing_projection_setup_started.elapsed());
 
         let mut replaced_projection_ids = HashSet::new();
         let symbol_seed_started = Instant::now();
         let symbol_table = Arc::new(SymbolTable::new());
-        Self::seed_symbol_table(storage, &symbol_table, plan.mode, &existing_projection_ids)?;
+        Self::seed_symbol_table(
+            storage,
+            &symbol_table,
+            plan.mode,
+            &existing_projection_file_ids,
+        )?;
         stats.setup_seed_symbol_table_ms = duration_ms_u64(symbol_seed_started.elapsed());
 
         // Clone for parallel closure
@@ -923,10 +934,11 @@ impl WorkspaceIndexer {
                 }
 
                 let normalized_path = Self::normalize_index_path(&root, path);
+                let file_id = Self::canonical_file_node_id_for_path(&normalized_path);
                 let existing_projection_id = (plan.mode
                     == codestory_workspace::BuildMode::Incremental)
-                    .then(|| existing_projection_ids.get(&normalized_path).copied())
-                    .flatten();
+                    .then_some(file_id)
+                    .filter(|file_id| existing_projection_file_ids.contains(file_id));
                 match self.prepare_index_work(
                     storage,
                     path,
@@ -1008,7 +1020,7 @@ impl WorkspaceIndexer {
                 all_errors.append(&mut local_storage.errors);
                 if let Some(file_info) = local_storage.files.first()
                     && plan.mode == codestory_workspace::BuildMode::Incremental
-                    && existing_projection_ids.contains_key(&file_info.path)
+                    && existing_projection_file_ids.contains(&file_info.id)
                     && replaced_projection_ids.insert(file_info.id)
                 {
                     let existing_states = storage
@@ -1249,13 +1261,13 @@ impl WorkspaceIndexer {
         storage: &Storage,
         symbol_table: &SymbolTable,
         mode: codestory_workspace::BuildMode,
-        existing_projection_ids: &HashMap<PathBuf, i64>,
+        existing_projection_file_ids: &HashSet<i64>,
     ) -> Result<()> {
         if mode == codestory_workspace::BuildMode::FullRefresh {
             return Ok(());
         }
-        let file_ids = existing_projection_ids
-            .values()
+        let file_ids = existing_projection_file_ids
+            .iter()
             .copied()
             .collect::<Vec<_>>();
         let node_kinds = storage
@@ -1265,6 +1277,39 @@ impl WorkspaceIndexer {
             symbol_table.insert(node_id.0, kind);
         }
         Ok(())
+    }
+
+    fn existing_projection_file_ids(
+        storage: &Storage,
+        root: &Path,
+        files_to_index: &[PathBuf],
+        existing_projection_ids: &HashMap<PathBuf, i64>,
+    ) -> Result<HashSet<i64>> {
+        let mut candidates = existing_projection_ids
+            .values()
+            .copied()
+            .collect::<HashSet<_>>();
+        for path in files_to_index {
+            let full_path = Self::normalize_index_path(root, path);
+            candidates.insert(Self::canonical_file_node_id_for_path(&full_path));
+            if let Ok(canonical) = full_path.canonicalize() {
+                candidates.insert(Self::canonical_file_node_id_for_path(&canonical));
+            }
+        }
+        if candidates.is_empty() {
+            return Ok(HashSet::new());
+        }
+
+        let candidate_ids = candidates.iter().copied().collect::<Vec<_>>();
+        let node_kinds = storage
+            .get_node_kinds_for_files(&candidate_ids)
+            .map_err(|e| anyhow!("Storage file identity lookup error: {:?}", e))?;
+        Ok(node_kinds
+            .into_iter()
+            .filter_map(|(node_id, kind)| {
+                (kind == NodeKind::FILE && candidates.contains(&node_id.0)).then_some(node_id.0)
+            })
+            .collect())
     }
 
     fn collect_touched_file_ids(root: &Path, files_to_index: &[PathBuf]) -> HashSet<i64> {
@@ -1306,9 +1351,21 @@ impl WorkspaceIndexer {
     }
 
     fn canonical_file_node_id_for_path(path: &Path) -> i64 {
-        let file_name = path.to_string_lossy();
+        let file_name = Self::file_identity_path(path);
         let canonical_id = format!("{file_name}:{file_name}:1");
         generate_id(&canonical_id)
+    }
+
+    fn file_identity_path(path: &Path) -> String {
+        #[cfg(windows)]
+        {
+            let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+            path.to_string_lossy().replace('\\', "/").to_lowercase()
+        }
+        #[cfg(not(windows))]
+        {
+            path.to_string_lossy().to_string()
+        }
     }
 
     fn flush_errors(
@@ -1756,6 +1813,7 @@ fn accumulate_flush_breakdown(
 
 pub(crate) fn file_node_from_source(path: &Path, source: &str) -> (Node, String, NodeId) {
     let file_name = path.to_string_lossy().to_string();
+    let file_identity = WorkspaceIndexer::file_identity_path(path);
     let file_id = NodeId(WorkspaceIndexer::canonical_file_node_id_for_path(path));
     let line_count = source.lines().count() as u32;
     let file_end_line = if line_count == 0 { 1 } else { line_count };
@@ -1770,7 +1828,7 @@ pub(crate) fn file_node_from_source(path: &Path, source: &str) -> (Node, String,
         ..Default::default()
     };
 
-    (file_node, file_name, file_id)
+    (file_node, file_identity, file_id)
 }
 
 fn rebase_cached_index_artifact(
@@ -1781,6 +1839,7 @@ fn rebase_cached_index_artifact(
     flags: IndexFeatureFlags,
 ) -> CachedIndexArtifact {
     let file_name = full_path.to_string_lossy().to_string();
+    let file_identity = WorkspaceIndexer::file_identity_path(full_path);
     for node in &mut artifact.nodes {
         if node.kind == NodeKind::FILE {
             node.serialized_name = file_name.clone();
@@ -1790,7 +1849,7 @@ fn rebase_cached_index_artifact(
     }
 
     let old_file_id = artifact.files.first().map(|file| NodeId(file.id));
-    let (nodes, id_remap) = canonicalize_nodes(&file_name, artifact.nodes, &HashMap::new());
+    let (nodes, id_remap) = canonicalize_nodes(&file_identity, artifact.nodes, &HashMap::new());
     let fallback_file_id = NodeId(WorkspaceIndexer::canonical_file_node_id_for_path(full_path));
     let new_file_id = old_file_id
         .and_then(|file_id| id_remap.get(&file_id).copied())
@@ -13492,6 +13551,15 @@ fn canonicalize_nodes(
     final_nodes: Vec<Node>,
     canonical_roles: &HashMap<NodeId, CanonicalNodeRole>,
 ) -> (Vec<Node>, HashMap<NodeId, NodeId>) {
+    canonicalize_nodes_with_file_identity(file_name, file_name, final_nodes, canonical_roles)
+}
+
+fn canonicalize_nodes_with_file_identity(
+    file_name: &str,
+    file_identity: &str,
+    final_nodes: Vec<Node>,
+    canonical_roles: &HashMap<NodeId, CanonicalNodeRole>,
+) -> (Vec<Node>, HashMap<NodeId, NodeId>) {
     let mut id_remap = HashMap::<NodeId, NodeId>::new();
     let mut grouped_nodes = BTreeMap::<String, Vec<Node>>::new();
 
@@ -13515,6 +13583,8 @@ fn canonicalize_nodes(
             .unwrap_or_else(|| {
                 if is_type_like_kind(node.kind) {
                     format!("{}:{}", file_name, qualified_name)
+                } else if node.kind == NodeKind::FILE {
+                    format!("{file_identity}:{file_identity}:1")
                 } else {
                     let start_line = node.start_line.unwrap_or(1);
                     format!("{}:{}:{}", file_name, qualified_name, start_line)
@@ -14423,9 +14493,14 @@ fn index_template_file(
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("template");
+    let file_identity = WorkspaceIndexer::file_identity_path(path);
     let flags = index_feature_flags();
-    let (final_nodes, id_remap) =
-        canonicalize_nodes(file_name, local_storage.nodes, &HashMap::new());
+    let (final_nodes, id_remap) = canonicalize_nodes_with_file_identity(
+        file_name,
+        &file_identity,
+        local_storage.nodes,
+        &HashMap::new(),
+    );
     let new_file_id = id_remap.get(&file_id).copied().unwrap_or(file_id);
     local_storage.nodes = final_nodes;
     remap_file_affinity(&mut local_storage.nodes, new_file_id);
@@ -16495,6 +16570,7 @@ fn tauri_command_invoke_edge(
         kind: EdgeKind::CALL,
         file_node_id: Some(file_id),
         line: Some(invocation.line),
+        resolved_target: Some(command_node_id),
         certainty: Some(ResolutionCertainty::Uncertain),
         confidence: Some(0.45),
         ..Default::default()

--- a/crates/codestory-indexer/src/resolution/sql.rs
+++ b/crates/codestory-indexer/src/resolution/sql.rs
@@ -13,7 +13,14 @@ pub(super) fn cleanup_stale_call_resolutions(
     let cutoff = policy.min_call_confidence;
     let mut low_confidence_query = String::from(
         "UPDATE edge SET resolved_target_node_id = NULL, confidence = NULL, certainty = NULL
-         WHERE kind = ?1 AND confidence IS NOT NULL AND confidence < ?2",
+         WHERE kind = ?1 AND confidence IS NOT NULL AND confidence < ?2
+         AND target_node_id NOT IN (
+             SELECT id FROM node
+             WHERE canonical_id LIKE 'tauri:command:%'
+                OR canonical_id LIKE 'openapi:endpoint:%'
+                OR canonical_id LIKE 'route_endpoint:%'
+                OR canonical_id LIKE 'payload:collection:%'
+         )",
     );
     if scope_context.is_scoped() {
         low_confidence_query.push_str(&format!(

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -489,6 +489,136 @@ fn keep() { fresh(); }
     Ok(())
 }
 
+#[cfg(windows)]
+#[test]
+fn test_windows_casing_refresh_reuses_projection_identity() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("main.rs");
+
+    fs::write(
+        &file_path,
+        r#"
+fn stale() {}
+fn keep() { stale(); }
+"#,
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    fs::write(
+        &file_path,
+        r#"
+fn fresh() {}
+fn keep() { fresh(); }
+"#,
+    )?;
+
+    run_incremental_indexing(root, &mut storage, vec![root.join("MAIN.rs")])?;
+
+    let files = storage.get_files()?;
+    assert_eq!(
+        files.len(),
+        1,
+        "casing-only refresh must not duplicate file rows"
+    );
+    let file_id = files[0].id;
+
+    let nodes = storage.get_nodes()?;
+    let file_nodes = nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::FILE)
+        .count();
+    assert_eq!(
+        file_nodes, 1,
+        "casing-only refresh must not duplicate file nodes"
+    );
+    assert!(!nodes.iter().any(|node| node.serialized_name == "stale"));
+    assert!(nodes.iter().any(|node| node.serialized_name == "fresh"));
+
+    let states = storage.get_callable_projection_states_for_file(file_id)?;
+    assert!(
+        states
+            .iter()
+            .all(|state| !state.symbol_key.contains("stale"))
+    );
+    assert!(
+        states
+            .iter()
+            .any(|state| state.symbol_key.contains("fresh"))
+    );
+
+    Ok(())
+}
+
+#[cfg(windows)]
+#[test]
+fn test_windows_template_casing_refresh_reuses_projection_identity() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("App.svelte");
+
+    fs::write(
+        &file_path,
+        r#"
+<script>
+function stale() {}
+function keep() { stale(); }
+</script>
+"#,
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    fs::write(
+        &file_path,
+        r#"
+<script>
+function fresh() {}
+function keep() { fresh(); }
+</script>
+"#,
+    )?;
+
+    run_incremental_indexing(root, &mut storage, vec![root.join("APP.svelte")])?;
+
+    let files = storage.get_files()?;
+    assert_eq!(
+        files.len(),
+        1,
+        "casing-only template refresh must not duplicate file rows"
+    );
+    let file_id = files[0].id;
+
+    let nodes = storage.get_nodes()?;
+    let file_nodes = nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::FILE)
+        .count();
+    assert_eq!(
+        file_nodes, 1,
+        "casing-only template refresh must not duplicate file nodes"
+    );
+    assert!(!nodes.iter().any(|node| node.serialized_name == "stale"));
+    assert!(nodes.iter().any(|node| node.serialized_name == "fresh"));
+
+    let states = storage.get_callable_projection_states_for_file(file_id)?;
+    assert!(
+        states
+            .iter()
+            .all(|state| !state.symbol_key.contains("stale"))
+    );
+    assert!(
+        states
+            .iter()
+            .any(|state| state.symbol_key.contains("fresh"))
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_incremental_go_structural_change_removes_stale_projection() -> anyhow::Result<()> {
     let dir = tempdir()?;


### PR DESCRIPTION
## Context

#686 found that Windows casing-only paths could split indexer identity: incremental refresh could reuse or clean up by exact path text while workspace discovery compared normalized Windows keys.

Closes #686
Refs #683

## What Changed

- Added a Windows-aware indexer identity path: canonicalize when possible, normalize separators, and lowercase identity input on Windows only.
- Preserved display/storage paths for user-facing file records while routing file-node canonical IDs, cached artifacts, projection reuse, and stale cleanup through stable identity.
- Kept template symbol seeds based on the original basename so Svelte/template callable keys stay readable, while FILE-node identity uses the normalized path.
- Excluded synthetic integration targets from the low-confidence cleanup pass so Tauri/OpenAPI/route/payload edges do not lose their resolved target solely because they are intentionally uncertain.
- Added Windows regressions for Rust source files and Svelte templates that refresh through casing-only alternate paths and prove file rows, FILE nodes, and callable projection states stay singular and fresh.

## How To Review

```mermaid
flowchart LR
  A[refresh path] --> B[Windows identity path]
  B --> C[file id set]
  C --> D[projection reuse]
  C --> E[stale cleanup]
  C --> F[FILE node id]
  A --> G[display path]
  G --> H[file row shown to users]
```

Start in `crates/codestory-indexer/src/lib.rs` at `file_identity_path`, `existing_projection_file_ids`, and `canonicalize_nodes_with_file_identity`. Then review `crates/codestory-indexer/src/resolution/sql.rs` for the synthetic-target cleanup boundary, and finish with the Windows regressions in `crates/codestory-indexer/tests/integration.rs`.

## Verification

- `cargo test -p codestory-indexer --test integration -- --nocapture` - 17 passed
- `cargo check -p codestory-indexer --all-targets` - passed
- `cargo fmt --all -- --check` - passed
- `git diff --check` - passed
- CI before the amended review fix: `require closing issue link`, `deny rustdoc warnings`, and `linux-contracts` passed; `windows-manifest-missing` skipped by workflow policy.

## Risk

This does not migrate old cache/index rows created by earlier versions with a different Windows path-id seed. It makes new incremental indexing stable across casing-only refreshes, keeps Unix-like case-sensitive behavior unchanged, and preserves template basename keys for agent-facing output.
