### PR TITLE
[codex] surface abandoned repair status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - Serialized first-boot agent sidecar port allocation through a cache-backed
   registry so concurrent namespaces do not choose duplicate dynamic ports before
   state files exist.
+- Reported stale ready-repair status as abandoned sidecar work in MCP status
+  with bounded inspect and cleanup commands instead of hiding aborted repairs.
 
 ### Documentation
 

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -15,6 +15,7 @@ const READY_REPAIR_LOCK_FILE: &str = "ready-repair.lock";
 const READY_REPAIR_PROJECT_LOCK_FILE: &str = "ready-repair-project.lock";
 const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
 const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
+const READY_REPAIR_ABANDONED_STATUS_TTL: Duration = Duration::from_secs(15 * 60);
 const READY_REPAIR_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -223,6 +224,17 @@ pub(crate) fn active_ready_repair_status(
         .max_by_key(|status| status.updated_at_epoch_ms)
 }
 
+pub(crate) fn abandoned_ready_repair_status(
+    project_root: &Path,
+    run_id: Option<&str>,
+) -> Option<ReadyRepairStatus> {
+    let now = now_epoch_ms();
+    ready_repair_status_paths(project_root, run_id)
+        .into_iter()
+        .filter_map(|path| read_abandoned_ready_repair_status(&path, project_root, now))
+        .max_by_key(|status| status.updated_at_epoch_ms)
+}
+
 pub(crate) fn ready_repair_status_cache_fingerprint(project_root: &Path) -> String {
     ready_repair_status_paths(project_root, None)
         .into_iter()
@@ -302,6 +314,28 @@ fn read_ready_repair_status(
     }
     let age_ms = now_epoch_ms.saturating_sub(status.updated_at_epoch_ms);
     if age_ms > READY_REPAIR_STATUS_TTL.as_millis() as i64 {
+        return None;
+    }
+    Some(status)
+}
+
+fn read_abandoned_ready_repair_status(
+    path: &Path,
+    project_root: &Path,
+    now_epoch_ms: i64,
+) -> Option<ReadyRepairStatus> {
+    let status = read_ready_repair_status_file(path)?;
+    if status.schema_version != READY_REPAIR_STATUS_SCHEMA_VERSION
+        || status.status != "repairing"
+        || status.profile != SidecarProfile::Agent.as_str()
+        || !same_path_text(Path::new(&status.project_root), project_root)
+    {
+        return None;
+    }
+    let age_ms = now_epoch_ms.saturating_sub(status.updated_at_epoch_ms);
+    if age_ms <= READY_REPAIR_STATUS_TTL.as_millis() as i64
+        || age_ms > READY_REPAIR_ABANDONED_STATUS_TTL.as_millis() as i64
+    {
         return None;
     }
     Some(status)

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3442,6 +3442,11 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
     let next_repair_command =
         env_nonempty("CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND").unwrap_or(default_repair);
     let active_repair = crate::ready_repair_status::active_ready_repair_status(project_root, None);
+    let abandoned_repair = active_repair
+        .as_ref()
+        .is_none()
+        .then(|| crate::ready_repair_status::abandoned_ready_repair_status(project_root, None))
+        .flatten();
     serde_json::json!({
         "state": state,
         "auto_repair": auto_repair,
@@ -3479,8 +3484,54 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
             "phase": &status.phase,
             "pid": status.pid,
             "updated_at_epoch_ms": status.updated_at_epoch_ms
-        }))
+        })),
+        "abandoned_repair": abandoned_repair.as_ref().map(|status| stdio_ready_repair_status_json(project_root, status, "abandoned"))
     })
+}
+
+fn stdio_ready_repair_status_json(
+    project_root: &Path,
+    status: &crate::ready_repair_status::ReadyRepairStatus,
+    state: &str,
+) -> serde_json::Value {
+    let run_id = status
+        .run_id
+        .as_deref()
+        .unwrap_or(codestory_retrieval::DEFAULT_AGENT_RUN_ID);
+    serde_json::json!({
+        "status": state,
+        "recorded_status": &status.status,
+        "project_root": &status.project_root,
+        "profile": &status.profile,
+        "run_id": &status.run_id,
+        "namespace": &status.namespace,
+        "phase": &status.phase,
+        "pid": status.pid,
+        "updated_at_epoch_ms": status.updated_at_epoch_ms,
+        "age_ms": crate::ready_repair_status::now_epoch_ms().saturating_sub(status.updated_at_epoch_ms),
+        "inspect_command": stdio_agent_retrieval_status_command(project_root, run_id),
+        "cleanup_command": stdio_agent_retrieval_down_command(project_root, run_id)
+    })
+}
+
+fn stdio_agent_retrieval_status_command(project_root: &Path, run_id: &str) -> String {
+    format!(
+        "codestory-cli retrieval status --project {} --profile agent --run-id {} --format json",
+        crate::display::quote_command_argument_value(&crate::display::clean_path_string(
+            &project_root.to_string_lossy()
+        )),
+        crate::display::quote_command_argument_value(run_id)
+    )
+}
+
+fn stdio_agent_retrieval_down_command(project_root: &Path, run_id: &str) -> String {
+    format!(
+        "codestory-cli retrieval down --project {} --profile agent --run-id {}",
+        crate::display::quote_command_argument_value(&crate::display::clean_path_string(
+            &project_root.to_string_lossy()
+        )),
+        crate::display::quote_command_argument_value(run_id)
+    )
 }
 
 fn stdio_sidecar_policy_file() -> Option<serde_json::Value> {
@@ -3577,6 +3628,17 @@ fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
                     crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
                     run_id
                 ),
+                "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
+            }
+        });
+    }
+    if let Some(status) =
+        crate::ready_repair_status::abandoned_ready_repair_status(&runtime.project_root, None)
+    {
+        return serde_json::json!({
+            "result": {
+                "status": "abandoned_repair",
+                "abandoned_repair": stdio_ready_repair_status_json(&runtime.project_root, &status, "abandoned"),
                 "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
             }
         });

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -727,6 +727,32 @@ fn write_active_repair_status_fixture(
     run_id: &str,
     phase: &str,
 ) -> (PathBuf, RemoveDirOnDrop) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_millis() as i64;
+    write_repair_status_fixture(fixture, run_id, phase, now)
+}
+
+fn write_abandoned_repair_status_fixture(
+    fixture: &StdioFixture,
+    run_id: &str,
+    phase: &str,
+) -> (PathBuf, RemoveDirOnDrop) {
+    let updated_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_millis() as i64
+        - 60_000;
+    write_repair_status_fixture(fixture, run_id, phase, updated_at)
+}
+
+fn write_repair_status_fixture(
+    fixture: &StdioFixture,
+    run_id: &str,
+    phase: &str,
+    updated_at_epoch_ms: i64,
+) -> (PathBuf, RemoveDirOnDrop) {
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
     let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
@@ -743,10 +769,6 @@ fn write_active_repair_status_fixture(
         .expect("repair status parent")
         .to_path_buf();
     fs::create_dir_all(&status_dir).expect("create repair status dir");
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time")
-        .as_millis() as i64;
     let project_root = canonical_root
         .to_string_lossy()
         .trim_start_matches(r"\\?\")
@@ -765,8 +787,8 @@ fn write_active_repair_status_fixture(
             "compose_project": sidecar.compose_project,
             "phase": phase,
             "pid": 4242,
-            "started_at_epoch_ms": now,
-            "updated_at_epoch_ms": now
+            "started_at_epoch_ms": updated_at_epoch_ms,
+            "updated_at_epoch_ms": updated_at_epoch_ms
         })
         .to_string(),
     )
@@ -2535,6 +2557,74 @@ fn resources_read_status_reports_active_agent_repair_phase() {
                 && command.contains("--run-id")
                 && command.contains("issue-661-proof")),
         "repairing lane should point at status proof, not a second repair: {status}"
+    );
+}
+
+#[test]
+fn resources_read_status_reports_abandoned_agent_repair_actions() {
+    let fixture = indexed_fixture();
+    let (status_path, _cleanup) =
+        write_abandoned_repair_status_fixture(&fixture, "aborted-run", "Embedding documents");
+    assert!(status_path.exists(), "repair status fixture should exist");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-abandoned-repair",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-abandoned-repair"));
+    let status = json_resource_content(result, "codestory://status");
+    assert_eq!(status["sidecar_setup"]["active_repair"], Value::Null);
+    assert_eq!(
+        status["sidecar_setup"]["abandoned_repair"]["status"],
+        json!("abandoned"),
+        "{status}"
+    );
+    assert_eq!(
+        status["sidecar_setup"]["abandoned_repair"]["run_id"],
+        json!("aborted-run"),
+        "{status}"
+    );
+    assert!(
+        status["sidecar_setup"]["abandoned_repair"]["inspect_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval status")
+                && command.contains("--run-id")
+                && command.contains("aborted-run")),
+        "abandoned repair should include a bounded inspect command: {status}"
+    );
+    assert!(
+        status["sidecar_setup"]["abandoned_repair"]["cleanup_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval down")
+                && command.contains("--run-id")
+                && command.contains("aborted-run")),
+        "abandoned repair should include an explicit cleanup command: {status}"
+    );
+
+    let repair_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-repair-abandoned",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "repair"}
+            }
+        }),
+    );
+    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair-abandoned"));
+    assert_eq!(repair["status"], json!("abandoned_repair"), "{repair}");
+    assert_eq!(
+        repair["abandoned_repair"]["cleanup_command"],
+        status["sidecar_setup"]["abandoned_repair"]["cleanup_command"],
+        "{repair}"
     );
 }
 


### PR DESCRIPTION
## Context

Interrupted Codex/plugin work can leave CodeStory ready-repair status files behind after the active TTL expires. Before this change, fresh `codestory://status` reads stopped reporting those stale records, which made aborted repair/search work look the same as no known work.

Closes #751
Refs #716
Refs #738
Refs #743

## What Changed

- Added a stale-but-recent `abandoned_ready_repair_status` reader beside the existing active repair reader.
- Exposed abandoned repair records through `sidecar_setup.abandoned_repair` with inspect and cleanup commands.
- Made `sidecar_setup` repair return `abandoned_repair` instead of spawning another repair when stale repair work is still known.
- Added a stdio regression covering stale/abandoned repair status without live sidecars.
- Updated `CHANGELOG.md`.

```mermaid
flowchart LR
    A["ready-repair status file"] --> B{"updated <= 30s?"}
    B -- yes --> C["active_repair"]
    B -- no --> D{"updated <= 15m?"}
    D -- yes --> E["abandoned_repair"]
    D -- no --> F["no known repair"]
    E --> G["inspect + cleanup commands"]
```

## How To Review

- Start in `crates/codestory-cli/src/ready_repair_status.rs` for the stale status boundary.
- Check `crates/codestory-cli/src/stdio_transport.rs` for the `sidecar_setup` response shape and repair-action guard.
- Review `resources_read_status_reports_abandoned_agent_repair_actions` in `crates/codestory-cli/tests/stdio_protocol_contracts.rs` for the acceptance path.

## Verification

- `cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_abandoned_agent_repair_actions`
- `cargo test -p codestory-cli --test stdio_protocol_contracts active_agent_repair`
- `cargo test -p codestory-cli ready_repair_status`
- `cargo test -p codestory-cli --test stdio_protocol_contracts -- --nocapture`
- `cargo check -p codestory-cli`
- `cargo fmt --check`
- `git diff --check`

## Risk

Low. This is read-only status reconciliation plus an explicit repair-action guard; it does not kill processes or manage generic Codex child processes. Abandoned repair records older than the bounded window still disappear as no known repair.
