### PR TITLE
Bind MCP project state per Codex thread

### DIFF
--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -7,6 +7,7 @@ const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 const STATE_FILE = '.codestory-active';
+const THREAD_STATE_PREFIX = '.codestory-active-thread-';
 const HOOK_STATE_FILE = '.codestory-hook-output-state.json';
 const MCP_RUNTIME_FILE = '.codestory-mcp-runtime.json';
 const DIRTY_MARKER_SCHEMA_VERSION = 1;
@@ -24,6 +25,14 @@ function pluginDataDir() {
 function stateFilePath() {
   const stateDir = pluginDataDir();
   return stateDir ? path.join(stateDir, STATE_FILE) : null;
+}
+
+function threadStateFilePath(threadId) {
+  const stateDir = pluginDataDir();
+  const normalized = String(threadId || '').trim();
+  if (!stateDir || !normalized) return null;
+  const key = createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  return path.join(stateDir, `${THREAD_STATE_PREFIX}${key}.json`);
 }
 
 function readJson(file) {
@@ -203,7 +212,7 @@ function rememberActiveState(state) {
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true });
     const previous = readActiveState() || {};
-    fs.writeFileSync(file, JSON.stringify({
+    const nextState = {
       ...previous,
       ...state,
       hook: {
@@ -211,7 +220,12 @@ function rememberActiveState(state) {
         ...(state.hook || {}),
       },
       updatedAt: new Date().toISOString(),
-    }));
+    };
+    fs.writeFileSync(file, JSON.stringify(nextState));
+    const threadFile = threadStateFilePath(nextState.codexThreadId);
+    if (threadFile) {
+      fs.writeFileSync(threadFile, JSON.stringify(nextState));
+    }
   } catch (e) {
     // Best effort only. Hook state must not block the host session.
   }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -15,6 +15,7 @@ const fallbackBinaryNames = process.platform === 'win32'
   ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
   : ['codestory-cli'];
 const activeStateFile = '.codestory-active';
+const activeThreadStatePrefix = '.codestory-active-thread-';
 const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
@@ -98,6 +99,13 @@ function activeStatePath(dataDir = pluginDataDir()) {
   return dataDir ? path.join(dataDir, activeStateFile) : null;
 }
 
+function activeThreadStatePath(threadId, dataDir = pluginDataDir()) {
+  const normalized = String(threadId || '').trim();
+  if (!dataDir || !normalized) return null;
+  const key = createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  return path.join(dataDir, `${activeThreadStatePrefix}${key}.json`);
+}
+
 function normalizeProjectRoot(projectRoot) {
   const resolved = path.resolve(projectRoot);
   try {
@@ -139,7 +147,7 @@ function activeProjectStateTimestamp(active, statePath) {
 
 function activeProjectStateMatchesHost(active) {
   const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
-  if (!currentThread) return true;
+  if (!currentThread) return !String(active?.codexThreadId || '').trim();
   return String(active?.codexThreadId || '').trim() === currentThread;
 }
 
@@ -160,6 +168,22 @@ function resolveProjectRoot(options = {}) {
   const cwd = existingProjectRoot(process.cwd());
   if (cwd && !samePathText(cwd, pluginRoot)) {
     return { projectRoot: cwd, source: 'process_cwd' };
+  }
+
+  const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
+  const threadStatePath = activeThreadStatePath(currentThread);
+  const threadActive = threadStatePath ? readJson(threadStatePath) : null;
+  if (threadActive && !activeProjectStateFresh(threadActive, threadStatePath)) {
+    return {
+      projectRoot: null,
+      source: 'plugin_active_thread_state_stale',
+      statePath: threadStatePath,
+      reason: 'project_root_unavailable',
+    };
+  }
+  const threadRoot = existingProjectRoot(threadActive?.cwd);
+  if (threadRoot && !samePathText(threadRoot, pluginRoot)) {
+    return { projectRoot: threadRoot, source: 'plugin_active_thread_state', statePath: threadStatePath };
   }
 
   const statePath = activeStatePath();

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -20,6 +20,11 @@ const {
   writeDirtyMarker,
 } = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
 
+function threadActiveStatePath(dataDir, threadId) {
+  const key = createHash("sha256").update(String(threadId)).digest("hex").slice(0, 16);
+  return join(dataDir, `.codestory-active-thread-${key}.json`);
+}
+
 function readCargoVersion(manifestText) {
   let inPackage = false;
   for (const line of manifestText.split(/\r?\n/u)) {
@@ -538,6 +543,183 @@ test("mcp launcher rejects active project state from another Codex thread", asyn
     assert.equal(status.project_root, null);
     assert.equal(status.project_root_source, "plugin_active_state_stale");
     assert.equal(status.readiness[0].goal, "project_root");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher prefers thread-scoped active project over another thread's global state", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-thread-active-project-"));
+  const currentRepo = join(dataDir, "current-repo");
+  const previousRepo = join(dataDir, "previous-repo");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const currentThread = "current-thread";
+
+  try {
+    await mkdir(currentRepo);
+    await mkdir(previousRepo);
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: previousRepo,
+        codexThreadId: "previous-thread",
+        updatedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      threadActiveStatePath(dataDir, currentThread),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: currentRepo,
+        codexThreadId: currentThread,
+        updatedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({",
+        "  args,",
+        "  cwd: process.cwd(),",
+        "  projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '',",
+        "  projectRootSource: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE || ''",
+        "}) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, 'serve-called'); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS: "600000",
+        CODEX_THREAD_ID: currentThread,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(await readFile(marker, "utf8"), "serve-called");
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    const serve = calls.find((call) => call.args[0] === "serve");
+    assert.ok(serve, "expected serve call");
+    assert.deepEqual(serve.args, ["serve", "--stdio", "--refresh", "none", "--project", currentRepo]);
+    assert.equal(serve.cwd, currentRepo);
+    assert.equal(serve.projectRoot, currentRepo);
+    assert.equal(serve.projectRootSource, "plugin_active_thread_state");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher rejects thread-owned global state when current thread is unavailable", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-missing-thread-active-project-"));
+  const previousRepo = join(dataDir, "previous-repo");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    await mkdir(previousRepo);
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: previousRepo,
+        codexThreadId: "previous-thread",
+        updatedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd(), projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '' }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS: "600000",
+        CODEX_THREAD_ID: "",
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_stale");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1497,8 +1679,11 @@ test("hook records Codex thread id in active project state", async () => {
 
     assert.equal(result.status, 0, result.stderr);
     const state = JSON.parse(await readFile(join(dataDir, ".codestory-active"), "utf8"));
+    const threadState = JSON.parse(await readFile(threadActiveStatePath(dataDir, "hook-thread-id"), "utf8"));
     assert.equal(state.cwd, repoRoot);
     assert.equal(state.codexThreadId, "hook-thread-id");
+    assert.equal(threadState.cwd, repoRoot);
+    assert.equal(threadState.codexThreadId, "hook-thread-id");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

Closes #738.
Refs #716.

Dogfood session `019f03a4-c1b0-76e1-83d5-5094256148c4` exposed plugin/MCP friction where CodeStory status/repair could report or act against a remembered project instead of the active session repo. In this thread, `mcp__codestory.ground` also timed out after 300s, so the fix is based on hook/source/session evidence plus plugin-static regression tests.

The root cause is the plugin active-project handoff: hooks persisted one global `.codestory-active` slot, while the MCP launcher may start from the plugin cache/root and bind `codestory-cli serve --stdio --project <root>` from that remembered state.

## What Changed

- Persist a thread-scoped active project file whenever hooks know `CODEX_THREAD_ID`.
- Make the MCP launcher prefer the current thread's active project state over the global fallback.
- Reject Codex-thread-owned global active state when the launcher has no current thread id, instead of silently binding a possibly stale repo.
- Add plugin-static coverage for multi-thread project binding, missing-thread fallback, and thread-state persistence.

```mermaid
flowchart LR
    H["Hook event"] --> G["global .codestory-active"]
    H --> T["thread .codestory-active-thread hash"]
    M["MCP launcher"] --> C{"CODEX_THREAD_ID?"}
    C -->|"yes"| T
    C -->|"no"| S{"global has thread owner?"}
    T --> P["serve --stdio --project active repo"]
    S -->|"yes"| F["fail open: project_root_unavailable"]
    S -->|"no"| G
    G --> P
```

## How To Review

Start with `plugins/codestory/scripts/codestory-mcp.cjs` around project root resolution. Then review `plugins/codestory/hooks/codestory-runtime.cjs` for the state writer and `plugins/codestory/tests/plugin-static.test.mjs` for the regression cases.

## Verification

- `node --test --test-name-pattern "mcp launcher.*active project|hook records Codex thread id" plugins/codestory/tests/plugin-static.test.mjs`
- `node --test --test-name-pattern "thread-owned global state" plugins/codestory/tests/plugin-static.test.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `git diff --check`

## Risk

Moderate but contained to plugin project binding. This intentionally fails open instead of using a global active project when the only available state belongs to a Codex thread and the launcher cannot prove it is that thread. Live installed-plugin proof is still required after this branch lands or is packaged; the Project proof field remains `Needs live proof`.
