### PR TITLE
Resolve existing callers for added definitions

### DIFF
--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1121,14 +1121,19 @@ impl WorkspaceIndexer {
         }
 
         // 3.5 Resolve call/import edges post-pass
-        if had_edges {
+        let (resolution_scope_file_ids, expanded_resolution_scope_files) =
+            if plan.mode == codestory_workspace::BuildMode::Incremental {
+                let mut file_ids = Self::collect_touched_file_ids(&root, &plan.files_to_index);
+                let expanded = Self::extend_resolution_scope_for_matching_unresolved_targets(
+                    storage,
+                    &mut file_ids,
+                )?;
+                (file_ids, expanded)
+            } else {
+                (HashSet::new(), 0)
+            };
+        if had_edges || expanded_resolution_scope_files > 0 {
             let resolver = resolution::ResolutionPass::new();
-            let resolution_scope_file_ids =
-                if plan.mode == codestory_workspace::BuildMode::Incremental {
-                    Self::collect_touched_file_ids(&root, &plan.files_to_index)
-                } else {
-                    Default::default()
-                };
             let resolution_scope = if plan.mode == codestory_workspace::BuildMode::Incremental {
                 (!resolution_scope_file_ids.is_empty()).then_some(&resolution_scope_file_ids)
             } else {
@@ -1322,6 +1327,109 @@ impl WorkspaceIndexer {
             }
         }
         file_ids
+    }
+
+    fn extend_resolution_scope_for_matching_unresolved_targets(
+        storage: &Storage,
+        scope_file_ids: &mut HashSet<i64>,
+    ) -> Result<usize> {
+        // New definitions can unblock old unresolved callers; keep the scope bounded
+        // to callers whose placeholder target names match names in touched files.
+        if scope_file_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let conn = storage.get_connection();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS incremental_resolution_touched_file_ids (
+                file_id INTEGER PRIMARY KEY
+             );
+             DELETE FROM incremental_resolution_touched_file_ids;
+             CREATE TEMP TABLE IF NOT EXISTS incremental_resolution_target_names (
+                name TEXT PRIMARY KEY
+             );
+             DELETE FROM incremental_resolution_target_names;",
+        )?;
+
+        {
+            let mut insert_touched = conn.prepare(
+                "INSERT OR IGNORE INTO incremental_resolution_touched_file_ids (file_id)
+                 VALUES (?1)",
+            )?;
+            for file_id in scope_file_ids.iter().copied() {
+                insert_touched.execute(rusqlite::params![file_id])?;
+            }
+        }
+
+        let definition_kind_values = incremental_resolution_target_node_kinds()
+            .iter()
+            .map(|kind| (*kind as i32).to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let definition_name_query = format!(
+            "INSERT OR IGNORE INTO incremental_resolution_target_names (name)
+             SELECT DISTINCT name FROM (
+                 SELECT serialized_name AS name
+                 FROM node
+                 WHERE file_node_id IN (
+                     SELECT file_id FROM incremental_resolution_touched_file_ids
+                 )
+                   AND kind IN ({definition_kind_values})
+                 UNION
+                 SELECT qualified_name AS name
+                 FROM node
+                 WHERE file_node_id IN (
+                     SELECT file_id FROM incremental_resolution_touched_file_ids
+                 )
+                   AND kind IN ({definition_kind_values})
+             )
+             WHERE name IS NOT NULL AND name <> ''"
+        );
+        conn.execute(&definition_name_query, [])?;
+        let target_name_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM incremental_resolution_target_names",
+            [],
+            |row| row.get(0),
+        )?;
+        if target_name_count == 0 {
+            return Ok(0);
+        }
+
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT COALESCE(caller.file_node_id, e.file_node_id) AS file_id
+             FROM edge e
+             JOIN node caller ON caller.id = e.source_node_id
+             JOIN node target ON target.id = e.target_node_id
+             JOIN incremental_resolution_target_names target_name
+               ON target_name.name = target.serialized_name
+               OR target_name.name = target.qualified_name
+             WHERE e.resolved_target_node_id IS NULL
+               AND e.kind IN (?1, ?2, ?3)
+               AND (e.kind != ?1 OR (e.confidence IS NULL AND e.certainty IS NULL))
+               AND COALESCE(caller.file_node_id, e.file_node_id) IS NOT NULL
+               AND (target.canonical_id IS NULL OR (
+                 target.canonical_id NOT LIKE 'tauri:command:%'
+                 AND target.canonical_id NOT LIKE 'openapi:endpoint:%'
+                 AND target.canonical_id NOT LIKE 'route_endpoint:%'
+                 AND target.canonical_id NOT LIKE 'payload:collection:%'
+               ))",
+        )?;
+        let rows = stmt.query_map(
+            rusqlite::params![
+                EdgeKind::CALL as i32,
+                EdgeKind::IMPORT as i32,
+                EdgeKind::OVERRIDE as i32
+            ],
+            |row| row.get::<_, i64>(0),
+        )?;
+
+        let mut added = 0;
+        for row in rows {
+            if scope_file_ids.insert(row?) {
+                added += 1;
+            }
+        }
+        Ok(added)
     }
 
     fn normalize_index_path(root: &Path, path: &Path) -> PathBuf {
@@ -1762,6 +1870,28 @@ impl WorkspaceIndexer {
             symbol_table.insert(node.id.0, node.kind);
         }
     }
+}
+
+fn incremental_resolution_target_node_kinds() -> &'static [NodeKind] {
+    &[
+        NodeKind::MODULE,
+        NodeKind::NAMESPACE,
+        NodeKind::PACKAGE,
+        NodeKind::STRUCT,
+        NodeKind::CLASS,
+        NodeKind::INTERFACE,
+        NodeKind::ANNOTATION,
+        NodeKind::UNION,
+        NodeKind::ENUM,
+        NodeKind::TYPEDEF,
+        NodeKind::FUNCTION,
+        NodeKind::METHOD,
+        NodeKind::MACRO,
+        NodeKind::GLOBAL_VARIABLE,
+        NodeKind::FIELD,
+        NodeKind::CONSTANT,
+        NodeKind::ENUM_CONSTANT,
+    ]
 }
 
 fn file_modification_time(path: &Path) -> i64 {

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -692,6 +692,85 @@ func (r *Router) Handle(path string) {}
 }
 
 #[test]
+fn test_incremental_added_definition_resolves_existing_unresolved_caller() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let caller = root.join("main.rs");
+    let callee = root.join("helper.rs");
+
+    fs::write(
+        &caller,
+        "mod helper;\nuse crate::helper::late_helper;\n\nfn run() {\n    late_helper();\n}\n",
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    let indexer = WorkspaceIndexer::new(root.to_path_buf());
+    let event_bus = EventBus::new();
+    let initial = codestory_workspace::RefreshInfo {
+        mode: codestory_workspace::BuildMode::Incremental,
+        files_to_index: vec![caller.clone()],
+        files_to_remove: vec![],
+        existing_file_ids: std::collections::HashMap::new(),
+    };
+    indexer.run_incremental(&mut storage, &initial, &event_bus, None)?;
+
+    let run_id = storage
+        .get_nodes()?
+        .into_iter()
+        .find(|node| node.serialized_name == "run" && node.kind == NodeKind::FUNCTION)
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing run() node after initial index"))?;
+    let initial_call_edges = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.source == run_id)
+        .collect::<Vec<_>>();
+    assert!(
+        !initial_call_edges.is_empty(),
+        "expected initial run() call edge to exist"
+    );
+    assert!(
+        initial_call_edges
+            .iter()
+            .all(|edge| edge.resolved_target.is_none()),
+        "late_helper() should be unresolved before helper.rs exists: {initial_call_edges:?}"
+    );
+
+    fs::write(&callee, "pub fn late_helper() {}\n")?;
+    let refresh = codestory_workspace::RefreshInfo {
+        mode: codestory_workspace::BuildMode::Incremental,
+        files_to_index: vec![callee.clone()],
+        files_to_remove: vec![],
+        existing_file_ids: std::collections::HashMap::new(),
+    };
+    let stats = indexer.run_incremental(&mut storage, &refresh, &event_bus, None)?;
+
+    let helper_id = storage
+        .get_nodes()?
+        .into_iter()
+        .find(|node| node.serialized_name == "late_helper" && node.kind == NodeKind::FUNCTION)
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing late_helper() node after incremental index"))?;
+    let refreshed_call_edges = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.source == run_id)
+        .collect::<Vec<_>>();
+    assert!(
+        refreshed_call_edges
+            .iter()
+            .any(|edge| edge.resolved_target == Some(helper_id)),
+        "unchanged run() caller should resolve to newly added helper: {refreshed_call_edges:?}"
+    );
+    assert!(
+        stats.resolved_calls > 0,
+        "incremental resolution should count the unchanged caller resolution"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_incremental_indexing_deletes_removed_files_before_resolution() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let root = dir.path();


### PR DESCRIPTION
## Context

#685 found that incremental indexing only resolved callers from touched files. If a refresh adds a definition, older unresolved callers in unchanged files can stay unresolved until a full reindex.

Closes #685
Refs #683

## What Changed

- Expanded incremental resolution scope by matching names from definition-like nodes in touched files against unresolved target placeholders in existing CALL, IMPORT, and OVERRIDE edges.
- Kept the expansion bounded: it only adds caller files whose unresolved target name or qualified name matches a name from the touched files; it does not fall back to repo-wide resolution.
- Allowed the scoped resolution pass to run when this name match adds affected caller files, even if the touched file itself did not introduce new unresolved edges.
- Added an early return when touched files produce no definition-like target names, avoiding a global unresolved-edge scan on no-op/non-definition incremental refreshes.
- Added an integration regression where `main.rs` has an unresolved call, `helper.rs` is added later, and the unchanged `run()` caller resolves during the incremental refresh.

## How To Review

```mermaid
flowchart LR
  A[touched files] --> B[definition-like names]
  B --> C{any names?}
  C -->|no| G[skip expansion]
  C -->|yes| D[unresolved placeholder targets]
  D --> E[matching caller files]
  A --> F[base touched scope]
  E --> H[expanded scoped resolution]
  F --> H
```

Start in `crates/codestory-indexer/src/lib.rs` at `extend_resolution_scope_for_matching_unresolved_targets`, then check the resolution gate just above the post-pass. Finish with `test_incremental_added_definition_resolves_existing_unresolved_caller` in `crates/codestory-indexer/tests/integration.rs`.

## Verification

- `cargo test -p codestory-indexer --test integration test_incremental_added_definition_resolves_existing_unresolved_caller -- --nocapture` - passed
- `cargo test -p codestory-indexer --test integration -- --nocapture` - 18 passed
- `cargo check -p codestory-indexer --all-targets` - passed
- `cargo fmt --all -- --check` - passed
- `git diff --check` - passed

## Risk

The new scope query runs on incremental refreshes that produce definition-like names and uses temporary tables plus exact name matching. It may include a small number of additional unresolved caller files when names collide, but it remains bounded to callers with unresolved placeholders matching names from touched files and does not perform full-repo re-resolution. A performance review caught and this PR fixed the zero-target-name case so edits without relevant definitions skip the unresolved-edge match query.
