### PR TITLE
Block model-hidden MCP grounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Blocked CodeStory grounding when the plugin MCP is launchable but not
+  model-visible, even when a managed CLI exists; diagnostic fail-open mode now
+  exposes status/repair guidance instead of normal grounding tool names.
+
 ## 0.12.6
 
 CodeStory 0.12.6 promotes the current `dev/codestory-next` release automation,

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -132,6 +132,7 @@ function writeProjectDirtyMarker(policy) {
 function runtimeFingerprint(mcp) {
   return [
     mcp.mcp_resource_status,
+    mcp.mcp_model_visible_blocked ? 'model-hidden' : 'model-visible-or-unlaunchable',
     mcp.managed_cli_present ? 'managed' : 'no-managed',
     mcp.degraded_no_surface ? 'degraded' : 'surface',
   ].join('|');
@@ -154,6 +155,14 @@ function firstRuntimeFailure(mcp) {
 }
 
 function shortDegradedNotice(mcp, reason, state = {}) {
+  if (mcp.mcp_model_visible_blocked) {
+    return [
+      'CodeStory setup blocked: MCP is configured and launchable, but resources are not model-visible.',
+      `First failing layer: ${firstRuntimeFailure(mcp)}.`,
+      reason ? `Reason: ${truncate(reason, 600)}` : null,
+      'Reload the host/plugin and read codestory://status; do not use managed CLI or PATH fallback as CodeStory grounding.',
+    ].filter(Boolean).join('\n');
+  }
   const hook = state.hook || {};
   return [
     'CodeStory degraded mode: no MCP or managed runtime surface is usable.',
@@ -170,7 +179,9 @@ function runtimeStatusBlock(policy, mcp) {
     `output_cap_chars: ${policy.cap}`,
     `dedupe_key: ${policy.dedupeKey}`,
     mcpDetectionText(mcp),
-    mcp.mcp_resources_exposed
+    mcp.mcp_model_visible_blocked
+      ? 'Next: reload the host/plugin and read codestory://status; do not use managed CLI or PATH fallback as CodeStory grounding.'
+      : mcp.mcp_resources_exposed
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
   ].join('\n');
@@ -179,7 +190,7 @@ function runtimeStatusBlock(policy, mcp) {
 function shouldBootstrapManagedRuntime(policy, mcp) {
   if (process.env.CODESTORY_CLI) return false;
   if (!BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) return false;
-  return Boolean(policy.project && mcp.mcp_process_launchable && !mcp.mcp_resources_exposed);
+  return Boolean(policy.project && mcp.mcp_process_launchable && mcp.mcp_resources_exposed && !mcp.managed_cli_present);
 }
 
 function bootstrapText(bootstrap) {
@@ -380,7 +391,7 @@ function runCodeStory(input, event, policy, state = {}) {
   }
   const bootstrapBlock = bootstrapText(bootstrap);
   if (policy.runtimeOnly) {
-    const heartbeatProbe = policy.heartbeat
+    const heartbeatProbe = policy.heartbeat && !mcp.mcp_model_visible_blocked
       ? heartbeatReadinessProbe(mcp, policy.project, input.cwd || process.cwd())
       : null;
     const output = state.hook?.preflight_failed && mcp.degraded_no_surface

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -133,6 +133,7 @@ function classifyMcpRuntime(options = {}) {
     : launchable
       ? 'mcp_resources_not_model_visible'
       : 'mcp_resources_unavailable';
+  const modelVisibleBlocked = launchable && !resourcesExposed;
 
   return {
     mcp_config_installed: mcp.installed,
@@ -142,12 +143,13 @@ function classifyMcpRuntime(options = {}) {
     mcp_process_launchable: launchable,
     mcp_resources_exposed: resourcesExposed,
     mcp_resource_status: resourceStatus,
+    mcp_model_visible_blocked: modelVisibleBlocked,
     mcp_runtime_state_path: runtimePath,
     mcp_runtime_state_present: Boolean(runtime),
     managed_cli_present: managed.present,
     managed_cli_path: managed.path,
     managed_cli_source: managed.source,
-    degraded_no_surface: !resourcesExposed && !managed.present,
+    degraded_no_surface: modelVisibleBlocked || (!resourcesExposed && !managed.present),
   };
 }
 
@@ -195,6 +197,7 @@ function mcpDetectionText(status) {
     `mcp_config_installed: ${status.mcp_config_installed ? 'yes' : 'no'}${status.mcp_config_installed ? ` (${status.mcp_config_path})` : ''}`,
     `mcp_process_launchable: ${status.mcp_process_launchable ? 'yes' : 'no'}`,
     `mcp_resources_exposed: ${status.mcp_resource_status}`,
+    `mcp_model_visible_blocked: ${status.mcp_model_visible_blocked ? 'yes' : 'no'}`,
     `managed_cli_present: ${status.managed_cli_present ? 'yes' : 'no'}${status.managed_cli_path ? ` (${status.managed_cli_path})` : ''}`,
     `degraded_no_surface: ${status.degraded_no_surface ? 'yes' : 'no'}`,
   ].join('\n');

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -1166,25 +1166,6 @@ function resourceContents(uri, value) {
   };
 }
 
-function failOpenToolResult(status) {
-  const readiness = status.readiness[0];
-  return {
-    isError: true,
-    content: [{ type: 'text', text: diagnosticText(status) }],
-    structuredContent: {
-      code: 'codestory_mcp_runtime_unavailable',
-      status: readiness.status,
-      repair_reason: status.degraded_reason,
-      local_refresh: status.local_refresh || null,
-      plugin_runtime: status.plugin_runtime,
-      setup: readiness.setup,
-      minimum_next: readiness.minimum_next,
-      full_repair: readiness.full_repair,
-      recommended_next_calls: status.recommended_next_calls,
-    },
-  };
-}
-
 function failOpenSidecarSetupResult(request) {
   const action = request.params?.arguments?.action || 'status';
   if (!['status', 'enable', 'disable', 'ask', 'repair'].includes(action)) {
@@ -1210,13 +1191,7 @@ function failOpenSidecarSetupResult(request) {
 }
 
 function runFailOpenMcp(status) {
-  const tools = ['ground', 'files', 'packet', 'search', 'context'].map((name) => ({
-    name,
-    description: 'CodeStory diagnostic fail-open surface; runtime repair is required before this tool can return repository grounding.',
-    inputSchema: { type: 'object', additionalProperties: true },
-    outputSchema: { type: 'object', additionalProperties: true },
-  }));
-  tools.unshift({
+  const tools = [{
     name: 'sidecar_setup',
     description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode.',
     inputSchema: {
@@ -1240,7 +1215,7 @@ function runFailOpenMcp(status) {
       idempotentHint: true,
       openWorldHint: false,
     },
-  });
+  }];
   const resources = [
     { uri: 'codestory://status', name: 'CodeStory runtime status', mimeType: 'application/json' },
     { uri: 'codestory://agent-guide', name: 'CodeStory agent guide', mimeType: 'application/json' },
@@ -1287,12 +1262,9 @@ function runFailOpenMcp(status) {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
       } else if (request.method === 'tools/call') {
-        response = jsonrpcResult(
-          request.id,
-          request.params?.name === 'sidecar_setup'
-            ? failOpenSidecarSetupResult(request)
-            : failOpenToolResult(status),
-        );
+        response = request.params?.name === 'sidecar_setup'
+          ? jsonrpcResult(request.id, failOpenSidecarSetupResult(request))
+          : jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status or call sidecar_setup.');
       } else {
         response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
       }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1041,7 +1041,8 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
   const input = [
     JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
-    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+    JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "ground", arguments: {} } }),
   ].join("\n") + "\n";
 
   try {
@@ -1060,7 +1061,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
 
     assert.equal(result.status, 0, result.stderr);
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 3, result.stdout);
+    assert.equal(responses.length, 4, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
     assert.equal(status.plugin_runtime.plugin_version, version);
     assert.equal(status.source_checkout_version, sourceVersion);
@@ -1084,15 +1085,9 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     assert.equal(status.readiness[0].status, "repair_setup");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
-    assert.equal(responses[2].result.isError, true);
-    assert.equal(
-      responses[2].result.structuredContent.code,
-      "codestory_mcp_runtime_unavailable",
-    );
-    assert.equal(
-      responses[2].result.structuredContent.plugin_runtime.plugin_root,
-      pluginRoot,
-    );
+    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["sidecar_setup"]);
+    assert.equal(responses[3].error.code, -32602);
+    assert.match(responses[3].error.message, /grounding tools are unavailable/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(pathDir, { recursive: true, force: true });
@@ -1230,9 +1225,9 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = JSON.stringify({
     jsonrpc: "2.0",
-    id: "tool",
-    method: "tools/call",
-    params: { name: "ground", arguments: {} },
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
   }) + "\n";
 
   try {
@@ -1265,13 +1260,13 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
 
     assert.equal(result.status, 0, result.stderr);
     const response = JSON.parse(result.stdout.trim());
-    assert.equal(response.result.isError, true);
+    const status = JSON.parse(response.result.contents[0].text);
     assert.equal(
-      response.result.structuredContent.repair_reason,
+      status.readiness[0].repair_reason,
       "managed_cli_unspawnable",
     );
     assert.equal(
-      response.result.structuredContent.plugin_runtime.plugin_version,
+      status.plugin_runtime.plugin_version,
       version,
     );
   } finally {
@@ -1456,7 +1451,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
-test("startup hook bootstraps managed cli before reporting MCP visibility", async (t) => {
+test("startup hook bootstraps managed cli when MCP resources are visible", async (t) => {
   const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
   if (tarProbe.status !== 0) {
     t.skip("tar unavailable for archive fixture");
@@ -1489,7 +1484,7 @@ test("startup hook bootstraps managed cli before reporting MCP visibility", asyn
       env: {
         ...process.env,
         CODESTORY_CLI: "",
-        CODESTORY_MCP_RESOURCES_EXPOSED: "",
+        CODESTORY_MCP_RESOURCES_EXPOSED: "1",
         CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
         COPILOT_PLUGIN_DATA: "",
         PLUGIN_DATA: dataDir,
@@ -1508,7 +1503,8 @@ test("startup hook bootstraps managed cli before reporting MCP visibility", asyn
     assert.match(context, /managed_bootstrap: ready/u);
     assert.match(context, /managed_bootstrap_cli_source: managed/u);
     assert.match(context, /managed_bootstrap_local_refresh: fresh/u);
-    assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+    assert.match(context, /mcp_resources_exposed: mcp_resources_exposed/u);
+    assert.match(context, /mcp_model_visible_blocked: no/u);
     assert.match(context, /managed_cli_present: yes/u);
     assert.doesNotMatch(context, /where\.exe codestory-cli|command -v codestory-cli|adding CodeStory to PATH/u);
 
@@ -2231,6 +2227,7 @@ test("hook goal heartbeat is quiet until readiness or freshness evidence changes
   const env = {
     PLUGIN_DATA: dataDir,
     CODESTORY_CLI: cliPath,
+    CODESTORY_MCP_RESOURCES_EXPOSED: "1",
     TEST_AGENT_STATUS: "repair_retrieval",
     TEST_FRESHNESS_STATUS: "stale",
     TEST_CHANGED_FILES: "1",
@@ -2266,6 +2263,55 @@ test("hook goal heartbeat is quiet until readiness or freshness evidence changes
   }
 });
 
+test("hook goal heartbeat skips managed cli readiness when MCP is model-hidden", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-hidden-mcp-"));
+  const version = await readPluginVersion();
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const marker = join(dataDir, "managed-cli-called.txt");
+  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    await writeNodeCli(
+      cliDir,
+      [
+        "const fs = require('node:fs');",
+        "fs.writeFileSync(process.env.TEST_MARKER, process.argv.slice(2).join(' '));",
+        "if (process.argv[2] === 'ready') {",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status: 'ready' }] }));",
+        "  process.exit(0);",
+        "}",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
+      "utf8",
+    );
+    await writeFile(
+      join(dataDir, ".codestory-mcp-runtime.json"),
+      JSON.stringify({ source: "managed", path: cliPath }),
+      "utf8",
+    );
+
+    const output = runCodexHook({
+      hook_event_name: "GoalLoopHeartbeat",
+      cwd: repoRoot,
+    }, {
+      PLUGIN_DATA: dataDir,
+      CODESTORY_MCP_RESOURCES_EXPOSED: "",
+      PATH: "",
+      TEST_MARKER: marker,
+    });
+
+    assert.equal(Object.hasOwn(output, "hookSpecificOutput"), false);
+    await assert.rejects(access(marker));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("hook MCP classifier distinguishes configured launchable and model-visible states", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-classify-"));
   const version = await readPluginVersion();
@@ -2278,6 +2324,7 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
     assert.equal(configured.mcp_process_launchable, true);
     assert.equal(configured.mcp_resources_exposed, false);
     assert.equal(configured.mcp_resource_status, "mcp_resources_not_model_visible");
+    assert.equal(configured.mcp_model_visible_blocked, true);
     assert.equal(configured.managed_cli_present, false);
 
     await mkdir(cliDir, { recursive: true });
@@ -2290,7 +2337,8 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
     const managed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
     assert.equal(managed.managed_cli_present, true);
     assert.equal(managed.managed_cli_path, cliPath);
-    assert.equal(managed.degraded_no_surface, false);
+    assert.equal(managed.mcp_model_visible_blocked, true);
+    assert.equal(managed.degraded_no_surface, true);
 
     await writeFile(
       join(dataDir, ".codestory-mcp-runtime.json"),
@@ -2301,7 +2349,8 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
     assert.equal(runtimeStateOnly.mcp_runtime_state_present, true);
     assert.equal(runtimeStateOnly.mcp_resources_exposed, false);
     assert.equal(runtimeStateOnly.mcp_resource_status, "mcp_resources_not_model_visible");
-    assert.equal(runtimeStateOnly.degraded_no_surface, false);
+    assert.equal(runtimeStateOnly.mcp_model_visible_blocked, true);
+    assert.equal(runtimeStateOnly.degraded_no_surface, true);
 
     const previous = process.env.CODESTORY_MCP_RESOURCES_EXPOSED;
     try {
@@ -2309,6 +2358,7 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
       const exposed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
       assert.equal(exposed.mcp_resources_exposed, true);
       assert.equal(exposed.mcp_resource_status, "mcp_resources_exposed");
+      assert.equal(exposed.mcp_model_visible_blocked, false);
       assert.equal(exposed.degraded_no_surface, false);
     } finally {
       if (previous === undefined) {
@@ -2448,10 +2498,14 @@ test("hook output reports model-invisible MCP instead of PATH setup guidance", a
   const context = output.hookSpecificOutput.additionalContext;
   assert.match(context, /mcp_config_installed: yes/u);
   assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+  assert.match(context, /mcp_model_visible_blocked: yes/u);
   assert.match(context, /managed_cli_present: yes/u);
+  assert.match(context, /degraded_no_surface: yes/u);
   assert.match(context, /MCP resources are not visible/u);
+  assert.doesNotMatch(context, /managed_bootstrap: ready/u);
   assert.doesNotMatch(context, /codestory-cli ENOENT/u);
   assert.doesNotMatch(context, /attempted request packet/u);
+  assert.doesNotMatch(context, /bounded source reads/u);
   assert.doesNotMatch(context, /adding CodeStory to PATH/u);
   await rm(dataDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Context

Closes #801
Refs #800

CodeStory plugin hooks could report a managed CLI as available while the configured MCP process was launchable but its resources were not model-visible. That made CLI fallback look like a supported grounding path even though the product contract is MCP-first when MCP is supported.

```mermaid
flowchart TD
    A[MCP configured + launchable] --> B{resources model-visible?}
    B -->|yes| C[status first; allowed surfaces decide]
    B -->|no| D[blocked setup state]
    D --> E[reload host/plugin + read codestory://status]
    D -. no .-> F[managed CLI grounding fallback]
```

## What Changed

- Added `mcp_model_visible_blocked` to the hook runtime classifier and made `degraded_no_surface` true for launchable-but-hidden MCP even when a managed CLI exists.
- Updated hook status/degraded text to instruct host/plugin reload plus `codestory://status` readback, without source/PATH/managed-CLI fallback guidance for this state.
- Limited diagnostic fail-open MCP tools to `sidecar_setup`; status and agent-guide remain the repair surfaces, while normal `ground`, `packet`, `search`, and `context` tool names are not advertised.
- Updated plugin static tests and `CHANGELOG.md`.

## How To Review

- Start in `plugins/codestory/hooks/codestory-runtime.cjs` at `classifyMcpRuntime`.
- Then check `plugins/codestory/hooks/codestory-activate.cjs` for hook output behavior.
- Finally review `plugins/codestory/scripts/codestory-mcp.cjs` and the changed static tests for the fail-open protocol contract.

## Verification

- `git diff --check`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` (44/44 pass)

## Risk

The main compatibility change is that diagnostic fail-open no longer exposes normal grounding tool names as error-returning placeholders. Clients should use `codestory://status`, `codestory://agent-guide`, or `sidecar_setup` during repair mode.