### PR TITLE
Surface non-default active repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Let `agent preflight` run one bounded quiet local refresh so repairable stale
   local indexes report refreshed local graph readiness while packet/search stays
   fail-closed.
+- Surfaced non-default active agent repairs in stdio status and `sidecar_setup`
+  so MCP repair does not spawn a duplicate shared-agent repair for the same
+  project.
 
 ### Documentation
 

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2202,10 +2202,8 @@ fn read_stdio_status_resource_cached(
     let project = stdio_project_args(runtime);
     let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
     let summary = inspect_runtime.open_project_summary()?;
-    let active_agent_repair = crate::ready_repair_status::active_ready_repair_status(
-        &runtime.project_root,
-        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-    );
+    let active_agent_repair =
+        crate::ready_repair_status::active_ready_repair_status(&runtime.project_root, None);
     let (summary, local_refresh) = if let Some(active_repair) = active_agent_repair.as_ref() {
         if crate::local_freshness_needs_refresh(&summary) {
             let mut output = crate::local_refresh_output_from_summary(&summary);
@@ -3443,10 +3441,7 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
     );
     let next_repair_command =
         env_nonempty("CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND").unwrap_or(default_repair);
-    let active_repair = crate::ready_repair_status::active_ready_repair_status(
-        project_root,
-        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-    );
+    let active_repair = crate::ready_repair_status::active_ready_repair_status(project_root, None);
     serde_json::json!({
         "state": state,
         "auto_repair": auto_repair,
@@ -3561,10 +3556,13 @@ fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
 }
 
 fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
-    if let Some(status) = crate::ready_repair_status::active_ready_repair_status(
-        &runtime.project_root,
-        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-    ) {
+    if let Some(status) =
+        crate::ready_repair_status::active_ready_repair_status(&runtime.project_root, None)
+    {
+        let run_id = status
+            .run_id
+            .as_deref()
+            .unwrap_or(codestory_retrieval::DEFAULT_AGENT_RUN_ID);
         return serde_json::json!({
             "result": {
                 "status": "already_running",
@@ -3577,7 +3575,7 @@ fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
                 "next_status_command": format!(
                     "codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}",
                     crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
-                    codestory_retrieval::DEFAULT_AGENT_RUN_ID
+                    run_id
                 ),
                 "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
             }

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2840,6 +2840,113 @@ fn tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting()
 }
 
 #[test]
+fn tools_call_sidecar_setup_reports_active_agent_repair_non_default_without_spawning_default() {
+    let fixture = indexed_fixture();
+    let run_id = "non-default-active";
+    let (status_path, _cleanup) =
+        write_active_repair_status_fixture(&fixture, run_id, "Embedding documents");
+    assert!(status_path.exists(), "repair status fixture should exist");
+    thread::sleep(Duration::from_millis(25));
+    fs::write(
+        fixture.workspace.path().join("src").join("runtime.rs"),
+        r#"pub fn normalize_project(project_name: &str) -> String {
+    format!("non-default-active-repair:{project_name}")
+}
+"#,
+    )
+    .expect("make local graph stale while non-default active repair is running");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let status_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-status-non-default-active",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "status"}
+            }
+        }),
+    );
+    let setup = assert_tool_success(
+        &status_response,
+        json!("sidecar-setup-status-non-default-active"),
+    );
+    assert_eq!(
+        setup["active_repair"]["run_id"],
+        json!(run_id),
+        "sidecar_setup status should surface non-default active repair lanes: {setup}"
+    );
+    assert!(
+        setup["next_repair_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("ready --goal agent --repair")
+                && command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+                && !command.contains(run_id)),
+        "normal repair command should remain shared-agent when no user action is taken: {setup}"
+    );
+
+    let status_resource = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-status-non-default-resource",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let status_result = assert_success_envelope(
+        &status_resource,
+        json!("sidecar-setup-status-non-default-resource"),
+    );
+    let status = json_resource_content(status_result, "codestory://status");
+    assert_eq!(
+        status["local_refresh"]["reason"],
+        json!("active_ready_repair:Embedding documents"),
+        "status should not start local refresh while any project agent repair is active: {status}"
+    );
+    assert_eq!(
+        status["sidecar_setup"]["active_repair"]["run_id"],
+        json!(run_id),
+        "runtime truth should expose the non-default active repair: {status}"
+    );
+
+    let repair_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-repair-non-default-active",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "repair"}
+            }
+        }),
+    );
+    let repair = assert_tool_success(
+        &repair_response,
+        json!("sidecar-setup-repair-non-default-active"),
+    );
+    assert_eq!(
+        repair["status"],
+        json!("already_running"),
+        "sidecar_setup repair should not spawn shared-agent while another run_id is active: {repair}"
+    );
+    assert_eq!(repair["run_id"], json!(run_id), "{repair}");
+    assert!(
+        repair["next_status_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval status")
+                && command.contains("--profile agent")
+                && command.contains("--run-id")
+                && command.contains(run_id)
+                && !command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)),
+        "already-running response should inspect the active non-default run: {repair}"
+    );
+}
+
+#[test]
 fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
     let mut fixture = indexed_fixture();
     let marker_path = write_dirty_marker_fixture(


### PR DESCRIPTION
## Context

Closes #749
Refs #716

Stdio status and `sidecar_setup` were checking only the default `shared-agent` ready-repair status. A repair running with a non-default `--run-id` could be invisible to MCP setup surfaces, allowing `sidecar_setup repair` to start a duplicate default repair for the same project.

```mermaid
flowchart LR
  Setup["sidecar_setup"] --> Active{"any project agent repair?"}
  Active -->|yes| Report["already_running + active run_id"]
  Active -->|no| Default["start shared-agent repair"]
  Status["codestory://status"] --> Active
```

## What Changed

- Switched stdio status local-refresh suppression to detect any active agent repair for the project.
- Switched `sidecar_setup status` to surface non-default active agent repairs.
- Switched `sidecar_setup repair` to return `already_running` for a non-default active repair instead of spawning `shared-agent`.
- Kept the normal next repair command on `shared-agent` when no repair is active.
- Added stdio contract coverage for the non-default active repair case.
- Updated the unreleased changelog before committing.

## How To Review

- Start in `crates/codestory-cli/src/stdio_transport.rs` and confirm the active repair lookups use the project-wide scan.
- Review the new stdio test to confirm the default repair command is preserved when idle while active non-default repairs block duplicate repair startup.

## Verification

- `cargo test -p codestory-cli --test stdio_protocol_contracts active_agent_repair`
- `cargo test -p codestory-cli ready_repair_status`
- `cargo fmt --check`
- `git diff --check`

## Risk

Project-wide repair detection picks the most recently updated active repair status. If two status files are alive at once, MCP setup reports the freshest one and avoids launching another repair, which is the conservative behavior for this lane.