### PR TITLE
promote 0.14.1 packaged proof repair

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -331,6 +331,7 @@ def stdio_status(cli: Path, project: Path, artifact: Path, timeout_secs: int) ->
         [str(cli), "serve", "--stdio", "--refresh", "none", "--project", str(project)],
         artifact,
         timeout_secs,
+        project,
     )
 
 
@@ -350,6 +351,7 @@ def plugin_stdio_status(
             ["node", str(launcher)],
             artifact,
             timeout_secs,
+            project,
             layer="plugin_stdio",
             cwd=project,
             env={
@@ -365,6 +367,7 @@ def stdio_status_command(
     command: list[str],
     artifact: Path,
     timeout_secs: int,
+    project: Path,
     layer: str = "serve_stdio",
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
@@ -388,7 +391,7 @@ def stdio_status_command(
             "jsonrpc": "2.0",
             "id": "status",
             "method": "resources/read",
-            "params": {"uri": STATUS_URI},
+            "params": {"uri": STATUS_URI, "project": str(project)},
         },
     ]
     transcript: list[dict] = []
@@ -1073,6 +1076,13 @@ def self_test() -> None:
         )
         run_gate(args)
         assert (out_dir / "summary.json").is_file()
+        stdio_artifact = read_json_file(out_dir / "serve-stdio-status.json")
+        status_request = next(
+            entry["request"]
+            for entry in stdio_artifact["transcript"]
+            if entry["request"].get("id") == "status"
+        )
+        assert status_request["params"]["project"] == str(project.resolve())
 
         version_only_out = root / "version-only-out"
         version_only_args = argparse.Namespace(**vars(args))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ repositories through the same plugin installation.
 - Added a two-repository stdio regression that queues requests for both projects
   before reading their responses, then switches back and verifies each result
   remains rooted in its requested repository.
+- Updated the packaged release proof to pass its repository explicitly when it
+  reads project-scoped MCP status.
 
 ## 0.14.0
 


### PR DESCRIPTION
## Context

The initial 0.14.1 release build exposed a mismatch in the packaged proof: MCP status is correctly project-scoped, but the proof omitted the caller's repository. PR #894 repaired that verifier on `dev/codestory-next`. This promotion puts the proof fix on `main` so a fresh 0.14.1 release can run from the corrected source.

Closes #893

## What Changed

- Pass the explicit project path when the packaged stdio proof reads MCP status.
- Assert the resolved project path in the proof's JSON-RPC transcript.
- Add the correction to the 0.14.1 changelog.

## How To Review

1. Review the one script change and its transcript assertion.
2. Confirm the runtime and multi-project routing code are untouched.
3. Confirm the release checks run against the protected promotion diff.

## Verification

Local:

- `python -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `python .github/scripts/check-codestory-release.py --version 0.14.1`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`

Protected GitHub checks are required before merge. After promotion, the remaining acceptance proof is a successful fresh 0.14.1 release with all platform assets and `SHA256SUMS.txt`.

## Risk

Low source risk: this is release-verifier-only. Operational risk remains until the cross-platform release finishes; the prior macOS runner also showed an unrelated transient Rust cache/filesystem failure.
