### PR TITLE
Add bounded readiness repair entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Added `codestory-cli fix` and MCP `repair_all` as the single supported
+  readiness repair entrypoint, with status recommendations collapsed to one
+  repair action plus a `codestory://status` readback.
 - Blocked CodeStory grounding when the plugin MCP is launchable but not
   model-visible, even when a managed CLI exists; diagnostic fail-open mode now
   exposes status/repair guidance instead of normal grounding tool names.

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -72,6 +72,8 @@ pub(crate) enum Command {
     Doctor(DoctorCommand),
     #[command(about = "Print compact readiness verdicts for local navigation or agent search.")]
     Ready(ReadyCommand),
+    #[command(about = "Run the single supported readiness repair entrypoint.")]
+    Fix(FixCommand),
     #[command(about = "Run a machine-readable smoke profile for CI and agent images.")]
     Smoke(SmokeCommand),
     #[command(about = "Agent-facing readiness and repair helpers.")]
@@ -607,6 +609,26 @@ pub(crate) struct ReadyCommand {
     )]
     pub(crate) run_id: Option<String>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct FixCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Use a specific agent sidecar run id when repairing agent readiness."
+    )]
+    pub(crate) run_id: Option<String>,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(
         long,
@@ -1577,6 +1599,15 @@ pub(crate) struct ReadyOutput {
     pub(crate) local_refresh: Option<crate::readiness::LocalRefreshOutput>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) readiness_lanes: BTreeMap<String, ReadinessLaneOutput>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct FixOutput {
+    pub(crate) status: &'static str,
+    pub(crate) ready: bool,
+    pub(crate) goal: ReadinessGoalDto,
+    pub(crate) action: &'static str,
+    pub(crate) result: ReadyOutput,
 }
 
 #[derive(Debug, Serialize)]
@@ -2639,6 +2670,29 @@ mod tests {
             .find_subcommand_mut(name)
             .expect("subcommand should exist");
         subcommand.render_long_help().to_string()
+    }
+
+    #[test]
+    fn fix_command_parses_as_single_repair_entrypoint() {
+        let cli = Cli::try_parse_from([
+            "codestory-cli",
+            "fix",
+            "--project",
+            "C:/repo",
+            "--format",
+            "json",
+            "--run-id",
+            "shared-agent",
+        ])
+        .expect("fix command should parse");
+        match cli.command {
+            Command::Fix(cmd) => {
+                assert_eq!(cmd.project.project, PathBuf::from("C:/repo"));
+                assert_eq!(cmd.run_id.as_deref(), Some("shared-agent"));
+                assert_eq!(cmd.format, OutputFormat::Json);
+            }
+            _ => panic!("expected fix command"),
+        }
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -81,14 +81,14 @@ use args::{
     DrillSummaryBridgeStatusOutput, DrillSummaryBridgesOutput, DrillSummaryMechanicalOutput,
     DrillSummaryOpenGapsOutput, DrillSummaryOutput, DrillSummarySourceTruthOutput,
     DrillSummarySourceTruthTargetOutput, DrillSummaryStatsOutput, DrillSummaryVerdictOutput,
-    DrillVerificationChecklistItemOutput, FilesCommand, GenerateCompletionsCommand, GroundCommand,
-    IndexCommand, IndexDryRunOutput, IndexOutput, PacketCommand, ProjectArgs, QueryCommand,
-    QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadinessLaneOutput, ReadyCommand,
-    ReadyOutput, RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand,
-    SetupAction, SetupCommand, SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile,
-    SnippetCommand, SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, SymbolWorkflowCommand,
-    TaskAction, TaskBriefCommand, TaskCommand, TrailCommand, TrailJsonOutput,
-    VerificationTargetOutput, build_trail_request,
+    DrillVerificationChecklistItemOutput, FilesCommand, FixCommand, FixOutput,
+    GenerateCompletionsCommand, GroundCommand, IndexCommand, IndexDryRunOutput, IndexOutput,
+    PacketCommand, ProjectArgs, QueryCommand, QueryOutput, QueryResolutionOutput,
+    QuerySelectorOutput, ReadinessLaneOutput, ReadyCommand, ReadyOutput, RepoTextMode,
+    SearchCommand, SearchHitOutput, SearchOutput, ServeCommand, SetupAction, SetupCommand,
+    SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile, SnippetCommand, SnippetJsonOutput,
+    SymbolCommand, SymbolJsonOutput, SymbolWorkflowCommand, TaskAction, TaskBriefCommand,
+    TaskCommand, TrailCommand, TrailJsonOutput, VerificationTargetOutput, build_trail_request,
 };
 #[cfg(test)]
 use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
@@ -96,9 +96,9 @@ use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
 use http_transport::search_repo_text_mode_param;
 use output::{
     REPO_CONTENT_BOUNDARY_LINE, context_packet_json, emit, emit_text, render_agent_citation,
-    render_context_markdown, render_doctor_markdown, render_drill_markdown, render_ground_markdown,
-    render_index_dry_run_markdown, render_index_markdown, render_query_markdown,
-    render_ready_markdown, render_search_hit_output, render_search_markdown,
+    render_context_markdown, render_doctor_markdown, render_drill_markdown, render_fix_markdown,
+    render_ground_markdown, render_index_dry_run_markdown, render_index_markdown,
+    render_query_markdown, render_ready_markdown, render_search_hit_output, render_search_markdown,
     render_snippet_markdown, render_symbol_markdown, render_symbol_mermaid, render_trail_dot,
     render_trail_markdown, render_trail_mermaid, render_trail_story_markdown,
     validate_output_file_parent,
@@ -196,6 +196,7 @@ fn main() -> Result<()> {
         Command::Task(cmd) => run_task(cmd),
         Command::Doctor(cmd) => run_doctor(cmd),
         Command::Ready(cmd) => run_ready(cmd),
+        Command::Fix(cmd) => run_fix(cmd),
         Command::Smoke(cmd) => run_smoke(cmd),
         Command::Agent(cmd) => run_agent(cmd),
         Command::Setup(cmd) => run_setup(cmd),
@@ -2138,6 +2139,37 @@ fn run_doctor(cmd: DoctorCommand) -> Result<()> {
 fn run_ready(cmd: ReadyCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "ready")?;
     preflight_output_file(cmd.output_file.as_deref())?;
+    let output = build_ready_output(&cmd)?;
+    let markdown = render_ready_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
+fn run_fix(cmd: FixCommand) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, "fix")?;
+    preflight_output_file(cmd.output_file.as_deref())?;
+    let ready_cmd = ReadyCommand {
+        project: cmd.project,
+        goal: Some(args::ReadyGoal::Agent),
+        repair: true,
+        wait_fresh: false,
+        run_id: cmd.run_id,
+        format: cmd.format,
+        output_file: None,
+    };
+    let ready = build_ready_output(&ready_cmd)?;
+    let status = fix_status(&ready);
+    let output = FixOutput {
+        status,
+        ready: status == "ready",
+        goal: ReadinessGoalDto::AgentPacketSearch,
+        action: "ready_agent_repair",
+        result: ready,
+    };
+    let markdown = render_fix_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
+fn build_ready_output(cmd: &ReadyCommand) -> Result<ReadyOutput> {
     let runtime = if cmd.repair {
         if matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
             new_agent_surface_runtime(&cmd.project)?
@@ -2185,8 +2217,23 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         local_refresh,
         readiness_lanes,
     };
-    let markdown = render_ready_markdown(&output);
-    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+    Ok(output)
+}
+
+fn fix_status(output: &ReadyOutput) -> &'static str {
+    let Some(non_ready) = readiness::primary_non_ready(&output.verdicts) else {
+        return "ready";
+    };
+    if non_ready
+        .minimum_next
+        .iter()
+        .chain(non_ready.full_repair.iter())
+        .any(|command| command.starts_with("Restart/reload the Codex host/app"))
+    {
+        "blocked_requires_host_reload"
+    } else {
+        "blocked_with_error"
+    }
 }
 
 pub(crate) fn wait_for_local_freshness(

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -29,9 +29,9 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use crate::args::{
-    CliTrailMode, DoctorOutput, DrillOutput, IndexDryRunOutput, IndexOutput, OutputFormat,
-    QueryItemOutput, QueryOutput, ReadyOutput, SearchHitOutput, SearchOutput, TrailCommand,
-    VerificationTargetOutput,
+    CliTrailMode, DoctorOutput, DrillOutput, FixOutput, IndexDryRunOutput, IndexOutput,
+    OutputFormat, QueryItemOutput, QueryOutput, ReadyOutput, SearchHitOutput, SearchOutput,
+    TrailCommand, VerificationTargetOutput,
 };
 use crate::display::{
     clean_path_string, default_trail_direction, format_budget, format_direction, format_kind,
@@ -192,6 +192,20 @@ pub(crate) fn render_ready_markdown(output: &ReadyOutput) -> String {
             }
         }
     }
+    markdown
+}
+
+pub(crate) fn render_fix_markdown(output: &FixOutput) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(markdown, "# Fix");
+    let _ = writeln!(markdown, "status: `{}`", output.status);
+    let _ = writeln!(markdown, "action: `{}`", output.action);
+    let _ = writeln!(
+        markdown,
+        "goal: `{}`",
+        crate::readiness::goal_label(output.goal)
+    );
+    markdown.push_str(&render_ready_markdown(&output.result));
     markdown
 }
 

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -1293,7 +1293,20 @@ static SIDECAR_SETUP_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     &[],
 );
 
+static REPAIR_ALL_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Run the single supported CodeStory readiness repair action.",
+    &[],
+    &[],
+);
+
 static TOOLS: &[ToolSpec] = &[
+    ToolSpec {
+        name: "repair_all",
+        description: "Run the single supported readiness repair action, then read codestory://status again.",
+        input_schema: REPAIR_ALL_INPUT_SCHEMA,
+        output_schema: Some(SchemaSpec::Object(GENERIC_OBJECT_SCHEMA)),
+        safety: SafetyMetadata::local_config_write(),
+    },
     ToolSpec {
         name: "sidecar_setup",
         description: "Read or change the plugin-local sidecar setup policy through MCP; use this instead of asking the user to run shell commands.",

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -847,6 +847,10 @@ fn handle_stdio_tool_call(
         "symbols" => handle_stdio_symbols(runtime, request),
         "snippet" => handle_stdio_snippet(runtime, request),
         "context" => handle_stdio_context(runtime, request),
+        "repair_all" => {
+            state.status_cache = None;
+            handle_stdio_sidecar_repair(runtime)
+        }
         "sidecar_setup" => handle_stdio_sidecar_setup(runtime, state, request),
         _ => serde_json::json!({"error": "unknown tool"}),
     }
@@ -3259,36 +3263,18 @@ fn stdio_status_recommended_next_calls(
                 _ => {}
             }
         }
-        let full_repair = if non_ready.goal == ReadinessGoalDto::AgentPacketSearch {
-            sidecar_setup
-                .get("next_repair_command")
-                .and_then(serde_json::Value::as_str)
-                .filter(|command| !command.trim().is_empty())
-                .map(|command| {
-                    std::iter::once(command.to_string())
-                        .chain(non_ready.full_repair.iter().skip(1).cloned())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_else(|| non_ready.full_repair.clone())
-        } else {
-            non_ready.full_repair.clone()
-        };
-        return serde_json::Value::Array(
-            full_repair
-                .iter()
-                .map(|command| stdio_recommended_next_call(command))
-                .chain([
-                    serde_json::json!({
-                        "method": "resources/read",
-                        "uri": "codestory://status"
-                    }),
-                    serde_json::json!({
-                        "method": "resources/read",
-                        "uri": "codestory://agent-guide"
-                    }),
-                ])
-                .collect(),
-        );
+        return serde_json::json!([
+            {
+                "method": "tools/call",
+                "tool": "repair_all",
+                "arguments": {},
+                "debug_commands": non_ready.full_repair
+            },
+            {
+                "method": "resources/read",
+                "uri": "codestory://status"
+            }
+        ]);
     }
 
     serde_json::json!([

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2688,10 +2688,10 @@ fn resources_read_status_recommends_sidecar_repair_when_policy_enabled() {
     );
     let next_call_text = status["recommended_next_calls"].to_string();
     assert!(
-        next_call_text.contains("\"tool\":\"sidecar_setup\"")
-            && next_call_text.contains("\"action\":\"repair\"")
-            && next_call_text.contains("\"debug_command\""),
-        "enabled policy should route agent repair through the MCP sidecar_setup tool: {status}"
+        next_call_text.contains("\"tool\":\"repair_all\"")
+            && next_call_text.contains("\"debug_commands\"")
+            && next_call_text.contains("\"uri\":\"codestory://status\""),
+        "enabled policy should route agent repair through one MCP repair tool plus status readback: {status}"
     );
     assert!(
         next_call_text.contains("--run-id") && next_call_text.contains("shared-agent"),

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -699,6 +699,25 @@ function mcpNextCallForCommand(command) {
   };
 }
 
+function singleRepairNextCalls(commands) {
+  const needsHost = commands.some((command) => command.startsWith('Restart/reload') || command.startsWith('Refresh or reinstall'));
+  if (needsHost) {
+    return [
+      { method: 'host/restart', instruction: commands[0] },
+      { method: 'resources/read', uri: 'codestory://status' },
+    ];
+  }
+  return [
+    {
+      method: 'tools/call',
+      tool: 'repair_all',
+      arguments: {},
+      debug_commands: commands,
+    },
+    { method: 'resources/read', uri: 'codestory://status' },
+  ];
+}
+
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
@@ -951,11 +970,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     local_refresh: options.localRefresh || null,
     readiness: [repair],
     allowed_surfaces: allowedSurfaces,
-    recommended_next_calls: [
-      { method: 'resources/read', uri: 'codestory://status' },
-      { method: 'resources/read', uri: 'codestory://agent-guide' },
-      ...recommendedNext.map((command) => mcpNextCallForCommand(command)),
-    ],
+    recommended_next_calls: singleRepairNextCalls(recommendedNext),
   };
 }
 
@@ -1200,6 +1215,28 @@ function failOpenSidecarSetupResult(request) {
 
 function runFailOpenMcp(status) {
   const tools = [{
+    name: 'repair_all',
+    description: 'Run the single supported CodeStory readiness repair action, then read codestory://status again.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    outputSchema: { type: 'object', additionalProperties: true },
+    safety: {
+      readOnly: false,
+      sideEffects: true,
+      localOnly: true,
+      openWorld: false,
+      mutation: 'local_plugin_configuration',
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, {
     name: 'sidecar_setup',
     description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode.',
     inputSchema: {
@@ -1270,9 +1307,18 @@ function runFailOpenMcp(status) {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
       } else if (request.method === 'tools/call') {
-        response = request.params?.name === 'sidecar_setup'
-          ? jsonrpcResult(request.id, failOpenSidecarSetupResult(request))
-          : jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status or call sidecar_setup.');
+        if (request.params?.name === 'repair_all') {
+          const repairRequest = {
+            params: {
+              arguments: { action: 'repair' },
+            },
+          };
+          response = jsonrpcResult(request.id, failOpenSidecarSetupResult(repairRequest));
+        } else if (request.params?.name === 'sidecar_setup') {
+          response = jsonrpcResult(request.id, failOpenSidecarSetupResult(request));
+        } else {
+          response = jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status or call repair_all.');
+        }
       } else {
         response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
       }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1086,7 +1086,7 @@ test("mcp launcher blocks managed setup when only PATH cli is available", async 
     assert.equal(status.readiness[0].repair_reason, "managed_cli_unavailable");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
-    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["sidecar_setup"]);
+    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["repair_all", "sidecar_setup"]);
     assert.equal(responses[3].error.code, -32602);
     assert.match(responses[3].error.message, /grounding tools are unavailable/u);
   } finally {


### PR DESCRIPTION
## Context

Closes #802
Refs #800

CodeStory status and agent guidance were still exposing command chains as the supported repair path. This adds one supported repair entrypoint for CLI and MCP while keeping the old low-level commands as debug transcript evidence.

## What Changed

- Added `codestory-cli fix --project <repo> --format json` as the single CLI repair command for agent readiness.
- Added MCP `repair_all` as the canonical repair tool and kept `sidecar_setup` as the lower-level policy/debug surface.
- Collapsed stdio status recommendations to one repair action plus a `codestory://status` reread.
- Updated the plugin diagnostic fail-open shim to expose `repair_all` and route unsupported tooling messages to it.
- Added parser and stdio/plugin contract coverage plus the Unreleased changelog entry.

## How To Review

```mermaid
flowchart TD
    A[codestory://status] --> B{ready?}
    B -- yes --> C[use grounding surfaces]
    B -- no --> D[tools/call repair_all]
    D --> E[codestory-cli fix / ready agent repair]
    E --> F[resources/read codestory://status]
```

Review `run_fix`, `stdio_status_recommended_next_calls`, and the plugin fail-open `repair_all` tool catalog.

## Verification

- `cargo fmt --check` -> passed
- `cargo test -p codestory-cli fix_command_parses_as_single_repair_entrypoint -- --nocapture` -> passed
- `cargo test -p codestory-cli --test stdio_protocol_contracts repair -- --nocapture` -> passed 7 tests
- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> passed 45 tests
- `git diff --check` -> passed
- `cargo check -p codestory-cli` -> passed

## Risk

This intentionally narrows agent-facing repair guidance. `sidecar_setup` remains available for policy/debug operations, but status now points normal repair through `repair_all` plus status reread.
