### PR TITLE
[codex] Guard release workflow before 0.12.6 sync

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -10,6 +10,7 @@ const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
 const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
 const rustCi = path.join(workflowRoot, "rust-ci.yml");
 const releaseWorkflow = path.join(workflowRoot, "release.yml");
+const mainBranchSourceGuard = path.join(workflowRoot, "main-branch-source-guard.yml");
 
 for (const file of fs
   .readdirSync(workflowRoot)
@@ -118,6 +119,25 @@ if (!fs.existsSync(releaseWorkflow)) {
   }
   if (content.includes("rustup toolchain install stable")) {
     violations.push("release.yml release builds must not install floating stable Rust");
+  }
+}
+
+if (!fs.existsSync(mainBranchSourceGuard)) {
+  violations.push("main-branch-source-guard.yml must guard PRs into main");
+} else {
+  const content = fs.readFileSync(mainBranchSourceGuard, "utf8");
+  const requiredSnippets = [
+    "pull_request:",
+    "- main",
+    "dev/codestory-next",
+    "HEAD_REPO",
+    "BASE_REPO",
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!content.includes(snippet)) {
+      violations.push(`main-branch-source-guard.yml must include ${snippet}`);
+    }
   }
 }
 

--- a/.github/scripts/detect-codestory-release.py
+++ b/.github/scripts/detect-codestory-release.py
@@ -16,6 +16,11 @@ SEMVER_RE = re.compile(
     r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
+SEMVER_PARTS_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
 
 
 @dataclass(frozen=True)
@@ -80,6 +85,46 @@ def github_release_exists(tag: str, repo: str) -> bool:
     raise RuntimeError(f"failed to inspect GitHub release {tag}: {result.stderr.strip()}")
 
 
+def compare_identifiers(left: str, right: str) -> int:
+    left_numeric = left.isdigit()
+    right_numeric = right.isdigit()
+    if left_numeric and right_numeric:
+        return (int(left) > int(right)) - (int(left) < int(right))
+    if left_numeric != right_numeric:
+        return -1 if left_numeric else 1
+    return (left > right) - (left < right)
+
+
+def compare_prerelease(left: str | None, right: str | None) -> int:
+    if left == right:
+        return 0
+    if left is None:
+        return 1
+    if right is None:
+        return -1
+
+    left_parts = left.split(".")
+    right_parts = right.split(".")
+    for index in range(min(len(left_parts), len(right_parts))):
+        compared = compare_identifiers(left_parts[index], right_parts[index])
+        if compared:
+            return compared
+    return (len(left_parts) > len(right_parts)) - (len(left_parts) < len(right_parts))
+
+
+def compare_semver(left: str, right: str) -> int:
+    left_match = SEMVER_PARTS_RE.fullmatch(left)
+    right_match = SEMVER_PARTS_RE.fullmatch(right)
+    if left_match is None or right_match is None:
+        raise ValueError(f"cannot compare non-semver versions: {left!r}, {right!r}.")
+
+    left_core = tuple(int(part) for part in left_match.group(1, 2, 3))
+    right_core = tuple(int(part) for part in right_match.group(1, 2, 3))
+    if left_core != right_core:
+        return (left_core > right_core) - (left_core < right_core)
+    return compare_prerelease(left_match.group(4), right_match.group(4))
+
+
 def decide_release(
     *,
     old_version: str,
@@ -107,6 +152,12 @@ def decide_release(
         return ReleaseDecision(
             True,
             f"v{new_version} has no tag or release; retrying the current source version.",
+        )
+
+    if old_version and compare_semver(new_version, old_version) <= 0:
+        raise ValueError(
+            f"codestory-cli version moved from {old_version} to {new_version}; "
+            "auto-release requires a higher version."
         )
 
     return ReleaseDecision(True, f"codestory-cli version changed to {new_version}.")

--- a/.github/scripts/test-detect-codestory-release.py
+++ b/.github/scripts/test-detect-codestory-release.py
@@ -40,13 +40,22 @@ class AutoReleaseDecisionTest(unittest.TestCase):
 
     def test_releases_changed_unpublished_version(self) -> None:
         decision = detector.decide_release(
-            old_version="0.12.4",
-            new_version="0.12.5",
+            old_version="0.12.5",
+            new_version="0.12.6",
             tag_exists=False,
             release_exists=False,
         )
 
         self.assertTrue(decision.should_release)
+
+    def test_refuses_downgrade(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires a higher version"):
+            detector.decide_release(
+                old_version="0.12.5",
+                new_version="0.12.4",
+                tag_exists=False,
+                release_exists=False,
+            )
 
     def test_refuses_changed_version_that_already_exists(self) -> None:
         with self.assertRaisesRegex(ValueError, "refusing to overwrite"):

--- a/.github/workflows/main-branch-source-guard.yml
+++ b/.github/workflows/main-branch-source-guard.yml
@@ -1,0 +1,34 @@
+name: main branch source guard
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-branch-source-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  enforce-source-branch:
+    name: enforce source branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require dev/codestory-next source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$HEAD_REF" != "dev/codestory-next" ] || [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::Pull requests into main must use $BASE_REPO:dev/codestory-next as the source branch."
+            echo "Current source: $HEAD_REPO:$HEAD_REF"
+            exit 1
+          fi
+          echo "Pull requests into main are allowed from $BASE_REPO:dev/codestory-next."

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ check_output*.txt
 check_tests_output*.txt
 .worktrees/
 
+# Python tooling
+__pycache__/
+*.py[cod]
+
 # Node tooling (if used locally)
 node_modules/
 pnpm-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Taught Auto Release to retry the current source version when a previous
   publish failed before creating a tag or release, while still refusing to
   overwrite existing release state.
+- Taught Auto Release to reject version downgrades and guarded `main`
+  promotions so release PRs must come from `dev/codestory-next`.
+- Ignored Python bytecode caches emitted by local release-script checks.
 - Removed shell execution from default file-open fallbacks so repo paths with
   shell metacharacters are passed as process arguments.
 - Shared retrieval file-role state across strict batch workers so cache-miss


### PR DESCRIPTION
## Context

CodeStory release promotion is blocked by branch/version drift: `dev/codestory-next` still reports `0.12.4`, while `main` is already `0.12.5` and both tags exist. Before the 0.12.6 sync, the release workflow needs to prevent downgrades and keep `main` promotions on the intended dev branch.

Closes #791

## What Changed

- Ignored Python bytecode caches produced by local release-script checks.
- Added SemVer ordering to Auto Release detection so unchanged unpublished versions can retry, but downgrades fail before publish.
- Added a `main` PR source guard requiring same-repo `dev/codestory-next` as the promotion branch.
- Extended workflow policy checks so the new source guard remains present.
- Updated the changelog under `Unreleased`.

## How To Review

- Start with `.github/scripts/detect-codestory-release.py` and its unit test for the downgrade decision.
- Then check `.github/workflows/main-branch-source-guard.yml` for the promotion-source rule.
- Confirm `.github/scripts/check-workflow-policy.mjs` requires the guard workflow.

## Verification

- `python .github/scripts/test-detect-codestory-release.py`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`
- `git check-ignore -v .github/scripts/__pycache__/detect-codestory-release.cpython-314.pyc`

## Risk

- This does not perform the 0.12.6 version sync. That should happen after this guard lands in `dev/codestory-next`.
- The new main guard will intentionally reject hotfix or direct feature branches into `main`; explicit exceptions would need a workflow change.
