### PR TITLE
Release CodeStory 0.13.6

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -42,6 +42,27 @@ jobs:
           rustup toolchain install stable --profile minimal --component clippy --component rustfmt
           rustup default stable
 
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Cargo registry, git sources, and build output
+        id: cargo-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-rust-ci-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-rust-ci-stable-${{ steps.rust-cache-key.outputs.version }}-
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
+            ${{ runner.os }}-cargo-stable-
+
       - name: Check formatting
         run: cargo fmt --check
 
@@ -53,3 +74,14 @@ jobs:
 
       - name: Lint workspace
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Save Cargo registry, git sources, and build output
+        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+## 0.13.6
+
+CodeStory 0.13.6 fixes fresh Codex plugin MCP startup without the removed hook
+bridge, and hardens explicit sidecar repair so first-use threads can recover
+through the live MCP server.
+
+### Fixed
+
+- Removed the Codex hook bridge from the shipped plugin path. Codex hooks now
+  only record active project state and route agents back to live CodeStory MCP
+  resources; status reads can start Rust-owned sidecar repair without
+  hook-injected substitute grounding.
+- Kept the plugin MCP launcher alive in diagnostic fail-open mode when the
+  delegated `codestory-cli serve --stdio` runtime exits nonzero, so Codex gets a
+  `codestory://status` diagnostic instead of a closed transport.
+- Let the MCP launcher accept a fresh hook-written global active project even
+  when Codex gives the MCP process a stale thread id, fixing fresh app-server
+  threads that ran CodeStory hooks but still reported `project_root_unavailable`.
+- Let sidecar-backed search return resolved full-mode hits when a later
+  expansion stage reaches its deadline, matching the packet path instead of
+  rejecting otherwise usable MCP search results.
+- Let explicit MCP repair retry after an abandoned sidecar setup record and
+  return the foreground repair result instead of leaving the agent with only a
+  detached setup worker to poll.
+- Treat dead ready-repair owner processes as abandoned immediately so fresh MCP
+  repairs do not wait behind stale sidecar setup locks.
+- Let `codestory://status` start MCP-owned sidecar repair when plugin setup is
+  enabled and agent packet/search readiness is blocked, then recommend status
+  rereads instead of hidden tool calls.
+
 ## 0.13.5
 
 CodeStory 0.13.5 makes first-turn Codex hook bridge proof explicit enough for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ CodeStory 0.13.6 fixes fresh Codex plugin MCP startup without the removed hook
 bridge, and hardens explicit sidecar repair so first-use threads can recover
 through the live MCP server.
 
+### Changed
+
+- Added Cargo registry/source/build-output caching to the default Rust CI
+  workspace checks so promotion PRs can reuse the cache already seeded by
+  sidecar smoke jobs instead of recompiling the workspace from scratch.
+
 ### Fixed
 
 - Removed the Codex hook bridge from the shipped plugin path. Codex hooks now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -8,6 +8,8 @@ use std::collections::BTreeSet;
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
+#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
+use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const READY_REPAIR_STATUS_FILE: &str = "ready-repair-status.json";
@@ -285,6 +287,9 @@ fn ready_repair_status_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
 fn ready_repair_lock_file_is_stale(path: &Path) -> bool {
     let now = now_epoch_ms();
     if let Some(lock) = read_ready_repair_lock_file(path) {
+        if !ready_repair_pid_is_running(lock.pid) {
+            return true;
+        }
         return now.saturating_sub(lock.started_at_epoch_ms)
             > READY_REPAIR_LOCK_STALE_TTL.as_millis() as i64;
     }
@@ -316,6 +321,9 @@ fn read_ready_repair_status(
     if age_ms > READY_REPAIR_STATUS_TTL.as_millis() as i64 {
         return None;
     }
+    if !ready_repair_pid_is_running(status.pid) {
+        return None;
+    }
     Some(status)
 }
 
@@ -333,12 +341,59 @@ fn read_abandoned_ready_repair_status(
         return None;
     }
     let age_ms = now_epoch_ms.saturating_sub(status.updated_at_epoch_ms);
+    if !ready_repair_pid_is_running(status.pid) {
+        return Some(status);
+    }
     if age_ms <= READY_REPAIR_STATUS_TTL.as_millis() as i64
         || age_ms > READY_REPAIR_ABANDONED_STATUS_TTL.as_millis() as i64
     {
         return None;
     }
     Some(status)
+}
+
+fn ready_repair_pid_is_running(pid: u32) -> bool {
+    if pid == std::process::id() {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        let filter = format!("PID eq {pid}");
+        let output = Command::new("tasklist")
+            .args(["/FI", &filter, "/FO", "CSV", "/NH"])
+            .output();
+        let Ok(output) = output else {
+            return true;
+        };
+        let pid_text = pid.to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout.lines().any(|line| {
+            let mut fields = line.split(',').map(|field| field.trim().trim_matches('"'));
+            let _image = fields.next();
+            fields.next() == Some(pid_text.as_str())
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Path::new("/proc").join(pid.to_string()).exists()
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    {
+        Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(true)
+    }
+
+    #[cfg(not(any(windows, unix)))]
+    {
+        true
+    }
 }
 
 fn read_ready_repair_lock_file(path: &Path) -> Option<ReadyRepairLockFile> {
@@ -465,7 +520,7 @@ mod tests {
         let state = tempfile::tempdir().expect("state");
         let sidecar = test_sidecar(state.path());
         let started_at = now_epoch_ms();
-        let pid = 4242;
+        let pid = std::process::id();
 
         write_ready_repair_status(&sidecar, project.path(), "Qdrant finalize", started_at, pid)
             .expect("write repair status");
@@ -599,5 +654,71 @@ mod tests {
             None,
             "stale repair state must not mask final readiness"
         );
+    }
+
+    #[test]
+    fn dead_pid_repair_status_is_abandoned_immediately() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let path = ready_repair_status_path(&sidecar);
+        fs::create_dir_all(path.parent().expect("repair status parent")).expect("state dir");
+        let now = now_epoch_ms();
+        let dead_pid = u32::MAX;
+        let status = ReadyRepairStatus {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            status: "repairing".to_string(),
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: Some("test-proof".to_string()),
+            namespace: "codestory-agent-test-proof".to_string(),
+            compose_project: "codestory-agent-test-proof".to_string(),
+            phase: "graph artifact".to_string(),
+            pid: dead_pid,
+            started_at_epoch_ms: now,
+            updated_at_epoch_ms: now,
+        };
+        fs::write(&path, serde_json::to_string(&status).expect("status json"))
+            .expect("write dead-pid status");
+
+        assert_eq!(
+            read_ready_repair_status(&path, project.path(), now),
+            None,
+            "dead repair pid must not block a fresh MCP repair"
+        );
+        assert_eq!(
+            read_abandoned_ready_repair_status(&path, project.path(), now),
+            Some(status),
+            "dead repair pid should still be reported as abandoned evidence"
+        );
+    }
+
+    #[test]
+    fn dead_pid_repair_lock_is_reclaimable_immediately() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let path = ready_repair_lock_path(&sidecar);
+        fs::create_dir_all(path.parent().expect("repair lock parent")).expect("state dir");
+        let now = now_epoch_ms();
+        let lock = ReadyRepairLockFile {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: Some("test-proof".to_string()),
+            namespace: "codestory-agent-test-proof".to_string(),
+            pid: u32::MAX,
+            started_at_epoch_ms: now,
+            token: format!("{}:{now}", u32::MAX),
+        };
+        fs::write(&path, serde_json::to_string(&lock).expect("lock json"))
+            .expect("write dead-pid lock");
+
+        match try_acquire_ready_repair_lock(&sidecar, project.path()).expect("lock attempt") {
+            ReadyRepairLockAttempt::Acquired(_) => {}
+            ReadyRepairLockAttempt::Busy(busy) => {
+                panic!("dead-pid repair lock should be reclaimed, got busy at {busy:?}")
+            }
+        }
     }
 }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -849,7 +849,7 @@ fn handle_stdio_tool_call(
         "context" => handle_stdio_context(runtime, request),
         "repair_all" => {
             state.status_cache = None;
-            handle_stdio_sidecar_repair(runtime)
+            handle_stdio_sidecar_repair(runtime, StdioSidecarRepairMode::Foreground)
         }
         "sidecar_setup" => handle_stdio_sidecar_setup(runtime, state, request),
         _ => serde_json::json!({"error": "unknown tool"}),
@@ -2226,12 +2226,23 @@ fn read_stdio_status_resource_cached(
     let key = stdio_status_cache_key(runtime);
     let value = read_stdio_status_resource(runtime, summary, local_refresh)?;
     // ponytail: short stdio snapshot cache; source/storage/sidecar fingerprints bust it when state changes.
-    state.status_cache = Some(StdioStatusCacheEntry {
-        key,
-        value: value.clone(),
-        cached_at: Instant::now(),
-    });
+    if !stdio_status_auto_repair_in_progress(&value) {
+        state.status_cache = Some(StdioStatusCacheEntry {
+            key,
+            value: value.clone(),
+            cached_at: Instant::now(),
+        });
+    }
     Ok(value)
+}
+
+fn stdio_status_auto_repair_in_progress(value: &serde_json::Value) -> bool {
+    matches!(
+        value
+            .pointer("/status_resource_auto_repair/result/status")
+            .and_then(serde_json::Value::as_str),
+        Some("started" | "already_running")
+    )
 }
 
 fn wait_for_stdio_local_freshness(
@@ -2735,7 +2746,12 @@ fn read_stdio_status_resource(
             manifest_input_hash: selected_agent_sidecar.manifest_input_hash.as_deref(),
         }),
     });
-    let sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
+    let mut sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
+    let status_resource_auto_repair =
+        stdio_status_resource_auto_repair(runtime, &readiness, &sidecar_setup);
+    if status_resource_auto_repair.is_some() {
+        sidecar_setup = stdio_sidecar_setup_status(&runtime.project_root);
+    }
     let allowed_surfaces = stdio_allowed_surfaces(&readiness);
     let readiness_lanes = crate::build_readiness_lanes_for_runtime(
         runtime,
@@ -2745,7 +2761,12 @@ fn read_stdio_status_resource(
     );
     let readiness_lanes_json =
         serde_json::to_value(&readiness_lanes).expect("serialize readiness lanes");
-    let recommended_next_calls = stdio_status_recommended_next_calls(&readiness, &sidecar_setup);
+    let recommended_next_calls =
+        if stdio_status_auto_repair_result_in_progress(status_resource_auto_repair.as_ref()) {
+            stdio_status_repair_in_progress_next_calls()
+        } else {
+            stdio_status_recommended_next_calls(&readiness, &sidecar_setup)
+        };
     let local = readiness
         .iter()
         .find(|verdict| verdict.goal == ReadinessGoalDto::LocalNavigation)
@@ -2810,8 +2831,66 @@ fn read_stdio_status_resource(
         "readiness": readiness,
         "readiness_lanes": readiness_lanes_json,
         "allowed_surfaces": allowed_surfaces,
+        "status_resource_auto_repair": status_resource_auto_repair,
         "recommended_next_calls": recommended_next_calls
     }))
+}
+
+fn stdio_status_resource_auto_repair(
+    runtime: &RuntimeContext,
+    readiness: &[ReadinessVerdictDto],
+    sidecar_setup: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    if !stdio_status_auto_repair_enabled() {
+        return None;
+    }
+    if sidecar_setup
+        .get("state")
+        .and_then(serde_json::Value::as_str)
+        != Some("enabled")
+    {
+        return None;
+    }
+    if stdio_sidecar_setup_has_active_repair(sidecar_setup)
+        || stdio_sidecar_setup_has_abandoned_repair(sidecar_setup)
+    {
+        return None;
+    }
+    let non_ready = crate::readiness::primary_non_ready(readiness)?;
+    if non_ready.goal != ReadinessGoalDto::AgentPacketSearch {
+        return None;
+    }
+    if non_ready
+        .minimum_next
+        .iter()
+        .chain(non_ready.full_repair.iter())
+        .any(|command| command.starts_with("Restart/reload the Codex host/app"))
+    {
+        return None;
+    }
+    Some(handle_stdio_sidecar_repair(
+        runtime,
+        StdioSidecarRepairMode::Background,
+    ))
+}
+
+fn stdio_status_auto_repair_result_in_progress(value: Option<&serde_json::Value>) -> bool {
+    matches!(
+        value
+            .and_then(|value| value.pointer("/result/status"))
+            .and_then(serde_json::Value::as_str),
+        Some("started" | "already_running")
+    )
+}
+
+fn stdio_status_auto_repair_enabled() -> bool {
+    match env_nonempty("CODESTORY_STDIO_AUTO_REPAIR_ON_STATUS") {
+        Some(value) => !matches!(
+            value.to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        None => true,
+    }
 }
 
 fn stdio_runtime_truth_status(
@@ -3156,6 +3235,9 @@ fn stdio_status_recommended_next_calls(
 ) -> serde_json::Value {
     if let Some(non_ready) = crate::readiness::primary_non_ready(readiness) {
         if non_ready.goal == ReadinessGoalDto::AgentPacketSearch {
+            if stdio_sidecar_setup_has_active_repair(sidecar_setup) {
+                return stdio_status_repair_in_progress_next_calls();
+            }
             match sidecar_setup
                 .get("state")
                 .and_then(serde_json::Value::as_str)
@@ -3282,6 +3364,31 @@ fn stdio_status_recommended_next_calls(
             "uri": "codestory://trail/<node_id-from-search>"
         }
     ])
+}
+
+fn stdio_status_repair_in_progress_next_calls() -> serde_json::Value {
+    serde_json::json!([
+        {
+            "method": "resources/read",
+            "uri": "codestory://status"
+        },
+        {
+            "method": "resources/read",
+            "uri": "codestory://agent-guide"
+        }
+    ])
+}
+
+fn stdio_sidecar_setup_has_active_repair(sidecar_setup: &serde_json::Value) -> bool {
+    sidecar_setup
+        .get("active_repair")
+        .is_some_and(|value| !value.is_null())
+}
+
+fn stdio_sidecar_setup_has_abandoned_repair(sidecar_setup: &serde_json::Value) -> bool {
+    sidecar_setup
+        .get("abandoned_repair")
+        .is_some_and(|value| !value.is_null())
 }
 
 fn stdio_recommended_next_call(command: &str) -> serde_json::Value {
@@ -3514,7 +3621,7 @@ fn handle_stdio_sidecar_setup(
         },
         "repair" => {
             state.status_cache = None;
-            handle_stdio_sidecar_repair(runtime)
+            handle_stdio_sidecar_repair(runtime, StdioSidecarRepairMode::Foreground)
         }
         _ => {
             serde_json::json!({"error": "sidecar_setup.action must be status, enable, disable, ask, or repair"})
@@ -3556,7 +3663,16 @@ fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
     Ok(())
 }
 
-fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StdioSidecarRepairMode {
+    Background,
+    Foreground,
+}
+
+fn handle_stdio_sidecar_repair(
+    runtime: &RuntimeContext,
+    mode: StdioSidecarRepairMode,
+) -> serde_json::Value {
     if let Some(status) =
         crate::ready_repair_status::active_ready_repair_status(&runtime.project_root, None)
     {
@@ -3567,6 +3683,10 @@ fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
         return serde_json::json!({
             "result": {
                 "status": "already_running",
+                "mode": match mode {
+                    StdioSidecarRepairMode::Background => "background",
+                    StdioSidecarRepairMode::Foreground => "foreground",
+                },
                 "project_root": status.project_root,
                 "profile": status.profile,
                 "run_id": status.run_id,
@@ -3582,22 +3702,17 @@ fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
             }
         });
     }
-    if let Some(status) =
-        crate::ready_repair_status::abandoned_ready_repair_status(&runtime.project_root, None)
-    {
-        return serde_json::json!({
-            "result": {
-                "status": "abandoned_repair",
-                "abandoned_repair": stdio_ready_repair_status_json(&runtime.project_root, &status, "abandoned"),
-                "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
-            }
-        });
-    }
+    let previous_abandoned_repair =
+        crate::ready_repair_status::abandoned_ready_repair_status(&runtime.project_root, None).map(
+            |status| stdio_ready_repair_status_json(&runtime.project_root, &status, "abandoned"),
+        );
     let exe = match std::env::current_exe() {
         Ok(exe) => exe,
         Err(error) => return serde_json::json!({"error": error.to_string()}),
     };
-    let child = Command::new(exe)
+
+    let mut command = Command::new(&exe);
+    command
         .arg("ready")
         .arg("--goal")
         .arg("agent")
@@ -3609,27 +3724,119 @@ fn handle_stdio_sidecar_repair(runtime: &RuntimeContext) -> serde_json::Value {
         .arg("--run-id")
         .arg(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
         .env("CODESTORY_PLUGIN_SIDECAR_REPAIR", "1")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn();
-    match child {
-        Ok(child) => {
+        .stdin(Stdio::null());
+
+    match mode {
+        StdioSidecarRepairMode::Background => {
+            match command.stdout(Stdio::null()).stderr(Stdio::null()).spawn() {
+                Ok(child) => {
+                    serde_json::json!({
+                        "result": {
+                            "status": "started",
+                            "mode": "background",
+                            "pid": child.id(),
+                            "previous_abandoned_repair": previous_abandoned_repair,
+                            "next_status_command": format!(
+                                "codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}",
+                                crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                                codestory_retrieval::DEFAULT_AGENT_RUN_ID
+                            ),
+                            "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
+                        }
+                    })
+                }
+                Err(error) => serde_json::json!({"error": error.to_string()}),
+            }
+        }
+        StdioSidecarRepairMode::Foreground => {
+            let child = command.stdout(Stdio::null()).stderr(Stdio::null()).spawn();
+            let child = match child {
+                Ok(child) => child,
+                Err(error) => return serde_json::json!({"error": error.to_string()}),
+            };
+            let pid = child.id();
+            let repair_status = match child.wait_with_output() {
+                Ok(output) => output.status,
+                Err(error) => return serde_json::json!({"error": error.to_string()}),
+            };
+            let ready_output = Command::new(&exe)
+                .arg("ready")
+                .arg("--goal")
+                .arg("agent")
+                .arg("--project")
+                .arg(&runtime.project_root)
+                .arg("--format")
+                .arg("json")
+                .arg("--run-id")
+                .arg(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+                .env("CODESTORY_PLUGIN_SIDECAR_REPAIR", "1")
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output();
+            let (ready_status_code, parsed_ready, ready_json_found, stdout_tail, stderr_tail) =
+                match ready_output {
+                    Ok(output) => {
+                        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                        let parsed_ready = stdio_parse_trailing_json_object(&stdout);
+                        let ready_json_found = parsed_ready.is_some();
+                        (
+                            output.status.code(),
+                            parsed_ready,
+                            ready_json_found,
+                            stdio_tail_text(&stdout, 4000),
+                            stdio_tail_text(&stderr, 4000),
+                        )
+                    }
+                    Err(error) => (
+                        None,
+                        None,
+                        false,
+                        String::new(),
+                        format!("failed to run readiness probe after repair: {error}"),
+                    ),
+                };
             serde_json::json!({
                 "result": {
-                    "status": "started",
-                    "pid": child.id(),
-                    "next_status_command": format!(
-                        "codestory-cli retrieval status --project \"{}\" --profile agent --run-id {}",
-                        crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
-                        codestory_retrieval::DEFAULT_AGENT_RUN_ID
-                    ),
+                    "status": if repair_status.success() { "completed" } else { "failed" },
+                    "mode": "foreground",
+                    "pid": pid,
+                    "exit_code": repair_status.code(),
+                    "repair_output_captured": false,
+                    "ready_probe_exit_code": ready_status_code,
+                    "ready": parsed_ready,
+                    "ready_json_found": ready_json_found,
+                    "previous_abandoned_repair": previous_abandoned_repair,
+                    "stdout_tail": stdout_tail,
+                    "stderr_tail": stderr_tail,
                     "sidecar_setup": stdio_sidecar_setup_status(&runtime.project_root)
                 }
             })
         }
-        Err(error) => serde_json::json!({"error": error.to_string()}),
     }
+}
+
+fn stdio_parse_trailing_json_object(text: &str) -> Option<serde_json::Value> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(value) = serde_json::from_str(trimmed) {
+        return Some(value);
+    }
+    for (index, _) in trimmed.match_indices('{').rev() {
+        if let Ok(value) = serde_json::from_str(&trimmed[index..]) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn stdio_tail_text(text: &str, max_chars: usize) -> String {
+    let mut chars: Vec<char> = text.chars().rev().take(max_chars).collect();
+    chars.reverse();
+    chars.into_iter().collect()
 }
 
 fn env_nonempty(name: &str) -> Option<String> {
@@ -4136,6 +4343,27 @@ version = "0.11.20"
             "version probe should return near the configured timeout"
         );
         let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn stdio_parse_trailing_json_object_skips_progress_logs() {
+        let output = r#"
+refreshing graph artifacts
+starting sidecar setup
+{
+  "status": "ready",
+  "summary": "resolved { enough context }",
+  "readiness": [
+    {"goal": "agent_packet_search", "status": "ready"}
+  ]
+}
+"#;
+
+        let parsed = stdio_parse_trailing_json_object(output)
+            .unwrap_or_else(|| panic!("expected trailing JSON object: {output}"));
+
+        assert_eq!(parsed["status"], json!("ready"));
+        assert_eq!(parsed["readiness"][0]["goal"], json!("agent_packet_search"));
     }
 
     #[test]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -786,7 +786,7 @@ fn write_repair_status_fixture(
             "namespace": sidecar.namespace,
             "compose_project": sidecar.compose_project,
             "phase": phase,
-            "pid": 4242,
+            "pid": std::process::id(),
             "started_at_epoch_ms": updated_at_epoch_ms,
             "updated_at_epoch_ms": updated_at_epoch_ms
         })
@@ -2592,25 +2592,10 @@ fn resources_read_status_reports_abandoned_agent_repair_actions() {
         "abandoned repair should include an explicit cleanup command: {status}"
     );
 
-    let repair_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-repair-abandoned",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "repair"}
-            }
-        }),
-    );
-    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair-abandoned"));
-    assert_eq!(repair["status"], json!("abandoned_repair"), "{repair}");
-    assert_eq!(
-        repair["abandoned_repair"]["cleanup_command"],
-        status["sidecar_setup"]["abandoned_repair"]["cleanup_command"],
-        "{repair}"
-    );
+    // The explicit MCP repair action retries past abandoned records. Do not call
+    // it from this contract test: it intentionally launches a real repair
+    // worker, which belongs in the live MCP proof lane rather than the cheap
+    // status-shape suite.
 }
 
 #[test]
@@ -2656,7 +2641,7 @@ fn resources_read_status_prompts_before_sidecar_repair_when_policy_is_ask() {
 }
 
 #[test]
-fn resources_read_status_recommends_sidecar_repair_when_policy_enabled() {
+fn resources_read_status_starts_sidecar_repair_when_policy_enabled() {
     let mut fixture = indexed_fixture();
     fixture.sidecar_policy_state = Some("enabled".to_string());
     let mut server = spawn_stdio_server(&fixture);
@@ -2685,14 +2670,24 @@ fn resources_read_status_recommends_sidecar_repair_when_policy_enabled() {
     );
     let next_call_text = status["recommended_next_calls"].to_string();
     assert!(
-        next_call_text.contains("\"tool\":\"repair_all\"")
-            && next_call_text.contains("\"debug_commands\"")
-            && next_call_text.contains("\"uri\":\"codestory://status\""),
-        "enabled policy should route agent repair through one MCP repair tool plus status readback: {status}"
+        status["status_resource_auto_repair"]["result"]["status"] == json!("started")
+            || status["status_resource_auto_repair"]["result"]["status"]
+                == json!("already_running"),
+        "enabled policy should start MCP-owned auto repair from the status resource: {status}"
     );
     assert!(
-        next_call_text.contains("--run-id") && next_call_text.contains("shared-agent"),
-        "enabled policy should point at the shared agent run id: {status}"
+        status["status_resource_auto_repair"]["result"]["next_status_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("--run-id")
+                && command.contains("shared-agent")
+                && command.contains("retrieval status")),
+        "status-started repair should point at shared-agent status readback: {status}"
+    );
+    assert!(
+        next_call_text.contains("\"uri\":\"codestory://status\"")
+            && next_call_text.contains("\"uri\":\"codestory://agent-guide\"")
+            && !next_call_text.contains("\"tool\":\"repair_all\""),
+        "enabled policy should recommend rereading status after status-started repair: {status}"
     );
     assert!(
         !next_call_text.contains("\"method\":\"cli\""),
@@ -2800,11 +2795,18 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
         json!("enabled"),
         "{status}"
     );
+    let next_call_text = status["recommended_next_calls"].to_string();
     assert!(
-        status["recommended_next_calls"]
-            .to_string()
-            .contains("\"tool\":\"repair_all\""),
-        "status should keep recovery on the single MCP repair tool after sidecar_setup enable: {status}"
+        status["status_resource_auto_repair"]["result"]["status"] == json!("started")
+            || status["status_resource_auto_repair"]["result"]["status"]
+                == json!("already_running"),
+        "status should start Rust-owned repair after sidecar_setup enable: {status}"
+    );
+    assert!(
+        next_call_text.contains("\"uri\":\"codestory://status\"")
+            && next_call_text.contains("\"uri\":\"codestory://agent-guide\"")
+            && !next_call_text.contains("\"tool\":\"repair_all\""),
+        "status should recommend status reread after status-started repair: {status}"
     );
 }
 

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -521,7 +521,7 @@ fn sidecar_primary_search_outcome_from_query_result(
         &resolved_hits,
     );
 
-    if let Some(reason) = packet_primary_result_rejection_reason(&query_result, &resolved_hits) {
+    if let Some(reason) = sidecar_primary_result_rejection_reason(&query_result, &resolved_hits) {
         let diagnostic = sidecar_rejection_diagnostic(controller, &query_result, &resolved_hits, 5);
         let reason = format!("{reason}; {diagnostic}");
         return SidecarPrimarySearchOutcome::Rejected { shadow, reason };
@@ -547,7 +547,7 @@ fn sidecar_primary_search_outcome_from_query_result(
     }
 }
 
-fn packet_primary_result_rejection_reason(
+pub(crate) fn sidecar_primary_result_rejection_reason(
     query_result: &QueryResult,
     resolved_hits: &[SearchHit],
 ) -> Option<String> {

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -8831,7 +8831,7 @@ impl AppController {
                     ),
                 )
             })?;
-        if let Some(reason) = agent::retrieval_primary::sidecar_result_rejection_reason(
+        if let Some(reason) = agent::retrieval_primary::sidecar_primary_result_rejection_reason(
             &query_result,
             &indexed_symbol_hits,
         ) {

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2024"
 
 [dependencies]

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -1,18 +1,19 @@
 # Codex
 
-Use CodeStory in Codex with the full plugin path: MCP auto-start, lifecycle
-hooks, the grounding skill, and managed CLI bootstrap.
+Use CodeStory in Codex with the plugin MCP path: MCP auto-start, lightweight
+repo-state hooks, the grounding skill, and managed CLI bootstrap. Hooks route
+the agent back to live MCP; they do not inject substitute grounding context.
 
 ## What you get
 
 | You | Agent |
 | --- | --- |
 | Install the plugin once from `/plugins` | MCP starts via `scripts/codestory-mcp.cjs` |
-| Open your repo and start a fresh thread | Hooks ground on session start; request-aware packets on prompts |
+| Open your repo and start a fresh thread | Records the repo target, then reads live CodeStory MCP resources before source reads |
 | Ask repo questions with concrete terms | Reads `codestory://status`, uses allowed surfaces, cites sources |
 
-Codex is the reference host: MCP, hooks, skill, and managed CLI bootstrap all
-ship together. See [capability matrix](README.md#capability-matrix).
+Codex is the reference host for the managed MCP plugin path. See
+[capability matrix](README.md#capability-matrix).
 
 Surfaces and readiness: [Glossary](../glossary.md).
 
@@ -61,9 +62,9 @@ Run these three checks before your first real task:
 
 1. **Adapter present** — Open `/plugins` and confirm **TheGreenCedar -> codestory**
    is listed as installed.
-2. **MCP and hooks live** — Start a **new** Codex thread in the grounded repo.
-   CodeStory MCP should start automatically and session hooks should run without
-   blocking the host.
+2. **MCP live** — Start a **new** Codex thread in the grounded repo. CodeStory
+   MCP should be registered by the plugin and start when Codex reads its status
+   or tools.
 3. **First status read succeeds** — Use a normal repository question or the
    readiness probe in [First session](#first-session). The agent should answer
    in plain English whether your repo map is ready and whether broad search is
@@ -134,11 +135,12 @@ More pairs, anti-patterns, and language-flavored examples:
 
 | Symptom | What to try |
 | --- | --- |
-| Hook says `mcp_resources_not_model_visible` | Let the agent request CodeStory MCP through host deferred discovery/tool_search when available; reload only after plugin install or config changes |
+| No `codestory://status` resource is visible | Reload only after plugin install or config changes, then start a fresh thread from the target repo |
+| `codestory://status` is visible but `mcp__codestory` tools are hidden | Use the live resource path. If `status_resource_auto_repair` starts, reread status until repair finishes; otherwise report that tool actions are blocked by host visibility |
 | Status shows `repair_setup` | Let the agent follow `recommended_next_calls` from status; restart host if binary was updated |
 | Terminal refresh says `Access is denied` | Quit stale Codex windows running the old plugin, then refresh from `/plugins` or rerun `codex plugin add codestory@TheGreenCedar` |
-| Packet/search blocked | Agent can call `sidecar_setup`; see [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
-| Hooks time out | Hooks fail open; ask the explicit status prompt above |
+| Packet/search blocked | Reread `codestory://status` after any `status_resource_auto_repair`; if tools are visible, follow `recommended_next_calls`; see [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
+| Status/grounding read times out | Restart stale CodeStory MCP processes, then read `codestory://status` in a fresh thread |
 
 Shared repair lanes: [Troubleshooting](troubleshooting.md).
 
@@ -150,8 +152,9 @@ node plugins/codestory/hooks/codestory-dirty-hook.cjs install --project <repo> -
 
 ## Limitations
 
-None relative to other hosts -- Codex ships the full adapter set. Other hosts
-may lack auto MCP start, full hooks, or managed CLI bootstrap; compare
+None relative to other hosts -- Codex ships the managed MCP adapter and
+repo-state hook path. Other hosts may lack auto MCP start, hooks, or managed CLI
+bootstrap; compare
 [capability matrix](README.md#capability-matrix).
 
 Plugin package details: [Plugin README](../../plugins/codestory/README.md).

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -168,7 +168,7 @@ Symptoms: skill or rule loads but no `codestory://status` or `mcp__codestory` to
 
 | Host | Check |
 | --- | --- |
-| Codex | If hook status says `mcp_resources_not_model_visible`, request CodeStory MCP through host deferred discovery/tool_search when available. Reload only after plugin install/config changes; see [Codex guide](codex.md#troubleshooting) |
+| Codex | Read `codestory://status` through live MCP resources. If `status_resource_auto_repair` starts, reread status until the repair finishes. If resources are visible but `mcp__codestory` tools are hidden and status did not start repair, report the host tool-visibility blocker; reload only after plugin install/config changes; see [Codex guide](codex.md#troubleshooting) |
 | Cursor | MCP config path to `plugins/codestory/scripts/codestory-mcp.cjs`; reload server |
 | Claude Code | MCP configured separately; hooks alone do not expose tools |
 | Copilot | MCP not auto-started; configure manually or use CLI |

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -1,62 +1,32 @@
 #!/usr/bin/env node
 
-const { spawnSync } = require('child_process');
 const { createHash } = require('crypto');
-const { eventHeader, getCodeStoryInstructions } = require('./codestory-instructions.cjs');
+const { eventHeader } = require('./codestory-instructions.cjs');
 const {
-  bootstrapManagedRuntime,
-  classifyMcpRuntime,
-  dirtyMarkerPathForProject,
-  mcpDetectionText,
-  readActiveState,
   readHookState,
   rememberActiveState,
-  writeDirtyMarker,
-  writeHookState,
   writeHookOutput,
+  writeHookState,
 } = require('./codestory-runtime.cjs');
 
-const MAX_OUTPUT_CHARS = 4000;
 const EVENT_CAPS = {
-  startup: 4000,
-  clear: 4000,
-  child_worktree_start: 4000,
-  user_prompt: 4000,
-  resume: 2200,
-  compact: 2200,
-  handoff: 2200,
-  goal_heartbeat: 1400,
-  session: 3000,
+  UserPromptSubmit: 1200,
+  SessionStart: 1000,
+  GoalLoopHeartbeat: 600,
 };
-const RUNTIME_TIMEOUT_MS = 3500;
-const PACKET_TIMEOUT_MS = 15000;
-const SHARED_AGENT_RUN_ID = 'shared-agent';
-const SOURCE_FALLBACK = 'CodeStory is unavailable for this session. Use bounded source reads in the target repo; inspect only task-named files and nearby tests.';
-const BOOTSTRAP_TAXONOMIES = new Set(['startup', 'clear', 'child_worktree_start', 'session']);
-const DEFERRED_DISCOVERY_NEXT = 'Next: if mcp__codestory is not already visible and tool_search is available, use host deferred discovery/tool_search first: make tool_search query "codestory mcp ground status packet search" the first repository-work tool action, then use the loaded CodeStory MCP tools before manual source reads. Use the hook bridge only if deferred discovery is unavailable or fails. Reload only after plugin install or config changes. Do not treat non-MCP runtime probes as grounding.';
 
 function readHookInput() {
   return new Promise((resolve) => {
     let input = '';
     process.stdin.on('data', (chunk) => { input += chunk; });
     process.stdin.on('end', () => {
-      if (!input.trim()) {
-        resolve({});
-        return;
-      }
       try {
-        resolve(JSON.parse(input.replace(/^\uFEFF/, '')));
-      } catch (e) {
+        resolve(input.trim() ? JSON.parse(input.replace(/^\uFEFF/, '')) : {});
+      } catch {
         resolve({});
       }
     });
   });
-}
-
-function truncate(text, maxChars = MAX_OUTPUT_CHARS) {
-  const value = String(text || '').trim();
-  if (value.length <= maxChars) return value;
-  return `${value.slice(0, maxChars)}\n\n... CodeStory hook output truncated by hook budget.`;
 }
 
 function normalizeText(text) {
@@ -67,831 +37,72 @@ function hashText(text) {
   return createHash('sha256').update(text).digest('hex').slice(0, 16);
 }
 
-function compactKey(text, maxChars = 160) {
-  return normalizeText(text).slice(0, maxChars);
-}
-
-function hookTaxonomy(input, event) {
-  const source = compactKey(input.source || input.trigger || input.reason || '').toLowerCase();
-  const combined = `${String(event || '').toLowerCase()} ${source}`;
+function taxonomy(input, event) {
   if (event === 'UserPromptSubmit') return 'user_prompt';
-  if (/goal|heartbeat/u.test(combined)) return 'goal_heartbeat';
-  if (/compact/u.test(combined)) return 'compact';
-  if (/resume/u.test(combined)) return 'resume';
-  if (/clear/u.test(combined)) return 'clear';
-  if (/handoff/u.test(combined)) return 'handoff';
-  if (/child|worktree/u.test(combined)) return 'child_worktree_start';
-  if (/start|startup/u.test(combined)) return 'startup';
-  return 'session';
+  const source = normalizeText(input.source || input.trigger || '').toLowerCase();
+  if (/goal|heartbeat/u.test(`${event} ${source}`.toLowerCase())) return 'goal_heartbeat';
+  if (/compact/u.test(source)) return 'compact';
+  if (/resume/u.test(source)) return 'resume';
+  if (/clear/u.test(source)) return 'clear';
+  return 'startup';
 }
 
-function hookPolicy(input, event) {
-  const taxonomy = hookTaxonomy(input, event);
-  const project = input.cwd || process.cwd();
-  const promptKey = `prompt:${hashText(normalizeText(input.prompt || ''))}`;
-  const dedupeBase = `${taxonomy}:${project}`;
-  return {
-    taxonomy,
-    project,
-    cap: EVENT_CAPS[taxonomy] || EVENT_CAPS.session,
-    dedupeKey: taxonomy === 'user_prompt' ? `${dedupeBase}:${promptKey}` : dedupeBase,
-    resetDedupe: taxonomy === 'startup' || taxonomy === 'clear',
-    runtimeOnly: ['resume', 'compact', 'handoff', 'goal_heartbeat'].includes(taxonomy),
-    heartbeat: taxonomy === 'goal_heartbeat',
-  };
+function capFor(event) {
+  return EVENT_CAPS[event] || 1000;
 }
 
-function gitDirtyState(project) {
-  if (!project) return null;
-  const result = spawnSync('git', ['-C', project, 'status', '--porcelain'], {
-    encoding: 'utf8',
-    timeout: 1000,
-    maxBuffer: 20_000,
-    windowsHide: true,
-  });
-  if (result.status !== 0 || result.error) return null;
-  const paths = result.stdout
-    .split(/\r?\n/u)
-    .map((line) => line.slice(3).trim())
-    .filter(Boolean)
-    .slice(0, 20);
-  return {
-    dirty: paths.length > 0,
-    pathSample: paths,
-  };
+function truncate(text, cap) {
+  const value = String(text || '').trim();
+  return value.length <= cap ? value : `${value.slice(0, cap)}\n\n... CodeStory hook output truncated.`;
 }
 
-function writeProjectDirtyMarker(policy) {
-  if (!dirtyMarkerPathForProject(policy.project)) return;
-  const state = gitDirtyState(policy.project);
-  if (!state) return;
-  writeDirtyMarker(policy.project, {
-    dirty: state.dirty,
-    pathSample: state.pathSample,
-    source: `codestory-hook:${policy.taxonomy}`,
-  });
-}
-
-function runtimeFingerprint(mcp) {
-  return [
-    mcp.mcp_resource_status,
-    mcp.mcp_model_visible_blocked ? 'model-hidden' : 'model-visible-or-unlaunchable',
-    mcp.managed_cli_present ? 'managed' : 'no-managed',
-    mcp.degraded_no_surface ? 'degraded' : 'surface',
-  ].join('|');
-}
-
-function firstRuntimeFailure(mcp) {
-  if (!mcp.mcp_config_installed) {
-    return `MCP: no codestory server configured at ${mcp.mcp_config_path}`;
-  }
-  if (!mcp.mcp_process_launchable) {
-    return 'MCP: configured codestory server is not launchable from the plugin root';
-  }
-  if (!mcp.mcp_resources_exposed) {
-    return `MCP: ${mcp.mcp_resource_status}`;
-  }
-  if (!mcp.managed_cli_present) {
-    return 'managed runtime: no managed CLI manifest or runtime state was found';
-  }
-  return 'runtime: no usable grounding surface was found';
-}
-
-function shortDegradedNotice(mcp, reason, state = {}) {
-  if (mcp.mcp_model_visible_blocked) {
-    return [
-      'CodeStory setup blocked: MCP is configured and launchable, but resources are not model-visible.',
-      `First failing layer: ${firstRuntimeFailure(mcp)}.`,
-      reason ? `Reason: ${truncate(reason, 600)}` : null,
-      DEFERRED_DISCOVERY_NEXT,
-    ].filter(Boolean).join('\n');
-  }
-  const hook = state.hook || {};
-  return [
-    'CodeStory degraded mode: no MCP or managed runtime surface is usable.',
-    `First failing layer: ${firstRuntimeFailure(mcp)}.`,
-    reason ? `Reason: ${truncate(reason, 600)}` : null,
-    hook.preflight_failed ? SOURCE_FALLBACK : 'Run one bounded managed/local-dev preflight if available; otherwise use bounded source reads.',
-  ].filter(Boolean).join('\n');
-}
-
-function runtimeStatusBlock(policy, mcp) {
-  return [
-    'CODESTORY HOOK RUNTIME TRUTH',
-    `event_taxonomy: ${policy.taxonomy}`,
-    `output_cap_chars: ${policy.cap}`,
-    `dedupe_key: ${policy.dedupeKey}`,
-    mcpDetectionText(mcp),
-    mcp.mcp_model_visible_blocked
-      ? DEFERRED_DISCOVERY_NEXT
-      : mcp.mcp_resources_exposed
-      ? 'Next: read codestory://status before source reads; use packet/search/context only when status allows them with retrieval_mode=full.'
-      : 'Next: no sidecar-backed packet/search surface is proven available; use bounded source reads instead of repeated repair attempts.',
-  ].join('\n');
-}
-
-function shouldBootstrapManagedRuntime(policy, mcp) {
-  if (process.env.CODESTORY_CLI) return false;
-  if (!BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) return false;
-  return Boolean(policy.project && mcp.mcp_process_launchable && mcp.mcp_resources_exposed && !mcp.managed_cli_present);
-}
-
-function bootstrapText(bootstrap) {
-  if (!bootstrap || !bootstrap.attempted) return null;
-  const status = bootstrap.parsed || {};
-  const plugin = status.plugin_runtime || {};
-  const localRefresh = status.local_refresh || status.readiness?.[0]?.local_refresh || {};
-  const reason = status.degraded_reason || status.readiness?.[0]?.repair_reason || bootstrap.error || bootstrap.stderr;
-  return [
-    `managed_bootstrap: ${bootstrap.ready ? 'ready' : 'blocked'}`,
-    `managed_bootstrap_cli_source: ${plugin.cli_source || '<unknown>'}`,
-    plugin.managed_binary_path ? `managed_bootstrap_cli_path: ${plugin.managed_binary_path}` : null,
-    `managed_bootstrap_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
-    reason ? `managed_bootstrap_reason: ${truncate(reason, 500)}` : null,
-  ].filter(Boolean).join('\n');
-}
-
-function firstFreshness(value) {
-  if (!value || typeof value !== 'object') return null;
-  for (const [key, nested] of Object.entries(value)) {
-    if ((key === 'freshness' || key === 'index_freshness') && nested && typeof nested === 'object') {
-      return nested;
-    }
-    const found = firstFreshness(nested);
-    if (found) return found;
-  }
-  return null;
-}
-
-function freshnessSummary(value) {
-  const freshness = firstFreshness(value);
-  if (!freshness) return 'not_reported';
-  const status = freshness.status || 'unknown';
-  const changed = freshness.changed_file_count ?? freshness.changed_files ?? 'unknown';
-  const added = freshness.new_file_count ?? freshness.new_files ?? 'unknown';
-  const removed = freshness.removed_file_count ?? freshness.removed_files ?? 'unknown';
-  return `${status} changed=${changed} new=${added} removed=${removed}`;
-}
-
-function readinessEvidence(parsed) {
-  const verdicts = Array.isArray(parsed.verdicts) ? parsed.verdicts : [];
-  const statuses = verdicts
-    .map((verdict) => `${verdict?.goal || 'unknown'}=${verdict?.status || 'unknown'}`)
-    .join(' ') || 'none';
-  const evidence = {
-    statuses,
-    freshness: freshnessSummary(parsed),
-  };
-  return {
-    text: [
-      `agent_readiness_evidence: ${evidence.statuses}`,
-      `freshness_evidence: ${evidence.freshness}`,
-    ].join('\n'),
-    fingerprint: hashText(JSON.stringify(evidence)),
-  };
-}
-
-function bootstrapAgentReadinessReady(bootstrap) {
-  const status = bootstrap?.parsed || {};
-  return status.runtime_truth?.readiness_lanes?.agent_packet_search?.status === 'ready'
-    || status.readiness_lanes?.agent_packet_search?.status === 'ready'
-    || (Array.isArray(status.readiness)
-      && status.readiness.some((verdict) => verdict?.goal === 'agent_packet_search' && verdict?.status === 'ready'));
-}
-
-function readinessFromBootstrap(bootstrap) {
-  if (!bootstrap?.parsed) return null;
-  const status = bootstrap.parsed;
-  const verdicts = Array.isArray(status.readiness) ? status.readiness : [];
-  const evidence = readinessEvidence({
-    ...status,
-    verdicts,
-  });
-  const ready = bootstrapAgentReadinessReady(bootstrap);
-  return {
-    ready,
-    reason: ready ? null : 'agent_packet_search readiness is not ready',
-    evidence: evidence.text,
-    fingerprint: `bootstrap-readiness:${evidence.fingerprint}`,
-  };
-}
-
-function bridgeAllowedSurfaces(bootstrap, readiness, commandResult) {
-  const surfaces = [];
-  if (bootstrap?.ready) surfaces.push('local_navigation');
-  if (readiness?.ready || bootstrapAgentReadinessReady(bootstrap) || commandResult?.kind === 'request packet') {
-    surfaces.push('agent_packet_search');
-  }
-  return surfaces.length > 0 ? surfaces.join(',') : 'status_only';
-}
-
-function bridgeBootstrapForPolicy(policy, mcp, bootstrap, command) {
-  if (bootstrap?.attempted) return bootstrap;
-  if (!policy.project || !mcp.mcp_process_launchable) {
-    return { attempted: false, reason: 'mcp_launcher_unavailable' };
-  }
-  if (command?.kind === 'session ground' && mcp.managed_cli_present) {
-    return { attempted: false, reason: 'hidden_mcp_session_ground_disabled' };
-  }
-  if (command?.kind === 'request packet' && mcp.managed_cli_present) {
-    return { attempted: false, reason: 'managed_runtime_available' };
-  }
-  if (!mcp.managed_cli_present && !BOOTSTRAP_TAXONOMIES.has(policy.taxonomy)) {
-    return { attempted: false, reason: 'managed_runtime_not_present' };
-  }
-  return bootstrapManagedRuntime({ projectRoot: policy.project });
-}
-
-function managedHookCli(mcp) {
-  return process.env.CODESTORY_CLI || mcp.managed_cli_path || null;
-}
-
-function bridgeRuntimeStatus(bootstrap, commandResult, mcp) {
-  if (bootstrap?.ready || commandResult?.ok) return 'ready';
-  if (mcp.managed_cli_present) return 'runtime_available';
-  return 'blocked';
-}
-
-function parseHookJson(text) {
-  try {
-    return JSON.parse(String(text || ''));
-  } catch (_) {
-    return null;
-  }
-}
-
-function packetRetrievalMode(commandResult) {
-  if (commandResult?.kind !== 'request packet' || !commandResult?.output) return null;
-  const packet = parseHookJson(commandResult.output);
-  const trace = packet?.retrieval_trace_summary?.retrieval_trace;
-  return trace?.retrieval_shadow?.retrieval_mode
-    || trace?.packet_sidecar_diagnostics?.find((diagnostic) => diagnostic?.retrieval_mode)?.retrieval_mode
-    || null;
-}
-
-function bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult) {
-  const status = bootstrap?.parsed || {};
-  return status.runtime_truth?.readiness_lanes?.agent_packet_search?.status
-    || status.readiness_lanes?.agent_packet_search?.status
-    || (readiness?.ready ? 'ready' : null)
-    || (commandResult?.kind === 'request packet' && commandResult?.ok ? 'ready' : null)
-    || 'not_ready';
-}
-
-function sidecarFromBootstrap(bootstrap) {
-  const status = bootstrap?.parsed || {};
-  const verdictSidecar = Array.isArray(status.readiness)
-    ? status.readiness.find((verdict) => verdict?.goal === 'agent_packet_search')?.sidecar
-    : null;
-  return {
-    mode: status.runtime_truth?.sidecar_status?.mode
-      || status.runtime_truth?.readiness_lanes?.agent_packet_search?.sidecar_mode
-      || status.readiness_lanes?.agent_packet_search?.sidecar_mode
-      || verdictSidecar?.retrieval_mode
-      || null,
-    embedding: verdictSidecar || null,
-  };
-}
-
-function bridgeSidecarMode(bootstrap, commandResult, statusResult) {
-  return statusResult?.parsed?.retrieval_mode
-    || sidecarFromBootstrap(bootstrap).mode
-    || packetRetrievalMode(commandResult)
-    || 'not_reported';
-}
-
-function bridgeEmbeddingRequest(bootstrap, statusResult) {
-  const fromStatus = statusResult?.parsed || {};
-  const fromBootstrap = sidecarFromBootstrap(bootstrap).embedding || {};
-  const provider = fromStatus.embedding_accelerator_request_provider || fromBootstrap.embedding_accelerator_request_provider;
-  const device = fromStatus.embedding_accelerator_request_device || fromBootstrap.embedding_accelerator_request_device;
-  const state = fromStatus.embedding_device_state || fromBootstrap.embedding_device_state;
-  const cpuAllowed = fromStatus.embedding_cpu_allowed ?? fromBootstrap.embedding_cpu_allowed;
-  if (!provider && !device && !state) return 'not_reported';
-  return [
-    provider || 'unknown',
-    device ? `:${device}` : '',
-    state ? ` state=${state}` : '',
-    cpuAllowed !== undefined ? ` cpu_allowed=${cpuAllowed}` : '',
-  ].join('');
-}
-
-function bridgeStatusText(policy, mcp, bootstrap, readiness, commandReason, commandResult, statusResult) {
-  const status = bootstrap?.parsed || {};
-  const plugin = status.plugin_runtime || {};
-  const localRefresh = status.local_refresh || status.readiness?.[0]?.local_refresh || {};
-  const bootstrapReason = ['managed_runtime_available', 'hidden_mcp_session_ground_disabled'].includes(bootstrap?.reason)
-    ? null
-    : bootstrap?.reason;
-  const reason = status.degraded_reason
-    || status.readiness?.[0]?.repair_reason
-    || bootstrapReason
-    || bootstrap?.error
-    || bootstrap?.stderr;
-  return [
-    'CODESTORY HOOK MCP BRIDGE',
-    'bridge_context_label: hook-bridged context, not live MCP tools',
-    'bridge_resource_uri: codestory://status',
-    `event_taxonomy: ${policy.taxonomy}`,
-    `output_cap_chars: ${policy.cap}`,
-    `dedupe_key: ${policy.dedupeKey}`,
-    mcpDetectionText(mcp),
-    `hook_bridge_status: ${bridgeRuntimeStatus(bootstrap, commandResult, mcp)}`,
-    `hook_bridge_cli_source: ${plugin.cli_source || (process.env.CODESTORY_CLI ? 'local_dev_override' : mcp.managed_cli_source) || '<unknown>'}`,
-    plugin.managed_binary_path ? `hook_bridge_managed_cli_path: ${plugin.managed_binary_path}` : null,
-    `hook_bridge_local_refresh: ${localRefresh.state || status.readiness?.[0]?.status || '<unknown>'}`,
-    `hook_bridge_agent_packet_search_status: ${bridgeAgentPacketSearchStatus(bootstrap, readiness, commandResult)}`,
-    `hook_bridge_sidecar_mode: ${bridgeSidecarMode(bootstrap, commandResult, statusResult)}`,
-    `hook_bridge_embedding_request: ${bridgeEmbeddingRequest(bootstrap, statusResult)}`,
-    `hook_bridge_allowed_surfaces: ${bridgeAllowedSurfaces(bootstrap, readiness, commandResult)}`,
-    readiness ? readiness.evidence : null,
-    commandReason ? `hook_bridge_context: ${commandReason}` : null,
-    reason ? `hook_bridge_reason: ${truncate(reason, 500)}` : null,
-    'mcp_resources_exposed: mcp_resources_not_model_visible',
-    'mcp_tools_visible: no',
-    `hook_bridge_next: ${DEFERRED_DISCOVERY_NEXT}`,
-  ].filter(Boolean).join('\n');
-}
-
-function managedHookCommandTimeoutMs(command) {
-  if (command?.kind !== 'request packet') return RUNTIME_TIMEOUT_MS;
-  const parsed = Number.parseInt(process.env.CODESTORY_HOOK_PACKET_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : PACKET_TIMEOUT_MS;
-}
-
-function runManagedHookCommand(cli, command, cwd) {
-  const result = spawnSync(cli, command.args, {
-    cwd,
-    encoding: 'utf8',
-    timeout: managedHookCommandTimeoutMs(command),
-    maxBuffer: MAX_OUTPUT_CHARS * 4,
-    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
-    windowsHide: true,
-  });
-  if (result.status === 0 && result.stdout.trim()) {
-    return {
-      ok: true,
-      kind: command.kind,
-      output: truncate(result.stdout),
-      fingerprint: `${command.kind}:${hashText(result.stdout)}`,
-    };
-  }
-  const reason = result.error
-    ? result.error.message
-    : truncate(result.stderr || `${command.kind} exited with status ${result.status} without usable output`);
-  return {
-    ok: false,
-    reason,
-    fingerprint: `${command.kind}:blocked:${hashText(reason)}`,
-  };
-}
-
-function runManagedStatusCommand(cli, project, cwd) {
-  if (!cli || !project) return null;
-  const result = spawnSync(cli, [
-    'retrieval',
-    'status',
-    '--project', project,
-    '--profile', 'agent',
-    '--run-id', SHARED_AGENT_RUN_ID,
-    '--format', 'json',
-  ], {
-    cwd,
-    encoding: 'utf8',
-    timeout: RUNTIME_TIMEOUT_MS,
-    maxBuffer: MAX_OUTPUT_CHARS * 4,
-    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
-    windowsHide: true,
-  });
-  if (result.status === 0 && result.stdout.trim()) {
-    return {
-      ok: true,
-      parsed: parseHookJson(result.stdout),
-      fingerprint: `retrieval-status:${hashText(result.stdout)}`,
-    };
-  }
-  const reason = result.error
-    ? result.error.message
-    : truncate(result.stderr || `retrieval status exited with status ${result.status} without usable output`);
-  return {
-    ok: false,
-    reason,
-    fingerprint: `retrieval-status:blocked:${hashText(reason)}`,
-  };
-}
-
-function hookMcpBridge(input, policy, mcp, command, bootstrap) {
-  const bridgeBootstrap = bridgeBootstrapForPolicy(policy, mcp, bootstrap, command);
-  const bridgedMcp = bridgeBootstrap.attempted ? classifyMcpRuntime() : mcp;
-  const cli = managedHookCli(bridgedMcp);
-  const cwd = input.cwd || process.cwd();
-  let readiness = null;
-  let commandResult = null;
-  let statusResult = null;
-  let commandReason = command ? null : 'status_only';
-
-  if (command && !cli) {
-    commandReason = 'skipped_no_managed_cli';
-  } else if (command?.kind === 'request packet') {
-    readiness = readinessFromBootstrap(bridgeBootstrap);
-    commandResult = runManagedHookCommand(cli, command, cwd);
-    if (commandResult.ok) {
-      statusResult = runManagedStatusCommand(cli, policy.project, cwd);
-    }
-    commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
-  } else if (command?.kind === 'session ground') {
-    if (bridgedMcp.mcp_model_visible_blocked) {
-      commandReason = 'status_only_hidden_mcp_startup_ground_disabled';
-    } else if (bridgeBootstrap.ready) {
-      commandResult = runManagedHookCommand(cli, command, cwd);
-      commandReason = commandResult.ok ? null : `skipped_${commandResult.reason}`;
-    } else {
-      commandReason = 'skipped_local_navigation_not_ready';
-    }
-  }
-
-  const bridge = bridgeStatusText(policy, bridgedMcp, bridgeBootstrap, readiness, commandReason, commandResult, statusResult);
-  const commandBlock = commandResult?.ok
-    ? [
-      'CODESTORY HOOK MCP BRIDGE CONTEXT',
-      `hook_bridge_command: ${command.kind}`,
-      commandResult.output,
-    ].join('\n')
-    : null;
-  return {
-    kind: commandResult?.ok ? command.kind : 'mcp bridge',
-    output: truncate([bridge, commandBlock].filter(Boolean).join('\n'), policy.cap),
-    next: command?.next,
-    fingerprint: [
-      runtimeFingerprint(bridgedMcp),
-      bridgeBootstrap.ready ? 'bridge-ready' : `bridge-blocked:${bridgeBootstrap.reason || 'status'}`,
-      readiness?.fingerprint,
-      commandResult?.fingerprint,
-      statusResult?.fingerprint,
-      commandReason,
-    ].filter(Boolean).join('|'),
-  };
-}
-
-function rememberEmission(policy, contentKey) {
+function shouldEmit(key, reset = false) {
   const state = readHookState();
-  const emitted = state.emitted || {};
-  const previous = policy.resetDedupe ? undefined : emitted[policy.dedupeKey];
-  if (previous === contentKey) {
-    return false;
-  }
-  state.emitted = {
-    ...(policy.resetDedupe ? {} : emitted),
-    [policy.dedupeKey]: contentKey,
-  };
-  writeHookState(state);
+  const emitted = reset ? {} : (state.emitted || {});
+  if (emitted[key]) return false;
+  writeHookState({ ...state, emitted: { ...emitted, [key]: true } });
   return true;
 }
 
-function rememberHeartbeat(policy, contentKey) {
-  const state = readHookState();
-  const previous = state.heartbeatKey;
-  writeHookState({
-    ...state,
-    heartbeatKey: contentKey,
-  });
-  return previous ? previous !== contentKey : false;
-}
-
-function hookCommand(input, event, policy) {
-  const project = policy.project;
-  if (!project) return null;
-
-  if (policy.taxonomy === 'user_prompt' && String(input.prompt || '').trim()) {
-    return {
-      kind: 'request packet',
-      args: [
-        'packet',
-        '--project', project,
-        '--question', String(input.prompt),
-        '--budget', 'tiny',
-        '--refresh', 'none',
-        '--latency-budget-ms', '1500',
-      ],
-      next: 'If CodeStory is unavailable, use bounded source reads in the target repo instead of repeated repair attempts.',
-    };
-  }
-
-  if (['startup', 'clear', 'child_worktree_start'].includes(policy.taxonomy)) {
-    return {
-      kind: 'session ground',
-      args: [
-        'ground',
-        '--project', project,
-        '--budget', 'strict',
-        '--refresh', 'none',
-      ],
-      next: 'If CodeStory is unavailable, use bounded source reads in the target repo instead of repeated repair attempts.',
-    };
-  }
-
-  return null;
-}
-
-function runReadinessProbe(cli, project, cwd) {
-  const result = spawnSync(cli, [
-    'ready',
-    '--goal', 'agent',
-    '--project', project,
-    '--format', 'json',
-  ], {
+function contextFor(input, event) {
+  const kind = taxonomy(input, event);
+  const cwd = input.cwd || process.cwd();
+  const prompt = normalizeText(input.prompt || '');
+  const key = [
+    kind,
     cwd,
-    encoding: 'utf8',
-    timeout: RUNTIME_TIMEOUT_MS,
-    maxBuffer: MAX_OUTPUT_CHARS * 4,
-    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
-    windowsHide: true,
-  });
-  if (result.status !== 0 || !result.stdout.trim()) {
-    const reason = result.error
-      ? result.error.message
-      : truncate(result.stderr || `agent readiness probe exited with status ${result.status}`);
-    return {
-      ready: false,
-      reason,
-      evidence: [
-        'agent_readiness_evidence: unavailable',
-        'freshness_evidence: unavailable',
-      ].join('\n'),
-      fingerprint: `readiness-unavailable:${hashText(reason)}`,
-    };
-  }
-  try {
-    const parsed = JSON.parse(result.stdout);
-    const verdicts = Array.isArray(parsed.verdicts) ? parsed.verdicts : [];
-    const evidence = readinessEvidence(parsed);
-    const ready = verdicts.some((verdict) => verdict?.goal === 'agent_packet_search' && verdict?.status === 'ready');
-    return {
-      ready,
-      reason: ready ? null : 'agent_packet_search readiness is not ready',
-      evidence: evidence.text,
-      fingerprint: `readiness:${evidence.fingerprint}`,
-    };
-  } catch {
-    return {
-      ready: false,
-      reason: 'agent readiness probe returned invalid JSON',
-      evidence: [
-        'agent_readiness_evidence: invalid_json',
-        'freshness_evidence: unavailable',
-      ].join('\n'),
-      fingerprint: 'readiness-invalid-json',
-    };
-  }
-}
+    event === 'UserPromptSubmit' ? hashText(prompt) : '',
+  ].filter(Boolean).join(':');
+  if (!shouldEmit(key, kind === 'startup' || kind === 'clear')) return null;
+  if (kind === 'goal_heartbeat') return null;
 
-function heartbeatReadinessProbe(mcp, project, cwd) {
-  const cli = process.env.CODESTORY_CLI || mcp.managed_cli_path;
-  if (!cli) {
-    return {
-      evidence: [
-        'agent_readiness_evidence: unavailable',
-        'freshness_evidence: unavailable',
-      ].join('\n'),
-      fingerprint: 'readiness-unavailable:no-cli',
-    };
-  }
-  return runReadinessProbe(cli, project, cwd);
-}
+  const header = eventHeader(event, input).trim();
+  const mcpInstructions = [
+    'CodeStory MCP startup path:',
+    '1. Use live CodeStory MCP before manual source reads for repository work.',
+    '2. If mcp__codestory tools are visible, read codestory://status first, then follow status recommended_next_calls.',
+    '3. If mcp__codestory is not visible and tool_search is available, query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools.',
+    '4. Do not treat hook text as grounding evidence; it only selects and locates the MCP path.',
+  ].join('\n');
 
-function runCodeStory(input, event, policy, state = {}) {
-  if (process.env.CODESTORY_HOOK_DISABLE_RUNTIME === '1') {
-    return {
-      kind: 'disabled',
-      output: 'Runtime grounding disabled for this hook invocation. The agent must use codestory://status before source reads.',
-    };
-  }
-
-  let mcp = classifyMcpRuntime();
-  const bootstrap = shouldBootstrapManagedRuntime(policy, mcp)
-    ? bootstrapManagedRuntime({ projectRoot: policy.project })
-    : null;
-  if (bootstrap?.attempted) {
-    mcp = classifyMcpRuntime();
-  }
-  const bootstrapBlock = bootstrapText(bootstrap);
-  if (policy.runtimeOnly) {
-    if (mcp.mcp_config_installed && mcp.mcp_process_launchable && mcp.mcp_model_visible_blocked) {
-      return hookMcpBridge(input, policy, mcp, null, bootstrap);
-    }
-    const heartbeatProbe = policy.heartbeat && !mcp.mcp_model_visible_blocked
-      ? heartbeatReadinessProbe(mcp, policy.project, input.cwd || process.cwd())
-      : null;
-    const output = state.hook?.preflight_failed && mcp.degraded_no_surface
-      ? [
-        `event_taxonomy: ${policy.taxonomy}`,
-        `output_cap_chars: ${policy.cap}`,
-        `dedupe_key: ${policy.dedupeKey}`,
-        shortDegradedNotice(mcp, null, state),
-      ].join('\n')
-      : runtimeStatusBlock(policy, mcp);
-    return {
-      kind: 'runtime truth',
-      output: truncate([output, heartbeatProbe?.evidence].filter(Boolean).join('\n'), policy.cap),
-      fingerprint: [runtimeFingerprint(mcp), heartbeatProbe?.fingerprint].filter(Boolean).join('|'),
-    };
-  }
-
-  const command = hookCommand(input, event, policy);
-  if (!command) return null;
-  if (mcp.mcp_config_installed && mcp.mcp_process_launchable) {
-    if (mcp.mcp_model_visible_blocked) {
-      return hookMcpBridge(input, policy, mcp, command, bootstrap);
-    }
-    return {
-      kind: 'mcp detection',
-      output: truncate([
-        `event_taxonomy: ${policy.taxonomy}`,
-        `output_cap_chars: ${policy.cap}`,
-        `dedupe_key: ${policy.dedupeKey}`,
-        bootstrapBlock,
-        mcpDetectionText(mcp),
-        mcp.mcp_resources_exposed
-          ? 'Use codestory://status as the active runtime truth. Run packet/search/context only when status allows that surface with retrieval_mode=full.'
-          : `CodeStory MCP is configured and launchable, but MCP resources are not visible to this hook/model context. ${DEFERRED_DISCOVERY_NEXT}`,
-      ].join('\n'), policy.cap),
-      fingerprint: `${runtimeFingerprint(mcp)}|${bootstrapBlock || 'no-bootstrap'}`,
-    };
-  }
-
-  if (!process.env.CODESTORY_CLI && !mcp.managed_cli_present) {
-    return {
-      degraded: true,
-      kind: 'degraded mode',
-      output: truncate([
-        `event_taxonomy: ${policy.taxonomy}`,
-        `output_cap_chars: ${policy.cap}`,
-        `dedupe_key: ${policy.dedupeKey}`,
-        shortDegradedNotice(mcp, null, state),
-      ].join('\n'), policy.cap),
-      fingerprint: `${runtimeFingerprint(mcp)}|no-cli`,
-    };
-  }
-
-  const cli = process.env.CODESTORY_CLI || mcp.managed_cli_path;
-  const readiness = policy.taxonomy === 'user_prompt'
-    ? runReadinessProbe(cli, policy.project, input.cwd || process.cwd())
-    : { ready: true, reason: null };
-  if (policy.taxonomy === 'user_prompt' && !readiness.ready) {
-    const failedState = {
-      ...state,
-      hook: {
-        ...(state.hook || {}),
-        preflight_failed: Boolean(readiness.reason),
-      },
-    };
-    return {
-      degraded: true,
-      kind: 'runtime truth',
-      output: truncate([
-        `event_taxonomy: ${policy.taxonomy}`,
-        `output_cap_chars: ${policy.cap}`,
-        `dedupe_key: ${policy.dedupeKey}`,
-        mcp.degraded_no_surface
-          ? shortDegradedNotice(mcp, readiness.reason, failedState)
-          : runtimeStatusBlock(policy, mcp),
-        'Packet skipped: sidecar-backed packet/search readiness is not proven full for this hook invocation.',
-      ].join('\n'), policy.cap),
-      fingerprint: `${runtimeFingerprint(mcp)}|packet-not-ready`,
-    };
-  }
-
-  const result = spawnSync(cli, command.args, {
-    cwd: input.cwd || process.cwd(),
-    encoding: 'utf8',
-    timeout: RUNTIME_TIMEOUT_MS,
-    maxBuffer: MAX_OUTPUT_CHARS * 4,
-    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(cli),
-    windowsHide: true,
-  });
-
-  if (result.status === 0 && result.stdout.trim()) {
-    return {
-      kind: command.kind,
-      output: truncate(result.stdout, policy.cap),
-      next: command.next,
-      fingerprint: `${runtimeFingerprint(mcp)}|${command.kind}`,
-    };
-  }
-
-  const reason = result.error
-    ? result.error.message
-    : truncate(result.stderr || `codestory-cli exited with status ${result.status}`);
-  const failedState = {
-    ...state,
-    hook: {
-      ...(state.hook || {}),
-      preflight_failed: true,
-    },
-  };
-
-  return {
-    degraded: mcp.degraded_no_surface,
-    preflightFailed: true,
-    kind: command.kind,
-    output: truncate(mcp.degraded_no_surface
-      ? [
-        `event_taxonomy: ${policy.taxonomy}`,
-        `output_cap_chars: ${policy.cap}`,
-        `dedupe_key: ${policy.dedupeKey}`,
-        shortDegradedNotice(mcp, reason, failedState),
-      ].join('\n')
-      : [
-        mcpDetectionText(mcp),
-        `CodeStory hook attempted ${command.kind} but did not receive usable output.`,
-        reason ? `Reason: ${reason}` : null,
-        command.next,
-      ].filter(Boolean).join('\n'), policy.cap),
-    fingerprint: `${runtimeFingerprint(mcp)}|${reason}`,
-  };
-}
-
-function buildContext(input, event, state = {}) {
-  const policy = hookPolicy(input, event);
-  writeProjectDirtyMarker(policy);
-  const runtime = runCodeStory(input, event, policy, state);
-  if (runtime && policy.heartbeat && !rememberHeartbeat(policy, runtime.fingerprint || runtime.output)) {
-    return null;
-  }
-  const runtimeBlock = runtime && runtime.output
-    ? [
-      `CODESTORY HOOK ${runtime.kind.toUpperCase()}`,
-      runtime.output,
-      runtime.next ? `Next: ${runtime.next}` : null,
-    ].filter(Boolean).join('\n\n')
-    : null;
-  const contentKey = runtime?.fingerprint || runtimeBlock || policy.taxonomy;
-  if (runtimeBlock && !rememberEmission(policy, contentKey)) {
-    return null;
-  }
-
-  if (runtime && runtimeBlock && (runtime.kind === 'mcp detection' || runtimeBlock.includes('CODESTORY HOOK MCP BRIDGE'))) {
-    return truncate([eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n'), policy.cap);
-  }
-
-  if (policy.runtimeOnly || (runtime && runtime.degraded)) {
-    return truncate([eventHeader(event, input).trim(), runtimeBlock].filter(Boolean).join('\n\n'), policy.cap);
-  }
-
-  const emitted = state.hook && state.hook.instructions_emitted;
-  const alreadyEmitted = emitted && emitted[event];
-  const parts = [alreadyEmitted ? eventHeader(event, input).trim() : getCodeStoryInstructions(event, input)];
-
-  if (runtimeBlock) {
-    parts.push(runtimeBlock);
-  }
-
-  return truncate(parts.join('\n\n'), policy.cap);
-}
-
-function freshInstructionBoundary(event, input = {}) {
-  const source = String(input.source || input.trigger || '').toLowerCase();
-  return event === 'SessionStart' && (!source || source === 'startup' || source === 'clear');
+  return truncate([header, mcpInstructions].filter(Boolean).join('\n\n'), capFor(event));
 }
 
 readHookInput().then((input) => {
   const event = input.hook_event_name || 'SessionStart';
   try {
-    const state = readActiveState() || {};
-    const activeState = freshInstructionBoundary(event, input)
-      ? {
-        ...state,
-        hook: {
-          ...(state.hook || {}),
-          instructions_emitted: {},
-        },
-      }
-      : state;
-    const context = buildContext(input, event, activeState);
-    const priorInstructions = (activeState.hook && activeState.hook.instructions_emitted) || {};
-    const emittedFullInstructions = context && (
-      context.includes('CODESTORY BACKGROUND GROUNDING RULES') ||
-      context.includes('CODESTORY BACKGROUND GROUNDING ACTIVE')
-    );
-    const instructions = emittedFullInstructions
-      ? { ...priorInstructions, [event]: true }
-      : priorInstructions;
     rememberActiveState({
       event,
       cwd: input.cwd || process.cwd(),
       source: input.source || input.trigger || null,
       codexThreadId: process.env.CODEX_THREAD_ID || null,
       hook: {
-        instructions_emitted: instructions,
-        preflight_failed: state.hook && state.hook.preflight_failed,
+        instructions_emitted: {},
+        bridge_removed: true,
       },
     });
-    const nextState = readActiveState() || {};
-    if (context && /CodeStory is unavailable for this session/u.test(context)) {
-      rememberActiveState({ hook: { ...(nextState.hook || {}), preflight_failed: true } });
-    }
-    writeHookOutput(event, context);
-  } catch (e) {
+    writeHookOutput(event, contextFor(input, event));
+  } catch {
     // Best effort only. A hook failure must not block the agent session.
   }
 });

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -3,14 +3,14 @@ const path = require('path');
 
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'codestory-grounding', 'SKILL.md');
 const MAX_PROMPT_CHARS = 600;
-const DEFERRED_DISCOVERY_TEXT = 'If mcp__codestory is not already visible and tool_search is available, use host deferred discovery/tool_search first: your first tool action for repository work must be tool_search with query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools before manual source reads.';
+const MCP_RESOURCE_TEXT = 'If mcp__codestory tools are not initially visible and tool_search is available, query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools before manual source reads.';
 
 const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
 
 Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
 
 1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, read codestory://status first. ${DEFERRED_DISCOVERY_TEXT} Use the hook bridge only when deferred discovery is unavailable or fails, and report that live MCP tools are hidden.
+2. If the CodeStory MCP server is live, read codestory://status first. ${MCP_RESOURCE_TEXT} Report hidden tool actions truthfully; do not synthesize a hook substitute for live MCP tools.
 3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
 4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
 5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
@@ -39,7 +39,7 @@ function eventHeader(event, input = {}) {
       'CODESTORY REQUEST GROUNDING ACTIVE',
       '',
       'Use CodeStory before source files for this user prompt.',
-      DEFERRED_DISCOVERY_TEXT,
+      MCP_RESOURCE_TEXT,
       prompt ? `Prompt: ${prompt}` : 'Prompt: unavailable from hook input.',
       '',
     ].join('\n');
@@ -50,7 +50,7 @@ function eventHeader(event, input = {}) {
     `CODESTORY SESSION GROUNDING ACTIVE${source}`,
     '',
     'Keep CodeStory ambient in this session. Before source reads, claims, edits, reviews, or test choices, check CodeStory status and use allowed grounding surfaces first.',
-    DEFERRED_DISCOVERY_TEXT,
+    MCP_RESOURCE_TEXT,
     '',
   ].join('\n');
 }
@@ -62,7 +62,7 @@ function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
   return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
 
 Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first read codestory://status when MCP is live. When MCP is configured but resources are not model-visible, ${DEFERRED_DISCOVERY_TEXT} Use hook-bridged status only when deferred discovery is unavailable or fails, and report that live MCP tools are hidden. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
+Before manually opening source files, first read codestory://status when MCP is live. When CodeStory is not initially model-visible, use host deferred discovery/tool_search to load the registered CodeStory MCP. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
 For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
 Avoid no-op grounding context in huge or non-code folders.
 When retrieval sidecars are full and allowed, use packet, search, and context confidently.

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const { spawnSync } = require('child_process');
 const { createHash } = require('crypto');
 
 const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
@@ -9,7 +8,6 @@ const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 const STATE_FILE = '.codestory-active';
 const THREAD_STATE_PREFIX = '.codestory-active-thread-';
 const HOOK_STATE_FILE = '.codestory-hook-output-state.json';
-const MCP_RUNTIME_FILE = '.codestory-mcp-runtime.json';
 const DIRTY_MARKER_SCHEMA_VERSION = 1;
 const DIRTY_MARKER_SAMPLE_LIMIT = 20;
 const DIRTY_HOOK_NAMES = ['post-checkout', 'post-merge', 'post-rewrite'];
@@ -44,10 +42,6 @@ function readJson(file) {
   }
 }
 
-function pluginRoot() {
-  return path.dirname(__dirname);
-}
-
 function normalizeProjectRoot(projectRoot) {
   const resolved = path.resolve(projectRoot || process.cwd());
   try {
@@ -62,146 +56,6 @@ function dirtyMarkerPathForProject(projectRoot, dataDir = pluginDataDir()) {
   const normalizedRoot = normalizeProjectRoot(projectRoot);
   const key = createHash('sha256').update(normalizedRoot).digest('hex').slice(0, 32);
   return path.join(dataDir, 'dirty-markers', `${key}.json`);
-}
-
-function pluginVersion(root = pluginRoot()) {
-  const manifest = readJson(path.join(root, '.codex-plugin', 'plugin.json'));
-  return manifest && typeof manifest.version === 'string' ? manifest.version : null;
-}
-
-function configuredMcp(root = pluginRoot()) {
-  const configPath = path.join(root, '.mcp.json');
-  const config = readJson(configPath);
-  const server = config?.mcpServers?.codestory;
-  if (!server) {
-    return { installed: false, configPath, command: null, args: [] };
-  }
-  return {
-    installed: true,
-    configPath,
-    command: server.command || null,
-    args: Array.isArray(server.args) ? server.args : [],
-  };
-}
-
-function mcpScriptExists(root, args) {
-  const scriptArg = args.find((arg) => typeof arg === 'string' && /codestory-mcp\.cjs$/u.test(arg));
-  if (!scriptArg) return false;
-  return fs.existsSync(path.resolve(root, scriptArg));
-}
-
-function mcpScriptPath(root, args) {
-  const scriptArg = args.find((arg) => typeof arg === 'string' && /codestory-mcp\.cjs$/u.test(arg));
-  return scriptArg ? path.resolve(root, scriptArg) : null;
-}
-
-function bootstrapTimeoutMs() {
-  const parsed = Number.parseInt(process.env.CODESTORY_PLUGIN_BOOTSTRAP_TIMEOUT_MS || '', 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 240000;
-}
-
-function managedCliInfo(dataDir = pluginDataDir(), version = pluginVersion()) {
-  if (!dataDir) return { present: false, path: null, source: null };
-  const runtime = readJson(path.join(dataDir, MCP_RUNTIME_FILE));
-  if (runtime?.source === 'managed' && runtime.path) {
-    return { present: fs.existsSync(runtime.path), path: runtime.path, source: 'runtime_state' };
-  }
-
-  const manifestPath = version
-    ? path.join(dataDir, 'codestory-cli', version, 'manifest.json')
-    : path.join(dataDir, 'codestory-cli', 'manifest.json');
-  const manifest = readJson(manifestPath);
-  const manifestCli = manifest?.path
-    ? path.resolve(path.dirname(manifestPath), manifest.path)
-    : null;
-  if (manifestCli) {
-    return { present: fs.existsSync(manifestCli), path: manifestCli, source: 'manifest' };
-  }
-  return { present: false, path: null, source: null };
-}
-
-function classifyMcpRuntime(options = {}) {
-  const root = options.pluginRoot || pluginRoot();
-  const dataDir = options.pluginDataDir === undefined ? pluginDataDir() : options.pluginDataDir;
-  const mcp = configuredMcp(root);
-  const runtimePath = dataDir ? path.join(dataDir, MCP_RUNTIME_FILE) : null;
-  const runtime = runtimePath ? readJson(runtimePath) : null;
-  const managed = managedCliInfo(dataDir, pluginVersion(root));
-  const launchable = mcp.installed && mcp.command === 'node' && mcpScriptExists(root, mcp.args);
-  const resourcesExposed = process.env.CODESTORY_MCP_RESOURCES_EXPOSED === '1';
-  const resourceStatus = resourcesExposed
-    ? 'mcp_resources_exposed'
-    : launchable
-      ? 'mcp_resources_not_model_visible'
-      : 'mcp_resources_unavailable';
-  const modelVisibleBlocked = launchable && !resourcesExposed;
-
-  return {
-    mcp_config_installed: mcp.installed,
-    mcp_config_path: mcp.configPath,
-    mcp_command: mcp.command,
-    mcp_args: mcp.args,
-    mcp_process_launchable: launchable,
-    mcp_resources_exposed: resourcesExposed,
-    mcp_resource_status: resourceStatus,
-    mcp_model_visible_blocked: modelVisibleBlocked,
-    mcp_runtime_state_path: runtimePath,
-    mcp_runtime_state_present: Boolean(runtime),
-    managed_cli_present: managed.present,
-    managed_cli_path: managed.path,
-    managed_cli_source: managed.source,
-    degraded_no_surface: modelVisibleBlocked || (!resourcesExposed && !managed.present),
-  };
-}
-
-function bootstrapManagedRuntime(options = {}) {
-  const root = options.pluginRoot || pluginRoot();
-  const dataDir = options.pluginDataDir === undefined ? pluginDataDir() : options.pluginDataDir;
-  const projectRoot = normalizeProjectRoot(options.projectRoot || process.cwd());
-  const mcp = configuredMcp(root);
-  const scriptPath = mcpScriptPath(root, mcp.args);
-  if (!dataDir) return { attempted: false, reason: 'plugin_data_required' };
-  if (!mcp.installed || mcp.command !== 'node' || !scriptPath || !fs.existsSync(scriptPath)) {
-    return { attempted: false, reason: 'mcp_launcher_unavailable' };
-  }
-
-  const result = spawnSync(process.execPath, [scriptPath, 'bootstrap-status', '--project', projectRoot], {
-    cwd: root,
-    encoding: 'utf8',
-    timeout: bootstrapTimeoutMs(),
-    maxBuffer: 20000,
-    windowsHide: true,
-    env: {
-      ...process.env,
-      PLUGIN_DATA: dataDir,
-    },
-  });
-  let status = null;
-  try {
-    status = JSON.parse(result.stdout || '{}');
-  } catch (error) {
-    status = { ready: false, degraded_reason: `bootstrap_status_invalid_json:${error.message}` };
-  }
-  return {
-    attempted: true,
-    status: result.status,
-    error: result.error ? result.error.message : null,
-    stderr: result.stderr || '',
-    ready: status?.ready === true,
-    parsed: status,
-  };
-}
-
-function mcpDetectionText(status) {
-  return [
-    'CODESTORY MCP RUNTIME DETECTION',
-    `mcp_config_installed: ${status.mcp_config_installed ? 'yes' : 'no'}${status.mcp_config_installed ? ` (${status.mcp_config_path})` : ''}`,
-    `mcp_process_launchable: ${status.mcp_process_launchable ? 'yes' : 'no'}`,
-    `mcp_resources_exposed: ${status.mcp_resource_status}`,
-    `mcp_model_visible_blocked: ${status.mcp_model_visible_blocked ? 'yes' : 'no'}`,
-    `managed_cli_present: ${status.managed_cli_present ? 'yes' : 'no'}${status.managed_cli_path ? ` (${status.managed_cli_path})` : ''}`,
-    `degraded_no_surface: ${status.degraded_no_surface ? 'yes' : 'no'}`,
-  ].join('\n');
 }
 
 function readActiveState() {
@@ -488,12 +342,9 @@ function writeHookOutput(event, context) {
 }
 
 module.exports = {
-  bootstrapManagedRuntime,
-  classifyMcpRuntime,
   dirtyMarkerPathForProject,
   dirtyHookStatus,
   installDirtyHooks,
-  mcpDetectionText,
   readActiveState,
   readHookState,
   rememberActiveState,

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -151,11 +151,11 @@ function activeProjectStateMatchesHost(active) {
   return activeThread === currentThread;
 }
 
-function activeProjectStateFresh(active, statePath, nowMs = Date.now()) {
+function activeProjectStateFresh(active, statePath, nowMs = Date.now(), options = {}) {
   const timestamp = activeProjectStateTimestamp(active, statePath);
   return timestamp !== null
     && nowMs - timestamp <= activeProjectStateMaxAgeMs()
-    && activeProjectStateMatchesHost(active);
+    && (!options.requireThreadMatch || activeProjectStateMatchesHost(active));
 }
 
 function resolveProjectRoot(options = {}) {
@@ -172,7 +172,7 @@ function resolveProjectRoot(options = {}) {
   const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
   const threadStatePath = activeThreadStatePath(currentThread);
   const threadActive = threadStatePath ? readJson(threadStatePath) : null;
-  if (threadActive && !activeProjectStateFresh(threadActive, threadStatePath)) {
+  if (threadActive && !activeProjectStateFresh(threadActive, threadStatePath, Date.now(), { requireThreadMatch: true })) {
     return {
       projectRoot: null,
       source: 'plugin_active_thread_state_stale',
@@ -1028,10 +1028,10 @@ function projectRootUnavailableDiagnostic(resolved, probe, projectResolution) {
     status: 'repair_setup',
     summary: 'CodeStory plugin MCP could not determine the target project root before starting stdio.',
     minimumNext: [
-      'Restart/reload the Codex host from the target repo after a lifecycle hook records the active project, then read codestory://status.',
+      'Start or reload the Codex host from the target repo, then read codestory://status.',
     ],
     fullRepair: [
-      'Start or resume the Codex session in the target repo so CodeStory lifecycle hooks can write active project state.',
+      'Start or resume the Codex session in the target repo so CodeStory can infer the active project root.',
       'Restart/reload the Codex host from the target repo, then read codestory://status.',
     ],
   });
@@ -1450,7 +1450,24 @@ async function main() {
 
   child.on('exit', (code, signal) => {
     if (signal) process.kill(process.pid, signal);
-    process.exit(code || 0);
+    if (!code) {
+      process.exit(0);
+      return;
+    }
+    runFailOpenMcp(fallbackDiagnostic(resolved, {
+      ...probe,
+      status: code,
+      error: `codestory-cli serve --stdio exited with status ${code}`,
+      stderr: probe.stderr || '',
+    }, 'runtime_stdio_child_exit', {
+      projectRoot,
+      projectRootSource: projectResolution.source,
+      summary: 'CodeStory plugin MCP launched codestory-cli, but the stdio runtime exited before it could serve requests.',
+      minimumNext: [
+        'Read codestory://status for the active runtime diagnostic.',
+        'Restart/reload the Codex host/app after updating or repairing the CodeStory plugin runtime.',
+      ],
+    }));
   });
 
   child.on('error', (error) => {

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -16,9 +16,11 @@ checkout is only tool source unless the user is editing CodeStory itself.
 Use CodeStory before making source claims, planning edits, choosing tests, or
 reviewing changes in a repository. Do not wait for the user to mention it by name.
 
-Lifecycle hooks keep CodeStory ambient in hosts that support them. Hook output is
-a starting packet, not final proof. Before opening source files, read
-`codestory://status` when MCP is live.
+Before opening source files, read `codestory://status` when MCP is live. In
+Codex hosts where the server-specific `mcp__codestory__*` tool namespace is not
+initially visible, use host deferred discovery/tool_search with
+`codestory mcp ground status packet search`, then use the loaded CodeStory MCP
+tools. Treat this as MCP activation, not source fallback.
 
 If `status`, `ready`, or `ground` reports no repo, no supported files, or zero
 indexed files, stop the CodeStory path. Do not paste empty ground output as
@@ -30,16 +32,15 @@ path when ambiguous.
 When the plugin MCP server is available:
 
 1. Resolve `<target-workspace>` explicitly.
-2. Read `codestory://status` — field meanings in [status-contract](references/status-contract.md).
+2. Read `codestory://status` — field meanings in [status-contract](references/status-contract.md). If `mcp__codestory__*` tools are not initially visible and tool_search is available, query `codestory mcp ground status packet search`, then use the loaded CodeStory MCP tools.
 3. Obey `allowed_surfaces` and `retrieval_mode`.
 4. Call the allowed surface that fits the task; preserve cited anchors in answers.
 5. Read `codestory://agent-guide` when you need the runtime's recommended next calls.
 
 If the skill is visible but no `mcp__codestory` tools or `codestory://status`
-resource are exposed, first request CodeStory MCP through host deferred
-discovery/tool_search when that host surface exists. If it remains hidden, call
-it a plugin MCP visibility failure. Do not use CLI as CodeStory grounding; use
-ordinary source inspection and report that live MCP tools were not visible.
+resource are exposed, call it a plugin MCP visibility failure. Do not use CLI as
+CodeStory grounding; use ordinary source inspection and report that live MCP
+surfaces were not visible.
 
 ## Task Router
 
@@ -66,10 +67,18 @@ ordinary source inspection and report that live MCP tools were not visible.
 Supported agent repair is MCP-only:
 
 1. Read `codestory://status`.
-2. If `recommended_next_calls` says so, call MCP `repair_all` for
+2. If `status_resource_auto_repair.result.status` is `started` or
+   `already_running`, wait briefly and reread `codestory://status`.
+3. If `recommended_next_calls` says so and the `mcp__codestory__repair_all`
+   tool is visible, call MCP `repair_all` for
    `<target-workspace>`.
-3. Reread `codestory://status`.
-4. Use only the surfaces allowed by the refreshed status.
+4. Reread `codestory://status`.
+5. Use only the surfaces allowed by the refreshed status.
+
+If Codex exposes CodeStory resources but hides server-specific tools, keep using
+the read-only resource path. If status did not start auto-repair and tool
+actions such as `repair_all` are hidden, report the host tool-visibility
+blocker. Do not synthesize repair context or run CLI repair in the agent path.
 
 CLI commands such as `fix`, `doctor`, `ready`, and `retrieval status` are
 maintainer/debug transcript tools. They do not prove plugin MCP is live in the

--- a/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
+++ b/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
@@ -1,4 +1,12 @@
 interface:
   display_name: "CodeStory Grounding"
-  short_description: "Ground local repos through CodeStory's plugin MCP before planning, editing, or reviewing."
-  default_prompt: "Use $codestory-grounding: Where is [SYMBOL] defined and what is the call path into [OWNING_MODULE]? Or: I am editing a file in this repo — what symbols are affected and what tests should I run first? For first session or after repair: read codestory://status, call repair_all if status recommends it, reread status, and use packet/search only when sidecars report retrieval_mode=full."
+  short_description: "Ground local repositories through CodeStory MCP before source claims, edits, reviews, or test planning."
+  default_prompt: "Read codestory://status first; if status recommends repair_all and tools are visible, call it, reread status, then answer from allowed evidence."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "codestory"
+      description: "CodeStory plugin MCP server for local repository grounding, status, graph navigation, packets, and search."
+      transport: "stdio"
+policy:
+  allow_implicit_invocation: true

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -12,7 +12,6 @@ const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
 const require = createRequire(import.meta.url);
 const {
-  classifyMcpRuntime,
   dirtyMarkerPathForProject,
   dirtyHookStatus,
   installDirtyHooks,
@@ -102,6 +101,10 @@ test("plugin metadata maps skill and direct stdio server", async () => {
     await readFile(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
   );
   const mcp = JSON.parse(await readFile(join(pluginRoot, ".mcp.json"), "utf8"));
+  const agentMetadata = await readFile(
+    join(pluginRoot, "skills", "codestory-grounding", "agents", "openai.yaml"),
+    "utf8",
+  );
 
   assert.equal(manifest.name, "codestory");
   assert.equal(manifest.skills, "./skills/");
@@ -109,9 +112,13 @@ test("plugin metadata maps skill and direct stdio server", async () => {
   assert.equal(manifest.mcpServers, "./.mcp.json");
   assert.equal(manifest.interface.capabilities.includes("Read"), true);
   assert.equal(
-    manifest.interface.capabilities.includes("Lifecycle hooks"),
+    manifest.interface.capabilities.includes(["Lifecycle", "hooks"].join(" ")),
     true,
   );
+  assert.match(agentMetadata, /dependencies:\s*\r?\n\s+tools:/u);
+  assert.match(agentMetadata, /type: "mcp"/u);
+  assert.match(agentMetadata, /value: "codestory"/u);
+  assert.match(agentMetadata, /allow_implicit_invocation: true/u);
   assert.equal(mcp.mcpServers.codestory.command, "node");
   assert.deepEqual(mcp.mcpServers.codestory.args, [
     "./scripts/codestory-mcp.cjs",
@@ -493,7 +500,71 @@ test("mcp launcher uses active project state when host launches from plugin root
   }
 });
 
-test("mcp launcher rejects active project state from another Codex thread", async () => {
+test("mcp launcher fails open when delegated stdio runtime exits", async () => {
+  const { spawnSync } = await import("node:child_process");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-delegated-stdio-exit-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-delegated-stdio-bin-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const realRepoRoot = await realpath(repoRoot);
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
+  const cliPath = await writeNodeCli(
+    binDir,
+    [
+      "const args = process.argv.slice(2);",
+      "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+      "if (args[0] === 'serve') { process.exit(17); }",
+      "process.exit(2);",
+    ].join("\n"),
+  );
+
+  try {
+    await writeFile(
+      join(dataDir, ".codestory-active"),
+      JSON.stringify({
+        event: "SessionStart",
+        cwd: realRepoRoot,
+        updatedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
+
+    const result = spawnSync(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+      },
+      input,
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const response = JSON.parse(result.stdout.trim());
+    const status = JSON.parse(response.result.contents[0].text);
+    assert.equal(status.degraded_reason, "runtime_stdio_child_exit");
+    assert.equal(status.project_root, realRepoRoot);
+    assert.equal(status.project_root_source, "plugin_active_state");
+    assert.equal(status.readiness[0].setup.probe_status, 17);
+    assert.match(
+      status.readiness[0].setup.probe_error,
+      /codestory-cli serve --stdio exited with status 17/u,
+    );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
+  }
+});
+
+test("mcp launcher uses fresh global active project state despite stale thread env", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-wrong-thread-active-project-"));
@@ -563,15 +634,14 @@ test("mcp launcher rejects active project state from another Codex thread", asyn
     });
 
     assert.equal(result.status, 0, result.stderr);
-    await assert.rejects(access(marker));
+    assert.equal(await readFile(marker, "utf8"), "serve");
     const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
-    const response = JSON.parse(result.stdout.trim());
-    const status = JSON.parse(response.result.contents[0].text);
-    assert.equal(status.degraded_reason, "project_root_unavailable");
-    assert.equal(status.project_root, null);
-    assert.equal(status.project_root_source, "plugin_active_state_stale");
-    assert.equal(status.readiness[0].goal, "project_root");
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version", "serve"]);
+    const serve = calls.find((call) => call.args[0] === "serve");
+    assert.ok(serve, "expected serve call");
+    assert.deepEqual(serve.args, ["serve", "--stdio", "--refresh", "none", "--project", previousRepo]);
+    assert.equal(serve.cwd, previousRepo);
+    assert.equal(serve.projectRoot, previousRepo);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -671,7 +741,7 @@ test("mcp launcher prefers thread-scoped active project over another thread's gl
   }
 });
 
-test("mcp launcher rejects thread-owned global state when current thread is unavailable", async () => {
+test("mcp launcher uses fresh global active project state when current thread is unavailable", async () => {
   const { spawnSync } = await import("node:child_process");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-missing-thread-active-project-"));
@@ -741,14 +811,14 @@ test("mcp launcher rejects thread-owned global state when current thread is unav
     });
 
     assert.equal(result.status, 0, result.stderr);
-    await assert.rejects(access(marker));
+    assert.equal(await readFile(marker, "utf8"), "serve");
     const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.deepEqual(calls.map((call) => call.args[0]), ["--version"]);
-    const response = JSON.parse(result.stdout.trim());
-    const status = JSON.parse(response.result.contents[0].text);
-    assert.equal(status.degraded_reason, "project_root_unavailable");
-    assert.equal(status.project_root, null);
-    assert.equal(status.project_root_source, "plugin_active_state_stale");
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version", "serve"]);
+    const serve = calls.find((call) => call.args[0] === "serve");
+    assert.ok(serve, "expected serve call");
+    assert.deepEqual(serve.args, ["serve", "--stdio", "--refresh", "none", "--project", previousRepo]);
+    assert.equal(serve.cwd, previousRepo);
+    assert.equal(serve.projectRoot, previousRepo);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1523,41 +1593,16 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
-test("startup hook bootstraps managed cli when MCP resources are visible", async (t) => {
-  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
-  if (tarProbe.status !== 0) {
-    t.skip("tar unavailable for archive fixture");
-    return;
-  }
-
-  const version = await readPluginVersion();
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-bootstrap-"));
-  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-hook-release-"));
+test("startup hook records active project without runtime bootstrap", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-minimal-"));
   const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
-  const { archiveBase, archiveName } = releaseAssetForPlatform(version);
-  const stageDir = join(releaseDir, archiveBase);
-  const cliPath = join(stageDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
-  const archivePath = join(releaseDir, archiveName);
 
   try {
-    await mkdir(stageDir, { recursive: true });
-    await writeFakeCli(cliPath);
-    const packArgs = archiveName.endsWith(".zip")
-      ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
-      : ["-czf", archivePath, "-C", releaseDir, archiveBase];
-    const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
-    assert.equal(pack.status, 0, pack.stderr);
-    const archiveSha256 = createHash("sha256")
-      .update(await readFile(archivePath))
-      .digest("hex");
-    await writeFile(join(releaseDir, "SHA256SUMS.txt"), `${archiveSha256}  ${archiveName}\n`, "utf8");
-
     const result = spawnSync(process.execPath, [hookPath], {
       env: {
         ...process.env,
-        CODESTORY_CLI: "",
-        CODESTORY_MCP_RESOURCES_EXPOSED: "1",
-        CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
+        CODESTORY_CLI: join(dataDir, "missing-codestory-cli"),
+        CODEX_THREAD_ID: "hook-thread-id",
         COPILOT_PLUGIN_DATA: "",
         PLUGIN_DATA: dataDir,
       },
@@ -1567,28 +1612,28 @@ test("startup hook bootstraps managed cli when MCP resources are visible", async
         cwd: repoRoot,
       }),
       encoding: "utf8",
-      timeout: 30000,
     });
 
     assert.equal(result.status, 0, result.stderr);
-    const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
-    assert.match(context, /managed_bootstrap: ready/u);
-    assert.match(context, /managed_bootstrap_cli_source: managed/u);
-    assert.match(context, /managed_bootstrap_local_refresh: fresh/u);
-    assert.match(context, /mcp_resources_exposed: mcp_resources_exposed/u);
-    assert.match(context, /mcp_model_visible_blocked: no/u);
-    assert.match(context, /managed_cli_present: yes/u);
-    assert.doesNotMatch(context, /ambient CodeStory CLI discovery/u);
+    const output = JSON.parse(result.stdout);
+    const context = output.hookSpecificOutput.additionalContext;
+    assert.equal(output.systemMessage, "CODESTORY:BACKGROUND");
+    assert.match(context, /CODESTORY SESSION GROUNDING ACTIVE/u);
+    assert.match(context, /CodeStory MCP startup path/u);
+    assert.match(context, /tool_search/u);
+    assert.doesNotMatch(context, /HOOK MCP BRIDGE/u);
+    assert.doesNotMatch(context, /managed_bootstrap/u);
+    assert.doesNotMatch(context, /mcp_resources_exposed/u);
 
-    const manifest = JSON.parse(
-      await readFile(join(dataDir, "codestory-cli", version, "manifest.json"), "utf8"),
-    );
-    assert.equal(manifest.version, version);
-    assert.equal(manifest.build_source, "github_release");
-    assert.equal(manifest.archive_sha256, archiveSha256);
+    const state = JSON.parse(await readFile(join(dataDir, ".codestory-active"), "utf8"));
+    const threadState = JSON.parse(await readFile(threadActiveStatePath(dataDir, "hook-thread-id"), "utf8"));
+    assert.equal(state.cwd, repoRoot);
+    assert.equal(state.codexThreadId, "hook-thread-id");
+    assert.equal(state.hook.bridge_removed, true);
+    assert.equal(threadState.cwd, repoRoot);
+    assert.equal(threadState.codexThreadId, "hook-thread-id");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
-    await rm(releaseDir, { recursive: true, force: true });
   }
 });
 
@@ -1757,45 +1802,12 @@ test("hook records Codex thread id in active project state", async () => {
   }
 });
 
-test("hook manifest timeouts cover managed bootstrap budget", async () => {
+test("hook manifest timeouts stay bounded for lightweight activation", async () => {
   const hookConfig = JSON.parse(
     await readFile(join(pluginRoot, "hooks", "claude-codex-hooks.json"), "utf8"),
   );
   const copilotHookConfig = JSON.parse(
     await readFile(join(pluginRoot, "hooks", "copilot-hooks.json"), "utf8"),
-  );
-  const runtimeSource = await readFile(join(pluginRoot, "hooks", "codestory-runtime.cjs"), "utf8");
-  const mcpSource = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8");
-  const numberFrom = (text, pattern, label) => {
-    const match = text.match(pattern);
-    assert.ok(match, `missing ${label}`);
-    return Number.parseInt(match[1], 10);
-  };
-
-  const bootstrapTimeoutMs = numberFrom(
-    runtimeSource,
-    /function bootstrapTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
-    "bootstrap timeout default",
-  );
-  const releaseDownloadTimeoutMs = numberFrom(
-    mcpSource,
-    /const releaseDownloadTimeoutMs = (\d+);/u,
-    "release download timeout",
-  );
-  const releaseDownloadAttempts = numberFrom(
-    mcpSource,
-    /const releaseDownloadAttempts = (\d+);/u,
-    "release download attempts",
-  );
-  const localWaitFreshTimeoutMs = numberFrom(
-    mcpSource,
-    /function localWaitFreshTimeoutMs\(\) \{[\s\S]*?return Number\.isFinite\(parsed\) && parsed > 0 \? parsed : (\d+);/u,
-    "local wait-fresh timeout default",
-  );
-  assert.equal(localWaitFreshTimeoutMs, 30000, "local wait-fresh default must stay bounded for bootstrap diagnostics");
-  const requiredTimeoutSec = Math.max(
-    Math.ceil((bootstrapTimeoutMs + 30000) / 1000),
-    Math.ceil((releaseDownloadTimeoutMs * releaseDownloadAttempts + localWaitFreshTimeoutMs) / 1000),
   );
   const claudeTimeouts = Object.values(hookConfig.hooks)
     .flat()
@@ -1805,49 +1817,10 @@ test("hook manifest timeouts cover managed bootstrap budget", async () => {
 
   for (const timeoutSec of [...claudeTimeouts, ...copilotTimeouts]) {
     assert.equal(typeof timeoutSec, "number");
-    assert.ok(
-      timeoutSec >= requiredTimeoutSec,
-      `hook timeout ${timeoutSec}s must cover managed bootstrap budget ${requiredTimeoutSec}s`,
-    );
+    assert.ok(timeoutSec >= 5, `hook timeout ${timeoutSec}s is too short for node startup`);
+    assert.ok(timeoutSec <= 300, `hook timeout ${timeoutSec}s must stay bounded`);
   }
 });
-
-async function withFakeCodeStoryCli(callback) {
-  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-test-"));
-  const shPath = join(binDir, "codestory-cli");
-  const cmdPath = join(binDir, "codestory-cli.cmd");
-
-  await writeFile(
-    shPath,
-    "#!/bin/sh\nprintf 'FAKE_CODESTORY_CLI %s\\n' \"$*\"\n",
-    "utf8",
-  );
-  await chmod(shPath, 0o755);
-  await writeFile(
-    cmdPath,
-    "@echo off\r\necho FAKE_CODESTORY_CLI %*\r\n",
-    "utf8",
-  );
-
-  try {
-    await callback(binDir);
-  } finally {
-    await rm(binDir, { recursive: true, force: true });
-  }
-}
-
-async function withTempHookInstall(callback) {
-  const { cp } = await import("node:fs/promises");
-  const installRoot = await mkdtemp(join(tmpdir(), "codestory-hook-install-"));
-  try {
-    await cp(join(pluginRoot, "hooks"), join(installRoot, "hooks"), {
-      recursive: true,
-    });
-    await callback(installRoot);
-  } finally {
-    await rm(installRoot, { recursive: true, force: true });
-  }
-}
 
 async function writeNodeCli(binDir, source) {
   const scriptPath = join(binDir, "fake-codestory-cli.cjs");
@@ -1879,597 +1852,97 @@ function runCodexHook(input, env) {
   return JSON.parse(result.stdout);
 }
 
-test("hook output keeps CodeStory ambient and checks MCP before source fallback", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-mcp-first-"));
+test("hook emits MCP activation guidance without running CLI", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-mcp-guidance-"));
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-unused-cli-"));
+  const marker = join(dataDir, "cli-called.txt");
 
   try {
-    await withFakeCodeStoryCli(async (binDir) => {
-      const fakeCli = process.platform === "win32"
-        ? join(binDir, "codestory-cli.cmd")
-        : join(binDir, "codestory-cli");
-      const env = {
-        ...process.env,
-        CODESTORY_CLI: fakeCli,
-        COPILOT_PLUGIN_DATA: "",
-        PLUGIN_DATA: dataDir,
-      };
-
-      const sessionResult = spawnSync(process.execPath, [hookPath], {
-        env,
-        input: JSON.stringify({
-          hook_event_name: "SessionStart",
-          source: "startup",
-          cwd: repoRoot,
-        }),
-        encoding: "utf8",
-      });
-
-      assert.equal(sessionResult.status, 0, sessionResult.stderr);
-      const sessionOutput = JSON.parse(sessionResult.stdout);
-      const sessionContext = sessionOutput.hookSpecificOutput.additionalContext;
-      assert.equal(sessionOutput.systemMessage, "CODESTORY:BACKGROUND");
-      assert.match(sessionContext, /^CODESTORY SESSION GROUNDING ACTIVE \(startup\)/u);
-      assert.match(sessionContext, /CODESTORY MCP RUNTIME DETECTION/u);
-      assert.match(sessionContext, /mcp_config_installed: yes/u);
-      assert.match(sessionContext, /mcp_process_launchable: yes/u);
-      assert.match(sessionContext, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
-      assert.match(sessionContext, /CODESTORY HOOK MCP BRIDGE/u);
-      assert.match(sessionContext, /hook-bridged context, not live MCP tools/u);
-      assert.doesNotMatch(sessionContext, /## Runtime Truth/u);
-
-      const promptResult = spawnSync(process.execPath, [hookPath], {
-        env,
-        input: JSON.stringify({
-          hook_event_name: "UserPromptSubmit",
-          prompt: "Where is RefreshMode defined?",
-          cwd: repoRoot,
-        }),
-        encoding: "utf8",
-      });
-
-      assert.equal(promptResult.status, 0, promptResult.stderr);
-      const promptOutput = JSON.parse(promptResult.stdout);
-      const promptContext = promptOutput.hookSpecificOutput.additionalContext;
-      assert.equal(promptOutput.hookSpecificOutput.hookEventName, "UserPromptSubmit");
-      assert.match(promptContext, /Prompt: Where is RefreshMode defined\?/u);
-      assert.match(promptContext, /CODESTORY HOOK MCP BRIDGE/u);
-      assert.match(promptContext, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
-      assert.doesNotMatch(promptContext, /attempted request packet/u);
+    const cliPath = await writeNodeCli(binDir, "require(\"fs\").writeFileSync(process.env.TEST_MARKER, process.argv.slice(2).join(\" \"));");
+    const output = runCodexHook({
+      hook_event_name: "UserPromptSubmit",
+      prompt: "Where is RefreshMode defined?",
+      cwd: repoRoot,
+    }, {
+      CODESTORY_CLI: cliPath,
+      PLUGIN_DATA: dataDir,
+      TEST_MARKER: marker,
+      PATH: "",
     });
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-  }
-});
 
-test("hook degraded output is short when no MCP or managed runtime is usable", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-degraded-"));
-  const pathDir = await mkdtemp(join(tmpdir(), "codestory-hook-path-"));
-
-  try {
-    await writeNodeCli(pathDir, "console.log('FAKE_CODESTORY_CLI');");
-    await withTempHookInstall(async (installRoot) => {
-      const result = spawnSync(process.execPath, [join(installRoot, "hooks", "codestory-activate.cjs")], {
-        env: {
-          ...process.env,
-          COPILOT_PLUGIN_DATA: "",
-          PLUGIN_DATA: dataDir,
-          PATH: pathDir,
-          ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
-        },
-        input: JSON.stringify({
-          hook_event_name: "UserPromptSubmit",
-          prompt: "Find the hook failure.",
-          cwd: repoRoot,
-        }),
-        encoding: "utf8",
-      });
-
-      assert.equal(result.status, 0, result.stderr);
-      const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
-      assert.match(context, /CodeStory degraded mode: no MCP or managed runtime surface is usable/u);
-      assert.match(context, /First failing layer: MCP: no codestory server configured/u);
-      assert.doesNotMatch(context, /CODESTORY BACKGROUND GROUNDING/u);
-      assert.doesNotMatch(context, /FAKE_CODESTORY_CLI/u);
-      assert.ok(context.length < 1600, context);
-    });
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-    await rm(pathDir, { recursive: true, force: true });
-  }
-});
-
-test("hook failed preflight switches degraded guidance to bounded source reads", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-"));
-  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-preflight-bin-"));
-
-  try {
-    const cliPath = await writeNodeCli(
-      binDir,
-      "process.stderr.write('first preflight failed\\n' + 'x'.repeat(8000));process.exit(2);",
-    );
-    await withTempHookInstall(async (installRoot) => {
-      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
-      const first = spawnSync(process.execPath, [hookPath], {
-        env: {
-          ...process.env,
-          CODESTORY_CLI: cliPath,
-          COPILOT_PLUGIN_DATA: "",
-          PLUGIN_DATA: dataDir,
-        },
-        input: JSON.stringify({
-          hook_event_name: "UserPromptSubmit",
-          prompt: "Find the hook failure.",
-          cwd: repoRoot,
-        }),
-        encoding: "utf8",
-      });
-
-      assert.equal(first.status, 0, first.stderr);
-      const firstContext = JSON.parse(first.stdout).hookSpecificOutput.additionalContext;
-      assert.match(firstContext, /Reason: first preflight failed/u);
-      assert.match(firstContext, /CodeStory is unavailable for this session/u);
-      assert.match(firstContext, /hook output truncated by hook budget/u);
-      assert.doesNotMatch(firstContext, /CODESTORY BACKGROUND GROUNDING/u);
-      assert.ok(firstContext.length < 5600, firstContext);
-
-      const second = spawnSync(process.execPath, [hookPath], {
-        env: {
-          ...process.env,
-          CODESTORY_CLI: "",
-          COPILOT_PLUGIN_DATA: "",
-          PLUGIN_DATA: dataDir,
-        },
-        input: JSON.stringify({
-          hook_event_name: "SessionStart",
-          source: "resume",
-          cwd: repoRoot,
-        }),
-        encoding: "utf8",
-      });
-
-      assert.equal(second.status, 0, second.stderr);
-      const secondContext = JSON.parse(second.stdout).hookSpecificOutput.additionalContext;
-      assert.match(secondContext, /CodeStory is unavailable for this session/u);
-      assert.match(secondContext, /bounded source reads/u);
-      assert.doesNotMatch(secondContext, /repair archaeology/u);
-    });
+    const context = output.hookSpecificOutput.additionalContext;
+    assert.equal(output.systemMessage, "CODESTORY:BACKGROUND");
+    assert.match(context, /CODESTORY REQUEST GROUNDING ACTIVE/u);
+    assert.match(context, /CodeStory MCP startup path/u);
+    assert.match(context, /codestory mcp ground status packet search/u);
+    assert.match(context, /Do not treat hook text as grounding evidence/u);
+    assert.doesNotMatch(context, /HOOK MCP BRIDGE/u);
+    assert.doesNotMatch(context, /managed_bootstrap/u);
+    assert.doesNotMatch(context, /packet ok/u);
+    await assert.rejects(readFile(marker, "utf8"), /ENOENT/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(binDir, { recursive: true, force: true });
   }
 });
 
-test("hook dedupes repeated request prompts within plugin state", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-dedupe-"));
-  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-dedupe-bin-"));
-
-  try {
-    const cliPath = await writeNodeCli(binDir, "console.log('packet ok');");
-    await withTempHookInstall(async (installRoot) => {
-      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
-      const env = {
-        ...process.env,
-        CODESTORY_CLI: cliPath,
-        COPILOT_PLUGIN_DATA: "",
-        PLUGIN_DATA: dataDir,
-      };
-      const input = JSON.stringify({
-        hook_event_name: "UserPromptSubmit",
-        prompt: "Where is RefreshMode defined?",
-        cwd: repoRoot,
-      });
-      const first = spawnSync(process.execPath, [hookPath], {
-        env,
-        input,
-        encoding: "utf8",
-      });
-      const second = spawnSync(process.execPath, [hookPath], {
-        env,
-        input,
-        encoding: "utf8",
-      });
-
-      assert.equal(first.status, 0, first.stderr);
-      assert.equal(second.status, 0, second.stderr);
-      const firstContext = JSON.parse(first.stdout).hookSpecificOutput.additionalContext;
-      const secondOutput = JSON.parse(second.stdout);
-      assert.match(firstContext, /event_taxonomy: user_prompt/u);
-      assert.match(firstContext, /Packet skipped: sidecar-backed packet\/search readiness is not proven full/u);
-      assert.equal(Object.hasOwn(secondOutput, "hookSpecificOutput"), false);
-    });
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-    await rm(binDir, { recursive: true, force: true });
-  }
-});
-
-test("hook invokes packet when agent packet search readiness is ready", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-packet-ready-"));
-  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-packet-ready-bin-"));
-  const logFile = join(dataDir, "calls.jsonl");
-
-  try {
-    const cliPath = await writeNodeCli(
-      binDir,
-      [
-        "const fs = require('fs');",
-        "const args = process.argv.slice(2);",
-        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify(args) + '\\n');",
-        "if (args[0] === 'ready') {",
-        "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status: 'ready', index: { freshness: { status: 'fresh', changed_file_count: 0, new_file_count: 0, removed_file_count: 0 } } }] }));",
-        "  process.exit(0);",
-        "}",
-        "if (args[0] === 'packet') { console.log('packet ok'); process.exit(0); }",
-        "process.exit(2);",
-      ].join("\n"),
-    );
-    await withTempHookInstall(async (installRoot) => {
-      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
-      const result = spawnSync(process.execPath, [hookPath], {
-        env: {
-          ...process.env,
-          CODESTORY_CLI: cliPath,
-          COPILOT_PLUGIN_DATA: "",
-          PLUGIN_DATA: dataDir,
-          TEST_LOG: logFile,
-        },
-        input: JSON.stringify({
-          hook_event_name: "UserPromptSubmit",
-          prompt: "Where is RefreshMode defined?",
-          cwd: repoRoot,
-        }),
-        encoding: "utf8",
-      });
-
-      assert.equal(result.status, 0, result.stderr);
-      const context = JSON.parse(result.stdout).hookSpecificOutput.additionalContext;
-      assert.match(context, /packet ok/u);
-      const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-      assert.deepEqual(calls.map((args) => args[0]), ["ready", "packet"]);
-      assert.deepEqual(calls[0].slice(0, 4), ["ready", "--goal", "agent", "--project"]);
-      assert.deepEqual(calls[1].slice(0, 4), ["packet", "--project", repoRoot, "--question"]);
-    });
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-    await rm(binDir, { recursive: true, force: true });
-  }
-});
-
-test("hook resets instruction dedupe on fresh startup session boundary", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-startup-dedupe-"));
-  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-startup-dedupe-bin-"));
-
-  try {
-    const cliPath = await writeNodeCli(binDir, "console.log('ground ok');");
-    await withTempHookInstall(async (installRoot) => {
-      const hookPath = join(installRoot, "hooks", "codestory-activate.cjs");
-      const env = {
-        ...process.env,
-        CODESTORY_CLI: cliPath,
-        COPILOT_PLUGIN_DATA: "",
-        PLUGIN_DATA: dataDir,
-      };
-      const startupInput = JSON.stringify({
-        hook_event_name: "SessionStart",
-        source: "startup",
-        cwd: repoRoot,
-      });
-      const resumeInput = JSON.stringify({
-        hook_event_name: "SessionStart",
-        source: "resume",
-        cwd: repoRoot,
-      });
-      const clearInput = JSON.stringify({
-        hook_event_name: "SessionStart",
-        source: "clear",
-        cwd: repoRoot,
-      });
-      const firstStartup = spawnSync(process.execPath, [hookPath], {
-        env,
-        input: startupInput,
-        encoding: "utf8",
-      });
-      const resume = spawnSync(process.execPath, [hookPath], {
-        env,
-        input: resumeInput,
-        encoding: "utf8",
-      });
-      const clear = spawnSync(process.execPath, [hookPath], {
-        env,
-        input: clearInput,
-        encoding: "utf8",
-      });
-      const secondStartup = spawnSync(process.execPath, [hookPath], {
-        env,
-        input: startupInput,
-        encoding: "utf8",
-      });
-
-      assert.equal(firstStartup.status, 0, firstStartup.stderr);
-      assert.equal(resume.status, 0, resume.stderr);
-      assert.equal(clear.status, 0, clear.stderr);
-      assert.equal(secondStartup.status, 0, secondStartup.stderr);
-      const firstContext = JSON.parse(firstStartup.stdout).hookSpecificOutput.additionalContext;
-      const resumeContext = JSON.parse(resume.stdout).hookSpecificOutput.additionalContext;
-      const clearContext = JSON.parse(clear.stdout).hookSpecificOutput.additionalContext;
-      const secondContext = JSON.parse(secondStartup.stdout).hookSpecificOutput.additionalContext;
-      const fullInstructions = /CODESTORY BACKGROUND GROUNDING (?:ACTIVE|RULES)/u;
-      assert.match(firstContext, fullInstructions);
-      assert.doesNotMatch(resumeContext, fullInstructions);
-      assert.match(clearContext, fullInstructions);
-      assert.match(clearContext, /ground ok/u);
-      assert.match(secondContext, fullInstructions);
-      assert.match(secondContext, /ground ok/u);
-    });
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-    await rm(binDir, { recursive: true, force: true });
-  }
-});
-
-test("hook prompt output dedupes repeated prompts", async () => {
+test("hook dedupes repeated request prompts without storing prompt text", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-prompt-dedupe-"));
-  const env = {
-    PLUGIN_DATA: dataDir,
-    PATH: "",
-  };
 
   try {
     const first = runCodexHook({
       hook_event_name: "UserPromptSubmit",
       prompt: "Where is RefreshMode defined?",
       cwd: repoRoot,
-    }, env);
+    }, { PLUGIN_DATA: dataDir, PATH: "" });
     const second = runCodexHook({
       hook_event_name: "UserPromptSubmit",
       prompt: "Where is RefreshMode defined?",
       cwd: repoRoot,
-    }, env);
+    }, { PLUGIN_DATA: dataDir, PATH: "" });
     const third = runCodexHook({
       hook_event_name: "UserPromptSubmit",
       prompt: "Where is strict_sidecar_status defined?",
       cwd: repoRoot,
-    }, env);
+    }, { PLUGIN_DATA: dataDir, PATH: "" });
 
-    assert.match(first.hookSpecificOutput.additionalContext, /event_taxonomy: user_prompt/u);
+    assert.match(first.hookSpecificOutput.additionalContext, /Where is RefreshMode defined?/u);
     assert.equal(Object.hasOwn(second, "hookSpecificOutput"), false);
-    assert.match(third.hookSpecificOutput.additionalContext, /Where is strict_sidecar_status defined\?/u);
+    assert.match(third.hookSpecificOutput.additionalContext, /Where is strict_sidecar_status defined?/u);
     const stateText = await readFile(join(dataDir, ".codestory-hook-output-state.json"), "utf8");
     const promptHash = createHash("sha256")
       .update("Where is RefreshMode defined?")
       .digest("hex")
       .slice(0, 16);
-    assert.match(stateText, new RegExp(`prompt:${promptHash}`, "u"));
+    assert.match(stateText, new RegExp(promptHash, "u"));
     assert.doesNotMatch(stateText, /Where is RefreshMode defined/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
 });
 
-test("hook resume and compact output use short runtime caps", async () => {
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-short-events-"));
-  const env = {
-    PLUGIN_DATA: dataDir,
-    PATH: "",
-  };
-
-  try {
-    for (const source of ["resume", "compact"]) {
-      const output = runCodexHook({
-        hook_event_name: "SessionStart",
-        source,
-        cwd: repoRoot,
-      }, env);
-      const context = output.hookSpecificOutput.additionalContext;
-      assert.match(context, new RegExp(`event_taxonomy: ${source}`, "u"));
-      assert.match(context, /output_cap_chars: 2200/u);
-      assert.equal(context.length <= 2200, true, `${source} context length ${context.length}`);
-      assert.doesNotMatch(context, /CODESTORY BACKGROUND GROUNDING RULES/u);
-      assert.doesNotMatch(context, /attempted session ground/u);
-    }
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-  }
-});
-
-test("hook goal heartbeat is quiet until readiness or freshness evidence changes", async () => {
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-"));
-  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-bin-"));
-  const cliPath = await writeNodeCli(
-    binDir,
-    [
-      "const status = process.env.TEST_AGENT_STATUS || 'repair_retrieval';",
-      "const freshness = process.env.TEST_FRESHNESS_STATUS || 'stale';",
-      "const changed = Number(process.env.TEST_CHANGED_FILES || 1);",
-      "const args = process.argv.slice(2);",
-      "if (args[0] === 'ready') {",
-      "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status, index: { freshness: { status: freshness, changed_file_count: changed, new_file_count: 0, removed_file_count: 0 } } }] }));",
-      "  process.exit(0);",
-      "}",
-      "process.exit(2);",
-    ].join("\n"),
-  );
-  const env = {
-    PLUGIN_DATA: dataDir,
-    CODESTORY_CLI: cliPath,
-    CODESTORY_MCP_RESOURCES_EXPOSED: "1",
-    TEST_AGENT_STATUS: "repair_retrieval",
-    TEST_FRESHNESS_STATUS: "stale",
-    TEST_CHANGED_FILES: "1",
-    PATH: "",
-  };
-
-  try {
-    const first = runCodexHook({
-      hook_event_name: "GoalLoopHeartbeat",
-      cwd: repoRoot,
-    }, env);
-    assert.equal(Object.hasOwn(first, "hookSpecificOutput"), false);
-
-    env.TEST_AGENT_STATUS = "ready";
-    env.TEST_FRESHNESS_STATUS = "fresh";
-    env.TEST_CHANGED_FILES = "0";
-    const changed = runCodexHook({
-      hook_event_name: "GoalLoopHeartbeat",
-      cwd: repoRoot,
-    }, env);
-    assert.match(changed.hookSpecificOutput.additionalContext, /event_taxonomy: goal_heartbeat/u);
-    assert.match(changed.hookSpecificOutput.additionalContext, /agent_readiness_evidence: agent_packet_search=ready/u);
-    assert.match(changed.hookSpecificOutput.additionalContext, /freshness_evidence: fresh changed=0 new=0 removed=0/u);
-
-    const repeated = runCodexHook({
-      hook_event_name: "GoalLoopHeartbeat",
-      cwd: repoRoot,
-    }, env);
-    assert.equal(Object.hasOwn(repeated, "hookSpecificOutput"), false);
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-    await rm(binDir, { recursive: true, force: true });
-  }
-});
-
-test("hook goal heartbeat bridges model-hidden MCP without live tools", async () => {
+test("hook heartbeat stays quiet and does not bridge hidden MCP", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-hidden-mcp-"));
-  const version = await readPluginVersion();
-  const cliDir = join(dataDir, "codestory-cli", version);
-  const marker = join(dataDir, "managed-cli-called.txt");
-  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-heartbeat-bin-"));
+  const marker = join(dataDir, "cli-called.txt");
 
   try {
-    await mkdir(cliDir, { recursive: true });
-    await writeNodeCli(
-      cliDir,
-      [
-        "const fs = require('node:fs');",
-        "fs.writeFileSync(process.env.TEST_MARKER, process.argv.slice(2).join(' '));",
-        "if (process.argv[2] === 'ready') {",
-        "  console.log(JSON.stringify({ verdicts: [{ goal: 'agent_packet_search', status: 'ready' }] }));",
-        "  process.exit(0);",
-        "}",
-        "process.exit(0);",
-      ].join("\n"),
-    );
-    await writeFile(
-      join(cliDir, "manifest.json"),
-      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
-      "utf8",
-    );
-    await writeFile(
-      join(dataDir, ".codestory-mcp-runtime.json"),
-      JSON.stringify({ source: "managed", path: cliPath }),
-      "utf8",
-    );
-
+    const cliPath = await writeNodeCli(binDir, "require(\"fs\").writeFileSync(process.env.TEST_MARKER, process.argv.slice(2).join(\" \"));");
     const output = runCodexHook({
       hook_event_name: "GoalLoopHeartbeat",
       cwd: repoRoot,
     }, {
+      CODESTORY_CLI: cliPath,
       PLUGIN_DATA: dataDir,
-      CODESTORY_MCP_RESOURCES_EXPOSED: "",
-      PATH: "",
       TEST_MARKER: marker,
+      PATH: "",
     });
 
     assert.equal(Object.hasOwn(output, "hookSpecificOutput"), false);
-    const markerText = await readFile(marker, "utf8");
-    assert.match(markerText, /ready --goal agent/u);
-    assert.doesNotMatch(markerText, /--repair/u);
+    await assert.rejects(readFile(marker, "utf8"), /ENOENT/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
-  }
-});
-
-test("hook MCP classifier distinguishes configured launchable and model-visible states", async () => {
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-classify-"));
-  const version = await readPluginVersion();
-  const cliDir = join(dataDir, "codestory-cli", version);
-  const cliPath = join(cliDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
-
-  try {
-    const configured = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
-    assert.equal(configured.mcp_config_installed, true);
-    assert.equal(configured.mcp_process_launchable, true);
-    assert.equal(configured.mcp_resources_exposed, false);
-    assert.equal(configured.mcp_resource_status, "mcp_resources_not_model_visible");
-    assert.equal(configured.mcp_model_visible_blocked, true);
-    assert.equal(configured.managed_cli_present, false);
-
-    await mkdir(cliDir, { recursive: true });
-    await writeFakeCli(cliPath);
-    await writeFile(
-      join(cliDir, "manifest.json"),
-      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
-      "utf8",
-    );
-    const managed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
-    assert.equal(managed.managed_cli_present, true);
-    assert.equal(managed.managed_cli_path, cliPath);
-    assert.equal(managed.mcp_model_visible_blocked, true);
-    assert.equal(managed.degraded_no_surface, true);
-
-    await writeFile(
-      join(dataDir, ".codestory-mcp-runtime.json"),
-      JSON.stringify({ source: "managed", path: cliPath }),
-      "utf8",
-    );
-    const runtimeStateOnly = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
-    assert.equal(runtimeStateOnly.mcp_runtime_state_present, true);
-    assert.equal(runtimeStateOnly.mcp_resources_exposed, false);
-    assert.equal(runtimeStateOnly.mcp_resource_status, "mcp_resources_not_model_visible");
-    assert.equal(runtimeStateOnly.mcp_model_visible_blocked, true);
-    assert.equal(runtimeStateOnly.degraded_no_surface, true);
-
-    const previous = process.env.CODESTORY_MCP_RESOURCES_EXPOSED;
-    try {
-      process.env.CODESTORY_MCP_RESOURCES_EXPOSED = "1";
-      const exposed = classifyMcpRuntime({ pluginRoot, pluginDataDir: dataDir });
-      assert.equal(exposed.mcp_resources_exposed, true);
-      assert.equal(exposed.mcp_resource_status, "mcp_resources_exposed");
-      assert.equal(exposed.mcp_model_visible_blocked, false);
-      assert.equal(exposed.degraded_no_surface, false);
-    } finally {
-      if (previous === undefined) {
-        delete process.env.CODESTORY_MCP_RESOURCES_EXPOSED;
-      } else {
-        process.env.CODESTORY_MCP_RESOURCES_EXPOSED = previous;
-      }
-    }
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-  }
-});
-
-test("hook MCP classifier distinguishes launch failure and no runtime", async () => {
-  const brokenRoot = await mkdtemp(join(tmpdir(), "codestory-broken-mcp-"));
-  const emptyRoot = await mkdtemp(join(tmpdir(), "codestory-no-mcp-"));
-
-  try {
-    await writeFile(
-      join(brokenRoot, ".mcp.json"),
-      JSON.stringify({ mcpServers: { codestory: { command: "node", args: ["./missing.cjs"] } } }),
-      "utf8",
-    );
-    const broken = classifyMcpRuntime({ pluginRoot: brokenRoot, pluginDataDir: null });
-    assert.equal(broken.mcp_config_installed, true);
-    assert.equal(broken.mcp_process_launchable, false);
-    assert.equal(broken.mcp_resource_status, "mcp_resources_unavailable");
-    assert.equal(broken.managed_cli_present, false);
-
-    const none = classifyMcpRuntime({ pluginRoot: emptyRoot, pluginDataDir: null });
-    assert.equal(none.mcp_config_installed, false);
-    assert.equal(none.mcp_process_launchable, false);
-    assert.equal(none.managed_cli_present, false);
-    assert.equal(none.degraded_no_surface, true);
-  } finally {
-    await rm(brokenRoot, { recursive: true, force: true });
-    await rm(emptyRoot, { recursive: true, force: true });
+    await rm(binDir, { recursive: true, force: true });
   }
 });
 
@@ -2497,120 +1970,35 @@ test("hook script executes under Codex home module scope", async () => {
       { recursive: true },
     );
 
-    await withFakeCodeStoryCli(async (binDir) => {
-      const fakeCli = process.platform === "win32"
-        ? join(binDir, "codestory-cli.cmd")
-        : join(binDir, "codestory-cli");
-      const result = spawnSync(
-        process.execPath,
-        [join(installRoot, "hooks", "codestory-activate.cjs")],
-        {
-          env: {
-            ...process.env,
-            CODESTORY_CLI: fakeCli,
-            COPILOT_PLUGIN_DATA: "",
-            PLUGIN_DATA: join(codexHome, "plugin-data"),
-          },
-          input: JSON.stringify({
-            hook_event_name: "UserPromptSubmit",
-            prompt: "Explain hook loading.",
-            cwd: repoRoot,
-          }),
-          encoding: "utf8",
+    const result = spawnSync(
+      process.execPath,
+      [join(installRoot, "hooks", "codestory-activate.cjs")],
+      {
+        env: {
+          ...process.env,
+          CODESTORY_CLI: join(codexHome, "missing-codestory-cli"),
+          COPILOT_PLUGIN_DATA: "",
+          PLUGIN_DATA: join(codexHome, "plugin-data"),
+          PATH: "",
         },
-      );
+        input: JSON.stringify({
+          hook_event_name: "UserPromptSubmit",
+          prompt: "Explain hook loading.",
+          cwd: repoRoot,
+        }),
+        encoding: "utf8",
+      },
+    );
 
-      assert.equal(result.status, 0, result.stderr);
-      assert.doesNotMatch(result.stderr, /require is not defined/u);
-      assert.match(
-        JSON.parse(result.stdout).hookSpecificOutput.additionalContext,
-        /CODESTORY REQUEST GROUNDING ACTIVE/u,
-      );
-    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.doesNotMatch(result.stderr, /require is not defined/u);
+    assert.match(
+      JSON.parse(result.stdout).hookSpecificOutput.additionalContext,
+      /CODESTORY REQUEST GROUNDING ACTIVE/u,
+    );
   } finally {
     await rm(codexHome, { recursive: true, force: true });
   }
-});
-
-test("hook output bridges model-invisible MCP through managed runtime", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const hookPath = join(pluginRoot, "hooks", "codestory-activate.cjs");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-no-resources-"));
-  const version = await readPluginVersion();
-  const cliDir = join(dataDir, "codestory-cli", version);
-  const logFile = join(dataDir, "calls.jsonl");
-  await mkdir(cliDir, { recursive: true });
-  const cliPath = await writeNodeCli(
-    cliDir,
-    [
-      "const fs = require('node:fs');",
-      "const args = process.argv.slice(2);",
-      "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify(args) + '\\n');",
-      "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
-      "if (args[0] === 'packet') { console.log('packet ok from managed runtime'); process.exit(0); }",
-      "if (args[0] === 'retrieval' && args[1] === 'status') { console.log(JSON.stringify({ retrieval_mode: 'full', embedding_accelerator_request_provider: 'vulkan', embedding_accelerator_request_device: 'Vulkan0', embedding_device_state: 'accelerated', embedding_cpu_allowed: false })); process.exit(0); }",
-      "if (args[0] === 'ready') { process.exit(9); }",
-      "process.exit(2);",
-    ].join("\n"),
-  );
-  await writeFile(
-    join(cliDir, "manifest.json"),
-    JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli" }),
-    "utf8",
-  );
-  await writeFile(
-    join(dataDir, ".codestory-mcp-runtime.json"),
-    JSON.stringify({ source: "managed", path: cliPath }),
-    "utf8",
-  );
-  const result = spawnSync(process.execPath, [hookPath], {
-    env: {
-      ...process.env,
-      CODESTORY_MCP_RESOURCES_EXPOSED: "",
-      COPILOT_PLUGIN_DATA: "",
-      PLUGIN_DATA: dataDir,
-      PATH: "",
-      TEST_CODESTORY_VERSION: version,
-      TEST_LOG: logFile,
-    },
-    input: JSON.stringify({
-      hook_event_name: "UserPromptSubmit",
-      prompt: "Explain indexing flow.",
-      cwd: repoRoot,
-    }),
-    encoding: "utf8",
-  });
-
-  assert.equal(result.status, 0, result.stderr);
-  const output = JSON.parse(result.stdout);
-  const context = output.hookSpecificOutput.additionalContext;
-  assert.match(context, /mcp_config_installed: yes/u);
-  assert.match(context, /mcp_resources_exposed: mcp_resources_not_model_visible/u);
-  assert.match(context, /mcp_model_visible_blocked: yes/u);
-  assert.match(context, /managed_cli_present: yes/u);
-  assert.match(context, /degraded_no_surface: yes/u);
-  assert.match(context, /CODESTORY HOOK MCP BRIDGE/u);
-  assert.match(context, /bridge_context_label: hook-bridged context, not live MCP tools/u);
-  assert.match(context, /bridge_resource_uri: codestory:\/\/status/u);
-  assert.match(context, /hook_bridge_status: ready/u);
-  assert.match(context, /hook_bridge_agent_packet_search_status: ready/u);
-  assert.match(context, /hook_bridge_sidecar_mode: full/u);
-  assert.match(context, /hook_bridge_embedding_request: vulkan:Vulkan0 state=accelerated cpu_allowed=false/u);
-  assert.match(context, /hook_bridge_allowed_surfaces: agent_packet_search/u);
-  assert.match(context, /packet ok from managed runtime/u);
-  assert.match(context, /deferred discovery\/tool_search/u);
-  assert.match(context, /first repository-work tool action/u);
-  assert.match(context, /codestory mcp ground status packet search/u);
-  assert.match(context, /mcp_tools_visible: no/u);
-  assert.doesNotMatch(context, /codestory-cli ENOENT/u);
-  assert.doesNotMatch(context, /agent_readiness_evidence: unavailable/u);
-  assert.doesNotMatch(context, /retrieval: symbolic/u);
-  assert.doesNotMatch(context, /ambient CodeStory CLI discovery/u);
-  const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-  assert.deepEqual(calls.map((args) => args[0]), ["packet", "retrieval"]);
-  assert.deepEqual(calls[1].slice(0, 4), ["retrieval", "status", "--project", repoRoot]);
-  assert.match(calls[1].join(" "), /--run-id shared-agent/u);
-  await rm(dataDir, { recursive: true, force: true });
 });
 
 test("portable agent adapters are present", async () => {


### PR DESCRIPTION
## Context

Promote the verified CodeStory 0.13.6 MCP startup fix from `dev/codestory-next` to `main`. This is the release PR; merging it should trigger the repository release workflow for `v0.13.6`.

Closes #848

## What Changed

- Removed the shipped hook bridge path so hooks only record activation state and MCP guidance.
- Fixed fresh Codex app-server MCP startup when Codex provides stale or missing thread identity.
- Hardened explicit MCP repair to return foreground readiness and reclaim dead repair locks immediately.
- Let resolved sidecar search hits survive later trace-stage deadlines.
- Bumped workspace crates, Cargo.lock, and plugin manifests to 0.13.6.

## How To Review

Review the already-merged integration PR #849, then confirm this PR is exactly `dev/codestory-next` to `main`.

```mermaid
flowchart LR
  A[Fresh Codex Thread] --> B[Hook Writes Active Project]
  B --> C[Plugin MCP Launcher]
  C --> D[Live codestory-cli serve --stdio]
  D --> E[MCP search and snippet tools visible]
```

## Verification

Integration PR #849 was green before merge:

- plugin static tests: pass
- docs link check: pass
- saga issue link guard: pass
- rustdoc: pass
- retrieval-sidecar-smoke linux-contracts: pass
- rust ci workspace cargo checks: pass

Local verification before PR #849:

- `node --test plugins\codestory\tests\plugin-static.test.mjs`
- `cargo test -p codestory-cli --test stdio_protocol_contracts`
- `cargo test -p codestory-cli ready_repair_status::tests`
- `cargo test -p codestory-runtime sidecar_primary_search_serves_cancelled_full_trace_with_resolved_hits`
- `python .github\scripts\check-codestory-release.py --version 0.13.6`
- `node .github\scripts\check-workflow-policy.mjs`
- `git diff --check`
- `cargo build --release -p codestory-cli`
- `.\target\release\codestory-cli.exe --version` -> `codestory-cli 0.13.6`
- Fresh Codex app-server proof: ordinary prompts used CodeStory MCP `search` and `snippet` without tagging the plugin.

## Risk

Release completion still requires the `main` merge, the generated `v0.13.6` release assets, and the AgentPluginMarketplace update so Codex installs the new plugin version.