### PR TITLE
[codex] Fix installed MCP active project state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Added `codestory-cli fix` and MCP `repair_all` as the single supported
   readiness repair entrypoint, with status recommendations collapsed to one
   repair action plus a `codestory://status` readback.
+- Let the installed plugin MCP launcher use fresh active-project state even
+  when the host hook cannot attach a Codex thread id or the state predates the
+  MCP process start, while still rejecting state owned by another thread, and
+  give local wait-fresh enough bounded time to pass on the CodeStory repo.
 - Made packaged and post-publish agent proof fail when the installed plugin MCP
   launcher omits server-advertised `codestory://status` or
   `codestory://agent-guide` resources, while leaving true Codex host/model

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -20,7 +20,6 @@ const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
 const releaseDownloadRetryDelaysMs = [1000, 3000];
-const processStartedAtMs = Date.now();
 
 function readJson(file) {
   try {
@@ -130,11 +129,6 @@ function activeProjectStateMaxAgeMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 60 * 60 * 1000;
 }
 
-function activeProjectStateLaunchGraceMs() {
-  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_ACTIVE_PROJECT_LAUNCH_GRACE_MS || '', 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5 * 1000;
-}
-
 function activeProjectStateTimestamp(active, statePath) {
   const parsed = Date.parse(active?.updatedAt || active?.updated_at || '');
   if (Number.isFinite(parsed)) return parsed;
@@ -147,15 +141,16 @@ function activeProjectStateTimestamp(active, statePath) {
 
 function activeProjectStateMatchesHost(active) {
   const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
-  if (!currentThread) return !String(active?.codexThreadId || '').trim();
-  return String(active?.codexThreadId || '').trim() === currentThread;
+  const activeThread = String(active?.codexThreadId || '').trim();
+  if (!activeThread) return true;
+  if (!currentThread) return false;
+  return activeThread === currentThread;
 }
 
 function activeProjectStateFresh(active, statePath, nowMs = Date.now()) {
   const timestamp = activeProjectStateTimestamp(active, statePath);
   return timestamp !== null
     && nowMs - timestamp <= activeProjectStateMaxAgeMs()
-    && timestamp >= processStartedAtMs - activeProjectStateLaunchGraceMs()
     && activeProjectStateMatchesHost(active);
 }
 
@@ -720,7 +715,7 @@ function singleRepairNextCalls(commands) {
 
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30000;
 }
 
 function runLocalNavigationWaitFresh(resolved, projectRoot) {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -416,7 +416,6 @@ test("mcp launcher uses active project state when host launches from plugin root
       JSON.stringify({
         event: "SessionStart",
         cwd: realRepoRoot,
-        codexThreadId: threadId,
         updatedAt: new Date().toISOString(),
       }),
       "utf8",
@@ -747,7 +746,7 @@ test("mcp launcher rejects thread-owned global state when current thread is unav
   }
 });
 
-test("mcp launcher rejects active project state from before launcher start", async () => {
+test("mcp launcher uses fresh active project state from before launcher start", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-prelaunch-active-project-"));
@@ -815,15 +814,9 @@ test("mcp launcher rejects active project state from before launcher start", asy
     });
 
     assert.equal(result.status, 0, result.stderr);
-    await assert.rejects(access(marker));
+    assert.equal(await readFile(marker, "utf8"), "serve");
     const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
-    const response = JSON.parse(result.stdout.trim());
-    const status = JSON.parse(response.result.contents[0].text);
-    assert.equal(status.degraded_reason, "project_root_unavailable");
-    assert.equal(status.project_root, null);
-    assert.equal(status.project_root_source, "plugin_active_state_stale");
-    assert.equal(status.readiness[0].goal, "project_root");
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version", "serve"]);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1760,7 +1753,7 @@ test("hook manifest timeouts cover managed bootstrap budget", async () => {
     /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
     "local wait-fresh timeout default",
   );
-  assert.equal(localWaitFreshTimeoutMs, 5000, "local wait-fresh default must stay bounded for bootstrap diagnostics");
+  assert.equal(localWaitFreshTimeoutMs, 30000, "local wait-fresh default must stay bounded for bootstrap diagnostics");
   const requiredTimeoutSec = Math.max(
     Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
     Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),


### PR DESCRIPTION
## Context

Closes #804
Refs #800

Installed CodeStory plugin MCP can launch from the plugin cache before the hook writes thread-scoped state. In this host, the hook wrote the right cwd but no `codexThreadId`, and the MCP process rejected that fresh unowned state. The launcher also treated active state written before the MCP process start as stale, and its 5s local wait-fresh budget was shorter than the managed CLI needed on this repo.

## What Changed

- Trust fresh unowned active-project state while still rejecting state owned by a different Codex thread.
- Stop requiring active-project state to be newer than the MCP launcher process.
- Raise the bounded plugin local wait-fresh budget from 5s to 30s.
- Cover unowned active state and prelaunch fresh state in plugin static tests.
- Document the shipped behavior fix in `CHANGELOG.md`.

## How To Review

Start in `plugins/codestory/scripts/codestory-mcp.cjs`, especially `activeProjectStateMatchesHost`, `activeProjectStateFresh`, and `localWaitFreshTimeoutMs`. Then review the matching expectations in `plugins/codestory/tests/plugin-static.test.mjs`.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 46 passed
- `git diff --check` -> passed
- Remote CI on PR #818 -> plugin static tests passed; saga issue link guard passed
- Installed launcher proof: `node C:\Users\alber\.codex\plugins\cache\TheGreenCedar\codestory\0.12.6\scripts\codestory-mcp.cjs bootstrap-status` -> `ready=True`, project root `C:\Users\alber\source\repos\codestory`, managed CLI 0.12.6, `path_fallback=False`, local navigation ready
- MCP resource visibility proof from this Codex host: `resources/list` for `codestory` returns `codestory://status` and `codestory://agent-guide`; `resources/read codestory://status` returns plugin version 0.12.6, managed CLI source/path, `path_fallback=false`, and the managed binary hash
- Agent retrieval proof: `codestory-cli retrieval status --project C:\Users\alber\source\repos\codestory --profile agent --run-id shared-agent --format json` -> `retrieval_mode=full`, lexical/semantic/graph/symbol-doc lanes ready

## Risk

`codestory://status` is model-visible now, but the resident MCP server still reports `project_root_unavailable` until the host records fresh active-project state for this thread and reloads from the target repo. This PR fixes the repo-side launcher rejection that made fresh unowned state unusable; project-root grounding readiness remains a separate runtime-state readback.
