### PR TITLE
[codex] Bump CodeStory to 0.13.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@
   the new release heading so release contents are tracked while the work is
   still reviewable.
 - Do not create or push `v*` release tags manually. A synchronized version bump on `main` triggers GitHub Actions to create the tag, GitHub release, cross-platform `codestory-cli` binary assets, and `SHA256SUMS.txt`.
+- After merging a `dev/codestory-next` promotion PR into `main`, verify
+  `dev/codestory-next` still exists and matches `main` with
+  `git ls-remote --heads origin main dev/codestory-next` and
+  `git rev-list --left-right --count origin/main...origin/dev/codestory-next`.
+  If GitHub deletes the head branch, restore it from the promoted `main` commit
+  before treating the release as complete.
 - After a plugin release or plugin-source update that Codex must detect through
   the marketplace, push a corresponding change to
   `TheGreenCedar/AgentPluginMarketplace`; Codex observes the marketplace repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.13.0
+
+CodeStory 0.13.0 promotes the current `dev/codestory-next` MCP readiness and
+agent-repair hardening work onto `main` as the next synchronized release.
+
 ### Fixed
 
 - Rewrote agent-facing CodeStory guidance to make MCP status plus `repair_all`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -73,6 +73,17 @@ python .github/scripts/check-codestory-release.py --version <version>
 After a `main` release, run the release version check on `dev/codestory-next`
 with the released version before starting the next release lane.
 
+After merging a `dev/codestory-next` promotion PR into `main`, verify the dev
+branch survived the merge and still matches `main`:
+
+```sh
+git ls-remote --heads origin main dev/codestory-next
+git rev-list --left-right --count origin/main...origin/dev/codestory-next
+```
+
+If GitHub deletes `dev/codestory-next`, restore it from the promoted `main`
+commit before treating the release as complete.
+
 Do not create or push `v*` tags manually. A synchronized version bump merged to
 `main` runs the auto-release workflow, which creates the GitHub tag, release,
 cross-platform `codestory-cli` archives, and `SHA256SUMS.txt`.

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context

Closes #798
Refs #799

`dev/codestory-next` is ahead of `main` and ready for the next synchronized release train. The remaining release-flow gap is that a prior main promotion deleted `dev/codestory-next`, so this bump also records the required post-promotion branch preservation proof.

## What Changed

- Bumped all `codestory-*` workspace crates and `Cargo.lock` to `0.13.0`.
- Bumped the three CodeStory plugin manifests to `0.13.0`.
- Moved the current unreleased MCP/readiness hardening notes under a `0.13.0` changelog heading.
- Added release operator guidance to verify `main` and `dev/codestory-next` both exist and match after a main promotion, and to restore the dev branch if GitHub deletes it.

## How To Review

Start with `crates/codestory-cli/Cargo.toml` as the release version source, then check `Cargo.lock`, the three plugin manifests, `CHANGELOG.md`, and the release guidance additions in `AGENTS.md` plus `docs/contributors/testing-matrix.md`.

## Verification

- `python .github/scripts/check-codestory-release.py --version 0.13.0` -> synchronized across 8 workspace crates, Cargo.lock, and 3 plugin manifests
- `node .github/scripts/check-workflow-policy.mjs` -> passed
- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 46 passed
- `node .github/scripts/check-doc-links.mjs` -> passed, 70 files and 279 links
- `git diff --check` -> passed
- `cargo check --locked -p codestory-cli` -> passed with CodeStory crates at 0.13.0

## Risk

This PR prepares the 0.13.0 release on `dev/codestory-next`; the actual tag, GitHub release, binary assets, and downstream marketplace pointer still require the follow-up `dev/codestory-next` -> `main` promotion and post-publish proof.