### PR TITLE
Bound stdio ground freshness waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Added a project-scoped single-flight lock/status for local refresh so
   concurrent Codex/plugin processes report refreshing or skipped_locked instead
   of launching duplicate incremental indexing.
+- Bounded stdio/MCP local-refresh waits so `ground` returns compact
+  `local_refresh` repair guidance instead of consuming the full tool timeout on
+  stale indexes.
 
 ### Documentation
 

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -24,6 +24,8 @@ use std::fs::{self, File};
 use std::io::{BufRead, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
 use std::time::{Duration as StdDuration, SystemTime, UNIX_EPOCH};
 
 use crate::args;
@@ -48,6 +50,7 @@ use std::time::{Duration, Instant};
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
+const STDIO_LOCAL_REFRESH_FOREGROUND_BUDGET: Duration = Duration::from_secs(5);
 const STDIO_SOURCE_FINGERPRINT_FILE_CAP: usize = 25_000;
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
 const STDIO_CLI_VERSION_TIMEOUT: Duration = Duration::from_secs(3);
@@ -416,6 +419,7 @@ fn stdio_tool_blocked_error(
         "status": surface.get("status").cloned().unwrap_or(serde_json::Value::Null),
         "failed_layer": surface.get("failed_layer").cloned().unwrap_or(serde_json::Value::Null),
         "repair_reason": surface.get("repair_reason").cloned().unwrap_or(serde_json::Value::Null),
+        "local_refresh": status.get("local_refresh").cloned().unwrap_or(serde_json::Value::Null),
         "minimum_next": stdio_repair_calls_from_value(surface.get("minimum_next")),
         "full_repair": stdio_repair_calls_from_value(surface.get("full_repair")),
         "setup": verdict.and_then(|verdict| verdict.get("setup")).cloned().unwrap_or(serde_json::Value::Null),
@@ -2213,7 +2217,7 @@ fn read_stdio_status_resource_cached(
             (summary, None)
         }
     } else if crate::local_freshness_needs_refresh(&summary) {
-        crate::wait_for_local_freshness(&project, &inspect_runtime)?
+        wait_for_stdio_local_freshness(&project, &summary)?
     } else {
         (summary, None)
     };
@@ -2226,6 +2230,66 @@ fn read_stdio_status_resource_cached(
         cached_at: Instant::now(),
     });
     Ok(value)
+}
+
+fn wait_for_stdio_local_freshness(
+    project: &args::ProjectArgs,
+    summary: &ProjectSummary,
+) -> Result<(ProjectSummary, Option<crate::readiness::LocalRefreshOutput>)> {
+    let (tx, rx) = mpsc::channel();
+    let project = project.clone();
+    thread::spawn(move || {
+        let result = RuntimeContext::new_inspect_only(&project).and_then(|inspect_runtime| {
+            crate::wait_for_local_freshness(&project, &inspect_runtime)
+        });
+        let _ = tx.send(result);
+    });
+
+    let budget = stdio_local_refresh_foreground_budget();
+    if budget.is_zero() {
+        return Ok((
+            summary.clone(),
+            Some(stdio_local_refresh_timeout_output(summary)),
+        ));
+    }
+
+    match rx.recv_timeout(budget) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok((
+            summary.clone(),
+            Some(stdio_local_refresh_timeout_output(summary)),
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let mut output = crate::local_refresh_output_from_summary(summary);
+            output.state = crate::readiness::LocalRefreshState::Failed;
+            output.blocks_local_surfaces = true;
+            output.readiness_status = ReadinessStatusDto::RepairIndex;
+            output.reason = Some("refresh_worker_disconnected".to_string());
+            output.updated_at_epoch_ms = Some(crate::local_refresh_status::now_epoch_ms());
+            Ok((summary.clone(), Some(output)))
+        }
+    }
+}
+
+fn stdio_local_refresh_timeout_output(
+    summary: &ProjectSummary,
+) -> crate::readiness::LocalRefreshOutput {
+    let mut output = crate::local_refresh_output_from_summary(summary);
+    output.state = crate::readiness::LocalRefreshState::Refreshing;
+    output.blocks_local_surfaces = true;
+    output.readiness_status = ReadinessStatusDto::RepairIndex;
+    output.reason = Some("refresh_timeout".to_string());
+    output.phase = Some("incremental_index".to_string());
+    output.updated_at_epoch_ms = Some(crate::local_refresh_status::now_epoch_ms());
+    output
+}
+
+fn stdio_local_refresh_foreground_budget() -> Duration {
+    std::env::var("CODESTORY_STDIO_LOCAL_REFRESH_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(STDIO_LOCAL_REFRESH_FOREGROUND_BUDGET)
 }
 
 fn stdio_project_args(runtime: &RuntimeContext) -> args::ProjectArgs {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -17,6 +17,7 @@ struct StdioFixture {
     sidecar_policy_state: Option<String>,
     dirty_marker_path: Option<PathBuf>,
     dirty_marker_project_root: Option<PathBuf>,
+    local_refresh_timeout_ms: Option<u64>,
 }
 
 struct StdioServer {
@@ -177,6 +178,7 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
         sidecar_policy_state: None,
         dirty_marker_path: None,
         dirty_marker_project_root: None,
+        local_refresh_timeout_ms: None,
     }
 }
 
@@ -194,6 +196,7 @@ fn unindexed_fixture() -> StdioFixture {
         sidecar_policy_state: None,
         dirty_marker_path: None,
         dirty_marker_project_root: None,
+        local_refresh_timeout_ms: None,
     }
 }
 
@@ -307,6 +310,12 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
     }
     if let Some(root) = &fixture.dirty_marker_project_root {
         command.env("CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT", root);
+    }
+    if let Some(timeout_ms) = fixture.local_refresh_timeout_ms {
+        command.env(
+            "CODESTORY_STDIO_LOCAL_REFRESH_TIMEOUT_MS",
+            timeout_ms.to_string(),
+        );
     }
     let mut child = command.spawn().expect("spawn stdio server");
 
@@ -3351,6 +3360,98 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
     let result = assert_success_envelope(&refreshed, json!("status-freshness-after-reindex"));
     let refreshed_status = json_resource_content(result, "codestory://status");
     assert_fresh_freshness_counts(&refreshed_status, "codestory://status after reindex");
+}
+
+#[test]
+fn ground_tool_returns_degraded_local_refresh_when_stale_refresh_budget_expires() {
+    let mut fixture = indexed_fixture();
+    fixture.local_refresh_timeout_ms = Some(0);
+
+    thread::sleep(Duration::from_millis(25));
+    fs::write(
+        fixture.workspace.path().join("src").join("runtime.rs"),
+        r#"pub fn normalize_project(project_name: &str) -> String {
+    format!("budget-expired:{project_name}")
+}
+"#,
+    )
+    .expect("modify indexed file after indexing");
+
+    let mut server = spawn_stdio_server(&fixture);
+    let started = Instant::now();
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-refresh-budget-expired",
+            "method": "tools/call",
+            "params": {
+                "name": "ground",
+                "arguments": {"budget": "strict"}
+            }
+        }),
+    );
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "ground should return degraded local-refresh guidance before an MCP tool timeout, got {elapsed:?}: {response}"
+    );
+
+    let error = assert_tool_error(&response, json!("ground-refresh-budget-expired"));
+    assert_eq!(
+        error.pointer("/code").and_then(Value::as_str),
+        Some("codestory_tool_blocked")
+    );
+    assert_eq!(
+        error.pointer("/tool").and_then(Value::as_str),
+        Some("ground")
+    );
+    assert_eq!(
+        error.pointer("/readiness_goal").and_then(Value::as_str),
+        Some("local_navigation")
+    );
+    assert_eq!(
+        error.pointer("/status").and_then(Value::as_str),
+        Some("repair_index")
+    );
+    assert_eq!(
+        error
+            .pointer("/local_refresh/state")
+            .and_then(Value::as_str),
+        Some("refreshing")
+    );
+    assert_eq!(
+        error
+            .pointer("/local_refresh/readiness_status")
+            .and_then(Value::as_str),
+        Some("repair_index")
+    );
+    assert_eq!(
+        error
+            .pointer("/local_refresh/blocks_local_surfaces")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        error
+            .pointer("/local_refresh/reason")
+            .and_then(Value::as_str),
+        Some("refresh_timeout")
+    );
+    assert_ne!(
+        error
+            .pointer("/sidecar/retrieval_mode")
+            .and_then(Value::as_str),
+        Some("full"),
+        "local refresh degradation must not claim packet/search sidecar readiness: {error}"
+    );
+    assert!(
+        error
+            .pointer("/minimum_next")
+            .and_then(Value::as_array)
+            .is_some_and(|commands| !commands.is_empty()),
+        "blocked ground should include compact next-step guidance: {error}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Context

Closes #758
Refs #752
Refs #716

Dogfooding caught `codestory://ground` spending the whole MCP tool timeout when the local index was stale. The status gate now needs to start repair work but return compact guidance when freshness cannot finish quickly.

```mermaid
flowchart LR
  Tool["tools/call: ground"] --> Status["codestory://status gate"]
  Status --> Fresh{"local index fresh?"}
  Fresh -->|yes| Ground["run ground"]
  Fresh -->|stale| Budget["foreground refresh budget"]
  Budget -->|finishes| Ground
  Budget -->|expires| Blocked["tool error with local_refresh"]
  Blocked --> Next["read status / ready local repair guidance"]
```

## What Changed

- Added a bounded stdio local-refresh wait with a five-second default and `CODESTORY_STDIO_LOCAL_REFRESH_TIMEOUT_MS` override.
- Let the refresh worker continue in the background after the foreground budget expires, relying on the existing project-scoped single-flight lock/status.
- Included `local_refresh` details in structured `codestory_tool_blocked` responses.
- Added a stdio contract regression for stale `ground` returning degraded local-refresh guidance before the MCP tool timeout.
- Updated the unreleased changelog before committing.

## How To Review

- Start in `crates/codestory-cli/src/stdio_transport.rs` at `read_stdio_status_resource_cached` and `wait_for_stdio_local_freshness`.
- Check that the timeout path reports local-navigation repair state without claiming full packet/search readiness.
- Review the regression in `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the stale-index/blocked-retrieval contract.

## Verification

- `cargo test -p codestory-cli --test stdio_protocol_contracts ground`
- `cargo test -p codestory-cli --test stdio_protocol_contracts background_local_refresh`
- `cargo test -p codestory-cli --test stdio_protocol_contracts tools_call_local_graph`
- `cargo fmt --check`
- `git diff --check`

## Risk

The timeout path spawns a background refresh worker and returns before it finishes. The single-flight lock should prevent duplicate indexers, but very stale or large repos may continue doing useful repair work after the MCP response has already returned.