### PR TITLE
[codex] bound managed CLI and sidecar retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+- Bounded plugin-managed CLI storage to the active checksummed runtime plus one
+  verified upgrade or rollback candidate, with atomic staged publication,
+  recoverable owner locks, Windows lock-safe cleanup, and retained, removed,
+  and reclaimable byte diagnostics in plugin runtime status.
+- Added post-publication sidecar generation retention across Qdrant, lexical,
+  and SCIP artifacts. CodeStory now protects every manifest-referenced active
+  generation sharing the sidecar scope plus at most one verified rollback,
+  suppresses pruning on malformed or stale protection state, coordinates
+  publication with namespace GC, and exposes the same byte-accounted plan to
+  `retrieval inventory` and its explicit `--apply` path.
 - Published lexical shard data, metadata, and runtime sidecar state through
   validated same-directory temporary files with atomic replacement. Shard
   readiness and search now reject malformed, truncated, count-mismatched, or

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -198,12 +198,18 @@ pub(crate) fn run_retrieval_inventory(cmd: RetrievalInventoryCommand) -> Result<
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
     if cmd.apply {
-        let report = codestory_retrieval::sidecar_gc_apply(&runtime.project_root)
-            .context("retrieval inventory apply")?;
+        let report = codestory_retrieval::sidecar_gc_apply_with_storage(
+            &runtime.project_root,
+            &runtime.storage_path,
+        )
+        .context("retrieval inventory apply")?;
         return emit_retrieval_gc(cmd.format, &report, cmd.output_file.as_deref());
     }
-    let report = codestory_retrieval::sidecar_inventory(&runtime.project_root)
-        .context("retrieval inventory")?;
+    let report = codestory_retrieval::sidecar_inventory_with_storage(
+        &runtime.project_root,
+        &runtime.storage_path,
+    )
+    .context("retrieval inventory")?;
     emit_retrieval_inventory(cmd.format, &report, cmd.output_file.as_deref())
 }
 
@@ -427,6 +433,8 @@ struct RetrievalIndexOutput<'a> {
     zoekt_stubbed: bool,
     qdrant_stubbed: bool,
     scip_stubbed: bool,
+    generation_retention_plan: &'a codestory_retrieval::GenerationRetentionPlan,
+    generation_retention: &'a codestory_retrieval::GenerationRetentionApplyReport,
 }
 
 fn emit_retrieval_index(
@@ -440,14 +448,21 @@ fn emit_retrieval_index(
         zoekt_stubbed: outcome.zoekt_stubbed,
         qdrant_stubbed: outcome.qdrant_stubbed,
         scip_stubbed: outcome.scip_stubbed,
+        generation_retention_plan: &outcome.generation_retention_plan,
+        generation_retention: &outcome.generation_retention,
     };
     let markdown = format!(
-        "# Retrieval index\n\n- project_id: `{}`\n- zoekt_version: `{}`\n- qdrant_collection: `{}`\n- scip_revision: {:?}\n- degraded_modes: {:?}\n",
+        "# Retrieval index\n\n- project_id: `{}`\n- zoekt_version: `{}`\n- qdrant_collection: `{}`\n- scip_revision: {:?}\n- degraded_modes: {:?}\n- retention_retained_bytes: {}\n- retention_reclaimable_bytes: {}\n- retention_removed_bytes: {}\n- retention_remaining_reclaimable_bytes: {}\n- retention_pruning_suppressed: {}\n",
         payload.manifest.project_id,
         payload.manifest.zoekt_version,
         payload.manifest.qdrant_collection,
         payload.manifest.scip_revision,
         payload.degraded_modes,
+        payload.generation_retention.retained_bytes,
+        payload.generation_retention.reclaimable_bytes,
+        payload.generation_retention.removed_bytes,
+        payload.generation_retention.remaining_reclaimable_bytes,
+        payload.generation_retention.pruning_suppressed,
     );
     emit(format, &payload, markdown, output_file)
 }
@@ -537,6 +552,13 @@ fn emit_retrieval_bootstrap(
         .prune_suppressed_reason
         .as_deref()
         .map(|reason| {
+            if reason
+                == codestory_retrieval::PRUNE_SUPPRESSED_POST_PUBLICATION_RETENTION
+            {
+                return format!(
+                    "\n- storage_repair_prune_suppressed: `{reason}` (valid generations are pruned only after a replacement is fully published)\n"
+                );
+            }
             format!(
                 "\n- storage_repair_prune_suppressed: `{reason}` (retention deletes skipped; set CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR=1 to override)\n"
             )
@@ -727,6 +749,18 @@ fn emit_retrieval_inventory(
     if let Some(error) = report.docker_error.as_deref() {
         markdown.push_str(&format!("- docker_error: `{error}`\n"));
     }
+    if let Some(retention) = report.generation_retention.as_ref() {
+        markdown.push_str(&format!(
+            "- generation_retention_retained_bytes: {}\n- generation_retention_reclaimable_bytes: {}\n- generation_retention_pruning_suppressed: {}\n",
+            retention.retained_bytes, retention.reclaimable_bytes, retention.pruning_suppressed
+        ));
+        if !retention.errors.is_empty() {
+            markdown.push_str(&format!(
+                "- generation_retention_errors: `{}`\n",
+                retention.errors.join("; ")
+            ));
+        }
+    }
     if report.namespaces.is_empty() {
         markdown.push_str("\nNo sidecar namespaces found.\n");
     }
@@ -785,6 +819,22 @@ fn emit_retrieval_gc(
     );
     if let Some(error) = report.docker_error.as_deref() {
         markdown.push_str(&format!("- docker_error: `{error}`\n"));
+    }
+    if let Some(retention) = report.generation_retention.as_ref() {
+        markdown.push_str(&format!(
+            "- generation_retention_retained_bytes: {}\n- generation_retention_reclaimable_bytes: {}\n- generation_retention_removed_bytes: {}\n- generation_retention_remaining_reclaimable_bytes: {}\n- generation_retention_pruning_suppressed: {}\n",
+            retention.retained_bytes,
+            retention.reclaimable_bytes,
+            retention.removed_bytes,
+            retention.remaining_reclaimable_bytes,
+            retention.pruning_suppressed
+        ));
+        if !retention.errors.is_empty() {
+            markdown.push_str(&format!(
+                "- generation_retention_errors: `{}`\n",
+                retention.errors.join("; ")
+            ));
+        }
     }
     markdown.push_str("\n## Removed namespaces\n");
     if report.removed.is_empty() {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -4523,6 +4523,9 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let managed_cli_retention = env_nonempty("CODESTORY_PLUGIN_CLI_RETENTION")
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(&value).ok())
+        .filter(|value| !value.is_null());
     serde_json::json!({
         "plugin_version": env_nonempty("CODESTORY_PLUGIN_VERSION"),
         "plugin_root": env_nonempty("CODESTORY_PLUGIN_ROOT"),
@@ -4540,6 +4543,7 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
         "managed_binary_path": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_PATH") } else { None },
         "managed_binary_sha256": if cli_source == "managed" { env_nonempty("CODESTORY_PLUGIN_CLI_SHA256") } else { None },
         "managed_manifest_path": env_nonempty("CODESTORY_PLUGIN_CLI_MANIFEST_PATH"),
+        "managed_cli_retention": managed_cli_retention,
         "warnings": warnings
     })
 }

--- a/crates/codestory-cli/tests/sidecar_status_cli.rs
+++ b/crates/codestory-cli/tests/sidecar_status_cli.rs
@@ -98,6 +98,21 @@ fn sidecar_inventory_reports_read_only_dry_run_json() {
     let json = stdout_json(&output);
     assert_eq!(json["dry_run"].as_bool(), Some(true));
     assert!(json["namespaces"].is_array());
+    assert_eq!(
+        json["generation_retention"]["dry_run"].as_bool(),
+        Some(true)
+    );
+    assert_eq!(
+        json["generation_retention"]["pruning_suppressed"].as_bool(),
+        Some(true)
+    );
+    assert!(
+        json["generation_retention"]["errors"]
+            .as_array()
+            .is_some_and(|errors| errors.iter().any(|error| error
+                .as_str()
+                .is_some_and(|error| error.contains("active retrieval manifest is unavailable"))))
+    );
 }
 
 #[test]
@@ -119,6 +134,7 @@ fn retrieval_inventory_has_human_output() {
         "inventory should have a human-readable heading:\n{stdout}"
     );
     assert!(stdout.contains("dry_run"));
+    assert!(stdout.contains("generation_retention_pruning_suppressed: true"));
 }
 
 #[test]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -5,6 +5,13 @@ use crate::generation::{
 };
 use crate::health::probe_sidecar_health_with_embedding_device;
 use crate::qdrant_client::{QDRANT_INDEX_UPSERT_BATCH_SIZE, QdrantClient, QdrantUpsertPoint};
+use crate::retention::{
+    FsQdrantGenerationRemover, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport,
+    GenerationRetentionLock, GenerationRetentionMarker, GenerationRetentionPlan,
+    VerifiedRollbackManifest, apply_generation_retention, global_generation_gc_state_file,
+    plan_generation_retention_with_qdrant_collections, read_retention_marker,
+    scan_retention_protection, write_retention_marker,
+};
 use crate::scip_index::{
     SCIP_PRECISE_SEMANTIC_IMPORT_DIR, emit_scip_artifacts_from_store,
     import_precise_semantic_scip_artifact,
@@ -28,6 +35,8 @@ pub struct FinalizeIndexOutcome {
     pub zoekt_stubbed: bool,
     pub qdrant_stubbed: bool,
     pub scip_stubbed: bool,
+    pub generation_retention_plan: GenerationRetentionPlan,
+    pub generation_retention: GenerationRetentionApplyReport,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -58,6 +67,13 @@ struct SidecarStubFlags {
     zoekt_stubbed: bool,
     qdrant_stubbed: bool,
     scip_stubbed: bool,
+}
+
+struct GenerationRetentionContext<'a> {
+    layout: &'a SidecarLayout,
+    workspace_id: &'a str,
+    previous_manifest: Option<&'a RetrievalIndexManifest>,
+    embedding_device: &'a crate::embeddings::EmbeddingDeviceReadiness,
 }
 
 const SIDECAR_INPUT_BATCH_SIZE: usize = QDRANT_INDEX_UPSERT_BATCH_SIZE * 8;
@@ -193,9 +209,21 @@ pub fn finalize_index_for_runtime_with_progress(
 ) -> Result<FinalizeIndexOutcome> {
     runtime.activate_embed_url_default();
     let layout = runtime.layout.clone();
-    layout.ensure_data_dirs()?;
-
     let project_id = sidecar_project_id_for_root(project_root);
+    let workspace_id = runtime
+        .project_identity
+        .as_ref()
+        .map(|identity| identity.workspace_id.clone())
+        .unwrap_or_else(|| codestory_workspace::workspace_id_for_root(project_root));
+    let global_gc_state_file = global_generation_gc_state_file(runtime);
+    let _global_gc_lock = GenerationRetentionLock::acquire_shared(
+        &global_gc_state_file,
+        GLOBAL_GENERATION_GC_LOCK_SCOPE,
+    )
+    .context("coordinate sidecar publication with global generation cleanup")?;
+    let _generation_lock = GenerationRetentionLock::acquire(&layout.state_file, &project_id)
+        .context("lock sidecar generation publication and retention")?;
+    layout.ensure_data_dirs()?;
     let degraded_modes = Vec::new();
     let zoekt_stubbed = false;
     let qdrant_stubbed = false;
@@ -236,6 +264,12 @@ pub fn finalize_index_for_runtime_with_progress(
         .as_ref()
         .and_then(|manifest| manifest_unavailable_reason(&project_id, &storage, manifest));
     drop(storage);
+    let retention_context = GenerationRetentionContext {
+        layout: &layout,
+        workspace_id: &workspace_id,
+        previous_manifest: previous_manifest.as_ref(),
+        embedding_device: &embedding_device,
+    };
 
     if let Some(previous) = previous_manifest.as_ref() {
         if let Some(reason) = previous_manifest_unavailable_reason.as_ref() {
@@ -269,6 +303,7 @@ pub fn finalize_index_for_runtime_with_progress(
                         return persist_finalized_manifest(
                             project_root,
                             storage_path,
+                            &retention_context,
                             &sidecar_input,
                             project_id,
                             manifest,
@@ -289,14 +324,20 @@ pub fn finalize_index_for_runtime_with_progress(
                     lexical_file_count = sidecar_input.lexical_file_count,
                     "retrieval sidecar generation unchanged; reused existing full sidecars"
                 );
-                return Ok(FinalizeIndexOutcome {
+                return persist_finalized_manifest(
+                    project_root,
+                    storage_path,
+                    &retention_context,
+                    &sidecar_input,
                     project_id,
-                    manifest: previous.clone(),
+                    previous.clone(),
                     degraded_modes,
-                    zoekt_stubbed,
-                    qdrant_stubbed,
-                    scip_stubbed,
-                });
+                    SidecarStubFlags {
+                        zoekt_stubbed,
+                        qdrant_stubbed,
+                        scip_stubbed,
+                    },
+                );
             }
             warn!(
                 project_id = %project_id,
@@ -344,7 +385,7 @@ pub fn finalize_index_for_runtime_with_progress(
 
     if zoekt_ready && qdrant_ready_points.is_some() && scip_ready {
         update_precise_semantic_import_status(&scip_dir, &mut manifest)?;
-        manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
+        manifest.disk_bytes = sidecar_disk_bytes(&layout, &generation, &collection, &scip_dir);
         let status = probe_sidecar_health_with_embedding_device(
             &layout,
             &project_id,
@@ -361,6 +402,7 @@ pub fn finalize_index_for_runtime_with_progress(
             return persist_finalized_manifest(
                 project_root,
                 storage_path,
+                &retention_context,
                 &sidecar_input,
                 project_id,
                 manifest,
@@ -414,12 +456,13 @@ pub fn finalize_index_for_runtime_with_progress(
 
     manifest.zoekt_version = zoekt_version;
     manifest.scip_revision = read_scip_revision(&scip_dir).or(manifest.scip_revision);
-    manifest.disk_bytes = sidecar_disk_bytes(&layout, &scip_dir);
+    manifest.disk_bytes = sidecar_disk_bytes(&layout, &generation, &collection, &scip_dir);
 
     with_finalize_progress(&mut progress, "manifest write", || {
         finalize_manifest_after_health_check(
             project_root,
             storage_path,
+            &retention_context,
             &layout,
             &qdrant_client,
             project_id,
@@ -658,6 +701,7 @@ fn update_precise_semantic_import_status(
 fn finalize_manifest_after_health_check(
     project_root: &Path,
     storage_path: &Path,
+    retention_context: &GenerationRetentionContext<'_>,
     layout: &SidecarLayout,
     qdrant_client: &QdrantClient,
     project_id: String,
@@ -705,6 +749,7 @@ fn finalize_manifest_after_health_check(
     persist_finalized_manifest(
         project_root,
         storage_path,
+        retention_context,
         sidecar_input,
         project_id,
         manifest,
@@ -804,11 +849,21 @@ fn read_scip_revision(scip_dir: &Path) -> Option<String> {
         .filter(|text| !text.is_empty())
 }
 
-fn sidecar_disk_bytes(layout: &SidecarLayout, scip_dir: &Path) -> Option<i64> {
+fn sidecar_disk_bytes(
+    layout: &SidecarLayout,
+    generation: &str,
+    collection: &str,
+    scip_dir: &Path,
+) -> Option<i64> {
     Some(
-        dir_size_bytes(&layout.zoekt_data_dir)
-            .saturating_add(dir_size_bytes(&layout.qdrant_data_dir))
-            .saturating_add(dir_size_bytes(scip_dir)) as i64,
+        dir_size_bytes(&crate::zoekt_index::shard_dir_for(
+            &layout.zoekt_data_dir,
+            generation,
+        ))
+        .saturating_add(dir_size_bytes(
+            &layout.qdrant_data_dir.join("collections").join(collection),
+        ))
+        .saturating_add(dir_size_bytes(scip_dir)) as i64,
     )
 }
 
@@ -843,9 +898,11 @@ fn qdrant_ready_point_count(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn persist_finalized_manifest(
     project_root: &Path,
     storage_path: &Path,
+    retention_context: &GenerationRetentionContext<'_>,
     sidecar_input: &SidecarInputFingerprint,
     project_id: String,
     mut manifest: RetrievalIndexManifest,
@@ -865,6 +922,10 @@ fn persist_finalized_manifest(
     storage
         .upsert_retrieval_index_manifest(&manifest)
         .context("persist retrieval_index_manifest")?;
+    drop(storage);
+
+    let (generation_retention_plan, generation_retention) =
+        retain_published_generations(storage_path, retention_context, &project_id, &manifest);
 
     info!(
         project_id = %project_id,
@@ -882,7 +943,103 @@ fn persist_finalized_manifest(
         zoekt_stubbed: stub_flags.zoekt_stubbed,
         qdrant_stubbed: stub_flags.qdrant_stubbed,
         scip_stubbed: stub_flags.scip_stubbed,
+        generation_retention_plan,
+        generation_retention,
     })
+}
+
+fn retain_published_generations(
+    storage_path: &Path,
+    context: &GenerationRetentionContext<'_>,
+    project_id: &str,
+    active: &RetrievalIndexManifest,
+) -> (GenerationRetentionPlan, GenerationRetentionApplyReport) {
+    let now = Utc::now().timestamp_millis();
+    let mut errors = Vec::new();
+    let existing_marker =
+        match read_retention_marker(&context.layout.state_file, context.workspace_id) {
+            Ok(marker) => marker,
+            Err(error) => {
+                errors.push(format!("read generation retention marker: {error:#}"));
+                None
+            }
+        };
+    let active_generation = active.sidecar_generation.as_deref();
+    let mut candidates = Vec::new();
+    if let Some(previous) = context.previous_manifest {
+        candidates.push(previous.clone());
+    }
+    if let Some(marker) = existing_marker.as_ref() {
+        candidates.push(marker.active.clone());
+        if let Some(rollback) = marker.rollback.as_ref() {
+            candidates.push(rollback.manifest.clone());
+        }
+    }
+    candidates.retain(|candidate| {
+        candidate.project_id == project_id
+            && candidate.sidecar_generation.as_deref() != active_generation
+            && manifest_has_current_sidecar_contract(project_id, candidate)
+    });
+    candidates.sort_by_key(|candidate| candidate.built_at_epoch_ms);
+    candidates.dedup_by(|left, right| left.sidecar_generation == right.sidecar_generation);
+    let verified_previous = candidates.into_iter().rev().find_map(|candidate| {
+        let status = probe_sidecar_health_with_embedding_device(
+            context.layout,
+            project_id,
+            Some(candidate.clone()),
+            context.embedding_device,
+        );
+        (status.retrieval_mode == "full").then_some(VerifiedRollbackManifest {
+            manifest: candidate,
+            verified_at_epoch_ms: now,
+        })
+    });
+
+    let marker = GenerationRetentionMarker::next(
+        context.workspace_id,
+        active.clone(),
+        verified_previous.clone(),
+        now,
+    );
+    match marker {
+        Ok(marker) => {
+            if let Err(error) = write_retention_marker(&context.layout.state_file, &marker) {
+                errors.push(format!("write generation retention marker: {error:#}"));
+            }
+        }
+        Err(error) => errors.push(format!("build generation retention marker: {error:#}")),
+    }
+
+    let mut protection = scan_retention_protection(
+        &crate::config::user_cache_root(),
+        Some(storage_path),
+        &context.layout.state_file,
+    );
+    if let Some(rollback) = verified_previous {
+        protection
+            .authoritative_rollback
+            .push(rollback.manifest.clone());
+        protection.rollback.push(rollback.manifest);
+    }
+    protection.errors.extend(errors);
+    let live_qdrant_collections = match QdrantClient::new(context.layout).list_collection_names() {
+        Ok(collections) => collections,
+        Err(error) => {
+            protection.errors.push(format!(
+                "list live Qdrant collections for retention: {error:#}"
+            ));
+            Vec::new()
+        }
+    };
+    let plan = plan_generation_retention_with_qdrant_collections(
+        context.layout,
+        project_id,
+        &protection,
+        &live_qdrant_collections,
+    );
+    let mut remover = FsQdrantGenerationRemover::new(context.layout);
+    let apply = apply_generation_retention(&plan, &mut remover);
+    (plan, apply)
 }
 
 pub(crate) fn compute_sidecar_input_fingerprint(

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -1,7 +1,17 @@
 use crate::compose::{EmbedModelInventory, embed_model_inventory};
 use crate::config::{SidecarRuntimeConfig, user_cache_root};
+use crate::generation::{manifest_has_current_sidecar_contract, manifest_unavailable_reason};
+use crate::health::probe_sidecar_health_with_embedding_device;
+use crate::qdrant_client::QdrantClient;
+use crate::retention::{
+    FsQdrantGenerationRemover, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport,
+    GenerationRetentionLock, GenerationRetentionPlan, apply_generation_retention,
+    global_generation_gc_state_file, plan_generation_retention_with_qdrant_collections,
+    scan_retention_protection,
+};
 use crate::sidecar::SidecarStateFile;
 use anyhow::{Context, Result};
+use codestory_store::Store;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -75,6 +85,8 @@ pub struct SidecarInventoryReport {
     pub docker_error: Option<String>,
     pub cache_root: String,
     pub namespaces: Vec<SidecarInventoryEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation_retention: Option<GenerationRetentionPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -100,6 +112,8 @@ pub struct SidecarGcReport {
     pub removed: Vec<SidecarGcNamespaceResult>,
     pub blocked: Vec<SidecarGcNamespaceResult>,
     pub namespaces: Vec<SidecarInventoryEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation_retention: Option<GenerationRetentionApplyReport>,
 }
 
 #[derive(Debug, Clone)]
@@ -122,6 +136,20 @@ pub fn sidecar_inventory(project_root: &Path) -> Result<SidecarInventoryReport> 
     sidecar_inventory_with_cache_root(project_root, &user_cache_root())
 }
 
+pub fn sidecar_inventory_with_storage(
+    project_root: &Path,
+    storage_path: &Path,
+) -> Result<SidecarInventoryReport> {
+    let cache_root = user_cache_root();
+    let mut report = sidecar_inventory_with_cache_root(project_root, &cache_root)?;
+    report.generation_retention = Some(generation_retention_plan_for_storage(
+        project_root,
+        storage_path,
+        &cache_root,
+    )?);
+    Ok(report)
+}
+
 pub fn sidecar_inventory_with_cache_root(
     project_root: &Path,
     cache_root: &Path,
@@ -137,6 +165,25 @@ pub fn sidecar_inventory_with_cache_root(
 
 pub fn sidecar_gc_apply(project_root: &Path) -> Result<SidecarGcReport> {
     sidecar_gc_apply_with_cache_root(project_root, &user_cache_root())
+}
+
+pub fn sidecar_gc_apply_with_storage(
+    project_root: &Path,
+    storage_path: &Path,
+) -> Result<SidecarGcReport> {
+    let cache_root = user_cache_root();
+    let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
+    let global_gc_state_file = global_generation_gc_state_file(&runtime);
+    let _global_gc_lock =
+        GenerationRetentionLock::acquire(&global_gc_state_file, GLOBAL_GENERATION_GC_LOCK_SCOPE)
+            .context("coordinate global sidecar cleanup with generation publication")?;
+    let mut report = sidecar_gc_apply_with_cache_root(project_root, &cache_root)?;
+    report.generation_retention = Some(apply_generation_retention_for_storage(
+        project_root,
+        storage_path,
+        &cache_root,
+    )?);
+    Ok(report)
 }
 
 pub fn sidecar_gc_apply_with_cache_root(
@@ -208,6 +255,7 @@ fn build_inventory_with_model(
         docker_error: docker.error,
         cache_root: cache_root.display().to_string(),
         namespaces: entries,
+        generation_retention: None,
     }
 }
 
@@ -332,6 +380,133 @@ fn apply_inventory(
         removed,
         blocked,
         namespaces: rows.into_iter().map(|(_, entry)| entry).collect(),
+        generation_retention: None,
+    }
+}
+
+fn generation_retention_plan_for_storage(
+    project_root: &Path,
+    storage_path: &Path,
+    cache_root: &Path,
+) -> Result<GenerationRetentionPlan> {
+    let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
+    let layout = &runtime.layout;
+    let project_id = crate::index::sidecar_project_id_for_root(project_root);
+    let _lock = GenerationRetentionLock::acquire(&layout.state_file, &project_id)
+        .context("lock sidecar generation inventory")?;
+    Ok(build_generation_retention_plan(
+        storage_path,
+        cache_root,
+        &runtime,
+        &project_id,
+    ))
+}
+
+fn apply_generation_retention_for_storage(
+    project_root: &Path,
+    storage_path: &Path,
+    cache_root: &Path,
+) -> Result<GenerationRetentionApplyReport> {
+    let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
+    let project_id = crate::index::sidecar_project_id_for_root(project_root);
+    let _lock = GenerationRetentionLock::acquire(&runtime.layout.state_file, &project_id)
+        .context("lock sidecar generation retention apply")?;
+    let plan = build_generation_retention_plan(storage_path, cache_root, &runtime, &project_id);
+    let mut remover = FsQdrantGenerationRemover::new(&runtime.layout);
+    Ok(apply_generation_retention(&plan, &mut remover))
+}
+
+fn build_generation_retention_plan(
+    storage_path: &Path,
+    cache_root: &Path,
+    runtime: &SidecarRuntimeConfig,
+    project_id: &str,
+) -> GenerationRetentionPlan {
+    let layout = &runtime.layout;
+    let mut protection =
+        scan_retention_protection(cache_root, Some(storage_path), &layout.state_file);
+    let manifest = if storage_path.is_file() {
+        match Store::open(storage_path) {
+            Ok(store) => match store.get_retrieval_index_manifest(project_id) {
+                Ok(Some(manifest)) => {
+                    record_manifest_retention_freshness(
+                        &store,
+                        project_id,
+                        &manifest,
+                        &mut protection.errors,
+                    );
+                    Some(manifest)
+                }
+                Ok(None) => None,
+                Err(error) => {
+                    protection
+                        .errors
+                        .push(format!("load active manifest for retention: {error:#}"));
+                    None
+                }
+            },
+            Err(error) => {
+                protection
+                    .errors
+                    .push(format!("open active storage for retention: {error:#}"));
+                None
+            }
+        }
+    } else {
+        None
+    };
+    match manifest {
+        Some(manifest) if manifest_has_current_sidecar_contract(project_id, &manifest) => {
+            let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
+            let health = probe_sidecar_health_with_embedding_device(
+                layout,
+                project_id,
+                Some(manifest),
+                &embedding_device,
+            );
+            if health.retrieval_mode != "full" {
+                protection.errors.push(format!(
+                    "active generation is not verified full; pruning suppressed: mode={} reason={}",
+                    health.retrieval_mode,
+                    health.degraded_reason.as_deref().unwrap_or("unknown")
+                ));
+            }
+        }
+        Some(_) => protection.errors.push(
+            "active retrieval manifest does not satisfy the current sidecar contract; pruning suppressed"
+                .to_string(),
+        ),
+        None => protection
+            .errors
+            .push("active retrieval manifest is unavailable; pruning suppressed".to_string()),
+    }
+    let live_qdrant_collections = match QdrantClient::new(layout).list_collection_names() {
+        Ok(collections) => collections,
+        Err(error) => {
+            protection.errors.push(format!(
+                "list live Qdrant collections for retention: {error:#}"
+            ));
+            Vec::new()
+        }
+    };
+    plan_generation_retention_with_qdrant_collections(
+        layout,
+        project_id,
+        &protection,
+        &live_qdrant_collections,
+    )
+}
+
+fn record_manifest_retention_freshness(
+    store: &Store,
+    project_id: &str,
+    manifest: &codestory_store::RetrievalIndexManifest,
+    errors: &mut Vec<String>,
+) {
+    if let Some(reason) = manifest_unavailable_reason(project_id, store, manifest) {
+        errors.push(format!(
+            "active retrieval manifest is stale; pruning suppressed: {reason}"
+        ));
     }
 }
 
@@ -838,6 +1013,22 @@ fn labels_from_value(value: Option<&serde_json::Value>) -> BTreeMap<String, Stri
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn stale_active_manifest_records_a_pruning_suppression_error() {
+        let root = tempdir().expect("root");
+        let store = Store::open(root.path().join("codestory.db")).expect("store");
+        let project_id = "repo-v1-project";
+        let mut manifest = crate::test_support::retrieval_manifest_fixture(project_id, "input");
+        manifest.embedding_dim = Some(1);
+        let mut errors = Vec::new();
+
+        record_manifest_retention_freshness(&store, project_id, &manifest, &mut errors);
+
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("active retrieval manifest is stale; pruning suppressed"));
+        assert!(errors[0].contains("sidecar_embedding_dim_changed"));
+    }
 
     fn write_state(path: &Path, state: &SidecarStateFile) {
         std::fs::create_dir_all(path.parent().expect("state parent")).expect("state parent");

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -28,6 +28,7 @@ mod qdrant_storage;
 mod query;
 mod query_features;
 mod ranker;
+mod retention;
 mod scip_client;
 mod scip_index;
 mod sidecar;
@@ -78,7 +79,7 @@ pub use index::{
 pub use inventory::{
     SidecarDockerResource, SidecarDockerResourceKind, SidecarGcNamespaceResult, SidecarGcReport,
     SidecarInventoryEntry, SidecarInventoryReport, SidecarInventoryState, sidecar_gc_apply,
-    sidecar_inventory,
+    sidecar_gc_apply_with_storage, sidecar_inventory, sidecar_inventory_with_storage,
 };
 pub use mode::RetrievalDegradedMode;
 pub use mode::derive_degraded_mode;
@@ -89,7 +90,8 @@ pub use qdrant_client::{
 };
 pub use qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION,
-    PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR, QdrantStorageRepairReport, repair_qdrant_storage,
+    PRUNE_SUPPRESSED_POST_PUBLICATION_RETENTION, PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR,
+    QdrantStorageRepairReport, repair_qdrant_storage,
 };
 pub use query::{
     QueryBatchItem, QueryBatchRequest, QueryRequest, execute_retrieval_query,
@@ -97,6 +99,7 @@ pub use query::{
 };
 pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
+pub use retention::{GenerationRetentionApplyReport, GenerationRetentionPlan};
 pub use scip_client::ScipClient;
 pub use sidecar::{
     NativeEmbeddingLaunchIdentityStatus, SidecarStateFile, ensure_native_embedding_launch_identity,

--- a/crates/codestory-retrieval/src/qdrant_client.rs
+++ b/crates/codestory-retrieval/src/qdrant_client.rs
@@ -37,6 +37,12 @@ pub struct QdrantHealthProbe {
     pub detail: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QdrantDeleteOutcome {
+    Deleted,
+    NotFound,
+}
+
 #[derive(Debug, Clone)]
 pub struct QdrantClient {
     base_url: String,
@@ -223,20 +229,31 @@ impl QdrantClient {
 
     /// Drop collection when embedding backend/dim changes (idempotent).
     pub fn delete_collection(&self, collection: &str) -> Result<()> {
+        self.delete_collection_with_outcome(collection).map(|_| ())
+    }
+
+    pub(crate) fn delete_collection_with_outcome(
+        &self,
+        collection: &str,
+    ) -> Result<QdrantDeleteOutcome> {
         let url = format!("{}/collections/{collection}", self.base_url);
         match read_text(ureq::delete(&url).timeout(QDRANT_MUTATION_BUDGET).call()) {
             Ok(response) => {
                 let status = response.status;
-                if status == 200 || status == 404 {
+                if status == 200 {
                     self.clear_collection_stub_marker(collection);
-                    return Ok(());
+                    return Ok(QdrantDeleteOutcome::Deleted);
+                }
+                if status == 404 {
+                    self.clear_collection_stub_marker(collection);
+                    return Ok(QdrantDeleteOutcome::NotFound);
                 }
                 bail!("delete collection http {status}");
             }
             Err(error) => {
                 if error.is_status(404) {
                     self.clear_collection_stub_marker(collection);
-                    return Ok(());
+                    return Ok(QdrantDeleteOutcome::NotFound);
                 }
                 bail!("delete collection request failed: {error}")
             }

--- a/crates/codestory-retrieval/src/qdrant_storage.rs
+++ b/crates/codestory-retrieval/src/qdrant_storage.rs
@@ -9,11 +9,13 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, warn};
 
-/// Default cap for `codestory_*` collections; protected manifest collections are never pruned.
-pub const DEFAULT_QDRANT_COLLECTION_RETENTION: usize = 64;
+/// Bootstrap repairs invalid storage only. Valid generation retention runs after publication.
+pub const DEFAULT_QDRANT_COLLECTION_RETENTION: usize = 0;
 
 /// Machine-readable reason when retention deletes are skipped after protection-scan errors.
 pub const PRUNE_SUPPRESSED_PROTECTION_SCAN_ERROR: &str = "protection_scan_error";
+pub const PRUNE_SUPPRESSED_POST_PUBLICATION_RETENTION: &str =
+    "post_publication_generation_retention";
 
 /// Inputs for manifest-aware Qdrant collection protection during bootstrap repair.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -87,7 +89,9 @@ pub fn repair_qdrant_storage(
             (0, 0)
         };
 
-    let prune_suppressed_reason = prune_suppressed_reason(&scan.scan_errors);
+    let prune_suppressed_reason = prune_suppressed_reason(&scan.scan_errors).or_else(|| {
+        (max_keep == 0).then(|| PRUNE_SUPPRESSED_POST_PUBLICATION_RETENTION.to_string())
+    });
     let suppress_prune = prune_suppressed_reason.is_some();
 
     let (pruned, collections_seen, prune_candidates, overflow_protected) = if suppress_prune {
@@ -97,7 +101,7 @@ pub fn repair_qdrant_storage(
             probe.reachable,
             &protected,
             &scan.recency_by_collection,
-            max_keep,
+            if max_keep == 0 { usize::MAX } else { max_keep },
         )?
     } else if probe.reachable {
         execute_retention_via_http(
@@ -842,6 +846,47 @@ mod tests {
         );
         assert_eq!(report.pruned_collections, 0);
         assert!(collections.join("codestory_prune_64").exists());
+    }
+
+    #[test]
+    fn bootstrap_default_defers_valid_collection_pruning_until_publication() {
+        let cache_root = tempdir().expect("cache");
+        let qdrant_data = tempdir().expect("qdrant data");
+        let collections = qdrant_data.path().join("collections");
+        for index in 0..3 {
+            touch_collection(
+                &collections,
+                &format!("codestory_deferred_{index:02}"),
+                true,
+            );
+        }
+        let scope = BootstrapStorageScope {
+            repo_root: None,
+            active_storage_path: None,
+            active_cache_root: Some(cache_root.path().to_path_buf()),
+            global_cache_root: cache_root.path().to_path_buf(),
+        };
+
+        let report = repair_qdrant_storage(
+            &offline_test_layout(&qdrant_data),
+            &scope,
+            DEFAULT_QDRANT_COLLECTION_RETENTION,
+        )
+        .expect("bootstrap repair");
+
+        assert_eq!(report.pruned_collections, 0);
+        assert_eq!(report.prune_candidates, 0);
+        assert_eq!(
+            report.prune_suppressed_reason.as_deref(),
+            Some(PRUNE_SUPPRESSED_POST_PUBLICATION_RETENTION)
+        );
+        for index in 0..3 {
+            assert!(
+                collections
+                    .join(format!("codestory_deferred_{index:02}"))
+                    .is_dir()
+            );
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -1,0 +1,1683 @@
+//! Bounded, post-publication retention for one sidecar namespace.
+
+use crate::config::{SidecarLayout, SidecarProfile, SidecarRuntimeConfig};
+use crate::qdrant_client::{QdrantClient, QdrantDeleteOutcome};
+use anyhow::{Context, Result, bail};
+use codestory_store::{RetrievalIndexManifest, Store};
+use fs4::fs_std::FileExt;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+const RETENTION_SCHEMA_VERSION: u32 = 1;
+const RETENTION_DIR: &str = "retention";
+pub const GLOBAL_GENERATION_GC_LOCK_SCOPE: &str = "global_generation_gc";
+
+pub fn global_generation_gc_state_file(runtime: &SidecarRuntimeConfig) -> PathBuf {
+    let base = match runtime.profile {
+        SidecarProfile::Local => runtime.layout.state_file.parent(),
+        SidecarProfile::Agent => runtime
+            .layout
+            .state_file
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::parent),
+    }
+    .unwrap_or_else(|| Path::new("."));
+    base.join("generation-retention-coordination.state")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifiedRollbackManifest {
+    pub manifest: RetrievalIndexManifest,
+    pub verified_at_epoch_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerationRetentionMarker {
+    pub schema_version: u32,
+    pub workspace_id: String,
+    pub project_id: String,
+    pub active: RetrievalIndexManifest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rollback: Option<VerifiedRollbackManifest>,
+    pub updated_at_epoch_ms: i64,
+}
+
+impl GenerationRetentionMarker {
+    pub fn next(
+        workspace_id: &str,
+        active: RetrievalIndexManifest,
+        verified_previous: Option<VerifiedRollbackManifest>,
+        updated_at_epoch_ms: i64,
+    ) -> Result<Self> {
+        validate_retention_component(workspace_id)?;
+        let active_generation = canonical_manifest_generation(&active)?;
+        let rollback = verified_previous.filter(|rollback| {
+            rollback.manifest.project_id == active.project_id
+                && canonical_manifest_generation(&rollback.manifest)
+                    .ok()
+                    .is_some_and(|generation| generation != active_generation)
+        });
+        let marker = Self {
+            schema_version: RETENTION_SCHEMA_VERSION,
+            workspace_id: workspace_id.to_string(),
+            project_id: active.project_id.clone(),
+            active,
+            rollback,
+            updated_at_epoch_ms,
+        };
+        validate_marker(&marker)?;
+        Ok(marker)
+    }
+}
+
+pub struct GenerationRetentionLock {
+    file: File,
+}
+
+impl GenerationRetentionLock {
+    pub fn acquire(state_file: &Path, scope_id: &str) -> Result<Self> {
+        Self::acquire_with_mode(state_file, scope_id, false)
+    }
+
+    pub fn acquire_shared(state_file: &Path, scope_id: &str) -> Result<Self> {
+        Self::acquire_with_mode(state_file, scope_id, true)
+    }
+
+    fn acquire_with_mode(state_file: &Path, scope_id: &str, shared: bool) -> Result<Self> {
+        let path = retention_lock_path(state_file, scope_id)?;
+        ensure_retention_dir(state_file)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("open generation retention lock {}", path.display()))?;
+        if shared {
+            FileExt::lock_shared(&file)
+                .with_context(|| format!("lock shared generation retention {}", path.display()))?;
+        } else {
+            FileExt::lock_exclusive(&file)
+                .with_context(|| format!("lock generation retention {}", path.display()))?;
+        }
+        Ok(Self { file })
+    }
+}
+
+impl Drop for GenerationRetentionLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+pub fn retention_marker_path(state_file: &Path, workspace_id: &str) -> Result<PathBuf> {
+    validate_retention_component(workspace_id)?;
+    Ok(retention_dir(state_file).join(format!("{workspace_id}.json")))
+}
+
+pub fn retention_lock_path(state_file: &Path, scope_id: &str) -> Result<PathBuf> {
+    validate_retention_component(scope_id)?;
+    Ok(retention_dir(state_file).join(format!("{scope_id}.lock")))
+}
+
+pub fn read_retention_marker(
+    state_file: &Path,
+    workspace_id: &str,
+) -> Result<Option<GenerationRetentionMarker>> {
+    let path = retention_marker_path(state_file, workspace_id)?;
+    read_marker_path(&path)
+}
+
+pub fn write_retention_marker(
+    state_file: &Path,
+    marker: &GenerationRetentionMarker,
+) -> Result<PathBuf> {
+    validate_marker(marker)?;
+    ensure_retention_dir(state_file)?;
+    let path = retention_marker_path(state_file, &marker.workspace_id)?;
+    let bytes =
+        serde_json::to_vec_pretty(marker).context("serialize generation retention marker")?;
+    codestory_workspace::atomic_file::write_file_atomic(
+        &path,
+        "generation-retention",
+        |file| {
+            use std::io::Write;
+            file.write_all(&bytes)
+                .context("write generation retention marker")
+        },
+        |temp_path| {
+            let candidate: GenerationRetentionMarker = serde_json::from_slice(
+                &std::fs::read(temp_path).context("read temporary retention marker")?,
+            )
+            .context("parse temporary retention marker")?;
+            validate_marker(&candidate)?;
+            if &candidate != marker {
+                bail!("temporary generation retention marker differs from expected marker");
+            }
+            Ok(())
+        },
+    )
+    .with_context(|| format!("publish generation retention marker {}", path.display()))?;
+    Ok(path)
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetentionProtectionScan {
+    /// Manifests from the storage path explicitly requested by the caller.
+    pub authoritative_active: Vec<RetrievalIndexManifest>,
+    /// A rollback re-verified during the current publication, when available.
+    pub authoritative_rollback: Vec<RetrievalIndexManifest>,
+    /// Other manifest-referenced active generations sharing the sidecar scope.
+    pub active: Vec<RetrievalIndexManifest>,
+    pub rollback: Vec<RetrievalIndexManifest>,
+    pub storage_paths_scanned: Vec<PathBuf>,
+    pub marker_paths_scanned: Vec<PathBuf>,
+    pub errors: Vec<String>,
+}
+
+pub fn scan_retention_protection(
+    cache_root: &Path,
+    active_storage_path: Option<&Path>,
+    state_file: &Path,
+) -> RetentionProtectionScan {
+    let mut scan = RetentionProtectionScan::default();
+    let storage_paths = storage_paths_for_scan(cache_root, active_storage_path, &mut scan.errors);
+    for storage_path in storage_paths {
+        match Store::open(&storage_path).and_then(|store| store.list_retrieval_index_manifests()) {
+            Ok(manifests) => {
+                if active_storage_path.is_some_and(|active| active == storage_path) {
+                    scan.authoritative_active.extend(manifests.clone());
+                }
+                scan.storage_paths_scanned.push(storage_path);
+                scan.active.extend(manifests);
+            }
+            Err(error) => scan.errors.push(format!(
+                "scan retrieval manifests in {}: {error}",
+                storage_path.display()
+            )),
+        }
+    }
+
+    let marker_dir = retention_dir(state_file);
+    match std::fs::symlink_metadata(&marker_dir) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            scan.errors.push(format!(
+                "retention marker path is not a direct directory: {}",
+                marker_dir.display()
+            ));
+        }
+        Ok(_) => match std::fs::read_dir(&marker_dir) {
+            Ok(entries) => {
+                for entry in entries {
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(error) => {
+                            scan.errors.push(format!(
+                                "read retention marker entry in {}: {error}",
+                                marker_dir.display()
+                            ));
+                            continue;
+                        }
+                    };
+                    let path = entry.path();
+                    if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                        continue;
+                    }
+                    let file_type = match entry.file_type() {
+                        Ok(file_type) => file_type,
+                        Err(error) => {
+                            scan.errors.push(format!(
+                                "read retention marker type {}: {error}",
+                                path.display()
+                            ));
+                            continue;
+                        }
+                    };
+                    if file_type.is_symlink() || !file_type.is_file() {
+                        scan.errors.push(format!(
+                            "retention marker is not a direct regular file: {}",
+                            path.display()
+                        ));
+                        continue;
+                    }
+                    match read_marker_path(&path) {
+                        Ok(Some(marker)) => {
+                            scan.marker_paths_scanned.push(path);
+                            scan.active.push(marker.active);
+                            if let Some(rollback) = marker.rollback {
+                                scan.rollback.push(rollback.manifest);
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(error) => scan.errors.push(format!(
+                            "scan retention marker {}: {error:#}",
+                            path.display()
+                        )),
+                    }
+                }
+            }
+            Err(error) => scan.errors.push(format!(
+                "read retention marker directory {}: {error}",
+                marker_dir.display()
+            )),
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => scan.errors.push(format!(
+            "inspect retention marker directory {}: {error}",
+            marker_dir.display()
+        )),
+    }
+    deduplicate_manifests(&mut scan.active);
+    deduplicate_manifests(&mut scan.rollback);
+    deduplicate_manifests(&mut scan.authoritative_active);
+    deduplicate_manifests(&mut scan.authoritative_rollback);
+    scan
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GenerationRetentionState {
+    Active,
+    Rollback,
+    Reclaimable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerationArtifact {
+    pub path: PathBuf,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerationBundle {
+    pub generation: String,
+    pub qdrant_collection: String,
+    pub state: GenerationRetentionState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lexical: Option<GenerationArtifact>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scip: Option<GenerationArtifact>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qdrant: Option<GenerationArtifact>,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockedGenerationEntry {
+    pub path: PathBuf,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerationRetentionPlan {
+    pub dry_run: bool,
+    pub project_id: String,
+    pub pruning_suppressed: bool,
+    pub retained_bytes: u64,
+    pub reclaimable_bytes: u64,
+    pub bundles: Vec<GenerationBundle>,
+    pub blocked: Vec<BlockedGenerationEntry>,
+    pub errors: Vec<String>,
+}
+
+#[cfg(test)]
+fn plan_generation_retention(
+    layout: &SidecarLayout,
+    project_id: &str,
+    protection: &RetentionProtectionScan,
+) -> GenerationRetentionPlan {
+    plan_generation_retention_with_qdrant_collections(layout, project_id, protection, &[])
+}
+
+/// Build a dry-run plan, supplementing on-disk Qdrant discovery with names
+/// returned by the live Qdrant API.
+pub fn plan_generation_retention_with_qdrant_collections(
+    layout: &SidecarLayout,
+    project_id: &str,
+    protection: &RetentionProtectionScan,
+    live_qdrant_collections: &[String],
+) -> GenerationRetentionPlan {
+    let mut errors = protection.errors.clone();
+    let mut blocked = Vec::new();
+    let mut builders = BTreeMap::<String, BundleBuilder>::new();
+    if direct_directory_exists_or_missing(&layout.zoekt_data_dir, "Zoekt data root", &mut errors) {
+        discover_generation_dirs(
+            &layout.zoekt_data_dir.join("shards"),
+            project_id,
+            ArtifactKind::Lexical,
+            &mut builders,
+            &mut blocked,
+            &mut errors,
+        );
+    }
+    discover_generation_dirs(
+        &layout.scip_artifacts_root,
+        project_id,
+        ArtifactKind::Scip,
+        &mut builders,
+        &mut blocked,
+        &mut errors,
+    );
+    if direct_directory_exists_or_missing(&layout.qdrant_data_dir, "Qdrant data root", &mut errors)
+    {
+        discover_qdrant_collections(
+            &layout.qdrant_data_dir.join("collections"),
+            project_id,
+            &mut builders,
+            &mut blocked,
+            &mut errors,
+        );
+    }
+    discover_live_qdrant_collections(
+        live_qdrant_collections,
+        project_id,
+        &mut builders,
+        &mut blocked,
+        &mut errors,
+    );
+
+    let mut active = BTreeSet::new();
+    let mut rollback = BTreeSet::new();
+    collect_protected_generations(
+        project_id,
+        &protection.authoritative_active,
+        &mut active,
+        &mut errors,
+        "active",
+    );
+    collect_protected_generations(
+        project_id,
+        &protection.active,
+        &mut active,
+        &mut errors,
+        "shared active",
+    );
+    let rollback_evidence = if protection.authoritative_rollback.is_empty() {
+        &protection.rollback
+    } else {
+        &protection.authoritative_rollback
+    };
+    collect_latest_protected_generation(
+        project_id,
+        rollback_evidence,
+        &mut rollback,
+        &mut errors,
+        "rollback",
+    );
+    if active.is_empty() {
+        errors.push(format!(
+            "no active generation is protected for project {project_id}; pruning suppressed"
+        ));
+    }
+    for generation in active.iter().chain(rollback.iter()) {
+        builders.entry(generation.clone()).or_default();
+    }
+
+    let mut bundles = builders
+        .into_iter()
+        .map(|(generation, builder)| {
+            let state = if active.contains(&generation) {
+                GenerationRetentionState::Active
+            } else if rollback.contains(&generation) {
+                GenerationRetentionState::Rollback
+            } else {
+                GenerationRetentionState::Reclaimable
+            };
+            builder.finish(project_id, generation, state)
+        })
+        .collect::<Vec<_>>();
+    bundles.sort_by(|left, right| left.generation.cmp(&right.generation));
+    let retained_bytes = bundles
+        .iter()
+        .filter(|bundle| bundle.state != GenerationRetentionState::Reclaimable)
+        .fold(0_u64, |total, bundle| total.saturating_add(bundle.bytes));
+    let reclaimable_bytes = bundles
+        .iter()
+        .filter(|bundle| bundle.state == GenerationRetentionState::Reclaimable)
+        .fold(0_u64, |total, bundle| total.saturating_add(bundle.bytes));
+
+    GenerationRetentionPlan {
+        dry_run: true,
+        project_id: project_id.to_string(),
+        pruning_suppressed: !errors.is_empty(),
+        retained_bytes,
+        reclaimable_bytes,
+        bundles,
+        blocked,
+        errors,
+    }
+}
+
+pub trait GenerationRemover {
+    fn remove_generation_dir(&mut self, path: &Path) -> Result<()>;
+    fn delete_qdrant_collection(&mut self, collection: &str) -> Result<bool>;
+}
+
+pub struct FsQdrantGenerationRemover {
+    qdrant: QdrantClient,
+    collections_dir: PathBuf,
+}
+
+impl FsQdrantGenerationRemover {
+    pub fn new(layout: &SidecarLayout) -> Self {
+        Self {
+            qdrant: QdrantClient::new(layout),
+            collections_dir: layout.qdrant_data_dir.join("collections"),
+        }
+    }
+}
+
+impl GenerationRemover for FsQdrantGenerationRemover {
+    fn remove_generation_dir(&mut self, path: &Path) -> Result<()> {
+        let metadata = std::fs::symlink_metadata(path)
+            .with_context(|| format!("inspect generation directory {}", path.display()))?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            bail!(
+                "refuse to remove non-direct generation directory {}",
+                path.display()
+            );
+        }
+        std::fs::remove_dir_all(path)
+            .with_context(|| format!("remove generation directory {}", path.display()))
+    }
+
+    fn delete_qdrant_collection(&mut self, collection: &str) -> Result<bool> {
+        let outcome = self.qdrant.delete_collection_with_outcome(collection)?;
+        let path = self.collections_dir.join(collection);
+        if outcome == QdrantDeleteOutcome::NotFound && path.exists() {
+            let metadata = std::fs::symlink_metadata(&path)
+                .with_context(|| format!("inspect orphan Qdrant collection {}", path.display()))?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                bail!(
+                    "refuse to remove non-direct orphan Qdrant collection {}",
+                    path.display()
+                );
+            }
+            std::fs::remove_dir_all(&path)
+                .with_context(|| format!("remove orphan Qdrant collection {}", path.display()))?;
+        }
+        Ok(!path.exists())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerationRemovalResult {
+    pub generation: String,
+    pub qdrant_collection: String,
+    pub removed_paths: Vec<PathBuf>,
+    pub qdrant_collection_removed: bool,
+    pub removed_bytes: u64,
+    pub remaining_reclaimable_bytes: u64,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenerationRetentionApplyReport {
+    pub dry_run: bool,
+    pub project_id: String,
+    pub pruning_suppressed: bool,
+    pub retained_bytes: u64,
+    pub reclaimable_bytes: u64,
+    pub removed_bytes: u64,
+    pub remaining_reclaimable_bytes: u64,
+    pub removals: Vec<GenerationRemovalResult>,
+    pub errors: Vec<String>,
+}
+
+pub fn apply_generation_retention(
+    plan: &GenerationRetentionPlan,
+    remover: &mut dyn GenerationRemover,
+) -> GenerationRetentionApplyReport {
+    if plan.pruning_suppressed {
+        return GenerationRetentionApplyReport {
+            dry_run: false,
+            project_id: plan.project_id.clone(),
+            pruning_suppressed: true,
+            retained_bytes: plan.retained_bytes,
+            reclaimable_bytes: plan.reclaimable_bytes,
+            removed_bytes: 0,
+            remaining_reclaimable_bytes: plan.reclaimable_bytes,
+            removals: Vec::new(),
+            errors: plan.errors.clone(),
+        };
+    }
+
+    let mut removed_bytes = 0_u64;
+    let mut removals = Vec::new();
+    for bundle in plan
+        .bundles
+        .iter()
+        .filter(|bundle| bundle.state == GenerationRetentionState::Reclaimable)
+    {
+        let mut result = GenerationRemovalResult {
+            generation: bundle.generation.clone(),
+            qdrant_collection: bundle.qdrant_collection.clone(),
+            removed_paths: Vec::new(),
+            qdrant_collection_removed: false,
+            removed_bytes: 0,
+            remaining_reclaimable_bytes: bundle.bytes,
+            errors: Vec::new(),
+        };
+        match remover.delete_qdrant_collection(&bundle.qdrant_collection) {
+            Ok(true) => {
+                result.qdrant_collection_removed = true;
+                result.removed_bytes = result
+                    .removed_bytes
+                    .saturating_add(bundle.qdrant.as_ref().map_or(0, |item| item.bytes));
+            }
+            Ok(false) => result.errors.push(format!(
+                "delete Qdrant collection {} was acknowledged but its local data remains",
+                bundle.qdrant_collection
+            )),
+            Err(error) => result.errors.push(format!(
+                "delete Qdrant collection {}: {error:#}",
+                bundle.qdrant_collection
+            )),
+        }
+        for artifact in [bundle.lexical.as_ref(), bundle.scip.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            match remover.remove_generation_dir(&artifact.path) {
+                Ok(()) => {
+                    result.removed_paths.push(artifact.path.clone());
+                    result.removed_bytes = result.removed_bytes.saturating_add(artifact.bytes);
+                }
+                Err(error) => result.errors.push(format!(
+                    "remove generation path {}: {error:#}",
+                    artifact.path.display()
+                )),
+            }
+        }
+        result.remaining_reclaimable_bytes = bundle.bytes.saturating_sub(result.removed_bytes);
+        removed_bytes = removed_bytes.saturating_add(result.removed_bytes);
+        removals.push(result);
+    }
+    let errors = removals
+        .iter()
+        .flat_map(|result| result.errors.iter().cloned())
+        .collect();
+    GenerationRetentionApplyReport {
+        dry_run: false,
+        project_id: plan.project_id.clone(),
+        pruning_suppressed: false,
+        retained_bytes: plan.retained_bytes,
+        reclaimable_bytes: plan.reclaimable_bytes,
+        removed_bytes,
+        remaining_reclaimable_bytes: plan.reclaimable_bytes.saturating_sub(removed_bytes),
+        removals,
+        errors,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ArtifactKind {
+    Lexical,
+    Scip,
+    Qdrant,
+}
+
+#[derive(Default)]
+struct BundleBuilder {
+    lexical: Option<GenerationArtifact>,
+    scip: Option<GenerationArtifact>,
+    qdrant: Option<GenerationArtifact>,
+}
+
+impl BundleBuilder {
+    fn set(&mut self, kind: ArtifactKind, artifact: GenerationArtifact) {
+        match kind {
+            ArtifactKind::Lexical => self.lexical = Some(artifact),
+            ArtifactKind::Scip => self.scip = Some(artifact),
+            ArtifactKind::Qdrant => self.qdrant = Some(artifact),
+        }
+    }
+
+    fn finish(
+        self,
+        project_id: &str,
+        generation: String,
+        state: GenerationRetentionState,
+    ) -> GenerationBundle {
+        let bytes = [&self.lexical, &self.scip, &self.qdrant]
+            .into_iter()
+            .flatten()
+            .fold(0_u64, |total, artifact| {
+                total.saturating_add(artifact.bytes)
+            });
+        let suffix = generation
+            .strip_prefix(&format!("{project_id}-"))
+            .expect("planned generation is canonical")
+            .to_string();
+        GenerationBundle {
+            generation,
+            qdrant_collection: format!("codestory_{project_id}_{suffix}"),
+            state,
+            lexical: self.lexical,
+            scip: self.scip,
+            qdrant: self.qdrant,
+            bytes,
+        }
+    }
+}
+
+fn retention_dir(state_file: &Path) -> PathBuf {
+    state_file
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(RETENTION_DIR)
+}
+
+fn ensure_retention_dir(state_file: &Path) -> Result<PathBuf> {
+    let path = retention_dir(state_file);
+    match std::fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            bail!(
+                "retention path is not a direct directory: {}",
+                path.display()
+            )
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(&path)
+                .with_context(|| format!("create retention directory {}", path.display()))?;
+            let metadata = std::fs::symlink_metadata(&path)
+                .with_context(|| format!("inspect retention directory {}", path.display()))?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                bail!(
+                    "retention path is not a direct directory: {}",
+                    path.display()
+                );
+            }
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect retention directory {}", path.display()));
+        }
+    }
+    Ok(path)
+}
+
+fn validate_retention_component(component: &str) -> Result<()> {
+    if component.is_empty()
+        || !component
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        bail!("value is not a safe retention path component");
+    }
+    Ok(())
+}
+
+fn validate_marker(marker: &GenerationRetentionMarker) -> Result<()> {
+    if marker.schema_version != RETENTION_SCHEMA_VERSION {
+        bail!("unsupported generation retention marker schema");
+    }
+    validate_retention_component(&marker.workspace_id)?;
+    if marker.project_id != marker.active.project_id {
+        bail!("generation retention marker active project does not match marker project");
+    }
+    let active_generation = canonical_manifest_generation(&marker.active)?;
+    if let Some(rollback) = marker.rollback.as_ref() {
+        if rollback.manifest.project_id != marker.project_id {
+            bail!("generation retention rollback project does not match marker project");
+        }
+        if canonical_manifest_generation(&rollback.manifest)? == active_generation {
+            bail!("generation retention rollback duplicates the active generation");
+        }
+    }
+    Ok(())
+}
+
+fn read_marker_path(path: &Path) -> Result<Option<GenerationRetentionMarker>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let marker: GenerationRetentionMarker = serde_json::from_slice(
+        &std::fs::read(path)
+            .with_context(|| format!("read generation retention marker {}", path.display()))?,
+    )
+    .with_context(|| format!("parse generation retention marker {}", path.display()))?;
+    validate_marker(&marker)?;
+    Ok(Some(marker))
+}
+
+fn canonical_manifest_generation(manifest: &RetrievalIndexManifest) -> Result<String> {
+    let generation = manifest
+        .sidecar_generation
+        .as_deref()
+        .context("retrieval manifest is missing sidecar generation")?;
+    let Some(suffix) = canonical_generation_suffix(&manifest.project_id, generation) else {
+        bail!("retrieval manifest has a noncanonical sidecar generation");
+    };
+    if manifest.qdrant_collection != format!("codestory_{}_{suffix}", manifest.project_id) {
+        bail!("retrieval manifest generation and Qdrant collection do not match");
+    }
+    Ok(generation.to_string())
+}
+
+fn canonical_generation_suffix<'a>(project_id: &str, generation: &'a str) -> Option<&'a str> {
+    canonical_suffix(generation.strip_prefix(&format!("{project_id}-"))?)
+}
+
+fn canonical_collection_suffix<'a>(project_id: &str, collection: &'a str) -> Option<&'a str> {
+    canonical_suffix(collection.strip_prefix(&format!("codestory_{project_id}_"))?)
+}
+
+fn canonical_suffix(suffix: &str) -> Option<&str> {
+    (suffix.len() == 16
+        && suffix
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')))
+    .then_some(suffix)
+}
+
+fn storage_paths_for_scan(
+    cache_root: &Path,
+    active_storage_path: Option<&Path>,
+    errors: &mut Vec<String>,
+) -> BTreeSet<PathBuf> {
+    let mut paths = BTreeSet::new();
+    if let Some(path) = active_storage_path {
+        insert_direct_storage_path(path, "active storage", &mut paths, errors);
+    }
+    let flat = cache_root.join("codestory.db");
+    insert_direct_storage_path(&flat, "flat cache storage", &mut paths, errors);
+    if !cache_root.exists() {
+        return paths;
+    }
+    match std::fs::read_dir(cache_root) {
+        Ok(entries) => {
+            for entry in entries {
+                match entry {
+                    Ok(entry) => {
+                        let file_type = match entry.file_type() {
+                            Ok(file_type) => file_type,
+                            Err(error) => {
+                                errors.push(format!(
+                                    "read cache entry type {}: {error}",
+                                    entry.path().display()
+                                ));
+                                continue;
+                            }
+                        };
+                        if file_type.is_symlink() {
+                            errors.push(format!(
+                                "cache scan refuses linked entry {}",
+                                entry.path().display()
+                            ));
+                            continue;
+                        }
+                        if !file_type.is_dir() {
+                            continue;
+                        }
+                        let path = entry.path().join("codestory.db");
+                        insert_direct_storage_path(
+                            &path,
+                            "project cache storage",
+                            &mut paths,
+                            errors,
+                        );
+                    }
+                    Err(error) => errors.push(format!(
+                        "read cache entry under {}: {error}",
+                        cache_root.display()
+                    )),
+                }
+            }
+        }
+        Err(error) => errors.push(format!(
+            "read cache root {} for retention manifests: {error}",
+            cache_root.display()
+        )),
+    }
+    paths
+}
+
+fn insert_direct_storage_path(
+    path: &Path,
+    label: &str,
+    paths: &mut BTreeSet<PathBuf>,
+    errors: &mut Vec<String>,
+) {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => errors.push(
+            format!("{label} is not a direct regular file: {}", path.display()),
+        ),
+        Ok(_) => {
+            paths.insert(path.to_path_buf());
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => errors.push(format!("inspect {label} {}: {error}", path.display())),
+    }
+}
+
+fn deduplicate_manifests(manifests: &mut Vec<RetrievalIndexManifest>) {
+    manifests.sort_by(|left, right| {
+        (
+            &left.project_id,
+            &left.sidecar_generation,
+            &left.qdrant_collection,
+        )
+            .cmp(&(
+                &right.project_id,
+                &right.sidecar_generation,
+                &right.qdrant_collection,
+            ))
+    });
+    manifests.dedup_by(|left, right| {
+        left.project_id == right.project_id
+            && left.sidecar_generation == right.sidecar_generation
+            && left.qdrant_collection == right.qdrant_collection
+    });
+}
+
+fn collect_protected_generations(
+    project_id: &str,
+    manifests: &[RetrievalIndexManifest],
+    generations: &mut BTreeSet<String>,
+    errors: &mut Vec<String>,
+    role: &str,
+) {
+    for manifest in manifests
+        .iter()
+        .filter(|manifest| manifest.project_id == project_id)
+    {
+        match canonical_manifest_generation(manifest) {
+            Ok(generation) => {
+                generations.insert(generation);
+            }
+            Err(error) => errors.push(format!(
+                "{role} manifest for {project_id} is not safe retention evidence: {error:#}"
+            )),
+        }
+    }
+}
+
+fn collect_latest_protected_generation(
+    project_id: &str,
+    manifests: &[RetrievalIndexManifest],
+    generations: &mut BTreeSet<String>,
+    errors: &mut Vec<String>,
+    role: &str,
+) {
+    let mut candidates = manifests
+        .iter()
+        .filter(|manifest| manifest.project_id == project_id)
+        .filter_map(|manifest| match canonical_manifest_generation(manifest) {
+            Ok(generation) => Some((manifest.built_at_epoch_ms, generation)),
+            Err(error) => {
+                errors.push(format!(
+                    "{role} manifest for {project_id} is not safe retention evidence: {error:#}"
+                ));
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+    if let Some((_, generation)) = candidates.pop() {
+        generations.insert(generation);
+    }
+}
+
+fn discover_generation_dirs(
+    root: &Path,
+    project_id: &str,
+    kind: ArtifactKind,
+    builders: &mut BTreeMap<String, BundleBuilder>,
+    blocked: &mut Vec<BlockedGenerationEntry>,
+    errors: &mut Vec<String>,
+) {
+    let Some(entries) = read_direct_directory(root, "generation root", errors) else {
+        return;
+    };
+    let project_prefix = format!("{project_id}-");
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                errors.push(format!(
+                    "read generation entry in {}: {error}",
+                    root.display()
+                ));
+                continue;
+            }
+        };
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with(&project_prefix) {
+            continue;
+        }
+        let Some(_) = canonical_generation_suffix(project_id, &name) else {
+            block_scoped_entry(path, "malformed generation name", blocked, errors);
+            continue;
+        };
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                errors.push(format!("read generation type {}: {error}", path.display()));
+                continue;
+            }
+        };
+        if file_type.is_symlink() || !file_type.is_dir() {
+            block_scoped_entry(
+                path,
+                "generation entry is not a direct directory",
+                blocked,
+                errors,
+            );
+            continue;
+        }
+        match directory_size(&path) {
+            Ok(bytes) => builders
+                .entry(name)
+                .or_default()
+                .set(kind, GenerationArtifact { path, bytes }),
+            Err(error) => errors.push(format!("measure generation {}: {error:#}", path.display())),
+        }
+    }
+}
+
+fn discover_qdrant_collections(
+    root: &Path,
+    project_id: &str,
+    builders: &mut BTreeMap<String, BundleBuilder>,
+    blocked: &mut Vec<BlockedGenerationEntry>,
+    errors: &mut Vec<String>,
+) {
+    let Some(entries) = read_direct_directory(root, "Qdrant collection root", errors) else {
+        return;
+    };
+    let project_prefix = format!("codestory_{project_id}_");
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                errors.push(format!(
+                    "read Qdrant collection in {}: {error}",
+                    root.display()
+                ));
+                continue;
+            }
+        };
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with(&project_prefix) {
+            continue;
+        }
+        let Some(suffix) = canonical_collection_suffix(project_id, &name) else {
+            block_scoped_entry(path, "malformed Qdrant collection name", blocked, errors);
+            continue;
+        };
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                errors.push(format!(
+                    "read Qdrant collection type {}: {error}",
+                    path.display()
+                ));
+                continue;
+            }
+        };
+        if file_type.is_symlink() || !file_type.is_dir() {
+            block_scoped_entry(
+                path,
+                "Qdrant collection entry is not a direct directory",
+                blocked,
+                errors,
+            );
+            continue;
+        }
+        match directory_size(&path) {
+            Ok(bytes) => builders
+                .entry(format!("{project_id}-{suffix}"))
+                .or_default()
+                .set(ArtifactKind::Qdrant, GenerationArtifact { path, bytes }),
+            Err(error) => errors.push(format!(
+                "measure Qdrant collection {}: {error:#}",
+                path.display()
+            )),
+        }
+    }
+}
+
+fn discover_live_qdrant_collections(
+    collections: &[String],
+    project_id: &str,
+    builders: &mut BTreeMap<String, BundleBuilder>,
+    blocked: &mut Vec<BlockedGenerationEntry>,
+    errors: &mut Vec<String>,
+) {
+    let project_prefix = format!("codestory_{project_id}_");
+    for collection in collections {
+        if !collection.starts_with(&project_prefix) {
+            continue;
+        }
+        let Some(suffix) = canonical_collection_suffix(project_id, collection) else {
+            block_scoped_entry(
+                PathBuf::from(format!("qdrant:{collection}")),
+                "malformed live Qdrant collection name",
+                blocked,
+                errors,
+            );
+            continue;
+        };
+        builders
+            .entry(format!("{project_id}-{suffix}"))
+            .or_default();
+    }
+}
+
+fn block_scoped_entry(
+    path: PathBuf,
+    reason: &str,
+    blocked: &mut Vec<BlockedGenerationEntry>,
+    errors: &mut Vec<String>,
+) {
+    errors.push(format!(
+        "scoped retention entry {} is unsafe: {reason}",
+        path.display()
+    ));
+    blocked.push(BlockedGenerationEntry {
+        path,
+        reason: reason.to_string(),
+    });
+}
+
+fn read_direct_directory(
+    root: &Path,
+    label: &str,
+    errors: &mut Vec<String>,
+) -> Option<std::fs::ReadDir> {
+    match std::fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            errors.push(format!(
+                "{label} is not a direct directory: {}",
+                root.display()
+            ));
+            None
+        }
+        Ok(_) => match std::fs::read_dir(root) {
+            Ok(entries) => Some(entries),
+            Err(error) => {
+                errors.push(format!("read {label} {}: {error}", root.display()));
+                None
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            errors.push(format!("inspect {label} {}: {error}", root.display()));
+            None
+        }
+    }
+}
+
+fn direct_directory_exists_or_missing(root: &Path, label: &str, errors: &mut Vec<String>) -> bool {
+    match std::fs::symlink_metadata(root) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            errors.push(format!(
+                "{label} is not a direct directory: {}",
+                root.display()
+            ));
+            false
+        }
+        Ok(_) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => {
+            errors.push(format!("inspect {label} {}: {error}", root.display()));
+            false
+        }
+    }
+}
+
+fn directory_size(path: &Path) -> Result<u64> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("inspect directory {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!("path is not a direct directory");
+    }
+    let mut total = 0_u64;
+    for entry in
+        std::fs::read_dir(path).with_context(|| format!("read directory {}", path.display()))?
+    {
+        let entry = entry.with_context(|| format!("read entry under {}", path.display()))?;
+        let entry_path = entry.path();
+        let metadata = std::fs::symlink_metadata(&entry_path)
+            .with_context(|| format!("inspect {}", entry_path.display()))?;
+        if metadata.file_type().is_symlink() {
+            bail!("directory contains a link: {}", entry_path.display());
+        }
+        if metadata.is_dir() {
+            total = total.saturating_add(directory_size(&entry_path)?);
+        } else if metadata.is_file() {
+            total = total.saturating_add(metadata.len());
+        } else {
+            bail!(
+                "directory contains an unsupported entry: {}",
+                entry_path.display()
+            );
+        }
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn manifest(project_id: &str, suffix: &str, built_at_epoch_ms: i64) -> RetrievalIndexManifest {
+        RetrievalIndexManifest {
+            project_id: project_id.into(),
+            zoekt_version: "v1".into(),
+            qdrant_collection: format!("codestory_{project_id}_{suffix}"),
+            scip_revision: Some(format!("graph-{suffix}")),
+            built_at_epoch_ms,
+            disk_bytes: None,
+            degraded_modes_json: "[]".into(),
+            embedding_backend: Some("llamacpp:bge-base-en-v1.5".into()),
+            embedding_dim: Some(768),
+            sidecar_schema_version: Some(2),
+            sidecar_input_hash: Some(suffix.repeat(4)),
+            sidecar_generation: Some(format!("{project_id}-{suffix}")),
+            projection_count: Some(1),
+            symbol_doc_count: Some(1),
+            dense_projection_count: Some(1),
+            semantic_policy_version: Some("graph_first_v1".into()),
+            graph_artifact_hash: Some("graph".into()),
+            dense_reason_counts_json: Some("{}".into()),
+            precise_semantic_import_status: None,
+            precise_semantic_import_reason: None,
+            precise_semantic_import_revision: None,
+            precise_semantic_import_producer: None,
+        }
+    }
+
+    fn layout(root: &Path) -> SidecarLayout {
+        SidecarLayout {
+            zoekt_http_port: 9,
+            qdrant_http_port: 9,
+            qdrant_grpc_port: 10,
+            zoekt_data_dir: root.join("zoekt"),
+            qdrant_data_dir: root.join("qdrant"),
+            scip_artifacts_root: root.join("scip"),
+            state_file: root.join("retrieval-sidecars.json"),
+        }
+    }
+
+    fn write_bundle(layout: &SidecarLayout, project_id: &str, suffix: &str, sizes: [usize; 3]) {
+        let generation = format!("{project_id}-{suffix}");
+        let lexical = layout.zoekt_data_dir.join("shards").join(&generation);
+        let scip = layout.scip_artifacts_root.join(&generation);
+        let qdrant = layout
+            .qdrant_data_dir
+            .join("collections")
+            .join(format!("codestory_{project_id}_{suffix}"));
+        for (dir, size) in [(&lexical, sizes[0]), (&scip, sizes[1]), (&qdrant, sizes[2])] {
+            std::fs::create_dir_all(dir).expect("artifact dir");
+            std::fs::write(dir.join("data"), vec![b'x'; size]).expect("artifact bytes");
+        }
+    }
+
+    #[test]
+    fn local_and_agent_profiles_share_one_global_gc_coordination_file() {
+        let root = tempdir().expect("root");
+        let runtime = |profile, state_file| SidecarRuntimeConfig {
+            project_identity: None,
+            layout: SidecarLayout {
+                state_file,
+                ..layout(root.path())
+            },
+            profile,
+            run_id: None,
+            namespace: "test".into(),
+            compose_project: "test".into(),
+            embed_http_port: 0,
+            cleanup_command: String::new(),
+            labels: BTreeMap::new(),
+        };
+        let local = runtime(
+            SidecarProfile::Local,
+            root.path().join("retrieval-sidecars.json"),
+        );
+        let agent = runtime(
+            SidecarProfile::Agent,
+            root.path()
+                .join("sidecars")
+                .join("codestory-agent-test")
+                .join("retrieval-sidecars.json"),
+        );
+
+        assert_eq!(
+            global_generation_gc_state_file(&local),
+            global_generation_gc_state_file(&agent)
+        );
+        assert_eq!(
+            global_generation_gc_state_file(&local),
+            root.path().join("generation-retention-coordination.state")
+        );
+    }
+
+    #[derive(Default)]
+    struct TestRemover {
+        removed_paths: Vec<PathBuf>,
+        removed_collections: Vec<String>,
+        fail_path_fragment: Option<String>,
+        qdrant_data_remains: bool,
+    }
+
+    impl GenerationRemover for TestRemover {
+        fn remove_generation_dir(&mut self, path: &Path) -> Result<()> {
+            if self
+                .fail_path_fragment
+                .as_deref()
+                .is_some_and(|fragment| path.display().to_string().contains(fragment))
+            {
+                bail!("planned path failure");
+            }
+            std::fs::remove_dir_all(path)?;
+            self.removed_paths.push(path.to_path_buf());
+            Ok(())
+        }
+
+        fn delete_qdrant_collection(&mut self, collection: &str) -> Result<bool> {
+            self.removed_collections.push(collection.to_string());
+            Ok(!self.qdrant_data_remains)
+        }
+    }
+
+    #[test]
+    fn active_and_rollback_are_retained_while_stale_bundle_is_removed() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let active = "aaaaaaaaaaaaaaaa";
+        let rollback = "bbbbbbbbbbbbbbbb";
+        let stale = "cccccccccccccccc";
+        write_bundle(&layout, project, active, [1, 2, 3]);
+        write_bundle(&layout, project, rollback, [4, 5, 6]);
+        write_bundle(&layout, project, stale, [7, 8, 9]);
+        let protection = RetentionProtectionScan {
+            authoritative_active: vec![manifest(project, active, 3)],
+            rollback: vec![manifest(project, rollback, 2)],
+            ..RetentionProtectionScan::default()
+        };
+
+        let plan = plan_generation_retention(&layout, project, &protection);
+
+        assert!(!plan.pruning_suppressed);
+        assert_eq!(plan.retained_bytes, 21);
+        assert_eq!(plan.reclaimable_bytes, 24);
+        assert_eq!(
+            plan.bundles
+                .iter()
+                .filter(|bundle| bundle.state == GenerationRetentionState::Reclaimable)
+                .map(|bundle| bundle.generation.as_str())
+                .collect::<Vec<_>>(),
+            vec!["repo-v1-project-cccccccccccccccc"]
+        );
+
+        let mut remover = TestRemover::default();
+        let report = apply_generation_retention(&plan, &mut remover);
+
+        assert_eq!(report.removed_bytes, 24);
+        assert_eq!(report.remaining_reclaimable_bytes, 0);
+        assert_eq!(remover.removed_paths.len(), 2);
+        assert_eq!(
+            remover.removed_collections,
+            vec!["codestory_repo-v1-project_cccccccccccccccc"]
+        );
+        assert!(
+            layout
+                .zoekt_data_dir
+                .join("shards")
+                .join(format!("{project}-{active}"))
+                .is_dir()
+        );
+    }
+
+    #[test]
+    fn shared_active_manifests_remain_protected_while_rollback_is_bounded() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        for suffix in [
+            "aaaaaaaaaaaaaaaa",
+            "bbbbbbbbbbbbbbbb",
+            "cccccccccccccccc",
+            "dddddddddddddddd",
+            "eeeeeeeeeeeeeeee",
+        ] {
+            write_bundle(&layout, project, suffix, [1, 1, 1]);
+        }
+        let protection = RetentionProtectionScan {
+            authoritative_active: vec![manifest(project, "aaaaaaaaaaaaaaaa", 10)],
+            active: vec![
+                manifest(project, "bbbbbbbbbbbbbbbb", 20),
+                manifest(project, "cccccccccccccccc", 30),
+            ],
+            rollback: vec![
+                manifest(project, "bbbbbbbbbbbbbbbb", 20),
+                manifest(project, "dddddddddddddddd", 40),
+            ],
+            ..RetentionProtectionScan::default()
+        };
+
+        let plan = plan_generation_retention(&layout, project, &protection);
+
+        assert_eq!(
+            plan.bundles
+                .iter()
+                .filter(|bundle| bundle.state != GenerationRetentionState::Reclaimable)
+                .map(|bundle| (bundle.generation.clone(), bundle.state))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "repo-v1-project-aaaaaaaaaaaaaaaa".to_string(),
+                    GenerationRetentionState::Active,
+                ),
+                (
+                    "repo-v1-project-bbbbbbbbbbbbbbbb".to_string(),
+                    GenerationRetentionState::Active,
+                ),
+                (
+                    "repo-v1-project-cccccccccccccccc".to_string(),
+                    GenerationRetentionState::Active,
+                ),
+                (
+                    "repo-v1-project-dddddddddddddddd".to_string(),
+                    GenerationRetentionState::Rollback,
+                ),
+            ]
+        );
+        assert_eq!(
+            plan.bundles
+                .iter()
+                .filter(|bundle| bundle.state == GenerationRetentionState::Reclaimable)
+                .map(|bundle| bundle.generation.as_str())
+                .collect::<Vec<_>>(),
+            vec!["repo-v1-project-eeeeeeeeeeeeeeee"]
+        );
+    }
+
+    #[test]
+    fn malformed_and_non_directory_entries_are_blocked_not_candidates() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let shards = layout.zoekt_data_dir.join("shards");
+        std::fs::create_dir_all(shards.join(format!("{project}-not-hex"))).expect("malformed");
+        std::fs::write(
+            shards.join(format!("{project}-dddddddddddddddd")),
+            "not a directory",
+        )
+        .expect("file");
+
+        let plan = plan_generation_retention(&layout, project, &RetentionProtectionScan::default());
+
+        assert_eq!(plan.blocked.len(), 2);
+        assert!(plan.bundles.is_empty());
+        assert_eq!(plan.reclaimable_bytes, 0);
+        assert!(plan.pruning_suppressed);
+    }
+
+    #[test]
+    fn scoped_malformed_entry_suppresses_otherwise_valid_stale_deletion() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let stale = "cccccccccccccccc";
+        write_bundle(&layout, project, stale, [2, 3, 4]);
+        std::fs::create_dir_all(
+            layout
+                .scip_artifacts_root
+                .join(format!("{project}-malformed")),
+        )
+        .expect("malformed");
+
+        let plan = plan_generation_retention(&layout, project, &RetentionProtectionScan::default());
+        let mut remover = TestRemover::default();
+        let report = apply_generation_retention(&plan, &mut remover);
+
+        assert!(plan.pruning_suppressed);
+        assert_eq!(plan.reclaimable_bytes, 9);
+        assert!(report.pruning_suppressed);
+        assert_eq!(report.removed_bytes, 0);
+        assert!(remover.removed_paths.is_empty());
+        assert!(remover.removed_collections.is_empty());
+        assert!(
+            layout
+                .zoekt_data_dir
+                .join("shards")
+                .join(format!("{project}-{stale}"))
+                .is_dir()
+        );
+    }
+
+    #[test]
+    fn missing_active_generation_suppresses_stale_deletion() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        write_bundle(&layout, project, "cccccccccccccccc", [2, 3, 4]);
+
+        let plan = plan_generation_retention(&layout, project, &RetentionProtectionScan::default());
+        let mut remover = TestRemover::default();
+        let report = apply_generation_retention(&plan, &mut remover);
+
+        assert!(plan.pruning_suppressed);
+        assert_eq!(plan.reclaimable_bytes, 9);
+        assert!(report.pruning_suppressed);
+        assert!(remover.removed_paths.is_empty());
+        assert!(remover.removed_collections.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_generation_is_blocked_without_following_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().expect("root");
+        let outside = tempdir().expect("outside");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let shards = layout.zoekt_data_dir.join("shards");
+        std::fs::create_dir_all(&shards).expect("shards");
+        std::fs::write(outside.path().join("keep"), "outside").expect("outside file");
+        symlink(
+            outside.path(),
+            shards.join(format!("{project}-eeeeeeeeeeeeeeee")),
+        )
+        .expect("symlink");
+
+        let plan = plan_generation_retention(&layout, project, &RetentionProtectionScan::default());
+
+        assert_eq!(plan.blocked.len(), 1);
+        assert!(plan.bundles.is_empty());
+        assert!(plan.pruning_suppressed);
+        assert!(outside.path().join("keep").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_generation_root_suppresses_pruning_without_following_target() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().expect("root");
+        let outside = tempdir().expect("outside");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let generation = format!("{project}-cccccccccccccccc");
+        std::fs::create_dir_all(outside.path().join(&generation)).expect("outside generation");
+        std::fs::create_dir_all(&layout.zoekt_data_dir).expect("zoekt parent");
+        symlink(outside.path(), layout.zoekt_data_dir.join("shards")).expect("linked root");
+        let protection = RetentionProtectionScan {
+            authoritative_active: vec![manifest(project, "aaaaaaaaaaaaaaaa", 1)],
+            ..RetentionProtectionScan::default()
+        };
+
+        let plan = plan_generation_retention(&layout, project, &protection);
+
+        assert!(plan.pruning_suppressed);
+        assert!(
+            plan.errors
+                .iter()
+                .any(|error| error.contains("generation root is not a direct directory"))
+        );
+        assert!(outside.path().join(generation).is_dir());
+    }
+
+    #[test]
+    fn deletion_failure_is_reported_without_touching_active_generation() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let active = "aaaaaaaaaaaaaaaa";
+        let stale = "cccccccccccccccc";
+        write_bundle(&layout, project, active, [1, 1, 1]);
+        write_bundle(&layout, project, stale, [2, 3, 4]);
+        let plan = plan_generation_retention(
+            &layout,
+            project,
+            &RetentionProtectionScan {
+                authoritative_active: vec![manifest(project, active, 2)],
+                ..RetentionProtectionScan::default()
+            },
+        );
+        let mut remover = TestRemover {
+            fail_path_fragment: Some("scip".into()),
+            ..TestRemover::default()
+        };
+
+        let report = apply_generation_retention(&plan, &mut remover);
+
+        assert_eq!(report.removed_bytes, 6);
+        assert_eq!(report.remaining_reclaimable_bytes, 3);
+        assert_eq!(report.errors.len(), 1);
+        assert!(
+            layout
+                .scip_artifacts_root
+                .join(format!("{project}-{stale}"))
+                .is_dir()
+        );
+        assert!(
+            layout
+                .scip_artifacts_root
+                .join(format!("{project}-{active}"))
+                .is_dir()
+        );
+    }
+
+    #[test]
+    fn acknowledged_qdrant_delete_does_not_overstate_removed_bytes_when_data_remains() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let active = "aaaaaaaaaaaaaaaa";
+        let stale = "cccccccccccccccc";
+        write_bundle(&layout, project, active, [1, 1, 1]);
+        write_bundle(&layout, project, stale, [2, 3, 4]);
+        let plan = plan_generation_retention(
+            &layout,
+            project,
+            &RetentionProtectionScan {
+                authoritative_active: vec![manifest(project, active, 2)],
+                ..RetentionProtectionScan::default()
+            },
+        );
+        let mut remover = TestRemover {
+            qdrant_data_remains: true,
+            ..TestRemover::default()
+        };
+
+        let report = apply_generation_retention(&plan, &mut remover);
+
+        assert_eq!(report.removed_bytes, 5);
+        assert_eq!(report.remaining_reclaimable_bytes, 4);
+        assert!(!report.removals[0].qdrant_collection_removed);
+        assert!(report.errors[0].contains("local data remains"));
+    }
+
+    #[test]
+    fn live_qdrant_collection_is_planned_when_disk_directory_is_absent() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        let active = "aaaaaaaaaaaaaaaa";
+        let collection = "codestory_repo-v1-project_ffffffffffffffff".to_string();
+        let protection = RetentionProtectionScan {
+            authoritative_active: vec![manifest(project, active, 1)],
+            ..RetentionProtectionScan::default()
+        };
+
+        let plan = plan_generation_retention_with_qdrant_collections(
+            &layout,
+            project,
+            &protection,
+            std::slice::from_ref(&collection),
+        );
+
+        assert!(!plan.pruning_suppressed);
+        let stale = plan
+            .bundles
+            .iter()
+            .find(|bundle| bundle.qdrant_collection == collection)
+            .expect("live-only stale collection");
+        assert_eq!(stale.state, GenerationRetentionState::Reclaimable);
+        assert!(stale.qdrant.is_none());
+        let mut remover = TestRemover::default();
+        let report = apply_generation_retention(&plan, &mut remover);
+        assert_eq!(remover.removed_collections, vec![collection]);
+        assert_eq!(report.removed_bytes, 0);
+    }
+
+    #[test]
+    fn marker_update_preserves_only_a_freshly_verified_rollback() {
+        let project = "repo-v1-project";
+        let active = manifest(project, "aaaaaaaaaaaaaaaa", 10);
+        let rollback = VerifiedRollbackManifest {
+            manifest: manifest(project, "bbbbbbbbbbbbbbbb", 9),
+            verified_at_epoch_ms: 11,
+        };
+        let mut refreshed_active = active;
+        refreshed_active.built_at_epoch_ms = 20;
+
+        let refreshed = GenerationRetentionMarker::next(
+            "workspace_1",
+            refreshed_active,
+            Some(rollback.clone()),
+            21,
+        )
+        .expect("refresh marker");
+
+        assert_eq!(refreshed.rollback, Some(rollback));
+    }
+
+    #[test]
+    fn marker_write_is_atomic_and_protection_scan_reports_malformed_marker() {
+        let root = tempdir().expect("root");
+        let state_file = root.path().join("retrieval-sidecars.json");
+        let marker = GenerationRetentionMarker::next(
+            "workspace_1",
+            manifest("repo-v1-project", "aaaaaaaaaaaaaaaa", 1),
+            None,
+            2,
+        )
+        .expect("marker");
+        write_retention_marker(&state_file, &marker).expect("write marker");
+        assert_eq!(
+            read_retention_marker(&state_file, "workspace_1").expect("read marker"),
+            Some(marker)
+        );
+        std::fs::write(retention_dir(&state_file).join("bad.json"), "{").expect("bad marker");
+
+        let scan = scan_retention_protection(root.path(), None, &state_file);
+
+        assert_eq!(scan.active.len(), 1);
+        assert_eq!(scan.errors.len(), 1);
+        assert!(scan.errors[0].contains("bad.json"));
+    }
+}

--- a/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
+++ b/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
@@ -1,5 +1,32 @@
 use super::{Storage, StorageError};
+use rusqlite::Row;
 use serde::{Deserialize, Serialize};
+
+const MANIFEST_SELECT: &str = "
+    SELECT
+        project_id,
+        zoekt_version,
+        qdrant_collection,
+        scip_revision,
+        built_at_epoch_ms,
+        disk_bytes,
+        degraded_modes_json,
+        embedding_backend,
+        embedding_dim,
+        sidecar_schema_version,
+        sidecar_input_hash,
+        sidecar_generation,
+        projection_count,
+        symbol_doc_count,
+        dense_projection_count,
+        semantic_policy_version,
+        graph_artifact_hash,
+        dense_reason_counts_json,
+        precise_semantic_import_status,
+        precise_semantic_import_reason,
+        precise_semantic_import_revision,
+        precise_semantic_import_producer
+    FROM retrieval_index_manifest";
 
 /// Manifest row describing retrieval sidecar freshness for one project id.
 ///
@@ -126,61 +153,30 @@ impl Storage {
         &self,
         project_id: &str,
     ) -> Result<Option<RetrievalIndexManifest>, StorageError> {
-        let mut stmt = self.conn.prepare(
-            "SELECT
-                project_id,
-                zoekt_version,
-                qdrant_collection,
-                scip_revision,
-                built_at_epoch_ms,
-                disk_bytes,
-                degraded_modes_json,
-                embedding_backend,
-                embedding_dim,
-                sidecar_schema_version,
-                sidecar_input_hash,
-                sidecar_generation,
-                projection_count,
-                symbol_doc_count,
-                dense_projection_count,
-                semantic_policy_version,
-                graph_artifact_hash,
-                dense_reason_counts_json,
-                precise_semantic_import_status,
-                precise_semantic_import_reason,
-                precise_semantic_import_revision,
-                precise_semantic_import_producer
-             FROM retrieval_index_manifest
-             WHERE project_id = ?1",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare(&format!("{MANIFEST_SELECT} WHERE project_id = ?1"))?;
         let mut rows = stmt.query(rusqlite::params![project_id])?;
         let Some(row) = rows.next()? else {
             return Ok(None);
         };
-        Ok(Some(RetrievalIndexManifest {
-            project_id: row.get(0)?,
-            zoekt_version: row.get(1)?,
-            qdrant_collection: row.get(2)?,
-            scip_revision: row.get(3)?,
-            built_at_epoch_ms: row.get(4)?,
-            disk_bytes: row.get(5)?,
-            degraded_modes_json: row.get(6)?,
-            embedding_backend: row.get(7)?,
-            embedding_dim: row.get(8)?,
-            sidecar_schema_version: row.get(9)?,
-            sidecar_input_hash: row.get(10)?,
-            sidecar_generation: row.get(11)?,
-            projection_count: row.get(12)?,
-            symbol_doc_count: row.get(13)?,
-            dense_projection_count: row.get(14)?,
-            semantic_policy_version: row.get(15)?,
-            graph_artifact_hash: row.get(16)?,
-            dense_reason_counts_json: row.get(17)?,
-            precise_semantic_import_status: row.get(18)?,
-            precise_semantic_import_reason: row.get(19)?,
-            precise_semantic_import_revision: row.get(20)?,
-            precise_semantic_import_producer: row.get(21)?,
-        }))
+        Ok(Some(manifest_from_row(row)?))
+    }
+
+    /// Return every current retrieval manifest in this store.
+    ///
+    /// Retention scans use the complete set so a shared sidecar root never
+    /// removes a generation still referenced by another project row.
+    pub fn list_retrieval_index_manifests(
+        &self,
+    ) -> Result<Vec<RetrievalIndexManifest>, StorageError> {
+        let mut stmt = self.conn.prepare(MANIFEST_SELECT)?;
+        let rows = stmt.query_map([], manifest_from_row)?;
+        let mut manifests = Vec::new();
+        for row in rows {
+            manifests.push(row?);
+        }
+        Ok(manifests)
     }
 
     /// Return Qdrant collection names referenced by stored retrieval manifests.
@@ -219,6 +215,33 @@ impl Storage {
         }
         Ok(collections)
     }
+}
+
+fn manifest_from_row(row: &Row<'_>) -> rusqlite::Result<RetrievalIndexManifest> {
+    Ok(RetrievalIndexManifest {
+        project_id: row.get(0)?,
+        zoekt_version: row.get(1)?,
+        qdrant_collection: row.get(2)?,
+        scip_revision: row.get(3)?,
+        built_at_epoch_ms: row.get(4)?,
+        disk_bytes: row.get(5)?,
+        degraded_modes_json: row.get(6)?,
+        embedding_backend: row.get(7)?,
+        embedding_dim: row.get(8)?,
+        sidecar_schema_version: row.get(9)?,
+        sidecar_input_hash: row.get(10)?,
+        sidecar_generation: row.get(11)?,
+        projection_count: row.get(12)?,
+        symbol_doc_count: row.get(13)?,
+        dense_projection_count: row.get(14)?,
+        semantic_policy_version: row.get(15)?,
+        graph_artifact_hash: row.get(16)?,
+        dense_reason_counts_json: row.get(17)?,
+        precise_semantic_import_status: row.get(18)?,
+        precise_semantic_import_reason: row.get(19)?,
+        precise_semantic_import_revision: row.get(20)?,
+        precise_semantic_import_producer: row.get(21)?,
+    })
 }
 
 #[cfg(test)]
@@ -316,6 +339,61 @@ mod tests {
             .expect("manifest exists");
 
         assert_eq!(loaded, manifest);
+    }
+
+    #[test]
+    fn list_retrieval_index_manifests_returns_every_project_row() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("codestory.db");
+        let mut storage = Storage::open(&db_path).expect("open storage");
+        for (project_id, suffix) in [
+            ("proj_a", "aaaaaaaaaaaaaaaa"),
+            ("proj_b", "bbbbbbbbbbbbbbbb"),
+        ] {
+            storage
+                .upsert_retrieval_index_manifest(&RetrievalIndexManifest {
+                    project_id: project_id.into(),
+                    zoekt_version: "v1".into(),
+                    qdrant_collection: format!("codestory_{project_id}_{suffix}"),
+                    scip_revision: Some(format!("graph-{suffix}")),
+                    built_at_epoch_ms: 1,
+                    disk_bytes: None,
+                    degraded_modes_json: "[]".into(),
+                    embedding_backend: None,
+                    embedding_dim: None,
+                    sidecar_schema_version: Some(2),
+                    sidecar_input_hash: Some(suffix.repeat(4)),
+                    sidecar_generation: Some(format!("{project_id}-{suffix}")),
+                    projection_count: Some(1),
+                    symbol_doc_count: Some(1),
+                    dense_projection_count: Some(1),
+                    semantic_policy_version: Some("graph_first_v1".into()),
+                    graph_artifact_hash: Some("graph".into()),
+                    dense_reason_counts_json: Some("{}".into()),
+                    precise_semantic_import_status: None,
+                    precise_semantic_import_reason: None,
+                    precise_semantic_import_revision: None,
+                    precise_semantic_import_producer: None,
+                })
+                .expect("upsert manifest");
+        }
+
+        let mut manifests = storage
+            .list_retrieval_index_manifests()
+            .expect("list manifests");
+        manifests.sort_by(|left, right| left.project_id.cmp(&right.project_id));
+
+        assert_eq!(
+            manifests
+                .iter()
+                .map(|manifest| manifest.project_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["proj_a", "proj_b"]
+        );
+        assert_eq!(
+            manifests[1].sidecar_generation.as_deref(),
+            Some("proj_b-bbbbbbbbbbbbbbbb")
+        );
     }
 
     #[test]

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -276,11 +276,14 @@ codestory-cli retrieval inventory --project <repo> --format json
 
 The inventory lists CodeStory-owned sidecar namespaces, state paths, cleanup
 commands, Compose projects, matching containers/networks, visible ports, and
-the required `bge-base-en-v1.5.Q8_0.gguf` model check. It classifies namespaces
-as `live`, `stale`, `orphaned`, `incomplete`, or `unknown` with safe-candidate
-and blocking reasons. It is a dry-run status surface only: it does not run
-Docker prune, remove containers, delete networks, or clear state files, and it
-works even when packet/search readiness is unavailable.
+the required `bge-base-en-v1.5.Q8_0.gguf` model check. It also reports the
+project's generation bundles as active, verified rollback, or reclaimable with
+retained and reclaimable byte totals. It classifies namespaces as `live`,
+`stale`, `orphaned`, `incomplete`, or `unknown` with safe-candidate and blocking
+reasons. The default command is a dry-run: it does not run Docker prune, remove
+containers, delete networks, clear state files, or delete generations. When
+the active manifest or sidecar proof is unavailable or malformed, generation
+pruning is explicitly suppressed rather than inferred.
 
 To let the CLI remove only CodeStory-owned inventory safe candidates, review the
 dry-run output first and then pass the explicit apply flag:
@@ -292,12 +295,15 @@ codestory-cli retrieval inventory --project <repo> --apply --format markdown
 codestory-cli retrieval inventory --project <repo> --apply --format json
 ```
 
-`--apply` removes only namespaces classified as inventory safe candidates. Live
-namespaces, incomplete state, and unknown ownership stay blocked with
-per-namespace reasons. The apply path removes exact CodeStory-owned state/data
-paths and explicitly matched sidecar resources only; it does not run Docker
-prune, broad Docker cleanup, host/global network deletion, readiness-triggered
-cleanup, or packet/search-triggered cleanup.
+`--apply` removes only namespaces classified as inventory safe candidates and
+applies the generation plan shown by the dry-run. Generation cleanup requires a
+fully healthy active manifest, retains every manifest-referenced active
+generation sharing that sidecar scope plus at most one health-verified
+rollback, and removes only matching stale Qdrant, SCIP, and lexical artifacts
+under the per-project publication lock. Live namespaces,
+incomplete state, unknown ownership, protection-scan errors, and malformed
+generation entries stay blocked with explicit reasons. The apply path does not
+run Docker prune, broad Docker cleanup, or host/global network deletion.
 
 1. Run the dry-run inventory in Markdown and JSON.
 2. Confirm the safe candidates and blocked reasons.
@@ -426,9 +432,14 @@ Before Compose starts, bootstrap may repair Qdrant storage:
    collections are protected.
 2. Offline cleanup runs only when Qdrant HTTP is unreachable. It removes invalid
    CodeStory collection dirs and migrates obsolete stub markers.
-3. Retention may prune unprotected `codestory_*` collections beyond the cap
-   (`64`). If scan errors exist, retention deletes are skipped unless
-   `CODESTORY_RETRIEVAL_PRUNE_ON_SCAN_ERROR=1`.
+3. Bootstrap does not prune valid generated collections. Bounded retention runs
+   only after a replacement generation reaches full mode and its manifest is
+   published, or through the operator-reviewed `retrieval inventory --apply`
+   path. The publication path retains the active Qdrant, SCIP, and lexical
+   manifest-referenced active generations sharing its sidecar scope plus at
+   most one health-verified rollback; protection-scan, inventory, or deletion
+   errors preserve active generations and are reported in retention
+   diagnostics.
 
 Non-`codestory_*` collection dirs are never deleted by this repair path.
 

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -31,6 +31,15 @@ and stay up with diagnostic `codestory://status` when managed setup fails.
 Ambient `PATH` binaries are reported as diagnostics only; installed plugin
 runtime does not launch them.
 
+After a managed runtime passes checksum and `--version` verification, the
+adapter retains that active version plus one verified pending upgrade or
+rollback. New installs publish from a verified staging directory under a
+PID/token lock. Older version directories are removed best-effort; live Windows
+executables, active installs, links, malformed manifests, and concurrent runs
+are preserved, while abandoned locks/staging are safely reclaimed. Results are
+reported under `managed_cli_retention` in `codestory://status`, including
+retained, removed, and reclaimable byte totals.
+
 ## Codex install (summary)
 
 1. Open Codex in the repository you want to ground.

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -2,7 +2,7 @@
 
 const { spawn } = require('child_process');
 const { spawnSync } = require('child_process');
-const { createHash } = require('crypto');
+const { createHash, randomBytes } = require('crypto');
 const fs = require('fs');
 const https = require('https');
 const os = require('os');
@@ -21,6 +21,9 @@ const sharedAgentRunId = 'shared-agent';
 const releaseDownloadTimeoutMs = 60000;
 const releaseDownloadAttempts = 3;
 const releaseDownloadRetryDelaysMs = [1000, 3000];
+const managedCliLockStaleMs = 10 * 60 * 1000;
+const managedCliLockMaxAgeMs = 30 * 60 * 1000;
+const managedCliLockWaitMs = 120000;
 
 function readJson(file) {
   try {
@@ -580,19 +583,120 @@ function extractArchive(archivePath, destination) {
   }
 }
 
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+}
+
+function sleepSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function managedCliRoot(dataDir, create = false) {
+  const root = path.join(dataDir, 'codestory-cli');
+  if (fs.existsSync(root)) {
+    const metadata = fs.lstatSync(root);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+      throw new Error(`managed_cli_root_not_direct:${root}`);
+    }
+  } else if (create) {
+    fs.mkdirSync(root, { recursive: true });
+  }
+  return root;
+}
+
+function reclaimStaleManagedCliLock(lockPath) {
+  let stale = false;
+  const ownerPath = path.join(lockPath, 'owner.json');
+  const owner = readJson(ownerPath);
+  if (owner && Number.isInteger(owner.pid)) {
+    const startedAt = Date.parse(owner.started_at || '');
+    const tooOld = Number.isFinite(startedAt) && Date.now() - startedAt > managedCliLockMaxAgeMs;
+    stale = !processIsAlive(owner.pid) || tooOld;
+  } else {
+    try {
+      stale = Date.now() - fs.statSync(lockPath).mtimeMs > managedCliLockStaleMs;
+    } catch {
+      return true;
+    }
+  }
+  if (!stale) return false;
+  const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(6).toString('hex')}`;
+  try {
+    fs.renameSync(lockPath, stalePath);
+    fs.rmSync(stalePath, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function acquireManagedCliLock(root, purpose, waitMs = 0) {
+  const lockPath = path.join(root, '.retention-lock');
+  const deadline = Date.now() + waitMs;
+  while (true) {
+    try {
+      fs.mkdirSync(lockPath);
+      const token = randomBytes(16).toString('hex');
+      try {
+        fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({
+          pid: process.pid,
+          purpose,
+          token,
+          started_at: new Date().toISOString(),
+        }));
+      } catch (error) {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+        throw error;
+      }
+      return { lockPath, token };
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      if (reclaimStaleManagedCliLock(lockPath)) continue;
+      if (Date.now() >= deadline) return null;
+      sleepSync(50);
+    }
+  }
+}
+
+function releaseManagedCliLock(lock) {
+  if (!lock) return;
+  const owner = readJson(path.join(lock.lockPath, 'owner.json'));
+  if (!owner || owner.token !== lock.token || owner.pid !== process.pid) return;
+  try {
+    fs.rmSync(lock.lockPath, { recursive: true, force: true });
+  } catch (error) {
+    try {
+      fs.writeFileSync(
+        path.join(lock.lockPath, 'owner.json'),
+        JSON.stringify({ ...owner, pid: -1, released_at: new Date().toISOString() }),
+      );
+    } catch {
+      // The next process can still reclaim a malformed lock after the stale timeout.
+    }
+    throw error;
+  }
+}
+
 async function provisionManagedCli(dataDir, version) {
   if (!dataDir || !version || process.env.CODESTORY_PLUGIN_DISABLE_PROVISION === '1') return null;
   const target = assetTarget();
   const asset = archiveName(version, target);
   if (!target || !asset) throw new Error(`unsupported_release_target:${process.platform}-${process.arch}`);
 
-  const versionDir = path.join(dataDir, 'codestory-cli', version);
-  const binDir = path.join(versionDir, 'bin');
-  const manifestPath = path.join(versionDir, 'manifest.json');
+  const root = managedCliRoot(dataDir, true);
+  const versionDir = path.join(root, version);
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codestory-plugin-cli-'));
   const sumsPath = path.join(tempRoot, 'SHA256SUMS.txt');
   const archivePath = path.join(tempRoot, asset);
   const extractDir = path.join(tempRoot, 'extract');
+  let stagingDir = null;
   try {
     await fetchReleaseFile(version, 'SHA256SUMS.txt', sumsPath);
     const archiveUrl = await fetchReleaseFile(version, asset, archivePath);
@@ -605,13 +709,16 @@ async function provisionManagedCli(dataDir, version) {
     const extracted = findFile(extractDir, fallbackBinaryNames);
     if (!extracted) throw new Error(`archive_missing_cli:${asset}`);
 
+    stagingDir = fs.mkdtempSync(path.join(root, `.provisioning-${version}-${process.pid}-`));
+    const binDir = path.join(stagingDir, 'bin');
+    const manifestPath = path.join(stagingDir, 'manifest.json');
     fs.mkdirSync(binDir, { recursive: true });
     const destination = path.join(binDir, path.basename(extracted));
     fs.copyFileSync(extracted, destination);
     if (process.platform !== 'win32') fs.chmodSync(destination, 0o755);
     const binarySha256 = fileSha256(destination);
     fs.writeFileSync(manifestPath, JSON.stringify({
-      path: path.relative(versionDir, destination).replace(/\\/gu, '/'),
+      path: path.relative(stagingDir, destination).replace(/\\/gu, '/'),
       sha256: binarySha256,
       version,
       build_source: 'github_release',
@@ -622,18 +729,58 @@ async function provisionManagedCli(dataDir, version) {
       target,
       provisioned_at: new Date().toISOString(),
     }, null, 2));
-    return resolveManifest(manifestPath);
+    const staged = resolveManifest(manifestPath);
+    if (!staged) {
+      throw new Error(`managed_cli_staging_verification_failed:${version}`);
+    }
+    const stagedProbe = probeResolvedCli({ ...staged, source: 'managed', version });
+    if (stagedProbe.error || stagedProbe.status !== 0 || stagedProbe.version !== version) {
+      throw new Error(`managed_cli_staging_version_probe_failed:${version}`);
+    }
+
+    const lock = acquireManagedCliLock(root, 'provision', managedCliLockWaitMs);
+    if (!lock) throw new Error('managed_cli_publish_locked');
+    try {
+      const existing = resolveManifest(path.join(versionDir, 'manifest.json'));
+      if (existing) return existing;
+      let replacedDir = null;
+      if (fs.existsSync(versionDir)) {
+        replacedDir = path.join(root, `.replaced-${version}-${process.pid}-${randomBytes(6).toString('hex')}`);
+        fs.renameSync(versionDir, replacedDir);
+      }
+      try {
+        fs.renameSync(stagingDir, versionDir);
+        stagingDir = null;
+      } catch (error) {
+        if (replacedDir && !fs.existsSync(versionDir) && fs.existsSync(replacedDir)) {
+          fs.renameSync(replacedDir, versionDir);
+        }
+        throw error;
+      }
+      if (replacedDir) fs.rmSync(replacedDir, { recursive: true, force: true });
+      return resolveManifest(path.join(versionDir, 'manifest.json'));
+    } finally {
+      releaseManagedCliLock(lock);
+    }
   } finally {
+    if (stagingDir) fs.rmSync(stagingDir, { recursive: true, force: true });
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 }
 
 async function resolveManagedCli(dataDir, version, warnings) {
   if (!dataDir || !version) return null;
+  try {
+    managedCliRoot(dataDir);
+  } catch (error) {
+    warnings.push(`managed_cli_root_invalid:${error.message}`);
+    return null;
+  }
   for (const manifestPath of [
     path.join(dataDir, 'codestory-cli', version, 'manifest.json'),
     path.join(dataDir, 'codestory-cli', 'manifest.json'),
   ]) {
+    if (managedProvisioningState(path.dirname(manifestPath)).active) continue;
     const resolved = resolveManifest(manifestPath);
     if (resolved) return resolved;
   }
@@ -642,7 +789,8 @@ async function resolveManagedCli(dataDir, version, warnings) {
     path.join(dataDir, 'codestory-cli', version, binaryName),
     path.join(dataDir, 'codestory-cli', version, 'bin', binaryName),
   ]) {
-    if (fs.existsSync(cliPath)) {
+    if (fs.existsSync(cliPath)
+        && !fs.existsSync(path.join(dataDir, 'codestory-cli', version, '.provisioning'))) {
       return { path: cliPath, sha256: fileSha256(cliPath), manifestPath: null };
     }
   }
@@ -650,6 +798,8 @@ async function resolveManagedCli(dataDir, version, warnings) {
     return await provisionManagedCli(dataDir, version);
   } catch (error) {
     warnings.push(`managed_cli_provision_failed:${error.message}`);
+    const concurrent = resolveManifest(path.join(dataDir, 'codestory-cli', version, 'manifest.json'));
+    if (concurrent) return concurrent;
   }
   return null;
 }
@@ -739,6 +889,418 @@ function failOpenReasonForProbe(resolved, probe) {
     return `${resolved.source}_cli_unspawnable`;
   }
   return null;
+}
+
+function compareManagedCliVersions(left, right) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function managedPathSize(pathname) {
+  const metadata = fs.lstatSync(pathname);
+  if (metadata.isSymbolicLink()) {
+    throw new Error(`managed_cli_retention_link:${pathname}`);
+  }
+  if (!metadata.isDirectory()) return metadata.size;
+  let bytes = 0;
+  for (const entry of fs.readdirSync(pathname, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) {
+      throw new Error(`managed_cli_retention_link:${path.join(pathname, entry.name)}`);
+    }
+    bytes += managedPathSize(path.join(pathname, entry.name));
+  }
+  return bytes;
+}
+
+function managedProvisioningState(versionDir) {
+  const sentinel = path.join(versionDir, '.provisioning');
+  if (!fs.existsSync(sentinel)) return { active: false, recovered: false };
+  let pid = null;
+  let staleByAge = false;
+  try {
+    pid = Number.parseInt(fs.readFileSync(sentinel, 'utf8').trim(), 10);
+    staleByAge = Date.now() - fs.statSync(sentinel).mtimeMs > managedCliLockStaleMs;
+  } catch {
+    return { active: true, recovered: false };
+  }
+  const stale = Number.isInteger(pid) && pid > 0
+    ? !processIsAlive(pid) || staleByAge
+    : staleByAge;
+  if (!stale) return { active: true, recovered: false };
+  try {
+    fs.unlinkSync(sentinel);
+    return { active: false, recovered: true };
+  } catch {
+    return { active: true, recovered: false };
+  }
+}
+
+function managedCliVersionEntries(dataDir) {
+  const root = path.join(dataDir, 'codestory-cli');
+  if (!fs.existsSync(root)) return { root, entries: [], staging: [], errors: [] };
+  const entries = [];
+  const staging = [];
+  const errors = [];
+  let children;
+  try {
+    const rootMetadata = fs.lstatSync(root);
+    if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) {
+      return { root, entries, staging, errors: [`managed_cli_root_not_direct:${root}`] };
+    }
+    children = fs.readdirSync(root, { withFileTypes: true });
+  } catch (error) {
+    return { root, entries, staging, errors: [`scan:${error.code || error.message}`] };
+  }
+  for (const child of children) {
+    if (child.name.startsWith('.provisioning-') || child.name.startsWith('.replaced-')) {
+      const stagingPath = path.join(root, child.name);
+      try {
+        if (!child.isDirectory() || child.isSymbolicLink()) {
+          errors.push(`managed_cli_staging_not_direct:${stagingPath}`);
+          continue;
+        }
+        const match = /^\.(?:provisioning|replaced)-(\d+\.\d+\.\d+)-(\d+)-/u.exec(child.name);
+        const pid = match ? Number.parseInt(match[2], 10) : null;
+        const ageMs = Date.now() - fs.statSync(stagingPath).mtimeMs;
+        const stale = pid ? !processIsAlive(pid) || ageMs > managedCliLockMaxAgeMs : ageMs > managedCliLockStaleMs;
+        staging.push({
+          version: match?.[1] || child.name,
+          versionDir: stagingPath,
+          bytes: managedPathSize(stagingPath),
+          stale,
+          reason: child.name.startsWith('.replaced-') ? 'publish_backup' : 'provisioning',
+        });
+      } catch (error) {
+        errors.push(`scan_staging:${error.code || error.message}`);
+      }
+      continue;
+    }
+    const version = normalizeVersion(child.name);
+    if (!version || version !== child.name) continue;
+    const versionDir = path.join(root, child.name);
+    if (!child.isDirectory() || child.isSymbolicLink()) {
+      entries.push({
+        version,
+        versionDir,
+        bytes: 0,
+        scanError: 'link_or_non_directory',
+        provisioning: false,
+      });
+      continue;
+    }
+    try {
+      const provisioning = managedProvisioningState(versionDir);
+      entries.push({
+        version,
+        versionDir,
+        bytes: managedPathSize(versionDir),
+        scanError: null,
+        provisioning: provisioning.active,
+      });
+    } catch (error) {
+      entries.push({
+        version,
+        versionDir,
+        bytes: 0,
+        scanError: error.message,
+        provisioning: false,
+      });
+    }
+  }
+  entries.sort((left, right) => compareManagedCliVersions(right.version, left.version));
+  return { root, entries, staging, errors };
+}
+
+function verifyManagedCliVersion(entry, probeVersion = probeResolvedCli) {
+  if (entry.scanError || entry.provisioning) {
+    return { verified: false, reason: entry.scanError || 'provisioning' };
+  }
+  const manifestPath = path.join(entry.versionDir, 'manifest.json');
+  const manifest = readJson(manifestPath);
+  if (!manifest || manifest.version !== entry.version) {
+    return { verified: false, reason: 'manifest_version_mismatch' };
+  }
+  const executable = manifest.executable_path || manifest.executablePath || manifest.path;
+  const expectedSha256 = manifest.sha256 || manifest.executable_sha256 || manifest.executableSha256;
+  if (!executable || !/^[0-9a-f]{64}$/iu.test(String(expectedSha256 || ''))) {
+    return { verified: false, reason: 'manifest_incomplete' };
+  }
+  const executablePath = path.resolve(entry.versionDir, executable);
+  if (!pathInside(executablePath, entry.versionDir) || !fs.existsSync(executablePath)) {
+    return { verified: false, reason: 'manifest_path_unsafe' };
+  }
+  let realVersionDir;
+  let realExecutable;
+  try {
+    realVersionDir = fs.realpathSync(entry.versionDir);
+    realExecutable = fs.realpathSync(executablePath);
+  } catch (error) {
+    return { verified: false, reason: `manifest_path_unreadable:${error.code || error.message}` };
+  }
+  if (!pathInside(realExecutable, realVersionDir)) {
+    return { verified: false, reason: 'manifest_path_escape' };
+  }
+  let actualSha256;
+  try {
+    actualSha256 = fileSha256(realExecutable);
+  } catch (error) {
+    return { verified: false, reason: `checksum_unreadable:${error.code || error.message}` };
+  }
+  if (actualSha256 !== String(expectedSha256).toLowerCase()) {
+    return { verified: false, reason: 'checksum_mismatch' };
+  }
+  const resolved = {
+    source: 'managed',
+    path: realExecutable,
+    sha256: actualSha256,
+    version: entry.version,
+    cliVersion: entry.version,
+    manifestPath,
+    warnings: [],
+  };
+  const probe = probeVersion(resolved);
+  if (probe.error || probe.status !== 0 || probe.version !== entry.version) {
+    return { verified: false, reason: 'version_probe_mismatch' };
+  }
+  return { verified: true, reason: null, executablePath: realExecutable, resolved };
+}
+
+function reportUnverifiedManagedCliInventory(report, entries, reason) {
+  for (const entry of entries) {
+    report.reclaimable.push({
+      version: entry.version,
+      path: entry.versionDir,
+      bytes: entry.bytes,
+      reason,
+    });
+    report.reclaimable_bytes += entry.bytes;
+  }
+}
+
+function managedCliRetentionReportUnlocked(resolved, probe, options = {}) {
+  const dataDir = options.dataDir || pluginDataDir();
+  const dryRun = options.dryRun ?? process.env.CODESTORY_PLUGIN_CLI_RETENTION_DRY_RUN === '1';
+  const report = {
+    policy: 'active_plus_one_verified_adjacent',
+    dry_run: dryRun,
+    active_version: probe.version || resolved.version || null,
+    retained: [],
+    removed: [],
+    reclaimable: [],
+    retained_bytes: 0,
+    removed_bytes: 0,
+    reclaimable_bytes: 0,
+    warnings: [],
+  };
+  if (!dataDir || resolved.source !== 'managed') {
+    report.warnings.push('managed_cli_retention_not_applicable');
+    return report;
+  }
+  const inventory = managedCliVersionEntries(dataDir);
+  report.warnings.push(...inventory.errors);
+  if (inventory.errors.length > 0) return report;
+  for (const entry of inventory.staging) {
+    if (!dryRun && entry.stale) {
+      try {
+        fs.rmSync(entry.versionDir, { recursive: true, force: false });
+        report.removed.push({
+          version: entry.version,
+          path: entry.versionDir,
+          bytes: entry.bytes,
+          reason: `abandoned_${entry.reason}`,
+        });
+        report.removed_bytes += entry.bytes;
+        continue;
+      } catch (error) {
+        report.warnings.push(`managed_cli_staging_remove_failed:${error.code || error.message}`);
+      }
+    }
+    report.reclaimable.push({
+      version: entry.version,
+      path: entry.versionDir,
+      bytes: entry.bytes,
+      reason: entry.stale ? `abandoned_${entry.reason}` : entry.reason,
+    });
+    report.reclaimable_bytes += entry.bytes;
+  }
+  if (probe.error || probe.status !== 0) {
+    report.warnings.push('managed_cli_retention_active_unverified:version_probe_failed');
+    reportUnverifiedManagedCliInventory(report, inventory.entries, 'active_unverified');
+    return report;
+  }
+  if (probe.version !== resolved.version) {
+    report.warnings.push('managed_cli_retention_active_version_mismatch');
+    reportUnverifiedManagedCliInventory(report, inventory.entries, 'active_version_mismatch');
+    return report;
+  }
+
+  const active = inventory.entries.find((entry) => entry.version === resolved.version);
+  if (!active) {
+    report.warnings.push('managed_cli_retention_active_directory_missing');
+    reportUnverifiedManagedCliInventory(report, inventory.entries, 'active_directory_missing');
+    return report;
+  }
+  const activeVerification = verifyManagedCliVersion(active, options.probeVersion || probeResolvedCli);
+  if (!activeVerification.verified
+      || !samePathText(activeVerification.executablePath, resolved.path)) {
+    report.warnings.push(`managed_cli_retention_active_unverified:${activeVerification.reason || 'path_mismatch'}`);
+    reportUnverifiedManagedCliInventory(report, inventory.entries, 'active_unverified');
+    return report;
+  }
+
+  const newer = inventory.entries.filter((entry) => compareManagedCliVersions(entry.version, active.version) > 0);
+  const older = inventory.entries.filter((entry) => compareManagedCliVersions(entry.version, active.version) < 0);
+  let adjacent = null;
+  for (const entry of [...newer, ...older]) {
+    const verification = verifyManagedCliVersion(entry, options.probeVersion || probeResolvedCli);
+    if (verification.verified) {
+      adjacent = entry;
+      break;
+    }
+  }
+
+  const retainedVersions = new Set([active.version]);
+  if (adjacent) retainedVersions.add(adjacent.version);
+  for (const entry of inventory.entries) {
+    if (retainedVersions.has(entry.version)) {
+      const reason = entry.version === active.version
+        ? 'active'
+        : compareManagedCliVersions(entry.version, active.version) > 0
+          ? 'newer_pending_activation'
+          : 'rollback';
+      report.retained.push({ version: entry.version, path: entry.versionDir, bytes: entry.bytes, reason });
+      report.retained_bytes += entry.bytes;
+      continue;
+    }
+    if (entry.scanError || entry.provisioning) {
+      report.reclaimable.push({
+        version: entry.version,
+        path: entry.versionDir,
+        bytes: entry.bytes,
+        reason: entry.scanError || 'provisioning',
+      });
+      report.reclaimable_bytes += entry.bytes;
+      continue;
+    }
+    if (dryRun) {
+      report.reclaimable.push({
+        version: entry.version,
+        path: entry.versionDir,
+        bytes: entry.bytes,
+        reason: 'outside_retention_window',
+      });
+      report.reclaimable_bytes += entry.bytes;
+      continue;
+    }
+    const removal = removeManagedCliVersion(entry, {
+      platform: options.platform || process.platform,
+      unlinkSync: options.unlinkSync || fs.unlinkSync,
+      rmSync: options.rmSync || fs.rmSync,
+    });
+    if (removal.removed) {
+      report.removed.push({
+        version: entry.version,
+        path: entry.versionDir,
+        bytes: entry.bytes,
+        reason: 'outside_retention_window',
+      });
+      report.removed_bytes += entry.bytes;
+    } else {
+      let remainingBytes = entry.bytes;
+      try {
+        remainingBytes = fs.existsSync(entry.versionDir) ? managedPathSize(entry.versionDir) : 0;
+      } catch {
+        // Keep the pre-delete size when a partial failure also prevents measurement.
+      }
+      report.reclaimable.push({
+        version: entry.version,
+        path: entry.versionDir,
+        bytes: remainingBytes,
+        reason: removal.reason,
+      });
+      report.reclaimable_bytes += remainingBytes;
+    }
+  }
+  return report;
+}
+
+function managedCliRetentionReport(resolved, probe, options = {}) {
+  const dataDir = options.dataDir || pluginDataDir();
+  if (!dataDir || resolved.source !== 'managed') {
+    return managedCliRetentionReportUnlocked(resolved, probe, options);
+  }
+  let root;
+  try {
+    root = managedCliRoot(dataDir, true);
+  } catch (error) {
+    const report = managedCliRetentionReportUnlocked(resolved, probe, {
+      ...options,
+      dataDir,
+      dryRun: true,
+    });
+    report.warnings.push(`managed_cli_retention_root_failed:${error.code || error.message}`);
+    return report;
+  }
+  let lock;
+  try {
+    lock = acquireManagedCliLock(root, 'retention');
+  } catch (error) {
+    const report = managedCliRetentionReportUnlocked(resolved, probe, {
+      ...options,
+      dataDir,
+      dryRun: true,
+    });
+    report.warnings.push(`managed_cli_retention_lock_failed:${error.code || error.message}`);
+    return report;
+  }
+  if (!lock) {
+    const report = managedCliRetentionReportUnlocked(resolved, probe, {
+      ...options,
+      dataDir,
+      dryRun: true,
+    });
+    report.warnings.push('managed_cli_retention_locked');
+    return report;
+  }
+  try {
+    return managedCliRetentionReportUnlocked(resolved, probe, { ...options, dataDir });
+  } finally {
+    try {
+      releaseManagedCliLock(lock);
+    } catch {
+      // The PID/token lock is reclaimed after an interrupted owner exits.
+    }
+  }
+}
+
+function removeManagedCliVersion(entry, options) {
+  if (options.platform === 'win32') {
+    const knownExecutables = [
+      path.join(entry.versionDir, 'bin', binaryName),
+      path.join(entry.versionDir, binaryName),
+    ].filter((candidate) => fs.existsSync(candidate) && pathInside(candidate, entry.versionDir));
+    for (const executable of knownExecutables) {
+      try {
+        options.unlinkSync(executable);
+      } catch (error) {
+        if (['EPERM', 'EBUSY', 'EACCES'].includes(error.code)) {
+          return { removed: false, reason: `locked:${error.code}` };
+        }
+        return { removed: false, reason: `unlink_failed:${error.code || error.message}` };
+      }
+    }
+  }
+  try {
+    options.rmSync(entry.versionDir, { recursive: true, force: false });
+    return { removed: true, reason: null };
+  } catch (error) {
+    return { removed: false, reason: `remove_failed:${error.code || error.message}` };
+  }
 }
 
 function localWaitFreshCommand(projectRoot = launchCwd) {
@@ -991,6 +1553,7 @@ function pluginRuntimeForResolved(resolved) {
     managed_binary_path: resolved.source === 'managed' ? resolved.path : null,
     managed_binary_sha256: resolved.source === 'managed' ? resolved.sha256 : null,
     managed_manifest_path: resolved.manifestPath || null,
+    managed_cli_retention: resolved.managedCliRetention || null,
     warnings: resolved.warnings.filter(Boolean),
   };
 }
@@ -1192,15 +1755,18 @@ function projectRootUnavailableDiagnostic(resolved, probe, projectResolution) {
 async function bootstrapStatus(projectRoot = launchCwd) {
   projectRoot = normalizeProjectRoot(projectRoot);
   const resolved = await resolveCli();
-  rememberLaunch(resolved);
   const probe = probeResolvedCli(resolved);
   const failOpenReason = failOpenReasonForProbe(resolved, probe);
   if (failOpenReason) {
+    resolved.managedCliRetention = managedCliRetentionReport(resolved, probe, { dryRun: true });
+    rememberLaunch(resolved);
     return {
       ready: false,
       ...fallbackDiagnostic(resolved, probe, failOpenReason, { projectRoot }),
     };
   }
+  resolved.managedCliRetention = managedCliRetentionReport(resolved, probe);
+  rememberLaunch(resolved);
 
   const localReadiness = probeLocalNavigation(resolved, projectRoot);
   if (!localReadiness.ready) {
@@ -1270,8 +1836,12 @@ async function handleBootstrapStatusCommand(argv) {
   try {
     if (!resolution.projectRoot) {
       const resolved = await resolveCli();
-      rememberLaunch(resolved);
       const probe = probeResolvedCli(resolved);
+      const failOpenReason = failOpenReasonForProbe(resolved, probe);
+      resolved.managedCliRetention = managedCliRetentionReport(resolved, probe, {
+        dryRun: Boolean(failOpenReason),
+      });
+      rememberLaunch(resolved);
       process.stdout.write(`${JSON.stringify({
         ready: false,
         ...projectRootUnavailableDiagnostic(resolved, probe, resolution),
@@ -1581,6 +2151,7 @@ function rememberLaunch(resolved, runtimeCwd = process.cwd()) {
       archiveSha256: resolved.archiveSha256 || null,
       archiveUrl: resolved.archiveUrl || null,
       provisionedAt: resolved.provisionedAt || null,
+      managedCliRetention: resolved.managedCliRetention || null,
       updatedAt: new Date().toISOString(),
     }, null, 2));
   } catch {
@@ -1607,6 +2178,7 @@ function stdioRuntimeEnv(resolved, runtimeCwd) {
     CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256: resolved.archiveSha256 || '',
     CODESTORY_PLUGIN_CLI_ARCHIVE_URL: resolved.archiveUrl || '',
     CODESTORY_PLUGIN_CLI_PROVISIONED_AT: resolved.provisionedAt || '',
+    CODESTORY_PLUGIN_CLI_RETENTION: JSON.stringify(resolved.managedCliRetention || null),
     CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
     CODESTORY_PLUGIN_MULTI_PROJECT: '1',
     CODESTORY_PLUGIN_DATA: pluginDataDir() || '',
@@ -1637,16 +2209,19 @@ async function main() {
   handleSidecarPolicyCommand(process.argv);
   const runtimeCwd = releasePluginCacheCwd();
   const resolved = await resolveCli();
-  rememberLaunch(resolved, runtimeCwd);
   const probe = probeResolvedCli(resolved);
   const failOpenReason = failOpenReasonForProbe(resolved, probe);
   if (failOpenReason) {
+    resolved.managedCliRetention = managedCliRetentionReport(resolved, probe, { dryRun: true });
+    rememberLaunch(resolved, runtimeCwd);
     runFailOpenMcp(fallbackDiagnostic(resolved, probe, failOpenReason, {
       projectRoot: null,
       projectRootSource: 'request_argument',
     }));
     return;
   }
+  resolved.managedCliRetention = managedCliRetentionReport(resolved, probe);
+  rememberLaunch(resolved, runtimeCwd);
   const child = spawnStdioRuntime(resolved, runtimeCwd, 'inherit');
 
   child.on('exit', (code, signal) => {
@@ -1714,7 +2289,12 @@ if (require.main === module) {
 } else {
   module.exports = {
     _test: {
+      compareManagedCliVersions,
       downloadFile,
+      managedCliRetentionReport,
+      managedCliVersionEntries,
+      removeManagedCliVersion,
+      verifyManagedCliVersion,
     },
   };
 }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -82,7 +82,7 @@ async function writeFakeCli(cliPath) {
   }
   await writeFile(
     cliPath,
-    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} "$@"\n`,
+    `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} -- "$@"\n`,
     "utf8",
   );
   await chmod(cliPath, 0o755);
@@ -94,7 +94,7 @@ async function writeRecordingCli(cliPath) {
     await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" -- %*\r\n`, "utf8");
     return;
   }
-  await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} "$@"\n`, "utf8");
+  await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} -- "$@"\n`, "utf8");
   await chmod(cliPath, 0o755);
 }
 

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { spawn, spawnSync } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -12,6 +12,7 @@ import { once } from "node:events";
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
 const require = createRequire(import.meta.url);
+const launcherTest = require(join(pluginRoot, "scripts", "codestory-mcp.cjs"))._test;
 const {
   dirtyMarkerPathForProject,
   dirtyHookStatus,
@@ -70,11 +71,11 @@ function releaseAssetForPlatform(version) {
 }
 
 async function writeFakeCli(cliPath) {
-  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,activeStatePath:process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,retention:process.env.CODESTORY_PLUGIN_CLI_RETENTION,activeStatePath:process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
-      `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`,
+      `@echo off\r\n"${process.execPath}" -e "${script}" -- %*\r\n`,
       "utf8",
     );
     return;
@@ -90,11 +91,26 @@ async function writeFakeCli(cliPath) {
 async function writeRecordingCli(cliPath) {
   const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'&&process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR!=='1'&&args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}fs.appendFileSync(process.env.TEST_LOG,JSON.stringify({repair:process.env.CODESTORY_PLUGIN_SIDECAR_REPAIR==='1',policy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,args})+'\\n')";
   if (process.platform === "win32") {
-    await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" %*\r\n`, "utf8");
+    await writeFile(cliPath, `@echo off\r\n"${process.execPath}" -e "${script}" -- %*\r\n`, "utf8");
     return;
   }
   await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} "$@"\n`, "utf8");
   await chmod(cliPath, 0o755);
+}
+
+async function writeManagedCliFixture(dataDir, version, body = version) {
+  const cliName = process.platform === "win32" ? "codestory-cli.exe" : "codestory-cli";
+  const versionDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(versionDir, "bin", cliName);
+  await mkdir(dirname(cliPath), { recursive: true });
+  await writeFile(cliPath, body, "utf8");
+  const sha256 = createHash("sha256").update(await readFile(cliPath)).digest("hex");
+  await writeFile(
+    join(versionDir, "manifest.json"),
+    JSON.stringify({ path: `bin/${cliName}`, sha256, version }),
+    "utf8",
+  );
+  return { cliPath, versionDir };
 }
 
 test("plugin metadata maps skill and direct stdio server", async () => {
@@ -348,13 +364,14 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       .digest("hex");
     await writeFile(
       join(cliDir, "manifest.json"),
-      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256, version }),
       "utf8",
     );
     const result = spawnSync(process.execPath, [launcher], {
       env: {
         PLUGIN_DATA: dataDir,
         TEST_OUT: outFile,
+        TEST_CODESTORY_VERSION: version,
         PATH: "",
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
@@ -366,6 +383,13 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.source, "managed");
     assert.equal(observed.path, cliPath);
     assert.equal(observed.sha256, sha256);
+    const retention = JSON.parse(observed.retention);
+    assert.deepEqual(
+      retention.retained.map((entry) => entry.version),
+      [version],
+      JSON.stringify(retention),
+    );
+    assert.equal(retention.reclaimable_bytes, 0);
     assert.equal(observed.pluginRoot, pluginRoot);
     assert.equal(observed.pluginCacheVersion, "");
     assert.equal(observed.activeStatePath, undefined);
@@ -393,6 +417,234 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(policy.state, "enabled");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli retention keeps active plus a verified adjacent version", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-"));
+  try {
+    assert.equal(launcherTest.compareManagedCliVersions("0.14.10", "0.14.9"), 1);
+    const oldest = await writeManagedCliFixture(dataDir, "0.14.0");
+    const active = await writeManagedCliFixture(dataDir, "0.14.1");
+    const newer = await writeManagedCliFixture(dataDir, "0.14.2");
+    const malformedDir = join(dataDir, "codestory-cli", "0.13.9");
+    await mkdir(malformedDir, { recursive: true });
+    await writeFile(join(malformedDir, "partial"), "stale", "utf8");
+    const probeVersion = (resolved) => ({
+      status: 0,
+      error: null,
+      version: resolved.version,
+      stdout: "",
+      stderr: "",
+    });
+    const resolved = {
+      source: "managed",
+      version: "0.14.1",
+      path: active.cliPath,
+      warnings: [],
+    };
+    const probe = probeVersion(resolved);
+
+    const dryRun = launcherTest.managedCliRetentionReport(resolved, probe, {
+      dataDir,
+      dryRun: true,
+      probeVersion,
+    });
+    assert.deepEqual(dryRun.retained.map((entry) => entry.version), ["0.14.2", "0.14.1"]);
+    assert.deepEqual(dryRun.reclaimable.map((entry) => entry.version), ["0.14.0", "0.13.9"]);
+    assert.equal(dryRun.removed_bytes, 0);
+    assert.equal(dryRun.reclaimable_bytes > 0, true);
+    await access(oldest.versionDir);
+    await access(malformedDir);
+
+    const applied = launcherTest.managedCliRetentionReport(resolved, probe, {
+      dataDir,
+      probeVersion,
+    });
+    assert.deepEqual(applied.retained.map((entry) => entry.version), ["0.14.2", "0.14.1"]);
+    assert.deepEqual(applied.removed.map((entry) => entry.version), ["0.14.0", "0.13.9"]);
+    assert.equal(applied.removed_bytes, dryRun.reclaimable_bytes);
+    await assert.rejects(access(oldest.versionDir));
+    await assert.rejects(access(malformedDir));
+    await access(active.versionDir);
+    await access(newer.versionDir);
+
+    const afterActivation = launcherTest.managedCliRetentionReport(
+      { ...resolved, version: "0.14.2", path: newer.cliPath },
+      { ...probe, version: "0.14.2" },
+      { dataDir, dryRun: true, probeVersion },
+    );
+    assert.deepEqual(afterActivation.retained.map((entry) => entry.version), ["0.14.2", "0.14.1"]);
+    assert.equal(afterActivation.retained.find((entry) => entry.version === "0.14.1").reason, "rollback");
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli retention reports a locked Windows executable without pruning it", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-lock-"));
+  try {
+    const stale = await writeManagedCliFixture(dataDir, "0.13.9");
+    const rollback = await writeManagedCliFixture(dataDir, "0.14.0");
+    const active = await writeManagedCliFixture(dataDir, "0.14.1");
+    const probeVersion = (resolved) => ({
+      status: 0,
+      error: null,
+      version: resolved.version,
+      stdout: "",
+      stderr: "",
+    });
+    const report = launcherTest.managedCliRetentionReport(
+      { source: "managed", version: "0.14.1", path: active.cliPath, warnings: [] },
+      probeVersion({ version: "0.14.1" }),
+      {
+        dataDir,
+        platform: "win32",
+        probeVersion,
+        unlinkSync(pathname) {
+          if (pathname.startsWith(stale.versionDir)) {
+            const error = new Error("locked");
+            error.code = "EPERM";
+            throw error;
+          }
+          return rm(pathname, { force: false });
+        },
+      },
+    );
+
+    assert.deepEqual(report.retained.map((entry) => entry.version), ["0.14.1", "0.14.0"]);
+    assert.equal(report.reclaimable.find((entry) => entry.version === "0.13.9").reason, "locked:EPERM");
+    assert.equal(report.removed_bytes, 0);
+    await access(stale.versionDir);
+    await access(rollback.versionDir);
+    await access(active.versionDir);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli retention suppresses deletion when the active manifest escapes its version", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-escape-"));
+  try {
+    const stale = await writeManagedCliFixture(dataDir, "0.14.0");
+    const active = await writeManagedCliFixture(dataDir, "0.14.1");
+    const outside = join(dataDir, "outside-cli");
+    await writeFile(outside, "outside", "utf8");
+    const outsideSha = createHash("sha256").update(await readFile(outside)).digest("hex");
+    await writeFile(
+      join(active.versionDir, "manifest.json"),
+      JSON.stringify({ path: "../../outside-cli", sha256: outsideSha, version: "0.14.1" }),
+      "utf8",
+    );
+    const probe = { status: 0, error: null, version: "0.14.1", stdout: "", stderr: "" };
+
+    const report = launcherTest.managedCliRetentionReport(
+      { source: "managed", version: "0.14.1", path: active.cliPath, warnings: [] },
+      probe,
+      {
+        dataDir,
+        probeVersion: () => probe,
+      },
+    );
+
+    assert.equal(
+      report.warnings.some((warning) => warning.includes("active_unverified:manifest_path_unsafe")),
+      true,
+    );
+    assert.equal(report.removed.length, 0);
+    await access(stale.versionDir);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli retention reclaims an abandoned lock and provisioning sentinel", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-abandoned-"));
+  try {
+    const stale = await writeManagedCliFixture(dataDir, "0.13.9");
+    await writeFile(join(stale.versionDir, ".provisioning"), "2147483647\n", "utf8");
+    await writeManagedCliFixture(dataDir, "0.14.0");
+    const active = await writeManagedCliFixture(dataDir, "0.14.1");
+    const lockDir = join(dataDir, "codestory-cli", ".retention-lock");
+    await mkdir(lockDir);
+    await writeFile(
+      join(lockDir, "owner.json"),
+      JSON.stringify({
+        pid: process.pid,
+        token: "abandoned",
+        purpose: "retention",
+        started_at: "2000-01-01T00:00:00.000Z",
+      }),
+      "utf8",
+    );
+    const probeVersion = (resolved) => ({
+      status: 0,
+      error: null,
+      version: resolved.version,
+      stdout: "",
+      stderr: "",
+    });
+
+    const report = launcherTest.managedCliRetentionReport(
+      { source: "managed", version: "0.14.1", path: active.cliPath, warnings: [] },
+      probeVersion({ version: "0.14.1" }),
+      { dataDir, probeVersion },
+    );
+
+    assert.deepEqual(report.removed.map((entry) => entry.version), ["0.13.9"]);
+    await assert.rejects(access(stale.versionDir));
+    await assert.rejects(access(lockDir));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli retention inventories versions when the active probe fails", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-unhealthy-"));
+  try {
+    const old = await writeManagedCliFixture(dataDir, "0.14.0");
+    const active = await writeManagedCliFixture(dataDir, "0.14.1");
+    const report = launcherTest.managedCliRetentionReport(
+      { source: "managed", version: "0.14.1", path: active.cliPath, warnings: [] },
+      { status: 1, error: null, version: null, stdout: "", stderr: "broken" },
+      { dataDir, dryRun: true },
+    );
+
+    assert.deepEqual(report.reclaimable.map((entry) => entry.version), ["0.14.1", "0.14.0"]);
+    assert.equal(report.reclaimable_bytes > 0, true);
+    assert.equal(report.removed.length, 0);
+    await access(old.versionDir);
+    await access(active.versionDir);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli retention refuses a linked managed root", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-linked-"));
+  const outside = await mkdtemp(join(tmpdir(), "codestory-managed-retention-outside-"));
+  try {
+    const outsideData = join(outside, "data");
+    const active = await writeManagedCliFixture(outsideData, "0.14.1");
+    await symlink(
+      join(outsideData, "codestory-cli"),
+      join(dataDir, "codestory-cli"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const probe = { status: 0, error: null, version: "0.14.1", stdout: "", stderr: "" };
+
+    const report = launcherTest.managedCliRetentionReport(
+      { source: "managed", version: "0.14.1", path: active.cliPath, warnings: [] },
+      probe,
+      { dataDir, probeVersion: () => probe },
+    );
+
+    assert.equal(report.warnings.some((warning) => warning.includes("managed_cli_root_not_direct")), true);
+    assert.equal(report.removed.length, 0);
+    await access(active.versionDir);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
   }
 });
 
@@ -1915,6 +2167,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
         CODESTORY_PLUGIN_RELEASE_DIR: releaseDir,
         PLUGIN_DATA: dataDir,
         TEST_OUT: outFile,
+        TEST_CODESTORY_VERSION: version,
       },
       encoding: "utf8",
     });


### PR DESCRIPTION
## Context

CodeStory retained every historical plugin-managed CLI and sidecar generation. On this machine that meant 23 managed CLI versions (about 1.66 GiB) and more than 5 GiB of currently discoverable sidecar generations for this project. Bootstrap also carried a legacy 64-collection cap that was disconnected from lexical and SCIP lifecycle state.

Closes #905
Refs #899

## What Changed

- Retain the active checksum/version-verified managed CLI plus one verified pending upgrade or rollback; prune older versions best-effort and expose retained, removed, and reclaimable byte totals through plugin runtime status.
- Publish managed CLIs from a verified staging directory under a recoverable PID/token lock. Active Windows executables, links, malformed roots, concurrent installs, and live provisioning are preserved; abandoned locks/staging are reclaimed safely.
- Add one post-publication sidecar retention planner spanning Qdrant, lexical shards, and SCIP artifacts. Every valid manifest-referenced active generation sharing a sidecar scope remains protected, while rollback protection is bounded to one freshly verified generation.
- Coordinate publication and namespace GC with one cache-root shared/exclusive lock, suppress deletion on stale/malformed protection state, and remove direct Qdrant disk orphans only after Qdrant explicitly reports `NotFound`.
- Add generation retention diagnostics to `retrieval index`, `retrieval inventory`, and `retrieval inventory --apply`; bootstrap no longer deletes valid collections under the unrelated 64-collection cap.
- Correct per-generation disk-byte accounting and document the new operator contract.

```mermaid
flowchart LR
  A["Build and verify replacement"] --> B["Publish active manifest"]
  B --> C["Verify one rollback"]
  C --> D["Inventory Qdrant + lexical + SCIP"]
  D --> E{"Protection state valid?"}
  E -- "no" --> F["Suppress pruning and report bytes"]
  E -- "yes" --> G["Remove only unreachable generations"]
```

## How To Review

1. Start with `crates/codestory-retrieval/src/retention.rs` for protection, planning, lock, byte, and removal contracts.
2. Review `crates/codestory-retrieval/src/index.rs` and `inventory.rs` for post-publication and operator wiring.
3. Review `plugins/codestory/scripts/codestory-mcp.cjs` for atomic managed CLI publication and retention.
4. Confirm bootstrap now defers valid collection pruning to post-publication retention in `qdrant_storage.rs`.
5. Review the tests for active/rollback/stale, malformed and linked roots, abandoned locks, Windows lock behavior, failed-probe inventory, shared worktrees, stale manifests, and Qdrant removal accounting.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p codestory-store -p codestory-retrieval -p codestory-cli --all-targets -- -D warnings`
- `cargo build --release -p codestory-cli`
- `cargo test -p codestory-retrieval -- --test-threads=1` (276 passed, 2 ignored across unit/integration binaries)
- `cargo test -p codestory-cli --test retrieval_bootstrap_contracts --test sidecar_status_cli -- --test-threads=1` (11 passed)
- `node --test plugins/codestory/tests/plugin-static.test.mjs` (47 passed)
- `node .github/scripts/check-doc-links.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- Live installed-plugin dry-run: active `0.14.2`; retained `0.14.2` + `0.14.1`; 21 versions / 1,587,836,242 bytes reclaimable; no warnings and no deletion.
- Live sidecar inventory dry-run: 23 generation bundles / 5,262,089,251 bytes reclaimable; pruning correctly suppressed because this checkout has no verified active manifest.

The required ignored repo-scale gate was attempted after the release build. It emitted no stats because `CODESTORY_REAL_REPO_DRILL_CASES` is unset and Windows denied `CREATE_BREAKAWAY_FROM_JOB` with error 5 during native embedding bootstrap.

## Risk

- Destructive generation apply and automatic post-publication pruning are covered through the remover/planner seams and publication wiring, but a healthy real-sidecar apply could not run in this Codex host because native embedding breakaway is denied. The live dry-run proves the fail-closed path and exact inventory only.
- Direct Qdrant filesystem cleanup is limited to canonical, direct collection directories after the live API explicitly returns `NotFound`; other deletion failures remain reclaimable and reported.
