### PR TITLE
Use selected runtime for bootstrap Qdrant repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Kept retrieval bootstrap Qdrant repair on the selected sidecar runtime so
+  explicit agent profiles and run IDs do not fall back to ambient/default
+  runtime layout during collection repair.
+
 ### Documentation
 
 - Documented Codex plugin refresh recovery for Windows cache-backup

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -54,9 +54,10 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
     )
     .context("retrieval bootstrap")?;
     activate_retrieval_profile_env(Some(sidecar_profile), sidecar.run_id.as_deref());
-    let project_qdrant_repair = codestory_retrieval::repair_project_qdrant_collection(
+    let project_qdrant_repair = codestory_retrieval::repair_project_qdrant_collection_for_runtime(
         &runtime.project_root,
         &runtime.storage_path,
+        &sidecar,
     )
     .context("retrieval project qdrant repair")?;
     let status = strict_sidecar_status_for_runtime(

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -2287,10 +2287,16 @@ fn assert_stdio_context_id_fails_closed_without_full_sidecars(
         stdio["result"]["isError"], true,
         "stdio context --id should return a tool error without full sidecars: {stdio:#}"
     );
-    let message = stdio["result"]["structuredContent"]["message"].as_str();
+    let structured = &stdio["result"]["structuredContent"];
+    assert_eq!(
+        structured["code"].as_str(),
+        Some("codestory_tool_blocked"),
+        "stdio context --id should fail closed with a typed tool block: {stdio:#}"
+    );
+    let status = structured["status"].as_str();
     assert!(
-        message.is_some_and(|message| message.contains("sidecar retrieval")),
-        "stdio context --id should fail closed without full sidecars: {stdio:#}"
+        status.is_some_and(|status| matches!(status, "repair_setup" | "repair_retrieval")),
+        "stdio context --id should fail closed before serving context: {stdio:#}"
     );
 }
 


### PR DESCRIPTION
## Context

Closes #748.
Refs #716.
Refs #743.
Refs #738.

The selected-runtime repair path already passes the agent `SidecarRuntimeConfig` through `ready --goal agent --repair`. One adjacent bootstrap path still selected an agent/profile runtime for startup and status, then ran Qdrant repair through the ambient/default wrapper.

## What Changed

- Switched `retrieval bootstrap` project Qdrant repair to `repair_project_qdrant_collection_for_runtime(..., &sidecar)`.
- Kept the ambient `repair_project_qdrant_collection` wrapper for default/local callers.
- Added an `Unreleased` changelog note for the selected-runtime bootstrap repair fix.

## How To Review

1. In `crates/codestory-cli/src/retrieval.rs`, confirm bootstrap, Qdrant repair, and status now use the same selected `sidecar`.
2. In `crates/codestory-retrieval/src/index.rs`, confirm the runtime-taking repair function still owns the layout-sensitive behavior and the default wrapper remains unchanged.

## Verification

- `cargo test -p codestory-retrieval qdrant --lib`
- `cargo test -p codestory-cli ready_repair`
- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts agent_profile_bootstrap_status_and_down_are_project_isolated`
- `cargo test -p codestory-cli --test cli_golden_path tiny_workspace_browser_loop_works_from_existing_cache`
- `cargo fmt --check`
- `git diff --check -- CHANGELOG.md crates\\codestory-cli\\src\\retrieval.rs`

## Risk

Low source risk: the fix reuses the selected runtime already computed by bootstrap. No live `ready --goal agent --repair` sidecar smoke was run in this lane; the proof is source-backed plus focused Cargo tests.
