### PR TITLE
fix 0.14.1 packaged project status proof

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -331,6 +331,7 @@ def stdio_status(cli: Path, project: Path, artifact: Path, timeout_secs: int) ->
         [str(cli), "serve", "--stdio", "--refresh", "none", "--project", str(project)],
         artifact,
         timeout_secs,
+        project,
     )
 
 
@@ -350,6 +351,7 @@ def plugin_stdio_status(
             ["node", str(launcher)],
             artifact,
             timeout_secs,
+            project,
             layer="plugin_stdio",
             cwd=project,
             env={
@@ -365,6 +367,7 @@ def stdio_status_command(
     command: list[str],
     artifact: Path,
     timeout_secs: int,
+    project: Path,
     layer: str = "serve_stdio",
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
@@ -388,7 +391,7 @@ def stdio_status_command(
             "jsonrpc": "2.0",
             "id": "status",
             "method": "resources/read",
-            "params": {"uri": STATUS_URI},
+            "params": {"uri": STATUS_URI, "project": str(project)},
         },
     ]
     transcript: list[dict] = []
@@ -1073,6 +1076,13 @@ def self_test() -> None:
         )
         run_gate(args)
         assert (out_dir / "summary.json").is_file()
+        stdio_artifact = read_json_file(out_dir / "serve-stdio-status.json")
+        status_request = next(
+            entry["request"]
+            for entry in stdio_artifact["transcript"]
+            if entry["request"].get("id") == "status"
+        )
+        assert status_request["params"]["project"] == str(project.resolve())
 
         version_only_out = root / "version-only-out"
         version_only_args = argparse.Namespace(**vars(args))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ repositories through the same plugin installation.
 - Added a two-repository stdio regression that queues requests for both projects
   before reading their responses, then switches back and verifies each result
   remains rooted in its requested repository.
+- Updated the packaged release proof to pass its repository explicitly when it
+  reads project-scoped MCP status.
 
 ## 0.14.0
 


### PR DESCRIPTION
## Context

The first 0.14.1 Auto Release run reached the packaged Linux x64 proof but failed when that proof read `codestory://status` without identifying a repository. The 0.14.1 MCP behavior is intentionally project-scoped so one server can serve independent callers across projects; the release proof had not been updated to match that contract.

Closes #893

## What Changed

- Pass the caller project on the packaged proof's MCP status resource request.
- Assert in the self-test transcript that the resolved project path is present.
- Record the release-proof correction in the 0.14.1 changelog.

## How To Review

1. Confirm `stdio_status_command` receives the same project used to launch the server.
2. Confirm only the status resource request gains `params.project`; the multi-project runtime behavior is unchanged.
3. Confirm the self-test checks the serialized request, not an implementation detail.

## Verification

- `python -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `python .github/scripts/check-codestory-release.py --version 0.14.1`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

## Risk

Low. This changes only release-package verification and its self-test. It does not bind the MCP server to a project or alter runtime routing. A fresh release run remains the final proof that all packaged targets publish successfully.
