### PR TITLE
Retry unpublished auto releases

### DIFF
--- a/.github/scripts/detect-codestory-release.py
+++ b/.github/scripts/detect-codestory-release.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+@dataclass(frozen=True)
+class ReleaseDecision:
+    should_release: bool
+    reason: str
+
+
+def read_version_bytes(data: bytes) -> str:
+    package = tomllib.loads(data.decode("utf-8")).get("package", {})
+    return str(package.get("version", ""))
+
+
+def read_current_version(package_path: Path) -> str:
+    return read_version_bytes(package_path.read_bytes())
+
+
+def read_previous_version(before_sha: str, package_path: str) -> str:
+    if not before_sha or re.fullmatch(r"0+", before_sha):
+        return ""
+
+    result = subprocess.run(
+        ["git", "show", f"{before_sha}:{package_path}"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        return ""
+    return read_version_bytes(result.stdout)
+
+
+def remote_tag_exists(tag: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 2:
+        return False
+    raise RuntimeError(f"failed to inspect remote tag {tag}: {result.stderr.strip()}")
+
+
+def github_release_exists(tag: str, repo: str) -> bool:
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", repo],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 0:
+        return True
+
+    stderr = result.stderr.lower()
+    if "not found" in stderr or "404" in stderr:
+        return False
+    raise RuntimeError(f"failed to inspect GitHub release {tag}: {result.stderr.strip()}")
+
+
+def decide_release(
+    *,
+    old_version: str,
+    new_version: str,
+    tag_exists: bool,
+    release_exists: bool,
+) -> ReleaseDecision:
+    if not SEMVER_RE.fullmatch(new_version):
+        raise ValueError(f"codestory-cli version must be strict semver, got {new_version!r}.")
+
+    if tag_exists != release_exists:
+        raise ValueError(
+            f"v{new_version} has partial release state "
+            f"(tag_exists={tag_exists}, release_exists={release_exists}); refusing automatic retry."
+        )
+
+    if tag_exists and release_exists:
+        if old_version != new_version:
+            raise ValueError(
+                f"v{new_version} already has a tag or release; refusing to overwrite it."
+            )
+        return ReleaseDecision(False, f"v{new_version} already has a tag or release.")
+
+    if old_version == new_version:
+        return ReleaseDecision(
+            True,
+            f"v{new_version} has no tag or release; retrying the current source version.",
+        )
+
+    return ReleaseDecision(True, f"codestory-cli version changed to {new_version}.")
+
+
+def write_outputs(output_path: str, *, version: str, tag: str, decision: ReleaseDecision) -> None:
+    if not output_path:
+        return
+
+    with open(output_path, "a", encoding="utf-8") as output:
+        output.write(f"version={version}\n")
+        output.write(f"tag={tag}\n")
+        output.write(f"should_release={str(decision.should_release).lower()}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Detect whether CodeStory should auto-release.")
+    parser.add_argument("--before-sha", default=os.environ.get("BEFORE_SHA", ""))
+    parser.add_argument(
+        "--package-path",
+        default="crates/codestory-cli/Cargo.toml",
+        help="Path to the codestory-cli Cargo manifest.",
+    )
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    args = parser.parse_args()
+
+    try:
+        new_version = read_current_version(Path(args.package_path))
+        old_version = read_previous_version(args.before_sha, args.package_path)
+        tag = f"v{new_version}"
+        tag_exists = remote_tag_exists(tag)
+        release_exists = github_release_exists(tag, args.repo) if args.repo else False
+        decision = decide_release(
+            old_version=old_version,
+            new_version=new_version,
+            tag_exists=tag_exists,
+            release_exists=release_exists,
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"::error::{error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+    print(f"Previous codestory-cli version: {old_version or '<missing>'}")
+    print(f"Current codestory-cli version: {new_version}")
+    print(f"Release tag exists: {str(tag_exists).lower()}")
+    print(f"GitHub release exists: {str(release_exists).lower()}")
+    print(f"Auto release decision: {decision.reason}")
+    write_outputs(args.output, version=new_version, tag=tag, decision=decision)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-detect-codestory-release.py
+++ b/.github/scripts/test-detect-codestory-release.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("detect-codestory-release.py")
+SPEC = importlib.util.spec_from_file_location("detect_codestory_release", SCRIPT)
+assert SPEC is not None
+detector = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = detector
+SPEC.loader.exec_module(detector)
+
+
+class AutoReleaseDecisionTest(unittest.TestCase):
+    def test_retries_unchanged_unpublished_version(self) -> None:
+        decision = detector.decide_release(
+            old_version="0.12.5",
+            new_version="0.12.5",
+            tag_exists=False,
+            release_exists=False,
+        )
+
+        self.assertTrue(decision.should_release)
+        self.assertIn("retrying", decision.reason)
+
+    def test_skips_unchanged_published_version(self) -> None:
+        decision = detector.decide_release(
+            old_version="0.12.5",
+            new_version="0.12.5",
+            tag_exists=True,
+            release_exists=True,
+        )
+
+        self.assertFalse(decision.should_release)
+
+    def test_releases_changed_unpublished_version(self) -> None:
+        decision = detector.decide_release(
+            old_version="0.12.4",
+            new_version="0.12.5",
+            tag_exists=False,
+            release_exists=False,
+        )
+
+        self.assertTrue(decision.should_release)
+
+    def test_refuses_changed_version_that_already_exists(self) -> None:
+        with self.assertRaisesRegex(ValueError, "refusing to overwrite"):
+            detector.decide_release(
+                old_version="0.12.4",
+                new_version="0.12.5",
+                tag_exists=True,
+                release_exists=True,
+            )
+
+    def test_refuses_partial_release_state(self) -> None:
+        with self.assertRaisesRegex(ValueError, "partial release state"):
+            detector.decide_release(
+                old_version="0.12.5",
+                new_version="0.12.5",
+                tag_exists=True,
+                release_exists=False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - crates/**/Cargo.toml
+      - crates/**
       - Cargo.lock
       - CHANGELOG.md
       - AGENTS.md
@@ -13,6 +13,7 @@ on:
       - .github/workflows/auto-release.yml
       - .github/workflows/release.yml
       - .github/scripts/**
+      - plugins/codestory/**
 
 permissions:
   contents: read
@@ -51,60 +52,13 @@ jobs:
         id: version
         env:
           BEFORE_SHA: ${{ github.event.before }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          python - <<'PY'
-          import os
-          import re
-          import subprocess
-          import sys
-          import tomllib
-          from pathlib import Path
-
-          semver = re.compile(
-              r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-              r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
-              r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
-          )
-          package_path = "crates/codestory-cli/Cargo.toml"
-
-          def read_version_bytes(data: bytes) -> str:
-              package = tomllib.loads(data.decode("utf-8")).get("package", {})
-              return str(package.get("version", ""))
-
-          new_version = read_version_bytes(Path(package_path).read_bytes())
-          before = os.environ.get("BEFORE_SHA", "")
-          old_version = ""
-          if before and not re.fullmatch(r"0+", before):
-              result = subprocess.run(
-                  ["git", "show", f"{before}:{package_path}"],
-                  check=False,
-                  stdout=subprocess.PIPE,
-                  stderr=subprocess.DEVNULL,
-              )
-              if result.returncode == 0:
-                  old_version = read_version_bytes(result.stdout)
-
-          print(f"Previous codestory-cli version: {old_version or '<missing>'}")
-          print(f"Current codestory-cli version: {new_version}")
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"version={new_version}\n")
-              if old_version == new_version:
-                  print("codestory-cli version did not change; skipping release.")
-                  output.write("should_release=false\n")
-                  sys.exit(0)
-
-              if not semver.fullmatch(new_version):
-                  print(
-                      f"::error::codestory-cli version must be strict semver, got {new_version!r}.",
-                      file=sys.stderr,
-                  )
-                  sys.exit(1)
-
-              output.write("should_release=true\n")
-          PY
+          python .github/scripts/detect-codestory-release.py \
+            --before-sha "$BEFORE_SHA" \
+            --repo "$GITHUB_REPOSITORY" \
+            --output "$GITHUB_OUTPUT"
 
       - name: Validate synchronized release version
         if: steps.version.outputs.should_release == 'true'

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - plugins/codestory/**
+      - .github/scripts/detect-codestory-release.py
+      - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/auto-release.yml
       - .github/workflows/plugin-static.yml
   push:
     branches:
@@ -13,8 +16,11 @@ on:
       - dev/codestory-next
     paths:
       - plugins/codestory/**
+      - .github/scripts/detect-codestory-release.py
+      - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/workflows/auto-release.yml
       - .github/workflows/plugin-static.yml
   workflow_dispatch:
 
@@ -38,6 +44,9 @@ jobs:
 
       - name: Check workflow policy
         run: node .github/scripts/check-workflow-policy.mjs
+
+      - name: Check auto-release detector
+        run: python .github/scripts/test-detect-codestory-release.py
 
       - name: Check release version surfaces
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Taught Auto Release to retry the current source version when a previous
+  publish failed before creating a tag or release, while still refusing to
+  overwrite existing release state.
 - Kept retrieval bootstrap Qdrant repair on the selected sidecar runtime so
   explicit agent profiles and run IDs do not fall back to ambient/default
   runtime layout during collection repair.


### PR DESCRIPTION
## Context

Auto Release could skip a retry after a failed publish if the next `main` merge kept the same unreleased source version. That happened in the v0.12.5 lane after a source-only hotfix reached `main` without touching version metadata.

## What Changed

- Moved Auto Release version detection into `.github/scripts/detect-codestory-release.py`.
- The detector now checks the current source version against remote tag and GitHub release state before deciding to skip.
- The workflow now runs for `crates/**` and `plugins/codestory/**` changes, so post-failure source hotfixes can reach the detector.
- Added a focused script test for unchanged-unpublished retry, published skip, changed unpublished release, existing release refusal, and partial tag/release failure.
- Routed Auto Release detector changes through the existing `plugin-static` PR gate and workflow-policy guard.
- Updated `CHANGELOG.md` under `Unreleased`.

```mermaid
flowchart LR
  Push[main push] --> Detect[detect source version]
  Detect --> State{tag/release state}
  State -->|none exists| Release[run release]
  State -->|tag and release exist| Skip[skip]
  State -->|partial state| Fail[fail for manual repair]
```

## How To Review

Start with `.github/scripts/test-detect-codestory-release.py`, then read `.github/scripts/detect-codestory-release.py` and the small workflow call-site change in `.github/workflows/auto-release.yml`.

## Verification

- `python .github\scripts\test-detect-codestory-release.py` -> 5 passed
- `python .github\scripts\detect-codestory-release.py --before-sha HEAD --repo TheGreenCedar/CodeStory` -> skipped published `v0.12.4`
- `node .github\scripts\check-workflow-policy.mjs` -> passed
- `node --test plugins\codestory\tests\plugin-static.test.mjs` -> 44 passed
- `python .github\scripts\check-codestory-release.py --version 0.12.4` -> passed
- `git diff --check` -> passed
- `git diff --cached --check` -> passed

## Risk

The detector intentionally fails on partial release state, such as a tag without a release, instead of deleting or overwriting remote release artifacts. That keeps automated retry safe but still requires manual cleanup for partial publishes.

Closes #763
Refs #716
