### PR TITLE
Compact local refresh status across agent surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Kept retrieval bootstrap Qdrant repair on the selected sidecar runtime so
   explicit agent profiles and run IDs do not fall back to ambient/default
   runtime layout during collection repair.
+- Compacted local-refresh status across ready, agent preflight, and
+  `codestory://status` so agent-facing output uses refreshed/refreshing/skipped
+  states while maintainer JSON keeps stale freshness details.
 
 ### Documentation
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2191,7 +2191,7 @@ pub(crate) fn wait_for_local_freshness(
     let summary = inspect_runtime.open_project_summary()?;
     if !local_freshness_needs_refresh(&summary) {
         let mut output = local_refresh_output_from_summary(&summary);
-        if output.state == readiness::LocalRefreshState::Fresh {
+        if output.state == readiness::LocalRefreshState::Refreshed {
             output.reason = Some("already_fresh".to_string());
         }
         return Ok((summary, Some(output)));
@@ -2201,7 +2201,7 @@ pub(crate) fn wait_for_local_freshness(
     match index_runtime.ensure_open(args::RefreshMode::Incremental) {
         Ok(opened) => {
             let mut output = local_refresh_output_from_summary(&opened.summary);
-            if output.state == readiness::LocalRefreshState::Fresh {
+            if output.state == readiness::LocalRefreshState::Refreshed {
                 output.reason = Some("refreshed".to_string());
             } else {
                 output.state = readiness::LocalRefreshState::Failed;
@@ -2230,7 +2230,9 @@ pub(crate) fn local_freshness_needs_refresh(summary: &ProjectSummary) -> bool {
     })
 }
 
-fn local_refresh_output_from_summary(summary: &ProjectSummary) -> readiness::LocalRefreshOutput {
+pub(crate) fn local_refresh_output_from_summary(
+    summary: &ProjectSummary,
+) -> readiness::LocalRefreshOutput {
     let verdict = readiness::build_readiness_verdict(
         ReadinessGoalDto::LocalNavigation,
         readiness::ReadinessInputs {
@@ -2251,7 +2253,7 @@ fn classify_local_refresh_failure_state(error: &anyhow::Error) -> readiness::Loc
         || message.contains("database table is locked")
         || message.contains("cache is busy")
     {
-        readiness::LocalRefreshState::SkippedLocked
+        readiness::LocalRefreshState::Skipped
     } else {
         readiness::LocalRefreshState::Failed
     }
@@ -12584,7 +12586,7 @@ mod tests {
         let locked = anyhow::anyhow!("cache_busy: database is locked");
         assert_eq!(
             classify_local_refresh_failure_state(&locked),
-            readiness::LocalRefreshState::SkippedLocked
+            readiness::LocalRefreshState::Skipped
         );
 
         let failed = anyhow::anyhow!("index refresh failed");

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -47,10 +47,9 @@ pub(crate) struct ReadinessSidecarInput<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum LocalRefreshState {
-    Fresh,
-    Stale,
-    NotChecked,
-    SkippedLocked,
+    Refreshing,
+    Refreshed,
+    Skipped,
     Failed,
 }
 
@@ -165,10 +164,9 @@ pub(crate) fn goal_label(goal: ReadinessGoalDto) -> &'static str {
 
 pub(crate) fn local_refresh_state_label(state: LocalRefreshState) -> &'static str {
     match state {
-        LocalRefreshState::Fresh => "fresh",
-        LocalRefreshState::Stale => "stale",
-        LocalRefreshState::NotChecked => "not_checked",
-        LocalRefreshState::SkippedLocked => "skipped_locked",
+        LocalRefreshState::Refreshing => "refreshing",
+        LocalRefreshState::Refreshed => "refreshed",
+        LocalRefreshState::Skipped => "skipped",
         LocalRefreshState::Failed => "failed",
     }
 }
@@ -178,22 +176,27 @@ pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefres
     let state = match verdict.status {
         ReadinessStatusDto::Ready
         | ReadinessStatusDto::Repairing
-        | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Fresh,
-        ReadinessStatusDto::CheckIndex => LocalRefreshState::NotChecked,
+        | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Refreshed,
+        ReadinessStatusDto::CheckIndex => LocalRefreshState::Skipped,
         ReadinessStatusDto::RepairSetup => LocalRefreshState::Failed,
         ReadinessStatusDto::RepairIndex => {
             if index.and_then(|index| index.status) == Some(IndexFreshnessStatusDto::Stale) {
-                LocalRefreshState::Stale
+                LocalRefreshState::Skipped
             } else {
                 LocalRefreshState::Failed
             }
         }
     };
     let reason = match state {
-        LocalRefreshState::Fresh => None,
-        LocalRefreshState::Stale => Some("index_changed".to_string()),
-        LocalRefreshState::NotChecked => Some("freshness_not_checked".to_string()),
-        LocalRefreshState::SkippedLocked => Some("index_locked".to_string()),
+        LocalRefreshState::Refreshing => Some("refresh_active".to_string()),
+        LocalRefreshState::Refreshed => None,
+        LocalRefreshState::Skipped => {
+            if index.and_then(|index| index.status) == Some(IndexFreshnessStatusDto::Stale) {
+                Some("index_changed".to_string())
+            } else {
+                Some("freshness_not_checked".to_string())
+            }
+        }
         LocalRefreshState::Failed => Some(verdict.summary.clone()),
     };
 
@@ -780,7 +783,7 @@ mod tests {
         assert_eq!(verdict.status, ReadinessStatusDto::Ready);
         assert_eq!(
             local_refresh_output(&verdict).state,
-            LocalRefreshState::Fresh
+            LocalRefreshState::Refreshed
         );
         assert!(
             verdict.summary.contains("2 nonfatal indexing errors"),
@@ -807,7 +810,7 @@ mod tests {
 
         assert_eq!(verdict.status, ReadinessStatusDto::CheckIndex);
         let refresh = local_refresh_output(&verdict);
-        assert_eq!(refresh.state, LocalRefreshState::NotChecked);
+        assert_eq!(refresh.state, LocalRefreshState::Skipped);
         assert!(refresh.blocks_local_surfaces);
         assert_eq!(
             verdict.index.as_ref().and_then(|index| index.status),
@@ -827,7 +830,7 @@ mod tests {
 
         assert_eq!(verdict.status, ReadinessStatusDto::RepairIndex);
         let refresh = local_refresh_output(&verdict);
-        assert_eq!(refresh.state, LocalRefreshState::Stale);
+        assert_eq!(refresh.state, LocalRefreshState::Skipped);
         assert!(refresh.blocks_local_surfaces);
         assert_eq!(refresh.changed_file_count, 1);
         assert!(
@@ -889,7 +892,7 @@ mod tests {
             inputs(&stats, Some(&freshness), None),
         );
         let refresh = local_refresh_output(&local);
-        assert_eq!(refresh.state, LocalRefreshState::Fresh);
+        assert_eq!(refresh.state, LocalRefreshState::Refreshed);
         assert!(!refresh.blocks_local_surfaces);
 
         let local_full = build_readiness_verdict(

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2202,8 +2202,16 @@ fn read_stdio_status_resource_cached(
         &runtime.project_root,
         Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
     );
-    let (summary, local_refresh) = if active_agent_repair.is_some() {
-        (summary, None)
+    let (summary, local_refresh) = if let Some(active_repair) = active_agent_repair.as_ref() {
+        if crate::local_freshness_needs_refresh(&summary) {
+            let mut output = crate::local_refresh_output_from_summary(&summary);
+            output.state = crate::readiness::LocalRefreshState::Refreshing;
+            output.blocks_local_surfaces = true;
+            output.reason = Some(format!("active_ready_repair:{}", active_repair.phase));
+            (summary, Some(output))
+        } else {
+            (summary, None)
+        }
     } else if crate::local_freshness_needs_refresh(&summary) {
         crate::wait_for_local_freshness(&project, &inspect_runtime)?
     } else {

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -803,7 +803,7 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
     assert_eq!(preflight["mode"], "local_graph", "{preflight:#}");
     assert_eq!(preflight["local_graph"]["ready"], true, "{preflight:#}");
     assert_eq!(
-        preflight["local_refresh"]["state"], "fresh",
+        preflight["local_refresh"]["state"], "refreshed",
         "{preflight:#}"
     );
     assert_eq!(

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -69,7 +69,7 @@ fn ready_command_emits_compact_verdicts_and_filters_goal() {
     );
     let wait_json: Value = serde_json::from_str(&wait_json_text).expect("ready wait json");
     assert_eq!(wait_json["verdicts"][0]["status"], "ready");
-    assert_eq!(wait_json["local_refresh"]["state"], "fresh");
+    assert_eq!(wait_json["local_refresh"]["state"], "refreshed");
     assert_eq!(wait_json["local_refresh"]["reason"], "already_fresh");
     assert_eq!(
         wait_json["verdicts"][0]["sidecar"]["degraded_reason"], "retrieval_manifest_missing",
@@ -286,7 +286,7 @@ fn helper(value: &str) -> String {
     let wait_json: Value = serde_json::from_str(&wait_json_text).expect("wait fresh json");
     assert_eq!(wait_json["verdicts"][0]["status"], "ready");
     assert_eq!(wait_json["verdicts"][0]["index"]["status"], "fresh");
-    assert_eq!(wait_json["local_refresh"]["state"], "fresh");
+    assert_eq!(wait_json["local_refresh"]["state"], "refreshed");
     assert_eq!(wait_json["local_refresh"]["reason"], "refreshed");
     assert_eq!(
         wait_json["verdicts"][0]["sidecar"]["retrieval_mode"],

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2295,7 +2295,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     );
     assert_eq!(
         status["local_refresh"]["state"],
-        json!("fresh"),
+        json!("refreshed"),
         "fresh local graph state should be explicit even when sidecar retrieval is unavailable: {status}"
     );
     assert_eq!(
@@ -2384,7 +2384,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     );
     assert_eq!(
         status["runtime_truth"]["readiness_lanes"]["local_graph"]["refresh_state"],
-        json!("fresh"),
+        json!("refreshed"),
         "runtime truth should include local refresh state: {status}"
     );
     assert_eq!(
@@ -2733,6 +2733,15 @@ fn tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting()
         "Qdrant finalize",
     );
     assert!(status_path.exists(), "repair status fixture should exist");
+    thread::sleep(Duration::from_millis(25));
+    fs::write(
+        fixture.workspace.path().join("src").join("runtime.rs"),
+        r#"pub fn normalize_project(project_name: &str) -> String {
+    format!("active-repair:{project_name}")
+}
+"#,
+    )
+    .expect("make local graph stale while active repair is running");
     let mut server = spawn_stdio_server(&fixture);
 
     let status_response = send_json(
@@ -2757,6 +2766,35 @@ fn tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting()
         setup["active_repair"]["run_id"],
         json!(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
         "{setup}"
+    );
+    let status_resource = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-status-active-resource",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let status_result = assert_success_envelope(
+        &status_resource,
+        json!("sidecar-setup-status-active-resource"),
+    );
+    let status = json_resource_content(status_result, "codestory://status");
+    assert_eq!(
+        status["local_refresh"]["state"],
+        json!("refreshing"),
+        "active repair should compact stale local refresh chatter into a refreshing lane: {status}"
+    );
+    assert_eq!(
+        status["local_refresh"]["reason"],
+        json!("active_ready_repair:Qdrant finalize"),
+        "{status}"
+    );
+    assert_eq!(
+        status["effective_index_freshness"]["status"],
+        json!("stale"),
+        "maintainer JSON should still expose stale freshness detail while agent status stays compact: {status}"
     );
 
     let repair_response = send_json(
@@ -2838,7 +2876,7 @@ fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
         status["effective_index_freshness"]["status"],
         json!("stale")
     );
-    assert_eq!(status["local_refresh"]["state"], json!("stale"));
+    assert_eq!(status["local_refresh"]["state"], json!("skipped"));
     assert_eq!(
         status["local_refresh"]["blocks_local_surfaces"],
         json!(true)
@@ -3164,7 +3202,7 @@ fn tool_calls_block_all_surfaces_when_active_cli_is_stale() {
 }
 
 #[test]
-fn resources_read_status_refreshes_long_lived_stale_index_with_bounded_latency() {
+fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded_latency() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);
     let warmup = send_json(


### PR DESCRIPTION
## Context

Closes #756
Refs #752
Refs #716

Agent-facing readiness/status output used local index states (`fresh`, `stale`, `not_checked`, `skipped_locked`) as the `local_refresh.state` vocabulary. That leaked freshness implementation detail into every agent packet and made active repair states harder to scan.

## What Changed

- Replaced `LocalRefreshState` with the compact refresh vocabulary: `refreshing`, `refreshed`, `skipped`, `failed`.
- Kept stale/not-checked details in readiness and freshness JSON while using `skipped` for compact agent-facing refresh state.
- Made `codestory://status` report `refreshing` with the active ready-repair phase when local freshness needs work but an agent repair is already active.
- Renamed the stdio refresh contract so the documented `background_local_refresh` verification filter runs a real test.
- Updated ready, agent preflight, stdio, and golden-path expectations plus the `Unreleased` changelog.

```mermaid
flowchart LR
    A["local freshness evidence"] --> B["debug JSON counts and samples"]
    A --> C["compact local_refresh state"]
    C --> D["refreshed"]
    C --> E["refreshing"]
    C --> F["skipped"]
    C --> G["failed"]
    B --> H["maintainer diagnosis"]
```

## How To Review

- Start with `crates/codestory-cli/src/readiness.rs` for the new shared state vocabulary.
- Check `crates/codestory-cli/src/stdio_transport.rs` for the active ready-repair `refreshing` branch.
- Review `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the debug JSON preservation and active-repair coverage.

## Verification

- `cargo test -p codestory-cli --test stdio_protocol_contracts background_local_refresh`
- `cargo test -p codestory-cli --test stdio_protocol_contracts tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting -- --exact`
- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls -- --exact`
- `cargo test -p codestory-cli --test ready_command`
- `cargo test -p codestory-cli readiness`
- `cargo test -p codestory-cli --test cli_golden_path agent_preflight_reports_local_graph_when_retrieval_is_degraded -- --exact`
- `cargo fmt --check`
- `git diff --check`
- `git diff --cached --check`

## Risk

Medium-low. This intentionally changes the serialized `local_refresh.state` contract, so downstream consumers expecting `fresh`/`stale` must use the new compact vocabulary. Detailed freshness status remains available under readiness/index freshness JSON.
