### PR TITLE
Defer CodeStory plugin MCP readiness work

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -10179,10 +10179,10 @@ fn run_serve(cmd: ServeCommand) -> Result<()> {
     }
     let runtime = new_agent_surface_runtime(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
-    ensure_index_ready(&opened, "serve")?;
     if cmd.stdio {
         return stdio_transport::run_stdio_server(runtime);
     }
+    ensure_index_ready(&opened, "serve")?;
     let listener = TcpListener::bind(&cmd.addr)
         .with_context(|| format!("Failed to bind server to {}", cmd.addr))?;
     eprintln!("codestory serve listening on http://{}", cmd.addr);

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -180,6 +180,23 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
     }
 }
 
+fn unindexed_fixture() -> StdioFixture {
+    let workspace = tempfile::tempdir().expect("workspace dir");
+    let cache_dir = tempfile::tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    StdioFixture {
+        workspace,
+        cache_dir,
+        hash_embeddings: true,
+        latest_release_version: env!("CARGO_PKG_VERSION").to_string(),
+        disable_installed_cli_probe: false,
+        sidecar_policy_state: None,
+        dirty_marker_path: None,
+        dirty_marker_project_root: None,
+    }
+}
+
 fn full_retrieval_fixture() -> Result<Option<StdioFixture>, String> {
     if !env_flag("CODESTORY_STDIO_FULL_RETRIEVAL_TESTS") {
         return Ok(None);
@@ -893,6 +910,49 @@ fn initialize_preserves_id_and_reports_server_info_and_capabilities() {
     assert!(
         result.get("capabilities").is_some(),
         "initialize should report server capabilities: {response}"
+    );
+}
+
+#[test]
+fn stdio_starts_without_prebuilt_index_and_reports_status() {
+    let fixture = unindexed_fixture();
+    let mut server = spawn_stdio_server(&fixture);
+
+    let init = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init-unindexed",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "contract-test", "version": "0"}
+            }
+        }),
+    );
+    assert_success_envelope(&init, json!("init-unindexed"));
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-unindexed",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let status_result = assert_success_envelope(&status_response, json!("status-unindexed"));
+    let status = json_resource_content(status_result, "codestory://status");
+
+    assert_eq!(status["readiness"][0]["status"], json!("ready"));
+    assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
+    assert_allowed_surface(
+        &status,
+        "search",
+        false,
+        "agent_packet_search",
+        "repair_retrieval",
     );
 }
 

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -657,11 +657,6 @@ function localWaitFreshTimeoutMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
 }
 
-function sidecarRepairTimeoutMs() {
-  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 120000;
-}
-
 function runLocalNavigationWaitFresh(resolved, projectRoot) {
   const args = ['ready', '--goal', 'local', '--wait-fresh'];
   args.push('--project', projectRoot, '--format', 'json');
@@ -673,39 +668,6 @@ function runLocalNavigationWaitFresh(resolved, projectRoot) {
     windowsHide: true,
   });
   return { args, result };
-}
-
-function runSidecarStartupRepair(resolved, sidecarStatus, projectRoot = process.cwd()) {
-  if (sidecarStatus.state !== 'enabled') return sidecarStatus;
-  if (resolved.source !== 'managed' && resolved.source !== 'local_dev_override') return sidecarStatus;
-  const args = ['ready', '--goal', 'agent', '--repair'];
-  args.push('--project', projectRoot, '--format', 'json', '--run-id', sharedAgentRunId);
-  const result = spawnSync(resolved.path, args, {
-    cwd: projectRoot,
-    encoding: 'utf8',
-    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
-    timeout: sidecarRepairTimeoutMs(),
-    windowsHide: true,
-    env: {
-      ...process.env,
-      CODESTORY_PLUGIN_SIDECAR_REPAIR: '1',
-      CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
-    },
-  });
-  const lastRepair = {
-    state: result.error?.code === 'ETIMEDOUT' ? 'timeout' : result.status === 0 ? 'completed' : 'failed',
-    updated_at: new Date().toISOString(),
-    project_root: projectRoot,
-    command: resolvedRepairCommandForProject(resolved, projectRoot),
-  };
-  if (sidecarStatus.path) {
-    writeSidecarPolicy(sidecarStatus.state, { last_repair: lastRepair }, sidecarStatus.path);
-    return readSidecarPolicy(sidecarStatus.path);
-  }
-  return {
-    ...sidecarStatus,
-    lastRepair,
-  };
 }
 
 function localReadySetup(prefix, args, result) {
@@ -1350,24 +1312,8 @@ async function main() {
     return;
   }
   const projectRoot = projectResolution.projectRoot;
-  const localReadiness = probeLocalNavigation(resolved, projectRoot);
-  if (!localReadiness.ready) {
-    runFailOpenMcp(fallbackDiagnostic(resolved, probe, localReadiness.reason, {
-      projectRoot,
-      projectRootSource: projectResolution.source,
-      status: localReadiness.status,
-      summary: localReadiness.summary,
-      minimumNext: localReadiness.minimumNext,
-      fullRepair: [
-        ...localReadiness.fullRepair,
-        'Restart/reload the Codex host/app after repairing the local CodeStory index, then read codestory://status in a fresh thread.',
-      ],
-      localRefresh: localReadiness.localRefresh,
-      setup: localReadiness.setup,
-    }));
-    return;
-  }
-  const sidecarStatus = runSidecarStartupRepair(resolved, readSidecarPolicy(), projectRoot);
+  // Keep the JSON-RPC server handshake first; codestory://status reports readiness after stdio is alive.
+  const sidecarStatus = readSidecarPolicy();
   const dirtyMarker = dirtyMarkerEnv(projectRoot);
 
   const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none', '--project', projectRoot], {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -437,12 +437,10 @@ test("mcp launcher uses active project state when host launches from plugin root
     assert.equal(result.status, 0, result.stderr);
     assert.equal(await readFile(marker, "utf8"), "serve-called");
     const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    const ready = calls.find((call) => call.args[0] === "ready" && call.args.includes("--wait-fresh"));
+    const readyCalls = calls.filter((call) => call.args[0] === "ready");
     const serve = calls.find((call) => call.args[0] === "serve");
-    assert.ok(ready, "expected local wait-fresh call");
+    assert.deepEqual(readyCalls, []);
     assert.ok(serve, "expected serve call");
-    assert.equal(ready.args[ready.args.indexOf("--project") + 1], realRepoRoot);
-    assert.equal(ready.cwd, realRepoRoot);
     assert.deepEqual(serve.args, ["serve", "--stdio", "--refresh", "none", "--project", realRepoRoot]);
     assert.equal(serve.cwd, realRepoRoot);
     assert.equal(serve.projectRoot, realRepoRoot);
@@ -746,7 +744,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
   }
 });
 
-test("mcp launcher waits for fresh local navigation without agent repair", async () => {
+test("mcp launcher starts stdio without local or agent repair", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-repair-index-"));
@@ -808,9 +806,7 @@ test("mcp launcher waits for fresh local navigation without agent repair", async
     assert.equal(await readFile(marker, "utf8"), "serve-called");
     const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
     const readyCalls = calls.filter((call) => call.args[0] === "ready");
-    assert.deepEqual(readyCalls.map((call) => call.args.slice(0, 5)), [
-      ["ready", "--goal", "local", "--wait-fresh", "--project"],
-    ]);
+    assert.deepEqual(readyCalls, []);
     assert.equal(calls.some((call) => call.args.includes("agent")), false);
     assert.equal(calls.some((call) => call.args.includes("--repair")), false);
     assert.equal(calls.some((call) => call.sidecarRepair), false);
@@ -826,180 +822,6 @@ test("mcp launcher waits for fresh local navigation without agent repair", async
       ]);
     }));
   } finally {
-    await rm(dataDir, { recursive: true, force: true });
-  }
-});
-
-test("mcp launcher fails open when wait-fresh skips local refresh", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const version = await readPluginVersion();
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-index-"));
-  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
-  const cliScript = join(dataDir, "fake-codestory-cli.cjs");
-  const cliPath = join(
-    dataDir,
-    process.platform === "win32" ? "fake-codestory-cli.cmd" : "fake-codestory-cli",
-  );
-  const marker = join(dataDir, "serve-called.txt");
-  const input = [
-    JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
-    JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
-    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
-    JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "sidecar_setup", arguments: { action: "repair" } } }),
-  ].join("\n") + "\n";
-
-  try {
-    await writeFile(
-      cliScript,
-      [
-        "const fs = require('node:fs');",
-        "const version = process.env.TEST_CODESTORY_VERSION;",
-        "const marker = process.env.TEST_OUT;",
-        "const command = process.argv[2];",
-        "if (command === '--version') { console.log('codestory-cli ' + version); process.exit(0); }",
-        "if (command === 'ready') {",
-        "  console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'repair_index', summary: 'No indexed symbols are available yet.', minimum_next: ['codestory-cli ready --goal local --wait-fresh --project \"fixture\" --format json'], full_repair: ['codestory-cli doctor --project \"fixture\"'] }], local_refresh: { state: 'skipped_locked', reason: 'index_locked', blocks_local_surfaces: true, readiness_status: 'repair_index', changed_file_count: 1, new_file_count: 0, removed_file_count: 0, fatal_error_count: 0 } }));",
-        "  process.exit(0);",
-        "}",
-        "if (command === 'serve') { fs.writeFileSync(marker, 'serve-called'); process.exit(1); }",
-        "process.exit(2);",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-    if (process.platform === "win32") {
-      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
-    } else {
-      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
-      await chmod(cliPath, 0o755);
-    }
-
-    const result = spawnSync(process.execPath, [launcher], {
-      cwd: dataDir,
-      env: {
-        ...process.env,
-        CODESTORY_CLI: cliPath,
-        PLUGIN_DATA: dataDir,
-        TEST_CODESTORY_VERSION: version,
-        TEST_OUT: marker,
-      },
-      input,
-      encoding: "utf8",
-      timeout: 15000,
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-    await assert.rejects(access(marker));
-    const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 4, result.stdout);
-    const status = JSON.parse(responses[1].result.contents[0].text);
-    assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
-    assert.equal(status.runtime_truth.runtime_source, "local_dev_override");
-    assert.equal(status.runtime_truth.sidecar_status.mode, "unavailable");
-    assert.equal(status.runtime_truth.readiness_lanes.local_graph.refresh_state, "skipped_locked");
-    assert.equal(status.readiness[0].status, "repair_index");
-    assert.equal(status.readiness[0].repair_reason, "local_navigation_wait_fresh_skipped_locked");
-    assert.equal(status.local_refresh.state, "skipped_locked");
-    assert.equal(status.readiness[0].local_refresh.reason, "index_locked");
-    assert.equal(status.allowed_surfaces.ground.allowed, false);
-    assert.equal(status.allowed_surfaces.ground.status, "repair_index");
-    assert.match(status.readiness[0].minimum_next[0], /ready --goal local --wait-fresh/u);
-    assert.deepEqual(status.readiness[0].setup.local_wait_fresh_args.slice(0, 5), [
-      "ready",
-      "--goal",
-      "local",
-      "--wait-fresh",
-      "--project",
-    ]);
-    assert.equal(responses[2].result.isError, true);
-    assert.equal(responses[2].result.structuredContent.status, "repair_index");
-    assert.equal(responses[2].result.structuredContent.local_refresh.state, "skipped_locked");
-    assert.equal(responses[2].result.structuredContent.local_refresh.reason, "index_locked");
-    assert.equal(responses[2].result.structuredContent.local_refresh.changed_file_count, 1);
-    assert.equal(responses[2].result.structuredContent.local_refresh.fatal_error_count, 0);
-    assert.equal(responses[3].result.structuredContent.state, "enabled");
-    const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
-    assert.equal(policy.state, "enabled");
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-  }
-});
-
-test("mcp launcher fails open when local navigation repair times out", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const version = await readPluginVersion();
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-repair-timeout-"));
-  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
-  const cliScript = join(dataDir, "fake-codestory-cli.cjs");
-  const cliPath = join(
-    dataDir,
-    process.platform === "win32" ? "fake-codestory-cli.cmd" : "fake-codestory-cli",
-  );
-  const marker = join(dataDir, "serve-called.txt");
-  const input = JSON.stringify({
-    jsonrpc: "2.0",
-    id: "status",
-    method: "resources/read",
-    params: { uri: "codestory://status" },
-  }) + "\n";
-
-  try {
-    await writeFile(
-      cliScript,
-      [
-        "const fs = require('node:fs');",
-        "const version = process.env.TEST_CODESTORY_VERSION;",
-        "const marker = process.env.TEST_OUT;",
-        "const args = process.argv.slice(2);",
-        "const command = args[0];",
-        "if (command === '--version') { console.log('codestory-cli ' + version); process.exit(0); }",
-        "if (command === 'ready' && args.includes('--wait-fresh')) { const end = Date.now() + 200; while (Date.now() < end) {} process.exit(0); }",
-        "if (command === 'ready') { console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'repair_index', summary: 'stale local graph', minimum_next: [], full_repair: [] }] })); process.exit(0); }",
-        "if (command === 'serve') { fs.writeFileSync(marker, 'serve-called'); process.exit(1); }",
-        "process.exit(2);",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-    if (process.platform === "win32") {
-      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
-    } else {
-      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
-      await chmod(cliPath, 0o755);
-    }
-
-    const result = spawnSync(process.execPath, [launcher], {
-      cwd: dataDir,
-      env: {
-        ...process.env,
-        CODESTORY_CLI: cliPath,
-        CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS: "50",
-        PLUGIN_DATA: dataDir,
-        TEST_CODESTORY_VERSION: version,
-        TEST_OUT: marker,
-      },
-      input,
-      encoding: "utf8",
-      timeout: 5000,
-    });
-
-    assert.equal(result.status, 0, result.stderr);
-    await assert.rejects(access(marker));
-    const response = JSON.parse(result.stdout.trim());
-    const status = JSON.parse(response.result.contents[0].text);
-    assert.equal(status.readiness[0].repair_reason, "local_navigation_wait_fresh_timeout");
-    assert.equal(status.local_refresh.state, "failed");
-    assert.equal(status.local_refresh.reason, "wait_fresh_timeout");
-    assert.deepEqual(status.readiness[0].setup.local_wait_fresh_args.slice(0, 5), [
-      "ready",
-      "--goal",
-      "local",
-      "--wait-fresh",
-      "--project",
-    ]);
-    assert.equal(status.allowed_surfaces.ground.allowed, false);
-  } finally {
-    await new Promise((resolve) => setTimeout(resolve, 300));
     await rm(dataDir, { recursive: true, force: true });
   }
 });
@@ -1138,7 +960,7 @@ test("mcp launcher persists sidecar setup policy in plugin data", async () => {
   }
 });
 
-test("enabled sidecar policy runs one agent repair at MCP startup", async () => {
+test("enabled sidecar policy defers repair until after MCP startup", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
@@ -1182,21 +1004,8 @@ test("enabled sidecar policy runs one agent repair at MCP startup", async () => 
     const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
     const repairCalls = calls.filter((call) => call.repair);
     const realRepoRoot = await realpath(repoRoot);
-    assert.equal(repairCalls.length, 1, text);
-    assert.equal(repairCalls[0].policy, "enabled");
-    assert.deepEqual(repairCalls[0].args, [
-      "ready",
-      "--goal",
-      "agent",
-      "--repair",
-      "--project",
-      realRepoRoot,
-      "--format",
-      "json",
-      "--run-id",
-      "shared-agent",
-    ]);
-    assert.ok(calls.some((call) => {
+    assert.equal(repairCalls.length, 0, text);
+    const serveCall = calls.find((call) => {
       return JSON.stringify(call.args) === JSON.stringify([
         "serve",
         "--stdio",
@@ -1205,12 +1014,12 @@ test("enabled sidecar policy runs one agent repair at MCP startup", async () => 
         "--project",
         realRepoRoot,
       ]);
-    }), text);
+    });
+    assert.ok(serveCall, text);
+    assert.equal(serveCall.policy, "enabled");
     const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
-    assert.equal(policy.last_repair.state, "completed");
-    assert.equal(policy.last_repair.project_root, realRepoRoot);
-    assert.match(policy.last_repair.command, /ready --goal agent --repair/u);
-    assert.match(policy.last_repair.command, /--run-id shared-agent/u);
+    assert.equal(policy.state, "enabled");
+    assert.equal(policy.last_repair, undefined);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1526,7 +1335,7 @@ test("hook manifest timeouts cover managed bootstrap budget", async () => {
     /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
     "local wait-fresh timeout default",
   );
-  assert.equal(localWaitFreshTimeoutMs, 5000, "local wait-fresh default must stay MCP startup-safe");
+  assert.equal(localWaitFreshTimeoutMs, 5000, "local wait-fresh default must stay bounded for bootstrap diagnostics");
   const requiredTimeoutSec = Math.max(
     Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
     Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),


### PR DESCRIPTION
## Context
CodeStory 0.12.3 was installed and the managed CLI was healthy, but Codex Desktop could still see the `codestory` MCP server as `Transport closed`. Direct JSON-RPC probes showed the plugin wrapper was doing readiness work before the stdio server could answer the MCP handshake.

The first fix moved plugin-wrapper readiness out of startup. Review then caught the remaining shared choke point: `codestory-cli serve --stdio` still called the index-ready guard before entering JSON-RPC, so an empty or first-run graph could still close before `initialize` / `codestory://status`.

```mermaid
flowchart LR
  A[Codex MCP launch] --> B[plugin wrapper]
  B --> C[serve --stdio]
  C --> D[initialize/resources]
  D --> E[codestory://status]
  E --> F[explicit local/sidecar repair]
```

Closes #710
Refs #618

## What Changed
- Removed pre-stdio local readiness probing from the plugin MCP launcher.
- Removed enabled sidecar auto-repair from plugin MCP startup.
- Kept sidecar policy metadata and next repair command in the server environment, so `codestory://status` and `sidecar_setup` remain the post-startup control surface.
- Let `serve --stdio` start before the index-ready guard; HTTP serve keeps the existing index-ready guard.
- Added a stdio regression test proving an unindexed workspace can still answer `initialize` and `codestory://status`.
- Updated plugin static tests to assert the launcher starts `serve --stdio` without local or agent repair calls.

## How To Review
- Start with `plugins/codestory/scripts/codestory-mcp.cjs`; `main()` now resolves the CLI/project and starts `serve --stdio` directly.
- Then review `crates/codestory-cli/src/main.rs`; only stdio bypasses the `serve` index-ready guard so status can report/repair after startup.
- Finally review `plugins/codestory/tests/plugin-static.test.mjs` and `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the startup-contract tests.

## Verification
- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> 39/39 passing.
- `cargo test -p codestory-cli --test stdio_protocol_contracts stdio_starts_without_prebuilt_index_and_reports_status -- --nocapture` -> passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts` -> 35 passed, 9 ignored.
- `cargo fmt --check` -> passed.
- `git diff --check` -> passed.
- Direct raw stdio baseline before the Rust follow-up: managed `codestory-cli.exe serve --stdio --refresh none --project .` answered `resources/list` in 243ms with 5 resources.
- Patched installed plugin cache answered `resources/list` in 412ms with 5 resources.
- After explicit sidecar repair, patched installed plugin cache read `codestory://status` with `agent_packet_search=ready`, `retrieval_mode=full`, `degraded_reason=null`.
- Post-restart model-visible proof with the locally patched cache: built-in MCP lists all five CodeStory resources; after explicit post-startup repair, model-visible `codestory://status` reports managed 0.12.3, `path_fallback=false`, `local_graph=ready`, `agent_packet_search=ready`, `retrieval_mode=full`, `degraded_reason=null`.

## Risk
- Startup no longer auto-repairs local or sidecar readiness before MCP visibility. That is intentional: readiness must be visible through `codestory://status` and repairable through `sidecar_setup` after the server is alive.
- HTTP `serve` still keeps the old index-ready guard; this PR only changes the MCP/stdio startup path.
- #618 remains open after this PR until the change is merged, released/refreshed through the official plugin path, and proven from a fresh model-visible `codestory://status` readback without a locally patched cache.