### PR TITLE
[codex] Release 0.13.11 Windows native sidecar repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.13.11
+
+CodeStory 0.13.11 fixes Windows native sidecar repair after the Linux
+accelerated backend work, keeping Windows on native Vulkan `llama-server.exe`
+without requiring Linux device mounts.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Windows native sidecar repair so Vulkan acceleration does not require
+  the Linux `/dev/dri` Compose override when Compose is only starting Qdrant and
+  Zoekt, managed llama.cpp installs restore the full Windows DLL payload, and
+  b9902 native sidecars can prove the requested Vulkan device through
+  `llama-server --list-devices`.
+
 ## 0.13.10
 
 CodeStory 0.13.10 defines the Linux accelerated sidecar backend matrix while

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.10"
+version = "0.13.11"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -28,6 +28,7 @@ const DOCKER_ADDRESS_POOL_EXHAUSTED_NEEDLE: &str =
 const LINUX_VULKAN_RENDER_NODE: &str = "/dev/dri";
 const VULKAN_COMPOSE_OVERRIDE: &str =
     "services:\n  embed:\n    devices:\n      - /dev/dri:/dev/dri\n";
+const MANAGED_LLAMA_EXTRACTED_MARKER: &str = ".codestory-extracted";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct EmbedModelInventory {
@@ -325,9 +326,7 @@ fn docker_compose_up(
     let vulkan_override = maybe_write_vulkan_compose_override(
         &user_cache_root(),
         Path::new(LINUX_VULKAN_RENDER_NODE),
-        accelerator_request
-            .as_ref()
-            .is_some_and(|request| request.provider == "vulkan"),
+        vulkan_compose_override_requested(launch_mode, accelerator_request.as_ref()),
     )?;
     command
         .arg("compose")
@@ -527,6 +526,14 @@ fn docker_compose_services_for_launch_mode(
         EmbeddingServerLaunchMode::DockerComposeEmbed => &[],
         EmbeddingServerLaunchMode::NativeSpawned => &["qdrant", "zoekt"],
     }
+}
+
+fn vulkan_compose_override_requested(
+    mode: EmbeddingServerLaunchMode,
+    request: Option<&crate::embeddings::EmbeddingAcceleratorRequest>,
+) -> bool {
+    mode == EmbeddingServerLaunchMode::DockerComposeEmbed
+        && request.is_some_and(|request| request.provider == "vulkan")
 }
 
 fn native_embedding_server_launch(
@@ -856,7 +863,6 @@ fn install_managed_native_llama_server_from_archive(
         .arg(archive)
         .arg("-C")
         .arg(&extract_root)
-        .arg(&backend.executable_archive_path)
         .output()
         .with_context(|| format!("run tar for {}", archive.display()))?;
     if !output.status.success() {
@@ -869,42 +875,61 @@ fn install_managed_native_llama_server_from_archive(
     }
     let extracted = extract_root.join(&member_path);
     validate_extracted_executable(&extracted, backend)?;
-    let parent = executable
+    let target_dir = executable
         .parent()
         .ok_or_else(|| anyhow::anyhow!("managed llama-server executable has no parent"))?;
-    fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-    let partial = executable.with_extension("download");
-    fs::copy(&extracted, &partial).with_context(|| {
+    let source_dir = extracted
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("managed llama-server archive member has no parent"))?;
+    let target_parent = target_dir
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("managed llama-server install dir has no parent"))?;
+    fs::create_dir_all(target_parent)
+        .with_context(|| format!("create {}", target_parent.display()))?;
+    let staging_dir = target_dir.with_extension("download");
+    if staging_dir.exists() {
+        fs::remove_dir_all(&staging_dir)
+            .with_context(|| format!("remove {}", staging_dir.display()))?;
+    }
+    copy_dir_contents(source_dir, &staging_dir).with_context(|| {
         format!(
-            "copy extracted llama-server {} to {}",
-            extracted.display(),
-            partial.display()
+            "copy extracted llama-server payload {} to {}",
+            source_dir.display(),
+            staging_dir.display()
         )
     })?;
+    let executable_rel_path = safe_archive_member_path(&backend.executable_rel_path)?;
+    let staged_executable = staging_dir.join(executable_rel_path);
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut permissions = fs::metadata(&partial)?.permissions();
+        let mut permissions = fs::metadata(&staged_executable)?.permissions();
         permissions.set_mode(0o755);
-        fs::set_permissions(&partial, permissions)?;
+        fs::set_permissions(&staged_executable, permissions)?;
     }
-    let executable_sha = sha256_file(&partial)?;
+    let executable_sha = sha256_file(&staged_executable)?;
     if !executable_sha.eq_ignore_ascii_case(&backend.executable_sha256) {
         bail!(
             "managed llama-server executable checksum mismatch for {}: expected {}, got {}",
-            partial.display(),
+            staged_executable.display(),
             backend.executable_sha256,
             executable_sha
         );
     }
-    fs::rename(&partial, executable).with_context(|| {
+    fs::write(staging_dir.join(MANAGED_LLAMA_EXTRACTED_MARKER), b"1")
+        .with_context(|| format!("write extraction marker {}", staging_dir.display()))?;
+    write_managed_native_llama_install_manifest(backend, &staged_executable, &executable_sha)?;
+    if target_dir.exists() {
+        fs::remove_dir_all(target_dir)
+            .with_context(|| format!("remove {}", target_dir.display()))?;
+    }
+    fs::rename(&staging_dir, target_dir).with_context(|| {
         format!(
-            "move downloaded llama-server {} to {}",
-            partial.display(),
-            executable.display()
+            "move downloaded llama-server payload {} to {}",
+            staging_dir.display(),
+            target_dir.display()
         )
     })?;
-    write_managed_native_llama_install_manifest(backend, executable, &executable_sha)?;
     validate_managed_native_llama_server(executable, backend)
 }
 
@@ -927,6 +952,40 @@ fn safe_archive_member_path(member: &str) -> Result<PathBuf> {
         bail!("managed llama-server archive path is empty");
     }
     Ok(safe)
+}
+
+fn copy_dir_contents(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target).with_context(|| format!("create {}", target.display()))?;
+    for entry in fs::read_dir(source).with_context(|| format!("read {}", source.display()))? {
+        let entry = entry.with_context(|| format!("read entry in {}", source.display()))?;
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("read file type {}", entry.path().display()))?;
+        if file_type.is_symlink() {
+            bail!(
+                "managed llama-server archive member must not be a symlink: {}",
+                entry.path().display()
+            );
+        }
+        let target_path = target.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_contents(&entry.path(), &target_path)?;
+        } else if file_type.is_file() {
+            fs::copy(entry.path(), &target_path).with_context(|| {
+                format!(
+                    "copy managed llama-server archive member {} to {}",
+                    entry.path().display(),
+                    target_path.display()
+                )
+            })?;
+        } else {
+            bail!(
+                "managed llama-server archive member is not a regular file or directory: {}",
+                entry.path().display()
+            );
+        }
+    }
+    Ok(())
 }
 
 fn validate_extracted_executable(
@@ -982,10 +1041,11 @@ fn validate_managed_native_llama_server(
     executable: &Path,
     backend: &crate::config::LlamaSidecarBackend,
 ) -> Result<()> {
-    let manifest_path = executable
+    let install_dir = executable
         .parent()
         .ok_or_else(|| anyhow::anyhow!("managed llama-server path has no parent"))?
-        .join("install-manifest.json");
+        .to_path_buf();
+    let manifest_path = install_dir.join("install-manifest.json");
     let manifest: NativeLlamaInstallManifest = serde_json::from_slice(
         &std::fs::read(&manifest_path)
             .with_context(|| format!("read {}", manifest_path.display()))?,
@@ -1036,6 +1096,14 @@ fn validate_managed_native_llama_server(
             executable.display(),
             backend.executable_sha256,
             actual_executable_sha
+        );
+    }
+    let extraction_marker = install_dir.join(MANAGED_LLAMA_EXTRACTED_MARKER);
+    if !extraction_marker.is_file() {
+        bail!(
+            "managed llama-server install is incomplete for {}; missing {}",
+            executable.display(),
+            extraction_marker.display()
         );
     }
     Ok(())
@@ -1430,6 +1498,28 @@ mod tests {
     }
 
     #[test]
+    fn native_launch_mode_does_not_require_vulkan_compose_override() {
+        let request = crate::embeddings::EmbeddingAcceleratorRequest {
+            provider: "vulkan".to_string(),
+            device: Some("Vulkan0".to_string()),
+            n_gpu_layers: "99".to_string(),
+        };
+
+        assert!(!vulkan_compose_override_requested(
+            EmbeddingServerLaunchMode::NativeSpawned,
+            Some(&request)
+        ));
+        assert!(vulkan_compose_override_requested(
+            EmbeddingServerLaunchMode::DockerComposeEmbed,
+            Some(&request)
+        ));
+        assert!(!vulkan_compose_override_requested(
+            EmbeddingServerLaunchMode::DockerComposeEmbed,
+            None
+        ));
+    }
+
+    #[test]
     fn bootstrap_progress_is_emitted_before_blocking_work() {
         let phases = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
         let progress_phases = std::rc::Rc::clone(&phases);
@@ -1557,6 +1647,8 @@ mod tests {
             serde_json::to_vec_pretty(&manifest).expect("manifest"),
         )
         .expect("manifest write");
+        std::fs::write(temp.path().join(MANAGED_LLAMA_EXTRACTED_MARKER), b"1")
+            .expect("marker write");
         let mut legacy = legacy;
         legacy.executable_sha256 = exe_sha;
         let selected = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
@@ -1588,7 +1680,7 @@ mod tests {
     }
 
     #[test]
-    fn managed_native_candidate_accepts_matching_install_manifest() {
+    fn managed_native_candidate_accepts_complete_extracted_install() {
         let _lock = crate::test_support::env_lock();
         let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "macos/aarch64");
         let mut backend =
@@ -1609,6 +1701,8 @@ mod tests {
             .expect("manifest"),
         )
         .expect("manifest write");
+        std::fs::write(temp.path().join(MANAGED_LLAMA_EXTRACTED_MARKER), b"1")
+            .expect("marker write");
 
         let selected = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
             path: exe.clone(),
@@ -1617,6 +1711,38 @@ mod tests {
         .expect("valid managed candidate");
 
         assert_eq!(selected, exe);
+    }
+
+    #[test]
+    fn managed_native_candidate_rejects_single_file_install() {
+        let _lock = crate::test_support::env_lock();
+        let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "windows/x86_64");
+        let mut backend = crate::config::selected_llama_sidecar_backend("vulkan")
+            .expect("windows vulkan backend");
+        let temp = tempdir().expect("temp");
+        let exe = temp.path().join("llama-server.exe");
+        std::fs::write(&exe, b"fake exe").expect("exe");
+        let executable_sha = sha256_file(&exe).expect("sha");
+        backend.executable_sha256 = executable_sha.clone();
+        std::fs::write(
+            temp.path().join("install-manifest.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "artifact": backend.artifact,
+                "artifact_sha256": backend.sha256,
+                "executable_rel_path": backend.executable_rel_path,
+                "executable_sha256": executable_sha,
+            }))
+            .expect("manifest"),
+        )
+        .expect("manifest write");
+
+        let error = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
+            path: exe,
+            backend: Some(backend),
+        }])
+        .expect_err("single-file install must not validate");
+
+        assert!(error.to_string().contains("install is incomplete"));
     }
 
     #[test]
@@ -1640,6 +1766,8 @@ mod tests {
             .expect("manifest"),
         )
         .expect("manifest write");
+        std::fs::write(temp.path().join(MANAGED_LLAMA_EXTRACTED_MARKER), b"1")
+            .expect("marker write");
 
         let error = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
             path: exe,
@@ -1675,6 +1803,8 @@ mod tests {
         let payload_dir = archive_root.join("llama-b9902");
         std::fs::create_dir_all(&payload_dir).expect("payload dir");
         std::fs::write(payload_dir.join("llama-server"), b"fake exe").expect("payload exe");
+        std::fs::write(payload_dir.join("libllama-test.dylib"), b"fake dylib")
+            .expect("payload dylib");
         backend.executable_archive_path = "llama-b9902/llama-server".to_string();
         backend.executable_sha256 =
             sha256_file(&payload_dir.join("llama-server")).expect("executable sha");
@@ -1709,6 +1839,18 @@ mod tests {
         assert_eq!(
             std::fs::read(&executable).expect("installed exe"),
             b"fake exe"
+        );
+        assert_eq!(
+            std::fs::read(executable.parent().unwrap().join("libllama-test.dylib"))
+                .expect("installed sibling"),
+            b"fake dylib"
+        );
+        assert!(
+            executable
+                .parent()
+                .unwrap()
+                .join(MANAGED_LLAMA_EXTRACTED_MARKER)
+                .is_file()
         );
         validate_managed_native_llama_server(&executable, &backend)
             .expect("installed manifest validates");

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -77,6 +77,17 @@ pub struct EmbeddingAcceleratorRequest {
     pub n_gpu_layers: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct NativeEmbeddingDeviceStateFile {
+    embedding_launch: Option<NativeEmbeddingDeviceLaunch>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NativeEmbeddingDeviceLaunch {
+    executable_path: Option<String>,
+    requested_device: Option<String>,
+}
+
 /// Stable id stored on retrieval manifest rows (backend + model family).
 pub fn embedding_runtime_id() -> String {
     if llamacpp_backend_selected() {
@@ -223,14 +234,68 @@ fn observe_sidecar_embedding_device_state(
 fn observe_native_embedding_device_state(
     runtime: &crate::config::SidecarRuntimeConfig,
 ) -> Option<EmbeddingDeviceObservation> {
-    let text = std::fs::read_to_string(native_embedding_log_path(runtime)).ok()?;
-    match observed_embedding_device_state_from_text(native_embedding_log_current_launch(&text)) {
-        "unknown" => None,
-        state => Some(EmbeddingDeviceObservation {
-            state,
-            source: "native_log",
-        }),
+    let text = std::fs::read_to_string(native_embedding_log_path(runtime)).ok();
+    if let Some(text) = text.as_deref() {
+        match observed_embedding_device_state_from_text(native_embedding_log_current_launch(text)) {
+            "unknown" => {}
+            state => {
+                return Some(EmbeddingDeviceObservation {
+                    state,
+                    source: "native_log",
+                });
+            }
+        }
     }
+    observe_native_embedding_device_state_from_device_list(runtime)
+}
+
+fn observe_native_embedding_device_state_from_device_list(
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> Option<EmbeddingDeviceObservation> {
+    let request = embedding_accelerator_request()?;
+    let state: NativeEmbeddingDeviceStateFile =
+        serde_json::from_slice(&std::fs::read(&runtime.layout.state_file).ok()?).ok()?;
+    let launch = state.embedding_launch?;
+    let executable = launch.executable_path?;
+    let output = Command::new(executable)
+        .arg("--list-devices")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if native_device_list_proves_accelerator(&text, &request, launch.requested_device.as_deref()) {
+        Some(EmbeddingDeviceObservation {
+            state: "accelerated",
+            source: "native_device_list",
+        })
+    } else {
+        None
+    }
+}
+
+fn native_device_list_proves_accelerator(
+    text: &str,
+    request: &EmbeddingAcceleratorRequest,
+    requested_device: Option<&str>,
+) -> bool {
+    let normalized = text.to_ascii_lowercase();
+    if let Some(device) = requested_device.or(request.device.as_deref()) {
+        let device = device.to_ascii_lowercase();
+        return text.lines().any(|line| {
+            let line = line.trim_start().to_ascii_lowercase();
+            line.starts_with(&format!("{device}:")) || line.contains(&device)
+        });
+    }
+    if request.provider.is_empty() {
+        return false;
+    }
+    normalized.contains(&request.provider.to_ascii_lowercase())
 }
 
 pub(crate) fn native_embedding_log_path(runtime: &crate::config::SidecarRuntimeConfig) -> PathBuf {
@@ -1232,6 +1297,49 @@ mod tests {
         assert_eq!(readiness.observed_state, "accelerated");
         assert_eq!(readiness.observation_source, "native_log");
         assert!(readiness.full_retrieval_allowed);
+    }
+
+    #[test]
+    fn native_device_list_proves_requested_vulkan_device() {
+        let request = EmbeddingAcceleratorRequest {
+            provider: "vulkan".to_string(),
+            device: Some("Vulkan0".to_string()),
+            n_gpu_layers: "99".to_string(),
+        };
+        let devices = "Available devices:\n  Vulkan0: AMD Radeon RX 7900 XT (20464 MiB)\n";
+
+        assert!(native_device_list_proves_accelerator(
+            devices,
+            &request,
+            Some("Vulkan0")
+        ));
+        assert!(!native_device_list_proves_accelerator(
+            "Available devices:\n  CUDA0: NVIDIA GPU\n",
+            &request,
+            Some("Vulkan0")
+        ));
+    }
+
+    #[test]
+    fn native_device_list_observation_allows_accelerator_required_readiness() {
+        let _lock = crate::test_support::env_lock();
+        let _allow_cpu = EnvGuard::remove(ALLOW_CPU_ENV);
+        let _policy = EnvGuard::remove(DEVICE_POLICY_ENV);
+        let _device = EnvGuard::remove(DEVICE_STATE_ENV);
+        let _provider = EnvGuard::set(DEVICE_PROVIDER_ENV, "amd");
+        let _name = EnvGuard::set(DEVICE_NAME_ENV, "AMD Radeon RX 7900 XT");
+        let _host_detect = EnvGuard::remove(DISABLE_HOST_GPU_DETECT_ENV);
+
+        let readiness =
+            embedding_device_readiness_with_observed_state(Some(EmbeddingDeviceObservation {
+                state: "accelerated",
+                source: "native_device_list",
+            }));
+
+        assert_eq!(readiness.observed_state, "accelerated");
+        assert_eq!(readiness.observation_source, "native_device_list");
+        assert!(readiness.full_retrieval_allowed);
+        assert!(readiness.degraded_reason.is_none());
     }
 
     #[test]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.10"
+version = "0.13.11"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context

Windows native sidecar repair regressed after the Linux accelerated sidecar work: `ready --goal agent --repair` requested Vulkan acceleration but failed on the Linux `/dev/dri` Compose override even though Windows should launch native `llama-server.exe` and use Compose only for Qdrant/Zoekt.

This PR is the 0.13.11 hotfix release. Merging to `main` should trigger the normal release/tag/assets automation; no manual `v*` tag is created here.

Closes #878

## What Changed

- Gate the Vulkan Compose override to `docker_compose_embed` only, so `native_spawned` Windows repair does not require `/dev/dri`.
- Install the full managed llama.cpp archive payload for native sidecars instead of copying only `llama-server.exe`; validation now rejects single-file installs without the extraction marker so broken b9902 caches self-heal.
- Let Windows b9902 native sidecars prove acceleration through `llama-server --list-devices` when the current launch log serves embeddings but does not emit the older `offloaded` marker.
- Bumped all CodeStory workspace crates, `Cargo.lock`, and CodeStory plugin manifests to `0.13.11`.
- Added the `0.13.11` changelog entry.

## How To Review

1. Start in `crates/codestory-retrieval/src/compose.rs` and check that native launch mode starts only Qdrant/Zoekt and never asks for the Linux Vulkan Compose override.
2. Review managed native install validation in the same file: full archive extraction, `.codestory-extracted`, manifest/checksum validation, and the single-file rejection test.
3. Review `crates/codestory-retrieval/src/embeddings.rs` for the fallback proof path from native logs to `--list-devices`.
4. Check the release bump with `python .github/scripts/check-codestory-release.py --version 0.13.11`.

## Verification

- `cargo fmt -- --check`
- `cargo check -p codestory-cli`
- `cargo build --release -p codestory-cli`
- `cargo test -p codestory-retrieval native_device_list`
- `cargo test -p codestory-retrieval native_launch_mode_does_not_require_vulkan_compose_override`
- `cargo test -p codestory-retrieval managed_native`
- `cargo test -p codestory-retrieval`
- `python .github/scripts/check-codestory-release.py --version 0.13.11`
- `node .github/scripts/check-workflow-policy.mjs`
- Independent subagent review found no blocking correctness or release-readiness findings.
- Windows live repair proof with patched release CLI: `codestory-cli ready --goal agent --repair --project C:\Users\alber\source\repos\codestory --format json --run-id shared-agent` returned `agent_packet_search` ready, `sidecar_mode=full`, `embedding_device_policy=accelerator_required`, `embedding_device_state=accelerated`, `observation_source=native_device_list`, `accelerator_request=vulkan:Vulkan0`, and `embedding_cpu_allowed=false`.
- Follow-up status proof: `codestory-cli retrieval status --project C:\Users\alber\source\repos\codestory --profile agent --run-id shared-agent --format json` returned `retrieval_mode=full`, `embedding_device_state=accelerated`, `embedding_device_observation_source=native_device_list`, `embedding_accelerator_request_device=Vulkan0`, and `embedding_cpu_allowed=false`.

The repo-scale ignored stats command was attempted twice. First run failed because `CODESTORY_REAL_REPO_DRILL_CASES` was unset. Second run used the test-supported `CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1`; the drill test passed with the intentional local skip, but `codestory_repo_release_e2e_emits_stats` wedged after spawning the native b9902 sidecar and no stats log entry was appended. I stopped the wedged run and did not commit any stats-log changes.

## Risk

- The current Codex MCP transport in this thread still returns `Transport closed` for `codestory/ground`, even after the patched CLI repairs agent sidecar readiness. This PR fixes the Windows sidecar repair path; the MCP host/session transport may still need a fresh host reload or a separate follow-up.
- The native device-list proof accepts the explicitly requested device reported by the managed binary itself. It remains fail-closed for CPU fallback: CPU is not allowed unless explicitly opted in.
- `docs/superpowers/` is untracked locally and intentionally not included in this PR.
