### PR TITLE
Document changelog discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,11 @@
 
 ## Commit & Pull Request Guidelines
 - Commit messages are short, lowercase, imperative (e.g., `fix minimap`, `refactor graph style`).
+- Before staging or committing, update `CHANGELOG.md` whenever the diff changes
+  shipped behavior, operator guidance, release automation, packaging, or version
+  metadata. If the work modifies the current latest unreleased version or
+  creates the next latest version heading, keep the entry under `Unreleased` or
+  that new release heading in the same commit.
 - PRs should include a summary, tests run, linked issues, and relevant artifacts for behavior changes.
 - Routine implementation PRs branch from and target `dev/codestory-next`. Do not target `main` directly unless the lane is an explicit release, hotfix, final comparison/review artifact, or promotion.
 - Agent branches should use the `codex/` prefix by default. Saga comparison/review branches may use `review/codestory-saga-*` when the branch exists only to support a reviewer comparison.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 - Documented Codex plugin refresh recovery for Windows cache-backup
   `Access is denied` failures and clarified marketplace snapshot vs package
   refresh vs runtime reload.
-- Added release guidance requiring changelog updates before version commits and
-  marketplace repo pushes when Codex needs to detect plugin updates.
+- Added contributor guidance requiring changelog updates before commits that
+  change shipped behavior, operator guidance, release automation, packaging, or
+  unreleased/latest version metadata, and requiring marketplace repo pushes when
+  Codex needs to detect plugin updates.
 - Restructured operator docs under `docs/users/` (host guides, CLI reference, troubleshooting, trust and readiness).
 - Added CI markdown link checker: `node .github/scripts/check-doc-links.mjs` (`.github/workflows/docs-link-check.yml`).
 


### PR DESCRIPTION
## Context

Closes #768.
Refs #716.
Refs #766.
Refs #767.

The review-hardening work surfaced two process rules that should be visible to future agents before they commit: marketplace repo state is part of Codex plugin update detection, and changelog maintenance needs to happen before release-bound or operator-visible commits land.

## What Changed

- Added a root `AGENTS.md` commit guideline requiring `CHANGELOG.md` updates before staging or committing changes that affect shipped behavior, operator guidance, release automation, packaging, or version metadata.
- Kept the existing release guidance for marketplace repo pushes when Codex must detect plugin updates.
- Updated `CHANGELOG.md` under `Unreleased` for this guidance change.

## How To Review

1. Read `AGENTS.md` under `Commit & Pull Request Guidelines` and `Release Guidelines`.
2. Confirm the changelog entry covers the new pre-commit guidance and the marketplace detection rule.

## Verification

- `git diff --check -- AGENTS.md CHANGELOG.md`
- `node .github\\scripts\\check-doc-links.mjs`

## Risk

Low. This is contributor guidance only; it does not change runtime code, release automation, or generated package artifacts.
