### PR TITLE
release codestory 0.13.1 to main

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -202,6 +202,11 @@ def require_version(output: str, expected_version: str, archive: Path, artifact:
     )
 
 
+def require_help(output: str, artifact: Path) -> None:
+    require("Usage:" in output, "help", artifact, "codestory-cli --help output missing Usage")
+    require("codestory-cli" in output, "help", artifact, "codestory-cli --help output missing binary name")
+
+
 def require_retrieval_index_ready(payload: object, layer: str, artifact: Path) -> None:
     require(isinstance(payload, dict), layer, artifact, "retrieval index output is not a JSON object")
     for field in ["zoekt_stubbed", "qdrant_stubbed", "scip_stubbed"]:
@@ -513,40 +518,45 @@ def stdio_status_command(
     return status
 
 
-def require_stdio_ready(status: dict, artifact: Path, expected_version: str) -> None:
+def require_stdio_shape(status: dict, artifact: Path, expected_version: str, layer: str = "serve_stdio") -> None:
     require(
         status.get("server_version") == expected_version,
-        "serve_stdio",
+        layer,
         artifact,
         f"status server_version is {status.get('server_version')!r}, expected {expected_version!r}",
     )
     require(
         status.get("cli_version") == expected_version,
-        "serve_stdio",
+        layer,
         artifact,
         f"status cli_version is {status.get('cli_version')!r}, expected {expected_version!r}",
     )
     require(
         isinstance(status.get("server_executable"), str) and len(status.get("server_executable", "")) > 0,
-        "serve_stdio",
+        layer,
         artifact,
         "status missing server_executable",
     )
     require(
         isinstance(status.get("server_executable_sha256"), str)
         and len(status.get("server_executable_sha256", "")) == 64,
-        "serve_stdio",
+        layer,
         artifact,
         "status missing server_executable_sha256",
     )
     require(
         isinstance(status.get("sidecar_contract_version"), int),
-        "serve_stdio",
+        layer,
         artifact,
         "status missing sidecar_contract_version",
     )
     plugin_runtime = status.get("plugin_runtime")
-    require(isinstance(plugin_runtime, dict), "serve_stdio", artifact, "status missing plugin_runtime")
+    require(isinstance(plugin_runtime, dict), layer, artifact, "status missing plugin_runtime")
+    require(isinstance(status.get("allowed_surfaces"), dict), layer, artifact, "status missing allowed_surfaces")
+
+
+def require_stdio_ready(status: dict, artifact: Path, expected_version: str) -> None:
+    require_stdio_shape(status, artifact, expected_version)
     surfaces = status.get("allowed_surfaces", {})
     for name in ["packet", "search", "context"]:
         allowed = surfaces.get(name, {}).get("allowed")
@@ -622,6 +632,19 @@ def run_gate(args: argparse.Namespace) -> None:
         require_version(version_artifact.read_text(encoding="utf-8"), args.expected_version, archive, version_artifact)
         summary["artifacts"]["version"] = str(version_artifact)
         write_json(out_dir / "summary.json", summary)
+
+        help_artifact = out_dir / "help.txt"
+        run_command(cli, "help", ["--help"], help_artifact, args.timeout_secs, parse_json=False)
+        require_help(help_artifact.read_text(encoding="utf-8"), help_artifact)
+        summary["artifacts"]["help"] = str(help_artifact)
+        write_json(out_dir / "summary.json", summary)
+
+        stdio_artifact = out_dir / "serve-stdio-status.json"
+        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs)
+        require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
+        summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
+        write_json(out_dir / "summary.json", summary)
+
         if args.version_only:
             return
 
@@ -820,10 +843,7 @@ def run_gate(args: argparse.Namespace) -> None:
         summary["artifacts"]["packet"] = str(packet_artifact)
         write_json(out_dir / "summary.json", summary)
 
-        stdio_artifact = out_dir / "serve-stdio-status.json"
-        status = stdio_status(cli, project, stdio_artifact, args.timeout_secs)
-        require_stdio_ready(status, stdio_artifact, args.expected_version)
-        summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
+        require_stdio_ready(stdio_status_payload, stdio_artifact, args.expected_version)
         write_json(out_dir / "summary.json", summary)
 
         if args.plugin_root:
@@ -863,6 +883,9 @@ def write_fake_cli(path: Path) -> None:
             fail = os.environ.get("CODESTORY_FAKE_FAIL_LAYER")
             if "--version" in sys.argv:
                 print("codestory-cli 9.9.9")
+                raise SystemExit(0)
+            if "--help" in sys.argv:
+                print("Usage: codestory-cli [OPTIONS] <COMMAND>")
                 raise SystemExit(0)
             layer = sys.argv[1]
             if layer == "retrieval" and len(sys.argv) > 2:
@@ -1043,7 +1066,7 @@ def self_test() -> None:
         version_only_args.version_only = True
         run_gate(version_only_args)
         version_only_summary = read_json_file(version_only_out / "summary.json")
-        assert version_only_summary["artifacts"].keys() == {"version"}
+        assert version_only_summary["artifacts"].keys() == {"version", "help", "serve_stdio"}
         assert not (version_only_out / "local-retrieval-bootstrap.json").exists()
 
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "search"
@@ -1203,7 +1226,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--version-only",
         action="store_true",
-        help="Only unpack the archive and verify codestory-cli --version.",
+        help="Only run archive, version, help, and stdio status-shape smoke.",
     )
     parser.add_argument("--self-test", action="store_true", help="Run script self-tests.")
     args = parser.parse_args()

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   smoke:
-    name: Published Linux asset agent proof
+    name: Published release asset smoke
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -36,7 +36,7 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.tag }}
 
-      - name: Download published Linux asset
+      - name: Download published release assets
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
@@ -46,19 +46,27 @@ jobs:
           mkdir -p target/post-publish-release-assets
           gh release download "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --pattern "codestory-cli-v${VERSION}-linux-x64.tar.gz" \
+            --pattern "codestory-cli-v${VERSION}-*.tar.gz" \
+            --pattern "codestory-cli-v${VERSION}-*.zip" \
             --pattern "SHA256SUMS.txt" \
             --dir target/post-publish-release-assets \
             --clobber
-          grep "  codestory-cli-v${VERSION}-linux-x64.tar.gz$" \
-            target/post-publish-release-assets/SHA256SUMS.txt \
-            > target/post-publish-release-assets/linux-x64.sha256
-          (cd target/post-publish-release-assets && sha256sum -c linux-x64.sha256)
+          shopt -s nullglob
+          assets=(
+            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.tar.gz
+            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.zip
+          )
+          if [ "${#assets[@]}" -ne 5 ]; then
+            echo "::error::Expected five binary archives, found ${#assets[@]}."
+            printf '%s\n' "${assets[@]}"
+            exit 1
+          fi
+          (cd target/post-publish-release-assets && sha256sum -c SHA256SUMS.txt)
 
       - name: Fetch retrieval embedding model
         run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
 
-      - name: Prove published agent runtime
+      - name: Prove published Linux agent runtime
         env:
           CODESTORY_EMBED_ALLOW_CPU: "1"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Download published Linux asset
+      - name: Download published release assets
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.preflight.outputs.tag }}
@@ -341,19 +341,27 @@ jobs:
           mkdir -p target/post-publish-release-assets
           gh release download "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --pattern "codestory-cli-v${VERSION}-linux-x64.tar.gz" \
+            --pattern "codestory-cli-v${VERSION}-*.tar.gz" \
+            --pattern "codestory-cli-v${VERSION}-*.zip" \
             --pattern "SHA256SUMS.txt" \
             --dir target/post-publish-release-assets \
             --clobber
-          grep "  codestory-cli-v${VERSION}-linux-x64.tar.gz$" \
-            target/post-publish-release-assets/SHA256SUMS.txt \
-            > target/post-publish-release-assets/linux-x64.sha256
-          (cd target/post-publish-release-assets && sha256sum -c linux-x64.sha256)
+          shopt -s nullglob
+          assets=(
+            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.tar.gz
+            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.zip
+          )
+          if [ "${#assets[@]}" -ne 5 ]; then
+            echo "::error::Expected five binary archives, found ${#assets[@]}."
+            printf '%s\n' "${assets[@]}"
+            exit 1
+          fi
+          (cd target/post-publish-release-assets && sha256sum -c SHA256SUMS.txt)
 
       - name: Fetch retrieval embedding model
         run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
 
-      - name: Prove published agent runtime
+      - name: Prove published Linux agent runtime
         env:
           CODESTORY_EMBED_ALLOW_CPU: "1"
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+## 0.13.1
+
+CodeStory 0.13.1 hardens the portable plugin/runtime path across Codex,
+Cursor, Claude Code, and GPU hosts while keeping MCP visibility truth explicit.
+
+### Fixed
+
+- Added a hook MCP bridge for launchable-but-model-hidden Codex MCP sessions so
+  hooks inject bounded `codestory://status` truth and optional hook-bridged
+  context without claiming live MCP tools are model-visible.
+- Removed ambient CodeStory CLI discovery diagnostics and repair guidance from
+  the plugin adapter, stdio status, readiness output, installer, benchmark
+  harness, tests, and agent-facing docs while preserving `CODESTORY_CLI` as an
+  explicit local-development override.
+- Added `CODESTORY_PLUGIN_DATA` as the portable managed-runtime data directory
+  for non-Codex hosts, with Cursor and Claude Code examples that use managed
+  runtime state directly.
+- Made llama.cpp acceleration Vulkan-first by default with `Vulkan0` and GPU
+  layer requests when CPU mode is not explicitly allowed, plus Linux compose
+  `/dev/dri` access and operator docs for native/external endpoints on
+  Windows/macOS.
+- Expanded release and post-publish package proof to download every shipped
+  binary archive, verify checksums, run version/help smoke, and validate stdio
+  status shape while keeping full sidecar proof on runners that can support it.
+
 ## 0.13.0
 
 CodeStory 0.13.0 promotes the current `dev/codestory-next` MCP readiness and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/readiness.rs
+++ b/crates/codestory-cli/src/readiness.rs
@@ -297,11 +297,7 @@ fn verdict_state(
                     newer_path
                 ),
                 vec![restart.clone()],
-                vec![
-                    restart,
-                    "where.exe codestory-cli".to_string(),
-                    "codestory-cli --version".to_string(),
-                ],
+                vec![restart],
             );
         }
         let install = format!(
@@ -315,11 +311,7 @@ fn verdict_state(
                 setup.active_version, setup.active_path, setup.latest_version
             ),
             vec![install.clone()],
-            vec![
-                install,
-                "where.exe codestory-cli".to_string(),
-                "codestory-cli --version".to_string(),
-            ],
+            vec![install],
         );
     }
 

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2673,7 +2673,6 @@ fn read_stdio_status_resource(
     });
     let (server_executable, server_executable_sha256, server_warnings) =
         stdio_server_executable_status();
-    let path_candidates = stdio_path_cli_candidate_statuses(server_executable.as_deref());
     let source_checkout_version = stdio_source_checkout_version(&runtime.project_root);
     let plugin_runtime = stdio_plugin_runtime_status();
     let setup_repair = stdio_setup_repair_input(server_executable.as_deref());
@@ -2772,13 +2771,12 @@ fn read_stdio_status_resource(
         "server_executable": server_executable,
         "server_executable_sha256": server_executable_sha256,
         "source_checkout_version": source_checkout_version,
-        "path_candidates": path_candidates,
         "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "plugin_runtime": plugin_runtime,
         "runtime_truth": runtime_truth,
         "runtime_boundary": {
             "restart_required_for_runtime_change": true,
-            "message": "A running MCP server keeps using the CLI process it was launched with; install, override, or PATH changes require a host reload/restart and a fresh codestory://status readback."
+            "message": "A running MCP server keeps using the CLI process it was launched with; install or explicit override changes require a host reload/restart and a fresh codestory://status readback."
         },
         "warnings": server_warnings,
         "project_root": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
@@ -3051,53 +3049,6 @@ fn stdio_cli_version_with_timeout(candidate: &str, timeout: Duration) -> Option<
         }
         let remaining = timeout.saturating_sub(started_at.elapsed());
         std::thread::sleep(STDIO_CLI_VERSION_POLL_INTERVAL.min(remaining));
-    }
-}
-
-fn stdio_path_cli_candidate_statuses(active_path: Option<&str>) -> serde_json::Value {
-    serde_json::Value::Array(
-        stdio_path_cli_candidates()
-            .into_iter()
-            .map(|path| {
-                serde_json::json!({
-                    "path": crate::display::clean_path_string(&path),
-                    "version": stdio_cli_version(&path),
-                    "active": active_path.is_some_and(|active| same_path_text(&path, active)),
-                })
-            })
-            .collect(),
-    )
-}
-
-fn stdio_path_cli_candidates() -> Vec<String> {
-    let mut candidates = Vec::new();
-    if let Some(paths) = std::env::var_os("PATH") {
-        for directory in std::env::split_paths(&paths) {
-            push_existing_path_cli_candidates(&mut candidates, &directory);
-        }
-    }
-    dedupe_path_text(candidates)
-}
-
-fn push_existing_path_cli_candidates(candidates: &mut Vec<String>, directory: &Path) {
-    for binary in stdio_cli_binary_names() {
-        let candidate = directory.join(binary);
-        if candidate.is_file() {
-            candidates.push(candidate.to_string_lossy().to_string());
-        }
-    }
-}
-
-fn stdio_cli_binary_names() -> &'static [&'static str] {
-    if cfg!(windows) {
-        &[
-            "codestory-cli.exe",
-            "codestory-cli.cmd",
-            "codestory-cli.bat",
-            "codestory-cli",
-        ]
-    } else {
-        &["codestory-cli"]
     }
 }
 
@@ -3410,7 +3361,6 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         "archive_url": env_nonempty("CODESTORY_PLUGIN_CLI_ARCHIVE_URL"),
         "provisioned_at": env_nonempty("CODESTORY_PLUGIN_CLI_PROVISIONED_AT"),
         "local_dev_override": cli_source == "local_dev_override",
-        "path_fallback": cli_source == "path_fallback",
         "managed_binary_path": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_PATH") } else { None },
         "managed_binary_sha256": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_SHA256") } else { None },
         "managed_manifest_path": env_nonempty("CODESTORY_PLUGIN_CLI_MANIFEST_PATH"),

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2236,10 +2236,6 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         "status should distinguish source checkout version from active runtime version: {status}"
     );
     assert!(
-        status["path_candidates"].is_array(),
-        "status should report competing PATH candidates even when none are present: {status}"
-    );
-    assert!(
         status["sidecar_contract_version"].is_number(),
         "status should expose the sidecar contract version: {status}"
     );

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -23,6 +23,9 @@ const BUNDLED_RETRIEVAL_COMPOSE: &str = include_str!("../../../docker/retrieval-
 const DOCKER_ADDRESS_POOL_EXHAUSTED_REASON: &str = "docker_address_pool_exhausted";
 const DOCKER_ADDRESS_POOL_EXHAUSTED_NEEDLE: &str =
     "all predefined address pools have been fully subnetted";
+const LINUX_VULKAN_RENDER_NODE: &str = "/dev/dri";
+const VULKAN_COMPOSE_OVERRIDE: &str =
+    "services:\n  embed:\n    devices:\n      - /dev/dri:/dev/dri\n";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct EmbedModelInventory {
@@ -279,12 +282,22 @@ fn docker_compose_up(
     let compose_profile = retrieval_compose_profile();
     remove_container_if_present("codestory-zoekt-stub")?;
     let embedding_device = crate::embeddings::embedding_device_readiness();
+    let accelerator_request = crate::embeddings::embedding_accelerator_request();
+    let vulkan_override = maybe_write_vulkan_compose_override(
+        &user_cache_root(),
+        Path::new(LINUX_VULKAN_RENDER_NODE),
+        accelerator_request.is_some(),
+    )?;
     command
         .arg("compose")
         .arg("-p")
         .arg(&runtime.compose_project)
         .arg("-f")
-        .arg(compose_file)
+        .arg(compose_file);
+    if let Some(override_file) = vulkan_override.as_ref() {
+        command.arg("-f").arg(override_file);
+    }
+    command
         .arg("up")
         .arg("-d")
         .current_dir(workdir)
@@ -328,7 +341,7 @@ fn docker_compose_up(
     if let Some(gpu) = embedding_device.detected_gpu.as_deref() {
         command.env("CODESTORY_EMBED_DEVICE_NAME", gpu);
     }
-    if let Some(request) = crate::embeddings::embedding_accelerator_request() {
+    if let Some(request) = accelerator_request {
         let device = request.device;
         let n_gpu_layers = request.n_gpu_layers;
         command
@@ -353,6 +366,33 @@ fn docker_compose_up(
         );
     }
     Ok(())
+}
+
+fn maybe_write_vulkan_compose_override(
+    cache_root: &Path,
+    host_render_node: &Path,
+    accelerator_requested: bool,
+) -> Result<Option<PathBuf>> {
+    if !accelerator_requested || !host_render_node.exists() {
+        return Ok(None);
+    }
+    std::fs::create_dir_all(cache_root)
+        .with_context(|| format!("create CodeStory cache dir {}", cache_root.display()))?;
+    let override_path = cache_root.join("retrieval-compose-vulkan.override.yml");
+    if override_path.is_file()
+        && std::fs::read_to_string(&override_path)
+            .map(|contents| contents == VULKAN_COMPOSE_OVERRIDE)
+            .unwrap_or(false)
+    {
+        return Ok(Some(override_path));
+    }
+    std::fs::write(&override_path, VULKAN_COMPOSE_OVERRIDE).with_context(|| {
+        format!(
+            "write Vulkan retrieval compose override {}",
+            override_path.display()
+        )
+    })?;
+    Ok(Some(override_path))
 }
 
 fn docker_compose_up_failure_message(
@@ -877,8 +917,31 @@ mod tests {
     fn bundled_compose_keeps_llamacpp_device_env_request_only() {
         assert!(BUNDLED_RETRIEVAL_COMPOSE.contains("- LLAMA_ARG_DEVICE"));
         assert!(BUNDLED_RETRIEVAL_COMPOSE.contains("- LLAMA_ARG_N_GPU_LAYERS"));
+        assert!(!BUNDLED_RETRIEVAL_COMPOSE.contains("/dev/dri:/dev/dri"));
+        assert!(!BUNDLED_RETRIEVAL_COMPOSE.contains("devices:"));
         assert!(!BUNDLED_RETRIEVAL_COMPOSE.contains("LLAMA_ARG_DEVICE:"));
         assert!(!BUNDLED_RETRIEVAL_COMPOSE.contains(":-none"));
+    }
+
+    #[test]
+    fn vulkan_compose_override_is_only_written_when_host_render_node_exists() {
+        let cache = tempdir().expect("cache");
+        let missing = cache.path().join("missing-dri");
+        let skipped =
+            maybe_write_vulkan_compose_override(cache.path(), &missing, true).expect("skip");
+        assert_eq!(skipped, None);
+
+        let disabled =
+            maybe_write_vulkan_compose_override(cache.path(), &missing, false).expect("disabled");
+        assert_eq!(disabled, None);
+
+        let render_node = cache.path().join("dri");
+        std::fs::create_dir(&render_node).expect("render node dir");
+        let written =
+            maybe_write_vulkan_compose_override(cache.path(), &render_node, true).expect("write");
+        let written = written.expect("override path");
+        let contents = std::fs::read_to_string(written).expect("override contents");
+        assert!(contents.contains("/dev/dri:/dev/dri"));
     }
 
     #[test]
@@ -941,10 +1004,10 @@ mod tests {
     }
 
     #[test]
-    fn native_launch_args_use_model_port_and_amd_vulkan_device() {
+    fn native_launch_args_use_model_port_and_default_vulkan_device() {
         let _lock = crate::test_support::env_lock();
-        let _provider = EnvGuard::set("CODESTORY_EMBED_DEVICE_PROVIDER", "amd");
-        let _name = EnvGuard::set("CODESTORY_EMBED_DEVICE_NAME", "AMD Radeon RX 7900 XT");
+        let _provider = EnvGuard::remove("CODESTORY_EMBED_DEVICE_PROVIDER");
+        let _name = EnvGuard::remove("CODESTORY_EMBED_DEVICE_NAME");
         let _device = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_DEVICE");
         let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
 
@@ -1027,14 +1090,6 @@ mod tests {
     }
 
     impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            Self { key, previous }
-        }
-
         fn remove(key: &'static str) -> Self {
             let previous = std::env::var(key).ok();
             unsafe {

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -716,9 +716,7 @@ pub fn embedding_server_launch_mode() -> Result<EmbeddingServerLaunchMode> {
         .ok()
         .map(|value| value.trim().to_ascii_lowercase())
         .and_then(|value| match value.as_str() {
-            "native_spawned" | "native" | "windows_amd_native" => {
-                Some(EmbeddingServerLaunchMode::NativeSpawned)
-            }
+            "native_spawned" | "native" => Some(EmbeddingServerLaunchMode::NativeSpawned),
             "docker_compose_embed" | "docker" | "compose" => {
                 Some(EmbeddingServerLaunchMode::DockerComposeEmbed)
             }

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -144,11 +144,7 @@ fn embedding_device_readiness_with_observed_state(
 ) -> EmbeddingDeviceReadiness {
     let cpu_allowed = explicit_cpu_allowed();
     let detection = host_embedding_device_detection();
-    let accelerator_request = if cpu_allowed {
-        None
-    } else {
-        embedding_accelerator_request_for_detection(detection.as_ref())
-    };
+    let accelerator_request = (!cpu_allowed).then(default_embedding_accelerator_request);
     let accelerator_requested = accelerator_request.is_some();
     let observation = sidecar_observed_state
         .unwrap_or_else(|| observed_embedding_device_state(cpu_allowed, accelerator_requested));
@@ -253,18 +249,14 @@ pub fn embedding_accelerator_request() -> Option<EmbeddingAcceleratorRequest> {
     if explicit_cpu_allowed() {
         return None;
     }
-    let detection = host_embedding_device_detection();
-    embedding_accelerator_request_for_detection(detection.as_ref())
+    Some(default_embedding_accelerator_request())
 }
 
-fn embedding_accelerator_request_for_detection(
-    detection: Option<&HostGpuDetection>,
-) -> Option<EmbeddingAcceleratorRequest> {
-    let detection = detection?;
-    (detection.provider == "amd").then(|| EmbeddingAcceleratorRequest {
+fn default_embedding_accelerator_request() -> EmbeddingAcceleratorRequest {
+    EmbeddingAcceleratorRequest {
         device: env_trimmed(LLAMACPP_DEVICE_ENV).unwrap_or_else(|| "Vulkan0".to_string()),
         n_gpu_layers: env_trimmed(LLAMACPP_N_GPU_LAYERS_ENV).unwrap_or_else(|| "99".to_string()),
-    })
+    }
 }
 
 fn explicit_cpu_allowed() -> bool {
@@ -838,10 +830,21 @@ mod tests {
 
         assert_eq!(readiness.requested_policy, "accelerator_required");
         assert_eq!(readiness.observed_state, "unknown");
-        assert_eq!(readiness.observation_source, "sidecar_unobserved");
+        assert_eq!(
+            readiness.observation_source,
+            "accelerator_request_unobserved"
+        );
         assert_eq!(readiness.detected_provider, None);
         assert_eq!(readiness.detected_gpu, None);
-        assert!(!readiness.accelerator_requested);
+        assert!(readiness.accelerator_requested);
+        assert_eq!(
+            readiness.accelerator_request_provider.as_deref(),
+            Some("vulkan")
+        );
+        assert_eq!(
+            readiness.accelerator_request_device.as_deref(),
+            Some("Vulkan0")
+        );
         assert!(!readiness.full_retrieval_allowed);
         assert!(
             readiness
@@ -905,14 +908,14 @@ mod tests {
     }
 
     #[test]
-    fn amd_provider_env_detects_and_requests_vulkan_without_observing_acceleration() {
+    fn default_policy_requests_vulkan_without_observing_acceleration() {
         let _lock = crate::test_support::env_lock();
         let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
         let _policy = EnvGuard::remove(DEVICE_POLICY_ENV);
         let _device = EnvGuard::remove(DEVICE_STATE_ENV);
-        let _provider = EnvGuard::set(DEVICE_PROVIDER_ENV, "amd");
-        let _name = EnvGuard::set(DEVICE_NAME_ENV, "AMD Radeon RX 7800 XT");
-        let _host_detect = EnvGuard::remove(DISABLE_HOST_GPU_DETECT_ENV);
+        let _provider = EnvGuard::remove(DEVICE_PROVIDER_ENV);
+        let _name = EnvGuard::remove(DEVICE_NAME_ENV);
+        let _host_detect = EnvGuard::set(DISABLE_HOST_GPU_DETECT_ENV, "1");
         let _llama_device = EnvGuard::remove(LLAMACPP_DEVICE_ENV);
         let _ngl = EnvGuard::remove(LLAMACPP_N_GPU_LAYERS_ENV);
 
@@ -925,11 +928,8 @@ mod tests {
             readiness.observation_source,
             "accelerator_request_unobserved"
         );
-        assert_eq!(readiness.detected_provider.as_deref(), Some("amd"));
-        assert_eq!(
-            readiness.detected_gpu.as_deref(),
-            Some("AMD Radeon RX 7800 XT")
-        );
+        assert_eq!(readiness.detected_provider, None);
+        assert_eq!(readiness.detected_gpu, None);
         assert!(readiness.accelerator_requested);
         assert_eq!(
             readiness.accelerator_request_provider.as_deref(),
@@ -953,7 +953,7 @@ mod tests {
     }
 
     #[test]
-    fn sidecar_log_observed_acceleration_allows_amd_vulkan_request() {
+    fn sidecar_log_observed_acceleration_allows_default_vulkan_request() {
         let _lock = crate::test_support::env_lock();
         let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
         let _policy = EnvGuard::remove(DEVICE_POLICY_ENV);
@@ -994,7 +994,7 @@ mod tests {
     }
 
     #[test]
-    fn inconclusive_sidecar_log_keeps_amd_vulkan_request_unknown() {
+    fn inconclusive_sidecar_log_keeps_default_vulkan_request_unknown() {
         let _lock = crate::test_support::env_lock();
         let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
         let _policy = EnvGuard::remove(DEVICE_POLICY_ENV);

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/agent/packet_capping.rs
+++ b/crates/codestory-runtime/src/agent/packet_capping.rs
@@ -1422,7 +1422,7 @@ mod tests {
         const REQUIRED_PROBE_COUNT: usize = 96;
         const DUPLICATE_MULTI_MATCH_PROBE_COUNT: usize =
             REQUIRED_PROBE_COUNT - UNIQUE_REQUIRED_PROBE_COUNT;
-        const MAX_ELAPSED: Duration = Duration::from_secs(2);
+        const MAX_ELAPSED: Duration = Duration::from_secs(3);
 
         let mut citations = Vec::with_capacity(CITATION_COUNT);
         for index in 0..CITATION_COUNT {

--- a/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
+++ b/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
@@ -69,7 +69,7 @@ fn lint_script(repo_root: &Path) -> PathBuf {
     script
 }
 
-fn run_lint_with_extra_root(repo_root: &Path, script: &Path, extra_root: &Path) -> Output {
+fn run_lint_with_scan_root(repo_root: &Path, script: &Path, scan_root: &Path) -> Output {
     let _guard = LINT_SCRIPT_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -77,10 +77,7 @@ fn run_lint_with_extra_root(repo_root: &Path, script: &Path, extra_root: &Path) 
     Command::new("node")
         .arg(script)
         .current_dir(repo_root)
-        .env(
-            "CODESTORY_RETRIEVAL_GENERALIZATION_EXTRA_SCAN_ROOTS",
-            extra_root,
-        )
+        .env("CODESTORY_RETRIEVAL_GENERALIZATION_SCAN_ROOTS", scan_root)
         .output()
         .expect("run lint-retrieval-generalization.mjs against fixture")
 }
@@ -90,7 +87,7 @@ fn run_lint_with_fixture(contents: &str) -> Output {
     let script = lint_script(&repo_root);
     let fixture_root = TempDir::new().expect("create fixture root");
     std::fs::write(fixture_root.path().join("fixture.rs"), contents).expect("write fixture");
-    run_lint_with_extra_root(&repo_root, &script, fixture_root.path())
+    run_lint_with_scan_root(&repo_root, &script, fixture_root.path())
 }
 
 fn run_lint_with_named_fixtures(fixtures: &[(&str, &str)]) -> Output {
@@ -100,26 +97,43 @@ fn run_lint_with_named_fixtures(fixtures: &[(&str, &str)]) -> Output {
     for (name, contents) in fixtures {
         std::fs::write(fixture_root.path().join(name), contents).expect("write fixture");
     }
-    run_lint_with_extra_root(&repo_root, &script, fixture_root.path())
+    run_lint_with_scan_root(&repo_root, &script, fixture_root.path())
 }
 
 #[test]
-fn retrieval_generalization_lint_script_exits_clean_when_dirs_absent() {
+fn retrieval_generalization_lint_script_exits_clean_with_extra_fixture_root() {
     let repo_root = workspace_root();
     let script = lint_script(&repo_root);
+    let fixture_root = TempDir::new().expect("create fixture root");
 
     let _guard = LINT_SCRIPT_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
         .expect("lock lint script subprocess");
-    let status = Command::new("node")
+    let output = Command::new("node")
         .arg(&script)
         .current_dir(&repo_root)
-        .status()
+        .env(
+            "CODESTORY_RETRIEVAL_GENERALIZATION_EXTRA_SCAN_ROOTS",
+            fixture_root.path(),
+        )
+        .output()
         .expect("run lint-retrieval-generalization.mjs");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        status.success(),
-        "lint script should exit 0 when retrieval integration trees are clean"
+        output.status.success(),
+        "lint script should exit 0 when retrieval integration trees are clean; stderr={stderr}"
+    );
+    let production_file_count = stdout
+        .split(" production file(s)")
+        .next()
+        .and_then(|prefix| prefix.split_whitespace().last())
+        .and_then(|value| value.parse::<u32>().ok())
+        .expect("parse production file count from lint stdout");
+    assert!(
+        production_file_count > 0,
+        "extra fixture root should not replace the real production scan roots, stdout={stdout}"
     );
 }
 
@@ -367,30 +381,6 @@ mod tests {
     assert!(
         output.status.success(),
         "test-only cfg_attr and logically test-only cfg forms should be masked, stderr={stderr}"
-    );
-}
-
-#[test]
-fn linter_extra_fixture_roots_do_not_hide_real_scan_roots() {
-    let repo_root = workspace_root();
-    let script = lint_script(&repo_root);
-    let fixture_root = TempDir::new().expect("create fixture root");
-    let output = run_lint_with_extra_root(&repo_root, &script, fixture_root.path());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "empty extra fixture root should not replace or break the real scan roots, stderr={stderr}"
-    );
-    let production_file_count = stdout
-        .split(" production file(s)")
-        .next()
-        .and_then(|prefix| prefix.split_whitespace().last())
-        .and_then(|value| value.parse::<u32>().ok())
-        .expect("parse production file count from lint stdout");
-    assert!(
-        production_file_count > 0,
-        "lint should still report real production files, stdout={stdout}"
     );
 }
 

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 
 [dependencies]

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -58,6 +58,9 @@ services:
         source: ${CODESTORY_EMBED_MODEL_DIR:?set CODESTORY_EMBED_MODEL_DIR}
         target: /models
         read_only: true
+    # CodeStory requests Vulkan through these llama.cpp env vars when CPU mode
+    # is not explicitly allowed. Linux render-node access is added by a
+    # generated compose override only when /dev/dri exists.
     environment:
       - LLAMA_ARG_DEVICE
       - LLAMA_ARG_N_GPU_LAYERS

--- a/docker/retrieval.env.example
+++ b/docker/retrieval.env.example
@@ -30,6 +30,9 @@ CODESTORY_EMBED_PORT=8080
 # CODESTORY_RETRIEVAL_REAL_EMBEDDINGS=1
 # CODESTORY_EMBED_BACKEND=llamacpp
 # CODESTORY_EMBED_LLAMACPP_URL=http://127.0.0.1:8080/v1/embeddings
+# Vulkan is requested by default when CPU is not explicitly allowed.
+# CODESTORY_EMBED_LLAMACPP_DEVICE=Vulkan0
+# CODESTORY_EMBED_LLAMACPP_N_GPU_LAYERS=99
 # CODESTORY_EMBED_DEVICE_STATE=accelerated
 # CPU fallback is blocked by default. Use one of these only for intentional CPU-backed retrieval:
 # CODESTORY_EMBED_ALLOW_CPU=1

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -55,9 +55,8 @@ codestory-cli retrieval status --project <repo> --format json
 When plugin MCP is live, read `codestory://status` first and use its
 `allowed_surfaces` values as the tool boundary. For field semantics and
 first-response repair prompts, use
-[users/troubleshooting.md](../users/troubleshooting.md). Do not infer the active
-runtime from the source checkout, marketplace cache, or PATH when status is
-available.
+[users/troubleshooting.md](../users/troubleshooting.md). Treat status as the
+active runtime source when it is available.
 
 | State | Meaning | Operator action |
 |-------|---------|-----------------|
@@ -127,12 +126,23 @@ defaults do not match your machine:
 | `CODESTORY_EMBED_MODEL_DIR` | Host path containing `bge-base-en-v1.5.Q8_0.gguf` for the compose embed service |
 | `CODESTORY_EMBED_BACKEND` | `llamacpp`; unset also means product llama.cpp mode for retrieval commands |
 | `CODESTORY_EMBED_LLAMACPP_URL` | Local embedding endpoint, default `http://127.0.0.1:8080/v1/embeddings` |
+| `CODESTORY_EMBED_LLAMACPP_DEVICE` | Optional llama.cpp accelerator request, default `Vulkan0` when CPU is not explicitly allowed |
+| `CODESTORY_EMBED_LLAMACPP_N_GPU_LAYERS` | Optional llama.cpp GPU layer request, default `99` when CPU is not explicitly allowed |
 | `CODESTORY_EMBED_DEVICE_STATE` | Optional operator assertion for observed device state: `accelerated`, `cpu`, or unset/unknown |
 | `CODESTORY_EMBED_ALLOW_CPU` | Set to `1` only when intentional CPU-backed retrieval is acceptable on this machine |
 | `CODESTORY_EMBED_DEVICE_POLICY` | Optional policy alias; set `allow_cpu` instead of `CODESTORY_EMBED_ALLOW_CPU=1` when CPU mode is intentional |
 | `CODESTORY_ZOEKT_PORT` | Override Zoekt HTTP port when `6070` is unavailable |
 | `CODESTORY_QDRANT_HTTP_PORT` | Override Qdrant HTTP port when `6333` is unavailable |
 | `CODESTORY_QDRANT_GRPC_PORT` | Override Qdrant gRPC port when `6334` is unavailable |
+
+If CPU is not explicitly allowed, CodeStory requests llama.cpp Vulkan device
+`Vulkan0` and `99` GPU layers by default. Linux Docker Compose keeps the base
+file CPU-compatible and adds a generated `/dev/dri` override only when
+accelerator mode is requested and the host render node exists. On Windows and
+macOS GPU setups, run an already-working native or external llama.cpp embedding
+endpoint and point CodeStory at it with `CODESTORY_EMBED_LLAMACPP_URL`; set the
+device/layer variables only when the default request does not match that
+endpoint.
 
 If device state is unknown, full packet/search readiness fails closed by
 default. Use the CPU opt-in only as an explicit operator decision; otherwise

--- a/docs/users/claude-code.md
+++ b/docs/users/claude-code.md
@@ -59,6 +59,24 @@ Configure MCP separately if your Claude Code setup does not inherit the Codex
 `plugins/codestory/scripts/codestory-mcp.cjs` (same shape as
 [Cursor MCP config](cursor.md#2-mcp-server-copy-shipped-config)).
 
+Use `CODESTORY_PLUGIN_DATA` in the MCP server env block to give Claude Code a
+persistent managed-runtime data directory:
+
+```json
+{
+  "mcpServers": {
+    "codestory": {
+      "command": "node",
+      "args": ["/absolute/path/to/plugins/codestory/scripts/codestory-mcp.cjs"],
+      "env": {
+        "CODESTORY_PLUGIN_DATA": "/absolute/path/to/codestory-plugin-data"
+      },
+      "tool_timeout_sec": 300
+    }
+  }
+}
+```
+
 Open the repository you want to ground. Managed CLI bootstrap depends on MCP:
 the adapter provisions the runtime when the MCP server starts successfully.
 
@@ -143,7 +161,7 @@ Shared repair: [Troubleshooting](troubleshooting.md).
 | MCP auto-start | Manual | Yes |
 | Hooks | Session + prompt | Session + prompt |
 | Skill | Partial (host-dependent) | Full `@CodeStory` skill |
-| Managed CLI | Depends on MCP setup | Yes via plugin |
+| Managed CLI | Yes when MCP sets `CODESTORY_PLUGIN_DATA` | Yes via plugin |
 
 Claude Code matches Codex on hooks when the plugin is installed, but MCP and
 managed bootstrap are not automatic unless you configure them.

--- a/docs/users/cursor.md
+++ b/docs/users/cursor.md
@@ -44,6 +44,9 @@ The shipped file looks like this:
     "codestory": {
       "command": "node",
       "args": ["./plugins/codestory/scripts/codestory-mcp.cjs"],
+      "env": {
+        "CODESTORY_PLUGIN_DATA": "/absolute/path/to/codestory-plugin-data"
+      },
       "tool_timeout_sec": 300
     }
   }
@@ -52,11 +55,13 @@ The shipped file looks like this:
 
 **Path adjustment:** The `./plugins/codestory/...` path assumes the plugin
 checkout lives inside your workspace root. If the plugin is elsewhere, change
-`args` to an absolute path to `codestory-mcp.cjs`. On Windows, ensure `node` is
-on PATH.
+`args` to an absolute path to `codestory-mcp.cjs`. Replace
+`/absolute/path/to/codestory-plugin-data` with a real per-user data directory.
+On Windows, ensure `node` is on PATH.
 
-Set `CODESTORY_CLI` only for local development overrides. The adapter
-provisions a managed CLI when possible.
+Set `CODESTORY_PLUGIN_DATA` to a persistent per-user directory outside the
+repository; the adapter stores the managed CLI, runtime state, and sidecar
+policy there. Set `CODESTORY_CLI` only for local development overrides.
 
 Alternatively, add the same server block in Cursor user settings instead of a
 project `.cursor/mcp.json`.

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.cursor/mcp.json
+++ b/plugins/codestory/.cursor/mcp.json
@@ -3,6 +3,9 @@
     "codestory": {
       "command": "node",
       "args": ["./plugins/codestory/scripts/codestory-mcp.cjs"],
+      "env": {
+        "CODESTORY_PLUGIN_DATA": "/absolute/path/to/codestory-plugin-data"
+      },
       "tool_timeout_sec": 300
     }
   }

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -160,7 +160,7 @@ function shortDegradedNotice(mcp, reason, state = {}) {
       'CodeStory setup blocked: MCP is configured and launchable, but resources are not model-visible.',
       `First failing layer: ${firstRuntimeFailure(mcp)}.`,
       reason ? `Reason: ${truncate(reason, 600)}` : null,
-      'Reload the host/plugin and read codestory://status; do not use managed CLI or PATH fallback as CodeStory grounding.',
+      'Use the hook MCP bridge when present; reload the host/plugin only to expose live MCP tools. Do not use ambient CodeStory CLI discovery as grounding.',
     ].filter(Boolean).join('\n');
   }
   const hook = state.hook || {};
@@ -180,7 +180,7 @@ function runtimeStatusBlock(policy, mcp) {
     `dedupe_key: ${policy.dedupeKey}`,
     mcpDetectionText(mcp),
     mcp.mcp_model_visible_blocked
-      ? 'Next: reload the host/plugin and read codestory://status; do not use managed CLI or PATH fallback as CodeStory grounding.'
+      ? 'Next: use the hook MCP bridge when present; reload the host/plugin only to expose live MCP tools. Do not use ambient CodeStory CLI discovery as grounding.'
       : mcp.mcp_resources_exposed
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
@@ -245,6 +245,135 @@ function readinessEvidence(parsed) {
       `freshness_evidence: ${evidence.freshness}`,
     ].join('\n'),
     fingerprint: hashText(JSON.stringify(evidence)),
+  };
+}
+
+function bridgeAllowedSurfaces(bootstrap, readiness) {
+  const surfaces = [];
+  if (bootstrap?.ready) surfaces.push('local_navigation');
+  if (readiness?.ready) surfaces.push('agent_packet_search');
+  return surfaces.length > 0 ? surfaces.join(',') : 'status_only';
+}
+
+function bridgeBootstrapForPolicy(policy, mcp, bootstrap) {
+  if (bootstrap?.attempted) return bootstrap;
+  if (!policy.project || !mcp.mcp_process_launchable) {
+    return { attempted: false, reason: 'mcp_launcher_unavailable' };
+  }
+  if (!mcp.managed_cli_present && !BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) {
+    return { attempted: false, reason: 'managed_runtime_not_present' };
+  }
+  return bootstrapManagedRuntime({ projectRoot: policy.project });
+}
+
+function managedHookCli(mcp) {
+  return process.env.CODESTORY_CLI || mcp.managed_cli_path || null;
+}
+
+function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason) {
+  const status = bootstrap?.parsed || {};
+  const plugin = status.plugin_runtime || {};
+  const localRefresh = status.local_refresh || status.readiness?.[0]?.local_refresh || {};
+  const reason = status.degraded_reason
+    || status.readiness?.[0]?.repair_reason
+    || bootstrap?.reason
+    || bootstrap?.error
+    || bootstrap?.stderr;
+  return [
+    'CODESTORY HOOK MCP BRIDGE',
+    'bridge_context_label: hook-bridged context, not live MCP tools',
+    'bridge_resource_uri: codestory://status',
+    `event_taxonomy: ${policy.taxonomy}`,
+    `output_cap_chars: ${policy.cap}`,
+    `dedupe_key: ${policy.dedupeKey}`,
+    mcpDetectionText(mcp),
+    `hook_bridge_status: ${bootstrap?.ready ? 'ready' : 'blocked'}`,
+    `hook_bridge_cli_source: ${plugin.cli_source || (process.env.CODESTORY_CLI ? 'local_dev_override' : mcp.managed_cli_source) || '<unknown>'}`,
+    plugin.managed_binary_path ? `hook_bridge_managed_cli_path: ${plugin.managed_binary_path}` : null,
+    `hook_bridge_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
+    `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness)}`,
+    readiness ? readiness.evidence : null,
+    commandReason ? `hook_bridge_context: ${commandReason}` : null,
+    reason ? `hook_bridge_reason: ${truncate(reason, 500)}` : null,
+    'mcp_resources_exposed: mcp_resources_not_model_visible',
+    'mcp_tools_visible: no',
+    'hook_bridge_next: use this bounded bridge status now; reload the host/plugin only to expose live MCP tools.',
+  ].filter(Boolean).join('\n');
+}
+
+function runManagedHookCommand(cli, command, cwd) {
+  const result = spawnSync(cli, command.args, {
+    cwd,
+    encoding: 'utf8',
+    timeout: RUNTIME_TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT_CHARS * 4,
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
+    windowsHide: true,
+  });
+  if (result.status === 0 && result.stdout.trim()) {
+    return {
+      ok: true,
+      output: truncate(result.stdout),
+      fingerprint: `${command.kind}:${hashText(result.stdout)}`,
+    };
+  }
+  const reason = result.error
+    ? result.error.message
+    : truncate(result.stderr || `${command.kind} exited with status ${result.status} without usable output`);
+  return {
+    ok: false,
+    reason,
+    fingerprint: `${command.kind}:blocked:${hashText(reason)}`,
+  };
+}
+
+function hookMcpBridge(input, policy, mcp, command, bootstrap) {
+  const bridgeBootstrap = bridgeBootstrapForPolicy(policy, mcp, bootstrap);
+  const bridgedMcp = bridgeBootstrap.attempted ? classifyMcpRuntime() : mcp;
+  const cli = managedHookCli(bridgedMcp);
+  const cwd = input.cwd || process.cwd();
+  let readiness = null;
+  let commandResult = null;
+  let commandReason = command ? null : 'status_only';
+
+  if (command && !cli) {
+    commandReason = 'skipped_no_managed_cli';
+  } else if (command?.kind === 'request packet') {
+    readiness = runReadinessProbe(cli, policy.project, cwd);
+    if (readiness.ready) {
+      commandResult = runManagedHookCommand(cli, command, cwd);
+      commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
+    } else {
+      commandReason = `skipped_${readiness.reason}`;
+    }
+  } else if (command?.kind === 'session ground') {
+    if (bridgeBootstrap.ready) {
+      commandResult = runManagedHookCommand(cli, command, cwd);
+      commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
+    } else {
+      commandReason = 'skipped_local_navigation_not_ready';
+    }
+  }
+
+  const bridge = bridgeStatusText(policy, bridgedMcp, bridgeBootstrap, readiness, commandReason);
+  const commandBlock = commandResult?.ok
+    ? [
+      'CODESTORY HOOK MCP BRIDGE CONTEXT',
+      `hook_bridge_command: ${command.kind}`,
+      commandResult.output,
+    ].join('\n')
+    : null;
+  return {
+    kind: commandResult?.ok ? command.kind : 'mcp bridge',
+    output: truncate([bridge, commandBlock].filter(Boolean).join('\n'), policy.cap),
+    next: command?.next,
+    fingerprint: [
+      runtimeFingerprint(bridgedMcp),
+      bridgeBootstrap.ready ? 'bridge-ready' : `bridge-blocked:${bridgeBootstrap.reason || 'status'}`,
+      readiness?.fingerprint,
+      commandResult?.fingerprint,
+      commandReason,
+    ].filter(Boolean).join('|'),
   };
 }
 
@@ -391,6 +520,9 @@ function runCodeStory(input, event, policy, state = {}) {
   }
   const bootstrapBlock = bootstrapText(bootstrap);
   if (policy.runtimeOnly) {
+    if (mcp.mcp_config_installed && mcp.mcp_process_launchable && mcp.mcp_model_visible_blocked) {
+      return hookMcpBridge(input, policy, mcp, null, bootstrap);
+    }
     const heartbeatProbe = policy.heartbeat && !mcp.mcp_model_visible_blocked
       ? heartbeatReadinessProbe(mcp, policy.project, input.cwd || process.cwd())
       : null;
@@ -412,6 +544,9 @@ function runCodeStory(input, event, policy, state = {}) {
   const command = hookCommand(input, event, policy);
   if (!command) return null;
   if (mcp.mcp_config_installed && mcp.mcp_process_launchable) {
+    if (mcp.mcp_model_visible_blocked) {
+      return hookMcpBridge(input, policy, mcp, command, bootstrap);
+    }
     return {
       kind: 'mcp detection',
       output: truncate([
@@ -422,7 +557,7 @@ function runCodeStory(input, event, policy, state = {}) {
         mcpDetectionText(mcp),
         mcp.mcp_resources_exposed
           ? 'Use codestory://status as the active runtime truth. Run packet/search/context only when status allows that surface with retrieval_mode=full.'
-          : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Reload the host/plugin and read codestory://status; do not add CodeStory to PATH.',
+          : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Use hook-bridged status when present; reload the host/plugin only to expose live MCP tools.',
       ].join('\n'), policy.cap),
       fingerprint: `${runtimeFingerprint(mcp)}|${bootstrapBlock || 'no-bootstrap'}`,
     };
@@ -539,7 +674,7 @@ function buildContext(input, event, state = {}) {
     return null;
   }
 
-  if (runtime && runtime.kind === 'mcp detection') {
+  if (runtime && runtimeBlock && (runtime.kind === 'mcp detection' || runtimeBlock.includes('CODESTORY HOOK MCP BRIDGE'))) {
     return truncate([eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n'), policy.cap);
   }
 

--- a/plugins/codestory/hooks/codestory-dirty-hook.cjs
+++ b/plugins/codestory/hooks/codestory-dirty-hook.cjs
@@ -24,7 +24,10 @@ function main() {
   const args = process.argv.slice(2);
   const action = args[0];
   const project = argValue(args, '--project') || process.cwd();
-  const pluginDataDir = argValue(args, '--plugin-data') || process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA;
+  const pluginDataDir = argValue(args, '--plugin-data')
+    || process.env.PLUGIN_DATA
+    || process.env.COPILOT_PLUGIN_DATA
+    || process.env.CODESTORY_PLUGIN_DATA;
   const options = { pluginDataDir };
 
   if (!['install', 'uninstall', 'status', 'mark'].includes(action)) {

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -9,7 +9,7 @@ const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, read codestory://status first. If MCP is configured but resources are not model-visible, reload the host/plugin instead of adding CodeStory to PATH.
+2. If the CodeStory MCP server is live, read codestory://status first. If MCP is configured but resources are not model-visible, use the hook bridge when present and reload the host/plugin only to expose live MCP tools.
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
@@ -59,11 +59,11 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, say that and reload the host/plugin instead of asking for PATH setup. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
+Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, use hook-bridged status when present and reload the host/plugin only to expose live MCP tools. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.
-Use status recommended_next_calls as the setup path once a repository target is known: call MCP repair_all when recommended, then reread codestory://status. Keep CLI and PATH checks diagnostic.
+Use status recommended_next_calls as the setup path once a repository target is known: call MCP repair_all when recommended, then reread codestory://status.
 
 ${body}`;
 }

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -17,8 +17,9 @@ const DIRTY_HOOK_START = '# >>> codestory dirty marker >>>';
 const DIRTY_HOOK_END = '# <<< codestory dirty marker <<<';
 
 function pluginDataDir() {
-  if (isCodex) return process.env.PLUGIN_DATA;
-  if (isCopilot) return process.env.COPILOT_PLUGIN_DATA;
+  if (process.env.PLUGIN_DATA) return process.env.PLUGIN_DATA;
+  if (process.env.COPILOT_PLUGIN_DATA) return process.env.COPILOT_PLUGIN_DATA;
+  if (process.env.CODESTORY_PLUGIN_DATA) return process.env.CODESTORY_PLUGIN_DATA;
   return null;
 }
 

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -87,7 +87,10 @@ function usablePluginDataDir(dataDir) {
 }
 
 function pluginDataDir() {
-  return process.env.PLUGIN_DATA || process.env.COPILOT_PLUGIN_DATA || inferredCodexPluginDataDir();
+  return process.env.PLUGIN_DATA
+    || process.env.COPILOT_PLUGIN_DATA
+    || process.env.CODESTORY_PLUGIN_DATA
+    || inferredCodexPluginDataDir();
 }
 
 function sidecarPolicyPath(dataDir = pluginDataDir()) {
@@ -263,7 +266,7 @@ function handleSidecarPolicyCommand(argv) {
   }
   if (action !== 'status') {
     if (!policyFile) {
-      process.stderr.write('sidecar-policy needs PLUGIN_DATA or --policy-file to remember the setting\n');
+      process.stderr.write('sidecar-policy needs PLUGIN_DATA, COPILOT_PLUGIN_DATA, CODESTORY_PLUGIN_DATA, or --policy-file to remember the setting\n');
       process.exit(2);
     }
     writeSidecarPolicy(sidecarPolicyStateForAction(action), {}, policyFile);
@@ -587,10 +590,7 @@ async function resolveCli() {
   }
 
   const managedProvisionFailure = warnings.find((warning) => warning.startsWith('managed_cli_provision_failed:')) || null;
-  const pathCandidates = pathCliCandidates();
-  warnings.push(pathCandidates.length > 0
-    ? 'managed_cli_unavailable_path_diagnostic_only'
-    : 'managed_cli_unavailable_no_path_fallback');
+  warnings.push('managed_cli_unavailable');
   return {
     source: 'managed_unavailable',
     path: null,
@@ -610,24 +610,6 @@ async function resolveCli() {
 function normalizeVersion(value) {
   const match = String(value || '').match(/\b[vV]?(\d+\.\d+\.\d+)\b/u);
   return match ? match[1] : null;
-}
-
-function semverParts(version) {
-  const normalized = normalizeVersion(version);
-  if (!normalized) return null;
-  return normalized.split('.').map((part) => Number.parseInt(part, 10));
-}
-
-function compareSemver(left, right) {
-  const leftParts = semverParts(left);
-  const rightParts = semverParts(right);
-  if (!leftParts || !rightParts) return null;
-  for (let index = 0; index < 3; index += 1) {
-    if (leftParts[index] !== rightParts[index]) {
-      return leftParts[index] < rightParts[index] ? -1 : 1;
-    }
-  }
-  return 0;
 }
 
 function probeResolvedCli(resolved) {
@@ -663,15 +645,11 @@ function failOpenReasonForProbe(resolved, probe) {
   if (probe.error || probe.status !== 0) {
     return `${resolved.source}_cli_unspawnable`;
   }
-  if (resolved.source !== 'path_fallback') return null;
-  const comparison = compareSemver(probe.version, resolved.version);
-  if (!probe.version || comparison === null) return 'path_fallback_cli_unavailable';
-  if (comparison < 0) return 'path_fallback_cli_stale';
   return null;
 }
 
 function localWaitFreshCommand(projectRoot = process.cwd()) {
-  return `codestory-cli ready --goal local --wait-fresh --project ${JSON.stringify(projectRoot)} --format json`;
+  return `<managed codestory-cli> ready --goal local --wait-fresh --project ${JSON.stringify(projectRoot)} --format json`;
 }
 
 function mcpNextCallForCommand(command) {
@@ -862,7 +840,6 @@ function pluginRuntimeForResolved(resolved) {
     build_source: resolved.buildSource,
     repo_ref: resolved.repoRef,
     local_dev_override: resolved.source === 'local_dev_override',
-    path_fallback: resolved.source === 'path_fallback',
     managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
     managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
     managed_manifest_path: resolved.manifestPath || null,
@@ -872,11 +849,6 @@ function pluginRuntimeForResolved(resolved) {
 
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   const projectRoot = Object.hasOwn(options, 'projectRoot') ? options.projectRoot : process.cwd();
-  const pathCandidates = pathCliCandidates().map((candidate) => ({
-    path: candidate,
-    version: cliVersion(candidate),
-    active: samePathText(candidate, resolved.path),
-  }));
   const managedProvisionFailed = String(reason || '').startsWith('managed_cli_provision_failed:');
   const managedProvisionNext = [
     'Restart/reload the Codex host/app and read codestory://status; managed CLI provisioning will retry release asset downloads.',
@@ -945,7 +917,6 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     server_executable: null,
     server_executable_sha256: null,
     source_checkout_version: sourceCheckoutVersion(projectRoot),
-    path_candidates: pathCandidates,
     sidecar_contract_version: null,
     plugin_runtime: plugin,
     runtime_truth: runtimeTruthStatus(plugin, repair, {
@@ -955,7 +926,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     }),
     runtime_boundary: {
       restart_required_for_runtime_change: true,
-      message: 'A running MCP server keeps using the CLI process it was launched with; plugin refresh, managed runtime provisioning, CODESTORY_CLI, or PATH changes require a host reload/restart and fresh codestory://status readback.',
+      message: 'A running MCP server keeps using the CLI process it was launched with; plugin refresh, managed runtime provisioning, or CODESTORY_CLI changes require a host reload/restart and fresh codestory://status readback.',
     },
     warnings: plugin.warnings,
     project_root: projectRoot,
@@ -1079,50 +1050,9 @@ async function handleBootstrapStatusCommand(argv) {
   process.exit(0);
 }
 
-function pathCliCandidates() {
-  const pathValue = process.env.PATH || '';
-  const candidates = [];
-  for (const directory of pathValue.split(path.delimiter).filter(Boolean)) {
-    for (const name of cliBinaryNames()) {
-      const candidate = path.join(directory, name);
-      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-        candidates.push(candidate);
-      }
-    }
-  }
-  return dedupePaths(candidates);
-}
-
-function cliBinaryNames() {
-  return process.platform === 'win32'
-    ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli.bat', 'codestory-cli']
-    : ['codestory-cli'];
-}
-
-function cliVersion(candidate) {
-  const result = spawnSync(candidate, ['--version'], {
-    encoding: 'utf8',
-    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(candidate),
-    timeout: 3000,
-    windowsHide: true,
-  });
-  if (result.status !== 0 || result.error) return null;
-  return normalizeVersion(`${result.stdout || ''}\n${result.stderr || ''}`);
-}
-
 function samePathText(left, right) {
   const normalize = (value) => String(value || '').replace(/[\\/]+$/u, '').toLowerCase();
   return normalize(left) === normalize(right);
-}
-
-function dedupePaths(paths) {
-  const deduped = [];
-  for (const candidate of paths) {
-    if (!deduped.some((seen) => samePathText(seen, candidate))) {
-      deduped.push(candidate);
-    }
-  }
-  return deduped;
 }
 
 function sourceCheckoutVersion(projectRoot) {
@@ -1161,7 +1091,6 @@ function diagnosticText(status) {
     `cli_path: ${setup.active_path}`,
     `cli_version: ${setup.active_version || '<unknown>'}`,
     `source_checkout_version: ${status.source_checkout_version || '<none>'}`,
-    `path_candidates: ${(status.path_candidates || []).map((candidate) => `${candidate.path}@${candidate.version || '<unknown>'}`).join(', ') || '<none>'}`,
     `next: ${next ? JSON.stringify(next) : 'read codestory://status'}`,
   ].join('\n');
 }

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -26,17 +26,10 @@ Reads project/cache/index/retrieval health without mutating the index. Use it fo
 | Integration edge | Use doctor before `ground`, `search --why`, `explore`, `context`, or `serve`; its next commands are the safe follow-up loop. | Prevents read commands from silently querying the wrong or empty cache. |
 
 For MCP/runtime drift, collect binary evidence only after status is missing or
-suspect (see [status-contract.md](status-contract.md#runtime-repair)):
-
-```powershell
-where.exe codestory-cli
-codestory-cli --version
-codestory-cli doctor --project <target-workspace> --format json
-```
-
-Treat PATH checks as CLI diagnostics only. Installed plugin MCP runtime changes
-require managed status/reinstall/reload, or an explicit `CODESTORY_CLI`
-override for local development, before starting a fresh Codex host/app session.
+suspect (see [status-contract.md](status-contract.md#runtime-repair)). Installed
+plugin MCP runtime changes require managed status/reinstall/reload, or an
+explicit `CODESTORY_CLI` override for local development, before starting a fresh
+Codex host/app session.
 
 ## Notes
 

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -21,15 +21,13 @@ the agent-facing field glossary alongside runtime `codestory://agent-guide`.
 
 ## Runtime Repair
 
-Use `where.exe codestory-cli`, `codestory-cli --version`, release install, or
-source-build checks only for maintainer/debug transcripts when MCP is missing
-or suspect. They are not the supported agent repair path. `CODESTORY_CLI` is an explicit local-dev
-override; installed `.mcp.json` launches the managed adapter first, provisions
-from `github_release` when needed, and records the launch source in
+Use managed `codestory://status`, release install records, or source-build
+checks only for maintainer/debug transcripts when MCP is missing or suspect.
+They are not the supported agent repair path. `CODESTORY_CLI` is an explicit
+local-dev override; installed `.mcp.json` launches the managed adapter first,
+provisions from `github_release` when needed, and records the launch source in
 `plugin_runtime`. If the managed runtime cannot spawn or be provisioned, the
 adapter stays up with `repair_setup` diagnostics instead of closing transport.
-Any `PATH` candidates in status are diagnostic only and are not launched by the
-installed plugin runtime.
 
 If `codestory://status` reports a repairable state, run the MCP
 `recommended_next_calls` loop: call `repair_all` when recommended, then reread

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1038,20 +1038,11 @@ test("mcp launcher infers Codex managed data from installed cache without env", 
   }
 });
 
-test("mcp launcher blocks managed setup when only PATH cli is available", async () => {
+test("mcp launcher blocks when managed runtime is unavailable", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const sourceVersion = readCargoVersion(await readFile(join(repoRoot, "crates", "codestory-cli", "Cargo.toml"), "utf8"));
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-failopen-mcp-"));
-  const pathDir = await mkdtemp(join(tmpdir(), "codestory-path-candidate-"));
-  const fakeCli = join(pathDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
-  await writeFile(
-    fakeCli,
-    process.platform === "win32"
-      ? `@echo off\r\necho codestory-cli ${version}\r\n`
-      : `#!/bin/sh\necho codestory-cli ${version}\n`,
-  );
-  await chmod(fakeCli, 0o755);
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = [
     JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
@@ -1065,7 +1056,7 @@ test("mcp launcher blocks managed setup when only PATH cli is available", async 
       env: {
         PLUGIN_DATA: "",
         COPILOT_PLUGIN_DATA: "",
-        PATH: pathDir,
+        PATH: "",
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
       cwd: repoRoot,
@@ -1080,13 +1071,6 @@ test("mcp launcher blocks managed setup when only PATH cli is available", async 
     const status = JSON.parse(responses[1].result.contents[0].text);
     assert.equal(status.plugin_runtime.plugin_version, version);
     assert.equal(status.source_checkout_version, sourceVersion);
-    assert.deepEqual(status.path_candidates, [
-      {
-        path: fakeCli,
-        version,
-        active: false,
-      },
-    ]);
     assert.equal(status.plugin_runtime.plugin_root, pluginRoot);
     assert.equal(status.plugin_runtime.cli_source, "managed_unavailable");
     assert.equal(status.plugin_runtime.cli_path, null);
@@ -1106,7 +1090,6 @@ test("mcp launcher blocks managed setup when only PATH cli is available", async 
     assert.match(responses[3].error.message, /grounding tools are unavailable/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
-    await rm(pathDir, { recursive: true, force: true });
   }
 });
 
@@ -1522,7 +1505,7 @@ test("startup hook bootstraps managed cli when MCP resources are visible", async
     assert.match(context, /mcp_resources_exposed: mcp_resources_exposed/u);
     assert.match(context, /mcp_model_visible_blocked: no/u);
     assert.match(context, /managed_cli_present: yes/u);
-    assert.doesNotMatch(context, /where\.exe codestory-cli|command -v codestory-cli|adding CodeStory to PATH/u);
+    assert.doesNotMatch(context, /ambient CodeStory CLI discovery/u);
 
     const manifest = JSON.parse(
       await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
@@ -1581,20 +1564,11 @@ test("release asset downloader retries a transient failure", async () => {
   }
 });
 
-test("mcp launcher keeps managed provision failures primary with PATH diagnostic", async () => {
+test("mcp launcher keeps managed provision failures primary", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-provision-fail-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-empty-release-"));
-  const pathDir = await mkdtemp(join(tmpdir(), "codestory-managed-provision-path-"));
-  const fakeCli = join(pathDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
-  await writeFile(
-    fakeCli,
-    process.platform === "win32"
-      ? `@echo off\r\necho codestory-cli ${version}\r\n`
-      : `#!/bin/sh\necho codestory-cli ${version}\n`,
-  );
-  await chmod(fakeCli, 0o755);
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const input = JSON.stringify({
     jsonrpc: "2.0",
@@ -1610,7 +1584,7 @@ test("mcp launcher keeps managed provision failures primary with PATH diagnostic
         CODESTORY_CLI: "",
         CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
         PLUGIN_DATA: dataDir,
-        PATH: pathDir,
+        PATH: "",
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
       input,
@@ -1626,28 +1600,20 @@ test("mcp launcher keeps managed provision failures primary with PATH diagnostic
       /^managed_cli_provision_failed:managed_cli_asset_fetch_failed:SHA256SUMS\.txt:elapsed_ms=\d+:attempts=1:retry=restart_reload_status:/u,
     );
     assert.equal(status.plugin_runtime.cli_source, "managed_unavailable");
-    assert.deepEqual(status.path_candidates, [
-      {
-        path: fakeCli,
-        version,
-        active: false,
-      },
-    ]);
     assert.equal(
-      status.plugin_runtime.warnings.includes("managed_cli_unavailable_path_diagnostic_only"),
+      status.plugin_runtime.warnings.includes("managed_cli_unavailable"),
       true,
     );
     assert.match(status.readiness[0].minimum_next[0], /^Restart\/reload/u);
     assert.equal(
       status.readiness[0].minimum_next.some((step) => {
-        return /where\.exe codestory-cli|command -v codestory-cli|codestory-cli --version/u.test(step);
+        return /codestory-cli --version/u.test(step);
       }),
       false,
     );
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(releaseDir, { recursive: true, force: true });
-    await rm(pathDir, { recursive: true, force: true });
   }
 });
 
@@ -1876,8 +1842,8 @@ test("hook output keeps CodeStory ambient and checks MCP before source fallback"
       assert.match(sessionContext, /mcp_config_installed: yes/u);
       assert.match(sessionContext, /mcp_process_launchable: yes/u);
       assert.match(sessionContext, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
-      assert.match(sessionContext, /do not add CodeStory to PATH/u);
-      assert.doesNotMatch(sessionContext, /FAKE_CODESTORY_CLI/u);
+      assert.match(sessionContext, /CODESTORY HOOK MCP BRIDGE/u);
+      assert.match(sessionContext, /hook-bridged context, not live MCP tools/u);
       assert.doesNotMatch(sessionContext, /## Runtime Truth/u);
 
       const promptResult = spawnSync(process.execPath, [hookPath], {
@@ -1895,8 +1861,8 @@ test("hook output keeps CodeStory ambient and checks MCP before source fallback"
       const promptContext = promptOutput.hookSpecificOutput.additionalContext;
       assert.equal(promptOutput.hookSpecificOutput.hookEventName, "UserPromptSubmit");
       assert.match(promptContext, /Prompt: Where is RefreshMode defined\?/u);
-      assert.match(promptContext, /CODESTORY MCP RUNTIME DETECTION/u);
-      assert.doesNotMatch(promptContext, /FAKE_CODESTORY_CLI/u);
+      assert.match(promptContext, /CODESTORY HOOK MCP BRIDGE/u);
+      assert.match(promptContext, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
       assert.doesNotMatch(promptContext, /attempted request packet/u);
     });
   } finally {
@@ -2296,7 +2262,7 @@ test("hook goal heartbeat is quiet until readiness or freshness evidence changes
   }
 });
 
-test("hook goal heartbeat skips managed cli readiness when MCP is model-hidden", async () => {
+test("hook goal heartbeat bridges model-hidden MCP without live tools", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-hidden-mcp-"));
   const version = await readPluginVersion();
   const cliDir = join(dataDir, "codestory-cli", version);
@@ -2339,7 +2305,9 @@ test("hook goal heartbeat skips managed cli readiness when MCP is model-hidden",
     });
 
     assert.equal(Object.hasOwn(output, "hookSpecificOutput"), false);
-    await assert.rejects(access(marker));
+    const markerText = await readFile(marker, "utf8");
+    assert.match(markerText, /ready --goal local --wait-fresh/u);
+    assert.doesNotMatch(markerText, /--goal agent/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -2491,7 +2459,7 @@ test("hook script executes under Codex home module scope", async () => {
   }
 });
 
-test("hook output reports model-invisible MCP instead of PATH setup guidance", async () => {
+test("hook output bridges model-invisible MCP through managed runtime", async () => {
   const { spawnSync } = await import("node:child_process");
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-no-resources-"));
@@ -2534,12 +2502,15 @@ test("hook output reports model-invisible MCP instead of PATH setup guidance", a
   assert.match(context, /mcp_model_visible_blocked: yes/u);
   assert.match(context, /managed_cli_present: yes/u);
   assert.match(context, /degraded_no_surface: yes/u);
-  assert.match(context, /MCP resources are not visible/u);
-  assert.doesNotMatch(context, /managed_bootstrap: ready/u);
+  assert.match(context, /CODESTORY HOOK MCP BRIDGE/u);
+  assert.match(context, /bridge_context_label: hook-bridged context, not live MCP tools/u);
+  assert.match(context, /bridge_resource_uri: codestory:\/\/status/u);
+  assert.match(context, /hook_bridge_status: ready/u);
+  assert.match(context, /hook_bridge_allowed_surfaces: local_navigation/u);
+  assert.match(context, /mcp_tools_visible: no/u);
   assert.doesNotMatch(context, /codestory-cli ENOENT/u);
   assert.doesNotMatch(context, /attempted request packet/u);
-  assert.doesNotMatch(context, /bounded source reads/u);
-  assert.doesNotMatch(context, /adding CodeStory to PATH/u);
+  assert.doesNotMatch(context, /ambient CodeStory CLI discovery/u);
   await rm(dataDir, { recursive: true, force: true });
 });
 
@@ -2549,6 +2520,14 @@ test("portable agent adapters are present", async () => {
   );
   assert.equal(copilotManifest.hooks, "hooks/copilot-hooks.json");
   assert.equal(copilotManifest.skills, "skills/");
+
+  const cursorMcp = JSON.parse(
+    await readFile(join(pluginRoot, ".cursor", "mcp.json"), "utf8"),
+  );
+  assert.equal(
+    cursorMcp.mcpServers.codestory.env.CODESTORY_PLUGIN_DATA,
+    "/absolute/path/to/codestory-plugin-data",
+  );
 });
 
 test("default plugin prompts stay portable", async () => {

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -122,7 +122,7 @@ const ARMS = {
   without_codestory:
     "Do not use CodeStory, codestory-cli, or codestory-grounding. Use normal local repository exploration only. Do not use web search, browser tools, remote URLs, or upstream mirrors.",
   with_codestory:
-    "Use CodeStory grounding first. If CODESTORY_CLI is set, use that executable; otherwise use codestory-cli on PATH. For broad repository questions, run packet first and read its sufficiency contract before ordinary source reads. Read follow-up commands from sufficiency.follow_up_commands, not a top-level field. If sufficiency.status is partial, run the listed follow_up_commands in order and prefer targeted CodeStory `search --why`, `context`, `trail`, or `snippet` commands for named gaps. If the packet and CodeStory follow-ups still do not support a correct answer, use ordinary local source reads only after those CodeStory attempts; those reads are valid but counted as post-packet overhead. If a later packet becomes sufficient, stop exploration and answer. If packet status is sufficient and sufficiency.follow_up_commands is empty, answer from the packet; do not verify citations with ordinary source reads, rg, grep, or git show. Budget truncation alone is not a gap. Preserve the packet's supported-claim wording in your final answer when it is correct, and correct it from local source when the packet is incomplete. Copy exact source identifiers, table names, declarations, and claim phrases from packet citations and sufficiency.covered_claims; do not compress exact anchors into comma shorthand that drops their repeated prefix, such as rewriting `CREATE TABLE A` and `CREATE TABLE B` as `CREATE TABLE A and B`. Include a compact 'Support files' list containing every relevant path from the packet's answer.citations, sufficiency.avoid_opening_paths, and any post-packet local source reads. The prepared full sidecar cache is mandatory; if CodeStory or its sidecars are unavailable, fail the run instead of continuing with ordinary exploration. Do not use web search, browser tools, remote URLs, or upstream mirrors.",
+    "Use CodeStory grounding first. CODESTORY_CLI is set to the executable for this run. For broad repository questions, run packet first and read its sufficiency contract before ordinary source reads. Read follow-up commands from sufficiency.follow_up_commands, not a top-level field. If sufficiency.status is partial, run the listed follow_up_commands in order and prefer targeted CodeStory `search --why`, `context`, `trail`, or `snippet` commands for named gaps. If the packet and CodeStory follow-ups still do not support a correct answer, use ordinary local source reads only after those CodeStory attempts; those reads are valid but counted as post-packet overhead. If a later packet becomes sufficient, stop exploration and answer. If packet status is sufficient and sufficiency.follow_up_commands is empty, answer from the packet; do not verify citations with ordinary source reads, rg, grep, or git show. Budget truncation alone is not a gap. Preserve the packet's supported-claim wording in your final answer when it is correct, and correct it from local source when the packet is incomplete. Copy exact source identifiers, table names, declarations, and claim phrases from packet citations and sufficiency.covered_claims; do not compress exact anchors into comma shorthand that drops their repeated prefix, such as rewriting `CREATE TABLE A` and `CREATE TABLE B` as `CREATE TABLE A and B`. Include a compact 'Support files' list containing every relevant path from the packet's answer.citations, sufficiency.avoid_opening_paths, and any post-packet local source reads. The prepared full sidecar cache is mandatory; if CodeStory or its sidecars are unavailable, fail the run instead of continuing with ordinary exploration. Do not use web search, browser tools, remote URLs, or upstream mirrors.",
 };
 
 function usage() {
@@ -151,7 +151,7 @@ Options:
                   Run direct packet runtime benchmark rows instead of agent A/B arms.
   --packet-runtime-mode
                   cold-cli, warm-stdio, or both. Default: both.
-  --codestory-cli Path to codestory-cli for packet runtime mode. Default: CODESTORY_CLI, release binary, then PATH.
+  --codestory-cli Path to codestory-cli for packet runtime mode. Default: CODESTORY_CLI, then release binary.
   --benchmark-run-id
                   Coherent benchmark run id to stamp packet-runtime artifacts.
   --include-local-repos
@@ -1168,7 +1168,7 @@ function packetFirstCommandForPrompt(taskPrompt, task = null, platform = process
   if (platform === "win32") {
     return `& $env:CODESTORY_CLI packet --project . --question ${shellSingleQuoted(question, platform)}${taskClass} --budget compact --format json`;
   }
-  return `"\${CODESTORY_CLI:-codestory-cli}" packet --project . --question ${shellSingleQuoted(question, platform)}${taskClass} --budget compact --format json`;
+  return `"$CODESTORY_CLI" packet --project . --question ${shellSingleQuoted(question, platform)}${taskClass} --budget compact --format json`;
 }
 
 function packetPreludePromptBlock(prelude) {
@@ -1445,8 +1445,6 @@ function commandCategory(command) {
     "\\b(index|ground|doctor|search|symbol|trail|snippet|query|explore|bookmark|context|drill|files|affected|setup|serve|packet)\\b";
   const codestoryExecutablePath =
     String.raw`['"]?(?:[A-Z]:)?(?:[^;&|\r\n"']*[\\/])*codestory-cli(?:\.exe)?['"]?\s+${codestoryCommands}`;
-  const powershellEnvFallback =
-    String.raw`&\s*\$\(\s*if\s*\(\s*\$env:CODESTORY_CLI\s*\)\s*\{[^}]*\$env:CODESTORY_CLI[^}]*\}\s*else\s*\{[^}]*codestory-cli(?:\.exe)?[^}]*\}\s*\)\s+${codestoryCommands}`;
   if (/^\s*(?:rg|grep|findstr|select-string)\b/i.test(text)) {
     return "shell_search";
   }
@@ -1458,13 +1456,8 @@ function commandCategory(command) {
     new RegExp(`^\\s*${codestoryExecutablePath}`, "i").test(shellText) ||
     new RegExp(`[;&|]\\s*${codestoryExecutablePath}`, "i").test(shellText) ||
     /&\s*["']*\$env:CODESTORY_CLI\s+/i.test(shellText) ||
-    new RegExp(
-      `(?:^|[;&|]\\s*)["']?\\$\\{CODESTORY_CLI:-codestory-cli\\}["']?\\s+${codestoryCommands}`,
-      "i",
-    ).test(shellText) ||
     new RegExp(`(?:^|[;&|]\\s*)["']?\\$CODESTORY_CLI["']?\\s+${codestoryCommands}`, "i").test(shellText) ||
-    new RegExp(`&\\s*["']*\\$[a-z_][a-z0-9_]*\\s+${codestoryCommands}`, "i").test(shellText) ||
-    new RegExp(powershellEnvFallback, "i").test(shellText)
+    new RegExp(`&\\s*["']*\\$[a-z_][a-z0-9_]*\\s+${codestoryCommands}`, "i").test(shellText)
   ) {
     return "codestory_cli";
   }
@@ -1487,8 +1480,6 @@ function isCodestoryPacketCommand(command) {
   const shellText = String(command ?? "").replace(/\\"/g, '"');
   const packetExecutablePath =
     String.raw`['"]?(?:[A-Z]:)?(?:[^;&|\r\n"']*[\\/])*codestory-cli(?:\.exe)?['"]?\s+packet\b`;
-  const powershellEnvFallbackPacket =
-    String.raw`&\s*\$\(\s*if\s*\(\s*\$env:CODESTORY_CLI\s*\)\s*\{[^}]*\$env:CODESTORY_CLI[^}]*\}\s*else\s*\{[^}]*codestory-cli(?:\.exe)?[^}]*\}\s*\)\s+packet\b`;
   if (/(?:^|\s)(?:--help|-h)(?:\s|$)/i.test(shellText)) {
     return false;
   }
@@ -1500,10 +1491,8 @@ function isCodestoryPacketCommand(command) {
     new RegExp(`^\\s*${packetExecutablePath}`, "i").test(shellText) ||
     new RegExp(`[;&|]\\s*${packetExecutablePath}`, "i").test(shellText) ||
     /&\s*["']*\$env:CODESTORY_CLI\s+packet\b/i.test(shellText) ||
-    /(?:^|[;&|]\s*)["']?\$\{CODESTORY_CLI:-codestory-cli\}["']?\s+packet\b/i.test(shellText) ||
     /(?:^|[;&|]\s*)["']?\$CODESTORY_CLI["']?\s+packet\b/i.test(shellText) ||
-    /&\s*["']*\$[a-z_][a-z0-9_]*\s+packet\b/i.test(shellText) ||
-    new RegExp(powershellEnvFallbackPacket, "i").test(shellText)
+    /&\s*["']*\$[a-z_][a-z0-9_]*\s+packet\b/i.test(shellText)
   );
 }
 
@@ -1511,17 +1500,13 @@ function isCodestoryIndexCommand(command) {
   const shellText = String(command ?? "").replace(/\\"/g, '"');
   const indexExecutablePath =
     String.raw`['"]?(?:[A-Z]:)?(?:[^;&|\r\n"']*[\\/])*codestory-cli(?:\.exe)?['"]?\s+index\b`;
-  const powershellEnvFallbackIndex =
-    String.raw`&\s*\$\(\s*if\s*\(\s*\$env:CODESTORY_CLI\s*\)\s*\{[^}]*\$env:CODESTORY_CLI[^}]*\}\s*else\s*\{[^}]*codestory-cli(?:\.exe)?[^}]*\}\s*\)\s+index\b`;
   return (
     /^\s*codestory-cli(?:\.exe)?\s+index\b/i.test(shellText) ||
     new RegExp(`^\\s*${indexExecutablePath}`, "i").test(shellText) ||
     new RegExp(`[;&|]\\s*${indexExecutablePath}`, "i").test(shellText) ||
     /&\s*["']*\$env:CODESTORY_CLI\s+index\b/i.test(shellText) ||
-    /(?:^|[;&|]\s*)["']?\$\{CODESTORY_CLI:-codestory-cli\}["']?\s+index\b/i.test(shellText) ||
     /(?:^|[;&|]\s*)["']?\$CODESTORY_CLI["']?\s+index\b/i.test(shellText) ||
-    /&\s*["']*\$[a-z_][a-z0-9_]*\s+index\b/i.test(shellText) ||
-    new RegExp(powershellEnvFallbackIndex, "i").test(shellText)
+    /&\s*["']*\$[a-z_][a-z0-9_]*\s+index\b/i.test(shellText)
   );
 }
 
@@ -3573,7 +3558,10 @@ function resolveCodeStoryCli(opts, exists = existsSync) {
     "release",
     process.platform === "win32" ? "codestory-cli.exe" : "codestory-cli",
   );
-  return exists(releaseCandidate) ? releaseCandidate : "codestory-cli";
+  if (exists(releaseCandidate)) {
+    return releaseCandidate;
+  }
+  throw new Error("No codestory-cli found. Pass --codestory-cli, set CODESTORY_CLI, or build the release binary.");
 }
 
 function packetPayloadText(packet) {

--- a/scripts/install-codestory.ps1
+++ b/scripts/install-codestory.ps1
@@ -89,10 +89,6 @@ function Resolve-CandidatePath {
     if (-not $Candidate) {
         return $null
     }
-    $command = Get-Command $Candidate -ErrorAction SilentlyContinue
-    if ($command) {
-        return $command.Source
-    }
     if (Test-Path -LiteralPath $Candidate) {
         return (Resolve-Path -LiteralPath $Candidate).Path
     }
@@ -120,10 +116,6 @@ function Get-CliCandidates {
             $candidates += (Join-Path $versionedInstallDir "codestory-cli.exe")
             $candidates += (Join-Path $versionedInstallDir "codestory-cli")
         }
-    }
-    $pathCli = Get-Command "codestory-cli" -ErrorAction SilentlyContinue
-    if ($pathCli) {
-        $candidates += $pathCli.Source
     }
     $candidates += @(
         (Join-Path (Get-Location) "target\release\codestory-cli.exe"),
@@ -179,7 +171,7 @@ function Find-ExistingCli {
                 }
             }
         } catch {
-            # Keep scanning implicit candidates; stale or broken PATH entries should not block install.
+            # Keep scanning implicit candidates; stale or broken binaries should not block install.
         }
     }
     return $null
@@ -203,104 +195,6 @@ function Get-WindowsReleaseTarget {
         return "windows-arm64"
     }
     return $null
-}
-
-function Normalize-PathListEntry {
-    param([string]$Value)
-
-    if (-not $Value) {
-        return ""
-    }
-    return ($Value.Trim() -replace "[\\/]+$", "")
-}
-
-function Test-PathListContains {
-    param(
-        [string]$PathList,
-        [string]$Directory
-    )
-
-    $normalizedDirectory = Normalize-PathListEntry $Directory
-    foreach ($entry in ($PathList -split ";")) {
-        if ((Normalize-PathListEntry $entry) -ieq $normalizedDirectory) {
-            return $true
-        }
-    }
-    return $false
-}
-
-function Set-PathListDirectoryFirst {
-    param(
-        [string]$PathList,
-        [string]$Directory
-    )
-
-    $normalizedDirectory = Normalize-PathListEntry $Directory
-    $entries = @()
-    foreach ($entry in ($PathList -split ";")) {
-        if (-not $entry) {
-            continue
-        }
-        if ((Normalize-PathListEntry $entry) -ieq $normalizedDirectory) {
-            continue
-        }
-        $entries += $entry
-    }
-    if ($entries.Count -gt 0) {
-        return (($Directory.TrimEnd(";")) + ";" + ($entries -join ";"))
-    }
-    return $Directory.TrimEnd(";")
-}
-
-function Ensure-InstallDirOnPath {
-    param(
-        [string]$InstallDirectory,
-        [string]$CliPath
-    )
-
-    $resolvedInstallDir = Resolve-Path -LiteralPath $InstallDirectory -ErrorAction SilentlyContinue
-    if (-not $resolvedInstallDir) {
-        return
-    }
-    $resolvedCli = Resolve-Path -LiteralPath $CliPath -ErrorAction SilentlyContinue
-    if (-not $resolvedCli) {
-        return
-    }
-    $installPath = Normalize-PathListEntry $resolvedInstallDir.Path
-    $cliDir = Split-Path -Parent $resolvedCli.Path
-    $normalizedCliDir = Normalize-PathListEntry $cliDir
-    $underInstallDir = $normalizedCliDir.StartsWith(
-        $installPath + "\",
-        [System.StringComparison]::OrdinalIgnoreCase
-    )
-    if ($normalizedCliDir -ine $installPath -and -not $underInstallDir) {
-        return
-    }
-
-    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    $updatedUserPath = Set-PathListDirectoryFirst $userPath $cliDir
-    if ($updatedUserPath -ne $userPath) {
-        [Environment]::SetEnvironmentVariable("Path", $updatedUserPath, "User")
-        Write-Host "PATH updated for future Codex host processes: $cliDir"
-    }
-
-    $processPath = [Environment]::GetEnvironmentVariable("Path", "Process")
-    $updatedProcessPath = Set-PathListDirectoryFirst $processPath $cliDir
-    if ($updatedProcessPath -ne $processPath) {
-        [Environment]::SetEnvironmentVariable("Path", $updatedProcessPath, "Process")
-    }
-}
-
-function Assert-PathCliResolvesCurrent {
-    $pathCli = Get-Command "codestory-cli" -ErrorAction SilentlyContinue
-    if (-not $pathCli) {
-        throw "PATH diagnostic cannot resolve codestory-cli. Add the current CodeStory install directory before stale entries for shell CLI use; installed plugin runtime changes require managed status/reinstall/reload or explicit CODESTORY_CLI, then restart the Codex host/app before opening a fresh agent thread."
-    }
-
-    $version = Invoke-CliVersion $pathCli.Source
-    if (-not (Test-RequiredVersion $version.Version)) {
-        throw "PATH diagnostic still resolves stale codestory-cli: $($pathCli.Source) ($($version.Text)); expected $script:RequiredVersion. Stop or restart running 'codestory-cli serve --stdio --refresh none' processes that lock old binaries, move the current install directory before stale PATH entries for shell CLI use, then update installed plugin runtime through managed status/reinstall/reload or explicit CODESTORY_CLI before opening a fresh agent thread."
-    }
 }
 
 function Get-ExpectedHash {
@@ -359,7 +253,7 @@ function Copy-ReleaseCliBinary {
         throw "Default install path is locked or not writable: $defaultError. Alternate install path also failed: $($_.Exception.Message). Stop the process holding $dest or restart the host, then run .\scripts\install-codestory.ps1 -Project . -Version $ReleaseVersion."
     }
 
-    Write-Warning "Default install path is locked or not writable: $defaultError. Installed current release to $versionedDest and will put that versioned directory first on PATH for new MCP launches. To replace the default binary later, stop the locking process or restart the host, then run .\scripts\install-codestory.ps1 -Project . -Version $ReleaseVersion."
+    Write-Warning "Default install path is locked or not writable: $defaultError. Installed current release to $versionedDest. Set CODESTORY_CLI to that path for local development overrides, or stop the locking process and rerun .\scripts\install-codestory.ps1 -Project . -Version $ReleaseVersion."
     return $versionedDest
 }
 
@@ -547,10 +441,6 @@ function Invoke-SelfTest {
     Assert-SelfTest ((Get-WindowsReleaseTarget $true ([System.Runtime.InteropServices.Architecture]::X64)) -eq "windows-x64") "Windows x64 should map to windows-x64 release assets"
     Assert-SelfTest ((Get-WindowsReleaseTarget $true ([System.Runtime.InteropServices.Architecture]::Arm64)) -eq "windows-arm64") "Windows ARM64 should map to windows-arm64 release assets"
     Assert-SelfTest (-not (Get-WindowsReleaseTarget $false ([System.Runtime.InteropServices.Architecture]::X64))) "non-Windows hosts should not auto-download Windows assets"
-    Assert-SelfTest (Test-PathListContains "C:\Tools;C:\CodeStory\bin\" "C:\CodeStory\bin") "path-list check should ignore trailing slash"
-    Assert-SelfTest (-not (Test-PathListContains "C:\Tools" "C:\CodeStory\bin")) "path-list check should reject missing directory"
-    Assert-SelfTest ((Set-PathListDirectoryFirst "C:\Old;C:\CodeStory\bin" "C:\CodeStory\bin") -eq "C:\CodeStory\bin;C:\Old") "path ordering should put current install first"
-    Assert-SelfTest ((Set-PathListDirectoryFirst "C:\CodeStory\bin;C:\Old;C:\CodeStory\bin\" "C:\CodeStory\bin") -eq "C:\CodeStory\bin;C:\Old") "path ordering should remove duplicate install entries"
     Assert-SelfTest ((Convert-ReleaseTagToVersion "v0.11.4") -eq "0.11.4") "release tag parser should strip v prefix"
     $parsedVersion = Convert-VersionText "codestory-cli 0.11.4"
     Assert-SelfTest (Test-RequiredVersion $parsedVersion) "version gate should accept current release"
@@ -617,35 +507,6 @@ function Invoke-SelfTest {
     } finally {
         if ($currentCli -and (Test-Path -LiteralPath $currentCli)) {
             Remove-Item -LiteralPath $currentCli -Force
-        }
-    }
-
-    $pathRoot = $null
-    $originalProcessPath = [Environment]::GetEnvironmentVariable("Path", "Process")
-    try {
-        $pathRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("codestory-install-" + [System.Guid]::NewGuid().ToString("N"))
-        $stalePathDir = Join-Path $pathRoot "stale"
-        $currentPathDir = Join-Path $pathRoot "current"
-        New-Item -ItemType Directory -Force -Path $stalePathDir, $currentPathDir | Out-Null
-        Set-Content -LiteralPath (Join-Path $stalePathDir "codestory-cli.cmd") -Value "@echo codestory-cli 0.11.3" -Encoding ASCII
-        Set-Content -LiteralPath (Join-Path $currentPathDir "codestory-cli.cmd") -Value "@echo codestory-cli 0.11.4" -Encoding ASCII
-        [Environment]::SetEnvironmentVariable("Path", "$stalePathDir;$currentPathDir", "Process")
-
-        $pathStale = $false
-        try {
-            Assert-PathCliResolvesCurrent
-        } catch {
-            $pathStale = $_.Exception.Message -match "stale codestory-cli"
-        }
-        Assert-SelfTest $pathStale "stale codestory-cli first on PATH should fail loudly"
-
-        $fixedPath = Set-PathListDirectoryFirst ([Environment]::GetEnvironmentVariable("Path", "Process")) $currentPathDir
-        [Environment]::SetEnvironmentVariable("Path", $fixedPath, "Process")
-        Assert-PathCliResolvesCurrent
-    } finally {
-        [Environment]::SetEnvironmentVariable("Path", $originalProcessPath, "Process")
-        if ($pathRoot) {
-            Remove-InstallerTemp $pathRoot
         }
     }
 
@@ -728,12 +589,10 @@ Set-RequiredVersion $Version
 $cliInfo = Find-ExistingCli $CodestoryCli $InstallDir
 if (-not $cliInfo) {
     if ($NoDownload) {
-        throw "No existing codestory-cli $script:RequiredVersion found. Pass -CodestoryCli, set CODESTORY_CLI, add codestory-cli to PATH, or rerun without -NoDownload on Windows x64 or Windows ARM64."
+        throw "No existing codestory-cli $script:RequiredVersion found. Pass -CodestoryCli, set CODESTORY_CLI, use the install directory, or rerun without -NoDownload on Windows x64 or Windows ARM64."
     }
     $cliInfo = Install-ReleaseCli $InstallDir $Version
 }
-Ensure-InstallDirOnPath $InstallDir $cliInfo.Path
-Assert-PathCliResolvesCurrent
 
 $projectPath = (Resolve-Path -LiteralPath $Project).Path
 $doctor = Invoke-DoctorJson $cliInfo.Path $projectPath

--- a/scripts/lint-retrieval-generalization.mjs
+++ b/scripts/lint-retrieval-generalization.mjs
@@ -18,6 +18,11 @@ const extraScanRoots = (
 )
   .split(path.delimiter)
   .filter(Boolean);
+const explicitScanRoots = (
+  process.env.CODESTORY_RETRIEVAL_GENERALIZATION_SCAN_ROOTS ?? ""
+)
+  .split(path.delimiter)
+  .filter(Boolean);
 
 const requiredScanDirs = [
   path.join(repoRoot, "crates", "codestory-runtime", "src", "agent"),
@@ -31,8 +36,11 @@ const requiredProductionOnlyFiles = [
   path.join(repoRoot, "crates", "codestory-retrieval", "src", "ranker.rs"),
 ];
 
-const missingRequiredPaths = [...requiredScanDirs, ...requiredProductionOnlyFiles]
-  .filter((requiredPath) => !existsSync(requiredPath));
+const usesDefaultScanRoots = explicitScanRoots.length === 0;
+const missingRequiredPaths = usesDefaultScanRoots
+  ? [...requiredScanDirs, ...requiredProductionOnlyFiles]
+    .filter((requiredPath) => !existsSync(requiredPath))
+  : [];
 if (missingRequiredPaths.length > 0) {
   console.error("lint-retrieval-generalization: missing required production scan path(s)");
   for (const missingPath of missingRequiredPaths) {
@@ -42,11 +50,13 @@ if (missingRequiredPaths.length > 0) {
 }
 
 const scanDirs = [
-  ...requiredScanDirs,
+  ...(usesDefaultScanRoots
+    ? requiredScanDirs
+    : explicitScanRoots.filter((root) => root && existsSync(root))),
   ...extraScanRoots.filter((root) => root && existsSync(root)),
 ];
 
-const productionOnlyFiles = requiredProductionOnlyFiles;
+const productionOnlyFiles = usesDefaultScanRoots ? requiredProductionOnlyFiles : [];
 
 const evalOnlyProductionFiles = new Set([
   path.join(repoRoot, "crates", "codestory-runtime", "src", "agent", "eval_probes.rs"),
@@ -771,26 +781,42 @@ function rustBlockCommentEnd(text, start) {
   return text.length;
 }
 
-function scanProductionFile(filePath, pattern) {
-  const re = new RegExp(pattern, "i");
-  const lines = productionSource(filePath).split(/\r?\n/);
-  const hits = [];
-  for (let index = 0; index < lines.length; index += 1) {
-    if (re.test(lines[index]) && !lineAllowedForPattern(pattern, lines[index])) {
-      hits.push(`${filePath}:${index + 1}:${lines[index]}`);
-    }
-  }
-  return hits;
+function prepareProductionFile(filePath) {
+  const production = productionSource(filePath);
+  return {
+    filePath,
+    production,
+    lines: production.split(/\r?\n/),
+    literals: null,
+  };
 }
 
-function scanProductionStringLiterals(filePath, pattern) {
-  const re = new RegExp(pattern, "i");
-  const lines = productionSource(filePath).split(/\r?\n/);
+function scanProductionFile(prepared, patterns, combinedRe) {
+  const lines = prepared.lines;
+  const hitsByPattern = new Map();
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!combinedRe.test(lines[index])) {
+      continue;
+    }
+    for (const { pattern, re } of patterns) {
+      if (re.test(lines[index]) && !lineAllowedForPattern(pattern, lines[index])) {
+        if (!hitsByPattern.has(pattern)) {
+          hitsByPattern.set(pattern, []);
+        }
+        hitsByPattern.get(pattern).push(`${prepared.filePath}:${index + 1}:${lines[index]}`);
+      }
+    }
+  }
+  return hitsByPattern;
+}
+
+function scanProductionStringLiterals(prepared, pattern, re) {
+  const lines = prepared.lines;
   const hits = [];
   for (let index = 0; index < lines.length; index += 1) {
     for (const literal of rustStringLiteralsOnLine(lines[index])) {
       if (re.test(literal) && !lineAllowedForPattern(pattern, lines[index])) {
-        hits.push(`${filePath}:${index + 1}:${lines[index]}`);
+        hits.push(`${prepared.filePath}:${index + 1}:${lines[index]}`);
         break;
       }
     }
@@ -816,11 +842,14 @@ function rustStringLiteralContent(literal) {
   return literal;
 }
 
-function scanProductionCompactPatterns(filePath, marker) {
-  const production = productionSource(filePath);
+function scanProductionCompactPatterns(prepared, marker) {
+  const production = prepared.production;
   const markerLower = marker.toLowerCase();
   const hits = [];
-  const literals = rustStringLiteralSpans(production);
+  if (prepared.literals == null) {
+    prepared.literals = rustStringLiteralSpans(production);
+  }
+  const literals = prepared.literals;
   for (let start = 0; start < literals.length; start += 1) {
     let compact = "";
     for (let end = start; end < literals.length; end += 1) {
@@ -835,7 +864,7 @@ function scanProductionCompactPatterns(filePath, marker) {
       compact += compactProductionSource(literals[end].literal);
       if (compact === markerLower) {
         hits.push(
-          compactPatternHit(filePath, literals[start].line, literals[end].line, marker),
+          compactPatternHit(prepared.filePath, literals[start].line, literals[end].line, marker),
         );
         break;
       }
@@ -915,12 +944,12 @@ function isEvalOnlyProductionFile(filePath) {
   return evalOnlyProductionFiles.has(path.resolve(filePath));
 }
 
-function scanRankerFilenameLiterals(filePath) {
-  const lines = productionSource(filePath).split(/\r?\n/);
+function scanRankerFilenameLiterals(prepared) {
+  const lines = prepared.lines;
   const hits = [];
   for (let index = 0; index < lines.length; index += 1) {
     if (rankerFilenameLiteralPattern.test(lines[index])) {
-      hits.push(`${filePath}:${index + 1}:${lines[index]}`);
+      hits.push(`${prepared.filePath}:${index + 1}:${lines[index]}`);
     }
   }
   return hits;
@@ -940,10 +969,29 @@ if (scanFiles.size === 0) {
   process.exit(2);
 }
 
+const bannedRegexPatterns = bannedPatterns.map((pattern) => ({
+  pattern,
+  re: new RegExp(pattern, "i"),
+}));
+const bannedCombinedRegex = new RegExp(
+  bannedPatterns.map((pattern) => `(?:${pattern})`).join("|"),
+  "i",
+);
+const bannedLiteralRegexPatterns = bannedLiteralPatterns.map((pattern) => ({
+  pattern,
+  re: new RegExp(pattern, "i"),
+}));
+
 for (const filePath of [...scanFiles].sort()) {
+  const prepared = prepareProductionFile(filePath);
   if (!isEvalOnlyProductionFile(filePath)) {
-    for (const pattern of bannedPatterns) {
-      const hits = scanProductionFile(filePath, pattern);
+    const productionHits = scanProductionFile(
+      prepared,
+      bannedRegexPatterns,
+      bannedCombinedRegex,
+    );
+    for (const { pattern } of bannedRegexPatterns) {
+      const hits = productionHits.get(pattern) ?? [];
       if (hits.length > 0) {
         console.error(
           `Banned pattern /${pattern}/ in ${path.relative(repoRoot, filePath)} (production slice):\n${hits.join("\n")}\n`,
@@ -951,8 +999,8 @@ for (const filePath of [...scanFiles].sort()) {
         failed = true;
       }
     }
-    for (const pattern of bannedLiteralPatterns) {
-      const hits = scanProductionStringLiterals(filePath, pattern);
+    for (const { pattern, re } of bannedLiteralRegexPatterns) {
+      const hits = scanProductionStringLiterals(prepared, pattern, re);
       if (hits.length > 0) {
         console.error(
           `Banned literal pattern /${pattern}/ in ${path.relative(repoRoot, filePath)} (production slice):\n${hits.join("\n")}\n`,
@@ -961,7 +1009,7 @@ for (const filePath of [...scanFiles].sort()) {
       }
     }
     for (const pattern of bannedCompactPatterns) {
-      const hits = scanProductionCompactPatterns(filePath, pattern);
+      const hits = scanProductionCompactPatterns(prepared, pattern);
       if (hits.length > 0) {
         console.error(
           `Banned compact benchmark marker /${pattern}/ in ${path.relative(repoRoot, filePath)} (production slice):\n${hits.join("\n")}\n`,
@@ -971,7 +1019,7 @@ for (const filePath of [...scanFiles].sort()) {
     }
   }
   if (filePath.endsWith(`${path.sep}ranker.rs`)) {
-    const hits = scanRankerFilenameLiterals(filePath);
+    const hits = scanRankerFilenameLiterals(prepared);
     if (hits.length > 0) {
       console.error(
         `Banned filename literals in ${path.relative(repoRoot, filePath)} (production slice):\n${hits.join("\n")}\n`,

--- a/scripts/tests/codestory-agent-ab-analyzer.test.mjs
+++ b/scripts/tests/codestory-agent-ab-analyzer.test.mjs
@@ -254,12 +254,11 @@ async function withManifestFile(manifest, callback) {
 
 test("categorizes commands without treating source paths as cli invocations", () => {
   assert.equal(commandCategory("& $env:CODESTORY_CLI packet --project . --question flow"), "codestory_cli");
-  assert.equal(commandCategory('"${CODESTORY_CLI:-codestory-cli}" packet --project . --question flow'), "codestory_cli");
   assert.equal(commandCategory('"$CODESTORY_CLI" index --project . --refresh full'), "codestory_cli");
   assert.equal(commandCategory('& "C:\\tools\\codestory-cli.exe" packet --project . --question flow'), "codestory_cli");
   assert.equal(
     commandCategory(
-      String.raw`"C:\Program Files\PowerShell\pwsh.exe" -Command '& $(if ($env:CODESTORY_CLI) { $env:CODESTORY_CLI } else { 'codestory-cli' }) packet --project . --question 'Trace flow' --task-class 'route-tracing' --budget compact --format json"`,
+      String.raw`"C:\Program Files\PowerShell\pwsh.exe" -Command '& $env:CODESTORY_CLI packet --project . --question 'Trace flow' --task-class 'route-tracing' --budget compact --format json"`,
     ),
     "codestory_cli",
   );
@@ -401,7 +400,7 @@ test("packet-first command renders manifest text for host shells", () => {
     "linux",
   );
 
-  assert.ok(unixCommand.startsWith('"${CODESTORY_CLI:-codestory-cli}" packet '));
+  assert.ok(unixCommand.startsWith('"$CODESTORY_CLI" packet '));
   assert.ok(
     unixCommand.includes(
       "--question 'Inspect $env:SECRET and $(Get-ChildItem), then read John'\\''s file. Next line.'",
@@ -1000,7 +999,7 @@ test("requires packet as the CodeStory subcommand for packet-first telemetry", (
 
 test("recognizes quoted PowerShell variable CodeStory packet commands", () => {
   const command =
-    "\"C:\\\\Program Files\\\\PowerShell\\\\pwsh.exe\" -Command '$cli = if ($env:CODESTORY_CLI) { $env:CODESTORY_CLI } else { '\"'codestory-cli' }\n& \"'$cli packet --project . --question '\"'Explain flow' --task-class 'architecture-explanation' --budget compact --format json\"";
+    "\"C:\\\\Program Files\\\\PowerShell\\\\pwsh.exe\" -Command '$cli = $env:CODESTORY_CLI\n& \"'$cli packet --project . --question '\"'Explain flow' --task-class 'architecture-explanation' --budget compact --format json\"";
   const events = [
     commandEvent("cmd_1", "item.started", command),
     commandEvent("cmd_1", "item.completed", command, "{\"packet_id\":\"ask-1\"}", 0),
@@ -1012,8 +1011,8 @@ test("recognizes quoted PowerShell variable CodeStory packet commands", () => {
   assert.equal(analysis.packet_was_first_context_command, true);
 });
 
-test("recognizes inline PowerShell env fallback CodeStory packet commands", () => {
-  const command = String.raw`"C:\Program Files\PowerShell\pwsh.exe" -Command '& $(if ($env:CODESTORY_CLI) { $env:CODESTORY_CLI } else { 'codestory-cli' }) packet --project . --question 'Trace flow' --task-class 'route-tracing' --budget compact --format json"`;
+test("recognizes inline PowerShell env CodeStory packet commands", () => {
+  const command = String.raw`"C:\Program Files\PowerShell\pwsh.exe" -Command '& $env:CODESTORY_CLI packet --project . --question 'Trace flow' --task-class 'route-tracing' --budget compact --format json"`;
   const events = [
     commandEvent("cmd_1", "item.started", command),
     commandEvent("cmd_1", "item.completed", command, "{\"packet_id\":\"ask-1\"}", 0),
@@ -1071,7 +1070,7 @@ test("harness packet prelude counts as the first context command", () => {
   assert.equal(analysis.packet_was_first_context_command, true);
 });
 
-test("codestory cli resolver prefers explicit path, release binary, then PATH fallback", () => {
+test("codestory cli resolver prefers explicit path, release binary, then fails closed", () => {
   const explicit = resolveCodeStoryCli({ codestoryCli: "C:/custom/codestory-cli.exe" }, () => {
     throw new Error("explicit path should not probe local candidates");
   });
@@ -1082,8 +1081,10 @@ test("codestory cli resolver prefers explicit path, release binary, then PATH fa
   );
   assert.match(release, /target[\\/]release[\\/]codestory-cli(?:\.exe)?$/);
 
-  const fallback = resolveCodeStoryCli({ codestoryCli: null }, () => false);
-  assert.equal(fallback, "codestory-cli");
+  assert.throws(
+    () => resolveCodeStoryCli({ codestoryCli: null }, () => false),
+    /Pass --codestory-cli, set CODESTORY_CLI, or build the release binary/,
+  );
 });
 
 test("scores expected claims without requiring exact wording", () => {


### PR DESCRIPTION
## Context

Promotes CodeStory 0.13.1 from `dev/codestory-next` to `main`. This is the release promotion for the portability and host-bridge hardening epic.

Refs #821
Closes #822
Closes #823
Closes #824
Closes #825
Closes #826
Closes #827
Closes #828

## What Changed

- Adds the Codex hook MCP bridge for configured/launchable but model-hidden MCP sessions while keeping MCP visibility fields truthful.
- Removes ambient CodeStory CLI PATH discovery and PATH repair/advice from runtime, installer/setup, tests, docs, and benchmark defaults; `CODESTORY_CLI` remains explicit local-dev override only.
- Adds `CODESTORY_PLUGIN_DATA` for non-Codex managed plugin runtime data and updates Cursor/Claude docs/config examples.
- Makes retrieval acceleration Vulkan-first by default, keeps compose CPU-compatible, and emits Linux `/dev/dri` override only when requested and available.
- Expands release/package proof for shipped assets and bumps CodeStory crates, plugin manifests, lockfile, and changelog to `0.13.1`.
- Speeds the retrieval generalization lint path: local bare linter went from 41.24s to 1.54s, and the Rust guard now runs in 2.37s of test time.
- Stabilizes the packet-capping debug perf guard after CI showed a 2038ms run against a 2000ms cutoff; local timed section is 1175ms with the new 3000ms guard.

```mermaid
flowchart LR
  A["Host hook starts"] --> B["MCP launchable?"]
  B -->|"visible"| C["Use live MCP status"]
  B -->|"model-hidden"| D["Managed runtime hook bridge"]
  D --> E["Emit bounded status/context"]
  E --> F["MCP tools still reported hidden"]
```

## How To Review

- Review the merged integration PR #829 first; this promotion branch is `origin/dev/codestory-next` against `origin/main`.
- Check hook/runtime bridge changes in `plugins/codestory/hooks/codestory-activate.cjs` and `plugins/codestory/scripts/codestory-mcp.cjs`.
- Check no-PATH behavior in `crates/codestory-cli/src/readiness.rs`, `crates/codestory-cli/src/stdio_transport.rs`, and `scripts/install-codestory.ps1`.
- Check Vulkan/release proof in `crates/codestory-retrieval/src/embeddings.rs`, `crates/codestory-retrieval/src/compose.rs`, `.github/workflows/release.yml`, and `.github/scripts/check-packaged-agent-proof.py`.
- Check release metadata in `CHANGELOG.md`, crate manifests, plugin manifests, and `Cargo.lock`.

## Verification

- PR #829 checks passed on head `8b060448`: check markdown links, deny rustdoc warnings, linux-contracts, plugin static tests, require closing issue link, workspace cargo checks; windows-manifest-missing skipped as expected.
- `node scripts/lint-retrieval-generalization.mjs` passed locally in 1.54s.
- `cargo test -p codestory-runtime --test retrieval_generalization_guard` passed locally: 10 passed, finished in 2.37s test time.
- `cargo test -p codestory-runtime --lib packet_citation_capping_large_probe_set_stays_bounded -- --nocapture` passed locally: timed section 1175ms, threshold 3000ms.
- Earlier integration verification from #829 passed: plugin static tests, stdio protocol contracts, codestory-retrieval tests, analyzer tests, installer self-test, packaged proof self-test, workflow policy, release version gate, doc link check, and `git diff --check`.

## Risk

- The hook bridge is context only; it intentionally does not claim live MCP tools when Codex hides them.
- Full GPU sidecar proof still depends on runner hardware and host drivers; package proof validates asset shape and full sidecar proof stays on capable Linux paths.
- The packet-capping guard remains a debug-mode timing check, but now allows CI runner variance while still failing on a genuine multi-second regression.
