### PR TITLE
publish sidecars atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- Published lexical shard data, metadata, and runtime sidecar state through
+  validated same-directory temporary files with atomic replacement. Shard
+  readiness and search now reject malformed, truncated, count-mismatched, or
+  hash-mismatched JSONL; bind published bytes and metadata to the manifest's
+  sidecar input; and recheck live lexical input before manifest publication so
+  failed or raced rebuilds preserve the last known good shard.
 - Added a `dev/codestory-next` merge workflow that closes same-repository
   issues named by `Closes`, `Fixes`, or `Resolves` in merged pull requests.
 - Made live incremental indexing crash-safe. Runs now persist an incomplete-run

--- a/crates/codestory-cli/src/file_state.rs
+++ b/crates/codestory-cli/src/file_state.rs
@@ -1,50 +1,27 @@
 use anyhow::Result;
 use serde::{Serialize, de::DeserializeOwned};
-use std::fs::{self, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::OpenOptions;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, UNIX_EPOCH};
 
-#[cfg(windows)]
-use std::os::windows::ffi::OsStrExt;
-
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 static ATOMIC_JSON_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 pub(crate) fn write_synced_new_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
-    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
-    file.write_all(content)?;
-    file.sync_all()?;
-    Ok(())
+    codestory_workspace::atomic_file::write_synced_new_file(path, content)
 }
 
 pub(crate) fn atomic_json_path(path: &Path, stem: &str) -> PathBuf {
-    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    path.with_file_name(format!(".{stem}.{}.{}.tmp", std::process::id(), counter))
+    codestory_workspace::atomic_file::atomic_temp_path(path, stem)
 }
 
 pub(crate) fn write_json_atomic<T: Serialize>(path: &Path, stem: &str, value: &T) -> Result<()> {
     let _write_guard = ATOMIC_JSON_WRITE_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let temp_path = atomic_json_path(path, stem);
-    let content = serde_json::to_string_pretty(value)?;
-    if let Err(error) = write_synced_new_file(&temp_path, content.as_bytes()) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(error.into());
-    }
-    match replace_file(&temp_path, path) {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            let _ = fs::remove_file(&temp_path);
-            Err(error.into())
-        }
-    }
+    let content = serde_json::to_vec_pretty(value)?;
+    codestory_workspace::atomic_file::write_bytes_atomic(path, stem, &content)
 }
 
 pub(crate) fn read_json<T: DeserializeOwned>(path: &Path) -> Option<T> {
@@ -96,99 +73,8 @@ fn publication_read_error_is_transient(error: &std::io::Error) -> bool {
     }
 }
 
-#[cfg(not(windows))]
-fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
-    fs::rename(source, destination)
-}
-
-#[cfg(windows)]
-fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
-    const ERROR_FILE_NOT_FOUND: i32 = 2;
-    const ERROR_ACCESS_DENIED: i32 = 5;
-    const ERROR_SHARING_VIOLATION: i32 = 32;
-    const ERROR_UNABLE_TO_REMOVE_REPLACED: i32 = 1175;
-    const ERROR_UNABLE_TO_MOVE_REPLACEMENT: i32 = 1176;
-    const REPLACE_ATTEMPTS: usize = 50;
-
-    #[link(name = "Kernel32")]
-    unsafe extern "system" {
-        fn ReplaceFileW(
-            replaced_file_name: *const u16,
-            replacement_file_name: *const u16,
-            backup_file_name: *const u16,
-            flags: u32,
-            exclude: *mut std::ffi::c_void,
-            reserved: *mut std::ffi::c_void,
-        ) -> i32;
-    }
-
-    let replacement = source
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect::<Vec<_>>();
-    let replaced = destination
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect::<Vec<_>>();
-
-    for attempt in 0..REPLACE_ATTEMPTS {
-        if !destination.exists() {
-            match fs::rename(source, destination) {
-                Ok(()) => return Ok(()),
-                Err(_) if !source.exists() && destination.exists() => return Ok(()),
-                Err(error) if !destination.exists() => {
-                    if attempt + 1 == REPLACE_ATTEMPTS {
-                        return Err(error);
-                    }
-                    std::thread::sleep(Duration::from_millis(1));
-                    continue;
-                }
-                Err(_) => {}
-            }
-        }
-
-        // SAFETY: both path buffers are null-terminated and remain alive for the call.
-        let result = unsafe {
-            ReplaceFileW(
-                replaced.as_ptr(),
-                replacement.as_ptr(),
-                std::ptr::null(),
-                0,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-            )
-        };
-        if result != 0 {
-            return Ok(());
-        }
-
-        let error = std::io::Error::last_os_error();
-        if !source.exists() && destination.exists() {
-            return Ok(());
-        }
-        let retryable = matches!(
-            error.raw_os_error(),
-            Some(
-                ERROR_FILE_NOT_FOUND
-                    | ERROR_ACCESS_DENIED
-                    | ERROR_SHARING_VIOLATION
-                    | ERROR_UNABLE_TO_REMOVE_REPLACED
-                    | ERROR_UNABLE_TO_MOVE_REPLACEMENT
-            )
-        );
-        if !retryable || attempt + 1 == REPLACE_ATTEMPTS {
-            return Err(error);
-        }
-        std::thread::sleep(Duration::from_millis(1));
-    }
-
-    unreachable!("replacement attempts always return")
-}
-
 pub(crate) fn file_modified_age_exceeds(path: &Path, ttl: Duration, now_epoch_ms: i64) -> bool {
-    fs::metadata(path)
+    std::fs::metadata(path)
         .ok()
         .and_then(|metadata| metadata.modified().ok())
         .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -92,6 +92,7 @@ impl<'a> QueryExecutor<'a> {
     /// `total_budget_ms` caps retrieval work only; it does not include runtime candidate
     /// resolution, packet sufficiency checks, or answer composition.
     pub fn execute(&mut self, query: &str, total_budget_ms: Option<u64>) -> Result<QueryResult> {
+        let request_started = Instant::now();
         let features = classify_query(query);
         let fingerprint = query_fingerprint(&features.raw_query);
 
@@ -115,7 +116,7 @@ impl<'a> QueryExecutor<'a> {
                         retrieval_mode: mode.as_str().into(),
                         degraded_reason: None,
                         total_budget_ms: 0,
-                        elapsed_ms: 0,
+                        elapsed_ms: request_started.elapsed().as_millis() as u64,
                         cancel_reason: None,
                         cache_hit: true,
                         stages: Vec::new(),
@@ -169,7 +170,7 @@ impl<'a> QueryExecutor<'a> {
                 retrieval_mode: mode.as_str().into(),
                 degraded_reason,
                 total_budget_ms: plan.total_budget_ms,
-                elapsed_ms: started.elapsed().as_millis() as u64,
+                elapsed_ms: request_started.elapsed().as_millis() as u64,
                 cancel_reason,
                 cache_hit: false,
                 stages: stage_traces,

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -455,14 +455,12 @@ pub fn probe_infrastructure_health_with_embedding_device(
 fn zoekt_capabilities(
     layout: &SidecarLayout,
     sidecar_generation: &str,
-    reachable: bool,
-    _zoekt_client: &ZoektClient,
+    sidecar_input_hash: &str,
 ) -> SidecarCapabilities {
     let shard_dir = crate::zoekt_index::shard_dir_for(&layout.zoekt_data_dir, sidecar_generation);
-    if !crate::zoekt_index::shard_has_lexical_index(&shard_dir) {
+    if !crate::zoekt_index::shard_has_lexical_index(&shard_dir, sidecar_input_hash) {
         return SidecarCapabilities::NONE;
     }
-    let _ = reachable;
     SidecarCapabilities {
         lexical: true,
         semantic: false,
@@ -610,12 +608,11 @@ pub fn probe_sidecar_health_with_embedding_device(
     let zoekt_client = ZoektClient::new(layout);
     let zoekt_probe = zoekt_client.health_probe();
     let sidecar_generation = manifest_sidecar_generation(&manifest);
-    let zoekt_capabilities = zoekt_capabilities(
-        layout,
-        sidecar_generation,
-        zoekt_probe.reachable,
-        &zoekt_client,
-    );
+    let sidecar_input_hash = manifest
+        .sidecar_input_hash
+        .as_deref()
+        .expect("manifest contract validation requires sidecar_input_hash");
+    let zoekt_capabilities = zoekt_capabilities(layout, sidecar_generation, sidecar_input_hash);
     let zoekt_stub = zoekt_probe.reachable && !zoekt_capabilities.lexical;
     let zoekt = ComponentHealth {
         name: "zoekt".into(),
@@ -804,6 +801,8 @@ fn zero_dense_qdrant_health(
 mod tests {
     use super::*;
     use crate::config::SidecarLayout;
+    use crate::test_support::retrieval_manifest_fixture;
+    use crate::zoekt_index::{build_zoekt_shard, lexical_input_fingerprint, shard_dir_for};
     use tempfile::TempDir;
 
     struct EnvGuard {
@@ -923,6 +922,37 @@ mod tests {
         assert_eq!(report.zoekt.capabilities, SidecarCapabilities::NONE);
         assert_eq!(report.qdrant.capabilities, SidecarCapabilities::NONE);
         assert_eq!(report.scip.capabilities, SidecarCapabilities::NONE);
+    }
+
+    #[test]
+    fn malformed_lexical_shard_cannot_report_full_readiness() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn alpha() {}").expect("write source");
+        let data = TempDir::new().expect("data");
+        let mut layout = SidecarLayout::from_env();
+        layout.zoekt_data_dir = data.path().to_path_buf();
+        let manifest = retrieval_manifest_fixture("testproject", "test-input");
+        let generation = manifest.sidecar_generation.as_deref().expect("generation");
+        let fingerprint = lexical_input_fingerprint(project.path(), None).expect("fingerprint");
+        build_zoekt_shard(
+            project.path(),
+            None,
+            &layout.zoekt_data_dir,
+            generation,
+            &fingerprint,
+            "test-input",
+        )
+        .expect("build shard");
+        std::fs::write(
+            shard_dir_for(&layout.zoekt_data_dir, generation).join("lexical-index.jsonl"),
+            b"{not-json}\n",
+        )
+        .expect("corrupt shard");
+
+        let report = probe_sidecar_health(&layout, "testproject", Some(manifest));
+
+        assert!(!report.zoekt.capabilities.lexical);
+        assert_ne!(report.retrieval_mode, "full");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -10,7 +10,7 @@ use crate::scip_index::{
     import_precise_semantic_scip_artifact,
 };
 use crate::zoekt_client::ZoektClient;
-use crate::zoekt_index::{build_zoekt_shard, lexical_input_fingerprint};
+use crate::zoekt_index::{LexicalInputFingerprint, build_zoekt_shard, lexical_input_fingerprint};
 use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use codestory_store::{FileRole, LlmSymbolDoc, RetrievalIndexManifest, Store, SymbolSearchDoc};
@@ -267,13 +267,17 @@ pub fn finalize_index_for_runtime_with_progress(
                     let scip_dir = layout.scip_project_dir(generation);
                     if update_precise_semantic_import_status(&scip_dir, &mut manifest)? {
                         return persist_finalized_manifest(
+                            project_root,
                             storage_path,
+                            &sidecar_input,
                             project_id,
                             manifest,
                             degraded_modes,
-                            zoekt_stubbed,
-                            qdrant_stubbed,
-                            scip_stubbed,
+                            SidecarStubFlags {
+                                zoekt_stubbed,
+                                qdrant_stubbed,
+                                scip_stubbed,
+                            },
                         );
                     }
                 }
@@ -329,6 +333,7 @@ pub fn finalize_index_for_runtime_with_progress(
             &generation,
             sidecar_input.lexical_file_count,
             &sidecar_input.lexical_hash,
+            &sidecar_input.hash,
         );
     let qdrant_ready_points = if existing_status.qdrant.capabilities.semantic {
         qdrant_ready_point_count(&qdrant_client, &collection, sidecar_input.projection_count)
@@ -354,13 +359,17 @@ pub fn finalize_index_for_runtime_with_progress(
                 "current generated sidecars already healthy; persisted manifest without rebuild"
             );
             return persist_finalized_manifest(
+                project_root,
                 storage_path,
+                &sidecar_input,
                 project_id,
                 manifest,
                 degraded_modes,
-                zoekt_stubbed,
-                qdrant_stubbed,
-                scip_stubbed,
+                SidecarStubFlags {
+                    zoekt_stubbed,
+                    qdrant_stubbed,
+                    scip_stubbed,
+                },
             );
         }
     }
@@ -370,9 +379,12 @@ pub fn finalize_index_for_runtime_with_progress(
             project_root,
             storage_path,
             &layout,
-            &project_id,
             &generation,
-            zoekt_probe.reachable,
+            &LexicalInputFingerprint {
+                file_count: sidecar_input.lexical_file_count,
+                hash: sidecar_input.lexical_hash.clone(),
+            },
+            &sidecar_input.hash,
             zoekt_ready,
         )
     })?;
@@ -406,6 +418,7 @@ pub fn finalize_index_for_runtime_with_progress(
 
     with_finalize_progress(&mut progress, "manifest write", || {
         finalize_manifest_after_health_check(
+            project_root,
             storage_path,
             &layout,
             &qdrant_client,
@@ -437,34 +450,42 @@ fn ensure_zoekt_generation(
     project_root: &Path,
     storage_path: &Path,
     layout: &SidecarLayout,
-    project_id: &str,
     generation: &str,
-    zoekt_probe_reachable: bool,
+    expected: &LexicalInputFingerprint,
+    sidecar_input_hash: &str,
     mut zoekt_ready: bool,
 ) -> Result<String> {
     if zoekt_ready {
-        info!(project_id = %project_id, sidecar_generation = %generation, "Zoekt lexical shard reused");
+        info!(sidecar_generation = %generation, "Zoekt lexical shard reused");
     } else {
         match build_zoekt_shard(
             project_root,
             Some(storage_path),
             &layout.zoekt_data_dir,
             generation,
-            zoekt_probe_reachable,
+            expected,
+            sidecar_input_hash,
         ) {
             Ok(true) => {
                 zoekt_ready = true;
-                info!(project_id = %project_id, sidecar_generation = %generation, "Zoekt lexical shard built");
+                info!(sidecar_generation = %generation, "Zoekt lexical shard built");
             }
             Ok(false) => {
-                warn!(project_id = %project_id, "Zoekt shard build produced no files");
+                warn!(sidecar_generation = %generation, "Zoekt shard build produced no files");
             }
-            Err(error) => bail!("mandatory Zoekt shard build failed for {project_id}: {error}"),
+            Err(error) => bail!("mandatory Zoekt shard build failed for {generation}: {error}"),
         }
     }
-    let shard_dir = crate::zoekt_index::shard_dir_for(&layout.zoekt_data_dir, generation);
-    if !zoekt_ready || !crate::zoekt_index::shard_has_lexical_index(&shard_dir) {
-        bail!("mandatory Zoekt lexical shard is missing for {project_id}");
+    if !zoekt_ready
+        || !crate::zoekt_index::shard_matches_lexical_input(
+            &layout.zoekt_data_dir,
+            generation,
+            expected.file_count,
+            &expected.hash,
+            sidecar_input_hash,
+        )
+    {
+        bail!("mandatory Zoekt lexical shard is incomplete for {generation}");
     }
     Ok(ZOEKT_REAL_VERSION_PIN.to_string())
 }
@@ -635,6 +656,7 @@ fn update_precise_semantic_import_status(
 
 #[allow(clippy::too_many_arguments)]
 fn finalize_manifest_after_health_check(
+    project_root: &Path,
     storage_path: &Path,
     layout: &SidecarLayout,
     qdrant_client: &QdrantClient,
@@ -646,6 +668,19 @@ fn finalize_manifest_after_health_check(
     stub_flags: SidecarStubFlags,
     embedding_device: &crate::embeddings::EmbeddingDeviceReadiness,
 ) -> Result<FinalizeIndexOutcome> {
+    let generation = manifest
+        .sidecar_generation
+        .as_deref()
+        .context("mandatory sidecar manifest is missing its generation")?;
+    if !crate::zoekt_index::shard_matches_lexical_input(
+        &layout.zoekt_data_dir,
+        generation,
+        sidecar_input.lexical_file_count,
+        &sidecar_input.lexical_hash,
+        &sidecar_input.hash,
+    ) {
+        bail!("mandatory Zoekt lexical shard is incomplete for {project_id}");
+    }
     let status = probe_sidecar_health_with_embedding_device(
         layout,
         &project_id,
@@ -668,14 +703,26 @@ fn finalize_manifest_after_health_check(
     }
 
     persist_finalized_manifest(
+        project_root,
         storage_path,
+        sidecar_input,
         project_id,
         manifest,
         degraded_modes,
-        stub_flags.zoekt_stubbed,
-        stub_flags.qdrant_stubbed,
-        stub_flags.scip_stubbed,
+        stub_flags,
     )
+}
+
+fn ensure_lexical_input_unchanged(
+    project_root: &Path,
+    storage_path: &Path,
+    expected: &SidecarInputFingerprint,
+) -> Result<()> {
+    let current = lexical_input_fingerprint(project_root, Some(storage_path))?;
+    if current.file_count != expected.lexical_file_count || current.hash != expected.lexical_hash {
+        bail!("lexical input changed before sidecar manifest publication");
+    }
+    Ok(())
 }
 
 #[allow(dead_code)] // Phase 2 cache keys
@@ -797,13 +844,13 @@ fn qdrant_ready_point_count(
 }
 
 fn persist_finalized_manifest(
+    project_root: &Path,
     storage_path: &Path,
+    sidecar_input: &SidecarInputFingerprint,
     project_id: String,
     mut manifest: RetrievalIndexManifest,
     degraded_modes: Vec<String>,
-    zoekt_stubbed: bool,
-    qdrant_stubbed: bool,
-    scip_stubbed: bool,
+    stub_flags: SidecarStubFlags,
 ) -> Result<FinalizeIndexOutcome> {
     manifest.built_at_epoch_ms = Utc::now().timestamp_millis();
     manifest.degraded_modes_json =
@@ -814,6 +861,7 @@ fn persist_finalized_manifest(
             "mandatory retrieval sidecar manifest would be unavailable immediately for {project_id}: {reason}"
         );
     }
+    ensure_lexical_input_unchanged(project_root, storage_path, sidecar_input)?;
     storage
         .upsert_retrieval_index_manifest(&manifest)
         .context("persist retrieval_index_manifest")?;
@@ -831,9 +879,9 @@ fn persist_finalized_manifest(
         project_id,
         manifest,
         degraded_modes,
-        zoekt_stubbed,
-        qdrant_stubbed,
-        scip_stubbed,
+        zoekt_stubbed: stub_flags.zoekt_stubbed,
+        qdrant_stubbed: stub_flags.qdrant_stubbed,
+        scip_stubbed: stub_flags.scip_stubbed,
     })
 }
 

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -153,8 +153,13 @@ pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
         cleanup_command: runtime.cleanup_command.clone(),
         started_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
     };
-    let json = serde_json::to_string_pretty(&state).context("serialize sidecar state")?;
-    std::fs::write(&layout.state_file, json).context("write retrieval-sidecars.json")?;
+    let json = serde_json::to_vec_pretty(&state).context("serialize sidecar state")?;
+    codestory_workspace::atomic_file::write_bytes_atomic(
+        &layout.state_file,
+        "retrieval-sidecars",
+        &json,
+    )
+    .context("write retrieval-sidecars.json")?;
     Ok(state)
 }
 
@@ -1138,6 +1143,24 @@ mod tests {
             .expect("rewrite state preserving launch");
 
         assert_eq!(preserved.embedding_launch, Some(launch));
+    }
+
+    #[test]
+    fn sidecar_state_replacement_is_complete_and_leaves_no_temp_file() {
+        let _lock = crate::test_support::env_lock();
+        let root = TempDir::new().expect("root");
+        let runtime = test_runtime(&root);
+        sidecar_up_with_runtime(&runtime, None).expect("initial state");
+        sidecar_up_with_runtime(&runtime, None).expect("replacement state");
+
+        let state = read_sidecar_state(&runtime.layout.state_file).expect("parse state");
+        assert!(sidecar_state_matches_runtime(&state, &runtime));
+        assert!(
+            std::fs::read_dir(root.path())
+                .expect("read root")
+                .flatten()
+                .all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp"))
+        );
     }
 
     fn native_embedding_launch_fixture() -> EmbeddingLaunchMetadata {

--- a/crates/codestory-retrieval/src/sidecar_search.rs
+++ b/crates/codestory-retrieval/src/sidecar_search.rs
@@ -27,6 +27,7 @@ pub struct LiveSidecarSearch {
     layout: SidecarLayout,
     project_id: String,
     sidecar_generation: String,
+    sidecar_input_hash: String,
     qdrant_collection: String,
     embedding_device: Option<EmbeddingDeviceReadiness>,
     zoekt: ZoektClient,
@@ -53,6 +54,9 @@ impl LiveSidecarSearch {
         let sidecar_generation = manifest
             .and_then(|manifest| manifest.sidecar_generation.clone())
             .unwrap_or_else(|| format!("{project_id}-missing-manifest"));
+        let sidecar_input_hash = manifest
+            .and_then(|manifest| manifest.sidecar_input_hash.clone())
+            .unwrap_or_else(|| "missing-manifest".to_string());
         let qdrant_collection = manifest
             .map(|manifest| manifest.qdrant_collection.clone())
             .unwrap_or_else(|| format!("codestory_{project_id}_missing_manifest"));
@@ -60,6 +64,7 @@ impl LiveSidecarSearch {
             layout,
             project_id,
             sidecar_generation,
+            sidecar_input_hash,
             qdrant_collection,
             embedding_device,
             zoekt,
@@ -90,8 +95,13 @@ impl SidecarSearch for LiveSidecarSearch {
     }
 
     fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
-        self.zoekt
-            .search(&self.layout, &self.sidecar_generation, query, limit)
+        self.zoekt.search(
+            &self.layout,
+            &self.sidecar_generation,
+            &self.sidecar_input_hash,
+            query,
+            limit,
+        )
     }
 
     fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {

--- a/crates/codestory-retrieval/src/zoekt_client.rs
+++ b/crates/codestory-retrieval/src/zoekt_client.rs
@@ -1,6 +1,6 @@
 use crate::config::{SidecarLayout, ZOEKT_HEALTH_BUDGET};
 use crate::outbound_http::read_text;
-use crate::zoekt_index::{search_lexical_index, shard_dir_for, shard_has_lexical_index};
+use crate::zoekt_index::{search_lexical_index, shard_dir_for};
 use anyhow::Result;
 use std::time::{Duration, Instant};
 
@@ -57,16 +57,13 @@ impl ZoektClient {
         &self,
         layout: &SidecarLayout,
         project_id: &str,
+        sidecar_input_hash: &str,
         query: &str,
         limit: usize,
     ) -> Result<Vec<super::CandidateHit>> {
         use super::candidate::{CandidateHit, CandidateSource};
         let shard_dir = shard_dir_for(&layout.zoekt_data_dir, project_id);
-        if !shard_has_lexical_index(&shard_dir) {
-            return Ok(Vec::new());
-        }
-
-        let hits = search_lexical_index(&shard_dir, query, limit)?
+        let hits = search_lexical_index(&shard_dir, sidecar_input_hash, query, limit)?
             .into_iter()
             .map(|hit| {
                 let mut candidate = CandidateHit::with_source(
@@ -89,8 +86,9 @@ impl ZoektClient {
         &self,
         layout: &SidecarLayout,
         project_id: &str,
+        sidecar_input_hash: &str,
     ) -> Result<Vec<String>> {
-        let hits = self.search(layout, project_id, "fn", 4)?;
+        let hits = self.search(layout, project_id, sidecar_input_hash, "fn", 4)?;
         Ok(hits.into_iter().map(|hit| hit.file_path).collect())
     }
 }
@@ -98,7 +96,7 @@ impl ZoektClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::zoekt_index::build_zoekt_shard;
+    use crate::zoekt_index::{build_zoekt_shard, lexical_input_fingerprint};
     use tempfile::TempDir;
 
     #[test]
@@ -119,20 +117,24 @@ mod tests {
         .expect("write b");
 
         let zoekt_data = TempDir::new().expect("zoekt data");
+        let fingerprint_a = lexical_input_fingerprint(project_a.path(), None).expect("input a");
         build_zoekt_shard(
             project_a.path(),
             None,
             zoekt_data.path(),
             "project-a",
-            false,
+            &fingerprint_a,
+            "input-a",
         )
         .expect("index a");
+        let fingerprint_b = lexical_input_fingerprint(project_b.path(), None).expect("input b");
         build_zoekt_shard(
             project_b.path(),
             None,
             zoekt_data.path(),
             "project-b",
-            false,
+            &fingerprint_b,
+            "input-b",
         )
         .expect("index b");
 
@@ -141,7 +143,7 @@ mod tests {
         let client = ZoektClient::new(&layout);
 
         let hits = client
-            .search(&layout, "project-a", "project_b_handler", 10)
+            .search(&layout, "project-a", "input-a", "project_b_handler", 10)
             .expect("search a");
         assert!(
             hits.is_empty(),

--- a/crates/codestory-retrieval/src/zoekt_index.rs
+++ b/crates/codestory-retrieval/src/zoekt_index.rs
@@ -1,16 +1,48 @@
 //! Build per-project Zoekt shard directories (lexical index + optional remote index).
 
 use crate::config::ZOEKT_REAL_VERSION_PIN;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use codestory_store::{FileRole, Store, SymbolSearchDoc};
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant, UNIX_EPOCH};
 
 const LEXICAL_INDEX_FILE: &str = "lexical-index.jsonl";
 const SHARD_META_FILE: &str = "shard-meta.json";
 const STUB_MARKER: &str = ".zoekt-stub";
 
 const MAX_FILE_BYTES: usize = 256 * 1024;
+const VALIDATED_SHARD_CACHE_CAPACITY: usize = 128;
+const VALIDATED_SHARD_CACHE_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileIdentity {
+    len: u64,
+    modified_nanos: u128,
+    change_token: i128,
+    device: u64,
+    file_id: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ShardValidationCacheKey {
+    index_path: PathBuf,
+    expected_sidecar_input_hash: String,
+    binding_sha256: String,
+    data_identity: FileIdentity,
+    meta_identity: FileIdentity,
+}
+
+#[derive(Debug, Clone)]
+struct CachedShardValidation {
+    key: ShardValidationCacheKey,
+    validated_at: Instant,
+}
+
+static VALIDATED_SHARD_CACHE: OnceLock<Mutex<VecDeque<CachedShardValidation>>> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct LexicalIndexEntry {
@@ -45,12 +77,20 @@ impl LexicalDocumentSource {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct ShardMeta {
     version: String,
     project_id: String,
     file_count: u32,
     lexical_hash: Option<String>,
+    #[serde(default)]
+    sidecar_input_hash: Option<String>,
+    #[serde(default)]
+    data_sha256: Option<String>,
+    #[serde(default)]
+    data_bytes: Option<u64>,
+    #[serde(default)]
+    binding_sha256: Option<String>,
     indexed_at_epoch_ms: i64,
 }
 
@@ -60,58 +100,127 @@ pub struct LexicalInputFingerprint {
     pub hash: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShardPublishPhase {
+    DataWrite,
+    DataPublish,
+    MetadataWrite,
+    MetadataPublish,
+}
+
 /// Populate `shards/<project_id>/` with a searchable lexical index; remove stub marker on success.
 pub fn build_zoekt_shard(
     project_root: &Path,
     storage_path: Option<&Path>,
     zoekt_data_dir: &Path,
     project_id: &str,
-    zoekt_http_reachable: bool,
+    expected: &LexicalInputFingerprint,
+    sidecar_input_hash: &str,
 ) -> Result<bool> {
-    let shard_dir = zoekt_data_dir.join("shards").join(project_id);
-    std::fs::create_dir_all(&shard_dir)
-        .with_context(|| format!("create zoekt shard dir {}", shard_dir.display()))?;
+    build_zoekt_shard_with_checkpoint(
+        project_root,
+        storage_path,
+        zoekt_data_dir,
+        project_id,
+        expected,
+        sidecar_input_hash,
+        |_| Ok(()),
+    )
+}
 
+fn build_zoekt_shard_with_checkpoint(
+    project_root: &Path,
+    storage_path: Option<&Path>,
+    zoekt_data_dir: &Path,
+    project_id: &str,
+    expected: &LexicalInputFingerprint,
+    sidecar_input_hash: &str,
+    mut checkpoint: impl FnMut(ShardPublishPhase) -> Result<()>,
+) -> Result<bool> {
     let entries = collect_lexical_entries(project_root, storage_path)?;
     if entries.is_empty() {
         return Ok(false);
     }
     let lexical_hash = lexical_entries_hash(&entries);
-
-    let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
-    let mut writer = std::fs::File::create(&index_path)
-        .with_context(|| format!("create {}", index_path.display()))?;
-    use std::io::Write;
-    for entry in &entries {
-        let line = serde_json::to_string(entry).context("serialize lexical index entry")?;
-        writeln!(writer, "{line}").context("write lexical index line")?;
+    if entries.len().min(u32::MAX as usize) as u32 != expected.file_count
+        || lexical_hash != expected.hash
+    {
+        bail!(
+            "lexical input changed while building shard: expected {} entries with hash {}, collected {} entries with hash {lexical_hash}",
+            expected.file_count,
+            expected.hash,
+            entries.len()
+        );
     }
 
+    let shard_dir = zoekt_data_dir.join("shards").join(project_id);
+    std::fs::create_dir_all(&shard_dir)
+        .with_context(|| format!("create zoekt shard dir {}", shard_dir.display()))?;
+
+    let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
     let version = ZOEKT_REAL_VERSION_PIN.to_string();
-    let meta = ShardMeta {
+    let mut meta = ShardMeta {
         version: version.clone(),
         project_id: project_id.to_string(),
         file_count: entries.len() as u32,
         lexical_hash: Some(lexical_hash),
+        sidecar_input_hash: Some(sidecar_input_hash.to_string()),
+        data_sha256: None,
+        data_bytes: None,
+        binding_sha256: None,
         indexed_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
     };
-    std::fs::write(
-        shard_dir.join(SHARD_META_FILE),
-        serde_json::to_string_pretty(&meta).context("serialize shard meta")?,
+    checkpoint(ShardPublishPhase::DataWrite)?;
+    codestory_workspace::atomic_file::write_file_atomic(
+        &index_path,
+        "lexical-index",
+        |file| write_lexical_entries(file, &entries),
+        |temp_path| {
+            validate_lexical_index_file(temp_path, &meta)?;
+            checkpoint(ShardPublishPhase::DataPublish)
+        },
     )
-    .context("write shard meta")?;
+    .context("publish lexical index")?;
+
+    let (data_bytes, data_sha256) = lexical_index_file_fingerprint(&index_path)?;
+    meta.data_bytes = Some(data_bytes);
+    meta.data_sha256 = Some(data_sha256);
+    meta.binding_sha256 = Some(shard_meta_binding(&meta));
+
+    let meta_path = shard_dir.join(SHARD_META_FILE);
+    checkpoint(ShardPublishPhase::MetadataWrite)?;
+    let meta_json = serde_json::to_vec_pretty(&meta).context("serialize shard meta")?;
+    codestory_workspace::atomic_file::write_file_atomic(
+        &meta_path,
+        "shard-meta",
+        |file| file.write_all(&meta_json).context("write shard metadata"),
+        |temp_path| {
+            let candidate = read_shard_meta(temp_path)?;
+            if candidate != meta {
+                bail!("temporary shard metadata differs from the expected metadata");
+            }
+            validate_lexical_index_file(&index_path, &candidate)?;
+            checkpoint(ShardPublishPhase::MetadataPublish)
+        },
+    )
+    .context("publish shard metadata")?;
 
     let stub = shard_dir.join(STUB_MARKER);
     if stub.is_file() {
         std::fs::remove_file(&stub).context("remove zoekt stub marker")?;
     }
 
-    let _ = zoekt_http_reachable;
     Ok(true)
 }
 
-pub fn shard_has_lexical_index(shard_dir: &Path) -> bool {
-    shard_dir.join(LEXICAL_INDEX_FILE).is_file() && !shard_dir.join(STUB_MARKER).is_file()
+pub fn shard_has_lexical_index(shard_dir: &Path, expected_sidecar_input_hash: &str) -> bool {
+    let Ok(Some((index_path, meta))) =
+        validated_shard_files(shard_dir, expected_sidecar_input_hash)
+    else {
+        return false;
+    };
+    validate_lexical_index_bytes_cached(shard_dir, &index_path, &meta, expected_sidecar_input_hash)
+        .is_ok()
 }
 
 pub fn shard_matches_lexical_input(
@@ -119,21 +228,374 @@ pub fn shard_matches_lexical_input(
     sidecar_generation: &str,
     expected_file_count: u32,
     expected_hash: &str,
+    expected_sidecar_input_hash: &str,
 ) -> bool {
     let shard_dir = shard_dir_for(zoekt_data_dir, sidecar_generation);
-    if !shard_has_lexical_index(&shard_dir) {
-        return false;
-    }
-    let Ok(body) = std::fs::read_to_string(shard_dir.join(SHARD_META_FILE)) else {
-        return false;
-    };
-    let Ok(meta) = serde_json::from_str::<ShardMeta>(&body) else {
+    let Ok(Some((meta, _entries))) = load_validated_shard(&shard_dir, expected_sidecar_input_hash)
+    else {
         return false;
     };
     meta.version == ZOEKT_REAL_VERSION_PIN
         && meta.project_id == sidecar_generation
         && meta.file_count == expected_file_count
         && meta.lexical_hash.as_deref() == Some(expected_hash)
+}
+
+fn write_lexical_entries(file: &mut std::fs::File, entries: &[LexicalIndexEntry]) -> Result<()> {
+    let mut writer = BufWriter::new(file);
+    for entry in entries {
+        serde_json::to_writer(&mut writer, entry).context("serialize lexical index entry")?;
+        writer
+            .write_all(b"\n")
+            .context("write lexical index newline")?;
+    }
+    writer.flush().context("flush lexical index")
+}
+
+fn load_validated_shard(
+    shard_dir: &Path,
+    expected_sidecar_input_hash: &str,
+) -> Result<Option<(ShardMeta, Vec<LexicalIndexEntry>)>> {
+    let Some((index_path, meta)) = validated_shard_files(shard_dir, expected_sidecar_input_hash)?
+    else {
+        return Ok(None);
+    };
+    let entries = validate_lexical_index_file(&index_path, &meta)?;
+    Ok(Some((meta, entries)))
+}
+
+fn validated_shard_files(
+    shard_dir: &Path,
+    expected_sidecar_input_hash: &str,
+) -> Result<Option<(PathBuf, ShardMeta)>> {
+    if shard_dir.join(STUB_MARKER).is_file() {
+        return Ok(None);
+    }
+    let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
+    let meta_path = shard_dir.join(SHARD_META_FILE);
+    match (index_path.is_file(), meta_path.is_file()) {
+        (false, false) => return Ok(None),
+        (true, true) => {}
+        _ => bail!("lexical shard is incomplete: data and metadata must both exist"),
+    }
+    let meta = read_shard_meta(&meta_path)?;
+    if meta.version != ZOEKT_REAL_VERSION_PIN {
+        bail!("lexical shard version is not current");
+    }
+    let expected_project_id = shard_dir.file_name().and_then(|name| name.to_str());
+    if expected_project_id != Some(meta.project_id.as_str()) {
+        bail!("lexical shard metadata project id does not match its directory");
+    }
+    if meta.sidecar_input_hash.as_deref() != Some(expected_sidecar_input_hash) {
+        bail!("lexical shard metadata does not match the sidecar input hash");
+    }
+    if meta.data_sha256.is_none() || meta.data_bytes.is_none() {
+        bail!("lexical shard metadata is missing the published data fingerprint");
+    }
+    if meta.binding_sha256.as_deref() != Some(shard_meta_binding(&meta).as_str()) {
+        bail!("lexical shard metadata binding is invalid");
+    }
+    Ok(Some((index_path, meta)))
+}
+
+fn read_shard_meta(path: &Path) -> Result<ShardMeta> {
+    let body =
+        std::fs::read(path).with_context(|| format!("read shard metadata {}", path.display()))?;
+    serde_json::from_slice(&body)
+        .with_context(|| format!("parse shard metadata {}", path.display()))
+}
+
+fn shard_meta_binding(meta: &ShardMeta) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"codestory-lexical-shard-meta-v1");
+    hasher.update(meta.version.as_bytes());
+    hasher.update([0]);
+    hasher.update(meta.project_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(meta.file_count.to_le_bytes());
+    hasher.update(meta.lexical_hash.as_deref().unwrap_or_default().as_bytes());
+    hasher.update([0]);
+    hasher.update(
+        meta.sidecar_input_hash
+            .as_deref()
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+    hasher.update([0]);
+    hasher.update(meta.data_sha256.as_deref().unwrap_or_default().as_bytes());
+    hasher.update([0]);
+    hasher.update(meta.data_bytes.unwrap_or_default().to_le_bytes());
+    hasher.update(meta.indexed_at_epoch_ms.to_le_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn validate_lexical_index_file(path: &Path, meta: &ShardMeta) -> Result<Vec<LexicalIndexEntry>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("open lexical index {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let mut entries = Vec::new();
+    let mut raw_hasher = sha2::Sha256::default();
+    let mut data_bytes = 0_u64;
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        let read = reader
+            .read_until(b'\n', &mut line)
+            .with_context(|| format!("read lexical index {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        use sha2::Digest;
+        raw_hasher.update(&line);
+        data_bytes = data_bytes.saturating_add(read as u64);
+        while matches!(line.last(), Some(b'\n' | b'\r')) {
+            line.pop();
+        }
+        let line_number = entries.len() + 1;
+        if line.is_empty() {
+            bail!(
+                "lexical index {} contains blank line {}",
+                path.display(),
+                line_number
+            );
+        }
+        let line = std::str::from_utf8(&line).with_context(|| {
+            format!(
+                "decode lexical index {} line {}",
+                path.display(),
+                line_number
+            )
+        })?;
+        entries.push(serde_json::from_str(line).with_context(|| {
+            format!(
+                "parse lexical index {} line {}",
+                path.display(),
+                line_number
+            )
+        })?);
+    }
+    let actual_count = entries.len().min(u32::MAX as usize) as u32;
+    if actual_count != meta.file_count {
+        bail!(
+            "lexical index row count mismatch: metadata={}, actual={actual_count}",
+            meta.file_count
+        );
+    }
+    let Some(expected_hash) = meta.lexical_hash.as_deref() else {
+        bail!("lexical shard metadata is missing lexical_hash");
+    };
+    let actual_hash = lexical_entries_hash(&entries);
+    if actual_hash != expected_hash {
+        bail!("lexical index hash mismatch: metadata={expected_hash}, actual={actual_hash}");
+    }
+    if let Some(expected_bytes) = meta.data_bytes
+        && data_bytes != expected_bytes
+    {
+        bail!("lexical index byte count mismatch: metadata={expected_bytes}, actual={data_bytes}");
+    }
+    if let Some(expected_sha256) = meta.data_sha256.as_deref() {
+        use sha2::Digest;
+        let actual_sha256 = format!("{:x}", raw_hasher.finalize());
+        if actual_sha256 != expected_sha256 {
+            bail!(
+                "lexical index data hash mismatch: metadata={expected_sha256}, actual={actual_sha256}"
+            );
+        }
+    }
+    Ok(entries)
+}
+
+fn validate_lexical_index_bytes(path: &Path, meta: &ShardMeta) -> Result<()> {
+    let (actual_bytes, actual_sha256) = lexical_index_file_fingerprint(path)?;
+    if meta.data_bytes != Some(actual_bytes)
+        || meta.data_sha256.as_deref() != Some(actual_sha256.as_str())
+    {
+        bail!("lexical index published data fingerprint does not match metadata");
+    }
+    Ok(())
+}
+
+fn validate_lexical_index_bytes_cached(
+    shard_dir: &Path,
+    index_path: &Path,
+    meta: &ShardMeta,
+    expected_sidecar_input_hash: &str,
+) -> Result<()> {
+    let key = shard_validation_cache_key(shard_dir, index_path, meta, expected_sidecar_input_hash)?;
+    let cache = VALIDATED_SHARD_CACHE.get_or_init(|| Mutex::new(VecDeque::new()));
+    {
+        let mut cache = cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.retain(|entry| entry.validated_at.elapsed() <= VALIDATED_SHARD_CACHE_TTL);
+        if cache.iter().any(|entry| entry.key == key) {
+            return Ok(());
+        }
+    }
+
+    validate_lexical_index_bytes(index_path, meta)?;
+    let validated_key =
+        shard_validation_cache_key(shard_dir, index_path, meta, expected_sidecar_input_hash)?;
+    if validated_key != key {
+        bail!("lexical shard changed while its published data was being validated");
+    }
+
+    let mut cache = cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    cache.retain(|entry| entry.key.index_path != key.index_path);
+    cache.push_back(CachedShardValidation {
+        key,
+        validated_at: Instant::now(),
+    });
+    while cache.len() > VALIDATED_SHARD_CACHE_CAPACITY {
+        cache.pop_front();
+    }
+    Ok(())
+}
+
+fn shard_validation_cache_key(
+    shard_dir: &Path,
+    index_path: &Path,
+    meta: &ShardMeta,
+    expected_sidecar_input_hash: &str,
+) -> Result<ShardValidationCacheKey> {
+    Ok(ShardValidationCacheKey {
+        index_path: index_path.to_path_buf(),
+        expected_sidecar_input_hash: expected_sidecar_input_hash.to_string(),
+        binding_sha256: meta.binding_sha256.clone().unwrap_or_default(),
+        data_identity: file_identity(index_path)?,
+        meta_identity: file_identity(&shard_dir.join(SHARD_META_FILE))?,
+    })
+}
+
+fn file_identity(path: &Path) -> Result<FileIdentity> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("open file for identity {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("read file metadata {}", path.display()))?;
+    let modified_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let (change_token, device, file_id) = platform_file_identity(&file, &metadata)?;
+    Ok(FileIdentity {
+        len: metadata.len(),
+        modified_nanos,
+        change_token,
+        device,
+        file_id,
+    })
+}
+
+#[cfg(unix)]
+fn platform_file_identity(
+    _file: &std::fs::File,
+    metadata: &std::fs::Metadata,
+) -> Result<(i128, u64, u128)> {
+    use std::os::unix::fs::MetadataExt;
+
+    let change_token = i128::from(metadata.ctime())
+        .saturating_mul(1_000_000_000)
+        .saturating_add(i128::from(metadata.ctime_nsec()));
+    Ok((change_token, metadata.dev(), u128::from(metadata.ino())))
+}
+
+#[cfg(windows)]
+fn platform_file_identity(
+    file: &std::fs::File,
+    _metadata: &std::fs::Metadata,
+) -> Result<(i128, u64, u128)> {
+    use std::ffi::c_void;
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle;
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct FileBasicInfo {
+        creation_time: i64,
+        last_access_time: i64,
+        last_write_time: i64,
+        change_time: i64,
+        file_attributes: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct FileIdInfo {
+        volume_serial_number: u64,
+        file_id: [u8; 16],
+    }
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn GetFileInformationByHandleEx(
+            file: *mut c_void,
+            file_information_class: i32,
+            file_information: *mut c_void,
+            buffer_size: u32,
+        ) -> i32;
+    }
+
+    const FILE_BASIC_INFO_CLASS: i32 = 0;
+    const FILE_ID_INFO_CLASS: i32 = 18;
+
+    fn query<T: Default>(file: &std::fs::File, class: i32) -> Result<T> {
+        let mut info = T::default();
+        let result = unsafe {
+            GetFileInformationByHandleEx(
+                file.as_raw_handle().cast(),
+                class,
+                std::ptr::from_mut(&mut info).cast(),
+                size_of::<T>() as u32,
+            )
+        };
+        if result == 0 {
+            return Err(std::io::Error::last_os_error()).context("query Windows file identity");
+        }
+        Ok(info)
+    }
+
+    let basic: FileBasicInfo = query(file, FILE_BASIC_INFO_CLASS)?;
+    let id: FileIdInfo = query(file, FILE_ID_INFO_CLASS)?;
+    Ok((
+        i128::from(basic.change_time),
+        id.volume_serial_number,
+        u128::from_le_bytes(id.file_id),
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn platform_file_identity(
+    _file: &std::fs::File,
+    _metadata: &std::fs::Metadata,
+) -> Result<(i128, u64, u128)> {
+    Ok((0, 0, 0))
+}
+
+fn lexical_index_file_fingerprint(path: &Path) -> Result<(u64, String)> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("open lexical index {}", path.display()))?;
+    let mut hasher = sha2::Sha256::default();
+    let mut bytes = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("read lexical index {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        use sha2::Digest;
+        hasher.update(&buffer[..read]);
+        bytes = bytes.saturating_add(read as u64);
+    }
+    use sha2::Digest;
+    Ok((bytes, format!("{:x}", hasher.finalize())))
 }
 
 pub fn lexical_input_fingerprint(
@@ -195,23 +657,19 @@ fn finalize_lexical_entries_hash(hasher: sha2::Sha256) -> String {
 
 pub fn search_lexical_index(
     shard_dir: &Path,
+    expected_sidecar_input_hash: &str,
     query: &str,
     limit: usize,
 ) -> Result<Vec<LexicalHit>> {
-    let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
-    if !index_path.is_file() {
+    let Some((_meta, entries)) = load_validated_shard(shard_dir, expected_sidecar_input_hash)?
+    else {
         return Ok(Vec::new());
-    }
+    };
     let tokens = lexical_query_tokens(query);
     if tokens.is_empty() {
         return Ok(Vec::new());
     }
     let command_tokens = command_query_tokens(query);
-    let content = std::fs::read_to_string(&index_path).context("read lexical index")?;
-    let entries = content
-        .lines()
-        .filter_map(|line| serde_json::from_str::<LexicalIndexEntry>(line).ok())
-        .collect::<Vec<_>>();
     let token_frequencies = token_document_frequencies(&entries, &tokens);
     let token_weights = token_frequencies
         .iter()
@@ -719,6 +1177,39 @@ mod tests {
         }
     }
 
+    fn write_test_shard(shard: &Path, entries: &[LexicalIndexEntry]) {
+        std::fs::create_dir_all(shard).expect("create shard");
+        let mut file = std::fs::File::create(shard.join(LEXICAL_INDEX_FILE)).expect("index file");
+        write_lexical_entries(&mut file, entries).expect("write index");
+        file.sync_all().expect("sync index");
+        drop(file);
+        let (data_bytes, data_sha256) =
+            lexical_index_file_fingerprint(&shard.join(LEXICAL_INDEX_FILE))
+                .expect("fingerprint index");
+        let meta = ShardMeta {
+            version: ZOEKT_REAL_VERSION_PIN.to_string(),
+            project_id: shard
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("shard name")
+                .to_string(),
+            file_count: entries.len() as u32,
+            lexical_hash: Some(lexical_entries_hash(entries)),
+            sidecar_input_hash: Some("test-input".to_string()),
+            data_sha256: Some(data_sha256),
+            data_bytes: Some(data_bytes),
+            binding_sha256: None,
+            indexed_at_epoch_ms: 1,
+        };
+        let mut meta = meta;
+        meta.binding_sha256 = Some(shard_meta_binding(&meta));
+        std::fs::write(
+            shard.join(SHARD_META_FILE),
+            serde_json::to_vec_pretty(&meta).expect("serialize meta"),
+        )
+        .expect("write meta");
+    }
+
     #[test]
     fn lexical_index_finds_repo_relative_paths() {
         let project = TempDir::new().expect("project");
@@ -728,10 +1219,19 @@ mod tests {
         )
         .expect("write");
         let zoekt_root = TempDir::new().expect("zoekt");
-        build_zoekt_shard(project.path(), None, zoekt_root.path(), "abc123", false).expect("build");
+        let fingerprint = lexical_input_fingerprint(project.path(), None).expect("fingerprint");
+        build_zoekt_shard(
+            project.path(),
+            None,
+            zoekt_root.path(),
+            "abc123",
+            &fingerprint,
+            "test-input",
+        )
+        .expect("build");
         let shard = shard_dir_for(zoekt_root.path(), "abc123");
-        assert!(shard_has_lexical_index(&shard));
-        let hits = search_lexical_index(&shard, "extension", 8).expect("search");
+        assert!(shard_has_lexical_index(&shard, "test-input"));
+        let hits = search_lexical_index(&shard, "test-input", "extension", 8).expect("search");
         assert!(hits.iter().any(|hit| hit.path == "lib.rs"));
     }
 
@@ -824,11 +1324,13 @@ mod tests {
             Some(&storage_path),
             zoekt_root.path(),
             "symbols",
-            false,
+            &streaming_fingerprint,
+            "test-input",
         )
         .expect("build");
         let shard = shard_dir_for(zoekt_root.path(), "symbols");
-        let hits = search_lexical_index(&shard, "cache skip logic", 4).expect("search");
+        let hits =
+            search_lexical_index(&shard, "test-input", "cache skip logic", 4).expect("search");
         let hit = hits
             .iter()
             .find(|hit| hit.symbol_name.as_deref() == Some("private_helper"))
@@ -844,21 +1346,251 @@ mod tests {
         std::fs::write(project.path().join("lib.rs"), "pub fn alpha() {}").expect("write");
         let zoekt_root = TempDir::new().expect("zoekt");
         let fingerprint = lexical_input_fingerprint(project.path(), None).expect("fingerprint");
-        build_zoekt_shard(project.path(), None, zoekt_root.path(), "generation", false)
-            .expect("build");
+        build_zoekt_shard(
+            project.path(),
+            None,
+            zoekt_root.path(),
+            "generation",
+            &fingerprint,
+            "test-input",
+        )
+        .expect("build");
 
         assert!(shard_matches_lexical_input(
             zoekt_root.path(),
             "generation",
             fingerprint.file_count,
-            &fingerprint.hash
+            &fingerprint.hash,
+            "test-input"
         ));
         assert!(!shard_matches_lexical_input(
             zoekt_root.path(),
             "generation",
             fingerprint.file_count,
-            "not-the-current-hash"
+            "not-the-current-hash",
+            "test-input"
         ));
+        assert!(!shard_matches_lexical_input(
+            zoekt_root.path(),
+            "generation",
+            fingerprint.file_count,
+            &fingerprint.hash,
+            "wrong-input"
+        ));
+        assert!(
+            search_lexical_index(
+                &shard_dir_for(zoekt_root.path(), "generation"),
+                "wrong-input",
+                "alpha",
+                4
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn malformed_or_truncated_rows_fail_closed() {
+        let shard_root = TempDir::new().expect("shard root");
+        let shard = shard_root.path().join("generation");
+        let entries = [entry("src/a.rs", "alpha"), entry("src/b.rs", "beta")];
+        write_test_shard(&shard, &entries);
+        let first = serde_json::to_string(&entries[0]).expect("serialize first");
+        let second = serde_json::to_string(&entries[1]).expect("serialize second");
+
+        std::fs::write(
+            shard.join(LEXICAL_INDEX_FILE),
+            format!("{first}\n{{not-json}}\n{second}\n"),
+        )
+        .expect("write malformed index");
+        assert!(!shard_has_lexical_index(&shard, "test-input"));
+        assert!(search_lexical_index(&shard, "test-input", "alpha", 4).is_err());
+
+        std::fs::write(
+            shard.join(LEXICAL_INDEX_FILE),
+            format!("{first}\n{}", &second[..second.len() - 1]),
+        )
+        .expect("write truncated index");
+        assert!(!shard_has_lexical_index(&shard, "test-input"));
+        assert!(search_lexical_index(&shard, "test-input", "alpha", 4).is_err());
+    }
+
+    #[test]
+    fn readiness_cache_invalidates_when_published_data_changes() {
+        let shard_root = TempDir::new().expect("shard root");
+        let shard = shard_root.path().join("generation");
+        write_test_shard(&shard, &[entry("src/a.rs", "alpha")]);
+        assert!(shard_has_lexical_index(&shard, "test-input"));
+
+        let index_path = shard.join(LEXICAL_INDEX_FILE);
+        let original_modified = std::fs::metadata(&index_path)
+            .expect("index metadata")
+            .modified()
+            .expect("index modified time");
+        let mut bytes = std::fs::read(&index_path).expect("read index");
+        bytes[0] = b'[';
+        std::fs::write(&index_path, bytes).expect("replace index");
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&index_path)
+            .expect("open index to restore timestamp")
+            .set_times(std::fs::FileTimes::new().set_modified(original_modified))
+            .expect("restore index timestamp");
+
+        assert!(!shard_has_lexical_index(&shard, "test-input"));
+    }
+
+    #[test]
+    fn readiness_cache_revalidates_expired_matching_identity() {
+        let shard_root = TempDir::new().expect("shard root");
+        let shard = shard_root.path().join("generation");
+        write_test_shard(&shard, &[entry("src/a.rs", "alpha")]);
+
+        let index_path = shard.join(LEXICAL_INDEX_FILE);
+        let mut bytes = std::fs::read(&index_path).expect("read index");
+        bytes[0] = b'[';
+        std::fs::write(&index_path, bytes).expect("replace index");
+        let meta = read_shard_meta(&shard.join(SHARD_META_FILE)).expect("read shard metadata");
+        let key = shard_validation_cache_key(&shard, &index_path, &meta, "test-input")
+            .expect("build cache key");
+        let cache = VALIDATED_SHARD_CACHE.get_or_init(|| Mutex::new(VecDeque::new()));
+        let mut cache = cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.retain(|entry| entry.key.index_path != index_path);
+        cache.push_back(CachedShardValidation {
+            key,
+            validated_at: Instant::now()
+                .checked_sub(VALIDATED_SHARD_CACHE_TTL + Duration::from_millis(1))
+                .expect("expired timestamp"),
+        });
+        drop(cache);
+
+        assert!(!shard_has_lexical_index(&shard, "test-input"));
+    }
+
+    #[test]
+    fn row_count_and_hash_mismatches_fail_closed() {
+        let shard_root = TempDir::new().expect("shard root");
+        let shard = shard_root.path().join("generation");
+        let entries = [entry("src/a.rs", "alpha")];
+        write_test_shard(&shard, &entries);
+        let meta_path = shard.join(SHARD_META_FILE);
+        let mut meta = read_shard_meta(&meta_path).expect("meta");
+
+        meta.file_count += 1;
+        std::fs::write(
+            &meta_path,
+            serde_json::to_vec_pretty(&meta).expect("serialize count mismatch"),
+        )
+        .expect("write count mismatch");
+        assert!(!shard_has_lexical_index(&shard, "test-input"));
+
+        meta.file_count = entries.len() as u32;
+        meta.lexical_hash = Some("wrong-hash".to_string());
+        std::fs::write(
+            &meta_path,
+            serde_json::to_vec_pretty(&meta).expect("serialize hash mismatch"),
+        )
+        .expect("write hash mismatch");
+        assert!(!shard_has_lexical_index(&shard, "test-input"));
+    }
+
+    #[test]
+    fn changed_input_does_not_replace_last_known_good_shard() {
+        let project = TempDir::new().expect("project");
+        let source = project.path().join("lib.rs");
+        std::fs::write(&source, "pub fn alpha() {}").expect("write alpha");
+        let fingerprint = lexical_input_fingerprint(project.path(), None).expect("fingerprint");
+        let zoekt_root = TempDir::new().expect("zoekt");
+        build_zoekt_shard(
+            project.path(),
+            None,
+            zoekt_root.path(),
+            "generation",
+            &fingerprint,
+            "test-input",
+        )
+        .expect("initial build");
+
+        std::fs::write(&source, "pub fn beta() {}").expect("write beta");
+        let error = build_zoekt_shard(
+            project.path(),
+            None,
+            zoekt_root.path(),
+            "generation",
+            &fingerprint,
+            "test-input",
+        )
+        .expect_err("changed input must not publish");
+        assert!(error.to_string().contains("lexical input changed"));
+
+        let shard = shard_dir_for(zoekt_root.path(), "generation");
+        assert!(shard_has_lexical_index(&shard, "test-input"));
+        assert_eq!(
+            search_lexical_index(&shard, "test-input", "alpha", 4)
+                .expect("search last-known-good")
+                .len(),
+            1
+        );
+        assert!(
+            search_lexical_index(&shard, "test-input", "beta", 4)
+                .expect("search old shard")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn publish_phase_failures_preserve_last_known_good_shard() {
+        let project = TempDir::new().expect("project");
+        std::fs::write(project.path().join("lib.rs"), "pub fn alpha() {}").expect("write source");
+        let fingerprint = lexical_input_fingerprint(project.path(), None).expect("fingerprint");
+        let zoekt_root = TempDir::new().expect("zoekt");
+        build_zoekt_shard(
+            project.path(),
+            None,
+            zoekt_root.path(),
+            "generation",
+            &fingerprint,
+            "test-input",
+        )
+        .expect("initial build");
+
+        for failure_phase in [
+            ShardPublishPhase::DataWrite,
+            ShardPublishPhase::DataPublish,
+            ShardPublishPhase::MetadataWrite,
+            ShardPublishPhase::MetadataPublish,
+        ] {
+            let error = build_zoekt_shard_with_checkpoint(
+                project.path(),
+                None,
+                zoekt_root.path(),
+                "generation",
+                &fingerprint,
+                "test-input",
+                |phase| {
+                    if phase == failure_phase {
+                        bail!("injected {phase:?} failure");
+                    }
+                    Ok(())
+                },
+            )
+            .expect_err("injected phase must fail");
+            assert!(format!("{error:#}").contains("injected"));
+
+            let shard = shard_dir_for(zoekt_root.path(), "generation");
+            assert!(
+                shard_has_lexical_index(&shard, "test-input"),
+                "{failure_phase:?} must preserve readiness"
+            );
+            assert_eq!(
+                search_lexical_index(&shard, "test-input", "alpha", 4)
+                    .expect("search last-known-good")
+                    .len(),
+                1,
+                "{failure_phase:?} must preserve search"
+            );
+        }
     }
 
     #[test]
@@ -867,14 +1599,9 @@ mod tests {
         let shard = zoekt_root.path();
         let weak = entry("src/a_weak.rs", "handler mentioned once");
         let strong = entry("src/z_strong_handler.rs", "handler handler handler");
-        let lines = [weak, strong]
-            .into_iter()
-            .map(|entry| serde_json::to_string(&entry).expect("serialize"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(shard.join(LEXICAL_INDEX_FILE), lines).expect("write index");
+        write_test_shard(shard, &[weak, strong]);
 
-        let hits = search_lexical_index(shard, "handler", 1).expect("search");
+        let hits = search_lexical_index(shard, "test-input", "handler", 1).expect("search");
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].path, "src/z_strong_handler.rs");
     }
@@ -893,9 +1620,18 @@ mod tests {
         }
 
         let zoekt_root = TempDir::new().expect("zoekt");
-        build_zoekt_shard(project.path(), None, zoekt_root.path(), "large", false).expect("build");
+        let fingerprint = lexical_input_fingerprint(project.path(), None).expect("fingerprint");
+        build_zoekt_shard(
+            project.path(),
+            None,
+            zoekt_root.path(),
+            "large",
+            &fingerprint,
+            "test-input",
+        )
+        .expect("build");
         let shard = shard_dir_for(zoekt_root.path(), "large");
-        let hits = search_lexical_index(&shard, "symbol_4099", 4).expect("search");
+        let hits = search_lexical_index(&shard, "test-input", "symbol_4099", 4).expect("search");
 
         assert!(
             hits.iter().any(|hit| hit.path == "src/file_4099.ts"),
@@ -909,14 +1645,9 @@ mod tests {
         let shard = zoekt_root.path();
         let later = entry("src/b.rs", "handler");
         let earlier = entry("src/a.rs", "handler");
-        let lines = [later, earlier]
-            .into_iter()
-            .map(|entry| serde_json::to_string(&entry).expect("serialize"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(shard.join(LEXICAL_INDEX_FILE), lines).expect("write index");
+        write_test_shard(shard, &[later, earlier]);
 
-        let hits = search_lexical_index(shard, "handler", 2).expect("search");
+        let hits = search_lexical_index(shard, "test-input", "handler", 2).expect("search");
         assert_eq!(
             hits.iter().map(|hit| hit.path.as_str()).collect::<Vec<_>>(),
             vec!["src/a.rs", "src/b.rs",]
@@ -944,15 +1675,14 @@ mod tests {
             "workspace/app-protocol/schema/typescript/v2/CommandRequestParams.ts",
             "app server command request turn start request",
         );
-        let lines = [test, unrelated, generic_agent_doc, generated_schema, source]
-            .into_iter()
-            .map(|entry| serde_json::to_string(&entry).expect("serialize"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(shard.join(LEXICAL_INDEX_FILE), lines).expect("write index");
+        write_test_shard(
+            shard,
+            &[test, unrelated, generic_agent_doc, generated_schema, source],
+        );
 
         let hits = search_lexical_index(
             shard,
+            "test-input",
             "Explain how `app request --json` flows from CLI into runtime thread turn start JSONL event output",
             4,
         )

--- a/crates/codestory-workspace/src/atomic_file.rs
+++ b/crates/codestory-workspace/src/atomic_file.rs
@@ -1,0 +1,257 @@
+use anyhow::{Context, Result, bail};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+#[cfg(windows)]
+use std::time::Duration;
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn atomic_temp_path(path: &Path, stem: &str) -> PathBuf {
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    path.with_file_name(format!(".{stem}.{}.{}.tmp", std::process::id(), counter))
+}
+
+pub fn write_synced_new_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(content)?;
+    file.sync_all()
+}
+
+pub fn write_bytes_atomic(path: &Path, stem: &str, content: &[u8]) -> Result<()> {
+    write_file_atomic(
+        path,
+        stem,
+        |file| file.write_all(content).context("write temporary file"),
+        |temp_path| {
+            let actual = fs::read(temp_path).context("read temporary file for validation")?;
+            if actual != content {
+                bail!("temporary file validation failed: written bytes differ from input");
+            }
+            Ok(())
+        },
+    )
+}
+
+pub fn write_file_atomic(
+    path: &Path,
+    stem: &str,
+    write: impl FnOnce(&mut File) -> Result<()>,
+    validate: impl FnOnce(&Path) -> Result<()>,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create parent directory {}", parent.display()))?;
+    }
+    let (temp_path, mut file) = create_unique_temp_file(path, stem)?;
+    let result = (|| {
+        write(&mut file)?;
+        file.sync_all()
+            .with_context(|| format!("sync temporary file {}", temp_path.display()))?;
+        drop(file);
+        validate(&temp_path)?;
+        replace_file(&temp_path, path).with_context(|| format!("publish {}", path.display()))?;
+        sync_parent_directory(path)
+            .with_context(|| format!("sync parent of {}", path.display()))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn create_unique_temp_file(path: &Path, stem: &str) -> Result<(PathBuf, File)> {
+    loop {
+        let temp_path = atomic_temp_path(path, stem);
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+        {
+            Ok(file) => return Ok((temp_path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("create temporary file {}", temp_path.display()));
+            }
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> std::io::Result<()> {
+    const ERROR_FILE_NOT_FOUND: i32 = 2;
+    const ERROR_ACCESS_DENIED: i32 = 5;
+    const ERROR_SHARING_VIOLATION: i32 = 32;
+    const ERROR_UNABLE_TO_REMOVE_REPLACED: i32 = 1175;
+    const ERROR_UNABLE_TO_MOVE_REPLACEMENT: i32 = 1176;
+    const REPLACE_ATTEMPTS: usize = 50;
+
+    #[link(name = "Kernel32")]
+    unsafe extern "system" {
+        fn ReplaceFileW(
+            replaced_file_name: *const u16,
+            replacement_file_name: *const u16,
+            backup_file_name: *const u16,
+            flags: u32,
+            exclude: *mut std::ffi::c_void,
+            reserved: *mut std::ffi::c_void,
+        ) -> i32;
+    }
+
+    let replacement = source
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let replaced = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+
+    for attempt in 0..REPLACE_ATTEMPTS {
+        if !destination.exists() {
+            match fs::rename(source, destination) {
+                Ok(()) => return Ok(()),
+                Err(_) if !source.exists() && destination.exists() => return Ok(()),
+                Err(error) if !destination.exists() => {
+                    if attempt + 1 == REPLACE_ATTEMPTS {
+                        return Err(error);
+                    }
+                    std::thread::sleep(Duration::from_millis(1));
+                    continue;
+                }
+                Err(_) => {}
+            }
+        }
+
+        // SAFETY: both path buffers are null-terminated and remain alive for the call.
+        let result = unsafe {
+            ReplaceFileW(
+                replaced.as_ptr(),
+                replacement.as_ptr(),
+                std::ptr::null(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if result != 0 {
+            return Ok(());
+        }
+
+        let error = std::io::Error::last_os_error();
+        if !source.exists() && destination.exists() {
+            return Ok(());
+        }
+        let retryable = matches!(
+            error.raw_os_error(),
+            Some(
+                ERROR_FILE_NOT_FOUND
+                    | ERROR_ACCESS_DENIED
+                    | ERROR_SHARING_VIOLATION
+                    | ERROR_UNABLE_TO_REMOVE_REPLACED
+                    | ERROR_UNABLE_TO_MOVE_REPLACEMENT
+            )
+        );
+        if !retryable || attempt + 1 == REPLACE_ATTEMPTS {
+            return Err(error);
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    unreachable!("replacement attempts always return")
+}
+
+#[cfg(not(windows))]
+fn sync_parent_directory(path: &Path) -> std::io::Result<()> {
+    match path.parent() {
+        Some(parent) => File::open(parent)?.sync_all(),
+        None => Ok(()),
+    }
+}
+
+#[cfg(windows)]
+fn sync_parent_directory(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_write_replaces_complete_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.json");
+        fs::write(&path, b"old").expect("old file");
+
+        write_bytes_atomic(&path, "state", b"new").expect("atomic write");
+
+        assert_eq!(fs::read(&path).expect("read"), b"new");
+    }
+
+    #[test]
+    fn failed_write_or_validation_preserves_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.json");
+        fs::write(&path, b"old").expect("old file");
+
+        let write_error = write_file_atomic(
+            &path,
+            "state",
+            |file| {
+                file.write_all(b"partial")?;
+                bail!("short write")
+            },
+            |_| Ok(()),
+        );
+        assert!(write_error.is_err());
+        assert_eq!(fs::read(&path).expect("read after write error"), b"old");
+
+        let validation_error = write_file_atomic(
+            &path,
+            "state",
+            |file| file.write_all(b"new").map_err(Into::into),
+            |_| bail!("invalid"),
+        );
+        assert!(validation_error.is_err());
+        assert_eq!(
+            fs::read(&path).expect("read after validation error"),
+            b"old"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn blocked_windows_replacement_preserves_destination() {
+        use std::os::windows::fs::OpenOptionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.json");
+        fs::write(&path, b"old").expect("old file");
+        let exclusive_reader = OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(&path)
+            .expect("exclusive reader");
+
+        let error = write_bytes_atomic(&path, "state", b"new")
+            .expect_err("replacement must fail while destination is exclusively open");
+
+        assert!(error.to_string().contains("publish"));
+        drop(exclusive_reader);
+        assert_eq!(fs::read(&path).expect("read old file"), b"old");
+    }
+}

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -21,6 +21,7 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
 
+pub mod atomic_file;
 mod repository_identity;
 pub use repository_identity::{
     PROJECT_IDENTITY_SCHEMA_VERSION, ProjectIdentityV2, REPOSITORY_IDENTITY_SCHEMA_VERSION,


### PR DESCRIPTION
## Context

CodeStory could expose partially written lexical shards or sidecar state after an interrupted or raced publish. Readiness also treated the existence of shard files as stronger proof than their contents justified.

Closes #904
Refs #899

## What Changed

- Added a shared same-directory atomic-file publisher with unique temporary files, validation before replacement, durable Unix directory sync, and the existing Windows `ReplaceFileW` retry behavior.
- Published lexical JSONL, shard metadata, and `retrieval-sidecars.json` through that helper.
- Made lexical parsing fail closed on malformed, blank, truncated, count-mismatched, hash-mismatched, or manifest-mismatched data.
- Bound shard metadata to both the published byte fingerprint and the manifest sidecar-input hash.
- Rechecked lexical input immediately before every finalized-manifest write so a raced rebuild cannot bless stale sidecars.
- Added bounded readiness validation caching keyed by OS file identity/change metadata, with a five-second maximum validation age.
- Included readiness work in retrieval elapsed-time traces.

```mermaid
flowchart LR
    A["Collect lexical input"] --> B["Write and validate unique data temp"]
    B --> C["Atomically replace shard data"]
    C --> D["Bind metadata to data and manifest input"]
    D --> E["Write and validate unique metadata temp"]
    E --> F["Atomically replace shard metadata"]
    F --> G["Recheck live lexical input"]
    G --> H["Publish finalized manifest"]
    B -. failure .-> I["Preserve last known good state"]
    E -. failure .-> I
    G -. race .-> I
```

## How To Review

1. Start with `crates/codestory-workspace/src/atomic_file.rs` for the cross-platform publication primitive.
2. Review `crates/codestory-retrieval/src/zoekt_index.rs` for strict shard validation, manifest binding, readiness caching, and publication-failure tests.
3. Follow the manifest compare-and-swap boundary in `crates/codestory-retrieval/src/index.rs`.
4. Confirm runtime state publication in `crates/codestory-retrieval/src/sidecar.rs` and the manifest hash propagation through health/search.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p codestory-workspace -p codestory-retrieval -p codestory-cli --all-targets -- -D warnings`
- `cargo test -p codestory-retrieval -- --test-threads=1` - 264 unit tests passed, 8 integration/holdout tests passed, 2 live-sidecar tests ignored by contract.
- `cargo test -p codestory-cli --bin codestory-cli -- --test-threads=1` - 320 tests passed before the final cache-only refinement; the final refinement is covered by the retrieval suite and clippy compilation of the CLI.
- `cargo test -p codestory-workspace` - 27 tests passed, including all atomic-file tests.
- `cargo build --release -p codestory-cli`
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Three adversarial review passes report no remaining source-level blockers.

The required ignored repo-scale stats run was attempted but could not execute because `CODESTORY_REAL_REPO_DRILL_CASES` is unset and this Windows host denied `CREATE_BREAKAWAY_FROM_JOB` with OS error 5. It emitted no stats, so the stats log was not changed.

## Risk

- Ubuntu CI is the final proof for the Unix-specific file identity and directory-sync paths.
- Live full-stack sidecar tests still require provisioned Qdrant, Zoekt, and embedding services and remain explicitly ignored locally.
- Readiness may reuse a validated shard for at most five seconds; OS file identity/change metadata invalidates ordinary replacements immediately, and the TTL bounds filesystems that cannot expose a reliable change token.
