### PR TITLE
Release CodeStory 0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.13.5
+
+CodeStory 0.13.5 makes first-turn Codex hook bridge proof explicit enough for
+fresh threads to distinguish runtime readiness from packet sufficiency.
+
+### Fixed
+
+- Added Rust-owned retrieval-status evidence to the hidden-MCP hook bridge after
+  a packet succeeds, so the visible bridge reports `agent_packet_search=ready`,
+  sidecar mode, and the Vulkan accelerator request without duplicating Rust
+  readiness logic in the hook.
+
 ## 0.13.4
 
 CodeStory 0.13.4 fixes the remaining first-turn Codex hook bridge failure found

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -30,6 +30,7 @@ const EVENT_CAPS = {
 };
 const RUNTIME_TIMEOUT_MS = 3500;
 const PACKET_TIMEOUT_MS = 15000;
+const SHARED_AGENT_RUN_ID = 'shared-agent';
 const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
 const BOOTSTRAP_TAXONOMIES = new Set(['startup', 'clear', 'child_worktree_start', 'session']);
 const DEFERRED_DISCOVERY_NEXT = 'Next: if mcp__codestory is not already visible and tool_search is available, use host deferred discovery/tool_search first: make tool_search query "codestory mcp ground status packet search" the first repository-work tool action, then use the loaded CodeStory MCP tools before manual source reads. Use the hook bridge only if deferred discovery is unavailable or fails. Reload only after plugin install or config changes. Do not treat non-MCP runtime probes as grounding.';
@@ -311,7 +312,71 @@ function bridgeRuntimeStatus(bootstrap, commandResult, mcp) {
   return 'blocked';
 }
 
-function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, commandResult) {
+function parseHookJson(text) {
+  try {
+    return JSON.parse(String(text || ''));
+  } catch (_) {
+    return null;
+  }
+}
+
+function packetRetrievalMode(commandResult) {
+  if (commandResult?.kind !== 'request packet' || !commandResult?.output) return null;
+  const packet = parseHookJson(commandResult.output);
+  const trace = packet?.retrieval_trace_summary?.retrieval_trace;
+  return trace?.retrieval_shadow?.retrieval_mode
+    || trace?.packet_sidecar_diagnostics?.find((diagnostic) => diagnostic?.retrieval_mode)?.retrieval_mode
+    || null;
+}
+
+function bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult) {
+  const status = bootstrap?.parsed || {};
+  return status.runtime_truth?.readiness_lanes?.agent_packet_search?.status
+    || status.readiness_lanes?.agent_packet_search?.status
+    || (readiness?.ready ? 'ready' : null)
+    || (commandResult?.kind === 'request packet' && commandResult?.ok ? 'ready' : null)
+    || 'not_ready';
+}
+
+function sidecarFromBootstrap(bootstrap) {
+  const status = bootstrap?.parsed || {};
+  const verdictSidecar = Array.isArray(status.readiness)
+    ? status.readiness.find((verdict) => verdict?.goal === 'agent_packet_search')?.sidecar
+    : null;
+  return {
+    mode: status.runtime_truth?.sidecar_status?.mode
+      || status.runtime_truth?.readiness_lanes?.agent_packet_search?.sidecar_mode
+      || status.readiness_lanes?.agent_packet_search?.sidecar_mode
+      || verdictSidecar?.retrieval_mode
+      || null,
+    embedding: verdictSidecar || null,
+  };
+}
+
+function bridgeSidecarMode(bootstrap, commandResult, statusResult) {
+  return statusResult?.parsed?.retrieval_mode
+    || sidecarFromBootstrap(bootstrap).mode
+    || packetRetrievalMode(commandResult)
+    || 'not_reported';
+}
+
+function bridgeEmbeddingRequest(bootstrap, statusResult) {
+  const fromStatus = statusResult?.parsed || {};
+  const fromBootstrap = sidecarFromBootstrap(bootstrap).embedding || {};
+  const provider = fromStatus.embedding_accelerator_request_provider || fromBootstrap.embedding_accelerator_request_provider;
+  const device = fromStatus.embedding_accelerator_request_device || fromBootstrap.embedding_accelerator_request_device;
+  const state = fromStatus.embedding_device_state || fromBootstrap.embedding_device_state;
+  const cpuAllowed = fromStatus.embedding_cpu_allowed ?? fromBootstrap.embedding_cpu_allowed;
+  if (!provider && !device && !state) return 'not_reported';
+  return [
+    provider || 'unknown',
+    device ? `:${device}` : '',
+    state ? ` state=${state}` : '',
+    cpuAllowed !== undefined ? ` cpu_allowed=${cpuAllowed}` : '',
+  ].join('');
+}
+
+function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, commandResult, statusResult) {
   const status = bootstrap?.parsed || {};
   const plugin = status.plugin_runtime || {};
   const localRefresh = status.local_refresh || status.readiness?.[0]?.local_refresh || {};
@@ -335,6 +400,9 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, comm
     `hook_bridge_cli_source: ${plugin.cli_source || (process.env.CODESTORY_CLI ? 'local_dev_override' : mcp.managed_cli_source) || '<unknown>'}`,
     plugin.managed_binary_path ? `hook_bridge_managed_cli_path: ${plugin.managed_binary_path}` : null,
     `hook_bridge_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
+    `hook_bridge_agent_packet_search_status: ${bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult)}`,
+    `hook_bridge_sidecar_mode: ${bridgeSidecarMode(bootstrap, commandResult, statusResult)}`,
+    `hook_bridge_embedding_request: ${bridgeEmbeddingRequest(bootstrap, statusResult)}`,
     `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness, commandResult)}`,
     readiness ? readiness.evidence : null,
     commandReason ? `hook_bridge_context: ${commandReason}` : null,
@@ -378,6 +446,40 @@ function runManagedHookCommand(cli, command, cwd) {
   };
 }
 
+function runManagedStatusCommand(cli, project, cwd) {
+  if (!cli || !project) return null;
+  const result = spawnSync(cli, [
+    'retrieval',
+    'status',
+    '--project', project,
+    '--profile', 'agent',
+    '--run-id', SHARED_AGENT_RUN_ID,
+    '--format', 'json',
+  ], {
+    cwd,
+    encoding: 'utf8',
+    timeout: RUNTIME_TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT_CHARS * 4,
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
+    windowsHide: true,
+  });
+  if (result.status === 0 && result.stdout.trim()) {
+    return {
+      ok: true,
+      parsed: parseHookJson(result.stdout),
+      fingerprint: `retrieval-status:${hashText(result.stdout)}`,
+    };
+  }
+  const reason = result.error
+    ? result.error.message
+    : truncate(result.stderr || `retrieval status exited with status ${result.status} without usable output`);
+  return {
+    ok: false,
+    reason,
+    fingerprint: `retrieval-status:blocked:${hashText(reason)}`,
+  };
+}
+
 function hookMcpBridge(input, policy, mcp, command, bootstrap) {
   const bridgeBootstrap = bridgeBootstrapForPolicy(policy, mcp, bootstrap, command);
   const bridgedMcp = bridgeBootstrap.attempted ? classifyMcpRuntime() : mcp;
@@ -385,6 +487,7 @@ function hookMcpBridge(input, policy, mcp, command, bootstrap) {
   const cwd = input.cwd || process.cwd();
   let readiness = null;
   let commandResult = null;
+  let statusResult = null;
   let commandReason = command ? null : 'status_only';
 
   if (command && !cli) {
@@ -392,6 +495,9 @@ function hookMcpBridge(input, policy, mcp, command, bootstrap) {
   } else if (command?.kind === 'request packet') {
     readiness = readinessFromBootstrap(bridgeBootstrap);
     commandResult = runManagedHookCommand(cli, command, cwd);
+    if (commandResult.ok) {
+      statusResult = runManagedStatusCommand(cli, policy.project, cwd);
+    }
     commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
   } else if (command?.kind === 'session ground') {
     if (bridgedMcp.mcp_model_visible_blocked) {
@@ -404,7 +510,7 @@ function hookMcpBridge(input, policy, mcp, command, bootstrap) {
     }
   }
 
-  const bridge = bridgeStatusText(policy, bridgedMcp, bridgeBootstrap, readiness, commandReason, commandResult);
+  const bridge = bridgeStatusText(policy, bridgedMcp, bridgeBootstrap, readiness, commandReason, commandResult, statusResult);
   const commandBlock = commandResult?.ok
     ? [
       'CODESTORY HOOK MCP BRIDGE CONTEXT',
@@ -421,6 +527,7 @@ function hookMcpBridge(input, policy, mcp, command, bootstrap) {
       bridgeBootstrap.ready ? 'bridge-ready' : `bridge-blocked:${bridgeBootstrap.reason || 'status'}`,
       readiness?.fingerprint,
       commandResult?.fingerprint,
+      statusResult?.fingerprint,
       commandReason,
     ].filter(Boolean).join('|'),
   };

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -2548,6 +2548,7 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
       "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify(args) + '\\n');",
       "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
       "if (args[0] === 'packet') { console.log('packet ok from managed runtime'); process.exit(0); }",
+      "if (args[0] === 'retrieval' && args[1] === 'status') { console.log(JSON.stringify({ retrieval_mode: 'full', embedding_accelerator_request_provider: 'vulkan', embedding_accelerator_request_device: 'Vulkan0', embedding_device_state: 'accelerated', embedding_cpu_allowed: false })); process.exit(0); }",
       "if (args[0] === 'ready') { process.exit(9); }",
       "process.exit(2);",
     ].join("\n"),
@@ -2592,6 +2593,9 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   assert.match(context, /bridge_context_label: hook-bridged context, not live MCP tools/u);
   assert.match(context, /bridge_resource_uri: codestory:\/\/status/u);
   assert.match(context, /hook_bridge_status: ready/u);
+  assert.match(context, /hook_bridge_agent_packet_search_status: ready/u);
+  assert.match(context, /hook_bridge_sidecar_mode: full/u);
+  assert.match(context, /hook_bridge_embedding_request: vulkan:Vulkan0 state=accelerated cpu_allowed=false/u);
   assert.match(context, /hook_bridge_allowed_surfaces: agent_packet_search/u);
   assert.match(context, /packet ok from managed runtime/u);
   assert.match(context, /deferred discovery\/tool_search/u);
@@ -2603,7 +2607,9 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   assert.doesNotMatch(context, /retrieval: symbolic/u);
   assert.doesNotMatch(context, /ambient CodeStory CLI discovery/u);
   const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-  assert.deepEqual(calls.map((args) => args[0]), ["packet"]);
+  assert.deepEqual(calls.map((args) => args[0]), ["packet", "retrieval"]);
+  assert.deepEqual(calls[1].slice(0, 4), ["retrieval", "status", "--project", repoRoot]);
+  assert.match(calls[1].join(" "), /--run-id shared-agent/u);
   await rm(dataDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Context

Promotes the `0.13.5` first-turn hook bridge patch from `dev/codestory-next` to `main` so release automation publishes the fixed plugin and CLI assets.

Closes #843

## What Changed

- Carries the hidden-MCP hook bridge visible-readiness fix from #844.
- Publishes version `0.13.5` across CodeStory crates, plugin manifests, `Cargo.lock`, and `CHANGELOG.md`.

## How To Review

Review #844 for the implementation details. This PR should be a straight promotion from `dev/codestory-next` to `main`.

## Verification

On #844:
- `node --test plugins\codestory\tests\plugin-static.test.mjs`
- `python .github\scripts\check-codestory-release.py --version 0.13.5`
- `node .github\scripts\check-workflow-policy.mjs`
- `git diff --check`

CI on this promotion must pass before merge.

## Risk

This is a release promotion. After merge, verify release assets, restore `dev/codestory-next` if GitHub deletes it, update the marketplace release pointer, reinstall the plugin, and rerun fresh Codex hook proof.
