### PR TITLE
[codex] Fix plugin MCP project root

### DIFF
--- a/plugins/codestory/.mcp.json
+++ b/plugins/codestory/.mcp.json
@@ -3,6 +3,7 @@
     "codestory": {
       "command": "node",
       "args": ["./scripts/codestory-mcp.cjs"],
+      "cwd": ".",
       "tool_timeout_sec": 300
     }
   }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -14,6 +14,7 @@ const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codesto
 const fallbackBinaryNames = process.platform === 'win32'
   ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
   : ['codestory-cli'];
+const activeStateFile = '.codestory-active';
 const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
@@ -90,6 +91,83 @@ function pluginDataDir() {
 
 function sidecarPolicyPath(dataDir = pluginDataDir()) {
   return dataDir ? path.join(dataDir, 'sidecar-setup-policy.json') : null;
+}
+
+function activeStatePath(dataDir = pluginDataDir()) {
+  return dataDir ? path.join(dataDir, activeStateFile) : null;
+}
+
+function normalizeProjectRoot(projectRoot) {
+  const resolved = path.resolve(projectRoot);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function existingProjectRoot(projectRoot) {
+  if (!projectRoot || typeof projectRoot !== 'string' || !projectRoot.trim()) return null;
+  const normalized = normalizeProjectRoot(projectRoot);
+  try {
+    return fs.statSync(normalized).isDirectory() ? normalized : null;
+  } catch {
+    return null;
+  }
+}
+
+function activeProjectStateMaxAgeMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60 * 60 * 1000;
+}
+
+function activeProjectStateTimestamp(active, statePath) {
+  const parsed = Date.parse(active?.updatedAt || active?.updated_at || '');
+  if (Number.isFinite(parsed)) return parsed;
+  try {
+    return fs.statSync(statePath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function activeProjectStateFresh(active, statePath, nowMs = Date.now()) {
+  const timestamp = activeProjectStateTimestamp(active, statePath);
+  return timestamp !== null && nowMs - timestamp <= activeProjectStateMaxAgeMs();
+}
+
+function resolveProjectRoot(options = {}) {
+  const explicit = existingProjectRoot(options.projectRoot || process.env.CODESTORY_PROJECT_ROOT);
+  if (explicit) {
+    return { projectRoot: explicit, source: options.projectRoot ? 'argument' : 'env' };
+  }
+
+  const cwd = existingProjectRoot(process.cwd());
+  if (cwd && !samePathText(cwd, pluginRoot)) {
+    return { projectRoot: cwd, source: 'process_cwd' };
+  }
+
+  const statePath = activeStatePath();
+  const active = statePath ? readJson(statePath) : null;
+  if (active && !activeProjectStateFresh(active, statePath)) {
+    return {
+      projectRoot: null,
+      source: 'plugin_active_state_stale',
+      statePath,
+      reason: 'project_root_unavailable',
+    };
+  }
+  const activeRoot = existingProjectRoot(active?.cwd);
+  if (activeRoot && !samePathText(activeRoot, pluginRoot)) {
+    return { projectRoot: activeRoot, source: 'plugin_active_state', statePath };
+  }
+
+  return {
+    projectRoot: null,
+    source: statePath ? 'plugin_active_state_missing' : 'plugin_data_missing',
+    statePath,
+    reason: 'project_root_unavailable',
+  };
 }
 
 function sidecarPolicyCommand(action, policyFile = sidecarPolicyPath()) {
@@ -588,6 +666,7 @@ function runLocalNavigationWaitFresh(resolved, projectRoot) {
   const args = ['ready', '--goal', 'local', '--wait-fresh'];
   args.push('--project', projectRoot, '--format', 'json');
   const result = spawnSync(resolved.path, args, {
+    cwd: projectRoot,
     encoding: 'utf8',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     timeout: localWaitFreshTimeoutMs(),
@@ -602,6 +681,7 @@ function runSidecarStartupRepair(resolved, sidecarStatus, projectRoot = process.
   const args = ['ready', '--goal', 'agent', '--repair'];
   args.push('--project', projectRoot, '--format', 'json', '--run-id', sharedAgentRunId);
   const result = spawnSync(resolved.path, args, {
+    cwd: projectRoot,
     encoding: 'utf8',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     timeout: sidecarRepairTimeoutMs(),
@@ -768,7 +848,7 @@ function pluginRuntimeForResolved(resolved) {
 }
 
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {
-  const projectRoot = options.projectRoot || process.cwd();
+  const projectRoot = Object.hasOwn(options, 'projectRoot') ? options.projectRoot : process.cwd();
   const pathCandidates = pathCliCandidates().map((candidate) => ({
     path: candidate,
     version: cliVersion(candidate),
@@ -856,6 +936,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     },
     warnings: plugin.warnings,
     project_root: projectRoot,
+    project_root_source: options.projectRootSource || null,
     retrieval_mode: 'unavailable',
     degraded_reason: reason,
     local_refresh: options.localRefresh || null,
@@ -869,7 +950,25 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   };
 }
 
+function projectRootUnavailableDiagnostic(resolved, probe, projectResolution) {
+  return fallbackDiagnostic(resolved, probe, projectResolution.reason, {
+    projectRoot: null,
+    projectRootSource: projectResolution.source,
+    goal: 'project_root',
+    status: 'repair_setup',
+    summary: 'CodeStory plugin MCP could not determine the target project root before starting stdio.',
+    minimumNext: [
+      'Restart/reload the Codex host from the target repo after a lifecycle hook records the active project, then read codestory://status.',
+    ],
+    fullRepair: [
+      'Start or resume the Codex session in the target repo so CodeStory lifecycle hooks can write active project state.',
+      'Restart/reload the Codex host from the target repo, then read codestory://status.',
+    ],
+  });
+}
+
 async function bootstrapStatus(projectRoot = process.cwd()) {
+  projectRoot = normalizeProjectRoot(projectRoot);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
   const probe = probeResolvedCli(resolved);
@@ -923,6 +1022,7 @@ async function bootstrapStatus(projectRoot = process.cwd()) {
     server_version: resolved.version,
     cli_version: probe.version,
     plugin_runtime: plugin,
+    project_root_source: 'argument',
     runtime_truth: runtimeTruthStatus(plugin, repair, {
       sidecarPolicy: sidecarPolicy.state || 'unavailable',
       localRefresh,
@@ -935,14 +1035,26 @@ async function bootstrapStatus(projectRoot = process.cwd()) {
 
 async function handleBootstrapStatusCommand(argv) {
   if (argv[2] !== 'bootstrap-status') return false;
-  const projectRoot = optionValue(argv, '--project') || process.cwd();
+  const resolution = resolveProjectRoot({ projectRoot: optionValue(argv, '--project') });
   try {
+    if (!resolution.projectRoot) {
+      const resolved = await resolveCli();
+      rememberLaunch(resolved);
+      const probe = probeResolvedCli(resolved);
+      process.stdout.write(`${JSON.stringify({
+        ready: false,
+        ...projectRootUnavailableDiagnostic(resolved, probe, resolution),
+      })}\n`);
+      process.exit(0);
+    }
+    const projectRoot = resolution.projectRoot;
     process.stdout.write(`${JSON.stringify(await bootstrapStatus(projectRoot))}\n`);
   } catch (error) {
     process.stdout.write(`${JSON.stringify({
       ready: false,
       degraded_reason: `launcher_error:${error.message}`,
-      project_root: projectRoot,
+      project_root: resolution.projectRoot,
+      project_root_source: resolution.source,
     })}\n`);
   }
   process.exit(0);
@@ -995,6 +1107,7 @@ function dedupePaths(paths) {
 }
 
 function sourceCheckoutVersion(projectRoot) {
+  if (!projectRoot) return null;
   try {
     return cargoPackageVersion(fs.readFileSync(path.join(projectRoot, 'crates', 'codestory-cli', 'Cargo.toml'), 'utf8'));
   } catch {
@@ -1223,14 +1336,25 @@ async function main() {
   const resolved = await resolveCli();
   rememberLaunch(resolved);
   const probe = probeResolvedCli(resolved);
+  const projectResolution = resolveProjectRoot();
   const failOpenReason = failOpenReasonForProbe(resolved, probe);
   if (failOpenReason) {
-    runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason));
+    runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason, {
+      projectRoot: projectResolution.projectRoot,
+      projectRootSource: projectResolution.source,
+    }));
     return;
   }
-  const localReadiness = probeLocalNavigation(resolved);
+  if (!projectResolution.projectRoot) {
+    runFailOpenMcp(projectRootUnavailableDiagnostic(resolved, probe, projectResolution));
+    return;
+  }
+  const projectRoot = projectResolution.projectRoot;
+  const localReadiness = probeLocalNavigation(resolved, projectRoot);
   if (!localReadiness.ready) {
     runFailOpenMcp(fallbackDiagnostic(resolved, probe, localReadiness.reason, {
+      projectRoot,
+      projectRootSource: projectResolution.source,
       status: localReadiness.status,
       summary: localReadiness.summary,
       minimumNext: localReadiness.minimumNext,
@@ -1243,10 +1367,11 @@ async function main() {
     }));
     return;
   }
-  const sidecarStatus = runSidecarStartupRepair(resolved, readSidecarPolicy(), process.cwd());
-  const dirtyMarker = dirtyMarkerEnv(process.cwd());
+  const sidecarStatus = runSidecarStartupRepair(resolved, readSidecarPolicy(), projectRoot);
+  const dirtyMarker = dirtyMarkerEnv(projectRoot);
 
-  const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
+  const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none', '--project', projectRoot], {
+    cwd: projectRoot,
     stdio: 'inherit',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     windowsHide: true,
@@ -1266,12 +1391,14 @@ async function main() {
       CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
       CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
       CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+      CODESTORY_PLUGIN_PROJECT_ROOT: projectRoot,
+      CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE: projectResolution.source,
       CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
       CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
       CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
       CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
       CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
-      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, process.cwd()),
+      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, projectRoot),
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
@@ -1293,7 +1420,10 @@ async function main() {
       version: null,
       stdout: '',
       stderr: '',
-    }, `${resolved.source}_cli_unspawnable`));
+    }, `${resolved.source}_cli_unspawnable`, {
+      projectRoot,
+      projectRootSource: projectResolution.source,
+    }));
   });
 }
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -111,7 +111,7 @@ test("plugin metadata maps skill and direct stdio server", async () => {
   assert.deepEqual(mcp.mcpServers.codestory.args, [
     "./scripts/codestory-mcp.cjs",
   ]);
-  assert.equal(Object.hasOwn(mcp.mcpServers.codestory, "cwd"), false);
+  assert.equal(mcp.mcpServers.codestory.cwd, ".");
 });
 
 test("plugin package version tracks the codestory-cli release version", async () => {
@@ -314,6 +314,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
       "utf8",
     );
+    const realRepoRoot = await realpath(repoRoot);
 
     const result = spawnSync(process.execPath, [launcher], {
       env: {
@@ -341,9 +342,9 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     );
     assert.match(observed.sidecarRepair, /ready --goal agent --repair/u);
     assert.match(observed.sidecarRepair, /--run-id shared-agent/u);
-    assert.equal(observed.dirtyMarkerRoot, await realpath(repoRoot));
-    assert.equal(observed.dirtyMarkerPath, dirtyMarkerPathForProject(repoRoot, dataDir));
-    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+    assert.equal(observed.dirtyMarkerRoot, realRepoRoot);
+    assert.equal(observed.dirtyMarkerPath, dirtyMarkerPathForProject(realRepoRoot, dataDir));
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none", "--project", realRepoRoot]);
 
     const enable = spawnSync(observed.sidecarEnable, {
       shell: true,
@@ -359,6 +360,230 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
     );
     assert.equal(policy.state, "enabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher uses active project state when host launches from plugin root", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-active-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const realRepoRoot = await realpath(repoRoot);
+
+  try {
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({ event: "SessionStart", cwd: realRepoRoot, updatedAt: new Date().toISOString() }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "const command = args[0];",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({",
+        "  cwd: process.cwd(),",
+        "  args,",
+        "  projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '',",
+        "  projectRootSource: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE || '',",
+        "  dirtyMarkerPath: process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH || '',",
+        "  dirtyMarkerRoot: process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT || ''",
+        "}) + '\\n');",
+        "if (command === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (command === 'ready' && args.includes('--wait-fresh') && !args.includes('--repair') && !args.includes('agent')) {",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'ready', summary: 'ready', minimum_next: [], full_repair: [] }], local_refresh: { state: 'fresh', reason: 'already_fresh', blocks_local_surfaces: false, readiness_status: 'ready', changed_file_count: 0, new_file_count: 0, removed_file_count: 0, fatal_error_count: 0 } }));",
+        "  process.exit(0);",
+        "}",
+        "if (command === 'serve') { fs.writeFileSync(process.env.TEST_OUT, 'serve-called'); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      encoding: "utf8",
+      timeout: 15000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(await readFile(marker, "utf8"), "serve-called");
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    const ready = calls.find((call) => call.args[0] === "ready" && call.args.includes("--wait-fresh"));
+    const serve = calls.find((call) => call.args[0] === "serve");
+    assert.ok(ready, "expected local wait-fresh call");
+    assert.ok(serve, "expected serve call");
+    assert.equal(ready.args[ready.args.indexOf("--project") + 1], realRepoRoot);
+    assert.equal(ready.cwd, realRepoRoot);
+    assert.deepEqual(serve.args, ["serve", "--stdio", "--refresh", "none", "--project", realRepoRoot]);
+    assert.equal(serve.cwd, realRepoRoot);
+    assert.equal(serve.projectRoot, realRepoRoot);
+    assert.equal(serve.projectRootSource, "plugin_active_state");
+    assert.equal(serve.dirtyMarkerRoot, realRepoRoot);
+    assert.equal(serve.dirtyMarkerPath, dirtyMarkerPathForProject(realRepoRoot, dataDir));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher rejects stale active project state from plugin root", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-stale-active-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({ event: "SessionStart", cwd: await realpath(repoRoot), updatedAt: "2000-01-01T00:00:00.000Z" }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd() }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_stale");
+    assert.equal(status.readiness[0].goal, "project_root");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap-status fails open when plugin-root launch lacks project state", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-bootstrap-no-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+
+  try {
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd() }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher, "bootstrap-status"], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const status = JSON.parse(result.stdout.trim());
+    assert.equal(status.ready, false);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_missing");
+    assert.equal(status.readiness[0].goal, "project_root");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -586,8 +811,16 @@ test("mcp launcher waits for fresh local navigation without agent repair", async
     assert.equal(calls.some((call) => call.args.includes("agent")), false);
     assert.equal(calls.some((call) => call.args.includes("--repair")), false);
     assert.equal(calls.some((call) => call.sidecarRepair), false);
+    const realDataDir = await realpath(dataDir);
     assert.ok(calls.some((call) => {
-      return JSON.stringify(call.args) === JSON.stringify(["serve", "--stdio", "--refresh", "none"]);
+      return JSON.stringify(call.args) === JSON.stringify([
+        "serve",
+        "--stdio",
+        "--refresh",
+        "none",
+        "--project",
+        realDataDir,
+      ]);
     }));
   } finally {
     await rm(dataDir, { recursive: true, force: true });
@@ -945,6 +1178,7 @@ test("enabled sidecar policy runs one agent repair at MCP startup", async () => 
     const text = await readFile(logFile, "utf8");
     const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
     const repairCalls = calls.filter((call) => call.repair);
+    const realRepoRoot = await realpath(repoRoot);
     assert.equal(repairCalls.length, 1, text);
     assert.equal(repairCalls[0].policy, "enabled");
     assert.deepEqual(repairCalls[0].args, [
@@ -953,18 +1187,25 @@ test("enabled sidecar policy runs one agent repair at MCP startup", async () => 
       "agent",
       "--repair",
       "--project",
-      repoRoot,
+      realRepoRoot,
       "--format",
       "json",
       "--run-id",
       "shared-agent",
     ]);
     assert.ok(calls.some((call) => {
-      return JSON.stringify(call.args) === JSON.stringify(["serve", "--stdio", "--refresh", "none"]);
+      return JSON.stringify(call.args) === JSON.stringify([
+        "serve",
+        "--stdio",
+        "--refresh",
+        "none",
+        "--project",
+        realRepoRoot,
+      ]);
     }), text);
     const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
     assert.equal(policy.last_repair.state, "completed");
-    assert.equal(policy.last_repair.project_root, repoRoot);
+    assert.equal(policy.last_repair.project_root, realRepoRoot);
     assert.match(policy.last_repair.command, /ready --goal agent --repair/u);
     assert.match(policy.last_repair.command, /--run-id shared-agent/u);
   } finally {
@@ -1021,6 +1262,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
 
     assert.equal(result.status, 0, result.stderr);
     const observed = JSON.parse(await readFile(outFile, "utf8"));
+    const realRepoRoot = await realpath(repoRoot);
     assert.equal(observed.source, "managed");
     assert.equal(observed.version, version);
     assert.equal(observed.repoRef, `v${version}`);
@@ -1030,7 +1272,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
       observed.path,
       new RegExp(String.raw`codestory-cli[\\/]+${version.replaceAll(".", String.raw`\.`)}[\\/]bin[\\/]codestory-cli`, "u"),
     );
-    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none", "--project", realRepoRoot]);
 
     const manifest = JSON.parse(
       await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),


### PR DESCRIPTION
## Context

The CodeStory plugin MCP config launched `node ./scripts/codestory-mcp.cjs` without a package-relative cwd. In Codex, that made a fresh model-visible MCP launch depend on the caller workspace containing `./scripts/codestory-mcp.cjs`, which fails for normal repo sessions.

The first obvious fix, setting `cwd: "."`, is not enough by itself because the launcher also used `process.cwd()` as the target project. This PR makes plugin-root launch safe without grounding the plugin cache or stale project state.

Closes #704
Refs #618

## What Changed

- Set the plugin MCP server `cwd` to `.` so relative `./scripts/codestory-mcp.cjs` resolves from the installed plugin package.
- Added launcher project-root resolution:
  - explicit `--project` / `CODESTORY_PROJECT_ROOT`
  - non-plugin `process.cwd()`
  - fresh hook-written `.codestory-active.cwd` from plugin data when Codex launches from the plugin root
  - diagnostic fail-open when no real project root is available
- Reject stale `.codestory-active` state before using it as a project root.
- Threaded the resolved project root through local wait-fresh, sidecar startup repair, dirty marker env, fail-open status, `bootstrap-status`, and the spawned stdio server.
- Spawn `codestory-cli serve --stdio --refresh none --project <project>` with `cwd` set to the real project root.
- Added regression coverage for:
  - installed-host shape where launcher cwd is the plugin root and active state points at the repo
  - stale active state failing open instead of targeting an old repo
  - `bootstrap-status` failing open when plugin-root launch lacks project state

```mermaid
flowchart LR
  A[Codex launches plugin MCP] --> B[Plugin cwd]
  B --> C[Resolve project root]
  C --> D{Fresh root found?}
  D -- yes --> E[wait-fresh / repair / serve use repo root]
  D -- no --> F[fail-open status: project_root_unavailable]
```

## How To Review

1. Check `plugins/codestory/.mcp.json` first: it now uses package-relative cwd.
2. Review `resolveProjectRoot` in `plugins/codestory/scripts/codestory-mcp.cjs`; the important guard is that plugin-root cwd and stale active state do not become the project root.
3. Review the new launcher tests around active project state, stale active state, and `bootstrap-status` missing-root behavior.

## Verification

- `node --test --test-name-pattern "active project|stale active|bootstrap-status|plugin metadata" plugins\codestory\tests\plugin-static.test.mjs`
- `node --test plugins\codestory\tests\plugin-static.test.mjs` (41/41 pass)
- `git diff --check`

## Risk

- This relies on lifecycle hooks having written fresh `.codestory-active` state when Codex launches the MCP from the plugin package. If that state is stale or unavailable, the launcher now fails open with `project_root_unavailable` rather than silently grounding the plugin package or an old repo.
- This PR fixes source/package behavior; #618 still needs fresh installed-plugin readback after merge/release before claiming the live model-visible runtime is fully repaired.
