### PR TITLE
recover interrupted incremental indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Added a `dev/codestory-next` merge workflow that closes same-repository
   issues named by `Closes`, `Fixes`, or `Resolves` in merged pull requests.
+- Made live incremental indexing crash-safe. Runs now persist an incomplete-run
+  marker and a transient cross-version schema fence before mutating graph
+  projections, exclude concurrent writers across processes, retry unchanged
+  `complete=false` files, and clear the marker only after resolution and both
+  grounding snapshot tiers succeed. Failed or cancelled runs report stale,
+  cannot serve strict sidecar retrieval or cache rehydrate, and recover through
+  the existing staged full-refresh publish path on the next refresh.
 - Separated release-update advice from runtime readiness. A newer GitHub
   release or a newer checksum-valid managed CLI now appears under the
   non-blocking `runtime_update` status field without disabling compatible local

--- a/crates/codestory-bench/benches/indexing.rs
+++ b/crates/codestory-bench/benches/indexing.rs
@@ -55,6 +55,7 @@ fn refresh_inputs_from_storage(storage: &Storage) -> codestory_workspace::Refres
                 path: file.path,
                 modification_time: file.modification_time,
                 indexed: file.indexed,
+                complete: file.complete,
             })
             .collect(),
         inventory: Default::default(),

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -15494,6 +15494,35 @@ mod tests {
     }
 
     #[test]
+    fn interrupted_incremental_resolves_and_labels_staged_full_recovery() {
+        let mut summary = summary_with_files(3);
+        summary.freshness = Some(IndexFreshnessDto {
+            status: IndexFreshnessStatusDto::Stale,
+            changed_file_count: 0,
+            new_file_count: 0,
+            removed_file_count: 0,
+            checked_file_count: 0,
+            indexed_file_count: 3,
+            duration_ms: 0,
+            reason: Some("previous_incremental_run_incomplete_full_refresh_required".to_string()),
+            samples: Vec::new(),
+        });
+
+        assert_eq!(
+            resolve_refresh_request(RefreshMode::Auto, &summary),
+            Some(IndexMode::Full)
+        );
+        assert_eq!(
+            resolve_refresh_request(RefreshMode::Incremental, &summary),
+            Some(IndexMode::Full)
+        );
+        assert_eq!(
+            refresh_label(RefreshMode::Incremental, Some(IndexMode::Full)),
+            "incremental(recovery-full)"
+        );
+    }
+
+    #[test]
     fn render_index_markdown_includes_rich_timing_breakdown_when_available() {
         let summary = summary_with_files(3);
         let timings = sample_phase_timings();

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -27,6 +27,8 @@ use crate::query_resolution::{
 };
 
 const HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT: usize = 10;
+const INCOMPLETE_INDEX_RECOVERY_REASON: &str =
+    "previous_incremental_run_incomplete_full_refresh_required";
 
 #[derive(Debug)]
 /// Project state after a command has opened or refreshed the repository.
@@ -469,14 +471,23 @@ pub(crate) fn resolve_refresh_request(
     refresh: RefreshMode,
     summary: &ProjectSummary,
 ) -> Option<IndexMode> {
+    let requires_full_recovery = summary
+        .freshness
+        .as_ref()
+        .and_then(|freshness| freshness.reason.as_deref())
+        == Some(INCOMPLETE_INDEX_RECOVERY_REASON);
     match refresh {
-        RefreshMode::Auto => Some(if summary.stats.node_count == 0 {
+        RefreshMode::Auto => Some(if summary.stats.node_count == 0 || requires_full_recovery {
             IndexMode::Full
         } else {
             IndexMode::Incremental
         }),
         RefreshMode::Full => Some(IndexMode::Full),
-        RefreshMode::Incremental => Some(IndexMode::Incremental),
+        RefreshMode::Incremental => Some(if requires_full_recovery {
+            IndexMode::Full
+        } else {
+            IndexMode::Incremental
+        }),
         RefreshMode::None => None,
     }
 }
@@ -487,7 +498,10 @@ pub(crate) fn refresh_label(requested: RefreshMode, resolved: Option<IndexMode>)
         (RefreshMode::Auto, Some(IndexMode::Full)) => "auto(full)".to_string(),
         (RefreshMode::Auto, Some(IndexMode::Incremental)) => "auto(incremental)".to_string(),
         (RefreshMode::Full, Some(_)) => "full".to_string(),
-        (RefreshMode::Incremental, Some(_)) => "incremental".to_string(),
+        (RefreshMode::Incremental, Some(IndexMode::Full)) => {
+            "incremental(recovery-full)".to_string()
+        }
+        (RefreshMode::Incremental, Some(IndexMode::Incremental)) => "incremental".to_string(),
         (RefreshMode::None, None) => "none".to_string(),
         _ => "unknown".to_string(),
     }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2765,7 +2765,7 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
         format!("storage:{}", runtime.storage_path.display()),
         format!(
             "storage_state:{}",
-            stdio_path_fingerprint(&runtime.storage_path)
+            stdio_storage_fingerprint(&runtime.storage_path)
         ),
         format!(
             "sidecar_state:{}",
@@ -7465,5 +7465,33 @@ starting sidecar setup
         std::fs::write(temp.path().join("codestory.db-wal"), b"wal").expect("write wal");
         let with_wal = stdio_storage_fingerprint(&db_path);
         assert_ne!(rewritten, with_wal);
+    }
+
+    #[test]
+    fn stdio_status_cache_key_tracks_wal_changes() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let runtime = crate::runtime::RuntimeContext::new_inspect_only(&crate::args::ProjectArgs {
+            project: project.path().to_path_buf(),
+            cache_dir: Some(cache.path().to_path_buf()),
+        })
+        .expect("inspect runtime");
+        std::fs::create_dir_all(runtime.storage_path.parent().expect("storage parent"))
+            .expect("create storage parent");
+        std::fs::write(&runtime.storage_path, b"db").expect("write db");
+        let clean = stdio_status_cache_key(&runtime);
+
+        let wal_path = runtime.storage_path.with_extension("db-wal");
+        std::fs::write(&wal_path, b"incomplete-marker-frame").expect("write marker WAL frame");
+        let incomplete = stdio_status_cache_key(&runtime);
+        assert_ne!(clean, incomplete, "WAL write must bust cached fresh status");
+
+        std::fs::write(&wal_path, b"incomplete-marker-frame-cleared")
+            .expect("write marker-clear WAL frame");
+        let finished = stdio_status_cache_key(&runtime);
+        assert_ne!(
+            incomplete, finished,
+            "marker clear must bust cached stale status"
+        );
     }
 }

--- a/crates/codestory-contracts/src/workspace.rs
+++ b/crates/codestory-contracts/src/workspace.rs
@@ -13,6 +13,7 @@ pub struct StoredFileState {
     pub path: PathBuf,
     pub modification_time: i64,
     pub indexed: bool,
+    pub complete: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -26,6 +27,7 @@ pub struct IndexedFileRecord {
     pub file_id: i64,
     pub modification_time: i64,
     pub indexed: bool,
+    pub complete: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -64,6 +66,7 @@ impl RefreshInputs {
                         path,
                         modification_time: record.modification_time,
                         indexed: record.indexed,
+                        complete: record.complete,
                     },
                 )
             })

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -843,6 +843,12 @@ fn strict_readiness_unavailable_reason(
     project_id: &str,
     manifest: &codestory_store::RetrievalIndexManifest,
 ) -> Result<Option<String>> {
+    if storage
+        .has_incomplete_incremental_run()
+        .context("inspect incomplete incremental index marker")?
+    {
+        return Ok(Some("incomplete_incremental_index_run".into()));
+    }
     if !manifest_has_current_sidecar_contract(project_id, manifest) {
         return Ok(None);
     }
@@ -850,6 +856,12 @@ fn strict_readiness_unavailable_reason(
         && manifest_contract_drift_should_win(&reason)
     {
         return Ok(None);
+    }
+    if let Some(path) = storage
+        .first_incomplete_file_path()
+        .context("inspect incomplete indexed files")?
+    {
+        return Ok(Some(format!("indexed_file_incomplete: {}", path.display())));
     }
 
     let embedding_backend = crate::embeddings::embedding_runtime_id();
@@ -905,6 +917,7 @@ fn strict_readiness_unavailable_reason(
                 path: file.path,
                 modification_time: file.modification_time,
                 indexed: file.indexed,
+                complete: file.complete,
             })
             .collect(),
         inventory: Default::default(),
@@ -1422,6 +1435,72 @@ mod tests {
             reason.contains("stored=onnx current=llamacpp"),
             "unexpected reason: {reason}"
         );
+    }
+
+    #[test]
+    fn strict_readiness_rejects_incomplete_run_before_manifest_fast_paths() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let project_id = project_id_for_root(project.path());
+        let manifest = retrieval_manifest_fixture(&project_id, "current");
+        let storage = Store::open(&storage_path).expect("open db");
+        storage
+            .begin_incremental_run()
+            .expect("mark incomplete run");
+
+        let reason = strict_readiness_unavailable_reason(
+            project.path(),
+            &storage_path,
+            &storage,
+            &project_id,
+            &manifest,
+        )
+        .expect("strict readiness")
+        .expect("incomplete run must degrade");
+
+        assert_eq!(reason, "incomplete_incremental_index_run");
+    }
+
+    #[test]
+    fn strict_readiness_rejects_unchanged_incomplete_indexed_file() {
+        let project = TempDir::new().expect("project");
+        let storage_dir = TempDir::new().expect("storage");
+        let storage_path = storage_dir.path().join("codestory.db");
+        let source_path = project.path().join("lib.rs");
+        std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let indexed_mtime = live_mtime_millis(&source_path);
+        let project_id = project_id_for_root(project.path());
+        let manifest = retrieval_manifest_fixture(&project_id, "current");
+        let storage = Store::open(&storage_path).expect("open db");
+        storage
+            .insert_file(&FileInfo {
+                id: 1,
+                path: source_path.clone(),
+                language: "rust".into(),
+                modification_time: indexed_mtime,
+                indexed: true,
+                complete: false,
+                line_count: 1,
+                file_role: FileRole::Source,
+            })
+            .expect("insert incomplete file");
+
+        let reason = strict_readiness_unavailable_reason(
+            project.path(),
+            &storage_path,
+            &storage,
+            &project_id,
+            &manifest,
+        )
+        .expect("strict readiness")
+        .expect("incomplete file must degrade");
+
+        assert!(
+            reason.contains("indexed_file_incomplete"),
+            "unexpected reason: {reason}"
+        );
+        assert!(reason.contains(&source_path.display().to_string()));
     }
 
     #[test]

--- a/crates/codestory-runtime/src/cache_rehydrate.rs
+++ b/crates/codestory-runtime/src/cache_rehydrate.rs
@@ -82,6 +82,42 @@ pub fn rehydrate_cache(request: CacheRehydrateRequest<'_>) -> Result<CacheRehydr
             rebuild,
         ));
     }
+    let _source_writer_guard = if request.dry_run {
+        None
+    } else {
+        Some(match super::IndexWriterGuard::try_acquire(&source_db) {
+            Ok(guard) => guard,
+            Err(error) if error.code == "cache_busy" => {
+                return Ok(skipped(
+                    request,
+                    format!("source cache is busy: {}", error.message),
+                    rebuild,
+                ));
+            }
+            Err(error) => bail!(
+                "failed to acquire source cache writer lock: {}",
+                error.message
+            ),
+        })
+    };
+    let _target_writer_guard = if request.dry_run {
+        None
+    } else {
+        Some(match super::IndexWriterGuard::try_acquire(&target_db) {
+            Ok(guard) => guard,
+            Err(error) if error.code == "cache_busy" => {
+                return Ok(skipped(
+                    request,
+                    format!("target cache is busy: {}", error.message),
+                    rebuild,
+                ));
+            }
+            Err(error) => bail!(
+                "failed to acquire target cache writer lock: {}",
+                error.message
+            ),
+        })
+    };
     if target_cache_has_contents(request.target_cache_dir)? {
         return Ok(skipped(request, "target cache dir is not empty", rebuild));
     }
@@ -247,6 +283,12 @@ fn source_cache_freshness(project: &Path, source_db: &Path) -> Result<SourceCach
     let workspace = WorkspaceManifest::open(project.to_path_buf())
         .with_context(|| format!("open source workspace {}", project.display()))?;
     let storage = Store::open(source_db).context("open source cache for freshness")?;
+    if storage
+        .has_incomplete_incremental_run()
+        .context("inspect source cache incomplete index marker")?
+    {
+        bail!("source cache has an incomplete incremental index run");
+    }
     let plan = workspace
         .build_execution_plan(&RefreshInputs {
             stored_files: storage.files().inventory()?,
@@ -298,11 +340,14 @@ fn target_cache_has_contents(path: &Path) -> Result<bool> {
     if !path.exists() {
         return Ok(false);
     }
-    Ok(fs::read_dir(path)
-        .with_context(|| format!("read target cache dir {}", path.display()))?
-        .next()
-        .transpose()?
-        .is_some())
+    for entry in
+        fs::read_dir(path).with_context(|| format!("read target cache dir {}", path.display()))?
+    {
+        if entry?.file_name() != "codestory.index-writer.lock" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn target_cache_nested_in_source(source: &Path, target: &Path) -> Result<bool> {
@@ -380,9 +425,9 @@ fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
             Store::copy_database_snapshot(&source_path, &target_path)?;
         } else if matches!(
             entry.file_name().to_string_lossy().as_ref(),
-            "codestory.db-wal" | "codestory.db-shm"
+            "codestory.db-wal" | "codestory.db-shm" | "codestory.index-writer.lock"
         ) {
-            // SQLite backup snapshots the DB; copying WAL/SHM would reintroduce live state.
+            // SQLite backup snapshots the DB; live sidecars and process locks are never portable.
             continue;
         } else {
             fs::copy(&source_path, &target_path)?;
@@ -536,6 +581,9 @@ mod tests {
         let source_cache = tempdir().expect("source cache");
         let target_cache = tempdir().expect("target cache");
         let target_cache_path = target_cache.path().join("empty");
+        fs::create_dir_all(&target_cache_path).expect("create lock-only target cache");
+        fs::write(target_cache_path.join("codestory.index-writer.lock"), b"")
+            .expect("seed persistent target lock");
         let source_db = source_cache.path().join("codestory.db");
         seed_cache(&source_db, source_project.path());
 
@@ -550,6 +598,12 @@ mod tests {
 
         assert_eq!(output.status, "rehydrated");
         assert!(target_cache_path.join("codestory.db").is_file());
+        assert!(
+            target_cache_path
+                .join("codestory.index-writer.lock")
+                .exists(),
+            "the target owns its persistent writer lock after rehydrate"
+        );
         assert_eq!(output.invalidated_retrieval_manifests, 1);
         assert_eq!(output.invalidated_index_artifact_rows, 1);
         assert!(output.rebased_path_bound_rows > 0);
@@ -616,6 +670,43 @@ mod tests {
                 .get_index_artifact_cache(Path::new("legacy.rs"), "v1:path-bound:legacy")
                 .expect("legacy artifact cache lookup")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn rehydrate_dry_run_does_not_create_target_cache_metadata() {
+        let Some((source_project, target_project)) = matching_git_projects() else {
+            return;
+        };
+        let source_cache = tempdir().expect("source cache");
+        let target_parent = tempdir().expect("target parent");
+        let target_cache_path = target_parent.path().join("absent-cache");
+        seed_cache(
+            &source_cache.path().join("codestory.db"),
+            source_project.path(),
+        );
+
+        let output = rehydrate_cache(CacheRehydrateRequest {
+            source_project: source_project.path(),
+            source_cache_dir: source_cache.path(),
+            target_project: target_project.path(),
+            target_cache_dir: &target_cache_path,
+            dry_run: true,
+        })
+        .expect("rehydrate dry run");
+
+        assert_eq!(output.status, "would_rehydrate");
+        assert!(!output.copied);
+        assert!(
+            !source_cache
+                .path()
+                .join("codestory.index-writer.lock")
+                .exists(),
+            "dry-run must not create a source lock"
+        );
+        assert!(
+            !target_cache_path.exists(),
+            "dry-run must not create a target lock or cache directory"
         );
     }
 
@@ -692,6 +783,104 @@ mod tests {
             );
             assert!(!target_cache.path().join("codestory.db").exists());
         }
+    }
+
+    #[test]
+    fn rehydrate_skips_incomplete_source_cache() {
+        let Some((source_project, target_project)) = matching_git_projects() else {
+            return;
+        };
+        let source_cache = tempdir().expect("source cache");
+        let target_cache = tempdir().expect("target cache");
+        let target_cache_path = target_cache.path().join("empty");
+        let source_db = source_cache.path().join("codestory.db");
+        seed_cache(&source_db, source_project.path());
+        Store::open(&source_db)
+            .expect("open source cache")
+            .get_connection()
+            .execute(
+                "INSERT INTO incomplete_index_run (id, started_at_epoch_ms) VALUES (1, 1)",
+                [],
+            )
+            .expect("seed schema-compatible incomplete marker");
+
+        let output = rehydrate_cache(CacheRehydrateRequest {
+            source_project: source_project.path(),
+            source_cache_dir: source_cache.path(),
+            target_project: target_project.path(),
+            target_cache_dir: &target_cache_path,
+            dry_run: false,
+        })
+        .expect("rehydrate");
+
+        assert_eq!(output.status, "skipped");
+        assert!(
+            output
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("incomplete incremental")),
+            "unexpected skip reason: {output:?}"
+        );
+        assert!(!target_cache_path.join("codestory.db").exists());
+    }
+
+    #[test]
+    fn rehydrate_skips_while_source_index_writer_is_active() {
+        let source_project = tempdir().expect("source project");
+        let target_project = tempdir().expect("target project");
+        let source_cache = tempdir().expect("source cache");
+        let target_cache = tempdir().expect("target cache");
+        let source_db = source_cache.path().join("codestory.db");
+        drop(Store::open(&source_db).expect("seed source cache"));
+        let _guard = crate::IndexWriterGuard::try_acquire(&source_db).expect("source writer lock");
+
+        let output = rehydrate_cache(CacheRehydrateRequest {
+            source_project: source_project.path(),
+            source_cache_dir: source_cache.path(),
+            target_project: target_project.path(),
+            target_cache_dir: target_cache.path(),
+            dry_run: false,
+        })
+        .expect("rehydrate");
+
+        assert_eq!(output.status, "skipped");
+        assert!(
+            output
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("source cache is busy")),
+            "unexpected skip reason: {output:?}"
+        );
+    }
+
+    #[test]
+    fn rehydrate_skips_while_target_index_writer_is_active() {
+        let source_project = tempdir().expect("source project");
+        let target_project = tempdir().expect("target project");
+        let source_cache = tempdir().expect("source cache");
+        let target_cache = tempdir().expect("target cache");
+        let source_db = source_cache.path().join("codestory.db");
+        let target_db = target_cache.path().join("codestory.db");
+        drop(Store::open(&source_db).expect("seed source cache"));
+        let _guard = crate::IndexWriterGuard::try_acquire(&target_db).expect("target writer lock");
+
+        let output = rehydrate_cache(CacheRehydrateRequest {
+            source_project: source_project.path(),
+            source_cache_dir: source_cache.path(),
+            target_project: target_project.path(),
+            target_cache_dir: target_cache.path(),
+            dry_run: false,
+        })
+        .expect("rehydrate");
+
+        assert_eq!(output.status, "skipped");
+        assert!(
+            output
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("target cache is busy")),
+            "unexpected skip reason: {output:?}"
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -51,6 +51,7 @@ use codestory_workspace::{
     IndexedFileRecord, RefreshExecutionPlan, RefreshInputs, WorkspaceInventory, WorkspaceManifest,
 };
 use crossbeam_channel::{Receiver, Sender, unbounded};
+use fs4::fs_std::FileExt;
 use parking_lot::Mutex;
 use rayon::prelude::*;
 use serde::Deserialize;
@@ -3488,6 +3489,7 @@ fn refresh_inputs_from_files(files: Vec<FileInfo>) -> RefreshInputs {
                     file_id: file.id,
                     modification_time: file.modification_time,
                     indexed: file.indexed,
+                    complete: file.complete,
                 },
             )
         })
@@ -3499,6 +3501,7 @@ fn refresh_inputs_from_files(files: Vec<FileInfo>) -> RefreshInputs {
             path: file.path,
             modification_time: file.modification_time,
             indexed: file.indexed,
+            complete: file.complete,
         });
 
     RefreshInputs {
@@ -3547,6 +3550,31 @@ fn index_freshness_from_storage(
         }
     };
     let indexed_file_count = clamp_usize_to_u32(files.len());
+    match storage.has_incomplete_incremental_run() {
+        Ok(true) => {
+            return IndexFreshnessDto {
+                status: IndexFreshnessStatusDto::Stale,
+                changed_file_count: 0,
+                new_file_count: 0,
+                removed_file_count: 0,
+                checked_file_count: 0,
+                indexed_file_count,
+                duration_ms: clamp_u128_to_u32(started_at.elapsed().as_millis()),
+                reason: Some(
+                    "previous_incremental_run_incomplete_full_refresh_required".to_string(),
+                ),
+                samples: Vec::new(),
+            };
+        }
+        Ok(false) => {}
+        Err(error) => {
+            return not_checked_index_freshness(
+                format!("failed to inspect incomplete index marker: {error}"),
+                indexed_file_count,
+                started_at,
+            );
+        }
+    }
     if files.is_empty() {
         return not_checked_index_freshness(
             "no indexed file inventory is available yet",
@@ -8037,6 +8065,7 @@ impl AppController {
                 .clone()
                 .unwrap_or_else(|| root.join("codestory.db"));
             s.is_indexing = true;
+            s.index_freshness_cache = None;
             (root, storage_path)
         };
 
@@ -8046,9 +8075,20 @@ impl AppController {
         // Use a dedicated thread so callers can keep their runtime responsive.
         std::thread::spawn(move || {
             let indexing_started = std::time::Instant::now();
-            let result = match req.mode {
-                IndexMode::Full => index_full(&root, &storage_path, &events_tx, None),
-                IndexMode::Incremental => index_incremental(&root, &storage_path, &events_tx, None),
+            let result = match IndexWriterGuard::try_acquire(&storage_path) {
+                Ok(_writer_guard) => {
+                    let result = match req.mode {
+                        IndexMode::Full => index_full(&root, &storage_path, &events_tx, None),
+                        IndexMode::Incremental => {
+                            index_incremental(&root, &storage_path, &events_tx, None)
+                        }
+                    };
+                    result.and_then(|summary| {
+                        finish_incremental_run_marker(&summary, &storage_path)?;
+                        Ok(summary)
+                    })
+                }
+                Err(error) => Err(error),
             };
 
             match result {
@@ -8090,7 +8130,16 @@ impl AppController {
                 .clone()
                 .unwrap_or_else(|| root.join("codestory.db"));
             s.is_indexing = true;
+            s.index_freshness_cache = None;
             (root, storage_path)
+        };
+
+        let _writer_guard = match IndexWriterGuard::try_acquire(&storage_path) {
+            Ok(guard) => guard,
+            Err(error) => {
+                self.state.lock().is_indexing = false;
+                return Err(error);
+            }
         };
 
         let result = match mode {
@@ -8101,9 +8150,12 @@ impl AppController {
         };
 
         match result {
-            Ok(summary) => {
-                self.finish_successful_indexing(summary, &storage_path, refresh_runtime_caches)
-            }
+            Ok(summary) => self.finish_successful_indexing(
+                summary,
+                &storage_path,
+                refresh_runtime_caches,
+                cancel_token,
+            ),
             Err(error) => {
                 self.recover_failed_indexing(&storage_path, refresh_runtime_caches);
                 Err(error)
@@ -8116,6 +8168,7 @@ impl AppController {
         mut summary: IndexingRunSummary,
         storage_path: &Path,
         refresh_runtime_caches: bool,
+        cancel_token: Option<&CancellationToken>,
     ) -> Result<IndexingPhaseTimings, ApiError> {
         // Drop any existing persisted search-index guard before rebuilding the index.
         self.clear_search_state();
@@ -8162,17 +8215,32 @@ impl AppController {
             cache_refresh_started.elapsed().as_millis(),
         ));
         apply_cache_refresh_stats(&mut summary.phase_timings, cache_stats);
+        if is_indexing_cancelled(cancel_token) {
+            self.clear_search_state();
+            self.state.lock().is_indexing = false;
+            return Err(indexing_cancelled_error());
+        }
+        if let Err(error) = finish_incremental_run_marker(&summary, storage_path) {
+            self.clear_search_state();
+            self.state.lock().is_indexing = false;
+            return Err(error);
+        }
         Ok(summary.phase_timings)
     }
 
     fn recover_failed_indexing(&self, storage_path: &Path, refresh_runtime_caches: bool) {
         if refresh_runtime_caches && let Ok(mut storage) = Storage::open(storage_path) {
-            self.clear_search_state();
-            let _ = refresh_caches(self, &mut storage, storage_path, None);
-            return;
+            let incomplete = storage.has_incomplete_incremental_run().unwrap_or(true);
+            if !incomplete {
+                self.clear_search_state();
+                let _ = refresh_caches(self, &mut storage, storage_path, None);
+                return;
+            }
         }
         self.clear_search_state();
-        self.state.lock().is_indexing = false;
+        let mut state = self.state.lock();
+        state.index_freshness_cache = None;
+        state.is_indexing = false;
     }
 
     pub fn run_indexing_blocking(&self, mode: IndexMode) -> Result<IndexingPhaseTimings, ApiError> {
@@ -8207,14 +8275,23 @@ impl AppController {
         let storage_path = self.require_storage_path()?;
         let workspace = WorkspaceManifest::open(root.clone())
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
+        let mut incomplete_incremental_run = false;
         let refresh_inputs = if storage_path.exists() {
             let store = Store::open(&storage_path)
                 .map_err(|e| ApiError::internal(format!("Failed to open storage: {e}")))?;
+            incomplete_incremental_run = store.has_incomplete_incremental_run().map_err(|e| {
+                ApiError::internal(format!("Failed to inspect incomplete index marker: {e}"))
+            })?;
             workspace_refresh_inputs(&store)?
         } else {
             RefreshInputs::default()
         };
-        let execution_plan = match mode {
+        let effective_mode = if mode == IndexMode::Incremental && incomplete_incremental_run {
+            IndexMode::Full
+        } else {
+            mode
+        };
+        let execution_plan = match effective_mode {
             IndexMode::Full => workspace.full_refresh_execution_plan().map_err(|e| {
                 ApiError::internal(format!("Failed to generate full refresh plan: {e}"))
             })?,
@@ -8233,7 +8310,7 @@ impl AppController {
         Ok(IndexDryRunDto {
             root: root.to_string_lossy().to_string(),
             storage_path: storage_path.to_string_lossy().to_string(),
-            refresh: mode,
+            refresh: effective_mode,
             files_to_index: execution_plan.files_to_index.len().min(u32::MAX as usize) as u32,
             files_to_remove: execution_plan.files_to_remove.len().min(u32::MAX as usize) as u32,
             sample_files_to_index: execution_plan
@@ -9551,22 +9628,8 @@ impl AppController {
     }
 
     pub(crate) fn index_freshness(&self) -> Result<IndexFreshnessDto, ApiError> {
-        let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
         let root = self.require_project_root()?;
         let storage_path = self.require_storage_path()?;
-        let storage_fingerprint = storage_fingerprint(&storage_path);
-        {
-            let state = self.state.lock();
-            if let Some(cached) = state.index_freshness_cache.as_ref()
-                && cached.root == root
-                && cached.storage_path == storage_path
-                && cached.storage_fingerprint == storage_fingerprint
-                && cached.cached_at.elapsed() < ttl
-            {
-                return Ok(cached.value.clone());
-            }
-        }
-
         let storage = self.open_storage()?;
         let workspace = WorkspaceManifest::open(root.clone())
             .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
@@ -9582,6 +9645,10 @@ impl AppController {
         workspace: &WorkspaceManifest,
         storage: &Storage,
     ) -> IndexFreshnessDto {
+        if !matches!(storage.has_incomplete_incremental_run(), Ok(false)) {
+            self.state.lock().index_freshness_cache = None;
+            return index_freshness_from_storage(root, workspace, storage);
+        }
         let ttl = Duration::from_secs(index_freshness_cache_ttl_secs());
         let storage_fingerprint = storage_fingerprint(storage_path);
         {
@@ -10482,6 +10549,81 @@ fn is_low_confidence_search_plan_bridge(bridge: &SearchPlanBridgeDto) -> bool {
 struct IndexingRunSummary {
     phase_timings: IndexingPhaseTimings,
     llm_refresh_scope: Option<HashSet<codestory_contracts::graph::NodeId>>,
+    finalize_incremental_run: bool,
+}
+
+struct IndexWriterGuard {
+    file: std::fs::File,
+    path: PathBuf,
+}
+
+impl IndexWriterGuard {
+    fn try_acquire(storage_path: &Path) -> Result<Self, ApiError> {
+        let path = storage_path.with_extension("index-writer.lock");
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to create index writer lock directory {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "Failed to open index writer lock {}: {error}",
+                    path.display()
+                ))
+            })?;
+        if !FileExt::try_lock_exclusive(&file).map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to acquire index writer lock {}: {error}",
+                path.display()
+            ))
+        })? {
+            return Err(ApiError::new(
+                "cache_busy",
+                format!(
+                    "Another indexing run owns the writer lock at {}. Wait for it to finish and retry.",
+                    path.display()
+                ),
+            ));
+        }
+        Ok(Self { file, path })
+    }
+}
+
+impl Drop for IndexWriterGuard {
+    fn drop(&mut self) {
+        if let Err(error) = FileExt::unlock(&self.file) {
+            tracing::warn!(
+                path = %self.path.display(),
+                "Failed to unlock index writer lock: {error}"
+            );
+        }
+    }
+}
+
+fn finish_incremental_run_marker(
+    summary: &IndexingRunSummary,
+    storage_path: &Path,
+) -> Result<(), ApiError> {
+    if !summary.finalize_incremental_run {
+        return Ok(());
+    }
+    let storage = Storage::open(storage_path)
+        .map_err(|e| ApiError::internal(format!("Failed to reopen storage: {e}")))?;
+    storage
+        .finish_incremental_run()
+        .map_err(|e| ApiError::internal(format!("Failed to clear incomplete index marker: {e}")))
 }
 
 fn index_full(
@@ -10490,6 +10632,34 @@ fn index_full(
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
 ) -> Result<IndexingRunSummary, ApiError> {
+    let recovering_incomplete_run = if storage_path.exists() {
+        match Storage::database_schema_version(storage_path) {
+            Ok(version) if version > codestory_store::CURRENT_SCHEMA_VERSION => {
+                Storage::database_has_incomplete_incremental_run(storage_path).map_err(|error| {
+                    ApiError::internal(format!("Failed to inspect live storage: {error}"))
+                })?
+            }
+            Ok(_) => match Storage::database_has_incomplete_incremental_run(storage_path) {
+                Ok(marked) => marked,
+                Err(error) => {
+                    tracing::warn!(
+                        path = %storage_path.display(),
+                        "Live storage could not be inspected; rebuilding without copying derived state: {error}"
+                    );
+                    true
+                }
+            },
+            Err(error) => {
+                tracing::warn!(
+                    path = %storage_path.display(),
+                    "Live storage schema could not be read; rebuilding without copying derived state: {error}"
+                );
+                true
+            }
+        }
+    } else {
+        false
+    };
     let workspace = WorkspaceManifest::open(root.to_path_buf())
         .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
     let execution_plan = workspace
@@ -10503,7 +10673,7 @@ fn index_full(
 
     let mut staged = SnapshotStore::open_staged(storage_path)
         .map_err(|e| ApiError::internal(format!("Failed to open staged storage: {e}")))?;
-    let can_copy_forward = storage_path.exists();
+    let can_copy_forward = !recovering_incomplete_run && storage_path.exists();
 
     let bus = EventBus::new();
     let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
@@ -10572,6 +10742,28 @@ fn index_full(
     };
     let deferred_indexes_ms = staged_finalize_stats.deferred_indexes_ms;
     let summary_snapshot_ms = staged_finalize_stats.summary_snapshot_ms;
+    let detail_snapshot_ms = if recovering_incomplete_run {
+        let started = Instant::now();
+        if let Err(err) = staged.snapshots().refresh_detail() {
+            let _ = staged.discard();
+            return Err(ApiError::internal(format!(
+                "Failed to finalize staged recovery detail snapshots: {err}"
+            )));
+        }
+        Some(clamp_u128_to_u32(started.elapsed().as_millis()))
+    } else {
+        None
+    };
+    if is_indexing_cancelled(cancel_token) {
+        let _ = staged.discard();
+        return Err(indexing_cancelled_error());
+    }
+    if recovering_incomplete_run && let Err(err) = staged.store_mut().begin_incremental_run() {
+        let _ = staged.discard();
+        return Err(ApiError::internal(format!(
+            "Failed to preserve incomplete marker through staged recovery: {err}"
+        )));
+    }
     let staged_path = staged.path().to_path_buf();
     let publish_started = std::time::Instant::now();
     if let Err(err) = staged.publish(storage_path) {
@@ -10612,7 +10804,7 @@ fn index_full(
             semantic_dense_unstructured_doc: None,
             deferred_indexes_ms: Some(deferred_indexes_ms),
             summary_snapshot_ms: Some(summary_snapshot_ms),
-            detail_snapshot_ms: None,
+            detail_snapshot_ms,
             publish_ms: Some(publish_ms),
             setup_existing_projection_ids_ms: resolution_telemetry.setup_existing_projection_ids_ms,
             setup_seed_symbol_table_ms: resolution_telemetry.setup_seed_symbol_table_ms,
@@ -10674,6 +10866,7 @@ fn index_full(
             resolved_imports_semantic: resolution_telemetry.resolved_imports_semantic,
         },
         llm_refresh_scope: None,
+        finalize_incremental_run: recovering_incomplete_run,
     })
 }
 
@@ -10731,6 +10924,26 @@ where
     let mut store = Store::open(storage_path)
         .map_err(|e| ApiError::internal(format!("Failed to open storage: {e}")))?;
 
+    if store.has_incomplete_incremental_run().map_err(|e| {
+        ApiError::internal(format!("Failed to inspect incomplete index marker: {e}"))
+    })? {
+        let _ = events_tx.send(AppEventPayload::StatusUpdate {
+            message: "A prior incremental index run was interrupted; rebuilding through staged full recovery."
+                .to_string(),
+        });
+        drop(store);
+        return index_full(root, storage_path, events_tx, cancel_token);
+    }
+    if is_indexing_cancelled(cancel_token) {
+        return Err(indexing_cancelled_error());
+    }
+    store.begin_incremental_run().map_err(|e| {
+        ApiError::internal(format!("Failed to persist incomplete index marker: {e}"))
+    })?;
+    store.invalidate_grounding_snapshots().map_err(|e| {
+        ApiError::internal(format!("Failed to invalidate derived index snapshots: {e}"))
+    })?;
+
     let workspace = WorkspaceManifest::open(root.to_path_buf())
         .map_err(|e| ApiError::internal(format!("Failed to open project: {e}")))?;
 
@@ -10745,6 +10958,11 @@ where
     let bus = EventBus::new();
     let forwarder = spawn_progress_forwarder(bus.receiver(), events_tx.clone());
 
+    if is_indexing_cancelled(cancel_token) {
+        drop(bus);
+        let _ = forwarder.join();
+        return Err(indexing_cancelled_error());
+    }
     let indexer = V2WorkspaceIndexer::new(root.to_path_buf());
     let result = indexer.run(&mut store, &execution_plan, &bus, cancel_token);
 
@@ -10763,6 +10981,9 @@ where
     })?;
     let summary_snapshot_ms = snapshot_refresh_stats.summary_snapshot_ms;
     let detail_snapshot_ms = snapshot_refresh_stats.detail_snapshot_ms;
+    if is_indexing_cancelled(cancel_token) {
+        return Err(indexing_cancelled_error());
+    }
     let resolution_telemetry = OptionalResolutionTelemetry::from_incremental_stats(&index_stats);
 
     let mut llm_refresh_scope = HashSet::new();
@@ -10872,6 +11093,7 @@ where
             resolved_imports_semantic: resolution_telemetry.resolved_imports_semantic,
         },
         llm_refresh_scope: Some(llm_refresh_scope),
+        finalize_incremental_run: true,
     })
 }
 
@@ -16534,6 +16756,7 @@ fn build_llm_symbol_doc_text() -> String {
         IndexingRunSummary {
             phase_timings: IndexingPhaseTimings::default(),
             llm_refresh_scope: None,
+            finalize_incremental_run: false,
         }
     }
 
@@ -16550,11 +16773,128 @@ fn build_llm_symbol_doc_text() -> String {
         }
 
         let timings = controller
-            .finish_successful_indexing(empty_indexing_run_summary(), &storage_path, true)
+            .finish_successful_indexing(empty_indexing_run_summary(), &storage_path, true, None)
             .expect("cache refresh should succeed");
 
         assert!(timings.cache_refresh_ms.is_some());
         assert!(!controller.state.lock().is_indexing);
+    }
+
+    #[test]
+    fn incremental_cache_rebuild_failure_keeps_incomplete_marker() {
+        let temp = tempdir().expect("create temp dir");
+        let storage_path = temp.path().join("codestory.db");
+        {
+            let mut storage = Storage::open(&storage_path).expect("seed storage");
+            storage
+                .insert_nodes_batch(&[Node {
+                    id: CoreNodeId(1),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "value".into(),
+                    ..Default::default()
+                }])
+                .expect("seed node");
+            storage
+                .begin_incremental_run()
+                .expect("mark incremental incomplete");
+            storage
+                .get_connection()
+                .execute_batch(
+                    "CREATE TRIGGER fail_search_projection_rebuild
+                     BEFORE INSERT ON search_symbol_projection
+                     BEGIN SELECT RAISE(ABORT, 'forced search projection failure'); END;",
+                )
+                .expect("install cache rebuild fault");
+        }
+        let controller = AppController::new();
+        controller.state.lock().is_indexing = true;
+        let mut summary = empty_indexing_run_summary();
+        summary.finalize_incremental_run = true;
+
+        let error = controller
+            .finish_successful_indexing(summary, &storage_path, false, None)
+            .expect_err("cache rebuild failure must fail indexing");
+
+        assert!(error.message.contains("forced search projection failure"));
+        let storage = Storage::open(&storage_path).expect("reopen interrupted storage");
+        assert!(
+            storage
+                .has_incomplete_incremental_run()
+                .expect("marker after cache failure")
+        );
+        assert_ne!(
+            Storage::database_schema_version(&storage_path).expect("schema fence"),
+            codestory_store::CURRENT_SCHEMA_VERSION
+        );
+        assert!(!controller.state.lock().is_indexing);
+    }
+
+    #[test]
+    fn staged_recovery_cache_failure_keeps_replacement_database_marked() {
+        let workspace = tempdir().expect("workspace dir");
+        fs::write(
+            workspace.path().join("lib.rs"),
+            "pub fn value() -> i32 { 1 }\n",
+        )
+        .expect("write source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("initial full index");
+        Storage::open(&storage_path)
+            .expect("open storage")
+            .begin_incremental_run()
+            .expect("simulate interrupted incremental");
+
+        let search_path = search_index_storage_path(&storage_path);
+        if search_path.is_dir() {
+            fs::remove_dir_all(&search_path).expect("remove search directory");
+        }
+        fs::write(&search_path, b"not a search directory").expect("block search rebuild path");
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect_err("explicit full recovery cache rebuild must fail");
+
+        assert!(
+            error.message.contains("search"),
+            "unexpected error: {error:?}"
+        );
+        let storage = Storage::open(&storage_path).expect("open replacement database");
+        assert!(
+            storage
+                .has_incomplete_incremental_run()
+                .expect("replacement marker")
+        );
+        assert!(
+            storage
+                .snapshots()
+                .has_ready_summary()
+                .expect("replacement summary readiness")
+                && storage
+                    .snapshots()
+                    .has_ready_detail()
+                    .expect("replacement detail readiness"),
+            "recovery publish must complete both snapshot tiers before cache finalization"
+        );
+        assert_ne!(
+            Storage::database_schema_version(&storage_path).expect("replacement schema"),
+            codestory_store::CURRENT_SCHEMA_VERSION
+        );
+        assert_eq!(
+            controller
+                .index_freshness()
+                .expect("recovery freshness")
+                .status,
+            IndexFreshnessStatusDto::Stale
+        );
     }
 
     #[test]
@@ -16574,7 +16914,7 @@ fn build_llm_symbol_doc_text() -> String {
         }
 
         let error = controller
-            .finish_successful_indexing(empty_indexing_run_summary(), &storage_path, true)
+            .finish_successful_indexing(empty_indexing_run_summary(), &storage_path, true, None)
             .expect_err("storage reopen failure should propagate");
 
         assert_eq!(error.code, "internal");
@@ -16596,6 +16936,324 @@ fn build_llm_symbol_doc_text() -> String {
 
         assert_eq!(error.code, "invalid_argument");
         assert!(!controller.state.lock().is_indexing);
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum IncrementalFailureBoundary {
+        Cleanup,
+        Resolution,
+        SnapshotRefresh,
+        MarkerClear,
+    }
+
+    fn incremental_failure_trigger(boundary: IncrementalFailureBoundary) -> &'static str {
+        match boundary {
+            IncrementalFailureBoundary::Cleanup => {
+                "CREATE TRIGGER fail_incremental_boundary
+                 BEFORE DELETE ON file
+                 BEGIN SELECT RAISE(ABORT, 'forced cleanup failure'); END;"
+            }
+            IncrementalFailureBoundary::Resolution => {
+                "CREATE TRIGGER fail_incremental_boundary
+                 BEFORE UPDATE OF resolved_source_node_id ON edge
+                 WHEN NEW.resolved_source_node_id IS NOT NULL
+                 BEGIN SELECT RAISE(ABORT, 'forced resolution failure'); END;"
+            }
+            IncrementalFailureBoundary::SnapshotRefresh => {
+                "CREATE TRIGGER fail_incremental_boundary
+                 BEFORE INSERT ON grounding_node_snapshot
+                 BEGIN SELECT RAISE(ABORT, 'forced snapshot failure'); END;"
+            }
+            IncrementalFailureBoundary::MarkerClear => {
+                "CREATE TRIGGER fail_incremental_boundary
+                 BEFORE DELETE ON incomplete_index_run
+                 BEGIN SELECT RAISE(ABORT, 'forced marker clear failure'); END;"
+            }
+        }
+    }
+
+    fn incremental_failure_message(boundary: IncrementalFailureBoundary) -> &'static str {
+        match boundary {
+            IncrementalFailureBoundary::Cleanup => "forced cleanup failure",
+            IncrementalFailureBoundary::Resolution => "forced resolution failure",
+            IncrementalFailureBoundary::SnapshotRefresh => "forced snapshot failure",
+            IncrementalFailureBoundary::MarkerClear => "forced marker clear failure",
+        }
+    }
+
+    fn assert_interrupted_incremental_recovers(boundary: IncrementalFailureBoundary) {
+        let workspace = tempdir().expect("workspace dir");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let old_path = workspace.path().join("old.rs");
+        let new_path = workspace.path().join("new.rs");
+        fs::write(&old_path, "pub fn old_value() -> i32 { 1 }\n").expect("write old source");
+
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("initial full index");
+
+        fs::remove_file(&old_path).expect("remove old source");
+        fs::write(
+            &new_path,
+            "pub fn caller() -> i32 { target() }\npub fn target() -> i32 { 2 }\n",
+        )
+        .expect("write new source");
+        {
+            let storage = Storage::open(&storage_path).expect("open storage for fault trigger");
+            storage
+                .get_connection()
+                .execute_batch(incremental_failure_trigger(boundary))
+                .expect("install fault trigger");
+        }
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect_err("incremental boundary fault must fail the run");
+        assert_eq!(error.code, "internal", "boundary={boundary:?}: {error:?}");
+        assert!(
+            error
+                .message
+                .contains(incremental_failure_message(boundary)),
+            "wrong failure boundary for {boundary:?}: {error:?}"
+        );
+
+        {
+            let storage = Storage::open(&storage_path).expect("reopen interrupted storage");
+            assert!(
+                storage
+                    .has_incomplete_incremental_run()
+                    .expect("read incomplete marker"),
+                "boundary={boundary:?}"
+            );
+            assert_ne!(
+                Storage::database_schema_version(&storage_path).expect("schema version"),
+                codestory_store::CURRENT_SCHEMA_VERSION,
+                "interrupted state must remain fenced from older runtimes"
+            );
+            assert!(
+                storage
+                    .get_file_by_path(&new_path)
+                    .expect("read new file")
+                    .is_some(),
+                "projection flush must commit before boundary={boundary:?}"
+            );
+            match boundary {
+                IncrementalFailureBoundary::Cleanup => assert!(
+                    storage
+                        .get_file_by_path(&old_path)
+                        .expect("read old file")
+                        .is_some(),
+                    "cleanup trigger should preserve the removed-file row"
+                ),
+                IncrementalFailureBoundary::Resolution
+                | IncrementalFailureBoundary::SnapshotRefresh
+                | IncrementalFailureBoundary::MarkerClear => assert!(
+                    storage
+                        .get_file_by_path(&old_path)
+                        .expect("read old file")
+                        .is_none(),
+                    "cleanup must commit before boundary={boundary:?}"
+                ),
+            }
+            if matches!(boundary, IncrementalFailureBoundary::SnapshotRefresh) {
+                assert!(
+                    storage
+                        .get_edges()
+                        .expect("read edges")
+                        .iter()
+                        .any(|edge| edge.resolved_target.is_some()),
+                    "resolution must commit before snapshot refresh"
+                );
+            }
+            if matches!(boundary, IncrementalFailureBoundary::MarkerClear) {
+                assert!(
+                    storage
+                        .snapshots()
+                        .has_ready_summary()
+                        .expect("summary readiness")
+                );
+                assert!(
+                    storage
+                        .snapshots()
+                        .has_ready_detail()
+                        .expect("detail readiness")
+                );
+            }
+        }
+
+        let recovery = AppController::new();
+        let summary = recovery
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open interrupted project");
+        let freshness = summary.freshness.expect("summary freshness");
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::Stale);
+        assert_eq!(
+            freshness.reason.as_deref(),
+            Some("previous_incremental_run_incomplete_full_refresh_required")
+        );
+        let dry_run = recovery
+            .dry_run_index(IndexMode::Incremental)
+            .expect("dry-run recovery");
+        assert_eq!(dry_run.refresh, IndexMode::Full);
+        assert!(
+            Storage::open(&storage_path)
+                .expect("open after dry run")
+                .has_incomplete_incremental_run()
+                .expect("marker after dry run"),
+            "dry-run must not mutate interrupted state"
+        );
+
+        let timings = recovery
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect("staged full recovery");
+        assert!(
+            timings.publish_ms.is_some(),
+            "recovery must use staged full publish"
+        );
+        let storage = Storage::open(&storage_path).expect("open recovered storage");
+        assert!(
+            !storage
+                .has_incomplete_incremental_run()
+                .expect("marker after recovery")
+        );
+        assert_eq!(
+            Storage::database_schema_version(&storage_path).expect("recovered schema"),
+            codestory_store::CURRENT_SCHEMA_VERSION
+        );
+        assert_eq!(
+            recovery
+                .index_freshness()
+                .expect("recovered freshness")
+                .status,
+            IndexFreshnessStatusDto::Fresh
+        );
+    }
+
+    #[test]
+    fn interrupted_incremental_boundaries_fail_closed_and_recover_through_staged_full() {
+        for boundary in [
+            IncrementalFailureBoundary::Cleanup,
+            IncrementalFailureBoundary::Resolution,
+            IncrementalFailureBoundary::SnapshotRefresh,
+            IncrementalFailureBoundary::MarkerClear,
+        ] {
+            assert_interrupted_incremental_recovers(boundary);
+        }
+    }
+
+    #[test]
+    fn index_writer_lock_reports_cache_busy_and_releases_after_drop() {
+        let workspace = tempdir().expect("workspace dir");
+        fs::write(
+            workspace.path().join("lib.rs"),
+            "pub fn value() -> i32 { 1 }\n",
+        )
+        .expect("write source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+
+        let guard = IndexWriterGuard::try_acquire(&storage_path).expect("first writer lock");
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect_err("second writer must be excluded");
+        assert_eq!(error.code, "cache_busy");
+        assert!(!controller.state.lock().is_indexing);
+
+        drop(guard);
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("writer lock should be reusable after drop");
+    }
+
+    #[test]
+    fn cancelled_incremental_stays_marked_until_recovery() {
+        let workspace = tempdir().expect("workspace dir");
+        for index in 0..64 {
+            fs::write(
+                workspace.path().join(format!("module_{index}.rs")),
+                format!(
+                    "pub fn caller_{index}() {{ callee_{index}(); }}\npub fn callee_{index}() {{}}\n"
+                ),
+            )
+            .expect("write source");
+        }
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary");
+
+        let events = controller.events();
+        let cancel_token = CancellationToken::new();
+        let cancel_from_progress = cancel_token.clone();
+        let canceller = std::thread::spawn(move || {
+            while let Ok(event) = events.recv_timeout(Duration::from_secs(10)) {
+                if let AppEventPayload::IndexingProgress { current, total } = event
+                    && current == total
+                {
+                    cancel_from_progress.cancel();
+                    return;
+                }
+            }
+            panic!("incremental progress did not reach the cancellation boundary");
+        });
+
+        let error = controller
+            .run_indexing_blocking_without_runtime_refresh_with_cancel(
+                IndexMode::Incremental,
+                &cancel_token,
+            )
+            .expect_err("cancelled incremental must fail visibly");
+        canceller.join().expect("progress canceller");
+        assert_eq!(error.code, "cancelled");
+        let storage = Storage::open(&storage_path).expect("open cancelled storage");
+        assert!(
+            storage
+                .has_incomplete_incremental_run()
+                .expect("cancelled marker")
+        );
+        drop(storage);
+
+        let recovery = AppController::new();
+        let summary = recovery
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open cancelled project");
+        assert_eq!(
+            summary.freshness.expect("cancelled freshness").status,
+            IndexFreshnessStatusDto::Stale
+        );
+        let timings = recovery
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect("recover cancelled index");
+        assert!(timings.publish_ms.is_some());
+        let storage = Storage::open(&storage_path).expect("open recovered storage");
+        assert!(
+            !storage
+                .has_incomplete_incremental_run()
+                .expect("marker after recovery")
+        );
     }
 
     #[test]

--- a/crates/codestory-store/src/file_store.rs
+++ b/crates/codestory-store/src/file_store.rs
@@ -47,6 +47,7 @@ impl<'a> FileStore<'a> {
                     path: file.path,
                     modification_time: file.modification_time,
                     indexed: file.indexed,
+                    complete: file.complete,
                 })
             })
             .collect()

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -29,6 +29,9 @@ use helpers::{
 };
 
 const SCHEMA_VERSION: u32 = 18;
+// Reserved outside the sequential migration range so a future real schema version cannot
+// accidentally be treated as an interrupted run from this release.
+const INCOMPLETE_INCREMENTAL_SCHEMA_VERSION: u32 = 0x4353_0001;
 /// Current SQLite schema version expected by `Store`.
 pub const CURRENT_SCHEMA_VERSION: u32 = SCHEMA_VERSION;
 const GROUNDING_SNAPSHOT_VERSION: i64 = 1;
@@ -895,6 +898,38 @@ impl Storage {
         Ok(version.max(0) as u32)
     }
 
+    /// Read the incomplete-run fence without migrating or otherwise mutating a live database.
+    pub fn database_has_incomplete_incremental_run(path: &Path) -> Result<bool, StorageError> {
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        let version = version.max(0) as u32;
+        if version != INCOMPLETE_INCREMENTAL_SCHEMA_VERSION && version > SCHEMA_VERSION {
+            return Err(StorageError::Other(format!(
+                "Unsupported database schema version: {version} (max supported: {SCHEMA_VERSION})"
+            )));
+        }
+        let table_exists: i64 = conn.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'table' AND name = 'incomplete_index_run'
+            )",
+            [],
+            |row| row.get(0),
+        )?;
+        let marked = table_exists != 0
+            && conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM incomplete_index_run WHERE id = 1)",
+                [],
+                |row| row.get::<_, i64>(0),
+            )? != 0;
+        if version == INCOMPLETE_INCREMENTAL_SCHEMA_VERSION && !marked {
+            return Err(StorageError::Other(format!(
+                "Database schema version {version} is only valid while an incremental index run is marked incomplete"
+            )));
+        }
+        Ok(marked)
+    }
+
     pub fn copy_database_snapshot(
         source_path: &Path,
         target_path: &Path,
@@ -1217,6 +1252,44 @@ impl Storage {
     pub fn invalidate_grounding_snapshots(&self) -> Result<(), StorageError> {
         self.mark_grounding_snapshots_dirty()?;
         self.invalidate_resolution_support_snapshot()?;
+        Ok(())
+    }
+
+    /// Mark a live incremental index run incomplete before it mutates projections.
+    pub fn begin_incremental_run(&self) -> Result<(), StorageError> {
+        let transaction = self.conn.unchecked_transaction()?;
+        transaction.execute(
+            "INSERT INTO incomplete_index_run (id, started_at_epoch_ms)
+             VALUES (1, ?1)
+             ON CONFLICT(id) DO UPDATE SET
+                started_at_epoch_ms = excluded.started_at_epoch_ms",
+            params![current_epoch_ms()],
+        )?;
+        transaction.pragma_update(
+            None,
+            "user_version",
+            INCOMPLETE_INCREMENTAL_SCHEMA_VERSION.to_string(),
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Whether a prior live incremental index run did not reach its success boundary.
+    pub fn has_incomplete_incremental_run(&self) -> Result<bool, StorageError> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM incomplete_index_run WHERE id = 1",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Clear the live incremental marker only after resolution and snapshots succeed.
+    pub fn finish_incremental_run(&self) -> Result<(), StorageError> {
+        let transaction = self.conn.unchecked_transaction()?;
+        transaction.execute("DELETE FROM incomplete_index_run WHERE id = 1", [])?;
+        transaction.pragma_update(None, "user_version", SCHEMA_VERSION.to_string())?;
+        transaction.commit()?;
         Ok(())
     }
 
@@ -5032,6 +5105,17 @@ impl Storage {
             }))
         } else {
             Ok(None)
+        }
+    }
+
+    pub fn first_incomplete_file_path(&self) -> Result<Option<PathBuf>, StorageError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path FROM file WHERE complete = 0 ORDER BY id LIMIT 1")?;
+        let mut rows = stmt.query([])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(PathBuf::from(row.get::<_, String>(0)?))),
+            None => Ok(None),
         }
     }
 

--- a/crates/codestory-store/src/storage_impl/schema.rs
+++ b/crates/codestory-store/src/storage_impl/schema.rs
@@ -52,6 +52,10 @@ const TABLE_STATEMENTS: &[&str] = &[
         line_count INTEGER DEFAULT 0,
         file_role TEXT NOT NULL DEFAULT 'source'
     )",
+    "CREATE TABLE IF NOT EXISTS incomplete_index_run (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        started_at_epoch_ms INTEGER NOT NULL
+    )",
     "CREATE TABLE IF NOT EXISTS local_symbol (
         id INTEGER PRIMARY KEY,
         name TEXT NOT NULL,
@@ -343,9 +347,16 @@ pub(super) fn create_deferred_indexes(conn: &Connection) -> Result<(), StorageEr
 pub(super) fn apply_schema_migrations(storage: &Storage) -> Result<(), StorageError> {
     let stored_version = storage.schema_version()?;
 
-    if stored_version > SCHEMA_VERSION {
+    if stored_version != INCOMPLETE_INCREMENTAL_SCHEMA_VERSION && stored_version > SCHEMA_VERSION {
         return Err(StorageError::Other(format!(
             "Unsupported database schema version: {stored_version} (max supported: {SCHEMA_VERSION})"
+        )));
+    }
+    if stored_version == INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+        && !storage.has_incomplete_incremental_run()?
+    {
+        return Err(StorageError::Other(format!(
+            "Database schema version {stored_version} is only valid while an incremental index run is marked incomplete"
         )));
     }
 

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -38,6 +38,101 @@ fn unique_temp_db_path(label: &str) -> PathBuf {
 }
 
 #[test]
+fn incomplete_incremental_run_marker_survives_reopen_until_success() -> Result<(), StorageError> {
+    let path = unique_temp_db_path("incomplete-incremental-run");
+    {
+        let storage = Storage::open(&path)?;
+        assert_eq!(Storage::database_schema_version(&path)?, SCHEMA_VERSION);
+        assert!(!Storage::database_has_incomplete_incremental_run(&path)?);
+        assert!(!storage.has_incomplete_incremental_run()?);
+        storage.begin_incremental_run()?;
+        assert!(storage.has_incomplete_incremental_run()?);
+        assert!(Storage::database_has_incomplete_incremental_run(&path)?);
+        assert_eq!(
+            Storage::database_schema_version(&path)?,
+            INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+        );
+    }
+    {
+        let storage = Storage::open(&path)?;
+        assert!(storage.has_incomplete_incremental_run()?);
+        storage.finish_incremental_run()?;
+        assert!(!storage.has_incomplete_incremental_run()?);
+        assert!(!Storage::database_has_incomplete_incremental_run(&path)?);
+        assert_eq!(Storage::database_schema_version(&path)?, SCHEMA_VERSION);
+    }
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+    let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    Ok(())
+}
+
+#[test]
+fn incomplete_incremental_begin_failure_keeps_clean_schema_and_no_marker()
+-> Result<(), StorageError> {
+    let path = unique_temp_db_path("incomplete-begin-rollback");
+    let storage = Storage::open(&path)?;
+    storage.get_connection().execute_batch(
+        "CREATE TRIGGER fail_incomplete_begin
+         BEFORE INSERT ON incomplete_index_run
+         BEGIN SELECT RAISE(ABORT, 'forced marker insert failure'); END;",
+    )?;
+
+    assert!(storage.begin_incremental_run().is_err());
+    assert!(!storage.has_incomplete_incremental_run()?);
+    assert_eq!(Storage::database_schema_version(&path)?, SCHEMA_VERSION);
+
+    drop(storage);
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+    let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    Ok(())
+}
+
+#[test]
+fn transient_incomplete_schema_fence_requires_marker() -> Result<(), StorageError> {
+    let path = unique_temp_db_path("incomplete-schema-fence");
+    {
+        let storage = Storage::open(&path)?;
+        storage.set_schema_version(INCOMPLETE_INCREMENTAL_SCHEMA_VERSION)?;
+    }
+
+    assert!(Storage::database_has_incomplete_incremental_run(&path).is_err());
+    let error = match Storage::open(&path) {
+        Ok(_) => panic!("schema fence without marker must fail closed"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("marked incomplete"));
+
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+    let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    Ok(())
+}
+
+#[test]
+fn sequential_future_schema_is_not_mistaken_for_incomplete_fence() -> Result<(), StorageError> {
+    let path = unique_temp_db_path("future-schema-fence");
+    {
+        let storage = Storage::open(&path)?;
+        storage.begin_incremental_run()?;
+        storage.set_schema_version(SCHEMA_VERSION + 1)?;
+    }
+
+    assert!(Storage::database_has_incomplete_incremental_run(&path).is_err());
+    let error = match Storage::open(&path) {
+        Ok(_) => panic!("future schema must fail even when the incomplete marker exists"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("Unsupported database schema"));
+
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+    let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    Ok(())
+}
+
+#[test]
 fn test_batch_inserts() -> Result<(), StorageError> {
     let mut storage = Storage::new_in_memory()?;
 

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -535,7 +535,9 @@ impl WorkspaceDiscovery {
                 Some(file) => {
                     existing_file_ids.insert(path.clone(), file.id);
                     match modification_time_millis(&path) {
-                        Ok(mtime) => mtime != file.modification_time || !file.indexed,
+                        Ok(mtime) => {
+                            mtime != file.modification_time || !file.indexed || !file.complete
+                        }
                         Err(_) => true,
                     }
                 }
@@ -920,6 +922,7 @@ mod tests {
                     path: file.clone(),
                     modification_time: 0,
                     indexed: true,
+                    complete: true,
                 }],
                 inventory: WorkspaceInventory::default(),
             },
@@ -948,6 +951,7 @@ mod tests {
                     path: file.clone(),
                     modification_time: modification_time_millis(&file)?,
                     indexed: true,
+                    complete: true,
                 }],
                 inventory: WorkspaceInventory::default(),
             },
@@ -958,6 +962,50 @@ mod tests {
             "unchanged files should not look dirty when stored mtimes use file-table millisecond precision"
         );
         assert_eq!(plan.existing_file_ids.get(&file), Some(&7));
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_refresh_retries_unchanged_incomplete_files_from_both_inventories() -> Result<()>
+    {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(&root)?;
+        let file = root.join("main.rs");
+        fs::write(&file, "fn main() {}\n")?;
+        let modification_time = modification_time_millis(&file)?;
+        let manifest = WorkspaceManifest::open(root)?;
+
+        let inputs = [
+            RefreshInputs {
+                stored_files: vec![StoredFileState {
+                    id: 7,
+                    path: file.clone(),
+                    modification_time,
+                    indexed: true,
+                    complete: false,
+                }],
+                inventory: WorkspaceInventory::default(),
+            },
+            RefreshInputs {
+                stored_files: Vec::new(),
+                inventory: WorkspaceInventory::from_records([(
+                    file.clone(),
+                    IndexedFileRecord {
+                        file_id: 7,
+                        modification_time,
+                        indexed: true,
+                        complete: false,
+                    },
+                )]),
+            },
+        ];
+
+        for input in inputs {
+            let plan = WorkspaceDiscovery.build_refresh_plan(&manifest, &input)?;
+            assert_eq!(plan.files_to_index, vec![file.clone()]);
+            assert_eq!(plan.existing_file_ids.get(&file), Some(&7));
+        }
         Ok(())
     }
 
@@ -983,6 +1031,7 @@ mod tests {
                             file_id: 11,
                             modification_time: modification_time_millis(&file)?,
                             indexed: true,
+                            complete: true,
                         },
                     ),
                     (
@@ -991,6 +1040,7 @@ mod tests {
                             file_id: 19,
                             modification_time: 0,
                             indexed: true,
+                            complete: true,
                         },
                     ),
                 ]),


### PR DESCRIPTION
## Context

Live incremental indexing commits graph batches before resolution and derived snapshots finish. Cancellation or a late failure could therefore leave a partially published database whose stored mtimes made the next refresh plan empty and whose readiness surfaces could still report fresh.

This closes #903 and advances #899.

## What Changed

- Persist an incomplete-run marker before incremental planning or mutation and pair it atomically with a reserved transient SQLite schema fence. Clean databases remain schema 18; interrupted databases reject older runtimes until recovery succeeds.
- Hold a persistent cross-process writer lock across indexing and final marker completion. Cache rehydrate now locks both source and target for real copies while keeping dry-run observational.
- Carry `file.complete` through workspace inventory and retry unchanged incomplete files.
- Keep failed or cancelled runs marked through resolution, both grounding snapshot tiers, and persisted search/semantic cache finalization.
- Make explicit Full and Incremental refreshes both self-detect recovery. Recovery builds a clean staged database, copies no derived state from the partial database, hydrates both snapshot tiers, publishes while still fenced, and clears only after outer finalization succeeds.
- Make freshness, strict sidecar readiness, stdio status caching, and cache rehydrate fail closed while marked.
- Report marker-driven CLI refreshes as `incremental(recovery-full)` instead of claiming an incremental execution.
- Document the recovery contract in `CHANGELOG.md`.

## How To Review

```mermaid
flowchart LR
    A["Acquire writer lock"] --> B["Persist marker + transient fence"]
    B --> C["Plan and mutate live index"]
    C --> D["Resolve + refresh both snapshots"]
    D --> E["Finalize search and semantic caches"]
    E --> F["Clear marker + restore schema 18"]
    B -->|failure or cancellation| G["Remain stale and fenced"]
    G --> H["Next Full or Incremental request"]
    H --> I["Build staged full index without copy-forward"]
    I --> J["Publish fenced replacement"]
    J --> E
```

Start with the marker/fence transaction in `codestory-store`, then follow `run_incremental_indexing_common`, `index_full`, and `finish_successful_indexing` in the runtime. The table-driven runtime regression exercises failures after projection flush, cleanup, resolution, snapshot refresh, and marker clear.

## Verification

- `cargo test -p codestory-workspace -p codestory-store -p codestory-retrieval -p codestory-runtime`
  - workspace: 24 passed
  - store: 69 passed
  - retrieval: 256 passed, 1 ignored
  - runtime: 611 passed, 1 ignored
- `cargo test -p codestory-cli`
  - CLI unit: 320 passed
  - all non-environment integration contracts passed; expected live-sidecar/stat harnesses remained ignored
- `cargo clippy -p codestory-workspace -p codestory-store -p codestory-retrieval -p codestory-runtime -p codestory-cli --all-targets -- -D warnings`
- `cargo build --release -p codestory-cli`
- `cargo test -p codestory-indexer --test fidelity_regression` — 8 passed
- `cargo test -p codestory-indexer --test tictactoe_language_coverage` — 12 passed
- `cargo fmt --all -- --check`
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Required ignored repo-scale gate was attempted. It could not complete because `CODESTORY_REAL_REPO_DRILL_CASES` is not configured and this Windows host denied `CREATE_BREAKAWAY_FROM_JOB` with OS error 5 during native embedding bootstrap.

## Risk

- The transient fence blocks every normal new v0.14.2 Store open while an interrupted run is active. A SQLite read already in flight before the fence may finish against its existing snapshot; normal CodeStory requests reopen Store connections and encounter the fence.
- Recovery intentionally performs a full staged rebuild and does not copy search/semantic artifacts from the known-partial database.
- Packaged cross-platform and managed-plugin proof remains a v0.14.3 release gate; this PR supplies source, Windows, fault-boundary, and compatibility-contract proof.
