### PR TITLE
Use agent lane in Codex setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Surfaced non-default active agent repairs in stdio status and `sidecar_setup`
   so MCP repair does not spawn a duplicate shared-agent repair for the same
   project.
+- Moved Codex worktree setup from local/default retrieval bootstrap/index steps
+  to the shared agent readiness lane used by MCP packet/search.
 
 ### Documentation
 

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -102,6 +102,23 @@ function Invoke-DoctorJson {
     return ($json | ConvertFrom-Json)
 }
 
+function Get-AgentReadyRepairArguments {
+    param([string]$ProjectPath)
+
+    return @(
+        "ready",
+        "--goal",
+        "agent",
+        "--repair",
+        "--project",
+        $ProjectPath,
+        "--format",
+        "json",
+        "--run-id",
+        "shared-agent"
+    )
+}
+
 function Invoke-GitText {
     param([string[]]$Arguments)
 
@@ -529,6 +546,9 @@ function Invoke-SelfTest {
         Assert-SelfTest ((Get-RemoteHeadRefName "codex/issue-670-handoff-proof-target") -eq "refs/heads/codex/issue-670-handoff-proof-target") "plain branch refs should map to ls-remote heads"
         Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $false) -eq "base:origin/dev/codestory-next + pr-head:origin/pr-branch") "PR proof target should default to base plus PR head"
         Assert-SelfTest ((Get-ProofTarget "origin/dev/codestory-next" "origin/pr-branch" $true) -eq "branch-head:origin/pr-branch") "branch-head proof should be explicit"
+        $agentRepairArgs = Get-AgentReadyRepairArguments $projectRoot
+        Assert-SelfTest (($agentRepairArgs -join " ") -match "ready --goal agent --repair") "setup should repair the agent readiness lane"
+        Assert-SelfTest (($agentRepairArgs -join " ") -match "--run-id shared-agent") "setup should target the shared agent run id"
     } finally {
         $env:CODESTORY_HOME = $oldCodeStoryHome
         $env:CODESTORY_CLI = $oldCodeStoryCli
@@ -635,12 +655,8 @@ try {
         Invoke-Checked $cli @("index", "--project", $projectPath, "--refresh", "auto")
     }
 
-    Invoke-SetupStep "Bootstrap retrieval sidecars" {
-        Invoke-Checked $cli @("retrieval", "bootstrap", "--project", $projectPath, "--wait-secs", "90")
-    } -Optional
-
-    Invoke-SetupStep "Refresh retrieval sidecar index" {
-        Invoke-Checked $cli @("retrieval", "index", "--project", $projectPath, "--refresh", "auto")
+    Invoke-SetupStep "Repair agent sidecar readiness" {
+        Invoke-Checked $cli (Get-AgentReadyRepairArguments $projectPath)
     } -Optional
 
     Invoke-SetupStep "Doctor readiness handoff" {


### PR DESCRIPTION
## Context

Closes #745
Refs #716

Codex worktree setup still prepared local/default retrieval sidecars directly, while MCP packet/search readiness uses the shared agent run id. That could make setup fight over local/default state or make the handoff inspect a different lane than the one MCP uses.

```mermaid
flowchart LR
  Setup["codex-worktree-setup.ps1"] --> Index["local graph refresh"]
  Index --> Agent["ready --goal agent --repair"]
  Agent --> Shared["--run-id shared-agent"]
  Shared --> Doctor["doctor handoff summary"]
```

## What Changed

- Added `Get-AgentReadyRepairArguments` to centralize the Codex setup repair command shape.
- Replaced local/default `retrieval bootstrap` plus `retrieval index` setup steps with `ready --goal agent --repair --run-id shared-agent`.
- Added self-test assertions that the setup script repairs the agent readiness lane and uses the shared agent run id.
- Updated the unreleased changelog before committing.

## How To Review

- Review `scripts/codex-worktree-setup.ps1` around `Get-AgentReadyRepairArguments` and the setup step sequence.
- Confirm setup still refreshes the local graph first, then prepares the same agent lane that MCP packet/search uses.

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/codex-worktree-setup.ps1 -SelfTest`
- `git diff --check`

## Risk

This changes Codex worktree setup from local/default sidecar preparation to agent readiness repair. It should reduce cross-project local/default contention, but it means setup now relies on the broader `ready --goal agent --repair` path for sidecar bootstrap and retrieval indexing.