### PR TITLE
Serialize shared-agent sidecar repair

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2326,6 +2326,37 @@ fn repair_ready_state(
         Some(runtime.cache_root.as_path()),
     );
     let sidecar = sidecar.expect("agent sidecar should be selected for agent goal");
+    let _repair_lock = match ready_repair_status::try_acquire_ready_repair_lock(
+        &sidecar,
+        &runtime.project_root,
+    )? {
+        ready_repair_status::ReadyRepairLockAttempt::Acquired(lock) => lock,
+        ready_repair_status::ReadyRepairLockAttempt::Busy(busy) => {
+            if let Some(status) = busy.status {
+                bail!(
+                    "ready repair already running for project={} profile={} run_id={} namespace={} phase={} pid={}; inspect with `codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}`",
+                    status.project_root,
+                    status.profile,
+                    status.run_id.as_deref().unwrap_or("none"),
+                    status.namespace,
+                    status.phase,
+                    status.pid,
+                    crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                    sidecar
+                        .run_id
+                        .as_deref()
+                        .unwrap_or(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+                );
+            }
+            bail!(
+                "ready repair already starting for project={} profile=agent run_id={} namespace={}; lock_path={}",
+                crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                sidecar.run_id.as_deref().unwrap_or("none"),
+                sidecar.namespace,
+                busy.lock_path.display()
+            );
+        }
+    };
     eprintln!(
         "ready repair agent sidecar: profile=agent run_id={} namespace={} compose_project={}",
         sidecar.run_id.as_deref().unwrap_or("none"),

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -5,13 +5,16 @@ use codestory_retrieval::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const READY_REPAIR_STATUS_FILE: &str = "ready-repair-status.json";
+const READY_REPAIR_LOCK_FILE: &str = "ready-repair.lock";
 const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
 const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
+const READY_REPAIR_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct ReadyRepairStatus {
@@ -28,11 +31,117 @@ pub(crate) struct ReadyRepairStatus {
     pub(crate) updated_at_epoch_ms: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ReadyRepairLockFile {
+    schema_version: u32,
+    project_root: String,
+    profile: String,
+    run_id: Option<String>,
+    namespace: String,
+    pid: u32,
+    started_at_epoch_ms: i64,
+    token: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReadyRepairBusy {
+    pub(crate) status: Option<ReadyRepairStatus>,
+    pub(crate) lock_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) enum ReadyRepairLockAttempt {
+    Acquired(ReadyRepairLock),
+    Busy(ReadyRepairBusy),
+}
+
+#[derive(Debug)]
+pub(crate) struct ReadyRepairLock {
+    path: PathBuf,
+    token: String,
+}
+
+impl Drop for ReadyRepairLock {
+    fn drop(&mut self) {
+        let Some(lock) = read_ready_repair_lock_file(&self.path) else {
+            return;
+        };
+        if lock.token == self.token {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn now_epoch_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
         .unwrap_or_default()
+}
+
+pub(crate) fn try_acquire_ready_repair_lock(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+) -> Result<ReadyRepairLockAttempt> {
+    let path = ready_repair_lock_path(sidecar);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let started_at_epoch_ms = now_epoch_ms();
+    let pid = std::process::id();
+    let token = format!("{pid}:{started_at_epoch_ms}");
+    let lock = ReadyRepairLockFile {
+        schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+        project_root: clean_path_text(project_root),
+        profile: sidecar.profile.as_str().to_string(),
+        run_id: sidecar.run_id.clone(),
+        namespace: sidecar.namespace.clone(),
+        pid,
+        started_at_epoch_ms,
+        token: token.clone(),
+    };
+    let content = serde_json::to_vec_pretty(&lock)?;
+
+    match create_ready_repair_lock_file(&path, &content) {
+        Ok(()) => {
+            return Ok(ReadyRepairLockAttempt::Acquired(ReadyRepairLock {
+                path,
+                token,
+            }));
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    if let Some(status) = active_ready_repair_status(project_root, sidecar.run_id.as_deref()) {
+        return Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
+            status: Some(status),
+            lock_path: path,
+        }));
+    }
+
+    if !ready_repair_lock_file_is_stale(&path) {
+        return Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
+            status: None,
+            lock_path: path,
+        }));
+    }
+
+    let _ = fs::remove_file(&path);
+    match create_ready_repair_lock_file(&path, &content) {
+        Ok(()) => Ok(ReadyRepairLockAttempt::Acquired(ReadyRepairLock {
+            path,
+            token,
+        })),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
+                status: active_ready_repair_status(project_root, sidecar.run_id.as_deref()),
+                lock_path: path,
+            }))
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 pub(crate) fn write_ready_repair_status(
@@ -96,11 +205,42 @@ pub(crate) fn ready_repair_status_cache_fingerprint(project_root: &Path) -> Stri
         .join(";")
 }
 
+fn create_ready_repair_lock_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(content)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn ready_repair_lock_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
+    sidecar
+        .layout
+        .state_file
+        .with_file_name(READY_REPAIR_LOCK_FILE)
+}
+
 fn ready_repair_status_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
     sidecar
         .layout
         .state_file
         .with_file_name(READY_REPAIR_STATUS_FILE)
+}
+
+fn ready_repair_lock_file_is_stale(path: &Path) -> bool {
+    let now = now_epoch_ms();
+    if let Some(lock) = read_ready_repair_lock_file(path) {
+        return now.saturating_sub(lock.started_at_epoch_ms)
+            > READY_REPAIR_LOCK_STALE_TTL.as_millis() as i64;
+    }
+    fs::metadata(path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|modified| {
+            let modified_ms = modified.as_millis().min(i64::MAX as u128) as i64;
+            now.saturating_sub(modified_ms) > READY_REPAIR_LOCK_STALE_TTL.as_millis() as i64
+        })
+        .unwrap_or(true)
 }
 
 fn read_ready_repair_status(
@@ -121,6 +261,12 @@ fn read_ready_repair_status(
         return None;
     }
     Some(status)
+}
+
+fn read_ready_repair_lock_file(path: &Path) -> Option<ReadyRepairLockFile> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
 }
 
 fn read_ready_repair_status_file(path: &Path) -> Option<ReadyRepairStatus> {
@@ -255,6 +401,45 @@ mod tests {
             !path.exists(),
             "drop cleanup should remove the matching repair state file"
         );
+    }
+
+    #[test]
+    fn repair_lock_is_single_flight_and_clears_on_drop() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+
+        let lock = match try_acquire_ready_repair_lock(&sidecar, project.path())
+            .expect("first lock attempt")
+        {
+            ReadyRepairLockAttempt::Acquired(lock) => lock,
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!(
+                    "first lock should be acquired, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        };
+
+        match try_acquire_ready_repair_lock(&sidecar, project.path()).expect("second lock attempt")
+        {
+            ReadyRepairLockAttempt::Busy(busy) => {
+                assert!(busy.status.is_none());
+                assert!(busy.lock_path.exists());
+            }
+            ReadyRepairLockAttempt::Acquired(_) => panic!("second lock must not be acquired"),
+        }
+
+        drop(lock);
+        match try_acquire_ready_repair_lock(&sidecar, project.path()).expect("third lock attempt") {
+            ReadyRepairLockAttempt::Acquired(_) => {}
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!(
+                    "lock should be reusable after drop, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        }
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2198,7 +2198,13 @@ fn read_stdio_status_resource_cached(
     let project = stdio_project_args(runtime);
     let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
     let summary = inspect_runtime.open_project_summary()?;
-    let (summary, local_refresh) = if crate::local_freshness_needs_refresh(&summary) {
+    let active_agent_repair = crate::ready_repair_status::active_ready_repair_status(
+        &runtime.project_root,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    );
+    let (summary, local_refresh) = if active_agent_repair.is_some() {
+        (summary, None)
+    } else if crate::local_freshness_needs_refresh(&summary) {
         crate::wait_for_local_freshness(&project, &inspect_runtime)?
     } else {
         (summary, None)
@@ -3323,6 +3329,10 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
     );
     let next_repair_command =
         env_nonempty("CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND").unwrap_or(default_repair);
+    let active_repair = crate::ready_repair_status::active_ready_repair_status(
+        project_root,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    );
     serde_json::json!({
         "state": state,
         "auto_repair": auto_repair,
@@ -3350,7 +3360,17 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
             "updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT"),
             "project_root": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT"),
             "command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND")
-        }
+        },
+        "active_repair": active_repair.as_ref().map(|status| serde_json::json!({
+            "status": &status.status,
+            "project_root": &status.project_root,
+            "profile": &status.profile,
+            "run_id": &status.run_id,
+            "namespace": &status.namespace,
+            "phase": &status.phase,
+            "pid": status.pid,
+            "updated_at_epoch_ms": status.updated_at_epoch_ms
+        }))
     })
 }
 
@@ -3427,11 +3447,33 @@ fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
 }
 
 fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
+    if let Some(status) = crate::ready_repair_status::active_ready_repair_status(
+        &runtime.project_root,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    ) {
+        return serde_json::json!({
+            "result": {
+                "status": "already_running",
+                "project_root": status.project_root,
+                "profile": status.profile,
+                "run_id": status.run_id,
+                "namespace": status.namespace,
+                "phase": status.phase,
+                "pid": status.pid,
+                "next_status_command": format!(
+                    "codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}",
+                    crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                    codestory_retrieval::DEFAULT_AGENT_RUN_ID
+                ),
+                "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
+            }
+        });
+    }
     let exe = match std::env::current_exe() {
         Ok(exe) => exe,
         Err(error) => return serde_json::json!({"error": error.to_string()}),
     };
-    let output = Command::new(exe)
+    let child = Command::new(exe)
         .arg("ready")
         .arg("--goal")
         .arg("agent")
@@ -3443,18 +3485,21 @@ fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
         .arg("--run-id")
         .arg(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
         .env("CODESTORY_PLUGIN_SIDECAR_REPAIR", "1")
-        .output();
-    match output {
-        Ok(output) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let parsed = serde_json::from_str::<serde_json::Value>(&stdout).ok();
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    match child {
+        Ok(child) => {
             serde_json::json!({
                 "result": {
-                    "status": if output.status.success() { "completed" } else { "failed" },
-                    "exit_code": output.status.code(),
-                    "stdout": stdout,
-                    "stderr": String::from_utf8_lossy(&output.stderr),
-                    "parsed": parsed,
+                    "status": "started",
+                    "pid": child.id(),
+                    "next_status_command": format!(
+                        "codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}",
+                        crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                        codestory_retrieval::DEFAULT_AGENT_RUN_ID
+                    ),
                     "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
                 }
             })

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2720,6 +2720,74 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
 }
 
 #[test]
+fn tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting() {
+    let fixture = indexed_fixture();
+    let (status_path, _cleanup) = write_active_repair_status_fixture(
+        &fixture,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+        "Qdrant finalize",
+    );
+    assert!(status_path.exists(), "repair status fixture should exist");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-status-active",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "status"}
+            }
+        }),
+    );
+    let setup = assert_tool_success(&status_response, json!("sidecar-setup-status-active"));
+    assert_eq!(
+        setup["active_repair"]["status"],
+        json!("repairing"),
+        "sidecar_setup status should surface the active shared-agent repair: {setup}"
+    );
+    assert_eq!(
+        setup["active_repair"]["run_id"],
+        json!(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+        "{setup}"
+    );
+
+    let repair_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-repair-active",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "repair"}
+            }
+        }),
+    );
+    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair-active"));
+    assert_eq!(
+        repair["status"],
+        json!("already_running"),
+        "sidecar_setup repair should not spawn or wait when shared-agent repair is active: {repair}"
+    );
+    assert_eq!(
+        repair["phase"],
+        json!("Qdrant finalize"),
+        "already-running response should preserve current repair phase: {repair}"
+    );
+    assert!(
+        repair["next_status_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval status")
+                && command.contains("--profile agent")
+                && command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)),
+        "already-running response should point to cheap status inspection: {repair}"
+    );
+}
+
+#[test]
 fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
     let mut fixture = indexed_fixture();
     let marker_path = write_dirty_marker_fixture(


### PR DESCRIPTION
## Context

Closes #743
Refs #716
Refs #738

Dogfood in this thread reproduced installed-plugin friction: `sidecar_setup({action:"status"})` timed out at the tool boundary after 300 seconds while another CodeStory/plugin lane appeared active. The related session `019f03a4-c1b0-76e1-83d5-5094256148c4` also showed project/session routing confusion. Cross-project sidecar identity is mostly project-hash isolated, but same-project `shared-agent` repair still needed a single-flight boundary.

```mermaid
flowchart LR
  M["MCP sidecar_setup repair"] --> S["spawn ready repair"]
  S --> R["returns pid immediately"]
  C["CLI ready --repair"] --> L{"project/run lock?"}
  L -->|free| W["bootstrap/index/finalize"]
  L -->|busy| B["already running/starting"]
  P["status"] --> A{"active repair?"}
  A -->|yes| O["overlay phase, skip refresh"]
  A -->|no| F["normal status refresh"]
```

## What Changed

- Added a per-project/run-id ready-repair lock file with stale-lock handling and token-based cleanup.
- Made `ready --goal agent --repair` acquire that lock before bootstrapping, indexing, or finalizing sidecar state.
- Changed stdio `sidecar_setup repair` to spawn the repair child and return immediately with pid/status guidance.
- Made stdio `sidecar_setup status` include active shared-agent repair phase/pid details.
- Kept stdio status from doing local refresh work while an active agent repair overlay is present.
- Added protocol coverage for the already-running shared-agent repair path.

## How To Review

Start with `crates/codestory-cli/src/ready_repair_status.rs` for the lock semantics. Then review `repair_ready_state` in `crates/codestory-cli/src/main.rs` and `handle_stdio_sidecar_repair` in `crates/codestory-cli/src/stdio_transport.rs`.

## Verification

- `cargo test -p codestory-cli ready_repair_status`
- `cargo test -p codestory-cli --test stdio_protocol_contracts tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting -- --exact --nocapture`
- `cargo test -p codestory-cli --test stdio_protocol_contracts`
- `cargo check -p codestory-cli --locked`
- `cargo test -p codestory-cli ready_repair`
- `cargo fmt --check`
- `git diff --check`

## Risk

Moderate. This intentionally changes MCP repair from synchronous completion to asynchronous start/status tracking. That should unblock the MCP server, but installed-plugin live proof remains pending until this source change lands in the packaged runtime; the source-side dogfood still showed the currently installed plugin timing out.