### PR TITLE
Guard active project handoff

### DIFF
--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -578,6 +578,7 @@ readHookInput().then((input) => {
       event,
       cwd: input.cwd || process.cwd(),
       source: input.source || input.trigger || null,
+      codexThreadId: process.env.CODEX_THREAD_ID || null,
       hook: {
         instructions_emitted: instructions,
         preflight_failed: state.hook && state.hook.preflight_failed,

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -19,6 +19,7 @@ const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
 const releaseDownloadRetryDelaysMs = [1000, 3000];
+const processStartedAtMs = Date.now();
 
 function readJson(file) {
   try {
@@ -121,6 +122,11 @@ function activeProjectStateMaxAgeMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 60 * 60 * 1000;
 }
 
+function activeProjectStateLaunchGraceMs() {
+  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_ACTIVE_PROJECT_LAUNCH_GRACE_MS || '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5 * 1000;
+}
+
 function activeProjectStateTimestamp(active, statePath) {
   const parsed = Date.parse(active?.updatedAt || active?.updated_at || '');
   if (Number.isFinite(parsed)) return parsed;
@@ -131,9 +137,18 @@ function activeProjectStateTimestamp(active, statePath) {
   }
 }
 
+function activeProjectStateMatchesHost(active) {
+  const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
+  if (!currentThread) return true;
+  return String(active?.codexThreadId || '').trim() === currentThread;
+}
+
 function activeProjectStateFresh(active, statePath, nowMs = Date.now()) {
   const timestamp = activeProjectStateTimestamp(active, statePath);
-  return timestamp !== null && nowMs - timestamp <= activeProjectStateMaxAgeMs();
+  return timestamp !== null
+    && nowMs - timestamp <= activeProjectStateMaxAgeMs()
+    && timestamp >= processStartedAtMs - activeProjectStateLaunchGraceMs()
+    && activeProjectStateMatchesHost(active);
 }
 
 function resolveProjectRoot(options = {}) {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -381,11 +381,17 @@ test("mcp launcher uses active project state when host launches from plugin root
   const logFile = join(dataDir, "calls.jsonl");
   const marker = join(dataDir, "serve-called.txt");
   const realRepoRoot = await realpath(repoRoot);
+  const threadId = "codestory-active-project-test-thread";
 
   try {
     await writeFile(
       join(dataDir, ".codestory-active"),
-      JSON.stringify({ event: "SessionStart", cwd: realRepoRoot, updatedAt: new Date().toISOString() }),
+      JSON.stringify({
+        event: "SessionStart",
+        cwd: realRepoRoot,
+        codexThreadId: threadId,
+        updatedAt: new Date().toISOString(),
+      }),
       "utf8",
     );
     await writeFile(
@@ -425,6 +431,7 @@ test("mcp launcher uses active project state when host launches from plugin root
       env: {
         ...process.env,
         CODESTORY_CLI: cliPath,
+        CODEX_THREAD_ID: threadId,
         PLUGIN_DATA: dataDir,
         TEST_CODESTORY_VERSION: version,
         TEST_LOG: logFile,
@@ -447,6 +454,172 @@ test("mcp launcher uses active project state when host launches from plugin root
     assert.equal(serve.projectRootSource, "plugin_active_state");
     assert.equal(serve.dirtyMarkerRoot, realRepoRoot);
     assert.equal(serve.dirtyMarkerPath, dirtyMarkerPathForProject(realRepoRoot, dataDir));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher rejects active project state from another Codex thread", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-wrong-thread-active-project-"));
+  const previousRepo = join(dataDir, "previous-repo");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    await mkdir(previousRepo);
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: previousRepo,
+        codexThreadId: "previous-thread",
+        updatedAt: new Date(Date.now() - 1000).toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd(), projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '' }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS: "600000",
+        CODEX_THREAD_ID: "current-thread",
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_stale");
+    assert.equal(status.readiness[0].goal, "project_root");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher rejects active project state from before launcher start", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-prelaunch-active-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: await realpath(repoRoot),
+        codexThreadId: "current-thread",
+        updatedAt: new Date(Date.now() - 10000).toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd() }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS: "600000",
+        CODEX_THREAD_ID: "current-thread",
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_stale");
+    assert.equal(status.readiness[0].goal, "project_root");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1298,6 +1471,37 @@ test("session-start hooks are thin and host manifests point at them", async () =
 
   const manifest = JSON.parse(await readFile(hostManifest, "utf8"));
   assert.equal(manifest.hooks, "./hooks/claude-codex-hooks.json");
+});
+
+test("hook records Codex thread id in active project state", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-thread-state-"));
+  const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
+
+  try {
+    const result = spawnSync(process.execPath, [hookPath], {
+      env: {
+        ...process.env,
+        CODESTORY_HOOK_DISABLE_RUNTIME: "1",
+        CODEX_THREAD_ID: "hook-thread-id",
+        COPILOT_PLUGIN_DATA: "",
+        PLUGIN_DATA: dataDir,
+      },
+      input: JSON.stringify({
+        hook_event_name: "SessionStart",
+        source: "startup",
+        cwd: repoRoot,
+      }),
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const state = JSON.parse(await readFile(join(dataDir, ".codestory-active"), "utf8"));
+    assert.equal(state.cwd, repoRoot);
+    assert.equal(state.codexThreadId, "hook-thread-id");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
 });
 
 test("hook manifest timeouts cover managed bootstrap budget", async () => {


### PR DESCRIPTION
## Context

Closes #714.

#618 proved the official 0.12.4 runtime can expose model-visible CodeStory status, but validation also found a narrower first-launch-after-repo-switch edge: the plugin MCP wrapper starts from the installed plugin root and falls back to `PLUGIN_DATA/.codestory-active` for the target repo. A previous thread's active project could still be inside the broad TTL, so the first `codestory://status` read could report the prior repo instead of failing closed.

This PR targets `main` directly because the branch is based on current `main` (`a7cf1647`) and `dev/codestory-next` is behind the release train. Targeting `dev/codestory-next` would mix this hotfix with release backfill instead of keeping #714 reviewable.

```mermaid
flowchart LR
  Hook["Lifecycle hook"] -->|"writes cwd + CODEX_THREAD_ID"| Active[".codestory-active"]
  Wrapper["MCP wrapper at plugin root"] -->|"reads active state"| Check{"same Codex thread and fresh?"}
  Check -->|"yes"| Serve["serve --stdio --project cwd"]
  Check -->|"no"| Closed["codestory://status: project_root_unavailable"]
```

## What Changed

- The lifecycle hook now records `codexThreadId` from `CODEX_THREAD_ID` in `.codestory-active`.
- The MCP wrapper now treats active project state as fresh only when:
  - it is inside the existing TTL,
  - it was written within the short startup handoff window, and
  - when `CODEX_THREAD_ID` is present, it matches the current launcher thread.
- Added regression coverage for:
  - the matching-thread plugin-root happy path,
  - a previous thread's active state updated one second ago failing closed with no `serve` call,
  - old pre-launch active state failing closed,
  - the hook persisting `codexThreadId`.

## How To Review

Start with `plugins/codestory/scripts/codestory-mcp.cjs`: the important behavior is `activeProjectStateFresh`.

Then read the three nearby launcher tests in `plugins/codestory/tests/plugin-static.test.mjs`. The key regression is `mcp launcher rejects active project state from another Codex thread`, which models the reviewer-found fast-switch gap.

## Verification

- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> 42/42 passing
- `git diff --check` -> clean
- Independent reviewer re-check found no blocking issues after the thread-id guard was added.

## Risk

Current Codex provides `CODEX_THREAD_ID`, so the wrong-thread guard applies to the target host path. If a future or non-Codex host launches this MCP wrapper without `CODEX_THREAD_ID`, active-state trust falls back to the TTL/startup-grace checks and cannot prove thread identity.
