### PR TITLE
[codex] Fix first-turn CodeStory plugin grounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## 0.13.3
+
+CodeStory 0.13.3 fixes first-turn Codex plugin startup truth after the 0.13.2
+Windows dogfood run.
+
+### Fixed
+
+- Tightened Codex startup guidance so model-hidden CodeStory MCP sessions make
+  host deferred discovery/tool_search the first repository-work action before
+  manual source reads, keeping the hook bridge as a last-resort status label.
+- Made hook bootstrap status ask the managed Rust runtime for the shared-agent
+  readiness lane, so hook-bridged `runtime_truth` reports packet/search as
+  `full` when `ready --goal agent` proves the sidecar instead of fabricating an
+  unavailable agent lane from local/default status.
+- Made retrieval bootstrap force-recreate CodeStory-owned Docker sidecars once
+  when post-start health probes still fail, covering stale Windows Docker port
+  proxies where containers are up but Zoekt is unreachable from the host.
+
 ## 0.13.2
 
 CodeStory 0.13.2 fixes Codex plugin startup lifecycle failures found during

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -135,7 +135,7 @@ pub fn bootstrap_sidecars_with_runtime_progress(
 
     let compose_started = if let Some(path) = resolved_compose.as_ref() {
         with_bootstrap_progress(&mut progress, "container startup", || {
-            docker_compose_up(path, repo_root, runtime, launch_mode)
+            docker_compose_up(path, repo_root, runtime, launch_mode, false)
         })?;
         true
     } else {
@@ -154,11 +154,29 @@ pub fn bootstrap_sidecars_with_runtime_progress(
             .as_ref()
             .map(|launch| embedding_launch_metadata(launch, runtime, repo_root)),
     )?;
-    if !wait_timeout.is_zero() {
-        let _ = with_bootstrap_progress(&mut progress, "model/bootstrap", || {
+
+    let infrastructure = if !wait_timeout.is_zero() {
+        with_bootstrap_progress(&mut progress, "model/bootstrap", || {
             wait_for_infrastructure(&layout, wait_timeout)
+        })?
+    } else {
+        probe_infrastructure_health(&layout)
+    };
+
+    if compose_started
+        && !infrastructure_ready(&infrastructure)
+        && let Some(path) = resolved_compose.as_ref()
+    {
+        with_bootstrap_progress(&mut progress, "container refresh", || {
+            docker_compose_up(path, repo_root, runtime, launch_mode, true)
         })?;
+        if !wait_timeout.is_zero() {
+            let _ = with_bootstrap_progress(&mut progress, "model/bootstrap", || {
+                wait_for_infrastructure(&layout, wait_timeout)
+            })?;
+        }
     }
+
     let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
     let infrastructure = crate::health::probe_infrastructure_health_with_embedding_device(
         &layout,
@@ -172,6 +190,10 @@ pub fn bootstrap_sidecars_with_runtime_progress(
         compose_file: resolved_compose,
         storage_repair,
     })
+}
+
+fn infrastructure_ready(health: &InfrastructureHealth) -> bool {
+    health.zoekt_reachable && health.qdrant_reachable && health.embed_reachable
 }
 
 fn with_bootstrap_progress<T>(
@@ -253,6 +275,7 @@ fn docker_compose_up(
     repo_root: Option<&Path>,
     runtime: &SidecarRuntimeConfig,
     launch_mode: EmbeddingServerLaunchMode,
+    force_recreate: bool,
 ) -> Result<()> {
     let layout = &runtime.layout;
     if !docker_available() {
@@ -297,9 +320,11 @@ fn docker_compose_up(
     if let Some(override_file) = vulkan_override.as_ref() {
         command.arg("-f").arg(override_file);
     }
+    command.arg("up").arg("-d");
+    if force_recreate {
+        command.arg("--force-recreate");
+    }
     command
-        .arg("up")
-        .arg("-d")
         .current_dir(workdir)
         .env(
             "CODESTORY_QDRANT_DATA_DIR",

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -31,6 +31,7 @@ const EVENT_CAPS = {
 const RUNTIME_TIMEOUT_MS = 3500;
 const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
 const BOOTSTRAP_TAXONOMIES = new Set(['startup', 'clear', 'child_worktree_start', 'session']);
+const DEFERRED_DISCOVERY_NEXT = 'Next: if mcp__codestory is not already visible and tool_search is available, use host deferred discovery/tool_search first: make tool_search query "codestory mcp ground status packet search" the first repository-work tool action, then use the loaded CodeStory MCP tools before manual source reads. Use the hook bridge only if deferred discovery is unavailable or fails. Reload only after plugin install or config changes. Do not treat non-MCP runtime probes as grounding.';
 
 function readHookInput() {
   return new Promise((resolve) => {
@@ -160,7 +161,7 @@ function shortDegradedNotice(mcp, reason, state = {}) {
       'CodeStory setup blocked: MCP is configured and launchable, but resources are not model-visible.',
       `First failing layer: ${firstRuntimeFailure(mcp)}.`,
       reason ? `Reason: ${truncate(reason, 600)}` : null,
-      'Request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use the hook MCP bridge when present. Reload only after plugin install or config changes. Do not use ambient CodeStory CLI discovery as grounding.',
+      DEFERRED_DISCOVERY_NEXT,
     ].filter(Boolean).join('\n');
   }
   const hook = state.hook || {};
@@ -180,7 +181,7 @@ function runtimeStatusBlock(policy, mcp) {
     `dedupe_key: ${policy.dedupeKey}`,
     mcpDetectionText(mcp),
     mcp.mcp_model_visible_blocked
-      ? 'Next: request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use the hook MCP bridge when present. Reload only after plugin install or config changes. Do not use ambient CodeStory CLI discovery as grounding.'
+      ? DEFERRED_DISCOVERY_NEXT
       : mcp.mcp_resources_exposed
       ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
       : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
@@ -248,10 +249,18 @@ function readinessEvidence(parsed) {
   };
 }
 
+function bootstrapAgentReadinessReady(bootstrap) {
+  const status = bootstrap?.parsed || {};
+  return status.runtime_truth?.readiness_lanes?.agent_packet_search?.status === 'ready'
+    || status.readiness_lanes?.agent_packet_search?.status === 'ready'
+    || (Array.isArray(status.readiness)
+      && status.readiness.some((verdict) => verdict?.goal === 'agent_packet_search' && verdict?.status === 'ready'));
+}
+
 function bridgeAllowedSurfaces(bootstrap, readiness) {
   const surfaces = [];
   if (bootstrap?.ready) surfaces.push('local_navigation');
-  if (readiness?.ready) surfaces.push('agent_packet_search');
+  if (readiness?.ready || bootstrapAgentReadinessReady(bootstrap)) surfaces.push('agent_packet_search');
   return surfaces.length > 0 ? surfaces.join(',') : 'status_only';
 }
 
@@ -297,7 +306,7 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason) {
     reason ? `hook_bridge_reason: ${truncate(reason, 500)}` : null,
     'mcp_resources_exposed: mcp_resources_not_model_visible',
     'mcp_tools_visible: no',
-    'hook_bridge_next: request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use this bounded bridge status and report that live MCP tools are hidden.',
+    `hook_bridge_next: ${DEFERRED_DISCOVERY_NEXT}`,
   ].filter(Boolean).join('\n');
 }
 
@@ -557,7 +566,7 @@ function runCodeStory(input, event, policy, state = {}) {
         mcpDetectionText(mcp),
         mcp.mcp_resources_exposed
           ? 'Use codestory://status as the active runtime truth. Run packet/search/context only when status allows that surface with retrieval_mode=full.'
-          : 'CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. Request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use hook-bridged status and report that live MCP tools are hidden.',
+          : `CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. ${DEFERRED_DISCOVERY_NEXT}`,
       ].join('\n'), policy.cap),
       fingerprint: `${runtimeFingerprint(mcp)}|${bootstrapBlock || 'no-bootstrap'}`,
     };

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -3,13 +3,14 @@ const path = require('path');
 
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'codestory-grounding', 'SKILL.md');
 const MAX_PROMPT_CHARS = 600;
+const DEFERRED_DISCOVERY_TEXT = 'If mcp__codestory is not already visible and tool_search is available, use host deferred discovery/tool_search first: your first tool action for repository work must be tool_search with query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools before manual source reads.';
 
 const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 
 Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, read codestory://status first. If MCP is configured but resources are not model-visible, request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use the hook bridge when present and report that live MCP tools are hidden.
+2. If the CodeStory MCP server is live, read codestory://status first. ${DEFERRED_DISCOVERY_TEXT} Use the hook bridge only when deferred discovery is unavailable or fails, and report that live MCP tools are hidden.
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
@@ -38,6 +39,7 @@ function eventHeader(event, input = {}) {
       'CODESTORY REQUEST GROUNDING ACTIVE',
       '',
       'Use CodeStory before source files for this user prompt.',
+      DEFERRED_DISCOVERY_TEXT,
       prompt ? `Prompt: ${prompt}` : 'Prompt: unavailable from hook input.',
       '',
     ].join('\n');
@@ -48,6 +50,7 @@ function eventHeader(event, input = {}) {
     `CODESTORY SESSION GROUNDING ACTIVE${source}`,
     '',
     'Keep CodeStory ambient in this session. Before source reads, claims, edits, reviews, or test choices, check CodeStory status and use allowed grounding surfaces first.',
+    DEFERRED_DISCOVERY_TEXT,
     '',
   ].join('\n');
 }
@@ -59,7 +62,7 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, request CodeStory MCP through host deferred discovery/tool_search when available; otherwise use hook-bridged status when present and report that live MCP tools are hidden. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
+Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, ${DEFERRED_DISCOVERY_TEXT} Use hook-bridged status only when deferred discovery is unavailable or fails, and report that live MCP tools are hidden. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -304,7 +304,36 @@ function dirtyMarkerEnv(projectRoot = launchCwd) {
   };
 }
 
+function runtimeLaneFromReadiness(lanes, name, fallback) {
+  const lane = lanes && typeof lanes === 'object' ? lanes[name] : null;
+  if (!lane || typeof lane !== 'object') return fallback;
+  return {
+    ...fallback,
+    ...lane,
+    sidecar_mode: lane.sidecar_mode || lane.mode || fallback.sidecar_mode,
+    degraded_reason: Object.hasOwn(lane, 'degraded_reason')
+      ? lane.degraded_reason
+      : fallback.degraded_reason,
+  };
+}
+
 function runtimeTruthStatus(plugin, repair, options = {}) {
+  const fallbackAgentLane = {
+    status: 'unavailable',
+    profile: 'agent',
+    run_id: 'unavailable',
+    sidecar_mode: 'unavailable',
+    degraded_reason: options.degradedReason || repair.repair_reason || null,
+  };
+  const fallbackLocalLane = {
+    status: 'unavailable',
+    profile: 'local',
+    sidecar_mode: 'unavailable',
+    degraded_reason: 'unavailable',
+  };
+  const readinessLanes = options.readinessLanes || null;
+  const agentLane = runtimeLaneFromReadiness(readinessLanes, 'agent_packet_search', fallbackAgentLane);
+  const localLane = runtimeLaneFromReadiness(readinessLanes, 'local_default', fallbackLocalLane);
   return {
     runtime_source: plugin.cli_source || 'unavailable',
     plugin_root: plugin.plugin_root || null,
@@ -312,10 +341,12 @@ function runtimeTruthStatus(plugin, repair, options = {}) {
     launcher_source: plugin.cli_source || 'unavailable',
     sidecar_policy: options.sidecarPolicy || 'unavailable',
     sidecar_status: {
-      profile: 'agent',
-      run_id: 'unavailable',
-      mode: 'unavailable',
-      degraded_reason: options.degradedReason || repair.repair_reason || null,
+      profile: agentLane.profile || 'agent',
+      run_id: agentLane.run_id || 'unavailable',
+      mode: agentLane.sidecar_mode || 'unavailable',
+      degraded_reason: agentLane.degraded_reason || null,
+      namespace: agentLane.namespace || null,
+      phase: agentLane.phase || null,
     },
     readiness_lanes: {
       local_graph: {
@@ -323,19 +354,8 @@ function runtimeTruthStatus(plugin, repair, options = {}) {
         refresh_state: options.localRefresh?.state || 'unavailable',
         blocks_local_surfaces: options.localRefresh?.blocks_local_surfaces ?? null,
       },
-      local_default: {
-        status: 'unavailable',
-        profile: 'local',
-        sidecar_mode: 'unavailable',
-        degraded_reason: 'unavailable',
-      },
-      agent_packet_search: {
-        status: 'unavailable',
-        profile: 'agent',
-        run_id: 'unavailable',
-        sidecar_mode: 'unavailable',
-        degraded_reason: options.degradedReason || repair.repair_reason || null,
-      },
+      local_default: localLane,
+      agent_packet_search: agentLane,
     },
   };
 }
@@ -704,6 +724,19 @@ function runLocalNavigationWaitFresh(resolved, projectRoot) {
   return { args, result };
 }
 
+function runAgentReadiness(resolved, projectRoot) {
+  const args = ['ready', '--goal', 'agent'];
+  args.push('--project', projectRoot, '--format', 'json');
+  const result = spawnSync(resolved.path, args, {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    timeout: localWaitFreshTimeoutMs(),
+    windowsHide: true,
+  });
+  return { args, result };
+}
+
 function localReadySetup(prefix, args, result) {
   return {
     [`${prefix}_args`]: args,
@@ -733,6 +766,30 @@ function parseLocalReadyResult(result) {
     invalidJson: null,
     verdict,
     localRefresh: parsed.local_refresh || null,
+  };
+}
+
+function parseAgentReadinessResult(result) {
+  let parsed;
+  try {
+    parsed = JSON.parse(result.stdout || '{}');
+  } catch (error) {
+    return {
+      ok: false,
+      invalidJson: error.message,
+      parsed: null,
+      verdict: null,
+    };
+  }
+  const verdict = Array.isArray(parsed.verdicts)
+    ? parsed.verdicts.find((item) => item && item.goal === 'agent_packet_search') || null
+    : null;
+  const lane = parsed.readiness_lanes?.agent_packet_search || null;
+  return {
+    ok: Boolean((verdict && verdict.status === 'ready') || (lane && lane.status === 'ready')),
+    invalidJson: null,
+    parsed,
+    verdict,
   };
 }
 
@@ -821,6 +878,32 @@ function probeLocalNavigation(resolved, projectRoot = process.cwd()) {
     verdict,
     parsedProbe.localRefresh || null,
   );
+}
+
+function probeAgentReadiness(resolved, projectRoot = process.cwd()) {
+  const probe = runAgentReadiness(resolved, projectRoot);
+  const setup = {
+    ...localReadySetup('agent_readiness', probe.args, probe.result),
+  };
+  if (probe.result.error || probe.result.status !== 0) {
+    return {
+      ready: false,
+      setup,
+      parsed: null,
+      verdict: null,
+      reason: probe.result.error
+        ? probe.result.error.message
+        : `agent_readiness_failed:${probe.result.status}`,
+    };
+  }
+  const parsedProbe = parseAgentReadinessResult(probe.result);
+  return {
+    ready: parsedProbe.ok,
+    setup,
+    parsed: parsedProbe.parsed,
+    verdict: parsedProbe.verdict,
+    reason: parsedProbe.invalidJson ? `agent_readiness_invalid_json:${parsedProbe.invalidJson}` : null,
+  };
 }
 
 function pluginRuntimeForResolved(resolved) {
@@ -985,6 +1068,7 @@ async function bootstrapStatus(projectRoot = launchCwd) {
 
   const sidecarPolicy = readSidecarPolicy();
   const plugin = pluginRuntimeForResolved(resolved);
+  const agentReadiness = probeAgentReadiness(resolved, projectRoot);
   const localRefresh = localReadiness.localRefresh || {
     state: 'fresh',
     blocks_local_surfaces: false,
@@ -1001,8 +1085,13 @@ async function bootstrapStatus(projectRoot = launchCwd) {
     setup: {
       ...localReadiness.setup,
       readiness_verdict: localReadiness.verdict,
+      ...agentReadiness.setup,
+      agent_readiness_verdict: agentReadiness.verdict,
+      agent_readiness_reason: agentReadiness.reason,
     },
   };
+  const readiness = [repair];
+  if (agentReadiness.verdict) readiness.push(agentReadiness.verdict);
   return {
     ready: true,
     project_root: projectRoot,
@@ -1013,9 +1102,11 @@ async function bootstrapStatus(projectRoot = launchCwd) {
     runtime_truth: runtimeTruthStatus(plugin, repair, {
       sidecarPolicy: sidecarPolicy.state || 'unavailable',
       localRefresh,
+      readinessLanes: agentReadiness.parsed?.readiness_lanes || null,
     }),
     local_refresh: localRefresh,
-    readiness: [repair],
+    readiness,
+    readiness_lanes: agentReadiness.parsed?.readiness_lanes || null,
     recommended_next_calls: [{ method: 'resources/read', uri: 'codestory://status' }],
   };
 }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -968,6 +968,67 @@ test("bootstrap-status fails open when plugin-root launch lacks project state", 
   }
 });
 
+test("bootstrap-status carries Rust agent readiness into runtime truth", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-bootstrap-agent-ready-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-bootstrap-agent-ready-bin-"));
+  const logFile = join(dataDir, "calls.jsonl");
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliPath = await writeNodeCli(
+    binDir,
+    [
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify(args) + '\\n');",
+      "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+      "if (args[0] === 'ready' && args.includes('--goal') && args.includes('local')) {",
+      "  console.log(JSON.stringify({ verdicts: [{ goal: 'local_navigation', status: 'ready', summary: 'ready', minimum_next: [], full_repair: [] }], local_refresh: { state: 'fresh', reason: 'already_fresh', blocks_local_surfaces: false, readiness_status: 'ready', changed_file_count: 0, new_file_count: 0, removed_file_count: 0, fatal_error_count: 0 } }));",
+      "  process.exit(0);",
+      "}",
+      "if (args[0] === 'ready' && args.includes('--goal') && args.includes('agent')) {",
+      "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status: 'ready', summary: 'agent ready', minimum_next: [], full_repair: [] }], readiness_lanes: { agent_packet_search: { status: 'ready', profile: 'agent', run_id: 'shared-agent', sidecar_mode: 'full', next_command: 'codestory-cli retrieval status --profile agent --run-id shared-agent --format json' }, local_default: { status: 'repair_retrieval', profile: 'local', sidecar_mode: 'unavailable', degraded_reason: 'zoekt_unreachable' } } }));",
+      "  process.exit(0);",
+      "}",
+      "process.exit(2);",
+    ].join("\n"),
+  );
+
+  try {
+    const result = spawnSync(process.execPath, [launcher, "bootstrap-status", "--project", dataDir], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+      },
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const status = JSON.parse(result.stdout.trim());
+    assert.equal(status.ready, true);
+    assert.equal(status.runtime_truth.sidecar_status.mode, "full");
+    assert.equal(status.runtime_truth.sidecar_status.run_id, "shared-agent");
+    assert.equal(status.runtime_truth.readiness_lanes.agent_packet_search.status, "ready");
+    assert.equal(status.readiness_lanes.agent_packet_search.status, "ready");
+    assert.equal(status.readiness.some((verdict) => verdict.goal === "agent_packet_search" && verdict.status === "ready"), true);
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((args) => args.slice(0, 3)), [
+      ["--version"],
+      ["ready", "--goal", "local"],
+      ["ready", "--goal", "agent"],
+    ]);
+    assert.equal(calls.some((args) => args.includes("--repair")), false);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  }
+});
+
 test("mcp launcher infers Codex managed data from installed cache without env", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
@@ -2318,8 +2379,8 @@ test("hook goal heartbeat bridges model-hidden MCP without live tools", async ()
 
     assert.equal(Object.hasOwn(output, "hookSpecificOutput"), false);
     const markerText = await readFile(marker, "utf8");
-    assert.match(markerText, /ready --goal local --wait-fresh/u);
-    assert.doesNotMatch(markerText, /--goal agent/u);
+    assert.match(markerText, /ready --goal agent/u);
+    assert.doesNotMatch(markerText, /--repair/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -2520,6 +2581,8 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   assert.match(context, /hook_bridge_status: ready/u);
   assert.match(context, /hook_bridge_allowed_surfaces: local_navigation/u);
   assert.match(context, /deferred discovery\/tool_search/u);
+  assert.match(context, /first repository-work tool action/u);
+  assert.match(context, /codestory mcp ground status packet search/u);
   assert.match(context, /mcp_tools_visible: no/u);
   assert.doesNotMatch(context, /codestory-cli ENOENT/u);
   assert.doesNotMatch(context, /attempted request packet/u);


### PR DESCRIPTION
## Context

Fresh Codex sessions were still fragile after 0.13.2: CodeStory MCP could be configured and launchable, but hidden from the model until deferred discovery, and the hook bridge reported agent packet/search from a JS-local unavailable skeleton instead of Rust's shared-agent readiness lane. Separately, Windows Docker could leave CodeStory-owned sidecar containers running while the host Zoekt port was dead, blocking sidecar manifest repair.

Closes #838

## What Changed

- Added the `0.13.3` release bump across all `codestory-*` crates, `Cargo.lock`, and Codex/Claude/GitHub plugin manifests.
- Made hook bootstrap status call the managed Rust runtime for `ready --goal agent` and carry the resulting `agent_packet_search` lane into hook `runtime_truth`.
- Tightened hook instructions so hidden-MCP Codex sessions use host deferred discovery/tool_search first, with the hook bridge labeled as hook-bridged context rather than live MCP tools.
- Made retrieval bootstrap force-recreate CodeStory-owned Docker sidecars once when post-start infrastructure health stays unreachable, covering stale Windows host-port proxy state.
- Added static plugin coverage for Rust-owned agent readiness in bootstrap `runtime_truth` and no hook-side repair during hidden-MCP heartbeat.

## How To Review

1. Start with `plugins/codestory/scripts/codestory-mcp.cjs`: bootstrap-status still proves local navigation first, then copies Rust's agent readiness lane instead of fabricating agent status.
2. Review `plugins/codestory/hooks/codestory-activate.cjs` and `plugins/codestory/hooks/codestory-instructions.cjs` for first-turn guidance and hook-bridge labeling.
3. Review `crates/codestory-retrieval/src/compose.rs` for the one-shot `docker compose up -d --force-recreate` path after failed infrastructure health.
4. Confirm the release bump in `CHANGELOG.md`, Cargo metadata, lockfile, and plugin manifests.

## Verification

- `node --test plugins\\codestory\\tests\\plugin-static.test.mjs`
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p codestory-cli`
- `cargo check -p codestory-retrieval`
- `cargo test -p codestory-retrieval`
- `cargo test -p codestory-cli --test stdio_protocol_contracts`
- `python .github\\scripts\\check-codestory-release.py --version 0.13.3`
- Source repair proof: `cargo run -p codestory-cli -- ready --goal agent --repair --project C:\\Users\\alber\\source\\repos\\codestory --format json --run-id shared-agent` returned `agent_packet_search=ready`, `retrieval_mode=full`, `embedding_accelerator_request_provider=vulkan`, `embedding_accelerator_request_device=Vulkan0`.
- Source wrapper proof: `node plugins\\codestory\\scripts\\codestory-mcp.cjs bootstrap-status --project C:\\Users\\alber\\source\\repos\\codestory` with `CODESTORY_CLI=target\\debug\\codestory-cli.exe` returned `runtime_truth.sidecar_status.mode=full`, `run_id=shared-agent`, and `agent_packet_search.status=ready`.

## Risk

- CodeStory still cannot force Codex to expose `mcp__codestory` in the initial model-visible tool list; this PR routes first-turn repository work through Codex deferred discovery/tool_search and reports hook bridge context truthfully when live MCP tools remain hidden.
- The force-recreate path is intentionally limited to CodeStory-owned compose sidecars and only runs after the first post-start infrastructure probe fails.
