### PR TITLE
Release CodeStory 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Windows dogfooding of the 0.13.1 release.
 - Updated Codex hook and user guidance for model-hidden plugin MCP sessions to
   request host deferred discovery/tool_search when available instead of
   treating reload as the first repair step.
+- Removed explicit `@CodeStory` tags from Codex marketplace prompt examples so
+  the installed plugin advertises natural fresh-thread usage.
 
 ## 0.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 0.13.2
+
+CodeStory 0.13.2 fixes Codex plugin startup lifecycle failures found during
+Windows dogfooding of the 0.13.1 release.
+
+### Fixed
+
+- Moved long-lived Codex plugin MCP wrapper processes out of the installed
+  plugin cache directory before serving so Windows plugin refreshes are not
+  blocked by the wrapper's current working directory.
+- Blocked MCP `repair_all` when `codestory://status` reports a stale active
+  CLI setup repair, preventing old runtimes from launching sidecar repair.
+- Updated Codex hook and user guidance for model-hidden plugin MCP sessions to
+  request host deferred discovery/tool_search when available instead of
+  treating reload as the first repair step.
+
 ## 0.13.1
 
 CodeStory 0.13.1 hardens the portable plugin/runtime path across Codex,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3678,7 +3678,32 @@ fn stdio_allowed_surfaces(readiness: &[ReadinessVerdictDto]) -> serde_json::Valu
     for surface in ["packet", "search", "context"] {
         surfaces.insert(surface.to_string(), stdio_allowed_surface(agent));
     }
+    surfaces.insert(
+        "repair_all".to_string(),
+        stdio_repair_all_surface(readiness),
+    );
     serde_json::Value::Object(surfaces)
+}
+
+fn stdio_repair_all_surface(readiness: &[ReadinessVerdictDto]) -> serde_json::Value {
+    if let Some(setup) = readiness
+        .iter()
+        .find(|verdict| verdict.status == ReadinessStatusDto::RepairSetup)
+    {
+        return stdio_allowed_surface(Some(setup));
+    }
+
+    serde_json::json!({
+        "allowed": true,
+        "readiness_goal": "agent_packet_search",
+        "status": "ready",
+        "failed_layer": null,
+        "summary": "MCP repair_all may run bounded CodeStory agent repair for this runtime.",
+        "repair_reason": null,
+        "blocked_reason": null,
+        "minimum_next": [],
+        "full_repair": [],
+    })
 }
 
 fn stdio_allowed_surface(verdict: Option<&ReadinessVerdictDto>) -> serde_json::Value {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -3289,7 +3289,14 @@ fn resources_read_status_blocks_all_surfaces_when_active_cli_is_stale() {
             .is_some_and(|path| path.contains("codestory-cli")),
         "setup snapshot should expose active executable path: {status}"
     );
-    for surface in ["ground", "files", "packet", "search", "context"] {
+    for surface in [
+        "ground",
+        "files",
+        "packet",
+        "search",
+        "context",
+        "repair_all",
+    ] {
         let surface_status = &status["allowed_surfaces"][surface];
         assert_eq!(surface_status["allowed"], json!(false));
         assert_eq!(surface_status["status"], json!("repair_setup"));
@@ -3312,6 +3319,7 @@ fn tool_calls_block_all_surfaces_when_active_cli_is_stale() {
     for (tool, arguments) in [
         ("ground", json!({})),
         ("search", json!({"query": "AppController"})),
+        ("repair_all", json!({})),
     ] {
         let response = send_json(
             &mut server,

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2024"
 
 [dependencies]

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -64,18 +64,19 @@ Run these three checks before your first real task:
 2. **MCP and hooks live** — Start a **new** Codex thread in the grounded repo.
    CodeStory MCP should start automatically and session hooks should run without
    blocking the host.
-3. **First status read succeeds** — Use the readiness prompt in [First
-   session](#first-session). The agent should answer in plain English whether
-   your repo map is ready and whether broad search is available.
+3. **First status read succeeds** — Use a normal repository question or the
+   readiness probe in [First session](#first-session). The agent should answer
+   in plain English whether your repo map is ready and whether broad search is
+   available.
 
 ## First session
 
 1. Start a **new** Codex thread in the grounded repository (not an old thread
    from before install).
-2. Ask:
+2. Ask a normal repository question. For an explicit readiness probe, ask:
 
 ```text
-@CodeStory read codestory://status, ground this checkout if allowed, and tell me which CodeStory surfaces are ready before I edit.
+Read codestory://status, ground this checkout if allowed, and tell me which CodeStory surfaces are ready before I edit.
 ```
 
 **Expected wait:** On a large repository, the first index build can take several
@@ -84,32 +85,32 @@ minutes. Let the agent finish grounding before you ask it to edit files.
 **Success looks like:** The agent confirms your repo map is ready, says whether
 broad search is available, and does not report a missing CLI or broken plugin.
 
-The agent reports `allowed_surfaces`, [local navigation](../glossary.md#local-navigation-readiness) vs [packet/search](../glossary.md#agent-packetsearch-readiness) readiness, and any repair steps. You do not install or run the CLI yourself for normal setup.
+The agent reports `allowed_surfaces`, [local navigation](../glossary.md#local-navigation-readiness) vs [packet/search](../glossary.md#agent-packetsearch-readiness) readiness, and any repair steps. You do not tag the plugin, install a CLI, or run the CLI yourself for normal setup.
 
 ## Example prompts
 
 **Readiness before editing**
 
 ```text
-@CodeStory read codestory://status and check allowed_surfaces before I change [path/to/file].
+Read codestory://status and check allowed_surfaces before I change [path/to/file].
 ```
 
 **Find ownership**
 
 ```text
-@CodeStory Where is [Feature] defined and who calls it?
+Where is [Feature] defined and who calls it?
 ```
 
 **Plan a change**
 
 ```text
-@CodeStory I am changing [path/to/file]. What symbols are affected and what tests should I run first?
+I am changing [path/to/file]. What symbols are affected and what tests should I run first?
 ```
 
 **Subsystem overview**
 
 ```text
-@CodeStory How does [subsystem] work? Cite concrete files and note any coverage gaps.
+How does [subsystem] work? Cite concrete files and note any coverage gaps.
 ```
 
 ## Prompt patterns
@@ -117,13 +118,13 @@ The agent reports `allowed_surfaces`, [local navigation](../glossary.md#local-na
 **Bad** — tree walk before grounding:
 
 ```text
-@CodeStory Grep the repo for [SYMBOL] and read every matching file.
+Grep the repo for [SYMBOL] and read every matching file.
 ```
 
 **Good** — repo question with concrete terms:
 
 ```text
-@CodeStory Where is [SYMBOL] defined, who calls it, and which tests cover that path?
+Where is [SYMBOL] defined, who calls it, and which tests cover that path?
 ```
 
 More pairs, anti-patterns, and language-flavored examples:
@@ -133,7 +134,7 @@ More pairs, anti-patterns, and language-flavored examples:
 
 | Symptom | What to try |
 | --- | --- |
-| `@CodeStory` loads but no MCP tools | Start a fresh Codex host session after install; confirm plugin shows in `/plugins` |
+| Hook says `mcp_resources_not_model_visible` | Let the agent request CodeStory MCP through host deferred discovery/tool_search when available; reload only after plugin install or config changes |
 | Status shows `repair_setup` | Let the agent follow `recommended_next_calls` from status; restart host if binary was updated |
 | Terminal refresh says `Access is denied` | Quit stale Codex windows running the old plugin, then refresh from `/plugins` or rerun `codex plugin add codestory@TheGreenCedar` |
 | Packet/search blocked | Agent can call `sidecar_setup`; see [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -162,13 +162,13 @@ codestory-cli fix --project <repo> --format json
 Require `retrieval_mode: "full"` before trusting packet/search evidence.
 Command table: [CLI reference - readiness and repair](cli-reference.md#readiness-and-repair).
 
-## MCP registration failure
+## MCP visibility failure
 
 Symptoms: skill or rule loads but no `codestory://status` or `mcp__codestory` tools.
 
 | Host | Check |
 | --- | --- |
-| Codex | Fresh host session after `/plugins` install; see [Codex guide](codex.md#troubleshooting) |
+| Codex | If hook status says `mcp_resources_not_model_visible`, request CodeStory MCP through host deferred discovery/tool_search when available. Reload only after plugin install/config changes; see [Codex guide](codex.md#troubleshooting) |
 | Cursor | MCP config path to `plugins/codestory/scripts/codestory-mcp.cjs`; reload server |
 | Claude Code | MCP configured separately; hooks alone do not expose tools |
 | Copilot | MCP not auto-started; configure manually or use CLI |
@@ -199,11 +199,13 @@ the installed plugin package when your Codex build supports terminal plugin
 management. A running Codex host can still keep the old MCP adapter and managed
 CLI alive until you start a fresh host session.
 
-On Windows, `codex plugin add codestory@TheGreenCedar` can fail with
-`Access is denied` while backing up the plugin cache if an old Codex/MCP process
-still has files open. Quit stale Codex windows, start a fresh host session, and
-retry the `/plugins` refresh or terminal install. After refresh, confirm the
-active runtime through `codestory://status`, not only `codex plugin list`.
+On Windows, older running CodeStory MCP processes can make
+`codex plugin add codestory@TheGreenCedar` fail with `Access is denied` while
+backing up the plugin cache. Current MCP adapters move their long-lived working
+directory out of the plugin cache, but stale hosts from older packages can still
+hold files open. Quit stale Codex windows, start a fresh host session, and retry
+the `/plugins` refresh or terminal install. After refresh, confirm the active
+runtime through `codestory://status`, not only `codex plugin list`.
 
 ## Still stuck?
 

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"
   },
-  "homepage": "https://github.com/TheGreenCedar/CodeStory/tree/dev/codestory-next/plugins/codestory",
+  "homepage": "https://github.com/TheGreenCedar/CodeStory/tree/main/plugins/codestory",
   "repository": "https://github.com/TheGreenCedar/CodeStory",
   "license": "Apache-2.0",
   "keywords": ["codestory", "codex", "grounding", "mcp", "local"],
@@ -24,9 +24,9 @@
     "privacyPolicyURL": "https://github.com/TheGreenCedar/CodeStory",
     "termsOfServiceURL": "https://github.com/TheGreenCedar/CodeStory",
     "defaultPrompt": [
-      "@CodeStory Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]?",
-      "@CodeStory I am editing a file in this repo. What symbols are affected and what tests should I run first?",
-      "@CodeStory Read codestory://status, ground this checkout if allowed, and report which surfaces are ready."
+      "Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]?",
+      "I am editing a file in this repo. What symbols are affected and what tests should I run first?",
+      "Read codestory://status, ground this checkout if allowed, and report which surfaces are ready."
     ],
     "brandColor": "#2563EB",
     "screenshots": []

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -160,7 +160,7 @@ function shortDegradedNotice(mcp, reason, state = {}) {
       'CodeStory setup blocked: MCP is configured and launchable, but resources are not model-visible.',
       `First failing layer: ${firstRuntimeFailure(mcp)}.`,
       reason ? `Reason: ${truncate(reason, 600)}` : null,
-      'Use the hook MCP bridge when present; reload the host/plugin only to expose live MCP tools. Do not use ambient CodeStory CLI discovery as grounding.',
+      'Request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use the hook MCP bridge when present. Reload only after plugin install or config changes. Do not use ambient CodeStory CLI discovery as grounding.',
     ].filter(Boolean).join('\n');
   }
   const hook = state.hook || {};
@@ -180,7 +180,7 @@ function runtimeStatusBlock(policy, mcp) {
     `dedupe_key: ${policy.dedupeKey}`,
     mcpDetectionText(mcp),
     mcp.mcp_model_visible_blocked
-      ? 'Next: use the hook MCP bridge when present; reload the host/plugin only to expose live MCP tools. Do not use ambient CodeStory CLI discovery as grounding.'
+      ? 'Next: request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use the hook MCP bridge when present. Reload only after plugin install or config changes. Do not use ambient CodeStory CLI discovery as grounding.'
       : mcp.mcp_resources_exposed
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
@@ -297,7 +297,7 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason) {
     reason ? `hook_bridge_reason: ${truncate(reason, 500)}` : null,
     'mcp_resources_exposed: mcp_resources_not_model_visible',
     'mcp_tools_visible: no',
-    'hook_bridge_next: use this bounded bridge status now; reload the host/plugin only to expose live MCP tools.',
+    'hook_bridge_next: request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use this bounded bridge status and report that live MCP tools are hidden.',
   ].filter(Boolean).join('\n');
 }
 
@@ -557,7 +557,7 @@ function runCodeStory(input, event, policy, state = {}) {
         mcpDetectionText(mcp),
         mcp.mcp_resources_exposed
           ? 'Use codestory://status as the active runtime truth. Run packet/search/context only when status allows that surface with retrieval_mode=full.'
-          : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Use hook-bridged status when present; reload the host/plugin only to expose live MCP tools.',
+          : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use hook-bridged status and report that live MCP tools are hidden.',
       ].join('\n'), policy.cap),
       fingerprint: `${runtimeFingerprint(mcp)}|${bootstrapBlock || 'no-bootstrap'}`,
     };

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -9,7 +9,7 @@ const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, read codestory://status first. If MCP is configured but resources are not model-visible, use the hook bridge when present and reload the host/plugin only to expose live MCP tools.
+2. If the CodeStory MCP server is live, read codestory://status first. If MCP is configured but resources are not model-visible, request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use the hook bridge when present and report that live MCP tools are hidden.
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
@@ -59,7 +59,7 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, use hook-bridged status when present and reload the host/plugin only to expose live MCP tools. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
+Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use hook-bridged status when present and report that live MCP tools are hidden. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -10,6 +10,7 @@ const path = require('path');
 const { dirtyMarkerPathForProject } = require('../hooks/codestory-runtime.cjs');
 
 const pluginRoot = path.dirname(__dirname);
+const launchCwd = process.cwd();
 const binaryName = process.platform === 'win32' ? 'codestory-cli.exe' : 'codestory-cli';
 const fallbackBinaryNames = process.platform === 'win32'
   ? ['codestory-cli.exe', 'codestory-cli.cmd', 'codestory-cli']
@@ -163,7 +164,7 @@ function resolveProjectRoot(options = {}) {
     return { projectRoot: explicit, source: options.projectRoot ? 'argument' : 'env' };
   }
 
-  const cwd = existingProjectRoot(process.cwd());
+  const cwd = existingProjectRoot(options.cwd || launchCwd);
   if (cwd && !samePathText(cwd, pluginRoot)) {
     return { projectRoot: cwd, source: 'process_cwd' };
   }
@@ -275,11 +276,11 @@ function handleSidecarPolicyCommand(argv) {
   process.exit(0);
 }
 
-function repairCommandForProject(projectRoot = process.cwd()) {
+function repairCommandForProject(projectRoot = launchCwd) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
 
-function resolvedRepairCommandForProject(resolved, projectRoot = process.cwd()) {
+function resolvedRepairCommandForProject(resolved, projectRoot = launchCwd) {
   return `${JSON.stringify(resolved.path)} ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
 
@@ -288,7 +289,7 @@ function optionValue(argv, name) {
   return index >= 0 ? argv[index + 1] : null;
 }
 
-function dirtyMarkerEnv(projectRoot = process.cwd()) {
+function dirtyMarkerEnv(projectRoot = launchCwd) {
   const markerPath = dirtyMarkerPathForProject(projectRoot, pluginDataDir());
   const normalizedRoot = (() => {
     try {
@@ -568,10 +569,13 @@ async function resolveCli() {
   const version = pluginVersion();
   const warnings = [];
   if (process.env.CODESTORY_CLI) {
+    const cliPath = path.isAbsolute(process.env.CODESTORY_CLI)
+      ? process.env.CODESTORY_CLI
+      : path.resolve(launchCwd, process.env.CODESTORY_CLI);
     return {
       source: 'local_dev_override',
-      path: process.env.CODESTORY_CLI,
-      sha256: fs.existsSync(process.env.CODESTORY_CLI) ? fileSha256(process.env.CODESTORY_CLI) : null,
+      path: cliPath,
+      sha256: fs.existsSync(cliPath) ? fileSha256(cliPath) : null,
       version,
       cliVersion: null,
       repoRef: null,
@@ -648,28 +652,8 @@ function failOpenReasonForProbe(resolved, probe) {
   return null;
 }
 
-function localWaitFreshCommand(projectRoot = process.cwd()) {
+function localWaitFreshCommand(projectRoot = launchCwd) {
   return `<managed codestory-cli> ready --goal local --wait-fresh --project ${JSON.stringify(projectRoot)} --format json`;
-}
-
-function mcpNextCallForCommand(command) {
-  if (command.startsWith('Restart/reload') || command.startsWith('Refresh or reinstall')) {
-    return { method: 'host/restart', instruction: command };
-  }
-  if (command.includes('ready --goal agent --repair')) {
-    return {
-      method: 'tools/call',
-      tool: 'sidecar_setup',
-      arguments: { action: 'repair' },
-      debug_command: command,
-    };
-  }
-  return {
-    method: 'resources/read',
-    uri: 'codestory://status',
-    instruction: 'Use MCP status and agent-guide first; debug_command is for maintainer transcripts only.',
-    debug_command: command,
-  };
 }
 
 function singleRepairNextCalls(commands) {
@@ -680,14 +664,25 @@ function singleRepairNextCalls(commands) {
       { method: 'resources/read', uri: 'codestory://status' },
     ];
   }
+  const sidecarRepair = commands.find((command) => command.includes('ready --goal agent --repair'));
+  if (sidecarRepair) {
+    return [
+      {
+        method: 'tools/call',
+        tool: 'sidecar_setup',
+        arguments: { action: 'repair' },
+        debug_command: sidecarRepair,
+      },
+      { method: 'resources/read', uri: 'codestory://status' },
+    ];
+  }
   return [
     {
-      method: 'tools/call',
-      tool: 'repair_all',
-      arguments: {},
+      method: 'resources/read',
+      uri: 'codestory://status',
+      instruction: 'Diagnostic MCP cannot run full repair until a compatible stdio runtime starts; restore the runtime before retrying grounding.',
       debug_commands: commands,
     },
-    { method: 'resources/read', uri: 'codestory://status' },
   ];
 }
 
@@ -834,6 +829,8 @@ function pluginRuntimeForResolved(resolved) {
     plugin_root: pluginRoot,
     plugin_cache_version: pluginCacheVersion(),
     plugin_data: pluginDataDir(),
+    launch_cwd: launchCwd,
+    runtime_cwd: process.cwd(),
     cli_source: resolved.source,
     cli_path: resolved.path,
     cli_sha256: resolved.sha256,
@@ -848,7 +845,7 @@ function pluginRuntimeForResolved(resolved) {
 }
 
 function fallbackDiagnostic(resolved, probe, reason, options = {}) {
-  const projectRoot = Object.hasOwn(options, 'projectRoot') ? options.projectRoot : process.cwd();
+  const projectRoot = Object.hasOwn(options, 'projectRoot') ? options.projectRoot : launchCwd;
   const managedProvisionFailed = String(reason || '').startsWith('managed_cli_provision_failed:');
   const managedProvisionNext = [
     'Restart/reload the Codex host/app and read codestory://status; managed CLI provisioning will retry release asset downloads.',
@@ -957,7 +954,7 @@ function projectRootUnavailableDiagnostic(resolved, probe, projectResolution) {
   });
 }
 
-async function bootstrapStatus(projectRoot = process.cwd()) {
+async function bootstrapStatus(projectRoot = launchCwd) {
   projectRoot = normalizeProjectRoot(projectRoot);
   const resolved = await resolveCli();
   rememberLaunch(resolved);
@@ -1055,6 +1052,47 @@ function samePathText(left, right) {
   return normalize(left) === normalize(right);
 }
 
+function pathInside(child, parent) {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function ensureRuntimeDirectory(candidate) {
+  if (!candidate) return null;
+  try {
+    fs.mkdirSync(candidate, { recursive: true });
+    return fs.statSync(candidate).isDirectory() ? fs.realpathSync(candidate) : null;
+  } catch {
+    return null;
+  }
+}
+
+function launcherRuntimeCwd() {
+  const dataDir = pluginDataDir();
+  for (const candidate of [
+    dataDir ? path.join(dataDir, 'runtime-cwd') : null,
+    dataDir,
+    os.tmpdir(),
+  ]) {
+    const runtimeCwd = ensureRuntimeDirectory(candidate);
+    if (runtimeCwd && !pathInside(runtimeCwd, pluginRoot)) return runtimeCwd;
+  }
+  return launchCwd;
+}
+
+function releasePluginCacheCwd() {
+  const current = path.resolve(process.cwd());
+  if (!pathInside(current, pluginRoot)) return current;
+  const runtimeCwd = launcherRuntimeCwd();
+  if (!runtimeCwd || pathInside(runtimeCwd, pluginRoot)) return current;
+  try {
+    process.chdir(runtimeCwd);
+    return runtimeCwd;
+  } catch {
+    return current;
+  }
+}
+
 function sourceCheckoutVersion(projectRoot) {
   if (!projectRoot) return null;
   try {
@@ -1139,28 +1177,6 @@ function failOpenSidecarSetupResult(request) {
 
 function runFailOpenMcp(status) {
   const tools = [{
-    name: 'repair_all',
-    description: 'Run the single supported CodeStory readiness repair action, then read codestory://status again.',
-    inputSchema: {
-      type: 'object',
-      properties: {},
-      additionalProperties: false,
-    },
-    outputSchema: { type: 'object', additionalProperties: true },
-    safety: {
-      readOnly: false,
-      sideEffects: true,
-      localOnly: true,
-      openWorld: false,
-      mutation: 'local_plugin_configuration',
-    },
-    annotations: {
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
-    },
-  }, {
     name: 'sidecar_setup',
     description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode.',
     inputSchema: {
@@ -1191,7 +1207,7 @@ function runFailOpenMcp(status) {
   ];
   const guide = {
     status: 'repair_setup',
-    message: 'Read codestory://status, follow recommended_next_calls, restart/reload the host, then retry grounding.',
+    message: 'Read codestory://status, follow recommended_next_calls, restore a compatible stdio runtime, then retry grounding.',
     recommended_next_calls: status.recommended_next_calls,
   };
   let buffer = '';
@@ -1231,17 +1247,10 @@ function runFailOpenMcp(status) {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
       } else if (request.method === 'tools/call') {
-        if (request.params?.name === 'repair_all') {
-          const repairRequest = {
-            params: {
-              arguments: { action: 'repair' },
-            },
-          };
-          response = jsonrpcResult(request.id, failOpenSidecarSetupResult(repairRequest));
-        } else if (request.params?.name === 'sidecar_setup') {
+        if (request.params?.name === 'sidecar_setup') {
           response = jsonrpcResult(request.id, failOpenSidecarSetupResult(request));
         } else {
-          response = jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status or call repair_all.');
+          response = jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status and restore a compatible stdio runtime.');
         }
       } else {
         response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
@@ -1255,7 +1264,7 @@ function resolvedVersionForStatus(status) {
   return status.plugin_runtime.plugin_version || 'unknown';
 }
 
-function rememberLaunch(resolved) {
+function rememberLaunch(resolved, runtimeCwd = process.cwd()) {
   const dataDir = pluginDataDir();
   if (!dataDir) return;
   try {
@@ -1265,6 +1274,8 @@ function rememberLaunch(resolved) {
       path: resolved.path,
       sha256: resolved.sha256,
       pluginRoot,
+      launchCwd,
+      runtimeCwd,
       pluginCacheVersion: pluginCacheVersion(),
       pluginVersion: resolved.version,
       manifestPath: resolved.manifestPath || null,
@@ -1284,8 +1295,9 @@ function rememberLaunch(resolved) {
 async function main() {
   if (await handleBootstrapStatusCommand(process.argv)) return;
   handleSidecarPolicyCommand(process.argv);
+  const runtimeCwd = releasePluginCacheCwd();
   const resolved = await resolveCli();
-  rememberLaunch(resolved);
+  rememberLaunch(resolved, runtimeCwd);
   const probe = probeResolvedCli(resolved);
   const projectResolution = resolveProjectRoot();
   const failOpenReason = failOpenReasonForProbe(resolved, probe);
@@ -1314,6 +1326,8 @@ async function main() {
       ...process.env,
       CODESTORY_PLUGIN_VERSION: resolved.version || '',
       CODESTORY_PLUGIN_ROOT: pluginRoot,
+      CODESTORY_PLUGIN_LAUNCH_CWD: launchCwd,
+      CODESTORY_PLUGIN_RUNTIME_CWD: runtimeCwd,
       CODESTORY_PLUGIN_CACHE_VERSION: pluginCacheVersion() || '',
       CODESTORY_PLUGIN_CLI_VERSION: resolved.cliVersion || resolved.version || '',
       CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
@@ -1363,6 +1377,7 @@ async function main() {
 }
 
 function runLauncherError(error) {
+  releasePluginCacheCwd();
   const resolved = {
     source: 'launcher',
     path: 'codestory-cli',

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -36,9 +36,10 @@ When the plugin MCP server is available:
 5. Read `codestory://agent-guide` when you need the runtime's recommended next calls.
 
 If the skill is visible but no `mcp__codestory` tools or `codestory://status`
-resource are exposed, call it a plugin MCP registration failure. Do not use CLI
-as CodeStory grounding; use ordinary source inspection and report that MCP was
-not live.
+resource are exposed, first request CodeStory MCP through host deferred
+discovery/tool_search when that host surface exists. If it remains hidden, call
+it a plugin MCP visibility failure. Do not use CLI as CodeStory grounding; use
+ordinary source inspection and report that live MCP tools were not visible.
 
 ## Task Router
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -70,7 +70,7 @@ function releaseAssetForPlatform(version) {
 }
 
 async function writeFakeCli(cliPath) {
-  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
@@ -431,6 +431,8 @@ test("mcp launcher uses active project state when host launches from plugin root
         "  args,",
         "  projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '',",
         "  projectRootSource: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE || '',",
+        "  launchCwd: process.env.CODESTORY_PLUGIN_LAUNCH_CWD || '',",
+        "  runtimeCwd: process.env.CODESTORY_PLUGIN_RUNTIME_CWD || '',",
         "  dirtyMarkerPath: process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH || '',",
         "  dirtyMarkerRoot: process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT || ''",
         "}) + '\\n');",
@@ -478,8 +480,14 @@ test("mcp launcher uses active project state when host launches from plugin root
     assert.equal(serve.cwd, realRepoRoot);
     assert.equal(serve.projectRoot, realRepoRoot);
     assert.equal(serve.projectRootSource, "plugin_active_state");
+    assert.equal(serve.launchCwd, pluginRoot);
+    assert.notEqual(serve.runtimeCwd, pluginRoot);
+    assert.match(serve.runtimeCwd, /runtime-cwd/u);
     assert.equal(serve.dirtyMarkerRoot, realRepoRoot);
     assert.equal(serve.dirtyMarkerPath, dirtyMarkerPathForProject(realRepoRoot, dataDir));
+    const runtimeState = JSON.parse(await readFile(join(dataDir, ".codestory-mcp-runtime.json"), "utf8"));
+    assert.equal(runtimeState.launchCwd, pluginRoot);
+    assert.equal(runtimeState.runtimeCwd, serve.runtimeCwd);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1084,10 +1092,12 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
     assert.equal(status.readiness[0].status, "repair_setup");
     assert.equal(status.readiness[0].repair_reason, "managed_cli_unavailable");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
+    assert.doesNotMatch(JSON.stringify(status.recommended_next_calls), /"tool":"repair_all"/u);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
-    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["repair_all", "sidecar_setup"]);
+    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["sidecar_setup"]);
     assert.equal(responses[3].error.code, -32602);
     assert.match(responses[3].error.message, /grounding tools are unavailable/u);
+    assert.match(responses[3].error.message, /restore a compatible stdio runtime/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1207,6 +1217,7 @@ test("mcp launcher fails open when CODESTORY_CLI override cannot spawn", async (
     assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
     assert.equal(status.readiness[0].repair_reason, "local_dev_override_cli_unspawnable");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
+    assert.doesNotMatch(JSON.stringify(status.recommended_next_calls), /"tool":"repair_all"/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1268,6 +1279,7 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
       status.plugin_runtime.plugin_version,
       version,
     );
+    assert.doesNotMatch(JSON.stringify(status.recommended_next_calls), /"tool":"repair_all"/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -2507,6 +2519,7 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   assert.match(context, /bridge_resource_uri: codestory:\/\/status/u);
   assert.match(context, /hook_bridge_status: ready/u);
   assert.match(context, /hook_bridge_allowed_surfaces: local_navigation/u);
+  assert.match(context, /deferred discovery\/tool_search/u);
   assert.match(context, /mcp_tools_visible: no/u);
   assert.doesNotMatch(context, /codestory-cli ENOENT/u);
   assert.doesNotMatch(context, /attempted request packet/u);


### PR DESCRIPTION
## Context

Promotes `dev/codestory-next` to `main` for the CodeStory `0.13.2` patch release.

This release carries the Codex MCP startup lifecycle fix from #835 / #834 and the final marketplace prompt polish from #837:
- long-lived MCP wrapper processes move out of the installed plugin cache before serving;
- stale active CLI runtimes block `repair_all` instead of running repair through the old executable;
- JS diagnostic fail-open no longer owns a duplicate `repair_all` contract;
- Codex hook/skill/docs tell agents to request host deferred discovery/tool_search when MCP is configured but model-hidden;
- Codex marketplace prompt examples no longer teach users to start with explicit `@CodeStory` tags;
- all CodeStory crates and plugin manifests are bumped to `0.13.2` so Codex gets a distinct plugin/runtime cache version.

## What Changed

- Promotes the current `dev/codestory-next` merge commit `b6f32c04` to `main`.
- Includes synchronized `0.13.2` release surfaces across workspace crates, Cargo.lock, and plugin manifests.
- Includes the startup lifecycle behavior and docs changes reviewed in #835.
- Includes the Codex plugin default prompt cleanup reviewed in #837.

## How To Review

1. Confirm this PR is exactly `origin/dev/codestory-next...origin/main` promotion content.
2. Review #835 for the implementation diff and focused review trail.
3. Review #837 for the marketplace-facing prompt metadata cleanup.
4. Confirm `0.13.2` is synchronized and release automation will create the tag/release from `main` after merge.

## Verification

From #835 / #837 before merge to `dev/codestory-next`:

- `node --check plugins/codestory/scripts/codestory-mcp.cjs`
- `node --check plugins/codestory/hooks/codestory-activate.cjs`
- `cargo fmt --check`
- `git diff --check`
- `python .github/scripts/check-codestory-release.py --version 0.13.2`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` - 46/46 passing
- `cargo test -p codestory-cli --test stdio_protocol_contracts active_cli_is_stale -- --nocapture` - 2/2 passing
- GitHub checks on #835: docs links, plugin static, linux contracts, rustdoc, workspace cargo checks, and issue-link guard all passed.
- GitHub checks on #837: plugin static and issue-link guard passed.

## Risk

This release still cannot force Codex to include plugin MCP tools in the model's initial tool set. It makes CodeStory's side of the boundary correct, removes prompt guidance that trained explicit tagging, and gives Codex a fresh `0.13.2` package/runtime version to install. After merge, release asset proof and marketplace update still need to be verified before calling the user-facing fix complete.
