### PR TITLE
Normalize release archive packaging

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -9,6 +9,7 @@ const violations = [];
 const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
 const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
 const rustCi = path.join(workflowRoot, "rust-ci.yml");
+const releaseWorkflow = path.join(workflowRoot, "release.yml");
 
 for (const file of fs
   .readdirSync(workflowRoot)
@@ -105,6 +106,18 @@ if (!fs.existsSync(rustCi)) {
     if (!content.includes(snippet)) {
       violations.push(`rust-ci.yml must include ${snippet}`);
     }
+  }
+}
+
+if (!fs.existsSync(releaseWorkflow)) {
+  violations.push("release.yml must exist for release automation");
+} else {
+  const content = fs.readFileSync(releaseWorkflow, "utf8");
+  if (!content.includes('RELEASE_RUST_TOOLCHAIN: "1.95.0"')) {
+    violations.push("release.yml must pin RELEASE_RUST_TOOLCHAIN to 1.95.0");
+  }
+  if (content.includes("rustup toolchain install stable")) {
+    violations.push("release.yml release builds must not install floating stable Rust");
   }
 }
 

--- a/.github/scripts/package-codestory-release.py
+++ b/.github/scripts/package-codestory-release.py
@@ -2,12 +2,16 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import hashlib
 import shutil
+import stat
 import tarfile
 import tempfile
 import zipfile
 from pathlib import Path
+
+NORMALIZED_MTIME = 315532800  # 1980-01-01T00:00:00Z, valid for zip and tar.
 
 
 def copy_required_file(root: Path, relative: str, destination_root: Path) -> None:
@@ -33,12 +37,44 @@ def archive_zip(source_dir: Path, archive_path: Path) -> None:
     with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for path in sorted(source_dir.rglob("*")):
             if path.is_file():
-                archive.write(path, path.relative_to(source_dir.parent).as_posix())
+                info = zipfile.ZipInfo(
+                    path.relative_to(source_dir.parent).as_posix(),
+                    date_time=(1980, 1, 1, 0, 0, 0),
+                )
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.create_system = 3
+                info.external_attr = normalized_file_mode(path) << 16
+                archive.writestr(info, path.read_bytes())
 
 
 def archive_tar_gz(source_dir: Path, archive_path: Path) -> None:
-    with tarfile.open(archive_path, "w:gz") as archive:
-        archive.add(source_dir, arcname=source_dir.name)
+    with archive_path.open("wb") as raw:
+        with gzip.GzipFile(
+            filename="", mode="wb", fileobj=raw, mtime=NORMALIZED_MTIME
+        ) as gzip_file:
+            with tarfile.open(fileobj=gzip_file, mode="w") as archive:
+                for path in [source_dir, *sorted(source_dir.rglob("*"))]:
+                    info = archive.gettarinfo(
+                        str(path), arcname=path.relative_to(source_dir.parent).as_posix()
+                    )
+                    info.mtime = NORMALIZED_MTIME
+                    info.uid = 0
+                    info.gid = 0
+                    info.uname = "root"
+                    info.gname = "root"
+                    info.mode = 0o755 if path.is_dir() else normalized_file_mode(path)
+                    if path.is_file():
+                        with path.open("rb") as handle:
+                            archive.addfile(info, handle)
+                    else:
+                        archive.addfile(info)
+
+
+def normalized_file_mode(path: Path) -> int:
+    mode = path.stat().st_mode
+    if path.suffix.lower() == ".exe" or mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+        return 0o755
+    return 0o644
 
 
 def sha256_file(path: Path) -> str:
@@ -49,25 +85,16 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Package a CodeStory CLI release binary.")
-    parser.add_argument("--version", required=True, help="Release version without v prefix.")
-    parser.add_argument("--target", required=True, help="Asset target label.")
-    parser.add_argument("--binary", required=True, help="Built codestory-cli binary path.")
-    parser.add_argument("--out-dir", required=True, help="Directory for archive and checksum outputs.")
-    parser.add_argument("--project-root", default=".", help="Repository root.")
-    args = parser.parse_args()
-
-    root = Path(args.project_root).resolve()
-    binary = Path(args.binary).resolve()
+def package_release(
+    version: str, target: str, binary: Path, out_dir: Path, root: Path
+) -> Path:
     if not binary.is_file():
         raise FileNotFoundError(f"binary does not exist: {binary}")
 
-    out_dir = Path(args.out_dir).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    archive_base = f"codestory-cli-v{args.version}-{args.target}"
-    archive_ext = ".zip" if "windows" in args.target.lower() else ".tar.gz"
+    archive_base = f"codestory-cli-v{version}-{target}"
+    archive_ext = ".zip" if "windows" in target.lower() else ".tar.gz"
     archive_path = out_dir / f"{archive_base}{archive_ext}"
 
     with tempfile.TemporaryDirectory(prefix="codestory-release-", dir=out_dir) as temp_dir:
@@ -93,6 +120,69 @@ def main() -> None:
     checksum_path = out_dir / f"{archive_path.name}.sha256"
     checksum_path.write_text(checksum_line, encoding="utf-8", newline="\n")
     (out_dir / "SHA256SUMS.txt").write_text(checksum_line, encoding="utf-8", newline="\n")
+    return archive_path
+
+
+def run_self_test() -> None:
+    with tempfile.TemporaryDirectory(prefix="codestory-package-self-test-") as temp_dir:
+        temp_root = Path(temp_dir)
+        repo_root = temp_root / "repo"
+        (repo_root / "docs/users").mkdir(parents=True)
+        (repo_root / "plugins/codestory/skills/codestory-grounding").mkdir(parents=True)
+        (repo_root / "README.md").write_text("readme\n", encoding="utf-8")
+        (repo_root / "LICENSE").write_text("license\n", encoding="utf-8")
+        (repo_root / "docs/glossary.md").write_text("glossary\n", encoding="utf-8")
+        (repo_root / "docs/users/guide.md").write_text("guide\n", encoding="utf-8")
+        (repo_root / "plugins/codestory/skills/codestory-grounding/SKILL.md").write_text(
+            "skill\n", encoding="utf-8"
+        )
+
+        linux_binary = temp_root / "codestory-cli"
+        linux_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        linux_binary.chmod(0o755)
+        windows_binary = temp_root / "codestory-cli.exe"
+        windows_binary.write_bytes(b"exe\n")
+
+        for target, binary in [
+            ("linux-x64", linux_binary),
+            ("windows-x64", windows_binary),
+        ]:
+            first = package_release("0.0.0", target, binary, temp_root / f"{target}-1", repo_root)
+            second = package_release("0.0.0", target, binary, temp_root / f"{target}-2", repo_root)
+            first_digest = sha256_file(first)
+            second_digest = sha256_file(second)
+            if first_digest != second_digest:
+                raise AssertionError(
+                    f"{target} package checksum changed across identical inputs: "
+                    f"{first_digest} != {second_digest}"
+                )
+
+    print("package self-test passed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Package a CodeStory CLI release binary.")
+    parser.add_argument("--self-test", action="store_true", help="Run package-twice proof.")
+    parser.add_argument("--version", help="Release version without v prefix.")
+    parser.add_argument("--target", help="Asset target label.")
+    parser.add_argument("--binary", help="Built codestory-cli binary path.")
+    parser.add_argument("--out-dir", help="Directory for archive and checksum outputs.")
+    parser.add_argument("--project-root", default=".", help="Repository root.")
+    args = parser.parse_args()
+
+    if args.self_test:
+        run_self_test()
+        return
+
+    for required in ["version", "target", "binary", "out_dir"]:
+        if getattr(args, required) is None:
+            parser.error(f"--{required.replace('_', '-')} is required unless --self-test is used")
+
+    root = Path(args.project_root).resolve()
+    binary = Path(args.binary).resolve()
+    out_dir = Path(args.out_dir).resolve()
+    archive_path = package_release(args.version, args.target, binary, out_dir, root)
+    checksum_path = out_dir / f"{archive_path.name}.sha256"
 
     print(f"archive={archive_path}")
     print(f"checksum={checksum_path}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ on:
 permissions:
   contents: read
 
+env:
+  RELEASE_RUST_TOOLCHAIN: "1.95.0"
+
 concurrency:
   group: release-${{ inputs.version }}
   cancel-in-progress: false
@@ -116,10 +119,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install Rust stable
+      - name: Install pinned Rust
         run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+          rustup toolchain install "${{ env.RELEASE_RUST_TOOLCHAIN }}" --profile minimal
+          rustup default "${{ env.RELEASE_RUST_TOOLCHAIN }}"
           rustup target add "${{ matrix.rust_target }}"
 
       - name: Capture Rust cache key
@@ -137,9 +140,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-release-stable-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-release-stable-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-
+            ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-
 
       - name: Build codestory-cli
         run: cargo build --release -p codestory-cli --target "${{ matrix.rust_target }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
   repeated owner-qualified member calls avoid scanning every candidate node.
 - Extended release readiness warnings to compare retrieval index/status/search
   timings against the latest stats-log baselines.
+- Normalized release archive metadata and pinned the release Rust toolchain so
+  package-twice checksum proof can catch reproducibility drift.
 
 ### Documentation
 


### PR DESCRIPTION
## Context

#728 asks the release lane to stop depending on floating Rust and nondeterministic archive metadata. This PR keeps the fix in the release surfaces only: the packager, release workflow, and workflow policy guard.

```mermaid
flowchart LR
  Build["pinned Rust build"] --> Stage["stage release files"]
  Stage --> Archive["normalized archive"]
  Archive --> Twice["package twice proof"]
  Archive --> Checksums["sha256 assets"]
```

## What Changed

- Pinned release builds to `RELEASE_RUST_TOOLCHAIN: "1.95.0"` instead of floating `stable`.
- Normalized zip and tar.gz package metadata: timestamps, modes, tar owners, and gzip header mtime.
- Added `--self-test` to `.github/scripts/package-codestory-release.py` for tar.gz and zip package-twice checksum proof.
- Extended workflow policy to reject floating stable release builds and require the release toolchain pin.
- Updated `CHANGELOG.md` before commit.

## How To Review

- Start in `.github/scripts/package-codestory-release.py`: `archive_zip`, `archive_tar_gz`, and `run_self_test` are the behavior change.
- Check `.github/workflows/release.yml` for the pinned toolchain and cache key.
- Check `.github/scripts/check-workflow-policy.mjs` for the release workflow guard.

## Verification

- `python .github/scripts/package-codestory-release.py --self-test` passed.
- `node .github/scripts/check-workflow-policy.mjs` passed.
- `python -m py_compile .github/scripts/package-codestory-release.py` passed.
- `git diff --check` passed.

## Risk

The release workflow now depends on Rust `1.95.0` being installable on every release runner. That is intentional reproducibility pressure; updating release Rust now requires changing the pinned env value and passing workflow policy.

Closes #728
Refs #716
