### PR TITLE
Reduce packet/search sidecar cache contention

### DIFF
--- a/crates/codestory-retrieval/src/cache.rs
+++ b/crates/codestory-retrieval/src/cache.rs
@@ -45,7 +45,7 @@ const DEFAULT_RETRIEVAL_CACHE_CAPACITY: usize = 128;
 /// Entries are safe only for the manifest identity captured by [`RetrievalCacheKey`]. Cache
 /// rehydration across worktrees must invalidate copied retrieval manifests before this cache is
 /// trusted again.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RetrievalCache {
     entries: HashMap<RetrievalCacheKey, Vec<super::CandidateHit>>,
     order: VecDeque<RetrievalCacheKey>,
@@ -86,6 +86,19 @@ impl RetrievalCache {
                 break;
             };
             self.entries.remove(&evicted);
+        }
+    }
+
+    pub fn merge_delta_from(&mut self, baseline: &RetrievalCache, other: RetrievalCache) {
+        let RetrievalCache { entries, order, .. } = other;
+        for key in order {
+            let Some(hits) = entries.get(&key) else {
+                continue;
+            };
+            if baseline.entries.get(&key) == Some(hits) {
+                continue;
+            }
+            self.insert(key, hits.clone());
         }
     }
 
@@ -164,6 +177,57 @@ mod tests {
         assert!(cache.get(&first).is_none());
         assert_eq!(
             cache.get(&second).expect("second entry should remain")[0].file_path,
+            "src/second.rs"
+        );
+    }
+
+    #[test]
+    fn merge_delta_from_does_not_replay_snapshot_entries() {
+        let first = RetrievalCacheKey {
+            project_id: "abc".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_abc".into(),
+            scip_revision: None,
+            sidecar_generation: Some("abc-hash".into()),
+            sidecar_input_hash: Some("hash".into()),
+            sidecar_schema_version: Some(1),
+            projection_count: Some(1),
+            query_fingerprint: "first".into(),
+        };
+        let second = RetrievalCacheKey {
+            query_fingerprint: "second".into(),
+            ..first.clone()
+        };
+
+        let mut target = RetrievalCache::with_capacity(1);
+        target.insert(
+            first.clone(),
+            vec![super::super::CandidateHit::lexical_stub(
+                "src/first.rs",
+                1.0,
+            )],
+        );
+        let baseline = target.clone();
+
+        let mut newer_worker = baseline.clone();
+        newer_worker.insert(
+            second.clone(),
+            vec![super::super::CandidateHit::lexical_stub(
+                "src/second.rs",
+                1.0,
+            )],
+        );
+        target.merge_delta_from(&baseline, newer_worker);
+        assert_eq!(
+            target.get(&second).expect("newer entry should remain")[0].file_path,
+            "src/second.rs"
+        );
+
+        target.merge_delta_from(&baseline, baseline.clone());
+
+        assert!(target.get(&first).is_none());
+        assert_eq!(
+            target.get(&second).expect("stale snapshot must not replay")[0].file_path,
             "src/second.rs"
         );
     }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -313,6 +313,23 @@ fn sidecar_packet_batch_budget_ms(latency_budget_ms: Option<u32>) -> u64 {
         .clamp(100, MAX_PACKET_BATCH_BUDGET_MS)
 }
 
+fn with_detached_sidecar_query_cache<T>(
+    controller: &AppController,
+    work: impl FnOnce(&mut codestory_retrieval::RetrievalCache) -> T,
+) -> T {
+    let (generation, mut cache) = {
+        let shared = controller.sidecar_query_cache.lock();
+        shared.snapshot()
+    };
+    let baseline = cache.clone();
+    let result = work(&mut cache);
+    controller
+        .sidecar_query_cache
+        .lock()
+        .merge_if_current(generation, &baseline, cache);
+    result
+}
+
 pub(crate) fn run_sidecar_query(
     controller: &AppController,
     query: &str,
@@ -324,17 +341,18 @@ pub(crate) fn run_sidecar_query(
     let storage_path = controller
         .require_storage_path()
         .map_err(|error| anyhow::anyhow!("storage path required: {}", error.message))?;
-    let mut cache = controller.sidecar_query_cache.lock();
-    execute_retrieval_query_with_cache(
-        QueryRequest {
-            project_root: &project_root,
-            storage_path: &storage_path,
-            query,
-            budget_ms: Some(sidecar_budget_ms(latency_budget_ms)),
-            cancelled: None,
-        },
-        &mut cache,
-    )
+    with_detached_sidecar_query_cache(controller, |cache| {
+        execute_retrieval_query_with_cache(
+            QueryRequest {
+                project_root: &project_root,
+                storage_path: &storage_path,
+                query,
+                budget_ms: Some(sidecar_budget_ms(latency_budget_ms)),
+                cancelled: None,
+            },
+            cache,
+        )
+    })
 }
 
 pub(crate) fn run_sidecar_query_batch(
@@ -354,16 +372,17 @@ pub(crate) fn run_sidecar_query_batch(
             budget_ms: Some(*budget_ms),
         })
         .collect::<Vec<_>>();
-    let mut cache = controller.sidecar_query_cache.lock();
-    execute_strict_retrieval_query_batch_with_cache(
-        QueryBatchRequest {
-            project_root: &project_root,
-            storage_path: &storage_path,
-            queries: &batch_items,
-            cancelled: None,
-        },
-        &mut cache,
-    )
+    with_detached_sidecar_query_cache(controller, |cache| {
+        execute_strict_retrieval_query_batch_with_cache(
+            QueryBatchRequest {
+                project_root: &project_root,
+                storage_path: &storage_path,
+                queries: &batch_items,
+                cancelled: None,
+            },
+            cache,
+        )
+    })
 }
 
 pub(crate) fn maybe_run_retrieval_shadow(
@@ -1473,8 +1492,9 @@ mod tests {
     use crate::agent::packet_evidence::PacketEvidenceTier;
     use codestory_contracts::api::{NodeId, NodeKind as ApiNodeKind, SearchHitOrigin};
     use codestory_retrieval::{
-        CandidateHit, QueryTrace, RetrievalStageKind, StageTrace, classify_query,
-        project_id_for_root, rank_candidates, test_support::retrieval_manifest_fixture,
+        CandidateHit, QueryTrace, RetrievalCacheKey, RetrievalStageKind, StageTrace,
+        classify_query, project_id_for_root, rank_candidates,
+        test_support::retrieval_manifest_fixture,
     };
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -1505,6 +1525,20 @@ mod tests {
         }
     }
 
+    fn retrieval_cache_key_for_test(query_fingerprint: &str) -> RetrievalCacheKey {
+        RetrievalCacheKey {
+            project_id: "abc".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_abc".into(),
+            scip_revision: None,
+            sidecar_generation: Some("abc-hash".into()),
+            sidecar_input_hash: Some("hash".into()),
+            sidecar_schema_version: Some(1),
+            projection_count: Some(1),
+            query_fingerprint: query_fingerprint.into(),
+        }
+    }
+
     #[test]
     fn env_flag_parsing_for_retrieval_rollout() {
         assert!(env_flag_enabled("1"));
@@ -1512,6 +1546,77 @@ mod tests {
         assert!(!env_flag_enabled("0"));
         assert!(env_flag_disabled("off"));
         assert!(!env_flag_disabled("yes"));
+    }
+
+    #[test]
+    fn detached_sidecar_query_cache_does_not_hold_mutex_during_work() {
+        let controller = AppController::new();
+        let first = retrieval_cache_key_for_test("first");
+        let second = retrieval_cache_key_for_test("second");
+        controller.sidecar_query_cache.lock().insert(
+            first.clone(),
+            vec![CandidateHit::lexical_stub("src/first.rs", 1.0)],
+        );
+
+        with_detached_sidecar_query_cache(&controller, |cache| {
+            assert!(
+                controller.sidecar_query_cache.try_lock().is_some(),
+                "sidecar query cache mutex should not be held during retrieval work"
+            );
+            assert_eq!(
+                cache.get(&first).expect("detached cache carries entries")[0].file_path,
+                "src/first.rs"
+            );
+            cache.insert(
+                second.clone(),
+                vec![CandidateHit::lexical_stub("src/second.rs", 1.0)],
+            );
+        });
+
+        let cache = controller.sidecar_query_cache.lock();
+        assert_eq!(
+            cache
+                .get(&first)
+                .expect("original cache entry should merge back")[0]
+                .file_path,
+            "src/first.rs"
+        );
+        assert_eq!(
+            cache
+                .get(&second)
+                .expect("new cache entry should merge back")[0]
+                .file_path,
+            "src/second.rs"
+        );
+    }
+
+    #[test]
+    fn detached_sidecar_query_cache_skips_merge_after_invalidation() {
+        let controller = AppController::new();
+        let first = retrieval_cache_key_for_test("first");
+        let second = retrieval_cache_key_for_test("second");
+        controller.sidecar_query_cache.lock().insert(
+            first.clone(),
+            vec![CandidateHit::lexical_stub("src/first.rs", 1.0)],
+        );
+
+        with_detached_sidecar_query_cache(&controller, |cache| {
+            controller.sidecar_query_cache.lock().clear();
+            cache.insert(
+                second.clone(),
+                vec![CandidateHit::lexical_stub("src/second.rs", 1.0)],
+            );
+        });
+
+        let cache = controller.sidecar_query_cache.lock();
+        assert!(
+            cache.get(&first).is_none(),
+            "clear during detached work should invalidate original entries"
+        );
+        assert!(
+            cache.get(&second).is_none(),
+            "detached entries must not merge after cache invalidation"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -7151,10 +7151,64 @@ fn clear_search_engine(state: &mut AppState) {
 #[derive(Clone)]
 pub struct AppController {
     state: Arc<Mutex<AppState>>,
-    sidecar_query_cache: Arc<Mutex<codestory_retrieval::RetrievalCache>>,
+    sidecar_query_cache: Arc<Mutex<SidecarQueryCacheState>>,
     grounding_detail_refresh: Arc<Mutex<()>>,
     events_tx: Sender<AppEventPayload>,
     events_rx: Receiver<AppEventPayload>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SidecarQueryCacheState {
+    generation: u64,
+    cache: codestory_retrieval::RetrievalCache,
+}
+
+impl SidecarQueryCacheState {
+    fn new() -> Self {
+        Self {
+            generation: 0,
+            cache: codestory_retrieval::RetrievalCache::new(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.cache.clear();
+    }
+
+    pub(crate) fn snapshot(&self) -> (u64, codestory_retrieval::RetrievalCache) {
+        (self.generation, self.cache.clone())
+    }
+
+    pub(crate) fn merge_if_current(
+        &mut self,
+        generation: u64,
+        baseline: &codestory_retrieval::RetrievalCache,
+        cache: codestory_retrieval::RetrievalCache,
+    ) -> bool {
+        if self.generation != generation {
+            return false;
+        }
+        self.cache.merge_delta_from(baseline, cache);
+        true
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert(
+        &mut self,
+        key: codestory_retrieval::RetrievalCacheKey,
+        hits: Vec<codestory_retrieval::CandidateHit>,
+    ) {
+        self.cache.insert(key, hits);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get(
+        &self,
+        key: &codestory_retrieval::RetrievalCacheKey,
+    ) -> Option<&[codestory_retrieval::CandidateHit]> {
+        self.cache.get(key)
+    }
 }
 
 impl Default for AppController {
@@ -7177,7 +7231,7 @@ impl AppController {
                 #[cfg(test)]
                 last_hybrid_instrumentation: None,
             })),
-            sidecar_query_cache: Arc::new(Mutex::new(codestory_retrieval::RetrievalCache::new())),
+            sidecar_query_cache: Arc::new(Mutex::new(SidecarQueryCacheState::new())),
             grounding_detail_refresh: Arc::new(Mutex::new(())),
             events_tx,
             events_rx,


### PR DESCRIPTION
## Context

Closes #691
Refs #683

The audit found packet/search cold-path contention risk in the runtime bridge: `AppController` held the shared sidecar query cache mutex while live retrieval work ran. That serialized packet/search sidecar calls behind one mutex even though the cache itself is small and manifest-scoped.

```mermaid
flowchart LR
  Before["before: lock cache"] --> IO["SCIP / Zoekt / Qdrant work"] --> Release["release lock"]
  Snapshot["after: snapshot cache"] --> Work["sidecar work without cache mutex"] --> Merge["merge new entries if generation is current"]
  Clear["open/index/refresh clear"] --> Gen["generation bump"] --> Drop["drop stale detached writes"]
```

## What Changed

- Wrapped the runtime sidecar query cache in a small generation-tracked state object.
- Changed single-query and batch packet/search paths to clone a small cache snapshot, run retrieval work without holding the controller cache mutex, then merge only entries written during that detached work.
- Kept open/index/refresh invalidation safe by bumping cache generation on `clear()` and dropping detached results if the generation changed.
- Added regression coverage for mutex release during detached work, invalidation during detached work, and the overlapping same-generation stale-snapshot replay/eviction race.

## How To Review

- Start with `crates/codestory-runtime/src/agent/retrieval_primary.rs`: `run_sidecar_query` and `run_sidecar_query_batch` now use `with_detached_sidecar_query_cache`.
- Check `SidecarQueryCacheState` in `crates/codestory-runtime/src/lib.rs` for generation-based invalidation.
- Check `RetrievalCache::merge_delta_from` in `crates/codestory-retrieval/src/cache.rs`; unchanged baseline entries are intentionally not replayed into the shared cache.

## Verification

- `cargo test -p codestory-retrieval cache --lib`
- `cargo test -p codestory-runtime retrieval_primary --lib`
- `cargo test -p codestory-cli --test packet_search_eval`
- `cargo check -p codestory-runtime`
- `cargo check -p codestory-cli`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p codestory-retrieval` passed before the final delta-writeback adjustment; the post-adjustment focused cache tests cover the changed retrieval-cache behavior.
- `cargo test -p codestory-runtime` passed before the final delta-writeback adjustment; the post-adjustment `retrieval_primary` group covers the changed runtime bridge behavior.
- Agent-profile measurement gate on this checkout: `retrieval status --profile agent --run-id issue-691` reported `retrieval_mode=unavailable` with `sidecar_manifest_stale`; packet/search both failed closed in about 6.8-6.9s on that same readiness blocker.
- Independent reviewer found a same-generation stale-snapshot replay race in the first implementation; fixed with delta-only writeback and re-reviewed with no findings.

## Risk

Live full-sidecar contention improvement is not measured in this lane because agent packet/search readiness is currently blocked by stale sidecar manifests. The intended full-sidecar before/after harness is `scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode both` after `retrieval_mode=full` is restored for the selected agent run id.

Duplicate in-flight misses for the same query remain possible under concurrency, but results stay manifest-keyed and no longer serialize all live sidecar I/O on the shared cache mutex.