### PR TITLE
[codex] smoke packaged release archives

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -585,6 +585,8 @@ def run_gate(args: argparse.Namespace) -> None:
         require_version(version_artifact.read_text(encoding="utf-8"), args.expected_version, archive, version_artifact)
         summary["artifacts"]["version"] = str(version_artifact)
         write_json(out_dir / "summary.json", summary)
+        if args.version_only:
+            return
 
         local_bootstrap_artifact = out_dir / "local-retrieval-bootstrap.json"
         run_command(
@@ -946,9 +948,19 @@ def self_test() -> None:
             expected_version="9.9.9",
             plugin_root=None,
             timeout_secs=30,
+            version_only=False,
         )
         run_gate(args)
         assert (out_dir / "summary.json").is_file()
+
+        version_only_out = root / "version-only-out"
+        version_only_args = argparse.Namespace(**vars(args))
+        version_only_args.out_dir = str(version_only_out)
+        version_only_args.version_only = True
+        run_gate(version_only_args)
+        version_only_summary = read_json_file(version_only_out / "summary.json")
+        assert version_only_summary["artifacts"].keys() == {"version"}
+        assert not (version_only_out / "local-retrieval-bootstrap.json").exists()
 
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "search"
         try:
@@ -1060,6 +1072,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--expected-version", help="Expected codestory-cli version in the archive.")
     parser.add_argument("--plugin-root", help="Plugin root to smoke through scripts/codestory-mcp.cjs.")
     parser.add_argument("--timeout-secs", type=int, default=1800, help="Per-layer timeout.")
+    parser.add_argument(
+        "--version-only",
+        action="store_true",
+        help="Only unpack the archive and verify codestory-cli --version.",
+    )
     parser.add_argument("--self-test", action="store_true", help="Run script self-tests.")
     args = parser.parse_args()
     if not args.self_test and not args.archive:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,15 @@ jobs:
             --binary "$bin" \
             --out-dir target/release-dist
 
+      - name: Smoke packaged release asset
+        if: runner.os != 'Windows'
+        run: |
+          python .github/scripts/check-packaged-agent-proof.py \
+            --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --expected-version "${{ needs.preflight.outputs.version }}" \
+            --version-only \
+            --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
+
       - name: Fetch retrieval embedding model
         if: matrix.asset_target == 'linux-x64'
         run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
@@ -206,6 +215,16 @@ jobs:
             --target "${{ matrix.asset_target }}" `
             --binary $bin `
             --out-dir target/release-dist
+
+      - name: Smoke packaged release asset on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python .github/scripts/check-packaged-agent-proof.py `
+            --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.zip" `
+            --expected-version "${{ needs.preflight.outputs.version }}" `
+            --version-only `
+            --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
 
       - name: Upload release asset
         uses: actions/upload-artifact@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   with bounded inspect and cleanup commands instead of hiding aborted repairs.
 - Skipped oversized parser-backed source files before reading their full body
   while persisting a nonfatal incomplete-file indexing error.
+- Smoked every release matrix archive after packaging by unpacking it and
+  verifying packaged `codestory-cli --version` before upload.
 
 ### Documentation
 


### PR DESCRIPTION
## Context

Release packaging already smoked the built binary before archive creation, and Linux x64 ran full packaged sidecar proof after archive creation. Issue #726 asks for every release matrix archive to be unpacked after packaging and for packaged `codestory-cli --version` to succeed from each asset.

## What Changed

- Added `--version-only` mode to `.github/scripts/check-packaged-agent-proof.py` so release jobs can reuse the safe archive extraction and version validation without running Linux-only sidecar proof.
- Added release workflow smoke steps after tar.gz packaging for non-Windows targets and after zip packaging for Windows targets.
- Kept full sidecar packaged proof Linux x64-only, after the lightweight packaged archive smoke.
- Updated the unreleased changelog.

```mermaid
flowchart LR
    A[Build matrix binary] --> B[Package archive]
    B --> C[Unpack packaged asset]
    C --> D[codestory-cli --version]
    D --> E[Upload archive]
    D -->|linux-x64 only| F[Full sidecar proof]
```

## How To Review

- Review `.github/workflows/release.yml` around the build job package/upload sequence.
- Review `.github/scripts/check-packaged-agent-proof.py` for the `--version-only` early return after archive unpack and version validation.
- Confirm Windows uses `.zip`, non-Windows uses `.tar.gz`, and Linux x64 still keeps full sidecar proof.

## Verification

- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `python -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

## Risk

This is workflow-only proof expansion. It does not run a full release dry run locally; final live proof is the next release workflow exercising every matrix asset.

Closes #726
Refs #716