### PR TITLE
Set plugin MCP startup timeout

### DIFF
--- a/plugins/codestory/.mcp.json
+++ b/plugins/codestory/.mcp.json
@@ -4,6 +4,9 @@
       "command": "node",
       "args": ["./scripts/codestory-mcp.cjs"],
       "cwd": ".",
+      "env": {
+        "CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS": "15000"
+      },
       "tool_timeout_sec": 300
     }
   }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -112,6 +112,9 @@ test("plugin metadata maps skill and direct stdio server", async () => {
     "./scripts/codestory-mcp.cjs",
   ]);
   assert.equal(mcp.mcpServers.codestory.cwd, ".");
+  assert.deepEqual(mcp.mcpServers.codestory.env, {
+    CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS: "15000",
+  });
 });
 
 test("plugin package version tracks the codestory-cli release version", async () => {


### PR DESCRIPTION
## Context

v0.12.3 is merged to `main`, published, and installed locally. The managed release CLI now reports `local_navigation=ready` and `agent_packet_search=ready` with full sidecar retrieval and accelerated embeddings.

The remaining #618 release-smoke blocker is narrower: the app-visible MCP startup path still uses the plugin script default local wait timeout of 5000ms unless the host config sets an env override. Direct installed MCP status with `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS=15000` returns the expected 0.12.3 managed-runtime proof; without that env, startup/status can fail with `local_navigation_wait_fresh_timeout` even when the underlying cache is ready.

Closes #708.
Refs #618.

## What Changed

- Adds `CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS=15000` to the packaged CodeStory MCP server config in `plugins/codestory/.mcp.json`.
- Pins that env contract in `plugins/codestory/tests/plugin-static.test.mjs` beside the existing command/args/cwd package assertions.

## How To Review

1. Check that the MCP config still launches `node ./scripts/codestory-mcp.cjs` from the plugin root.
2. Confirm the new env value matches the timeout that made direct installed MCP status green during the v0.12.3 smoke.
3. Confirm this does not alter CLI runtime logic or release asset contents.

## Verification

- `node --test plugins\codestory\tests\plugin-static.test.mjs` passed: 41 tests, 41 pass.
- `git diff --check` passed.

## Risk

Low. This is a plugin package config default plus a static packaging assertion. It does not change the Rust CLI or sidecar implementation. The remaining proof after merge is to reinstall/refresh the plugin package and rerun the app-visible MCP resource path without a user-local env override.
