### PR TITLE
[codex] narrow owner alias candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
   verifying packaged `codestory-cli --version` before upload.
 - Pinned the manual post-publish release smoke checkout to the requested release
   tag so older release proofs do not drift with the current branch.
+- Narrowed owner-alias call resolution through exact/suffix candidate maps so
+  repeated owner-qualified member calls avoid scanning every candidate node.
 
 ### Documentation
 

--- a/crates/codestory-bench/benches/resolution_full_scope.rs
+++ b/crates/codestory-bench/benches/resolution_full_scope.rs
@@ -7,6 +7,8 @@ const FILE_COUNT: usize = 140;
 const CALLERS_PER_FILE: usize = 22;
 const CALL_EDGES_PER_CALLER: usize = 8;
 const IMPORT_EDGES_PER_FILE: usize = 12;
+const OWNER_ALIAS_CALL_COUNT: usize = 2_000;
+const OWNER_ALIAS_NOISE_NODE_COUNT: usize = 8_000;
 
 const CALL_TARGETS: &[&str] = &[
     "run", "save", "persist", "notify", "track", "compute", "helper", "build",
@@ -27,6 +29,17 @@ fn bench_resolution_full_scope(c: &mut Criterion) {
         b.iter(|| {
             reset_resolution_columns(&storage).expect("failed to reset resolution");
             resolver.run(&mut storage).expect("resolution pass failed");
+        })
+    });
+
+    let mut owner_alias_storage = build_owner_alias_benchmark_storage()
+        .expect("failed to seed owner-alias benchmark storage");
+    c.bench_function("resolution_owner_alias_member_calls", |b| {
+        b.iter(|| {
+            reset_resolution_columns(&owner_alias_storage).expect("failed to reset resolution");
+            resolver
+                .run(&mut owner_alias_storage)
+                .expect("resolution pass failed");
         })
     });
 }
@@ -204,6 +217,110 @@ fn build_benchmark_storage() -> anyhow::Result<Storage> {
             });
             edge_id += 1;
         }
+    }
+
+    storage.insert_nodes_batch(&nodes)?;
+    storage.insert_edges_batch(&edges)?;
+    Ok(storage)
+}
+
+fn build_owner_alias_benchmark_storage() -> anyhow::Result<Storage> {
+    let mut storage = Storage::new_in_memory()?;
+    let mut nodes = Vec::new();
+    let mut edges = Vec::new();
+    let mut node_id = 1_i64;
+    let mut edge_id = 1_i64;
+
+    let file_id = node_id;
+    node_id += 1;
+    nodes.push(Node {
+        id: NodeId(file_id),
+        kind: NodeKind::FILE,
+        serialized_name: "/bench/owner_alias.rs".to_string(),
+        qualified_name: None,
+        canonical_id: None,
+        file_node_id: None,
+        start_line: Some(1),
+        start_col: Some(1),
+        end_line: Some(1),
+        end_col: Some(1),
+    });
+
+    nodes.push(Node {
+        id: NodeId(node_id),
+        kind: NodeKind::METHOD,
+        serialized_name: "Storage.open".to_string(),
+        qualified_name: Some("crate::Storage::open".to_string()),
+        canonical_id: None,
+        file_node_id: Some(NodeId(file_id)),
+        start_line: Some(2),
+        start_col: Some(1),
+        end_line: Some(2),
+        end_col: Some(20),
+    });
+    node_id += 1;
+
+    for idx in 0..OWNER_ALIAS_NOISE_NODE_COUNT {
+        nodes.push(Node {
+            id: NodeId(node_id),
+            kind: NodeKind::FUNCTION,
+            serialized_name: format!("Noise{idx}.unrelated"),
+            qualified_name: Some(format!("crate::Noise{idx}::unrelated")),
+            canonical_id: None,
+            file_node_id: Some(NodeId(file_id)),
+            start_line: Some((10 + idx) as u32),
+            start_col: Some(1),
+            end_line: Some((10 + idx) as u32),
+            end_col: Some(20),
+        });
+        node_id += 1;
+    }
+
+    let caller_id = node_id;
+    node_id += 1;
+    nodes.push(Node {
+        id: NodeId(caller_id),
+        kind: NodeKind::FUNCTION,
+        serialized_name: "caller".to_string(),
+        qualified_name: Some("crate::caller".to_string()),
+        canonical_id: None,
+        file_node_id: Some(NodeId(file_id)),
+        start_line: Some(20_000),
+        start_col: Some(1),
+        end_line: Some(20_000),
+        end_col: Some(20),
+    });
+
+    for idx in 0..OWNER_ALIAS_CALL_COUNT {
+        let target_id = node_id;
+        node_id += 1;
+        nodes.push(Node {
+            id: NodeId(target_id),
+            kind: NodeKind::UNKNOWN,
+            serialized_name: "open".to_string(),
+            qualified_name: None,
+            canonical_id: None,
+            file_node_id: Some(NodeId(file_id)),
+            start_line: Some((21_000 + idx) as u32),
+            start_col: Some(1),
+            end_line: Some((21_000 + idx) as u32),
+            end_col: Some(8),
+        });
+        edges.push(Edge {
+            id: EdgeId(edge_id),
+            source: NodeId(caller_id),
+            target: NodeId(target_id),
+            kind: EdgeKind::CALL,
+            file_node_id: Some(NodeId(file_id)),
+            line: Some((21_000 + idx) as u32),
+            resolved_source: None,
+            resolved_target: None,
+            confidence: None,
+            certainty: None,
+            callsite_identity: Some("receiver-owner:Store".to_string()),
+            candidate_targets: Vec::new(),
+        });
+        edge_id += 1;
     }
 
     storage.insert_nodes_batch(&nodes)?;

--- a/crates/codestory-indexer/src/resolution/mod.rs
+++ b/crates/codestory-indexer/src/resolution/mod.rs
@@ -2239,9 +2239,13 @@ impl CandidateIndex {
         let key = (name.to_string(), name_ascii_lower.to_string());
         self.cached_lookup(&self.global_owner_alias_cache, key, || {
             let (requested_owner, requested_member) = split_owner_member_name(name)?;
+            let offsets = self.owner_member_candidate_offsets(requested_owner, requested_member);
             let mut selected = None;
             let mut ambiguous = false;
-            for node in &self.nodes {
+            for offset in offsets {
+                let Some(node) = self.nodes.get(offset) else {
+                    continue;
+                };
                 let Some((candidate_owner, candidate_member)) =
                     split_owner_member_name(&node.serialized_name)
                 else {
@@ -2261,6 +2265,39 @@ impl CandidateIndex {
             }
             (!ambiguous).then_some(selected).flatten()
         })
+    }
+
+    fn owner_member_candidate_offsets(&self, owner_name: &str, method_name: &str) -> Vec<usize> {
+        let method_name_ascii_lower = method_name.to_ascii_lowercase();
+        let owner_dot_name = format!("{owner_name}.{method_name}");
+        let owner_colon_name = format!("{owner_name}::{method_name}");
+        let owner_dot_name_ascii_lower = owner_dot_name.to_ascii_lowercase();
+        let owner_colon_name_ascii_lower = owner_colon_name.to_ascii_lowercase();
+        let mut offsets = Vec::new();
+        if let Some(exact) = self.exact_map.get(method_name) {
+            offsets.extend(exact.iter().copied());
+        }
+        if let Some(exact) = self.exact_map.get(&owner_dot_name) {
+            offsets.extend(exact.iter().copied());
+        }
+        if let Some(exact) = self.exact_map.get(&owner_colon_name) {
+            offsets.extend(exact.iter().copied());
+        }
+        if let Some(suffix) = self.suffix_map_ascii_lower.get(&method_name_ascii_lower) {
+            offsets.extend(suffix.iter().copied());
+        }
+        if let Some(suffix) = self.suffix_map_ascii_lower.get(&owner_dot_name_ascii_lower) {
+            offsets.extend(suffix.iter().copied());
+        }
+        if let Some(suffix) = self
+            .suffix_map_ascii_lower
+            .get(&owner_colon_name_ascii_lower)
+        {
+            offsets.extend(suffix.iter().copied());
+        }
+        offsets.sort_unstable();
+        offsets.dedup();
+        offsets
     }
 
     #[cfg(test)]
@@ -3338,6 +3375,42 @@ mod tests {
                 "Client",
                 "client",
             ),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn test_owner_alias_lookup_uses_member_candidate_offsets() {
+        let mut nodes = (0..250)
+            .map(|idx| CandidateNode {
+                id: 10_000 + idx,
+                file_node_id: Some(1),
+                file_path: None,
+                normalized_file_path: None,
+                serialized_name: format!("Noise{idx}.unrelated"),
+                serialized_name_ascii_lower: format!("noise{idx}.unrelated"),
+                qualified_name: None,
+            })
+            .collect::<Vec<_>>();
+        nodes.push(CandidateNode {
+            id: 42,
+            file_node_id: Some(1),
+            file_path: None,
+            normalized_file_path: None,
+            serialized_name: "Storage.open".to_string(),
+            serialized_name_ascii_lower: "storage.open".to_string(),
+            qualified_name: None,
+        });
+        let index = CandidateIndex::from_nodes(nodes);
+
+        let offsets = index.owner_member_candidate_offsets("Store", "open");
+        assert_eq!(
+            offsets.len(),
+            1,
+            "owner alias lookup should narrow to member candidates before alias filtering"
+        );
+        assert_eq!(
+            index.find_global_unique_owner_alias_readonly("Store.open", "store.open"),
             Some(42)
         );
     }


### PR DESCRIPTION
## Context

Issue #729 found that owner-alias call resolution could scan every candidate node for each uncached owner-qualified receiver/member key. Large repos with repeated `receiver-owner` calls paid that full scan before alias filtering.

## What Changed

- Narrowed `find_global_unique_owner_alias_readonly` through exact and suffix candidate maps before owner-alias filtering.
- Added a unit test proving `Store.open` -> `Storage.open` alias resolution only considers the member candidate set despite unrelated noise nodes.
- Added a Criterion benchmark case for repeated owner-qualified/member-call resolution.
- Updated the unreleased changelog.

```mermaid
flowchart LR
    A[Store.open lookup] --> B[Exact and suffix maps]
    B --> C[Small member candidate set]
    C --> D[Owner alias filter]
    D --> E[Unique Storage.open match]
```

## How To Review

- Start with `CandidateIndex::find_global_unique_owner_alias_readonly` in `crates/codestory-indexer/src/resolution/mod.rs`.
- Check `owner_member_candidate_offsets` for exact/suffix map coverage of method, dot-qualified, and `::`-qualified names.
- Review `resolution_owner_alias_member_calls` in `crates/codestory-bench/benches/resolution_full_scope.rs` for the repeated receiver-owner shape.

## Verification

- `cargo test -p codestory-indexer resolution --lib`
- `cargo bench -p codestory-bench --bench resolution_full_scope -- --warm-up-time 1 --measurement-time 2`
  - `resolution_full_scope`: 298.19 ms to 302.40 ms
  - `resolution_owner_alias_member_calls`: 64.164 ms to 67.001 ms
- `cargo fmt --check`
- `git diff --check`

## Risk

The alias lookup now depends on candidates being reachable through existing exact/suffix maps. That matches the intended indexed lookup path, and the new unit test covers the alias case with many unrelated nodes.

Closes #729
Refs #716