### PR TITLE
promote 0.13.1 packaged proof hotfix

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -6,6 +6,7 @@ import json
 import os
 import queue
 import signal
+import shutil
 import stat
 import subprocess
 import sys
@@ -609,6 +610,7 @@ def run_gate(args: argparse.Namespace) -> None:
     archive = Path(args.archive).resolve()
     project = Path(args.project).resolve()
     out_dir = Path(args.out_dir).resolve()
+    shutil.rmtree(out_dir, ignore_errors=True)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     with tempfile.TemporaryDirectory(prefix="codestory-packaged-agent-proof-", dir=out_dir) as temp:
@@ -843,6 +845,7 @@ def run_gate(args: argparse.Namespace) -> None:
         summary["artifacts"]["packet"] = str(packet_artifact)
         write_json(out_dir / "summary.json", summary)
 
+        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs)
         require_stdio_ready(stdio_status_payload, stdio_artifact, args.expected_version)
         write_json(out_dir / "summary.json", summary)
 
@@ -944,6 +947,13 @@ def write_fake_cli(path: Path) -> None:
                 else:
                     emit({"sufficiency": {"status": "sufficient"}, "answer": {"retrieval_version": "sidecar"}, "retrieval_trace_summary": {}})
             elif layer == "serve":
+                marker = None
+                if fail == "serve_first_blocked":
+                    try:
+                        project = sys.argv[sys.argv.index("--project") + 1]
+                        marker = os.path.join(project, ".fake-serve-first-blocked-seen")
+                    except (ValueError, IndexError):
+                        marker = os.path.join(os.getcwd(), ".fake-serve-first-blocked-seen")
                 for line in sys.stdin:
                     request = json.loads(line)
                     if fail == "serve_timeout":
@@ -957,6 +967,10 @@ def write_fake_cli(path: Path) -> None:
                             resources.append({"uri": "codestory://agent-guide", "name": "CodeStory agent guide"})
                         result = {"resources": resources}
                     else:
+                        serve_allowed = True
+                        if marker is not None and not os.path.exists(marker):
+                            open(marker, "w", encoding="utf-8").write("seen")
+                            serve_allowed = False
                         status = {
                             "server_version": "9.9.9",
                             "cli_version": "9.9.9",
@@ -965,9 +979,9 @@ def write_fake_cli(path: Path) -> None:
                             "sidecar_contract_version": 1,
                             "plugin_runtime": {"cli_source": "direct_cli_launch"},
                             "allowed_surfaces": {
-                                "packet": {"allowed": True},
-                                "search": {"allowed": True},
-                                "context": {"allowed": True},
+                                "packet": {"allowed": serve_allowed},
+                                "search": {"allowed": serve_allowed},
+                                "context": {"allowed": serve_allowed},
                             },
                         }
                         result = {"contents": [{"uri": "codestory://status", "mimeType": "application/json", "text": json.dumps(status)}]}
@@ -1068,6 +1082,32 @@ def self_test() -> None:
         version_only_summary = read_json_file(version_only_out / "summary.json")
         assert version_only_summary["artifacts"].keys() == {"version", "help", "serve_stdio"}
         assert not (version_only_out / "local-retrieval-bootstrap.json").exists()
+
+        stale_out = root / "stale-out"
+        stale_out.mkdir()
+        stale_file = stale_out / "stale-plugin-stdio-status.json"
+        stale_file.write_text("stale", encoding="utf-8")
+        stale_args = argparse.Namespace(**vars(version_only_args))
+        stale_args.out_dir = str(stale_out)
+        run_gate(stale_args)
+        assert not stale_file.exists()
+        assert (stale_out / "summary.json").is_file()
+
+        delayed_stdio_project = root / "repo-delayed-stdio"
+        delayed_stdio_project.mkdir()
+        delayed_stdio_out = root / "delayed-stdio-out"
+        delayed_stdio_args = argparse.Namespace(**vars(args))
+        delayed_stdio_args.project = str(delayed_stdio_project)
+        delayed_stdio_args.out_dir = str(delayed_stdio_out)
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "serve_first_blocked"
+        try:
+            run_gate(delayed_stdio_args)
+            delayed_stdio_status = read_json_file(delayed_stdio_out / "serve-stdio-status.json")
+            delayed_status = delayed_stdio_status["status"]
+            assert delayed_status["allowed_surfaces"]["packet"]["allowed"] is True
+            assert (delayed_stdio_project / ".fake-serve-first-blocked-seen").is_file()
+        finally:
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
 
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "search"
         try:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Cursor, Claude Code, and GPU hosts while keeping MCP visibility truth explicit.
 - Expanded release and post-publish package proof to download every shipped
   binary archive, verify checksums, run version/help smoke, and validate stdio
   status shape while keeping full sidecar proof on runners that can support it.
+- Refreshed packaged proof stdio status after sidecar repair and cleared cached
+  proof output before each run so release artifacts reflect the current proof.
 
 ## 0.13.0
 


### PR DESCRIPTION
## Context

v0.13.1 reached main in #830, but Auto Release run 28522409902 failed before tag or release creation. The linux-x64 packaged full-sidecar proof validated sidecar readiness after repair, then failed because it checked a stale pre-repair serve --stdio status snapshot.

This promotion moves the hotfix from #832 onto main so Auto Release can rerun from the guarded main release path.

Refs #821. Refs #831.

## What Changed

- Promote the packaged proof fix from dev/codestory-next to main.
- The proof now clears cached output before each run and re-reads serve --stdio status after sidecar repair before validating packet/search/context allowed_surfaces.
- The self-test now covers stale output and the delayed stdio readiness case from the failed release run.

## How To Review

- Compare origin/main...origin/dev/codestory-next; it should contain only the release-proof hotfix commit de1914e4.
- Review .github/scripts/check-packaged-agent-proof.py and CHANGELOG.md.

## Verification

- PR #832 passed require closing issue link and was merged into dev/codestory-next.
- Local before #832: python .github\scripts\check-packaged-agent-proof.py --self-test
- Local before #832: git diff --check

## Risk

Low. This changes release evidence collection only. The runtime package contents are unchanged; the release automation will rerun on main after this promotion merges.
