### PR TITLE
Prune packet evidence candidate wrapper

### DIFF
--- a/crates/codestory-cli/tests/fixtures/packet_search_eval/production_packet_search_fixtures.json
+++ b/crates/codestory-cli/tests/fixtures/packet_search_eval/production_packet_search_fixtures.json
@@ -46,7 +46,7 @@
         ],
         "anchors": [
           "decorate_search_hit_evidence",
-          "evidence_candidate_from_hit"
+          "evidence_tier_for_hit"
         ]
       },
       "provenance": {

--- a/crates/codestory-cli/tests/packet_search_eval.rs
+++ b/crates/codestory-cli/tests/packet_search_eval.rs
@@ -449,11 +449,10 @@ fn packet_search_eval_baseline_scores_full_mode_category_breakdowns() {
                 "append_search_evidence_packet".to_string(),
                 "decorate_search_hit_evidence".to_string(),
             ],
-            packet_text: "decorate_search_hit_evidence uses evidence_candidate_from_hit"
-                .to_string(),
+            packet_text: "decorate_search_hit_evidence uses evidence_tier_for_hit".to_string(),
             anchor_offsets: BTreeMap::from([
-                ("decorate_search_hit_evidence".to_string(), 5),
-                ("evidence_candidate_from_hit".to_string(), 40),
+                ("decorate_search_hit_evidence".to_string(), 0),
+                ("evidence_tier_for_hit".to_string(), 34),
             ]),
         },
     ];

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -13,45 +13,16 @@ const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
 pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
 pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
 
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub(crate) struct EvidenceCandidate {
-    pub display_name: String,
-    pub path: Option<String>,
-    pub node_id: Option<String>,
-    pub tier: PacketEvidenceTier,
-    pub resolution: PacketEvidenceResolution,
-    pub producer: String,
-    pub score: f32,
-    pub loss_reason: Option<String>,
-}
-
-pub(crate) fn evidence_candidate_from_hit(hit: &SearchHit) -> EvidenceCandidate {
-    EvidenceCandidate {
-        display_name: hit.display_name.clone(),
-        path: hit.file_path.clone(),
-        node_id: Some(hit.node_id.0.clone()),
-        tier: evidence_tier_for_hit(hit),
-        resolution: evidence_resolution_for_hit(hit),
-        producer: evidence_producer_for_hit(hit),
-        score: hit.score,
-        loss_reason: hit.loss_reason.clone(),
-    }
-}
-
 pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
-    let candidate = evidence_candidate_from_hit(hit);
     let diagnostic_source_proof = hit_is_diagnostic_source_proof(hit);
-    hit.evidence_tier = Some(candidate.tier);
-    hit.evidence_producer = Some(candidate.producer);
-    hit.resolution_status = Some(candidate.resolution);
-    if hit.loss_reason.is_none() {
-        hit.loss_reason = candidate.loss_reason;
-    }
-    hit.eligible_for_sufficiency = Some(
-        !diagnostic_source_proof
-            && evidence_is_sufficiency_eligible(candidate.tier, candidate.resolution),
-    );
+    let tier = evidence_tier_for_hit(hit);
+    let resolution = evidence_resolution_for_hit(hit);
+    let producer = evidence_producer_for_hit(hit);
+    hit.evidence_tier = Some(tier);
+    hit.evidence_producer = Some(producer);
+    hit.resolution_status = Some(resolution);
+    hit.eligible_for_sufficiency =
+        Some(!diagnostic_source_proof && evidence_is_sufficiency_eligible(tier, resolution));
 }
 
 pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &SearchHit) {


### PR DESCRIPTION
## Context

Audit follow-up #692 asks for small, mechanical cleanup of confirmed-dead code without mixing in behavioral fixes. The packet evidence module still carried a private `EvidenceCandidate` wrapper that only existed to shuttle values from `SearchHit` back onto the same hit.

## What Changed

- Removed the private `EvidenceCandidate` struct and `evidence_candidate_from_hit` helper from `packet_evidence.rs`.
- Kept `decorate_search_hit_evidence` behavior by computing tier, resolution, and producer directly before assigning the same fields.
- Updated the packet/search production eval fixture and synthetic scoring test to anchor on surviving production code, `evidence_tier_for_hit`, instead of the deleted helper.

```mermaid
flowchart LR
    A["SearchHit"] --> B["decorate_search_hit_evidence"]
    B --> C["evidence_tier_for_hit"]
    B --> D["evidence_resolution_for_hit"]
    B --> E["evidence_producer_for_hit"]
    C --> F["decorated hit"]
    D --> F
    E --> F
```

## How To Review

1. Check `crates/codestory-runtime/src/agent/packet_evidence.rs` and confirm the deleted wrapper had no external API surface.
2. Confirm `decorate_search_hit_evidence` still assigns the same tier, resolution, producer, and sufficiency values.
3. Check the `packet-anchor-placement` eval fixture update and confirm it now references an existing helper in the same production path.

## Verification

- `cargo test -p codestory-cli --test packet_search_eval`  
  - 9 passed, 1 ignored live full-sidecar eval.
- `cargo test -p codestory-runtime packet_evidence --lib`  
  - 9 passed.
- `cargo check -p codestory-runtime`
- `cargo check -p codestory-cli`
- `cargo fmt --check`
- `git diff --check`
- Independent review: first pass found the stale eval anchor; after the fixture/test update, second pass reported no correctness findings.

## Risk

Low. This removes a private wrapper and updates eval anchors to a surviving symbol. No public API or retrieval behavior is intended to change.

The live packet/search eval remains ignored unless this checkout has `retrieval_mode=full` sidecars, so this PR proves the checked-in eval harness and focused packet evidence behavior rather than live sidecar quality.

Closes #692
Refs #683
