### PR TITLE
[codex] pin post-publish smoke to release tag

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -996,6 +996,16 @@ def self_test() -> None:
         else:
             raise AssertionError("plugin manifest version mismatch should fail the gate")
 
+        plugin_drift_args = argparse.Namespace(**vars(args))
+        plugin_drift_args.plugin_root = str(plugin_root)
+        try:
+            run_gate(plugin_drift_args)
+        except GateFailure as exc:
+            assert exc.layer == "plugin_manifest"
+            assert exc.artifact == plugin_manifest
+        else:
+            raise AssertionError("plugin-root drift should fail the packaged proof gate")
+
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "doctor_stderr"
         try:
             try:

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
       - name: Normalize release version
         id: release
         shell: bash
@@ -33,6 +30,11 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.release.outputs.tag }}
 
       - name: Download published Linux asset
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   while persisting a nonfatal incomplete-file indexing error.
 - Smoked every release matrix archive after packaging by unpacking it and
   verifying packaged `codestory-cli --version` before upload.
+- Pinned the manual post-publish release smoke checkout to the requested release
+  tag so older release proofs do not drift with the current branch.
 
 ### Documentation
 


### PR DESCRIPTION
## Context

Manual post-publish release smoke accepted a version input but checked out the workflow's current ref before proving the published archive. That could make an older release smoke fail because the current checkout's plugin manifest drifted away from the requested release version.

## What Changed

- Normalize the workflow input before checkout.
- Checkout `v<version>` through `steps.release.outputs.tag` before downloading/proving the published asset.
- Added packaged-proof self-test coverage that fails through the `plugin_root` gate when the checked-out plugin manifest version does not match the requested release.
- Updated the unreleased changelog.

```mermaid
flowchart LR
    A[Manual version input] --> B[Normalize version/tag]
    B --> C[Checkout requested tag]
    C --> D[Download published asset]
    D --> E[Packaged proof]
    C --> F[Plugin manifest matches tag]
```

## How To Review

- Review `.github/workflows/post-publish-release-smoke.yml` to confirm checkout happens after normalization and uses the requested tag.
- Review `.github/scripts/check-packaged-agent-proof.py` self-test for the mismatched `plugin_root` manifest fixture.

## Verification

- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `python -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

## Risk

This is workflow-only. It has not executed a live manual post-publish smoke; the next manual workflow run will be the end-to-end proof against an actual release tag.

Closes #727
Refs #716