### PR TITLE
Treat missing retrieval shadow as unavailable

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -2302,6 +2302,26 @@ mod tests {
         });
     }
 
+    fn mark_full_retrieval_available(answer: &mut AgentAnswerDto) {
+        answer.retrieval_trace.retrieval_shadow = Some(RetrievalShadowDto {
+            retrieval_mode: "full".to_string(),
+            degraded_reason: None,
+            retrieval_total_ms: 1,
+            total_budget_ms: Some(500),
+            cancel_reason: None,
+            cache_hit: false,
+            stage_timings: Vec::new(),
+            candidates: Vec::new(),
+            would_rank: Vec::new(),
+            error: None,
+            candidate_count: 0,
+            resolved_hit_count: 0,
+            unresolved_candidate_count: 0,
+            diagnostic_only: false,
+            candidate_resolution_counts: Vec::new(),
+        });
+    }
+
     fn unresolved_sidecar_diagnostic(query: &str) -> PacketSidecarQueryDiagnosticDto {
         PacketSidecarQueryDiagnosticDto {
             query: query.to_string(),
@@ -3608,7 +3628,8 @@ mod tests {
     #[test]
     fn compact_proof_omission_reports_missing_role_and_standard_budget_follow_up() {
         let question = "Explain how formatting arguments become type-erased format args and reach vformat or format_to output paths.";
-        let answer = answer_fixture(question);
+        let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         let budget = compact_truncated_budget(question, vec!["citations", "markdown_blocks"]);
         let claims = vec![
             claim(
@@ -3650,7 +3671,8 @@ mod tests {
     #[test]
     fn compact_budget_blocks_sufficiency_when_source_proof_probe_is_missing() {
         let question = "Explain how buffered Source and Sink wrappers use Buffer state during reads and writes.";
-        let answer = answer_fixture(question);
+        let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         let budget = compact_truncated_budget(question, vec!["citations", "trail_edges"]);
         let claims = vec![
             claim("Buffer is the in-memory byte store used by buffered reads and writes."),
@@ -3841,6 +3863,7 @@ mod tests {
     fn unresolved_selected_probe_blocks_when_express_response_coverage_is_missing() {
         let question = "Trace how Express creates an application, registers middleware/routes, and handles an incoming request through the router and response helpers.";
         let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         answer.retrieval_trace.packet_sidecar_diagnostics =
             vec![unresolved_sidecar_diagnostic("response send")];
         let budget = budget_fixture();
@@ -3901,6 +3924,7 @@ mod tests {
     fn missing_flow_seed_follow_up_precedes_unresolved_selected_probe() {
         let question = "Trace how a server request enters route registration, reaches request handler dispatch, and finalizes a response.";
         let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         answer.retrieval_trace.packet_sidecar_diagnostics =
             vec![unresolved_sidecar_diagnostic("response send")];
         let budget = budget_fixture();
@@ -4044,6 +4068,41 @@ mod tests {
                     && !command.contains("codestory-cli context")
             }),
             "blocked full retrieval must not recommend blocked search/context surfaces: {sufficiency:?}"
+        );
+    }
+
+    #[test]
+    fn partial_packets_with_missing_retrieval_shadow_recommend_repair() {
+        let question = "Trace how route registration reaches response finalization.";
+        let answer = answer_fixture(question);
+        let budget = budget_fixture();
+        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
+            project_root: Path::new("C:/workspace/service"),
+            question,
+            task_class: PacketTaskClassDto::RouteTracing,
+            answer: &answer,
+            budget: &budget,
+            supported_claims: vec![claim(
+                "Dispatch request invokes the selected view function or handler for the matched route.",
+            )],
+            missing_required_probe_queries: vec!["route registration".to_string()],
+            targeted_follow_up_queries: vec!["response finalization".to_string()],
+        });
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .follow_up_commands
+                .first()
+                .is_some_and(|command| command.contains("ready --goal agent --repair")),
+            "missing retrieval shadow should lead with canonical sidecar repair: {sufficiency:?}"
+        );
+        assert!(
+            sufficiency.follow_up_commands.iter().all(|command| {
+                !command.contains("codestory-cli search")
+                    && !command.contains("codestory-cli context")
+            }),
+            "missing retrieval shadow must not recommend unproven search/context surfaces: {sufficiency:?}"
         );
     }
 
@@ -4461,7 +4520,7 @@ fn packet_full_retrieval_available(answer: &AgentAnswerDto) -> bool {
         .retrieval_trace
         .retrieval_shadow
         .as_ref()
-        .is_none_or(|shadow| shadow.retrieval_mode == "full")
+        .is_some_and(|shadow| shadow.retrieval_mode == "full")
 }
 
 fn packet_agent_repair_command(quoted_project: &str) -> String {


### PR DESCRIPTION
## Context

Closes #719.

Packet sufficiency treated `retrieval_shadow: None` as full retrieval availability. That meant follow-up commands could recommend packet/search recovery even when sidecar-backed retrieval had not actually been proven.

## What Changed

- Require an explicit `retrieval_shadow.retrieval_mode == "full"` before packet sufficiency treats full retrieval as available.
- Add a missing-shadow regression that recommends agent readiness repair and avoids unproven search/context follow-ups.
- Make tests that intentionally expect full retrieval set an explicit full shadow.

```mermaid
flowchart LR
    S["retrieval_shadow"] --> F{"mode == full?"}
    F -->|"yes"| P["search/context follow-ups allowed"]
    F -->|"missing or non-full"| R["ready --goal agent --repair"]
```

## How To Review

Start with `packet_full_retrieval_available` in `crates/codestory-runtime/src/agent/packet_sufficiency.rs`. The rest of the diff is test setup that makes full-vs-missing retrieval shadow explicit.

## Verification

- `cargo test -p codestory-runtime packet_sufficiency --lib`
- `git diff --check`

## Risk

Low. This tightens follow-up selection only when full retrieval was not proven by an explicit retrieval shadow.
