### PR TITLE
Add plugin static CI

### DIFF
--- a/.github/scripts/check-codestory-release.py
+++ b/.github/scripts/check-codestory-release.py
@@ -15,6 +15,12 @@ SEMVER_RE = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
+PLUGIN_MANIFESTS = (
+    Path("plugins/codestory/.codex-plugin/plugin.json"),
+    Path("plugins/codestory/.claude-plugin/plugin.json"),
+    Path("plugins/codestory/.github/plugin/plugin.json"),
+)
+
 
 def read_toml(path: Path) -> dict:
     with path.open("rb") as handle:
@@ -50,16 +56,19 @@ def lock_packages(root: Path) -> dict[str, set[str]]:
     return packages
 
 
-def plugin_version(root: Path) -> str:
-    manifest_path = root / "plugins" / "codestory" / ".codex-plugin" / "plugin.json"
-    try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise ValueError(f"{manifest_path} does not exist") from exc
-    version = manifest.get("version")
-    if not isinstance(version, str) or not version:
-        raise ValueError(f"{manifest_path} must declare a string version")
-    return version
+def plugin_versions(root: Path) -> dict[Path, str]:
+    versions: dict[Path, str] = {}
+    for relative_path in PLUGIN_MANIFESTS:
+        manifest_path = root / relative_path
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise ValueError(f"{manifest_path} does not exist") from exc
+        version = manifest.get("version")
+        if not isinstance(version, str) or not version:
+            raise ValueError(f"{manifest_path} must declare a string version")
+        versions[relative_path] = version
+    return versions
 
 
 def fail(message: str) -> None:
@@ -91,12 +100,9 @@ def main() -> None:
     if cli_version != expected:
         fail(f"codestory-cli version is {cli_version}, expected {expected}")
 
-    current_plugin_version = plugin_version(root)
-    if current_plugin_version != expected:
-        fail(
-            "plugins/codestory/.codex-plugin/plugin.json version is "
-            f"{current_plugin_version}, expected {expected}"
-        )
+    for manifest_path, current_plugin_version in plugin_versions(root).items():
+        if current_plugin_version != expected:
+            fail(f"{manifest_path} version is {current_plugin_version}, expected {expected}")
 
     workspace_versions: dict[str, str] = {}
     for manifest_path in workspace_members(root):
@@ -131,7 +137,8 @@ def main() -> None:
 
     print(
         f"CodeStory release version {expected} is synchronized across "
-        f"{len(workspace_versions)} workspace crates, Cargo.lock, and the codestory plugin."
+        f"{len(workspace_versions)} workspace crates, Cargo.lock, and "
+        f"{len(PLUGIN_MANIFESTS)} codestory plugin manifests."
     )
 
 

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -7,6 +7,7 @@ const trustedOwners = new Set(["actions", "github"]);
 const shaPattern = /^[0-9a-f]{40}$/i;
 const violations = [];
 const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
+const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
 
 for (const file of fs
   .readdirSync(workflowRoot)
@@ -62,6 +63,25 @@ if (fs.existsSync(sagaIssueLinkGuard)) {
     !closingRef.test("Closes https://github.com/TheGreenCedar/CodeStory/issues/123")
   ) {
     violations.push("saga-issue-link-guard.yml closing ref policy must reject bare numbers and accept # or full issue URLs");
+  }
+}
+
+if (!fs.existsSync(pluginStatic)) {
+  violations.push("plugin-static.yml must run plugin static tests for plugin changes");
+} else {
+  const content = fs.readFileSync(pluginStatic, "utf8");
+  const requiredSnippets = [
+    "plugins/codestory/**",
+    "dev/codestory-next",
+    "node --test plugins/codestory/tests/plugin-static.test.mjs",
+    "node .github/scripts/check-workflow-policy.mjs",
+    "python .github/scripts/check-codestory-release.py --version",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!content.includes(snippet)) {
+      violations.push(`plugin-static.yml must include ${snippet}`);
+    }
   }
 }
 

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -1,0 +1,46 @@
+name: plugin static
+
+on:
+  pull_request:
+    paths:
+      - plugins/codestory/**
+      - .github/scripts/check-codestory-release.py
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/plugin-static.yml
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - plugins/codestory/**
+      - .github/scripts/check-codestory-release.py
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/plugin-static.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: plugin-static-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-static:
+    name: plugin static tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check plugin static wiring
+        run: node --test plugins/codestory/tests/plugin-static.test.mjs
+
+      - name: Check workflow policy
+        run: node .github/scripts/check-workflow-policy.mjs
+
+      - name: Check release version surfaces
+        shell: bash
+        run: |
+          version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
+          python .github/scripts/check-codestory-release.py --version "$version"


### PR DESCRIPTION
## Context

Closes #725.
Refs #716.

Plugin static tests were documented and useful locally, but plugin changes did not have their own CI lane. Release preflight also checked only the Codex plugin manifest while `plugin-static` verifies the Codex, Claude, and Copilot/GitHub plugin manifests.

## What Changed

- Add a `plugin static` workflow for `plugins/codestory/**` and adjacent release/workflow policy files.
- Run plugin static tests, workflow policy, and release version checks in that workflow.
- Align `check-codestory-release.py` with the plugin-static manifest set.
- Teach `check-workflow-policy.mjs` to guard the plugin static workflow shape.

## How To Review

Start with `.github/workflows/plugin-static.yml`, then review `.github/scripts/check-codestory-release.py` for the manifest-list alignment and `.github/scripts/check-workflow-policy.mjs` for the workflow guard.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `python .github/scripts/check-codestory-release.py --version 0.12.4`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

## Risk

Low. This adds a CI lane and widens release preflight to already-shipped plugin manifests. The only likely failure mode is CI noise if future plugin manifests intentionally diverge; that should be a release decision, not silent drift.
