### PR TITLE
Release 0.13.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Made diagnostic fail-open MCP re-read plugin active-state files and hand off
+  to `codestory-cli serve --stdio` once a project root appears after startup,
+  instead of freezing the stale startup diagnosis.
+- Detached Windows native `llama-server.exe` embedding sidecars from the ready
+  repair process so semantic endpoints can survive after repair exits, or fail
+  spawn before claiming agent packet/search readiness.
+- Reused an already-healthy native embedding endpoint during sidecar bootstrap
+  so repeated CLI or MCP repairs do not spawn extra `llama-server.exe`
+  processes for the same agent sidecar port.
+- Made stdio `sidecar_setup repair` start the Rust repair in the background so
+  long sidecar rebuilds do not block the MCP request past the host tool timeout.
+
 ## 0.13.11
 
 CodeStory 0.13.11 fixes Windows native sidecar repair after the Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.13.12
+
+CodeStory 0.13.12 fixes the installed plugin MCP recovery path so Codex can
+reconnect to the runtime after startup drift without getting trapped in stale
+diagnostic mode or foreground sidecar repair.
+
 ### Fixed
 
 - Made diagnostic fail-open MCP re-read plugin active-state files and hand off

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.13.11"
+version = "0.13.12"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3875,7 +3875,7 @@ fn handle_stdio_sidecar_setup(
                 }});
             }
             state.status_cache = None;
-            handle_stdio_sidecar_repair(runtime, StdioSidecarRepairMode::Foreground)
+            handle_stdio_sidecar_repair(runtime, StdioSidecarRepairMode::Background)
         }
         _ => {
             serde_json::json!({"error": "sidecar_setup.action must be status, enable, disable, ask, or repair"})

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2822,6 +2822,37 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
         "sidecar policy should record an update timestamp: {policy}"
     );
 
+    let repair_response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "sidecar-setup-repair",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "repair"}
+            }
+        }),
+    );
+    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair"));
+    assert!(
+        repair["status"] == json!("started") || repair["status"] == json!("already_running"),
+        "sidecar_setup repair should return a bounded repair state: {repair}"
+    );
+    assert_eq!(
+        repair["mode"],
+        json!("background"),
+        "sidecar_setup repair should not wait for full repair inside the MCP request: {repair}"
+    );
+    assert!(
+        repair["next_status_command"]
+            .as_str()
+            .is_some_and(|command| command.contains("retrieval status")
+                && command.contains("--profile agent")
+                && command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)),
+        "sidecar_setup repair should point to cheap status inspection: {repair}"
+    );
+
     let status_response = send_json(
         &mut server,
         json!({
@@ -2842,8 +2873,9 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
     assert!(
         status["status_resource_auto_repair"]["result"]["status"] == json!("started")
             || status["status_resource_auto_repair"]["result"]["status"]
-                == json!("already_running"),
-        "status should start Rust-owned repair after sidecar_setup enable: {status}"
+                == json!("already_running")
+            || status["sidecar_setup"]["active_repair"]["status"] == json!("repairing"),
+        "status should report Rust-owned repair after sidecar_setup enable: {status}"
     );
     assert!(
         next_call_text.contains("\"uri\":\"codestory://status\"")

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 
 [features]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -14,6 +14,8 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
@@ -29,6 +31,19 @@ const LINUX_VULKAN_RENDER_NODE: &str = "/dev/dri";
 const VULKAN_COMPOSE_OVERRIDE: &str =
     "services:\n  embed:\n    devices:\n      - /dev/dri:/dev/dri\n";
 const MANAGED_LLAMA_EXTRACTED_MARKER: &str = ".codestory-extracted";
+#[cfg(windows)]
+const WINDOWS_DETACHED_PROCESS: u32 = 0x00000008;
+#[cfg(windows)]
+const WINDOWS_CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+#[cfg(windows)]
+const WINDOWS_CREATE_BREAKAWAY_FROM_JOB: u32 = 0x01000000;
+#[cfg(windows)]
+const WINDOWS_CREATE_NO_WINDOW: u32 = 0x08000000;
+#[cfg(windows)]
+const NATIVE_EMBEDDING_WINDOWS_CREATION_FLAGS: u32 = WINDOWS_DETACHED_PROCESS
+    | WINDOWS_CREATE_NEW_PROCESS_GROUP
+    | WINDOWS_CREATE_BREAKAWAY_FROM_JOB
+    | WINDOWS_CREATE_NO_WINDOW;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct EmbedModelInventory {
@@ -1148,30 +1163,69 @@ fn spawn_native_embedding_server(launch: &NativeEmbeddingServerLaunch) -> Result
         .append(true)
         .open(&launch.log_path)
         .with_context(|| format!("open native llama.cpp log {}", launch.log_path.display()))?;
+    let probe = crate::embeddings::probe_product_embedding_runtime();
+    if native_embedding_server_reusable(&probe) {
+        writeln!(
+            log,
+            "reusing existing native llama.cpp embedding server: {}",
+            probe.detail
+        )
+        .ok();
+        return Ok(());
+    }
     writeln!(
         log,
-        "starting native llama.cpp embedding server: {} {}",
+        "starting native llama.cpp embedding server after probe failed ({}): {} {}",
+        probe.detail,
         launch.executable.display(),
         launch.args.join(" ")
+    )
+    .ok();
+    #[cfg(windows)]
+    writeln!(
+        log,
+        "native llama.cpp embedding server Windows creation_flags=0x{NATIVE_EMBEDDING_WINDOWS_CREATION_FLAGS:08x}"
     )
     .ok();
     let stdout = log
         .try_clone()
         .context("clone native llama.cpp stdout log")?;
-    let _child = Command::new(&launch.executable)
+    let mut command = Command::new(&launch.executable);
+    command
         .args(&launch.args)
         .current_dir(launch.executable.parent().unwrap_or_else(|| Path::new(".")))
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(log))
-        .spawn()
-        .with_context(|| {
-            format!(
-                "spawn native llama.cpp server {}",
-                launch.executable.display()
-            )
-        })?;
+        .stderr(Stdio::from(log));
+    configure_native_embedding_command(&mut command);
+    let _child = command.spawn().with_context(|| {
+        format!(
+            "spawn native llama.cpp server {}{}",
+            launch.executable.display(),
+            native_embedding_spawn_detail()
+        )
+    })?;
     Ok(())
+}
+
+fn native_embedding_server_reusable(probe: &crate::embeddings::EmbeddingRuntimeProbe) -> bool {
+    probe.reachable
+}
+
+fn configure_native_embedding_command(_command: &mut Command) {
+    #[cfg(windows)]
+    _command.creation_flags(NATIVE_EMBEDDING_WINDOWS_CREATION_FLAGS);
+}
+
+fn native_embedding_spawn_detail() -> &'static str {
+    #[cfg(windows)]
+    {
+        " with detached Windows creation flags"
+    }
+    #[cfg(not(windows))]
+    {
+        ""
+    }
 }
 
 fn remove_container_if_present(name: &str) -> Result<()> {
@@ -1943,6 +1997,42 @@ mod tests {
         assert!(!launch.args.iter().any(|arg| arg == "--device"));
         let metadata = embedding_launch_metadata(&launch, &runtime, Some(temp.path()));
         assert_eq!(metadata.requested_device, None);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn native_embedding_windows_spawn_detaches_from_ready_repair_process() {
+        assert_ne!(
+            NATIVE_EMBEDDING_WINDOWS_CREATION_FLAGS & WINDOWS_DETACHED_PROCESS,
+            0
+        );
+        assert_ne!(
+            NATIVE_EMBEDDING_WINDOWS_CREATION_FLAGS & WINDOWS_CREATE_NEW_PROCESS_GROUP,
+            0
+        );
+        assert_ne!(
+            NATIVE_EMBEDDING_WINDOWS_CREATION_FLAGS & WINDOWS_CREATE_BREAKAWAY_FROM_JOB,
+            0
+        );
+        assert_ne!(
+            NATIVE_EMBEDDING_WINDOWS_CREATION_FLAGS & WINDOWS_CREATE_NO_WINDOW,
+            0
+        );
+    }
+
+    #[test]
+    fn native_embedding_reuses_healthy_existing_endpoint() {
+        let reachable = crate::embeddings::EmbeddingRuntimeProbe {
+            reachable: true,
+            detail: "llama.cpp embeddings reachable dim=768".into(),
+        };
+        let unreachable = crate::embeddings::EmbeddingRuntimeProbe {
+            reachable: false,
+            detail: "llama.cpp embeddings unavailable".into(),
+        };
+
+        assert!(native_embedding_server_reusable(&reachable));
+        assert!(!native_embedding_server_reusable(&unreachable));
     }
 
     #[test]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.13.11"
+version = "0.13.12"
 edition = "2024"
 
 [dependencies]

--- a/docs/superpowers/plans/2026-07-08-codestory-plugin-recovery.md
+++ b/docs/superpowers/plans/2026-07-08-codestory-plugin-recovery.md
@@ -1,0 +1,66 @@
+# CodeStory Plugin Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` or `superpowers:subagent-driven-development` to implement this plan task-by-task. Keep checkbox state current as work lands.
+
+**Goal:** Restore plugin-first CodeStory grounding after the 0.13.11 release by fixing the MCP project-root bind failure and the Windows native semantic sidecar lifetime failure.
+
+**Architecture:** The CodeStory plugin is a thin Node MCP launcher around the managed `codestory-cli` binary. The launcher decides the target project root, then starts `codestory-cli serve --stdio --project <root>`. The Rust CLI owns graph refresh, sidecar setup, packet/search readiness, and retrieval status. The recovery keeps that boundary: the wrapper should only bind or diagnose the runtime, while the CLI remains the source of retrieval behavior.
+
+**Tech Stack:** Node.js plugin launcher and hooks, MCP stdio, Rust 2024 workspace crates, Windows native `llama.cpp` embeddings, Qdrant, Zoekt, SQLite graph cache.
+
+---
+
+## Evidence Snapshot
+
+- Live `codestory://status` reports plugin/runtime `0.13.11`, managed CLI path under `C:\Users\alber\.codex\plugins\data\codestory-TheGreenCedar`, `project_root: null`, `project_root_source: plugin_active_state_stale`, and all grounding surfaces blocked with `project_root_unavailable`.
+- The plugin active-state file later refreshed to `C:\Users\alber\source\repos\codestory`, but the already-running fail-open MCP server continued to report the stale startup decision. This makes the MCP failure a wrapper lifecycle problem, not a CLI graph problem.
+- Managed CLI with explicit `--project C:\Users\alber\source\repos\codestory` can repair local graph readiness and run `ground`.
+- `ready --goal agent --repair --run-id shared-agent` can temporarily report `retrieval_mode=full`, but immediate `retrieval status` degrades to `no_semantic` because the native embedding endpoint refuses connections on the recorded port.
+- The native `llama-server.exe` log shows successful startup and listening during repair, while `Get-Process -Name llama-server` is empty after the command exits. Qdrant and Zoekt containers remain running.
+- Today-facing source history points at `2db3c20b fix windows native sidecar repair` and the later `0.13.11` release as the sidecar regression window.
+
+## Workstreams
+
+### A. MCP Project Root Binding
+
+- [x] Add a focused regression test in `plugins/codestory/tests/plugin-static.test.mjs` for the startup ordering that failed here: MCP starts from the plugin root with stale or missing active state, then a hook writes fresh global active state for the current repo.
+- [x] Decide and implement the least surprising recovery behavior in `plugins/codestory/scripts/codestory-mcp.cjs`:
+  - If fail-open mode is protocol-bound and cannot become a normal MCP server, make `codestory://status` re-read active state live and report `project_root_available_after_launch` plus `restart_required`, instead of freezing `plugin_active_state_stale`.
+  - If protocol-safe, let fail-open mode lazily re-resolve active state and start/proxy the real stdio CLI once a fresh root appears.
+- [x] Keep the wrapper thin: do not duplicate graph or retrieval logic in Node. Normal grounding tools should still come from `codestory-cli serve --stdio --project <root>`.
+- [x] Expose enough diagnostic fields in fail-open status to debug this without filesystem spelunking: active state path, active state timestamp, thread id observed by the MCP process, thread-state path, launch cwd, runtime cwd, and the startup-vs-current root decision.
+- [x] Update hook or launcher tests if the real failure is an env mismatch between hook `PLUGIN_DATA` and MCP `PLUGIN_DATA`, or a missing `CODEX_THREAD_ID`. Current proof points to stale fail-open startup state rather than env mismatch; the launcher regression now covers stale active state becoming fresh after MCP startup.
+
+### B. Windows Native Semantic Sidecar Lifetime
+
+- [x] Add a narrow test around native embedding launch configuration in `crates/codestory-retrieval/src/compose.rs` that captures Windows process-detach intent without requiring a real model.
+- [x] Refactor native launch construction so Windows creation flags are explicit and testable. The expected behavior is that the embedding server can outlive `ready --goal agent --repair` when the sidecar state records a native spawned endpoint.
+- [x] Investigate whether the Codex host or PowerShell job object requires `CREATE_BREAKAWAY_FROM_JOB` in addition to `DETACHED_PROCESS`, `CREATE_NEW_PROCESS_GROUP`, and `CREATE_NO_WINDOW`. If breakaway is unavailable, fail clearly and fall back to a durable backend rather than recording a dead native endpoint.
+- [x] After launch, perform a post-repair semantic smoke check that proves the recorded embedding endpoint is still reachable after bootstrap completes. Do not write a `full` manifest if the native process is already gone or cannot be reattached.
+- [x] Keep Qdrant/Zoekt evidence separate from semantic evidence in `retrieval status`; `no_semantic` with healthy Qdrant/Zoekt is not full agent packet/search readiness.
+
+### C. Operator Surfaces And Release Hygiene
+
+- [x] Update `CHANGELOG.md` under `Unreleased` before committing behavior, release, packaging, or operator-guidance changes.
+- [x] Update `docs/testing/codestory-plugin-friction-2026-07-07.md` as each hypothesis is confirmed or rejected.
+- [x] If plugin source or packaged behavior changes, verify whether `TheGreenCedar/AgentPluginMarketplace` needs a corresponding pointer or metadata update before treating Codex plugin pickup as complete. This PR is verified through the local `CodeStoryLocal` override rather than a released marketplace pointer; marketplace follow-through is still required when the plugin release is published.
+- [x] Keep current-state proof separate from source proof: source changes are not enough until the managed plugin runtime or explicit target binary shows the fixed behavior.
+- [x] Keep MCP repair calls bounded: `sidecar_setup repair` starts Rust repair in background and returns status inspection guidance instead of blocking the stdio request through long sidecar rebuilds.
+
+## Verification Plan
+
+- [x] `node --test plugins/codestory/tests/plugin-static.test.mjs`
+- [x] `cargo test -p codestory-retrieval --lib native_embedding`
+- [x] `cargo build --release -p codestory-cli`
+- [x] `target\release\codestory-cli.exe ready --goal local --repair --project C:\Users\alber\source\repos\codestory --format json`
+- [x] `target\release\codestory-cli.exe ready --goal agent --repair --project C:\Users\alber\source\repos\codestory --format json --run-id shared-agent`
+- [x] `target\release\codestory-cli.exe retrieval status --project C:\Users\alber\source\repos\codestory --profile agent --run-id shared-agent --format json`
+- [x] `cargo test -p codestory-cli --test stdio_protocol_contracts tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps -- --nocapture`
+- [x] Fresh release-stdio smoke: `sidecar_setup repair` returned `status=started`, `mode=background`; delayed `retrieval status --profile agent --run-id shared-agent` reported `retrieval_mode=full`.
+- [x] Fresh Codex host or plugin reload: read `codestory://status` and confirm `project_root` is the repo path, local grounding surfaces are allowed, and packet/search readiness reflects sidecar truth.
+
+## Stop Conditions
+
+- Stop and split work if MCP root binding and sidecar lifetime require unrelated release vehicles.
+- Stop before claiming plugin recovery if the fixed source binary has not been exercised through the same managed runtime surface Codex will actually use.
+- Stop before closing any issue if packet/search readiness is semantic-only fallback, `no_semantic`, or inferred from local graph freshness alone.

--- a/docs/testing/codestory-plugin-friction-2026-07-07.md
+++ b/docs/testing/codestory-plugin-friction-2026-07-07.md
@@ -1,0 +1,114 @@
+# CodeStory plugin friction log - 2026-07-07
+
+## Context
+
+- Host cwd: `C:\Users\alber\source\repos\codestory`.
+- Git state before the note: `## main...origin/main`, no local changes.
+- Plugin requested through `[@codestory](plugin://codestory@TheGreenCedar)`.
+- Live MCP discovery required `tool_search` for `codestory mcp ground status packet search`.
+
+## Observations
+
+| Surface | Result | Evidence |
+| --- | --- | --- |
+| `codestory://status` | MCP was visible, but repo binding failed. | `plugin_version=0.13.11`, managed CLI path under `plugins\data\codestory-TheGreenCedar`, `project_root=null`, `project_root_source=plugin_active_state_stale`, warning `project_root_unavailable`. |
+| MCP tools | Only `sidecar_setup` was exposed. | A second `tool_search` after repair still did not expose `ground`, `packet`, or `search` tools. |
+| `codestory://agent-guide` | Correctly pointed back to host restart/read status. | `status=repair_setup`; recommended calls were host restart and `codestory://status`. |
+| Managed CLI with explicit `--project` | Worked around MCP repo-root failure. | `doctor` resolved `C:/Users/alber/source/repos/codestory` and found the cache. |
+| Local graph repair | Successful. | `ready --goal local --repair` changed local navigation from stale to `ready`; index became fresh with 280/280 files and 0 errors. |
+| Agent sidecar repair | Initially reported success, then degraded immediately. | `ready --goal agent --repair --run-id shared-agent` ended with `retrieval_mode=full`, but immediate `retrieval status` and `doctor` reported `retrieval_mode=no_semantic`. |
+| Packet call | Correctly failed closed after sidecar degradation. | `packet` returned `retrieval_unavailable` because expected `profile=agent mode=full`, observed `mode=no_semantic`. |
+| Native embedding process | Starts during repair, then is gone after the command exits. | `llama-server-native.log` shows `listening on http://127.0.0.1:37040`; later `Get-Process llama-server` found no process and `netstat` showed only `TIME_WAIT` for port 37040. |
+| Qdrant/Zoekt sidecars | Stayed up. | `docker ps` showed `shared-agent-qdrant` and `shared-agent-zoekt` running. |
+| MCP `sidecar_setup repair` | Did not perform fresh repair. | Returned state `enabled`, but `last_repair` still referenced an old `0.12.3` command from 2026-06-27. |
+
+## Current state
+
+- Installed/plugin-managed runtime is current for this session: `0.13.11`.
+- Live MCP status remains blocked by `project_root_unavailable`; repaired CLI state did not update MCP active state.
+- Local navigation via explicit managed CLI is usable.
+- Agent packet/search must not be trusted: latest verified mode is `no_semantic`, with `embedding_runtime_unavailable` from refused connections to `http://127.0.0.1:37040/v1/embeddings`.
+
+## Likely fix targets
+
+1. MCP startup/root inference: preserve or recover the active target project root instead of reporting `plugin_active_state_stale` when the Codex thread cwd is the repo.
+2. Native embedding process lifetime: ensure `llama-server.exe` survives beyond `ready --goal agent --repair` when `embedding_launch.launch_mode=native_spawned`, or make repair fail instead of briefly reporting `full`.
+3. `sidecar_setup repair`: either run a current repair through the managed `0.13.11` binary or report that it only updates policy metadata.
+
+## Follow-up source trace
+
+- `git fetch origin --prune` on 2026-07-07 left local `main` matching `origin/main`.
+- The MCP/CLI divergence is before shared Rust runtime logic: `plugins/codestory/scripts/codestory-mcp.cjs` resolves project root from explicit env/args, process cwd, thread active state, then global active state. If that fails, it starts diagnostic fail-open MCP with only `sidecar_setup`, `codestory://status`, and `codestory://agent-guide` instead of spawning `codestory-cli serve --stdio --project <root>`.
+- The normal MCP handoff would share CLI logic: the launcher spawns the managed binary as `serve --stdio --refresh none --project <root>`, and Rust stdio dispatch then calls the same packet/search/grounding runtime handlers.
+- After the failure, `.codestory-active` refreshed to `C:\Users\alber\source\repos\codestory`, but the already-running fail-open MCP process still reported the startup decision `plugin_active_state_stale`. That narrows the MCP issue to launch lifecycle or fail-open rebinding, not graph indexing.
+- The semantic sidecar failure was introduced by commits pushed on 2026-07-07. The most relevant commit is `2db3c20b fix windows native sidecar repair`, later carried into `988478ff release 0.13.11`. It changed `crates/codestory-retrieval/src/compose.rs` and `crates/codestory-retrieval/src/embeddings.rs`.
+- Current native spawn code starts `llama-server.exe` from the repair process and logs it, but there is no durable process supervision/detach boundary recorded there. Observed behavior on this machine: the server is reachable during repair, then no `llama-server` process remains after the command exits, so `retrieval status` downgrades to `no_semantic`.
+
+## Non-claims
+
+- This note does not prove a fresh host restart fixes MCP root binding.
+- This note does not prove whether the embedding process exits voluntarily or is killed with the repair command parent.
+- This note does not change product guidance; it records this session's evidence.
+
+## Fix evidence on branch `codex/plugin-mcp-ux-fix`
+
+- The plugin MCP wrapper now re-reads active project state in diagnostic fail-open mode and, when a project root appears after startup, hands the next MCP request to `codestory-cli serve --stdio` instead of freezing the stale `plugin_active_state_stale` response.
+- `node --test plugins/codestory/tests/plugin-static.test.mjs` passed with a regression case where fail-open starts from stale state, the client initializes and sees only `sidecar_setup`, a fresh `.codestory-active` appears, and both `sidecar_setup repair` and a later `tools/list` are served by the delegated stdio runtime.
+- The Windows native sidecar spawn path now applies detached process creation flags to `llama-server.exe`; `cargo test -p codestory-retrieval --lib native_embedding` passed the Windows flag regression test.
+- `target\release\codestory-cli.exe ready --goal agent --repair --project C:\Users\alber\source\repos\codestory --format json --run-id shared-agent` returned `agent_packet_search` ready with `retrieval_mode=full`.
+- Immediate and 20-second delayed `target\release\codestory-cli.exe retrieval status --project C:\Users\alber\source\repos\codestory --profile agent --run-id shared-agent --format json` both reported `retrieval_mode=full`.
+- `Get-Process -Name llama-server` showed PID `45768`, and `netstat -ano` showed `127.0.0.1:37040` listening after the repair command exited.
+- A fresh Codex CLI child could test the local plugin without publishing a new
+  release after installing `codestory@CodeStoryLocal`, mirroring this worktree's
+  `plugins/codestory` into the local marketplace, and setting
+  `CODESTORY_CLI=C:\Users\alber\source\repos\codestory\target\release\codestory-cli.exe`
+  inside the local plugin `.mcp.json` env block.
+- Plain parent-process `CODESTORY_CLI` and
+  `-c shell_environment_policy.inherit=all` did not affect the plugin MCP
+  runtime. The fresh child still reported `runtime_source=managed` until the
+  local plugin `.mcp.json` carried the override. A partial
+  `-c mcp_servers.codestory.env.CODESTORY_CLI=...` override failed with
+  `invalid transport`.
+- With the local manifest override, fresh `codex.cmd exec` read
+  `codestory://status` through `codestory@CodeStoryLocal` and reported
+  `runtime_source=local_dev_override`,
+  `server_executable=C:/Users/alber/source/repos/codestory/target/release/codestory-cli.exe`,
+  and model-visible tools including `ground`, `search`, `packet`,
+  `sidecar_setup`, and `repair_all`.
+- A local Codex CLI child ran MCP `sidecar_setup repair`, then reread
+  `codestory://status`; repair returned `exit_code=0`, `retrieval_mode=full`,
+  `packet.allowed=true`, `search.allowed=true`, and `blocked_reason=null`.
+- Repeated MCP repair exposed a second native-process friction point: pre-fix
+  repairs had already left two persistent `llama-server.exe` processes for port
+  `37040`. After adding the healthy-endpoint reuse guard and rebuilding
+  `target\release\codestory-cli.exe`, a later MCP repair logged
+  `reusing existing native llama.cpp embedding server: llama.cpp embeddings reachable dim=768`
+  and status remained `retrieval_mode=full`. No new persistent server process
+  remained after the transient child activity ended.
+- After amending the plan doc, `codestory://status` correctly failed closed with
+  `sidecar_manifest_stale`, but MCP `sidecar_setup repair` ran in foreground
+  long enough to hit the host's 300-second tool timeout. The Rust stdio runtime
+  now starts that repair in background and returns `started` or
+  `already_running` with a `retrieval status` command instead of blocking the
+  MCP request.
+- Fresh release-stdio smoke with the rebuilt local binary returned
+  `sidecar_setup repair` as `status=started`, `mode=background`, `pid=37900`;
+  the background repair exited on its own, and a delayed
+  `retrieval status --profile agent --run-id shared-agent` reported
+  `retrieval_mode=full` with healthy Zoekt, Qdrant `points_count=940`, and SCIP
+  artifacts.
+
+## Local Codex CLI friction captured
+
+- `codex.cmd exec` rejected the top-level CLI shorthand `-a never` with
+  `unexpected argument '-a'`; using
+  `--dangerously-bypass-approvals-and-sandbox` worked for the automation smoke.
+- Having both `codestory@TheGreenCedar` and `codestory@CodeStoryLocal`
+  installed produced duplicate MCP server warnings. The resolver selected
+  `codestory@CodeStoryLocal` for `server="codestory"` when the prompt used
+  `plugin://codestory@CodeStoryLocal`, but the warning is noisy and should be
+  treated as operator friction.
+- Fresh child sessions repeatedly emitted unrelated plugin-loader noise
+  (`chatgpt-apps@openai-curated` not installed, remote installed bundle sync
+  failures, shortened skill descriptions). The CodeStory MCP signal was still
+  usable, but the raw `--json` stream is noisy for plugin recovery work.

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -158,6 +158,33 @@ function activeProjectStateFresh(active, statePath, nowMs = Date.now(), options 
     && (!options.requireThreadMatch || activeProjectStateMatchesHost(active));
 }
 
+function activeProjectStateSummary(statePath, nowMs = Date.now()) {
+  const active = statePath ? readJson(statePath) : null;
+  const timestamp = activeProjectStateTimestamp(active, statePath);
+  return {
+    path: statePath,
+    cwd: active?.cwd || null,
+    updated_at: active?.updatedAt || active?.updated_at || null,
+    age_ms: timestamp === null ? null : Math.max(0, Math.round(nowMs - timestamp)),
+    codex_thread_id: active?.codexThreadId || null,
+  };
+}
+
+function projectResolutionDiagnostics(projectResolution, nowMs = Date.now()) {
+  const currentThread = String(process.env.CODEX_THREAD_ID || '').trim();
+  const threadStatePath = activeThreadStatePath(currentThread);
+  return {
+    project_root_resolution_source: projectResolution.source || null,
+    project_root_resolution_state_path: projectResolution.statePath || null,
+    project_root_available_after_launch: Boolean(projectResolution.projectRoot),
+    active_state: activeProjectStateSummary(activeStatePath(), nowMs),
+    thread_state: activeProjectStateSummary(threadStatePath, nowMs),
+    codex_thread_id: currentThread || null,
+    launch_cwd: launchCwd,
+    runtime_cwd: process.cwd(),
+  };
+}
+
 function resolveProjectRoot(options = {}) {
   const explicit = existingProjectRoot(options.projectRoot || process.env.CODESTORY_PROJECT_ROOT);
   if (explicit) {
@@ -1021,19 +1048,29 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
 }
 
 function projectRootUnavailableDiagnostic(resolved, probe, projectResolution) {
-  return fallbackDiagnostic(resolved, probe, projectResolution.reason, {
-    projectRoot: null,
+  const projectRoot = projectResolution.projectRoot || null;
+  const reason = projectRoot ? 'project_root_recovered_after_launch' : projectResolution.reason;
+  return fallbackDiagnostic(resolved, probe, reason, {
+    projectRoot,
     projectRootSource: projectResolution.source,
     goal: 'project_root',
     status: 'repair_setup',
-    summary: 'CodeStory plugin MCP could not determine the target project root before starting stdio.',
-    minimumNext: [
-      'Start or reload the Codex host from the target repo, then read codestory://status.',
-    ],
-    fullRepair: [
-      'Start or resume the Codex session in the target repo so CodeStory can infer the active project root.',
-      'Restart/reload the Codex host from the target repo, then read codestory://status.',
-    ],
+    summary: projectRoot
+      ? 'CodeStory plugin MCP found a target project root after diagnostic startup and will hand off to the real stdio runtime on the next request.'
+      : 'CodeStory plugin MCP could not determine the target project root before starting stdio.',
+    minimumNext: projectRoot
+      ? ['Retry the CodeStory MCP request; this diagnostic wrapper will hand off to codestory-cli serve --stdio.']
+      : ['Start or reload the Codex host from the target repo, then read codestory://status.'],
+    fullRepair: projectRoot
+      ? [
+          'Retry the CodeStory MCP request; this diagnostic wrapper will hand off to codestory-cli serve --stdio.',
+          'If the client cached the earlier tool list, restart/reload the Codex host and read codestory://status.',
+        ]
+      : [
+          'Start or resume the Codex session in the target repo so CodeStory can infer the active project root.',
+          'Restart/reload the Codex host from the target repo, then read codestory://status.',
+        ],
+    setup: projectResolutionDiagnostics(projectResolution),
   });
 }
 
@@ -1266,7 +1303,29 @@ function failOpenSidecarSetupResult(request) {
   };
 }
 
-function runFailOpenMcp(status) {
+function runFailOpenMcp(status, options = {}) {
+  const currentStatus = () => (typeof status === 'function' ? status() : status);
+  let handoff = null;
+  const maybeHandoff = () => {
+    if (handoff || typeof options.startRuntime !== 'function') {
+      return handoff;
+    }
+    const liveStatus = currentStatus();
+    if (!liveStatus.project_root || liveStatus.degraded_reason !== 'project_root_recovered_after_launch') {
+      return null;
+    }
+    handoff = options.startRuntime(liveStatus);
+    handoff.stdout?.pipe(process.stdout);
+    handoff.stderr?.pipe(process.stderr);
+    handoff.on('exit', (code, signal) => {
+      if (signal) process.kill(process.pid, signal);
+      process.exit(code || 0);
+    });
+    handoff.on('error', (error) => {
+      process.stdout.write(`${JSON.stringify(jsonrpcError(null, -32000, `CodeStory stdio handoff failed: ${error.message}`))}\n`);
+    });
+    return handoff;
+  };
   const tools = [{
     name: 'sidecar_setup',
     description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode.',
@@ -1296,10 +1355,13 @@ function runFailOpenMcp(status) {
     { uri: 'codestory://status', name: 'CodeStory runtime status', mimeType: 'application/json' },
     { uri: 'codestory://agent-guide', name: 'CodeStory agent guide', mimeType: 'application/json' },
   ];
-  const guide = {
-    status: 'repair_setup',
-    message: 'Read codestory://status, follow recommended_next_calls, restore a compatible stdio runtime, then retry grounding.',
-    recommended_next_calls: status.recommended_next_calls,
+  const guide = () => {
+    const liveStatus = currentStatus();
+    return {
+      status: 'repair_setup',
+      message: 'Read codestory://status, follow recommended_next_calls, restore a compatible stdio runtime, then retry grounding.',
+      recommended_next_calls: liveStatus.recommended_next_calls,
+    };
   };
   let buffer = '';
   process.stdin.setEncoding('utf8');
@@ -1316,13 +1378,19 @@ function runFailOpenMcp(status) {
         process.stdout.write(`${JSON.stringify(jsonrpcError(null, -32700, 'Parse error'))}\n`);
         continue;
       }
+      const delegated = maybeHandoff();
+      if (delegated) {
+        delegated.stdin.write(`${line}\n`);
+        continue;
+      }
       if (request.id === undefined) continue;
       let response;
       if (request.method === 'initialize') {
+        const liveStatus = currentStatus();
         response = jsonrpcResult(request.id, {
           protocolVersion: request.params?.protocolVersion || '2024-11-05',
           capabilities: { tools: {}, resources: {} },
-          serverInfo: { name: 'codestory', version: resolvedVersionForStatus(status) },
+          serverInfo: { name: 'codestory', version: resolvedVersionForStatus(liveStatus) },
         });
       } else if (request.method === 'tools/list') {
         response = jsonrpcResult(request.id, { tools });
@@ -1331,9 +1399,9 @@ function runFailOpenMcp(status) {
       } else if (request.method === 'resources/read') {
         const uri = request.params?.uri;
         if (uri === 'codestory://status') {
-          response = jsonrpcResult(request.id, resourceContents(uri, status));
+          response = jsonrpcResult(request.id, resourceContents(uri, currentStatus()));
         } else if (uri === 'codestory://agent-guide') {
-          response = jsonrpcResult(request.id, resourceContents(uri, guide));
+          response = jsonrpcResult(request.id, resourceContents(uri, guide()));
         } else {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
@@ -1383,6 +1451,55 @@ function rememberLaunch(resolved, runtimeCwd = process.cwd()) {
   }
 }
 
+function stdioRuntimeEnv(resolved, projectRoot, projectRootSource, runtimeCwd, projectStatePath) {
+  const sidecarStatus = readSidecarPolicy();
+  const dirtyMarker = dirtyMarkerEnv(projectRoot);
+  return {
+    ...process.env,
+    CODESTORY_PLUGIN_VERSION: resolved.version || '',
+    CODESTORY_PLUGIN_ROOT: pluginRoot,
+    CODESTORY_PLUGIN_LAUNCH_CWD: launchCwd,
+    CODESTORY_PLUGIN_RUNTIME_CWD: runtimeCwd,
+    CODESTORY_PLUGIN_CACHE_VERSION: pluginCacheVersion() || '',
+    CODESTORY_PLUGIN_CLI_VERSION: resolved.cliVersion || resolved.version || '',
+    CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
+    CODESTORY_PLUGIN_CLI_PATH: resolved.path,
+    CODESTORY_PLUGIN_CLI_SHA256: resolved.sha256 || '',
+    CODESTORY_PLUGIN_CLI_MANIFEST_PATH: resolved.manifestPath || '',
+    CODESTORY_PLUGIN_CLI_BUILD_SOURCE: resolved.buildSource || '',
+    CODESTORY_PLUGIN_CLI_REPO_REF: resolved.repoRef || '',
+    CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256: resolved.archiveSha256 || '',
+    CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
+    CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
+    CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
+    CODESTORY_PLUGIN_PROJECT_ROOT: projectRoot,
+    CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE: projectRootSource,
+    CODESTORY_PLUGIN_ACTIVE_STATE_PATH: projectStatePath || activeStatePath() || '',
+    CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
+    CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
+    CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
+    CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
+    CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
+    CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, projectRoot),
+    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
+    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
+    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
+    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND: sidecarStatus.lastRepair?.command || '',
+    CODESTORY_PLUGIN_DIRTY_MARKER_PATH: dirtyMarker.path,
+    CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT: dirtyMarker.projectRoot,
+  };
+}
+
+function spawnStdioRuntime(resolved, projectRoot, projectRootSource, runtimeCwd, stdio, projectStatePath = null) {
+  return spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none', '--project', projectRoot], {
+    cwd: projectRoot,
+    stdio,
+    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
+    windowsHide: true,
+    env: stdioRuntimeEnv(resolved, projectRoot, projectRootSource, runtimeCwd, projectStatePath),
+  });
+}
+
 async function main() {
   if (await handleBootstrapStatusCommand(process.argv)) return;
   handleSidecarPolicyCommand(process.argv);
@@ -1400,54 +1517,31 @@ async function main() {
     return;
   }
   if (!projectResolution.projectRoot) {
-    runFailOpenMcp(projectRootUnavailableDiagnostic(resolved, probe, projectResolution));
+    runFailOpenMcp(
+      () => projectRootUnavailableDiagnostic(resolved, probe, resolveProjectRoot()),
+      {
+        startRuntime: (liveStatus) => spawnStdioRuntime(
+          resolved,
+          liveStatus.project_root,
+          liveStatus.project_root_source,
+          runtimeCwd,
+          ['pipe', 'pipe', 'pipe'],
+          liveStatus.readiness?.[0]?.setup?.project_root_resolution_state_path || null,
+        ),
+      },
+    );
     return;
   }
   const projectRoot = projectResolution.projectRoot;
   // Keep the JSON-RPC server handshake first; codestory://status reports readiness after stdio is alive.
-  const sidecarStatus = readSidecarPolicy();
-  const dirtyMarker = dirtyMarkerEnv(projectRoot);
-
-  const child = spawn(resolved.path, ['serve', '--stdio', '--refresh', 'none', '--project', projectRoot], {
-    cwd: projectRoot,
-    stdio: 'inherit',
-    shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
-    windowsHide: true,
-    env: {
-      ...process.env,
-      CODESTORY_PLUGIN_VERSION: resolved.version || '',
-      CODESTORY_PLUGIN_ROOT: pluginRoot,
-      CODESTORY_PLUGIN_LAUNCH_CWD: launchCwd,
-      CODESTORY_PLUGIN_RUNTIME_CWD: runtimeCwd,
-      CODESTORY_PLUGIN_CACHE_VERSION: pluginCacheVersion() || '',
-      CODESTORY_PLUGIN_CLI_VERSION: resolved.cliVersion || resolved.version || '',
-      CODESTORY_PLUGIN_CLI_SOURCE: resolved.source,
-      CODESTORY_PLUGIN_CLI_PATH: resolved.path,
-      CODESTORY_PLUGIN_CLI_SHA256: resolved.sha256 || '',
-      CODESTORY_PLUGIN_CLI_MANIFEST_PATH: resolved.manifestPath || '',
-      CODESTORY_PLUGIN_CLI_BUILD_SOURCE: resolved.buildSource || '',
-      CODESTORY_PLUGIN_CLI_REPO_REF: resolved.repoRef || '',
-      CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256: resolved.archiveSha256 || '',
-      CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
-      CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
-      CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
-      CODESTORY_PLUGIN_PROJECT_ROOT: projectRoot,
-      CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE: projectResolution.source,
-      CODESTORY_PLUGIN_ACTIVE_STATE_PATH: projectResolution.statePath || activeStatePath() || '',
-      CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
-      CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
-      CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
-      CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
-      CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
-      CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND: resolvedRepairCommandForProject(resolved, projectRoot),
-      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
-      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
-      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
-      CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND: sidecarStatus.lastRepair?.command || '',
-      CODESTORY_PLUGIN_DIRTY_MARKER_PATH: dirtyMarker.path,
-      CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT: dirtyMarker.projectRoot,
-    },
-  });
+  const child = spawnStdioRuntime(
+    resolved,
+    projectRoot,
+    projectResolution.source,
+    runtimeCwd,
+    'inherit',
+    projectResolution.statePath || null,
+  );
 
   child.on('exit', (code, signal) => {
     if (signal) process.kill(process.pid, signal);

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import { once } from "node:events";
 
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
@@ -505,7 +506,8 @@ test("stdio workspace mismatch blocks stale repo repair guidance", async () => {
   const launcher = await readFile(join(pluginRoot, "scripts", "codestory-mcp.cjs"), "utf8");
   const transport = await readFile(join(repoRoot, "crates", "codestory-cli", "src", "stdio_transport.rs"), "utf8");
 
-  assert.match(launcher, /CODESTORY_PLUGIN_ACTIVE_STATE_PATH:\s*projectResolution\.statePath \|\| activeStatePath\(\) \|\| ''/u);
+  assert.match(launcher, /function stdioRuntimeEnv\(resolved, projectRoot, projectRootSource, runtimeCwd, projectStatePath\)/u);
+  assert.match(launcher, /CODESTORY_PLUGIN_ACTIVE_STATE_PATH:\s*projectStatePath \|\| activeStatePath\(\) \|\| ''/u);
   assert.match(transport, /fn stdio_workspace_mismatch\(runtime: &RuntimeContext\)/u);
   assert.match(transport, /CODESTORY_PLUGIN_ACTIVE_STATE_PATH/u);
   assert.match(transport, /let active_root = stdio_active_state_root\(&active_state_path\)\?/u);
@@ -1011,6 +1013,173 @@ test("mcp launcher rejects stale active project state from plugin root", async (
     assert.equal(status.project_root_source, "plugin_active_state_stale");
     assert.equal(status.readiness[0].goal, "project_root");
   } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("fail-open mcp hands off to stdio runtime after active project appears", async () => {
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-live-active-project-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const cliScript = join(dataDir, "recording-codestory-cli.cjs");
+  const cliPath = join(
+    dataDir,
+    process.platform === "win32" ? "recording-codestory-cli.cmd" : "recording-codestory-cli",
+  );
+  const logFile = join(dataDir, "calls.jsonl");
+  const marker = join(dataDir, "serve-called.txt");
+  const realRepoRoot = await realpath(repoRoot);
+  const activePath = join(dataDir, ".codestory-active");
+  let child;
+
+  try {
+    await writeFile(
+      activePath,
+      JSON.stringify({ event: "SessionStart", cwd: realRepoRoot, updatedAt: "2000-01-01T00:00:00.000Z" }),
+      "utf8",
+    );
+    await writeFile(
+      cliScript,
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.TEST_LOG, JSON.stringify({ args, cwd: process.cwd(), projectRoot: process.env.CODESTORY_PLUGIN_PROJECT_ROOT || '', activeStatePath: process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH || '' }) + '\\n');",
+        "if (args[0] === '--version') { console.log('codestory-cli ' + process.env.TEST_CODESTORY_VERSION); process.exit(0); }",
+        "if (args[0] === 'ready') { fs.writeFileSync(process.env.TEST_OUT, args[0]); process.exit(0); }",
+        "if (args[0] === 'serve') {",
+        "  fs.writeFileSync(process.env.TEST_OUT, args[0]);",
+        "  let buffer = '';",
+        "  process.stdin.setEncoding('utf8');",
+        "  process.stdin.on('data', (chunk) => {",
+        "    buffer += chunk;",
+        "    const lines = buffer.split(/\\r?\\n/u);",
+        "    buffer = lines.pop() || '';",
+        "    for (const line of lines) {",
+        "      if (!line.trim()) continue;",
+        "      const request = JSON.parse(line);",
+      "      if (request.method === 'tools/list') {",
+      "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'ground' }] } }) + '\\n');",
+      "      } else if (request.method === 'tools/call' && request.params && request.params.name === 'sidecar_setup') {",
+      "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { structuredContent: { state: 'runtime-sidecar-setup' } } }) + '\\n');",
+      "      } else if (request.method === 'resources/read') {",
+      "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { contents: [{ uri: request.params.uri, mimeType: 'application/json', text: JSON.stringify({ project_root: process.env.CODESTORY_PLUGIN_PROJECT_ROOT, project_root_source: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE }) }] } }) + '\\n');",
+      "      }",
+        "    }",
+        "  });",
+        "  return;",
+        "}",
+        "process.exit(2);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      await writeFile(cliPath, `@echo off\r\n"${process.execPath}" "${cliScript}" %*\r\n`, "utf8");
+    } else {
+      await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} ${JSON.stringify(cliScript)} "$@"\n`, "utf8");
+      await chmod(cliPath, 0o755);
+    }
+
+    child = spawn(process.execPath, [launcher], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        CODESTORY_CLI: cliPath,
+        PLUGIN_DATA: dataDir,
+        TEST_CODESTORY_VERSION: version,
+        TEST_LOG: logFile,
+        TEST_OUT: marker,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const waiters = [];
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      for (;;) {
+        const newline = stdout.indexOf("\n");
+        if (newline < 0) break;
+        const line = stdout.slice(0, newline).trim();
+        stdout = stdout.slice(newline + 1);
+        if (line && waiters.length > 0) {
+          waiters.shift().resolve(JSON.parse(line));
+        }
+      }
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    const nextResponse = () => Promise.race([
+      new Promise((resolve, reject) => waiters.push({ resolve, reject })),
+      new Promise((_, reject) => setTimeout(() => reject(new Error(`timed out waiting for MCP response: ${stderr}`)), 5000)),
+    ]);
+    const sendRequest = async (request) => {
+      const pending = nextResponse();
+      child.stdin.write(`${JSON.stringify(request)}\n`);
+      return pending;
+    };
+    const readStatus = async (id) => {
+      const response = await sendRequest({
+        jsonrpc: "2.0",
+        id,
+        method: "resources/read",
+        params: { uri: "codestory://status" },
+      });
+      return JSON.parse(response.result.contents[0].text);
+    };
+
+    const init = await sendRequest({
+      jsonrpc: "2.0",
+      id: "init",
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05" },
+    });
+    assert.equal(init.result.serverInfo.name, "codestory");
+
+    const staleStatus = await readStatus("stale");
+    assert.equal(staleStatus.degraded_reason, "project_root_unavailable");
+    assert.equal(staleStatus.project_root, null);
+    assert.equal(staleStatus.project_root_source, "plugin_active_state_stale");
+
+    const failOpenTools = await sendRequest({ jsonrpc: "2.0", id: "fail-open-tools", method: "tools/list" });
+    assert.deepEqual(failOpenTools.result.tools.map((tool) => tool.name), ["sidecar_setup"]);
+
+    await writeFile(
+      activePath,
+      JSON.stringify({ event: "UserPromptSubmit", cwd: realRepoRoot, updatedAt: new Date().toISOString() }),
+      "utf8",
+    );
+
+    const repaired = await sendRequest({
+      jsonrpc: "2.0",
+      id: "repair",
+      method: "tools/call",
+      params: { name: "sidecar_setup", arguments: { action: "repair" } },
+    });
+    assert.equal(repaired.result.structuredContent.state, "runtime-sidecar-setup");
+
+    const tools = await sendRequest({ jsonrpc: "2.0", id: "tools", method: "tools/list" });
+    assert.deepEqual(tools.result.tools.map((tool) => tool.name), ["ground"]);
+
+    const runtimeStatus = await readStatus("runtime-status");
+    assert.equal(runtimeStatus.project_root, realRepoRoot);
+    assert.equal(runtimeStatus.project_root_source, "plugin_active_state");
+    assert.equal(await readFile(marker, "utf8"), "serve");
+    const calls = (await readFile(logFile, "utf8")).trim().split(/\r?\n/u).map((line) => JSON.parse(line));
+    assert.deepEqual(calls.map((call) => call.args[0]), ["--version", "serve"]);
+    const serve = calls.find((call) => call.args[0] === "serve");
+    assert.equal(serve.cwd, realRepoRoot);
+    assert.equal(serve.projectRoot, realRepoRoot);
+    assert.equal(serve.activeStatePath, activePath);
+  } finally {
+    if (child && !child.killed) {
+      child.kill();
+      await Promise.race([once(child, "exit"), new Promise((resolve) => setTimeout(resolve, 1000))]);
+    }
     await rm(dataDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Context

This promotes `dev/codestory-next` to `main` for CodeStory 0.13.12.

The release includes PR #882, which fixes plugin MCP recovery after startup drift and Windows native embedding sidecar lifetime. Closes #881.

## What Changed

- Recover diagnostic fail-open MCP by re-reading active project state and handing off to `codestory-cli serve --stdio` once a repo root exists.
- Keep Windows native `llama-server.exe` embedding sidecars detached and reusable so repair does not kill semantic retrieval after exit.
- Start stdio `sidecar_setup repair` in the background so MCP repair calls return before the host timeout.
- Bump CodeStory workspace crates and packaged plugin manifests to 0.13.12, with the changelog entry promoted from `Unreleased`.

## How To Review

Compare `origin/main...origin/dev/codestory-next`.

Focus the code review on:
- `plugins/codestory/scripts/codestory-mcp.cjs`
- `crates/codestory-retrieval/src/compose.rs`
- `crates/codestory-cli/src/stdio_transport.rs`
- the 0.13.12 version/changelog surfaces

## Verification

PR #882 GitHub checks passed before merge: markdown links, plugin static tests, linux contracts, workspace cargo checks, rustdoc warnings, saga issue-link guard, with the Windows manifest lane skipped by policy.

Local release-bump verification:
- `cargo check --workspace`
- `python .github/scripts/check-codestory-release.py --version 0.13.12`
- `node .github/scripts/check-workflow-policy.mjs`
- `cargo fmt --check`
- `git diff --check`

Current installed-plugin evidence: this Codex session still timed out reading `codestory://status` from the installed 0.13.11 MCP after 300 seconds, which matches the pre-release failure mode rather than proving the fixed package.

## Risk

Existing Codex threads can keep an old long-lived MCP process until plugin install/session refresh. Release proof still needs the post-merge GitHub release assets and the AgentPluginMarketplace pointer update.
