### PR TITLE
promote 0.13.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.13.9
+
+CodeStory 0.13.9 moves Windows native llama.cpp sidecar selection onto the same
+manifest-backed backend contract used by Apple Silicon.
+
 ### Changed
 
 - Moved Windows x64 Vulkan native llama.cpp sidecar selection onto the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
+- Moved Windows x64 Vulkan native llama.cpp sidecar selection onto the
+  manifest-backed backend resolver while preserving the existing b9058 managed
+  cache path as a legacy fallback.
+
 ## 0.13.8
 
 CodeStory 0.13.8 fixes Apple Silicon sidecar acceleration by launching a native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/assets/llama-sidecar-backends.json
+++ b/crates/codestory-retrieval/assets/llama-sidecar-backends.json
@@ -25,6 +25,62 @@
       ],
       "device_arg_policy": "none_by_default",
       "log_markers": ["metal", "offloaded"]
+    },
+    {
+      "id": "windows-x86_64-vulkan",
+      "os": "windows",
+      "arch": "x86_64",
+      "provider": "vulkan",
+      "artifact": "llama-b9902-bin-win-vulkan-x64.zip",
+      "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9902/llama-b9902-bin-win-vulkan-x64.zip",
+      "sha256": "66d6c78a45663cf3818caf962371f5d557a74ab8cc47b419d6be4b005b8a9d17",
+      "executable_archive_path": "llama-server.exe",
+      "executable_rel_path": "llama-server.exe",
+      "executable_sha256": "d772b1d999f9c7aaacebd2b08c8ba705f5e6b7891388c417b711b439d3185bc5",
+      "managed_cache_rel_dir": "managed-embeddings/llama/b9902/llama-b9902-bin-win-vulkan-x64",
+      "launch_args": [
+        "--embedding",
+        "--model",
+        "{model}",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "{port}",
+        "--n-gpu-layers",
+        "{n_gpu_layers}",
+        "--device",
+        "{device}"
+      ],
+      "device_arg_policy": "request_device",
+      "log_markers": ["vulkan", "offloaded"]
+    },
+    {
+      "id": "windows-x86_64-vulkan-b9058-legacy",
+      "os": "windows",
+      "arch": "x86_64",
+      "provider": "vulkan",
+      "artifact": "llama-b9058-bin-win-vulkan-x64.zip",
+      "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9058/llama-b9058-bin-win-vulkan-x64.zip",
+      "sha256": "d0a52a50c021d80d49acfbdae38faafed2dd1e4923790bafb5e701f13548d893",
+      "executable_archive_path": "llama-server.exe",
+      "executable_rel_path": "llama-server.exe",
+      "executable_sha256": "cbae9326269e66c2acb67daf1e6e7ba31779badcde6e8b1312418909089a261f",
+      "managed_cache_rel_dir": "managed-embeddings/llama/b9058/llama-b9058-bin-win-vulkan-x64",
+      "launch_args": [
+        "--embedding",
+        "--model",
+        "{model}",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "{port}",
+        "--n-gpu-layers",
+        "{n_gpu_layers}",
+        "--device",
+        "{device}"
+      ],
+      "device_arg_policy": "request_device",
+      "log_markers": ["vulkan", "offloaded"]
     }
   ]
 }

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -527,7 +527,7 @@ fn native_embedding_server_launch(
     repo_root: Option<&Path>,
     runtime: &SidecarRuntimeConfig,
 ) -> Result<NativeEmbeddingServerLaunch> {
-    ensure_selected_managed_native_llama_server()?;
+    ensure_selected_managed_native_llama_server(repo_root)?;
     let executable = native_llama_server_path(repo_root)?;
     let model_path =
         embed_model_dir(repo_root, &runtime.layout)?.join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF);
@@ -548,11 +548,11 @@ fn native_embedding_server_launch_from_paths(
     runtime: &SidecarRuntimeConfig,
 ) -> NativeEmbeddingServerLaunch {
     let mut args = native_embedding_launch_args(&model_path, runtime);
-    if let Some(request) = crate::embeddings::embedding_accelerator_request() {
-        if selected_native_llama_backend().is_none() {
-            args.push("--n-gpu-layers".to_string());
-            args.push(request.n_gpu_layers);
-        }
+    if let Some(request) = crate::embeddings::embedding_accelerator_request()
+        && selected_native_llama_backend().is_none()
+    {
+        args.push("--n-gpu-layers".to_string());
+        args.push(request.n_gpu_layers.clone());
         if let Some(device) = request.device {
             args.push("--device".to_string());
             args.push(device);
@@ -568,18 +568,34 @@ fn native_embedding_server_launch_from_paths(
 
 fn native_embedding_launch_args(model_path: &Path, runtime: &SidecarRuntimeConfig) -> Vec<String> {
     if let Some(backend) = selected_native_llama_backend() {
-        let n_gpu_layers = crate::embeddings::embedding_accelerator_request()
-            .map(|request| request.n_gpu_layers)
-            .unwrap_or_else(|| "0".to_string());
-        return backend
-            .launch_args
-            .into_iter()
-            .map(|arg| {
-                arg.replace("{model}", &model_path.display().to_string())
-                    .replace("{port}", &runtime.embed_http_port.to_string())
-                    .replace("{n_gpu_layers}", &n_gpu_layers)
-            })
-            .collect();
+        let request = crate::embeddings::embedding_accelerator_request();
+        let n_gpu_layers = request
+            .as_ref()
+            .map(|request| request.n_gpu_layers.as_str())
+            .unwrap_or("0");
+        let device = request
+            .as_ref()
+            .and_then(|request| request.device.as_deref());
+        let model = model_path.display().to_string();
+        let port = runtime.embed_http_port.to_string();
+        let mut args = Vec::new();
+        let mut iter = backend.launch_args.into_iter().peekable();
+        while let Some(arg) = iter.next() {
+            if arg == "--device"
+                && iter.peek().is_some_and(|next| next == "{device}")
+                && device.is_none()
+            {
+                iter.next();
+                continue;
+            }
+            args.push(
+                arg.replace("{model}", &model)
+                    .replace("{port}", &port)
+                    .replace("{n_gpu_layers}", n_gpu_layers)
+                    .replace("{device}", device.unwrap_or_default()),
+            );
+        }
+        return args;
     }
     vec![
         "--embedding".to_string(),
@@ -619,14 +635,16 @@ fn native_llama_executable_source(path: &Path, repo_root: Option<&Path>) -> Stri
         return "env:CODESTORY_EMBED_NATIVE_LLAMA_SERVER".to_string();
     }
     if let Some(backend) = selected_native_llama_backend() {
-        let rel_path = native_llama_backend_rel_path(&backend);
-        if path == user_cache_root().join(&rel_path) {
-            return "managed_cache".to_string();
-        }
-        if let Some(root) = repo_root
-            && path == root.join(&rel_path)
-        {
-            return "repo_managed_cache".to_string();
+        for backend in matching_native_llama_backends(&backend.provider) {
+            let rel_path = native_llama_backend_rel_path(&backend);
+            if path == user_cache_root().join(&rel_path) {
+                return "managed_cache".to_string();
+            }
+            if let Some(root) = repo_root
+                && path == root.join(&rel_path)
+            {
+                return "repo_managed_cache".to_string();
+            }
         }
     }
     if path == user_cache_root().join(NATIVE_LLAMA_MANAGED_CACHE_REL_PATH) {
@@ -702,16 +720,19 @@ fn native_llama_server_path_from_candidates(
 
 fn native_llama_server_candidates(repo_root: Option<&Path>) -> Vec<NativeLlamaCandidate> {
     if let Some(backend) = selected_native_llama_backend() {
-        let rel_path = native_llama_backend_rel_path(&backend);
-        let mut candidates = vec![NativeLlamaCandidate {
-            path: user_cache_root().join(&rel_path),
-            backend: Some(backend.clone()),
-        }];
-        if let Some(root) = repo_root {
+        let mut candidates = Vec::new();
+        for backend in matching_native_llama_backends(&backend.provider) {
+            let rel_path = native_llama_backend_rel_path(&backend);
             candidates.push(NativeLlamaCandidate {
-                path: root.join(rel_path),
-                backend: Some(backend),
+                path: user_cache_root().join(&rel_path),
+                backend: Some(backend.clone()),
             });
+            if let Some(root) = repo_root {
+                candidates.push(NativeLlamaCandidate {
+                    path: root.join(rel_path),
+                    backend: Some(backend),
+                });
+            }
         }
         return candidates;
     }
@@ -737,15 +758,24 @@ fn selected_native_llama_backend() -> Option<crate::config::LlamaSidecarBackend>
         .and_then(|request| crate::config::selected_llama_sidecar_backend(&request.provider))
 }
 
+fn matching_native_llama_backends(provider: &str) -> Vec<crate::config::LlamaSidecarBackend> {
+    crate::config::llama_sidecar_backends(provider)
+}
+
 fn native_llama_backend_rel_path(backend: &crate::config::LlamaSidecarBackend) -> PathBuf {
     Path::new(&backend.managed_cache_rel_dir).join(&backend.executable_rel_path)
 }
 
-fn ensure_selected_managed_native_llama_server() -> Result<()> {
+fn ensure_selected_managed_native_llama_server(repo_root: Option<&Path>) -> Result<()> {
     if std::env::var("CODESTORY_EMBED_NATIVE_LLAMA_SERVER").is_ok() {
         return Ok(());
     }
     if let Some(backend) = selected_native_llama_backend() {
+        if native_llama_server_path_from_candidates(native_llama_server_candidates(repo_root))
+            .is_ok()
+        {
+            return Ok(());
+        }
         ensure_managed_native_llama_server(&backend)?;
     }
     Ok(())
@@ -1436,6 +1466,96 @@ mod tests {
                 .to_string()
                 .contains("ambient PATH lookup is not allowed")
         );
+    }
+
+    #[test]
+    fn windows_manifest_candidates_prefer_b9902_and_keep_legacy_b9058() {
+        let _lock = crate::test_support::env_lock();
+        let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "windows/x86_64");
+        let _device = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_DEVICE");
+        let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
+
+        let candidates = native_llama_server_candidates(None);
+        let ids = candidates
+            .iter()
+            .filter_map(|candidate| {
+                candidate
+                    .backend
+                    .as_ref()
+                    .map(|backend| backend.id.as_str())
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ids,
+            vec![
+                "windows-x86_64-vulkan",
+                "windows-x86_64-vulkan-b9058-legacy"
+            ]
+        );
+        assert!(
+            candidates[0]
+                .path
+                .display()
+                .to_string()
+                .contains("llama-b9902-bin-win-vulkan-x64")
+        );
+        assert!(
+            candidates[1]
+                .path
+                .display()
+                .to_string()
+                .contains("llama-b9058-bin-win-vulkan-x64")
+        );
+    }
+
+    #[test]
+    fn legacy_windows_vulkan_cache_requires_matching_install_manifest() {
+        let _lock = crate::test_support::env_lock();
+        let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "windows/x86_64");
+        let legacy = crate::config::llama_sidecar_backends("vulkan")
+            .into_iter()
+            .find(|backend| backend.id == "windows-x86_64-vulkan-b9058-legacy")
+            .expect("legacy windows vulkan backend");
+        let temp = tempdir().expect("temp");
+        let exe = temp.path().join("llama-server.exe");
+        std::fs::write(&exe, b"legacy exe").expect("exe");
+
+        let missing_manifest =
+            native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
+                path: exe.clone(),
+                backend: Some(legacy.clone()),
+            }])
+            .expect_err("legacy cache still needs install manifest");
+        assert!(
+            missing_manifest
+                .to_string()
+                .contains("install-manifest.json")
+        );
+
+        let exe_sha = sha256_file(&exe).expect("exe sha");
+        let manifest = serde_json::json!({
+            "backend": legacy.id,
+            "artifact": legacy.artifact,
+            "artifact_sha256": legacy.sha256,
+            "executable_rel_path": legacy.executable_rel_path,
+            "executable_sha256": exe_sha,
+            "source_url": legacy.url,
+        });
+        std::fs::write(
+            temp.path().join("install-manifest.json"),
+            serde_json::to_vec_pretty(&manifest).expect("manifest"),
+        )
+        .expect("manifest write");
+        let mut legacy = legacy;
+        legacy.executable_sha256 = exe_sha;
+        let selected = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
+            path: exe.clone(),
+            backend: Some(legacy),
+        }])
+        .expect("legacy cache path with manifest");
+
+        assert_eq!(selected, exe);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -102,15 +102,20 @@ fn parse_test_host_platform(value: &str) -> Option<(String, String)> {
 }
 
 pub(crate) fn selected_llama_sidecar_backend(provider: &str) -> Option<LlamaSidecarBackend> {
+    llama_sidecar_backends(provider).into_iter().next()
+}
+
+pub(crate) fn llama_sidecar_backends(provider: &str) -> Vec<LlamaSidecarBackend> {
     let platform = embedding_host_platform();
     llama_sidecar_backend_manifest()
         .backends
         .into_iter()
-        .find(|backend| {
+        .filter(|backend| {
             backend.os == platform.os
                 && backend.arch == platform.arch
                 && backend.provider == provider
         })
+        .collect()
 }
 
 fn llama_sidecar_backend_manifest() -> LlamaSidecarBackendManifest {
@@ -1045,6 +1050,28 @@ mod tests {
         assert_eq!(
             embedding_server_launch_mode().expect("launch mode"),
             EmbeddingServerLaunchMode::DockerComposeEmbed
+        );
+    }
+
+    #[test]
+    fn simulated_windows_x64_selects_current_vulkan_manifest_backend() {
+        let _lock = crate::test_support::env_lock();
+        let _host = EnvGuard::set(TEST_HOST_PLATFORM_ENV, "windows/x86_64");
+
+        let selected = selected_llama_sidecar_backend("vulkan").expect("windows vulkan backend");
+        let matching = llama_sidecar_backends("vulkan");
+
+        assert_eq!(selected.id, "windows-x86_64-vulkan");
+        assert_eq!(selected.artifact, "llama-b9902-bin-win-vulkan-x64.zip");
+        assert_eq!(selected.executable_archive_path, "llama-server.exe");
+        assert!(selected.managed_cache_rel_dir.contains("/llama/b9902/"));
+        assert!(
+            matching
+                .iter()
+                .any(|backend| backend.id == "windows-x86_64-vulkan-b9058-legacy"
+                    && backend.artifact == "llama-b9058-bin-win-vulkan-x64.zip"
+                    && !backend.sha256.is_empty()
+                    && !backend.executable_sha256.is_empty())
         );
     }
 

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2024"
 
 [dependencies]

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -144,14 +144,16 @@ a `vulkan:Vulkan0` request on Apple Silicon. Use
 prewarm the managed Metal cache cell. Set `CODESTORY_EMBED_NATIVE_LLAMA_SERVER`
 only when overriding the managed binary with an absolute path.
 
-On Linux Docker Compose, the base file stays CPU-compatible and CodeStory adds a
-generated `/dev/dri` override only when accelerator mode is requested and the
-host render node exists. On Windows and current non-macOS defaults, the resolver
-keeps the managed Vulkan request (`Vulkan0`, `99` GPU layers) unless an explicit
-endpoint or device override is configured. On other GPU setups, run an
-already-working native or external llama.cpp embedding endpoint and point
-CodeStory at it with `CODESTORY_EMBED_LLAMACPP_URL`; set the device/layer
-variables only when the resolver request does not match that endpoint.
+On Windows x64, the native llama.cpp resolver selects the manifest-backed b9902
+Vulkan cell by default and launches it with `Vulkan0` plus `99` GPU layers. A
+previous b9058 managed-cache install remains a recognized legacy cell only when
+its install manifest and executable checksum match. On Linux Docker Compose,
+the base file stays CPU-compatible and CodeStory adds a generated `/dev/dri`
+override only when accelerator mode is requested and the host render node
+exists. On other GPU setups, run an already-working native or external
+llama.cpp embedding endpoint and point CodeStory at it with
+`CODESTORY_EMBED_LLAMACPP_URL`; set the device/layer variables only when the
+resolver request does not match that endpoint.
 
 If device state is unknown, full packet/search readiness fails closed by
 default. Use the CPU opt-in only as an explicit operator decision; otherwise

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/scripts/setup-retrieval-env.mjs
+++ b/scripts/setup-retrieval-env.mjs
@@ -378,7 +378,11 @@ function selectedLlamaBackend(opts) {
   const arch = hostArch();
   const provider =
     process.env.CODESTORY_EMBED_DEVICE_PROVIDER?.trim().toLowerCase() ||
-    (osName === "macos" && arch === "aarch64" ? "metal" : "");
+    (osName === "macos" && arch === "aarch64"
+      ? "metal"
+      : osName === "windows" && arch === "x86_64"
+        ? "vulkan"
+        : "");
   const backend = backends.find(
     (candidate) =>
       candidate.os === osName && candidate.arch === arch && candidate.provider === provider,
@@ -526,8 +530,18 @@ async function fetchLlamaServer(opts) {
 async function runSelfTest() {
   const backends = readLlamaBackends();
   const macMetal = backends.find((backend) => backend.id === "macos-aarch64-metal");
+  const winVulkan = backends.find((backend) => backend.id === "windows-x86_64-vulkan");
+  const winLegacy = backends.find(
+    (backend) => backend.id === "windows-x86_64-vulkan-b9058-legacy",
+  );
   if (!macMetal) {
     throw new Error("missing macos-aarch64-metal backend");
+  }
+  if (!winVulkan) {
+    throw new Error("missing windows-x86_64-vulkan backend");
+  }
+  if (!winLegacy || !winLegacy.sha256 || !winLegacy.executable_sha256) {
+    throw new Error("missing checksum-backed legacy Windows Vulkan managed-cache fallback");
   }
   if (backends.some((backend) => backend.os === "macos" && backend.arch !== "aarch64")) {
     throw new Error("macOS Intel llama-server backend must not be present");
@@ -540,6 +554,15 @@ async function runSelfTest() {
   }
   if (!/^[0-9a-f]{64}$/.test(macMetal.executable_sha256)) {
     throw new Error(`unexpected executable sha256: ${macMetal.executable_sha256}`);
+  }
+  if (safeArchiveMemberPath(winVulkan.executable_archive_path) !== "llama-server.exe") {
+    throw new Error(`unexpected Windows executable archive path: ${winVulkan.executable_archive_path}`);
+  }
+  if (!winVulkan.managed_cache_rel_dir.includes("/llama/b9902/")) {
+    throw new Error(`unexpected Windows managed cache version path: ${winVulkan.managed_cache_rel_dir}`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(winVulkan.executable_sha256)) {
+    throw new Error(`unexpected Windows executable sha256: ${winVulkan.executable_sha256}`);
   }
   const selected = selectedLlamaBackend({ llamaBackend: "macos-aarch64-metal" });
   if (managedLlamaServerPath(selected).split(path.sep).join("/").endsWith("llama-server") !== true) {


### PR DESCRIPTION
## Context

Promotes `dev/codestory-next` to `main` for the CodeStory 0.13.9 release.

Closes #859.
Refs #854.

## What Changed

- Promotes the Windows manifest-backed native sidecar backend work.
- Promotes the synchronized 0.13.9 version bump for all workspace crates, Cargo.lock, and CodeStory plugin manifests.

## How To Review

- Compare `dev/codestory-next` to `main`; this should contain the merged #872 product PR plus #873 release bump.
- Confirm `crates/codestory-cli/Cargo.toml` reports `0.13.9`.

## Verification

PR checks on #872:
- check markdown links: pass
- deny rustdoc warnings: pass
- linux-contracts: pass
- require closing issue link: pass
- workspace cargo checks: pass

PR checks on #873:
- plugin static tests: pass
- deny rustdoc warnings: pass
- linux-contracts: pass
- require closing issue link: pass
- workspace cargo checks: pass

Local release bump verification:
- `cargo check -p codestory-cli`
- `python .github/scripts/check-codestory-release.py --version 0.13.9`
- `node .github/scripts/check-workflow-policy.mjs`
- `cargo fmt --check`
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`

## Risk

- Auto Release must publish `v0.13.9` after this merges to `main`; verify the GitHub release and restore `dev/codestory-next` parity afterward.