### PR TITLE
automatically close issues merged into dev

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -7,6 +7,7 @@ const trustedOwners = new Set(["actions", "github"]);
 const shaPattern = /^[0-9a-f]{40}$/i;
 const violations = [];
 const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
+const closeDevIssues = path.join(workflowRoot, "close-dev-issues.yml");
 const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
 const rustCi = path.join(workflowRoot, "rust-ci.yml");
 const releaseWorkflow = path.join(workflowRoot, "release.yml");
@@ -66,6 +67,35 @@ if (fs.existsSync(sagaIssueLinkGuard)) {
     !closingRef.test("Closes https://github.com/TheGreenCedar/CodeStory/issues/123")
   ) {
     violations.push("saga-issue-link-guard.yml closing ref policy must reject bare numbers and accept # or full issue URLs");
+  }
+}
+
+if (!fs.existsSync(closeDevIssues)) {
+  violations.push("close-dev-issues.yml must close linked issues for merged dev PRs");
+} else {
+  const content = fs.readFileSync(closeDevIssues, "utf8");
+  const requiredSnippets = [
+    "pull_request:",
+    "dev/codestory-next",
+    "types: [closed]",
+    "github.event.pull_request.merged == true",
+    "issues: write",
+    'if "pull_request" in issue:',
+    '"state_reason=completed"',
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!content.includes(snippet)) {
+      violations.push(`close-dev-issues.yml must include ${snippet}`);
+    }
+  }
+
+  if (
+    !content.includes(
+      'r"(?:#(\\d+)|https://github\\.com/TheGreenCedar/CodeStory/issues/(\\d+))\\b"',
+    )
+  ) {
+    violations.push("close-dev-issues.yml must accept only # or same-repository issue URLs");
   }
 }
 

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -75,10 +75,11 @@ if (!fs.existsSync(closeDevIssues)) {
 } else {
   const content = fs.readFileSync(closeDevIssues, "utf8");
   const requiredSnippets = [
-    "pull_request:",
+    "push:",
     "dev/codestory-next",
-    "types: [closed]",
-    "github.event.pull_request.merged == true",
+    'commit = event["after"]',
+    'pull_request.get("merged_at")',
+    'pull_request.get("merge_commit_sha") == commit',
     "issues: write",
     'if "pull_request" in issue:',
     '"state_reason=completed"',

--- a/.github/workflows/close-dev-issues.yml
+++ b/.github/workflows/close-dev-issues.yml
@@ -1,0 +1,71 @@
+name: close dev merged issues
+
+on:
+  pull_request:
+    branches:
+      - dev/codestory-next
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  close-linked-issues:
+    name: close linked issues
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Close issues referenced by closing keywords
+        shell: python
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          import json
+          import os
+          import re
+          import subprocess
+
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as event_file:
+              event = json.load(event_file)
+
+          repository = event["repository"]["full_name"]
+          pull_request = event["pull_request"]
+          body = pull_request.get("body") or ""
+          closing_keyword = re.compile(
+              r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+"
+              r"(?:#(\d+)|https://github\.com/TheGreenCedar/CodeStory/issues/(\d+))\b"
+          )
+          issue_numbers = sorted(
+              {int(short or full) for short, full in closing_keyword.findall(body)}
+          )
+
+          if not issue_numbers:
+              print("No closing issue references found.")
+
+          for issue_number in issue_numbers:
+              endpoint = f"repos/{repository}/issues/{issue_number}"
+              issue = json.loads(
+                  subprocess.check_output(["gh", "api", endpoint], text=True)
+              )
+              if "pull_request" in issue:
+                  print(f"::warning::Skipping #{issue_number}: it is a pull request.")
+                  continue
+              if issue["state"] == "closed":
+                  print(f"Issue #{issue_number} is already closed.")
+                  continue
+              subprocess.run(
+                  [
+                      "gh",
+                      "api",
+                      "--method",
+                      "PATCH",
+                      endpoint,
+                      "-f",
+                      "state=closed",
+                      "-f",
+                      "state_reason=completed",
+                  ],
+                  check=True,
+              )
+              print(f"Closed issue #{issue_number} from merged PR #{pull_request['number']}.")

--- a/.github/workflows/close-dev-issues.yml
+++ b/.github/workflows/close-dev-issues.yml
@@ -1,22 +1,22 @@
 name: close dev merged issues
 
 on:
-  pull_request:
+  push:
     branches:
       - dev/codestory-next
-    types: [closed]
 
 permissions:
+  contents: read
   issues: write
+  pull-requests: read
 
 jobs:
   close-linked-issues:
     name: close linked issues
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Close issues referenced by closing keywords
+      - name: Close issues referenced by the merged PR
         shell: python
         env:
           GH_TOKEN: ${{ github.token }}
@@ -30,42 +30,62 @@ jobs:
               event = json.load(event_file)
 
           repository = event["repository"]["full_name"]
-          pull_request = event["pull_request"]
-          body = pull_request.get("body") or ""
+          commit = event["after"]
+          pull_requests = json.loads(
+              subprocess.check_output(
+                  ["gh", "api", f"repos/{repository}/commits/{commit}/pulls"],
+                  text=True,
+              )
+          )
+          merged_pull_requests = [
+              pull_request
+              for pull_request in pull_requests
+              if pull_request.get("merged_at")
+              and pull_request.get("merge_commit_sha") == commit
+              and pull_request.get("base", {}).get("ref") == "dev/codestory-next"
+          ]
+
+          if not merged_pull_requests:
+              print("Push was not a pull request merge into dev/codestory-next.")
+
           closing_keyword = re.compile(
               r"(?im)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+"
               r"(?:#(\d+)|https://github\.com/TheGreenCedar/CodeStory/issues/(\d+))\b"
           )
-          issue_numbers = sorted(
-              {int(short or full) for short, full in closing_keyword.findall(body)}
-          )
-
-          if not issue_numbers:
-              print("No closing issue references found.")
-
-          for issue_number in issue_numbers:
-              endpoint = f"repos/{repository}/issues/{issue_number}"
-              issue = json.loads(
-                  subprocess.check_output(["gh", "api", endpoint], text=True)
+          for pull_request in merged_pull_requests:
+              body = pull_request.get("body") or ""
+              issue_numbers = sorted(
+                  {int(short or full) for short, full in closing_keyword.findall(body)}
               )
-              if "pull_request" in issue:
-                  print(f"::warning::Skipping #{issue_number}: it is a pull request.")
-                  continue
-              if issue["state"] == "closed":
-                  print(f"Issue #{issue_number} is already closed.")
-                  continue
-              subprocess.run(
-                  [
-                      "gh",
-                      "api",
-                      "--method",
-                      "PATCH",
-                      endpoint,
-                      "-f",
-                      "state=closed",
-                      "-f",
-                      "state_reason=completed",
-                  ],
-                  check=True,
-              )
-              print(f"Closed issue #{issue_number} from merged PR #{pull_request['number']}.")
+              if not issue_numbers:
+                  print(f"PR #{pull_request['number']} has no closing issue references.")
+
+              for issue_number in issue_numbers:
+                  endpoint = f"repos/{repository}/issues/{issue_number}"
+                  issue = json.loads(
+                      subprocess.check_output(["gh", "api", endpoint], text=True)
+                  )
+                  if "pull_request" in issue:
+                      print(f"::warning::Skipping #{issue_number}: it is a pull request.")
+                      continue
+                  if issue["state"] == "closed":
+                      print(f"Issue #{issue_number} is already closed.")
+                      continue
+                  subprocess.run(
+                      [
+                          "gh",
+                          "api",
+                          "--method",
+                          "PATCH",
+                          endpoint,
+                          "-f",
+                          "state=closed",
+                          "-f",
+                          "state_reason=completed",
+                      ],
+                      check=True,
+                  )
+                  print(
+                      f"Closed issue #{issue_number} from merged PR "
+                      f"#{pull_request['number']}."
+                  )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Added a `dev/codestory-next` merge workflow that closes same-repository
+  issues named by `Closes`, `Fixes`, or `Resolves` in merged pull requests.
 - Separated release-update advice from runtime readiness. A newer GitHub
   release or a newer checksum-valid managed CLI now appears under the
   non-blocking `runtime_update` status field without disabling compatible local


### PR DESCRIPTION
## Context

GitHub only honors issue-closing keywords automatically when a pull request reaches the default branch. CodeStory routine PRs merge into `dev/codestory-next`, so bodies such as `Closes #901` link the work but leave the issue open.

Closes #926

## What Changed

- Added a workflow owned by `dev/codestory-next` that runs on pushes to that branch.
- Resolves the PR associated with the pushed merge commit and ignores direct/non-PR pushes.
- Parses only `Closes`, `Fixes`, and `Resolves` references using `#123` or same-repository issue URLs.
- Skips PR numbers and already-closed issues before closing open issues as completed.
- Added workflow-policy checks and changelog coverage.

## How To Review

1. Review `.github/workflows/close-dev-issues.yml`: trigger, merge-commit association, reference parser, and issue/PR guard.
2. Review `.github/scripts/check-workflow-policy.mjs`: the dev-only trigger and safety invariants are now enforced.
3. Confirm the workflow has only the permissions required to resolve a merge commit and close issues.

## Verification

- `node .github/scripts/check-workflow-policy.mjs` — passed.
- Embedded Python extracted from the workflow compiled successfully.
- Synthetic exact-script test — passed: the dev merge closed `Closes #926` and a full same-repo `Fixes` URL; `Refs #897`, PR number `#123`, and a main-target PR were skipped.
- `git diff --check` — passed.
- `actionlint` was unavailable locally.

## Risk

The workflow intentionally does nothing for direct pushes or commits that GitHub does not associate with a merged PR into `dev/codestory-next`. GitHub also suppresses workflows caused by pushes made with a repository `GITHUB_TOKEN`; normal user, GitHub App, and merge-button merges are the supported path.