### PR TITLE
[codex] Promote CodeStory v0.12.3

### DIFF
--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -15,6 +15,8 @@ on:
       - crates/codestory-cli/src/args.rs
       - crates/codestory-cli/src/runtime.rs
       - crates/codestory-cli/src/stdio_*.rs
+      - crates/codestory-cli/tests/fixtures/packet_search_eval/**
+      - crates/codestory-cli/tests/packet_search_eval.rs
       - crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
       - crates/codestory-cli/tests/search_json_output.rs
       - crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -43,6 +45,8 @@ on:
       - crates/codestory-cli/src/args.rs
       - crates/codestory-cli/src/runtime.rs
       - crates/codestory-cli/src/stdio_*.rs
+      - crates/codestory-cli/tests/fixtures/packet_search_eval/**
+      - crates/codestory-cli/tests/packet_search_eval.rs
       - crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
       - crates/codestory-cli/tests/search_json_output.rs
       - crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -116,6 +120,9 @@ jobs:
 
       - name: CLI search JSON fail-closed contract tests
         run: cargo test -p codestory-cli --test search_json_output
+
+      - name: Packet/search fixture and baseline contract tests
+        run: cargo test -p codestory-cli --test packet_search_eval
 
       - name: Retrieval crate unit tests
         run: cargo test -p codestory-retrieval

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -19,27 +19,34 @@ uuid = { workspace = true }
 [[bench]]
 name = "indexing"
 harness = false
+bench = false
 
 [[bench]]
 name = "graph_fidelity"
 harness = false
+bench = false
 
 [[bench]]
 name = "resolution_full_scope"
 harness = false
+bench = false
 
 [[bench]]
 name = "ask_latency"
 harness = false
+bench = false
 
 [[bench]]
 name = "grounding"
 harness = false
+bench = false
 
 [[bench]]
 name = "incremental_cleanup"
 harness = false
+bench = false
 
 [[bench]]
 name = "browser_stress"
 harness = false
+bench = false

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -1526,6 +1526,11 @@ pub(crate) struct ServeCommand {
     pub(crate) addr: String,
     #[arg(
         long,
+        help = "Allow HTTP serve to bind and answer non-loopback addresses. Use only behind an intentional network boundary."
+    )]
+    pub(crate) allow_non_loopback: bool,
+    #[arg(
+        long,
         help = "Serve a small MCP-style JSON-lines protocol over stdio instead of HTTP."
     )]
     pub(crate) stdio: bool,

--- a/crates/codestory-cli/src/http_transport.rs
+++ b/crates/codestory-cli/src/http_transport.rs
@@ -6,7 +6,7 @@ use codestory_contracts::api::{
 use std::{
     collections::HashMap,
     io::{Read, Write},
-    net::TcpStream,
+    net::{IpAddr, TcpStream},
     time::Duration,
 };
 
@@ -24,7 +24,22 @@ const BROWSER_REFERENCES_MAX_NODES: u32 = 120;
 pub(crate) const BROWSER_SYMBOLS_DEFAULT_LIMIT: u32 = 300;
 pub(crate) const BROWSER_SYMBOLS_MAX_LIMIT: u32 = 2_000;
 
-pub(crate) fn handle_http_request(runtime: &RuntimeContext, mut stream: TcpStream) -> Result<()> {
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct HttpServePolicy {
+    allow_non_loopback: bool,
+}
+
+impl HttpServePolicy {
+    pub(crate) fn new(allow_non_loopback: bool) -> Self {
+        Self { allow_non_loopback }
+    }
+}
+
+pub(crate) fn handle_http_request(
+    runtime: &RuntimeContext,
+    mut stream: TcpStream,
+    policy: HttpServePolicy,
+) -> Result<()> {
     stream.set_read_timeout(Some(Duration::from_secs(2)))?;
     let mut request_bytes = Vec::with_capacity(1024);
     let mut buffer = [0u8; 1024];
@@ -66,6 +81,10 @@ pub(crate) fn handle_http_request(runtime: &RuntimeContext, mut stream: TcpStrea
     let mut parts = line.split_whitespace();
     let method = parts.next().unwrap_or_default();
     let target = parts.next().unwrap_or("/");
+    let headers = parse_http_headers(&request);
+    if let Some(message) = http_boundary_rejection(&headers, policy) {
+        return write_http_error_json(&mut stream, 403, "forbidden_http_boundary", message);
+    }
     if method != "GET" {
         return write_http_json(
             &mut stream,
@@ -199,6 +218,104 @@ pub(crate) fn handle_http_request(runtime: &RuntimeContext, mut stream: TcpStrea
         }
         _ => write_http_json(&mut stream, 404, &serde_json::json!({"error": "not found"})),
     }
+}
+
+fn parse_http_headers(request: &str) -> Vec<(&str, &str)> {
+    request
+        .lines()
+        .skip(1)
+        .take_while(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim(), value.trim()))
+        })
+        .collect()
+}
+
+fn http_boundary_rejection(headers: &[(&str, &str)], policy: HttpServePolicy) -> Option<String> {
+    if policy.allow_non_loopback {
+        return None;
+    }
+
+    let host_values = http_header_values(headers, "host");
+    if host_values.len() != 1 {
+        return Some(
+            "HTTP serve requires exactly one loopback Host header unless --allow-non-loopback is set."
+                .to_string(),
+        );
+    }
+    let host = host_values[0];
+    if !http_authority_is_loopback(host) {
+        return Some(format!(
+            "Refusing HTTP serve request with non-loopback Host `{host}`. Use 127.0.0.1, localhost, or --allow-non-loopback behind an intentional network boundary."
+        ));
+    }
+
+    for origin in http_header_values(headers, "origin") {
+        if !http_origin_is_loopback(origin) {
+            return Some(format!(
+                "Refusing HTTP serve request with non-loopback Origin `{origin}`. Use a loopback origin or --allow-non-loopback behind an intentional network boundary."
+            ));
+        }
+    }
+
+    None
+}
+
+fn http_header_values<'a>(headers: &'a [(&str, &str)], name: &str) -> Vec<&'a str> {
+    headers
+        .iter()
+        .filter_map(|(header_name, value)| header_name.eq_ignore_ascii_case(name).then_some(*value))
+        .collect()
+}
+
+fn http_origin_is_loopback(origin: &str) -> bool {
+    let origin = origin.trim();
+    let Some(authority_and_path) = origin
+        .strip_prefix("http://")
+        .or_else(|| origin.strip_prefix("https://"))
+    else {
+        return false;
+    };
+    let authority = authority_and_path.split('/').next().unwrap_or_default();
+    http_authority_is_loopback(authority)
+}
+
+fn http_authority_is_loopback(authority: &str) -> bool {
+    let Some(host) = http_authority_host(authority.trim()) else {
+        return false;
+    };
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+fn http_authority_host(authority: &str) -> Option<&str> {
+    if authority.is_empty() {
+        return None;
+    }
+    if let Some(rest) = authority.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let host = &rest[..end];
+        let suffix = &rest[end + 1..];
+        if suffix.is_empty()
+            || suffix
+                .strip_prefix(':')
+                .is_some_and(|port| !port.is_empty() && port.chars().all(|ch| ch.is_ascii_digit()))
+        {
+            return (!host.is_empty()).then_some(host);
+        }
+        return None;
+    }
+    if let Some((host, port)) = authority.rsplit_once(':')
+        && !host.contains(':')
+        && !port.is_empty()
+        && port.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return (!host.is_empty()).then_some(host);
+    }
+    Some(authority)
 }
 
 fn resolve_http_target_from_params(
@@ -352,6 +469,7 @@ fn write_http_json<T: serde::Serialize>(
     let status_text = match status {
         200 => "OK",
         400 => "Bad Request",
+        403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
         _ => "OK",

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -33,7 +33,7 @@ use std::{
     fmt::Write as _,
     fs,
     io::{IsTerminal, Read},
-    net::TcpListener,
+    net::{TcpListener, ToSocketAddrs},
     path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
@@ -10174,6 +10174,9 @@ fn render_affected_footer(
 }
 
 fn run_serve(cmd: ServeCommand) -> Result<()> {
+    if !cmd.stdio {
+        ensure_http_serve_bind_allowed(&cmd.addr, cmd.allow_non_loopback)?;
+    }
     let runtime = new_agent_surface_runtime(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "serve")?;
@@ -10183,10 +10186,11 @@ fn run_serve(cmd: ServeCommand) -> Result<()> {
     let listener = TcpListener::bind(&cmd.addr)
         .with_context(|| format!("Failed to bind server to {}", cmd.addr))?;
     eprintln!("codestory serve listening on http://{}", cmd.addr);
+    let policy = http_transport::HttpServePolicy::new(cmd.allow_non_loopback);
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                if let Err(error) = http_transport::handle_http_request(&runtime, stream) {
+                if let Err(error) = http_transport::handle_http_request(&runtime, stream, policy) {
                     eprintln!("serve request failed: {error:#}");
                 }
             }
@@ -10194,6 +10198,32 @@ fn run_serve(cmd: ServeCommand) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn ensure_http_serve_bind_allowed(addr: &str, allow_non_loopback: bool) -> Result<()> {
+    if allow_non_loopback {
+        return Ok(());
+    }
+
+    let resolved = addr
+        .to_socket_addrs()
+        .with_context(|| format!("Failed to resolve serve address {addr}"))?
+        .collect::<Vec<_>>();
+    if resolved.is_empty() {
+        bail!("Serve address {addr} did not resolve to a socket address");
+    }
+    if resolved
+        .iter()
+        .all(|socket_addr| socket_addr.ip().is_loopback())
+    {
+        return Ok(());
+    }
+
+    bail!(
+        "Refusing to bind HTTP serve to non-loopback address `{addr}` without --allow-non-loopback. \
+serve exposes local graph/search endpoints without request authentication; bind to 127.0.0.1/localhost \
+or rerun with --allow-non-loopback only behind an intentional network boundary."
+    )
 }
 
 fn run_generate_completions(cmd: GenerateCompletionsCommand) -> Result<()> {
@@ -12447,6 +12477,34 @@ mod tests {
             first_index < second_index,
             "expected `{first}` before `{second}` in:\n{markdown}"
         );
+    }
+
+    #[test]
+    fn http_serve_allows_loopback_bind_without_acknowledgement() {
+        ensure_http_serve_bind_allowed("127.0.0.1:3917", false)
+            .expect("ipv4 loopback should be allowed by default");
+        ensure_http_serve_bind_allowed("localhost:3917", false)
+            .expect("localhost should resolve to loopback and stay ergonomic");
+        ensure_http_serve_bind_allowed("[::1]:3917", false)
+            .expect("ipv6 loopback should be allowed by default");
+    }
+
+    #[test]
+    fn http_serve_rejects_non_loopback_bind_without_acknowledgement() {
+        let error = ensure_http_serve_bind_allowed("0.0.0.0:3917", false)
+            .expect_err("wildcard bind should require explicit acknowledgement");
+        let message = error.to_string();
+        assert!(
+            message.contains("--allow-non-loopback")
+                && message.contains("without request authentication"),
+            "unsafe bind error should name the guard and auth boundary: {message}"
+        );
+    }
+
+    #[test]
+    fn http_serve_allows_non_loopback_bind_with_acknowledgement() {
+        ensure_http_serve_bind_allowed("0.0.0.0:3917", true)
+            .expect("explicit acknowledgement should allow intentional remote binds");
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -678,7 +678,7 @@ impl ReadyRepairProgress {
                     continue;
                 }
                 let elapsed = start.elapsed().as_secs();
-                if elapsed % READY_REPAIR_PROGRESS_INTERVAL.as_secs() != 0 {
+                if !elapsed.is_multiple_of(READY_REPAIR_PROGRESS_INTERVAL.as_secs()) {
                     continue;
                 }
                 let phase = *worker_phase.lock().expect("ready repair phase lock");
@@ -2294,25 +2294,24 @@ fn repair_ready_state(
             run_id,
         )
     });
-    if let Some(sidecar) = sidecar.as_ref() {
-        if let Ok(existing_status) = codestory_retrieval::strict_sidecar_status_for_runtime(
+    if let Some(sidecar) = sidecar.as_ref()
+        && let Ok(existing_status) = codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
             Some(&runtime.storage_path),
             sidecar.clone(),
-        ) {
-            if ready_repair_existing_sidecar_is_reusable(&existing_status) {
-                eprintln!(
-                    "ready repair agent sidecar already full: profile=agent run_id={} namespace={} compose_project={} embedding_device_state={} observation_source={} cpu_allowed={}",
-                    sidecar.run_id.as_deref().unwrap_or("none"),
-                    sidecar.namespace,
-                    sidecar.compose_project,
-                    existing_status.embedding_device_state,
-                    existing_status.embedding_device_observation_source,
-                    existing_status.embedding_cpu_allowed
-                );
-                return Ok(Some(sidecar.clone()));
-            }
-        }
+        )
+        && ready_repair_existing_sidecar_is_reusable(&existing_status)
+    {
+        eprintln!(
+            "ready repair agent sidecar already full: profile=agent run_id={} namespace={} compose_project={} embedding_device_state={} observation_source={} cpu_allowed={}",
+            sidecar.run_id.as_deref().unwrap_or("none"),
+            sidecar.namespace,
+            sidecar.compose_project,
+            existing_status.embedding_device_state,
+            existing_status.embedding_device_observation_source,
+            existing_status.embedding_cpu_allowed
+        );
+        return Ok(Some(sidecar.clone()));
     }
 
     let opened = runtime.ensure_open(args::RefreshMode::Auto)?;

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -12590,6 +12590,7 @@ mod tests {
         codestory_retrieval::RetrievalStatusReport {
             retrieval_mode: mode.into(),
             ownership: None,
+            sidecar_images: codestory_retrieval::default_sidecar_image_pins(),
             degraded_reason: reason.map(str::to_string),
             repair: None,
             query_embedding_backend: "llamacpp:bge-base-en-v1.5".into(),

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -333,20 +333,19 @@ fn verdict_state(
                             )
                         })
                         .unwrap_or_default();
-                    let request = sidecar
-                        .embedding_accelerator_requested
-                        .then(|| {
-                            format!(
-                                " accelerator_request=`{}:{}`",
-                                sidecar
-                                    .embedding_accelerator_request_provider
-                                    .unwrap_or("unknown"),
-                                sidecar
-                                    .embedding_accelerator_request_device
-                                    .unwrap_or("unknown")
-                            )
-                        })
-                        .unwrap_or_default();
+                    let request = if sidecar.embedding_accelerator_requested {
+                        format!(
+                            " accelerator_request=`{}:{}`",
+                            sidecar
+                                .embedding_accelerator_request_provider
+                                .unwrap_or("unknown"),
+                            sidecar
+                                .embedding_accelerator_request_device
+                                .unwrap_or("unknown")
+                        )
+                    } else {
+                        String::new()
+                    };
                     let source = sidecar
                         .embedding_device_observation_source
                         .map(|source| format!(" observation_source=`{source}`"))

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -478,6 +478,12 @@ fn emit_retrieval_bootstrap(
             )
         })
         .unwrap_or_default();
+    let sidecar_images_note = format!(
+        "\n- sidecar_images: qdrant=`{}` zoekt=`{}` embed=`{}`",
+        payload.sidecar_state.sidecar_images.qdrant,
+        payload.sidecar_state.sidecar_images.zoekt,
+        payload.sidecar_state.sidecar_images.embed
+    );
     let markdown = format!(
         "# Retrieval bootstrap\n\n- compose_started: {}\n- zoekt_reachable: {} ({})\n- qdrant_reachable: {} ({})\n- embed_reachable: {} ({})\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- retrieval_mode: `{}`\n- storage_repair: protected={} pruned={} invalid_dirs_removed={} stub_markers_migrated={} collections_seen={} overflow_protected={}{overflow_note}{scan_warning}{prune_suppressed_note}",
         payload.compose_started,
@@ -513,7 +519,7 @@ fn emit_retrieval_bootstrap(
     emit(
         format,
         &payload,
-        format!("{markdown}{project_repair_note}"),
+        format!("{markdown}{sidecar_images_note}{project_repair_note}"),
         output_file,
     )
 }
@@ -574,8 +580,12 @@ fn emit_retrieval_status(
             )
         })
         .unwrap_or_default();
+    let sidecar_images_note = format!(
+        "- sidecar_images: qdrant=`{}` zoekt=`{}` embed=`{}`\n",
+        report.sidecar_images.qdrant, report.sidecar_images.zoekt, report.sidecar_images.embed
+    );
     let markdown = format!(
-        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
+        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}{}- zoekt: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
         report.retrieval_mode,
         report.degraded_reason,
         report.query_embedding_backend,
@@ -596,6 +606,7 @@ fn emit_retrieval_status(
         manifest_contract_note,
         repair_note,
         ownership_note,
+        sidecar_images_note,
         report.zoekt.status,
         report.zoekt.detail,
         report.zoekt.capabilities.lexical,

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -83,7 +83,7 @@ pub(crate) fn run_stdio_server(runtime: RuntimeContext) -> Result<()> {
             continue;
         }
         let line = match std::str::from_utf8(&line) {
-            Ok(line) => line.trim_end_matches(&['\r', '\n']),
+            Ok(line) => line.trim_end_matches(['\r', '\n']),
             Err(error) => {
                 let response = stdio_jsonrpc_error(
                     serde_json::Value::Null,

--- a/crates/codestory-cli/tests/fixtures/packet_search_eval/production_packet_search_fixtures.json
+++ b/crates/codestory-cli/tests/fixtures/packet_search_eval/production_packet_search_fixtures.json
@@ -46,7 +46,7 @@
         ],
         "anchors": [
           "decorate_search_hit_evidence",
-          "evidence_candidate_from_hit"
+          "evidence_tier_for_hit"
         ]
       },
       "provenance": {

--- a/crates/codestory-cli/tests/http_transport_contracts.rs
+++ b/crates/codestory-cli/tests/http_transport_contracts.rs
@@ -173,6 +173,38 @@ fn free_local_addr() -> String {
     addr.to_string()
 }
 
+#[test]
+fn http_serve_rejects_non_loopback_addr_before_opening_runtime_state() {
+    let workspace = tempfile::tempdir().expect("workspace dir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    write_deep_rust_workspace(workspace.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+        .arg("serve")
+        .arg("--refresh")
+        .arg("none")
+        .arg("--project")
+        .arg(workspace.path())
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .arg("--addr")
+        .arg("0.0.0.0:0")
+        .env("CODESTORY_EMBED_RUNTIME_MODE", "hash")
+        .output()
+        .expect("run serve");
+    assert!(
+        !output.status.success(),
+        "non-loopback serve should be rejected without an acknowledgement flag"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--allow-non-loopback")
+            && stderr.contains("without request authentication")
+            && !stderr.contains("index not ready"),
+        "serve should fail at the bind guard before opening cache/index state:\n{stderr}"
+    );
+}
+
 fn spawn_http_server(fixture: &HttpFixture) -> (HttpServer, String) {
     let addr = free_local_addr();
     let child = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
@@ -218,11 +250,20 @@ struct HttpResponse {
 }
 
 fn http_get(addr: &str, target: &str) -> std::io::Result<HttpResponse> {
+    http_get_with_headers(addr, target, &[("Host", addr)])
+}
+
+fn http_get_with_headers(
+    addr: &str,
+    target: &str,
+    headers: &[(&str, &str)],
+) -> std::io::Result<HttpResponse> {
     let mut stream = TcpStream::connect(addr)?;
-    write!(
-        stream,
-        "GET {target} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
-    )?;
+    write!(stream, "GET {target} HTTP/1.1\r\n")?;
+    for (name, value) in headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
+    write!(stream, "Connection: close\r\n\r\n")?;
     stream.flush()?;
     stream.shutdown(Shutdown::Write)?;
 
@@ -255,6 +296,82 @@ fn http_get(addr: &str, target: &str) -> std::io::Result<HttpResponse> {
     let body = serde_json::from_str(body.trim())
         .unwrap_or_else(|error| panic!("HTTP body should be JSON: {error}\n{body}"));
     Ok(HttpResponse { status, body })
+}
+
+#[test]
+fn http_serve_rejects_non_loopback_host_and_origin_headers() {
+    let fixture = indexed_fixture();
+    let (_server, addr) = spawn_http_server(&fixture);
+
+    let bad_host = http_get_with_headers(&addr, "/health", &[("Host", "evil.test:3917")])
+        .expect("bad host response");
+    assert_eq!(bad_host.status, 403);
+    assert_eq!(
+        bad_host.body.pointer("/error/code").and_then(Value::as_str),
+        Some("forbidden_http_boundary"),
+        "non-loopback Host should fail closed: {}",
+        bad_host.body
+    );
+
+    let bad_origin = http_get_with_headers(
+        &addr,
+        "/health",
+        &[("Host", &addr), ("Origin", "http://evil.test:3917")],
+    )
+    .expect("bad origin response");
+    assert_eq!(bad_origin.status, 403);
+    assert_eq!(
+        bad_origin
+            .body
+            .pointer("/error/code")
+            .and_then(Value::as_str),
+        Some("forbidden_http_boundary"),
+        "non-loopback Origin should fail closed: {}",
+        bad_origin.body
+    );
+
+    let malformed_ipv6_host =
+        http_get_with_headers(&addr, "/health", &[("Host", "[::1]evil.test:3917")])
+            .expect("malformed ipv6 host response");
+    assert_eq!(
+        malformed_ipv6_host.status, 403,
+        "malformed bracketed Host should fail closed: {}",
+        malformed_ipv6_host.body
+    );
+
+    let malformed_ipv6_origin = http_get_with_headers(
+        &addr,
+        "/health",
+        &[("Host", &addr), ("Origin", "http://[::1]evil.test:3917")],
+    )
+    .expect("malformed ipv6 origin response");
+    assert_eq!(
+        malformed_ipv6_origin.status, 403,
+        "malformed bracketed Origin should fail closed: {}",
+        malformed_ipv6_origin.body
+    );
+
+    for host in ["localhost:3917", "[::1]:3917"] {
+        let response = http_get_with_headers(&addr, "/health", &[("Host", host)])
+            .unwrap_or_else(|error| panic!("loopback Host {host}: {error}"));
+        assert_eq!(
+            response.status, 200,
+            "loopback Host {host} should stay allowed: {}",
+            response.body
+        );
+    }
+
+    let loopback_origin = http_get_with_headers(
+        &addr,
+        "/health",
+        &[("Host", &addr), ("Origin", "http://localhost:3917")],
+    )
+    .expect("loopback origin response");
+    assert_eq!(
+        loopback_origin.status, 200,
+        "loopback Origin should stay allowed: {}",
+        loopback_origin.body
+    );
 }
 
 fn get_json(addr: &str, target: &str) -> Value {

--- a/crates/codestory-cli/tests/packet_search_eval.rs
+++ b/crates/codestory-cli/tests/packet_search_eval.rs
@@ -449,11 +449,10 @@ fn packet_search_eval_baseline_scores_full_mode_category_breakdowns() {
                 "append_search_evidence_packet".to_string(),
                 "decorate_search_hit_evidence".to_string(),
             ],
-            packet_text: "decorate_search_hit_evidence uses evidence_candidate_from_hit"
-                .to_string(),
+            packet_text: "decorate_search_hit_evidence uses evidence_tier_for_hit".to_string(),
             anchor_offsets: BTreeMap::from([
-                ("decorate_search_hit_evidence".to_string(), 5),
-                ("evidence_candidate_from_hit".to_string(), 40),
+                ("decorate_search_hit_evidence".to_string(), 0),
+                ("evidence_tier_for_hit".to_string(), 34),
             ]),
         },
     ];

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -46,6 +46,18 @@ fn run_down(project: &std::path::Path, extra_args: &[&str]) {
     );
 }
 
+fn assert_digest_image_pins(json: &Value) {
+    for field in ["qdrant", "zoekt", "embed"] {
+        let image = json[field]
+            .as_str()
+            .unwrap_or_else(|| panic!("sidecar_images.{field} should be a string: {json}"));
+        assert!(
+            image.contains("@sha256:"),
+            "sidecar_images.{field} must include a digest pin: {image}"
+        );
+    }
+}
+
 fn create_valid_cache_with_cli(project: &std::path::Path, cache: &std::path::Path) {
     let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
         .args(["index", "--project"])
@@ -113,6 +125,7 @@ fn bootstrap_json_includes_storage_repair_fields() {
         json.get("embed_detail").is_some(),
         "bootstrap output missing embed_detail: {json}"
     );
+    assert_digest_image_pins(&json["sidecar_state"]["sidecar_images"]);
     assert!(repair["scan_errors"].is_array());
     assert!(
         repair["prune_suppressed_reason"].is_null()
@@ -146,11 +159,13 @@ fn bootstrap_then_status_reports_manifest_missing_before_indexing() {
         bootstrap["storage_repair"].is_object(),
         "bootstrap output missing storage repair: {bootstrap}"
     );
+    assert_digest_image_pins(&bootstrap["sidecar_state"]["sidecar_images"]);
 
     let status = run_status(
         project.path(),
         &["--cache-dir", cache_arg, "--format", "json"],
     );
+    assert_digest_image_pins(&status["sidecar_images"]);
     assert_eq!(
         status["degraded_reason"].as_str(),
         Some("retrieval_manifest_missing"),

--- a/crates/codestory-cli/tests/sidecar_status_cli.rs
+++ b/crates/codestory-cli/tests/sidecar_status_cli.rs
@@ -76,6 +76,10 @@ fn sidecar_status_uses_retrieval_status_human_output() {
         stdout.contains("# Retrieval status"),
         "sidecar status should reuse retrieval status output:\n{stdout}"
     );
+    assert!(
+        stdout.contains("sidecar_images:") && stdout.contains("@sha256:"),
+        "sidecar status should expose digest-pinned images:\n{stdout}"
+    );
 }
 
 #[test]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -3821,13 +3821,13 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
         .as_array()
         .unwrap_or_else(|| panic!("stdio search error should include full_repair: {response}"));
     assert!(
-        full_repair.iter().all(
-            |call| call.to_string().contains("\"method\":\"cli\"") == false
+        full_repair
+            .iter()
+            .all(|call| !call.to_string().contains("\"method\":\"cli\"")
                 && call
                     .get("debug_command")
                     .and_then(Value::as_str)
-                    .is_none_or(|text| !text.contains("codestory-cli index"))
-        ),
+                    .is_none_or(|text| !text.contains("codestory-cli index"))),
         "stdio search sidecar errors should not repeat core index repair commands: {response}"
     );
     assert!(

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-indexer/src/cache.rs
+++ b/crates/codestory-indexer/src/cache.rs
@@ -198,7 +198,7 @@ fn has_unportable_embedded_absolute_path(flag: &str) -> bool {
         .iter()
         .any(|prefix| {
             flag.strip_prefix(prefix)
-                .is_some_and(|value| starts_with_absolute_path_like(value))
+                .is_some_and(starts_with_absolute_path_like)
         })
 }
 

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1356,7 +1356,7 @@ impl WorkspaceIndexer {
                 "INSERT OR IGNORE INTO incremental_resolution_touched_file_ids (file_id)
                  VALUES (?1)",
             )?;
-            for file_id in scope_file_ids.iter().copied() {
+            for file_id in scope_file_ids.iter() {
                 insert_touched.execute(rusqlite::params![file_id])?;
             }
         }

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -860,15 +860,26 @@ impl WorkspaceIndexer {
         let processed_count = Arc::new(AtomicUsize::new(0));
         let cancelled = Arc::new(AtomicBool::new(false));
         let root = self.root.clone();
-        let existing_projection_ids = plan.existing_file_ids.clone();
         let existing_projection_setup_started = Instant::now();
+        let existing_projection_ids = plan.existing_file_ids.clone();
+        let existing_projection_file_ids = Self::existing_projection_file_ids(
+            storage,
+            &root,
+            &plan.files_to_index,
+            &existing_projection_ids,
+        )?;
         stats.setup_existing_projection_ids_ms =
             duration_ms_u64(existing_projection_setup_started.elapsed());
 
         let mut replaced_projection_ids = HashSet::new();
         let symbol_seed_started = Instant::now();
         let symbol_table = Arc::new(SymbolTable::new());
-        Self::seed_symbol_table(storage, &symbol_table, plan.mode, &existing_projection_ids)?;
+        Self::seed_symbol_table(
+            storage,
+            &symbol_table,
+            plan.mode,
+            &existing_projection_file_ids,
+        )?;
         stats.setup_seed_symbol_table_ms = duration_ms_u64(symbol_seed_started.elapsed());
 
         // Clone for parallel closure
@@ -923,10 +934,11 @@ impl WorkspaceIndexer {
                 }
 
                 let normalized_path = Self::normalize_index_path(&root, path);
+                let file_id = Self::canonical_file_node_id_for_path(&normalized_path);
                 let existing_projection_id = (plan.mode
                     == codestory_workspace::BuildMode::Incremental)
-                    .then(|| existing_projection_ids.get(&normalized_path).copied())
-                    .flatten();
+                    .then_some(file_id)
+                    .filter(|file_id| existing_projection_file_ids.contains(file_id));
                 match self.prepare_index_work(
                     storage,
                     path,
@@ -1008,7 +1020,7 @@ impl WorkspaceIndexer {
                 all_errors.append(&mut local_storage.errors);
                 if let Some(file_info) = local_storage.files.first()
                     && plan.mode == codestory_workspace::BuildMode::Incremental
-                    && existing_projection_ids.contains_key(&file_info.path)
+                    && existing_projection_file_ids.contains(&file_info.id)
                     && replaced_projection_ids.insert(file_info.id)
                 {
                     let existing_states = storage
@@ -1249,13 +1261,13 @@ impl WorkspaceIndexer {
         storage: &Storage,
         symbol_table: &SymbolTable,
         mode: codestory_workspace::BuildMode,
-        existing_projection_ids: &HashMap<PathBuf, i64>,
+        existing_projection_file_ids: &HashSet<i64>,
     ) -> Result<()> {
         if mode == codestory_workspace::BuildMode::FullRefresh {
             return Ok(());
         }
-        let file_ids = existing_projection_ids
-            .values()
+        let file_ids = existing_projection_file_ids
+            .iter()
             .copied()
             .collect::<Vec<_>>();
         let node_kinds = storage
@@ -1265,6 +1277,39 @@ impl WorkspaceIndexer {
             symbol_table.insert(node_id.0, kind);
         }
         Ok(())
+    }
+
+    fn existing_projection_file_ids(
+        storage: &Storage,
+        root: &Path,
+        files_to_index: &[PathBuf],
+        existing_projection_ids: &HashMap<PathBuf, i64>,
+    ) -> Result<HashSet<i64>> {
+        let mut candidates = existing_projection_ids
+            .values()
+            .copied()
+            .collect::<HashSet<_>>();
+        for path in files_to_index {
+            let full_path = Self::normalize_index_path(root, path);
+            candidates.insert(Self::canonical_file_node_id_for_path(&full_path));
+            if let Ok(canonical) = full_path.canonicalize() {
+                candidates.insert(Self::canonical_file_node_id_for_path(&canonical));
+            }
+        }
+        if candidates.is_empty() {
+            return Ok(HashSet::new());
+        }
+
+        let candidate_ids = candidates.iter().copied().collect::<Vec<_>>();
+        let node_kinds = storage
+            .get_node_kinds_for_files(&candidate_ids)
+            .map_err(|e| anyhow!("Storage file identity lookup error: {:?}", e))?;
+        Ok(node_kinds
+            .into_iter()
+            .filter_map(|(node_id, kind)| {
+                (kind == NodeKind::FILE && candidates.contains(&node_id.0)).then_some(node_id.0)
+            })
+            .collect())
     }
 
     fn collect_touched_file_ids(root: &Path, files_to_index: &[PathBuf]) -> HashSet<i64> {
@@ -1306,9 +1351,21 @@ impl WorkspaceIndexer {
     }
 
     fn canonical_file_node_id_for_path(path: &Path) -> i64 {
-        let file_name = path.to_string_lossy();
+        let file_name = Self::file_identity_path(path);
         let canonical_id = format!("{file_name}:{file_name}:1");
         generate_id(&canonical_id)
+    }
+
+    fn file_identity_path(path: &Path) -> String {
+        #[cfg(windows)]
+        {
+            let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+            path.to_string_lossy().replace('\\', "/").to_lowercase()
+        }
+        #[cfg(not(windows))]
+        {
+            path.to_string_lossy().to_string()
+        }
     }
 
     fn flush_errors(
@@ -1756,6 +1813,7 @@ fn accumulate_flush_breakdown(
 
 pub(crate) fn file_node_from_source(path: &Path, source: &str) -> (Node, String, NodeId) {
     let file_name = path.to_string_lossy().to_string();
+    let file_identity = WorkspaceIndexer::file_identity_path(path);
     let file_id = NodeId(WorkspaceIndexer::canonical_file_node_id_for_path(path));
     let line_count = source.lines().count() as u32;
     let file_end_line = if line_count == 0 { 1 } else { line_count };
@@ -1770,7 +1828,7 @@ pub(crate) fn file_node_from_source(path: &Path, source: &str) -> (Node, String,
         ..Default::default()
     };
 
-    (file_node, file_name, file_id)
+    (file_node, file_identity, file_id)
 }
 
 fn rebase_cached_index_artifact(
@@ -1781,6 +1839,7 @@ fn rebase_cached_index_artifact(
     flags: IndexFeatureFlags,
 ) -> CachedIndexArtifact {
     let file_name = full_path.to_string_lossy().to_string();
+    let file_identity = WorkspaceIndexer::file_identity_path(full_path);
     for node in &mut artifact.nodes {
         if node.kind == NodeKind::FILE {
             node.serialized_name = file_name.clone();
@@ -1790,7 +1849,7 @@ fn rebase_cached_index_artifact(
     }
 
     let old_file_id = artifact.files.first().map(|file| NodeId(file.id));
-    let (nodes, id_remap) = canonicalize_nodes(&file_name, artifact.nodes, &HashMap::new());
+    let (nodes, id_remap) = canonicalize_nodes(&file_identity, artifact.nodes, &HashMap::new());
     let fallback_file_id = NodeId(WorkspaceIndexer::canonical_file_node_id_for_path(full_path));
     let new_file_id = old_file_id
         .and_then(|file_id| id_remap.get(&file_id).copied())
@@ -13492,6 +13551,15 @@ fn canonicalize_nodes(
     final_nodes: Vec<Node>,
     canonical_roles: &HashMap<NodeId, CanonicalNodeRole>,
 ) -> (Vec<Node>, HashMap<NodeId, NodeId>) {
+    canonicalize_nodes_with_file_identity(file_name, file_name, final_nodes, canonical_roles)
+}
+
+fn canonicalize_nodes_with_file_identity(
+    file_name: &str,
+    file_identity: &str,
+    final_nodes: Vec<Node>,
+    canonical_roles: &HashMap<NodeId, CanonicalNodeRole>,
+) -> (Vec<Node>, HashMap<NodeId, NodeId>) {
     let mut id_remap = HashMap::<NodeId, NodeId>::new();
     let mut grouped_nodes = BTreeMap::<String, Vec<Node>>::new();
 
@@ -13515,6 +13583,8 @@ fn canonicalize_nodes(
             .unwrap_or_else(|| {
                 if is_type_like_kind(node.kind) {
                     format!("{}:{}", file_name, qualified_name)
+                } else if node.kind == NodeKind::FILE {
+                    format!("{file_identity}:{file_identity}:1")
                 } else {
                     let start_line = node.start_line.unwrap_or(1);
                     format!("{}:{}:{}", file_name, qualified_name, start_line)
@@ -14423,9 +14493,14 @@ fn index_template_file(
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("template");
+    let file_identity = WorkspaceIndexer::file_identity_path(path);
     let flags = index_feature_flags();
-    let (final_nodes, id_remap) =
-        canonicalize_nodes(file_name, local_storage.nodes, &HashMap::new());
+    let (final_nodes, id_remap) = canonicalize_nodes_with_file_identity(
+        file_name,
+        &file_identity,
+        local_storage.nodes,
+        &HashMap::new(),
+    );
     let new_file_id = id_remap.get(&file_id).copied().unwrap_or(file_id);
     local_storage.nodes = final_nodes;
     remap_file_affinity(&mut local_storage.nodes, new_file_id);
@@ -16495,6 +16570,7 @@ fn tauri_command_invoke_edge(
         kind: EdgeKind::CALL,
         file_node_id: Some(file_id),
         line: Some(invocation.line),
+        resolved_target: Some(command_node_id),
         certainty: Some(ResolutionCertainty::Uncertain),
         confidence: Some(0.45),
         ..Default::default()

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -1121,14 +1121,19 @@ impl WorkspaceIndexer {
         }
 
         // 3.5 Resolve call/import edges post-pass
-        if had_edges {
+        let (resolution_scope_file_ids, expanded_resolution_scope_files) =
+            if plan.mode == codestory_workspace::BuildMode::Incremental {
+                let mut file_ids = Self::collect_touched_file_ids(&root, &plan.files_to_index);
+                let expanded = Self::extend_resolution_scope_for_matching_unresolved_targets(
+                    storage,
+                    &mut file_ids,
+                )?;
+                (file_ids, expanded)
+            } else {
+                (HashSet::new(), 0)
+            };
+        if had_edges || expanded_resolution_scope_files > 0 {
             let resolver = resolution::ResolutionPass::new();
-            let resolution_scope_file_ids =
-                if plan.mode == codestory_workspace::BuildMode::Incremental {
-                    Self::collect_touched_file_ids(&root, &plan.files_to_index)
-                } else {
-                    Default::default()
-                };
             let resolution_scope = if plan.mode == codestory_workspace::BuildMode::Incremental {
                 (!resolution_scope_file_ids.is_empty()).then_some(&resolution_scope_file_ids)
             } else {
@@ -1322,6 +1327,109 @@ impl WorkspaceIndexer {
             }
         }
         file_ids
+    }
+
+    fn extend_resolution_scope_for_matching_unresolved_targets(
+        storage: &Storage,
+        scope_file_ids: &mut HashSet<i64>,
+    ) -> Result<usize> {
+        // New definitions can unblock old unresolved callers; keep the scope bounded
+        // to callers whose placeholder target names match names in touched files.
+        if scope_file_ids.is_empty() {
+            return Ok(0);
+        }
+
+        let conn = storage.get_connection();
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS incremental_resolution_touched_file_ids (
+                file_id INTEGER PRIMARY KEY
+             );
+             DELETE FROM incremental_resolution_touched_file_ids;
+             CREATE TEMP TABLE IF NOT EXISTS incremental_resolution_target_names (
+                name TEXT PRIMARY KEY
+             );
+             DELETE FROM incremental_resolution_target_names;",
+        )?;
+
+        {
+            let mut insert_touched = conn.prepare(
+                "INSERT OR IGNORE INTO incremental_resolution_touched_file_ids (file_id)
+                 VALUES (?1)",
+            )?;
+            for file_id in scope_file_ids.iter().copied() {
+                insert_touched.execute(rusqlite::params![file_id])?;
+            }
+        }
+
+        let definition_kind_values = incremental_resolution_target_node_kinds()
+            .iter()
+            .map(|kind| (*kind as i32).to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let definition_name_query = format!(
+            "INSERT OR IGNORE INTO incremental_resolution_target_names (name)
+             SELECT DISTINCT name FROM (
+                 SELECT serialized_name AS name
+                 FROM node
+                 WHERE file_node_id IN (
+                     SELECT file_id FROM incremental_resolution_touched_file_ids
+                 )
+                   AND kind IN ({definition_kind_values})
+                 UNION
+                 SELECT qualified_name AS name
+                 FROM node
+                 WHERE file_node_id IN (
+                     SELECT file_id FROM incremental_resolution_touched_file_ids
+                 )
+                   AND kind IN ({definition_kind_values})
+             )
+             WHERE name IS NOT NULL AND name <> ''"
+        );
+        conn.execute(&definition_name_query, [])?;
+        let target_name_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM incremental_resolution_target_names",
+            [],
+            |row| row.get(0),
+        )?;
+        if target_name_count == 0 {
+            return Ok(0);
+        }
+
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT COALESCE(caller.file_node_id, e.file_node_id) AS file_id
+             FROM edge e
+             JOIN node caller ON caller.id = e.source_node_id
+             JOIN node target ON target.id = e.target_node_id
+             JOIN incremental_resolution_target_names target_name
+               ON target_name.name = target.serialized_name
+               OR target_name.name = target.qualified_name
+             WHERE e.resolved_target_node_id IS NULL
+               AND e.kind IN (?1, ?2, ?3)
+               AND (e.kind != ?1 OR (e.confidence IS NULL AND e.certainty IS NULL))
+               AND COALESCE(caller.file_node_id, e.file_node_id) IS NOT NULL
+               AND (target.canonical_id IS NULL OR (
+                 target.canonical_id NOT LIKE 'tauri:command:%'
+                 AND target.canonical_id NOT LIKE 'openapi:endpoint:%'
+                 AND target.canonical_id NOT LIKE 'route_endpoint:%'
+                 AND target.canonical_id NOT LIKE 'payload:collection:%'
+               ))",
+        )?;
+        let rows = stmt.query_map(
+            rusqlite::params![
+                EdgeKind::CALL as i32,
+                EdgeKind::IMPORT as i32,
+                EdgeKind::OVERRIDE as i32
+            ],
+            |row| row.get::<_, i64>(0),
+        )?;
+
+        let mut added = 0;
+        for row in rows {
+            if scope_file_ids.insert(row?) {
+                added += 1;
+            }
+        }
+        Ok(added)
     }
 
     fn normalize_index_path(root: &Path, path: &Path) -> PathBuf {
@@ -1762,6 +1870,28 @@ impl WorkspaceIndexer {
             symbol_table.insert(node.id.0, node.kind);
         }
     }
+}
+
+fn incremental_resolution_target_node_kinds() -> &'static [NodeKind] {
+    &[
+        NodeKind::MODULE,
+        NodeKind::NAMESPACE,
+        NodeKind::PACKAGE,
+        NodeKind::STRUCT,
+        NodeKind::CLASS,
+        NodeKind::INTERFACE,
+        NodeKind::ANNOTATION,
+        NodeKind::UNION,
+        NodeKind::ENUM,
+        NodeKind::TYPEDEF,
+        NodeKind::FUNCTION,
+        NodeKind::METHOD,
+        NodeKind::MACRO,
+        NodeKind::GLOBAL_VARIABLE,
+        NodeKind::FIELD,
+        NodeKind::CONSTANT,
+        NodeKind::ENUM_CONSTANT,
+    ]
 }
 
 fn file_modification_time(path: &Path) -> i64 {

--- a/crates/codestory-indexer/src/resolution/pipeline.rs
+++ b/crates/codestory-indexer/src/resolution/pipeline.rs
@@ -276,6 +276,7 @@ pub(super) fn resolve_overrides_on_conn(
     Ok(resolved)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_edges_after_prepare<F>(
     pass: &ResolutionPass,
     conn: &rusqlite::Connection,
@@ -505,6 +506,62 @@ fn collect_override_candidates(
     candidates.into_vec()
 }
 
+fn collect_override_candidates_by_owner_name(
+    owner_name: &str,
+    method_name: &str,
+    inheritance_by_owner_name: &HashMap<String, Vec<String>>,
+    methods_by_owner_name_and_name: &HashMap<(String, String), Vec<i64>>,
+) -> Vec<i64> {
+    let mut pending = std::collections::VecDeque::from([owner_name.to_string()]);
+    let mut visited = HashSet::new();
+    let mut candidates = OrderedCandidateIds::default();
+    let method_name = method_name.to_string();
+
+    while let Some(current_owner) = pending.pop_front() {
+        if !visited.insert(current_owner.clone()) {
+            continue;
+        }
+        if current_owner != owner_name
+            && let Some(method_ids) =
+                methods_by_owner_name_and_name.get(&(current_owner.clone(), method_name.clone()))
+        {
+            candidates.extend_stage(method_ids, usize::MAX);
+        }
+        if let Some(parents) = inheritance_by_owner_name.get(&current_owner) {
+            for parent in parents {
+                pending.push_back(parent.clone());
+            }
+        }
+    }
+
+    candidates.into_vec()
+}
+
+fn owner_name_from_member_name(name: &str) -> Option<&str> {
+    let colon = name.rfind("::");
+    let dot = name.rfind('.');
+    match (colon, dot) {
+        (Some(colon_idx), Some(dot_idx)) => {
+            let split = if colon_idx + 1 > dot_idx {
+                colon_idx
+            } else {
+                dot_idx
+            };
+            Some(&name[..split])
+        }
+        (Some(colon_idx), None) => Some(&name[..colon_idx]),
+        (None, Some(dot_idx)) => Some(&name[..dot_idx]),
+        (None, None) => None,
+    }
+}
+
+fn short_member_name(name: &str) -> &str {
+    let colon = name.rfind("::").map(|idx| idx + 2).unwrap_or(0);
+    let dot = name.rfind('.').map(|idx| idx + 1).unwrap_or(0);
+    let split = colon.max(dot);
+    &name[split..]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -613,60 +670,4 @@ mod tests {
 
         Ok(())
     }
-}
-
-fn collect_override_candidates_by_owner_name(
-    owner_name: &str,
-    method_name: &str,
-    inheritance_by_owner_name: &HashMap<String, Vec<String>>,
-    methods_by_owner_name_and_name: &HashMap<(String, String), Vec<i64>>,
-) -> Vec<i64> {
-    let mut pending = std::collections::VecDeque::from([owner_name.to_string()]);
-    let mut visited = HashSet::new();
-    let mut candidates = OrderedCandidateIds::default();
-    let method_name = method_name.to_string();
-
-    while let Some(current_owner) = pending.pop_front() {
-        if !visited.insert(current_owner.clone()) {
-            continue;
-        }
-        if current_owner != owner_name
-            && let Some(method_ids) =
-                methods_by_owner_name_and_name.get(&(current_owner.clone(), method_name.clone()))
-        {
-            candidates.extend_stage(method_ids, usize::MAX);
-        }
-        if let Some(parents) = inheritance_by_owner_name.get(&current_owner) {
-            for parent in parents {
-                pending.push_back(parent.clone());
-            }
-        }
-    }
-
-    candidates.into_vec()
-}
-
-fn owner_name_from_member_name(name: &str) -> Option<&str> {
-    let colon = name.rfind("::");
-    let dot = name.rfind('.');
-    match (colon, dot) {
-        (Some(colon_idx), Some(dot_idx)) => {
-            let split = if colon_idx + 1 > dot_idx {
-                colon_idx
-            } else {
-                dot_idx
-            };
-            Some(&name[..split])
-        }
-        (Some(colon_idx), None) => Some(&name[..colon_idx]),
-        (None, Some(dot_idx)) => Some(&name[..dot_idx]),
-        (None, None) => None,
-    }
-}
-
-fn short_member_name(name: &str) -> &str {
-    let colon = name.rfind("::").map(|idx| idx + 2).unwrap_or(0);
-    let dot = name.rfind('.').map(|idx| idx + 1).unwrap_or(0);
-    let split = colon.max(dot);
-    &name[split..]
 }

--- a/crates/codestory-indexer/src/resolution/sql.rs
+++ b/crates/codestory-indexer/src/resolution/sql.rs
@@ -13,7 +13,14 @@ pub(super) fn cleanup_stale_call_resolutions(
     let cutoff = policy.min_call_confidence;
     let mut low_confidence_query = String::from(
         "UPDATE edge SET resolved_target_node_id = NULL, confidence = NULL, certainty = NULL
-         WHERE kind = ?1 AND confidence IS NOT NULL AND confidence < ?2",
+         WHERE kind = ?1 AND confidence IS NOT NULL AND confidence < ?2
+         AND target_node_id NOT IN (
+             SELECT id FROM node
+             WHERE canonical_id LIKE 'tauri:command:%'
+                OR canonical_id LIKE 'openapi:endpoint:%'
+                OR canonical_id LIKE 'route_endpoint:%'
+                OR canonical_id LIKE 'payload:collection:%'
+         )",
     );
     if scope_context.is_scoped() {
         low_confidence_query.push_str(&format!(

--- a/crates/codestory-indexer/src/structural/cargo_manifest.rs
+++ b/crates/codestory-indexer/src/structural/cargo_manifest.rs
@@ -151,7 +151,7 @@ fn strip_toml_comment(line: &str) -> &str {
 }
 
 fn toml_key(trimmed: &str) -> Option<&str> {
-    trimmed.split_once('=')?.0.trim().split_whitespace().next()
+    trimmed.split_once('=')?.0.split_whitespace().next()
 }
 
 fn dependency_key(line: &str) -> Option<(String, u32)> {

--- a/crates/codestory-indexer/src/structural/docker_compose.rs
+++ b/crates/codestory-indexer/src/structural/docker_compose.rs
@@ -183,6 +183,7 @@ fn push_service(
     service_id
 }
 
+#[allow(clippy::too_many_arguments)]
 fn push_anchor(
     storage: &mut IntermediateStorage,
     file_id: NodeId,

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -489,6 +489,136 @@ fn keep() { fresh(); }
     Ok(())
 }
 
+#[cfg(windows)]
+#[test]
+fn test_windows_casing_refresh_reuses_projection_identity() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("main.rs");
+
+    fs::write(
+        &file_path,
+        r#"
+fn stale() {}
+fn keep() { stale(); }
+"#,
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    fs::write(
+        &file_path,
+        r#"
+fn fresh() {}
+fn keep() { fresh(); }
+"#,
+    )?;
+
+    run_incremental_indexing(root, &mut storage, vec![root.join("MAIN.rs")])?;
+
+    let files = storage.get_files()?;
+    assert_eq!(
+        files.len(),
+        1,
+        "casing-only refresh must not duplicate file rows"
+    );
+    let file_id = files[0].id;
+
+    let nodes = storage.get_nodes()?;
+    let file_nodes = nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::FILE)
+        .count();
+    assert_eq!(
+        file_nodes, 1,
+        "casing-only refresh must not duplicate file nodes"
+    );
+    assert!(!nodes.iter().any(|node| node.serialized_name == "stale"));
+    assert!(nodes.iter().any(|node| node.serialized_name == "fresh"));
+
+    let states = storage.get_callable_projection_states_for_file(file_id)?;
+    assert!(
+        states
+            .iter()
+            .all(|state| !state.symbol_key.contains("stale"))
+    );
+    assert!(
+        states
+            .iter()
+            .any(|state| state.symbol_key.contains("fresh"))
+    );
+
+    Ok(())
+}
+
+#[cfg(windows)]
+#[test]
+fn test_windows_template_casing_refresh_reuses_projection_identity() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("App.svelte");
+
+    fs::write(
+        &file_path,
+        r#"
+<script>
+function stale() {}
+function keep() { stale(); }
+</script>
+"#,
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    fs::write(
+        &file_path,
+        r#"
+<script>
+function fresh() {}
+function keep() { fresh(); }
+</script>
+"#,
+    )?;
+
+    run_incremental_indexing(root, &mut storage, vec![root.join("APP.svelte")])?;
+
+    let files = storage.get_files()?;
+    assert_eq!(
+        files.len(),
+        1,
+        "casing-only template refresh must not duplicate file rows"
+    );
+    let file_id = files[0].id;
+
+    let nodes = storage.get_nodes()?;
+    let file_nodes = nodes
+        .iter()
+        .filter(|node| node.kind == NodeKind::FILE)
+        .count();
+    assert_eq!(
+        file_nodes, 1,
+        "casing-only template refresh must not duplicate file nodes"
+    );
+    assert!(!nodes.iter().any(|node| node.serialized_name == "stale"));
+    assert!(nodes.iter().any(|node| node.serialized_name == "fresh"));
+
+    let states = storage.get_callable_projection_states_for_file(file_id)?;
+    assert!(
+        states
+            .iter()
+            .all(|state| !state.symbol_key.contains("stale"))
+    );
+    assert!(
+        states
+            .iter()
+            .any(|state| state.symbol_key.contains("fresh"))
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_incremental_go_structural_change_removes_stale_projection() -> anyhow::Result<()> {
     let dir = tempdir()?;

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -692,6 +692,85 @@ func (r *Router) Handle(path string) {}
 }
 
 #[test]
+fn test_incremental_added_definition_resolves_existing_unresolved_caller() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let caller = root.join("main.rs");
+    let callee = root.join("helper.rs");
+
+    fs::write(
+        &caller,
+        "mod helper;\nuse crate::helper::late_helper;\n\nfn run() {\n    late_helper();\n}\n",
+    )?;
+
+    let mut storage = Storage::new_in_memory()?;
+    let indexer = WorkspaceIndexer::new(root.to_path_buf());
+    let event_bus = EventBus::new();
+    let initial = codestory_workspace::RefreshInfo {
+        mode: codestory_workspace::BuildMode::Incremental,
+        files_to_index: vec![caller.clone()],
+        files_to_remove: vec![],
+        existing_file_ids: std::collections::HashMap::new(),
+    };
+    indexer.run_incremental(&mut storage, &initial, &event_bus, None)?;
+
+    let run_id = storage
+        .get_nodes()?
+        .into_iter()
+        .find(|node| node.serialized_name == "run" && node.kind == NodeKind::FUNCTION)
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing run() node after initial index"))?;
+    let initial_call_edges = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.source == run_id)
+        .collect::<Vec<_>>();
+    assert!(
+        !initial_call_edges.is_empty(),
+        "expected initial run() call edge to exist"
+    );
+    assert!(
+        initial_call_edges
+            .iter()
+            .all(|edge| edge.resolved_target.is_none()),
+        "late_helper() should be unresolved before helper.rs exists: {initial_call_edges:?}"
+    );
+
+    fs::write(&callee, "pub fn late_helper() {}\n")?;
+    let refresh = codestory_workspace::RefreshInfo {
+        mode: codestory_workspace::BuildMode::Incremental,
+        files_to_index: vec![callee.clone()],
+        files_to_remove: vec![],
+        existing_file_ids: std::collections::HashMap::new(),
+    };
+    let stats = indexer.run_incremental(&mut storage, &refresh, &event_bus, None)?;
+
+    let helper_id = storage
+        .get_nodes()?
+        .into_iter()
+        .find(|node| node.serialized_name == "late_helper" && node.kind == NodeKind::FUNCTION)
+        .map(|node| node.id)
+        .ok_or_else(|| anyhow::anyhow!("missing late_helper() node after incremental index"))?;
+    let refreshed_call_edges = storage
+        .get_edges()?
+        .into_iter()
+        .filter(|edge| edge.kind == EdgeKind::CALL && edge.source == run_id)
+        .collect::<Vec<_>>();
+    assert!(
+        refreshed_call_edges
+            .iter()
+            .any(|edge| edge.resolved_target == Some(helper_id)),
+        "unchanged run() caller should resolve to newly added helper: {refreshed_call_edges:?}"
+    );
+    assert!(
+        stats.resolved_calls > 0,
+        "incremental resolution should count the unchanged caller resolution"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_incremental_indexing_deletes_removed_files_before_resolution() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let root = dir.path();

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/cache.rs
+++ b/crates/codestory-retrieval/src/cache.rs
@@ -45,7 +45,7 @@ const DEFAULT_RETRIEVAL_CACHE_CAPACITY: usize = 128;
 /// Entries are safe only for the manifest identity captured by [`RetrievalCacheKey`]. Cache
 /// rehydration across worktrees must invalidate copied retrieval manifests before this cache is
 /// trusted again.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RetrievalCache {
     entries: HashMap<RetrievalCacheKey, Vec<super::CandidateHit>>,
     order: VecDeque<RetrievalCacheKey>,
@@ -86,6 +86,19 @@ impl RetrievalCache {
                 break;
             };
             self.entries.remove(&evicted);
+        }
+    }
+
+    pub fn merge_delta_from(&mut self, baseline: &RetrievalCache, other: RetrievalCache) {
+        let RetrievalCache { entries, order, .. } = other;
+        for key in order {
+            let Some(hits) = entries.get(&key) else {
+                continue;
+            };
+            if baseline.entries.get(&key) == Some(hits) {
+                continue;
+            }
+            self.insert(key, hits.clone());
         }
     }
 
@@ -164,6 +177,57 @@ mod tests {
         assert!(cache.get(&first).is_none());
         assert_eq!(
             cache.get(&second).expect("second entry should remain")[0].file_path,
+            "src/second.rs"
+        );
+    }
+
+    #[test]
+    fn merge_delta_from_does_not_replay_snapshot_entries() {
+        let first = RetrievalCacheKey {
+            project_id: "abc".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_abc".into(),
+            scip_revision: None,
+            sidecar_generation: Some("abc-hash".into()),
+            sidecar_input_hash: Some("hash".into()),
+            sidecar_schema_version: Some(1),
+            projection_count: Some(1),
+            query_fingerprint: "first".into(),
+        };
+        let second = RetrievalCacheKey {
+            query_fingerprint: "second".into(),
+            ..first.clone()
+        };
+
+        let mut target = RetrievalCache::with_capacity(1);
+        target.insert(
+            first.clone(),
+            vec![super::super::CandidateHit::lexical_stub(
+                "src/first.rs",
+                1.0,
+            )],
+        );
+        let baseline = target.clone();
+
+        let mut newer_worker = baseline.clone();
+        newer_worker.insert(
+            second.clone(),
+            vec![super::super::CandidateHit::lexical_stub(
+                "src/second.rs",
+                1.0,
+            )],
+        );
+        target.merge_delta_from(&baseline, newer_worker);
+        assert_eq!(
+            target.get(&second).expect("newer entry should remain")[0].file_path,
+            "src/second.rs"
+        );
+
+        target.merge_delta_from(&baseline, baseline.clone());
+
+        assert!(target.get(&first).is_none());
+        assert_eq!(
+            target.get(&second).expect("stale snapshot must not replay")[0].file_path,
             "src/second.rs"
         );
     }

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -883,7 +883,20 @@ mod tests {
         assert_eq!(path, cache.path().join("retrieval-compose.yml"));
         let contents = std::fs::read_to_string(path).expect("read bundled compose");
         assert!(contents.contains("name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}"));
-        assert!(contents.contains("qdrant/qdrant:v1.12.5"));
+        for image in [
+            crate::config::QDRANT_IMAGE_PIN,
+            crate::config::ZOEKT_WEBSERVER_IMAGE_PIN,
+            crate::config::LLAMACPP_SERVER_IMAGE_PIN,
+        ] {
+            assert!(
+                image.contains("@sha256:"),
+                "image pin must include digest: {image}"
+            );
+            assert!(
+                contents.contains(image),
+                "bundled compose should contain exact image pin {image}"
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -664,7 +664,7 @@ fn embed_model_dir(repo_root: Option<&Path>, layout: &SidecarLayout) -> Result<P
     let inventory = embed_model_inventory(repo_root, layout);
     if let Some(model_dir) = inventory
         .required_gguf_present
-        .then(|| inventory.model_dir.as_ref())
+        .then_some(inventory.model_dir.as_ref())
         .flatten()
     {
         return Ok(PathBuf::from(model_dir));

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -10,15 +10,30 @@ use std::time::{Duration, SystemTime};
 pub const ZOEKT_REAL_VERSION_PIN: &str = "zoekt-20250506123554";
 
 /// Zoekt webserver image for `COMPOSE_PROFILES=real`.
-pub const ZOEKT_WEBSERVER_IMAGE_PIN: &str =
-    "sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4";
+pub const ZOEKT_WEBSERVER_IMAGE_PIN: &str = "sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4@sha256:34c77a62bcafc41ce3ee193e44f42aa84690d9ec51b953e7efae4dfdfae80aff";
 
 /// Qdrant container image pin for local dev and CI smoke.
-pub const QDRANT_IMAGE_PIN: &str = "qdrant/qdrant:v1.12.5";
+pub const QDRANT_IMAGE_PIN: &str =
+    "qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae";
 
 /// llama.cpp server image for `COMPOSE_PROFILES=real` embed service (see `docker/retrieval-compose.yml`).
 #[allow(dead_code)]
-pub const LLAMACPP_SERVER_IMAGE_PIN: &str = "ghcr.io/ggml-org/llama.cpp:server";
+pub const LLAMACPP_SERVER_IMAGE_PIN: &str = "ghcr.io/ggml-org/llama.cpp:server@sha256:f16ca66f3ba316b7a7a16003ddfa88d29c3404fbe86550da086736864c11574c";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SidecarImagePins {
+    pub qdrant: String,
+    pub zoekt: String,
+    pub embed: String,
+}
+
+pub fn default_sidecar_image_pins() -> SidecarImagePins {
+    SidecarImagePins {
+        qdrant: QDRANT_IMAGE_PIN.into(),
+        zoekt: ZOEKT_WEBSERVER_IMAGE_PIN.into(),
+        embed: LLAMACPP_SERVER_IMAGE_PIN.into(),
+    }
+}
 
 pub const DEFAULT_ZOEKT_HTTP_PORT: u16 = 6070;
 pub const DEFAULT_QDRANT_HTTP_PORT: u16 = 6333;

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,7 +1,8 @@
 use crate::capabilities::SidecarCapabilities;
 use crate::config::{
-    QDRANT_HEALTH_BUDGET, SidecarLayout, SidecarOwnership, SidecarProfile, SidecarRuntimeConfig,
-    ZOEKT_HEALTH_BUDGET, qdrant_semantic_vectors_enabled, retrieval_command,
+    QDRANT_HEALTH_BUDGET, SidecarImagePins, SidecarLayout, SidecarOwnership, SidecarProfile,
+    SidecarRuntimeConfig, ZOEKT_HEALTH_BUDGET, default_sidecar_image_pins,
+    qdrant_semantic_vectors_enabled, retrieval_command,
 };
 use crate::embeddings::{EmbeddingDeviceReadiness, manifest_embedding_backend_is_product};
 use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
@@ -90,6 +91,8 @@ pub struct RetrievalStatusReport {
     pub retrieval_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ownership: Option<SidecarOwnership>,
+    #[serde(default = "default_sidecar_image_pins")]
+    pub sidecar_images: SidecarImagePins,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -378,6 +381,7 @@ pub fn unavailable_status_report_with_embedding_device(
     RetrievalStatusReport {
         retrieval_mode: "unavailable".into(),
         ownership: None,
+        sidecar_images: default_sidecar_image_pins(),
         degraded_reason: Some(reason.clone()),
         repair: None,
         query_embedding_backend: crate::embeddings::embedding_runtime_id(),
@@ -734,6 +738,7 @@ pub fn probe_sidecar_health_with_embedding_device(
     RetrievalStatusReport {
         retrieval_mode: mode.as_str().into(),
         ownership: None,
+        sidecar_images: default_sidecar_image_pins(),
         degraded_reason,
         repair: None,
         query_embedding_backend: current_embedding_backend,
@@ -1063,6 +1068,7 @@ mod tests {
         let report = RetrievalStatusReport {
             retrieval_mode: "full".into(),
             ownership: None,
+            sidecar_images: default_sidecar_image_pins(),
             degraded_reason: None,
             query_embedding_backend: "llamacpp:bge-base-en-v1.5".into(),
             manifest_vector_embedding_backend: manifest.embedding_backend.clone(),

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -638,7 +638,7 @@ pub fn probe_sidecar_health_with_embedding_device(
         .or(manifest.projection_count)
         .unwrap_or(0);
     let qdrant = if dense_anchor_count == 0 {
-        zero_dense_qdrant_health(&embedding_device)
+        zero_dense_qdrant_health(embedding_device)
     } else {
         let collection = manifest.qdrant_collection.clone();
         let qdrant_probe = QdrantClient::new(layout).health_probe(&collection);

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -484,6 +484,7 @@ fn ensure_zoekt_generation(
     Ok(ZOEKT_REAL_VERSION_PIN.to_string())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ensure_qdrant_collection(
     storage_path: &Path,
     project_root: &Path,

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -870,6 +870,7 @@ mod tests {
             embedding_accelerator_request_device: None,
             embedding_cpu_allowed: false,
             embedding_launch: None,
+            sidecar_images: crate::config::default_sidecar_image_pins(),
             zoekt_data_dir: root.join("zoekt").display().to_string(),
             qdrant_data_dir: root.join("qdrant").display().to_string(),
             scip_artifacts_root: root.join("scip").display().to_string(),

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -537,7 +537,7 @@ fn match_resource(
         return Some(resource);
     }
     if resource.kind == SidecarDockerResourceKind::Network
-        && resource.labels.get("dev.codestory.owner").is_none()
+        && !resource.labels.contains_key("dev.codestory.owner")
         && compose_project
             .as_ref()
             .is_some_and(|project| owned_compose_projects.contains(project))
@@ -620,6 +620,7 @@ fn inventory_entry(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn classify_entry(
     state: Option<&SidecarStateFile>,
     state_exists: bool,

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -51,10 +51,10 @@ pub use compose::{
 };
 pub use config::{
     DEFAULT_AGENT_RUN_ID, DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT,
-    DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarLayout,
-    SidecarOwnership, SidecarPorts, SidecarProfile, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN,
-    ZOEKT_WEBSERVER_IMAGE_PIN, sidecar_runtime_auto, sidecar_runtime_for_project,
-    sidecar_runtime_for_project_with_run_id,
+    DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, QDRANT_IMAGE_PIN, SidecarImagePins,
+    SidecarLayout, SidecarOwnership, SidecarPorts, SidecarProfile, SidecarRuntimeConfig,
+    ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN, default_sidecar_image_pins,
+    sidecar_runtime_auto, sidecar_runtime_for_project, sidecar_runtime_for_project_with_run_id,
 };
 pub use config::{qdrant_enabled, qdrant_semantic_vectors_enabled};
 pub use embeddings::qdrant_vector_dim;

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -241,10 +241,7 @@ fn strict_batch_worker_limit(query_count: usize) -> usize {
         .map(usize::from)
         .unwrap_or(1);
     // Cap sidecar fan-out; make this configurable only if telemetry needs it.
-    query_count
-        .min(available)
-        .min(STRICT_BATCH_WORKER_CAP)
-        .max(1)
+    query_count.min(available).clamp(1, STRICT_BATCH_WORKER_CAP)
 }
 
 struct QueryContext {

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    SidecarLayout, SidecarProfile, SidecarRuntimeConfig, sidecar_runtime_auto,
-    sidecar_runtime_for_project,
+    SidecarImagePins, SidecarLayout, SidecarProfile, SidecarRuntimeConfig,
+    default_sidecar_image_pins, sidecar_runtime_auto, sidecar_runtime_for_project,
 };
 use crate::generation::{
     SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
@@ -63,6 +63,8 @@ pub struct SidecarStateFile {
     pub embedding_cpu_allowed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding_launch: Option<EmbeddingLaunchMetadata>,
+    #[serde(default = "default_sidecar_image_pins")]
+    pub sidecar_images: SidecarImagePins,
     pub zoekt_data_dir: String,
     pub qdrant_data_dir: String,
     pub scip_artifacts_root: String,
@@ -113,6 +115,7 @@ pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
         embedding_accelerator_request_device: embedding_device.accelerator_request_device,
         embedding_cpu_allowed: embedding_device.cpu_allowed,
         embedding_launch,
+        sidecar_images: default_sidecar_image_pins(),
         zoekt_data_dir: layout.zoekt_data_dir.display().to_string(),
         qdrant_data_dir: layout.qdrant_data_dir.display().to_string(),
         scip_artifacts_root: layout.scip_artifacts_root.display().to_string(),
@@ -310,9 +313,10 @@ fn attach_status_ownership(
     runtime: &SidecarRuntimeConfig,
 ) -> RetrievalStatusReport {
     report.ownership = Some(runtime.ownership());
-    report.embedding_launch = read_sidecar_state(&runtime.layout.state_file)
-        .and_then(|state| state.embedding_launch)
-        .or(report.embedding_launch);
+    if let Some(state) = read_sidecar_state(&runtime.layout.state_file) {
+        report.embedding_launch = state.embedding_launch.or(report.embedding_launch);
+        report.sidecar_images = state.sidecar_images;
+    }
     report
 }
 

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -1180,6 +1180,7 @@ fn maybe_append_generic_source_shape_citations(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_generic_source_shape_candidates(
     project_root: &Path,
     dir: &Path,

--- a/crates/codestory-runtime/src/agent/packet_batch.rs
+++ b/crates/codestory-runtime/src/agent/packet_batch.rs
@@ -609,9 +609,7 @@ pub(crate) fn packet_anchor_probe_limit_for_budget(
     let usage_pct = packet_latency.budget_usage_percent(consumed_trace_ms);
     if usage_pct >= 75 {
         (base / 4).max(1)
-    } else if usage_pct >= 50 {
-        (base / 2).max(1)
-    } else if budget == PacketBudgetModeDto::Compact && usage_pct >= 25 {
+    } else if usage_pct >= 50 || (budget == PacketBudgetModeDto::Compact && usage_pct >= 25) {
         (base / 2).max(1)
     } else {
         base

--- a/crates/codestory-runtime/src/agent/packet_claim_profiles.rs
+++ b/crates/codestory-runtime/src/agent/packet_claim_profiles.rs
@@ -533,23 +533,21 @@ fn buffered_io_buffer_storage_claim(ctx: &SourceClaimContext<'_>) -> Option<Stri
     let normalized_symbol = normalize_identifier(ctx.symbol);
     let normalized_source = normalize_identifier(ctx.source);
     let lower = ctx.source.to_ascii_lowercase();
-    if normalized_symbol == "buffer"
+    if (normalized_symbol == "buffer"
         || normalized_symbol.ends_with("buffer")
-        || normalized_symbol.contains("bytebuffer")
-    {
-        if (lower.contains("class buffer")
+        || normalized_symbol.contains("bytebuffer"))
+        && (lower.contains("class buffer")
             || lower.contains("struct buffer")
             || lower.contains("interface buffer")
             || lower.contains("expect class buffer")
             || lower.contains("actual class buffer")
             || lower.contains("typealias buffer"))
-            && (normalized_source.contains("read") || normalized_source.contains("write"))
-            && (normalized_source.contains("byte") || normalized_source.contains("segment"))
-        {
-            return Some(
-                "Buffer is the in-memory byte store used by buffered reads and writes.".to_string(),
-            );
-        }
+        && (normalized_source.contains("read") || normalized_source.contains("write"))
+        && (normalized_source.contains("byte") || normalized_source.contains("segment"))
+    {
+        return Some(
+            "Buffer is the in-memory byte store used by buffered reads and writes.".to_string(),
+        );
     }
     None
 }
@@ -1364,15 +1362,14 @@ pub(crate) fn packet_generic_html_css_template_structure_claims(
     let lower = source.to_ascii_lowercase();
     let mut claims = Vec::new();
 
-    if file_name.ends_with(".html") || (lower.contains("<html") && lower.contains("<body")) {
-        if lower.contains("id=\"app\"")
-            && lower.contains("type=\"module\"")
-            && lower.contains("viewport")
-        {
-            claims.push(format!(
-                "{file_name} provides the app shell with viewport metadata, div#app, and a script[type=\"module\"] module script entry."
-            ));
-        }
+    if (file_name.ends_with(".html") || (lower.contains("<html") && lower.contains("<body")))
+        && lower.contains("id=\"app\"")
+        && lower.contains("type=\"module\"")
+        && lower.contains("viewport")
+    {
+        claims.push(format!(
+            "{file_name} provides the app shell with viewport metadata, div#app, and a script[type=\"module\"] module script entry."
+        ));
     }
 
     if file_name.ends_with(".css") {

--- a/crates/codestory-runtime/src/agent/packet_claims.rs
+++ b/crates/codestory-runtime/src/agent/packet_claims.rs
@@ -796,7 +796,7 @@ fn packet_citation_shaped_claim(citation: &AgentCitationDto, prompt: &str) -> Op
             .as_deref()
             .map(packet_display_path)
             .unwrap_or_default();
-        return eval_citation_shaped_claim(citation, prompt, &path);
+        eval_citation_shaped_claim(citation, prompt, &path)
     }
     #[cfg(not(test))]
     {

--- a/crates/codestory-runtime/src/agent/packet_evidence.rs
+++ b/crates/codestory-runtime/src/agent/packet_evidence.rs
@@ -13,45 +13,16 @@ const OPENAPI_ENDPOINT_SCHEMA_PRODUCER: &str = "openapi_endpoint_schema";
 pub(crate) type PacketEvidenceTier = PacketEvidenceTierDto;
 pub(crate) type PacketEvidenceResolution = PacketEvidenceResolutionDto;
 
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub(crate) struct EvidenceCandidate {
-    pub display_name: String,
-    pub path: Option<String>,
-    pub node_id: Option<String>,
-    pub tier: PacketEvidenceTier,
-    pub resolution: PacketEvidenceResolution,
-    pub producer: String,
-    pub score: f32,
-    pub loss_reason: Option<String>,
-}
-
-pub(crate) fn evidence_candidate_from_hit(hit: &SearchHit) -> EvidenceCandidate {
-    EvidenceCandidate {
-        display_name: hit.display_name.clone(),
-        path: hit.file_path.clone(),
-        node_id: Some(hit.node_id.0.clone()),
-        tier: evidence_tier_for_hit(hit),
-        resolution: evidence_resolution_for_hit(hit),
-        producer: evidence_producer_for_hit(hit),
-        score: hit.score,
-        loss_reason: hit.loss_reason.clone(),
-    }
-}
-
 pub(crate) fn decorate_search_hit_evidence(hit: &mut SearchHit) {
-    let candidate = evidence_candidate_from_hit(hit);
     let diagnostic_source_proof = hit_is_diagnostic_source_proof(hit);
-    hit.evidence_tier = Some(candidate.tier);
-    hit.evidence_producer = Some(candidate.producer);
-    hit.resolution_status = Some(candidate.resolution);
-    if hit.loss_reason.is_none() {
-        hit.loss_reason = candidate.loss_reason;
-    }
-    hit.eligible_for_sufficiency = Some(
-        !diagnostic_source_proof
-            && evidence_is_sufficiency_eligible(candidate.tier, candidate.resolution),
-    );
+    let tier = evidence_tier_for_hit(hit);
+    let resolution = evidence_resolution_for_hit(hit);
+    let producer = evidence_producer_for_hit(hit);
+    hit.evidence_tier = Some(tier);
+    hit.evidence_producer = Some(producer);
+    hit.resolution_status = Some(resolution);
+    hit.eligible_for_sufficiency =
+        Some(!diagnostic_source_proof && evidence_is_sufficiency_eligible(tier, resolution));
 }
 
 pub(crate) fn decorate_citation_from_hit(citation: &mut AgentCitationDto, hit: &SearchHit) {

--- a/crates/codestory-runtime/src/agent/packet_required_probes.rs
+++ b/crates/codestory-runtime/src/agent/packet_required_probes.rs
@@ -1037,21 +1037,17 @@ pub(crate) fn packet_citation_probe_match_rank(
         } else {
             None
         }
-    } else if packet_citation_matches_route_registration_probe(query, citation) {
+    } else if packet_citation_matches_route_registration_probe(query, citation)
+        || packet_citation_matches_route_engine_constructor_probe(query, citation)
+        || packet_citation_matches_route_dispatch_probe(query, citation)
+        || packet_citation_matches_argument_planning_probe(query, citation)
+        || packet_citation_matches_buffered_wrapper_implementation(query, citation)
+        || packet_citation_matches_public_api_surface_probe(query, citation)
+    {
         Some(6)
-    } else if packet_citation_matches_route_engine_constructor_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_route_dispatch_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_argument_planning_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_buffered_wrapper_implementation(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_public_api_surface_probe(query, citation) {
-        Some(6)
-    } else if packet_citation_matches_validation_bypass_probe(query, citation) {
-        Some(5)
-    } else if packet_citation_matches_sql_schema_scripts_probe(query, citation) {
+    } else if packet_citation_matches_validation_bypass_probe(query, citation)
+        || packet_citation_matches_sql_schema_scripts_probe(query, citation)
+    {
         Some(5)
     } else if packet_required_probe_needs_request_validation_anchor(query) {
         packet_citation_matches_request_validation_anchor(query, citation).then_some(5)

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -896,9 +896,11 @@ fn packet_coverage_report(
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect::<Vec<_>>();
-    let budget_omitted = has_sufficiency_blocking_budget_omission
-        .then(|| budget.omitted_sections.clone())
-        .unwrap_or_default();
+    let budget_omitted = if has_sufficiency_blocking_budget_omission {
+        budget.omitted_sections.clone()
+    } else {
+        Vec::new()
+    };
     let provenance_counts = packet_provenance_counts(supported_claims);
     let provenance_labels = provenance_counts.keys().cloned().collect::<Vec<_>>();
     PacketCoverageReportDto {
@@ -1047,8 +1049,7 @@ fn packet_escape_coverage_report_value(value: &str) -> String {
     value
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
-        .replace('\r', " ")
-        .replace('\n', " ")
+        .replace(['\r', '\n'], " ")
 }
 
 struct PacketFlowContext {
@@ -1495,7 +1496,7 @@ fn packet_missing_required_flow_requirements(
         .requirements
         .iter()
         .copied()
-        .filter(|requirement| flow_requirement_blocks_sufficiency(requirement))
+        .filter(flow_requirement_blocks_sufficiency)
         .filter(|requirement| {
             !supported_claims
                 .iter()
@@ -1638,6 +1639,7 @@ fn packet_blocking_follow_up_probe_queries(
     queries
 }
 
+#[allow(clippy::too_many_arguments)]
 fn packet_flow_roles_for_claim(
     claim: &PacketClaimDto,
     site_build_flow: bool,
@@ -2162,6 +2164,7 @@ fn insert_generic_boundary_roles(roles: &mut HashSet<FlowRole>) {
     roles.insert(FlowRole::TerminalBoundary);
 }
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4374,13 +4377,12 @@ fn packet_has_sufficiency_blocking_budget_omission(
         return false;
     }
 
-    budget
-        .omitted_sections
-        .iter()
-        .any(|section| match section.as_str() {
-            "citations" | "markdown_blocks" | "trail_edges" | "output_bytes" => true,
-            _ => false,
-        })
+    budget.omitted_sections.iter().any(|section| {
+        matches!(
+            section.as_str(),
+            "citations" | "markdown_blocks" | "trail_edges" | "output_bytes"
+        )
+    })
 }
 
 fn packet_missing_probe_requires_compact_proof(query: &str) -> bool {
@@ -4459,7 +4461,7 @@ fn packet_full_retrieval_available(answer: &AgentAnswerDto) -> bool {
         .retrieval_trace
         .retrieval_shadow
         .as_ref()
-        .map_or(true, |shadow| shadow.retrieval_mode == "full")
+        .is_none_or(|shadow| shadow.retrieval_mode == "full")
 }
 
 fn packet_agent_repair_command(quoted_project: &str) -> String {

--- a/crates/codestory-runtime/src/agent/packet_trace.rs
+++ b/crates/codestory-runtime/src/agent/packet_trace.rs
@@ -31,6 +31,7 @@ fn sanitize_section_id(value: &str) -> String {
     }
     id.trim_matches('-').chars().take(48).collect()
 }
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn merge_packet_lexical_subquery_batch(
     answer: &mut AgentAnswerDto,
     pending: &[(usize, &PacketPlanQueryDto)],

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -138,7 +138,7 @@ pub(crate) fn sidecar_retrieval_unavailable_error(
 fn sidecar_retrieval_recovery_commands(project_root: &Path) -> Vec<String> {
     let runtime = sidecar_runtime_auto(project_root);
     let agent_run_id = (runtime.profile == SidecarProfile::Agent)
-        .then(|| runtime.run_id.as_deref())
+        .then_some(runtime.run_id.as_deref())
         .flatten();
     sidecar_retrieval_recovery_commands_for_project(&project_root.to_string_lossy(), agent_run_id)
 }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -313,6 +313,23 @@ fn sidecar_packet_batch_budget_ms(latency_budget_ms: Option<u32>) -> u64 {
         .clamp(100, MAX_PACKET_BATCH_BUDGET_MS)
 }
 
+fn with_detached_sidecar_query_cache<T>(
+    controller: &AppController,
+    work: impl FnOnce(&mut codestory_retrieval::RetrievalCache) -> T,
+) -> T {
+    let (generation, mut cache) = {
+        let shared = controller.sidecar_query_cache.lock();
+        shared.snapshot()
+    };
+    let baseline = cache.clone();
+    let result = work(&mut cache);
+    controller
+        .sidecar_query_cache
+        .lock()
+        .merge_if_current(generation, &baseline, cache);
+    result
+}
+
 pub(crate) fn run_sidecar_query(
     controller: &AppController,
     query: &str,
@@ -324,17 +341,18 @@ pub(crate) fn run_sidecar_query(
     let storage_path = controller
         .require_storage_path()
         .map_err(|error| anyhow::anyhow!("storage path required: {}", error.message))?;
-    let mut cache = controller.sidecar_query_cache.lock();
-    execute_retrieval_query_with_cache(
-        QueryRequest {
-            project_root: &project_root,
-            storage_path: &storage_path,
-            query,
-            budget_ms: Some(sidecar_budget_ms(latency_budget_ms)),
-            cancelled: None,
-        },
-        &mut cache,
-    )
+    with_detached_sidecar_query_cache(controller, |cache| {
+        execute_retrieval_query_with_cache(
+            QueryRequest {
+                project_root: &project_root,
+                storage_path: &storage_path,
+                query,
+                budget_ms: Some(sidecar_budget_ms(latency_budget_ms)),
+                cancelled: None,
+            },
+            cache,
+        )
+    })
 }
 
 pub(crate) fn run_sidecar_query_batch(
@@ -354,16 +372,17 @@ pub(crate) fn run_sidecar_query_batch(
             budget_ms: Some(*budget_ms),
         })
         .collect::<Vec<_>>();
-    let mut cache = controller.sidecar_query_cache.lock();
-    execute_strict_retrieval_query_batch_with_cache(
-        QueryBatchRequest {
-            project_root: &project_root,
-            storage_path: &storage_path,
-            queries: &batch_items,
-            cancelled: None,
-        },
-        &mut cache,
-    )
+    with_detached_sidecar_query_cache(controller, |cache| {
+        execute_strict_retrieval_query_batch_with_cache(
+            QueryBatchRequest {
+                project_root: &project_root,
+                storage_path: &storage_path,
+                queries: &batch_items,
+                cancelled: None,
+            },
+            cache,
+        )
+    })
 }
 
 pub(crate) fn maybe_run_retrieval_shadow(
@@ -1473,8 +1492,9 @@ mod tests {
     use crate::agent::packet_evidence::PacketEvidenceTier;
     use codestory_contracts::api::{NodeId, NodeKind as ApiNodeKind, SearchHitOrigin};
     use codestory_retrieval::{
-        CandidateHit, QueryTrace, RetrievalStageKind, StageTrace, classify_query,
-        project_id_for_root, rank_candidates, test_support::retrieval_manifest_fixture,
+        CandidateHit, QueryTrace, RetrievalCacheKey, RetrievalStageKind, StageTrace,
+        classify_query, project_id_for_root, rank_candidates,
+        test_support::retrieval_manifest_fixture,
     };
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
@@ -1505,6 +1525,20 @@ mod tests {
         }
     }
 
+    fn retrieval_cache_key_for_test(query_fingerprint: &str) -> RetrievalCacheKey {
+        RetrievalCacheKey {
+            project_id: "abc".into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: "codestory_abc".into(),
+            scip_revision: None,
+            sidecar_generation: Some("abc-hash".into()),
+            sidecar_input_hash: Some("hash".into()),
+            sidecar_schema_version: Some(1),
+            projection_count: Some(1),
+            query_fingerprint: query_fingerprint.into(),
+        }
+    }
+
     #[test]
     fn env_flag_parsing_for_retrieval_rollout() {
         assert!(env_flag_enabled("1"));
@@ -1512,6 +1546,77 @@ mod tests {
         assert!(!env_flag_enabled("0"));
         assert!(env_flag_disabled("off"));
         assert!(!env_flag_disabled("yes"));
+    }
+
+    #[test]
+    fn detached_sidecar_query_cache_does_not_hold_mutex_during_work() {
+        let controller = AppController::new();
+        let first = retrieval_cache_key_for_test("first");
+        let second = retrieval_cache_key_for_test("second");
+        controller.sidecar_query_cache.lock().insert(
+            first.clone(),
+            vec![CandidateHit::lexical_stub("src/first.rs", 1.0)],
+        );
+
+        with_detached_sidecar_query_cache(&controller, |cache| {
+            assert!(
+                controller.sidecar_query_cache.try_lock().is_some(),
+                "sidecar query cache mutex should not be held during retrieval work"
+            );
+            assert_eq!(
+                cache.get(&first).expect("detached cache carries entries")[0].file_path,
+                "src/first.rs"
+            );
+            cache.insert(
+                second.clone(),
+                vec![CandidateHit::lexical_stub("src/second.rs", 1.0)],
+            );
+        });
+
+        let cache = controller.sidecar_query_cache.lock();
+        assert_eq!(
+            cache
+                .get(&first)
+                .expect("original cache entry should merge back")[0]
+                .file_path,
+            "src/first.rs"
+        );
+        assert_eq!(
+            cache
+                .get(&second)
+                .expect("new cache entry should merge back")[0]
+                .file_path,
+            "src/second.rs"
+        );
+    }
+
+    #[test]
+    fn detached_sidecar_query_cache_skips_merge_after_invalidation() {
+        let controller = AppController::new();
+        let first = retrieval_cache_key_for_test("first");
+        let second = retrieval_cache_key_for_test("second");
+        controller.sidecar_query_cache.lock().insert(
+            first.clone(),
+            vec![CandidateHit::lexical_stub("src/first.rs", 1.0)],
+        );
+
+        with_detached_sidecar_query_cache(&controller, |cache| {
+            controller.sidecar_query_cache.lock().clear();
+            cache.insert(
+                second.clone(),
+                vec![CandidateHit::lexical_stub("src/second.rs", 1.0)],
+            );
+        });
+
+        let cache = controller.sidecar_query_cache.lock();
+        assert!(
+            cache.get(&first).is_none(),
+            "clear during detached work should invalidate original entries"
+        );
+        assert!(
+            cache.get(&second).is_none(),
+            "detached entries must not merge after cache invalidation"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -7151,10 +7151,64 @@ fn clear_search_engine(state: &mut AppState) {
 #[derive(Clone)]
 pub struct AppController {
     state: Arc<Mutex<AppState>>,
-    sidecar_query_cache: Arc<Mutex<codestory_retrieval::RetrievalCache>>,
+    sidecar_query_cache: Arc<Mutex<SidecarQueryCacheState>>,
     grounding_detail_refresh: Arc<Mutex<()>>,
     events_tx: Sender<AppEventPayload>,
     events_rx: Receiver<AppEventPayload>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SidecarQueryCacheState {
+    generation: u64,
+    cache: codestory_retrieval::RetrievalCache,
+}
+
+impl SidecarQueryCacheState {
+    fn new() -> Self {
+        Self {
+            generation: 0,
+            cache: codestory_retrieval::RetrievalCache::new(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.cache.clear();
+    }
+
+    pub(crate) fn snapshot(&self) -> (u64, codestory_retrieval::RetrievalCache) {
+        (self.generation, self.cache.clone())
+    }
+
+    pub(crate) fn merge_if_current(
+        &mut self,
+        generation: u64,
+        baseline: &codestory_retrieval::RetrievalCache,
+        cache: codestory_retrieval::RetrievalCache,
+    ) -> bool {
+        if self.generation != generation {
+            return false;
+        }
+        self.cache.merge_delta_from(baseline, cache);
+        true
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert(
+        &mut self,
+        key: codestory_retrieval::RetrievalCacheKey,
+        hits: Vec<codestory_retrieval::CandidateHit>,
+    ) {
+        self.cache.insert(key, hits);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get(
+        &self,
+        key: &codestory_retrieval::RetrievalCacheKey,
+    ) -> Option<&[codestory_retrieval::CandidateHit]> {
+        self.cache.get(key)
+    }
 }
 
 impl Default for AppController {
@@ -7177,7 +7231,7 @@ impl AppController {
                 #[cfg(test)]
                 last_hybrid_instrumentation: None,
             })),
-            sidecar_query_cache: Arc::new(Mutex::new(codestory_retrieval::RetrievalCache::new())),
+            sidecar_query_cache: Arc::new(Mutex::new(SidecarQueryCacheState::new())),
             grounding_detail_refresh: Arc::new(Mutex::new(())),
             events_tx,
             events_rx,

--- a/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
+++ b/crates/codestory-runtime/tests/retrieval_browser_contracts.rs
@@ -295,8 +295,7 @@ fn assert_mandatory_sidecar_unavailable(error: &ApiError) {
     assert!(
         details
             .next_commands
-            .iter()
-            .next()
+            .first()
             .is_some_and(|command| command.contains("codestory-cli ready --goal agent --repair")),
         "retrieval error should start with the canonical agent repair command: {error:?}"
     );

--- a/crates/codestory-runtime/tests/retrieval_eval.rs
+++ b/crates/codestory-runtime/tests/retrieval_eval.rs
@@ -183,8 +183,7 @@ fn retrieval_eval_search_fails_closed_without_full_retrieval_sidecars() {
     assert!(
         details
             .next_commands
-            .iter()
-            .next()
+            .first()
             .is_some_and(|command| command.contains("codestory-cli ready --goal agent --repair")),
         "retrieval error should start with the canonical agent repair command: {error:?}"
     );

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 
 [dependencies]

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -10,7 +10,7 @@ name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory-retrieval}
 
 services:
   qdrant:
-    image: qdrant/qdrant:v1.12.5
+    image: qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-qdrant
     restart: unless-stopped
     labels:
@@ -27,7 +27,7 @@ services:
 
   # Zoekt webserver (mount index dir populated by `retrieval index`).
   zoekt:
-    image: sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4
+    image: sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4@sha256:34c77a62bcafc41ce3ee193e44f42aa84690d9ec51b953e7efae4dfdfae80aff
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-zoekt
     restart: unless-stopped
     labels:
@@ -44,7 +44,7 @@ services:
   # BAAI/bge-base-en-v1.5 embeddings via llama.cpp OpenAI-compatible API (768-dim).
   # Model GGUF must exist under CODESTORY_EMBED_MODEL_DIR (see setup-retrieval-env.mjs).
   embed:
-    image: ghcr.io/ggml-org/llama.cpp:server
+    image: ghcr.io/ggml-org/llama.cpp:server@sha256:f16ca66f3ba316b7a7a16003ddfa88d29c3404fbe86550da086736864c11574c
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-embed
     restart: unless-stopped
     labels:

--- a/docs/architecture/subsystems/cli.md
+++ b/docs/architecture/subsystems/cli.md
@@ -94,7 +94,7 @@ not expose ranking knobs for product search/context calls.
 
 ## Serving And Integration Surface
 
-HTTP serving keeps the current small GET/query-string shape. The stable routes are `/health`, `/search`, `/symbol`, `/definition`, `/references`, `/symbols`, and `/trail`. Definition and references accept either `q` or `id`, so agents can resolve from a query first and then reuse exact node ids.
+HTTP serving keeps the current small GET/query-string shape. It is local-only by default: non-loopback binds and non-loopback `Host`/`Origin` headers are rejected unless the operator passes `--allow-non-loopback` behind an intentional network boundary. The stable routes are `/health`, `/search`, `/symbol`, `/definition`, `/references`, `/symbols`, and `/trail`. Definition and references accept either `q` or `id`, so agents can resolve from a query first and then reuse exact node ids.
 
 `serve --stdio` is MCP-style JSON lines. It exposes tools for ground, files, affected, packet, search, context, symbol, callers, callees, trace, trail, definition, references, symbols, snippet, and warm graph primitives (`get_node`, `neighbors`, `shortest_path`, and `query_subgraph`); resources for project, grounding, and root symbols; resource templates for node-specific symbol/reference/snippet/trail reads; and prompts for explain-symbol, callflow tracing, and impact analysis.
 

--- a/docs/contributors/documentation-maintenance-checklist.md
+++ b/docs/contributors/documentation-maintenance-checklist.md
@@ -65,7 +65,7 @@ contract-complete.
 ### Verification process
 - [ ] Run `cargo fmt --check` on all documentation-related code
 - [ ] Run `cargo check` to ensure no documentation compilation errors
-- [ ] Run `cargo clippy --all-targets -- -D warnings` for linting
+- [ ] Run `cargo clippy --workspace --all-targets --all-features -- -D warnings` for strict linting
 - [ ] Run plugin static tests with `node --test plugins/codestory/tests/plugin-static.test.mjs` when plugin files change (structure and runtime shape only — not doc copy)
 - [ ] Check for broken links with `node .github/scripts/check-doc-links.mjs` (covers `README.md`, `docs/**` including templates, `plugins/codestory/README.md`, `plugins/codestory/docs/**`, and `plugins/codestory/skills/**`)
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -23,7 +23,7 @@ flowchart TD
     store --> store_tests["cargo test -p codestory-store"]
     runtime --> runtime_tests["cargo test -p codestory-runtime and retrieval_eval"]
     cli --> cli_tests["cargo test -p codestory-cli"]
-    bench --> bench_checks["cargo check -p codestory-bench --benches"]
+    bench --> bench_checks["cargo check -p codestory-bench --bench name"]
     e2e --> e2e_stats["release build + codestory_repo_e2e_stats"]
 ```
 
@@ -34,7 +34,7 @@ Run Cargo commands serially in this repo.
 | Lane | Commands |
 | --- | --- |
 | Docs only | `git diff --check`, `node .github/scripts/check-doc-links.mjs` |
-| Routine code | `cargo fmt --check`, `cargo check`, `cargo test`, `cargo clippy --all-targets -- -D warnings` |
+| Routine code | `cargo fmt --check`, `cargo check`, `cargo test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` |
 | Release-blocking fidelity | `cargo test -p codestory-indexer --test fidelity_regression`, `cargo test -p codestory-indexer --test tictactoe_language_coverage`, `cargo test -p codestory-runtime --test retrieval_eval` |
 | Heavy repo-scale timing | `cargo build --release -p codestory-cli`, then `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture` |
 
@@ -49,11 +49,15 @@ changes.
 cargo fmt --check
 cargo check
 cargo test
-cargo clippy --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
 These are the default broad checks for code changes after the lane picker says
 workspace-wide proof is useful.
+
+Do not use `cargo test --workspace --all-targets` as the routine broad test
+gate. `--all-targets` expands into benchmark targets; Criterion benches are
+compiled or run through the bench lane below.
 
 ## Release And Version Bumps
 
@@ -300,8 +304,14 @@ present. A zero-evaluated run is not quality proof.
 
 ```sh
 node scripts/semantic-doc-leakage-check.mjs
-cargo check -p codestory-bench --benches
+cargo check -p codestory-bench --bench <name>
 ```
+
+Criterion benches opt out of broad workspace test selection. Run them
+explicitly with `cargo bench -p codestory-bench --bench <name>` when the lane
+needs performance numbers. Use the same explicit `--bench <name>` form for
+compile-only proof; aggregate `--benches` does not select benches that opt out
+of broad workspace test selection.
 
 When changing embedding backends, model profiles, pooling, prefixes, batching,
 hardware-provider settings, generated symbol-doc text, or dense-anchor text, run

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -302,13 +302,31 @@ sidecar implementation, CI policy, retention behavior, or promotion gates.
 
 ### Version pins
 
-| Dependency | Pin policy | Pinned version | Notes |
-|------------|------------|----------------|-------|
-| Zoekt real | `COMPOSE_PROFILES=real` | `zoekt-20250506123554` | `sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4` plus lexical shards |
-| Qdrant | Fixed container image tag | `qdrant/qdrant:v1.12.5` | HTTP `6333`, gRPC `6334` |
+| Dependency | Pin policy | Pinned identity | Notes |
+|------------|------------|-----------------|-------|
+| Zoekt real | `COMPOSE_PROFILES=real` plus digest-pinned image | `zoekt-20250506123554`; `sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4@sha256:34c77a62bcafc41ce3ee193e44f42aa84690d9ec51b953e7efae4dfdfae80aff` | Lexical shards still live under the sidecar generation |
+| Qdrant | Digest-pinned container image | `qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae` | HTTP `6333`, gRPC `6334` |
+| llama.cpp embed | Digest-pinned container image | `ghcr.io/ggml-org/llama.cpp:server@sha256:f16ca66f3ba316b7a7a16003ddfa88d29c3404fbe86550da086736864c11574c` | Used only when the embedding launch mode is Docker Compose |
 | SCIP | CodeStory graph artifact emitter | `graph-<hash>` | Generated local graph artifacts under the sidecar generation |
 
 CI `retrieval-sidecar-smoke` should use the same pins as local development.
+`retrieval bootstrap --format json`, `retrieval status --format json`, and the
+sidecar state file expose `sidecar_images` so smoke artifacts record the exact
+image identities used for packet/search readiness.
+
+To refresh an image pin safely:
+
+1. Inspect the candidate tag with Docker manifest tooling, for example
+   `docker buildx imagetools inspect qdrant/qdrant:v1.12.5`.
+2. Copy the top-level `Digest:` value for multi-arch images or the manifest
+   digest for single-manifest images.
+3. Update `docker/retrieval-compose.yml`,
+   `crates/codestory-retrieval/src/config.rs`, this table, and any manual
+   fallback command that names the image.
+4. Run `docker compose -f docker/retrieval-compose.yml config`,
+   `cargo test -p codestory-retrieval`, `cargo test -p codestory-cli --test
+   retrieval_bootstrap_contracts`, and the `retrieval-sidecar-smoke` workflow
+   before treating packet/search evidence as refreshed.
 
 ### Manifest and generation contract
 

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -386,7 +386,9 @@ expansion lanes are skipped for that query.
 
 `retrieval-sidecar-smoke` is a reduced CI contract lane, not the operator repair
 path and not a full sidecar proof. Linux carries generic
-lint/runtime/search/retrieval contract slices. Windows carries the
+lint/runtime/search/retrieval contract slices plus the non-live packet/search
+fixture and baseline gate (`cargo test -p codestory-cli --test packet_search_eval`).
+Windows carries the
 manifest-missing bootstrap/status shape only when manually dispatched or when a
 PR has the `ci:windows-smoke` label.
 

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -61,11 +61,14 @@ cargo build --release -p codestory-cli
 cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture
 cargo test -p codestory-cli --test search_json_output -- --ignored --nocapture search_quality_eval
 cargo test -p codestory-runtime --test retrieval_eval
-cargo check -p codestory-bench --benches
+cargo check -p codestory-bench --bench <name>
 ```
 
 `retrieval_eval` needs `CODESTORY_RETRIEVAL_EVAL_FULL_TESTS=1` for full sidecar quality assertions;
 without it, the suite checks that non-full retrieval fails closed.
+
+Bench targets opt out of broad workspace test selection, so compile or run them
+with an explicit `--bench <name>` target.
 
 Use Criterion benches from `crates/codestory-bench` only when the measured hot
 path is narrower than the repo-scale e2e test can explain.

--- a/docs/testing/search-quality-eval.md
+++ b/docs/testing/search-quality-eval.md
@@ -43,6 +43,10 @@ schema, category, baseline, and non-full-mode gating checks with:
 cargo test -p codestory-cli --test packet_search_eval
 ```
 
+This non-ignored command is the CI-safe packet/search gate. It validates fixture
+schema, category coverage, baselines, and non-full-mode behavior without claiming
+live sidecar readiness.
+
 The live production-path check is ignored by default because it repairs and
 requires `retrieval_mode=full` agent sidecars for the checkout:
 

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/.mcp.json
+++ b/plugins/codestory/.mcp.json
@@ -3,6 +3,7 @@
     "codestory": {
       "command": "node",
       "args": ["./scripts/codestory-mcp.cjs"],
+      "cwd": ".",
       "tool_timeout_sec": 300
     }
   }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -14,6 +14,7 @@ const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codesto
 const fallbackBinaryNames = process.platform === 'win32'
   ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
   : ['codestory-cli'];
+const activeStateFile = '.codestory-active';
 const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
@@ -90,6 +91,83 @@ function pluginDataDir() {
 
 function sidecarPolicyPath(dataDir = pluginDataDir()) {
   return dataDir ? path.join(dataDir, 'sidecar-setup-policy.json') : null;
+}
+
+function activeStatePath(dataDir = pluginDataDir()) {
+  return dataDir ? path.join(dataDir, activeStateFile) : null;
+}
+
+function normalizeProjectRoot(projectRoot) {
+  const resolved = path.resolve(projectRoot);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function existingProjectRoot(projectRoot) {
+  if (!projectRoot || typeof projectRoot !== 'string' || !projectRoot.trim()) return null;
+  const normalized = normalizeProjectRoot(projectRoot);
+  try {
+    return fs.statSync(normalized).isDirectory() ? normalized : null;
+  } catch {
+    return null;
+  }
+}
+
+function activeProjectStateMaxAgeMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60 * 60 * 1000;
+}
+
+function activeProjectStateTimestamp(active, statePath) {
+  const parsed = Date.parse(active?.updatedAt || active?.updated_at || '');
+  if (Number.isFinite(parsed)) return parsed;
+  try {
+    return fs.statSync(statePath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function activeProjectStateFresh(active, statePath, nowMs = Date.now()) {
+  const timestamp = activeProjectStateTimestamp(active, statePath);
+  return timestamp !== null && nowMs - timestamp <= activeProjectStateMaxAgeMs();
+}
+
+function resolveProjectRoot(options = {}) {
+  const explicit = existingProjectRoot(options.projectRoot || process.env.CODESTORY_PROJECT_ROOT);
+  if (explicit) {
+    return { projectRoot: explicit, source: options.projectRoot ? 'argument' : 'env' };
+  }
+
+  const cwd = existingProjectRoot(process.cwd());
+  if (cwd && !samePathText(cwd, pluginRoot)) {
+    return { projectRoot: cwd, source: 'process_cwd' };
+  }
+
+  const statePath = activeStatePath();
+  const active = statePath ? readJson(statePath) : null;
+  if (active && !activeProjectStateFresh(active, statePath)) {
+    return {
+      projectRoot: null,
+      source: 'plugin_active_state_stale',
+      statePath,
+      reason: 'project_root_unavailable',
+    };
+  }
+  const activeRoot = existingProjectRoot(active?.cwd);
+  if (activeRoot && !samePathText(activeRoot, pluginRoot)) {
+    return { projectRoot: activeRoot, source: 'plugin_active_state', statePath };
+  }
+
+  return {
+    projectRoot: null,
+    source: statePath ? 'plugin_active_state_missing' : 'plugin_data_missing',
+    statePath,
+    reason: 'project_root_unavailable',
+  };
 }
 
 function sidecarPolicyCommand(action, policyFile = sidecarPolicyPath()) {
@@ -588,6 +666,7 @@ function runLocalNavigationWaitFresh(resolved, projectRoot) {
   const args = ['ready', '--goal', 'local', '--wait-fresh'];
   args.push('--project', projectRoot, '--format', 'json');
   const result = spawnSync(resolved.path, args, {
+    cwd: projectRoot,
     encoding: 'utf8',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     timeout: localWaitFreshTimeoutMs(),
@@ -602,6 +681,7 @@ function runSidecarStartupRepair(resolved, sidecarStatus, projectRoot = process.
   const args = ['ready', '--goal', 'agent', '--repair'];
   args.push('--project', projectRoot, '--format', 'json', '--run-id', sharedAgentRunId);
   const result = spawnSync(resolved.path, args, {
+    cwd: projectRoot,
     encoding: 'utf8',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     timeout: sidecarRepairTimeoutMs(),
@@ -768,7 +848,7 @@ function pluginRuntimeForResolved(resolved) {
 }
 
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {
-  const projectRoot = options.projectRoot || process.cwd();
+  const projectRoot = Object.hasOwn(options, 'projectRoot') ? options.projectRoot : process.cwd();
   const pathCandidates = pathCliCandidates().map((candidate) => ({
     path: candidate,
     version: cliVersion(candidate),
@@ -856,6 +936,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     },
     warnings: plugin.warnings,
     project_root: projectRoot,
+    project_root_source: options.projectRootSource || null,
     retrieval_mode: 'unavailable',
     degraded_reason: reason,
     local_refresh: options.localRefresh || null,
@@ -869,7 +950,25 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   };
 }
 
+function projectRootUnavailableDiagnostic(resolved, probe, projectResolution) {
+  return fallbackDiagnostic(resolved, probe, projectResolution.reason, {
+    projectRoot: null,
+    projectRootSource: projectResolution.source,
+    goal: 'project_root',
+    status: 'repair_setup',
+    summary: 'CodeStory plugin MCP could not determine the target project root before starting stdio.',
+    minimumNext: [
+      'Restart/reload the Codex host from the target repo after a lifecycle hook records the active project, then read codestory://status.',
+    ],
+    fullRepair: [
+      'Start or resume the Codex session in the target repo so CodeStory lifecycle hooks can write active project state.',
+      'Restart/reload the Codex host from the target repo, then read codestory://status.',
+    ],
+  });
+}
+
 async function bootstrapStatus(projectRoot = process.cwd()) {
+  projectRoot = normalizeProjectRoot(projectRoot);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
   const probe = probeResolvedCli(resolved);
@@ -923,6 +1022,7 @@ async function bootstrapStatus(projectRoot = process.cwd()) {
     server_version: resolved.version,
     cli_version: probe.version,
     plugin_runtime: plugin,
+    project_root_source: 'argument',
     runtime_truth: runtimeTruthStatus(plugin, repair, {
       sidecarPolicy: sidecarPolicy.state || 'unavailable',
       localRefresh,
@@ -935,14 +1035,26 @@ async function bootstrapStatus(projectRoot = process.cwd()) {
 
 async function handleBootstrapStatusCommand(argv) {
   if (argv[2] !== 'bootstrap-status') return false;
-  const projectRoot = optionValue(argv, '--project') || process.cwd();
+  const resolution = resolveProjectRoot({ projectRoot: optionValue(argv, '--project') });
   try {
+    if (!resolution.projectRoot) {
+      const resolved = await resolveCli();
+      rememberLaunch(resolved);
+      const probe = probeResolvedCli(resolved);
+      process.stdout.write(`${JSON.stringify({
+        ready: false,
+        ...projectRootUnavailableDiagnostic(resolved, probe, resolution),
+      })}\n`);
+      process.exit(0);
+    }
+    const projectRoot = resolution.projectRoot;
     process.stdout.write(`${JSON.stringify(await bootstrapStatus(projectRoot))}\n`);
   } catch (error) {
     process.stdout.write(`${JSON.stringify({
       ready: false,
       degraded_reason: `launcher_error:${error.message}`,
-      project_root: projectRoot,
+      project_root: resolution.projectRoot,
+      project_root_source: resolution.source,
     })}\n`);
   }
   process.exit(0);
@@ -995,6 +1107,7 @@ function dedupePaths(paths) {
 }
 
 function sourceCheckoutVersion(projectRoot) {
+  if (!projectRoot) return null;
   try {
     return cargoPackageVersion(fs.readFileSync(path.join(projectRoot, 'crates', 'codestory-cli', 'Cargo.toml'), 'utf8'));
   } catch {
@@ -1223,14 +1336,25 @@ async function main() {
   const resolved = await resolveCli();
   rememberLaunch(resolved);
   const probe = probeResolvedCli(resolved);
+  const projectResolution = resolveProjectRoot();
   const failOpenReason = failOpenReasonForProbe(resolved, probe);
   if (failOpenReason) {
-    runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason));
+    runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason, {
+      projectRoot: projectResolution.projectRoot,
+      projectRootSource: projectResolution.source,
+    }));
     return;
   }
-  const localReadiness = probeLocalNavigation(resolved);
+  if (!projectResolution.projectRoot) {
+    runFailOpenMcp(projectRootUnavailableDiagnostic(resolved, probe, projectResolution));
+    return;
+  }
+  const projectRoot = projectResolution.projectRoot;
+  const localReadiness = probeLocalNavigation(resolved, projectRoot);
   if (!localReadiness.ready) {
     runFailOpenMcp(fallbackDiagnostic(resolved, probe, localReadiness.reason, {
+      projectRoot,
+      projectRootSource: projectResolution.source,
       status: localReadiness.status,
       summary: localReadiness.summary,
       minimumNext: localReadiness.minimumNext,
@@ -1243,10 +1367,11 @@ async function main() {
     }));
     return;
   }
-  const sidecarStatus = runSidecarStartupRepair(resolved, readSidecarPolicy(), process.cwd());
-  const dirtyMarker = dirtyMarkerEnv(process.cwd());
+  const sidecarStatus = runSidecarStartupRepair(resolved, readSidecarPolicy(), projectRoot);
+  const dirtyMarker = dirtyMarkerEnv(projectRoot);
 
-  const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none'], {
+  const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none', '--project', projectRoot], {
+    cwd: projectRoot,
     stdio: 'inherit',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     windowsHide: true,
@@ -1266,12 +1391,14 @@ async function main() {
       CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
       CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
       CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+      CODESTORY_PLUGIN_PROJECT_ROOT: projectRoot,
+      CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE: projectResolution.source,
       CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
       CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
       CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
       CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
       CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
-      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, process.cwd()),
+      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, projectRoot),
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
       CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
@@ -1293,7 +1420,10 @@ async function main() {
       version: null,
       stdout: '',
       stderr: '',
-    }, `${resolved.source}_cli_unspawnable`));
+    }, `${resolved.source}_cli_unspawnable`, {
+      projectRoot,
+      projectRootSource: projectResolution.source,
+    }));
   });
 }
 

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -105,6 +105,12 @@ function normalizeSidecarPolicyState(value) {
   return 'ask';
 }
 
+function sidecarPolicyStateForAction(action) {
+  if (action === 'enable' || action === 'repair') return 'enabled';
+  if (action === 'disable') return 'disabled';
+  return 'ask';
+}
+
 function readSidecarPolicy(file = sidecarPolicyPath()) {
   const policy = file ? readJson(file) : null;
   const state = normalizeSidecarPolicyState(process.env.CODESTORY_PLUGIN_SIDECAR_POLICY || policy?.state);
@@ -135,8 +141,8 @@ function handleSidecarPolicyCommand(argv) {
   const action = argv[3] || 'status';
   const policyFileFlag = argv.indexOf('--policy-file');
   const policyFile = policyFileFlag >= 0 ? argv[policyFileFlag + 1] : sidecarPolicyPath();
-  if (!['enable', 'disable', 'ask', 'status'].includes(action)) {
-    process.stderr.write('usage: codestory-mcp.cjs sidecar-policy [enable|disable|ask|status] [--policy-file PATH]\n');
+  if (!['enable', 'disable', 'ask', 'repair', 'status'].includes(action)) {
+    process.stderr.write('usage: codestory-mcp.cjs sidecar-policy [enable|disable|ask|repair|status] [--policy-file PATH]\n');
     process.exit(2);
   }
   if (policyFileFlag >= 0 && !policyFile) {
@@ -148,7 +154,7 @@ function handleSidecarPolicyCommand(argv) {
       process.stderr.write('sidecar-policy needs PLUGIN_DATA or --policy-file to remember the setting\n');
       process.exit(2);
     }
-    writeSidecarPolicy(action === 'enable' ? 'enabled' : action === 'disable' ? 'disabled' : 'ask', {}, policyFile);
+    writeSidecarPolicy(sidecarPolicyStateForAction(action), {}, policyFile);
   }
   process.stdout.write(`${JSON.stringify(readSidecarPolicy(policyFile), null, 2)}\n`);
   process.exit(0);
@@ -1067,15 +1073,15 @@ function failOpenToolResult(status) {
 
 function failOpenSidecarSetupResult(request) {
   const action = request.params?.arguments?.action || 'status';
-  if (!['status', 'enable', 'disable', 'ask'].includes(action)) {
+  if (!['status', 'enable', 'disable', 'ask', 'repair'].includes(action)) {
     return {
       isError: true,
-      content: [{ type: 'text', text: 'sidecar_setup.action must be status, enable, disable, or ask while the runtime is in diagnostic mode.' }],
+      content: [{ type: 'text', text: 'sidecar_setup.action must be status, enable, disable, ask, or repair while the runtime is in diagnostic mode.' }],
       structuredContent: { code: 'invalid_sidecar_setup_action', action },
     };
   }
   if (action !== 'status') {
-    writeSidecarPolicy(action === 'enable' ? 'enabled' : action === 'disable' ? 'disabled' : 'ask');
+    writeSidecarPolicy(sidecarPolicyStateForAction(action));
   }
   const policy = readSidecarPolicy();
   return {
@@ -1102,7 +1108,7 @@ function runFailOpenMcp(status) {
     inputSchema: {
       type: 'object',
       properties: {
-        action: { type: 'string', enum: ['status', 'enable', 'disable', 'ask'], default: 'status' },
+        action: { type: 'string', enum: ['status', 'enable', 'disable', 'ask', 'repair'], default: 'status' },
       },
       additionalProperties: false,
     },

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -23,6 +23,7 @@ The installed plugin starts `scripts/codestory-mcp.cjs` (managed CLI bootstrap a
 | `--project <path>` | `.` | Repository root to serve. Always pass it explicitly. |
 | `--cache-dir <path>` | auto | Serve a specific cache directory. |
 | `--addr <host:port>` | `127.0.0.1:3917` | HTTP bind address. |
+| `--allow-non-loopback` | off | Required before HTTP serve can bind or answer wildcard/remote-facing addresses. Use only behind an intentional network boundary; HTTP routes do not require request authentication. |
 | `--stdio` | off | Use JSON-lines stdio instead of HTTP. |
 | `--refresh <auto|full|incremental|none>` | `none` | Read an existing cache unless you intentionally refresh. |
 
@@ -50,7 +51,7 @@ Stdio MCP status fields and allowed-surface rules: [status-contract.md](status-c
 
 ## Notes
 
-- `serve` is local by default on `127.0.0.1`; do not bind wider unless the user explicitly needs remote access.
+- `serve` is local by default on `127.0.0.1`; non-loopback HTTP binds and non-loopback `Host`/`Origin` headers fail unless `--allow-non-loopback` is set. Do not bind wider unless the user explicitly needs remote access and the network boundary is intentional.
 - HTTP only accepts GET requests for the documented routes.
 - Start it after a successful index or with an intentional refresh mode.
 - In one `serve --stdio` process, identical successful `packet` and search-fragment requests are cached with small LRUs keyed by request arguments, the current SQLite/WAL fingerprint, and a mandatory sidecar-readiness fingerprint. The sidecar fingerprint includes the active embedding backend, sidecar state-file metadata, strict retrieval mode, degraded reason, manifest generation/input hash/backend/dimension, and status errors. This is for repeated agent calls only; changed index files, sidecar state drift, and strict stale/unavailable readiness bypass the cache.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -111,7 +111,7 @@ test("plugin metadata maps skill and direct stdio server", async () => {
   assert.deepEqual(mcp.mcpServers.codestory.args, [
     "./scripts/codestory-mcp.cjs",
   ]);
-  assert.equal(Object.hasOwn(mcp.mcpServers.codestory, "cwd"), false);
+  assert.equal(mcp.mcpServers.codestory.cwd, ".");
 });
 
 test("plugin package version tracks the codestory-cli release version", async () => {
@@ -314,6 +314,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
       "utf8",
     );
+    const realRepoRoot = await realpath(repoRoot);
 
     const result = spawnSync(process.execPath, [launcher], {
       env: {
@@ -341,9 +342,9 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     );
     assert.match(observed.sidecarRepair, /ready --goal agent --repair/u);
     assert.match(observed.sidecarRepair, /--run-id shared-agent/u);
-    assert.equal(observed.dirtyMarkerRoot, await realpath(repoRoot));
-    assert.equal(observed.dirtyMarkerPath, dirtyMarkerPathForProject(repoRoot, dataDir));
-    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+    assert.equal(observed.dirtyMarkerRoot, realRepoRoot);
+    assert.equal(observed.dirtyMarkerPath, dirtyMarkerPathForProject(realRepoRoot, dataDir));
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none", "--project", realRepoRoot]);
 
     const enable = spawnSync(observed.sidecarEnable, {
       shell: true,
@@ -359,6 +360,230 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
     );
     assert.equal(policy.state, "enabled");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher uses active project state when host launches from plugin root", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-active-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const realRepoRoot = await realpath(repoRoot);
+
+  try {
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({ event: "SessionStart", cwd: realRepoRoot, updatedAt: new Date().toISOString() }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "const command = args[0];",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({",
+        "  cwd: process.cwd(),",
+        "  args,",
+        "  projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '',",
+        "  projectRootSource: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE || '',",
+        "  dirtyMarkerPath: process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH || '',",
+        "  dirtyMarkerRoot: process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT || ''",
+        "}) + '\\n');",
+        "if (command === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (command === 'ready' && args.includes('--wait-fresh') && !args.includes('--repair') && !args.includes('agent')) {",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'ready', summary: 'ready', minimum_next: [], full_repair: [] }], local_refresh: { state: 'fresh', reason: 'already_fresh', blocks_local_surfaces: false, readiness_status: 'ready', changed_file_count: 0, new_file_count: 0, removed_file_count: 0, fatal_error_count: 0 } }));",
+        "  process.exit(0);",
+        "}",
+        "if (command === 'serve') { fs.writeFileSync(process.env.TEST_OUT, 'serve-called'); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      encoding: "utf8",
+      timeout: 15000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(await readFile(marker, "utf8"), "serve-called");
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    const ready = calls.find((call) => call.args[0] === "ready" && call.args.includes("--wait-fresh"));
+    const serve = calls.find((call) => call.args[0] === "serve");
+    assert.ok(ready, "expected local wait-fresh call");
+    assert.ok(serve, "expected serve call");
+    assert.equal(ready.args[ready.args.indexOf("--project") + 1], realRepoRoot);
+    assert.equal(ready.cwd, realRepoRoot);
+    assert.deepEqual(serve.args, ["serve", "--stdio", "--refresh", "none", "--project", realRepoRoot]);
+    assert.equal(serve.cwd, realRepoRoot);
+    assert.equal(serve.projectRoot, realRepoRoot);
+    assert.equal(serve.projectRootSource, "plugin_active_state");
+    assert.equal(serve.dirtyMarkerRoot, realRepoRoot);
+    assert.equal(serve.dirtyMarkerPath, dirtyMarkerPathForProject(realRepoRoot, dataDir));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher rejects stale active project state from plugin root", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-stale-active-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({ event: "SessionStart", cwd: await realpath(repoRoot), updatedAt: "2000-01-01T00:00:00.000Z" }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd() }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_stale");
+    assert.equal(status.readiness[0].goal, "project_root");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("bootstrap-status fails open when plugin-root launch lacks project state", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-bootstrap-no-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+
+  try {
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd() }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher, "bootstrap-status"], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const status = JSON.parse(result.stdout.trim());
+    assert.equal(status.ready, false);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_missing");
+    assert.equal(status.readiness[0].goal, "project_root");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -586,8 +811,16 @@ test("mcp launcher waits for fresh local navigation without agent repair", async
     assert.equal(calls.some((call) => call.args.includes("agent")), false);
     assert.equal(calls.some((call) => call.args.includes("--repair")), false);
     assert.equal(calls.some((call) => call.sidecarRepair), false);
+    const realDataDir = await realpath(dataDir);
     assert.ok(calls.some((call) => {
-      return JSON.stringify(call.args) === JSON.stringify(["serve", "--stdio", "--refresh", "none"]);
+      return JSON.stringify(call.args) === JSON.stringify([
+        "serve",
+        "--stdio",
+        "--refresh",
+        "none",
+        "--project",
+        realDataDir,
+      ]);
     }));
   } finally {
     await rm(dataDir, { recursive: true, force: true });
@@ -945,6 +1178,7 @@ test("enabled sidecar policy runs one agent repair at MCP startup", async () => 
     const text = await readFile(logFile, "utf8");
     const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
     const repairCalls = calls.filter((call) => call.repair);
+    const realRepoRoot = await realpath(repoRoot);
     assert.equal(repairCalls.length, 1, text);
     assert.equal(repairCalls[0].policy, "enabled");
     assert.deepEqual(repairCalls[0].args, [
@@ -953,18 +1187,25 @@ test("enabled sidecar policy runs one agent repair at MCP startup", async () => 
       "agent",
       "--repair",
       "--project",
-      repoRoot,
+      realRepoRoot,
       "--format",
       "json",
       "--run-id",
       "shared-agent",
     ]);
     assert.ok(calls.some((call) => {
-      return JSON.stringify(call.args) === JSON.stringify(["serve", "--stdio", "--refresh", "none"]);
+      return JSON.stringify(call.args) === JSON.stringify([
+        "serve",
+        "--stdio",
+        "--refresh",
+        "none",
+        "--project",
+        realRepoRoot,
+      ]);
     }), text);
     const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
     assert.equal(policy.last_repair.state, "completed");
-    assert.equal(policy.last_repair.project_root, repoRoot);
+    assert.equal(policy.last_repair.project_root, realRepoRoot);
     assert.match(policy.last_repair.command, /ready --goal agent --repair/u);
     assert.match(policy.last_repair.command, /--run-id shared-agent/u);
   } finally {
@@ -1021,6 +1262,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
 
     assert.equal(result.status, 0, result.stderr);
     const observed = JSON.parse(await readFile(outFile, "utf8"));
+    const realRepoRoot = await realpath(repoRoot);
     assert.equal(observed.source, "managed");
     assert.equal(observed.version, version);
     assert.equal(observed.repoRef, `v${version}`);
@@ -1030,7 +1272,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
       observed.path,
       new RegExp(String.raw`codestory-cli[\\/]+${version.replaceAll(".", String.raw`\.`)}[\\/]bin[\\/]codestory-cli`, "u"),
     );
-    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none"]);
+    assert.deepEqual(observed.args, ["serve", "--stdio", "--refresh", "none", "--project", realRepoRoot]);
 
     const manifest = JSON.parse(
       await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -609,6 +609,7 @@ test("mcp launcher fails open when wait-fresh skips local refresh", async () => 
     JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "sidecar_setup", arguments: { action: "repair" } } }),
   ].join("\n") + "\n";
 
   try {
@@ -654,7 +655,7 @@ test("mcp launcher fails open when wait-fresh skips local refresh", async () => 
     assert.equal(result.status, 0, result.stderr);
     await assert.rejects(access(marker));
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 3, result.stdout);
+    assert.equal(responses.length, 4, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
     assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
     assert.equal(status.runtime_truth.runtime_source, "local_dev_override");
@@ -680,6 +681,9 @@ test("mcp launcher fails open when wait-fresh skips local refresh", async () => 
     assert.equal(responses[2].result.structuredContent.local_refresh.reason, "index_locked");
     assert.equal(responses[2].result.structuredContent.local_refresh.changed_file_count, 1);
     assert.equal(responses[2].result.structuredContent.local_refresh.fatal_error_count, 0);
+    assert.equal(responses[3].result.structuredContent.state, "enabled");
+    const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
+    assert.equal(policy.state, "enabled");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -882,10 +886,17 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
     assert.equal(disable.status, 0, disable.stderr);
     assert.equal(JSON.parse(disable.stdout).state, "disabled");
 
+    const repair = spawnSync(process.execPath, [launcher, "sidecar-policy", "repair"], {
+      env: { PLUGIN_DATA: dataDir },
+      encoding: "utf8",
+    });
+    assert.equal(repair.status, 0, repair.stderr);
+    assert.equal(JSON.parse(repair.stdout).state, "enabled");
+
     const policy = JSON.parse(
       await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
     );
-    assert.equal(policy.state, "disabled");
+    assert.equal(policy.state, "enabled");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }

--- a/scripts/setup-retrieval-env.mjs
+++ b/scripts/setup-retrieval-env.mjs
@@ -211,7 +211,7 @@ function printPrereqReport(opts) {
     console.log("\nManual Qdrant without compose:");
     console.log(
       `  docker run -d --name codestory-qdrant -p 127.0.0.1:6333:6333 -p 127.0.0.1:6334:6334 ` +
-        `-v "${path.join(cacheRoot, "qdrant")}:/qdrant/storage" qdrant/qdrant:v1.12.5`,
+        `-v "${path.join(cacheRoot, "qdrant")}:/qdrant/storage" qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae`,
     );
     console.log("\nZoekt without compose:");
     console.log("  run sourcegraph/zoekt-webserver on 127.0.0.1:6070 with the CodeStory shard directory mounted");


### PR DESCRIPTION
## Context

Closes #706
Refs #618
Refs #683

The post-review follow-up wave is complete on `dev/codestory-next`, but the published `v0.12.2` package and installed `0.12.2` plugin still predate the #704 package-root MCP launch fix. In particular, `plugins/codestory/.mcp.json` has `cwd: "."` on `dev/codestory-next` and does not have it on `main`/`v0.12.2`.

This PR promotes the completed dev wave to `main` as `0.12.3` so the fixed plugin package can be released and then validated by #618.

## What Changed

- Promotes the closed post-review follow-ups from `dev/codestory-next` to `main`, including:
  - #685 incremental resolution for added definitions.
  - #686 Windows projection identity normalization.
  - #687 MCP sidecar repair action alignment.
  - #688 HTTP serve bind/auth boundary hardening.
  - #689 retrieval sidecar digest pins.
  - #690 restored Rust verification gates.
  - #691 packet/search sidecar cache contention reduction.
  - #692 packet evidence cleanup.
  - #704 plugin MCP package-root cwd and project-root handoff fix.
- Bumps synchronized release surfaces to `0.12.3`:
  - all eight `codestory-*` workspace crates
  - `Cargo.lock`
  - Codex, Claude, and GitHub plugin manifests

```mermaid
flowchart LR
  Dev["dev/codestory-next aa8ec370"] --> PR["v0.12.3 promotion PR"]
  PR --> Main["main"]
  Main --> Release["v0.12.3 release assets"]
  Release --> Installed["refreshed installed plugin"]
  Installed --> Proof["#618 codestory://status proof"]
```

## How To Review

1. Confirm the release bump is synchronized with `python .github/scripts/check-codestory-release.py --version 0.12.3`.
2. Review the branch diff from `origin/main` to this PR; the non-version commits are the already-merged dev follow-up wave.
3. For the #704 acceptance path, inspect `plugins/codestory/.mcp.json`, `plugins/codestory/scripts/codestory-mcp.cjs`, and `plugins/codestory/tests/plugin-static.test.mjs`.
4. Keep #618 open after this PR; it requires a fresh installed/plugin model-visible `codestory://status` readback after release/refresh.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.12.3` - passed
- `node --test plugins\codestory\tests\plugin-static.test.mjs` - passed, 41/41
- `cargo fmt --all -- --check` - passed
- `git diff --check` - passed
- `node .github\scripts\check-doc-links.mjs` - passed, 70 files / 279 links
- `node .github\scripts\check-workflow-policy.mjs` - passed
- `cargo check --workspace --all-targets` - passed
- Independent release-promotion review found the version bump needed to be committed before PR creation; fixed in commit `b2c0ae2f` and rechecked from committed `HEAD`.
- GitHub PR checks are green for markdown links, linux-contracts, rustdoc, and issue-link guard; the Windows manifest job is intentionally skipped by the retrieval-sidecar-smoke workflow.

## Risk

This is a main promotion plus patch release bump, not fresh product work. The main residual risk is broad dev-wave blast radius, mitigated by the individual closed child PR verifications and the checks above.

This PR does not prove #618. It only makes the fixed package source releasable. #618 remains open until the installed plugin is refreshed and a fresh model-visible `codestory://status` readback proves managed runtime, `path_fallback=false`, project-root handoff, local graph state, packet/search sidecar state, and lifecycle/status behavior.