### PR TITLE
[codex] document release marketplace workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,15 @@
 ## Release Guidelines
 - `crates/codestory-cli/Cargo.toml` is the release version source.
 - Update every `codestory-*` workspace crate version and `Cargo.lock` together.
+- Before committing a change that modifies the current unreleased version or
+  creates the next latest version, update `CHANGELOG.md` under `Unreleased` or
+  the new release heading so release contents are tracked while the work is
+  still reviewable.
 - Do not create or push `v*` release tags manually. A synchronized version bump on `main` triggers GitHub Actions to create the tag, GitHub release, cross-platform `codestory-cli` binary assets, and `SHA256SUMS.txt`.
+- After a plugin release or plugin-source update that Codex must detect through
+  the marketplace, push a corresponding change to
+  `TheGreenCedar/AgentPluginMarketplace`; Codex observes the marketplace repo
+  state, not only the CodeStory repo release.
 - CI binary assets prove build/package smoke only. Packet/search readiness still requires the sidecar evidence tiers in `docs/contributors/testing-matrix.md`.
 
 ## Retrieval documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Documentation
 
+- Added release guidance requiring changelog updates before version commits and
+  marketplace repo pushes when Codex needs to detect plugin updates.
 - Restructured operator docs under `docs/users/` (host guides, CLI reference, troubleshooting, trust and readiness).
 - Added CI markdown link checker: `node .github/scripts/check-doc-links.mjs` (`.github/workflows/docs-link-check.yml`).
 


### PR DESCRIPTION
## Context

The v0.12.5 release follow-through showed two workflow facts that should be durable: Codex needs a pushed AgentPluginMarketplace repo change to detect plugin update readiness, and latest/unreleased version work should update the changelog before commit.

Closes #764.
Refs #758.
Refs #763.

## What Changed

- Added release guidance in AGENTS.md for changelog-before-commit discipline when modifying the unreleased/latest version.
- Added release guidance that plugin updates requiring Codex marketplace detection need a corresponding AgentPluginMarketplace push.
- Recorded the guidance change in CHANGELOG.md under Unreleased.

## How To Review

- Read the Release Guidelines bullets in AGENTS.md.
- Confirm the CHANGELOG.md Unreleased entry describes the contributor-facing guidance change.

## Verification

- git diff --check -- AGENTS.md CHANGELOG.md

## Risk

Low. This is documentation-only guidance. It does not change release automation or marketplace manifests.