### PR TITLE
Harden HTTP serve boundary

### DIFF
--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1526,6 +1526,11 @@ pub(crate) struct ServeCommand {
     pub(crate) addr: String,
     #[arg(
         long,
+        help = "Allow HTTP serve to bind and answer non-loopback addresses. Use only behind an intentional network boundary."
+    )]
+    pub(crate) allow_non_loopback: bool,
+    #[arg(
+        long,
         help = "Serve a small MCP-style JSON-lines protocol over stdio instead of HTTP."
     )]
     pub(crate) stdio: bool,

--- a/crates/codestory-cli/src/http_transport.rs
+++ b/crates/codestory-cli/src/http_transport.rs
@@ -6,7 +6,7 @@ use codestory_contracts::api::{
 use std::{
     collections::HashMap,
     io::{Read, Write},
-    net::TcpStream,
+    net::{IpAddr, TcpStream},
     time::Duration,
 };
 
@@ -24,7 +24,22 @@ const BROWSER_REFERENCES_MAX_NODES: u32 = 120;
 pub(crate) const BROWSER_SYMBOLS_DEFAULT_LIMIT: u32 = 300;
 pub(crate) const BROWSER_SYMBOLS_MAX_LIMIT: u32 = 2_000;
 
-pub(crate) fn handle_http_request(runtime: &RuntimeContext, mut stream: TcpStream) -> Result<()> {
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct HttpServePolicy {
+    allow_non_loopback: bool,
+}
+
+impl HttpServePolicy {
+    pub(crate) fn new(allow_non_loopback: bool) -> Self {
+        Self { allow_non_loopback }
+    }
+}
+
+pub(crate) fn handle_http_request(
+    runtime: &RuntimeContext,
+    mut stream: TcpStream,
+    policy: HttpServePolicy,
+) -> Result<()> {
     stream.set_read_timeout(Some(Duration::from_secs(2)))?;
     let mut request_bytes = Vec::with_capacity(1024);
     let mut buffer = [0u8; 1024];
@@ -66,6 +81,10 @@ pub(crate) fn handle_http_request(runtime: &RuntimeContext, mut stream: TcpStrea
     let mut parts = line.split_whitespace();
     let method = parts.next().unwrap_or_default();
     let target = parts.next().unwrap_or("/");
+    let headers = parse_http_headers(&request);
+    if let Some(message) = http_boundary_rejection(&headers, policy) {
+        return write_http_error_json(&mut stream, 403, "forbidden_http_boundary", message);
+    }
     if method != "GET" {
         return write_http_json(
             &mut stream,
@@ -199,6 +218,104 @@ pub(crate) fn handle_http_request(runtime: &RuntimeContext, mut stream: TcpStrea
         }
         _ => write_http_json(&mut stream, 404, &serde_json::json!({"error": "not found"})),
     }
+}
+
+fn parse_http_headers(request: &str) -> Vec<(&str, &str)> {
+    request
+        .lines()
+        .skip(1)
+        .take_while(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim(), value.trim()))
+        })
+        .collect()
+}
+
+fn http_boundary_rejection(headers: &[(&str, &str)], policy: HttpServePolicy) -> Option<String> {
+    if policy.allow_non_loopback {
+        return None;
+    }
+
+    let host_values = http_header_values(headers, "host");
+    if host_values.len() != 1 {
+        return Some(
+            "HTTP serve requires exactly one loopback Host header unless --allow-non-loopback is set."
+                .to_string(),
+        );
+    }
+    let host = host_values[0];
+    if !http_authority_is_loopback(host) {
+        return Some(format!(
+            "Refusing HTTP serve request with non-loopback Host `{host}`. Use 127.0.0.1, localhost, or --allow-non-loopback behind an intentional network boundary."
+        ));
+    }
+
+    for origin in http_header_values(headers, "origin") {
+        if !http_origin_is_loopback(origin) {
+            return Some(format!(
+                "Refusing HTTP serve request with non-loopback Origin `{origin}`. Use a loopback origin or --allow-non-loopback behind an intentional network boundary."
+            ));
+        }
+    }
+
+    None
+}
+
+fn http_header_values<'a>(headers: &'a [(&str, &str)], name: &str) -> Vec<&'a str> {
+    headers
+        .iter()
+        .filter_map(|(header_name, value)| header_name.eq_ignore_ascii_case(name).then_some(*value))
+        .collect()
+}
+
+fn http_origin_is_loopback(origin: &str) -> bool {
+    let origin = origin.trim();
+    let Some(authority_and_path) = origin
+        .strip_prefix("http://")
+        .or_else(|| origin.strip_prefix("https://"))
+    else {
+        return false;
+    };
+    let authority = authority_and_path.split('/').next().unwrap_or_default();
+    http_authority_is_loopback(authority)
+}
+
+fn http_authority_is_loopback(authority: &str) -> bool {
+    let Some(host) = http_authority_host(authority.trim()) else {
+        return false;
+    };
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+fn http_authority_host(authority: &str) -> Option<&str> {
+    if authority.is_empty() {
+        return None;
+    }
+    if let Some(rest) = authority.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let host = &rest[..end];
+        let suffix = &rest[end + 1..];
+        if suffix.is_empty()
+            || suffix
+                .strip_prefix(':')
+                .is_some_and(|port| !port.is_empty() && port.chars().all(|ch| ch.is_ascii_digit()))
+        {
+            return (!host.is_empty()).then_some(host);
+        }
+        return None;
+    }
+    if let Some((host, port)) = authority.rsplit_once(':')
+        && !host.contains(':')
+        && !port.is_empty()
+        && port.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return (!host.is_empty()).then_some(host);
+    }
+    Some(authority)
 }
 
 fn resolve_http_target_from_params(
@@ -352,6 +469,7 @@ fn write_http_json<T: serde::Serialize>(
     let status_text = match status {
         200 => "OK",
         400 => "Bad Request",
+        403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
         _ => "OK",

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -33,7 +33,7 @@ use std::{
     fmt::Write as _,
     fs,
     io::{IsTerminal, Read},
-    net::TcpListener,
+    net::{TcpListener, ToSocketAddrs},
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
@@ -10174,6 +10174,9 @@ fn render_affected_footer(
 }
 
 fn run_serve(cmd: ServeCommand) -> Result<()> {
+    if !cmd.stdio {
+        ensure_http_serve_bind_allowed(&cmd.addr, cmd.allow_non_loopback)?;
+    }
     let runtime = new_agent_surface_runtime(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "serve")?;
@@ -10183,10 +10186,11 @@ fn run_serve(cmd: ServeCommand) -> Result<()> {
     let listener = TcpListener::bind(&cmd.addr)
         .with_context(|| format!("Failed to bind server to {}", cmd.addr))?;
     eprintln!("codestory serve listening on http://{}", cmd.addr);
+    let policy = http_transport::HttpServePolicy::new(cmd.allow_non_loopback);
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                if let Err(error) = http_transport::handle_http_request(&runtime, stream) {
+                if let Err(error) = http_transport::handle_http_request(&runtime, stream, policy) {
                     eprintln!("serve request failed: {error:#}");
                 }
             }
@@ -10194,6 +10198,32 @@ fn run_serve(cmd: ServeCommand) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn ensure_http_serve_bind_allowed(addr: &str, allow_non_loopback: bool) -> Result<()> {
+    if allow_non_loopback {
+        return Ok(());
+    }
+
+    let resolved = addr
+        .to_socket_addrs()
+        .with_context(|| format!("Failed to resolve serve address {addr}"))?
+        .collect::<Vec<_>>();
+    if resolved.is_empty() {
+        bail!("Serve address {addr} did not resolve to a socket address");
+    }
+    if resolved
+        .iter()
+        .all(|socket_addr| socket_addr.ip().is_loopback())
+    {
+        return Ok(());
+    }
+
+    bail!(
+        "Refusing to bind HTTP serve to non-loopback address `{addr}` without --allow-non-loopback. \
+serve exposes local graph/search endpoints without request authentication; bind to 127.0.0.1/localhost \
+or rerun with --allow-non-loopback only behind an intentional network boundary."
+    )
 }
 
 fn run_generate_completions(cmd: GenerateCompletionsCommand) -> Result<()> {
@@ -12447,6 +12477,34 @@ mod tests {
             first_index < second_index,
             "expected `{first}` before `{second}` in:\n{markdown}"
         );
+    }
+
+    #[test]
+    fn http_serve_allows_loopback_bind_without_acknowledgement() {
+        ensure_http_serve_bind_allowed("127.0.0.1:3917", false)
+            .expect("ipv4 loopback should be allowed by default");
+        ensure_http_serve_bind_allowed("localhost:3917", false)
+            .expect("localhost should resolve to loopback and stay ergonomic");
+        ensure_http_serve_bind_allowed("[::1]:3917", false)
+            .expect("ipv6 loopback should be allowed by default");
+    }
+
+    #[test]
+    fn http_serve_rejects_non_loopback_bind_without_acknowledgement() {
+        let error = ensure_http_serve_bind_allowed("0.0.0.0:3917", false)
+            .expect_err("wildcard bind should require explicit acknowledgement");
+        let message = error.to_string();
+        assert!(
+            message.contains("--allow-non-loopback")
+                && message.contains("without request authentication"),
+            "unsafe bind error should name the guard and auth boundary: {message}"
+        );
+    }
+
+    #[test]
+    fn http_serve_allows_non_loopback_bind_with_acknowledgement() {
+        ensure_http_serve_bind_allowed("0.0.0.0:3917", true)
+            .expect("explicit acknowledgement should allow intentional remote binds");
     }
 
     #[test]

--- a/crates/codestory-cli/tests/http_transport_contracts.rs
+++ b/crates/codestory-cli/tests/http_transport_contracts.rs
@@ -173,6 +173,38 @@ fn free_local_addr() -> String {
     addr.to_string()
 }
 
+#[test]
+fn http_serve_rejects_non_loopback_addr_before_opening_runtime_state() {
+    let workspace = tempfile::tempdir().expect("workspace dir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    write_deep_rust_workspace(workspace.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+        .arg("serve")
+        .arg("--refresh")
+        .arg("none")
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .arg("--addr")
+        .arg("0.0.0.0:0")
+        .env("CODESTORY_EMBED_RUNTIME_MODE", "hash")
+        .output()
+        .expect("run serve");
+    assert!(
+        !output.status.success(),
+        "non-loopback serve should be rejected without an acknowledgement flag"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--allow-non-loopback")
+            && stderr.contains("without request authentication")
+            && !stderr.contains("index not ready"),
+        "serve should fail at the bind guard before opening cache/index state:\n{stderr}"
+    );
+}
+
 fn spawn_http_server(fixture: &HttpFixture) -> (HttpServer, String) {
     let addr = free_local_addr();
     let child = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
@@ -218,11 +250,20 @@ struct HttpResponse {
 }
 
 fn http_get(addr: &str, target: &str) -> std::io::Result<HttpResponse> {
+    http_get_with_headers(addr, target, &[("Host", addr)])
+}
+
+fn http_get_with_headers(
+    addr: &str,
+    target: &str,
+    headers: &[(&str, &str)],
+) -> std::io::Result<HttpResponse> {
     let mut stream = TcpStream::connect(addr)?;
-    write!(
-        stream,
-        "GET {target} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
-    )?;
+    write!(stream, "GET {target} HTTP/1.1\r\n")?;
+    for (name, value) in headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
+    write!(stream, "Connection: close\r\n\r\n")?;
     stream.flush()?;
     stream.shutdown(Shutdown::Write)?;
 
@@ -255,6 +296,82 @@ fn http_get(addr: &str, target: &str) -> std::io::Result<HttpResponse> {
     let body = serde_json::from_str(body.trim())
         .unwrap_or_else(|error| panic!("HTTP body should be JSON: {error}\n{body}"));
     Ok(HttpResponse { status, body })
+}
+
+#[test]
+fn http_serve_rejects_non_loopback_host_and_origin_headers() {
+    let fixture = indexed_fixture();
+    let (_server, addr) = spawn_http_server(&fixture);
+
+    let bad_host = http_get_with_headers(&addr, "/health", &[("Host", "evil.test:3917")])
+        .expect("bad host response");
+    assert_eq!(bad_host.status, 403);
+    assert_eq!(
+        bad_host.body.pointer("/error/code").and_then(Value::as_str),
+        Some("forbidden_http_boundary"),
+        "non-loopback Host should fail closed: {}",
+        bad_host.body
+    );
+
+    let bad_origin = http_get_with_headers(
+        &addr,
+        "/health",
+        &[("Host", &addr), ("Origin", "http://evil.test:3917")],
+    )
+    .expect("bad origin response");
+    assert_eq!(bad_origin.status, 403);
+    assert_eq!(
+        bad_origin
+            .body
+            .pointer("/error/code")
+            .and_then(Value::as_str),
+        Some("forbidden_http_boundary"),
+        "non-loopback Origin should fail closed: {}",
+        bad_origin.body
+    );
+
+    let malformed_ipv6_host =
+        http_get_with_headers(&addr, "/health", &[("Host", "[::1]evil.test:3917")])
+            .expect("malformed ipv6 host response");
+    assert_eq!(
+        malformed_ipv6_host.status, 403,
+        "malformed bracketed Host should fail closed: {}",
+        malformed_ipv6_host.body
+    );
+
+    let malformed_ipv6_origin = http_get_with_headers(
+        &addr,
+        "/health",
+        &[("Host", &addr), ("Origin", "http://[::1]evil.test:3917")],
+    )
+    .expect("malformed ipv6 origin response");
+    assert_eq!(
+        malformed_ipv6_origin.status, 403,
+        "malformed bracketed Origin should fail closed: {}",
+        malformed_ipv6_origin.body
+    );
+
+    for host in ["localhost:3917", "[::1]:3917"] {
+        let response = http_get_with_headers(&addr, "/health", &[("Host", host)])
+            .unwrap_or_else(|error| panic!("loopback Host {host}: {error}"));
+        assert_eq!(
+            response.status, 200,
+            "loopback Host {host} should stay allowed: {}",
+            response.body
+        );
+    }
+
+    let loopback_origin = http_get_with_headers(
+        &addr,
+        "/health",
+        &[("Host", &addr), ("Origin", "http://localhost:3917")],
+    )
+    .expect("loopback origin response");
+    assert_eq!(
+        loopback_origin.status, 200,
+        "loopback Origin should stay allowed: {}",
+        loopback_origin.body
+    );
 }
 
 fn get_json(addr: &str, target: &str) -> Value {

--- a/docs/architecture/subsystems/cli.md
+++ b/docs/architecture/subsystems/cli.md
@@ -94,7 +94,7 @@ not expose ranking knobs for product search/context calls.
 
 ## Serving And Integration Surface
 
-HTTP serving keeps the current small GET/query-string shape. The stable routes are `/health`, `/search`, `/symbol`, `/definition`, `/references`, `/symbols`, and `/trail`. Definition and references accept either `q` or `id`, so agents can resolve from a query first and then reuse exact node ids.
+HTTP serving keeps the current small GET/query-string shape. It is local-only by default: non-loopback binds and non-loopback `Host`/`Origin` headers are rejected unless the operator passes `--allow-non-loopback` behind an intentional network boundary. The stable routes are `/health`, `/search`, `/symbol`, `/definition`, `/references`, `/symbols`, and `/trail`. Definition and references accept either `q` or `id`, so agents can resolve from a query first and then reuse exact node ids.
 
 `serve --stdio` is MCP-style JSON lines. It exposes tools for ground, files, affected, packet, search, context, symbol, callers, callees, trace, trail, definition, references, symbols, snippet, and warm graph primitives (`get_node`, `neighbors`, `shortest_path`, and `query_subgraph`); resources for project, grounding, and root symbols; resource templates for node-specific symbol/reference/snippet/trail reads; and prompts for explain-symbol, callflow tracing, and impact analysis.
 

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -23,6 +23,7 @@ The installed plugin starts `scripts/codestory-mcp.cjs` (managed CLI bootstrap a
 | `--project <path>` | `.` | Repository root to serve. Always pass it explicitly. |
 | `--cache-dir <path>` | auto | Serve a specific cache directory. |
 | `--addr <host:port>` | `127.0.0.1:3917` | HTTP bind address. |
+| `--allow-non-loopback` | off | Required before HTTP serve can bind or answer wildcard/remote-facing addresses. Use only behind an intentional network boundary; HTTP routes do not require request authentication. |
 | `--stdio` | off | Use JSON-lines stdio instead of HTTP. |
 | `--refresh <auto|full|incremental|none>` | `none` | Read an existing cache unless you intentionally refresh. |
 
@@ -50,7 +51,7 @@ Stdio MCP status fields and allowed-surface rules: [status-contract.md](status-c
 
 ## Notes
 
-- `serve` is local by default on `127.0.0.1`; do not bind wider unless the user explicitly needs remote access.
+- `serve` is local by default on `127.0.0.1`; non-loopback HTTP binds and non-loopback `Host`/`Origin` headers fail unless `--allow-non-loopback` is set. Do not bind wider unless the user explicitly needs remote access and the network boundary is intentional.
 - HTTP only accepts GET requests for the documented routes.
 - Start it after a successful index or with an intentional refresh mode.
 - In one `serve --stdio` process, identical successful `packet` and search-fragment requests are cached with small LRUs keyed by request arguments, the current SQLite/WAL fingerprint, and a mandatory sidecar-readiness fingerprint. The sidecar fingerprint includes the active embedding backend, sidecar state-file metadata, strict retrieval mode, degraded reason, manifest generation/input hash/backend/dimension, and status errors. This is for repeated agent calls only; changed index files, sidecar state drift, and strict stale/unavailable readiness bypass the cache.


### PR DESCRIPTION
## Context

Closes #688.

`codestory-cli serve` exposes local graph/search HTTP routes for editor/browser integrations. The default loopback bind is fine for local developer use, but wildcard or remote-facing binds and rebinding-style Host/Origin requests need an explicit boundary because the HTTP routes do not require request authentication.

## What Changed

- Added `serve --allow-non-loopback` as the explicit acknowledgement for remote-facing HTTP serve usage.
- Refused non-loopback HTTP binds before opening runtime/cache/index state unless that acknowledgement is present.
- Added a default Host/Origin policy for HTTP requests:
  - exactly one loopback Host is required by default
  - non-loopback Origin values return `403 forbidden_http_boundary`
  - malformed bracketed IPv6 authorities fail closed
  - `--allow-non-loopback` disables the local-only request boundary for intentional remote deployments
- Updated the CLI architecture notes and plugin serve reference to describe the local-only default.

## How To Review

1. Start with `crates/codestory-cli/src/main.rs` and confirm the bind guard runs before runtime/index state opens.
2. Review `crates/codestory-cli/src/http_transport.rs` for the request Host/Origin policy and the acknowledged remote-mode bypass.
3. Review `crates/codestory-cli/tests/http_transport_contracts.rs` for denied wildcard binds, denied Host/Origin requests, malformed IPv6 authority coverage, and preserved loopback behavior.
4. Check the docs updates for accurate operator language.

## Verification

- `cargo fmt --check`
- `cargo test -p codestory-cli http_serve_ -- --nocapture`
- `cargo test -p codestory-cli --test http_transport_contracts -- --nocapture`
- `cargo check -p codestory-cli`
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- Security reviewer re-check found no remaining issues after the malformed bracketed IPv6 fix.

## Risk

- HTTP/1.1 clients without a Host header now fail closed by default; browser/curl-style local clients keep working.
- `--allow-non-loopback` is an explicit acknowledgement, not token auth. The issue acceptance allowed a guard/token/acknowledgement path, and the docs label the unauthenticated boundary.