### PR TITLE
Release CodeStory 0.13.0

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -21,6 +21,8 @@ from pathlib import Path
 DEFAULT_QUESTION = "Explain how CodeStory validates packaged agent readiness."
 DEFAULT_QUERY = "RuntimeContext"
 STATUS_URI = "codestory://status"
+AGENT_GUIDE_URI = "codestory://agent-guide"
+SERVER_RESOURCE_URIS = (STATUS_URI, AGENT_GUIDE_URI)
 PLUGIN_SKILL_RELATIVE = Path("plugins/codestory/skills/codestory-grounding/SKILL.md")
 
 
@@ -342,6 +344,7 @@ def plugin_stdio_status(
             ["node", str(launcher)],
             artifact,
             timeout_secs,
+            layer="plugin_stdio",
             cwd=project,
             env={
                 **os.environ,
@@ -356,6 +359,7 @@ def stdio_status_command(
     command: list[str],
     artifact: Path,
     timeout_secs: int,
+    layer: str = "serve_stdio",
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
 ) -> dict:
@@ -373,6 +377,7 @@ def stdio_status_command(
     )
     requests = [
         {"jsonrpc": "2.0", "id": "tools", "method": "tools/list"},
+        {"jsonrpc": "2.0", "id": "resources", "method": "resources/list"},
         {
             "jsonrpc": "2.0",
             "id": "status",
@@ -413,13 +418,13 @@ def stdio_status_command(
                     stderr_path,
                     {"timed_out": True, "timeout_secs": timeout_secs},
                 )
-                fail("serve_stdio", artifact, f"serve --stdio timed out after {timeout_secs}s")
+                fail(layer, artifact, f"stdio MCP request timed out after {timeout_secs}s")
             if line is None:
                 terminate_process_tree(process)
                 process_terminated = True
                 stderr_path.write_text("".join(stderr_lines), encoding="utf-8")
                 write_stdio_artifact(artifact, transcript, "".join(stdout_lines), stderr_path)
-                fail("serve_stdio", artifact, "serve --stdio closed before responding")
+                fail(layer, artifact, "stdio MCP server closed before responding")
             try:
                 response = json.loads(line)
             except json.JSONDecodeError as exc:
@@ -434,7 +439,7 @@ def stdio_status_command(
                     stderr_path,
                     {"invalid_line": line},
                 )
-                fail("serve_stdio", artifact, f"serve --stdio emitted invalid JSON: {exc}")
+                fail(layer, artifact, f"stdio MCP server emitted invalid JSON: {exc}")
             entry["response"] = response
             responses.append(response)
     finally:
@@ -457,22 +462,54 @@ def stdio_status_command(
     stderr_path.write_text("".join(stderr_lines), encoding="utf-8")
     responses_by_id = {response.get("id"): response for response in responses if isinstance(response, dict)}
     tools = responses_by_id.get("tools")
+    resources = responses_by_id.get("resources")
     status_response = responses_by_id.get("status")
-    payload = {"tools": tools, "status_response": status_response, "transcript": transcript, "stdout": "".join(stdout_lines)}
+    payload = {
+        "tools": tools,
+        "resources": resources,
+        "status_response": status_response,
+        "transcript": transcript,
+        "stdout": "".join(stdout_lines),
+    }
     write_json(artifact, payload)
-    require(isinstance(tools, dict), "serve_stdio", artifact, "serve --stdio did not return tools/list response")
-    require(isinstance(status_response, dict), "serve_stdio", artifact, "serve --stdio did not return status response")
+    require(isinstance(tools, dict), layer, artifact, "stdio MCP server did not return tools/list response")
+    require(isinstance(resources, dict), layer, artifact, "stdio MCP server did not return resources/list response")
+    require(isinstance(status_response, dict), layer, artifact, "stdio MCP server did not return status response")
     if "error" in tools:
-        fail("serve_stdio", artifact, f"tools/list failed: {tools['error']}")
+        fail(layer, artifact, f"tools/list failed: {tools['error']}")
+    if "error" in resources:
+        fail(layer, artifact, f"resources/list failed: {resources['error']}")
     if "error" in status_response:
-        fail("serve_stdio", artifact, f"status resource failed: {status_response['error']}")
+        fail(layer, artifact, f"status resource failed: {status_response['error']}")
+
+    listed_resources = resources.get("result", {}).get("resources", [])
+    observed_uris = sorted(
+        item.get("uri")
+        for item in listed_resources
+        if isinstance(item, dict) and isinstance(item.get("uri"), str)
+    )
+    missing_uris = [uri for uri in SERVER_RESOURCE_URIS if uri not in observed_uris]
+    visibility = {
+        "required": list(SERVER_RESOURCE_URIS),
+        "observed": observed_uris,
+        "missing": missing_uris,
+        "available": not missing_uris,
+    }
+    payload["server_advertised_mcp_resources"] = visibility
+    write_json(artifact, payload)
 
     contents = status_response.get("result", {}).get("contents", [])
     content = next((item for item in contents if item.get("uri") == STATUS_URI), None)
-    require(content is not None, "serve_stdio", artifact, "status response missing codestory://status")
+    require(content is not None, layer, artifact, "status response missing codestory://status")
     status = json.loads(content.get("text", "{}"))
     payload["status"] = status
     write_json(artifact, payload)
+    require(
+        not missing_uris,
+        layer,
+        artifact,
+        f"resources/list missing server-advertised CodeStory resources: {', '.join(missing_uris)}",
+    )
     return status
 
 
@@ -891,6 +928,11 @@ def write_fake_cli(path: Path) -> None:
                         continue
                     if request.get("method") == "tools/list":
                         result = {"tools": [{"name": "packet"}, {"name": "search"}, {"name": "context"}]}
+                    elif request.get("method") == "resources/list":
+                        resources = [{"uri": "codestory://status", "name": "CodeStory runtime status"}]
+                        if fail != "resources_hidden":
+                            resources.append({"uri": "codestory://agent-guide", "name": "CodeStory agent guide"})
+                        result = {"resources": resources}
                     else:
                         status = {
                             "server_version": "9.9.9",
@@ -920,6 +962,48 @@ def write_fake_cli(path: Path) -> None:
         wrapper = path / "codestory-cli"
         wrapper.write_text(f"#!{sys.executable}\nimport runpy\nrunpy.run_path({str(fake)!r}, run_name='__main__')\n", encoding="utf-8")
         wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR)
+
+
+def write_fake_plugin_launcher(plugin_root: Path) -> None:
+    launcher = plugin_root / "scripts" / "codestory-mcp.cjs"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text(
+        textwrap.dedent(
+            r'''
+            const { spawn } = require('child_process');
+
+            const cli = process.env.CODESTORY_FAKE_PLUGIN_CLI;
+            if (!cli) {
+              process.stderr.write('CODESTORY_FAKE_PLUGIN_CLI is required\n');
+              process.exit(2);
+            }
+
+            const child = spawn(
+              cli,
+              ['serve', '--stdio', '--refresh', 'none', '--project', process.cwd()],
+              {
+                stdio: 'inherit',
+                shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
+                env: {
+                  ...process.env,
+                  CODESTORY_FAKE_FAIL_LAYER: process.env.CODESTORY_FAKE_PLUGIN_HIDE_RESOURCES === '1'
+                    ? 'resources_hidden'
+                    : process.env.CODESTORY_FAKE_FAIL_LAYER || '',
+                },
+              },
+            );
+            child.on('exit', (code, signal) => {
+              if (signal) process.kill(process.pid, signal);
+              process.exit(code || 0);
+            });
+            child.on('error', (error) => {
+              process.stderr.write(`${error.message}\n`);
+              process.exit(1);
+            });
+            '''
+        ).lstrip(),
+        encoding="utf-8",
+    )
 
 
 def self_test() -> None:
@@ -1006,6 +1090,28 @@ def self_test() -> None:
         else:
             raise AssertionError("plugin-root drift should fail the packaged proof gate")
 
+        plugin_manifest.write_text(json.dumps({"version": "9.9.9"}), encoding="utf-8")
+        write_fake_plugin_launcher(plugin_root)
+        plugin_hidden_args = argparse.Namespace(**vars(args))
+        plugin_hidden_args.plugin_root = str(plugin_root)
+        plugin_hidden_args.out_dir = str(root / "plugin-hidden-out")
+        os.environ["CODESTORY_FAKE_PLUGIN_HIDE_RESOURCES"] = "1"
+        os.environ["CODESTORY_FAKE_PLUGIN_CLI"] = str(stage / ("codestory-cli.cmd" if os.name == "nt" else "codestory-cli"))
+        try:
+            try:
+                run_gate(plugin_hidden_args)
+            except GateFailure as exc:
+                assert exc.layer == "plugin_stdio"
+                assert "plugin-stdio-status.json" in str(exc.artifact)
+                artifact = read_json_file(exc.artifact)
+                assert artifact["server_advertised_mcp_resources"]["missing"] == ["codestory://agent-guide"]
+                assert artifact["status"]["plugin_runtime"]["cli_source"] == "direct_cli_launch"
+            else:
+                raise AssertionError("hidden plugin MCP resources should fail the plugin stdio gate")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_PLUGIN_HIDE_RESOURCES", None)
+            os.environ.pop("CODESTORY_FAKE_PLUGIN_CLI", None)
+
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "doctor_stderr"
         try:
             try:
@@ -1065,6 +1171,18 @@ def self_test() -> None:
                 assert "serve-stdio-status.json" in str(exc.artifact)
             else:
                 raise AssertionError("silent fake stdio server should fail the gate")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "resources_hidden"
+        try:
+            try:
+                run_gate(args)
+            except GateFailure as exc:
+                assert exc.layer == "serve_stdio"
+                assert "serve-stdio-status.json" in str(exc.artifact)
+            else:
+                raise AssertionError("hidden MCP resources should fail the gate")
         finally:
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@
   the new release heading so release contents are tracked while the work is
   still reviewable.
 - Do not create or push `v*` release tags manually. A synchronized version bump on `main` triggers GitHub Actions to create the tag, GitHub release, cross-platform `codestory-cli` binary assets, and `SHA256SUMS.txt`.
+- After merging a `dev/codestory-next` promotion PR into `main`, verify
+  `dev/codestory-next` still exists and matches `main` with
+  `git ls-remote --heads origin main dev/codestory-next` and
+  `git rev-list --left-right --count origin/main...origin/dev/codestory-next`.
+  If GitHub deletes the head branch, restore it from the promoted `main` commit
+  before treating the release as complete.
 - After a plugin release or plugin-source update that Codex must detect through
   the marketplace, push a corresponding change to
   `TheGreenCedar/AgentPluginMarketplace`; Codex observes the marketplace repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Blocked agent packet/search readiness when the selected sidecar retrieval is
+  not full, while keeping local/default graph readiness reported separately.
+
 ## 0.12.6
 
 CodeStory 0.12.6 promotes the current `dev/codestory-next` release automation,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Added `codestory-cli fix` and MCP `repair_all` as the single supported
+  readiness repair entrypoint, with status recommendations collapsed to one
+  repair action plus a `codestory://status` readback.
 - Made packaged and post-publish agent proof fail when the installed plugin MCP
   launcher omits server-advertised `codestory://status` or
   `codestory://agent-guide` resources, while leaving true Codex host/model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Made packaged and post-publish agent proof fail when the installed plugin MCP
+  launcher omits server-advertised `codestory://status` or
+  `codestory://agent-guide` resources, while leaving true Codex host/model
+  visibility proof open.
 - Blocked CodeStory grounding when the plugin MCP is launchable but not
   model-visible, even when a managed CLI exists; diagnostic fail-open mode now
   exposes status/repair guidance instead of normal grounding tool names.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Bounded required-probe citation promotion by deduplicating probe queries and
+  using set membership for promoted citation indexes, with a regression guard
+  for large synthetic packet capping.
 - Blocked agent packet/search readiness when the selected sidecar retrieval is
   not full, while keeping local/default graph readiness reported separately.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Added `codestory-cli fix` and MCP `repair_all` as the single supported
   readiness repair entrypoint, with status recommendations collapsed to one
   repair action plus a `codestory://status` readback.
+- Let the installed plugin MCP launcher use fresh active-project state even
+  when the host hook cannot attach a Codex thread id or the state predates the
+  MCP process start, while still rejecting state owned by another thread, and
+  give local wait-fresh enough bounded time to pass on the CodeStory repo.
 - Made packaged and post-publish agent proof fail when the installed plugin MCP
   launcher omits server-advertised `codestory://status` or
   `codestory://agent-guide` resources, while leaving true Codex host/model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Rewrote agent-facing CodeStory guidance to make MCP status plus `repair_all`
+  the single supported repair loop, with CLI commands labeled as
+  maintainer/debug transcripts.
 - Added `codestory-cli fix` and MCP `repair_all` as the single supported
   readiness repair entrypoint, with status recommendations collapsed to one
   repair action plus a `codestory://status` readback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Blocked CodeStory grounding when the plugin MCP is launchable but not
+  model-visible, even when a managed CLI exists; diagnostic fail-open mode now
+  exposes status/repair guidance instead of normal grounding tool names.
 - Bounded required-probe citation promotion by deduplicating probe queries and
   using set membership for promoted citation indexes, with a regression guard
   for large synthetic packet capping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.13.0
+
+CodeStory 0.13.0 promotes the current `dev/codestory-next` MCP readiness and
+agent-repair hardening work onto `main` as the next synchronized release.
+
 ### Fixed
 
 - Rewrote agent-facing CodeStory guidance to make MCP status plus `repair_all`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Blocked CodeStory grounding when the plugin MCP is launchable but not
   model-visible, even when a managed CLI exists; diagnostic fail-open mode now
   exposes status/repair guidance instead of normal grounding tool names.
+- Disabled ambient `PATH` CLI fallback for installed plugin runtime launches;
+  missing managed CLI setup now stays in `managed_unavailable` diagnostics while
+  preserving `CODESTORY_CLI` as an explicit local-dev override and keeping PATH
+  checks documented as CLI diagnostics only.
 - Bounded required-probe citation promotion by deduplicating probe queries and
   using set membership for promoted citation indexes, with a regression guard
   for large synthetic packet capping.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.12.6"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -72,6 +72,8 @@ pub(crate) enum Command {
     Doctor(DoctorCommand),
     #[command(about = "Print compact readiness verdicts for local navigation or agent search.")]
     Ready(ReadyCommand),
+    #[command(about = "Run the single supported readiness repair entrypoint.")]
+    Fix(FixCommand),
     #[command(about = "Run a machine-readable smoke profile for CI and agent images.")]
     Smoke(SmokeCommand),
     #[command(about = "Agent-facing readiness and repair helpers.")]
@@ -607,6 +609,26 @@ pub(crate) struct ReadyCommand {
     )]
     pub(crate) run_id: Option<String>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
+    pub(crate) format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Write command output to this file instead of stdout. The parent directory must already exist."
+    )]
+    pub(crate) output_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct FixCommand {
+    #[command(flatten)]
+    pub(crate) project: ProjectArgs,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Use a specific agent sidecar run id when repairing agent readiness."
+    )]
+    pub(crate) run_id: Option<String>,
+    #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "json")]
     pub(crate) format: OutputFormat,
     #[arg(
         long,
@@ -1577,6 +1599,15 @@ pub(crate) struct ReadyOutput {
     pub(crate) local_refresh: Option<crate::readiness::LocalRefreshOutput>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) readiness_lanes: BTreeMap<String, ReadinessLaneOutput>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct FixOutput {
+    pub(crate) status: &'static str,
+    pub(crate) ready: bool,
+    pub(crate) goal: ReadinessGoalDto,
+    pub(crate) action: &'static str,
+    pub(crate) result: ReadyOutput,
 }
 
 #[derive(Debug, Serialize)]
@@ -2639,6 +2670,29 @@ mod tests {
             .find_subcommand_mut(name)
             .expect("subcommand should exist");
         subcommand.render_long_help().to_string()
+    }
+
+    #[test]
+    fn fix_command_parses_as_single_repair_entrypoint() {
+        let cli = Cli::try_parse_from([
+            "codestory-cli",
+            "fix",
+            "--project",
+            "C:/repo",
+            "--format",
+            "json",
+            "--run-id",
+            "shared-agent",
+        ])
+        .expect("fix command should parse");
+        match cli.command {
+            Command::Fix(cmd) => {
+                assert_eq!(cmd.project.project, PathBuf::from("C:/repo"));
+                assert_eq!(cmd.run_id.as_deref(), Some("shared-agent"));
+                assert_eq!(cmd.format, OutputFormat::Json);
+            }
+            _ => panic!("expected fix command"),
+        }
     }
 
     #[test]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -11096,6 +11096,7 @@ fn readiness_lane_status(
         ReadinessStatusDto::RepairRetrieval
     };
     match verdict.map(|verdict| verdict.status) {
+        Some(ReadinessStatusDto::Blocked) => ReadinessStatusDto::Blocked,
         Some(status @ (ReadinessStatusDto::RepairSetup | ReadinessStatusDto::RepairIndex)) => {
             status
         }
@@ -11500,9 +11501,9 @@ fn doctor_sidecar_check(sidecar: &DoctorSidecarStatusOutput) -> DoctorCheckOutpu
         .unwrap_or("no degraded_reason reported");
     doctor_check(
         "sidecar_retrieval",
-        "warn",
+        "error",
         format!(
-            "mandatory sidecar retrieval is not full (mode={} reason={reason}; embedding_device_policy={} observed_device={} cpu_allowed={}); repair sidecars before trusting packet/search evidence.",
+            "mandatory sidecar retrieval is not full (mode={} reason={reason}; embedding_device_policy={} observed_device={} cpu_allowed={}); packet/search evidence is blocked until sidecars are full.",
             sidecar.retrieval_mode,
             sidecar.embedding_device_policy,
             sidecar.embedding_device_state,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -81,14 +81,14 @@ use args::{
     DrillSummaryBridgeStatusOutput, DrillSummaryBridgesOutput, DrillSummaryMechanicalOutput,
     DrillSummaryOpenGapsOutput, DrillSummaryOutput, DrillSummarySourceTruthOutput,
     DrillSummarySourceTruthTargetOutput, DrillSummaryStatsOutput, DrillSummaryVerdictOutput,
-    DrillVerificationChecklistItemOutput, FilesCommand, GenerateCompletionsCommand, GroundCommand,
-    IndexCommand, IndexDryRunOutput, IndexOutput, PacketCommand, ProjectArgs, QueryCommand,
-    QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadinessLaneOutput, ReadyCommand,
-    ReadyOutput, RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand,
-    SetupAction, SetupCommand, SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile,
-    SnippetCommand, SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, SymbolWorkflowCommand,
-    TaskAction, TaskBriefCommand, TaskCommand, TrailCommand, TrailJsonOutput,
-    VerificationTargetOutput, build_trail_request,
+    DrillVerificationChecklistItemOutput, FilesCommand, FixCommand, FixOutput,
+    GenerateCompletionsCommand, GroundCommand, IndexCommand, IndexDryRunOutput, IndexOutput,
+    PacketCommand, ProjectArgs, QueryCommand, QueryOutput, QueryResolutionOutput,
+    QuerySelectorOutput, ReadinessLaneOutput, ReadyCommand, ReadyOutput, RepoTextMode,
+    SearchCommand, SearchHitOutput, SearchOutput, ServeCommand, SetupAction, SetupCommand,
+    SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile, SnippetCommand, SnippetJsonOutput,
+    SymbolCommand, SymbolJsonOutput, SymbolWorkflowCommand, TaskAction, TaskBriefCommand,
+    TaskCommand, TrailCommand, TrailJsonOutput, VerificationTargetOutput, build_trail_request,
 };
 #[cfg(test)]
 use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
@@ -96,9 +96,9 @@ use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
 use http_transport::search_repo_text_mode_param;
 use output::{
     REPO_CONTENT_BOUNDARY_LINE, context_packet_json, emit, emit_text, render_agent_citation,
-    render_context_markdown, render_doctor_markdown, render_drill_markdown, render_ground_markdown,
-    render_index_dry_run_markdown, render_index_markdown, render_query_markdown,
-    render_ready_markdown, render_search_hit_output, render_search_markdown,
+    render_context_markdown, render_doctor_markdown, render_drill_markdown, render_fix_markdown,
+    render_ground_markdown, render_index_dry_run_markdown, render_index_markdown,
+    render_query_markdown, render_ready_markdown, render_search_hit_output, render_search_markdown,
     render_snippet_markdown, render_symbol_markdown, render_symbol_mermaid, render_trail_dot,
     render_trail_markdown, render_trail_mermaid, render_trail_story_markdown,
     validate_output_file_parent,
@@ -196,6 +196,7 @@ fn main() -> Result<()> {
         Command::Task(cmd) => run_task(cmd),
         Command::Doctor(cmd) => run_doctor(cmd),
         Command::Ready(cmd) => run_ready(cmd),
+        Command::Fix(cmd) => run_fix(cmd),
         Command::Smoke(cmd) => run_smoke(cmd),
         Command::Agent(cmd) => run_agent(cmd),
         Command::Setup(cmd) => run_setup(cmd),
@@ -2138,6 +2139,37 @@ fn run_doctor(cmd: DoctorCommand) -> Result<()> {
 fn run_ready(cmd: ReadyCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "ready")?;
     preflight_output_file(cmd.output_file.as_deref())?;
+    let output = build_ready_output(&cmd)?;
+    let markdown = render_ready_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
+fn run_fix(cmd: FixCommand) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, "fix")?;
+    preflight_output_file(cmd.output_file.as_deref())?;
+    let ready_cmd = ReadyCommand {
+        project: cmd.project,
+        goal: Some(args::ReadyGoal::Agent),
+        repair: true,
+        wait_fresh: false,
+        run_id: cmd.run_id,
+        format: cmd.format,
+        output_file: None,
+    };
+    let ready = build_ready_output(&ready_cmd)?;
+    let status = fix_status(&ready);
+    let output = FixOutput {
+        status,
+        ready: status == "ready",
+        goal: ReadinessGoalDto::AgentPacketSearch,
+        action: "ready_agent_repair",
+        result: ready,
+    };
+    let markdown = render_fix_markdown(&output);
+    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+}
+
+fn build_ready_output(cmd: &ReadyCommand) -> Result<ReadyOutput> {
     let runtime = if cmd.repair {
         if matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
             new_agent_surface_runtime(&cmd.project)?
@@ -2185,8 +2217,23 @@ fn run_ready(cmd: ReadyCommand) -> Result<()> {
         local_refresh,
         readiness_lanes,
     };
-    let markdown = render_ready_markdown(&output);
-    emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
+    Ok(output)
+}
+
+fn fix_status(output: &ReadyOutput) -> &'static str {
+    let Some(non_ready) = readiness::primary_non_ready(&output.verdicts) else {
+        return "ready";
+    };
+    if non_ready
+        .minimum_next
+        .iter()
+        .chain(non_ready.full_repair.iter())
+        .any(|command| command.starts_with("Restart/reload the Codex host/app"))
+    {
+        "blocked_requires_host_reload"
+    } else {
+        "blocked_with_error"
+    }
 }
 
 pub(crate) fn wait_for_local_freshness(

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -29,9 +29,9 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 use crate::args::{
-    CliTrailMode, DoctorOutput, DrillOutput, IndexDryRunOutput, IndexOutput, OutputFormat,
-    QueryItemOutput, QueryOutput, ReadyOutput, SearchHitOutput, SearchOutput, TrailCommand,
-    VerificationTargetOutput,
+    CliTrailMode, DoctorOutput, DrillOutput, FixOutput, IndexDryRunOutput, IndexOutput,
+    OutputFormat, QueryItemOutput, QueryOutput, ReadyOutput, SearchHitOutput, SearchOutput,
+    TrailCommand, VerificationTargetOutput,
 };
 use crate::display::{
     clean_path_string, default_trail_direction, format_budget, format_direction, format_kind,
@@ -192,6 +192,20 @@ pub(crate) fn render_ready_markdown(output: &ReadyOutput) -> String {
             }
         }
     }
+    markdown
+}
+
+pub(crate) fn render_fix_markdown(output: &FixOutput) -> String {
+    let mut markdown = String::new();
+    let _ = writeln!(markdown, "# Fix");
+    let _ = writeln!(markdown, "status: `{}`", output.status);
+    let _ = writeln!(markdown, "action: `{}`", output.action);
+    let _ = writeln!(
+        markdown,
+        "goal: `{}`",
+        crate::readiness::goal_label(output.goal)
+    );
+    markdown.push_str(&render_ready_markdown(&output.result));
     markdown
 }
 

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -2313,7 +2313,9 @@ fn compact_doctor_check_message(check: &crate::args::DoctorCheckOutput) -> Strin
 }
 
 fn doctor_operator_status(output: &DoctorOutput) -> &'static str {
-    if output.checks.iter().any(|check| check.status == "error") {
+    if doctor_agent_packet_search_readiness(output) == "blocked"
+        || output.checks.iter().any(|check| check.status == "error")
+    {
         "blocked"
     } else if doctor_agent_packet_search_readiness(output) != "ready"
         || output.checks.iter().any(|check| check.status == "warn")

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -171,7 +171,7 @@ pub(crate) fn status_label_for_goal(
     }
 
     if goal == ReadinessGoalDto::AgentPacketSearch && retrieval_mode != "full" {
-        return "repair_retrieval";
+        return "blocked";
     }
 
     "ready"
@@ -184,6 +184,7 @@ pub(crate) fn status_label(status: ReadinessStatusDto) -> &'static str {
         ReadinessStatusDto::RepairSetup => "repair_setup",
         ReadinessStatusDto::RepairIndex => "repair_index",
         ReadinessStatusDto::CheckIndex => "check_index",
+        ReadinessStatusDto::Blocked => "blocked",
         ReadinessStatusDto::RepairRetrieval => "repair_retrieval",
     }
 }
@@ -195,6 +196,7 @@ pub(crate) fn failed_layer(verdict: &ReadinessVerdictDto) -> Option<&'static str
         ReadinessStatusDto::RepairSetup => Some("runtime_setup"),
         ReadinessStatusDto::RepairIndex => Some("local_index"),
         ReadinessStatusDto::CheckIndex => Some("index_freshness"),
+        ReadinessStatusDto::Blocked => Some("retrieval_sidecar"),
         ReadinessStatusDto::RepairRetrieval => Some("retrieval_sidecar"),
     }
 }
@@ -222,7 +224,7 @@ pub(crate) fn local_refresh_output(verdict: &ReadinessVerdictDto) -> LocalRefres
         | ReadinessStatusDto::Repairing
         | ReadinessStatusDto::RepairRetrieval => LocalRefreshState::Refreshed,
         ReadinessStatusDto::CheckIndex => LocalRefreshState::Skipped,
-        ReadinessStatusDto::RepairSetup => LocalRefreshState::Failed,
+        ReadinessStatusDto::RepairSetup | ReadinessStatusDto::Blocked => LocalRefreshState::Failed,
         ReadinessStatusDto::RepairIndex => {
             if index.and_then(|index| index.status) == Some(IndexFreshnessStatusDto::Stale) {
                 LocalRefreshState::Skipped
@@ -409,9 +411,9 @@ fn verdict_state(
             let full_repair = agent_packet_search_repair_commands(project_arg, sidecar_run_id);
             let minimum_next = full_repair.iter().take(1).cloned().collect();
             return (
-                ReadinessStatusDto::RepairRetrieval,
+                ReadinessStatusDto::Blocked,
                 format!(
-                    "Agent packet/search needs full agent sidecar retrieval; current profile is `{}` and mode is `{sidecar_mode}`.{device_note}",
+                    "Agent packet/search is blocked until full agent sidecar retrieval is proven; current profile is `{}` and mode is `{sidecar_mode}`.{device_note}",
                     sidecar_profile.unwrap_or("unknown")
                 ),
                 minimum_next,
@@ -669,7 +671,7 @@ mod tests {
                 Some(IndexFreshnessStatusDto::Fresh),
                 "unavailable",
             ),
-            "repair_retrieval"
+            "blocked"
         );
 
         let verdict = ReadinessVerdictDto {
@@ -704,7 +706,7 @@ mod tests {
         assert_eq!(verdicts[0].status, ReadinessStatusDto::RepairIndex);
         assert_eq!(
             verdicts[1].status,
-            ReadinessStatusDto::RepairRetrieval,
+            ReadinessStatusDto::Blocked,
             "missing local index should not collapse agent retrieval readiness: {verdicts:?}"
         );
         assert!(
@@ -986,11 +988,11 @@ mod tests {
             inputs(&stats, Some(&freshness), None),
         );
 
-        assert_eq!(unavailable.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(unavailable.status, ReadinessStatusDto::Blocked);
         assert!(
             unavailable
                 .summary
-                .contains("current profile is `unknown` and mode is `unavailable`")
+                .contains("blocked until full agent sidecar retrieval is proven")
         );
         assert!(unavailable.sidecar.is_none());
 
@@ -1027,7 +1029,7 @@ mod tests {
             ),
         );
 
-        assert_eq!(local_full.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(local_full.status, ReadinessStatusDto::Blocked);
         assert!(
             local_full.summary.contains("current profile is `local`"),
             "local/default full retrieval must not unlock agent packet/search: {local_full:?}"
@@ -1058,7 +1060,7 @@ mod tests {
             ),
         );
 
-        assert_eq!(degraded.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(degraded.status, ReadinessStatusDto::Blocked);
         assert_eq!(
             degraded
                 .sidecar
@@ -1139,7 +1141,7 @@ mod tests {
                 inputs(&stats, Some(&freshness), sidecar),
             );
 
-            assert_eq!(verdict.status, ReadinessStatusDto::RepairRetrieval);
+            assert_eq!(verdict.status, ReadinessStatusDto::Blocked);
             assert_eq!(failed_layer(&verdict), Some("retrieval_sidecar"));
             assert_eq!(verdict.minimum_next.len(), 1);
             assert!(
@@ -1177,7 +1179,7 @@ mod tests {
             ),
         );
 
-        assert_eq!(verdict.status, ReadinessStatusDto::RepairRetrieval);
+        assert_eq!(verdict.status, ReadinessStatusDto::Blocked);
         assert!(
             verdict
                 .full_repair

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -1293,7 +1293,20 @@ static SIDECAR_SETUP_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     &[],
 );
 
+static REPAIR_ALL_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
+    "Run the single supported CodeStory readiness repair action.",
+    &[],
+    &[],
+);
+
 static TOOLS: &[ToolSpec] = &[
+    ToolSpec {
+        name: "repair_all",
+        description: "Run the single supported readiness repair action, then read codestory://status again.",
+        input_schema: REPAIR_ALL_INPUT_SCHEMA,
+        output_schema: Some(SchemaSpec::Object(GENERIC_OBJECT_SCHEMA)),
+        safety: SafetyMetadata::local_config_write(),
+    },
     ToolSpec {
         name: "sidecar_setup",
         description: "Read or change the plugin-local sidecar setup policy through MCP; use this instead of asking the user to run shell commands.",

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3263,6 +3263,20 @@ fn stdio_status_recommended_next_calls(
                 _ => {}
             }
         }
+        if let Some(host_action) = non_ready
+            .minimum_next
+            .iter()
+            .chain(non_ready.full_repair.iter())
+            .find(|command| command.starts_with("Restart/reload the Codex host/app"))
+        {
+            return serde_json::json!([
+                stdio_recommended_next_call(host_action),
+                {
+                    "method": "resources/read",
+                    "uri": "codestory://status"
+                }
+            ]);
+        }
         return serde_json::json!([
             {
                 "method": "tools/call",
@@ -3329,9 +3343,9 @@ fn stdio_recommended_next_call(command: &str) -> serde_json::Value {
     if command.contains("ready --goal agent --repair") {
         return serde_json::json!({
             "method": "tools/call",
-            "tool": "sidecar_setup",
-            "arguments": {"action": "repair"},
-            "debug_command": command
+            "tool": "repair_all",
+            "arguments": {},
+            "debug_commands": [command]
         });
     }
     if command.contains("ready --goal local") || command.contains("codestory-cli doctor") {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -847,6 +847,10 @@ fn handle_stdio_tool_call(
         "symbols" => handle_stdio_symbols(runtime, request),
         "snippet" => handle_stdio_snippet(runtime, request),
         "context" => handle_stdio_context(runtime, request),
+        "repair_all" => {
+            state.status_cache = None;
+            handle_stdio_sidecar_repair(runtime)
+        }
         "sidecar_setup" => handle_stdio_sidecar_setup(runtime, state, request),
         _ => serde_json::json!({"error": "unknown tool"}),
     }
@@ -3259,36 +3263,18 @@ fn stdio_status_recommended_next_calls(
                 _ => {}
             }
         }
-        let full_repair = if non_ready.goal == ReadinessGoalDto::AgentPacketSearch {
-            sidecar_setup
-                .get("next_repair_command")
-                .and_then(serde_json::Value::as_str)
-                .filter(|command| !command.trim().is_empty())
-                .map(|command| {
-                    std::iter::once(command.to_string())
-                        .chain(non_ready.full_repair.iter().skip(1).cloned())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_else(|| non_ready.full_repair.clone())
-        } else {
-            non_ready.full_repair.clone()
-        };
-        return serde_json::Value::Array(
-            full_repair
-                .iter()
-                .map(|command| stdio_recommended_next_call(command))
-                .chain([
-                    serde_json::json!({
-                        "method": "resources/read",
-                        "uri": "codestory://status"
-                    }),
-                    serde_json::json!({
-                        "method": "resources/read",
-                        "uri": "codestory://agent-guide"
-                    }),
-                ])
-                .collect(),
-        );
+        return serde_json::json!([
+            {
+                "method": "tools/call",
+                "tool": "repair_all",
+                "arguments": {},
+                "debug_commands": non_ready.full_repair
+            },
+            {
+                "method": "resources/read",
+                "uri": "codestory://status"
+            }
+        ]);
     }
 
     serde_json::json!([

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3765,7 +3765,10 @@ fn stdio_repair_reason(verdict: &ReadinessVerdictDto) -> Option<String> {
     if verdict.status == ReadinessStatusDto::RepairSetup {
         return Some("stale_active_cli".to_string());
     }
-    if verdict.status == ReadinessStatusDto::RepairRetrieval {
+    if matches!(
+        verdict.status,
+        ReadinessStatusDto::Blocked | ReadinessStatusDto::RepairRetrieval
+    ) {
         return verdict
             .sidecar
             .as_ref()
@@ -4167,9 +4170,9 @@ version = "0.11.20"
                 .to_string();
         let readiness = vec![ReadinessVerdictDto {
             goal: ReadinessGoalDto::AgentPacketSearch,
-            status: ReadinessStatusDto::RepairRetrieval,
+            status: ReadinessStatusDto::Blocked,
             summary:
-                "Agent packet/search needs full sidecar retrieval; current mode is `unavailable`."
+                "Agent packet/search is blocked until full sidecar retrieval is proven; current mode is `unavailable`."
                     .to_string(),
             minimum_next: vec![repair.clone()],
             full_repair: vec![
@@ -4327,7 +4330,7 @@ version = "0.11.20"
             );
             assert_eq!(
                 surfaces[surface]["status"],
-                json!("repair_retrieval"),
+                json!("blocked"),
                 "blocked agent surface should stay on the agent retrieval lane: {surfaces}"
             );
         }

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -671,9 +671,7 @@ fn doctor_next_commands_stop_at_index_repair_when_inventory_is_stale() {
     );
     let markdown = String::from_utf8_lossy(&markdown.stdout);
     assert!(
-        markdown.contains(
-            "readiness: local_navigation=repair_index agent_packet_search=repair_retrieval"
-        ),
+        markdown.contains("readiness: local_navigation=repair_index agent_packet_search=blocked"),
         "doctor markdown should show local index repair without collapsing agent retrieval readiness:\n{markdown}"
     );
 }
@@ -729,7 +727,7 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
         "local/default lane should expose a local-scoped next command: {doctor:#}"
     );
     assert_eq!(
-        doctor["readiness_lanes"]["agent_packet_search"]["status"], "repair_retrieval",
+        doctor["readiness_lanes"]["agent_packet_search"]["status"], "blocked",
         "doctor should keep agent packet/search readiness separate: {doctor:#}"
     );
     assert_eq!(
@@ -776,8 +774,8 @@ fn doctor_next_commands_stop_at_retrieval_repair_when_sidecar_is_not_full() {
     );
     let markdown = String::from_utf8_lossy(&markdown.stdout);
     assert!(
-        markdown.contains("readiness: local_navigation=ready agent_packet_search=repair_retrieval"),
-        "doctor markdown should show split readiness with retrieval repair for agent use:\n{markdown}"
+        markdown.contains("readiness: local_navigation=ready agent_packet_search=blocked"),
+        "doctor markdown should show split readiness with blocked agent packet/search:\n{markdown}"
     );
 }
 
@@ -811,7 +809,7 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
         "{preflight:#}"
     );
     assert_eq!(
-        preflight["full_retrieval"]["status"], "repair_retrieval",
+        preflight["full_retrieval"]["status"], "blocked",
         "{preflight:#}"
     );
     assert_eq!(
@@ -829,7 +827,7 @@ fn agent_preflight_reports_local_graph_when_retrieval_is_degraded() {
         "local/default lane should expose a local-scoped next command: {preflight:#}"
     );
     assert_eq!(
-        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        preflight["agent_packet_search"]["status"], "blocked",
         "preflight should expose agent packet/search lane: {preflight:#}"
     );
     assert_eq!(
@@ -927,11 +925,11 @@ pub fn schedule_index(project_path: &str) -> usize {
         "{preflight:#}"
     );
     assert_eq!(
-        preflight["full_retrieval"]["status"], "repair_retrieval",
+        preflight["full_retrieval"]["status"], "blocked",
         "local refresh must not claim full retrieval readiness: {preflight:#}"
     );
     assert_eq!(
-        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        preflight["agent_packet_search"]["status"], "blocked",
         "agent packet/search should remain fail-closed without full sidecars: {preflight:#}"
     );
     assert!(
@@ -1004,7 +1002,7 @@ pub fn schedule_index(project_path: &str) -> usize {
         "local graph surfaces should stay blocked when refresh does not finish: {preflight:#}"
     );
     assert_eq!(
-        preflight["agent_packet_search"]["status"], "repair_retrieval",
+        preflight["agent_packet_search"]["status"], "blocked",
         "timeout must not escalate into agent sidecar repair or readiness: {preflight:#}"
     );
 }
@@ -1067,8 +1065,8 @@ fn doctor_reports_current_and_stored_semantic_doc_embedding_contract() {
     );
     let sidecar_check = check_with_name(&doctor, "sidecar_retrieval");
     assert_eq!(
-        sidecar_check["status"], "warn",
-        "doctor should warn when mandatory sidecar retrieval is unavailable despite legacy semantic docs: {doctor:#}"
+        sidecar_check["status"], "error",
+        "doctor should block when mandatory sidecar retrieval is unavailable despite legacy semantic docs: {doctor:#}"
     );
     let next_commands = doctor["next_commands"]
         .as_array()
@@ -2425,7 +2423,7 @@ fn assert_stdio_context_id_fails_closed_without_full_sidecars(
     );
     let status = structured["status"].as_str();
     assert!(
-        status.is_some_and(|status| matches!(status, "repair_setup" | "repair_retrieval")),
+        status.is_some_and(|status| matches!(status, "repair_setup" | "blocked")),
         "stdio context --id should fail closed before serving context: {stdio:#}"
     );
 }

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -103,7 +103,7 @@ fn ready_command_emits_compact_verdicts_and_filters_goal() {
     );
     let agent_json: Value = serde_json::from_str(&agent_json_text).expect("ready agent json");
     let agent = &agent_json["verdicts"][0];
-    assert_eq!(agent["status"], "repair_retrieval");
+    assert_eq!(agent["status"], "blocked");
     assert_eq!(
         agent["sidecar"]["degraded_reason"],
         "retrieval_manifest_missing"

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -859,39 +859,40 @@ fn assert_read_only_tool_metadata(tool: &Value) {
     );
 }
 
-fn assert_sidecar_setup_tool_metadata(tool: &Value) {
+fn assert_local_plugin_mutation_tool_metadata(tool: &Value) {
+    let name = tool["name"].as_str().expect("tool name");
     let annotations = tool
         .get("annotations")
-        .unwrap_or_else(|| panic!("sidecar_setup should include MCP-style annotations: {tool}"));
+        .unwrap_or_else(|| panic!("{name} should include MCP-style annotations: {tool}"));
     let safety = tool
         .get("safety")
         .or_else(|| tool.get("metadata"))
-        .unwrap_or_else(|| panic!("sidecar_setup should include safety metadata: {tool}"));
+        .unwrap_or_else(|| panic!("{name} should include safety metadata: {tool}"));
 
     assert_eq!(
         annotations.get("readOnlyHint").and_then(Value::as_bool),
         Some(false),
-        "sidecar_setup should declare local config writes: {tool}"
+        "{name} should declare local config writes: {tool}"
     );
     assert_eq!(
         annotations.get("destructiveHint").and_then(Value::as_bool),
         Some(false),
-        "sidecar_setup should declare non-destructive behavior: {tool}"
+        "{name} should declare non-destructive behavior: {tool}"
     );
     assert_eq!(
         annotations.get("idempotentHint").and_then(Value::as_bool),
         Some(true),
-        "sidecar_setup should declare idempotent behavior: {tool}"
+        "{name} should declare idempotent behavior: {tool}"
     );
     assert!(
         contains_bool_recursive(safety, &["localOnly", "local_only"], true)
             && contains_bool_recursive(safety, &["openWorld", "open_world"], false),
-        "sidecar_setup should declare local-only closed-world behavior: {tool}"
+        "{name} should declare local-only closed-world behavior: {tool}"
     );
     assert_eq!(
         safety.get("mutation").and_then(Value::as_str),
         Some("local_plugin_configuration"),
-        "sidecar_setup should label the plugin-local mutation: {tool}"
+        "{name} should label the plugin-local mutation: {tool}"
     );
 }
 
@@ -1040,6 +1041,7 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
             "packet",
             "query_subgraph",
             "references",
+            "repair_all",
             "search",
             "shortest_path",
             "sidecar_setup",
@@ -1114,8 +1116,8 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
 
     for tool in tools["tools"].as_array().expect("tools array") {
         let name = tool["name"].as_str().expect("tool name");
-        if name == "sidecar_setup" {
-            assert_sidecar_setup_tool_metadata(tool);
+        if matches!(name, "repair_all" | "sidecar_setup") {
+            assert_local_plugin_mutation_tool_metadata(tool);
         } else {
             assert_read_only_tool_metadata(tool);
         }
@@ -2468,12 +2470,11 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         !next_call_text.contains("codestory-cli index --project")
             && !next_call_text.contains("retrieval bootstrap")
             && !next_call_text.contains("retrieval index")
-            && next_call_text.contains("\"tool\":\"sidecar_setup\"")
-            && next_call_text.contains("\"action\":\"repair\"")
-            && next_call_text.contains("\"debug_command\"")
+            && next_call_text.contains("\"tool\":\"repair_all\"")
+            && next_call_text.contains("\"debug_commands\"")
             && next_call_text.contains("retrieval status")
             && next_call_text.contains("codestory://status")
-            && next_call_text.contains("codestory://agent-guide"),
+            && !next_call_text.contains("codestory://agent-guide"),
         "status should recommend MCP-managed sidecar repair without repeating a fresh core index when mode is not full: {status}"
     );
     assert!(
@@ -2806,8 +2807,8 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
     assert!(
         status["recommended_next_calls"]
             .to_string()
-            .contains("\"tool\":\"sidecar_setup\""),
-        "status should keep recovery on MCP tooling after sidecar_setup enable: {status}"
+            .contains("\"tool\":\"repair_all\""),
+        "status should keep recovery on the single MCP repair tool after sidecar_setup enable: {status}"
     );
 }
 
@@ -4242,12 +4243,11 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
         minimum_next.iter().any(|call| call
             .get("tool")
             .and_then(Value::as_str)
-            .is_some_and(|tool| tool == "sidecar_setup")
+            .is_some_and(|tool| tool == "repair_all")
             && call
-                .pointer("/arguments/action")
-                .and_then(Value::as_str)
-                .is_some_and(|action| action == "repair")
-            && call.get("debug_command").and_then(Value::as_str).is_some()),
+                .get("debug_commands")
+                .and_then(Value::as_array)
+                .is_some_and(|commands| !commands.is_empty())),
         "stdio search readiness error should point at MCP-managed agent repair: {response}"
     );
     let full_repair = error["full_repair"]
@@ -4264,11 +4264,10 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
         "stdio search sidecar errors should not repeat core index repair commands: {response}"
     );
     assert!(
-        full_repair.iter().any(|call| call
-            .get("debug_command")
-            .and_then(Value::as_str)
-            .is_some_and(|text| text.contains("codestory-cli retrieval status")
-                && text.contains("--format json"))),
+        full_repair.iter().any(
+            |call| call.to_string().contains("codestory-cli retrieval status")
+                && call.to_string().contains("--format json")
+        ),
         "stdio search error should include sidecar status proof debug command: {response}"
     );
 }

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2688,10 +2688,10 @@ fn resources_read_status_recommends_sidecar_repair_when_policy_enabled() {
     );
     let next_call_text = status["recommended_next_calls"].to_string();
     assert!(
-        next_call_text.contains("\"tool\":\"sidecar_setup\"")
-            && next_call_text.contains("\"action\":\"repair\"")
-            && next_call_text.contains("\"debug_command\""),
-        "enabled policy should route agent repair through the MCP sidecar_setup tool: {status}"
+        next_call_text.contains("\"tool\":\"repair_all\"")
+            && next_call_text.contains("\"debug_commands\"")
+            && next_call_text.contains("\"uri\":\"codestory://status\""),
+        "enabled policy should route agent repair through one MCP repair tool plus status readback: {status}"
     );
     assert!(
         next_call_text.contains("--run-id") && next_call_text.contains("shared-agent"),

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -978,13 +978,7 @@ fn stdio_starts_without_prebuilt_index_and_reports_status() {
 
     assert_eq!(status["readiness"][0]["status"], json!("ready"));
     assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-    assert_allowed_surface(
-        &status,
-        "search",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "search", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -2388,7 +2382,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         .unwrap_or_else(|| panic!("status should include agent_packet_search lane: {status}"));
     assert_eq!(
         agent_lane["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "agent lane should report blocked packet/search readiness: {status}"
     );
     assert_eq!(
@@ -2420,7 +2414,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
     );
     assert_eq!(
         status["runtime_truth"]["readiness_lanes"]["agent_packet_search"]["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "runtime truth should include the agent packet/search readiness lane: {status}"
     );
     for surface in [
@@ -2444,13 +2438,7 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         assert_allowed_surface(&status, surface, true, "local_navigation", "ready");
     }
     for surface in ["packet", "search", "context"] {
-        assert_allowed_surface(
-            &status,
-            surface,
-            false,
-            "agent_packet_search",
-            "repair_retrieval",
-        );
+        assert_allowed_surface(&status, surface, false, "agent_packet_search", "blocked");
         assert_eq!(
             status
                 .pointer(&format!("/allowed_surfaces/{surface}/repair_reason"))
@@ -3089,13 +3077,7 @@ fn resources_read_status_reports_dirty_marker_as_stale_local_index() {
     );
     assert_eq!(status["readiness"][0]["status"], json!("repair_index"));
     assert_allowed_surface(&status, "ground", false, "local_navigation", "repair_index");
-    assert_allowed_surface(
-        &status,
-        "packet",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -3139,13 +3121,7 @@ fn resources_read_status_uses_full_storage_state_for_dirty_marker_freshness() {
     );
     assert_fresh_freshness_counts(&status, "dirty marker older than full storage state");
     assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-    assert_allowed_surface(
-        &status,
-        "packet",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -3182,13 +3158,7 @@ fn resources_read_status_reports_unknown_dirty_marker_without_blocking_local_ind
     );
     assert_fresh_freshness_counts(&status, "status with unknown dirty marker");
     assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-    assert_allowed_surface(
-        &status,
-        "packet",
-        false,
-        "agent_packet_search",
-        "repair_retrieval",
-    );
+    assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
 }
 
 #[test]
@@ -3285,13 +3255,7 @@ fn resources_read_status_dirty_marker_fail_open_matrix() {
         }
         assert_fresh_freshness_counts(&status, name);
         assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
-        assert_allowed_surface(
-            &status,
-            "packet",
-            false,
-            "agent_packet_search",
-            "repair_retrieval",
-        );
+        assert_allowed_surface(&status, "packet", false, "agent_packet_search", "blocked");
     }
 }
 
@@ -3475,7 +3439,7 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
     );
     assert_eq!(
         refreshed_status["allowed_surfaces"]["packet"]["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "packet/search should stay gated by the agent retrieval lane after local refresh: {refreshed_status}"
     );
     let status_next_call_text = refreshed_status["recommended_next_calls"].to_string();
@@ -3745,7 +3709,7 @@ fn tools_call_local_graph_refreshes_long_lived_index_after_source_mutation() {
     );
     assert_eq!(
         status["allowed_surfaces"]["search"]["status"],
-        json!("repair_retrieval"),
+        json!("blocked"),
         "local graph refresh must not make packet/search readiness claims: {status}"
     );
 
@@ -4250,7 +4214,7 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
     );
     assert_eq!(
         error.pointer("/status").and_then(Value::as_str),
-        Some("repair_retrieval")
+        Some("blocked")
     );
     assert_eq!(
         error.pointer("/failed_layer").and_then(Value::as_str),

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -315,6 +315,7 @@ pub enum ReadinessStatusDto {
     RepairSetup,
     RepairIndex,
     CheckIndex,
+    Blocked,
     RepairRetrieval,
 }
 

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/agent/packet_capping.rs
+++ b/crates/codestory-runtime/src/agent/packet_capping.rs
@@ -520,15 +520,23 @@ pub(crate) fn promote_required_probe_citations(
         return HashSet::new();
     }
 
+    let mut seen_probe_queries = HashSet::new();
+    let required_probe_queries = required_probe_queries
+        .iter()
+        .filter(|query| seen_probe_queries.insert(query.as_str()))
+        .collect::<Vec<_>>();
     let focus_roots = packet_command_focus_roots(&answer.citations);
     let mut promoted_indices = Vec::new();
-    for query in required_probe_queries {
+    let mut promoted_index_set = HashSet::new();
+    for query in &required_probe_queries {
+        let query = query.as_str();
         if let Some(limit) = packet_required_probe_multi_match_limit(query) {
             promote_distinct_required_probe_matches(
                 answer,
                 query,
                 limit,
                 &mut promoted_indices,
+                &mut promoted_index_set,
                 &focus_roots,
             );
             continue;
@@ -541,7 +549,7 @@ pub(crate) fn promote_required_probe_citations(
         }
         let mut best_match = None;
         for (index, citation) in answer.citations.iter().enumerate() {
-            if promoted_indices.contains(&index) {
+            if promoted_index_set.contains(&index) {
                 continue;
             }
             let Some(match_rank) = packet_citation_probe_match_rank(query, citation) else {
@@ -568,7 +576,9 @@ pub(crate) fn promote_required_probe_citations(
                 best_match = Some((index, match_rank));
             }
         }
-        if let Some((index, _)) = best_match {
+        if let Some((index, _)) = best_match
+            && promoted_index_set.insert(index)
+        {
             promoted_indices.push(index);
         }
     }
@@ -580,10 +590,9 @@ pub(crate) fn promote_required_probe_citations(
         .iter()
         .map(|index| packet_citation_key(&answer.citations[*index]))
         .collect::<HashSet<_>>();
-    let promoted_index_set = promoted_indices.iter().copied().collect::<HashSet<_>>();
     let mut reordered = Vec::with_capacity(answer.citations.len());
-    for index in promoted_indices {
-        reordered.push(answer.citations[index].clone());
+    for index in &promoted_indices {
+        reordered.push(answer.citations[*index].clone());
     }
     for (index, citation) in answer.citations.drain(..).enumerate() {
         if !promoted_index_set.contains(&index) {
@@ -594,7 +603,12 @@ pub(crate) fn promote_required_probe_citations(
     answer.retrieval_trace.annotations.push(format!(
         "packet_required_probe_citations promoted={} required={}",
         promoted_index_set.len(),
-        required_probe_queries.join("|").replace('`', "'")
+        required_probe_queries
+            .iter()
+            .map(|query| query.as_str())
+            .collect::<Vec<_>>()
+            .join("|")
+            .replace('`', "'")
     ));
     protected_citation_keys
 }
@@ -604,6 +618,7 @@ fn promote_distinct_required_probe_matches(
     query: &str,
     limit: usize,
     promoted_indices: &mut Vec<usize>,
+    promoted_index_set: &mut HashSet<usize>,
     focus_roots: &[PacketCommandFocusRoot],
 ) {
     let mut promoted_paths = promoted_indices
@@ -624,7 +639,7 @@ fn promote_distinct_required_probe_matches(
             .unwrap_or_default();
         let mut best_match = None;
         for (index, citation) in answer.citations.iter().enumerate() {
-            if promoted_indices.contains(&index) {
+            if promoted_index_set.contains(&index) {
                 continue;
             }
             let Some(path) = packet_citation_file_path_key(citation) else {
@@ -672,7 +687,9 @@ fn promote_distinct_required_probe_matches(
         if let Some(path) = packet_citation_file_path_key(&answer.citations[index]) {
             promoted_paths.insert(path);
         }
-        promoted_indices.push(index);
+        if promoted_index_set.insert(index) {
+            promoted_indices.push(index);
+        }
     }
 }
 
@@ -1210,6 +1227,7 @@ mod tests {
         AgentRetrievalPresetDto, AgentRetrievalTraceDto, NodeId, PacketEvidenceResolutionDto,
         PacketEvidenceTierDto,
     };
+    use std::time::{Duration, Instant};
 
     fn citation(display_name: &str, file_path: &str, score: f32) -> AgentCitationDto {
         AgentCitationDto {
@@ -1393,6 +1411,153 @@ mod tests {
                 .take(2)
                 .all(|path| path.contains("commonMain")),
             "generic source probes should protect shared source-set evidence before platform variants: {protected_paths:?}"
+        );
+    }
+
+    #[test]
+    fn packet_citation_capping_large_probe_set_stays_bounded() {
+        const CITATION_COUNT: usize = 1_024;
+        const MULTI_MATCH_CITATION_COUNT: usize = 256;
+        const UNIQUE_REQUIRED_PROBE_COUNT: usize = 16;
+        const REQUIRED_PROBE_COUNT: usize = 96;
+        const DUPLICATE_MULTI_MATCH_PROBE_COUNT: usize =
+            REQUIRED_PROBE_COUNT - UNIQUE_REQUIRED_PROBE_COUNT;
+        const MAX_ELAPSED: Duration = Duration::from_secs(2);
+
+        let mut citations = Vec::with_capacity(CITATION_COUNT);
+        for index in 0..CITATION_COUNT {
+            let display_name = if index < MULTI_MATCH_CITATION_COUNT {
+                format!("RealBufferedSource.read{index}")
+            } else if index < MULTI_MATCH_CITATION_COUNT + UNIQUE_REQUIRED_PROBE_COUNT {
+                format!("UniqueProbeKey{:03}", index - MULTI_MATCH_CITATION_COUNT)
+            } else {
+                match index % 8 {
+                    0 => format!("Client send implementation {index}"),
+                    1 => format!("Submit prevent default guard {index}"),
+                    2 => format!("Session request creation {index}"),
+                    3 => format!("Network command input {index}"),
+                    4 => format!("Input helper {index}"),
+                    5 => format!("DataRequest.validate {index}"),
+                    6 => format!("Route registration {index}"),
+                    _ => format!("Auxiliary evidence {index}"),
+                }
+            };
+            let file_path = if index < MULTI_MATCH_CITATION_COUNT {
+                format!("src/flow/source_buffer_{index}.rs")
+            } else if index < MULTI_MATCH_CITATION_COUNT + UNIQUE_REQUIRED_PROBE_COUNT {
+                format!(
+                    "src/flow/synthetic_probe_{}.rs",
+                    index - MULTI_MATCH_CITATION_COUNT
+                )
+            } else if index % 17 == 0 {
+                format!("docs/flow-guide-{index}.md")
+            } else if index % 13 == 0 {
+                format!("tests/flow_{index}_test.rs")
+            } else if index % 5 == 0 {
+                format!("src/commonMain/kotlin/io/common_{index}.kt")
+            } else {
+                format!("src/flow/module_{index}.rs")
+            };
+            citations.push(citation(&display_name, &file_path, index as f32));
+        }
+
+        let mut required_probe_queries = (0..UNIQUE_REQUIRED_PROBE_COUNT)
+            .map(|index| format!("UniqueProbeKey{index:03}"))
+            .collect::<Vec<_>>();
+        required_probe_queries.extend(
+            (0..DUPLICATE_MULTI_MATCH_PROBE_COUNT).map(|_| "source read buffer".to_string()),
+        );
+        let limits = PacketBudgetLimitsDto {
+            max_anchors: 18,
+            max_files: 18,
+            max_snippets: 80,
+            max_trail_edges: 240,
+            max_output_bytes: 512 * 1024,
+        };
+        let mut answer = answer_fixture(citations);
+
+        let started = Instant::now();
+        let truncated = cap_packet_citations(&mut answer, &limits, &required_probe_queries);
+        let elapsed = started.elapsed();
+
+        eprintln!(
+            "packet_citation_capping_large_probe_set elapsed_ms={} citations={} required_probes={} kept={} threshold_ms={}",
+            elapsed.as_millis(),
+            CITATION_COUNT,
+            REQUIRED_PROBE_COUNT,
+            answer.citations.len(),
+            MAX_ELAPSED.as_millis()
+        );
+
+        assert!(
+            truncated,
+            "large synthetic packet should hit the citation cap"
+        );
+        assert!(
+            answer.citations.len() <= limits.max_anchors as usize,
+            "citation cap should stay within max_anchors"
+        );
+        let leading_paths = answer
+            .citations
+            .iter()
+            .take(UNIQUE_REQUIRED_PROBE_COUNT)
+            .filter_map(|citation| citation.file_path.clone())
+            .collect::<Vec<_>>();
+        let expected_leading_paths = (0..UNIQUE_REQUIRED_PROBE_COUNT)
+            .map(|index| format!("src/flow/synthetic_probe_{index}.rs"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            leading_paths, expected_leading_paths,
+            "unique required probes should keep their protected citation order"
+        );
+        let multi_match_paths = answer
+            .citations
+            .iter()
+            .filter_map(|citation| citation.file_path.as_deref())
+            .filter(|path| path.contains("source_buffer_"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            multi_match_paths.len(),
+            2,
+            "duplicated multi-match source probes should protect exactly two distinct source-buffer citations"
+        );
+        let kept_files = answer
+            .citations
+            .iter()
+            .filter_map(|citation| citation.file_path.as_deref().map(packet_display_path))
+            .collect::<HashSet<_>>();
+        assert!(
+            kept_files.len() <= limits.max_files as usize,
+            "citation cap should stay within max_files"
+        );
+        assert!(
+            answer
+                .retrieval_trace
+                .annotations
+                .iter()
+                .any(|annotation| annotation.starts_with("packet_required_probe_citations ")),
+            "required-probe promotion should still run on the large synthetic packet"
+        );
+        let required_probe_annotation = answer
+            .retrieval_trace
+            .annotations
+            .iter()
+            .find(|annotation| annotation.starts_with("packet_required_probe_citations "))
+            .expect("large guard should record required-probe promotion");
+        assert_eq!(
+            required_probe_annotation
+                .matches("source read buffer")
+                .count(),
+            1,
+            "duplicate required probes should be deduped before promotion"
+        );
+        assert!(
+            elapsed <= MAX_ELAPSED,
+            "packet citation capping regressed past the bounded guard: elapsed_ms={} threshold_ms={} citations={} required_probes={}",
+            elapsed.as_millis(),
+            MAX_ELAPSED.as_millis(),
+            CITATION_COUNT,
+            REQUIRED_PROBE_COUNT
         );
     }
 }

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.12.6"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -73,6 +73,17 @@ python .github/scripts/check-codestory-release.py --version <version>
 After a `main` release, run the release version check on `dev/codestory-next`
 with the released version before starting the next release lane.
 
+After merging a `dev/codestory-next` promotion PR into `main`, verify the dev
+branch survived the merge and still matches `main`:
+
+```sh
+git ls-remote --heads origin main dev/codestory-next
+git rev-list --left-right --count origin/main...origin/dev/codestory-next
+```
+
+If GitHub deletes `dev/codestory-next`, restore it from the promoted `main`
+commit before treating the release as complete.
+
 Do not create or push `v*` tags manually. A synchronized version bump merged to
 `main` runs the auto-release workflow, which creates the GitHub tag, release,
 cross-platform `codestory-cli` archives, and `SHA256SUMS.txt`.

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -81,6 +81,14 @@ Binary release assets are packaging evidence only. They are not packet/search
 readiness proof; keep using the sidecar evidence tiers below before claiming
 agent-facing packet/search readiness.
 
+Release and post-publish agent proof must also exercise the installed plugin
+launcher with `--plugin-root plugins/codestory`. The packaged proof fails if
+the MCP `resources/list` response does not expose both `codestory://status` and
+`codestory://agent-guide`, and its `plugin-stdio-status.json` artifact records
+the active plugin runtime plus observed and missing server-advertised MCP
+resources. This proves the installed plugin launcher advertises the resources;
+it is not Codex host/model visibility proof.
+
 ## Docs-Only Fast Path
 
 If you only changed documentation or plugin doc surfaces, use the smallest credible

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -41,7 +41,10 @@ navigation and agent retrieval separate: a ready SQLite graph can support
 `ground`, `files`, and symbol navigation while sidecar packet/search remains
 blocked.
 
-Start with the active runtime surface:
+Start with the active runtime surface. When plugin MCP is live, read
+`codestory://status`, follow `recommended_next_calls`, call MCP `repair_all`
+when recommended, and reread `codestory://status`. The CLI commands below are
+maintainer/debug transcripts, not the supported agent repair path:
 
 ```sh
 codestory-cli agent preflight --project <repo> --format json
@@ -60,9 +63,9 @@ available.
 |-------|---------|-----------------|
 | `local_navigation=ready`, `agent_packet_search=ready`, `sidecar_mode=full` | Local graph and sidecar packet/search infrastructure are ready | Use packet/search/context as infrastructure-eligible, then prove answer quality with source, packet-runtime, drill, or benchmark evidence |
 | `local_navigation=ready`, `agent_packet_search=repairing` | Agent sidecar repair is active and status should include the current `phase`, `profile`, `run_id`, and `namespace` | Wait or reread `codestory://status`; do not start a second agent repair for the same run |
-| `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; run the repair command from preflight/status before packet/search claims |
-| `local_navigation=repair_local` | Core index or cache is missing or stale | Run `codestory-cli ready --goal local --repair --project <repo> --format json`, then rerun `doctor` |
-| `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Repair the failing sidecar layer, rerun `retrieval index --refresh full`, then rerun `retrieval status` |
+| `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; call MCP `repair_all` from status before packet/search claims |
+| `local_navigation=repair_local` | Core index or cache is missing or stale | Call MCP `repair_all`, then reread status; use CLI `fix` only for maintainer transcripts |
+| `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Call MCP `repair_all`, then reread status; maintainers can inspect `retrieval status` and rerun explicit sidecar commands if needed |
 | `doctor` ready but a packet/search command returns `retrieval_unavailable` | Runtime/status disagreement or sidecar process drift | Capture the failing command output, `doctor`, and `retrieval status`; repair the named layer before retrying |
 
 Layer repair should follow the first failing layer, not a broad rebuild:
@@ -70,7 +73,7 @@ Layer repair should follow the first failing layer, not a broad rebuild:
 | Failing layer | Evidence to capture | Small repair |
 |---------------|---------------------|--------------|
 | Active runtime or plugin adapter | `codestory://status` fields, `server_executable`, `cli_version`, `plugin_runtime`, `allowed_surfaces` | Reload or reinstall the active CLI/plugin runtime, then reread status |
-| Core SQLite graph | `doctor` cache/index checks and indexed file counts | `codestory-cli ready --goal local --repair --project <repo> --format json` |
+| Core SQLite graph | `doctor` cache/index checks and indexed file counts | MCP `repair_all`; CLI transcript: `codestory-cli fix --project <repo> --format json` |
 | Zoekt lexical sidecar | `retrieval status` mode/degraded reason and Zoekt health text | Free port `6070` or rerun bootstrap, then `retrieval index --refresh full` |
 | Qdrant dense sidecar | Qdrant health, collection name, point count, dense-anchor count, backend/dimension fields | Fix Qdrant/model/backend state; move the Qdrant cache aside only if repeated health checks fail |
 | SCIP graph artifacts | `scip_unavailable`, graph artifact hash/path, manifest contract | Rerun `retrieval index --refresh full`; inspect SCIP cache paths if it repeats |

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -6,16 +6,19 @@ work through the steps in order.
 Trust boundaries: [Trust and readiness](trust-and-readiness.md). Terms:
 [Glossary](../glossary.md).
 
-**Need JSON field names?** Common status keys: `allowed_surfaces`, `retrieval_mode`, `repair_command`. Full agent contract: [status-contract](../../plugins/codestory/skills/codestory-grounding/references/status-contract.md). CLI repair commands: [CLI reference](cli-reference.md#readiness-and-repair).
+**Need JSON field names?** Common status keys: `allowed_surfaces`,
+`retrieval_mode`, and `recommended_next_calls`. Full agent contract:
+[status-contract](../../plugins/codestory/skills/codestory-grounding/references/status-contract.md).
+CLI commands are maintainer/debug transcripts: [CLI reference](cli-reference.md#readiness-and-repair).
 
 ## Repair quick reference
 
-| Symptom | CLI command | Check in output |
+| Symptom | Supported action | Check in output |
 | --- | --- | --- |
-| Repo map stale or blocked | `codestory-cli ready --goal local --repair --project <repo> --format json` | `verdicts[].goal` is `local_navigation`; `status` is `ready` or follow `minimum_next` |
-| Broad search blocked | `codestory-cli ready --goal agent --repair --project <repo> --format json` | `verdicts[].goal` is `agent_packet_search`; `retrieval_mode` is `full` in retrieval status |
-| MCP down, need handoff | `codestory-cli agent preflight --project <repo> --format json` | `safe_surfaces`, `blocked_surfaces`, `repair_command` |
-| Sidecar health | `codestory-cli retrieval status --project <repo> --format json` | `retrieval_mode` is `full` before trusting packet/search |
+| Repo map stale or blocked | Agent reads `codestory://status`, calls MCP `repair_all` if recommended, then rereads status | Local graph surfaces are allowed after the reread |
+| Broad search blocked | Same MCP `repair_all` loop | `packet`, `search`, or `context` allowed and `retrieval_mode` is `full` |
+| MCP down, need handoff | Reload/fix host MCP; CLI can collect a debug transcript only | `codestory://status` becomes visible in the agent host |
+| Sidecar health | MCP status first; CLI `retrieval status` only for maintainer evidence | `retrieval_mode` is `full` before trusting packet/search |
 
 ## Decision tree
 
@@ -34,8 +37,9 @@ flowchart TD
   local --> fix_local[Refresh or repair local index]
   sidecar --> fix_sidecar[Sidecar setup or repair]
   fix_mcp --> host[Host guide]
-  fix_local --> cli_local["CLI: ready --goal local"]
-  fix_sidecar --> cli_agent["CLI: ready --goal agent"]
+  fix_local --> mcp_repair["MCP: repair_all"]
+  fix_sidecar --> mcp_repair
+  mcp_repair --> reread["Reread codestory://status"]
   host --> codex[Codex guide]
   host --> cursor[Cursor guide]
   host --> claude[Claude Code guide]
@@ -48,7 +52,7 @@ flowchart TD
 | --- | --- | --- | --- | --- |
 | MCP missing | Fresh thread after `/plugins` install | Check `.cursor/mcp.json`; reload MCP server | MCP configured separately from hooks | MCP not auto-started; configure or use CLI |
 | Stale index / wrong symbols | New thread; hooks refresh on session start | Reload MCP; run local repair | New session; run local repair | New session; run [local repair](cli-reference.md#readiness-and-repair) |
-| Packet/search blocked | Agent calls sidecar setup when status says so | Same; verify retrieval mode | Same | Use CLI [retrieval status](cli-reference.md#readiness-and-repair) |
+| Packet/search blocked | Agent calls MCP `repair_all` when status says so | Same; verify retrieval mode | Same | Use CLI [retrieval status](cli-reference.md#readiness-and-repair) only as a debug transcript |
 | Version drift after update | Refresh marketplace, refresh plugin package, restart host, fresh status read | Reload MCP server | Restart session | Reinstall or point to current binary |
 
 Host-specific steps: [Codex](codex.md#troubleshooting), [Cursor](cursor.md#troubleshooting), [Claude Code](claude-code.md#troubleshooting), [Copilot](copilot.md).
@@ -90,8 +94,8 @@ Ask the agent:
 Read codestory://status, report allowed_surfaces, and tell me what is blocked and the next repair action.
 ```
 
-The agent uses MCP status, `codestory://agent-guide`, and `sidecar_setup` when
-packet/search needs repair. Re-read status after any repair.
+The agent uses MCP status, `codestory://agent-guide`, and `repair_all` when
+status recommends repair. Re-read status after any repair.
 
 </details>
 
@@ -107,8 +111,8 @@ codestory-cli agent preflight --project <repo> --format json
 codestory-cli doctor --project <repo>
 ```
 
-**Agent:** Can interpret `safe_surfaces`, `blocked_surfaces`, and
-`repair_command` from preflight when MCP is down.
+**Agent:** Treats CLI output as a debug transcript only. CLI output does not
+make CodeStory MCP live in the agent host.
 
 On Windows PowerShell, use `.\target\release\codestory-cli.exe` for a
 source-built binary.
@@ -120,10 +124,10 @@ Symptoms: missing symbols, old file list, `ground` or `files` not allowed.
 **Agent (MCP live):** Use allowed local graph tools only; request index refresh
 through status guidance.
 
-**You (CLI fallback):**
+**You (CLI debug transcript):**
 
 ```sh
-codestory-cli ready --goal local --repair --project <repo> --format json
+codestory-cli fix --project <repo> --format json
 codestory-cli doctor --project <repo>
 ```
 
@@ -141,8 +145,9 @@ node plugins/codestory/hooks/codestory-dirty-hook.cjs install --project <repo> -
 Symptoms: `packet`, `search`, or `context` not allowed; retrieval mode not
 `full`.
 
-**Agent:** Call `sidecar_setup` with `enable` or `repair` when status says so.
-Do not treat degraded output as proof. See [Trust and readiness](trust-and-readiness.md#proof-vs-hint).
+**Agent:** Call MCP `repair_all` when status says so, then reread
+`codestory://status`. Do not treat degraded output as proof. See
+[Trust and readiness](trust-and-readiness.md#proof-vs-hint).
 
 **You:** Sidecar model download and lifecycle:
 [Retrieval sidecars ops](../ops/retrieval-sidecars.md).
@@ -151,7 +156,7 @@ CLI check:
 
 ```sh
 codestory-cli retrieval status --project <repo> --format json
-codestory-cli ready --goal agent --repair --project <repo> --format json
+codestory-cli fix --project <repo> --format json
 ```
 
 Require `retrieval_mode: "full"` before trusting packet/search evidence.

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -25,7 +25,9 @@ comparison and portable prompts.
 
 The adapter prefers a checksummed plugin-managed CLI. It can provision from
 GitHub release `SHA256SUMS.txt`, honor `CODESTORY_CLI` as a local-dev override,
-and stay up with diagnostic `codestory://status` when spawn fails.
+and stay up with diagnostic `codestory://status` when managed setup fails.
+Ambient `PATH` binaries are reported as diagnostics only; installed plugin
+runtime does not launch them.
 
 ## Codex install (summary)
 

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -132,6 +132,7 @@ function writeProjectDirtyMarker(policy) {
 function runtimeFingerprint(mcp) {
   return [
     mcp.mcp_resource_status,
+    mcp.mcp_model_visible_blocked ? 'model-hidden' : 'model-visible-or-unlaunchable',
     mcp.managed_cli_present ? 'managed' : 'no-managed',
     mcp.degraded_no_surface ? 'degraded' : 'surface',
   ].join('|');
@@ -154,6 +155,14 @@ function firstRuntimeFailure(mcp) {
 }
 
 function shortDegradedNotice(mcp, reason, state = {}) {
+  if (mcp.mcp_model_visible_blocked) {
+    return [
+      'CodeStory setup blocked: MCP is configured and launchable, but resources are not model-visible.',
+      `First failing layer: ${firstRuntimeFailure(mcp)}.`,
+      reason ? `Reason: ${truncate(reason, 600)}` : null,
+      'Reload the host/plugin and read codestory://status; do not use managed CLI or PATH fallback as CodeStory grounding.',
+    ].filter(Boolean).join('\n');
+  }
   const hook = state.hook || {};
   return [
     'CodeStory degraded mode: no MCP or managed runtime surface is usable.',
@@ -170,7 +179,9 @@ function runtimeStatusBlock(policy, mcp) {
     `output_cap_chars: ${policy.cap}`,
     `dedupe_key: ${policy.dedupeKey}`,
     mcpDetectionText(mcp),
-    mcp.mcp_resources_exposed
+    mcp.mcp_model_visible_blocked
+      ? 'Next: reload the host/plugin and read codestory://status; do not use managed CLI or PATH fallback as CodeStory grounding.'
+      : mcp.mcp_resources_exposed
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
   ].join('\n');
@@ -179,7 +190,7 @@ function runtimeStatusBlock(policy, mcp) {
 function shouldBootstrapManagedRuntime(policy, mcp) {
   if (process.env.CODESTORY_CLI) return false;
   if (!BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) return false;
-  return Boolean(policy.project && mcp.mcp_process_launchable && !mcp.mcp_resources_exposed);
+  return Boolean(policy.project && mcp.mcp_process_launchable && mcp.mcp_resources_exposed && !mcp.managed_cli_present);
 }
 
 function bootstrapText(bootstrap) {
@@ -380,7 +391,7 @@ function runCodeStory(input, event, policy, state = {}) {
   }
   const bootstrapBlock = bootstrapText(bootstrap);
   if (policy.runtimeOnly) {
-    const heartbeatProbe = policy.heartbeat
+    const heartbeatProbe = policy.heartbeat && !mcp.mcp_model_visible_blocked
       ? heartbeatReadinessProbe(mcp, policy.project, input.cwd || process.cwd())
       : null;
     const output = state.hook?.preflight_failed && mcp.degraded_no_surface

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -13,7 +13,7 @@ Before reading source files, making source claims, planning edits, choosing test
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
-6. If MCP is truly unavailable, use managed CLI or local-dev CODESTORY_CLI preflight as the setup/repair fallback. PATH checks are diagnostics only; reserve full rebuilds for explicit stale, corrupt, schema, or root-change cases.
+6. If MCP is unavailable, CodeStory grounding is unavailable in this host. Use ordinary source inspection, report the MCP blocker, and reserve CLI commands for maintainer/debug transcripts only.
 
 Do this without waiting for the user to mention CodeStory.`;
 
@@ -59,11 +59,11 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, say that and reload the host/plugin instead of asking for PATH setup. When MCP is truly unavailable, use managed CLI or local-dev CODESTORY_CLI preflight and use the reported safe_surfaces.
+Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, say that and reload the host/plugin instead of asking for PATH setup. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.
-Use the managed/runtime preflight repair_command as the default setup path once a repository target is known; keep PATH checks diagnostic.
+Use status recommended_next_calls as the setup path once a repository target is known: call MCP repair_all when recommended, then reread codestory://status. Keep CLI and PATH checks diagnostic.
 
 ${body}`;
 }

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -133,6 +133,7 @@ function classifyMcpRuntime(options = {}) {
     : launchable
       ? 'mcp_resources_not_model_visible'
       : 'mcp_resources_unavailable';
+  const modelVisibleBlocked = launchable && !resourcesExposed;
 
   return {
     mcp_config_installed: mcp.installed,
@@ -142,12 +143,13 @@ function classifyMcpRuntime(options = {}) {
     mcp_process_launchable: launchable,
     mcp_resources_exposed: resourcesExposed,
     mcp_resource_status: resourceStatus,
+    mcp_model_visible_blocked: modelVisibleBlocked,
     mcp_runtime_state_path: runtimePath,
     mcp_runtime_state_present: Boolean(runtime),
     managed_cli_present: managed.present,
     managed_cli_path: managed.path,
     managed_cli_source: managed.source,
-    degraded_no_surface: !resourcesExposed && !managed.present,
+    degraded_no_surface: modelVisibleBlocked || (!resourcesExposed && !managed.present),
   };
 }
 
@@ -195,6 +197,7 @@ function mcpDetectionText(status) {
     `mcp_config_installed: ${status.mcp_config_installed ? 'yes' : 'no'}${status.mcp_config_installed ? ` (${status.mcp_config_path})` : ''}`,
     `mcp_process_launchable: ${status.mcp_process_launchable ? 'yes' : 'no'}`,
     `mcp_resources_exposed: ${status.mcp_resource_status}`,
+    `mcp_model_visible_blocked: ${status.mcp_model_visible_blocked ? 'yes' : 'no'}`,
     `managed_cli_present: ${status.managed_cli_present ? 'yes' : 'no'}${status.managed_cli_path ? ` (${status.managed_cli_path})` : ''}`,
     `degraded_no_surface: ${status.degraded_no_surface ? 'yes' : 'no'}`,
   ].join('\n');

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -699,6 +699,25 @@ function mcpNextCallForCommand(command) {
   };
 }
 
+function singleRepairNextCalls(commands) {
+  const needsHost = commands.some((command) => command.startsWith('Restart/reload') || command.startsWith('Refresh or reinstall'));
+  if (needsHost) {
+    return [
+      { method: 'host/restart', instruction: commands[0] },
+      { method: 'resources/read', uri: 'codestory://status' },
+    ];
+  }
+  return [
+    {
+      method: 'tools/call',
+      tool: 'repair_all',
+      arguments: {},
+      debug_commands: commands,
+    },
+    { method: 'resources/read', uri: 'codestory://status' },
+  ];
+}
+
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
@@ -951,11 +970,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     local_refresh: options.localRefresh || null,
     readiness: [repair],
     allowed_surfaces: allowedSurfaces,
-    recommended_next_calls: [
-      { method: 'resources/read', uri: 'codestory://status' },
-      { method: 'resources/read', uri: 'codestory://agent-guide' },
-      ...recommendedNext.map((command) => mcpNextCallForCommand(command)),
-    ],
+    recommended_next_calls: singleRepairNextCalls(recommendedNext),
   };
 }
 
@@ -1200,6 +1215,28 @@ function failOpenSidecarSetupResult(request) {
 
 function runFailOpenMcp(status) {
   const tools = [{
+    name: 'repair_all',
+    description: 'Run the single supported CodeStory readiness repair action, then read codestory://status again.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    outputSchema: { type: 'object', additionalProperties: true },
+    safety: {
+      readOnly: false,
+      sideEffects: true,
+      localOnly: true,
+      openWorld: false,
+      mutation: 'local_plugin_configuration',
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  }, {
     name: 'sidecar_setup',
     description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode.',
     inputSchema: {
@@ -1270,9 +1307,18 @@ function runFailOpenMcp(status) {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
       } else if (request.method === 'tools/call') {
-        response = request.params?.name === 'sidecar_setup'
-          ? jsonrpcResult(request.id, failOpenSidecarSetupResult(request))
-          : jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status or call sidecar_setup.');
+        if (request.params?.name === 'repair_all') {
+          const repairRequest = {
+            params: {
+              arguments: { action: 'repair' },
+            },
+          };
+          response = jsonrpcResult(request.id, failOpenSidecarSetupResult(repairRequest));
+        } else if (request.params?.name === 'sidecar_setup') {
+          response = jsonrpcResult(request.id, failOpenSidecarSetupResult(request));
+        } else {
+          response = jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status or call repair_all.');
+        }
       } else {
         response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
       }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -1166,25 +1166,6 @@ function resourceContents(uri, value) {
   };
 }
 
-function failOpenToolResult(status) {
-  const readiness = status.readiness[0];
-  return {
-    isError: true,
-    content: [{ type: 'text', text: diagnosticText(status) }],
-    structuredContent: {
-      code: 'codestory_mcp_runtime_unavailable',
-      status: readiness.status,
-      repair_reason: status.degraded_reason,
-      local_refresh: status.local_refresh || null,
-      plugin_runtime: status.plugin_runtime,
-      setup: readiness.setup,
-      minimum_next: readiness.minimum_next,
-      full_repair: readiness.full_repair,
-      recommended_next_calls: status.recommended_next_calls,
-    },
-  };
-}
-
 function failOpenSidecarSetupResult(request) {
   const action = request.params?.arguments?.action || 'status';
   if (!['status', 'enable', 'disable', 'ask', 'repair'].includes(action)) {
@@ -1210,13 +1191,7 @@ function failOpenSidecarSetupResult(request) {
 }
 
 function runFailOpenMcp(status) {
-  const tools = ['ground', 'files', 'packet', 'search', 'context'].map((name) => ({
-    name,
-    description: 'CodeStory diagnostic fail-open surface; runtime repair is required before this tool can return repository grounding.',
-    inputSchema: { type: 'object', additionalProperties: true },
-    outputSchema: { type: 'object', additionalProperties: true },
-  }));
-  tools.unshift({
+  const tools = [{
     name: 'sidecar_setup',
     description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode.',
     inputSchema: {
@@ -1240,7 +1215,7 @@ function runFailOpenMcp(status) {
       idempotentHint: true,
       openWorldHint: false,
     },
-  });
+  }];
   const resources = [
     { uri: 'codestory://status', name: 'CodeStory runtime status', mimeType: 'application/json' },
     { uri: 'codestory://agent-guide', name: 'CodeStory agent guide', mimeType: 'application/json' },
@@ -1287,12 +1262,9 @@ function runFailOpenMcp(status) {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
       } else if (request.method === 'tools/call') {
-        response = jsonrpcResult(
-          request.id,
-          request.params?.name === 'sidecar_setup'
-            ? failOpenSidecarSetupResult(request)
-            : failOpenToolResult(status),
-        );
+        response = request.params?.name === 'sidecar_setup'
+          ? jsonrpcResult(request.id, failOpenSidecarSetupResult(request))
+          : jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status or call sidecar_setup.');
       } else {
         response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
       }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -20,7 +20,6 @@ const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
 const releaseDownloadRetryDelaysMs = [1000, 3000];
-const processStartedAtMs = Date.now();
 
 function readJson(file) {
   try {
@@ -130,11 +129,6 @@ function activeProjectStateMaxAgeMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 60 * 60 * 1000;
 }
 
-function activeProjectStateLaunchGraceMs() {
-  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_ACTIVE_PROJECT_LAUNCH_GRACE_MS || '', 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 5 * 1000;
-}
-
 function activeProjectStateTimestamp(active, statePath) {
   const parsed = Date.parse(active?.updatedAt || active?.updated_at || '');
   if (Number.isFinite(parsed)) return parsed;
@@ -147,15 +141,16 @@ function activeProjectStateTimestamp(active, statePath) {
 
 function activeProjectStateMatchesHost(active) {
   const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
-  if (!currentThread) return !String(active?.codexThreadId || '').trim();
-  return String(active?.codexThreadId || '').trim() === currentThread;
+  const activeThread = String(active?.codexThreadId || '').trim();
+  if (!activeThread) return true;
+  if (!currentThread) return false;
+  return activeThread === currentThread;
 }
 
 function activeProjectStateFresh(active, statePath, nowMs = Date.now()) {
   const timestamp = activeProjectStateTimestamp(active, statePath);
   return timestamp !== null
     && nowMs - timestamp <= activeProjectStateMaxAgeMs()
-    && timestamp >= processStartedAtMs - activeProjectStateLaunchGraceMs()
     && activeProjectStateMatchesHost(active);
 }
 
@@ -720,7 +715,7 @@ function singleRepairNextCalls(commands) {
 
 function localWaitFreshTimeoutMs() {
   const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_LOCAL_REPAIR_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30000;
 }
 
 function runLocalNavigationWaitFresh(resolved, projectRoot) {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -594,17 +594,16 @@ async function resolveCli() {
   const managedProvisionFailure = warnings.find((warning) => warning.startsWith('managed_cli_provision_failed:')) || null;
   const pathCandidates = pathCliCandidates();
   warnings.push(pathCandidates.length > 0
-    ? 'managed_cli_unavailable_using_path_fallback'
+    ? 'managed_cli_unavailable_path_diagnostic_only'
     : 'managed_cli_unavailable_no_path_fallback');
-  const pathFallback = pathCandidates[0] || 'codestory-cli';
   return {
-    source: 'path_fallback',
-    path: pathFallback,
+    source: 'managed_unavailable',
+    path: null,
     sha256: null,
     version,
     cliVersion: null,
     repoRef: null,
-    buildSource: 'path_fallback',
+    buildSource: 'managed_unavailable',
     archiveSha256: null,
     archiveUrl: null,
     provisionedAt: null,
@@ -637,6 +636,15 @@ function compareSemver(left, right) {
 }
 
 function probeResolvedCli(resolved) {
+  if (!resolved.path) {
+    return {
+      status: null,
+      error: `${resolved.source || 'unavailable'}_cli_unavailable`,
+      version: null,
+      stdout: '',
+      stderr: '',
+    };
+  }
   const result = spawnSync(resolved.path, ['--version'], {
     encoding: 'utf8',
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
@@ -654,8 +662,8 @@ function probeResolvedCli(resolved) {
 }
 
 function failOpenReasonForProbe(resolved, probe) {
-  if (resolved.managedProvisionFailure && resolved.source === 'path_fallback' && pathCliCandidates().length === 0) {
-    return resolved.managedProvisionFailure;
+  if (resolved.source === 'managed_unavailable') {
+    return resolved.managedProvisionFailure || 'managed_cli_unavailable';
   }
   if (probe.error || probe.status !== 0) {
     return `${resolved.source}_cli_unspawnable`;
@@ -860,7 +868,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     'Restart/reload the Codex host/app and read codestory://status; managed CLI provisioning will retry release asset downloads.',
     'Refresh or reinstall the CodeStory plugin after GitHub release assets are reachable, then restart/reload the Codex host/app and read codestory://status.',
   ];
-  const minimumNext = options.minimumNext || (managedProvisionFailed && pathCandidates.length === 0 ? managedProvisionNext : [
+  const minimumNext = options.minimumNext || (managedProvisionFailed ? managedProvisionNext : [
     'Refresh or reinstall the CodeStory plugin, then restart/reload the Codex host/app and read codestory://status in a fresh thread.',
   ]);
   const fullRepair = options.fullRepair || minimumNext;

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codestory-grounding
-description: Use when an agent should ground a local repository with CodeStory before making source claims, planning edits, choosing tests, reviewing changes, or using packet/search evidence through the CodeStory plugin or codestory-cli.
+description: Use when an agent should ground a local repository with CodeStory before making source claims, planning edits, choosing tests, reviewing changes, or using packet/search evidence through the CodeStory plugin MCP.
 ---
 
 # CodeStory Grounding
@@ -36,8 +36,9 @@ When the plugin MCP server is available:
 5. Read `codestory://agent-guide` when you need the runtime's recommended next calls.
 
 If the skill is visible but no `mcp__codestory` tools or `codestory://status`
-resource are exposed, call it a plugin MCP registration failure. Use CLI only as
-a degraded fallback and report that MCP was not live.
+resource are exposed, call it a plugin MCP registration failure. Do not use CLI
+as CodeStory grounding; use ordinary source inspection and report that MCP was
+not live.
 
 ## Task Router
 
@@ -48,7 +49,7 @@ a degraded fallback and report that MCP was not live.
 | Trace: "Who calls this?" | `callers`, `callees`, `trace`, or `trail --story --hide-speculative`. |
 | Impact: "What might this change touch?" | `affected` with changed files from git; planning hints only, not proof. |
 | Broad question | `packet`, `search`, or `context` only when allowed and `retrieval_mode=full`. |
-| Blocked surface | Follow `recommended_next_calls` from status; see [doctor](references/doctor.md) and [serve](references/serve.md). |
+| Blocked surface | Follow `recommended_next_calls` from status; normally call MCP `repair_all`, then reread `codestory://status`. |
 
 ## Evidence Rules
 
@@ -59,17 +60,21 @@ a degraded fallback and report that MCP was not live.
 - `retrieval_mode=full` is infrastructure eligibility, not answer-quality proof;
   anything weaker is navigation hints only.
 
-## CLI Fallback
+## Repair Loop
 
-Only when MCP is missing, repair is needed, or a transcript is requested:
+Supported agent repair is MCP-only:
 
-1. `ready --goal local --repair --project <target-workspace> --format json`
-2. `ready --goal agent --repair --project <target-workspace> --format json` before packet/search
-3. `doctor --project <target-workspace>` for a read-only health transcript
-4. Mirror allowed MCP surfaces: `ground`, `files`, `symbol`, `trail`, `snippet`, `search`, `packet`, `context`
+1. Read `codestory://status`.
+2. If `recommended_next_calls` says so, call MCP `repair_all` for
+   `<target-workspace>`.
+3. Reread `codestory://status`.
+4. Use only the surfaces allowed by the refreshed status.
 
-Always pass `--project <target-workspace>` explicitly. Repair details:
-[serve](references/serve.md), [doctor](references/doctor.md).
+CLI commands such as `fix`, `doctor`, `ready`, and `retrieval status` are
+maintainer/debug transcript tools. They do not prove plugin MCP is live in the
+agent host and are not the supported repair path for agent grounding.
+
+Repair details: [serve](references/serve.md), [doctor](references/doctor.md).
 
 `setup.ps1` and `setup.sh` under this skill are build-from-source paths for
 contributors only, not the normal user install path.

--- a/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
+++ b/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CodeStory Grounding"
-  short_description: "Ground local repos through CodeStory's plugin MCP or CLI fallback before planning, editing, or reviewing."
-  default_prompt: "Use $codestory-grounding: Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]? Or: I am editing a file in this repo — what symbols are affected and what tests should I run first? For first session or after repair: read codestory://status, ground if allowed, and use packet/search only when sidecars report retrieval_mode=full."
+  short_description: "Ground local repos through CodeStory's plugin MCP before planning, editing, or reviewing."
+  default_prompt: "Use $codestory-grounding: Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]? Or: I am editing a file in this repo — what symbols are affected and what tests should I run first? For first session or after repair: read codestory://status, call repair_all if status recommends it, reread status, and use packet/search only when sidecars report retrieval_mode=full."

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -1,6 +1,6 @@
 # `doctor` - Project And Retrieval Health
 
-Reads project/cache/index/retrieval health without mutating the index. Use it at the start of an LLM browser loop and when a read command fails unexpectedly. For MCP runtime truth and surface gating, see [status-contract.md](status-contract.md). Use `doctor` when MCP is missing, a repair transcript is needed, or status points to stale evidence.
+Reads project/cache/index/retrieval health without mutating the index. Use it for maintainer/debug transcripts and when a read command fails unexpectedly. For agent MCP runtime truth, repair, and surface gating, see [status-contract.md](status-contract.md).
 
 ## Usage
 
@@ -22,7 +22,7 @@ Reads project/cache/index/retrieval health without mutating the index. Use it at
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> doctor --project <target-workspace>` | Reports project root, cache path, indexed stats, retrieval state, sidecar embedding setup, environment hints, and next commands. |
-| Failure path | If cache or index checks warn, run `ready --goal local --repair --project <target-workspace> --format json` or the setup/index command surfaced by `doctor`; use explicit `index --refresh full` only when the reported failure calls for a rebuild. If mandatory sidecars are missing or stale, run the sidecar setup/index commands surfaced by `doctor`; if symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, repair before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
+| Failure path | In MCP, follow `codestory://status` `recommended_next_calls`, normally `repair_all` then a status reread. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific setup/index command surfaced by `doctor`; use explicit `index --refresh full` only when the reported failure calls for a rebuild. If symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, repair before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
 | Integration edge | Use doctor before `ground`, `search --why`, `explore`, `context`, or `serve`; its next commands are the safe follow-up loop. | Prevents read commands from silently querying the wrong or empty cache. |
 
 For MCP/runtime drift, collect binary evidence only after status is missing or

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -34,8 +34,9 @@ codestory-cli --version
 codestory-cli doctor --project <target-workspace> --format json
 ```
 
-If PATH repair changes which binary `codestory-cli` resolves to, start a fresh
-Codex host/app session before treating the plugin MCP runtime as updated.
+Treat PATH checks as CLI diagnostics only. Installed plugin MCP runtime changes
+require managed status/reinstall/reload, or an explicit `CODESTORY_CLI`
+override for local development, before starting a fresh Codex host/app session.
 
 ## Notes
 

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -44,7 +44,7 @@ The installed plugin starts `scripts/codestory-mcp.cjs` (managed CLI bootstrap a
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
-| Failure path | If serve reports missing index, run `doctor --project <target-workspace>` and `ready --goal local --repair --project <target-workspace> --format json`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
+| Failure path | If MCP status reports missing index, follow `recommended_next_calls`, normally `repair_all` then a status reread. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific command surfaced by `doctor`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
 | Integration edge | Use `serve --stdio` for MCP-style clients; it exposes tools for `ground`, `files`, `affected`, `packet`, `search`, `symbol`, `callers`, `callees`, `trail`, `trace`, `definition`, `references`, `symbols`, `snippet`, `context`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph`, plus project/grounding resources, warm graph primitives, and prompts. | Gives agents the same read-only packet and browser primitives without shelling each command. |
 
 Stdio MCP status fields and allowed-surface rules: [status-contract.md](status-contract.md).

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -13,7 +13,7 @@ the agent-facing field glossary alongside runtime `codestory://agent-guide`.
 | `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
 | `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
 | `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
-| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `path_fallback` as degraded launch evidence. |
+| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `managed_unavailable` as blocked managed setup. |
 | `runtime_truth` | Grouped runtime source, plugin root, managed CLI path, launcher source, sidecar policy/status, and readiness lanes. | Use as the concise bounded runtime summary; fall back to the source fields when a nested value needs detail. |
 | `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Ask before first automatic sidecar setup; respect `enabled` and `disabled`. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trail`, `trace`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
@@ -22,13 +22,14 @@ the agent-facing field glossary alongside runtime `codestory://agent-guide`.
 ## Runtime Repair
 
 Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
-source-build checks only when MCP is missing, the plugin needs repair, status
-shows `path_fallback`, or the user asks for a CLI transcript. `CODESTORY_CLI`
-is an explicit local-dev override; installed `.mcp.json` launches the managed
-adapter first, provisions from `github_release` when needed, and records the
-launch source in `plugin_runtime`. If the resolved runtime cannot spawn, or if
-only a missing, unversioned, or stale `PATH` fallback is available, the adapter
-stays up with `repair_setup` diagnostics instead of closing transport.
+source-build checks only when MCP is missing, the plugin needs repair, or the
+user asks for a CLI transcript. `CODESTORY_CLI` is an explicit local-dev
+override; installed `.mcp.json` launches the managed adapter first, provisions
+from `github_release` when needed, and records the launch source in
+`plugin_runtime`. If the managed runtime cannot spawn or be provisioned, the
+adapter stays up with `repair_setup` diagnostics instead of closing transport.
+Any `PATH` candidates in status are diagnostic only and are not launched by the
+installed plugin runtime.
 
 If `codestory://status` reports `repair_setup` because the active
 `server_version` is older than the latest release, repair the CLI before local

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -15,15 +15,15 @@ the agent-facing field glossary alongside runtime `codestory://agent-guide`.
 | `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
 | `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `managed_unavailable` as blocked managed setup. |
 | `runtime_truth` | Grouped runtime source, plugin root, managed CLI path, launcher source, sidecar policy/status, and readiness lanes. | Use as the concise bounded runtime summary; fall back to the source fields when a nested value needs detail. |
-| `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Ask before first automatic sidecar setup; respect `enabled` and `disabled`. |
+| `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Diagnostic sidecar policy detail. For agent repair, follow `recommended_next_calls` and prefer MCP `repair_all`. |
 | `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is allowed. | Use local graph entries such as `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trail`, `trace`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, and `query_subgraph` only when their surface is allowed. |
 | `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
 
 ## Runtime Repair
 
 Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
-source-build checks only when MCP is missing, the plugin needs repair, or the
-user asks for a CLI transcript. `CODESTORY_CLI` is an explicit local-dev
+source-build checks only for maintainer/debug transcripts when MCP is missing
+or suspect. They are not the supported agent repair path. `CODESTORY_CLI` is an explicit local-dev
 override; installed `.mcp.json` launches the managed adapter first, provisions
 from `github_release` when needed, and records the launch source in
 `plugin_runtime`. If the managed runtime cannot spawn or be provisioned, the
@@ -31,7 +31,8 @@ adapter stays up with `repair_setup` diagnostics instead of closing transport.
 Any `PATH` candidates in status are diagnostic only and are not launched by the
 installed plugin runtime.
 
-If `codestory://status` reports `repair_setup` because the active
-`server_version` is older than the latest release, repair the CLI before local
-navigation, packet, search, or context. The agent runs the installer command from `recommended_next_calls`; do not ask the human to install the binary unless
-network, permissions, or release assets block the repair.
+If `codestory://status` reports a repairable state, run the MCP
+`recommended_next_calls` loop: call `repair_all` when recommended, then reread
+`codestory://status` before local navigation, packet, search, or context. Do not
+ask the human to install the binary unless network, permissions, host reload, or
+release assets block the repair.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -122,6 +122,28 @@ test("plugin metadata maps skill and direct stdio server", async () => {
   });
 });
 
+test("agent-facing guidance keeps MCP repair as the only supported repair path", async () => {
+  const guidanceFiles = [
+    join(pluginRoot, "hooks", "codestory-instructions.cjs"),
+    join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"),
+    join(pluginRoot, "skills", "codestory-grounding", "agents", "openai.yaml"),
+    join(pluginRoot, "skills", "codestory-grounding", "references", "status-contract.md"),
+    join(pluginRoot, "skills", "codestory-grounding", "references", "doctor.md"),
+    join(pluginRoot, "skills", "codestory-grounding", "references", "serve.md"),
+    join(repoRoot, "docs", "users", "troubleshooting.md"),
+    join(repoRoot, "docs", "ops", "retrieval-sidecars.md"),
+  ];
+
+  for (const file of guidanceFiles) {
+    const text = await readFile(file, "utf8");
+    assert.doesNotMatch(text, /CLI Fallback/u, file);
+    assert.doesNotMatch(text, /CLI fallback/u, file);
+    assert.doesNotMatch(text, /managed CLI or local-dev CODESTORY_CLI preflight/u, file);
+    assert.doesNotMatch(text, /Call `sidecar_setup`/u, file);
+    assert.match(text, /repair_all/u, file);
+  }
+});
+
 test("plugin package version tracks the codestory-cli release version", async () => {
   const cliManifest = await readFile(
     join(repoRoot, "crates", "codestory-cli", "Cargo.toml"),
@@ -1825,7 +1847,7 @@ function runCodexHook(input, env) {
   return JSON.parse(result.stdout);
 }
 
-test("hook output keeps CodeStory ambient and checks MCP before CLI fallback", async () => {
+test("hook output keeps CodeStory ambient and checks MCP before source fallback", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-mcp-first-"));
@@ -1927,7 +1949,7 @@ test("hook degraded output is short when no MCP or managed runtime is usable", a
   }
 });
 
-test("hook failed preflight switches degraded guidance to bounded source fallback", async () => {
+test("hook failed preflight switches degraded guidance to bounded source reads", async () => {
   const { spawnSync } = await import("node:child_process");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-"));
   const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-bin-"));

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -416,7 +416,6 @@ test("mcp launcher uses active project state when host launches from plugin root
       JSON.stringify({
         event: "SessionStart",
         cwd: realRepoRoot,
-        codexThreadId: threadId,
         updatedAt: new Date().toISOString(),
       }),
       "utf8",
@@ -747,7 +746,7 @@ test("mcp launcher rejects thread-owned global state when current thread is unav
   }
 });
 
-test("mcp launcher rejects active project state from before launcher start", async () => {
+test("mcp launcher uses fresh active project state from before launcher start", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-prelaunch-active-project-"));
@@ -815,15 +814,9 @@ test("mcp launcher rejects active project state from before launcher start", asy
     });
 
     assert.equal(result.status, 0, result.stderr);
-    await assert.rejects(access(marker));
+    assert.equal(await readFile(marker, "utf8"), "serve");
     const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
-    const response = JSON.parse(result.stdout.trim());
-    const status = JSON.parse(response.result.contents[0].text);
-    assert.equal(status.degraded_reason, "project_root_unavailable");
-    assert.equal(status.project_root, null);
-    assert.equal(status.project_root_source, "plugin_active_state_stale");
-    assert.equal(status.readiness[0].goal, "project_root");
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version", "serve"]);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1760,7 +1753,7 @@ test("hook manifest timeouts cover managed bootstrap budget", async () => {
     /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
     "local wait-fresh timeout default",
   );
-  assert.equal(localWaitFreshTimeoutMs, 5000, "local wait-fresh default must stay bounded for bootstrap diagnostics");
+  assert.equal(localWaitFreshTimeoutMs, 30000, "local wait-fresh default must stay bounded for bootstrap diagnostics");
   const requiredTimeoutSec = Math.max(
     Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
     Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1086,7 +1086,7 @@ test("mcp launcher blocks managed setup when only PATH cli is available", async 
     assert.equal(status.readiness[0].repair_reason, "managed_cli_unavailable");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
-    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["sidecar_setup"]);
+    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["repair_all", "sidecar_setup"]);
     assert.equal(responses[3].error.code, -32602);
     assert.match(responses[3].error.message, /grounding tools are unavailable/u);
   } finally {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1023,7 +1023,7 @@ test("mcp launcher infers Codex managed data from installed cache without env", 
   }
 });
 
-test("mcp launcher fails open when only unusable PATH fallback is available", async () => {
+test("mcp launcher blocks managed setup when only PATH cli is available", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const sourceVersion = readCargoVersion(await readFile(join(repoRoot, "crates", "codestory-cli", "Cargo.toml"), "utf8"));
@@ -1033,8 +1033,8 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
   await writeFile(
     fakeCli,
     process.platform === "win32"
-      ? "@echo off\r\necho codestory-cli 0.0.1\r\n"
-      : "#!/bin/sh\necho codestory-cli 0.0.1\n",
+      ? `@echo off\r\necho codestory-cli ${version}\r\n`
+      : `#!/bin/sh\necho codestory-cli ${version}\n`,
   );
   await chmod(fakeCli, 0o755);
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
@@ -1068,14 +1068,14 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     assert.deepEqual(status.path_candidates, [
       {
         path: fakeCli,
-        version: "0.0.1",
-        active: true,
+        version,
+        active: false,
       },
     ]);
     assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
-    assert.equal(status.plugin_runtime.cli_source, "path_fallback");
-    assert.equal(status.plugin_runtime.cli_path, fakeCli);
-    assert.equal(status.runtime_truth.runtime_source, "path_fallback");
+    assert.equal(status.plugin_runtime.cli_source, "managed_unavailable");
+    assert.equal(status.plugin_runtime.cli_path, null);
+    assert.equal(status.runtime_truth.runtime_source, "managed_unavailable");
     assert.equal(status.runtime_truth.plugin_root, pluginRoot);
     assert.equal(status.runtime_truth.sidecar_policy, "ask");
     assert.equal(status.runtime_truth.sidecar_status.mode, "unavailable");
@@ -1083,6 +1083,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     assert.equal(status.runtime_truth.readiness_lanes.local_graph.status, "repair_setup");
     assert.equal(status.runtime_truth.readiness_lanes.agent_packet_search.profile, "agent");
     assert.equal(status.readiness[0].status, "repair_setup");
+    assert.equal(status.readiness[0].repair_reason, "managed_cli_unavailable");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
     assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["sidecar_setup"]);
@@ -1565,10 +1566,20 @@ test("release asset downloader retries a transient failure", async () => {
   }
 });
 
-test("mcp launcher keeps managed provision failures primary without PATH", async () => {
+test("mcp launcher keeps managed provision failures primary with PATH diagnostic", async () => {
   const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-provision-fail-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-empty-release-"));
+  const pathDir = await mkdtemp(join(tmpdir(), "codestory-managed-provision-path-"));
+  const fakeCli = join(pathDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  await writeFile(
+    fakeCli,
+    process.platform === "win32"
+      ? `@echo off\r\necho codestory-cli ${version}\r\n`
+      : `#!/bin/sh\necho codestory-cli ${version}\n`,
+  );
+  await chmod(fakeCli, 0o755);
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = JSON.stringify({
     jsonrpc: "2.0",
@@ -1584,7 +1595,7 @@ test("mcp launcher keeps managed provision failures primary without PATH", async
         CODESTORY_CLI: "",
         CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
         PLUGIN_DATA: dataDir,
-        PATH: "",
+        PATH: pathDir,
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
       input,
@@ -1599,10 +1610,16 @@ test("mcp launcher keeps managed provision failures primary without PATH", async
       status.degraded_reason,
       /^managed_cli_provision_failed:managed_cli_asset_fetch_failed:SHA256SUMS\.txt:elapsed_ms=\d+:attempts=1:retry=restart_reload_status:/u,
     );
-    assert.equal(status.plugin_runtime.cli_source, "path_fallback");
-    assert.deepEqual(status.path_candidates, []);
+    assert.equal(status.plugin_runtime.cli_source, "managed_unavailable");
+    assert.deepEqual(status.path_candidates, [
+      {
+        path: fakeCli,
+        version,
+        active: false,
+      },
+    ]);
     assert.equal(
-      status.plugin_runtime.warnings.includes("managed_cli_unavailable_no_path_fallback"),
+      status.plugin_runtime.warnings.includes("managed_cli_unavailable_path_diagnostic_only"),
       true,
     );
     assert.match(status.readiness[0].minimum_next[0], /^Restart\/reload/u);
@@ -1615,6 +1632,7 @@ test("mcp launcher keeps managed provision failures primary without PATH", async
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(releaseDir, { recursive: true, force: true });
+    await rm(pathDir, { recursive: true, force: true });
   }
 });
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1041,7 +1041,8 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
   const input = [
     JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
-    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "ground", arguments: {} } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+    JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "ground", arguments: {} } }),
   ].join("\n") + "\n";
 
   try {
@@ -1060,7 +1061,7 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
 
     assert.equal(result.status, 0, result.stderr);
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 3, result.stdout);
+    assert.equal(responses.length, 4, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
     assert.equal(status.plugin_runtime.plugin_version, version);
     assert.equal(status.source_checkout_version, sourceVersion);
@@ -1084,15 +1085,9 @@ test("mcp launcher fails open when only unusable PATH fallback is available", as
     assert.equal(status.readiness[0].status, "repair_setup");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
-    assert.equal(responses[2].result.isError, true);
-    assert.equal(
-      responses[2].result.structuredContent.code,
-      "codestory_mcp_runtime_unavailable",
-    );
-    assert.equal(
-      responses[2].result.structuredContent.plugin_runtime.plugin_root,
-      pluginRoot,
-    );
+    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["sidecar_setup"]);
+    assert.equal(responses[3].error.code, -32602);
+    assert.match(responses[3].error.message, /grounding tools are unavailable/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(pathDir, { recursive: true, force: true });
@@ -1230,9 +1225,9 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = JSON.stringify({
     jsonrpc: "2.0",
-    id: "tool",
-    method: "tools/call",
-    params: { name: "ground", arguments: {} },
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
   }) + "\n";
 
   try {
@@ -1265,13 +1260,13 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
 
     assert.equal(result.status, 0, result.stderr);
     const response = JSON.parse(result.stdout.trim());
-    assert.equal(response.result.isError, true);
+    const status = JSON.parse(response.result.contents[0].text);
     assert.equal(
-      response.result.structuredContent.repair_reason,
+      status.readiness[0].repair_reason,
       "managed_cli_unspawnable",
     );
     assert.equal(
-      response.result.structuredContent.plugin_runtime.plugin_version,
+      status.plugin_runtime.plugin_version,
       version,
     );
   } finally {
@@ -1456,7 +1451,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
-test("startup hook bootstraps managed cli before reporting MCP visibility", async (t) => {
+test("startup hook bootstraps managed cli when MCP resources are visible", async (t) => {
   const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
   if (tarProbe.status !== 0) {
     t.skip("tar unavailable for archive fixture");
@@ -1489,7 +1484,7 @@ test("startup hook bootstraps managed cli before reporting MCP visibility", asyn
       env: {
         ...process.env,
         CODESTORY_CLI: "",
-        CODESTORY_MCP_RESOURCES_EXPOSED: "",
+        CODESTORY_MCP_RESOURCES_EXPOSED: "1",
         CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
         COPILOT_PLUGIN_DATA: "",
         PLUGIN_DATA: dataDir,
@@ -1508,7 +1503,8 @@ test("startup hook bootstraps managed cli before reporting MCP visibility", asyn
     assert.match(context, /managed_bootstrap: ready/u);
     assert.match(context, /managed_bootstrap_cli_source: managed/u);
     assert.match(context, /managed_bootstrap_local_refresh: fresh/u);
-    assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+    assert.match(context, /mcp_resources_exposed: mcp_resources_exposed/u);
+    assert.match(context, /mcp_model_visible_blocked: no/u);
     assert.match(context, /managed_cli_present: yes/u);
     assert.doesNotMatch(context, /where\.exe codestory-cli|command -v codestory-cli|adding CodeStory to PATH/u);
 
@@ -2231,6 +2227,7 @@ test("hook goal heartbeat is quiet until readiness or freshness evidence changes
   const env = {
     PLUGIN_DATA: dataDir,
     CODESTORY_CLI: cliPath,
+    CODESTORY_MCP_RESOURCES_EXPOSED: "1",
     TEST_AGENT_STATUS: "repair_retrieval",
     TEST_FRESHNESS_STATUS: "stale",
     TEST_CHANGED_FILES: "1",
@@ -2266,6 +2263,55 @@ test("hook goal heartbeat is quiet until readiness or freshness evidence changes
   }
 });
 
+test("hook goal heartbeat skips managed cli readiness when MCP is model-hidden", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-hidden-mcp-"));
+  const version = await readPluginVersion();
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const marker = join(dataDir, "managed-cli-called.txt");
+  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+
+  try {
+    await mkdir(cliDir, { recursive: true });
+    await writeNodeCli(
+      cliDir,
+      [
+        "const fs = require('node:fs');",
+        "fs.writeFileSync(process.env.TEST_MARKER, process.argv.slice(2).join(' '));",
+        "if (process.argv[2] === 'ready') {",
+        "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status: 'ready' }] }));",
+        "  process.exit(0);",
+        "}",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(cliDir, "manifest.json"),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
+      "utf8",
+    );
+    await writeFile(
+      join(dataDir, ".codestory-mcp-runtime.json"),
+      JSON.stringify({ source: "managed", path: cliPath }),
+      "utf8",
+    );
+
+    const output = runCodexHook({
+      hook_event_name: "GoalLoopHeartbeat",
+      cwd: repoRoot,
+    }, {
+      PLUGIN_DATA: dataDir,
+      CODESTORY_MCP_RESOURCES_EXPOSED: "",
+      PATH: "",
+      TEST_MARKER: marker,
+    });
+
+    assert.equal(Object.hasOwn(output, "hookSpecificOutput"), false);
+    await assert.rejects(access(marker));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("hook MCP classifier distinguishes configured launchable and model-visible states", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-classify-"));
   const version = await readPluginVersion();
@@ -2278,6 +2324,7 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
     assert.equal(configured.mcp_process_launchable, true);
     assert.equal(configured.mcp_resources_exposed, false);
     assert.equal(configured.mcp_resource_status, "mcp_resources_not_model_visible");
+    assert.equal(configured.mcp_model_visible_blocked, true);
     assert.equal(configured.managed_cli_present, false);
 
     await mkdir(cliDir, { recursive: true });
@@ -2290,7 +2337,8 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
     const managed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
     assert.equal(managed.managed_cli_present, true);
     assert.equal(managed.managed_cli_path, cliPath);
-    assert.equal(managed.degraded_no_surface, false);
+    assert.equal(managed.mcp_model_visible_blocked, true);
+    assert.equal(managed.degraded_no_surface, true);
 
     await writeFile(
       join(dataDir, ".codestory-mcp-runtime.json"),
@@ -2301,7 +2349,8 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
     assert.equal(runtimeStateOnly.mcp_runtime_state_present, true);
     assert.equal(runtimeStateOnly.mcp_resources_exposed, false);
     assert.equal(runtimeStateOnly.mcp_resource_status, "mcp_resources_not_model_visible");
-    assert.equal(runtimeStateOnly.degraded_no_surface, false);
+    assert.equal(runtimeStateOnly.mcp_model_visible_blocked, true);
+    assert.equal(runtimeStateOnly.degraded_no_surface, true);
 
     const previous = process.env.CODESTORY_MCP_RESOURCES_EXPOSED;
     try {
@@ -2309,6 +2358,7 @@ test("hook MCP classifier distinguishes configured launchable and model-visible 
       const exposed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
       assert.equal(exposed.mcp_resources_exposed, true);
       assert.equal(exposed.mcp_resource_status, "mcp_resources_exposed");
+      assert.equal(exposed.mcp_model_visible_blocked, false);
       assert.equal(exposed.degraded_no_surface, false);
     } finally {
       if (previous === undefined) {
@@ -2448,10 +2498,14 @@ test("hook output reports model-invisible MCP instead of PATH setup guidance", a
   const context = output.hookSpecificOutput.additionalContext;
   assert.match(context, /mcp_config_installed: yes/u);
   assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
+  assert.match(context, /mcp_model_visible_blocked: yes/u);
   assert.match(context, /managed_cli_present: yes/u);
+  assert.match(context, /degraded_no_surface: yes/u);
   assert.match(context, /MCP resources are not visible/u);
+  assert.doesNotMatch(context, /managed_bootstrap: ready/u);
   assert.doesNotMatch(context, /codestory-cli ENOENT/u);
   assert.doesNotMatch(context, /attempted request packet/u);
+  assert.doesNotMatch(context, /bounded source reads/u);
   assert.doesNotMatch(context, /adding CodeStory to PATH/u);
   await rm(dataDir, { recursive: true, force: true });
 });

--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -294,12 +294,12 @@ function Ensure-InstallDirOnPath {
 function Assert-PathCliResolvesCurrent {
     $pathCli = Get-Command "codestory-cli" -ErrorAction SilentlyContinue
     if (-not $pathCli) {
-        throw "Installed MCP runtime cannot resolve codestory-cli from PATH. Add the current CodeStory install directory before stale entries, then restart the Codex host/app before opening a fresh agent thread."
+        throw "PATH diagnostic cannot resolve codestory-cli. Add the current CodeStory install directory before stale entries for shell CLI use; installed plugin runtime changes require managed status/reinstall/reload or explicit CODESTORY_CLI, then restart the Codex host/app before opening a fresh agent thread."
     }
 
     $version = Invoke-CliVersion $pathCli.Source
     if (-not (Test-RequiredVersion $version.Version)) {
-        throw "Installed MCP runtime still resolves stale codestory-cli from PATH: $($pathCli.Source) ($($version.Text)); expected $script:RequiredVersion. Stop or restart running 'codestory-cli serve --stdio --refresh none' processes that lock old binaries, move the current install directory before stale PATH entries, then restart the Codex host/app before opening a fresh agent thread."
+        throw "PATH diagnostic still resolves stale codestory-cli: $($pathCli.Source) ($($version.Text)); expected $script:RequiredVersion. Stop or restart running 'codestory-cli serve --stdio --refresh none' processes that lock old binaries, move the current install directory before stale PATH entries for shell CLI use, then update installed plugin runtime through managed status/reinstall/reload or explicit CODESTORY_CLI before opening a fresh agent thread."
     }
 }
 


### PR DESCRIPTION
## Context

Closes #798
Refs #799

This promotes `dev/codestory-next` to `main` for the synchronized CodeStory 0.13.0 release. The branch contains the MCP readiness and one-command repair hardening work, plus the 0.13.0 version bump merged in PR #819.

## What Changed

- Promotes the current `dev/codestory-next` release train to `main`.
- Carries the synchronized `0.13.0` crate, lockfile, and plugin manifest versions.
- Carries release guidance that verifies `dev/codestory-next` survives the main promotion and is restored if GitHub deletes it.

## How To Review

Review the compare from `dev/codestory-next` into `main`, with the release-version source at `crates/codestory-cli/Cargo.toml` and changelog entry `0.13.0`.

## Verification

From PR #819:
- `python .github/scripts/check-codestory-release.py --version 0.13.0` -> synchronized across 8 workspace crates, Cargo.lock, and 3 plugin manifests
- `node .github/scripts/check-workflow-policy.mjs` -> passed
- `node --test plugins/codestory/tests/plugin-static.test.mjs` -> 46 passed
- `node .github/scripts/check-doc-links.mjs` -> passed, 70 files and 279 links
- `git diff --check` -> passed
- `cargo check --locked -p codestory-cli` -> passed with CodeStory crates at 0.13.0
- PR #819 CI passed: docs link check, plugin static tests, linux-contracts, rustdoc, workspace cargo checks, and saga issue-link guard

Promotion proof before this PR:
- `git rev-list --left-right --count origin/main...origin/dev/codestory-next` -> `0 9`

## Risk

Merging this PR to `main` should trigger Auto Release for `v0.13.0`. After merge, verify the tag/release assets, confirm `dev/codestory-next` still exists and matches `main`, and update the AgentPluginMarketplace pointer only after the release is real.
