### PR TITLE
[codex] document Windows plugin refresh recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Documentation
 
+- Documented Codex plugin refresh recovery for Windows cache-backup
+  `Access is denied` failures and clarified marketplace snapshot vs package
+  refresh vs runtime reload.
 - Added release guidance requiring changelog updates before version commits and
   marketplace repo pushes when Codex needs to detect plugin updates.
 - Restructured operator docs under `docs/users/` (host guides, CLI reference, troubleshooting, trust and readiness).

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -37,6 +37,24 @@ Then install from `/plugins` as above. Marketplace catalog repo:
 `TheGreenCedar/AgentPluginMarketplace`; plugin source lives in this repository
 at `plugins/codestory`.
 
+## Refresh or update
+
+There are three separate steps:
+
+1. `codex plugin marketplace upgrade TheGreenCedar` refreshes the marketplace
+   snapshot only.
+2. `/plugins` refresh or `codex plugin add codestory@TheGreenCedar` updates
+   the installed plugin package.
+3. A fresh Codex host session starts the new MCP adapter and lets it provision
+   the matching managed CLI.
+
+If terminal refresh fails on Windows with `Access is denied` while backing up
+the plugin cache, quit stale Codex windows that may still be running the old
+CodeStory MCP process, then retry the `/plugins` refresh or terminal install.
+The marketplace may already show the new version before the running host has
+reloaded the package; prove the active runtime with a fresh
+`codestory://status` read.
+
 ## Install verification
 
 Run these three checks before your first real task:
@@ -117,6 +135,7 @@ More pairs, anti-patterns, and language-flavored examples:
 | --- | --- |
 | `@CodeStory` loads but no MCP tools | Start a fresh Codex host session after install; confirm plugin shows in `/plugins` |
 | Status shows `repair_setup` | Let the agent follow `recommended_next_calls` from status; restart host if binary was updated |
+| Terminal refresh says `Access is denied` | Quit stale Codex windows running the old plugin, then refresh from `/plugins` or rerun `codex plugin add codestory@TheGreenCedar` |
 | Packet/search blocked | Agent can call `sidecar_setup`; see [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
 | Hooks time out | Hooks fail open; ask the explicit status prompt above |
 

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -49,7 +49,7 @@ flowchart TD
 | MCP missing | Fresh thread after `/plugins` install | Check `.cursor/mcp.json`; reload MCP server | MCP configured separately from hooks | MCP not auto-started; configure or use CLI |
 | Stale index / wrong symbols | New thread; hooks refresh on session start | Reload MCP; run local repair | New session; run local repair | New session; run [local repair](cli-reference.md#readiness-and-repair) |
 | Packet/search blocked | Agent calls sidecar setup when status says so | Same; verify retrieval mode | Same | Use CLI [retrieval status](cli-reference.md#readiness-and-repair) |
-| Version drift after update | Restart host; fresh status read | Reload MCP server | Restart session | Reinstall or point to current binary |
+| Version drift after update | Refresh marketplace, refresh plugin package, restart host, fresh status read | Reload MCP server | Restart session | Reinstall or point to current binary |
 
 Host-specific steps: [Codex](codex.md#troubleshooting), [Cursor](cursor.md#troubleshooting), [Claude Code](claude-code.md#troubleshooting), [Copilot](copilot.md).
 
@@ -179,6 +179,26 @@ install. Confirm with a fresh `codestory://status` read.
 
 **Local dev:** Set `CODESTORY_CLI` to a built binary; status labels this
 `local_dev_override`.
+
+### Codex marketplace refresh vs runtime reload
+
+For Codex, marketplace refresh, package refresh, and runtime reload are separate:
+
+```sh
+codex plugin marketplace upgrade TheGreenCedar
+codex plugin add codestory@TheGreenCedar
+```
+
+The first command only updates Codex's marketplace snapshot. The second refreshes
+the installed plugin package when your Codex build supports terminal plugin
+management. A running Codex host can still keep the old MCP adapter and managed
+CLI alive until you start a fresh host session.
+
+On Windows, `codex plugin add codestory@TheGreenCedar` can fail with
+`Access is denied` while backing up the plugin cache if an old Codex/MCP process
+still has files open. Quit stale Codex windows, start a fresh host session, and
+retry the `/plugins` refresh or terminal install. After refresh, confirm the
+active runtime through `codestory://status`, not only `codex plugin list`.
 
 ## Still stuck?
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -40,6 +40,13 @@ Refresh or uninstall from `/plugins` in the Codex UI. Terminal marketplace
 commands (`codex plugin marketplace add|upgrade|remove`) are optional when your
 Codex build exposes them.
 
+Marketplace refresh is not runtime reload: `codex plugin marketplace upgrade`
+only refreshes the catalog snapshot. Refresh the installed package from
+`/plugins` or `codex plugin add codestory@TheGreenCedar`, then start a fresh
+Codex host session before trusting the active MCP runtime. On Windows, an
+`Access is denied` cache-backup error usually means an old host still has the
+previous plugin files open; quit stale Codex windows and retry.
+
 ## Repair and CLI
 
 Normal users repair through the agent and MCP (`codestory://status`,


### PR DESCRIPTION
## Context

During the v0.12.5 marketplace follow-through, Codex detected the refreshed marketplace, but `codex plugin add codestory@TheGreenCedar --json` failed on Windows while backing up the existing plugin cache with `Access is denied`. The installed package and active runtime also proved to be separate surfaces: `codex plugin list` could show `0.12.5` while old host-owned MCP processes were still running.

Closes #766.
Refs #738.
Refs #743.
Refs #758.

## What Changed

- Added a Codex refresh/update section that separates marketplace snapshot refresh, installed package refresh, and host/runtime reload.
- Added Windows `Access is denied` recovery guidance for stale Codex/MCP processes holding plugin cache files.
- Mirrored the short warning in the plugin README and shared troubleshooting page.
- Recorded the documentation change in CHANGELOG.md.

## How To Review

- Read `docs/users/codex.md#refresh-or-update` first.
- Check `docs/users/troubleshooting.md#codex-marketplace-refresh-vs-runtime-reload` for the shared recovery path.
- Confirm the plugin README summary points users to the same mental model without turning into a long runbook.

## Verification

- `git diff --check -- docs\users\codex.md docs\users\troubleshooting.md plugins\codestory\README.md CHANGELOG.md`
- `node .github\scripts\check-doc-links.mjs`

## Risk

Low. Documentation-only. It does not change plugin install behavior; it makes the current Windows failure mode and recovery path explicit.
