### PR TITLE
fix MCP repair worker handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- Made MCP sidecar repair transfer one durable attempt reservation to the
+  spawned CLI worker instead of rejecting its own handoff as a competing
+  repair. The worker now inherits the parent cache scope, and MCP records its
+  terminal exit code plus bounded stdout/stderr tails before clearing repair
+  ownership.
+
 ## 0.14.2
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "crossbeam-channel",
  "crossterm 0.28.1",
  "directories",
+ "fs4",
  "notify",
  "ratatui",
  "serde",

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -17,6 +17,7 @@ codestory-workspace = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 directories = { workspace = true }
+fs4 = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -657,6 +657,7 @@ struct ReadyRepairProgress {
     start: Instant,
     started_at_epoch_ms: i64,
     pid: u32,
+    attempt_id: Option<String>,
     sidecar: codestory_retrieval::SidecarRuntimeConfig,
     handle: Option<std::thread::JoinHandle<()>>,
 }
@@ -672,6 +673,9 @@ impl ReadyRepairProgress {
         let start = Instant::now();
         let started_at_epoch_ms = ready_repair_status::now_epoch_ms();
         let pid = std::process::id();
+        let attempt_id = std::env::var(ready_repair_status::READY_REPAIR_ATTEMPT_ENV)
+            .ok()
+            .filter(|value| !value.trim().is_empty());
         let profile = sidecar.profile.as_str();
         let run_id = sidecar.run_id.as_deref().unwrap_or("none").to_string();
         let namespace = sidecar.namespace.clone();
@@ -684,12 +688,14 @@ impl ReadyRepairProgress {
         let worker_namespace = namespace.clone();
         let worker_project_root = project_root.clone();
         let worker_cache_root = cache_root.clone();
-        let _ = ready_repair_status::write_ready_repair_status(
+        let worker_attempt_id = attempt_id.clone();
+        let _ = ready_repair_status::write_ready_repair_status_for_attempt(
             sidecar,
             &project_root,
             "starting",
             started_at_epoch_ms,
             pid,
+            attempt_id.as_deref(),
         );
         let _ = readiness_broker::refresh_broker_snapshot(readiness_broker::BrokerSnapshotInput {
             project_root: project_root.clone(),
@@ -721,12 +727,13 @@ impl ReadyRepairProgress {
                         "active"
                     )
                 );
-                let _ = ready_repair_status::write_ready_repair_status(
+                let _ = ready_repair_status::write_ready_repair_status_for_attempt(
                     &sidecar_for_worker,
                     &worker_project_root,
                     phase,
                     started_at_epoch_ms,
                     pid,
+                    worker_attempt_id.as_deref(),
                 );
                 let _ = readiness_broker::refresh_broker_snapshot(
                     readiness_broker::BrokerSnapshotInput {
@@ -752,6 +759,7 @@ impl ReadyRepairProgress {
             start,
             started_at_epoch_ms,
             pid,
+            attempt_id,
             sidecar: sidecar.clone(),
             handle: Some(handle),
         }
@@ -770,12 +778,13 @@ impl ReadyRepairProgress {
                 "started"
             )
         );
-        let _ = ready_repair_status::write_ready_repair_status(
+        let _ = ready_repair_status::write_ready_repair_status_for_attempt(
             &self.sidecar,
             &self.project_root,
             phase,
             self.started_at_epoch_ms,
             self.pid,
+            self.attempt_id.as_deref(),
         );
         let _ = readiness_broker::refresh_broker_snapshot(readiness_broker::BrokerSnapshotInput {
             project_root: self.project_root.clone(),
@@ -794,10 +803,11 @@ impl Drop for ReadyRepairProgress {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
-        ready_repair_status::clear_ready_repair_status(
+        ready_repair_status::clear_ready_repair_status_for_attempt(
             &self.sidecar,
             self.started_at_epoch_ms,
             self.pid,
+            self.attempt_id.as_deref(),
         );
     }
 }
@@ -2575,6 +2585,29 @@ fn repair_ready_state(
             run_id,
         )
     });
+    let plugin_worker = std::env::var("CODESTORY_PLUGIN_SIDECAR_REPAIR").as_deref() == Ok("1");
+    let handoff_attempt = std::env::var(ready_repair_status::READY_REPAIR_ATTEMPT_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let mut handoff_reservation =
+        match (sidecar.as_ref(), plugin_worker, handoff_attempt.as_deref()) {
+            (Some(sidecar), true, Some(attempt_id)) => Some(
+                ready_repair_status::adopt_ready_repair_reservation(
+                    sidecar,
+                    &runtime.project_root,
+                    attempt_id,
+                )
+                .context("adopt MCP ready-repair reservation")?,
+            ),
+            (_, true, None) => {
+                bail!("MCP ready-repair worker is missing its reservation attempt id")
+            }
+            (_, false, Some(_)) => bail!("ready-repair attempt id requires the MCP worker marker"),
+            _ => None,
+        };
+    if let Some(reservation) = handoff_reservation.as_mut() {
+        reservation.disarm();
+    }
     if let Some(sidecar) = sidecar.as_ref()
         && let Ok(existing_status) = codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
@@ -2622,6 +2655,9 @@ fn repair_ready_state(
             );
         }
     }
+
+    #[cfg(debug_assertions)]
+    maybe_exit_ready_repair_worker_probe(handoff_reservation.as_ref());
 
     let opened = runtime.ensure_open(args::RefreshMode::Auto)?;
     ensure_index_ready(&opened, "ready repair")?;
@@ -2724,6 +2760,44 @@ fn repair_ready_state(
         reconciliation: None,
     });
     Ok(Some(sidecar))
+}
+
+#[cfg(debug_assertions)]
+fn maybe_exit_ready_repair_worker_probe(
+    reservation: Option<&ready_repair_status::ReadyRepairReservation>,
+) {
+    use std::io::Write as _;
+
+    let Some(reservation) = reservation else {
+        return;
+    };
+    if std::env::var("CODESTORY_PLUGIN_SIDECAR_REPAIR").as_deref() != Ok("1") {
+        return;
+    }
+    let Some(exit_code) = std::env::var("CODESTORY_TEST_READY_REPAIR_WORKER_EXIT_CODE")
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+    else {
+        return;
+    };
+    let attempt_id = reservation.attempt_id();
+    let mut stdout = std::io::stdout().lock();
+    let mut stderr = std::io::stderr().lock();
+    let stdout_payload = vec![b'o'; 40 * 1024];
+    let stderr_payload = vec![b'e'; 40 * 1024];
+    let _ = stdout.write_all(&stdout_payload);
+    let _ = writeln!(
+        stdout,
+        "ready-repair worker probe stdout attempt_id={attempt_id}"
+    );
+    let _ = stderr.write_all(&stderr_payload);
+    let _ = writeln!(
+        stderr,
+        "ready-repair worker probe stderr attempt_id={attempt_id}"
+    );
+    let _ = stdout.flush();
+    let _ = stderr.flush();
+    std::process::exit(exit_code);
 }
 
 #[derive(Debug, Clone)]

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -3,22 +3,34 @@ use codestory_retrieval::{
     DEFAULT_AGENT_RUN_ID, SidecarProfile, SidecarRuntimeConfig,
     sidecar_runtime_for_project_with_run_id,
 };
+use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 #[cfg(any(windows, all(unix, not(target_os = "linux"))))]
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::OnceLock;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const READY_REPAIR_STATUS_FILE: &str = "ready-repair-status.json";
+const READY_REPAIR_RESULT_FILE: &str = "ready-repair-result.json";
+const READY_REPAIR_ENQUEUE_LOCK_FILE: &str = "ready-repair-enqueue.lock";
+const READY_REPAIR_COORDINATION_LOCK_FILE: &str = "ready-repair-coordination.lock";
 const READY_REPAIR_LOCK_FILE: &str = "ready-repair.lock";
 const READY_REPAIR_PROJECT_LOCK_FILE: &str = "ready-repair-project.lock";
-const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
+pub(crate) const READY_REPAIR_STATUS_SCHEMA_VERSION: u32 = 1;
 const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
 const READY_REPAIR_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
+const READY_REPAIR_COORDINATION_TIMEOUT: Duration = Duration::from_secs(5);
+const READY_REPAIR_COORDINATION_POLL: Duration = Duration::from_millis(10);
+#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
+const READY_REPAIR_PROCESS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
+const READY_REPAIR_PROCESS_PROBE_REAP_TIMEOUT: Duration = Duration::from_millis(250);
+pub(crate) const READY_REPAIR_ATTEMPT_ENV: &str = "CODESTORY_READY_REPAIR_ATTEMPT_ID";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct ReadyRepairStatus {
@@ -32,9 +44,95 @@ pub(crate) struct ReadyRepairStatus {
     pub(crate) phase: String,
     pub(crate) pid: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) attempt_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) process_start_identity: Option<String>,
     pub(crate) started_at_epoch_ms: i64,
     pub(crate) updated_at_epoch_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct ReadyRepairReservationFile {
+    schema_version: u32,
+    pid: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    process_start_identity: Option<String>,
+    started_at_epoch_ms: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    created_at_epoch_ms: Option<i64>,
+    #[serde(rename = "token", alias = "attempt_id")]
+    attempt_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    project_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    namespace: Option<String>,
+    #[serde(default)]
+    adopted: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReadyRepairReservation {
+    path: PathBuf,
+    attempt_id: String,
+    started_at_epoch_ms: i64,
+    armed: bool,
+}
+
+#[derive(Debug)]
+struct ReadyRepairCoordinationGuard {
+    file: File,
+}
+
+impl Drop for ReadyRepairCoordinationGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+impl ReadyRepairReservation {
+    pub(crate) fn attempt_id(&self) -> &str {
+        &self.attempt_id
+    }
+
+    pub(crate) fn started_at_epoch_ms(&self) -> i64 {
+        self.started_at_epoch_ms
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ReadyRepairReservation {
+    fn drop(&mut self) {
+        if self.armed {
+            remove_ready_repair_reservation_if_attempt_at(&self.path, &self.attempt_id);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct ReadyRepairWorkerResult {
+    pub(crate) schema_version: u32,
+    pub(crate) attempt_id: String,
+    pub(crate) project_root: String,
+    pub(crate) profile: String,
+    pub(crate) run_id: Option<String>,
+    pub(crate) namespace: String,
+    pub(crate) pid: u32,
+    pub(crate) started_at_epoch_ms: i64,
+    pub(crate) finished_at_epoch_ms: i64,
+    pub(crate) outcome: String,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) wait_error: Option<String>,
+    pub(crate) stdout_tail: String,
+    pub(crate) stderr_tail: String,
+    pub(crate) stdout_truncated: bool,
+    pub(crate) stderr_truncated: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -108,6 +206,271 @@ pub(crate) fn now_epoch_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
         .unwrap_or_default()
+}
+
+fn new_ready_repair_attempt_id() -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("{}:{nonce}", std::process::id())
+}
+
+fn acquire_ready_repair_coordination(
+    sidecar: &SidecarRuntimeConfig,
+) -> Result<ReadyRepairCoordinationGuard> {
+    acquire_ready_repair_coordination_at(&ready_repair_reservation_path(sidecar))
+}
+
+fn acquire_ready_repair_coordination_at(
+    reservation_path: &Path,
+) -> Result<ReadyRepairCoordinationGuard> {
+    let path = reservation_path.with_file_name(READY_REPAIR_COORDINATION_LOCK_FILE);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    let deadline = Instant::now() + READY_REPAIR_COORDINATION_TIMEOUT;
+    loop {
+        if FileExt::try_lock_exclusive(&file)? {
+            return Ok(ReadyRepairCoordinationGuard { file });
+        }
+        if Instant::now() >= deadline {
+            return Err(anyhow::anyhow!(
+                "timed out coordinating ready-repair state at {}",
+                path.display()
+            ));
+        }
+        thread::sleep(READY_REPAIR_COORDINATION_POLL);
+    }
+}
+
+pub(crate) fn try_reserve_ready_repair(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+) -> Result<Option<ReadyRepairReservation>> {
+    let path = ready_repair_reservation_path(sidecar);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let attempt_id = new_ready_repair_attempt_id();
+    let pid = std::process::id();
+    let started_at_epoch_ms = now_epoch_ms();
+    let reservation = ReadyRepairReservationFile {
+        schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+        pid,
+        process_start_identity: recorded_process_start_identity(pid),
+        started_at_epoch_ms,
+        created_at_epoch_ms: Some(started_at_epoch_ms),
+        attempt_id: attempt_id.clone(),
+        project_root: Some(clean_path_text(project_root)),
+        profile: Some(sidecar.profile.as_str().to_string()),
+        run_id: sidecar.run_id.clone(),
+        namespace: Some(sidecar.namespace.clone()),
+        adopted: false,
+    };
+    let content = serde_json::to_vec_pretty(&reservation)?;
+    let _coordination = acquire_ready_repair_coordination(sidecar)?;
+    match create_ready_repair_lock_file(&path, &content) {
+        Ok(()) => {
+            return Ok(Some(ReadyRepairReservation {
+                path,
+                attempt_id,
+                started_at_epoch_ms,
+                armed: true,
+            }));
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
+    if !ready_repair_reservation_is_stale(&path) {
+        return Ok(None);
+    }
+    if let Some(stale) = read_ready_repair_reservation_file(&path)
+        && !ready_repair_terminal_result_matches(sidecar, &stale.attempt_id)
+    {
+        let abandoned = ReadyRepairWorkerResult {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            attempt_id: stale.attempt_id.clone(),
+            project_root: stale
+                .project_root
+                .unwrap_or_else(|| clean_path_text(project_root)),
+            profile: stale
+                .profile
+                .unwrap_or_else(|| sidecar.profile.as_str().to_string()),
+            run_id: stale.run_id,
+            namespace: stale.namespace.unwrap_or_else(|| sidecar.namespace.clone()),
+            pid: stale.pid,
+            started_at_epoch_ms: stale
+                .created_at_epoch_ms
+                .unwrap_or(stale.started_at_epoch_ms),
+            finished_at_epoch_ms: now_epoch_ms(),
+            outcome: "abandoned".to_string(),
+            exit_code: None,
+            wait_error: Some(
+                "repair worker reservation owner exited before recording a terminal result"
+                    .to_string(),
+            ),
+            stdout_tail: String::new(),
+            stderr_tail: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        if write_ready_repair_worker_result_locked(sidecar, &abandoned).is_err() {
+            return Ok(None);
+        }
+    }
+    match fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    match create_ready_repair_lock_file(&path, &content) {
+        Ok(()) => Ok(Some(ReadyRepairReservation {
+            path,
+            attempt_id,
+            started_at_epoch_ms,
+            armed: true,
+        })),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(crate) fn adopt_ready_repair_reservation(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+    attempt_id: &str,
+) -> Result<ReadyRepairReservation> {
+    let pid = std::process::id();
+    let process_start_identity = recorded_process_start_identity(pid);
+    let _coordination = acquire_ready_repair_coordination(sidecar)?;
+    let path = ready_repair_reservation_path(sidecar);
+    let mut reservation = read_ready_repair_reservation_file(&path)
+        .ok_or_else(|| anyhow::anyhow!("ready repair reservation is missing or unreadable"))?;
+    let project_root = clean_path_text(project_root);
+    if reservation.attempt_id != attempt_id
+        || reservation.project_root.as_deref() != Some(project_root.as_str())
+        || reservation.profile.as_deref() != Some(sidecar.profile.as_str())
+        || reservation.run_id != sidecar.run_id
+        || reservation.namespace.as_deref() != Some(sidecar.namespace.as_str())
+    {
+        anyhow::bail!("ready repair reservation does not match the requested attempt and scope");
+    }
+    if process_owner_state(
+        reservation.pid,
+        reservation.process_start_identity.as_deref(),
+    ) == ProcessOwnerState::GoneOrReused
+    {
+        anyhow::bail!("ready repair reservation parent is no longer the recorded process");
+    }
+    reservation.pid = pid;
+    reservation.process_start_identity = process_start_identity;
+    reservation.started_at_epoch_ms = now_epoch_ms();
+    reservation.adopted = true;
+    crate::file_state::write_json_atomic(&path, "ready-repair-reservation", &reservation)?;
+    Ok(ReadyRepairReservation {
+        path,
+        attempt_id: attempt_id.to_string(),
+        started_at_epoch_ms: reservation
+            .created_at_epoch_ms
+            .unwrap_or(reservation.started_at_epoch_ms),
+        armed: true,
+    })
+}
+
+pub(crate) fn remove_ready_repair_reservation_if_attempt(
+    sidecar: &SidecarRuntimeConfig,
+    attempt_id: &str,
+) {
+    remove_ready_repair_reservation_if_attempt_at(
+        &ready_repair_reservation_path(sidecar),
+        attempt_id,
+    );
+}
+
+fn remove_ready_repair_reservation_if_attempt_at(path: &Path, attempt_id: &str) {
+    let Ok(_coordination) = acquire_ready_repair_coordination_at(path) else {
+        return;
+    };
+    remove_ready_repair_reservation_if_attempt_locked(path, attempt_id);
+}
+
+fn remove_ready_repair_reservation_if_attempt_locked(path: &Path, attempt_id: &str) {
+    let Some(reservation) = read_ready_repair_reservation_file(path) else {
+        return;
+    };
+    if reservation.attempt_id == attempt_id {
+        let _ = fs::remove_file(path);
+    }
+}
+
+pub(crate) fn heartbeat_ready_repair_reservation(
+    sidecar: &SidecarRuntimeConfig,
+    attempt_id: &str,
+) -> Result<bool> {
+    let _coordination = acquire_ready_repair_coordination(sidecar)?;
+    let path = ready_repair_reservation_path(sidecar);
+    let Some(mut reservation) = read_ready_repair_reservation_file(&path) else {
+        return Ok(false);
+    };
+    if reservation.attempt_id != attempt_id {
+        return Ok(false);
+    }
+    reservation.started_at_epoch_ms = now_epoch_ms();
+    crate::file_state::write_json_atomic(&path, "ready-repair-reservation", &reservation)?;
+    Ok(true)
+}
+
+pub(crate) fn write_ready_repair_worker_result(
+    sidecar: &SidecarRuntimeConfig,
+    result: &ReadyRepairWorkerResult,
+) -> Result<()> {
+    let _coordination = acquire_ready_repair_coordination(sidecar)?;
+    write_ready_repair_worker_result_locked(sidecar, result)
+}
+
+fn write_ready_repair_worker_result_locked(
+    sidecar: &SidecarRuntimeConfig,
+    result: &ReadyRepairWorkerResult,
+) -> Result<()> {
+    crate::file_state::write_json_atomic(
+        &ready_repair_result_path(sidecar),
+        "ready-repair-result",
+        result,
+    )
+}
+
+pub(crate) fn read_ready_repair_worker_result(
+    project_root: &Path,
+    run_id: Option<&str>,
+) -> Option<ReadyRepairWorkerResult> {
+    let sidecar = sidecar_runtime_for_project_with_run_id(
+        project_root,
+        SidecarProfile::Agent,
+        run_id.or(Some(DEFAULT_AGENT_RUN_ID)),
+    );
+    fs::read_to_string(ready_repair_result_path(&sidecar))
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+}
+
+fn ready_repair_terminal_result_matches(sidecar: &SidecarRuntimeConfig, attempt_id: &str) -> bool {
+    fs::read_to_string(ready_repair_result_path(sidecar))
+        .ok()
+        .and_then(|text| serde_json::from_str::<ReadyRepairWorkerResult>(&text).ok())
+        .is_some_and(|result| {
+            result.attempt_id == attempt_id
+                && matches!(
+                    result.outcome.as_str(),
+                    "succeeded" | "failed" | "abandoned"
+                )
+        })
 }
 
 pub(crate) fn try_acquire_ready_repair_lock(
@@ -206,12 +569,31 @@ fn try_acquire_ready_repair_lock_at(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn write_ready_repair_status(
     sidecar: &SidecarRuntimeConfig,
     project_root: &Path,
     phase: &str,
     started_at_epoch_ms: i64,
     pid: u32,
+) -> Result<()> {
+    write_ready_repair_status_for_attempt(
+        sidecar,
+        project_root,
+        phase,
+        started_at_epoch_ms,
+        pid,
+        None,
+    )
+}
+
+pub(crate) fn write_ready_repair_status_for_attempt(
+    sidecar: &SidecarRuntimeConfig,
+    project_root: &Path,
+    phase: &str,
+    started_at_epoch_ms: i64,
+    pid: u32,
+    attempt_id: Option<&str>,
 ) -> Result<()> {
     let path = ready_repair_status_path(sidecar);
     let status = ReadyRepairStatus {
@@ -224,23 +606,57 @@ pub(crate) fn write_ready_repair_status(
         compose_project: sidecar.compose_project.clone(),
         phase: phase.to_string(),
         pid,
+        attempt_id: attempt_id.map(str::to_string),
         process_start_identity: recorded_process_start_identity(pid),
         started_at_epoch_ms,
         updated_at_epoch_ms: now_epoch_ms(),
     };
+    let _coordination = acquire_ready_repair_coordination(sidecar)?;
     crate::file_state::write_json_atomic(&path, "ready-repair-status", &status)
 }
 
+#[cfg(test)]
 pub(crate) fn clear_ready_repair_status(
     sidecar: &SidecarRuntimeConfig,
     started_at_epoch_ms: i64,
     pid: u32,
 ) {
+    clear_ready_repair_status_for_attempt(sidecar, started_at_epoch_ms, pid, None);
+}
+
+pub(crate) fn clear_ready_repair_status_for_attempt(
+    sidecar: &SidecarRuntimeConfig,
+    started_at_epoch_ms: i64,
+    pid: u32,
+    attempt_id: Option<&str>,
+) {
+    let Ok(_coordination) = acquire_ready_repair_coordination(sidecar) else {
+        return;
+    };
     let path = ready_repair_status_path(sidecar);
     let Some(status) = read_ready_repair_status_file(&path) else {
         return;
     };
-    if status.pid == pid && status.started_at_epoch_ms == started_at_epoch_ms {
+    if status.pid == pid
+        && status.started_at_epoch_ms == started_at_epoch_ms
+        && attempt_id.is_none_or(|attempt_id| status.attempt_id.as_deref() == Some(attempt_id))
+    {
+        let _ = fs::remove_file(path);
+    }
+}
+
+pub(crate) fn clear_ready_repair_status_by_attempt(
+    sidecar: &SidecarRuntimeConfig,
+    attempt_id: &str,
+) {
+    let Ok(_coordination) = acquire_ready_repair_coordination(sidecar) else {
+        return;
+    };
+    let path = ready_repair_status_path(sidecar);
+    let Some(status) = read_ready_repair_status_file(&path) else {
+        return;
+    };
+    if status.attempt_id.as_deref() == Some(attempt_id) {
         let _ = fs::remove_file(path);
     }
 }
@@ -286,11 +702,56 @@ pub(crate) fn cleanup_abandoned_ready_repair_status(
     ready_repair_status_paths(project_root, run_id)
         .into_iter()
         .filter_map(|path| {
-            let status = read_abandoned_ready_repair_status(&path, project_root, now)?;
+            let observed = read_abandoned_ready_repair_status(&path, project_root, now)?;
+            let run_id = observed.run_id.as_deref().unwrap_or(DEFAULT_AGENT_RUN_ID);
+            let sidecar = sidecar_runtime_for_project_with_run_id(
+                project_root,
+                SidecarProfile::Agent,
+                Some(run_id),
+            );
+            let observed_stale_locks = ready_repair_lock_paths_for_status(project_root, &observed)
+                .into_iter()
+                .filter_map(|lock_path| {
+                    let lock = read_ready_repair_lock_file(&lock_path)?;
+                    ready_repair_lock_file_is_stale(&lock_path).then_some((lock_path, lock))
+                })
+                .collect::<Vec<_>>();
+            let _coordination = acquire_ready_repair_coordination(&sidecar).ok()?;
+            let status = read_ready_repair_status_file(&path)?;
+            if status != observed {
+                return None;
+            }
+            let result = ReadyRepairWorkerResult {
+                schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+                attempt_id: status.attempt_id.clone().unwrap_or_else(|| {
+                    format!("legacy:{}:{}", status.pid, status.started_at_epoch_ms)
+                }),
+                project_root: status.project_root.clone(),
+                profile: status.profile.clone(),
+                run_id: status.run_id.clone(),
+                namespace: status.namespace.clone(),
+                pid: status.pid,
+                started_at_epoch_ms: status.started_at_epoch_ms,
+                finished_at_epoch_ms: now,
+                outcome: "abandoned".to_string(),
+                exit_code: None,
+                wait_error: Some(
+                    "repair worker process exited without recording a terminal result".to_string(),
+                ),
+                stdout_tail: String::new(),
+                stderr_tail: String::new(),
+                stdout_truncated: false,
+                stderr_truncated: false,
+            };
+            if !ready_repair_terminal_result_matches(&sidecar, &result.attempt_id)
+                && write_ready_repair_worker_result_locked(&sidecar, &result).is_err()
+            {
+                return None;
+            }
             let removed_status_path = fs::remove_file(&path).is_ok();
             let mut removed_lock_paths = Vec::new();
-            for lock_path in ready_repair_lock_paths_for_status(project_root, &status) {
-                if ready_repair_lock_file_is_stale(&lock_path)
+            for (lock_path, observed_lock) in observed_stale_locks {
+                if read_ready_repair_lock_file(&lock_path).as_ref() == Some(&observed_lock)
                     && fs::remove_file(&lock_path).is_ok()
                 {
                     removed_lock_paths.push(lock_path);
@@ -309,7 +770,13 @@ pub(crate) fn cleanup_abandoned_ready_repair_status(
 pub(crate) fn ready_repair_status_cache_fingerprint(project_root: &Path) -> String {
     ready_repair_status_paths(project_root, None)
         .into_iter()
-        .map(|path| path_fingerprint(&path))
+        .flat_map(|path| {
+            [
+                path_fingerprint(&path),
+                path_fingerprint(&path.with_file_name(READY_REPAIR_RESULT_FILE)),
+                path_fingerprint(&path.with_file_name(READY_REPAIR_ENQUEUE_LOCK_FILE)),
+            ]
+        })
         .collect::<Vec<_>>()
         .join(";")
 }
@@ -348,6 +815,42 @@ fn ready_repair_status_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
         .layout
         .state_file
         .with_file_name(READY_REPAIR_STATUS_FILE)
+}
+
+fn ready_repair_result_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
+    sidecar
+        .layout
+        .state_file
+        .with_file_name(READY_REPAIR_RESULT_FILE)
+}
+
+fn ready_repair_reservation_path(sidecar: &SidecarRuntimeConfig) -> PathBuf {
+    sidecar
+        .layout
+        .state_file
+        .with_file_name(READY_REPAIR_ENQUEUE_LOCK_FILE)
+}
+
+fn read_ready_repair_reservation_file(path: &Path) -> Option<ReadyRepairReservationFile> {
+    crate::file_state::read_json(path)
+}
+
+fn ready_repair_reservation_is_stale(path: &Path) -> bool {
+    if let Some(reservation) = read_ready_repair_reservation_file(path) {
+        return match process_owner_state(
+            reservation.pid,
+            reservation.process_start_identity.as_deref(),
+        ) {
+            ProcessOwnerState::Matching => false,
+            ProcessOwnerState::GoneOrReused => true,
+            ProcessOwnerState::Unknown => crate::file_state::file_modified_age_exceeds(
+                path,
+                READY_REPAIR_LOCK_STALE_TTL,
+                now_epoch_ms(),
+            ),
+        };
+    }
+    crate::file_state::file_modified_age_exceeds(path, READY_REPAIR_LOCK_STALE_TTL, now_epoch_ms())
 }
 
 fn ready_repair_lock_file_is_stale(path: &Path) -> bool {
@@ -489,15 +992,45 @@ fn probe_process(pid: u32) -> ProcessProbe {
     probe
 }
 
+#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
+fn bounded_process_probe_output(command: &mut Command) -> Option<std::process::Output> {
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let deadline = Instant::now() + READY_REPAIR_PROCESS_PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return child.wait_with_output().ok(),
+            Ok(None) if Instant::now() < deadline => {
+                thread::sleep(READY_REPAIR_COORDINATION_POLL);
+            }
+            Ok(None) | Err(_) => {
+                if child.kill().is_ok() {
+                    let reap_deadline = Instant::now() + READY_REPAIR_PROCESS_PROBE_REAP_TIMEOUT;
+                    while Instant::now() < reap_deadline {
+                        if child.try_wait().ok().flatten().is_some() {
+                            break;
+                        }
+                        thread::sleep(READY_REPAIR_COORDINATION_POLL);
+                    }
+                }
+                return None;
+            }
+        }
+    }
+}
+
 #[cfg(windows)]
 fn probe_process_platform(pid: u32) -> ProcessProbe {
     let script = format!(
         "$p=Get-CimInstance Win32_Process -Filter \"ProcessId = {pid}\" -ErrorAction Stop; if ($null -eq $p) {{ exit 2 }}; $p.CreationDate.ToUniversalTime().Ticks"
     );
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
-        .output();
-    let Ok(output) = output else {
+    let mut command = Command::new("powershell");
+    command.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+    let Some(output) = bounded_process_probe_output(&mut command) else {
         return ProcessProbe::Unknown;
     };
     if output.status.code() == Some(2) {
@@ -536,10 +1069,9 @@ fn probe_process_platform(pid: u32) -> ProcessProbe {
 
 #[cfg(all(unix, not(target_os = "linux")))]
 fn probe_process_platform(pid: u32) -> ProcessProbe {
-    let output = Command::new("ps")
-        .args(["-o", "lstart=", "-p", &pid.to_string()])
-        .output();
-    let Ok(output) = output else {
+    let mut command = Command::new("ps");
+    command.args(["-o", "lstart=", "-p", &pid.to_string()]);
+    let Some(output) = bounded_process_probe_output(&mut command) else {
         return ProcessProbe::Unknown;
     };
     if !output.status.success() {
@@ -665,8 +1197,8 @@ fn path_fingerprint(path: &Path) -> String {
 mod tests {
     use super::*;
     use codestory_retrieval::SidecarLayout;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Barrier};
     use std::thread;
 
     fn test_sidecar(root: &Path) -> SidecarRuntimeConfig {
@@ -735,6 +1267,344 @@ mod tests {
         assert_eq!(failed_probe, ProcessOwnerState::Unknown);
         assert_eq!(missing_identity, ProcessOwnerState::Unknown);
         assert_eq!(legacy_live, ProcessOwnerState::Matching);
+    }
+
+    #[test]
+    fn ready_repair_reservation_transfers_exact_attempt_and_scope() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let mut parent = try_reserve_ready_repair(&sidecar, project.path())
+            .expect("reserve")
+            .expect("reservation acquired");
+        let attempt_id = parent.attempt_id().to_string();
+        let serialized = fs::read_to_string(ready_repair_reservation_path(&sidecar))
+            .expect("serialized reservation");
+        assert!(serialized.contains("\"token\""));
+        assert!(!serialized.contains("\"attempt_id\""));
+        parent.disarm();
+
+        let adopted = adopt_ready_repair_reservation(&sidecar, project.path(), &attempt_id)
+            .expect("adopt exact reservation");
+        let stored = read_ready_repair_reservation_file(&ready_repair_reservation_path(&sidecar))
+            .expect("stored adopted reservation");
+
+        assert_eq!(stored.attempt_id, attempt_id);
+        assert!(stored.adopted);
+        assert_eq!(stored.pid, std::process::id());
+        drop(adopted);
+        assert!(!ready_repair_reservation_path(&sidecar).exists());
+    }
+
+    #[test]
+    fn ready_repair_reservation_rejects_scope_mismatch() {
+        let project = tempfile::tempdir().expect("project");
+        let other = tempfile::tempdir().expect("other project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let reservation = try_reserve_ready_repair(&sidecar, project.path())
+            .expect("reserve")
+            .expect("reservation acquired");
+
+        let error =
+            adopt_ready_repair_reservation(&sidecar, other.path(), reservation.attempt_id())
+                .expect_err("scope mismatch must fail");
+
+        assert!(error.to_string().contains("does not match"));
+        assert!(ready_repair_reservation_path(&sidecar).exists());
+    }
+
+    #[test]
+    fn aged_malformed_reservation_is_recoverable() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let path = ready_repair_reservation_path(&sidecar);
+        fs::create_dir_all(path.parent().expect("reservation parent")).expect("state dir");
+        fs::write(&path, "{not-json").expect("malformed reservation");
+        let old = SystemTime::now()
+            .checked_sub(READY_REPAIR_LOCK_STALE_TTL + Duration::from_secs(1))
+            .expect("old file time");
+        fs::File::options()
+            .write(true)
+            .open(&path)
+            .expect("open reservation")
+            .set_times(std::fs::FileTimes::new().set_modified(old))
+            .expect("age reservation");
+
+        let replacement = try_reserve_ready_repair(&sidecar, project.path())
+            .expect("replace malformed reservation")
+            .expect("replacement acquired");
+
+        assert_ne!(replacement.attempt_id(), "");
+        assert!(read_ready_repair_reservation_file(&path).is_some());
+    }
+
+    #[test]
+    fn stale_reservation_does_not_overwrite_matching_terminal_result() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let path = ready_repair_reservation_path(&sidecar);
+        fs::create_dir_all(path.parent().expect("reservation parent")).expect("state dir");
+        let attempt_id = "finished-attempt";
+        crate::file_state::write_json_atomic(
+            &path,
+            "stale-reservation",
+            &ReadyRepairReservationFile {
+                schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+                pid: u32::MAX,
+                process_start_identity: None,
+                started_at_epoch_ms: 100,
+                created_at_epoch_ms: Some(100),
+                attempt_id: attempt_id.to_string(),
+                project_root: Some(clean_path_text(project.path())),
+                profile: Some("agent".to_string()),
+                run_id: sidecar.run_id.clone(),
+                namespace: Some(sidecar.namespace.clone()),
+                adopted: true,
+            },
+        )
+        .expect("stale reservation");
+        let terminal = ReadyRepairWorkerResult {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            attempt_id: attempt_id.to_string(),
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: sidecar.run_id.clone(),
+            namespace: sidecar.namespace.clone(),
+            pid: u32::MAX,
+            started_at_epoch_ms: 100,
+            finished_at_epoch_ms: 200,
+            outcome: "succeeded".to_string(),
+            exit_code: Some(0),
+            wait_error: None,
+            stdout_tail: "done".to_string(),
+            stderr_tail: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        write_ready_repair_worker_result(&sidecar, &terminal).expect("terminal result");
+
+        let _replacement = try_reserve_ready_repair(&sidecar, project.path())
+            .expect("replace stale reservation")
+            .expect("replacement acquired");
+        let preserved: ReadyRepairWorkerResult =
+            crate::file_state::read_json(&ready_repair_result_path(&sidecar))
+                .expect("preserved terminal result");
+
+        assert_eq!(preserved, terminal);
+    }
+
+    #[test]
+    fn concurrent_stale_reservation_reclaim_has_one_winner() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let path = ready_repair_reservation_path(&sidecar);
+        fs::create_dir_all(path.parent().expect("reservation parent")).expect("state dir");
+        crate::file_state::write_json_atomic(
+            &path,
+            "stale-reservation",
+            &ReadyRepairReservationFile {
+                schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+                pid: u32::MAX,
+                process_start_identity: None,
+                started_at_epoch_ms: 100,
+                created_at_epoch_ms: Some(100),
+                attempt_id: "stale-attempt".to_string(),
+                project_root: Some(clean_path_text(project.path())),
+                profile: Some("agent".to_string()),
+                run_id: sidecar.run_id.clone(),
+                namespace: Some(sidecar.namespace.clone()),
+                adopted: true,
+            },
+        )
+        .expect("stale reservation");
+        let barrier = Arc::new(Barrier::new(3));
+        let mut workers = Vec::new();
+        for _ in 0..2 {
+            let barrier = Arc::clone(&barrier);
+            let sidecar = sidecar.clone();
+            let project_root = project.path().to_path_buf();
+            workers.push(thread::spawn(move || {
+                barrier.wait();
+                try_reserve_ready_repair(&sidecar, &project_root).expect("reclaim attempt")
+            }));
+        }
+        barrier.wait();
+
+        let reservations = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("reclaimer"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            reservations
+                .iter()
+                .filter(|reservation| reservation.is_some())
+                .count(),
+            1,
+            "coordination must allow exactly one replacement attempt"
+        );
+        let stored = read_ready_repair_reservation_file(&path).expect("winning reservation");
+        assert_ne!(stored.attempt_id, "stale-attempt");
+    }
+
+    #[test]
+    fn reservation_heartbeat_preserves_original_start_time() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar(state.path());
+        let reservation = try_reserve_ready_repair(&sidecar, project.path())
+            .expect("reserve")
+            .expect("reservation acquired");
+        let before = read_ready_repair_reservation_file(&ready_repair_reservation_path(&sidecar))
+            .expect("reservation before heartbeat");
+        thread::sleep(Duration::from_millis(2));
+
+        assert!(
+            heartbeat_ready_repair_reservation(&sidecar, reservation.attempt_id())
+                .expect("heartbeat")
+        );
+        let after = read_ready_repair_reservation_file(&ready_repair_reservation_path(&sidecar))
+            .expect("reservation after heartbeat");
+
+        assert_eq!(after.created_at_epoch_ms, before.created_at_epoch_ms);
+        assert!(after.started_at_epoch_ms >= before.started_at_epoch_ms);
+    }
+
+    #[test]
+    fn ready_repair_worker_result_round_trips() {
+        let project = tempfile::tempdir().expect("project");
+        let sidecar = sidecar_runtime_for_project_with_run_id(
+            project.path(),
+            SidecarProfile::Agent,
+            Some(DEFAULT_AGENT_RUN_ID),
+        );
+        let result = ReadyRepairWorkerResult {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            attempt_id: "test-attempt".to_string(),
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: Some(DEFAULT_AGENT_RUN_ID.to_string()),
+            namespace: sidecar.namespace.clone(),
+            pid: 42,
+            started_at_epoch_ms: 100,
+            finished_at_epoch_ms: 200,
+            outcome: "failed".to_string(),
+            exit_code: Some(17),
+            wait_error: None,
+            stdout_tail: "stdout".to_string(),
+            stderr_tail: "stderr".to_string(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let fingerprint_before = ready_repair_status_cache_fingerprint(project.path());
+
+        write_ready_repair_worker_result(&sidecar, &result).expect("write worker result");
+
+        assert_ne!(
+            ready_repair_status_cache_fingerprint(project.path()),
+            fingerprint_before,
+            "terminal result should invalidate cached MCP status"
+        );
+        assert_eq!(
+            read_ready_repair_worker_result(project.path(), Some(DEFAULT_AGENT_RUN_ID)),
+            Some(result)
+        );
+        let _ = fs::remove_dir_all(
+            sidecar
+                .layout
+                .state_file
+                .parent()
+                .expect("sidecar state parent"),
+        );
+    }
+
+    #[test]
+    fn concurrent_terminal_write_and_abandoned_cleanup_preserve_terminal_result() {
+        let project = tempfile::tempdir().expect("project");
+        let sidecar = sidecar_runtime_for_project_with_run_id(
+            project.path(),
+            SidecarProfile::Agent,
+            Some(DEFAULT_AGENT_RUN_ID),
+        );
+        let status_path = ready_repair_status_path(&sidecar);
+        fs::create_dir_all(status_path.parent().expect("status parent")).expect("state dir");
+        let attempt_id = "terminal-race";
+        let status = ReadyRepairStatus {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            status: "repairing".to_string(),
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: Some(DEFAULT_AGENT_RUN_ID.to_string()),
+            namespace: sidecar.namespace.clone(),
+            compose_project: sidecar.compose_project.clone(),
+            phase: "starting".to_string(),
+            pid: u32::MAX,
+            attempt_id: Some(attempt_id.to_string()),
+            process_start_identity: None,
+            started_at_epoch_ms: 100,
+            updated_at_epoch_ms: 100,
+        };
+        fs::write(
+            &status_path,
+            serde_json::to_string(&status).expect("status json"),
+        )
+        .expect("abandoned status");
+        let terminal = ReadyRepairWorkerResult {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            attempt_id: attempt_id.to_string(),
+            project_root: status.project_root.clone(),
+            profile: status.profile.clone(),
+            run_id: status.run_id.clone(),
+            namespace: status.namespace.clone(),
+            pid: status.pid,
+            started_at_epoch_ms: status.started_at_epoch_ms,
+            finished_at_epoch_ms: 200,
+            outcome: "succeeded".to_string(),
+            exit_code: Some(0),
+            wait_error: None,
+            stdout_tail: "success".to_string(),
+            stderr_tail: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        let barrier = Arc::new(Barrier::new(3));
+        let writer = {
+            let barrier = Arc::clone(&barrier);
+            let sidecar = sidecar.clone();
+            let terminal = terminal.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                write_ready_repair_worker_result(&sidecar, &terminal).expect("terminal write");
+            })
+        };
+        let cleaner = {
+            let barrier = Arc::clone(&barrier);
+            let project_root = project.path().to_path_buf();
+            thread::spawn(move || {
+                barrier.wait();
+                cleanup_abandoned_ready_repair_status(&project_root, Some(DEFAULT_AGENT_RUN_ID));
+            })
+        };
+        barrier.wait();
+        writer.join().expect("terminal writer");
+        cleaner.join().expect("abandoned cleaner");
+
+        assert_eq!(
+            read_ready_repair_worker_result(project.path(), Some(DEFAULT_AGENT_RUN_ID)),
+            Some(terminal),
+            "terminal success must win regardless of cleanup ordering"
+        );
+        let _ = fs::remove_dir_all(
+            sidecar
+                .layout
+                .state_file
+                .parent()
+                .expect("sidecar state parent"),
+        );
     }
 
     #[test]
@@ -954,6 +1824,7 @@ mod tests {
             compose_project: "codestory-agent-test-proof".to_string(),
             phase: "embeddings".to_string(),
             pid: 4242,
+            attempt_id: None,
             process_start_identity: None,
             started_at_epoch_ms: now - 60_000,
             updated_at_epoch_ms: now - READY_REPAIR_STATUS_TTL.as_millis() as i64 - 1,
@@ -987,6 +1858,7 @@ mod tests {
             compose_project: "codestory-agent-test-proof".to_string(),
             phase: "graph artifact".to_string(),
             pid: dead_pid,
+            attempt_id: None,
             process_start_identity: None,
             started_at_epoch_ms: now,
             updated_at_epoch_ms: now,
@@ -1030,6 +1902,7 @@ mod tests {
             compose_project: "codestory-agent-test-proof".to_string(),
             phase: "Embedding documents".to_string(),
             pid,
+            attempt_id: None,
             process_start_identity: None,
             started_at_epoch_ms: old,
             updated_at_epoch_ms: old,
@@ -1163,6 +2036,7 @@ mod tests {
             compose_project: sidecar.compose_project.clone(),
             phase: "graph artifact".to_string(),
             pid: u32::MAX,
+            attempt_id: Some("abandoned-test".to_string()),
             process_start_identity: None,
             started_at_epoch_ms: now,
             updated_at_epoch_ms: now,
@@ -1211,6 +2085,44 @@ mod tests {
         assert!(
             active_ready_repair_status(project.path(), Some("shared-agent")).is_none(),
             "abandoned cleanup must leave no active repair"
+        );
+        let result = read_ready_repair_worker_result(project.path(), Some("shared-agent"))
+            .expect("abandoned cleanup terminal result");
+        assert_eq!(result.attempt_id, "abandoned-test");
+        assert_eq!(result.outcome, "abandoned");
+
+        let terminal = ReadyRepairWorkerResult {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            attempt_id: "abandoned-test".to_string(),
+            project_root: status.project_root.clone(),
+            profile: status.profile.clone(),
+            run_id: status.run_id.clone(),
+            namespace: status.namespace.clone(),
+            pid: status.pid,
+            started_at_epoch_ms: status.started_at_epoch_ms,
+            finished_at_epoch_ms: now + 1,
+            outcome: "failed".to_string(),
+            exit_code: Some(17),
+            wait_error: None,
+            stdout_tail: "terminal evidence".to_string(),
+            stderr_tail: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        write_ready_repair_worker_result(&sidecar, &terminal).expect("terminal result");
+        fs::write(
+            &status_path,
+            serde_json::to_string(&status).expect("status json"),
+        )
+        .expect("recreate abandoned status");
+
+        let repeated = cleanup_abandoned_ready_repair_status(project.path(), Some("shared-agent"));
+
+        assert_eq!(repeated.len(), 1);
+        assert_eq!(
+            read_ready_repair_worker_result(project.path(), Some("shared-agent")),
+            Some(terminal),
+            "cleanup must preserve an existing matching terminal result"
         );
     }
 }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -18,11 +18,11 @@ use codestory_contracts::api::{
     TrailMode,
 };
 use codestory_retrieval::SidecarLayout;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::VecDeque;
-use std::fs::{self, File, OpenOptions};
-use std::io::{ErrorKind, Write};
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{
@@ -57,8 +57,8 @@ use std::time::{Duration, Instant};
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
 const STDIO_RECENT_REPAIR_TTL: Duration = Duration::from_secs(30);
-const STDIO_READY_REPAIR_ENQUEUE_LOCK_FILE: &str = "ready-repair-enqueue.lock";
-const STDIO_READY_REPAIR_ENQUEUE_LOCK_TTL: Duration = Duration::from_secs(15);
+const STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES: usize = 32 * 1024;
+const STDIO_READY_REPAIR_RESERVATION_HEARTBEAT: Duration = Duration::from_secs(5);
 const STDIO_LOCAL_REFRESH_FOREGROUND_BUDGET: Duration = Duration::from_secs(5);
 const STDIO_SOURCE_FINGERPRINT_FILE_CAP: usize = 25_000;
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
@@ -453,6 +453,7 @@ struct StdioRecentSidecarRepair {
     namespace: String,
     compose_project: String,
     pid: u32,
+    attempt_id: String,
     started_at_epoch_ms: i64,
     observed_at: Instant,
 }
@@ -2617,6 +2618,7 @@ fn stdio_status_with_recent_sidecar_repair(
         "namespace": repair.namespace.clone(),
         "phase": "starting",
         "pid": repair.pid,
+        "attempt_id": repair.attempt_id,
         "updated_at_epoch_ms": repair.started_at_epoch_ms
     });
     let live_active_repair = status
@@ -2666,6 +2668,7 @@ fn stdio_status_with_recent_sidecar_repair(
                 .get("pid")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!(repair.pid)),
+            "attempt_id": repair.attempt_id.clone(),
             "started_at_epoch_ms": repair.started_at_epoch_ms,
             "updated_at_epoch_ms": active_repair
                 .get("updated_at_epoch_ms")
@@ -4407,6 +4410,8 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
         .is_none()
         .then(|| crate::ready_repair_status::abandoned_ready_repair_status(project_root, None))
         .flatten();
+    let last_worker_result =
+        crate::ready_repair_status::read_ready_repair_worker_result(project_root, None);
     let last_repair_command = env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND");
     let active_cli_version = env_nonempty("CODESTORY_PLUGIN_CLI_VERSION")
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
@@ -4447,9 +4452,11 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
             "namespace": &status.namespace,
             "phase": &status.phase,
             "pid": status.pid,
+            "attempt_id": &status.attempt_id,
             "updated_at_epoch_ms": status.updated_at_epoch_ms
         })),
-        "abandoned_repair": abandoned_repair.as_ref().map(|status| stdio_ready_repair_status_json(project_root, status, "abandoned"))
+        "abandoned_repair": abandoned_repair.as_ref().map(|status| stdio_ready_repair_status_json(project_root, status, "abandoned")),
+        "last_worker_result": last_worker_result
     })
 }
 
@@ -4502,6 +4509,7 @@ fn stdio_ready_repair_status_json(
         "namespace": &status.namespace,
         "phase": &status.phase,
         "pid": status.pid,
+        "attempt_id": &status.attempt_id,
         "updated_at_epoch_ms": status.updated_at_epoch_ms,
         "age_ms": crate::ready_repair_status::now_epoch_ms().saturating_sub(status.updated_at_epoch_ms),
         "inspect_command": stdio_agent_retrieval_status_command(project_root, run_id),
@@ -4620,94 +4628,6 @@ fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
     Ok(())
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct StdioReadyRepairEnqueueLockFile {
-    schema_version: u32,
-    pid: u32,
-    started_at_epoch_ms: i64,
-    token: String,
-}
-
-#[derive(Debug)]
-struct StdioReadyRepairEnqueueLock {
-    path: PathBuf,
-    token: String,
-}
-
-impl Drop for StdioReadyRepairEnqueueLock {
-    fn drop(&mut self) {
-        let Some(lock) = read_stdio_ready_repair_enqueue_lock(&self.path) else {
-            return;
-        };
-        if lock.token == self.token {
-            let _ = fs::remove_file(&self.path);
-        }
-    }
-}
-
-fn try_acquire_stdio_ready_repair_enqueue_lock(
-    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
-) -> std::io::Result<Option<StdioReadyRepairEnqueueLock>> {
-    let path = sidecar
-        .layout
-        .state_file
-        .with_file_name(STDIO_READY_REPAIR_ENQUEUE_LOCK_FILE);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let started_at_epoch_ms = crate::ready_repair_status::now_epoch_ms();
-    let pid = std::process::id();
-    let token = format!("{pid}:{started_at_epoch_ms}");
-    let lock = StdioReadyRepairEnqueueLockFile {
-        schema_version: 1,
-        pid,
-        started_at_epoch_ms,
-        token: token.clone(),
-    };
-    let content = serde_json::to_vec_pretty(&lock)?;
-    match create_stdio_ready_repair_enqueue_lock(&path, &content) {
-        Ok(()) => {
-            return Ok(Some(StdioReadyRepairEnqueueLock { path, token }));
-        }
-        Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
-        Err(error) => return Err(error),
-    }
-    if !stdio_ready_repair_enqueue_lock_is_stale(&path) {
-        return Ok(None);
-    }
-    let _ = fs::remove_file(&path);
-    match create_stdio_ready_repair_enqueue_lock(&path, &content) {
-        Ok(()) => Ok(Some(StdioReadyRepairEnqueueLock { path, token })),
-        Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(None),
-        Err(error) => Err(error),
-    }
-}
-
-fn create_stdio_ready_repair_enqueue_lock(path: &Path, content: &[u8]) -> std::io::Result<()> {
-    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
-    file.write_all(content)?;
-    file.sync_all()?;
-    Ok(())
-}
-
-fn stdio_ready_repair_enqueue_lock_is_stale(path: &Path) -> bool {
-    let Some(lock) = read_stdio_ready_repair_enqueue_lock(path) else {
-        return true;
-    };
-    if !crate::ready_repair_status::process_is_running(lock.pid) {
-        return true;
-    }
-    let now = crate::ready_repair_status::now_epoch_ms();
-    now.saturating_sub(lock.started_at_epoch_ms)
-        > STDIO_READY_REPAIR_ENQUEUE_LOCK_TTL.as_millis() as i64
-}
-
-fn read_stdio_ready_repair_enqueue_lock(path: &Path) -> Option<StdioReadyRepairEnqueueLockFile> {
-    fs::read_to_string(path)
-        .ok()
-        .and_then(|text| serde_json::from_str(&text).ok())
-}
-
 fn handle_stdio_sidecar_repair(
     runtime: &RuntimeContext,
     state: &mut StdioServerState,
@@ -4778,8 +4698,11 @@ fn handle_stdio_sidecar_repair(
     ) {
         return stdio_sidecar_repair_machine_busy_result(busy, &sidecar_setup);
     }
-    let _enqueue_lock = match try_acquire_stdio_ready_repair_enqueue_lock(&repair_sidecar) {
-        Ok(Some(lock)) => lock,
+    let mut reservation = match crate::ready_repair_status::try_reserve_ready_repair(
+        &repair_sidecar,
+        &runtime.project_root,
+    ) {
+        Ok(Some(reservation)) => reservation,
         Ok(None) => {
             return stdio_sidecar_repair_already_starting_result(
                 &runtime.project_root,
@@ -4817,6 +4740,8 @@ fn handle_stdio_sidecar_repair(
     };
 
     let mut command = Command::new(&exe);
+    let attempt_id = reservation.attempt_id().to_string();
+    let repair_started_at_epoch_ms = reservation.started_at_epoch_ms();
     command
         .arg("ready")
         .arg("--goal")
@@ -4824,32 +4749,34 @@ fn handle_stdio_sidecar_repair(
         .arg("--repair")
         .arg("--project")
         .arg(&runtime.project_root)
+        .arg("--cache-dir")
+        .arg(&runtime.cache_root)
         .arg("--format")
         .arg("json")
         .arg("--run-id")
         .arg(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
         .env("CODESTORY_PLUGIN_SIDECAR_REPAIR", "1")
+        .env(
+            crate::ready_repair_status::READY_REPAIR_ATTEMPT_ENV,
+            &attempt_id,
+        )
         .stdin(Stdio::null());
 
-    match command.stdout(Stdio::null()).stderr(Stdio::null()).spawn() {
-        Ok(mut child) => {
+    match command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => {
             let child_pid = child.id();
-            let repair_started_at_epoch_ms = crate::ready_repair_status::now_epoch_ms();
-            if let Err(error) = crate::ready_repair_status::write_ready_repair_status(
-                &repair_sidecar,
-                &runtime.project_root,
-                "starting",
+            reservation.disarm();
+            monitor_stdio_ready_repair_worker(
+                child,
+                repair_sidecar.clone(),
+                runtime.project_root.clone(),
+                attempt_id.clone(),
                 repair_started_at_epoch_ms,
-                child_pid,
-            ) {
-                let _ = child.kill();
-                let _ = child.wait();
-                return serde_json::json!({
-                    "error": format!(
-                        "repair process was stopped because its durable status could not be published: {error}"
-                    )
-                });
-            }
+            );
             let broker_snapshot = crate::readiness_broker::refresh_broker_snapshot(
                 crate::readiness_broker::BrokerSnapshotInput {
                     project_root: runtime.project_root.clone(),
@@ -4866,6 +4793,7 @@ fn handle_stdio_sidecar_repair(
                 namespace: repair_sidecar.namespace.clone(),
                 compose_project: repair_sidecar.compose_project.clone(),
                 pid: child_pid,
+                attempt_id: attempt_id.clone(),
                 started_at_epoch_ms: repair_started_at_epoch_ms,
                 observed_at: Instant::now(),
             });
@@ -4874,7 +4802,8 @@ fn handle_stdio_sidecar_repair(
                     "status": "started",
                     "mode": "background",
                     "pid": child_pid,
-                    "status_published": true,
+                    "attempt_id": attempt_id,
+                    "reservation_published": true,
                     "broker_snapshot": broker_snapshot,
                     "previous_abandoned_repair": previous_abandoned_repair,
                     "broker_reconciliation": broker_reconciliation_json,
@@ -4898,6 +4827,125 @@ fn handle_stdio_sidecar_repair(
             })
         }
         Err(error) => serde_json::json!({"error": error.to_string()}),
+    }
+}
+
+fn monitor_stdio_ready_repair_worker(
+    mut child: std::process::Child,
+    sidecar: codestory_retrieval::SidecarRuntimeConfig,
+    project_root: PathBuf,
+    attempt_id: String,
+    started_at_epoch_ms: i64,
+) {
+    thread::spawn(move || {
+        let pid = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .map(|stdout| thread::spawn(move || read_stdio_ready_repair_tail(stdout)));
+        let stderr = child
+            .stderr
+            .take()
+            .map(|stderr| thread::spawn(move || read_stdio_ready_repair_tail(stderr)));
+        let mut last_heartbeat = Instant::now();
+        let wait = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break Ok(status),
+                Ok(None) => {}
+                Err(error) => break Err(error),
+            }
+            if last_heartbeat.elapsed() >= STDIO_READY_REPAIR_RESERVATION_HEARTBEAT {
+                let _ = crate::ready_repair_status::heartbeat_ready_repair_reservation(
+                    &sidecar,
+                    &attempt_id,
+                );
+                last_heartbeat = Instant::now();
+            }
+            thread::sleep(Duration::from_millis(50));
+        };
+        let (stdout_tail, stdout_truncated) = join_stdio_ready_repair_tail(stdout, "stdout");
+        let (stderr_tail, stderr_truncated) = join_stdio_ready_repair_tail(stderr, "stderr");
+        let (outcome, exit_code, wait_error) = match wait {
+            Ok(status) if status.success() => ("succeeded", status.code(), None),
+            Ok(status) => ("failed", status.code(), None),
+            Err(error) => ("failed", None, Some(error.to_string())),
+        };
+        let result = crate::ready_repair_status::ReadyRepairWorkerResult {
+            schema_version: crate::ready_repair_status::READY_REPAIR_STATUS_SCHEMA_VERSION,
+            attempt_id: attempt_id.clone(),
+            project_root: crate::display::clean_path_string(&project_root.to_string_lossy()),
+            profile: sidecar.profile.as_str().to_string(),
+            run_id: sidecar.run_id.clone(),
+            namespace: sidecar.namespace.clone(),
+            pid,
+            started_at_epoch_ms,
+            finished_at_epoch_ms: crate::ready_repair_status::now_epoch_ms(),
+            outcome: outcome.to_string(),
+            exit_code,
+            wait_error,
+            stdout_tail,
+            stderr_tail,
+            stdout_truncated,
+            stderr_truncated,
+        };
+        if let Err(error) =
+            crate::ready_repair_status::write_ready_repair_worker_result(&sidecar, &result)
+        {
+            eprintln!(
+                "[ready-repair] attempt_id={} pid={} status=result_write_failed error={error:#}",
+                attempt_id, pid
+            );
+            return;
+        }
+        crate::ready_repair_status::clear_ready_repair_status_by_attempt(&sidecar, &attempt_id);
+        crate::ready_repair_status::remove_ready_repair_reservation_if_attempt(
+            &sidecar,
+            &attempt_id,
+        );
+    });
+}
+
+fn read_stdio_ready_repair_tail(mut reader: impl Read) -> (String, bool) {
+    let mut tail = VecDeque::with_capacity(STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES);
+    let mut buffer = [0_u8; 8 * 1024];
+    let mut truncated = false;
+    loop {
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) => {
+                let marker = format!("\n[output read failed: {error}]\n");
+                for byte in marker.bytes() {
+                    if tail.len() == STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES {
+                        tail.pop_front();
+                        truncated = true;
+                    }
+                    tail.push_back(byte);
+                }
+                break;
+            }
+        };
+        for byte in &buffer[..read] {
+            if tail.len() == STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES {
+                tail.pop_front();
+                truncated = true;
+            }
+            tail.push_back(*byte);
+        }
+    }
+    let bytes: Vec<u8> = tail.into_iter().collect();
+    (String::from_utf8_lossy(&bytes).into_owned(), truncated)
+}
+
+fn join_stdio_ready_repair_tail(
+    reader: Option<thread::JoinHandle<(String, bool)>>,
+    stream: &str,
+) -> (String, bool) {
+    match reader {
+        Some(reader) => reader
+            .join()
+            .unwrap_or_else(|_| (format!("[{stream} reader thread panicked]"), false)),
+        None => (String::new(), false),
     }
 }
 
@@ -5710,18 +5758,18 @@ mod tests {
             Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
         );
 
-        let first = try_acquire_stdio_ready_repair_enqueue_lock(&sidecar)
+        let first = crate::ready_repair_status::try_reserve_ready_repair(&sidecar, project.path())
             .expect("first enqueue lock")
             .expect("first enqueue lock acquired");
         assert!(
-            try_acquire_stdio_ready_repair_enqueue_lock(&sidecar)
+            crate::ready_repair_status::try_reserve_ready_repair(&sidecar, project.path())
                 .expect("second enqueue lock")
                 .is_none(),
             "concurrent stdio repair enqueue should be blocked"
         );
         drop(first);
         assert!(
-            try_acquire_stdio_ready_repair_enqueue_lock(&sidecar)
+            crate::ready_repair_status::try_reserve_ready_repair(&sidecar, project.path())
                 .expect("third enqueue lock")
                 .is_some(),
             "enqueue lock should be reusable after drop"
@@ -5869,6 +5917,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: std::process::id(),
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -5920,6 +5969,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: live_pid,
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -5946,6 +5996,18 @@ mod tests {
             updated["readiness_broker"]["operations"][0]["pid"],
             json!(live_pid)
         );
+    }
+
+    #[test]
+    fn ready_repair_output_capture_keeps_only_the_bounded_tail() {
+        let mut bytes = vec![b'a'; STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES + 17];
+        bytes.extend_from_slice(b"terminal-marker");
+
+        let (tail, truncated) = read_stdio_ready_repair_tail(std::io::Cursor::new(bytes));
+
+        assert!(truncated);
+        assert_eq!(tail.len(), STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES);
+        assert!(tail.ends_with("terminal-marker"));
     }
 
     fn empty_recent_repair_status() -> serde_json::Value {
@@ -6001,6 +6063,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: u32::MAX,
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -6030,6 +6093,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: u32::MAX,
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -6068,6 +6132,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: std::process::id(),
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now()
                 .checked_sub(STDIO_RECENT_REPAIR_TTL + Duration::from_secs(1))
@@ -6098,6 +6163,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: std::process::id(),
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -6124,6 +6190,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: std::process::id(),
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -6140,6 +6207,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: std::process::id(),
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now()
                 .checked_sub(STDIO_RECENT_REPAIR_TTL + Duration::from_secs(1))
@@ -6158,6 +6226,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: u32::MAX,
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -6178,6 +6247,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: u32::MAX,
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });
@@ -6198,6 +6268,7 @@ mod tests {
             namespace: "codestory-test".to_string(),
             compose_project: "codestory-test".to_string(),
             pid: std::process::id(),
+            attempt_id: "test-attempt".to_string(),
             started_at_epoch_ms: 100,
             observed_at: Instant::now(),
         });

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -19,6 +19,7 @@ struct StdioFixture {
     dirty_marker_path: Option<PathBuf>,
     dirty_marker_project_root: Option<PathBuf>,
     local_refresh_timeout_ms: Option<u64>,
+    ready_repair_worker_probe_exit_code: Option<i32>,
 }
 
 struct StdioServer {
@@ -181,6 +182,7 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
         dirty_marker_path: None,
         dirty_marker_project_root: None,
         local_refresh_timeout_ms: None,
+        ready_repair_worker_probe_exit_code: None,
     }
 }
 
@@ -200,6 +202,7 @@ fn unindexed_fixture() -> StdioFixture {
         dirty_marker_path: None,
         dirty_marker_project_root: None,
         local_refresh_timeout_ms: None,
+        ready_repair_worker_probe_exit_code: None,
     }
 }
 
@@ -324,6 +327,12 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
             timeout_ms.to_string(),
         );
     }
+    if let Some(exit_code) = fixture.ready_repair_worker_probe_exit_code {
+        command.env(
+            "CODESTORY_TEST_READY_REPAIR_WORKER_EXIT_CODE",
+            exit_code.to_string(),
+        );
+    }
     let mut child = command.spawn().expect("spawn stdio server");
 
     let stdin = child.stdin.take().expect("stdio stdin");
@@ -399,6 +408,36 @@ fn assert_tool_success(response: &Value, id: Value) -> &Value {
     result
         .get("structuredContent")
         .expect("tools/call success should include structuredContent")
+}
+
+#[cfg(debug_assertions)]
+fn wait_for_sidecar_worker_result(server: &mut StdioServer, attempt_id: &str) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let response = send_json(
+            server,
+            json!({
+                "jsonrpc": "2.0",
+                "id": "sidecar-setup-terminal-status",
+                "method": "tools/call",
+                "params": {
+                    "name": "sidecar_setup",
+                    "arguments": {"action": "status"}
+                }
+            }),
+        );
+        let setup = assert_tool_success(&response, json!("sidecar-setup-terminal-status"));
+        if setup["last_worker_result"]["attempt_id"] == json!(attempt_id)
+            && setup["active_repair"].is_null()
+        {
+            return setup.clone();
+        }
+        assert!(
+            Instant::now() < deadline,
+            "repair worker did not reach a durable terminal state: {setup}"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 fn assert_structured_citations_have_no_evidence(value: &Value) {
@@ -3134,11 +3173,27 @@ fn sidecar_setup_status_marks_old_last_repair_as_stale() {
     );
 }
 
+#[cfg(debug_assertions)]
 #[test]
 fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
     let mut fixture = indexed_fixture();
     fixture.sidecar_policy_state = Some("ask".to_string());
+    fixture.ready_repair_worker_probe_exit_code = Some(17);
     let policy_path = fixture.cache_dir.path().join("plugin-sidecar-policy.json");
+    let canonical_root =
+        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
+    let repair_sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &canonical_root,
+        codestory_retrieval::SidecarProfile::Agent,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    );
+    let repair_state_dir = repair_sidecar
+        .layout
+        .state_file
+        .parent()
+        .expect("repair state dir")
+        .to_path_buf();
+    let _repair_state_cleanup = RemoveDirOnDrop(repair_state_dir);
     let mut server = spawn_stdio_server(&fixture);
 
     let response = send_json(
@@ -3216,13 +3271,15 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
         }),
     );
     let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair"));
-    assert!(
-        matches!(
-            repair["status"].as_str(),
-            Some("started" | "already_running" | "already_starting")
-        ),
-        "sidecar_setup repair should return a bounded repair state: {repair}"
+    assert_eq!(
+        repair["status"],
+        json!("started"),
+        "a unique fixture must start exactly one repair worker: {repair}"
     );
+    let attempt_id = repair["attempt_id"]
+        .as_str()
+        .expect("started repair attempt id")
+        .to_string();
     assert_eq!(
         repair["mode"],
         json!("background"),
@@ -3246,47 +3303,142 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
             })),
         "sidecar_setup repair should point agents back to project-scoped status: {repair}"
     );
-    if repair["status"] == json!("started") {
-        assert!(
-            repair["broker_reconciliation"]["status"]
-                .as_str()
-                .is_some_and(|status| matches!(status, "clean" | "abandoned_cleaned")),
-            "sidecar_setup repair should reconcile broker state before spawning: {repair}"
-        );
-    }
+    assert!(
+        repair["broker_reconciliation"]["status"]
+            .as_str()
+            .is_some_and(|status| matches!(status, "clean" | "abandoned_cleaned")),
+        "sidecar_setup repair should reconcile broker state before spawning: {repair}"
+    );
 
-    let status_response = send_json(
+    let terminal_setup = wait_for_sidecar_worker_result(&mut server, &attempt_id);
+    let terminal = &terminal_setup["last_worker_result"];
+    assert_eq!(terminal["outcome"], json!("failed"), "{terminal_setup}");
+    assert_eq!(terminal["exit_code"], json!(17), "{terminal_setup}");
+    assert!(terminal["wait_error"].is_null(), "{terminal_setup}");
+    assert_eq!(terminal["stdout_truncated"], json!(true));
+    assert_eq!(terminal["stderr_truncated"], json!(true));
+    assert_eq!(
+        terminal_setup["state"],
+        json!("enabled"),
+        "{terminal_setup}"
+    );
+    assert!(
+        terminal["stdout_tail"]
+            .as_str()
+            .is_some_and(|tail| tail.contains("worker probe stdout") && tail.contains(&attempt_id)),
+        "{terminal_setup}"
+    );
+    assert!(
+        terminal["stderr_tail"]
+            .as_str()
+            .is_some_and(|tail| tail.contains("worker probe stderr") && tail.contains(&attempt_id)),
+        "{terminal_setup}"
+    );
+
+    let result_path = repair_sidecar
+        .layout
+        .state_file
+        .with_file_name("ready-repair-result.json");
+    let durable: Value = serde_json::from_str(
+        &fs::read_to_string(&result_path).expect("durable repair worker result"),
+    )
+    .expect("repair worker result json");
+    assert_eq!(durable["attempt_id"], json!(attempt_id));
+    assert_eq!(durable["exit_code"], json!(17));
+    assert_eq!(durable["outcome"], json!("failed"));
+    assert!(
+        !repair_sidecar
+            .layout
+            .state_file
+            .with_file_name("ready-repair-enqueue.lock")
+            .exists(),
+        "terminal monitor should compare-and-clear the adopted reservation"
+    );
+    assert!(
+        !repair_sidecar
+            .layout
+            .state_file
+            .with_file_name("ready-repair-status.json")
+            .exists(),
+        "terminal monitor should leave no active repair marker"
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn tools_call_sidecar_setup_records_successful_worker_terminal_state() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("enabled".to_string());
+    fixture.ready_repair_worker_probe_exit_code = Some(0);
+    let canonical_root =
+        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
+    let repair_sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+        &canonical_root,
+        codestory_retrieval::SidecarProfile::Agent,
+        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+    );
+    let _repair_state_cleanup = RemoveDirOnDrop(
+        repair_sidecar
+            .layout
+            .state_file
+            .parent()
+            .expect("repair state dir")
+            .to_path_buf(),
+    );
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
         &mut server,
         json!({
             "jsonrpc": "2.0",
-            "id": "sidecar-setup-status",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
+            "id": "sidecar-setup-success-repair",
+            "method": "tools/call",
+            "params": {
+                "name": "sidecar_setup",
+                "arguments": {"action": "repair"}
+            }
         }),
     );
-    let result = assert_success_envelope(&status_response, json!("sidecar-setup-status"));
-    let status = json_resource_content(result, "codestory://status");
-    assert_eq!(
-        status["sidecar_setup"]["state"],
-        json!("enabled"),
-        "{status}"
-    );
-    let next_call_text = status["recommended_next_calls"].to_string();
-    assert_eq!(
-        status["status_resource_auto_repair"],
-        Value::Null,
-        "status should not start another repair after explicit repair: {status}"
+    let repair = assert_tool_success(&response, json!("sidecar-setup-success-repair"));
+    assert_eq!(repair["status"], json!("started"), "{repair}");
+    let attempt_id = repair["attempt_id"]
+        .as_str()
+        .expect("repair attempt id")
+        .to_string();
+
+    let setup = wait_for_sidecar_worker_result(&mut server, &attempt_id);
+    let terminal = &setup["last_worker_result"];
+
+    assert_eq!(terminal["outcome"], json!("succeeded"), "{setup}");
+    assert_eq!(terminal["exit_code"], json!(0), "{setup}");
+    assert!(terminal["wait_error"].is_null(), "{setup}");
+    assert_eq!(terminal["stdout_truncated"], json!(true));
+    assert_eq!(terminal["stderr_truncated"], json!(true));
+    assert!(
+        terminal["stdout_tail"]
+            .as_str()
+            .is_some_and(|tail| tail.contains(&attempt_id)),
+        "{setup}"
     );
     assert!(
-        status["sidecar_setup"]["active_repair"]["status"] == json!("repairing")
-            || status["readiness_broker"]["operations"]
-                .as_array()
-                .is_some_and(|operations| !operations.is_empty()),
-        "status should report Rust-owned repair through setup or broker state after explicit repair: {status}"
+        terminal["stderr_tail"]
+            .as_str()
+            .is_some_and(|tail| tail.contains(&attempt_id)),
+        "{setup}"
     );
     assert!(
-        next_call_text.contains("\"tool\":\"status\"") && next_call_text.contains("\"project\":"),
-        "status should recommend status readback after explicit repair: {status}"
+        !repair_sidecar
+            .layout
+            .state_file
+            .with_file_name("ready-repair-enqueue.lock")
+            .exists()
+    );
+    assert!(
+        !repair_sidecar
+            .layout
+            .state_file
+            .with_file_name("ready-repair-status.json")
+            .exists()
     );
 }
 

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -62,6 +62,7 @@ active runtime source when it is available.
 |-------|---------|-----------------|
 | `local_navigation=ready`, `agent_packet_search=ready`, `sidecar_mode=full` | Local graph and sidecar packet/search infrastructure are ready | Use packet/search/context as infrastructure-eligible, then prove answer quality with source, packet-runtime, drill, or benchmark evidence |
 | `local_navigation=ready`, `agent_packet_search=repairing` | Agent sidecar repair is active and status should include the current `phase`, `profile`, `run_id`, and `namespace` | Wait or reread `codestory://status`; do not start a second agent repair for the same run |
+| `sidecar_setup.last_worker_result.outcome=failed` or `abandoned` | The background repair worker reached a durable terminal state without completing | Match `attempt_id`, then inspect `exit_code`, `wait_error`, and the bounded `stdout_tail` / `stderr_tail` before retrying the named failing layer |
 | `local_navigation=ready`, `agent_packet_search=repair_retrieval` | SQLite graph is usable, but sidecar retrieval is missing, stale, or unhealthy | Use local graph surfaces for source navigation; call MCP `sidecar_setup repair` from status before packet/search claims |
 | `local_navigation=repair_local` | Core index or cache is missing or stale | Follow `recommended_next_calls`, then reread status; use CLI local repair commands only for maintainer transcripts |
 | `sidecar_mode` not `full` | Packet/search sidecars are diagnostic only | Call MCP `sidecar_setup repair`, then reread status; maintainers can inspect `retrieval status` and rerun explicit sidecar commands if needed |
@@ -89,6 +90,8 @@ Attach these artifacts to issues or PRs that claim readiness repair:
 
 - `codestory://status` transcript when MCP is live, or the full
   `agent preflight` JSON when it is not.
+- The matching `sidecar_setup.last_worker_result` when background repair fails,
+  including its `attempt_id`, exit code, and truncated-output flags.
 - `doctor --format markdown` or JSON output, including readiness verdicts and
   legacy/managed embedding diagnostics.
 - `retrieval status --format json`, including `retrieval_mode`,

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -162,6 +162,7 @@ More pairs, anti-patterns, and language-flavored examples:
 | `readiness_broker.resources.native_embedding_runtime.status` | `available` | `busy` blocks repair only when the owner is foreign or unverifiable; same-project reusable owners should continue through `recommended_next_calls`; `stale` means retry repair so the broker can reclaim it |
 | `readiness_broker.gpu_proof.proof_status` | `verified` when accelerator is required and live embed smoke succeeded | `gpu_unverified` means repair should stop before a long semantic rebuild; inspect `embed_smoke_ok` / `embed_smoke_ms` |
 | `readiness_broker.persistence_status` | `persisted` | `failed` means inspect `persistence_error`; status may be live but not durable across processes |
+| `sidecar_setup.last_worker_result` | `outcome=succeeded` for the matching repair `attempt_id` | `failed` or `abandoned` means inspect the exit code and bounded output tails before retrying; it is terminal evidence, not an active lock |
 | `recommended_next_calls` | Start with `agent-guide`, then use allowed tools | For packet/search blockers, follow the listed `sidecar_setup repair` and status read sequence; if tools are hidden, stop and report host visibility |
 
 Shared repair lanes: [Troubleshooting](troubleshooting.md).


### PR DESCRIPTION
## Context

MCP `sidecar_setup repair` spawned `ready --goal agent --repair`, then published the child as a competing active repair. The child reconciled that parent-owned state and could reject its own handoff. This left managed CodeStory repair stuck and discarded the worker's stdout, stderr, and exit status.

Closes #901
Refs #897
Refs #899

## What Changed

- Replaced the separate enqueue-lock behavior with one attempt-scoped reservation that the MCP parent creates and the exact child process adopts.
- Forwarded the parent's explicit cache root so parent and child reconcile the same broker and workspace state.
- Serialized reservation, status, and terminal-result mutations with the existing workspace `fs4` dependency.
- Heartbeat the adopted reservation while the worker is alive, with a legacy-compatible `token` field for rolling upgrades.
- Persisted success, failure, or abandonment with exit code, wait error, and bounded 32 KiB stdout/stderr tails.
- Exposed `sidecar_setup.last_worker_result` and included result/reservation changes in MCP status cache invalidation.
- Added stale/corrupt recovery, PID/start-identity validation, bounded Windows/macOS process probes, and compare-before-clear behavior.
- Updated the changelog and operator guidance.

```mermaid
flowchart LR
    MCP["MCP sidecar_setup repair"] --> R["Reserve attempt token"]
    R --> C["Spawn CLI with attempt + cache root"]
    C --> A["Child validates and adopts reservation"]
    A --> B["Reconcile and run repair"]
    B --> M["Parent monitor captures bounded output + exit"]
    M --> T["Persist terminal result"]
    T --> X["Compare-and-clear status and reservation"]
```

## How To Review

1. Start in `ready_repair_status.rs`: reservation adoption, fs4 coordination, heartbeat, terminal-result preservation, and stale cleanup.
2. Review `stdio_transport.rs`: child command scope, monitor lifecycle, bounded pipe draining, and status surface.
3. Review `main.rs`: child adoption before reconciliation and the debug-only abrupt-exit probe.
4. Review the two real MCP-to-CLI subprocess cases in `stdio_protocol_contracts.rs` for exit 0/17, dual-stream truncation, durable result, and cleanup.

## Verification

- `cargo test -p codestory-cli -- --test-threads=1` — package suites passed (318 unit tests; all non-ignored integration suites passed).
- Final focused reruns after the last coordination/probe adjustments:
  - `cargo test -p codestory-cli --bin codestory-cli ready_repair -- --test-threads=1` — 33 passed.
  - `cargo test -p codestory-cli --test stdio_protocol_contracts tools_call_sidecar_setup_ -- --test-threads=1` — 5 passed.
- `cargo clippy -p codestory-cli --all-targets -- -D warnings` — passed.
- `cargo build --release -p codestory-cli` — passed.
- `git diff --check`, docs link check, and workflow policy check — passed.
- Mandatory ignored repo e2e was attempted. It cannot complete on this host because `CODESTORY_REAL_REPO_DRILL_CASES` is unset and the Codex host job object denies `CREATE_BREAKAWAY_FROM_JOB` for the native embedding process. No stats were appended.

## Risk

The main risk is cross-process lifecycle behavior under a managed plugin install. Source and subprocess coverage include concurrent reclaimers, terminal-write/cleanup races, fast abrupt exits, success/failure/abandonment, corrupt state, PID reuse, and bounded probes. Live managed-plugin stale-state proof remains a release-lane checkpoint before #901 is treated as fully proven.