### PR TITLE
Prune stale ports and bound embedding logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- Compacted stale agent sidecar port allocations atomically under the existing
+  registry lock while preserving live, state-backed, recently reserved, and
+  unverified owners. Native embedding launches now attempt to preserve only a
+  bounded previous log tail and truncate the current log without blocking
+  startup when housekeeping fails, while accelerator proof reads only a bounded
+  current tail.
 - Bounded plugin-managed CLI storage to the active checksummed runtime plus one
   verified upgrade or rollback candidate, with atomic staged publication,
   recoverable owner locks, Windows lock-safe cleanup, and retained, removed,

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -261,6 +261,7 @@ pub fn bootstrap_sidecars_with_runtime_progress(
     options: BootstrapSidecarsOptions,
     mut progress: impl FnMut(&'static str),
 ) -> Result<BootstrapReport> {
+    runtime.ensure_ports_allocated()?;
     let BootstrapSidecarsOptions {
         storage_scope,
         compose_file,
@@ -1468,12 +1469,8 @@ fn spawn_native_embedding_server_with_probe(
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create native llama.cpp log dir {}", parent.display()))?;
     }
-    let mut log = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&launch.log_path)
-        .with_context(|| format!("open native llama.cpp log {}", launch.log_path.display()))?;
     if native_embedding_server_reusable(&probe) {
+        let mut log = open_native_embedding_log(&launch.log_path)?;
         if let Some(spawn) = reusable_native_embedding_spawn_from_state(runtime, launch)? {
             writeln!(
                 log,
@@ -1494,6 +1491,7 @@ fn spawn_native_embedding_server_with_probe(
         );
     }
     if !allow_spawn {
+        let mut log = open_native_embedding_log(&launch.log_path)?;
         writeln!(
             log,
             "refusing native llama.cpp embedding server spawn under reuse-only broker lease after probe failed: {}",
@@ -1504,6 +1502,14 @@ fn spawn_native_embedding_server_with_probe(
             "native llama.cpp embedding endpoint is unreachable and the broker lease is reuse-only; refusing to start another native embedding server"
         );
     }
+    if let Err(error) = crate::embeddings::prepare_native_embedding_log_for_launch(&launch.log_path)
+    {
+        eprintln!(
+            "CodeStory native embedding log rotation warning: path={} error={error:#}",
+            launch.log_path.display()
+        );
+    }
+    let mut log = open_native_embedding_log(&launch.log_path)?;
     writeln!(
         log,
         "starting native llama.cpp embedding server: after probe failed ({}) {} {}",
@@ -1534,6 +1540,14 @@ fn spawn_native_embedding_server_with_probe(
             )
         }),
     }
+}
+
+fn open_native_embedding_log(path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("open native llama.cpp log {}", path.display()))
 }
 
 fn spawn_native_embedding_server_once(
@@ -2684,6 +2698,8 @@ mod tests {
             detail: "llama.cpp embeddings unavailable".into(),
             elapsed_ms: Some(5),
         };
+        std::fs::create_dir_all(launch.log_path.parent().expect("log parent")).expect("log parent");
+        std::fs::write(&launch.log_path, b"existing launch output\n").expect("existing log");
 
         let error = spawn_native_embedding_server_with_probe(&launch, &runtime, false, probe)
             .expect_err("reuse-only lease must not fall through to spawn");
@@ -2697,6 +2713,80 @@ mod tests {
             !error_text.contains("missing-llama-server"),
             "spawn path should not run under reuse-only lease: {error:?}"
         );
+        let log = std::fs::read_to_string(&launch.log_path).expect("current log");
+        assert!(log.contains("existing launch output"));
+        assert!(log.contains("reuse-only"));
+        assert!(
+            !launch
+                .log_path
+                .with_file_name("llama-server-native.previous.log")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn native_embedding_new_spawn_rotates_log_before_attempt() {
+        let temp = tempdir().expect("temp");
+        let runtime = compose_test_runtime(temp.path());
+        let launch = native_embedding_server_launch_from_paths(
+            temp.path().join("missing-llama-server.exe"),
+            temp.path().join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF),
+            &runtime,
+        );
+        std::fs::create_dir_all(launch.log_path.parent().expect("log parent")).expect("log parent");
+        std::fs::write(&launch.log_path, b"existing launch output\n").expect("existing log");
+        let probe = crate::embeddings::EmbeddingRuntimeProbe {
+            reachable: false,
+            detail: "llama.cpp embeddings unavailable".into(),
+            elapsed_ms: Some(5),
+        };
+
+        spawn_native_embedding_server_with_probe(&launch, &runtime, true, probe)
+            .expect_err("missing executable must fail after rotation");
+
+        let current = std::fs::read_to_string(&launch.log_path).expect("current log");
+        assert!(!current.contains("existing launch output"));
+        assert!(current.contains("starting native llama.cpp embedding server"));
+        let previous = std::fs::read_to_string(
+            launch
+                .log_path
+                .with_file_name("llama-server-native.previous.log"),
+        )
+        .expect("previous log");
+        assert_eq!(previous, "existing launch output\n");
+    }
+
+    #[test]
+    fn native_embedding_spawn_continues_when_log_rotation_is_blocked() {
+        let temp = tempdir().expect("temp");
+        let runtime = compose_test_runtime(temp.path());
+        let launch = native_embedding_server_launch_from_paths(
+            temp.path().join("missing-llama-server.exe"),
+            temp.path().join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF),
+            &runtime,
+        );
+        std::fs::create_dir_all(launch.log_path.parent().expect("log parent")).expect("log parent");
+        std::fs::write(&launch.log_path, b"existing launch output\n").expect("existing log");
+        std::fs::create_dir(
+            launch
+                .log_path
+                .with_file_name("llama-server-native.previous.log"),
+        )
+        .expect("block previous log publication");
+        let probe = crate::embeddings::EmbeddingRuntimeProbe {
+            reachable: false,
+            detail: "llama.cpp embeddings unavailable".into(),
+            elapsed_ms: Some(5),
+        };
+
+        let error = spawn_native_embedding_server_with_probe(&launch, &runtime, true, probe)
+            .expect_err("missing executable must still be the terminal failure");
+
+        let error = format!("{error:?}");
+        assert!(!error.contains("write bounded previous native embedding log"));
+        let current = std::fs::read_to_string(&launch.log_path).expect("current log");
+        assert!(current.contains("existing launch output"));
+        assert!(current.contains("starting native llama.cpp embedding server"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -6,8 +6,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::OpenOptions;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
-use tracing::warn;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Phase 2 lexical shard pin (local index + optional Zoekt webserver).
 pub const ZOEKT_REAL_VERSION_PIN: &str = "zoekt-20250506123554";
@@ -48,6 +47,7 @@ pub const NATIVE_LLAMA_MANAGED_CACHE_REL_PATH: &str =
 pub const NATIVE_LLAMA_SOURCE_CACHE_REL_PATH: &str = "target/llamacpp/b8840/llama-server.exe";
 const LLAMA_SIDECAR_BACKENDS_JSON: &str = include_str!("../assets/llama-sidecar-backends.json");
 const TEST_HOST_PLATFORM_ENV: &str = "CODESTORY_TEST_HOST_PLATFORM";
+const AGENT_PORT_RESERVATION_GRACE: Duration = Duration::from_secs(10 * 60);
 
 pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
 pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
@@ -279,47 +279,55 @@ impl SidecarRuntimeConfig {
         };
         let stored = read_ports_from_state(&state_file);
         let dynamic = profile == SidecarProfile::Agent && stored.is_none();
-        let dynamic_ports = dynamic.then(|| dynamic_agent_ports(&base, &namespace));
-        let zoekt_http_port = env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT)
-            .or_else(|| stored.as_ref().map(|ports| ports.zoekt_http))
-            .or_else(|| dynamic_ports.as_ref().map(|ports| ports.zoekt_http))
-            .unwrap_or_else(|| {
-                if dynamic {
-                    dynamic_agent_port(&namespace, "zoekt")
+        let configured_ports = [
+            env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT),
+            env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT),
+            env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT),
+            env_port("CODESTORY_EMBED_PORT", DEFAULT_EMBED_HTTP_PORT),
+        ];
+        let dynamic_ports =
+            dynamic.then(|| dynamic_agent_ports(&base, &namespace, configured_ports));
+        let dynamic_failed = dynamic_ports.as_ref().is_some_and(|ports| {
+            [
+                ports.zoekt_http,
+                ports.qdrant_http,
+                ports.qdrant_grpc,
+                ports.embed_http,
+            ]
+            .contains(&0)
+        });
+        let selected_port =
+            |configured: Option<u16>, stored: Option<u16>, dynamic: Option<u16>, default| {
+                if dynamic_failed {
+                    0
                 } else {
-                    DEFAULT_ZOEKT_HTTP_PORT
+                    configured.or(stored).or(dynamic).unwrap_or(default)
                 }
-            });
-        let qdrant_http_port = env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT)
-            .or_else(|| stored.as_ref().map(|ports| ports.qdrant_http))
-            .or_else(|| dynamic_ports.as_ref().map(|ports| ports.qdrant_http))
-            .unwrap_or_else(|| {
-                if dynamic {
-                    dynamic_agent_port(&namespace, "qdrant-http")
-                } else {
-                    DEFAULT_QDRANT_HTTP_PORT
-                }
-            });
-        let qdrant_grpc_port = env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT)
-            .or_else(|| stored.as_ref().map(|ports| ports.qdrant_grpc))
-            .or_else(|| dynamic_ports.as_ref().map(|ports| ports.qdrant_grpc))
-            .unwrap_or_else(|| {
-                if dynamic {
-                    dynamic_agent_port(&namespace, "qdrant-grpc")
-                } else {
-                    DEFAULT_QDRANT_GRPC_PORT
-                }
-            });
-        let embed_http_port = env_port("CODESTORY_EMBED_PORT", DEFAULT_EMBED_HTTP_PORT)
-            .or_else(|| stored.as_ref().map(|ports| ports.embed_http))
-            .or_else(|| dynamic_ports.as_ref().map(|ports| ports.embed_http))
-            .unwrap_or_else(|| {
-                if dynamic {
-                    dynamic_agent_port(&namespace, "embed")
-                } else {
-                    DEFAULT_EMBED_HTTP_PORT
-                }
-            });
+            };
+        let zoekt_http_port = selected_port(
+            configured_ports[0],
+            stored.as_ref().map(|ports| ports.zoekt_http),
+            dynamic_ports.as_ref().map(|ports| ports.zoekt_http),
+            DEFAULT_ZOEKT_HTTP_PORT,
+        );
+        let qdrant_http_port = selected_port(
+            configured_ports[1],
+            stored.as_ref().map(|ports| ports.qdrant_http),
+            dynamic_ports.as_ref().map(|ports| ports.qdrant_http),
+            DEFAULT_QDRANT_HTTP_PORT,
+        );
+        let qdrant_grpc_port = selected_port(
+            configured_ports[2],
+            stored.as_ref().map(|ports| ports.qdrant_grpc),
+            dynamic_ports.as_ref().map(|ports| ports.qdrant_grpc),
+            DEFAULT_QDRANT_GRPC_PORT,
+        );
+        let embed_http_port = selected_port(
+            configured_ports[3],
+            stored.as_ref().map(|ports| ports.embed_http),
+            dynamic_ports.as_ref().map(|ports| ports.embed_http),
+            DEFAULT_EMBED_HTTP_PORT,
+        );
         let root = match profile {
             SidecarProfile::Local => base.clone(),
             SidecarProfile::Agent => base.join("sidecars").join(&namespace),
@@ -402,6 +410,23 @@ impl SidecarRuntimeConfig {
             },
             labels: self.labels.clone(),
         }
+    }
+
+    pub(crate) fn ensure_ports_allocated(&self) -> Result<()> {
+        if self.profile == SidecarProfile::Agent
+            && [
+                self.layout.zoekt_http_port,
+                self.layout.qdrant_http_port,
+                self.layout.qdrant_grpc_port,
+                self.embed_http_port,
+            ]
+            .contains(&0)
+        {
+            anyhow::bail!(
+                "agent sidecar port allocation is unavailable; inspect sidecars/port-allocations.json and retry"
+            );
+        }
+        Ok(())
     }
 
     pub fn activate_embed_url_default(&self) {
@@ -641,22 +666,26 @@ fn read_ports_from_state(path: &Path) -> Option<SidecarPorts> {
     })
 }
 
-fn dynamic_agent_port(namespace: &str, salt: &str) -> u16 {
-    dynamic_agent_port_excluding(namespace, salt, &BTreeSet::new())
-}
-
-fn dynamic_agent_ports(base: &Path, namespace: &str) -> SidecarPorts {
-    allocate_agent_ports_in_registry(base, namespace).unwrap_or_else(|error| {
-        warn!(
-            namespace,
-            error = %error,
-            "falling back to unlocked dynamic agent sidecar port allocation"
+fn dynamic_agent_ports(base: &Path, namespace: &str, configured: [Option<u16>; 4]) -> SidecarPorts {
+    allocate_agent_ports_in_registry(base, namespace, configured).unwrap_or_else(|error| {
+        eprintln!(
+            "CodeStory sidecar port allocation failed closed: namespace={namespace} error={error:#}"
         );
-        fallback_dynamic_agent_ports(namespace)
+        SidecarPorts {
+            zoekt_http: 0,
+            qdrant_http: 0,
+            qdrant_grpc: 0,
+            embed_http: 0,
+            embed_url: SidecarLayout::embed_base_url(0),
+        }
     })
 }
 
-fn allocate_agent_ports_in_registry(base: &Path, namespace: &str) -> Result<SidecarPorts> {
+fn allocate_agent_ports_in_registry(
+    base: &Path,
+    namespace: &str,
+    configured: [Option<u16>; 4],
+) -> Result<SidecarPorts> {
     let root = base.join("sidecars");
     std::fs::create_dir_all(&root)
         .with_context(|| format!("create sidecar port registry dir {}", root.display()))?;
@@ -672,16 +701,40 @@ fn allocate_agent_ports_in_registry(base: &Path, namespace: &str) -> Result<Side
         .with_context(|| format!("take sidecar port allocation lock {}", lock_path.display()))?;
 
     let registry_path = root.join("port-allocations.json");
-    let mut registry = read_agent_port_registry(&registry_path);
-    if let Some(ports) = registry.get(namespace) {
-        return Ok(ports.clone());
-    }
-
-    let mut reserved = reserved_registry_ports(&registry);
-    let zoekt_http = reserve_dynamic_agent_port(namespace, "zoekt", &mut reserved);
-    let qdrant_http = reserve_dynamic_agent_port(namespace, "qdrant-http", &mut reserved);
-    let qdrant_grpc = reserve_dynamic_agent_port(namespace, "qdrant-grpc", &mut reserved);
-    let embed_http = reserve_dynamic_agent_port(namespace, "embed", &mut reserved);
+    let mut registry = read_agent_port_registry(&registry_path)?;
+    let existing = registry.get(namespace).cloned();
+    let current_reservation_is_recent =
+        agent_port_reservation_is_recent(&root, namespace, now_epoch_ms())?;
+    let cleanup = prune_agent_port_registry(&root, namespace, &mut registry);
+    let mut reserved = reserved_registry_ports_excluding(&registry, namespace);
+    let zoekt_http = select_agent_port(
+        configured[0],
+        existing.as_ref().map(|ports| ports.zoekt_http),
+        namespace,
+        "zoekt",
+        &mut reserved,
+    )?;
+    let qdrant_http = select_agent_port(
+        configured[1],
+        existing.as_ref().map(|ports| ports.qdrant_http),
+        namespace,
+        "qdrant-http",
+        &mut reserved,
+    )?;
+    let qdrant_grpc = select_agent_port(
+        configured[2],
+        existing.as_ref().map(|ports| ports.qdrant_grpc),
+        namespace,
+        "qdrant-grpc",
+        &mut reserved,
+    )?;
+    let embed_http = select_agent_port(
+        configured[3],
+        existing.as_ref().map(|ports| ports.embed_http),
+        namespace,
+        "embed",
+        &mut reserved,
+    )?;
     let ports = SidecarPorts {
         zoekt_http,
         qdrant_http,
@@ -689,27 +742,245 @@ fn allocate_agent_ports_in_registry(base: &Path, namespace: &str) -> Result<Side
         embed_http,
         embed_url: SidecarLayout::embed_base_url(embed_http),
     };
-    registry.insert(namespace.to_string(), ports.clone());
-    std::fs::write(&registry_path, serde_json::to_vec_pretty(&registry)?).with_context(|| {
-        format!(
-            "write sidecar port allocation registry {}",
-            registry_path.display()
-        )
-    })?;
+    let changed = existing.as_ref() != Some(&ports);
+    if changed
+        && existing
+            .as_ref()
+            .is_some_and(|ports| current_reservation_is_recent || sidecar_ports_are_bound(ports))
+    {
+        anyhow::bail!(
+            "agent sidecar namespace {namespace} already has an active or recently reserved port allocation"
+        );
+    }
+    write_agent_port_reservation(&root, namespace)?;
+    if changed {
+        registry.insert(namespace.to_string(), ports.clone());
+    }
+    if changed || cleanup.pruned > 0 {
+        write_agent_port_registry(&registry_path, &registry)?;
+    }
+    if cleanup.pruned > 0 || cleanup.failures > 0 {
+        eprintln!(
+            "CodeStory sidecar port cleanup: pruned={} retained={} failures={}",
+            cleanup.pruned, cleanup.retained, cleanup.failures
+        );
+        for detail in &cleanup.failure_details {
+            eprintln!("CodeStory sidecar port cleanup warning: {detail}");
+        }
+        if cleanup.failures > cleanup.failure_details.len() {
+            eprintln!(
+                "CodeStory sidecar port cleanup warning: {} additional failures omitted",
+                cleanup.failures - cleanup.failure_details.len()
+            );
+        }
+    }
     Ok(ports)
 }
 
-fn read_agent_port_registry(path: &Path) -> BTreeMap<String, SidecarPorts> {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|body| serde_json::from_str(&body).ok())
-        .unwrap_or_default()
+#[derive(Debug, Default, PartialEq, Eq)]
+struct AgentPortRegistryCleanup {
+    pruned: usize,
+    retained: usize,
+    failures: usize,
+    failure_details: Vec<String>,
 }
 
-fn reserved_registry_ports(registry: &BTreeMap<String, SidecarPorts>) -> BTreeSet<u16> {
+#[derive(Debug, Serialize, Deserialize)]
+struct AgentPortReservation {
+    reserved_at_epoch_ms: i64,
+}
+
+fn write_agent_port_reservation(root: &Path, namespace: &str) -> Result<()> {
+    let reservation = AgentPortReservation {
+        reserved_at_epoch_ms: now_epoch_ms(),
+    };
+    let bytes = serde_json::to_vec_pretty(&reservation)?;
+    codestory_workspace::atomic_file::write_bytes_atomic(
+        &agent_port_reservation_path(root, namespace),
+        "agent-port-reservation",
+        &bytes,
+    )
+    .with_context(|| format!("write agent port reservation for {namespace}"))
+}
+
+fn agent_port_reservation_is_recent(
+    root: &Path,
+    namespace: &str,
+    now_epoch_ms: i64,
+) -> Result<bool> {
+    let path = agent_port_reservation_path(root, namespace);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    let reservation: AgentPortReservation =
+        serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))?;
+    Ok(
+        now_epoch_ms.saturating_sub(reservation.reserved_at_epoch_ms)
+            < AGENT_PORT_RESERVATION_GRACE.as_millis() as i64,
+    )
+}
+
+fn write_agent_port_registry(path: &Path, registry: &BTreeMap<String, SidecarPorts>) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(registry)?;
+    codestory_workspace::atomic_file::write_bytes_atomic(path, "agent-port-registry", &bytes)
+        .with_context(|| format!("write sidecar port allocation registry {}", path.display()))
+}
+
+fn prune_agent_port_registry(
+    root: &Path,
+    current_namespace: &str,
+    registry: &mut BTreeMap<String, SidecarPorts>,
+) -> AgentPortRegistryCleanup {
+    let now = now_epoch_ms();
+    let mut cleanup = AgentPortRegistryCleanup::default();
+    registry.retain(|namespace, ports| {
+        if namespace == current_namespace {
+            return true;
+        }
+        match agent_port_allocation_is_retained(root, namespace, ports, now) {
+            Ok(true) => {
+                cleanup.retained += 1;
+                true
+            }
+            Ok(false) => {
+                cleanup.pruned += 1;
+                if let Err(error) =
+                    std::fs::remove_file(agent_port_reservation_path(root, namespace))
+                    && error.kind() != std::io::ErrorKind::NotFound
+                {
+                    cleanup.failures += 1;
+                    cleanup.record_failure(format!(
+                        "namespace={namespace} failed to remove stale reservation: {error}"
+                    ));
+                }
+                false
+            }
+            Err(error) => {
+                cleanup.failures += 1;
+                cleanup.record_failure(format!(
+                    "namespace={namespace} preserved unverified allocation: {error:#}"
+                ));
+                true
+            }
+        }
+    });
+    cleanup
+}
+
+impl AgentPortRegistryCleanup {
+    fn record_failure(&mut self, detail: String) {
+        if self.failure_details.len() < 5 {
+            self.failure_details.push(detail);
+        }
+    }
+}
+
+fn agent_port_allocation_is_retained(
+    root: &Path,
+    namespace: &str,
+    ports: &SidecarPorts,
+    now_epoch_ms: i64,
+) -> Result<bool> {
+    if !is_agent_namespace_path_component(namespace) {
+        anyhow::bail!("registry namespace is not a safe agent path component");
+    }
+    let namespace_root = root.join(namespace);
+    if agent_port_reservation_is_recent(root, namespace, now_epoch_ms)? {
+        return Ok(true);
+    }
+
+    let state_path = namespace_root.join("retrieval-sidecars.json");
+    let state_bytes = match std::fs::read(&state_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(sidecar_ports_are_bound(ports));
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("read {}", state_path.display()));
+        }
+    };
+    let value: serde_json::Value = serde_json::from_slice(&state_bytes)
+        .with_context(|| format!("parse {}", state_path.display()))?;
+    if value.get("owner").and_then(|value| value.as_str()) != Some("codestory")
+        || value.get("namespace").and_then(|value| value.as_str()) != Some(namespace)
+    {
+        anyhow::bail!("state owner or namespace does not match registry allocation");
+    }
+    let state_ports = sidecar_ports_from_value(&value)
+        .context("state does not contain a complete sidecar port allocation")?;
+    if &state_ports != ports {
+        anyhow::bail!("state ports do not match registry allocation");
+    }
+    // A valid state file still causes runtime construction to reuse these ports, even if the
+    // owner is temporarily down. Reclaim only after normal teardown removes the state contract.
+    Ok(true)
+}
+
+fn is_agent_namespace_path_component(namespace: &str) -> bool {
+    !namespace.is_empty()
+        && namespace
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn sidecar_ports_are_bound(ports: &SidecarPorts) -> bool {
+    [
+        ports.zoekt_http,
+        ports.qdrant_http,
+        ports.qdrant_grpc,
+        ports.embed_http,
+    ]
+    .into_iter()
+    .any(|port| !local_port_available(port))
+}
+
+fn agent_port_reservation_path(root: &Path, namespace: &str) -> PathBuf {
+    root.join(format!(".port-allocation-{namespace}.json"))
+}
+
+fn sidecar_ports_from_value(value: &serde_json::Value) -> Option<SidecarPorts> {
+    let embed_http = value.get("embed_http_port")?.as_u64()?.try_into().ok()?;
+    Some(SidecarPorts {
+        zoekt_http: value.get("zoekt_http_port")?.as_u64()?.try_into().ok()?,
+        qdrant_http: value.get("qdrant_http_port")?.as_u64()?.try_into().ok()?,
+        qdrant_grpc: value.get("qdrant_grpc_port")?.as_u64()?.try_into().ok()?,
+        embed_http,
+        embed_url: value.get("embed_url")?.as_str().map(ToOwned::to_owned)?,
+    })
+}
+
+fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(i64::MAX as u128) as i64
+}
+
+fn read_agent_port_registry(path: &Path) -> Result<BTreeMap<String, SidecarPorts>> {
+    let body = match std::fs::read_to_string(path) {
+        Ok(body) => body,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("read sidecar port allocation registry {}", path.display())
+            });
+        }
+    };
+    serde_json::from_str(&body)
+        .with_context(|| format!("parse sidecar port allocation registry {}", path.display()))
+}
+
+fn reserved_registry_ports_excluding(
+    registry: &BTreeMap<String, SidecarPorts>,
+    namespace: &str,
+) -> BTreeSet<u16> {
     registry
-        .values()
-        .flat_map(|ports| {
+        .iter()
+        .filter(|(candidate, _)| candidate.as_str() != namespace)
+        .flat_map(|(_, ports)| {
             [
                 ports.zoekt_http,
                 ports.qdrant_http,
@@ -718,6 +989,22 @@ fn reserved_registry_ports(registry: &BTreeMap<String, SidecarPorts>) -> BTreeSe
             ]
         })
         .collect()
+}
+
+fn select_agent_port(
+    configured: Option<u16>,
+    existing: Option<u16>,
+    namespace: &str,
+    salt: &str,
+    reserved: &mut BTreeSet<u16>,
+) -> Result<u16> {
+    if let Some(port) = configured.or(existing) {
+        if !reserved.insert(port) {
+            anyhow::bail!("agent sidecar port {port} is already reserved");
+        }
+        return Ok(port);
+    }
+    Ok(reserve_dynamic_agent_port(namespace, salt, reserved))
 }
 
 fn reserve_dynamic_agent_port(namespace: &str, salt: &str, reserved: &mut BTreeSet<u16>) -> u16 {
@@ -758,21 +1045,6 @@ fn free_local_port() -> u16 {
         .and_then(|listener| listener.local_addr())
         .map(|addr| addr.port())
         .unwrap_or(0)
-}
-
-fn fallback_dynamic_agent_ports(namespace: &str) -> SidecarPorts {
-    let mut reserved = BTreeSet::new();
-    let zoekt_http = reserve_dynamic_agent_port(namespace, "zoekt", &mut reserved);
-    let qdrant_http = reserve_dynamic_agent_port(namespace, "qdrant-http", &mut reserved);
-    let qdrant_grpc = reserve_dynamic_agent_port(namespace, "qdrant-grpc", &mut reserved);
-    let embed_http = reserve_dynamic_agent_port(namespace, "embed", &mut reserved);
-    SidecarPorts {
-        zoekt_http,
-        qdrant_http,
-        qdrant_grpc,
-        embed_http,
-        embed_url: SidecarLayout::embed_base_url(embed_http),
-    }
 }
 
 fn fnv1a_hex(bytes: &[u8]) -> String {
@@ -1063,12 +1335,12 @@ mod tests {
     fn agent_port_registry_reuses_namespace_and_avoids_registered_ports() {
         let cache = tempdir().expect("cache");
 
-        let first =
-            allocate_agent_ports_in_registry(cache.path(), "codestory-agent-a").expect("first");
-        let same =
-            allocate_agent_ports_in_registry(cache.path(), "codestory-agent-a").expect("same");
-        let other =
-            allocate_agent_ports_in_registry(cache.path(), "codestory-agent-b").expect("other");
+        let first = allocate_agent_ports_in_registry(cache.path(), "codestory-agent-a", [None; 4])
+            .expect("first");
+        let same = allocate_agent_ports_in_registry(cache.path(), "codestory-agent-a", [None; 4])
+            .expect("same");
+        let other = allocate_agent_ports_in_registry(cache.path(), "codestory-agent-b", [None; 4])
+            .expect("other");
 
         assert_eq!(first, same);
         let ports = [
@@ -1083,6 +1355,313 @@ mod tests {
         ];
         let unique: BTreeSet<_> = ports.into_iter().collect();
         assert_eq!(unique.len(), ports.len());
+    }
+
+    #[test]
+    fn agent_port_registry_refuses_recent_same_namespace_reassignment() {
+        let cache = tempdir().expect("cache");
+        let first =
+            allocate_agent_ports_in_registry(cache.path(), "same", [None; 4]).expect("first");
+        let (listeners, configured) = test_sidecar_ports();
+        drop(listeners);
+
+        allocate_agent_ports_in_registry(
+            cache.path(),
+            "same",
+            [
+                Some(configured.zoekt_http),
+                Some(configured.qdrant_http),
+                Some(configured.qdrant_grpc),
+                Some(configured.embed_http),
+            ],
+        )
+        .expect_err("recent allocation must not be reassigned");
+
+        let registry =
+            read_agent_port_registry(&cache.path().join("sidecars").join("port-allocations.json"))
+                .expect("registry");
+        assert_eq!(registry.get("same"), Some(&first));
+    }
+
+    #[test]
+    fn agent_port_registry_tracks_explicit_runtime_ports() {
+        let _lock = crate::test_support::env_lock();
+        let cache = tempdir().expect("cache");
+        let (listeners, configured) = test_sidecar_ports();
+        drop(listeners);
+        let _cache = EnvGuard::set(
+            "CODESTORY_CACHE_ROOT",
+            cache.path().to_str().expect("utf8 cache"),
+        );
+        let _zoekt = EnvGuard::set("CODESTORY_ZOEKT_PORT", &configured.zoekt_http.to_string());
+        let _qdrant_http = EnvGuard::set(
+            "CODESTORY_QDRANT_HTTP_PORT",
+            &configured.qdrant_http.to_string(),
+        );
+        let _qdrant_grpc = EnvGuard::set(
+            "CODESTORY_QDRANT_GRPC_PORT",
+            &configured.qdrant_grpc.to_string(),
+        );
+        let _embed = EnvGuard::set("CODESTORY_EMBED_PORT", &configured.embed_http.to_string());
+
+        let runtime = SidecarRuntimeConfig::for_project_profile_with_run_id(
+            None,
+            SidecarProfile::Agent,
+            Some("configured"),
+        );
+        let root = cache.path().join("sidecars");
+        let registry =
+            read_agent_port_registry(&root.join("port-allocations.json")).expect("read registry");
+
+        assert_eq!(registry.get(&runtime.namespace), Some(&configured));
+        std::fs::remove_file(agent_port_reservation_path(&root, &runtime.namespace))
+            .expect("remove startup reservation");
+        write_test_sidecar_state(&root, &runtime.namespace, &configured, None);
+        let mut registry = registry;
+        let cleanup = prune_agent_port_registry(&root, "other", &mut registry);
+        assert_eq!(cleanup.retained, 1);
+        assert_eq!(cleanup.failures, 0);
+    }
+
+    fn test_sidecar_ports() -> (Vec<TcpListener>, SidecarPorts) {
+        let listeners: Vec<_> = (0..4)
+            .map(|_| TcpListener::bind(("127.0.0.1", 0)).expect("reserve test port"))
+            .collect();
+        let ports: Vec<_> = listeners
+            .iter()
+            .map(|listener| listener.local_addr().expect("local address").port())
+            .collect();
+        (
+            listeners,
+            SidecarPorts {
+                zoekt_http: ports[0],
+                qdrant_http: ports[1],
+                qdrant_grpc: ports[2],
+                embed_http: ports[3],
+                embed_url: SidecarLayout::embed_base_url(ports[3]),
+            },
+        )
+    }
+
+    fn write_test_sidecar_state(
+        root: &Path,
+        namespace: &str,
+        ports: &SidecarPorts,
+        embedding_launch: Option<serde_json::Value>,
+    ) {
+        let namespace_root = root.join(namespace);
+        std::fs::create_dir_all(&namespace_root).expect("namespace root");
+        std::fs::write(
+            namespace_root.join("retrieval-sidecars.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "owner": "codestory",
+                "namespace": namespace,
+                "zoekt_http_port": ports.zoekt_http,
+                "qdrant_http_port": ports.qdrant_http,
+                "qdrant_grpc_port": ports.qdrant_grpc,
+                "embed_http_port": ports.embed_http,
+                "embed_url": ports.embed_url,
+                "embedding_launch": embedding_launch,
+            }))
+            .expect("serialize state"),
+        )
+        .expect("write state");
+    }
+
+    #[test]
+    fn agent_port_registry_prunes_missing_state() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        let (listeners, ports) = test_sidecar_ports();
+        drop(listeners);
+        let mut registry = BTreeMap::from([("stale".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert!(registry.is_empty());
+        assert_eq!(cleanup.pruned, 1);
+        assert_eq!(cleanup.failures, 0);
+    }
+
+    #[test]
+    fn agent_port_registry_preserves_live_bound_state() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        let (listeners, ports) = test_sidecar_ports();
+        write_test_sidecar_state(&root, "live", &ports, None);
+        let mut registry = BTreeMap::from([("live".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert_eq!(listeners.len(), 4);
+        assert!(registry.contains_key("live"));
+        assert_eq!(cleanup.retained, 1);
+        assert_eq!(cleanup.pruned, 0);
+    }
+
+    #[test]
+    fn agent_port_registry_preserves_bound_port_without_state() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        let (listeners, ports) = test_sidecar_ports();
+        let mut registry = BTreeMap::from([("ownerless".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert_eq!(listeners.len(), 4);
+        assert!(registry.contains_key("ownerless"));
+        assert_eq!(cleanup.retained, 1);
+    }
+
+    #[test]
+    fn agent_port_registry_preserves_malformed_state_fail_closed() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        let namespace_root = root.join("malformed");
+        std::fs::create_dir_all(&namespace_root).expect("namespace root");
+        std::fs::write(namespace_root.join("retrieval-sidecars.json"), b"{")
+            .expect("malformed state");
+        let (_listeners, ports) = test_sidecar_ports();
+        let mut registry = BTreeMap::from([("malformed".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert!(registry.contains_key("malformed"));
+        assert_eq!(cleanup.failures, 1);
+        assert_eq!(cleanup.pruned, 0);
+    }
+
+    #[test]
+    fn agent_port_registry_preserves_unreadable_state_shape_fail_closed() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        std::fs::create_dir_all(root.join("unreadable").join("retrieval-sidecars.json"))
+            .expect("state path directory");
+        let (listeners, ports) = test_sidecar_ports();
+        drop(listeners);
+        let mut registry = BTreeMap::from([("unreadable".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert!(registry.contains_key("unreadable"));
+        assert_eq!(cleanup.failures, 1);
+    }
+
+    #[test]
+    fn agent_port_registry_rejects_traversal_namespace_without_touching_outside_file() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        std::fs::create_dir_all(&root).expect("sidecars root");
+        let sentinel = cache.path().join("outside.json");
+        std::fs::write(&sentinel, b"keep").expect("outside sentinel");
+        let (listeners, ports) = test_sidecar_ports();
+        drop(listeners);
+        let mut registry = BTreeMap::from([("../outside".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert!(registry.contains_key("../outside"));
+        assert_eq!(cleanup.failures, 1);
+        assert_eq!(std::fs::read(&sentinel).expect("outside sentinel"), b"keep");
+    }
+
+    #[test]
+    fn agent_port_registry_preserves_state_with_reused_pid_fail_closed() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        let (listeners, ports) = test_sidecar_ports();
+        drop(listeners);
+        write_test_sidecar_state(
+            &root,
+            "reused",
+            &ports,
+            Some(serde_json::json!({
+                "provider": "llamacpp",
+                "launch_mode": "native_spawned",
+                "endpoint": ports.embed_url,
+                "pid": std::process::id(),
+            })),
+        );
+        let mut registry = BTreeMap::from([("reused".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert!(registry.contains_key("reused"));
+        assert_eq!(cleanup.retained, 1);
+    }
+
+    #[test]
+    fn agent_port_registry_preserves_recent_startup_reservation() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        write_agent_port_reservation(&root, "starting").expect("reservation");
+        let (_listeners, ports) = test_sidecar_ports();
+        let mut registry = BTreeMap::from([("starting".to_string(), ports)]);
+
+        let cleanup = prune_agent_port_registry(&root, "current", &mut registry);
+
+        assert!(registry.contains_key("starting"));
+        assert_eq!(cleanup.retained, 1);
+    }
+
+    #[test]
+    fn agent_port_registry_compaction_is_complete_and_parseable() {
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        std::fs::create_dir_all(&root).expect("sidecars root");
+        let (listeners, stale_ports) = test_sidecar_ports();
+        drop(listeners);
+        let registry_path = root.join("port-allocations.json");
+        write_agent_port_registry(
+            &registry_path,
+            &BTreeMap::from([("stale".to_string(), stale_ports)]),
+        )
+        .expect("seed registry");
+
+        let current = allocate_agent_ports_in_registry(cache.path(), "current", [None; 4])
+            .expect("allocate after compaction");
+        let compacted = read_agent_port_registry(&registry_path).expect("parse compacted registry");
+
+        assert_eq!(
+            compacted,
+            BTreeMap::from([("current".to_string(), current)])
+        );
+    }
+
+    #[test]
+    fn malformed_agent_port_registry_fails_closed_in_runtime_path() {
+        let _lock = crate::test_support::env_lock();
+        let cache = tempdir().expect("cache");
+        let root = cache.path().join("sidecars");
+        std::fs::create_dir_all(&root).expect("sidecars root");
+        let registry_path = root.join("port-allocations.json");
+        std::fs::write(&registry_path, b"{").expect("malformed registry");
+        let _cache = EnvGuard::set(
+            "CODESTORY_CACHE_ROOT",
+            cache.path().to_str().expect("utf8 cache"),
+        );
+        let _zoekt = EnvGuard::set("CODESTORY_ZOEKT_PORT", "invalid");
+        let _qdrant_http = EnvGuard::set("CODESTORY_QDRANT_HTTP_PORT", "invalid");
+        let _qdrant_grpc = EnvGuard::set("CODESTORY_QDRANT_GRPC_PORT", "invalid");
+        let _embed = EnvGuard::set("CODESTORY_EMBED_PORT", "invalid");
+
+        let runtime = SidecarRuntimeConfig::for_project_profile_with_run_id(
+            None,
+            SidecarProfile::Agent,
+            Some("current"),
+        );
+
+        assert_eq!(runtime.layout.zoekt_http_port, 0);
+        assert_eq!(runtime.layout.qdrant_http_port, 0);
+        assert_eq!(runtime.layout.qdrant_grpc_port, 0);
+        assert_eq!(runtime.embed_http_port, 0);
+        runtime
+            .ensure_ports_allocated()
+            .expect_err("malformed registry must block sidecar startup");
+        assert_eq!(
+            std::fs::read(&registry_path).expect("registry remains"),
+            b"{"
+        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -9,8 +9,10 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::hash_map::DefaultHasher;
+use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -42,6 +44,8 @@ const LLAMACPP_DEVICE_ENV: &str = "CODESTORY_EMBED_LLAMACPP_DEVICE";
 const LLAMACPP_N_GPU_LAYERS_ENV: &str = "CODESTORY_EMBED_LLAMACPP_N_GPU_LAYERS";
 const ALLOW_CPU_ENV: &str = "CODESTORY_EMBED_ALLOW_CPU";
 const NATIVE_LLAMA_LOG_START_MARKER: &str = "starting native llama.cpp embedding server:";
+const NATIVE_LLAMA_LOG_READ_TAIL_BYTES: u64 = 512 * 1024;
+const NATIVE_LLAMA_PREVIOUS_LOG_TAIL_BYTES: u64 = 256 * 1024;
 const RUNTIME_EMBED_DEVICE_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(10);
 const RUNTIME_EMBED_DEVICE_OBSERVATION_POLL: Duration = Duration::from_millis(250);
 
@@ -236,7 +240,11 @@ fn observe_sidecar_embedding_device_state(
 fn observe_native_embedding_device_state(
     runtime: &crate::config::SidecarRuntimeConfig,
 ) -> Option<EmbeddingDeviceObservation> {
-    let text = std::fs::read_to_string(native_embedding_log_path(runtime)).ok();
+    let text = read_native_embedding_log_tail(
+        &native_embedding_log_path(runtime),
+        NATIVE_LLAMA_LOG_READ_TAIL_BYTES,
+    )
+    .ok();
     if let Some(text) = text.as_deref() {
         match observed_embedding_device_state_from_text(native_embedding_log_current_launch(text)) {
             "unknown" => {}
@@ -307,6 +315,49 @@ pub(crate) fn native_embedding_log_path(runtime: &crate::config::SidecarRuntimeC
         .parent()
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("llama-server-native.log")
+}
+
+pub(crate) fn prepare_native_embedding_log_for_launch(path: &Path) -> Result<()> {
+    if !path.is_file() {
+        return Ok(());
+    }
+    let previous = read_native_embedding_log_tail_bytes(path, NATIVE_LLAMA_PREVIOUS_LOG_TAIL_BYTES)
+        .with_context(|| format!("read bounded native embedding log tail {}", path.display()))?;
+    let previous_path = path.with_file_name("llama-server-native.previous.log");
+    codestory_workspace::atomic_file::write_bytes_atomic(
+        &previous_path,
+        "native-embedding-log",
+        &previous,
+    )
+    .with_context(|| {
+        format!(
+            "write bounded previous native embedding log {}",
+            previous_path.display()
+        )
+    })?;
+    OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .with_context(|| format!("truncate native embedding log {}", path.display()))?;
+    Ok(())
+}
+
+fn read_native_embedding_log_tail(path: &Path, max_bytes: u64) -> std::io::Result<String> {
+    Ok(
+        String::from_utf8_lossy(&read_native_embedding_log_tail_bytes(path, max_bytes)?)
+            .into_owned(),
+    )
+}
+
+fn read_native_embedding_log_tail_bytes(path: &Path, max_bytes: u64) -> std::io::Result<Vec<u8>> {
+    let mut file = File::open(path)?;
+    let len = file.metadata()?.len();
+    file.seek(SeekFrom::Start(len.saturating_sub(max_bytes)))?;
+    let remaining = len.min(max_bytes);
+    let mut bytes = Vec::with_capacity(remaining as usize);
+    file.take(remaining).read_to_end(&mut bytes)?;
+    Ok(bytes)
 }
 
 fn native_embedding_log_current_launch(text: &str) -> &str {
@@ -1415,6 +1466,51 @@ mod tests {
             observed_embedding_device_state_from_text(current),
             "accelerated"
         );
+    }
+
+    #[test]
+    fn native_log_rotation_keeps_exact_bounded_raw_tail() {
+        let dir = tempfile::tempdir().expect("log dir");
+        let path = dir.path().join("llama-server-native.log");
+        let mut bytes = vec![b'x'; NATIVE_LLAMA_PREVIOUS_LOG_TAIL_BYTES as usize + 37];
+        let tail_start = bytes.len() - NATIVE_LLAMA_PREVIOUS_LOG_TAIL_BYTES as usize;
+        bytes[tail_start] = 0xff;
+        std::fs::write(&path, &bytes).expect("write oversized log");
+
+        prepare_native_embedding_log_for_launch(&path).expect("rotate log");
+
+        assert_eq!(std::fs::metadata(&path).expect("current metadata").len(), 0);
+        let previous = std::fs::read(dir.path().join("llama-server-native.previous.log"))
+            .expect("previous tail");
+        assert_eq!(
+            previous.len(),
+            NATIVE_LLAMA_PREVIOUS_LOG_TAIL_BYTES as usize
+        );
+        assert_eq!(previous, bytes[tail_start..]);
+    }
+
+    #[test]
+    fn bounded_native_log_read_ignores_stale_acceleration_outside_tail() {
+        let dir = tempfile::tempdir().expect("log dir");
+        let path = dir.path().join("llama-server-native.log");
+        let mut bytes =
+            b"starting native llama.cpp embedding server: old\noffloaded 33/33 layers to GPU\n"
+                .to_vec();
+        bytes.extend(std::iter::repeat_n(
+            b'x',
+            NATIVE_LLAMA_LOG_READ_TAIL_BYTES as usize,
+        ));
+        bytes.extend_from_slice(NATIVE_LLAMA_LOG_START_MARKER.as_bytes());
+        bytes.extend_from_slice(b" current\nn_gpu_layers = 0\n");
+        std::fs::write(&path, bytes).expect("write multi-launch log");
+
+        let text = read_native_embedding_log_tail(&path, NATIVE_LLAMA_LOG_READ_TAIL_BYTES)
+            .expect("bounded tail");
+        let current = native_embedding_log_current_launch(&text);
+
+        assert!(current.contains("current"));
+        assert!(!current.contains("offloaded 33/33"));
+        assert_eq!(observed_embedding_device_state_from_text(current), "cpu");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -120,6 +120,7 @@ pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
     compose_file: Option<&Path>,
     embedding_launch: Option<EmbeddingLaunchMetadata>,
 ) -> Result<SidecarStateFile> {
+    runtime.ensure_ports_allocated()?;
     let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
     let embedding_device = crate::embeddings::embedding_device_readiness();

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -316,6 +316,23 @@ run Docker prune, broad Docker cleanup, or host/global network deletion.
 `retrieval down` clears the sidecar state file only. Stop Docker/Compose
 separately if containers must be removed.
 
+Agent namespaces reserve dynamic ports in
+`<cache>/sidecars/port-allocations.json`. Allocation automatically compacts
+state-less entries whose ports are free while holding the registry lock and
+publishes the compacted file atomically. Valid state, bound ports, malformed or
+unreadable ownership, and a ten-minute startup reservation are retained
+fail-closed. Cleanup that prunes entries or encounters failures reports pruned,
+retained, and failed counts on stderr; renewable owner leases remain a separate
+lifecycle contract.
+
+Native embedding output uses `llama-server-native.log` for the current launch
+and `llama-server-native.previous.log` for at most the final 256 KiB of the
+previous launch. A verified new spawn truncates the current log after publishing
+that bounded tail when the files are writable; housekeeping failures are
+reported on stderr and do not block the server launch. Readiness inspects at
+most the final 512 KiB of current output, so a long-running server cannot make
+status latency scale with the full log.
+
 Default Windows cache locations:
 
 | Service | Default port | Data dir |


### PR DESCRIPTION
## Context

Issue #906 identified unbounded agent port-registry growth and an append-only native embedding log that readiness reread in full. The immediate v0.14.3 fix must reclaim only provably stale allocations, preserve every uncertain owner, publish registry changes atomically, and bound log housekeeping without introducing the renewable lease contract owned by #915.

Closes #906
Refs #899

## What Changed

- Compact non-current agent allocations under the existing exclusive registry lock only when no state exists, no recent startup reservation exists, and every recorded port is free.
- Preserve valid, malformed, unreadable, bound, reused, or otherwise unverified owners fail-closed; reject unsafe registry namespace path components before any filesystem join or removal.
- Publish the compacted registry and per-namespace startup reservations atomically, track explicit runtime port overrides in the registry, reject recent/bound same-namespace reassignment, and fail sidecar startup closed when allocation cannot be verified.
- Emit bounded cleanup diagnostics: pruned, retained, and failure counts plus at most five failure details.
- Preserve at most the last 256 KiB as `llama-server-native.previous.log`, truncate the current log before an actual new spawn when writable, and continue startup with a warning if housekeeping is blocked.
- Read at most the final 512 KiB for native accelerator proof and keep reuse/reuse-only paths from rotating a live child log.
- Document the operator-visible lifecycle and update the changelog.

## How To Review

1. Review `config.rs` from `allocate_agent_ports_in_registry` through the cleanup helpers, especially the lock scope, reservation grace, path-component validation, explicit-port handling, and port-0 startup guard.
2. Review `compose.rs` and `embeddings.rs` together: rotation occurs only after a failed reachability probe and an allowed new spawn; readiness reads only a byte-bounded tail.
3. Run the focused registry and native-log tests, then the full `codestory-retrieval` suite.

## Verification

- `cargo test -p codestory-retrieval -- --nocapture` — 293 unit tests passed, 1 ignored; all integration test binaries passed, with the live-sidecar fixture intentionally ignored.
- `cargo test -p codestory-retrieval agent_port_registry -- --nocapture` — 13 passed.
- Native log rotation, reuse-only preservation, blocked-housekeeping continuation, multiple-launch, and raw-byte hard-cap tests passed.
- `cargo clippy -p codestory-retrieval --all-targets -- -D warnings` — passed.
- `cargo build --release -p codestory-cli` — passed.
- `cargo fmt --all -- --check`, `git diff --check`, `node .github/scripts/check-doc-links.mjs`, and `node .github/scripts/check-workflow-policy.mjs` — passed.
- Live-registry-copy proof: a 438-namespace registry completed status successfully; the cleanup diagnostic reported `pruned=280 retained=158 failures=0`, and the atomically rewritten registry remained parseable.
- Live 76,184,280-byte log comparison, five alternating runs per binary: managed 0.14.2 median 1565.6 ms; candidate median 1594.3 ms. Full status was effectively flat because other probes dominate, while candidate log I/O is hard-capped at 512 KiB instead of the full 76.2 MB.
- Required ignored repo-scale gate was attempted. It could not emit stats because `CODESTORY_REAL_REPO_DRILL_CASES` is unset and Windows denied `CREATE_BREAKAWAY_FROM_JOB` (`os error 5`) during native embedding bootstrap.
- Three independent final reviews found no remaining P0/P1 issues after fixes for malformed-registry fallback, explicit ports, same-namespace races, traversal keys, and Windows log sharing.

## Risk

- A single continuously running native server can still grow the current log; readiness cost is bounded and the next writable new launch compacts it. A live ring buffer would require a different logging transport.
- Valid or unverified state is deliberately retained even when its process appears dead because runtime construction still reuses state ports. Renewable owner identity, renewal, and expiry remain #915.
- Log rotation is best-effort so an editor, antivirus scanner, or tailer cannot prevent embedding startup; failures remain visible on stderr.
- Linux and macOS behavior is covered by portable filesystem APIs and unit contracts; hosted cross-platform CI remains the final platform proof.