### PR TITLE
Pin release artifact action refs

### DIFF
--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload post-publish agent proof artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: post-publish-agent-proof-linux-x64-${{ steps.release.outputs.version }}
           path: target/post-publish-agent-proof

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload packaged agent proof artifacts
         if: always() && matrix.asset_target == 'linux-x64'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: packaged-agent-proof-${{ matrix.asset_target }}
           path: target/packaged-agent-proof
@@ -230,7 +230,7 @@ jobs:
             --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
 
       - name: Upload release asset
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: codestory-cli-${{ matrix.asset_target }}
           path: |
@@ -266,7 +266,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download release assets
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8.0.1
         with:
           path: target/release-assets
           pattern: codestory-cli-*
@@ -375,7 +375,7 @@ jobs:
 
       - name: Upload post-publish agent proof artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: post-publish-agent-proof-linux-x64
           path: target/post-publish-agent-proof

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Pinned release artifact upload/download actions to Node 24-backed versions so
+  release runs stop emitting Node 20 deprecation annotations.
+
 ## 0.13.7
 
 CodeStory 0.13.7 fixes automatic first-start sidecar repair when a stale


### PR DESCRIPTION
## Context

Closes #867
Refs #799

The release workflow and post-publish smoke workflow still used artifact action v5 refs, which #799 tracks because release annotations showed Node 20 deprecation warnings. This PR handles the source-only workflow ref update; #799 stays open until a release run proves those annotations are gone.

## What Changed

- Pinned release upload steps from `actions/upload-artifact@v5` to `actions/upload-artifact@v7.0.1`.
- Pinned the release download step from `actions/download-artifact@v5` to `actions/download-artifact@v8.0.1`.
- Added an Unreleased changelog note for the release automation change.

## How To Review

- Check `.github/workflows/release.yml` for the three upload refs and one download ref.
- Check `.github/workflows/post-publish-release-smoke.yml` for the post-publish upload ref.
- Confirm the PR closes #867 only and leaves #799 open for release-run proof.

## Verification

- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `git diff --check` -> passed.

Coordinator-provided baselines already passed in this worktree before this slice:

- `node .github/scripts/check-workflow-policy.mjs` -> passed.
- `cargo test -p codestory-retrieval native_launch_mode_limits_compose_to_qdrant_and_zoekt` -> passed.

## Risk

Local policy and diff checks passed. The remaining proof is the next release/post-publish workflow run showing the Node 20 artifact-action annotations are gone.