### PR TITLE
Bump CodeStory to 0.12.5

### DIFF
--- a/.github/scripts/check-codestory-release.py
+++ b/.github/scripts/check-codestory-release.py
@@ -15,6 +15,12 @@ SEMVER_RE = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
+PLUGIN_MANIFESTS = (
+    Path("plugins/codestory/.codex-plugin/plugin.json"),
+    Path("plugins/codestory/.claude-plugin/plugin.json"),
+    Path("plugins/codestory/.github/plugin/plugin.json"),
+)
+
 
 def read_toml(path: Path) -> dict:
     with path.open("rb") as handle:
@@ -50,16 +56,19 @@ def lock_packages(root: Path) -> dict[str, set[str]]:
     return packages
 
 
-def plugin_version(root: Path) -> str:
-    manifest_path = root / "plugins" / "codestory" / ".codex-plugin" / "plugin.json"
-    try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise ValueError(f"{manifest_path} does not exist") from exc
-    version = manifest.get("version")
-    if not isinstance(version, str) or not version:
-        raise ValueError(f"{manifest_path} must declare a string version")
-    return version
+def plugin_versions(root: Path) -> dict[Path, str]:
+    versions: dict[Path, str] = {}
+    for relative_path in PLUGIN_MANIFESTS:
+        manifest_path = root / relative_path
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise ValueError(f"{manifest_path} does not exist") from exc
+        version = manifest.get("version")
+        if not isinstance(version, str) or not version:
+            raise ValueError(f"{manifest_path} must declare a string version")
+        versions[relative_path] = version
+    return versions
 
 
 def fail(message: str) -> None:
@@ -91,12 +100,9 @@ def main() -> None:
     if cli_version != expected:
         fail(f"codestory-cli version is {cli_version}, expected {expected}")
 
-    current_plugin_version = plugin_version(root)
-    if current_plugin_version != expected:
-        fail(
-            "plugins/codestory/.codex-plugin/plugin.json version is "
-            f"{current_plugin_version}, expected {expected}"
-        )
+    for manifest_path, current_plugin_version in plugin_versions(root).items():
+        if current_plugin_version != expected:
+            fail(f"{manifest_path} version is {current_plugin_version}, expected {expected}")
 
     workspace_versions: dict[str, str] = {}
     for manifest_path in workspace_members(root):
@@ -131,7 +137,8 @@ def main() -> None:
 
     print(
         f"CodeStory release version {expected} is synchronized across "
-        f"{len(workspace_versions)} workspace crates, Cargo.lock, and the codestory plugin."
+        f"{len(workspace_versions)} workspace crates, Cargo.lock, and "
+        f"{len(PLUGIN_MANIFESTS)} codestory plugin manifests."
     )
 
 

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -7,6 +7,7 @@ const trustedOwners = new Set(["actions", "github"]);
 const shaPattern = /^[0-9a-f]{40}$/i;
 const violations = [];
 const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
+const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
 
 for (const file of fs
   .readdirSync(workflowRoot)
@@ -62,6 +63,25 @@ if (fs.existsSync(sagaIssueLinkGuard)) {
     !closingRef.test("Closes https://github.com/TheGreenCedar/CodeStory/issues/123")
   ) {
     violations.push("saga-issue-link-guard.yml closing ref policy must reject bare numbers and accept # or full issue URLs");
+  }
+}
+
+if (!fs.existsSync(pluginStatic)) {
+  violations.push("plugin-static.yml must run plugin static tests for plugin changes");
+} else {
+  const content = fs.readFileSync(pluginStatic, "utf8");
+  const requiredSnippets = [
+    "plugins/codestory/**",
+    "dev/codestory-next",
+    "node --test plugins/codestory/tests/plugin-static.test.mjs",
+    "node .github/scripts/check-workflow-policy.mjs",
+    "python .github/scripts/check-codestory-release.py --version",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!content.includes(snippet)) {
+      violations.push(`plugin-static.yml must include ${snippet}`);
+    }
   }
 }
 

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -8,6 +8,7 @@ const shaPattern = /^[0-9a-f]{40}$/i;
 const violations = [];
 const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
 const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
+const rustCi = path.join(workflowRoot, "rust-ci.yml");
 
 for (const file of fs
   .readdirSync(workflowRoot)
@@ -81,6 +82,28 @@ if (!fs.existsSync(pluginStatic)) {
   for (const snippet of requiredSnippets) {
     if (!content.includes(snippet)) {
       violations.push(`plugin-static.yml must include ${snippet}`);
+    }
+  }
+}
+
+if (!fs.existsSync(rustCi)) {
+  violations.push("rust-ci.yml must run default Rust workspace checks for routine code changes");
+} else {
+  const content = fs.readFileSync(rustCi, "utf8");
+  const requiredSnippets = [
+    "Cargo.lock",
+    "Cargo.toml",
+    "crates/**",
+    "dev/codestory-next",
+    "cargo fmt --check",
+    "cargo check --workspace --locked",
+    "cargo test --locked",
+    "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!content.includes(snippet)) {
+      violations.push(`rust-ci.yml must include ${snippet}`);
     }
   }
 }

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -1,0 +1,46 @@
+name: plugin static
+
+on:
+  pull_request:
+    paths:
+      - plugins/codestory/**
+      - .github/scripts/check-codestory-release.py
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/plugin-static.yml
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - plugins/codestory/**
+      - .github/scripts/check-codestory-release.py
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/plugin-static.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: plugin-static-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-static:
+    name: plugin static tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check plugin static wiring
+        run: node --test plugins/codestory/tests/plugin-static.test.mjs
+
+      - name: Check workflow policy
+        run: node .github/scripts/check-workflow-policy.mjs
+
+      - name: Check release version surfaces
+        shell: bash
+        run: |
+          version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
+          python .github/scripts/check-codestory-release.py --version "$version"

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -6,6 +6,7 @@ on:
       - plugins/codestory/**
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/rust-ci.yml
       - .github/workflows/plugin-static.yml
   push:
     branches:
@@ -15,6 +16,7 @@ on:
       - plugins/codestory/**
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/rust-ci.yml
       - .github/workflows/plugin-static.yml
   workflow_dispatch:
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,55 @@
+name: rust ci
+
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - docs/contributors/testing-matrix.md
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/rust-ci.yml
+  push:
+    branches:
+      - main
+      - dev/codestory-next
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - crates/**
+      - docs/contributors/testing-matrix.md
+      - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/rust-ci.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workspace:
+    name: workspace cargo checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy --component rustfmt
+          rustup default stable
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Check workspace
+        run: cargo check --workspace --locked
+
+      - name: Test workspace
+        run: cargo test --locked
+
+      - name: Lint workspace
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2326,6 +2326,37 @@ fn repair_ready_state(
         Some(runtime.cache_root.as_path()),
     );
     let sidecar = sidecar.expect("agent sidecar should be selected for agent goal");
+    let _repair_lock = match ready_repair_status::try_acquire_ready_repair_lock(
+        &sidecar,
+        &runtime.project_root,
+    )? {
+        ready_repair_status::ReadyRepairLockAttempt::Acquired(lock) => lock,
+        ready_repair_status::ReadyRepairLockAttempt::Busy(busy) => {
+            if let Some(status) = busy.status {
+                bail!(
+                    "ready repair already running for project={} profile={} run_id={} namespace={} phase={} pid={}; inspect with `codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}`",
+                    status.project_root,
+                    status.profile,
+                    status.run_id.as_deref().unwrap_or("none"),
+                    status.namespace,
+                    status.phase,
+                    status.pid,
+                    crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                    sidecar
+                        .run_id
+                        .as_deref()
+                        .unwrap_or(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+                );
+            }
+            bail!(
+                "ready repair already starting for project={} profile=agent run_id={} namespace={}; lock_path={}",
+                crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                sidecar.run_id.as_deref().unwrap_or("none"),
+                sidecar.namespace,
+                busy.lock_path.display()
+            );
+        }
+    };
     eprintln!(
         "ready repair agent sidecar: profile=agent run_id={} namespace={} compose_project={}",
         sidecar.run_id.as_deref().unwrap_or("none"),

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2385,9 +2385,10 @@ fn repair_ready_state(
     );
     ensure_ready_repair_embed_liveness(&infrastructure)?;
     progress.set_phase("Qdrant finalize");
-    codestory_retrieval::repair_project_qdrant_collection(
+    codestory_retrieval::repair_project_qdrant_collection_for_runtime(
         &runtime.project_root,
         &runtime.storage_path,
+        &sidecar,
     )
     .context("ready repair project qdrant repair")?;
     progress.set_phase("graph artifact");

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2153,14 +2153,11 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
     } else {
         (runtime.open_project_summary()?, None)
     };
-    let sidecar = ready_sidecar_status(&runtime, repaired_sidecar, cmd.goal, agent_run_id);
-    let readiness_sidecar = if !cmd.repair
-        && agent_run_id.is_none()
-        && matches!(cmd.goal, Some(args::ReadyGoal::Agent))
-    {
-        agent_goal_readiness_sidecar_status(&runtime, &sidecar)
+    let raw_sidecar = ready_sidecar_status(&runtime, repaired_sidecar, cmd.goal, agent_run_id);
+    let readiness_sidecar = if matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
+        selected_agent_readiness_sidecar_status(&runtime, agent_run_id, &raw_sidecar)
     } else {
-        sidecar
+        raw_sidecar
     };
     let mut verdicts = build_summary_readiness(
         &summary.root,
@@ -2168,7 +2165,12 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         summary.freshness.as_ref(),
         &readiness_sidecar,
     );
-    let readiness_lanes = build_readiness_lanes_for_runtime(&runtime, &verdicts, agent_run_id);
+    let readiness_lanes = build_readiness_lanes_for_runtime(
+        &runtime,
+        &verdicts,
+        agent_run_id,
+        Some(&readiness_sidecar),
+    );
     if let Some(goal) = cmd.goal {
         let goal = goal.as_dto();
         verdicts.retain(|verdict| verdict.goal == goal);
@@ -2267,14 +2269,15 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let summary = runtime.open_project_summary()?;
     let sidecar = doctor_sidecar_status(&runtime);
-    let readiness_sidecar = agent_goal_readiness_sidecar_status(&runtime, &sidecar);
+    let readiness_sidecar = selected_agent_readiness_sidecar_status(&runtime, None, &sidecar);
     let readiness = build_summary_readiness(
         &summary.root,
         &summary.stats,
         summary.freshness.as_ref(),
         &readiness_sidecar,
     );
-    let readiness_lanes = build_readiness_lanes_for_runtime(&runtime, &readiness, None);
+    let readiness_lanes =
+        build_readiness_lanes_for_runtime(&runtime, &readiness, None, Some(&readiness_sidecar));
     let output =
         build_agent_preflight_output(&readiness, Path::new(&summary.root), readiness_lanes);
     let markdown = render_agent_preflight_markdown(&output);
@@ -10478,14 +10481,16 @@ fn build_doctor_output(
     let storage_path = display::clean_path_string(&runtime.storage_path.to_string_lossy());
     let storage_exists = runtime.storage_path.exists();
     let sidecar_retrieval = doctor_sidecar_status(runtime);
-    let readiness_sidecar = agent_goal_readiness_sidecar_status(runtime, &sidecar_retrieval);
+    let readiness_sidecar =
+        selected_agent_readiness_sidecar_status(runtime, None, &sidecar_retrieval);
     let readiness = build_summary_readiness(
         &project,
         &summary.stats,
         summary.freshness.as_ref(),
         &readiness_sidecar,
     );
-    let readiness_lanes = build_readiness_lanes_for_runtime(runtime, &readiness, None);
+    let readiness_lanes =
+        build_readiness_lanes_for_runtime(runtime, &readiness, None, Some(&readiness_sidecar));
     let next_commands = readiness::compatibility_next_commands(&readiness);
     let mut checks = Vec::new();
     checks.push(doctor_check(
@@ -10765,11 +10770,12 @@ fn doctor_sidecar_status_error(
     }
 }
 
-fn agent_goal_readiness_sidecar_status(
+pub(crate) fn selected_agent_readiness_sidecar_status(
     runtime: &RuntimeContext,
+    run_id: Option<&str>,
     fallback: &DoctorSidecarStatusOutput,
 ) -> DoctorSidecarStatusOutput {
-    let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, None);
+    let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, run_id);
     let agent_status = doctor_sidecar_status_for_runtime(runtime, agent_runtime);
     lane_scoped_agent_readiness_sidecar(fallback, agent_status)
 }
@@ -10796,6 +10802,7 @@ pub(crate) fn build_readiness_lanes_for_runtime(
     runtime: &RuntimeContext,
     readiness: &[codestory_contracts::api::ReadinessVerdictDto],
     agent_run_id: Option<&str>,
+    selected_agent_status: Option<&DoctorSidecarStatusOutput>,
 ) -> BTreeMap<String, ReadinessLaneOutput> {
     let project = display::clean_path_string(&runtime.project_root.to_string_lossy());
     let project_arg = display::quote_command_argument_value(&project);
@@ -10805,7 +10812,9 @@ pub(crate) fn build_readiness_lanes_for_runtime(
     );
     let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, agent_run_id);
     let local_status = doctor_sidecar_status_for_runtime(runtime, local_runtime);
-    let agent_status = doctor_sidecar_status_for_runtime(runtime, agent_runtime);
+    let agent_status = selected_agent_status
+        .cloned()
+        .unwrap_or_else(|| doctor_sidecar_status_for_runtime(runtime, agent_runtime));
     let agent_verdict = readiness
         .iter()
         .find(|verdict| verdict.goal == ReadinessGoalDto::AgentPacketSearch);

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2329,6 +2329,37 @@ fn repair_ready_state(
         Some(runtime.cache_root.as_path()),
     );
     let sidecar = sidecar.expect("agent sidecar should be selected for agent goal");
+    let _project_repair_lock = match ready_repair_status::try_acquire_project_ready_repair_lock(
+        &sidecar,
+        &runtime.project_root,
+    )? {
+        ready_repair_status::ReadyRepairLockAttempt::Acquired(lock) => lock,
+        ready_repair_status::ReadyRepairLockAttempt::Busy(busy) => {
+            if let Some(status) = busy.status {
+                bail!(
+                    "ready repair already running for project={} profile={} run_id={} namespace={} phase={} pid={}; inspect with `codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}`",
+                    status.project_root,
+                    status.profile,
+                    status.run_id.as_deref().unwrap_or("none"),
+                    status.namespace,
+                    status.phase,
+                    status.pid,
+                    crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                    sidecar
+                        .run_id
+                        .as_deref()
+                        .unwrap_or(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+                );
+            }
+            bail!(
+                "ready repair already starting for project={} profile=agent run_id={} namespace={}; lock_path={}",
+                crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                sidecar.run_id.as_deref().unwrap_or("none"),
+                sidecar.namespace,
+                busy.lock_path.display()
+            );
+        }
+    };
     let _repair_lock = match ready_repair_status::try_acquire_ready_repair_lock(
         &sidecar,
         &runtime.project_root,

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const READY_REPAIR_STATUS_FILE: &str = "ready-repair-status.json";
 const READY_REPAIR_LOCK_FILE: &str = "ready-repair.lock";
+const READY_REPAIR_PROJECT_LOCK_FILE: &str = "ready-repair-project.lock";
 const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
 const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
 const READY_REPAIR_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
@@ -83,7 +84,32 @@ pub(crate) fn try_acquire_ready_repair_lock(
     sidecar: &SidecarRuntimeConfig,
     project_root: &Path,
 ) -> Result<ReadyRepairLockAttempt> {
-    let path = ready_repair_lock_path(sidecar);
+    try_acquire_ready_repair_lock_at(
+        ready_repair_lock_path(sidecar),
+        sidecar,
+        project_root,
+        sidecar.run_id.as_deref(),
+    )
+}
+
+pub(crate) fn try_acquire_project_ready_repair_lock(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+) -> Result<ReadyRepairLockAttempt> {
+    try_acquire_ready_repair_lock_at(
+        project_ready_repair_lock_path(sidecar),
+        sidecar,
+        project_root,
+        None,
+    )
+}
+
+fn try_acquire_ready_repair_lock_at(
+    path: PathBuf,
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+    active_run_id: Option<&str>,
+) -> Result<ReadyRepairLockAttempt> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -114,7 +140,7 @@ pub(crate) fn try_acquire_ready_repair_lock(
         Err(error) => return Err(error.into()),
     }
 
-    if let Some(status) = active_ready_repair_status(project_root, sidecar.run_id.as_deref()) {
+    if let Some(status) = active_ready_repair_status(project_root, active_run_id) {
         return Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
             status: Some(status),
             lock_path: path,
@@ -136,7 +162,7 @@ pub(crate) fn try_acquire_ready_repair_lock(
         })),
         Err(error) if error.kind() == ErrorKind::AlreadyExists => {
             Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
-                status: active_ready_repair_status(project_root, sidecar.run_id.as_deref()),
+                status: active_ready_repair_status(project_root, active_run_id),
                 lock_path: path,
             }))
         }
@@ -217,6 +243,24 @@ fn ready_repair_lock_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
         .layout
         .state_file
         .with_file_name(READY_REPAIR_LOCK_FILE)
+}
+
+fn project_ready_repair_lock_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
+    let Some(run_id) = sidecar.run_id.as_deref() else {
+        return ready_repair_lock_path(sidecar).with_file_name(READY_REPAIR_PROJECT_LOCK_FILE);
+    };
+    let Some(namespace_prefix) = sidecar.namespace.strip_suffix(run_id) else {
+        return ready_repair_lock_path(sidecar).with_file_name(READY_REPAIR_PROJECT_LOCK_FILE);
+    };
+    let Some(namespace_dir) = sidecar.layout.state_file.parent() else {
+        return ready_repair_lock_path(sidecar).with_file_name(READY_REPAIR_PROJECT_LOCK_FILE);
+    };
+    let Some(sidecars_root) = namespace_dir.parent() else {
+        return ready_repair_lock_path(sidecar).with_file_name(READY_REPAIR_PROJECT_LOCK_FILE);
+    };
+    sidecars_root
+        .join(format!("{namespace_prefix}project"))
+        .join(READY_REPAIR_PROJECT_LOCK_FILE)
 }
 
 fn ready_repair_status_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
@@ -356,7 +400,11 @@ mod tests {
     use codestory_retrieval::SidecarLayout;
 
     fn test_sidecar(root: &Path) -> SidecarRuntimeConfig {
-        let namespace = "codestory-agent-test-proof".to_string();
+        test_sidecar_with_run_id(root, "test-proof")
+    }
+
+    fn test_sidecar_with_run_id(root: &Path, run_id: &str) -> SidecarRuntimeConfig {
+        let namespace = format!("codestory-agent-{run_id}");
         SidecarRuntimeConfig {
             layout: SidecarLayout {
                 zoekt_http_port: 6070,
@@ -365,10 +413,10 @@ mod tests {
                 zoekt_data_dir: root.join("zoekt"),
                 qdrant_data_dir: root.join("qdrant"),
                 scip_artifacts_root: root.join("scip"),
-                state_file: root.join("retrieval-sidecars.json"),
+                state_file: root.join(&namespace).join("retrieval-sidecars.json"),
             },
             profile: SidecarProfile::Agent,
-            run_id: Some("test-proof".to_string()),
+            run_id: Some(run_id.to_string()),
             namespace: namespace.clone(),
             compose_project: namespace,
             embed_http_port: 8080,
@@ -438,6 +486,52 @@ mod tests {
                     "lock should be reusable after drop, got busy at {:?}",
                     busy.lock_path
                 )
+            }
+        }
+    }
+
+    #[test]
+    fn project_repair_lock_serializes_different_run_ids() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let first = test_sidecar_with_run_id(state.path(), "first");
+        let second = test_sidecar_with_run_id(state.path(), "second");
+
+        let project_lock = match try_acquire_project_ready_repair_lock(&first, project.path())
+            .expect("first project lock")
+        {
+            ReadyRepairLockAttempt::Acquired(lock) => lock,
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!("first project lock should be acquired, got {busy:?}")
+            }
+        };
+
+        match try_acquire_project_ready_repair_lock(&second, project.path())
+            .expect("second project lock")
+        {
+            ReadyRepairLockAttempt::Busy(busy) => {
+                assert!(busy.status.is_none());
+                assert!(busy.lock_path.exists());
+            }
+            ReadyRepairLockAttempt::Acquired(_) => {
+                panic!("same project with different run id must be serialized")
+            }
+        }
+
+        match try_acquire_ready_repair_lock(&second, project.path()).expect("namespace lock") {
+            ReadyRepairLockAttempt::Acquired(namespace_lock) => drop(namespace_lock),
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!("namespace lock should remain separate, got {busy:?}")
+            }
+        }
+
+        drop(project_lock);
+        match try_acquire_project_ready_repair_lock(&second, project.path())
+            .expect("project lock after drop")
+        {
+            ReadyRepairLockAttempt::Acquired(_) => {}
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!("project lock should be reusable after drop, got {busy:?}")
             }
         }
     }

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -5,13 +5,16 @@ use codestory_retrieval::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const READY_REPAIR_STATUS_FILE: &str = "ready-repair-status.json";
+const READY_REPAIR_LOCK_FILE: &str = "ready-repair.lock";
 const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
 const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
+const READY_REPAIR_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct ReadyRepairStatus {
@@ -28,11 +31,117 @@ pub(crate) struct ReadyRepairStatus {
     pub(crate) updated_at_epoch_ms: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ReadyRepairLockFile {
+    schema_version: u32,
+    project_root: String,
+    profile: String,
+    run_id: Option<String>,
+    namespace: String,
+    pid: u32,
+    started_at_epoch_ms: i64,
+    token: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReadyRepairBusy {
+    pub(crate) status: Option<ReadyRepairStatus>,
+    pub(crate) lock_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub(crate) enum ReadyRepairLockAttempt {
+    Acquired(ReadyRepairLock),
+    Busy(ReadyRepairBusy),
+}
+
+#[derive(Debug)]
+pub(crate) struct ReadyRepairLock {
+    path: PathBuf,
+    token: String,
+}
+
+impl Drop for ReadyRepairLock {
+    fn drop(&mut self) {
+        let Some(lock) = read_ready_repair_lock_file(&self.path) else {
+            return;
+        };
+        if lock.token == self.token {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub(crate) fn now_epoch_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
         .unwrap_or_default()
+}
+
+pub(crate) fn try_acquire_ready_repair_lock(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+) -> Result<ReadyRepairLockAttempt> {
+    let path = ready_repair_lock_path(sidecar);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let started_at_epoch_ms = now_epoch_ms();
+    let pid = std::process::id();
+    let token = format!("{pid}:{started_at_epoch_ms}");
+    let lock = ReadyRepairLockFile {
+        schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+        project_root: clean_path_text(project_root),
+        profile: sidecar.profile.as_str().to_string(),
+        run_id: sidecar.run_id.clone(),
+        namespace: sidecar.namespace.clone(),
+        pid,
+        started_at_epoch_ms,
+        token: token.clone(),
+    };
+    let content = serde_json::to_vec_pretty(&lock)?;
+
+    match create_ready_repair_lock_file(&path, &content) {
+        Ok(()) => {
+            return Ok(ReadyRepairLockAttempt::Acquired(ReadyRepairLock {
+                path,
+                token,
+            }));
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    if let Some(status) = active_ready_repair_status(project_root, sidecar.run_id.as_deref()) {
+        return Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
+            status: Some(status),
+            lock_path: path,
+        }));
+    }
+
+    if !ready_repair_lock_file_is_stale(&path) {
+        return Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
+            status: None,
+            lock_path: path,
+        }));
+    }
+
+    let _ = fs::remove_file(&path);
+    match create_ready_repair_lock_file(&path, &content) {
+        Ok(()) => Ok(ReadyRepairLockAttempt::Acquired(ReadyRepairLock {
+            path,
+            token,
+        })),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            Ok(ReadyRepairLockAttempt::Busy(ReadyRepairBusy {
+                status: active_ready_repair_status(project_root, sidecar.run_id.as_deref()),
+                lock_path: path,
+            }))
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 pub(crate) fn write_ready_repair_status(
@@ -96,11 +205,42 @@ pub(crate) fn ready_repair_status_cache_fingerprint(project_root: &Path) -> Stri
         .join(";")
 }
 
+fn create_ready_repair_lock_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(content)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn ready_repair_lock_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
+    sidecar
+        .layout
+        .state_file
+        .with_file_name(READY_REPAIR_LOCK_FILE)
+}
+
 fn ready_repair_status_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
     sidecar
         .layout
         .state_file
         .with_file_name(READY_REPAIR_STATUS_FILE)
+}
+
+fn ready_repair_lock_file_is_stale(path: &Path) -> bool {
+    let now = now_epoch_ms();
+    if let Some(lock) = read_ready_repair_lock_file(path) {
+        return now.saturating_sub(lock.started_at_epoch_ms)
+            > READY_REPAIR_LOCK_STALE_TTL.as_millis() as i64;
+    }
+    fs::metadata(path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|modified| {
+            let modified_ms = modified.as_millis().min(i64::MAX as u128) as i64;
+            now.saturating_sub(modified_ms) > READY_REPAIR_LOCK_STALE_TTL.as_millis() as i64
+        })
+        .unwrap_or(true)
 }
 
 fn read_ready_repair_status(
@@ -121,6 +261,12 @@ fn read_ready_repair_status(
         return None;
     }
     Some(status)
+}
+
+fn read_ready_repair_lock_file(path: &Path) -> Option<ReadyRepairLockFile> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
 }
 
 fn read_ready_repair_status_file(path: &Path) -> Option<ReadyRepairStatus> {
@@ -255,6 +401,45 @@ mod tests {
             !path.exists(),
             "drop cleanup should remove the matching repair state file"
         );
+    }
+
+    #[test]
+    fn repair_lock_is_single_flight_and_clears_on_drop() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+
+        let lock = match try_acquire_ready_repair_lock(&sidecar, project.path())
+            .expect("first lock attempt")
+        {
+            ReadyRepairLockAttempt::Acquired(lock) => lock,
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!(
+                    "first lock should be acquired, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        };
+
+        match try_acquire_ready_repair_lock(&sidecar, project.path()).expect("second lock attempt")
+        {
+            ReadyRepairLockAttempt::Busy(busy) => {
+                assert!(busy.status.is_none());
+                assert!(busy.lock_path.exists());
+            }
+            ReadyRepairLockAttempt::Acquired(_) => panic!("second lock must not be acquired"),
+        }
+
+        drop(lock);
+        match try_acquire_ready_repair_lock(&sidecar, project.path()).expect("third lock attempt") {
+            ReadyRepairLockAttempt::Acquired(_) => {}
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!(
+                    "lock should be reusable after drop, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        }
     }
 
     #[test]

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2599,33 +2599,71 @@ fn read_stdio_status_resource(
     let setup_repair = stdio_setup_repair_input(server_executable.as_deref());
     let dirty_marker = stdio_dirty_marker_status(&runtime.project_root, &runtime.storage_path);
     let effective_freshness = stdio_effective_freshness(summary.freshness.as_ref(), &dirty_marker);
+    let raw_sidecar_status = crate::DoctorSidecarStatusOutput {
+        profile: Some(sidecar_runtime.profile.as_str().to_string()),
+        run_id: sidecar_runtime.run_id.clone(),
+        retrieval_mode: sidecar_mode.clone(),
+        degraded_reason: degraded_reason.clone(),
+        embedding_device_policy: embedding_device_policy.clone(),
+        embedding_device_state: embedding_device_state.clone(),
+        embedding_device_observation_source: embedding_device_observation_source.clone(),
+        embedding_detected_provider: embedding_detected_provider.clone(),
+        embedding_detected_gpu: embedding_detected_gpu.clone(),
+        embedding_accelerator_requested,
+        embedding_accelerator_request_provider: embedding_accelerator_request_provider.clone(),
+        embedding_accelerator_request_device: embedding_accelerator_request_device.clone(),
+        embedding_cpu_allowed,
+        manifest_generation: manifest_generation.clone(),
+        manifest_input_hash: manifest_input_hash.clone(),
+        precise_semantic_import_status: None,
+        precise_semantic_import_reason: None,
+        precise_semantic_import_revision: None,
+        precise_semantic_import_producer: None,
+    };
+    let selected_agent_sidecar = crate::selected_agent_readiness_sidecar_status(
+        runtime,
+        sidecar_runtime.run_id.as_deref(),
+        &raw_sidecar_status,
+    );
     let readiness = crate::readiness::build_readiness_verdicts(crate::readiness::ReadinessInputs {
         project: &summary.root,
         stats: &summary.stats,
         freshness: effective_freshness.as_ref(),
         setup: setup_repair.as_ref(),
         sidecar: Some(crate::readiness::ReadinessSidecarInput {
-            profile: Some(sidecar_runtime.profile.as_str()),
-            run_id: sidecar_runtime.run_id.as_deref(),
-            retrieval_mode: &sidecar_mode,
-            degraded_reason: degraded_reason.as_deref(),
-            embedding_device_policy: Some(&embedding_device_policy),
-            embedding_device_state: Some(&embedding_device_state),
-            embedding_device_observation_source: Some(&embedding_device_observation_source),
-            embedding_detected_provider: embedding_detected_provider.as_deref(),
-            embedding_detected_gpu: embedding_detected_gpu.as_deref(),
-            embedding_accelerator_requested,
-            embedding_accelerator_request_provider: embedding_accelerator_request_provider
+            profile: selected_agent_sidecar.profile.as_deref(),
+            run_id: selected_agent_sidecar.run_id.as_deref(),
+            retrieval_mode: &selected_agent_sidecar.retrieval_mode,
+            degraded_reason: selected_agent_sidecar.degraded_reason.as_deref(),
+            embedding_device_policy: Some(&selected_agent_sidecar.embedding_device_policy),
+            embedding_device_state: Some(&selected_agent_sidecar.embedding_device_state),
+            embedding_device_observation_source: Some(
+                &selected_agent_sidecar.embedding_device_observation_source,
+            ),
+            embedding_detected_provider: selected_agent_sidecar
+                .embedding_detected_provider
                 .as_deref(),
-            embedding_accelerator_request_device: embedding_accelerator_request_device.as_deref(),
-            embedding_cpu_allowed,
-            manifest_generation: manifest_generation.as_deref(),
-            manifest_input_hash: manifest_input_hash.as_deref(),
+            embedding_detected_gpu: selected_agent_sidecar.embedding_detected_gpu.as_deref(),
+            embedding_accelerator_requested: selected_agent_sidecar.embedding_accelerator_requested,
+            embedding_accelerator_request_provider: selected_agent_sidecar
+                .embedding_accelerator_request_provider
+                .as_deref(),
+            embedding_accelerator_request_device: selected_agent_sidecar
+                .embedding_accelerator_request_device
+                .as_deref(),
+            embedding_cpu_allowed: selected_agent_sidecar.embedding_cpu_allowed,
+            manifest_generation: selected_agent_sidecar.manifest_generation.as_deref(),
+            manifest_input_hash: selected_agent_sidecar.manifest_input_hash.as_deref(),
         }),
     });
     let sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
     let allowed_surfaces = stdio_allowed_surfaces(&readiness);
-    let readiness_lanes = crate::build_readiness_lanes_for_runtime(runtime, &readiness, None);
+    let readiness_lanes = crate::build_readiness_lanes_for_runtime(
+        runtime,
+        &readiness,
+        None,
+        Some(&selected_agent_sidecar),
+    );
     let readiness_lanes_json =
         serde_json::to_value(&readiness_lanes).expect("serialize readiness lanes");
     let recommended_next_calls = stdio_status_recommended_next_calls(&readiness, &sidecar_setup);
@@ -2644,7 +2682,6 @@ fn read_stdio_status_resource(
     let runtime_truth = stdio_runtime_truth_status(
         &plugin_runtime,
         &sidecar_setup,
-        &sidecar,
         &readiness_lanes_json,
         local,
         &local_refresh_json,
@@ -2702,7 +2739,6 @@ fn read_stdio_status_resource(
 fn stdio_runtime_truth_status(
     plugin_runtime: &serde_json::Value,
     sidecar_setup: &serde_json::Value,
-    sidecar: &serde_json::Value,
     readiness_lanes: &serde_json::Value,
     local: &ReadinessVerdictDto,
     local_refresh: &serde_json::Value,
@@ -2734,12 +2770,12 @@ fn stdio_runtime_truth_status(
                 .pointer("/agent_packet_search/run_id")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!("unavailable")),
-            "mode": sidecar
-                .get("retrieval_mode")
+            "mode": readiness_lanes
+                .pointer("/agent_packet_search/sidecar_mode")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!("unavailable")),
-            "degraded_reason": sidecar
-                .get("degraded_reason")
+            "degraded_reason": readiness_lanes
+                .pointer("/agent_packet_search/degraded_reason")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null),
             "namespace": readiness_lanes

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2198,7 +2198,13 @@ fn read_stdio_status_resource_cached(
     let project = stdio_project_args(runtime);
     let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
     let summary = inspect_runtime.open_project_summary()?;
-    let (summary, local_refresh) = if crate::local_freshness_needs_refresh(&summary) {
+    let active_agent_repair = crate::ready_repair_status::active_ready_repair_status(
+        &runtime.project_root,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    );
+    let (summary, local_refresh) = if active_agent_repair.is_some() {
+        (summary, None)
+    } else if crate::local_freshness_needs_refresh(&summary) {
         crate::wait_for_local_freshness(&project, &inspect_runtime)?
     } else {
         (summary, None)
@@ -3323,6 +3329,10 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
     );
     let next_repair_command =
         env_nonempty("CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND").unwrap_or(default_repair);
+    let active_repair = crate::ready_repair_status::active_ready_repair_status(
+        project_root,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    );
     serde_json::json!({
         "state": state,
         "auto_repair": auto_repair,
@@ -3350,7 +3360,17 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
             "updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT"),
             "project_root": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT"),
             "command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND")
-        }
+        },
+        "active_repair": active_repair.as_ref().map(|status| serde_json::json!({
+            "status": &status.status,
+            "project_root": &status.project_root,
+            "profile": &status.profile,
+            "run_id": &status.run_id,
+            "namespace": &status.namespace,
+            "phase": &status.phase,
+            "pid": status.pid,
+            "updated_at_epoch_ms": status.updated_at_epoch_ms
+        }))
     })
 }
 
@@ -3427,11 +3447,33 @@ fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
 }
 
 fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
+    if let Some(status) = crate::ready_repair_status::active_ready_repair_status(
+        &runtime.project_root,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    ) {
+        return serde_json::json!({
+            "result": {
+                "status": "already_running",
+                "project_root": status.project_root,
+                "profile": status.profile,
+                "run_id": status.run_id,
+                "namespace": status.namespace,
+                "phase": status.phase,
+                "pid": status.pid,
+                "next_status_command": format!(
+                    "codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}",
+                    crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                    codestory_retrieval::DEFAULT_AGENT_RUN_ID
+                ),
+                "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
+            }
+        });
+    }
     let exe = match std::env::current_exe() {
         Ok(exe) => exe,
         Err(error) => return serde_json::json!({"error": error.to_string()}),
     };
-    let output = Command::new(exe)
+    let child = Command::new(exe)
         .arg("ready")
         .arg("--goal")
         .arg("agent")
@@ -3443,18 +3485,21 @@ fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
         .arg("--run-id")
         .arg(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
         .env("CODESTORY_PLUGIN_SIDECAR_REPAIR", "1")
-        .output();
-    match output {
-        Ok(output) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let parsed = serde_json::from_str::<serde_json::Value>(&stdout).ok();
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    match child {
+        Ok(child) => {
             serde_json::json!({
                 "result": {
-                    "status": if output.status.success() { "completed" } else { "failed" },
-                    "exit_code": output.status.code(),
-                    "stdout": stdout,
-                    "stderr": String::from_utf8_lossy(&output.stderr),
-                    "parsed": parsed,
+                    "status": "started",
+                    "pid": child.id(),
+                    "next_status_command": format!(
+                        "codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}",
+                        crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                        codestory_retrieval::DEFAULT_AGENT_RUN_ID
+                    ),
                     "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
                 }
             })

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -1185,8 +1185,9 @@ fn doctor_reports_managed_embedding_setup_state() {
             "doctor should label missing ONNX assets as diagnostic and name product sidecar repair: {doctor:#}"
         ),
         "ok" => assert!(
-            message.contains("Diagnostic ONNX embeddings are installed"),
-            "doctor should label globally available ONNX assets as diagnostic: {doctor:#}"
+            message.contains("Diagnostic ONNX embeddings are installed")
+                || message.contains("External llama.cpp endpoint"),
+            "doctor should label diagnostic ONNX assets or product endpoint readiness: {doctor:#}"
         ),
         "warn" => assert!(
             message.contains("External llama.cpp endpoint"),
@@ -1209,7 +1210,13 @@ fn doctor_does_not_autostart_installed_managed_embeddings() {
         workspace.path(),
         cache_dir.path(),
         &["doctor", "--format", "json"],
-        &[],
+        &[
+            ("CODESTORY_EMBED_BACKEND", "llamacpp"),
+            (
+                "CODESTORY_EMBED_LLAMACPP_URL",
+                "http://127.0.0.1:9/v1/embeddings",
+            ),
+        ],
     );
 
     let managed = check_with_name(&doctor, "managed_embeddings");

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -162,8 +162,22 @@ fn ready_command_emits_compact_verdicts_and_filters_goal() {
     let explicit_agent_json: Value =
         serde_json::from_str(&explicit_agent_json_text).expect("explicit ready agent json");
     assert_eq!(
+        explicit_agent_json["verdicts"][0]["sidecar"]["run_id"],
+        "isolated-proof"
+    );
+    assert_eq!(
         explicit_agent_json["readiness_lanes"]["agent_packet_search"]["run_id"],
         "isolated-proof"
+    );
+    assert_eq!(
+        explicit_agent_json["verdicts"][0]["sidecar"]["run_id"],
+        explicit_agent_json["readiness_lanes"]["agent_packet_search"]["run_id"],
+        "explicit ready agent verdict and rendered lane should use one selected runtime status: {explicit_agent_json_text}"
+    );
+    assert_eq!(
+        explicit_agent_json["verdicts"][0]["sidecar"]["retrieval_mode"],
+        explicit_agent_json["readiness_lanes"]["agent_packet_search"]["sidecar_mode"],
+        "explicit ready agent verdict and rendered lane should agree on full-vs-degraded state: {explicit_agent_json_text}"
     );
     assert!(
         explicit_agent_json["verdicts"][0]["minimum_next"]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2720,6 +2720,74 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
 }
 
 #[test]
+fn tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting() {
+    let fixture = indexed_fixture();
+    let (status_path, _cleanup) = write_active_repair_status_fixture(
+        &fixture,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+        "Qdrant finalize",
+    );
+    assert!(status_path.exists(), "repair status fixture should exist");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-status-active",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "status"}
+            }
+        }),
+    );
+    let setup = assert_tool_success(&status_response, json!("sidecar-setup-status-active"));
+    assert_eq!(
+        setup["active_repair"]["status"],
+        json!("repairing"),
+        "sidecar_setup status should surface the active shared-agent repair: {setup}"
+    );
+    assert_eq!(
+        setup["active_repair"]["run_id"],
+        json!(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+        "{setup}"
+    );
+
+    let repair_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-repair-active",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "repair"}
+            }
+        }),
+    );
+    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair-active"));
+    assert_eq!(
+        repair["status"],
+        json!("already_running"),
+        "sidecar_setup repair should not spawn or wait when shared-agent repair is active: {repair}"
+    );
+    assert_eq!(
+        repair["phase"],
+        json!("Qdrant finalize"),
+        "already-running response should preserve current repair phase: {repair}"
+    );
+    assert!(
+        repair["next_status_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval status")
+                && command.contains("--profile agent")
+                && command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)),
+        "already-running response should point to cheap status inspection: {repair}"
+    );
+}
+
+#[test]
 fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
     let mut fixture = indexed_fixture();
     let marker_path = write_dirty_marker_fixture(

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2261,8 +2261,13 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     );
     assert_eq!(
         status["runtime_truth"]["sidecar_status"]["mode"],
-        status["sidecar_retrieval"]["retrieval_mode"],
-        "runtime truth should reuse sidecar retrieval mode: {status}"
+        status["readiness_lanes"]["agent_packet_search"]["sidecar_mode"],
+        "runtime truth should reuse the selected agent readiness lane mode: {status}"
+    );
+    assert_eq!(
+        status["runtime_truth"]["sidecar_status"]["degraded_reason"],
+        status["readiness_lanes"]["agent_packet_search"]["degraded_reason"],
+        "runtime truth should reuse the selected agent readiness lane reason: {status}"
     );
     assert!(
         status

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -4189,6 +4189,7 @@ mod tests {
                 kind INTEGER NOT NULL,
                 serialized_name TEXT NOT NULL,
                 qualified_name TEXT,
+                canonical_id TEXT,
                 file_node_id INTEGER,
                 start_line INTEGER NOT NULL DEFAULT 0
             );

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -83,6 +83,15 @@ pub fn repair_project_qdrant_collection(
     project_root: &Path,
     storage_path: &Path,
 ) -> Result<Option<ProjectQdrantRepairOutcome>> {
+    let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
+    repair_project_qdrant_collection_for_runtime(project_root, storage_path, &runtime)
+}
+
+pub fn repair_project_qdrant_collection_for_runtime(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<Option<ProjectQdrantRepairOutcome>> {
     if !storage_path.is_file() {
         return Ok(None);
     }
@@ -118,9 +127,9 @@ pub fn repair_project_qdrant_collection(
         }));
     }
 
-    let layout = SidecarLayout::from_env_for_project(project_root);
+    let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
-    let qdrant_client = QdrantClient::new(&layout);
+    let qdrant_client = QdrantClient::new(layout);
     let probe = qdrant_client.health_probe(&manifest.qdrant_collection);
     if !probe.reachable {
         return Ok(Some(ProjectQdrantRepairOutcome {
@@ -1310,6 +1319,81 @@ mod tests {
         let repair =
             repair_project_qdrant_collection(project.path(), &storage_path).expect("repair");
         assert!(repair.is_none());
+    }
+
+    #[test]
+    fn project_qdrant_repair_uses_selected_runtime_layout() {
+        let project = TempDir::new().expect("project dir");
+        let storage_dir = TempDir::new().expect("storage dir");
+        let sidecar_dir = TempDir::new().expect("sidecar dir");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let project_id = sidecar_project_id_for_root(project.path());
+        let input = SidecarInputFingerprint {
+            hash: "0123456789abcdef0123456789abcdef".into(),
+            symbol_doc_count: 0,
+            projection_count: 0,
+            dense_projection_count: 0,
+            semantic_policy_version: Some(crate::generation::SEMANTIC_POLICY_VERSION.into()),
+            graph_artifact_hash: "graph-hash".into(),
+            dense_reason_counts_json: "{}".into(),
+            lexical_file_count: 1,
+            lexical_hash: "lexical".into(),
+        };
+        let collection = QdrantClient::collection_name_for_generation(&project_id, &input.hash);
+        let manifest = retrieval_manifest_for_sidecar(
+            &project_id,
+            &sidecar_generation_id(&project_id, &input.hash),
+            &collection,
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            768,
+            &input,
+        );
+        {
+            let mut storage = Store::open(&storage_path).expect("open db");
+            storage
+                .upsert_retrieval_index_manifest(&manifest)
+                .expect("write manifest");
+            assert_eq!(
+                manifest_unavailable_reason(&project_id, &storage, &manifest),
+                None
+            );
+        }
+
+        let runtime = SidecarRuntimeConfig {
+            layout: SidecarLayout {
+                zoekt_http_port: 9,
+                qdrant_http_port: 9,
+                qdrant_grpc_port: 10,
+                zoekt_data_dir: sidecar_dir.path().join("selected-zoekt"),
+                qdrant_data_dir: sidecar_dir.path().join("selected-qdrant"),
+                scip_artifacts_root: sidecar_dir.path().join("selected-scip"),
+                state_file: sidecar_dir.path().join("selected-state.json"),
+            },
+            profile: crate::config::SidecarProfile::Agent,
+            run_id: Some("selected-run".into()),
+            namespace: "selected-run".into(),
+            compose_project: "selected-run".into(),
+            embed_http_port: 11,
+            cleanup_command: "codestory-cli retrieval down".into(),
+            labels: BTreeMap::new(),
+        };
+
+        let repair =
+            repair_project_qdrant_collection_for_runtime(project.path(), &storage_path, &runtime)
+                .expect("repair")
+                .expect("manifest-backed repair");
+
+        assert!(runtime.layout.zoekt_data_dir.is_dir());
+        assert!(runtime.layout.qdrant_data_dir.is_dir());
+        assert!(runtime.layout.scip_artifacts_root.is_dir());
+        assert_eq!(repair.qdrant_collection, collection);
+        assert!(
+            repair
+                .skipped_reason
+                .as_deref()
+                .is_some_and(|reason| reason.starts_with("qdrant_unreachable:")),
+            "{repair:?}"
+        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -73,7 +73,8 @@ pub use health::{
 pub use index::{
     FinalizeIndexOutcome, ProjectQdrantRepairOutcome, finalize_index, finalize_index_for_runtime,
     finalize_index_for_runtime_with_progress, project_id_for_root,
-    repair_project_qdrant_collection, sidecar_project_id_for_root,
+    repair_project_qdrant_collection, repair_project_qdrant_collection_for_runtime,
+    sidecar_project_id_for_root,
 };
 pub use inventory::{
     SidecarDockerResource, SidecarDockerResourceKind, SidecarGcNamespaceResult, SidecarGcReport,

--- a/crates/codestory-retrieval/src/mode.rs
+++ b/crates/codestory-retrieval/src/mode.rs
@@ -48,33 +48,36 @@ pub fn derive_degraded_mode(
     qdrant: &ComponentHealth,
     scip: &ComponentHealth,
 ) -> (RetrievalDegradedMode, Option<String>) {
-    if zoekt.status == ComponentStatus::Unavailable || !zoekt.capabilities.lexical {
+    if zoekt.status != ComponentStatus::Healthy || !zoekt.capabilities.lexical {
         return (
             RetrievalDegradedMode::Unavailable,
-            zoekt
-                .degraded_reason
-                .clone()
-                .or_else(|| Some("mandatory_zoekt_unavailable".into())),
+            mandatory_failure_reason(zoekt, "zoekt"),
         );
     }
-    if qdrant.status == ComponentStatus::Unavailable || !qdrant.capabilities.semantic {
+    if qdrant.status != ComponentStatus::Healthy || !qdrant.capabilities.semantic {
         let mode = if scip.capabilities.graph {
             RetrievalDegradedMode::NoSemantic
         } else {
             RetrievalDegradedMode::LexicalOnly
         };
-        return (
-            mode,
-            qdrant
-                .degraded_reason
-                .clone()
-                .or_else(|| Some("mandatory_qdrant_unavailable".into())),
-        );
+        return (mode, mandatory_failure_reason(qdrant, "qdrant"));
     }
     if scip.status != ComponentStatus::Healthy || !scip.capabilities.graph {
         return (RetrievalDegradedMode::NoScip, scip.degraded_reason.clone());
     }
     (RetrievalDegradedMode::Full, None)
+}
+
+fn mandatory_failure_reason(component: &ComponentHealth, name: &str) -> Option<String> {
+    let state = if component.status == ComponentStatus::Unavailable {
+        "unavailable"
+    } else {
+        "degraded"
+    };
+    component
+        .degraded_reason
+        .clone()
+        .or_else(|| Some(format!("mandatory_{name}_{state}")))
 }
 
 #[cfg(test)]

--- a/crates/codestory-retrieval/tests/degraded_modes.rs
+++ b/crates/codestory-retrieval/tests/degraded_modes.rs
@@ -79,3 +79,21 @@ fn degraded_mode_planner_matrix() {
     assert_eq!(unavailable, RetrievalDegradedMode::Unavailable);
     assert!(plan_query(&features, unavailable).stages.is_empty());
 }
+
+#[test]
+fn degraded_mandatory_sidecars_are_not_full_even_with_capabilities() {
+    let production = codestory_retrieval::SidecarCapabilities::production_stack();
+    let zoekt_up = component("zoekt", ComponentStatus::Healthy, None, production);
+    let qdrant_up = component("qdrant", ComponentStatus::Healthy, None, production);
+    let scip_up = component("scip", ComponentStatus::Healthy, None, production);
+
+    let zoekt_slow = component("zoekt", ComponentStatus::Degraded, None, production);
+    let (zoekt_mode, zoekt_reason) = derive_degraded_mode(&zoekt_slow, &qdrant_up, &scip_up);
+    assert_eq!(zoekt_mode, RetrievalDegradedMode::Unavailable);
+    assert_eq!(zoekt_reason.as_deref(), Some("mandatory_zoekt_degraded"));
+
+    let qdrant_slow = component("qdrant", ComponentStatus::Degraded, None, production);
+    let (qdrant_mode, qdrant_reason) = derive_degraded_mode(&zoekt_up, &qdrant_slow, &scip_up);
+    assert_eq!(qdrant_mode, RetrievalDegradedMode::NoSemantic);
+    assert_eq!(qdrant_reason.as_deref(), Some("mandatory_qdrant_degraded"));
+}

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -102,7 +102,7 @@ use codestory_contracts::api::{
 use codestory_contracts::api::{
     AgentRetrievalStepDto, AgentRetrievalStepStatusDto, EdgeId, PacketBudgetDto,
     PacketBudgetUsageDto, PacketClaimDto, PacketPlanQueryDto, PacketSidecarQueryDiagnosticDto,
-    PacketSufficiencyDto, PacketSufficiencyStatusDto, SearchMatchQualityDto,
+    PacketSufficiencyDto, PacketSufficiencyStatusDto, RetrievalShadowDto, SearchMatchQualityDto,
 };
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -5059,6 +5059,26 @@ mod tests {
         }
     }
 
+    fn mark_packet_fixture_full_retrieval_available(answer: &mut AgentAnswerDto) {
+        answer.retrieval_trace.retrieval_shadow = Some(RetrievalShadowDto {
+            retrieval_mode: "full".to_string(),
+            degraded_reason: None,
+            retrieval_total_ms: 1,
+            total_budget_ms: Some(500),
+            cancel_reason: None,
+            cache_hit: false,
+            stage_timings: Vec::new(),
+            candidates: Vec::new(),
+            would_rank: Vec::new(),
+            error: None,
+            candidate_count: 0,
+            resolved_hit_count: 0,
+            unresolved_candidate_count: 0,
+            diagnostic_only: false,
+            candidate_resolution_counts: Vec::new(),
+        });
+    }
+
     fn packet_fixture_project_root() -> &'static std::path::Path {
         std::path::Path::new("C:/workspace/project root")
     }
@@ -9429,6 +9449,7 @@ mod tests {
                 0.8,
             )],
         );
+        mark_packet_fixture_full_retrieval_available(&mut partial_answer);
         let mut budget = apply_packet_budget(
             packet_fixture_project_root(),
             question,
@@ -9509,6 +9530,7 @@ mod tests {
         );
 
         let mut empty_answer = packet_answer_fixture(question, Vec::new());
+        mark_packet_fixture_full_retrieval_available(&mut empty_answer);
         let empty_budget = apply_packet_budget(
             packet_fixture_project_root(),
             question,
@@ -9882,6 +9904,7 @@ mod tests {
                 test_packet_citation("WorkspacePlan", "crates/core/src/workspace/plan.rs", 0.8),
             ],
         );
+        mark_packet_fixture_full_retrieval_available(&mut answer);
         let mut budget = apply_packet_budget(
             packet_fixture_project_root(),
             question,

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -2302,6 +2302,26 @@ mod tests {
         });
     }
 
+    fn mark_full_retrieval_available(answer: &mut AgentAnswerDto) {
+        answer.retrieval_trace.retrieval_shadow = Some(RetrievalShadowDto {
+            retrieval_mode: "full".to_string(),
+            degraded_reason: None,
+            retrieval_total_ms: 1,
+            total_budget_ms: Some(500),
+            cancel_reason: None,
+            cache_hit: false,
+            stage_timings: Vec::new(),
+            candidates: Vec::new(),
+            would_rank: Vec::new(),
+            error: None,
+            candidate_count: 0,
+            resolved_hit_count: 0,
+            unresolved_candidate_count: 0,
+            diagnostic_only: false,
+            candidate_resolution_counts: Vec::new(),
+        });
+    }
+
     fn unresolved_sidecar_diagnostic(query: &str) -> PacketSidecarQueryDiagnosticDto {
         PacketSidecarQueryDiagnosticDto {
             query: query.to_string(),
@@ -3608,7 +3628,8 @@ mod tests {
     #[test]
     fn compact_proof_omission_reports_missing_role_and_standard_budget_follow_up() {
         let question = "Explain how formatting arguments become type-erased format args and reach vformat or format_to output paths.";
-        let answer = answer_fixture(question);
+        let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         let budget = compact_truncated_budget(question, vec!["citations", "markdown_blocks"]);
         let claims = vec![
             claim(
@@ -3650,7 +3671,8 @@ mod tests {
     #[test]
     fn compact_budget_blocks_sufficiency_when_source_proof_probe_is_missing() {
         let question = "Explain how buffered Source and Sink wrappers use Buffer state during reads and writes.";
-        let answer = answer_fixture(question);
+        let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         let budget = compact_truncated_budget(question, vec!["citations", "trail_edges"]);
         let claims = vec![
             claim("Buffer is the in-memory byte store used by buffered reads and writes."),
@@ -3841,6 +3863,7 @@ mod tests {
     fn unresolved_selected_probe_blocks_when_express_response_coverage_is_missing() {
         let question = "Trace how Express creates an application, registers middleware/routes, and handles an incoming request through the router and response helpers.";
         let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         answer.retrieval_trace.packet_sidecar_diagnostics =
             vec![unresolved_sidecar_diagnostic("response send")];
         let budget = budget_fixture();
@@ -3901,6 +3924,7 @@ mod tests {
     fn missing_flow_seed_follow_up_precedes_unresolved_selected_probe() {
         let question = "Trace how a server request enters route registration, reaches request handler dispatch, and finalizes a response.";
         let mut answer = answer_fixture(question);
+        mark_full_retrieval_available(&mut answer);
         answer.retrieval_trace.packet_sidecar_diagnostics =
             vec![unresolved_sidecar_diagnostic("response send")];
         let budget = budget_fixture();
@@ -4044,6 +4068,41 @@ mod tests {
                     && !command.contains("codestory-cli context")
             }),
             "blocked full retrieval must not recommend blocked search/context surfaces: {sufficiency:?}"
+        );
+    }
+
+    #[test]
+    fn partial_packets_with_missing_retrieval_shadow_recommend_repair() {
+        let question = "Trace how route registration reaches response finalization.";
+        let answer = answer_fixture(question);
+        let budget = budget_fixture();
+        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
+            project_root: Path::new("C:/workspace/service"),
+            question,
+            task_class: PacketTaskClassDto::RouteTracing,
+            answer: &answer,
+            budget: &budget,
+            supported_claims: vec![claim(
+                "Dispatch request invokes the selected view function or handler for the matched route.",
+            )],
+            missing_required_probe_queries: vec!["route registration".to_string()],
+            targeted_follow_up_queries: vec!["response finalization".to_string()],
+        });
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        assert!(
+            sufficiency
+                .follow_up_commands
+                .first()
+                .is_some_and(|command| command.contains("ready --goal agent --repair")),
+            "missing retrieval shadow should lead with canonical sidecar repair: {sufficiency:?}"
+        );
+        assert!(
+            sufficiency.follow_up_commands.iter().all(|command| {
+                !command.contains("codestory-cli search")
+                    && !command.contains("codestory-cli context")
+            }),
+            "missing retrieval shadow must not recommend unproven search/context surfaces: {sufficiency:?}"
         );
     }
 
@@ -4461,7 +4520,7 @@ fn packet_full_retrieval_available(answer: &AgentAnswerDto) -> bool {
         .retrieval_trace
         .retrieval_shadow
         .as_ref()
-        .is_none_or(|shadow| shadow.retrieval_mode == "full")
+        .is_some_and(|shadow| shadow.retrieval_mode == "full")
 }
 
 fn packet_agent_repair_command(quoted_project: &str) -> String {

--- a/crates/codestory-runtime/src/agent/packet_sufficiency.rs
+++ b/crates/codestory-runtime/src/agent/packet_sufficiency.rs
@@ -22,7 +22,8 @@ use crate::agent::packet_terms::{
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentRetrievalStepStatusDto, PacketBudgetDto,
     PacketBudgetModeDto, PacketClaimDto, PacketCoverageReportDto, PacketEvidenceResolutionDto,
-    PacketEvidenceTierDto, PacketSufficiencyDto, PacketSufficiencyStatusDto, PacketTaskClassDto,
+    PacketEvidenceTierDto, PacketSidecarQueryDiagnosticDto, PacketSufficiencyDto,
+    PacketSufficiencyStatusDto, PacketTaskClassDto,
 };
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::Path;
@@ -393,14 +394,23 @@ fn unresolved_sidecar_queries(answer: &AgentAnswerDto) -> Vec<String> {
         .retrieval_trace
         .packet_sidecar_diagnostics
         .iter()
-        .filter(|diagnostic| {
-            diagnostic.candidate_count > 0
-                && diagnostic.resolved_hit_count == 0
-                && diagnostic.unresolved_candidate_count > 0
-        })
+        .filter(|diagnostic| sidecar_diagnostic_blocks_sufficiency(diagnostic))
         .filter(|diagnostic| seen.insert(diagnostic.query.clone()))
         .map(|diagnostic| diagnostic.query.clone())
         .collect()
+}
+
+fn sidecar_diagnostic_blocks_sufficiency(diagnostic: &PacketSidecarQueryDiagnosticDto) -> bool {
+    if diagnostic.candidate_count > 0
+        && diagnostic.resolved_hit_count == 0
+        && diagnostic.unresolved_candidate_count > 0
+    {
+        return true;
+    }
+    diagnostic
+        .diagnostic
+        .as_deref()
+        .is_some_and(|message| message.starts_with("sidecar query has blocking cancel reason "))
 }
 
 fn packet_sufficiency_min_citations(task_class: PacketTaskClassDto) -> usize {
@@ -2339,6 +2349,25 @@ mod tests {
         }
     }
 
+    fn cancelled_sidecar_diagnostic(query: &str) -> PacketSidecarQueryDiagnosticDto {
+        PacketSidecarQueryDiagnosticDto {
+            query: query.to_string(),
+            retrieval_mode: "full".to_string(),
+            sidecar_query_ms: None,
+            candidate_resolution_ms: None,
+            total_elapsed_ms: None,
+            sidecar_stage_count: 0,
+            sidecar_stage_total_ms: None,
+            batch_query_wall_ms: None,
+            candidate_count: 0,
+            resolved_hit_count: 0,
+            unresolved_candidate_count: 0,
+            diagnostic: Some(
+                "sidecar query has blocking cancel reason `stage_deadline`".to_string(),
+            ),
+        }
+    }
+
     fn budget_fixture() -> PacketBudgetDto {
         PacketBudgetDto {
             requested: PacketBudgetModeDto::Standard,
@@ -3988,6 +4017,51 @@ mod tests {
         let mut answer = answer_fixture(question);
         answer.retrieval_trace.packet_sidecar_diagnostics =
             vec![unresolved_sidecar_diagnostic("response finalization")];
+        let budget = budget_fixture();
+        let claims = vec![
+            claim(
+                "Public request entrypoint registers route wrappers before dispatching handler calls.",
+            ),
+            claim(
+                "Dispatch request invokes the selected view function or handler for the matched route.",
+            ),
+        ];
+
+        let sufficiency = assemble_packet_sufficiency(PacketSufficiencyInput {
+            project_root: Path::new("C:/workspace/service"),
+            question,
+            task_class: PacketTaskClassDto::RouteTracing,
+            answer: &answer,
+            budget: &budget,
+            supported_claims: claims,
+            missing_required_probe_queries: Vec::new(),
+            targeted_follow_up_queries: Vec::new(),
+        });
+
+        assert_eq!(sufficiency.status, PacketSufficiencyStatusDto::Partial);
+        let report = sufficiency.coverage_report.as_ref().unwrap();
+        assert!(report.missing.iter().any(|gap| gap == "request_terminal"));
+        assert_eq!(report.unresolved, vec!["response finalization".to_string()]);
+        assert!(
+            sufficiency
+                .gaps
+                .iter()
+                .any(|gap| gap.contains("response finalization"))
+        );
+        assert!(
+            sufficiency
+                .follow_up_commands
+                .iter()
+                .any(|command| command.contains("--query 'response finalization'"))
+        );
+    }
+
+    #[test]
+    fn cancelled_sidecar_diagnostics_block_when_required_coverage_is_missing() {
+        let question = "Trace how a server request enters route registration, reaches request handler dispatch, and finalizes a response.";
+        let mut answer = answer_fixture(question);
+        answer.retrieval_trace.packet_sidecar_diagnostics =
+            vec![cancelled_sidecar_diagnostic("response finalization")];
         let budget = budget_fixture();
         let claims = vec![
             claim(

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -293,10 +293,24 @@ pub(crate) fn sidecar_result_rejection_reason(
             query_result.trace.retrieval_mode
         ));
     }
+    if let Some(reason) = sidecar_blocking_cancel_reason(query_result) {
+        return Some(format!(
+            "sidecar retrieval trace `{reason}` is not eligible for primary results"
+        ));
+    }
     if !query_result.hits.is_empty() && resolved_hits.is_empty() {
         return Some("sidecar retrieval candidates did not resolve to indexed symbols".into());
     }
     None
+}
+
+fn sidecar_blocking_cancel_reason(query_result: &QueryResult) -> Option<&str> {
+    match query_result.trace.cancel_reason.as_deref() {
+        Some("deadline" | "stage_deadline" | "stage_worker_limit" | "cancelled") => {
+            query_result.trace.cancel_reason.as_deref()
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn sidecar_budget_ms(latency_budget_ms: Option<u32>) -> u64 {
@@ -580,8 +594,13 @@ fn packet_sidecar_query_diagnostic(
         resolved_hit_count: u32::try_from(resolution.resolved_hits.len()).unwrap_or(u32::MAX),
         unresolved_candidate_count: u32::try_from(resolution.unresolved_candidate_count)
             .unwrap_or(u32::MAX),
-        diagnostic: (resolution.unresolved_candidate_count > 0)
-            .then(|| "sidecar candidates did not all resolve to indexed symbols".to_string()),
+        diagnostic: sidecar_blocking_cancel_reason(query_result)
+            .map(|reason| format!("sidecar query has blocking cancel reason `{reason}`"))
+            .or_else(|| {
+                (resolution.unresolved_candidate_count > 0).then(|| {
+                    "sidecar candidates did not all resolve to indexed symbols".to_string()
+                })
+            }),
     }
 }
 
@@ -669,6 +688,10 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
         ));
         let resolved_hits = resolution.resolved_hits;
         if let Some(reason) = sidecar_packet_batch_rejection_reason(&query_result, &resolved_hits) {
+            if sidecar_blocking_cancel_reason(&query_result).is_some() {
+                results.push((query.clone(), Vec::new()));
+                continue;
+            }
             let diagnostic =
                 sidecar_rejection_diagnostic(controller, &query_result, &resolved_hits, 5);
             return Err(sidecar_retrieval_unavailable_error(
@@ -698,6 +721,11 @@ fn sidecar_packet_batch_rejection_reason(
         return Some(format!(
             "sidecar retrieval mode `{}` is not eligible for packet batch results",
             query_result.trace.retrieval_mode
+        ));
+    }
+    if let Some(reason) = sidecar_blocking_cancel_reason(query_result) {
+        return Some(format!(
+            "sidecar retrieval trace `{reason}` is not eligible for packet batch results"
         ));
     }
     None
@@ -2475,6 +2503,47 @@ mod tests {
     }
 
     #[test]
+    fn sidecar_result_rejects_blocking_cancel_reasons_even_with_resolved_hits() {
+        use codestory_retrieval::{CandidateSource, classify_query};
+
+        for reason in [
+            "deadline",
+            "stage_deadline",
+            "stage_worker_limit",
+            "cancelled",
+        ] {
+            let candidate = CandidateHit::with_source(
+                "src/handler.rs",
+                Some("handler".into()),
+                0.9,
+                CandidateSource::Zoekt,
+            );
+            let resolved_hit = search_hit_for_candidate(&candidate);
+            let result = QueryResult {
+                query: "handler".into(),
+                features: classify_query("handler"),
+                hits: vec![candidate],
+                trace: QueryTrace {
+                    retrieval_mode: "full".into(),
+                    degraded_reason: None,
+                    total_budget_ms: 500,
+                    elapsed_ms: 100,
+                    cancel_reason: Some(reason.into()),
+                    cache_hit: false,
+                    stages: Vec::new(),
+                },
+            };
+
+            let expected =
+                format!("sidecar retrieval trace `{reason}` is not eligible for primary results");
+            assert_eq!(
+                sidecar_result_rejection_reason(&result, &[resolved_hit]).as_deref(),
+                Some(expected.as_str())
+            );
+        }
+    }
+
+    #[test]
     fn sidecar_search_result_rejects_non_full_modes_even_without_candidates() {
         use codestory_retrieval::classify_query;
 
@@ -2567,6 +2636,38 @@ mod tests {
                 .diagnostic
                 .as_deref()
                 .is_some_and(|value| value.contains("did not all resolve"))
+        );
+
+        let cancelled = QueryResult {
+            query: "handler".into(),
+            features: classify_query("handler"),
+            hits: vec![CandidateHit::with_source(
+                "src/handler.rs",
+                Some("handler".into()),
+                0.9,
+                CandidateSource::Zoekt,
+            )],
+            trace: QueryTrace {
+                retrieval_mode: "full".into(),
+                degraded_reason: None,
+                total_budget_ms: 500,
+                elapsed_ms: 100,
+                cancel_reason: Some("stage_deadline".into()),
+                cache_hit: false,
+                stages: Vec::new(),
+            },
+        };
+        let cancelled_resolution = SidecarCandidateResolutionOutcome {
+            resolved_hits: vec![search_hit_for_candidate(&cancelled.hits[0])],
+            attempted_candidate_count: 1,
+            unresolved_candidate_count: 0,
+        };
+        let cancelled_diagnostic =
+            packet_sidecar_query_diagnostic(&cancelled, &cancelled_resolution, 100, 1, 101);
+        assert_eq!(cancelled_diagnostic.resolved_hit_count, 1);
+        assert_eq!(
+            cancelled_diagnostic.diagnostic.as_deref(),
+            Some("sidecar query has blocking cancel reason `stage_deadline`")
         );
     }
 

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -9,7 +9,7 @@
 //! same project root they are planning, and must treat unreadable files as
 //! needing reindexing rather than as clean.
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 pub use codestory_contracts::workspace::{
     BuildMode, IndexedFileRecord, RefreshExecutionPlan, RefreshInfo, RefreshInputs, RefreshMode,
     RefreshPlan, StoredFileRecord, StoredFileState, WorkspaceInventory,
@@ -90,11 +90,12 @@ pub struct WorkspaceSettings {
 
 /// One discovered source group in a project manifest.
 ///
-/// `source_paths` may be files or directories, relative to the manifest root or
-/// absolute. `exclude_patterns` are applied against both workspace-relative and
-/// source-root-relative paths so repo-local build output can be pruned without
-/// excluding an explicitly selected workspace under a directory such as
-/// `target`.
+/// `source_paths` may be files or directories relative to the manifest root.
+/// Programmatic callers that construct a trusted manifest can also opt into
+/// absolute or outside-root paths. `exclude_patterns` are applied against both
+/// workspace-relative and source-root-relative paths so repo-local build output
+/// can be pruned without excluding an explicitly selected workspace under a
+/// directory such as `target`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceGroupSettings {
     pub id: Uuid,
@@ -142,6 +143,7 @@ pub struct WorkspaceManifest {
     settings: WorkspaceSettings,
     manifest_path: PathBuf,
     is_synthetic_default: Cell<bool>,
+    trusted_source_paths: Cell<bool>,
     members: Vec<PathBuf>,
 }
 
@@ -179,6 +181,7 @@ impl WorkspaceManifest {
             settings,
             manifest_path,
             is_synthetic_default: Cell::new(false),
+            trusted_source_paths: Cell::new(true),
             members: Vec::new(),
         }
     }
@@ -191,6 +194,7 @@ impl WorkspaceManifest {
             settings,
             manifest_path: path,
             is_synthetic_default: Cell::new(false),
+            trusted_source_paths: Cell::new(false),
             members: Vec::new(),
         })
     }
@@ -216,6 +220,7 @@ impl WorkspaceManifest {
             },
             manifest_path,
             is_synthetic_default: Cell::new(false),
+            trusted_source_paths: Cell::new(false),
             members: Vec::new(),
         }
     }
@@ -260,6 +265,7 @@ impl WorkspaceManifest {
                 language_specific: LanguageSpecificSettings::Other,
             });
             manifest.is_synthetic_default.set(true);
+            manifest.trusted_source_paths.set(true);
             Ok(manifest)
         }
     }
@@ -297,6 +303,7 @@ impl WorkspaceManifest {
                 language_specific: LanguageSpecificSettings::Other,
             })
             .collect();
+        manifest.trusted_source_paths.set(false);
         Ok(manifest)
     }
 
@@ -408,12 +415,7 @@ impl WorkspaceDiscovery {
             let exclude_patterns = compile_exclude_patterns(&group.exclude_patterns)?;
             let filter_by_language = manifest.should_filter_source_group_language();
             for source_path in &group.source_paths {
-                let full_path = if source_path.is_absolute() {
-                    source_path.clone()
-                } else {
-                    manifest.root_dir().join(source_path)
-                };
-                let full_path = normalize_lexical_path(&full_path);
+                let full_path = resolve_manifest_source_path(manifest, source_path)?;
                 let source_root = discovery_root(&full_path);
 
                 if full_path.is_file() {
@@ -596,6 +598,43 @@ fn workspace_root(manifest: &WorkspaceManifest) -> PathBuf {
         .root_dir()
         .canonicalize()
         .unwrap_or_else(|_| normalize_lexical_path(&manifest.root_dir()))
+}
+
+fn resolve_manifest_source_path(
+    manifest: &WorkspaceManifest,
+    source_path: &Path,
+) -> Result<PathBuf> {
+    let root = manifest.root_dir();
+    if manifest.trusted_source_paths.get() {
+        return Ok(normalize_lexical_path(&if source_path.is_absolute() {
+            source_path.to_path_buf()
+        } else {
+            root.join(source_path)
+        }));
+    }
+
+    if source_path.is_absolute() {
+        bail!(
+            "repo-local manifest source path `{}` must be relative to `{}`",
+            source_path.display(),
+            root.display()
+        );
+    }
+
+    let full_path = normalize_lexical_path(&root.join(source_path));
+    let canonical_root = workspace_root(manifest);
+    let canonical_source = full_path
+        .canonicalize()
+        .unwrap_or_else(|_| normalize_lexical_path(&full_path));
+    if !canonical_source.starts_with(&canonical_root) {
+        bail!(
+            "repo-local manifest source path `{}` resolves outside manifest root `{}`",
+            source_path.display(),
+            root.display()
+        );
+    }
+
+    Ok(full_path)
 }
 
 fn compile_exclude_patterns(patterns: &[String]) -> Result<Vec<CompiledExcludePattern>> {
@@ -846,6 +885,28 @@ mod tests {
     use std::io;
     use std::path::Path;
     use tempfile::tempdir;
+
+    fn write_repo_manifest(root: &Path, source_paths: Vec<PathBuf>) -> Result<()> {
+        let settings = WorkspaceSettings {
+            name: "repo".to_string(),
+            version: 1,
+            source_groups: vec![SourceGroupSettings {
+                id: Uuid::new_v4(),
+                language: Language::Rust,
+                standard: LanguageStandard::Default,
+                source_paths,
+                exclude_patterns: Vec::new(),
+                include_paths: Vec::new(),
+                defines: HashMap::new(),
+                language_specific: LanguageSpecificSettings::Other,
+            }],
+        };
+        fs::write(
+            root.join("codestory_project.json"),
+            serde_json::to_string_pretty(&settings)?,
+        )?;
+        Ok(())
+    }
 
     #[test]
     fn builds_incremental_refresh_plan_without_storage_dependency() -> Result<()> {
@@ -1213,6 +1274,48 @@ mod tests {
         assert!(files.contains(&root.join("backend").join("src").join("lib.rs")));
         assert!(files.contains(&root.join("frontend").join("app.ts")));
         assert!(!files.contains(&root.join("backend").join("target").join("generated.rs")));
+        Ok(())
+    }
+
+    #[test]
+    fn repo_local_manifest_rejects_absolute_source_paths_by_default() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(root.join("src"))?;
+        fs::write(root.join("src").join("lib.rs"), "pub fn local() {}\n")?;
+        write_repo_manifest(&root, vec![root.join("src")])?;
+
+        let manifest = WorkspaceManifest::open(root)?;
+        let error = WorkspaceDiscovery
+            .source_files(&manifest)
+            .expect_err("repo-local manifest should reject absolute source paths");
+
+        assert!(
+            error.to_string().contains("must be relative"),
+            "absolute source path rejection should explain the trusted boundary: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn repo_local_manifest_rejects_paths_that_escape_manifest_root_by_default() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        let shared = temp.path().join("shared");
+        fs::create_dir_all(&root)?;
+        fs::create_dir_all(&shared)?;
+        fs::write(shared.join("escape.rs"), "pub fn escape() {}\n")?;
+        write_repo_manifest(&root, vec![PathBuf::from("../shared")])?;
+
+        let manifest = WorkspaceManifest::open(root)?;
+        let error = WorkspaceDiscovery
+            .source_files(&manifest)
+            .expect_err("repo-local manifest should reject source paths outside its root");
+
+        assert!(
+            error.to_string().contains("outside manifest root"),
+            "outside-root rejection should explain the trusted boundary: {error}"
+        );
         Ok(())
     }
 

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -7,6 +7,7 @@ const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 const STATE_FILE = '.codestory-active';
+const THREAD_STATE_PREFIX = '.codestory-active-thread-';
 const HOOK_STATE_FILE = '.codestory-hook-output-state.json';
 const MCP_RUNTIME_FILE = '.codestory-mcp-runtime.json';
 const DIRTY_MARKER_SCHEMA_VERSION = 1;
@@ -24,6 +25,14 @@ function pluginDataDir() {
 function stateFilePath() {
   const stateDir = pluginDataDir();
   return stateDir ? path.join(stateDir, STATE_FILE) : null;
+}
+
+function threadStateFilePath(threadId) {
+  const stateDir = pluginDataDir();
+  const normalized = String(threadId || '').trim();
+  if (!stateDir || !normalized) return null;
+  const key = createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  return path.join(stateDir, `${THREAD_STATE_PREFIX}${key}.json`);
 }
 
 function readJson(file) {
@@ -203,7 +212,7 @@ function rememberActiveState(state) {
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true });
     const previous = readActiveState() || {};
-    fs.writeFileSync(file, JSON.stringify({
+    const nextState = {
       ...previous,
       ...state,
       hook: {
@@ -211,7 +220,12 @@ function rememberActiveState(state) {
         ...(state.hook || {}),
       },
       updatedAt: new Date().toISOString(),
-    }));
+    };
+    fs.writeFileSync(file, JSON.stringify(nextState));
+    const threadFile = threadStateFilePath(nextState.codexThreadId);
+    if (threadFile) {
+      fs.writeFileSync(threadFile, JSON.stringify(nextState));
+    }
   } catch (e) {
     // Best effort only. Hook state must not block the host session.
   }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -15,6 +15,7 @@ const fallbackBinaryNames = process.platform === 'win32'
   ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
   : ['codestory-cli'];
 const activeStateFile = '.codestory-active';
+const activeThreadStatePrefix = '.codestory-active-thread-';
 const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
@@ -98,6 +99,13 @@ function activeStatePath(dataDir = pluginDataDir()) {
   return dataDir ? path.join(dataDir, activeStateFile) : null;
 }
 
+function activeThreadStatePath(threadId, dataDir = pluginDataDir()) {
+  const normalized = String(threadId || '').trim();
+  if (!dataDir || !normalized) return null;
+  const key = createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  return path.join(dataDir, `${activeThreadStatePrefix}${key}.json`);
+}
+
 function normalizeProjectRoot(projectRoot) {
   const resolved = path.resolve(projectRoot);
   try {
@@ -139,7 +147,7 @@ function activeProjectStateTimestamp(active, statePath) {
 
 function activeProjectStateMatchesHost(active) {
   const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
-  if (!currentThread) return true;
+  if (!currentThread) return !String(active?.codexThreadId || '').trim();
   return String(active?.codexThreadId || '').trim() === currentThread;
 }
 
@@ -160,6 +168,22 @@ function resolveProjectRoot(options = {}) {
   const cwd = existingProjectRoot(process.cwd());
   if (cwd && !samePathText(cwd, pluginRoot)) {
     return { projectRoot: cwd, source: 'process_cwd' };
+  }
+
+  const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
+  const threadStatePath = activeThreadStatePath(currentThread);
+  const threadActive = threadStatePath ? readJson(threadStatePath) : null;
+  if (threadActive && !activeProjectStateFresh(threadActive, threadStatePath)) {
+    return {
+      projectRoot: null,
+      source: 'plugin_active_thread_state_stale',
+      statePath: threadStatePath,
+      reason: 'project_root_unavailable',
+    };
+  }
+  const threadRoot = existingProjectRoot(threadActive?.cwd);
+  if (threadRoot && !samePathText(threadRoot, pluginRoot)) {
+    return { projectRoot: threadRoot, source: 'plugin_active_thread_state', statePath: threadStatePath };
   }
 
   const statePath = activeStatePath();

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -20,6 +20,11 @@ const {
   writeDirtyMarker,
 } = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
 
+function threadActiveStatePath(dataDir, threadId) {
+  const key = createHash("sha256").update(String(threadId)).digest("hex").slice(0, 16);
+  return join(dataDir, `.codestory-active-thread-${key}.json`);
+}
+
 function readCargoVersion(manifestText) {
   let inPackage = false;
   for (const line of manifestText.split(/\r?\n/u)) {
@@ -538,6 +543,183 @@ test("mcp launcher rejects active project state from another Codex thread", asyn
     assert.equal(status.project_root, null);
     assert.equal(status.project_root_source, "plugin_active_state_stale");
     assert.equal(status.readiness[0].goal, "project_root");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher prefers thread-scoped active project over another thread's global state", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-thread-active-project-"));
+  const currentRepo = join(dataDir, "current-repo");
+  const previousRepo = join(dataDir, "previous-repo");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const currentThread = "current-thread";
+
+  try {
+    await mkdir(currentRepo);
+    await mkdir(previousRepo);
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: previousRepo,
+        codexThreadId: "previous-thread",
+        updatedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      threadActiveStatePath(dataDir, currentThread),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: currentRepo,
+        codexThreadId: currentThread,
+        updatedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({",
+        "  args,",
+        "  cwd: process.cwd(),",
+        "  projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '',",
+        "  projectRootSource: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE || ''",
+        "}) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, 'serve-called'); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS: "600000",
+        CODEX_THREAD_ID: currentThread,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(await readFile(marker, "utf8"), "serve-called");
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    const serve = calls.find((call) => call.args[0] === "serve");
+    assert.ok(serve, "expected serve call");
+    assert.deepEqual(serve.args, ["serve", "--stdio", "--refresh", "none", "--project", currentRepo]);
+    assert.equal(serve.cwd, currentRepo);
+    assert.equal(serve.projectRoot, currentRepo);
+    assert.equal(serve.projectRootSource, "plugin_active_thread_state");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher rejects thread-owned global state when current thread is unavailable", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-missing-thread-active-project-"));
+  const previousRepo = join(dataDir, "previous-repo");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+
+  try {
+    await mkdir(previousRepo);
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({
+        event: "UserPromptSubmit",
+        cwd: previousRepo,
+        codexThreadId: "previous-thread",
+        updatedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd(), projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '' }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready' || args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS: "600000",
+        CODEX_THREAD_ID: "",
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    await assert.rejects(access(marker));
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.degraded_reason, "project_root_unavailable");
+    assert.equal(status.project_root, null);
+    assert.equal(status.project_root_source, "plugin_active_state_stale");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1497,8 +1679,11 @@ test("hook records Codex thread id in active project state", async () => {
 
     assert.equal(result.status, 0, result.stderr);
     const state = JSON.parse(await readFile(join(dataDir, ".codestory-active"), "utf8"));
+    const threadState = JSON.parse(await readFile(threadActiveStatePath(dataDir, "hook-thread-id"), "utf8"));
     assert.equal(state.cwd, repoRoot);
     assert.equal(state.codexThreadId, "hook-thread-id");
+    assert.equal(threadState.cwd, repoRoot);
+    assert.equal(threadState.codexThreadId, "hook-thread-id");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

This prepares the `v0.12.5 - Review hardening` release after the source-side P1 readiness fixes landed on `dev/codestory-next`.

Closes #759.
Refs #716, #720, #738, #743, #747, and #748.

## What Changed

- Bumped all CodeStory workspace crates, `Cargo.lock`, and packaged CodeStory plugin manifests to `0.12.5`.
- Hardened agent readiness and repair status reporting so failed or unavailable sidecar readiness is visible instead of blending into local-only success.
- Tightened thread-scoped CodeStory MCP project binding, active-project state handling, and plugin startup checks for multi-thread/plugin-root launches.
- Added repo manifest path trust checks and retrieval degradation evidence paths for safer stale or missing sidecar behavior.
- Added workflow policy enforcement and release-surface validation for the CI/plugin release path.
- Fixed the pre-release review blockers:
  - Cancelled packet sidecar queries now keep packet sufficiency partial when required coverage is missing, even when cancellation produced zero candidates.
  - `plugin-static` now runs when `.github/workflows/rust-ci.yml` changes, so the workflow policy guard covers future CI-policy edits.

## How To Review

1. Review this as the full `main...codex/release-0.12.5` hardening release diff, not a version-only bump.
2. Spot-check `crates/codestory-runtime/src/agent/packet_sufficiency.rs` for the cancelled sidecar diagnostic sufficiency path.
3. Spot-check `.github/workflows/plugin-static.yml` and `.github/scripts/check-workflow-policy.mjs` together; workflow policy changes should run the guard before merge.
4. Confirm the version surfaces match `crates/codestory-cli/Cargo.toml`, since merge to `main` is the release trigger path.

## Verification

- `cargo fmt --check`
- `cargo test -p codestory-runtime cancelled_sidecar_diagnostics_block_when_required_coverage_is_missing --lib`
- `node .github/scripts/check-workflow-policy.mjs`
- `python .github/scripts/check-codestory-release.py --version 0.12.5`
- `git diff --check`
- `node --test plugins/codestory/tests/plugin-static.test.mjs`

## Risk

Runtime risk is concentrated in readiness/sidecar behavior and plugin startup routing. The pre-release review blockers have focused regression coverage, but release-pipeline/runtime proof still needs to be checked from the release workflow output after merge: tagged assets, packaged binaries, and installed-plugin proof are not produced until the `main` release path runs.
