### PR TITLE
Pin retrieval sidecar images by digest

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -12590,6 +12590,7 @@ mod tests {
         codestory_retrieval::RetrievalStatusReport {
             retrieval_mode: mode.into(),
             ownership: None,
+            sidecar_images: codestory_retrieval::default_sidecar_image_pins(),
             degraded_reason: reason.map(str::to_string),
             repair: None,
             query_embedding_backend: "llamacpp:bge-base-en-v1.5".into(),

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -478,6 +478,12 @@ fn emit_retrieval_bootstrap(
             )
         })
         .unwrap_or_default();
+    let sidecar_images_note = format!(
+        "\n- sidecar_images: qdrant=`{}` zoekt=`{}` embed=`{}`",
+        payload.sidecar_state.sidecar_images.qdrant,
+        payload.sidecar_state.sidecar_images.zoekt,
+        payload.sidecar_state.sidecar_images.embed
+    );
     let markdown = format!(
         "# Retrieval bootstrap\n\n- compose_started: {}\n- zoekt_reachable: {} ({})\n- qdrant_reachable: {} ({})\n- embed_reachable: {} ({})\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- retrieval_mode: `{}`\n- storage_repair: protected={} pruned={} invalid_dirs_removed={} stub_markers_migrated={} collections_seen={} overflow_protected={}{overflow_note}{scan_warning}{prune_suppressed_note}",
         payload.compose_started,
@@ -513,7 +519,7 @@ fn emit_retrieval_bootstrap(
     emit(
         format,
         &payload,
-        format!("{markdown}{project_repair_note}"),
+        format!("{markdown}{sidecar_images_note}{project_repair_note}"),
         output_file,
     )
 }
@@ -574,8 +580,12 @@ fn emit_retrieval_status(
             )
         })
         .unwrap_or_default();
+    let sidecar_images_note = format!(
+        "- sidecar_images: qdrant=`{}` zoekt=`{}` embed=`{}`\n",
+        report.sidecar_images.qdrant, report.sidecar_images.zoekt, report.sidecar_images.embed
+    );
     let markdown = format!(
-        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
+        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
         report.retrieval_mode,
         report.degraded_reason,
         report.query_embedding_backend,
@@ -596,6 +606,7 @@ fn emit_retrieval_status(
         manifest_contract_note,
         repair_note,
         ownership_note,
+        sidecar_images_note,
         report.zoekt.status,
         report.zoekt.detail,
         report.zoekt.capabilities.lexical,

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -46,6 +46,18 @@ fn run_down(project: &std::path::Path, extra_args: &[&str]) {
     );
 }
 
+fn assert_digest_image_pins(json: &Value) {
+    for field in ["qdrant", "zoekt", "embed"] {
+        let image = json[field]
+            .as_str()
+            .unwrap_or_else(|| panic!("sidecar_images.{field} should be a string: {json}"));
+        assert!(
+            image.contains("@sha256:"),
+            "sidecar_images.{field} must include a digest pin: {image}"
+        );
+    }
+}
+
 fn create_valid_cache_with_cli(project: &std::path::Path, cache: &std::path::Path) {
     let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
         .args(["index", "--project"])
@@ -113,6 +125,7 @@ fn bootstrap_json_includes_storage_repair_fields() {
         json.get("embed_detail").is_some(),
         "bootstrap output missing embed_detail: {json}"
     );
+    assert_digest_image_pins(&json["sidecar_state"]["sidecar_images"]);
     assert!(repair["scan_errors"].is_array());
     assert!(
         repair["prune_suppressed_reason"].is_null()
@@ -146,11 +159,13 @@ fn bootstrap_then_status_reports_manifest_missing_before_indexing() {
         bootstrap["storage_repair"].is_object(),
         "bootstrap output missing storage repair: {bootstrap}"
     );
+    assert_digest_image_pins(&bootstrap["sidecar_state"]["sidecar_images"]);
 
     let status = run_status(
         project.path(),
         &["--cache-dir", cache_arg, "--format", "json"],
     );
+    assert_digest_image_pins(&status["sidecar_images"]);
     assert_eq!(
         status["degraded_reason"].as_str(),
         Some("retrieval_manifest_missing"),

--- a/crates/codestory-cli/tests/sidecar_status_cli.rs
+++ b/crates/codestory-cli/tests/sidecar_status_cli.rs
@@ -76,6 +76,10 @@ fn sidecar_status_uses_retrieval_status_human_output() {
         stdout.contains("# Retrieval status"),
         "sidecar status should reuse retrieval status output:\n{stdout}"
     );
+    assert!(
+        stdout.contains("sidecar_images:") && stdout.contains("@sha256:"),
+        "sidecar status should expose digest-pinned images:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -883,7 +883,20 @@ mod tests {
         assert_eq!(path, cache.path().join("retrieval-compose.yml"));
         let contents = std::fs::read_to_string(path).expect("read bundled compose");
         assert!(contents.contains("name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}"));
-        assert!(contents.contains("qdrant/qdrant:v1.12.5"));
+        for image in [
+            crate::config::QDRANT_IMAGE_PIN,
+            crate::config::ZOEKT_WEBSERVER_IMAGE_PIN,
+            crate::config::LLAMACPP_SERVER_IMAGE_PIN,
+        ] {
+            assert!(
+                image.contains("@sha256:"),
+                "image pin must include digest: {image}"
+            );
+            assert!(
+                contents.contains(image),
+                "bundled compose should contain exact image pin {image}"
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -10,15 +10,30 @@ use std::time::{Duration, SystemTime};
 pub const ZOEKT_REAL_VERSION_PIN: &str = "zoekt-20250506123554";
 
 /// Zoekt webserver image for `COMPOSE_PROFILES=real`.
-pub const ZOEKT_WEBSERVER_IMAGE_PIN: &str =
-    "sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4";
+pub const ZOEKT_WEBSERVER_IMAGE_PIN: &str = "sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4@sha256:34c77a62bcafc41ce3ee193e44f42aa84690d9ec51b953e7efae4dfdfae80aff";
 
 /// Qdrant container image pin for local dev and CI smoke.
-pub const QDRANT_IMAGE_PIN: &str = "qdrant/qdrant:v1.12.5";
+pub const QDRANT_IMAGE_PIN: &str =
+    "qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae";
 
 /// llama.cpp server image for `COMPOSE_PROFILES=real` embed service (see `docker/retrieval-compose.yml`).
 #[allow(dead_code)]
-pub const LLAMACPP_SERVER_IMAGE_PIN: &str = "ghcr.io/ggml-org/llama.cpp:server";
+pub const LLAMACPP_SERVER_IMAGE_PIN: &str = "ghcr.io/ggml-org/llama.cpp:server@sha256:f16ca66f3ba316b7a7a16003ddfa88d29c3404fbe86550da086736864c11574c";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SidecarImagePins {
+    pub qdrant: String,
+    pub zoekt: String,
+    pub embed: String,
+}
+
+pub fn default_sidecar_image_pins() -> SidecarImagePins {
+    SidecarImagePins {
+        qdrant: QDRANT_IMAGE_PIN.into(),
+        zoekt: ZOEKT_WEBSERVER_IMAGE_PIN.into(),
+        embed: LLAMACPP_SERVER_IMAGE_PIN.into(),
+    }
+}
 
 pub const DEFAULT_ZOEKT_HTTP_PORT: u16 = 6070;
 pub const DEFAULT_QDRANT_HTTP_PORT: u16 = 6333;

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,7 +1,8 @@
 use crate::capabilities::SidecarCapabilities;
 use crate::config::{
-    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, SidecarProfile, SidecarRuntimeConfig,
-    ZOEKT_HEALTH_BUDGET, qdrant_semantic_vectors_enabled, retrieval_command,
+    QDRANT_HEALTH_BUDGET, SidecarImagePins, SidecarLayout, SidecarOwnership, SidecarProfile,
+    SidecarRuntimeConfig, ZOEKT_HEALTH_BUDGET, default_sidecar_image_pins,
+    qdrant_semantic_vectors_enabled, retrieval_command,
 };
 use crate::embeddings::{EmbeddingDeviceReadiness, manifest_embedding_backend_is_product};
 use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
@@ -90,6 +91,8 @@ pub struct RetrievalStatusReport {
     pub retrieval_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ownership: Option<SidecarOwnership>,
+    #[serde(default = "default_sidecar_image_pins")]
+    pub sidecar_images: SidecarImagePins,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -378,6 +381,7 @@ pub fn unavailable_status_report_with_embedding_device(
     RetrievalStatusReport {
         retrieval_mode: "unavailable".into(),
         ownership: None,
+        sidecar_images: default_sidecar_image_pins(),
         degraded_reason: Some(reason.clone()),
         repair: None,
         query_embedding_backend: crate::embeddings::embedding_runtime_id(),
@@ -734,6 +738,7 @@ pub fn probe_sidecar_health_with_embedding_device(
     RetrievalStatusReport {
         retrieval_mode: mode.as_str().into(),
         ownership: None,
+        sidecar_images: default_sidecar_image_pins(),
         degraded_reason,
         repair: None,
         query_embedding_backend: current_embedding_backend,
@@ -1063,6 +1068,7 @@ mod tests {
         let report = RetrievalStatusReport {
             retrieval_mode: "full".into(),
             ownership: None,
+            sidecar_images: default_sidecar_image_pins(),
             degraded_reason: None,
             query_embedding_backend: "llamacpp:bge-base-en-v1.5".into(),
             manifest_vector_embedding_backend: manifest.embedding_backend.clone(),

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -870,6 +870,7 @@ mod tests {
             embedding_accelerator_request_device: None,
             embedding_cpu_allowed: false,
             embedding_launch: None,
+            sidecar_images: crate::config::default_sidecar_image_pins(),
             zoekt_data_dir: root.join("zoekt").display().to_string(),
             qdrant_data_dir: root.join("qdrant").display().to_string(),
             scip_artifacts_root: root.join("scip").display().to_string(),

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -51,10 +51,10 @@ pub use compose::{
 };
 pub use config::{
     DEFAULT_AGENT_RUN_ID, DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT,
-    DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarLayout,
-    SidecarOwnership, SidecarPorts, SidecarProfile, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN,
-    ZOEKT_WEBSERVER_IMAGE_PIN, sidecar_runtime_auto, sidecar_runtime_for_project,
-    sidecar_runtime_for_project_with_run_id,
+    DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarImagePins,
+    SidecarLayout, SidecarOwnership, SidecarPorts, SidecarProfile, SidecarRuntimeConfig,
+    ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN, default_sidecar_image_pins,
+    sidecar_runtime_auto, sidecar_runtime_for_project, sidecar_runtime_for_project_with_run_id,
 };
 pub use config::{qdrant_enabled, qdrant_semantic_vectors_enabled};
 pub use embeddings::qdrant_vector_dim;

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    SidecarLayout, SidecarProfile, SidecarRuntimeConfig, sidecar_runtime_auto,
-    sidecar_runtime_for_project,
+    SidecarImagePins, SidecarLayout, SidecarProfile, SidecarRuntimeConfig,
+    default_sidecar_image_pins, sidecar_runtime_auto, sidecar_runtime_for_project,
 };
 use crate::generation::{
     SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
@@ -63,6 +63,8 @@ pub struct SidecarStateFile {
     pub embedding_cpu_allowed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding_launch: Option<EmbeddingLaunchMetadata>,
+    #[serde(default = "default_sidecar_image_pins")]
+    pub sidecar_images: SidecarImagePins,
     pub zoekt_data_dir: String,
     pub qdrant_data_dir: String,
     pub scip_artifacts_root: String,
@@ -113,6 +115,7 @@ pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
         embedding_accelerator_request_device: embedding_device.accelerator_request_device,
         embedding_cpu_allowed: embedding_device.cpu_allowed,
         embedding_launch,
+        sidecar_images: default_sidecar_image_pins(),
         zoekt_data_dir: layout.zoekt_data_dir.display().to_string(),
         qdrant_data_dir: layout.qdrant_data_dir.display().to_string(),
         scip_artifacts_root: layout.scip_artifacts_root.display().to_string(),
@@ -310,9 +313,10 @@ fn attach_status_ownership(
     runtime: &SidecarRuntimeConfig,
 ) -> RetrievalStatusReport {
     report.ownership = Some(runtime.ownership());
-    report.embedding_launch = read_sidecar_state(&runtime.layout.state_file)
-        .and_then(|state| state.embedding_launch)
-        .or(report.embedding_launch);
+    if let Some(state) = read_sidecar_state(&runtime.layout.state_file) {
+        report.embedding_launch = state.embedding_launch.or(report.embedding_launch);
+        report.sidecar_images = state.sidecar_images;
+    }
     report
 }
 

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -10,7 +10,7 @@ name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}
 
 services:
   qdrant:
-    image: qdrant/qdrant:v1.12.5
+    image: qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-qdrant
     restart: unless-stopped
     labels:
@@ -27,7 +27,7 @@ services:
 
   # Zoekt webserver (mount index dir populated by `retrieval index`).
   zoekt:
-    image: sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4
+    image: sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4@sha256:34c77a62bcafc41ce3ee193e44f42aa84690d9ec51b953e7efae4dfdfae80aff
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-zoekt
     restart: unless-stopped
     labels:
@@ -44,7 +44,7 @@ services:
   # BAAI/bge-base-en-v1.5 embeddings via llama.cpp OpenAI-compatible API (768-dim).
   # Model GGUF must exist under CODESTORY_EMBED_MODEL_DIR (see setup-retrieval-env.mjs).
   embed:
-    image: ghcr.io/ggml-org/llama.cpp:server
+    image: ghcr.io/ggml-org/llama.cpp:server@sha256:f16ca66f3ba316b7a7a16003ddfa88d29c3404fbe86550da086736864c11574c
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-embed
     restart: unless-stopped
     labels:

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -302,13 +302,31 @@ sidecar implementation, CI policy, retention behavior, or promotion gates.
 
 ### Version pins
 
-| Dependency | Pin policy | Pinned version | Notes |
-|------------|------------|----------------|-------|
-| Zoekt real | `COMPOSE_PROFILES=real` | `zoekt-20250506123554` | `sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4` plus lexical shards |
-| Qdrant | Fixed container image tag | `qdrant/qdrant:v1.12.5` | HTTP `6333`, gRPC `6334` |
+| Dependency | Pin policy | Pinned identity | Notes |
+|------------|------------|-----------------|-------|
+| Zoekt real | `COMPOSE_PROFILES=real` plus digest-pinned image | `zoekt-20250506123554`; `sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4@sha256:34c77a62bcafc41ce3ee193e44f42aa84690d9ec51b953e7efae4dfdfae80aff` | Lexical shards still live under the sidecar generation |
+| Qdrant | Digest-pinned container image | `qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae` | HTTP `6333`, gRPC `6334` |
+| llama.cpp embed | Digest-pinned container image | `ghcr.io/ggml-org/llama.cpp:server@sha256:f16ca66f3ba316b7a7a16003ddfa88d29c3404fbe86550da086736864c11574c` | Used only when the embedding launch mode is Docker Compose |
 | SCIP | CodeStory graph artifact emitter | `graph-<hash>` | Generated local graph artifacts under the sidecar generation |
 
 CI `retrieval-sidecar-smoke` should use the same pins as local development.
+`retrieval bootstrap --format json`, `retrieval status --format json`, and the
+sidecar state file expose `sidecar_images` so smoke artifacts record the exact
+image identities used for packet/search readiness.
+
+To refresh an image pin safely:
+
+1. Inspect the candidate tag with Docker manifest tooling, for example
+   `docker buildx imagetools inspect qdrant/qdrant:v1.12.5`.
+2. Copy the top-level `Digest:` value for multi-arch images or the manifest
+   digest for single-manifest images.
+3. Update `docker/retrieval-compose.yml`,
+   `crates/codestory-retrieval/src/config.rs`, this table, and any manual
+   fallback command that names the image.
+4. Run `docker compose -f docker/retrieval-compose.yml config`,
+   `cargo test -p codestory-retrieval`, `cargo test -p codestory-cli --test
+   retrieval_bootstrap_contracts`, and the `retrieval-sidecar-smoke` workflow
+   before treating packet/search evidence as refreshed.
 
 ### Manifest and generation contract
 

--- a/scripts/setup-retrieval-env.mjs
+++ b/scripts/setup-retrieval-env.mjs
@@ -211,7 +211,7 @@ function printPrereqReport(opts) {
     console.log("\nManual Qdrant without compose:");
     console.log(
       `  docker run -d --name codestory-qdrant -p 127.0.0.1:6333:6333 -p 127.0.0.1:6334:6334 ` +
-        `-v "${path.join(cacheRoot, "qdrant")}:/qdrant/storage" qdrant/qdrant:v1.12.5`,
+        `-v "${path.join(cacheRoot, "qdrant")}:/qdrant/storage" qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae`,
     );
     console.log("\nZoekt without compose:");
     console.log("  run sourcegraph/zoekt-webserver on 127.0.0.1:6070 with the CodeStory shard directory mounted");


### PR DESCRIPTION
## Context

Closes #689
Refs #683

Retrieval sidecar smoke evidence was still tied to mutable image tags even though packet/search readiness depends on the exact sidecar runtime. This pins the declared sidecar image identities and records them in the status surfaces reviewers already inspect.

```mermaid
flowchart LR
  Compose["docker/retrieval-compose.yml"] --> Pins["codestory-retrieval image pins"]
  Pins --> State["sidecar state file"]
  State --> Bootstrap["retrieval bootstrap JSON/markdown"]
  State --> Status["retrieval status JSON/markdown"]
  Status --> Evidence["packet/search readiness evidence"]
```

## What Changed

- Digest-pinned Qdrant, Zoekt, and llama.cpp sidecar image refs in the bundled compose file, retrieval constants, and manual Qdrant fallback text.
- Added `sidecar_images` to sidecar state and retrieval status so bootstrap/status JSON and markdown report the exact declared pins.
- Added regression coverage that bundled compose contains digest pins and CLI status/bootstrap output exposes digest-qualified image refs.
- Updated the sidecar ops docs with digest-pinned identities and a safe refresh recipe.

## How To Review

- Confirm the three image refs use `repo:tag@sha256:<digest>` consistently across `docker/retrieval-compose.yml`, `config.rs`, and docs.
- Check the `sidecar_images` field path from state creation through `retrieval bootstrap`, `retrieval status`, and `sidecar status`.
- Review the tests added around compose pin consistency and CLI evidence surfaces.

## Verification

- `docker buildx imagetools inspect qdrant/qdrant:v1.12.5`
- `docker buildx imagetools inspect sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4`
- `docker buildx imagetools inspect ghcr.io/ggml-org/llama.cpp:server`
- `docker compose -f docker/retrieval-compose.yml config`
- `cargo test -p codestory-retrieval`
- `cargo check -p codestory-cli`
- `cargo test -p codestory-cli --bin codestory-cli --no-run`
- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts -- --nocapture`
- `cargo test -p codestory-cli --test sidecar_status_cli -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`
- Independent reviewer found one bin-test fixture compile gap; fixed by adding `sidecar_images` to the `RetrievalStatusReport` fixture and verified with `cargo test -p codestory-cli --bin codestory-cli --no-run`.

## Risk

Live sidecar container startup was not run in this lane. The digest refs resolve through registry inspection and Docker Compose accepts the rendered config, but runtime pull/start behavior remains covered by CI/live smoke rather than a local container start here.