### PR TITLE
Restore verification gates

### DIFF
--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -15,6 +15,8 @@ on:
       - crates/codestory-cli/src/args.rs
       - crates/codestory-cli/src/runtime.rs
       - crates/codestory-cli/src/stdio_*.rs
+      - crates/codestory-cli/tests/fixtures/packet_search_eval/**
+      - crates/codestory-cli/tests/packet_search_eval.rs
       - crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
       - crates/codestory-cli/tests/search_json_output.rs
       - crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -43,6 +45,8 @@ on:
       - crates/codestory-cli/src/args.rs
       - crates/codestory-cli/src/runtime.rs
       - crates/codestory-cli/src/stdio_*.rs
+      - crates/codestory-cli/tests/fixtures/packet_search_eval/**
+      - crates/codestory-cli/tests/packet_search_eval.rs
       - crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
       - crates/codestory-cli/tests/search_json_output.rs
       - crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -116,6 +120,9 @@ jobs:
 
       - name: CLI search JSON fail-closed contract tests
         run: cargo test -p codestory-cli --test search_json_output
+
+      - name: Packet/search fixture and baseline contract tests
+        run: cargo test -p codestory-cli --test packet_search_eval
 
       - name: Retrieval crate unit tests
         run: cargo test -p codestory-retrieval

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -19,27 +19,34 @@ uuid = { workspace = true }
 [[bench]]
 name = "indexing"
 harness = false
+bench = false
 
 [[bench]]
 name = "graph_fidelity"
 harness = false
+bench = false
 
 [[bench]]
 name = "resolution_full_scope"
 harness = false
+bench = false
 
 [[bench]]
 name = "ask_latency"
 harness = false
+bench = false
 
 [[bench]]
 name = "grounding"
 harness = false
+bench = false
 
 [[bench]]
 name = "incremental_cleanup"
 harness = false
+bench = false
 
 [[bench]]
 name = "browser_stress"
 harness = false
+bench = false

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -678,7 +678,7 @@ impl ReadyRepairProgress {
                     continue;
                 }
                 let elapsed = start.elapsed().as_secs();
-                if elapsed % READY_REPAIR_PROGRESS_INTERVAL.as_secs() != 0 {
+                if !elapsed.is_multiple_of(READY_REPAIR_PROGRESS_INTERVAL.as_secs()) {
                     continue;
                 }
                 let phase = *worker_phase.lock().expect("ready repair phase lock");
@@ -2294,25 +2294,24 @@ fn repair_ready_state(
             run_id,
         )
     });
-    if let Some(sidecar) = sidecar.as_ref() {
-        if let Ok(existing_status) = codestory_retrieval::strict_sidecar_status_for_runtime(
+    if let Some(sidecar) = sidecar.as_ref()
+        && let Ok(existing_status) = codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
             Some(&runtime.storage_path),
             sidecar.clone(),
-        ) {
-            if ready_repair_existing_sidecar_is_reusable(&existing_status) {
-                eprintln!(
-                    "ready repair agent sidecar already full: profile=agent run_id={} namespace={} compose_project={} embedding_device_state={} observation_source={} cpu_allowed={}",
-                    sidecar.run_id.as_deref().unwrap_or("none"),
-                    sidecar.namespace,
-                    sidecar.compose_project,
-                    existing_status.embedding_device_state,
-                    existing_status.embedding_device_observation_source,
-                    existing_status.embedding_cpu_allowed
-                );
-                return Ok(Some(sidecar.clone()));
-            }
-        }
+        )
+        && ready_repair_existing_sidecar_is_reusable(&existing_status)
+    {
+        eprintln!(
+            "ready repair agent sidecar already full: profile=agent run_id={} namespace={} compose_project={} embedding_device_state={} observation_source={} cpu_allowed={}",
+            sidecar.run_id.as_deref().unwrap_or("none"),
+            sidecar.namespace,
+            sidecar.compose_project,
+            existing_status.embedding_device_state,
+            existing_status.embedding_device_observation_source,
+            existing_status.embedding_cpu_allowed
+        );
+        return Ok(Some(sidecar.clone()));
     }
 
     let opened = runtime.ensure_open(args::RefreshMode::Auto)?;

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -333,20 +333,19 @@ fn verdict_state(
                             )
                         })
                         .unwrap_or_default();
-                    let request = sidecar
-                        .embedding_accelerator_requested
-                        .then(|| {
-                            format!(
-                                " accelerator_request=`{}:{}`",
-                                sidecar
-                                    .embedding_accelerator_request_provider
-                                    .unwrap_or("unknown"),
-                                sidecar
-                                    .embedding_accelerator_request_device
-                                    .unwrap_or("unknown")
-                            )
-                        })
-                        .unwrap_or_default();
+                    let request = if sidecar.embedding_accelerator_requested {
+                        format!(
+                            " accelerator_request=`{}:{}`",
+                            sidecar
+                                .embedding_accelerator_request_provider
+                                .unwrap_or("unknown"),
+                            sidecar
+                                .embedding_accelerator_request_device
+                                .unwrap_or("unknown")
+                        )
+                    } else {
+                        String::new()
+                    };
                     let source = sidecar
                         .embedding_device_observation_source
                         .map(|source| format!(" observation_source=`{source}`"))

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -83,7 +83,7 @@ pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
             continue;
         }
         let line = match std::str::from_utf8(&line) {
-            Ok(line) => line.trim_end_matches(&['\r', '\n']),
+            Ok(line) => line.trim_end_matches(['\r', '\n']),
             Err(error) => {
                 let response = stdio_jsonrpc_error(
                     serde_json::Value::Null,

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -3821,13 +3821,13 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
         .as_array()
         .unwrap_or_else(|| panic!("stdio search error should include full_repair: {response}"));
     assert!(
-        full_repair.iter().all(
-            |call| call.to_string().contains("\"method\":\"cli\"") == false
+        full_repair
+            .iter()
+            .all(|call| !call.to_string().contains("\"method\":\"cli\"")
                 && call
                     .get("debug_command")
                     .and_then(Value::as_str)
-                    .is_none_or(|text| !text.contains("codestory-cli index"))
-        ),
+                    .is_none_or(|text| !text.contains("codestory-cli index"))),
         "stdio search sidecar errors should not repeat core index repair commands: {response}"
     );
     assert!(

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -198,7 +198,7 @@ fn has_unportable_embedded_absolute_path(flag: &str) -> bool {
         .iter()
         .any(|prefix| {
             flag.strip_prefix(prefix)
-                .is_some_and(|value| starts_with_absolute_path_like(value))
+                .is_some_and(starts_with_absolute_path_like)
         })
 }
 

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1356,7 +1356,7 @@ impl WorkspaceIndexer {
                 "INSERT OR IGNORE INTO incremental_resolution_touched_file_ids (file_id)
                  VALUES (?1)",
             )?;
-            for file_id in scope_file_ids.iter().copied() {
+            for file_id in scope_file_ids.iter() {
                 insert_touched.execute(rusqlite::params![file_id])?;
             }
         }

--- a/crates/codestory-indexer/src/resolution/pipeline.rs
+++ b/crates/codestory-indexer/src/resolution/pipeline.rs
@@ -276,6 +276,7 @@ pub(super) fn resolve_overrides_on_conn(
     Ok(resolved)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_edges_after_prepare<F>(
     pass: &ResolutionPass,
     conn: &rusqlite::Connection,
@@ -505,6 +506,62 @@ fn collect_override_candidates(
     candidates.into_vec()
 }
 
+fn collect_override_candidates_by_owner_name(
+    owner_name: &str,
+    method_name: &str,
+    inheritance_by_owner_name: &HashMap<String, Vec<String>>,
+    methods_by_owner_name_and_name: &HashMap<(String, String), Vec<i64>>,
+) -> Vec<i64> {
+    let mut pending = std::collections::VecDeque::from([owner_name.to_string()]);
+    let mut visited = HashSet::new();
+    let mut candidates = OrderedCandidateIds::default();
+    let method_name = method_name.to_string();
+
+    while let Some(current_owner) = pending.pop_front() {
+        if !visited.insert(current_owner.clone()) {
+            continue;
+        }
+        if current_owner != owner_name
+            && let Some(method_ids) =
+                methods_by_owner_name_and_name.get(&(current_owner.clone(), method_name.clone()))
+        {
+            candidates.extend_stage(method_ids, usize::MAX);
+        }
+        if let Some(parents) = inheritance_by_owner_name.get(&current_owner) {
+            for parent in parents {
+                pending.push_back(parent.clone());
+            }
+        }
+    }
+
+    candidates.into_vec()
+}
+
+fn owner_name_from_member_name(name: &str) -> Option<&str> {
+    let colon = name.rfind("::");
+    let dot = name.rfind('.');
+    match (colon, dot) {
+        (Some(colon_idx), Some(dot_idx)) => {
+            let split = if colon_idx + 1 > dot_idx {
+                colon_idx
+            } else {
+                dot_idx
+            };
+            Some(&name[..split])
+        }
+        (Some(colon_idx), None) => Some(&name[..colon_idx]),
+        (None, Some(dot_idx)) => Some(&name[..dot_idx]),
+        (None, None) => None,
+    }
+}
+
+fn short_member_name(name: &str) -> &str {
+    let colon = name.rfind("::").map(|idx| idx + 2).unwrap_or(0);
+    let dot = name.rfind('.').map(|idx| idx + 1).unwrap_or(0);
+    let split = colon.max(dot);
+    &name[split..]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -613,60 +670,4 @@ mod tests {
 
         Ok(())
     }
-}
-
-fn collect_override_candidates_by_owner_name(
-    owner_name: &str,
-    method_name: &str,
-    inheritance_by_owner_name: &HashMap<String, Vec<String>>,
-    methods_by_owner_name_and_name: &HashMap<(String, String), Vec<i64>>,
-) -> Vec<i64> {
-    let mut pending = std::collections::VecDeque::from([owner_name.to_string()]);
-    let mut visited = HashSet::new();
-    let mut candidates = OrderedCandidateIds::default();
-    let method_name = method_name.to_string();
-
-    while let Some(current_owner) = pending.pop_front() {
-        if !visited.insert(current_owner.clone()) {
-            continue;
-        }
-        if current_owner != owner_name
-            && let Some(method_ids) =
-                methods_by_owner_name_and_name.get(&(current_owner.clone(), method_name.clone()))
-        {
-            candidates.extend_stage(method_ids, usize::MAX);
-        }
-        if let Some(parents) = inheritance_by_owner_name.get(&current_owner) {
-            for parent in parents {
-                pending.push_back(parent.clone());
-            }
-        }
-    }
-
-    candidates.into_vec()
-}
-
-fn owner_name_from_member_name(name: &str) -> Option<&str> {
-    let colon = name.rfind("::");
-    let dot = name.rfind('.');
-    match (colon, dot) {
-        (Some(colon_idx), Some(dot_idx)) => {
-            let split = if colon_idx + 1 > dot_idx {
-                colon_idx
-            } else {
-                dot_idx
-            };
-            Some(&name[..split])
-        }
-        (Some(colon_idx), None) => Some(&name[..colon_idx]),
-        (None, Some(dot_idx)) => Some(&name[..dot_idx]),
-        (None, None) => None,
-    }
-}
-
-fn short_member_name(name: &str) -> &str {
-    let colon = name.rfind("::").map(|idx| idx + 2).unwrap_or(0);
-    let dot = name.rfind('.').map(|idx| idx + 1).unwrap_or(0);
-    let split = colon.max(dot);
-    &name[split..]
 }

--- a/crates/codestory-indexer/src/structural/cargo_manifest.rs
+++ b/crates/codestory-indexer/src/structural/cargo_manifest.rs
@@ -151,7 +151,7 @@ fn strip_toml_comment(line: &str) -> &str {
 }
 
 fn toml_key(trimmed: &str) -> Option<&str> {
-    trimmed.split_once('=')?.0.trim().split_whitespace().next()
+    trimmed.split_once('=')?.0.split_whitespace().next()
 }
 
 fn dependency_key(line: &str) -> Option<(String, u32)> {

--- a/crates/codestory-indexer/src/structural/docker_compose.rs
+++ b/crates/codestory-indexer/src/structural/docker_compose.rs
@@ -183,6 +183,7 @@ fn push_service(
     service_id
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_anchor(
     storage: &mut IntermediateStorage,
     file_id: NodeId,

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -664,7 +664,7 @@ fn embed_model_dir(repo_root: Option<&Path>, layout: &SidecarLayout) -> Result<P
     let inventory = embed_model_inventory(repo_root, layout);
     if let Some(model_dir) = inventory
         .required_gguf_present
-        .then(|| inventory.model_dir.as_ref())
+        .then_some(inventory.model_dir.as_ref())
         .flatten()
     {
         return Ok(PathBuf::from(model_dir));

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -638,7 +638,7 @@ pub fn probe_sidecar_health_with_embedding_device(
         .or(manifest.projection_count)
         .unwrap_or(0);
     let qdrant = if dense_anchor_count == 0 {
-        zero_dense_qdrant_health(&embedding_device)
+        zero_dense_qdrant_health(embedding_device)
     } else {
         let collection = manifest.qdrant_collection.clone();
         let qdrant_probe = QdrantClient::new(layout).health_probe(&collection);

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -484,6 +484,7 @@ fn ensure_zoekt_generation(
     Ok(ZOEKT_REAL_VERSION_PIN.to_string())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ensure_qdrant_collection(
     storage_path: &Path,
     project_root: &Path,

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -537,7 +537,7 @@ fn match_resource(
         return Some(resource);
     }
     if resource.kind == SidecarDockerResourceKind::Network
-        && resource.labels.get("dev.codestory.owner").is_none()
+        && !resource.labels.contains_key("dev.codestory.owner")
         && compose_project
             .as_ref()
             .is_some_and(|project| owned_compose_projects.contains(project))
@@ -620,6 +620,7 @@ fn inventory_entry(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn classify_entry(
     state: Option<&SidecarStateFile>,
     state_exists: bool,

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -241,10 +241,7 @@ fn strict_batch_worker_limit(query_count: usize) -> usize {
         .map(usize::from)
         .unwrap_or(1);
     // Cap sidecar fan-out; make this configurable only if telemetry needs it.
-    query_count
-        .min(available)
-        .min(STRICT_BATCH_WORKER_CAP)
-        .max(1)
+    query_count.min(available).clamp(1, STRICT_BATCH_WORKER_CAP)
 }
 
 struct QueryContext {

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -1180,6 +1180,7 @@ fn maybe_append_generic_source_shape_citations(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_generic_source_shape_candidates(
     project_root: &Path,
     dir: &Path,

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -609,9 +609,7 @@ pub(crate) fn packet_anchor_probe_limit_for_budget(
     let usage_pct = packet_latency.budget_usage_percent(consumed_trace_ms);
     if usage_pct >= 75 {
         (base / 4).max(1)
-    } else if usage_pct >= 50 {
-        (base / 2).max(1)
-    } else if budget == PacketBudgetModeDto::Compact && usage_pct >= 25 {
+    } else if usage_pct >= 50 || (budget == PacketBudgetModeDto::Compact && usage_pct >= 25) {
         (base / 2).max(1)
     } else {
         base

--- a/crates/codestory-runtime/src/agent/packet_claim_profiles.rs
+++ b/crates/codestory-runtime/src/agent/packet_claim_profiles.rs
@@ -533,23 +533,21 @@ fn buffered_io_buffer_storage_claim(ctx: &SourceClaimContext<'_>) -> Option<Stri
     let normalized_symbol = normalize_identifier(ctx.symbol);
     let normalized_source = normalize_identifier(ctx.source);
     let lower = ctx.source.to_ascii_lowercase();
-    if normalized_symbol == "buffer"
+    if (normalized_symbol == "buffer"
         || normalized_symbol.ends_with("buffer")
-        || normalized_symbol.contains("bytebuffer")
-    {
-        if (lower.contains("class buffer")
+        || normalized_symbol.contains("bytebuffer"))
+        && (lower.contains("class buffer")
             || lower.contains("struct buffer")
             || lower.contains("interface buffer")
             || lower.contains("expect class buffer")
             || lower.contains("actual class buffer")
             || lower.contains("typealias buffer"))
-            && (normalized_source.contains("read") || normalized_source.contains("write"))
-            && (normalized_source.contains("byte") || normalized_source.contains("segment"))
-        {
-            return Some(
-                "Buffer is the in-memory byte store used by buffered reads and writes.".to_string(),
-            );
-        }
+        && (normalized_source.contains("read") || normalized_source.contains("write"))
+        && (normalized_source.contains("byte") || normalized_source.contains("segment"))
+    {
+        return Some(
+            "Buffer is the in-memory byte store used by buffered reads and writes.".to_string(),
+        );
     }
     None
 }
@@ -1364,15 +1362,14 @@ pub(crate) fn packet_generic_html_css_template_structure_claims(
     let lower = source.to_ascii_lowercase();
     let mut claims = Vec::new();
 
-    if file_name.ends_with(".html") || (lower.contains("<html") && lower.contains("<body")) {
-        if lower.contains("id=\"app\"")
-            && lower.contains("type=\"module\"")
-            && lower.contains("viewport")
-        {
-            claims.push(format!(
-                "{file_name} provides the app shell with viewport metadata, div#app, and a script[type=\"module\"] module script entry."
-            ));
-        }
+    if (file_name.ends_with(".html") || (lower.contains("<html") && lower.contains("<body")))
+        && lower.contains("id=\"app\"")
+        && lower.contains("type=\"module\"")
+        && lower.contains("viewport")
+    {
+        claims.push(format!(
+            "{file_name} provides the app shell with viewport metadata, div#app, and a script[type=\"module\"] module script entry."
+        ));
     }
 
     if file_name.ends_with(".css") {

--- a/crates/codestory-runtime/src/agent/packet_claims.rs
+++ b/crates/codestory-runtime/src/agent/packet_claims.rs
@@ -796,7 +796,7 @@ fn packet_citation_shaped_claim(citation: &AgentCitationDto, prompt: &str) -> Op
             .as_deref()
             .map(packet_display_path)
             .unwrap_or_default();
-        return eval_citation_shaped_claim(citation, prompt, &path);
+        eval_citation_shaped_claim(citation, prompt, &path)
     }
     #[cfg(not(test))]
     {

--- a/crates/codestory-runtime/src/agent/packet_required_probes.rs
+++ b/crates/codestory-runtime/src/agent/packet_required_probes.rs
@@ -1037,21 +1037,17 @@ pub(crate) fn packet_citation_probe_match_rank(
         } else {
             None
         }
-    } else if packet_citation_matches_route_registration_probe(query, citation) {
+    } else if packet_citation_matches_route_registration_probe(query, citation)
+        || packet_citation_matches_route_engine_constructor_probe(query, citation)
+        || packet_citation_matches_route_dispatch_probe(query, citation)
+        || packet_citation_matches_argument_planning_probe(query, citation)
+        || packet_citation_matches_buffered_wrapper_implementation(query, citation)
+        || packet_citation_matches_public_api_surface_probe(query, citation)
+    {
         Some(6)
-    } else if packet_citation_matches_route_engine_constructor_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_route_dispatch_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_argument_planning_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_buffered_wrapper_implementation(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_public_api_surface_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_validation_bypass_probe(query, citation) {
-        Some(5)
-    } else if packet_citation_matches_sql_schema_scripts_probe(query, citation) {
+    } else if packet_citation_matches_validation_bypass_probe(query, citation)
+        || packet_citation_matches_sql_schema_scripts_probe(query, citation)
+    {
         Some(5)
     } else if packet_required_probe_needs_request_validation_anchor(query) {
         packet_citation_matches_request_validation_anchor(query, citation).then_some(5)

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -896,9 +896,11 @@ fn packet_coverage_report(
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    let budget_omitted = has_sufficiency_blocking_budget_omission
-        .then(|| budget.omitted_sections.clone())
-        .unwrap_or_default();
+    let budget_omitted = if has_sufficiency_blocking_budget_omission {
+        budget.omitted_sections.clone()
+    } else {
+        Vec::new()
+    };
     let provenance_counts = packet_provenance_counts(supported_claims);
     let provenance_labels = provenance_counts.keys().cloned().collect::<Vec<_>>();
     PacketCoverageReportDto {
@@ -1047,8 +1049,7 @@ fn packet_escape_coverage_report_value(value: &str) -> String {
     value
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
-        .replace('\r', " ")
-        .replace('\n', " ")
+        .replace(['\r', '\n'], " ")
 }
 
 struct PacketFlowContext {
@@ -1495,7 +1496,7 @@ fn packet_missing_required_flow_requirements(
         .requirements
         .iter()
         .copied()
-        .filter(|requirement| flow_requirement_blocks_sufficiency(requirement))
+        .filter(flow_requirement_blocks_sufficiency)
         .filter(|requirement| {
             !supported_claims
                 .iter()
@@ -1638,6 +1639,7 @@ fn packet_blocking_follow_up_probe_queries(
     queries
 }
 
+#[allow(clippy::too_many_arguments)]
 fn packet_flow_roles_for_claim(
     claim: &PacketClaimDto,
     site_build_flow: bool,
@@ -2162,6 +2164,7 @@ fn insert_generic_boundary_roles(roles: &mut HashSet<FlowRole>) {
     roles.insert(FlowRole::TerminalBoundary);
 }
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4374,13 +4377,12 @@ fn packet_has_sufficiency_blocking_budget_omission(
         return false;
     }
 
-    budget
-        .omitted_sections
-        .iter()
-        .any(|section| match section.as_str() {
-            "citations" | "markdown_blocks" | "trail_edges" | "output_bytes" => true,
-            _ => false,
-        })
+    budget.omitted_sections.iter().any(|section| {
+        matches!(
+            section.as_str(),
+            "citations" | "markdown_blocks" | "trail_edges" | "output_bytes"
+        )
+    })
 }
 
 fn packet_missing_probe_requires_compact_proof(query: &str) -> bool {
@@ -4459,7 +4461,7 @@ fn packet_full_retrieval_available(answer: &AgentAnswerDto) -> bool {
         .retrieval_trace
         .retrieval_shadow
         .as_ref()
-        .map_or(true, |shadow| shadow.retrieval_mode == "full")
+        .is_none_or(|shadow| shadow.retrieval_mode == "full")
 }
 
 fn packet_agent_repair_command(quoted_project: &str) -> String {

--- a/crates/codestory-runtime/src/agent/packet_trace.rs
+++ b/crates/codestory-runtime/src/agent/packet_trace.rs
@@ -31,6 +31,7 @@ fn sanitize_section_id(value: &str) -> String {
     }
     id.trim_matches('-').chars().take(48).collect()
 }
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn merge_packet_lexical_subquery_batch(
     answer: &mut AgentAnswerDto,
     pending: &[(usize, &PacketPlanQueryDto)],

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -138,7 +138,7 @@ pub(crate) fn sidecar_retrieval_unavailable_error(
 fn sidecar_retrieval_recovery_commands(project_root: &Path) -> Vec<String> {
     let runtime = sidecar_runtime_auto(project_root);
     let agent_run_id = (runtime.profile == SidecarProfile::Agent)
-        .then(|| runtime.run_id.as_deref())
+        .then_some(runtime.run_id.as_deref())
         .flatten();
     sidecar_retrieval_recovery_commands_for_project(&project_root.to_string_lossy(), agent_run_id)
 }

--- a/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
+++ b/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
@@ -295,8 +295,7 @@ fn assert_mandatory_sidecar_unavailable(error: &ApiError) {
     assert!(
         details
             .next_commands
-            .iter()
-            .next()
+            .first()
             .is_some_and(|command| command.contains("codestory-cli ready --goal agent --repair")),
         "retrieval error should start with the canonical agent repair command: {error:?}"
     );

--- a/crates/codestory-runtime/tests/retrieval_eval.rs
+++ b/crates/codestory-runtime/tests/retrieval_eval.rs
@@ -183,8 +183,7 @@ fn retrieval_eval_search_fails_closed_without_full_retrieval_sidecars() {
     assert!(
         details
             .next_commands
-            .iter()
-            .next()
+            .first()
             .is_some_and(|command| command.contains("codestory-cli ready --goal agent --repair")),
         "retrieval error should start with the canonical agent repair command: {error:?}"
     );

--- a/docs/contributors/documentation-maintenance-checklist.md
+++ b/docs/contributors/documentation-maintenance-checklist.md
@@ -65,7 +65,7 @@ contract-complete.
 ### Verification process
 - [ ] Run `cargo fmt --check` on all documentation-related code
 - [ ] Run `cargo check` to ensure no documentation compilation errors
-- [ ] Run `cargo clippy --all-targets -- -D warnings` for linting
+- [ ] Run `cargo clippy --workspace --all-targets --all-features -- -D warnings` for strict linting
 - [ ] Run plugin static tests with `node --test plugins/codestory/tests/plugin-static.test.mjs` when plugin files change (structure and runtime shape only — not doc copy)
 - [ ] Check for broken links with `node .github/scripts/check-doc-links.mjs` (covers `README.md`, `docs/**` including templates, `plugins/codestory/README.md`, `plugins/codestory/docs/**`, and `plugins/codestory/skills/**`)
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -23,7 +23,7 @@ flowchart TD
     store --> store_tests["cargo test -p codestory-store"]
     runtime --> runtime_tests["cargo test -p codestory-runtime and retrieval_eval"]
     cli --> cli_tests["cargo test -p codestory-cli"]
-    bench --> bench_checks["cargo check -p codestory-bench --benches"]
+    bench --> bench_checks["cargo check -p codestory-bench --bench name"]
     e2e --> e2e_stats["release build + codestory_repo_e2e_stats"]
 ```
 
@@ -34,7 +34,7 @@ Run Cargo commands serially in this repo.
 | Lane | Commands |
 | --- | --- |
 | Docs only | `git diff --check`, `node .github/scripts/check-doc-links.mjs` |
-| Routine code | `cargo fmt --check`, `cargo check`, `cargo test`, `cargo clippy --all-targets -- -D warnings` |
+| Routine code | `cargo fmt --check`, `cargo check`, `cargo test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` |
 | Release-blocking fidelity | `cargo test -p codestory-indexer --test fidelity_regression`, `cargo test -p codestory-indexer --test tictactoe_language_coverage`, `cargo test -p codestory-runtime --test retrieval_eval` |
 | Heavy repo-scale timing | `cargo build --release -p codestory-cli`, then `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture` |
 
@@ -49,11 +49,15 @@ changes.
 cargo fmt --check
 cargo check
 cargo test
-cargo clippy --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
 These are the default broad checks for code changes after the lane picker says
 workspace-wide proof is useful.
+
+Do not use `cargo test --workspace --all-targets` as the routine broad test
+gate. `--all-targets` expands into benchmark targets; Criterion benches are
+compiled or run through the bench lane below.
 
 ## Release And Version Bumps
 
@@ -300,8 +304,14 @@ present. A zero-evaluated run is not quality proof.
 
 ```sh
 node scripts/semantic-doc-leakage-check.mjs
-cargo check -p codestory-bench --benches
+cargo check -p codestory-bench --bench <name>
 ```
+
+Criterion benches opt out of broad workspace test selection. Run them
+explicitly with `cargo bench -p codestory-bench --bench <name>` when the lane
+needs performance numbers. Use the same explicit `--bench <name>` form for
+compile-only proof; aggregate `--benches` does not select benches that opt out
+of broad workspace test selection.
 
 When changing embedding backends, model profiles, pooling, prefixes, batching,
 hardware-provider settings, generated symbol-doc text, or dense-anchor text, run

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -386,7 +386,9 @@ expansion lanes are skipped for that query.
 
 `retrieval-sidecar-smoke` is a reduced CI contract lane, not the operator repair
 path and not a full sidecar proof. Linux carries generic
-lint/runtime/search/retrieval contract slices. Windows carries the
+lint/runtime/search/retrieval contract slices plus the non-live packet/search
+fixture and baseline gate (`cargo test -p codestory-cli --test packet_search_eval`).
+Windows carries the
 manifest-missing bootstrap/status shape only when manually dispatched or when a
 PR has the `ci:windows-smoke` label.
 

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -61,11 +61,14 @@ cargo build --release -p codestory-cli
 cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture
 cargo test -p codestory-cli --test search_json_output -- --ignored --nocapture search_quality_eval
 cargo test -p codestory-runtime --test retrieval_eval
-cargo check -p codestory-bench --benches
+cargo check -p codestory-bench --bench <name>
 ```
 
 `retrieval_eval` needs `CODESTORY_RETRIEVAL_EVAL_FULL_TESTS=1` for full sidecar quality assertions;
 without it, the suite checks that non-full retrieval fails closed.
+
+Bench targets opt out of broad workspace test selection, so compile or run them
+with an explicit `--bench <name>` target.
 
 Use Criterion benches from `crates/codestory-bench` only when the measured hot
 path is narrower than the repo-scale e2e test can explain.

--- a/docs/testing/search-quality-eval.md
+++ b/docs/testing/search-quality-eval.md
@@ -43,6 +43,10 @@ schema, category, baseline, and non-full-mode gating checks with:
 cargo test -p codestory-cli --test packet_search_eval
 ```
 
+This non-ignored command is the CI-safe packet/search gate. It validates fixture
+schema, category coverage, baselines, and non-full-mode behavior without claiming
+live sidecar readiness.
+
 The live production-path check is ignored by default because it repairs and
 requires `retrieval_mode=full` agent sidecars for the checkout:
 


### PR DESCRIPTION
## Context

#690 found three verification-gate mismatches: strict Clippy did not pass under the documented strict form, broad all-target workspace tests could select Criterion benches, and retrieval smoke did not include the non-live packet/search eval surface.

Closes #690
Refs #683

## What Changed

- Burned down strict workspace Clippy warnings so `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes.
- Marked Criterion bench targets with `bench = false` so broad workspace test target selection does not pull custom benchmark executables into normal test gates; explicit `cargo bench -p codestory-bench --bench <name>` still works.
- Added the non-live `packet_search_eval` fixture/baseline test to `retrieval-sidecar-smoke` and to the workflow trigger paths.
- Updated contributor and retrieval docs to name the supported strict Clippy command, keep `cargo test --workspace --all-targets` out of the routine gate, document explicit bench compile/run commands, and clarify that packet/search CI is fixture/baseline proof, not live full-sidecar readiness proof.

## How To Review

```mermaid
flowchart LR
  A[documented gates] --> B[strict clippy]
  A --> C[workspace tests]
  A --> D[retrieval smoke]
  B --> E[warning cleanup]
  C --> F[bench opt-in]
  D --> G[packet_search_eval]
  E --> H[#690 gate truth]
  F --> H
  G --> H
```

Start with `docs/contributors/testing-matrix.md`, then check `crates/codestory-bench/Cargo.toml` and `.github/workflows/retrieval-sidecar-smoke.yml`. The Rust code changes are Clippy-driven mechanical rewrites plus targeted allowances for existing high-arity internal helpers.

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` - passed
- `cargo test --workspace --all-targets --no-run` - passed; output no longer listed Criterion bench executables
- `cargo test -p codestory-bench --all-targets --no-run` - passed; produced only the `codestory_bench` lib test executable
- `cargo check -p codestory-bench --bench indexing --bench graph_fidelity --bench resolution_full_scope --bench ask_latency --bench grounding --bench incremental_cleanup --bench browser_stress` - passed
- `cargo bench -p codestory-bench --bench ask_latency --no-run` - passed; explicit bench still builds
- `cargo test -p codestory-cli --test packet_search_eval` - 9 passed, 1 ignored live test
- `cargo test -p codestory-cli --test stdio_protocol_contracts` - 34 passed, 9 ignored live tests
- `cargo test -p codestory-cli --test search_json_output` - 3 passed, 12 ignored live tests
- `cargo test -p codestory-runtime --test retrieval_eval` - 1 passed, 5 ignored live tests
- `cargo test -p codestory-runtime --test retrieval_browser_contracts` - 2 passed, 9 ignored live tests
- `cargo test -p codestory-runtime --lib agent::retrieval_primary::tests` - 35 passed
- `cargo test -p codestory-runtime --lib agent::packet_search::tests` - 1 passed
- `cargo test -p codestory-runtime --lib agent::packet_claim_profiles::tests` - 17 passed
- `cargo test -p codestory-runtime --lib agent::packet_sufficiency::tests` - 50 passed
- `node .github/scripts/check-workflow-policy.mjs` - passed
- `node .github/scripts/check-doc-links.mjs` - passed
- `cargo fmt --all -- --check` - passed
- `git diff --check` - passed

## Risk

The packet/search CI addition is intentionally non-live; it does not claim `retrieval_mode=full` or device-truth readiness. The Clippy code edits should be behavior-preserving, but they touch broad runtime/CLI surfaces, so reviewer focus should be on the small rewritten predicates and targeted `allow` annotations. Bench targets now require explicit `--bench <name>` commands for compile/run proof.
