### PR TITLE
[codex] stage release 0.13.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.13.8
+
+CodeStory 0.13.8 fixes Apple Silicon sidecar acceleration by launching a native
+Metal llama.cpp embedding sidecar on macOS arm64, hardens stale MCP workspace
+detection, and updates release artifact actions to Node 24-backed versions.
+
 ### Changed
 
 - Pinned release artifact upload/download actions to Node 24-backed versions so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.7"
+version = "0.13.8"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.7"
+version = "0.13.8"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context

Closes #855
Closes #856
Closes #857
Closes #858
Closes #864
Refs #799
Refs #854

This stages the `0.13.8` release bump on `dev/codestory-next` so the final promotion PR can follow the repository guard that only allows `dev/codestory-next` into `main`.

`#854` intentionally remains open after release until Apple Silicon user confirmation is available. `#799` should close only after the release workflow run proves the deprecation annotations are gone.

## What Changed

- Bumped all `codestory-*` workspace crate versions and `Cargo.lock` to `0.13.8`.
- Bumped the Codex, Claude, and GitHub plugin manifests to `0.13.8`.
- Promoted the Unreleased changelog entries into the `0.13.8` release section.

## How To Review

- Review the final release commit: `543c78bb release 0.13.8`.
- Confirm the included train on `dev/codestory-next` matches the merged dev PRs for artifact actions, stale MCP workspace detection, macOS Metal resolver, managed Metal llama-server install, and Apple Silicon operator guidance.
- After this merges to `dev/codestory-next`, open the required `dev/codestory-next` -> `main` promotion PR.

## Verification

- `python .github\scripts\check-codestory-release.py --version 0.13.8`
- `node .github\scripts\check-workflow-policy.mjs`
- `git diff --check`
- `cargo check -p codestory-cli`

## Risk

This only stages release metadata on the protected dev branch. The actual release still depends on the follow-up promotion PR to `main` and the release workflow proof.
