### PR TITLE
Refresh local graph in agent preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Bounded stdio/MCP local-refresh waits so `ground` returns compact
   `local_refresh` repair guidance instead of consuming the full tool timeout on
   stale indexes.
+- Let `agent preflight` run one bounded quiet local refresh so repairable stale
+  local indexes report refreshed local graph readiness while packet/search stays
+  fail-closed.
 
 ### Documentation
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -38,7 +38,9 @@ use std::{
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
+        mpsc,
     },
+    thread,
     time::{Duration, Instant},
 };
 
@@ -59,6 +61,8 @@ mod retrieval;
 mod runtime;
 mod stdio_catalog;
 mod stdio_transport;
+
+const AGENT_PREFLIGHT_LOCAL_REFRESH_FOREGROUND_BUDGET: Duration = Duration::from_secs(5);
 
 use args::{
     AffectedChangeSource, AffectedCommand, AffectedStdinFormat, BookmarkAction, BookmarkAddCommand,
@@ -2347,6 +2351,11 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
     preflight_output_file(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     let summary = runtime.open_project_summary()?;
+    let (summary, local_refresh) = if local_freshness_needs_refresh(&summary) {
+        wait_for_agent_preflight_local_freshness(&cmd.project, &summary)?
+    } else {
+        (summary, None)
+    };
     let sidecar = doctor_sidecar_status(&runtime);
     let readiness_sidecar = selected_agent_readiness_sidecar_status(&runtime, None, &sidecar);
     let readiness = build_summary_readiness(
@@ -2357,10 +2366,73 @@ fn run_agent_preflight(cmd: args::AgentPreflightCommand) -> Result<()> {
     );
     let readiness_lanes =
         build_readiness_lanes_for_runtime(&runtime, &readiness, None, Some(&readiness_sidecar));
-    let output =
-        build_agent_preflight_output(&readiness, Path::new(&summary.root), readiness_lanes);
+    let output = build_agent_preflight_output(
+        &readiness,
+        Path::new(&summary.root),
+        readiness_lanes,
+        local_refresh,
+    );
     let markdown = render_agent_preflight_markdown(&output);
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
+fn wait_for_agent_preflight_local_freshness(
+    project: &ProjectArgs,
+    summary: &ProjectSummary,
+) -> Result<(ProjectSummary, Option<readiness::LocalRefreshOutput>)> {
+    let (tx, rx) = mpsc::channel();
+    let project = project.clone();
+    thread::spawn(move || {
+        let result = RuntimeContext::new_inspect_only(&project)
+            .and_then(|runtime| wait_for_local_freshness(&project, &runtime));
+        let _ = tx.send(result);
+    });
+
+    let budget = agent_preflight_local_refresh_foreground_budget();
+    if budget.is_zero() {
+        return Ok((
+            summary.clone(),
+            Some(agent_preflight_local_refresh_timeout_output(summary)),
+        ));
+    }
+
+    match rx.recv_timeout(budget) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Ok((
+            summary.clone(),
+            Some(agent_preflight_local_refresh_timeout_output(summary)),
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let mut output = local_refresh_output_from_summary(summary);
+            output.state = readiness::LocalRefreshState::Failed;
+            output.blocks_local_surfaces = true;
+            output.readiness_status = ReadinessStatusDto::RepairIndex;
+            output.reason = Some("refresh_worker_disconnected".to_string());
+            output.updated_at_epoch_ms = Some(local_refresh_status::now_epoch_ms());
+            Ok((summary.clone(), Some(output)))
+        }
+    }
+}
+
+fn agent_preflight_local_refresh_timeout_output(
+    summary: &ProjectSummary,
+) -> readiness::LocalRefreshOutput {
+    let mut output = local_refresh_output_from_summary(summary);
+    output.state = readiness::LocalRefreshState::Refreshing;
+    output.blocks_local_surfaces = true;
+    output.readiness_status = ReadinessStatusDto::RepairIndex;
+    output.reason = Some("refresh_timeout".to_string());
+    output.phase = Some("incremental_index".to_string());
+    output.updated_at_epoch_ms = Some(local_refresh_status::now_epoch_ms());
+    output
+}
+
+fn agent_preflight_local_refresh_foreground_budget() -> Duration {
+    std::env::var("CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(AGENT_PREFLIGHT_LOCAL_REFRESH_FOREGROUND_BUDGET)
 }
 
 fn repair_ready_state(
@@ -2665,6 +2737,7 @@ fn build_agent_preflight_output(
     readiness: &[codestory_contracts::api::ReadinessVerdictDto],
     project_root: &Path,
     readiness_lanes: BTreeMap<String, ReadinessLaneOutput>,
+    local_refresh: Option<readiness::LocalRefreshOutput>,
 ) -> args::AgentPreflightOutput {
     let local = readiness
         .iter()
@@ -2705,7 +2778,7 @@ fn build_agent_preflight_output(
         usable: local_ready || full_ready,
         mode: mode.to_string(),
         local_graph: agent_preflight_lane(local),
-        local_refresh: readiness::local_refresh_output(local),
+        local_refresh: local_refresh.unwrap_or_else(|| readiness::local_refresh_output(local)),
         full_retrieval: agent_preflight_lane(agent),
         local_default: readiness_lanes
             .get("local_default")
@@ -13251,7 +13324,8 @@ mod tests {
             ),
         );
 
-        let output = build_agent_preflight_output(&verdicts, Path::new("C:/repo"), readiness_lanes);
+        let output =
+            build_agent_preflight_output(&verdicts, Path::new("C:/repo"), readiness_lanes, None);
 
         assert!(output.usable);
         assert_eq!(output.mode, "full_retrieval");

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -880,6 +880,136 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
 }
 
 #[test]
+fn agent_preflight_refreshes_stale_local_graph_before_reporting() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+
+    thread::sleep(Duration::from_millis(25));
+    fs::write(
+        workspace.path().join("src").join("runtime.rs"),
+        r#"pub fn normalize_project(project_name: &str) -> String {
+    format!("preflight-refreshed:{project_name}")
+}
+
+pub fn schedule_index(project_path: &str) -> usize {
+    super::open_project(project_path).len() + 1
+}
+"#,
+    )
+    .expect("modify indexed file after indexing");
+
+    let preflight = run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["agent", "preflight", "--format", "json"],
+    );
+
+    assert_eq!(preflight["usable"], true, "{preflight:#}");
+    assert_eq!(preflight["mode"], "local_graph", "{preflight:#}");
+    assert_eq!(preflight["local_graph"]["ready"], true, "{preflight:#}");
+    assert_eq!(
+        preflight["local_refresh"]["state"], "refreshed",
+        "agent preflight should quietly refresh stale local freshness: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["local_refresh"]["reason"], "refreshed",
+        "agent preflight should report the bounded refresh result: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["local_refresh"]["blocks_local_surfaces"], false,
+        "{preflight:#}"
+    );
+    assert_eq!(
+        preflight["full_retrieval"]["status"], "repair_retrieval",
+        "local refresh must not claim full retrieval readiness: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        "agent packet/search should remain fail-closed without full sidecars: {preflight:#}"
+    );
+    assert!(
+        preflight["blocked_surfaces"]
+            .as_array()
+            .expect("blocked surfaces")
+            .iter()
+            .any(|surface| surface == "packet_full"),
+        "full retrieval surfaces should stay blocked after local refresh: {preflight:#}"
+    );
+}
+
+#[test]
+fn agent_preflight_reports_compact_reason_when_local_refresh_budget_expires() {
+    let workspace = tempdir().expect("workspace dir");
+    let cache_dir = tempdir().expect("cache dir");
+    write_tiny_rust_workspace(workspace.path());
+
+    run_cli_json(
+        workspace.path(),
+        cache_dir.path(),
+        &["index", "--refresh", "full", "--format", "json"],
+    );
+
+    thread::sleep(Duration::from_millis(25));
+    fs::write(
+        workspace.path().join("src").join("runtime.rs"),
+        r#"pub fn normalize_project(project_name: &str) -> String {
+    format!("preflight-timeout:{project_name}")
+}
+
+pub fn schedule_index(project_path: &str) -> usize {
+    super::open_project(project_path).len() + 2
+}
+"#,
+    )
+    .expect("modify indexed file after indexing");
+
+    let preflight = run_cli_json_with_embedding_env(
+        workspace.path(),
+        cache_dir.path(),
+        &["agent", "preflight", "--format", "json"],
+        &[
+            ("CODESTORY_EMBED_RUNTIME_MODE", "hash"),
+            ("CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS", "0"),
+        ],
+    );
+
+    assert_eq!(preflight["usable"], false, "{preflight:#}");
+    assert_eq!(preflight["mode"], "blocked", "{preflight:#}");
+    assert_eq!(preflight["local_graph"]["ready"], false, "{preflight:#}");
+    assert_eq!(
+        preflight["local_refresh"]["state"], "refreshing",
+        "{preflight:#}"
+    );
+    assert_eq!(
+        preflight["local_refresh"]["reason"], "refresh_timeout",
+        "agent preflight should report one compact local refresh reason: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["local_refresh"]["blocks_local_surfaces"], true,
+        "{preflight:#}"
+    );
+    assert!(
+        preflight["blocked_surfaces"]
+            .as_array()
+            .expect("blocked surfaces")
+            .iter()
+            .any(|surface| surface == "ground"),
+        "local graph surfaces should stay blocked when refresh does not finish: {preflight:#}"
+    );
+    assert_eq!(
+        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        "timeout must not escalate into agent sidecar repair or readiness: {preflight:#}"
+    );
+}
+
+#[test]
 fn doctor_reports_current_and_stored_semantic_doc_embedding_contract() {
     let workspace = tempdir().expect("workspace dir");
     let cache_dir = tempdir().expect("cache dir");


### PR DESCRIPTION
## Context

Closes #755
Refs #752
Refs #716

`agent preflight` was still reporting stale local index state directly, even though `ready --goal local --wait-fresh` and stdio status can run one bounded local refresh. That made repairable local freshness gaps show up as repeated agent-context noise before the agent reached the real retrieval truth.

```mermaid
flowchart LR
  Preflight["agent preflight"] --> Inspect["inspect summary"]
  Inspect --> Stale{"local freshness stale?"}
  Stale -->|no| Readiness["build readiness"]
  Stale -->|yes| Budget["bounded local refresh"]
  Budget -->|refreshed| Readiness
  Budget -->|timeout / lock / failure| Blocked["compact local_refresh reason"]
  Blocked --> Readiness
  Readiness --> Output["safe + blocked surfaces"]
```

## What Changed

- Added a five-second bounded local-refresh attempt to `agent preflight`, with `CODESTORY_AGENT_PREFLIGHT_LOCAL_REFRESH_TIMEOUT_MS` for deterministic tests or operator overrides.
- Rebuilds preflight readiness from the refreshed summary when local incremental refresh succeeds.
- Carries the actual `local_refresh` result into the preflight output so refreshed, timeout, and worker-disconnected states are visible.
- Added golden tests for stale local graph refresh success and zero-budget compact fail-closed reporting.
- Updated the unreleased changelog before committing.

## How To Review

- Start in `crates/codestory-cli/src/main.rs` at `run_agent_preflight` and `wait_for_agent_preflight_local_freshness`.
- Check that this path only calls the local freshness refresh helper and does not start sidecar bootstrap or full agent repair.
- Review `crates/codestory-cli/tests/cli_golden_path.rs` for both refreshed and timeout/fail-closed preflight contracts.

## Verification

- `cargo test -p codestory-cli --test cli_golden_path agent_preflight`
- `cargo test -p codestory-cli ready_command`
- `cargo test -p codestory-cli --test stdio_protocol_contracts local_refresh`
- `cargo fmt --check`
- `git diff --check`

## Risk

The timeout path uses a short-lived worker thread to cap foreground wait time. In the CLI process, work that does not finish before process exit should be treated only as attempted repair, so the output stays blocked and reports `local_refresh.reason` instead of implying background completion.