### PR TITLE
[codex] Block non-full agent sidecar readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Blocked agent packet/search readiness when the selected sidecar retrieval is
+  not full, while keeping local/default graph readiness reported separately.
+
 ## 0.12.6
 
 CodeStory 0.12.6 promotes the current `dev/codestory-next` release automation,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -11096,6 +11096,7 @@ fn readiness_lane_status(
         ReadinessStatusDto::RepairRetrieval
     };
     match verdict.map(|verdict| verdict.status) {
+        Some(ReadinessStatusDto::Blocked) => ReadinessStatusDto::Blocked,
         Some(status @ (ReadinessStatusDto::RepairSetup | ReadinessStatusDto::RepairIndex)) => {
             status
         }
@@ -11500,9 +11501,9 @@ fn doctor_sidecar_check(sidecar: &DoctorSidecarStatusOutput) -> DoctorCheckOutpu
         .unwrap_or("no degraded_reason reported");
     doctor_check(
         "sidecar_retrieval",
-        "warn",
+        "error",
         format!(
-            "mandatory sidecar retrieval is not full (mode={} reason={reason}; embedding_device_policy={} observed_device={} cpu_allowed={}); repair sidecars before trusting packet/search evidence.",
+            "mandatory sidecar retrieval is not full (mode={} reason={reason}; embedding_device_policy={} observed_device={} cpu_allowed={}); packet/search evidence is blocked until sidecars are full.",
             sidecar.retrieval_mode,
             sidecar.embedding_device_policy,
             sidecar.embedding_device_state,

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -2313,7 +2313,9 @@ fn compact_doctor_check_message(check: &crate::args::DoctorCheckOutput) -> Strin
 }
 
 fn doctor_operator_status(output: &DoctorOutput) -> &'static str {
-    if output.checks.iter().any(|check| check.status == "error") {
+    if doctor_agent_packet_search_readiness(output) == "blocked"
+        || output.checks.iter().any(|check| check.status == "error")
+    {
         "blocked"
     } else if doctor_agent_packet_search_readiness(output) != "ready"
         || output.checks.iter().any(|check| check.status == "warn")

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -171,7 +171,7 @@ pub(crate) fn status_label_for_goal(
     }
 
     if goal == ReadinessGoalDto::AgentPacketSearch && retrieval_mode != "full" {
-        return "repair_retrieval";
+        return "blocked";
     }
 
     "ready"
@@ -184,6 +184,7 @@ pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
         ReadinessStatusDto::RepairSetup => "repair_setup",
         ReadinessStatusDto::RepairIndex => "repair_index",
         ReadinessStatusDto::CheckIndex => "check_index",
+        ReadinessStatusDto::Blocked => "blocked",
         ReadinessStatusDto::RepairRetrieval => "repair_retrieval",
     }
 }
@@ -195,6 +196,7 @@ pub(crate) fn failed_layer(verdict: &ReadinessVerdictDto) -> Option<&'static str
         ReadinessStatusDto::RepairSetup => Some("runtime_setup"),
         ReadinessStatusDto::RepairIndex => Some("local_index"),
         ReadinessStatusDto::CheckIndex => Some("index_freshness"),
+        ReadinessStatusDto::Blocked => Some("retrieval_sidecar"),
         ReadinessStatusDto::RepairRetrieval => Some("retrieval_sidecar"),
     }
 }
@@ -222,7 +224,7 @@ pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefres
         | ReadinessStatusDto::Repairing
         | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Refreshed,
         ReadinessStatusDto::CheckIndex => LocalRefreshState::Skipped,
-        ReadinessStatusDto::RepairSetup => LocalRefreshState::Failed,
+        ReadinessStatusDto::RepairSetup | ReadinessStatusDto::Blocked => LocalRefreshState::Failed,
         ReadinessStatusDto::RepairIndex => {
             if index.and_then(|index| index.status) == Some(IndexFreshnessStatusDto::Stale) {
                 LocalRefreshState::Skipped
@@ -409,9 +411,9 @@ fn verdict_state(
             let full_repair = agent_packet_search_repair_commands(project_arg, sidecar_run_id);
             let minimum_next = full_repair.iter().take(1).cloned().collect();
             return (
-                ReadinessStatusDto::RepairRetrieval,
+                ReadinessStatusDto::Blocked,
                 format!(
-                    "Agent packet/search needs full agent sidecar retrieval; current profile is `{}` and mode is `{sidecar_mode}`.{device_note}",
+                    "Agent packet/search is blocked until full agent sidecar retrieval is proven; current profile is `{}` and mode is `{sidecar_mode}`.{device_note}",
                     sidecar_profile.unwrap_or("unknown")
                 ),
                 minimum_next,
@@ -669,7 +671,7 @@ mod tests {
                 Some(IndexFreshnessStatusDto::Fresh),
                 "unavailable",
             ),
-            "repair_retrieval"
+            "blocked"
         );
 
         let verdict = ReadinessVerdictDto {
@@ -704,7 +706,7 @@ mod tests {
         assert_eq!(verdicts[0].status, ReadinessStatusDto::RepairIndex);
         assert_eq!(
             verdicts[1].status,
-            ReadinessStatusDto::RepairRetrieval,
+            ReadinessStatusDto::Blocked,
             "missing local index should not collapse agent retrieval readiness: {verdicts:?}"
         );
         assert!(
@@ -986,11 +988,11 @@ mod tests {
             inputs(&stats, Some(&freshness), None),
         );
 
-        assert_eq!(unavailable.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(unavailable.status, ReadinessStatusDto::Blocked);
         assert!(
             unavailable
                 .summary
-                .contains("current profile is `unknown` and mode is `unavailable`")
+                .contains("blocked until full agent sidecar retrieval is proven")
         );
         assert!(unavailable.sidecar.is_none());
 
@@ -1027,7 +1029,7 @@ mod tests {
             ),
         );
 
-        assert_eq!(local_full.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(local_full.status, ReadinessStatusDto::Blocked);
         assert!(
             local_full.summary.contains("current profile is `local`"),
             "local/default full retrieval must not unlock agent packet/search: {local_full:?}"
@@ -1058,7 +1060,7 @@ mod tests {
             ),
         );
 
-        assert_eq!(degraded.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(degraded.status, ReadinessStatusDto::Blocked);
         assert_eq!(
             degraded
                 .sidecar
@@ -1139,7 +1141,7 @@ mod tests {
                 inputs(&stats, Some(&freshness), sidecar),
             );
 
-            assert_eq!(verdict.status, ReadinessStatusDto::RepairRetrieval);
+            assert_eq!(verdict.status, ReadinessStatusDto::Blocked);
             assert_eq!(failed_layer(&verdict), Some("retrieval_sidecar"));
             assert_eq!(verdict.minimum_next.len(), 1);
             assert!(
@@ -1177,7 +1179,7 @@ mod tests {
             ),
         );
 
-        assert_eq!(verdict.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(verdict.status, ReadinessStatusDto::Blocked);
         assert!(
             verdict
                 .full_repair

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3765,7 +3765,10 @@ fn stdio_repair_reason(verdict: &ReadinessVerdictDto) -> Option<String> {
     if verdict.status == ReadinessStatusDto::RepairSetup {
         return Some("stale_active_cli".to_string());
     }
-    if verdict.status == ReadinessStatusDto::RepairRetrieval {
+    if matches!(
+        verdict.status,
+        ReadinessStatusDto::Blocked | ReadinessStatusDto::RepairRetrieval
+    ) {
         return verdict
             .sidecar
             .as_ref()
@@ -4167,9 +4170,9 @@ version = "0.11.20"
                 .to_string();
         let readiness = vec![ReadinessVerdictDto {
             goal: ReadinessGoalDto::AgentPacketSearch,
-            status: ReadinessStatusDto::RepairRetrieval,
+            status: ReadinessStatusDto::Blocked,
             summary:
-                "Agent packet/search needs full sidecar retrieval; current mode is `unavailable`."
+                "Agent packet/search is blocked until full sidecar retrieval is proven; current mode is `unavailable`."
                     .to_string(),
             minimum_next: vec![repair.clone()],
             full_repair: vec![
@@ -4327,7 +4330,7 @@ version = "0.11.20"
             );
             assert_eq!(
                 surfaces[surface]["status"],
-                json!("repair_retrieval"),
+                json!("blocked"),
                 "blocked agent surface should stay on the agent retrieval lane: {surfaces}"
             );
         }

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -671,9 +671,7 @@ fn doctor_next_commands_stop_at_index_repair_when_inventory_is_stale() {
     );
     let markdown = String::from_utf8_lossy(&markdown.stdout);
     assert!(
-        markdown.contains(
-            "readiness: local_navigation=repair_index agent_packet_search=repair_retrieval"
-        ),
+        markdown.contains("readiness: local_navigation=repair_index agent_packet_search=blocked"),
         "doctor markdown should show local index repair without collapsing agent retrieval readiness:\n{markdown}"
     );
 }
@@ -729,7 +727,7 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
         "local/default lane should expose a local-scoped next command: {doctor:#}"
     );
     assert_eq!(
-        doctor["readiness_lanes"]["agent_packet_search"]["status"], "repair_retrieval",
+        doctor["readiness_lanes"]["agent_packet_search"]["status"], "blocked",
         "doctor should keep agent packet/search readiness separate: {doctor:#}"
     );
     assert_eq!(
@@ -776,8 +774,8 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
     );
     let markdown = String::from_utf8_lossy(&markdown.stdout);
     assert!(
-        markdown.contains("readiness: local_navigation=ready agent_packet_search=repair_retrieval"),
-        "doctor markdown should show split readiness with retrieval repair for agent use:\n{markdown}"
+        markdown.contains("readiness: local_navigation=ready agent_packet_search=blocked"),
+        "doctor markdown should show split readiness with blocked agent packet/search:\n{markdown}"
     );
 }
 
@@ -811,7 +809,7 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
         "{preflight:#}"
     );
     assert_eq!(
-        preflight["full_retrieval"]["status"], "repair_retrieval",
+        preflight["full_retrieval"]["status"], "blocked",
         "{preflight:#}"
     );
     assert_eq!(
@@ -829,7 +827,7 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
         "local/default lane should expose a local-scoped next command: {preflight:#}"
     );
     assert_eq!(
-        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        preflight["agent_packet_search"]["status"], "blocked",
         "preflight should expose agent packet/search lane: {preflight:#}"
     );
     assert_eq!(
@@ -927,11 +925,11 @@ pub fn schedule_index(project_path: &str) -> usize {
         "{preflight:#}"
     );
     assert_eq!(
-        preflight["full_retrieval"]["status"], "repair_retrieval",
+        preflight["full_retrieval"]["status"], "blocked",
         "local refresh must not claim full retrieval readiness: {preflight:#}"
     );
     assert_eq!(
-        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        preflight["agent_packet_search"]["status"], "blocked",
         "agent packet/search should remain fail-closed without full sidecars: {preflight:#}"
     );
     assert!(
@@ -1004,7 +1002,7 @@ pub fn schedule_index(project_path: &str) -> usize {
         "local graph surfaces should stay blocked when refresh does not finish: {preflight:#}"
     );
     assert_eq!(
-        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        preflight["agent_packet_search"]["status"], "blocked",
         "timeout must not escalate into agent sidecar repair or readiness: {preflight:#}"
     );
 }
@@ -1067,8 +1065,8 @@ fn doctor_reports_current_and_stored_semantic_doc_embedding_contract() {
     );
     let sidecar_check = check_with_name(&doctor, "sidecar_retrieval");
     assert_eq!(
-        sidecar_check["status"], "warn",
-        "doctor should warn when mandatory sidecar retrieval is unavailable despite legacy semantic docs: {doctor:#}"
+        sidecar_check["status"], "error",
+        "doctor should block when mandatory sidecar retrieval is unavailable despite legacy semantic docs: {doctor:#}"
     );
     let next_commands = doctor["next_commands"]
         .as_array()
@@ -2425,7 +2423,7 @@ fn assert_stdio_context_id_fails_closed_without_full_sidecars(
     );
     let status = structured["status"].as_str();
     assert!(
-        status.is_some_and(|status| matches!(status, "repair_setup" | "repair_retrieval")),
+        status.is_some_and(|status| matches!(status, "repair_setup" | "blocked")),
         "stdio context --id should fail closed before serving context: {stdio:#}"
     );
 }

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -103,7 +103,7 @@ fn ready_command_emits_compact_verdicts_and_filters_goal() {
     );
     let agent_json: Value = serde_json::from_str(&agent_json_text).expect("ready agent json");
     let agent = &agent_json["verdicts"][0];
-    assert_eq!(agent["status"], "repair_retrieval");
+    assert_eq!(agent["status"], "blocked");
     assert_eq!(
         agent["sidecar"]["degraded_reason"],
         "retrieval_manifest_missing"

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -978,13 +978,7 @@ fn stdio_starts_without_prebuilt_index_and_reports_status() {
 
     assert_eq!(status["readiness"][0]["status"], json!("ready"));
     assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-    assert_allowed_surface(
-        &status,
-        "search",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "search", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -2388,7 +2382,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         .unwrap_or_else(|| panic!("status should include agent_packet_search lane: {status}"));
     assert_eq!(
         agent_lane["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "agent lane should report blocked packet/search readiness: {status}"
     );
     assert_eq!(
@@ -2420,7 +2414,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     );
     assert_eq!(
         status["runtime_truth"]["readiness_lanes"]["agent_packet_search"]["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "runtime truth should include the agent packet/search readiness lane: {status}"
     );
     for surface in [
@@ -2444,13 +2438,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         assert_allowed_surface(&status, surface, true, "local_navigation", "ready");
     }
     for surface in ["packet", "search", "context"] {
-        assert_allowed_surface(
-            &status,
-            surface,
-            false,
-            "agent_packet_search",
-            "repair_retrieval",
-        );
+        assert_allowed_surface(&status, surface, false, "agent_packet_search", "blocked");
         assert_eq!(
             status
                 .pointer(&format!("/allowed_surfaces/{surface}/repair_reason"))
@@ -3089,13 +3077,7 @@ fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
     );
     assert_eq!(status["readiness"][0]["status"], json!("repair_index"));
     assert_allowed_surface(&status, "ground", false, "local_navigation", "repair_index");
-    assert_allowed_surface(
-        &status,
-        "packet",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -3139,13 +3121,7 @@ fn resources_read_status_uses_full_storage_state_for_dirty_marker_freshness() {
     );
     assert_fresh_freshness_counts(&status, "dirty marker older than full storage state");
     assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-    assert_allowed_surface(
-        &status,
-        "packet",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -3182,13 +3158,7 @@ fn resources_read_status_reports_unknown_dirty_marker_without_blocking_local_ind
     );
     assert_fresh_freshness_counts(&status, "status with unknown dirty marker");
     assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-    assert_allowed_surface(
-        &status,
-        "packet",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -3285,13 +3255,7 @@ fn resources_read_status_dirty_marker_fail_open_matrix() {
         }
         assert_fresh_freshness_counts(&status, name);
         assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-        assert_allowed_surface(
-            &status,
-            "packet",
-            false,
-            "agent_packet_search",
-            "repair_retrieval",
-        );
+        assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
     }
 }
 
@@ -3475,7 +3439,7 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
     );
     assert_eq!(
         refreshed_status["allowed_surfaces"]["packet"]["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "packet/search should stay gated by the agent retrieval lane after local refresh: {refreshed_status}"
     );
     let status_next_call_text = refreshed_status["recommended_next_calls"].to_string();
@@ -3745,7 +3709,7 @@ fn tools_call_local_graph_refreshes_long_lived_index_after_source_mutation() {
     );
     assert_eq!(
         status["allowed_surfaces"]["search"]["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "local graph refresh must not make packet/search readiness claims: {status}"
     );
 
@@ -4250,7 +4214,7 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
     );
     assert_eq!(
         error.pointer("/status").and_then(Value::as_str),
-        Some("repair_retrieval")
+        Some("blocked")
     );
     assert_eq!(
         error.pointer("/failed_layer").and_then(Value::as_str),

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -315,6 +315,7 @@ pub enum ReadinessStatusDto {
     RepairSetup,
     RepairIndex,
     CheckIndex,
+    Blocked,
     RepairRetrieval,
 }
 


### PR DESCRIPTION
## Context

Parent: #800

Agent packet/search readiness was still reporting non-full sidecars as `repair_retrieval` / warning-level health. That made stale or unavailable sidecars look advisory even though packet/search/context must fail closed until the selected agent sidecar is full.

Closes https://github.com/TheGreenCedar/CodeStory/issues/803

## What Changed

- Added a `blocked` readiness status for agent packet/search when the selected sidecar is not full or not the agent lane.
- Kept local/default sidecar repair reported separately as `repair_retrieval` so local graph/navigation readiness remains distinct.
- Promoted mandatory non-full sidecar doctor health from `warn` to `error` and made doctor operator status report `blocked` for blocked agent packet/search.
- Updated stdio allowed-surface/status contracts so `packet`, `search`, and `context` stay disallowed with `status=blocked` until full agent sidecar readiness is proven.

```mermaid
flowchart LR
  Local[local navigation] -->|fresh index| LocalReady[ready]
  Agent[agent packet/search] --> Sidecar{agent sidecar full?}
  Sidecar -->|yes| AgentReady[ready]
  Sidecar -->|no| Blocked[blocked]
  LocalDefault[local/default sidecar] --> Repair[repair_retrieval]
```

## How To Review

- Start in `crates/codestory-cli/src/readiness.rs` for the new `Blocked` verdict path and status label.
- Check `crates/codestory-cli/src/main.rs` and `src/output.rs` for doctor severity/operator status.
- Check `crates/codestory-cli/src/stdio_transport.rs` and the updated tests for packet/search/context allowed-surface behavior.

## Verification

- `cargo fmt`
- `git diff --check`
- `$env:RUSTC_WRAPPER=''; cargo test -p codestory-cli readiness`
- `$env:RUSTC_WRAPPER=''; cargo test -p codestory-cli --test cli_golden_path doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full -- --nocapture`
- `$env:RUSTC_WRAPPER=''; cargo test -p codestory-cli --test ready_command ready_command_emits_compact_verdicts_and_filters_goal -- --nocapture`
- `$env:RUSTC_WRAPPER=''; cargo test -p codestory-cli --test stdio_protocol_contracts search_tool_fails_closed_without_full_retrieval_sidecars -- --nocapture`
- `$env:RUSTC_WRAPPER=''; cargo test -p codestory-cli --test stdio_protocol_contracts resources_read_status_reports_browser_readiness_and_next_calls -- --nocapture`
- `$env:RUSTC_WRAPPER=''; cargo test -p codestory-cli --test cli_golden_path doctor_reports_current_and_stored_semantic_doc_embedding_contract -- --nocapture`
- Runtime boundary check: `target/debug/codestory-cli.exe doctor --project <803 worktree> --format json` showed `agent_packet_search.status=blocked`, `local_default.status=repair_retrieval`, and `sidecar_retrieval.status=error` when sidecars were unavailable.

Note: initial cargo attempts through `sccache` failed without Rust diagnostics while compiling test binaries. Re-running with process-local `RUSTC_WRAPPER=` produced the actionable test output and then passed.

## Risk

- `blocked` is a new JSON enum value in readiness output. Existing callers that check `status != ready` remain safe, but callers matching only known repair statuses should be updated to handle `blocked` explicitly.

