### PR TITLE
[codex] Rewrite MCP-only repair guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Rewrote agent-facing CodeStory guidance to make MCP status plus `repair_all`
+  the single supported repair loop, with CLI commands labeled as
+  maintainer/debug transcripts.
 - Added `codestory-cli fix` and MCP `repair_all` as the single supported
   readiness repair entrypoint, with status recommendations collapsed to one
   repair action plus a `codestory://status` readback.

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -41,7 +41,10 @@ navigation and agent retrieval separate: a ready SQLite graph can support
 `ground`, `files`, and symbol navigation while sidecar packet/search remains
 blocked.
 
-Start with the active runtime surface:
+Start with the active runtime surface. When plugin MCP is live, read
+`codestory://status`, follow `recommended_next_calls`, call MCP `repair_all`
+when recommended, and reread `codestory://status`. The CLI commands below are
+maintainer/debug transcripts, not the supported agent repair path:
 
 ```sh
 codestory-cli agent preflight --project <repo> --format json
@@ -60,9 +63,9 @@ available.
 |-------|---------|-----------------|
 | `local_navigation=ready`, `agent_packet_search=ready`, `sidecar_mode=full` | Local graph and sidecar packet/search infrastructure are ready | Use packet/search/context as infrastructure-eligible, then prove answer quality with source, packet-runtime, drill, or benchmark evidence |
 | `local_navigation=ready`, `agent_packet_search=repairing` | Agent sidecar repair is active and status should include the current `phase`, `profile`, `run_id`, and `namespace` | Wait or reread `codestory://status`; do not start a second agent repair for the same run |
-| `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; run the repair command from preflight/status before packet/search claims |
-| `local_navigation=repair_local` | Core index or cache is missing or stale | Run `codestory-cli ready --goal local --repair --project <repo> --format json`, then rerun `doctor` |
-| `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Repair the failing sidecar layer, rerun `retrieval index --refresh full`, then rerun `retrieval status` |
+| `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; call MCP `repair_all` from status before packet/search claims |
+| `local_navigation=repair_local` | Core index or cache is missing or stale | Call MCP `repair_all`, then reread status; use CLI `fix` only for maintainer transcripts |
+| `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Call MCP `repair_all`, then reread status; maintainers can inspect `retrieval status` and rerun explicit sidecar commands if needed |
 | `doctor` ready but a packet/search command returns `retrieval_unavailable` | Runtime/status disagreement or sidecar process drift | Capture the failing command output, `doctor`, and `retrieval status`; repair the named layer before retrying |
 
 Layer repair should follow the first failing layer, not a broad rebuild:
@@ -70,7 +73,7 @@ Layer repair should follow the first failing layer, not a broad rebuild:
 | Failing layer | Evidence to capture | Small repair |
 |---------------|---------------------|--------------|
 | Active runtime or plugin adapter | `codestory://status` fields, `server_executable`, `cli_version`, `plugin_runtime`, `allowed_surfaces` | Reload or reinstall the active CLI/plugin runtime, then reread status |
-| Core SQLite graph | `doctor` cache/index checks and indexed file counts | `codestory-cli ready --goal local --repair --project <repo> --format json` |
+| Core SQLite graph | `doctor` cache/index checks and indexed file counts | MCP `repair_all`; CLI transcript: `codestory-cli fix --project <repo> --format json` |
 | Zoekt lexical sidecar | `retrieval status` mode/degraded reason and Zoekt health text | Free port `6070` or rerun bootstrap, then `retrieval index --refresh full` |
 | Qdrant dense sidecar | Qdrant health, collection name, point count, dense-anchor count, backend/dimension fields | Fix Qdrant/model/backend state; move the Qdrant cache aside only if repeated health checks fail |
 | SCIP graph artifacts | `scip_unavailable`, graph artifact hash/path, manifest contract | Rerun `retrieval index --refresh full`; inspect SCIP cache paths if it repeats |

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -6,16 +6,19 @@ work through the steps in order.
 Trust boundaries: [Trust and readiness](trust-and-readiness.md). Terms:
 [Glossary](../glossary.md).
 
-**Need JSON field names?** Common status keys: `allowed_surfaces`, `retrieval_mode`, `repair_command`. Full agent contract: [status-contract](../../plugins/codestory/skills/codestory-grounding/references/status-contract.md). CLI repair commands: [CLI reference](cli-reference.md#readiness-and-repair).
+**Need JSON field names?** Common status keys: `allowed_surfaces`,
+`retrieval_mode`, and `recommended_next_calls`. Full agent contract:
+[status-contract](../../plugins/codestory/skills/codestory-grounding/references/status-contract.md).
+CLI commands are maintainer/debug transcripts: [CLI reference](cli-reference.md#readiness-and-repair).
 
 ## Repair quick reference
 
-| Symptom | CLI command | Check in output |
+| Symptom | Supported action | Check in output |
 | --- | --- | --- |
-| Repo map stale or blocked | `codestory-cli ready --goal local --repair --project <repo> --format json` | `verdicts[].goal` is `local_navigation`; `status` is `ready` or follow `minimum_next` |
-| Broad search blocked | `codestory-cli ready --goal agent --repair --project <repo> --format json` | `verdicts[].goal` is `agent_packet_search`; `retrieval_mode` is `full` in retrieval status |
-| MCP down, need handoff | `codestory-cli agent preflight --project <repo> --format json` | `safe_surfaces`, `blocked_surfaces`, `repair_command` |
-| Sidecar health | `codestory-cli retrieval status --project <repo> --format json` | `retrieval_mode` is `full` before trusting packet/search |
+| Repo map stale or blocked | Agent reads `codestory://status`, calls MCP `repair_all` if recommended, then rereads status | Local graph surfaces are allowed after the reread |
+| Broad search blocked | Same MCP `repair_all` loop | `packet`, `search`, or `context` allowed and `retrieval_mode` is `full` |
+| MCP down, need handoff | Reload/fix host MCP; CLI can collect a debug transcript only | `codestory://status` becomes visible in the agent host |
+| Sidecar health | MCP status first; CLI `retrieval status` only for maintainer evidence | `retrieval_mode` is `full` before trusting packet/search |
 
 ## Decision tree
 
@@ -34,8 +37,9 @@ flowchart TD
   local --> fix_local[Refresh or repair local index]
   sidecar --> fix_sidecar[Sidecar setup or repair]
   fix_mcp --> host[Host guide]
-  fix_local --> cli_local["CLI: ready --goal local"]
-  fix_sidecar --> cli_agent["CLI: ready --goal agent"]
+  fix_local --> mcp_repair["MCP: repair_all"]
+  fix_sidecar --> mcp_repair
+  mcp_repair --> reread["Reread codestory://status"]
   host --> codex[Codex guide]
   host --> cursor[Cursor guide]
   host --> claude[Claude Code guide]
@@ -48,7 +52,7 @@ flowchart TD
 | --- | --- | --- | --- | --- |
 | MCP missing | Fresh thread after `/plugins` install | Check `.cursor/mcp.json`; reload MCP server | MCP configured separately from hooks | MCP not auto-started; configure or use CLI |
 | Stale index / wrong symbols | New thread; hooks refresh on session start | Reload MCP; run local repair | New session; run local repair | New session; run [local repair](cli-reference.md#readiness-and-repair) |
-| Packet/search blocked | Agent calls sidecar setup when status says so | Same; verify retrieval mode | Same | Use CLI [retrieval status](cli-reference.md#readiness-and-repair) |
+| Packet/search blocked | Agent calls MCP `repair_all` when status says so | Same; verify retrieval mode | Same | Use CLI [retrieval status](cli-reference.md#readiness-and-repair) only as a debug transcript |
 | Version drift after update | Refresh marketplace, refresh plugin package, restart host, fresh status read | Reload MCP server | Restart session | Reinstall or point to current binary |
 
 Host-specific steps: [Codex](codex.md#troubleshooting), [Cursor](cursor.md#troubleshooting), [Claude Code](claude-code.md#troubleshooting), [Copilot](copilot.md).
@@ -90,8 +94,8 @@ Ask the agent:
 Read codestory://status, report allowed_surfaces, and tell me what is blocked and the next repair action.
 ```
 
-The agent uses MCP status, `codestory://agent-guide`, and `sidecar_setup` when
-packet/search needs repair. Re-read status after any repair.
+The agent uses MCP status, `codestory://agent-guide`, and `repair_all` when
+status recommends repair. Re-read status after any repair.
 
 </details>
 
@@ -107,8 +111,8 @@ codestory-cli agent preflight --project <repo> --format json
 codestory-cli doctor --project <repo>
 ```
 
-**Agent:** Can interpret `safe_surfaces`, `blocked_surfaces`, and
-`repair_command` from preflight when MCP is down.
+**Agent:** Treats CLI output as a debug transcript only. CLI output does not
+make CodeStory MCP live in the agent host.
 
 On Windows PowerShell, use `.\target\release\codestory-cli.exe` for a
 source-built binary.
@@ -120,10 +124,10 @@ Symptoms: missing symbols, old file list, `ground` or `files` not allowed.
 **Agent (MCP live):** Use allowed local graph tools only; request index refresh
 through status guidance.
 
-**You (CLI fallback):**
+**You (CLI debug transcript):**
 
 ```sh
-codestory-cli ready --goal local --repair --project <repo> --format json
+codestory-cli fix --project <repo> --format json
 codestory-cli doctor --project <repo>
 ```
 
@@ -141,8 +145,9 @@ node plugins/codestory/hooks/codestory-dirty-hook.cjs install --project <repo> -
 Symptoms: `packet`, `search`, or `context` not allowed; retrieval mode not
 `full`.
 
-**Agent:** Call `sidecar_setup` with `enable` or `repair` when status says so.
-Do not treat degraded output as proof. See [Trust and readiness](trust-and-readiness.md#proof-vs-hint).
+**Agent:** Call MCP `repair_all` when status says so, then reread
+`codestory://status`. Do not treat degraded output as proof. See
+[Trust and readiness](trust-and-readiness.md#proof-vs-hint).
 
 **You:** Sidecar model download and lifecycle:
 [Retrieval sidecars ops](../ops/retrieval-sidecars.md).
@@ -151,7 +156,7 @@ CLI check:
 
 ```sh
 codestory-cli retrieval status --project <repo> --format json
-codestory-cli ready --goal agent --repair --project <repo> --format json
+codestory-cli fix --project <repo> --format json
 ```
 
 Require `retrieval_mode: "full"` before trusting packet/search evidence.

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -13,7 +13,7 @@ Before reading source files, making source claims, planning edits, choosing test
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
-6. If MCP is truly unavailable, use managed CLI or local-dev CODESTORY_CLI preflight as the setup/repair fallback. PATH checks are diagnostics only; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
+6. If MCP is unavailable, CodeStory grounding is unavailable in this host. Use ordinary source inspection, report the MCP blocker, and reserve CLI commands for maintainer/debug transcripts only.
 
 Do this without waiting for the user to mention CodeStory.`;
 
@@ -59,11 +59,11 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, say that and reload the host/plugin instead of asking for PATH setup. When MCP is truly unavailable, use managed CLI or local-dev CODESTORY_CLI preflight and use the reported safe_surfaces.
+Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, say that and reload the host/plugin instead of asking for PATH setup. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.
-Use the managed/runtime preflight repair_command as the default setup path once a repository target is known; keep PATH checks diagnostic.
+Use status recommended_next_calls as the setup path once a repository target is known: call MCP repair_all when recommended, then reread codestory://status. Keep CLI and PATH checks diagnostic.
 
 ${body}`;
 }

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codestory-grounding
-description: Use when an agent should ground a local repository with CodeStory before making source claims, planning edits, choosing tests, reviewing changes, or using packet/search evidence through the CodeStory plugin or codestory-cli.
+description: Use when an agent should ground a local repository with CodeStory before making source claims, planning edits, choosing tests, reviewing changes, or using packet/search evidence through the CodeStory plugin MCP.
 ---
 
 # CodeStory Grounding
@@ -36,8 +36,9 @@ When the plugin MCP server is available:
 5. Read `codestory://agent-guide` when you need the runtime's recommended next calls.
 
 If the skill is visible but no `mcp__codestory` tools or `codestory://status`
-resource are exposed, call it a plugin MCP registration failure. Use CLI only as
-a degraded fallback and report that MCP was not live.
+resource are exposed, call it a plugin MCP registration failure. Do not use CLI
+as CodeStory grounding; use ordinary source inspection and report that MCP was
+not live.
 
 ## Task Router
 
@@ -48,7 +49,7 @@ a degraded fallback and report that MCP was not live.
 | Trace: "Who calls this?" | `callers`, `callees`, `trace`, or `trail --story --hide-speculative`. |
 | Impact: "What might this change touch?" | `affected` with changed files from git; planning hints only, not proof. |
 | Broad question | `packet`, `search`, or `context` only when allowed and `retrieval_mode=full`. |
-| Blocked surface | Follow `recommended_next_calls` from status; see [doctor](references/doctor.md) and [serve](references/serve.md). |
+| Blocked surface | Follow `recommended_next_calls` from status; normally call MCP `repair_all`, then reread `codestory://status`. |
 
 ## Evidence Rules
 
@@ -59,17 +60,21 @@ a degraded fallback and report that MCP was not live.
 - `retrieval_mode=full` is infrastructure eligibility, not answer-quality proof;
   anything weaker is navigation hints only.
 
-## CLI Fallback
+## Repair Loop
 
-Only when MCP is missing, repair is needed, or a transcript is requested:
+Supported agent repair is MCP-only:
 
-1. `ready --goal local --repair --project <target-workspace> --format json`
-2. `ready --goal agent --repair --project <target-workspace> --format json` before packet/search
-3. `doctor --project <target-workspace>` for a read-only health transcript
-4. Mirror allowed MCP surfaces: `ground`, `files`, `symbol`, `trail`, `snippet`, `search`, `packet`, `context`
+1. Read `codestory://status`.
+2. If `recommended_next_calls` says so, call MCP `repair_all` for
+   `<target-workspace>`.
+3. Reread `codestory://status`.
+4. Use only the surfaces allowed by the refreshed status.
 
-Always pass `--project <target-workspace>` explicitly. Repair details:
-[serve](references/serve.md), [doctor](references/doctor.md).
+CLI commands such as `fix`, `doctor`, `ready`, and `retrieval status` are
+maintainer/debug transcript tools. They do not prove plugin MCP is live in the
+agent host and are not the supported repair path for agent grounding.
+
+Repair details: [serve](references/serve.md), [doctor](references/doctor.md).
 
 `setup.ps1` and `setup.sh` under this skill are build-from-source paths for
 contributors only, not the normal user install path.

--- a/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
+++ b/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CodeStory Grounding"
-  short_description: "Ground local repos through CodeStory's plugin MCP or CLI fallback before planning, editing, or reviewing."
-  default_prompt: "Use $codestory-grounding: Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]? Or: I am editing a file in this repo — what symbols are affected and what tests should I run first? For first session or after repair: read codestory://status, ground if allowed, and use packet/search only when sidecars report retrieval_mode=full."
+  short_description: "Ground local repos through CodeStory's plugin MCP before planning, editing, or reviewing."
+  default_prompt: "Use $codestory-grounding: Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]? Or: I am editing a file in this repo — what symbols are affected and what tests should I run first? For first session or after repair: read codestory://status, call repair_all if status recommends it, reread status, and use packet/search only when sidecars report retrieval_mode=full."

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -1,6 +1,6 @@
 # `doctor` - Project And Retrieval Health
 
-Reads project/cache/index/retrieval health without mutating the index. Use it at the start of an LLM browser loop and when a read command fails unexpectedly. For MCP runtime truth and surface gating, see [status-contract.md](status-contract.md). Use `doctor` when MCP is missing, a repair transcript is needed, or status points to stale evidence.
+Reads project/cache/index/retrieval health without mutating the index. Use it for maintainer/debug transcripts and when a read command fails unexpectedly. For agent MCP runtime truth, repair, and surface gating, see [status-contract.md](status-contract.md).
 
 ## Usage
 
@@ -22,7 +22,7 @@ Reads project/cache/index/retrieval health without mutating the index. Use it at
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> doctor --project <target-workspace>` | Reports project root, cache path, indexed stats, retrieval state, sidecar embedding setup, environment hints, and next commands. |
-| Failure path | If cache or index checks warn, run `ready --goal local --repair --project <target-workspace> --format json` or the setup/index command surfaced by `doctor`; use explicit `index --refresh full` only when the reported failure calls for a rebuild. If mandatory sidecars are missing or stale, run the sidecar setup/index commands surfaced by `doctor`; if symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, repair before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
+| Failure path | In MCP, follow `codestory://status` `recommended_next_calls`, normally `repair_all` then a status reread. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific setup/index command surfaced by `doctor`; use explicit `index --refresh full` only when the reported failure calls for a rebuild. If symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, repair before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
 | Integration edge | Use doctor before `ground`, `search --why`, `explore`, `context`, or `serve`; its next commands are the safe follow-up loop. | Prevents read commands from silently querying the wrong or empty cache. |
 
 For MCP/runtime drift, collect binary evidence only after status is missing or

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -44,7 +44,7 @@ The installed plugin starts `scripts/codestory-mcp.cjs` (managed CLI bootstrap a
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
-| Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `ready --goal local --repair --project <target-workspace> --format json`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
+| Failure path | If MCP status reports missing index, follow `recommended_next_calls`, normally `repair_all` then a status reread. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific command surfaced by `doctor`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
 | Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `affected`, `packet`, `search`, `symbol`, `callers`, `callees`, `trail`, `trace`, `definition`, `references`, `symbols`, `snippet`, `context`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
 
 Stdio MCP status fields and allowed-surface rules: [status-contract.md](status-contract.md).

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -15,15 +15,15 @@ the agent-facing field glossary alongside runtime `codestory://agent-guide`.
 | `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
 | `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `managed_unavailable` as blocked managed setup. |
 | `runtime_truth` | Grouped runtime source, plugin root, managed CLI path, launcher source, sidecar policy/status, and readiness lanes. | Use as the concise bounded runtime summary; fall back to the source fields when a nested value needs detail. |
-| `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Ask before first automatic sidecar setup; respect `enabled` and `disabled`. |
+| `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Diagnostic sidecar policy detail. For agent repair, follow `recommended_next_calls` and prefer MCP `repair_all`. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trail`, `trace`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 
 ## Runtime Repair
 
 Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
-source-build checks only when MCP is missing, the plugin needs repair, or the
-user asks for a CLI transcript. `CODESTORY_CLI` is an explicit local-dev
+source-build checks only for maintainer/debug transcripts when MCP is missing
+or suspect. They are not the supported agent repair path. `CODESTORY_CLI` is an explicit local-dev
 override; installed `.mcp.json` launches the managed adapter first, provisions
 from `github_release` when needed, and records the launch source in
 `plugin_runtime`. If the managed runtime cannot spawn or be provisioned, the
@@ -31,7 +31,8 @@ adapter stays up with `repair_setup` diagnostics instead of closing transport.
 Any `PATH` candidates in status are diagnostic only and are not launched by the
 installed plugin runtime.
 
-If `codestory://status` reports `repair_setup` because the active
-`server_version` is older than the latest release, repair the CLI before local
-navigation, packet, search, or context. The agent runs the installer command from `recommended_next_calls`; do not ask the human to install the binary unless
-network, permissions, or release assets block the repair.
+If `codestory://status` reports a repairable state, run the MCP
+`recommended_next_calls` loop: call `repair_all` when recommended, then reread
+`codestory://status` before local navigation, packet, search, or context. Do not
+ask the human to install the binary unless network, permissions, host reload, or
+release assets block the repair.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -122,6 +122,28 @@ test("plugin metadata maps skill and direct stdio server", async () => {
   });
 });
 
+test("agent-facing guidance keeps MCP repair as the only supported repair path", async () => {
+  const guidanceFiles = [
+    join(pluginRoot, "hooks", "codestory-instructions.cjs"),
+    join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"),
+    join(pluginRoot, "skills", "codestory-grounding", "agents", "openai.yaml"),
+    join(pluginRoot, "skills", "codestory-grounding", "references", "status-contract.md"),
+    join(pluginRoot, "skills", "codestory-grounding", "references", "doctor.md"),
+    join(pluginRoot, "skills", "codestory-grounding", "references", "serve.md"),
+    join(repoRoot, "docs", "users", "troubleshooting.md"),
+    join(repoRoot, "docs", "ops", "retrieval-sidecars.md"),
+  ];
+
+  for (const file of guidanceFiles) {
+    const text = await readFile(file, "utf8");
+    assert.doesNotMatch(text, /CLI Fallback/u, file);
+    assert.doesNotMatch(text, /CLI fallback/u, file);
+    assert.doesNotMatch(text, /managed CLI or local-dev CODESTORY_CLI preflight/u, file);
+    assert.doesNotMatch(text, /Call `sidecar_setup`/u, file);
+    assert.match(text, /repair_all/u, file);
+  }
+});
+
 test("plugin package version tracks the codestory-cli release version", async () => {
   const cliManifest = await readFile(
     join(repoRoot, "crates", "codestory-cli", "Cargo.toml"),
@@ -1825,7 +1847,7 @@ function runCodexHook(input, env) {
   return JSON.parse(result.stdout);
 }
 
-test("hook output keeps CodeStory ambient and checks MCP before CLI fallback", async () => {
+test("hook output keeps CodeStory ambient and checks MCP before source fallback", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-mcp-first-"));
@@ -1927,7 +1949,7 @@ test("hook degraded output is short when no MCP or managed runtime is usable", a
   }
 });
 
-test("hook failed preflight switches degraded guidance to bounded source fallback", async () => {
+test("hook failed preflight switches degraded guidance to bounded source reads", async () => {
   const { spawnSync } = await import("node:child_process");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-"));
   const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-bin-"));


### PR DESCRIPTION
## Context

Closes #805
Refs #800

The `repair_all` MCP tool from #802 gives CodeStory one supported agent repair loop. The remaining guidance still described CLI fallback, direct `sidecar_setup`, and multi-command repair as normal agent behavior, which made MCP readiness feel optional.

## What Changed

- Rewrote the CodeStory grounding skill, injected hook instructions, OpenAI skill prompt, and status/doctor/serve references so the supported path is: read `codestory://status`, call MCP `repair_all` if recommended, then reread `codestory://status`.
- Updated user troubleshooting and retrieval-sidecar ops docs to label CLI commands as maintainer/debug transcripts, not agent repair fallback.
- Added a plugin static guard that scans agent-facing guidance for stale CLI fallback and direct `sidecar_setup` repair wording.
- Updated `CHANGELOG.md` under `Unreleased`.

## How To Review

1. Start with `plugins/codestory/skills/codestory-grounding/SKILL.md` and `plugins/codestory/hooks/codestory-instructions.cjs` to verify the agent-facing loop.
2. Check `docs/users/troubleshooting.md` and `docs/ops/retrieval-sidecars.md` for operator wording and the MCP-vs-CLI boundary.
3. Review `plugins/codestory/tests/plugin-static.test.mjs` for the regression guard.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

## Risk

Low. This is guidance and test coverage only. It depends on the `repair_all` runtime/tool behavior already merged in #814.