### PR TITLE
Release CodeStory 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 0.13.4
+
+CodeStory 0.13.4 fixes the remaining first-turn Codex hook bridge failure found
+after the 0.13.3 release proof.
+
+### Fixed
+
+- Stopped hidden-MCP startup hooks from injecting `ground` output, which could
+  report local symbolic retrieval and mask the repaired agent sidecar state.
+- Made hidden-MCP prompt hooks call the managed Rust `packet` path directly
+  instead of rerunning a duplicate short-timeout `ready --goal agent` probe.
+- Extended the hook packet timeout to cover the measured Rust packet path while
+  preserving fast status-only startup when Codex still hides live MCP tools.
+
 ## 0.13.3
 
 CodeStory 0.13.3 fixes first-turn Codex plugin startup truth after the 0.13.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -29,6 +29,7 @@ const EVENT_CAPS = {
   session: 3000,
 };
 const RUNTIME_TIMEOUT_MS = 3500;
+const PACKET_TIMEOUT_MS = 15000;
 const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
 const BOOTSTRAP_TAXONOMIES = new Set(['startup', 'clear', 'child_worktree_start', 'session']);
 const DEFERRED_DISCOVERY_NEXT = 'Next: if mcp__codestory is not already visible and tool_search is available, use host deferred discovery/tool_search first: make tool_search query "codestory mcp ground status packet search" the first repository-work tool action, then use the loaded CodeStory MCP tools before manual source reads. Use the hook bridge only if deferred discovery is unavailable or fails. Reload only after plugin install or config changes. Do not treat non-MCP runtime probes as grounding.';
@@ -257,17 +258,42 @@ function bootstrapAgentReadinessReady(bootstrap) {
       && status.readiness.some((verdict) => verdict?.goal === 'agent_packet_search' && verdict?.status === 'ready'));
 }
 
-function bridgeAllowedSurfaces(bootstrap, readiness) {
+function readinessFromBootstrap(bootstrap) {
+  if (!bootstrap?.parsed) return null;
+  const status = bootstrap.parsed;
+  const verdicts = Array.isArray(status.readiness) ? status.readiness : [];
+  const evidence = readinessEvidence({
+    ...status,
+    verdicts,
+  });
+  const ready = bootstrapAgentReadinessReady(bootstrap);
+  return {
+    ready,
+    reason: ready ? null : 'agent_packet_search readiness is not ready',
+    evidence: evidence.text,
+    fingerprint: `bootstrap-readiness:${evidence.fingerprint}`,
+  };
+}
+
+function bridgeAllowedSurfaces(bootstrap, readiness, commandResult) {
   const surfaces = [];
   if (bootstrap?.ready) surfaces.push('local_navigation');
-  if (readiness?.ready || bootstrapAgentReadinessReady(bootstrap)) surfaces.push('agent_packet_search');
+  if (readiness?.ready || bootstrapAgentReadinessReady(bootstrap) || commandResult?.kind === 'request packet') {
+    surfaces.push('agent_packet_search');
+  }
   return surfaces.length > 0 ? surfaces.join(',') : 'status_only';
 }
 
-function bridgeBootstrapForPolicy(policy, mcp, bootstrap) {
+function bridgeBootstrapForPolicy(policy, mcp, bootstrap, command) {
   if (bootstrap?.attempted) return bootstrap;
   if (!policy.project || !mcp.mcp_process_launchable) {
     return { attempted: false, reason: 'mcp_launcher_unavailable' };
+  }
+  if (command?.kind === 'session ground' && mcp.managed_cli_present) {
+    return { attempted: false, reason: 'hidden_mcp_session_ground_disabled' };
+  }
+  if (command?.kind === 'request packet' && mcp.managed_cli_present) {
+    return { attempted: false, reason: 'managed_runtime_available' };
   }
   if (!mcp.managed_cli_present && !BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) {
     return { attempted: false, reason: 'managed_runtime_not_present' };
@@ -279,13 +305,22 @@ function managedHookCli(mcp) {
   return process.env.CODESTORY_CLI || mcp.managed_cli_path || null;
 }
 
-function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason) {
+function bridgeRuntimeStatus(bootstrap, commandResult, mcp) {
+  if (bootstrap?.ready || commandResult?.ok) return 'ready';
+  if (mcp.managed_cli_present) return 'runtime_available';
+  return 'blocked';
+}
+
+function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, commandResult) {
   const status = bootstrap?.parsed || {};
   const plugin = status.plugin_runtime || {};
   const localRefresh = status.local_refresh || status.readiness?.[0]?.local_refresh || {};
+  const bootstrapReason = ['managed_runtime_available', 'hidden_mcp_session_ground_disabled'].includes(bootstrap?.reason)
+    ? null
+    : bootstrap?.reason;
   const reason = status.degraded_reason
     || status.readiness?.[0]?.repair_reason
-    || bootstrap?.reason
+    || bootstrapReason
     || bootstrap?.error
     || bootstrap?.stderr;
   return [
@@ -296,11 +331,11 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason) {
     `output_cap_chars: ${policy.cap}`,
     `dedupe_key: ${policy.dedupeKey}`,
     mcpDetectionText(mcp),
-    `hook_bridge_status: ${bootstrap?.ready ? 'ready' : 'blocked'}`,
+    `hook_bridge_status: ${bridgeRuntimeStatus(bootstrap, commandResult, mcp)}`,
     `hook_bridge_cli_source: ${plugin.cli_source || (process.env.CODESTORY_CLI ? 'local_dev_override' : mcp.managed_cli_source) || '<unknown>'}`,
     plugin.managed_binary_path ? `hook_bridge_managed_cli_path: ${plugin.managed_binary_path}` : null,
     `hook_bridge_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
-    `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness)}`,
+    `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness, commandResult)}`,
     readiness ? readiness.evidence : null,
     commandReason ? `hook_bridge_context: ${commandReason}` : null,
     reason ? `hook_bridge_reason: ${truncate(reason, 500)}` : null,
@@ -310,11 +345,17 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason) {
   ].filter(Boolean).join('\n');
 }
 
+function managedHookCommandTimeoutMs(command) {
+  if (command?.kind !== 'request packet') return RUNTIME_TIMEOUT_MS;
+  const parsed = Number.parseInt(process.env.CODESTORY_HOOK_PACKET_TIMEOUT_MS || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : PACKET_TIMEOUT_MS;
+}
+
 function runManagedHookCommand(cli, command, cwd) {
   const result = spawnSync(cli, command.args, {
     cwd,
     encoding: 'utf8',
-    timeout: RUNTIME_TIMEOUT_MS,
+    timeout: managedHookCommandTimeoutMs(command),
     maxBuffer: MAX_OUTPUT_CHARS * 4,
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
     windowsHide: true,
@@ -322,6 +363,7 @@ function runManagedHookCommand(cli, command, cwd) {
   if (result.status === 0 && result.stdout.trim()) {
     return {
       ok: true,
+      kind: command.kind,
       output: truncate(result.stdout),
       fingerprint: `${command.kind}:${hashText(result.stdout)}`,
     };
@@ -337,7 +379,7 @@ function runManagedHookCommand(cli, command, cwd) {
 }
 
 function hookMcpBridge(input, policy, mcp, command, bootstrap) {
-  const bridgeBootstrap = bridgeBootstrapForPolicy(policy, mcp, bootstrap);
+  const bridgeBootstrap = bridgeBootstrapForPolicy(policy, mcp, bootstrap, command);
   const bridgedMcp = bridgeBootstrap.attempted ? classifyMcpRuntime() : mcp;
   const cli = managedHookCli(bridgedMcp);
   const cwd = input.cwd || process.cwd();
@@ -348,15 +390,13 @@ function hookMcpBridge(input, policy, mcp, command, bootstrap) {
   if (command && !cli) {
     commandReason = 'skipped_no_managed_cli';
   } else if (command?.kind === 'request packet') {
-    readiness = runReadinessProbe(cli, policy.project, cwd);
-    if (readiness.ready) {
-      commandResult = runManagedHookCommand(cli, command, cwd);
-      commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
-    } else {
-      commandReason = `skipped_${readiness.reason}`;
-    }
+    readiness = readinessFromBootstrap(bridgeBootstrap);
+    commandResult = runManagedHookCommand(cli, command, cwd);
+    commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
   } else if (command?.kind === 'session ground') {
-    if (bridgeBootstrap.ready) {
+    if (bridgedMcp.mcp_model_visible_blocked) {
+      commandReason = 'status_only_hidden_mcp_startup_ground_disabled';
+    } else if (bridgeBootstrap.ready) {
       commandResult = runManagedHookCommand(cli, command, cwd);
       commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
     } else {
@@ -364,7 +404,7 @@ function hookMcpBridge(input, policy, mcp, command, bootstrap) {
     }
   }
 
-  const bridge = bridgeStatusText(policy, bridgedMcp, bridgeBootstrap, readiness, commandReason);
+  const bridge = bridgeStatusText(policy, bridgedMcp, bridgeBootstrap, readiness, commandReason, commandResult);
   const commandBlock = commandResult?.ok
     ? [
       'CODESTORY HOOK MCP BRIDGE CONTEXT',

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -2538,9 +2538,20 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-no-resources-"));
   const version = await readPluginVersion();
   const cliDir = join(dataDir, "codestory-cli", version);
-  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const logFile = join(dataDir, "calls.jsonl");
   await mkdir(cliDir, { recursive: true });
-  await writeFakeCli(cliPath);
+  const cliPath = await writeNodeCli(
+    cliDir,
+    [
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify(args) + '\\n');",
+      "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+      "if (args[0] === 'packet') { console.log('packet ok from managed runtime'); process.exit(0); }",
+      "if (args[0] === 'ready') { process.exit(9); }",
+      "process.exit(2);",
+    ].join("\n"),
+  );
   await writeFile(
     join(cliDir, "manifest.json"),
     JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
@@ -2558,6 +2569,8 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
       COPILOT_PLUGIN_DATA: "",
       PLUGIN_DATA: dataDir,
       PATH: "",
+      TEST_CODESTORY_VERSION: version,
+      TEST_LOG: logFile,
     },
     input: JSON.stringify({
       hook_event_name: "UserPromptSubmit",
@@ -2579,14 +2592,18 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   assert.match(context, /bridge_context_label: hook-bridged context, not live MCP tools/u);
   assert.match(context, /bridge_resource_uri: codestory:\/\/status/u);
   assert.match(context, /hook_bridge_status: ready/u);
-  assert.match(context, /hook_bridge_allowed_surfaces: local_navigation/u);
+  assert.match(context, /hook_bridge_allowed_surfaces: agent_packet_search/u);
+  assert.match(context, /packet ok from managed runtime/u);
   assert.match(context, /deferred discovery\/tool_search/u);
   assert.match(context, /first repository-work tool action/u);
   assert.match(context, /codestory mcp ground status packet search/u);
   assert.match(context, /mcp_tools_visible: no/u);
   assert.doesNotMatch(context, /codestory-cli ENOENT/u);
-  assert.doesNotMatch(context, /attempted request packet/u);
+  assert.doesNotMatch(context, /agent_readiness_evidence: unavailable/u);
+  assert.doesNotMatch(context, /retrieval: symbolic/u);
   assert.doesNotMatch(context, /ambient CodeStory CLI discovery/u);
+  const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+  assert.deepEqual(calls.map((args) => args[0]), ["packet"]);
   await rm(dataDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Context

Promotes the 0.13.4 first-turn hook bridge fix from `dev/codestory-next` to `main` so release automation can publish the corrected plugin/runtime package.

Closes #838

## What Changed

- Carries the hidden-MCP hook bridge fix that stops startup `ground` from masking sidecar state and uses the managed Rust `packet` path for prompt context.
- Bumps all CodeStory crates, plugin manifests, `Cargo.lock`, and `CHANGELOG.md` to 0.13.4.

## How To Review

1. Review PR #841 for the implementation diff and CI history.
2. Confirm this PR is the dev-to-main promotion diff for 0.13.4.
3. After merge, verify the GitHub release and marketplace update before treating first-turn proof as complete.

## Verification

- PR #841 checks passed: plugin static tests, workspace cargo checks, deny rustdoc warnings, Linux sidecar contracts, saga issue guard.
- Local before #841: `node --test plugins\codestory\tests\plugin-static.test.mjs`, `python .github\scripts\check-codestory-release.py --version 0.13.4`, `node .github\scripts\check-workflow-policy.mjs`, `git diff --check`, `cargo check -p codestory-cli`.

## Risk

- Codex host MCP initial visibility remains host-controlled; 0.13.4 fixes the hook bridge fallback and does not claim live MCP tools are visible when Codex hides them.
- Post-publish proof still needs to install 0.13.4 through the marketplace and run a fresh Codex hook proof.