### PR TITLE
Consolidate readiness status selection

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2153,14 +2153,11 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     } else {
         (runtime.open_project_summary()?, None)
     };
-    let sidecar = ready_sidecar_status(&runtime, repaired_sidecar, cmd.goal, agent_run_id);
-    let readiness_sidecar = if !cmd.repair
-        && agent_run_id.is_none()
-        && matches!(cmd.goal, Some(args::ReadyGoal::Agent))
-    {
-        agent_goal_readiness_sidecar_status(&runtime, &sidecar)
+    let raw_sidecar = ready_sidecar_status(&runtime, repaired_sidecar, cmd.goal, agent_run_id);
+    let readiness_sidecar = if matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
+        selected_agent_readiness_sidecar_status(&runtime, agent_run_id, &raw_sidecar)
     } else {
-        sidecar
+        raw_sidecar
     };
     let mut verdicts = build_summary_readiness(
         &summary.root,
@@ -2168,7 +2165,12 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         summary.freshness.as_ref(),
         &readiness_sidecar,
     );
-    let readiness_lanes = build_readiness_lanes_for_runtime(&runtime, &verdicts, agent_run_id);
+    let readiness_lanes = build_readiness_lanes_for_runtime(
+        &runtime,
+        &verdicts,
+        agent_run_id,
+        Some(&readiness_sidecar),
+    );
     if let Some(goal) = cmd.goal {
         let goal = goal.as_dto();
         verdicts.retain(|verdict| verdict.goal == goal);
@@ -2267,14 +2269,15 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let summary = runtime.open_project_summary()?;
     let sidecar = doctor_sidecar_status(&runtime);
-    let readiness_sidecar = agent_goal_readiness_sidecar_status(&runtime, &sidecar);
+    let readiness_sidecar = selected_agent_readiness_sidecar_status(&runtime, None, &sidecar);
     let readiness = build_summary_readiness(
         &summary.root,
         &summary.stats,
         summary.freshness.as_ref(),
         &readiness_sidecar,
     );
-    let readiness_lanes = build_readiness_lanes_for_runtime(&runtime, &readiness, None);
+    let readiness_lanes =
+        build_readiness_lanes_for_runtime(&runtime, &readiness, None, Some(&readiness_sidecar));
     let output =
         build_agent_preflight_output(&readiness, Path::new(&summary.root), readiness_lanes);
     let markdown = render_agent_preflight_markdown(&output);
@@ -10478,14 +10481,16 @@ fn build_doctor_output(
     let storage_path = display::clean_path_string(&runtime.storage_path.to_string_lossy());
     let storage_exists = runtime.storage_path.exists();
     let sidecar_retrieval = doctor_sidecar_status(runtime);
-    let readiness_sidecar = agent_goal_readiness_sidecar_status(runtime, &sidecar_retrieval);
+    let readiness_sidecar =
+        selected_agent_readiness_sidecar_status(runtime, None, &sidecar_retrieval);
     let readiness = build_summary_readiness(
         &project,
         &summary.stats,
         summary.freshness.as_ref(),
         &readiness_sidecar,
     );
-    let readiness_lanes = build_readiness_lanes_for_runtime(runtime, &readiness, None);
+    let readiness_lanes =
+        build_readiness_lanes_for_runtime(runtime, &readiness, None, Some(&readiness_sidecar));
     let next_commands = readiness::compatibility_next_commands(&readiness);
     let mut checks = Vec::new();
     checks.push(doctor_check(
@@ -10765,11 +10770,12 @@ fn doctor_sidecar_status_error(
     }
 }
 
-fn agent_goal_readiness_sidecar_status(
+pub(crate) fn selected_agent_readiness_sidecar_status(
     runtime: &RuntimeContext,
+    run_id: Option<&str>,
     fallback: &DoctorSidecarStatusOutput,
 ) -> DoctorSidecarStatusOutput {
-    let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, None);
+    let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, run_id);
     let agent_status = doctor_sidecar_status_for_runtime(runtime, agent_runtime);
     lane_scoped_agent_readiness_sidecar(fallback, agent_status)
 }
@@ -10796,6 +10802,7 @@ pub(crate) fn build_readiness_lanes_for_runtime(
     runtime: &RuntimeContext,
     readiness: &[codestory_contracts::api::ReadinessVerdictDto],
     agent_run_id: Option<&str>,
+    selected_agent_status: Option<&DoctorSidecarStatusOutput>,
 ) -> BTreeMap<String, ReadinessLaneOutput> {
     let project = display::clean_path_string(&runtime.project_root.to_string_lossy());
     let project_arg = display::quote_command_argument_value(&project);
@@ -10805,7 +10812,9 @@ pub(crate) fn build_readiness_lanes_for_runtime(
     );
     let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, agent_run_id);
     let local_status = doctor_sidecar_status_for_runtime(runtime, local_runtime);
-    let agent_status = doctor_sidecar_status_for_runtime(runtime, agent_runtime);
+    let agent_status = selected_agent_status
+        .cloned()
+        .unwrap_or_else(|| doctor_sidecar_status_for_runtime(runtime, agent_runtime));
     let agent_verdict = readiness
         .iter()
         .find(|verdict| verdict.goal == ReadinessGoalDto::AgentPacketSearch);

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2599,33 +2599,71 @@ fn read_stdio_status_resource(
     let setup_repair = stdio_setup_repair_input(server_executable.as_deref());
     let dirty_marker = stdio_dirty_marker_status(&runtime.project_root, &runtime.storage_path);
     let effective_freshness = stdio_effective_freshness(summary.freshness.as_ref(), &dirty_marker);
+    let raw_sidecar_status = crate::DoctorSidecarStatusOutput {
+        profile: Some(sidecar_runtime.profile.as_str().to_string()),
+        run_id: sidecar_runtime.run_id.clone(),
+        retrieval_mode: sidecar_mode.clone(),
+        degraded_reason: degraded_reason.clone(),
+        embedding_device_policy: embedding_device_policy.clone(),
+        embedding_device_state: embedding_device_state.clone(),
+        embedding_device_observation_source: embedding_device_observation_source.clone(),
+        embedding_detected_provider: embedding_detected_provider.clone(),
+        embedding_detected_gpu: embedding_detected_gpu.clone(),
+        embedding_accelerator_requested,
+        embedding_accelerator_request_provider: embedding_accelerator_request_provider.clone(),
+        embedding_accelerator_request_device: embedding_accelerator_request_device.clone(),
+        embedding_cpu_allowed,
+        manifest_generation: manifest_generation.clone(),
+        manifest_input_hash: manifest_input_hash.clone(),
+        precise_semantic_import_status: None,
+        precise_semantic_import_reason: None,
+        precise_semantic_import_revision: None,
+        precise_semantic_import_producer: None,
+    };
+    let selected_agent_sidecar = crate::selected_agent_readiness_sidecar_status(
+        runtime,
+        sidecar_runtime.run_id.as_deref(),
+        &raw_sidecar_status,
+    );
     let readiness = crate::readiness::build_readiness_verdicts(crate::readiness::ReadinessInputs {
         project: &summary.root,
         stats: &summary.stats,
         freshness: effective_freshness.as_ref(),
         setup: setup_repair.as_ref(),
         sidecar: Some(crate::readiness::ReadinessSidecarInput {
-            profile: Some(sidecar_runtime.profile.as_str()),
-            run_id: sidecar_runtime.run_id.as_deref(),
-            retrieval_mode: &sidecar_mode,
-            degraded_reason: degraded_reason.as_deref(),
-            embedding_device_policy: Some(&embedding_device_policy),
-            embedding_device_state: Some(&embedding_device_state),
-            embedding_device_observation_source: Some(&embedding_device_observation_source),
-            embedding_detected_provider: embedding_detected_provider.as_deref(),
-            embedding_detected_gpu: embedding_detected_gpu.as_deref(),
-            embedding_accelerator_requested,
-            embedding_accelerator_request_provider: embedding_accelerator_request_provider
+            profile: selected_agent_sidecar.profile.as_deref(),
+            run_id: selected_agent_sidecar.run_id.as_deref(),
+            retrieval_mode: &selected_agent_sidecar.retrieval_mode,
+            degraded_reason: selected_agent_sidecar.degraded_reason.as_deref(),
+            embedding_device_policy: Some(&selected_agent_sidecar.embedding_device_policy),
+            embedding_device_state: Some(&selected_agent_sidecar.embedding_device_state),
+            embedding_device_observation_source: Some(
+                &selected_agent_sidecar.embedding_device_observation_source,
+            ),
+            embedding_detected_provider: selected_agent_sidecar
+                .embedding_detected_provider
                 .as_deref(),
-            embedding_accelerator_request_device: embedding_accelerator_request_device.as_deref(),
-            embedding_cpu_allowed,
-            manifest_generation: manifest_generation.as_deref(),
-            manifest_input_hash: manifest_input_hash.as_deref(),
+            embedding_detected_gpu: selected_agent_sidecar.embedding_detected_gpu.as_deref(),
+            embedding_accelerator_requested: selected_agent_sidecar.embedding_accelerator_requested,
+            embedding_accelerator_request_provider: selected_agent_sidecar
+                .embedding_accelerator_request_provider
+                .as_deref(),
+            embedding_accelerator_request_device: selected_agent_sidecar
+                .embedding_accelerator_request_device
+                .as_deref(),
+            embedding_cpu_allowed: selected_agent_sidecar.embedding_cpu_allowed,
+            manifest_generation: selected_agent_sidecar.manifest_generation.as_deref(),
+            manifest_input_hash: selected_agent_sidecar.manifest_input_hash.as_deref(),
         }),
     });
     let sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
     let allowed_surfaces = stdio_allowed_surfaces(&readiness);
-    let readiness_lanes = crate::build_readiness_lanes_for_runtime(runtime, &readiness, None);
+    let readiness_lanes = crate::build_readiness_lanes_for_runtime(
+        runtime,
+        &readiness,
+        None,
+        Some(&selected_agent_sidecar),
+    );
     let readiness_lanes_json =
         serde_json::to_value(&readiness_lanes).expect("serialize readiness lanes");
     let recommended_next_calls = stdio_status_recommended_next_calls(&readiness, &sidecar_setup);
@@ -2644,7 +2682,6 @@ fn read_stdio_status_resource(
     let runtime_truth = stdio_runtime_truth_status(
         &plugin_runtime,
         &sidecar_setup,
-        &sidecar,
         &readiness_lanes_json,
         local,
         &local_refresh_json,
@@ -2702,7 +2739,6 @@ fn read_stdio_status_resource(
 fn stdio_runtime_truth_status(
     plugin_runtime: &serde_json::Value,
     sidecar_setup: &serde_json::Value,
-    sidecar: &serde_json::Value,
     readiness_lanes: &serde_json::Value,
     local: &ReadinessVerdictDto,
     local_refresh: &serde_json::Value,
@@ -2734,12 +2770,12 @@ fn stdio_runtime_truth_status(
                 .pointer("/agent_packet_search/run_id")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!("unavailable")),
-            "mode": sidecar
-                .get("retrieval_mode")
+            "mode": readiness_lanes
+                .pointer("/agent_packet_search/sidecar_mode")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!("unavailable")),
-            "degraded_reason": sidecar
-                .get("degraded_reason")
+            "degraded_reason": readiness_lanes
+                .pointer("/agent_packet_search/degraded_reason")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null),
             "namespace": readiness_lanes

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -162,8 +162,22 @@ fn ready_command_emits_compact_verdicts_and_filters_goal() {
     let explicit_agent_json: Value =
         serde_json::from_str(&explicit_agent_json_text).expect("explicit ready agent json");
     assert_eq!(
+        explicit_agent_json["verdicts"][0]["sidecar"]["run_id"],
+        "isolated-proof"
+    );
+    assert_eq!(
         explicit_agent_json["readiness_lanes"]["agent_packet_search"]["run_id"],
         "isolated-proof"
+    );
+    assert_eq!(
+        explicit_agent_json["verdicts"][0]["sidecar"]["run_id"],
+        explicit_agent_json["readiness_lanes"]["agent_packet_search"]["run_id"],
+        "explicit ready agent verdict and rendered lane should use one selected runtime status: {explicit_agent_json_text}"
+    );
+    assert_eq!(
+        explicit_agent_json["verdicts"][0]["sidecar"]["retrieval_mode"],
+        explicit_agent_json["readiness_lanes"]["agent_packet_search"]["sidecar_mode"],
+        "explicit ready agent verdict and rendered lane should agree on full-vs-degraded state: {explicit_agent_json_text}"
     );
     assert!(
         explicit_agent_json["verdicts"][0]["minimum_next"]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2261,8 +2261,13 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     );
     assert_eq!(
         status["runtime_truth"]["sidecar_status"]["mode"],
-        status["sidecar_retrieval"]["retrieval_mode"],
-        "runtime truth should reuse sidecar retrieval mode: {status}"
+        status["readiness_lanes"]["agent_packet_search"]["sidecar_mode"],
+        "runtime truth should reuse the selected agent readiness lane mode: {status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["sidecar_status"]["degraded_reason"],
+        status["readiness_lanes"]["agent_packet_search"]["degraded_reason"],
+        "runtime truth should reuse the selected agent readiness lane reason: {status}"
     );
     assert!(
         status


### PR DESCRIPTION
## Context

Closes #720.
Refs #716.

Readiness rendering was still split after the earlier fail-closed fixes: `doctor`, `ready --goal agent`, and MCP `codestory://status` could re-probe or render different sidecar objects after selecting the agent packet/search lane. That made it possible for the verdict, readiness lane, and runtime truth block to disagree on profile/run id or full-vs-degraded state.

```mermaid
flowchart LR
  S["strict sidecar status"] --> A["selected agent status"]
  A --> V["readiness verdict"]
  A --> L["readiness lane"]
  L --> R["runtime truth"]
  V --> O["doctor/ready/status output"]
  R --> O
```

## What Changed

- Replaced the old default-only agent readiness helper with a run-id-aware selected agent status helper.
- Passed the selected agent status into readiness lane rendering so `ready --goal agent --run-id ...` keeps verdicts and lanes on the same runtime.
- Made `doctor` and `agent preflight` render lanes from the same selected agent status used for the aggregate verdict.
- Made MCP runtime truth read mode/reason from the selected `agent_packet_search` lane instead of mixing that lane's profile/run id with a separate sidecar status blob.
- Added regression assertions for explicit run-id verdict/lane agreement and MCP runtime-truth lane agreement.

## How To Review

Start in `crates/codestory-cli/src/main.rs` at `selected_agent_readiness_sidecar_status` and the `run_ready` call site. Then review `read_stdio_status_resource` in `crates/codestory-cli/src/stdio_transport.rs` for the MCP status path, followed by the two test files.

## Verification

- `cargo fmt --check`
- `cargo test -p codestory-cli readiness --lib` failed as a stale issue command because `codestory-cli` has no lib target.
- `cargo test -p codestory-cli readiness`
- `cargo test -p codestory-cli --test ready_command`
- `cargo test -p codestory-cli --test stdio_protocol_contracts`
- `cargo check -p codestory-cli --locked`
- `git diff --check`
- Source-binary smoke: `target\debug\codestory-cli.exe ready --goal agent --project C:\Users\alber\source\repos\codestory --format json`
- Source-binary smoke: `target\debug\codestory-cli.exe doctor --project C:\Users\alber\source\repos\codestory --format json`

## Risk

Moderate and contained to readiness reporting. This does not repair or rebuild sidecars. The source-binary smoke currently reports `agent/shared-agent` as `repair_retrieval` with `retrieval_manifest_missing`, which is expected because this branch has unindexed source changes and no sidecar repair was run. Installed-plugin proof remains pending until this lands in the packaged runtime.