### PR TITLE
Release 0.12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context

PR #711 merged the CodeStory MCP stdio startup fix on `main`, but the installed plugin refresh still provisions the released `codestory-cli` binary for `0.12.3`. This patch release moves the release surfaces to `0.12.4` so the managed CLI asset can carry the fix.

Closes #712.
Refs #618, #710, #711.

## What Changed

- Bumped all CodeStory workspace crates from `0.12.3` to `0.12.4`.
- Regenerated `Cargo.lock` package metadata for the workspace crates.
- Bumped the Codex, Claude, and GitHub plugin manifests to `0.12.4` so plugin-managed CLI provisioning looks for the matching `v0.12.4` release asset.

## How To Review

1. Confirm the diff is version-only across the workspace crate manifests, `Cargo.lock`, and plugin manifests.
2. Confirm `.github/scripts/check-codestory-release.py` accepts `0.12.4` as the synchronized release version.
3. After merge, confirm the release automation creates the `v0.12.4` tag/release assets before refreshing the installed plugin.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p codestory-cli`
- `python .github\scripts\check-codestory-release.py --version 0.12.4`
- `node .github\scripts\check-workflow-policy.mjs`
- `node --test plugins\codestory\tests\plugin-static.test.mjs`
- `cargo test -p codestory-cli --test stdio_protocol_contracts` (35 passed, 9 ignored live full-retrieval contracts)
- `cargo build --release -p codestory-cli`
- `.\target\release\codestory-cli.exe --version` -> `codestory-cli 0.12.4`

## Risk

Release automation and published asset install are still post-merge proof. Do not create manual `v0.12.4` tags; the synchronized version bump on `main` should trigger the existing release workflow.