### PR TITLE
Share retrieval file roles across strict batch workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   overwrite existing release state.
 - Removed shell execution from default file-open fallbacks so repo paths with
   shell metacharacters are passed as process arguments.
+- Shared retrieval file-role state across strict batch workers so cache-miss
+  fan-out does not clone the repo-wide role map per worker.
 - Kept retrieval bootstrap Qdrant repair on the selected sidecar runtime so
   explicit agent profiles and run IDs do not fall back to ambient/default
   runtime layout during collection repair.

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -80,7 +80,7 @@ pub struct QueryExecutor<'a> {
     pub sidecars: Arc<dyn SidecarSearch>,
     pub cache: &'a mut RetrievalCache,
     pub manifest: Option<RetrievalIndexManifest>,
-    pub file_roles: HashMap<String, codestory_store::FileRole>,
+    pub file_roles: Arc<HashMap<String, codestory_store::FileRole>>,
     pub cancelled: Arc<AtomicBool>,
     /// When set (tests), skips live health probing.
     pub mode_override: Option<RetrievalDegradedMode>,
@@ -664,7 +664,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -688,7 +688,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(manifest),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -718,7 +718,7 @@ mod tests {
                 sidecars: mock.clone(),
                 cache: &mut cache,
                 manifest: Some(manifest.clone()),
-                file_roles: HashMap::new(),
+                file_roles: Arc::new(HashMap::new()),
                 cancelled: cancellation_flag(),
                 mode_override: Some(RetrievalDegradedMode::Full),
             };
@@ -735,7 +735,7 @@ mod tests {
             sidecars: mock.clone(),
             cache: &mut cancelled_cache,
             manifest: Some(manifest.clone()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled,
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -778,7 +778,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -814,7 +814,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::NoSemantic),
         };
@@ -838,7 +838,7 @@ mod tests {
             sidecars: sidecars.clone(),
             cache: &mut cache,
             manifest: Some(manifest),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: None,
         };
@@ -862,7 +862,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(manifest),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::NoSemantic),
         };
@@ -891,7 +891,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -959,7 +959,7 @@ mod tests {
             sidecars: Arc::new(SlowZoektSidecars),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1061,7 +1061,7 @@ mod tests {
             sidecars: Arc::new(SlowScipExpandSidecars),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1157,7 +1157,7 @@ mod tests {
             sidecars: Arc::new(DenseAnchorExpandSidecars),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1243,7 +1243,7 @@ mod tests {
             sidecars: Arc::new(SlowLexicalUsefulSidecars),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: roles,
+            file_roles: Arc::new(roles),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1312,7 +1312,7 @@ mod tests {
             sidecars: Arc::new(SlowScipAnchorSidecars),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1400,7 +1400,7 @@ mod tests {
             sidecars: Arc::new(SlowDenseSymbolSidecars),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1464,7 +1464,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(manifest),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1525,7 +1525,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1558,7 +1558,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled,
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1597,7 +1597,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: roles,
+            file_roles: Arc::new(roles),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1636,7 +1636,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
@@ -1703,7 +1703,7 @@ mod tests {
             sidecars: Arc::new(mock),
             cache: &mut cache,
             manifest: Some(sample_manifest()),
-            file_roles: HashMap::new(),
+            file_roles: Arc::new(HashMap::new()),
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -123,7 +123,7 @@ pub fn execute_strict_retrieval_query_batch_with_cache(
 fn execute_strict_retrieval_query_batch_against_sidecars(
     sidecars: Arc<dyn SidecarSearch>,
     manifest: Option<RetrievalIndexManifest>,
-    file_roles: HashMap<String, FileRole>,
+    file_roles: Arc<HashMap<String, FileRole>>,
     cancelled: Arc<AtomicBool>,
     mode: RetrievalDegradedMode,
     queries: &[QueryBatchItem<'_>],
@@ -152,7 +152,7 @@ fn execute_strict_retrieval_query_batch_against_sidecars(
             let mut handles = Vec::with_capacity(wave.len());
             for (index, query, budget_ms) in wave {
                 let manifest = manifest.clone();
-                let file_roles = file_roles.clone();
+                let file_roles = Arc::clone(&file_roles);
                 let cancelled = Arc::clone(&cancelled);
                 let sidecars = Arc::clone(&sidecars);
                 handles.push(scope.spawn(move || {
@@ -248,7 +248,7 @@ struct QueryContext {
     layout: SidecarLayout,
     project_id: String,
     manifest: Option<RetrievalIndexManifest>,
-    file_roles: HashMap<String, FileRole>,
+    file_roles: Arc<HashMap<String, FileRole>>,
     embedding_device: EmbeddingDeviceReadiness,
 }
 
@@ -299,7 +299,7 @@ fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryC
         layout,
         project_id,
         manifest,
-        file_roles,
+        file_roles: Arc::new(file_roles),
         embedding_device,
     })
 }
@@ -441,11 +441,21 @@ mod tests {
                 budget_ms: Some(500),
             },
         ];
+        let file_roles = Arc::new(
+            (0..10_000)
+                .map(|index| (format!("src/unrelated_{index}.rs"), FileRole::Source))
+                .chain([
+                    ("src/slow.rs".to_string(), FileRole::Source),
+                    ("src/fast.rs".to_string(), FileRole::Test),
+                    ("src/last.rs".to_string(), FileRole::Generated),
+                ])
+                .collect::<HashMap<_, _>>(),
+        );
 
         let results = execute_strict_retrieval_query_batch_against_sidecars(
             sidecars.clone(),
             Some(manifest),
-            HashMap::new(),
+            Arc::clone(&file_roles),
             cancellation_flag(),
             RetrievalDegradedMode::Full,
             &queries,
@@ -460,6 +470,19 @@ mod tests {
                 .map(|result| result.query.as_str())
                 .collect::<Vec<_>>(),
             ["slow", "fast", "last"]
+        );
+        assert_eq!(file_roles.len(), 10_003);
+        assert_eq!(
+            results
+                .iter()
+                .flat_map(|result| result.hits.iter())
+                .map(|hit| hit.file_role)
+                .collect::<Vec<_>>(),
+            [
+                Some(FileRole::Source),
+                Some(FileRole::Test),
+                Some(FileRole::Generated)
+            ]
         );
         assert_eq!(sidecars.max_active.load(Ordering::SeqCst), 2);
     }
@@ -481,7 +504,7 @@ mod tests {
         let error = execute_strict_retrieval_query_batch_against_sidecars(
             Arc::new(sidecars),
             Some(manifest),
-            HashMap::new(),
+            Arc::new(HashMap::new()),
             cancellation_flag(),
             RetrievalDegradedMode::NoSemantic,
             &queries,


### PR DESCRIPTION
## Context

Closes #730
Refs #716

Strict retrieval batch workers were cloning the repo-wide file-role map for each cache miss. That made miss fan-out pay for a full `HashMap<String, FileRole>` clone per worker even though role enrichment only reads from that map.

## What Changed

- Changed `QueryExecutor.file_roles` and strict batch query context to use `Arc<HashMap<String, FileRole>>`.
- Updated strict batch miss workers to clone the shared `Arc` instead of cloning the full role map.
- Extended the strict batch cache-miss/order regression to run with 10,003 file roles and assert role enrichment still applies to miss results.
- Added an `Unreleased` changelog entry for the retrieval fan-out fix.

```mermaid
flowchart LR
    A["load file roles once"] --> B["Arc role map"]
    B --> C["worker 1 cache miss"]
    B --> D["worker 2 cache miss"]
    B --> E["worker N cache miss"]
    C --> F["ordered results"]
    D --> F
    E --> F
```

## How To Review

- Start with `crates/codestory-retrieval/src/query.rs` and confirm strict batch workers now receive `Arc::clone(&file_roles)`.
- Check `crates/codestory-retrieval/src/executor.rs` for the shared read-only executor field and test constructor updates.
- Review the expanded `strict_batch_runs_cache_misses_bounded_and_keeps_order` test for order, bounded fan-out, and many-role enrichment coverage.

## Verification

- `cargo test -p codestory-retrieval --lib query::tests::strict_batch_runs_cache_misses_bounded_and_keeps_order -- --exact`
- `cargo test -p codestory-retrieval --lib`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`

## Risk

Low. The role map remains immutable after loading; this changes ownership/sharing only. Remaining runtime memory is still one repo-wide role map per query context, not candidate-path-only role loading.
