### PR TITLE
Add local refresh single-flight lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Compacted local-refresh status across ready, agent preflight, and
   `codestory://status` so agent-facing output uses refreshed/refreshing/skipped
   states while maintainer JSON keeps stale freshness details.
+- Added a project-scoped single-flight lock/status for local refresh so
+  concurrent Codex/plugin processes report refreshing or skipped_locked instead
+  of launching duplicate incremental indexing.
 
 ### Documentation
 

--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -1,0 +1,433 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const LOCAL_REFRESH_STATUS_FILE: &str = "local-refresh-status.json";
+const LOCAL_REFRESH_LOCK_FILE: &str = "local-refresh.lock";
+const LOCAL_REFRESH_STATUS_SCHEMA_VERSION: u32 = 1;
+const LOCAL_REFRESH_STATUS_TTL: Duration = Duration::from_secs(30);
+const LOCAL_REFRESH_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct LocalRefreshStatus {
+    pub(crate) schema_version: u32,
+    pub(crate) status: String,
+    pub(crate) project_root: String,
+    pub(crate) phase: String,
+    pub(crate) pid: u32,
+    pub(crate) started_at_epoch_ms: i64,
+    pub(crate) updated_at_epoch_ms: i64,
+    #[serde(default)]
+    pub(crate) last_failure_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct LocalRefreshLockFile {
+    schema_version: u32,
+    project_root: String,
+    pid: u32,
+    started_at_epoch_ms: i64,
+    token: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalRefreshBusy {
+    pub(crate) status: Option<LocalRefreshStatus>,
+    pub(crate) lock_path: PathBuf,
+    pub(crate) pid: Option<u32>,
+    pub(crate) started_at_epoch_ms: Option<i64>,
+}
+
+#[derive(Debug)]
+pub(crate) enum LocalRefreshLockAttempt {
+    Acquired(LocalRefreshLock),
+    Busy(LocalRefreshBusy),
+}
+
+#[derive(Debug)]
+pub(crate) struct LocalRefreshLock {
+    path: PathBuf,
+    token: String,
+    pid: u32,
+    started_at_epoch_ms: i64,
+}
+
+impl Drop for LocalRefreshLock {
+    fn drop(&mut self) {
+        let Some(lock) = read_local_refresh_lock_file(&self.path) else {
+            return;
+        };
+        if lock.token == self.token {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub(crate) fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
+impl LocalRefreshLock {
+    pub(crate) fn started_at_epoch_ms(&self) -> i64 {
+        self.started_at_epoch_ms
+    }
+
+    pub(crate) fn pid(&self) -> u32 {
+        self.pid
+    }
+}
+
+pub(crate) fn try_acquire_local_refresh_lock(
+    cache_root: &Path,
+    project_root: &Path,
+) -> Result<LocalRefreshLockAttempt> {
+    let path = local_refresh_lock_path(cache_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let started_at_epoch_ms = now_epoch_ms();
+    let pid = std::process::id();
+    let token = format!("{pid}:{started_at_epoch_ms}");
+    let lock = LocalRefreshLockFile {
+        schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
+        project_root: clean_path_text(project_root),
+        pid,
+        started_at_epoch_ms,
+        token: token.clone(),
+    };
+    let content = serde_json::to_vec_pretty(&lock)?;
+
+    match create_local_refresh_lock_file(&path, &content) {
+        Ok(()) => {
+            return Ok(LocalRefreshLockAttempt::Acquired(LocalRefreshLock {
+                path,
+                token,
+                pid,
+                started_at_epoch_ms,
+            }));
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    if let Some(status) = active_local_refresh_status(cache_root, project_root) {
+        return Ok(LocalRefreshLockAttempt::Busy(LocalRefreshBusy {
+            status: Some(status),
+            lock_path: path,
+            pid: None,
+            started_at_epoch_ms: None,
+        }));
+    }
+
+    let existing = read_local_refresh_lock_file(&path);
+    if !local_refresh_lock_file_is_stale(&path) {
+        return Ok(LocalRefreshLockAttempt::Busy(LocalRefreshBusy {
+            status: None,
+            lock_path: path,
+            pid: existing.as_ref().map(|lock| lock.pid),
+            started_at_epoch_ms: existing.as_ref().map(|lock| lock.started_at_epoch_ms),
+        }));
+    }
+
+    let _ = fs::remove_file(&path);
+    match create_local_refresh_lock_file(&path, &content) {
+        Ok(()) => Ok(LocalRefreshLockAttempt::Acquired(LocalRefreshLock {
+            path,
+            token,
+            pid,
+            started_at_epoch_ms,
+        })),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            let existing = read_local_refresh_lock_file(&path);
+            Ok(LocalRefreshLockAttempt::Busy(LocalRefreshBusy {
+                status: active_local_refresh_status(cache_root, project_root),
+                lock_path: path,
+                pid: existing.as_ref().map(|lock| lock.pid),
+                started_at_epoch_ms: existing.as_ref().map(|lock| lock.started_at_epoch_ms),
+            }))
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(crate) fn write_local_refresh_status(
+    cache_root: &Path,
+    project_root: &Path,
+    status: &str,
+    phase: &str,
+    started_at_epoch_ms: i64,
+    pid: u32,
+    last_failure_reason: Option<String>,
+) -> Result<()> {
+    let path = local_refresh_status_path(cache_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let status = LocalRefreshStatus {
+        schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
+        status: status.to_string(),
+        project_root: clean_path_text(project_root),
+        phase: phase.to_string(),
+        pid,
+        started_at_epoch_ms,
+        updated_at_epoch_ms: now_epoch_ms(),
+        last_failure_reason,
+    };
+    Ok(fs::write(path, serde_json::to_string_pretty(&status)?)?)
+}
+
+pub(crate) fn active_local_refresh_status(
+    cache_root: &Path,
+    project_root: &Path,
+) -> Option<LocalRefreshStatus> {
+    let now = now_epoch_ms();
+    read_local_refresh_status(&local_refresh_status_path(cache_root), project_root, now)
+}
+
+pub(crate) fn local_refresh_status_cache_fingerprint(cache_root: &Path) -> String {
+    [
+        local_refresh_status_path(cache_root),
+        local_refresh_lock_path(cache_root),
+    ]
+    .into_iter()
+    .map(|path| path_fingerprint(&path))
+    .collect::<Vec<_>>()
+    .join(";")
+}
+
+fn create_local_refresh_lock_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(content)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn local_refresh_status_path(cache_root: &Path) -> PathBuf {
+    cache_root.join(LOCAL_REFRESH_STATUS_FILE)
+}
+
+fn local_refresh_lock_path(cache_root: &Path) -> PathBuf {
+    cache_root.join(LOCAL_REFRESH_LOCK_FILE)
+}
+
+fn local_refresh_lock_file_is_stale(path: &Path) -> bool {
+    let now = now_epoch_ms();
+    if let Some(lock) = read_local_refresh_lock_file(path) {
+        return now.saturating_sub(lock.started_at_epoch_ms)
+            > LOCAL_REFRESH_LOCK_STALE_TTL.as_millis() as i64;
+    }
+    fs::metadata(path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|modified| {
+            let modified_ms = modified.as_millis().min(i64::MAX as u128) as i64;
+            now.saturating_sub(modified_ms) > LOCAL_REFRESH_LOCK_STALE_TTL.as_millis() as i64
+        })
+        .unwrap_or(true)
+}
+
+fn read_local_refresh_status(
+    path: &Path,
+    project_root: &Path,
+    now_epoch_ms: i64,
+) -> Option<LocalRefreshStatus> {
+    let status = read_local_refresh_status_file(path)?;
+    if status.schema_version != LOCAL_REFRESH_STATUS_SCHEMA_VERSION
+        || status.status != "refreshing"
+        || !same_path_text(Path::new(&status.project_root), project_root)
+    {
+        return None;
+    }
+    let age_ms = now_epoch_ms.saturating_sub(status.updated_at_epoch_ms);
+    if age_ms > LOCAL_REFRESH_STATUS_TTL.as_millis() as i64 {
+        return None;
+    }
+    Some(status)
+}
+
+fn read_local_refresh_status_file(path: &Path) -> Option<LocalRefreshStatus> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+}
+
+fn read_local_refresh_lock_file(path: &Path) -> Option<LocalRefreshLockFile> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+}
+
+fn clean_path_text(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+}
+
+fn same_path_text(left: &Path, right: &Path) -> bool {
+    clean_path_text(left) == clean_path_text(right)
+}
+
+fn path_fingerprint(path: &Path) -> String {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            let modified_ms = metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_millis())
+                .unwrap_or_default();
+            format!("{}:{}:{}", path.display(), metadata.len(), modified_ms)
+        }
+        Err(_) => format!("{}:missing", path.display()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_refresh_lock_is_single_flight_and_reports_owner() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+
+        let lock = match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("first lock attempt")
+        {
+            LocalRefreshLockAttempt::Acquired(lock) => lock,
+            LocalRefreshLockAttempt::Busy(busy) => {
+                panic!(
+                    "first lock should be acquired, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        };
+
+        match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("second lock attempt")
+        {
+            LocalRefreshLockAttempt::Busy(busy) => {
+                assert!(busy.status.is_none());
+                assert_eq!(busy.pid, Some(std::process::id()));
+                assert!(busy.started_at_epoch_ms.is_some());
+                assert!(busy.lock_path.exists());
+            }
+            LocalRefreshLockAttempt::Acquired(_) => panic!("second lock must not be acquired"),
+        }
+
+        drop(lock);
+        match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("third lock attempt")
+        {
+            LocalRefreshLockAttempt::Acquired(_) => {}
+            LocalRefreshLockAttempt::Busy(busy) => {
+                panic!(
+                    "lock should be reusable after drop, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn local_refresh_lock_busy_prefers_active_status_phase() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let _lock = match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("first lock attempt")
+        {
+            LocalRefreshLockAttempt::Acquired(lock) => lock,
+            LocalRefreshLockAttempt::Busy(busy) => {
+                panic!(
+                    "first lock should be acquired, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        };
+        write_local_refresh_status(
+            cache.path(),
+            project.path(),
+            "refreshing",
+            "incremental_index",
+            now_epoch_ms(),
+            4242,
+            None,
+        )
+        .expect("write refresh status");
+
+        match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("second lock attempt")
+        {
+            LocalRefreshLockAttempt::Busy(busy) => {
+                let status = busy.status.expect("active status");
+                assert_eq!(status.phase, "incremental_index");
+                assert_eq!(status.pid, 4242);
+            }
+            LocalRefreshLockAttempt::Acquired(_) => panic!("second lock must not be acquired"),
+        }
+    }
+
+    #[test]
+    fn local_refresh_lock_reclaims_stale_file_and_expires_status() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let old_started = now_epoch_ms() - LOCAL_REFRESH_LOCK_STALE_TTL.as_millis() as i64 - 1_000;
+        fs::write(
+            local_refresh_lock_path(cache.path()),
+            serde_json::to_string(&LocalRefreshLockFile {
+                schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
+                project_root: clean_path_text(project.path()),
+                pid: 4242,
+                started_at_epoch_ms: old_started,
+                token: "stale".to_string(),
+            })
+            .expect("lock json"),
+        )
+        .expect("write stale lock");
+        fs::write(
+            local_refresh_status_path(cache.path()),
+            serde_json::to_string(&LocalRefreshStatus {
+                schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
+                status: "refreshing".to_string(),
+                project_root: clean_path_text(project.path()),
+                phase: "incremental_index".to_string(),
+                pid: 4242,
+                started_at_epoch_ms: old_started,
+                updated_at_epoch_ms: now_epoch_ms()
+                    - LOCAL_REFRESH_STATUS_TTL.as_millis() as i64
+                    - 1_000,
+                last_failure_reason: None,
+            })
+            .expect("status json"),
+        )
+        .expect("write stale status");
+
+        assert!(
+            active_local_refresh_status(cache.path(), project.path()).is_none(),
+            "stale refresh status must not block future refresh"
+        );
+        match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("stale lock attempt")
+        {
+            LocalRefreshLockAttempt::Acquired(_) => {}
+            LocalRefreshLockAttempt::Busy(busy) => {
+                panic!(
+                    "stale lock should be reclaimed, got busy at {:?}",
+                    busy.lock_path
+                )
+            }
+        }
+    }
+}

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -48,6 +48,7 @@ mod display;
 mod drill_targeting;
 mod explore;
 mod http_transport;
+mod local_refresh_status;
 mod managed_embeddings;
 mod output;
 mod query_resolution;
@@ -2197,10 +2198,71 @@ pub(crate) fn wait_for_local_freshness(
         return Ok((summary, Some(output)));
     }
 
+    let lock = match local_refresh_status::try_acquire_local_refresh_lock(
+        &inspect_runtime.cache_root,
+        &inspect_runtime.project_root,
+    )? {
+        local_refresh_status::LocalRefreshLockAttempt::Acquired(lock) => lock,
+        local_refresh_status::LocalRefreshLockAttempt::Busy(busy) => {
+            let mut output = local_refresh_output_from_summary(&summary);
+            output.state = if busy.status.is_some() {
+                readiness::LocalRefreshState::Refreshing
+            } else {
+                readiness::LocalRefreshState::Skipped
+            };
+            output.blocks_local_surfaces = true;
+            output.readiness_status = ReadinessStatusDto::RepairIndex;
+            output.reason = Some(if busy.status.is_some() {
+                "refreshing".to_string()
+            } else {
+                "skipped_locked".to_string()
+            });
+            if let Some(status) = busy.status {
+                output.phase = Some(status.phase);
+                output.pid = Some(status.pid);
+                output.started_at_epoch_ms = Some(status.started_at_epoch_ms);
+                output.updated_at_epoch_ms = Some(status.updated_at_epoch_ms);
+                output.last_failure_reason = status.last_failure_reason;
+            } else {
+                output.pid = busy.pid;
+                output.started_at_epoch_ms = busy.started_at_epoch_ms;
+            }
+            output.lock_path = Some(display::clean_path_string(
+                &busy.lock_path.to_string_lossy(),
+            ));
+            return Ok((summary, Some(output)));
+        }
+    };
+    let refresh_started_at_epoch_ms = lock.started_at_epoch_ms();
+    let refresh_pid = lock.pid();
+    let refresh_phase = "incremental_index";
+    local_refresh_status::write_local_refresh_status(
+        &inspect_runtime.cache_root,
+        &inspect_runtime.project_root,
+        "refreshing",
+        refresh_phase,
+        refresh_started_at_epoch_ms,
+        refresh_pid,
+        None,
+    )?;
+
     let index_runtime = RuntimeContext::new(project)?;
     match index_runtime.ensure_open(args::RefreshMode::Incremental) {
         Ok(opened) => {
+            let _ = local_refresh_status::write_local_refresh_status(
+                &inspect_runtime.cache_root,
+                &inspect_runtime.project_root,
+                "refreshed",
+                refresh_phase,
+                refresh_started_at_epoch_ms,
+                refresh_pid,
+                None,
+            );
             let mut output = local_refresh_output_from_summary(&opened.summary);
+            output.phase = Some(refresh_phase.to_string());
+            output.pid = Some(refresh_pid);
+            output.started_at_epoch_ms = Some(refresh_started_at_epoch_ms);
+            output.updated_at_epoch_ms = Some(local_refresh_status::now_epoch_ms());
             if output.state == readiness::LocalRefreshState::Refreshed {
                 output.reason = Some("refreshed".to_string());
             } else {
@@ -2211,11 +2273,26 @@ pub(crate) fn wait_for_local_freshness(
             Ok((opened.summary, Some(output)))
         }
         Err(error) => {
+            let error_text = error.to_string();
+            let _ = local_refresh_status::write_local_refresh_status(
+                &inspect_runtime.cache_root,
+                &inspect_runtime.project_root,
+                "failed",
+                refresh_phase,
+                refresh_started_at_epoch_ms,
+                refresh_pid,
+                Some(error_text.clone()),
+            );
             let mut output = local_refresh_output_from_summary(&summary);
             output.state = classify_local_refresh_failure_state(&error);
             output.blocks_local_surfaces = true;
             output.readiness_status = ReadinessStatusDto::RepairIndex;
-            output.reason = Some(error.to_string());
+            output.reason = Some(error_text.clone());
+            output.phase = Some(refresh_phase.to_string());
+            output.pid = Some(refresh_pid);
+            output.started_at_epoch_ms = Some(refresh_started_at_epoch_ms);
+            output.updated_at_epoch_ms = Some(local_refresh_status::now_epoch_ms());
+            output.last_failure_reason = Some(error_text);
             Ok((summary, Some(output)))
         }
     }

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -60,6 +60,18 @@ pub(crate) struct LocalRefreshOutput {
     pub(crate) readiness_status: ReadinessStatusDto,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) started_at_epoch_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) updated_at_epoch_ms: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) lock_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) last_failure_reason: Option<String>,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub(crate) changed_file_count: u32,
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -205,6 +217,12 @@ pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefres
         blocks_local_surfaces: verdict.status != ReadinessStatusDto::Ready,
         readiness_status: verdict.status,
         reason,
+        phase: None,
+        pid: None,
+        started_at_epoch_ms: None,
+        updated_at_epoch_ms: None,
+        lock_path: None,
+        last_failure_reason: None,
         changed_file_count: index
             .map(|index| index.changed_file_count)
             .unwrap_or_default(),

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2256,6 +2256,12 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
             )
         ),
         format!(
+            "local_refresh_state:{}",
+            crate::local_refresh_status::local_refresh_status_cache_fingerprint(
+                &runtime.cache_root
+            )
+        ),
+        format!(
             "source_state:{}",
             stdio_source_fingerprint(&runtime.project_root)
         ),


### PR DESCRIPTION
## Context

Closes #757.
Refs #752.
Refs #716.

Local graph refresh could be triggered by multiple Codex/plugin processes for the same checkout. The existing ready-repair lock protected sidecar repair, but the local incremental refresh path still let concurrent processes race into duplicate indexing or SQLite contention.

```mermaid
flowchart LR
    A["status or ready sees stale local graph"] --> B["try local-refresh.lock"]
    B -->|acquired| C["write refreshing status"]
    C --> D["run incremental index"]
    D --> E["write refreshed or failed status"]
    B -->|busy| F["return refreshing or skipped_locked"]
```

## What Changed

- Added a cache-root local refresh lock/status file with create-new acquisition, TTL stale-lock recovery, owner pid/start metadata, phase, and last-failure status.
- Wrapped `wait_for_local_freshness` so `ready --wait-fresh` and `codestory://status` share the same single-flight local refresh guard.
- Added optional local refresh metadata fields to readiness JSON and included the local refresh lock/status fingerprint in the stdio status cache key.
- Updated `CHANGELOG.md` under Unreleased.

## How To Review

- Start in `crates/codestory-cli/src/local_refresh_status.rs` for the lock/status contract and TTL behavior.
- Then read `wait_for_local_freshness` in `crates/codestory-cli/src/main.rs` to confirm the lock wraps the shared incremental refresh path.
- Check `crates/codestory-cli/src/stdio_transport.rs` to confirm status cache invalidates when lock/status files change.

## Verification

- `cargo test -p codestory-cli local_refresh_lock`
- `cargo test -p codestory-cli ready_repair_status`
- `cargo test -p codestory-cli --test stdio_protocol_contracts background_local_refresh`
- `cargo test -p codestory-cli --test ready_command`
- `cargo fmt --check`
- `git diff --check`
- Live smoke against a temp project/cache with a held `local-refresh.lock` and active `local-refresh-status.json`: `ready --goal local --wait-fresh` returned `local_refresh.state=refreshing`, `reason=refreshing`, `phase=incremental_index`, owner pid, `blocks_local_surfaces=true`, and `readiness_status=repair_index`.

## Risk

- The lock is cache-root scoped. Normal cache roots are project-scoped; an explicit shared `--cache-dir` will serialize all local refreshes using that cache, which is safer than duplicate indexing.
