### PR TITLE
[codex] Fix startup hook bridge readiness proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.13.6
+
+CodeStory 0.13.6 makes the startup hook bridge use the same Rust-owned
+sidecar-status truth as prompt hooks.
+
+### Fixed
+
+- Made hidden-MCP startup, heartbeat, and prompt bridges use the Rust
+  `retrieval status` surface for existing agent sidecar truth, so a fresh Codex
+  thread sees `agent_packet_search=ready`, `sidecar_mode=full`, and the Vulkan
+  accelerator request before it can mistake startup status for a blocked packet.
+
 ## 0.13.5
 
 CodeStory 0.13.5 makes first-turn Codex hook bridge proof explicit enough for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -283,10 +283,11 @@ function statusResultAgentReady(statusResult) {
 function bridgeAllowedSurfaces(bootstrap, readiness, commandResult, statusResult) {
   const surfaces = [];
   if (bootstrap?.ready) surfaces.push('local_navigation');
-  if (readiness?.ready
-    || bootstrapAgentReadinessReady(bootstrap)
-    || statusResultAgentReady(statusResult)
-    || commandResult?.kind === 'request packet') {
+  const statusReady = statusResult ? statusResultAgentReady(statusResult) : null;
+  if (statusReady === true
+    || (statusReady === null && readiness?.ready)
+    || (statusReady === null && bootstrapAgentReadinessReady(bootstrap))
+    || (statusReady === null && commandResult?.kind === 'request packet')) {
     surfaces.push('agent_packet_search');
   }
   return surfaces.length > 0 ? surfaces.join(',') : 'status_only';
@@ -337,11 +338,13 @@ function packetRetrievalMode(commandResult) {
 }
 
 function bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult, statusResult) {
+  if (statusResult) {
+    return statusResultAgentReady(statusResult) ? 'ready' : 'not_ready';
+  }
   const status = bootstrap?.parsed || {};
   return status.runtime_truth?.readiness_lanes?.agent_packet_search?.status
     || status.readiness_lanes?.agent_packet_search?.status
     || (readiness?.ready ? 'ready' : null)
-    || (statusResultAgentReady(statusResult) ? 'ready' : null)
     || (commandResult?.kind === 'request packet' && commandResult?.ok ? 'ready' : null)
     || 'not_ready';
 }
@@ -395,7 +398,8 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, comm
     || status.readiness?.[0]?.repair_reason
     || bootstrapReason
     || bootstrap?.error
-    || bootstrap?.stderr;
+    || bootstrap?.stderr
+    || (statusResult?.ok === false ? statusResult.reason : null);
   return [
     'CODESTORY HOOK MCP BRIDGE',
     'bridge_context_label: hook-bridged context, not live MCP tools',
@@ -412,6 +416,7 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, comm
     `hook_bridge_sidecar_mode: ${bridgeSidecarMode(bootstrap, commandResult, statusResult)}`,
     `hook_bridge_embedding_request: ${bridgeEmbeddingRequest(bootstrap, statusResult)}`,
     `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness, commandResult, statusResult)}`,
+    statusResult?.ok === false ? `hook_bridge_status_reason: ${truncate(statusResult.reason, 500)}` : null,
     readiness ? readiness.evidence : null,
     commandReason ? `hook_bridge_context: ${commandReason}` : null,
     reason ? `hook_bridge_reason: ${truncate(reason, 500)}` : null,
@@ -582,6 +587,7 @@ function hookCommand(input, event, policy) {
         '--question', String(input.prompt),
         '--budget', 'tiny',
         '--refresh', 'none',
+        '--run-id', SHARED_AGENT_RUN_ID,
         '--latency-budget-ms', '1500',
       ],
       next: 'If CodeStory is unavailable, use bounded source reads in the target repo instead of repeated repair attempts.',

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -276,10 +276,17 @@ function readinessFromBootstrap(bootstrap) {
   };
 }
 
-function bridgeAllowedSurfaces(bootstrap, readiness, commandResult) {
+function statusResultAgentReady(statusResult) {
+  return statusResult?.parsed?.retrieval_mode === 'full';
+}
+
+function bridgeAllowedSurfaces(bootstrap, readiness, commandResult, statusResult) {
   const surfaces = [];
   if (bootstrap?.ready) surfaces.push('local_navigation');
-  if (readiness?.ready || bootstrapAgentReadinessReady(bootstrap) || commandResult?.kind === 'request packet') {
+  if (readiness?.ready
+    || bootstrapAgentReadinessReady(bootstrap)
+    || statusResultAgentReady(statusResult)
+    || commandResult?.kind === 'request packet') {
     surfaces.push('agent_packet_search');
   }
   return surfaces.length > 0 ? surfaces.join(',') : 'status_only';
@@ -329,11 +336,12 @@ function packetRetrievalMode(commandResult) {
     || null;
 }
 
-function bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult) {
+function bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult, statusResult) {
   const status = bootstrap?.parsed || {};
   return status.runtime_truth?.readiness_lanes?.agent_packet_search?.status
     || status.readiness_lanes?.agent_packet_search?.status
     || (readiness?.ready ? 'ready' : null)
+    || (statusResultAgentReady(statusResult) ? 'ready' : null)
     || (commandResult?.kind === 'request packet' && commandResult?.ok ? 'ready' : null)
     || 'not_ready';
 }
@@ -400,10 +408,10 @@ function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, comm
     `hook_bridge_cli_source: ${plugin.cli_source || (process.env.CODESTORY_CLI ? 'local_dev_override' : mcp.managed_cli_source) || '<unknown>'}`,
     plugin.managed_binary_path ? `hook_bridge_managed_cli_path: ${plugin.managed_binary_path}` : null,
     `hook_bridge_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
-    `hook_bridge_agent_packet_search_status: ${bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult)}`,
+    `hook_bridge_agent_packet_search_status: ${bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult, statusResult)}`,
     `hook_bridge_sidecar_mode: ${bridgeSidecarMode(bootstrap, commandResult, statusResult)}`,
     `hook_bridge_embedding_request: ${bridgeEmbeddingRequest(bootstrap, statusResult)}`,
-    `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness, commandResult)}`,
+    `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness, commandResult, statusResult)}`,
     readiness ? readiness.evidence : null,
     commandReason ? `hook_bridge_context: ${commandReason}` : null,
     reason ? `hook_bridge_reason: ${truncate(reason, 500)}` : null,
@@ -508,6 +516,9 @@ function hookMcpBridge(input, policy, mcp, command, bootstrap) {
     } else {
       commandReason = 'skipped_local_navigation_not_ready';
     }
+  }
+  if (!statusResult && bridgedMcp.mcp_model_visible_blocked && cli && policy.project) {
+    statusResult = runManagedStatusCommand(cli, policy.project, cwd);
   }
 
   const bridge = bridgeStatusText(policy, bridgedMcp, bridgeBootstrap, readiness, commandReason, commandResult, statusResult);

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -2638,8 +2638,76 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   assert.deepEqual(calls[0].slice(0, 4), ["retrieval", "status", "--project", repoRoot]);
   assert.deepEqual(calls[2].slice(0, 4), ["retrieval", "status", "--project", repoRoot]);
   assert.match(calls[0].join(" "), /--run-id shared-agent/u);
+  assert.match(calls[1].join(" "), /--run-id shared-agent/u);
   assert.match(calls[2].join(" "), /--run-id shared-agent/u);
   await rm(dataDir, { recursive: true, force: true });
+});
+
+test("hook bridge does not treat packet output as agent readiness without full status", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-status-not-full-"));
+  const version = await readPluginVersion();
+  const cliDir = join(dataDir, "codestory-cli", version);
+  const logFile = join(dataDir, "calls.jsonl");
+  await mkdir(cliDir, { recursive: true });
+  const cliPath = await writeNodeCli(
+    cliDir,
+    [
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify(args) + '\\n');",
+      "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+      "if (args[0] === 'packet') { console.log('packet ok from managed runtime'); process.exit(0); }",
+      "if (args[0] === 'retrieval' && args[1] === 'status') { console.log(JSON.stringify({ retrieval_mode: 'symbolic', degraded_reason: 'qdrant_unavailable' })); process.exit(0); }",
+      "if (args[0] === 'ready') { process.exit(9); }",
+      "process.exit(2);",
+    ].join("\n"),
+  );
+  await writeFile(
+    join(cliDir, "manifest.json"),
+    JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
+    "utf8",
+  );
+  await writeFile(
+    join(dataDir, ".codestory-mcp-runtime.json"),
+    JSON.stringify({ source: "managed", path: cliPath }),
+    "utf8",
+  );
+
+  try {
+    const result = spawnSync(process.execPath, [hookPath], {
+      env: {
+        ...process.env,
+        CODESTORY_MCP_RESOURCES_EXPOSED: "",
+        COPILOT_PLUGIN_DATA: "",
+        PLUGIN_DATA: dataDir,
+        PATH: "",
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+      },
+      input: JSON.stringify({
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Explain indexing flow.",
+        cwd: repoRoot,
+      }),
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
+    assert.match(context, /packet ok from managed runtime/u);
+    assert.match(context, /hook_bridge_agent_packet_search_status: not_ready/u);
+    assert.match(context, /hook_bridge_sidecar_mode: symbolic/u);
+    assert.match(context, /hook_bridge_allowed_surfaces: status_only/u);
+    assert.doesNotMatch(context, /hook_bridge_allowed_surfaces: agent_packet_search/u);
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((args) => args[0]), ["packet", "retrieval"]);
+    assert.match(calls[0].join(" "), /--run-id shared-agent/u);
+    assert.match(calls[1].join(" "), /--run-id shared-agent/u);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
 });
 
 test("portable agent adapters are present", async () => {

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -2379,7 +2379,8 @@ test("hook goal heartbeat bridges model-hidden MCP without live tools", async ()
 
     assert.equal(Object.hasOwn(output, "hookSpecificOutput"), false);
     const markerText = await readFile(marker, "utf8");
-    assert.match(markerText, /ready --goal agent/u);
+    assert.match(markerText, /retrieval status/u);
+    assert.match(markerText, /--run-id shared-agent/u);
     assert.doesNotMatch(markerText, /--repair/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
@@ -2563,6 +2564,32 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
     JSON.stringify({ source: "managed", path: cliPath }),
     "utf8",
   );
+  const startup = spawnSync(process.execPath, [hookPath], {
+    env: {
+      ...process.env,
+      CODESTORY_MCP_RESOURCES_EXPOSED: "",
+      COPILOT_PLUGIN_DATA: "",
+      PLUGIN_DATA: dataDir,
+      PATH: "",
+      TEST_CODESTORY_VERSION: version,
+      TEST_LOG: logFile,
+    },
+    input: JSON.stringify({
+      hook_event_name: "SessionStart",
+      source: "startup",
+      cwd: repoRoot,
+    }),
+    encoding: "utf8",
+  });
+
+  assert.equal(startup.status, 0, startup.stderr);
+  const startupContext = JSON.parse(startup.stdout).hookSpecificOutput.additionalContext;
+  assert.match(startupContext, /CODESTORY HOOK MCP BRIDGE/u);
+  assert.match(startupContext, /hook_bridge_agent_packet_search_status: ready/u);
+  assert.match(startupContext, /hook_bridge_sidecar_mode: full/u);
+  assert.match(startupContext, /hook_bridge_embedding_request: vulkan:Vulkan0 state=accelerated cpu_allowed=false/u);
+  assert.match(startupContext, /hook_bridge_allowed_surfaces: agent_packet_search/u);
+
   const result = spawnSync(process.execPath, [hookPath], {
     env: {
       ...process.env,
@@ -2607,9 +2634,11 @@ test("hook output bridges model-invisible MCP through managed runtime", async ()
   assert.doesNotMatch(context, /retrieval: symbolic/u);
   assert.doesNotMatch(context, /ambient CodeStory CLI discovery/u);
   const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-  assert.deepEqual(calls.map((args) => args[0]), ["packet", "retrieval"]);
-  assert.deepEqual(calls[1].slice(0, 4), ["retrieval", "status", "--project", repoRoot]);
-  assert.match(calls[1].join(" "), /--run-id shared-agent/u);
+  assert.deepEqual(calls.map((args) => args[0]), ["retrieval", "packet", "retrieval"]);
+  assert.deepEqual(calls[0].slice(0, 4), ["retrieval", "status", "--project", repoRoot]);
+  assert.deepEqual(calls[2].slice(0, 4), ["retrieval", "status", "--project", repoRoot]);
+  assert.match(calls[0].join(" "), /--run-id shared-agent/u);
+  assert.match(calls[2].join(" "), /--run-id shared-agent/u);
   await rm(dataDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Context
Fresh Codex proof after 0.13.5 still failed the first-turn bar because the model latched onto the startup hook bridge before prompt context. The startup bridge reported agent packet/search as `not_ready` and sidecar details as `not_reported`, even when the prepared agent sidecar was already full.

Closes #846

## What Changed
- Made hidden-MCP startup, heartbeat, and prompt bridges query the managed Rust CLI `retrieval status --profile agent --run-id shared-agent --format json` surface for sidecar truth.
- Mark `agent_packet_search` as an allowed bridge surface when Rust status reports full retrieval.
- Report `hook_bridge_agent_packet_search_status`, `hook_bridge_sidecar_mode`, and `hook_bridge_embedding_request` from that Rust-owned status instead of JS-side guesses.
- Bumped CodeStory crates, plugin manifests, `Cargo.lock`, and `CHANGELOG.md` to `0.13.6`.

## How To Review
1. Review `plugins/codestory/hooks/codestory-activate.cjs` around `hookMcpBridge`, `runManagedStatusCommand`, and bridge status rendering.
2. Review `plugins/codestory/tests/plugin-static.test.mjs` for the SessionStart regression case that used to show `not_ready` / `not_reported`.
3. Confirm the bridge still says `hook-bridged context, not live MCP tools` and keeps `mcp_tools_visible: no` when Codex hides live tools.

## Verification
- `node --test plugins/codestory/tests/plugin-static.test.mjs`
- `python .github/scripts/check-codestory-release.py --version 0.13.6`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`
- `git diff --cached --check`

## Risk
The hook now runs a short `retrieval status` probe for model-hidden MCP bridge output. If that probe fails or times out, the bridge reports missing/blocking status rather than fabricating readiness. Full release proof still requires installing the marketplace-updated plugin and running a fresh Codex start after merge.
