### PR TITLE
Avoid shell default file open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Taught Auto Release to retry the current source version when a previous
   publish failed before creating a tag or release, while still refusing to
   overwrite existing release state.
+- Removed shell execution from default file-open fallbacks so repo paths with
+  shell metacharacters are passed as process arguments.
 - Kept retrieval bootstrap Qdrant repair on the selected sidecar runtime so
   explicit agent profiles and run IDs do not fall back to ambient/default
   runtime layout during collection repair.

--- a/crates/codestory-runtime/src/system_actions.rs
+++ b/crates/codestory-runtime/src/system_actions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::ffi::OsString;
 use std::process::Command;
 
 pub(super) fn expand_ide_template(
@@ -25,19 +26,19 @@ pub(super) fn run_shell_command(command: &str) -> io::Result<()> {
     Ok(())
 }
 
-pub(super) fn open_with_os_default(path: &Path) -> io::Result<()> {
+fn os_default_open_invocation(path: &Path) -> (&'static str, Vec<OsString>) {
     if cfg!(target_os = "windows") {
-        Command::new("cmd")
-            .args(["/C", "start", ""])
-            .arg(path)
-            .spawn()?;
-        return Ok(());
+        return ("explorer", vec![path.as_os_str().to_os_string()]);
     }
     if cfg!(target_os = "macos") {
-        Command::new("open").arg(path).spawn()?;
-        return Ok(());
+        return ("open", vec![path.as_os_str().to_os_string()]);
     }
-    Command::new("xdg-open").arg(path).spawn()?;
+    ("xdg-open", vec![path.as_os_str().to_os_string()])
+}
+
+pub(super) fn open_with_os_default(path: &Path) -> io::Result<()> {
+    let (program, args) = os_default_open_invocation(path);
+    Command::new(program).args(args).spawn()?;
     Ok(())
 }
 
@@ -71,6 +72,7 @@ pub(super) fn launch_definition_in_ide(
     if let Ok(template) = std::env::var("CODESTORY_IDE_COMMAND") {
         let trimmed = template.trim();
         if !trimmed.is_empty() {
+            // CODESTORY_IDE_COMMAND is an explicit user shell template.
             let expanded = expand_ide_template(trimmed, path, line, col);
             if run_shell_command(&expanded).is_ok() {
                 return Ok(status_response(format!(
@@ -108,4 +110,28 @@ pub(super) fn launch_definition_in_ide(
         "Opened definition with OS default handler: {}",
         path.display()
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn os_default_open_passes_metacharacter_path_as_argument() {
+        let path = Path::new("repo & $(touch nope); file.rs");
+        let (program, args) = os_default_open_invocation(path);
+
+        assert_ne!(program, "cmd");
+        assert_ne!(program, "sh");
+        assert_eq!(args, vec![path.as_os_str().to_os_string()]);
+    }
+
+    #[test]
+    fn ide_template_substitution_is_for_explicit_shell_templates() {
+        let path = Path::new("repo & $(touch nope); file.rs");
+
+        let expanded = expand_ide_template("code --goto {file}:{line}:{col}", path, Some(7), None);
+
+        assert_eq!(expanded, "code --goto repo & $(touch nope); file.rs:7:1");
+    }
 }

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -131,6 +131,7 @@ Does not prove agent packet/search readiness.
 | Variable | Purpose |
 | --- | --- |
 | `CODESTORY_CLI` | Local-dev override for MCP adapter binary path |
+| `CODESTORY_IDE_COMMAND` | Optional shell command template for definition-open actions. Supports `{file}`, `{line}`, and `{col}`; set only trusted local templates because the template runs through your shell. |
 | `CODESTORY_NO_TUI` | Disable TUI for `explore` in CI or scripts |
 | `CODESTORY_SUMMARY_ENDPOINT` | Trusted summary endpoint |
 | `CODESTORY_EMBED_LLAMACPP_URL` | Trusted embedding endpoint |


### PR DESCRIPTION
## Context

Issue #723 found that default definition-open fallback could pass repo-controlled file paths through shell command strings on Windows.

## What Changed

- Replaced the Windows default open fallback from `cmd /C start` to direct `explorer` process invocation.
- Kept macOS/Linux default open paths as direct process invocations.
- Left `CODESTORY_IDE_COMMAND` as an explicit opt-in shell template and documented that boundary in the CLI reference.
- Added focused tests for shell metacharacters in file paths and explicit IDE template substitution.
- Updated `CHANGELOG.md` under `Unreleased`.

## How To Review

Review `crates/codestory-runtime/src/system_actions.rs`; the behavior change is isolated to the default OS-open helper and tests.

## Verification

- `cargo test -p codestory-runtime system_actions --lib` -> 2 passed
- `cargo fmt --check` -> passed
- `node .github\scripts\check-doc-links.mjs` -> passed
- `git diff --check` -> passed
- `git diff --cached --check` -> passed

## Risk

On Windows, `explorer <path>` is now the default opener instead of `cmd /C start`. That removes shell parsing; the remaining risk is platform-specific file association behavior, which is why the explicit `CODESTORY_IDE_COMMAND` override remains available for local users.

Closes #723
Refs #716
