### PR TITLE
Polish Codex plugin fresh-thread prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Windows dogfooding of the 0.13.1 release.
 - Updated Codex hook and user guidance for model-hidden plugin MCP sessions to
   request host deferred discovery/tool_search when available instead of
   treating reload as the first repair step.
+- Removed explicit `@CodeStory` tags from Codex marketplace prompt examples so
+  the installed plugin advertises natural fresh-thread usage.
 
 ## 0.13.1
 

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"
   },
-  "homepage": "https://github.com/TheGreenCedar/CodeStory/tree/dev/codestory-next/plugins/codestory",
+  "homepage": "https://github.com/TheGreenCedar/CodeStory/tree/main/plugins/codestory",
   "repository": "https://github.com/TheGreenCedar/CodeStory",
   "license": "Apache-2.0",
   "keywords": ["codestory", "codex", "grounding", "mcp", "local"],
@@ -24,9 +24,9 @@
     "privacyPolicyURL": "https://github.com/TheGreenCedar/CodeStory",
     "termsOfServiceURL": "https://github.com/TheGreenCedar/CodeStory",
     "defaultPrompt": [
-      "@CodeStory Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]?",
-      "@CodeStory I am editing a file in this repo. What symbols are affected and what tests should I run first?",
-      "@CodeStory Read codestory://status, ground this checkout if allowed, and report which surfaces are ready."
+      "Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]?",
+      "I am editing a file in this repo. What symbols are affected and what tests should I run first?",
+      "Read codestory://status, ground this checkout if allowed, and report which surfaces are ready."
     ],
     "brandColor": "#2563EB",
     "screenshots": []


### PR DESCRIPTION
## Context

The 0.13.2 release candidate removes startup friction around the CodeStory Codex plugin. One remaining marketplace-facing detail still suggested users should begin with explicit \@CodeStory\ tags even though the intended Codex path is natural fresh-thread use.

## What Changed

- Removed explicit \@CodeStory\ tags from the Codex plugin default prompt examples.
- Pointed the Codex plugin homepage at the main-branch plugin source.
- Recorded the prompt cleanup in the 0.13.2 changelog.

## How To Review

- Check \plugins/codestory/.codex-plugin/plugin.json\ for the marketplace prompt examples and homepage URL.
- Check \CHANGELOG.md\ under 0.13.2 for the release note.

## Verification

- \
ode --test plugins/codestory/tests/plugin-static.test.mjs\`n- \python .github/scripts/check-codestory-release.py --version 0.13.2\`n- \git diff --check\`n
## Risk

Low. This changes Codex plugin metadata only; it does not change launcher or Rust runtime behavior.

Closes #834