### PR TITLE
Fail closed on degraded mandatory sidecars

### DIFF
--- a/crates/codestory-retrieval/src/mode.rs
+++ b/crates/codestory-retrieval/src/mode.rs
@@ -48,33 +48,36 @@ pub fn derive_degraded_mode(
     qdrant: &ComponentHealth,
     scip: &ComponentHealth,
 ) -> (RetrievalDegradedMode, Option<String>) {
-    if zoekt.status == ComponentStatus::Unavailable || !zoekt.capabilities.lexical {
+    if zoekt.status != ComponentStatus::Healthy || !zoekt.capabilities.lexical {
         return (
             RetrievalDegradedMode::Unavailable,
-            zoekt
-                .degraded_reason
-                .clone()
-                .or_else(|| Some("mandatory_zoekt_unavailable".into())),
+            mandatory_failure_reason(zoekt, "zoekt"),
         );
     }
-    if qdrant.status == ComponentStatus::Unavailable || !qdrant.capabilities.semantic {
+    if qdrant.status != ComponentStatus::Healthy || !qdrant.capabilities.semantic {
         let mode = if scip.capabilities.graph {
             RetrievalDegradedMode::NoSemantic
         } else {
             RetrievalDegradedMode::LexicalOnly
         };
-        return (
-            mode,
-            qdrant
-                .degraded_reason
-                .clone()
-                .or_else(|| Some("mandatory_qdrant_unavailable".into())),
-        );
+        return (mode, mandatory_failure_reason(qdrant, "qdrant"));
     }
     if scip.status != ComponentStatus::Healthy || !scip.capabilities.graph {
         return (RetrievalDegradedMode::NoScip, scip.degraded_reason.clone());
     }
     (RetrievalDegradedMode::Full, None)
+}
+
+fn mandatory_failure_reason(component: &ComponentHealth, name: &str) -> Option<String> {
+    let state = if component.status == ComponentStatus::Unavailable {
+        "unavailable"
+    } else {
+        "degraded"
+    };
+    component
+        .degraded_reason
+        .clone()
+        .or_else(|| Some(format!("mandatory_{name}_{state}")))
 }
 
 #[cfg(test)]

--- a/crates/codestory-retrieval/tests/degraded_modes.rs
+++ b/crates/codestory-retrieval/tests/degraded_modes.rs
@@ -79,3 +79,21 @@ fn degraded_mode_planner_matrix() {
     assert_eq!(unavailable, RetrievalDegradedMode::Unavailable);
     assert!(plan_query(&features, unavailable).stages.is_empty());
 }
+
+#[test]
+fn degraded_mandatory_sidecars_are_not_full_even_with_capabilities() {
+    let production = codestory_retrieval::SidecarCapabilities::production_stack();
+    let zoekt_up = component("zoekt", ComponentStatus::Healthy, None, production);
+    let qdrant_up = component("qdrant", ComponentStatus::Healthy, None, production);
+    let scip_up = component("scip", ComponentStatus::Healthy, None, production);
+
+    let zoekt_slow = component("zoekt", ComponentStatus::Degraded, None, production);
+    let (zoekt_mode, zoekt_reason) = derive_degraded_mode(&zoekt_slow, &qdrant_up, &scip_up);
+    assert_eq!(zoekt_mode, RetrievalDegradedMode::Unavailable);
+    assert_eq!(zoekt_reason.as_deref(), Some("mandatory_zoekt_degraded"));
+
+    let qdrant_slow = component("qdrant", ComponentStatus::Degraded, None, production);
+    let (qdrant_mode, qdrant_reason) = derive_degraded_mode(&zoekt_up, &qdrant_slow, &scip_up);
+    assert_eq!(qdrant_mode, RetrievalDegradedMode::NoSemantic);
+    assert_eq!(qdrant_reason.as_deref(), Some("mandatory_qdrant_degraded"));
+}


### PR DESCRIPTION
## Context

Closes #717.

Mandatory sidecar readiness should fail closed. Before this change, a reachable but `Degraded` Zoekt or Qdrant component could still produce `retrieval_mode=full` when its capability bit stayed true.

## What Changed

- Treat mandatory Zoekt as unavailable unless its status is `Healthy` and lexical capability is present.
- Treat mandatory Qdrant as non-semantic unless its status is `Healthy` and semantic capability is present.
- Preserve explicit degraded reasons and add fallback reason codes for degraded mandatory sidecars.
- Add regression coverage for degraded-but-capable Zoekt and Qdrant.

```mermaid
flowchart LR
    Z["Zoekt status"] --> M["derive_degraded_mode"]
    Q["Qdrant status"] --> M
    M -->|"Healthy + capability"| F["full allowed"]
    M -->|"Degraded or unavailable"| D["non-full mode with reason"]
```

## How To Review

Start with `crates/codestory-retrieval/src/mode.rs`; the behavioral change is contained in `derive_degraded_mode`. Then review `crates/codestory-retrieval/tests/degraded_modes.rs` for the new degraded mandatory sidecar cases.

## Verification

- `cargo test -p codestory-retrieval --test degraded_modes`
- `cargo test -p codestory-retrieval --lib`
- `git diff --check`

## Risk

Low. This intentionally tightens full-mode eligibility for mandatory sidecars. Systems that previously reported `full` while a mandatory sidecar was only degraded will now report a non-full mode and repair reason.
