### PR TITLE
Fix abandoned sidecar auto-repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.13.7
+
+CodeStory 0.13.7 fixes automatic first-start sidecar repair when a stale
+ready-repair record was left behind by an earlier failed startup.
+
+### Fixed
+
+- Let status auto-repair retry past abandoned ready-repair records when plugin
+  sidecar setup is enabled, so stale startup state cannot permanently block
+  agent packet/search repair.
+
 ## 0.13.6
 
 CodeStory 0.13.6 fixes fresh Codex plugin MCP startup without the removed hook

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2851,9 +2851,7 @@ fn stdio_status_resource_auto_repair(
     {
         return None;
     }
-    if stdio_sidecar_setup_has_active_repair(sidecar_setup)
-        || stdio_sidecar_setup_has_abandoned_repair(sidecar_setup)
-    {
+    if stdio_sidecar_setup_has_active_repair(sidecar_setup) {
         return None;
     }
     let non_ready = crate::readiness::primary_non_ready(readiness)?;
@@ -3382,12 +3380,6 @@ fn stdio_status_repair_in_progress_next_calls() -> serde_json::Value {
 fn stdio_sidecar_setup_has_active_repair(sidecar_setup: &serde_json::Value) -> bool {
     sidecar_setup
         .get("active_repair")
-        .is_some_and(|value| !value.is_null())
-}
-
-fn stdio_sidecar_setup_has_abandoned_repair(sidecar_setup: &serde_json::Value) -> bool {
-    sidecar_setup
-        .get("abandoned_repair")
         .is_some_and(|value| !value.is_null())
 }
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2696,6 +2696,49 @@ fn resources_read_status_starts_sidecar_repair_when_policy_enabled() {
 }
 
 #[test]
+fn resources_read_status_starts_sidecar_repair_after_abandoned_repair_when_policy_enabled() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("enabled".to_string());
+    let (status_path, _cleanup) = write_abandoned_repair_status_fixture(
+        &fixture,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+        "graph artifact",
+    );
+    assert!(status_path.exists(), "repair status fixture should exist");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-sidecar-enabled-abandoned",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let result = assert_success_envelope(&response, json!("status-sidecar-enabled-abandoned"));
+    let status = json_resource_content(result, "codestory://status");
+
+    assert_eq!(status["sidecar_setup"]["state"], json!("enabled"));
+    assert_eq!(
+        status["sidecar_setup"]["abandoned_repair"]["status"],
+        json!("abandoned"),
+        "{status}"
+    );
+    assert!(
+        status["status_resource_auto_repair"]["result"]["status"] == json!("started")
+            || status["status_resource_auto_repair"]["result"]["status"]
+                == json!("already_running"),
+        "enabled policy should retry MCP-owned auto repair past abandoned records: {status}"
+    );
+    assert_eq!(
+        status["status_resource_auto_repair"]["result"]["previous_abandoned_repair"]["status"],
+        json!("abandoned"),
+        "{status}"
+    );
+}
+
+#[test]
 fn resources_read_status_suppresses_auto_repair_when_policy_disabled() {
     let mut fixture = indexed_fixture();
     fixture.sidecar_policy_state = Some("disabled".to_string());

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.6"
+version = "0.13.7"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context

CodeStory MCP is visible on fresh Codex startup now, but agent packet/search still failed first-start readiness when a stale ready-repair record was present. The status resource reported sidecar setup enabled and an abandoned repair, then refused to start the automatic repair path.

Closes #851

## What Changed

- Let codestory://status auto-repair retry past abandoned ready-repair records while still suppressing duplicate active repairs.
- Added the missing stdio contract for enabled sidecar policy plus an abandoned shared-agent repair record.
- Bumped CodeStory release surfaces to 