### PR TITLE
[codex] fail closed on stale MCP workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Pinned release artifact upload/download actions to Node 24-backed versions so
   release runs stop emitting Node 20 deprecation annotations.
 
+### Fixed
+
+- Made installed CodeStory MCP detect when its live stdio child is serving a
+  stale workspace, report `workspace_mismatch` diagnostics, and block stale
+  repo repair commands until the host relaunches MCP for the active workspace.
+
 ## 0.13.7
 
 CodeStory 0.13.7 fixes automatic first-start sidecar repair when a stale

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -197,6 +197,18 @@ struct StdioDirtyMarkerStatus {
     reason: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct StdioActiveState {
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct StdioWorkspaceMismatch {
+    active_state_path: PathBuf,
+    served_root: PathBuf,
+    active_root: PathBuf,
+}
+
 fn handle_stdio_message(
     runtime: &RuntimeContext,
     state: &mut StdioServerState,
@@ -2195,6 +2207,11 @@ fn read_stdio_status_resource_cached(
     runtime: &RuntimeContext,
     state: &mut StdioServerState,
 ) -> Result<serde_json::Value> {
+    if let Some(mismatch) = stdio_workspace_mismatch(runtime) {
+        state.status_cache = None;
+        return Ok(stdio_workspace_mismatch_status(&mismatch));
+    }
+
     let key = stdio_status_cache_key(runtime);
     if let Some(cached) = state.status_cache.as_ref()
         && cached.key == key
@@ -2347,6 +2364,13 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
             marker_path
                 .as_ref()
                 .map(|path| stdio_path_fingerprint(path))
+                .unwrap_or_else(|| "not_configured".to_string())
+        ),
+        format!(
+            "active_state:{}",
+            std::env::var_os("CODESTORY_PLUGIN_ACTIVE_STATE_PATH")
+                .map(PathBuf::from)
+                .map(|path| stdio_path_fingerprint(&path))
                 .unwrap_or_else(|| "not_configured".to_string())
         ),
         format!(
@@ -2541,6 +2565,225 @@ fn stdio_same_path_text(left: &Path, right: &Path) -> bool {
             .to_ascii_lowercase()
     };
     clean(left) == clean(right)
+}
+
+fn stdio_workspace_mismatch(runtime: &RuntimeContext) -> Option<StdioWorkspaceMismatch> {
+    let active_state_path =
+        std::env::var_os("CODESTORY_PLUGIN_ACTIVE_STATE_PATH").map(PathBuf::from)?;
+    let active_root = stdio_active_state_root(&active_state_path)?;
+    if stdio_same_path_text(&active_root, &runtime.project_root) {
+        return None;
+    }
+    Some(StdioWorkspaceMismatch {
+        active_state_path,
+        served_root: runtime.project_root.clone(),
+        active_root,
+    })
+}
+
+fn stdio_active_state_root(active_state_path: &Path) -> Option<PathBuf> {
+    if !stdio_active_state_fresh(active_state_path) {
+        return None;
+    }
+    let active: StdioActiveState =
+        serde_json::from_str(&fs::read_to_string(active_state_path).ok()?).ok()?;
+    let cwd = active.cwd?.trim().to_string();
+    (!cwd.is_empty()).then(|| PathBuf::from(cwd))
+}
+
+fn stdio_active_state_fresh(active_state_path: &Path) -> bool {
+    let max_age_ms = env_nonempty("CODESTORY_PLUGIN_ACTIVE_PROJECT_TTL_MS")
+        .and_then(|value| value.parse::<u128>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(60 * 60 * 1000);
+    fs::metadata(active_state_path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_none_or(|age| age.as_millis() <= max_age_ms)
+}
+
+fn stdio_workspace_mismatch_status(mismatch: &StdioWorkspaceMismatch) -> serde_json::Value {
+    let plugin_runtime = stdio_plugin_runtime_status();
+    let diagnostic = stdio_workspace_mismatch_diagnostic(mismatch, &plugin_runtime);
+    let local_refresh = serde_json::json!({
+        "state": "blocked",
+        "reason": "workspace_mismatch",
+        "blocks_local_surfaces": true,
+        "readiness_status": "blocked",
+    });
+    serde_json::json!({
+        "status": "workspace_mismatch",
+        "server_version": env!("CARGO_PKG_VERSION"),
+        "cli_version": env!("CARGO_PKG_VERSION"),
+        "plugin_runtime": plugin_runtime,
+        "runtime_truth": {
+            "runtime_source": diagnostic["cli_source"].clone(),
+            "plugin_root": env_nonempty("CODESTORY_PLUGIN_ROOT"),
+            "managed_cli_path": diagnostic["managed_cli_path"].clone(),
+            "launcher_source": diagnostic["cli_source"].clone(),
+            "workspace": diagnostic.clone(),
+        },
+        "runtime_boundary": {
+            "restart_required_for_runtime_change": true,
+            "message": "The live CodeStory MCP child is serving a different workspace than the active plugin state. Restart/reload the host so MCP relaunches for the active workspace, then reread codestory://status."
+        },
+        "degraded_reason": "workspace_mismatch",
+        "project_root": diagnostic["served_root"].clone(),
+        "workspace_mismatch": diagnostic,
+        "local_refresh": local_refresh,
+        "readiness": [{
+            "goal": "workspace",
+            "status": "blocked",
+            "summary": "CodeStory MCP is serving a stale workspace; repo-specific tools and repairs are blocked until the host relaunches the MCP child for the active workspace.",
+            "repair_reason": "workspace_mismatch",
+            "minimum_next": [],
+            "full_repair": []
+        }],
+        "allowed_surfaces": stdio_workspace_mismatch_allowed_surfaces(),
+        "status_resource_auto_repair": null,
+        "recommended_next_calls": [{
+            "method": "host/restart",
+            "instruction": "Restart/reload the Codex host/app so CodeStory MCP relaunches for the active workspace; then read codestory://status."
+        }, {
+            "method": "resources/read",
+            "uri": "codestory://status"
+        }]
+    })
+}
+
+fn stdio_workspace_mismatch_diagnostic(
+    mismatch: &StdioWorkspaceMismatch,
+    plugin_runtime: &serde_json::Value,
+) -> serde_json::Value {
+    let cli_source = plugin_runtime
+        .get("cli_source")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("direct_cli_launch");
+    serde_json::json!({
+        "code": "workspace_mismatch",
+        "served_root": crate::display::clean_path_string(&mismatch.served_root.to_string_lossy()),
+        "active_root": crate::display::clean_path_string(&mismatch.active_root.to_string_lossy()),
+        "active_state_path": crate::display::clean_path_string(&mismatch.active_state_path.to_string_lossy()),
+        "launch_cwd": env_nonempty("CODESTORY_PLUGIN_LAUNCH_CWD"),
+        "runtime_cwd": env_nonempty("CODESTORY_PLUGIN_RUNTIME_CWD"),
+        "cli_source": cli_source,
+        "managed_cli_path": if cli_source == "managed" {
+            plugin_runtime.get("managed_binary_path").cloned().unwrap_or(serde_json::Value::Null)
+        } else {
+            serde_json::Value::Null
+        },
+        "managed_cli_version": if cli_source == "managed" {
+            plugin_runtime.get("cli_version").cloned().unwrap_or(serde_json::Value::Null)
+        } else {
+            serde_json::Value::Null
+        },
+    })
+}
+
+fn stdio_workspace_mismatch_sidecar_setup(mismatch: &StdioWorkspaceMismatch) -> serde_json::Value {
+    let policy = stdio_sidecar_policy_file();
+    let env_state = env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE");
+    let state = match policy
+        .as_ref()
+        .and_then(|policy| policy.get("state"))
+        .and_then(serde_json::Value::as_str)
+        .or(env_state.as_deref())
+    {
+        Some("enabled") => "enabled",
+        Some("disabled") => "disabled",
+        Some(_) => "ask",
+        None => "unmanaged",
+    };
+    serde_json::json!({
+        "state": state,
+        "auto_repair": false,
+        "prompt_required": false,
+        "prompt": null,
+        "status": "workspace_mismatch",
+        "blocked_reason": "CodeStory MCP is serving a stale workspace; sidecar repair commands are hidden until the host relaunches MCP for the active workspace.",
+        "workspace_mismatch": stdio_workspace_mismatch_diagnostic(
+            mismatch,
+            &stdio_plugin_runtime_status(),
+        ),
+        "mcp_control": {
+            "status": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "status"}},
+            "enable": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "enable"}},
+            "disable": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "disable"}},
+            "ask": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "ask"}},
+            "repair": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"action": "repair"}}
+        },
+        "enable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND"),
+        "disable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND"),
+        "next_repair_command": null,
+        "policy_path": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH"),
+        "policy_updated_at": policy
+            .as_ref()
+            .and_then(|policy| policy.get("updated_at"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .or_else(|| env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT")),
+        "last_repair": null,
+        "active_repair": null,
+        "abandoned_repair": null
+    })
+}
+
+fn stdio_workspace_mismatch_allowed_surfaces() -> serde_json::Value {
+    let mut surfaces = serde_json::Map::new();
+    for surface in [
+        "ground",
+        "files",
+        "symbol",
+        "definition",
+        "get_node",
+        "callers",
+        "callees",
+        "neighbors",
+        "shortest_path",
+        "query_subgraph",
+        "symbols",
+        "trace",
+        "trail",
+        "references",
+        "snippet",
+        "affected",
+        "packet",
+        "search",
+        "context",
+        "repair_all",
+    ] {
+        surfaces.insert(surface.to_string(), stdio_workspace_mismatch_surface());
+    }
+    serde_json::Value::Object(surfaces)
+}
+
+fn stdio_workspace_mismatch_surface() -> serde_json::Value {
+    serde_json::json!({
+        "allowed": false,
+        "readiness_goal": "workspace",
+        "status": "workspace_mismatch",
+        "failed_layer": "workspace_binding",
+        "summary": "CodeStory MCP is serving a stale workspace; restart/reload the host before using repo-specific tools or repairs.",
+        "repair_reason": "workspace_mismatch",
+        "blocked_reason": "CodeStory MCP is serving a stale workspace.",
+        "minimum_next": [],
+        "full_repair": [],
+    })
+}
+
+fn stdio_workspace_mismatch_error(runtime: &RuntimeContext) -> Option<serde_json::Value> {
+    let mismatch = stdio_workspace_mismatch(runtime)?;
+    Some(serde_json::json!({
+        "code": "workspace_mismatch",
+        "message": "CodeStory MCP is serving a stale workspace; repair is blocked until the host relaunches MCP for the active workspace.",
+        "workspace_mismatch": stdio_workspace_mismatch_diagnostic(
+            &mismatch,
+            &stdio_plugin_runtime_status(),
+        ),
+        "minimum_next": [],
+        "full_repair": [],
+    }))
 }
 
 fn stdio_effective_freshness(
@@ -3600,18 +3843,37 @@ fn handle_stdio_sidecar_setup(
         .pointer("/params/arguments/action")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("status");
+    let mismatch = stdio_workspace_mismatch(runtime);
     match action {
         "status" => {
+            if let Some(mismatch) = mismatch.as_ref() {
+                return serde_json::json!({"result": stdio_workspace_mismatch_sidecar_setup(mismatch)});
+            }
             serde_json::json!({"result": stdio_sidecar_setup_status(&runtime.project_root)})
         }
         "enable" | "disable" | "ask" => match stdio_write_sidecar_policy(action) {
             Ok(()) => {
                 state.status_cache = None;
+                if let Some(mismatch) = mismatch.as_ref() {
+                    return serde_json::json!({"result": stdio_workspace_mismatch_sidecar_setup(mismatch)});
+                }
                 serde_json::json!({"result": stdio_sidecar_setup_status(&runtime.project_root)})
             }
             Err(error) => serde_json::json!({"error": error.to_string()}),
         },
         "repair" => {
+            if let Some(mismatch) = mismatch.as_ref() {
+                return serde_json::json!({"error": {
+                    "code": "workspace_mismatch",
+                    "message": "CodeStory MCP is serving a stale workspace; repair is blocked until the host relaunches MCP for the active workspace.",
+                    "workspace_mismatch": stdio_workspace_mismatch_diagnostic(
+                        mismatch,
+                        &stdio_plugin_runtime_status(),
+                    ),
+                    "minimum_next": [],
+                    "full_repair": [],
+                }});
+            }
             state.status_cache = None;
             handle_stdio_sidecar_repair(runtime, StdioSidecarRepairMode::Foreground)
         }
@@ -3665,6 +3927,9 @@ fn handle_stdio_sidecar_repair(
     runtime: &RuntimeContext,
     mode: StdioSidecarRepairMode,
 ) -> serde_json::Value {
+    if let Some(error) = stdio_workspace_mismatch_error(runtime) {
+        return serde_json::json!({"error": error});
+    }
     if let Some(status) =
         crate::ready_repair_status::active_ready_repair_status(&runtime.project_root, None)
     {

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -1433,6 +1433,7 @@ async function main() {
       CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
       CODESTORY_PLUGIN_PROJECT_ROOT: projectRoot,
       CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE: projectResolution.source,
+      CODESTORY_PLUGIN_ACTIVE_STATE_PATH: projectResolution.statePath || activeStatePath() || '',
       CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
       CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
       CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -69,7 +69,7 @@ function releaseAssetForPlatform(version) {
 }
 
 async function writeFakeCli(cliPath) {
-  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,activeStatePath:process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
@@ -370,6 +370,7 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.sha256, sha256);
     assert.equal(observed.pluginRoot, pluginRoot);
     assert.equal(observed.pluginCacheVersion, "");
+    assert.equal(observed.activeStatePath, join(dataDir, ".codestory-active"));
     assert.equal(observed.sidecarPolicy, "ask");
     assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
     assert.match(observed.sidecarEnable, /--policy-file/u);
@@ -498,6 +499,43 @@ test("mcp launcher uses active project state when host launches from plugin root
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
+});
+
+test("stdio workspace mismatch blocks stale repo repair guidance", async () => {
+  const launcher = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8");
+  const transport = await readFile(join(repoRoot, "crates", "codestory-cli", "src", "stdio_transport.rs"), "utf8");
+
+  assert.match(launcher, /CODESTORY_PLUGIN_ACTIVE_STATE_PATH:\s*projectResolution\.statePath \|\| activeStatePath\(\) \|\| ''/u);
+  assert.match(transport, /fn stdio_workspace_mismatch\(runtime: &RuntimeContext\)/u);
+  assert.match(transport, /CODESTORY_PLUGIN_ACTIVE_STATE_PATH/u);
+  assert.match(transport, /let active_root = stdio_active_state_root\(&active_state_path\)\?/u);
+  assert.match(transport, /if stdio_same_path_text\(&active_root, &runtime\.project_root\)/u);
+  assert.match(transport, /fn read_stdio_status_resource_cached[\s\S]*if let Some\(mismatch\) = stdio_workspace_mismatch\(runtime\)/u);
+  assert.match(transport, /"status": "workspace_mismatch"/u);
+  assert.match(transport, /"served_root"/u);
+  assert.match(transport, /"active_root"/u);
+  assert.match(transport, /"launch_cwd"/u);
+  assert.match(transport, /"runtime_cwd"/u);
+  assert.match(transport, /"managed_cli_path"/u);
+  assert.match(transport, /"managed_cli_version"/u);
+  assert.match(transport, /fn stdio_workspace_mismatch_sidecar_setup\(mismatch: &StdioWorkspaceMismatch\)/u);
+  assert.match(transport, /"status": "workspace_mismatch"[\s\S]*"next_repair_command": null/u);
+  assert.match(transport, /"last_repair": null/u);
+  assert.match(transport, /"status" => \{[\s\S]*stdio_workspace_mismatch_sidecar_setup\(mismatch\)[\s\S]*stdio_sidecar_setup_status/u);
+  assert.match(transport, /"enable" \| "disable" \| "ask"[\s\S]*stdio_workspace_mismatch_sidecar_setup\(mismatch\)[\s\S]*stdio_sidecar_setup_status/u);
+  assert.match(transport, /"repair_all"[\s\S]*stdio_workspace_mismatch_surface/u);
+  assert.match(transport, /"minimum_next": \[\]/u);
+  assert.match(transport, /"full_repair": \[\]/u);
+  assert.match(transport, /"repair" => \{[\s\S]*"code": "workspace_mismatch"[\s\S]*handle_stdio_sidecar_repair/u);
+  assert.match(transport, /fn handle_stdio_sidecar_repair[\s\S]*stdio_workspace_mismatch_error\(runtime\)/u);
+  assert.doesNotMatch(
+    transport.match(/fn stdio_workspace_mismatch_status[\s\S]*?fn stdio_workspace_mismatch_diagnostic/u)?.[0] || "",
+    /ready --goal agent --repair/u,
+  );
+  assert.doesNotMatch(
+    transport.match(/fn stdio_workspace_mismatch_sidecar_setup[\s\S]*?fn stdio_workspace_mismatch_allowed_surfaces/u)?.[0] || "",
+    /ready --goal agent --repair|next_repair_command":\s*"/u,
+  );
 });
 
 test("mcp launcher fails open when delegated stdio runtime exits", async () => {
@@ -695,7 +733,8 @@ test("mcp launcher prefers thread-scoped active project over another thread's gl
         "  args,",
         "  cwd: process.cwd(),",
         "  projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '',",
-        "  projectRootSource: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE || ''",
+        "  projectRootSource: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE || '',",
+        "  activeStatePath: process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH || ''",
         "}) + '\\n');",
         "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
         "if (args[0] === 'serve') { fs.writeFileSync(process.env.TEST_OUT, 'serve-called'); process.exit(0); }",
@@ -736,6 +775,7 @@ test("mcp launcher prefers thread-scoped active project over another thread's gl
     assert.equal(serve.cwd, currentRepo);
     assert.equal(serve.projectRoot, currentRepo);
     assert.equal(serve.projectRootSource, "plugin_active_thread_state");
+    assert.equal(serve.activeStatePath, threadActiveStatePath(dataDir, currentThread));
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

Refs #855
Closes #864

CodeStory MCP can keep serving a repo after the host/plugin has moved to another workspace. This PR ships the v0.13.8 fail-loud slice: detect the stale binding, expose the mismatch clearly, and block repo-specific tools and repair commands instead of letting the model act on the wrong checkout.

This does not close #855. The remaining #855 work is the model-visible rebind/open or host-driven restart path.

```mermaid
flowchart LR
  Host["Plugin active state"] --> Child["stdio child env"]
  Child --> Status["codestory://status"]
  Status --> Match{"served root == active root"}
  Match -->|yes| Tools["repo tools allowed"]
  Match -->|no| Block["workspace_mismatch + tools blocked"]
```

## What Changed

- Passed `CODESTORY_PLUGIN_ACTIVE_STATE_PATH` from `plugins/codestory/scripts/codestory-mcp.cjs` into the managed `codestory-cli serve --stdio` child.
- Preferred the thread-scoped active-state path over the global `.codestory-active` fallback.
- Added stdio-side workspace mismatch detection with served root, active root, launch/runtime cwd, managed CLI path, and version metadata.
- Blocked stale repo-specific tool surfaces, including `repair_all` and `sidecar_setup repair`, while a mismatch is active.
- Suppressed stale repair guidance such as `ready --goal agent --repair` during mismatch.
- Added CHANGELOG coverage under `Unreleased`.

## How To Review

- Start in `plugins/codestory/scripts/codestory-mcp.cjs` to see the child env contract.
- Review `crates/codestory-cli/src/stdio_transport.rs` for status/tool gating and mismatch payloads.
- Review `plugins/codestory/tests/plugin-static.test.mjs` for thread-scoped active-state and stale-tool behavior.
- Confirm the PR closes #864 only and leaves #855 open.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` passed: 39 tests.
- `cargo check -p codestory-cli` passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts` passed: 40 passed, 9 ignored.
- `node .github/scripts/check-workflow-policy.mjs` passed.
- `git diff --check HEAD^ HEAD` passed.
- Targeted code-quality re-review approved the thread-scoped active-state fix.

## Risk

- This is intentionally fail-loud only. It prevents stale workspace actions, but it does not yet provide a model-visible workspace rebind/open tool or automatically restart the child process.
- The mismatch check depends on the plugin active-state file being readable by the child process; unreadable state falls back to the existing served workspace behavior.