### PR TITLE
[codex] Extract doctor readiness status helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 - Removed deprecated benchmark, sidecar bootstrap, snapshot publish, and
   workspace alias compatibility surfaces after moving guards to maintained task
   manifests and concrete types.
+- Extracted CLI doctor readiness fallback status selection into the shared
+  readiness helper so rendering stays separate from local/default versus
+  agent packet/search readiness truth.
 
 ### Documentation
 

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -6,16 +6,18 @@
 //! already-computed response.
 
 use anyhow::{Context, Result, bail};
+#[cfg(test)]
+use codestory_contracts::api::IndexFreshnessStatusDto;
 use codestory_contracts::api::{
     AgentAnswerDto, AgentCitationDto, AgentResponseBlockDto, AgentRetrievalPolicyModeDto,
     AgentRetrievalPresetDto, AgentRetrievalStepDto, AgentRetrievalStepKindDto,
     AgentRetrievalStepStatusDto, ClaimReadinessDto, EvidenceTypeDto, GraphArtifactDto,
-    GroundingSnapshotDto, IndexFreshnessStatusDto, IndexingPhaseTimings, NodeDetailsDto,
-    PacketEvidenceResolutionDto, PacketEvidenceTierDto, RepoTextScanStatsDto,
-    RetrievalFallbackReasonDto, RetrievalModeDto, RetrievalStateDto, SearchHit, SearchHitOrigin,
-    SearchPlanBridgeConfidenceDto, SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto,
-    SearchPlanBridgeStatusDto, SearchPlanChannelDto, SearchPlanDto, SearchPlanPromotionStatusDto,
-    SnippetContextDto, SymbolContextDto, TrailContextDto, TrailStoryDto,
+    GroundingSnapshotDto, IndexingPhaseTimings, NodeDetailsDto, PacketEvidenceResolutionDto,
+    PacketEvidenceTierDto, RepoTextScanStatsDto, RetrievalFallbackReasonDto, RetrievalModeDto,
+    RetrievalStateDto, SearchHit, SearchHitOrigin, SearchPlanBridgeConfidenceDto,
+    SearchPlanBridgeDto, SearchPlanBridgeEvidenceKindDto, SearchPlanBridgeStatusDto,
+    SearchPlanChannelDto, SearchPlanDto, SearchPlanPromotionStatusDto, SnippetContextDto,
+    SymbolContextDto, TrailContextDto, TrailStoryDto,
 };
 use codestory_contracts::language_support::language_name_for_path;
 use serde::Serialize;
@@ -2343,44 +2345,23 @@ fn doctor_operator_next_action(output: &DoctorOutput) -> &str {
 }
 
 fn doctor_local_navigation_readiness(output: &DoctorOutput) -> &'static str {
-    if let Some(verdict) = output
-        .readiness
-        .iter()
-        .find(|verdict| crate::readiness::goal_label(verdict.goal) == "local_navigation")
-    {
-        return crate::readiness::status_label(verdict.status);
-    }
-    if !output.indexed
-        || output
-            .freshness
-            .as_ref()
-            .is_some_and(|freshness| freshness.status == IndexFreshnessStatusDto::Stale)
-    {
-        return "repair_index";
-    }
-    "ready"
+    crate::readiness::status_label_for_goal(
+        codestory_contracts::api::ReadinessGoalDto::LocalNavigation,
+        &output.readiness,
+        output.indexed,
+        output.freshness.as_ref().map(|freshness| freshness.status),
+        &output.retrieval_mode,
+    )
 }
 
 fn doctor_agent_packet_search_readiness(output: &DoctorOutput) -> &'static str {
-    if let Some(verdict) = output
-        .readiness
-        .iter()
-        .find(|verdict| crate::readiness::goal_label(verdict.goal) == "agent_packet_search")
-    {
-        return crate::readiness::status_label(verdict.status);
-    }
-    if !output.indexed {
-        return "repair_index";
-    }
-    match output.freshness.as_ref().map(|freshness| freshness.status) {
-        Some(IndexFreshnessStatusDto::Stale) => return "repair_index",
-        Some(IndexFreshnessStatusDto::NotChecked) => return "check_index",
-        Some(IndexFreshnessStatusDto::Fresh) | None => {}
-    }
-    if output.retrieval_mode != "full" {
-        return "repair_retrieval";
-    }
-    "ready"
+    crate::readiness::status_label_for_goal(
+        codestory_contracts::api::ReadinessGoalDto::AgentPacketSearch,
+        &output.readiness,
+        output.indexed,
+        output.freshness.as_ref().map(|freshness| freshness.status),
+        &output.retrieval_mode,
+    )
 }
 
 pub(crate) fn render_drill_markdown(output: &DrillOutput) -> String {

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -145,6 +145,38 @@ pub(crate) fn primary_non_ready(verdicts: &[ReadinessVerdictDto]) -> Option<&Rea
         .find(|verdict| verdict.status != ReadinessStatusDto::Ready)
 }
 
+pub(crate) fn status_label_for_goal(
+    goal: ReadinessGoalDto,
+    verdicts: &[ReadinessVerdictDto],
+    indexed: bool,
+    freshness_status: Option<IndexFreshnessStatusDto>,
+    retrieval_mode: &str,
+) -> &'static str {
+    if let Some(verdict) = verdicts.iter().find(|verdict| verdict.goal == goal) {
+        return status_label(verdict.status);
+    }
+
+    if !indexed {
+        return "repair_index";
+    }
+
+    match freshness_status {
+        Some(IndexFreshnessStatusDto::Stale) => return "repair_index",
+        Some(IndexFreshnessStatusDto::NotChecked)
+            if goal == ReadinessGoalDto::AgentPacketSearch =>
+        {
+            return "check_index";
+        }
+        Some(IndexFreshnessStatusDto::Fresh | IndexFreshnessStatusDto::NotChecked) | None => {}
+    }
+
+    if goal == ReadinessGoalDto::AgentPacketSearch && retrieval_mode != "full" {
+        return "repair_retrieval";
+    }
+
+    "ready"
+}
+
 pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
     match status {
         ReadinessStatusDto::Ready => "ready",
@@ -604,6 +636,63 @@ mod tests {
             setup: None,
             sidecar,
         }
+    }
+
+    #[test]
+    fn status_label_for_goal_preserves_doctor_fallback_readiness_lanes() {
+        assert_eq!(
+            status_label_for_goal(
+                ReadinessGoalDto::LocalNavigation,
+                &[],
+                true,
+                Some(IndexFreshnessStatusDto::NotChecked),
+                "unavailable",
+            ),
+            "ready",
+            "legacy doctor fallback kept local/default freshness separate from agent proof"
+        );
+        assert_eq!(
+            status_label_for_goal(
+                ReadinessGoalDto::AgentPacketSearch,
+                &[],
+                true,
+                Some(IndexFreshnessStatusDto::NotChecked),
+                "full",
+            ),
+            "check_index"
+        );
+        assert_eq!(
+            status_label_for_goal(
+                ReadinessGoalDto::AgentPacketSearch,
+                &[],
+                true,
+                Some(IndexFreshnessStatusDto::Fresh),
+                "unavailable",
+            ),
+            "repair_retrieval"
+        );
+
+        let verdict = ReadinessVerdictDto {
+            goal: ReadinessGoalDto::AgentPacketSearch,
+            status: ReadinessStatusDto::Ready,
+            summary: "ready".to_string(),
+            minimum_next: Vec::new(),
+            full_repair: Vec::new(),
+            setup: None,
+            index: None,
+            sidecar: None,
+        };
+        assert_eq!(
+            status_label_for_goal(
+                ReadinessGoalDto::AgentPacketSearch,
+                &[verdict],
+                false,
+                Some(IndexFreshnessStatusDto::Stale),
+                "unavailable",
+            ),
+            "ready",
+            "rendering must trust the selected readiness verdict when present"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

#732 asks for the next touched CLI/runtime readiness island to be extracted without a broad module reshuffle. The current touched surface is CLI doctor readiness rendering, which still had local/default and agent packet/search fallback status selection embedded in `output.rs`.

## What Changed

- Moved doctor fallback readiness status selection into `readiness::status_label_for_goal`.
- Kept `output.rs` focused on rendering by passing selected verdicts, freshness, indexed state, and retrieval mode into the shared helper.
- Added a focused readiness unit test covering local/default versus agent fallback behavior and selected-verdict precedence.
- Updated the unreleased changelog before commit.

```mermaid
flowchart LR
    A[DoctorOutput] --> B[readiness::status_label_for_goal]
    B --> C[local_navigation label]
    B --> D[agent_packet_search label]
    C --> E[doctor markdown]
    D --> E
```

## How To Review

- Start in `crates/codestory-cli/src/readiness.rs` at `status_label_for_goal`.
- Confirm `crates/codestory-cli/src/output.rs` now calls that helper instead of duplicating readiness fallback logic.
- Check `status_label_for_goal_preserves_doctor_fallback_readiness_lanes` for the local/default and agent packet/search separation.

## Verification

- `cargo test -p codestory-cli --bin codestory-cli readiness` passed: 20 passed.
- `cargo test -p codestory-cli --bin codestory-cli` passed: 229 passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed.
- `cargo fmt --check` passed.
- `git diff --check` passed.

## Risk

Behavior should be unchanged. The main risk is that another renderer still grows its own readiness fallback logic later; this PR only extracts the doctor markdown island touched for #732.

Closes #732
Refs #716
