### PR TITLE
Isolate integration tests from user state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- Isolated CLI integration tests from user caches, install identity, plugin
+  data, stdio state, sidecar port registries, and managed runtime roots. Test
+  processes now share one explicit per-process state root, broker unit tests
+  inject machine-state roots across worker threads, and a regression invariant
+  rejects direct CLI process construction that bypasses the isolation helper.
 - Compacted stale agent sidecar port allocations atomically under the existing
   registry lock while preserving live, state-backed, recently reserved, and
   unverified owners. Native embedding launches now attempt to preserve only a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,6 @@ dependencies = [
  "codestory-workspace",
  "crossbeam-channel",
  "crossterm 0.28.1",
- "directories",
  "fs4",
  "notify",
  "ratatui",

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -16,7 +16,6 @@ codestory-runtime = { workspace = true }
 codestory-workspace = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-directories = { workspace = true }
 fs4 = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
@@ -31,4 +30,5 @@ crossterm = { workspace = true }
 ratatui = { workspace = true }
 
 [dev-dependencies]
+codestory-retrieval = { workspace = true, features = ["test-support"] }
 tempfile = { workspace = true }

--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -541,8 +541,8 @@ mod tests {
             serde_json::to_string(&LocalRefreshLockFile {
                 schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
                 project_root: clean_path_text(project.path()),
-                pid: u32::MAX,
-                process_start_identity: None,
+                pid: std::process::id(),
+                process_start_identity: Some("different-process-start".to_string()),
                 started_at_epoch_ms: old_started,
                 token: "stale".to_string(),
             })
@@ -556,8 +556,8 @@ mod tests {
                 status: "refreshing".to_string(),
                 project_root: clean_path_text(project.path()),
                 phase: "incremental_index".to_string(),
-                pid: u32::MAX,
-                process_start_identity: None,
+                pid: std::process::id(),
+                process_start_identity: Some("different-process-start".to_string()),
                 started_at_epoch_ms: old_started,
                 updated_at_epoch_ms: now_epoch_ms()
                     - LOCAL_REFRESH_STATUS_TTL.as_millis() as i64

--- a/crates/codestory-cli/src/managed_embeddings.rs
+++ b/crates/codestory-cli/src/managed_embeddings.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result, anyhow, bail};
-use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
@@ -144,13 +143,7 @@ pub(crate) fn managed_root(cache_override: Option<&Path>) -> Result<PathBuf> {
     if let Some(cache_override) = cache_override {
         return Ok(cache_override.join(MANAGED_DIR_NAME));
     }
-    Ok(ProjectDirs::from("dev", "codestory", "codestory")
-        .map(|dirs| dirs.cache_dir().join(MANAGED_DIR_NAME))
-        .unwrap_or_else(|| {
-            std::env::temp_dir()
-                .join("codestory")
-                .join(MANAGED_DIR_NAME)
-        }))
+    Ok(codestory_retrieval::user_cache_root().join(MANAGED_DIR_NAME))
 }
 
 pub(crate) fn runtime_managed_root(cache_override: Option<&Path>) -> Result<PathBuf> {

--- a/crates/codestory-cli/src/readiness_broker/paths.rs
+++ b/crates/codestory-cli/src/readiness_broker/paths.rs
@@ -92,6 +92,7 @@ pub(crate) fn install_id() -> String {
     )
 }
 
+#[cfg(not(test))]
 pub(crate) fn broker_cache_root() -> PathBuf {
     codestory_retrieval::SidecarRuntimeConfig::local()
         .layout
@@ -99,6 +100,46 @@ pub(crate) fn broker_cache_root() -> PathBuf {
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(std::env::temp_dir)
+}
+
+#[cfg(test)]
+pub(crate) fn broker_cache_root() -> PathBuf {
+    if let Some(root) = codestory_retrieval::active_test_cache_root() {
+        return root;
+    }
+    static PROCESS_ROOT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    let process_root = PROCESS_ROOT.get_or_init(|| {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir()
+            .join("codestory-cli-unit-tests")
+            .join(format!("{}-{nonce}", std::process::id()))
+    });
+    let thread = std::thread::current();
+    let label = thread
+        .name()
+        .map(safe_name)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| format!("{:?}", thread.id()));
+    let prefix = &label[..label.len().min(32)];
+    let root = process_root.join(format!("{prefix}-{}", &hash_text(&label)[..12]));
+    std::fs::create_dir_all(root.join("sidecars")).expect("create broker test state root");
+    root
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_broker_root<T>(task: impl FnOnce() -> T) -> T {
+    codestory_retrieval::with_test_cache_root(&broker_cache_root(), task)
+}
+
+#[cfg(test)]
+pub(crate) fn spawn_with_test_broker_root<T: Send + 'static>(
+    task: impl FnOnce() -> T + Send + 'static,
+) -> std::thread::JoinHandle<T> {
+    let root = broker_cache_root();
+    std::thread::spawn(move || codestory_retrieval::with_test_cache_root(&root, task))
 }
 
 pub(crate) fn safe_name(value: &str) -> String {

--- a/crates/codestory-cli/src/readiness_broker/reconcile.rs
+++ b/crates/codestory-cli/src/readiness_broker/reconcile.rs
@@ -15,6 +15,20 @@ pub(crate) fn reconcile_before_enqueue(
     run_id: Option<&str>,
     cli_version: &str,
 ) -> BrokerReconciliationSnapshot {
+    #[cfg(test)]
+    return super::paths::with_test_broker_root(|| {
+        reconcile_before_enqueue_inner(project_root, cache_root, run_id, cli_version)
+    });
+    #[cfg(not(test))]
+    reconcile_before_enqueue_inner(project_root, cache_root, run_id, cli_version)
+}
+
+fn reconcile_before_enqueue_inner(
+    project_root: &Path,
+    cache_root: &Path,
+    run_id: Option<&str>,
+    cli_version: &str,
+) -> BrokerReconciliationSnapshot {
     if let Some(active) = ready_repair_status::active_ready_repair_status(project_root, run_id) {
         return BrokerReconciliationSnapshot {
             status: "active_repair".to_string(),

--- a/crates/codestory-cli/src/readiness_broker/snapshot.rs
+++ b/crates/codestory-cli/src/readiness_broker/snapshot.rs
@@ -19,6 +19,13 @@ use super::types::{
 };
 
 pub(crate) fn refresh_broker_snapshot(input: BrokerSnapshotInput) -> ReadinessBrokerSnapshot {
+    #[cfg(test)]
+    return super::paths::with_test_broker_root(|| refresh_broker_snapshot_inner(input));
+    #[cfg(not(test))]
+    refresh_broker_snapshot_inner(input)
+}
+
+fn refresh_broker_snapshot_inner(input: BrokerSnapshotInput) -> ReadinessBrokerSnapshot {
     let identity = codestory_workspace::project_identity_v2(&input.project_root);
     let runtime_identity = current_gpu_runtime_identity(&input, &identity);
     refresh_broker_snapshot_with_identity(input, identity, runtime_identity.as_ref())
@@ -49,6 +56,13 @@ fn refresh_broker_snapshot_with_identity(
 }
 
 pub(crate) fn observe_broker_snapshot(input: BrokerSnapshotInput) -> ReadinessBrokerSnapshot {
+    #[cfg(test)]
+    return super::paths::with_test_broker_root(|| observe_broker_snapshot_inner(input));
+    #[cfg(not(test))]
+    observe_broker_snapshot_inner(input)
+}
+
+fn observe_broker_snapshot_inner(input: BrokerSnapshotInput) -> ReadinessBrokerSnapshot {
     let identity = codestory_workspace::cached_project_identity_v2(&input.project_root);
     let runtime_identity = current_gpu_runtime_identity(&input, &identity);
     observe_broker_snapshot_with_identity(input, identity, runtime_identity.as_ref())
@@ -90,8 +104,10 @@ pub(super) fn refresh_broker_snapshot_with_runtime_identity(
     input: BrokerSnapshotInput,
     runtime_identity: Option<&BrokerGpuRuntimeIdentity>,
 ) -> ReadinessBrokerSnapshot {
-    let identity = codestory_workspace::project_identity_v2(&input.project_root);
-    refresh_broker_snapshot_with_identity(input, identity, runtime_identity)
+    super::paths::with_test_broker_root(|| {
+        let identity = codestory_workspace::project_identity_v2(&input.project_root);
+        refresh_broker_snapshot_with_identity(input, identity, runtime_identity)
+    })
 }
 
 #[cfg(test)]
@@ -99,8 +115,10 @@ pub(super) fn observe_broker_snapshot_with_runtime_identity(
     input: BrokerSnapshotInput,
     runtime_identity: Option<&BrokerGpuRuntimeIdentity>,
 ) -> ReadinessBrokerSnapshot {
-    let identity = codestory_workspace::cached_project_identity_v2(&input.project_root);
-    observe_broker_snapshot_with_identity(input, identity, runtime_identity)
+    super::paths::with_test_broker_root(|| {
+        let identity = codestory_workspace::cached_project_identity_v2(&input.project_root);
+        observe_broker_snapshot_with_identity(input, identity, runtime_identity)
+    })
 }
 
 fn current_gpu_runtime_identity(
@@ -112,11 +130,20 @@ fn current_gpu_runtime_identity(
     } else {
         codestory_retrieval::SidecarProfile::Local
     };
+    #[cfg(not(test))]
     let runtime = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
         &input.project_root,
         profile,
         input.agent_run_id.as_deref(),
     );
+    #[cfg(test)]
+    let runtime =
+        codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+            Some(&input.project_root),
+            profile,
+            input.agent_run_id.as_deref(),
+            &super::paths::broker_cache_root(),
+        );
     let state: codestory_retrieval::SidecarStateFile =
         serde_json::from_slice(&fs::read(&runtime.layout.state_file).ok()?).ok()?;
     if !codestory_retrieval::sidecar_state_matches_runtime(&state, &runtime) {

--- a/crates/codestory-cli/src/readiness_broker/tests.rs
+++ b/crates/codestory-cli/src/readiness_broker/tests.rs
@@ -26,6 +26,19 @@ fn test_scope(project: &Path, run_id: &str) -> BrokerScope {
     agent_repair_scope(project, Some(run_id), "9.9.9")
 }
 
+fn test_sidecar_runtime(
+    project: &Path,
+    profile: codestory_retrieval::SidecarProfile,
+    run_id: Option<&str>,
+) -> codestory_retrieval::SidecarRuntimeConfig {
+    codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        Some(project),
+        profile,
+        run_id,
+        &broker_cache_root(),
+    )
+}
+
 fn write_machine_lock(resource: &str, scope: &BrokerScope, pid: u32) -> PathBuf {
     write_machine_lock_at(resource, scope, pid, now_epoch_ms())
 }
@@ -344,7 +357,7 @@ fn native_embedding_reuse_does_not_cross_workspace_roots() {
     let project = tempdir().expect("project");
     let other_worktree = tempdir().expect("other worktree");
     let scope = test_scope(project.path(), "shared-agent");
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
@@ -380,7 +393,7 @@ fn native_embedding_busy_lock_reuses_matching_sidecar_owner() {
     let resource = unique_resource("native-reuse");
     cleanup_machine_resource(&resource);
     let scope = test_scope(project.path(), "shared-agent");
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
@@ -411,7 +424,7 @@ fn native_embedding_busy_lock_rejects_mismatched_state_pid() {
     let resource = unique_resource("native-mismatch");
     cleanup_machine_resource(&resource);
     let scope = test_scope(project.path(), "shared-agent");
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
@@ -463,7 +476,7 @@ fn native_embedding_acquired_lease_releases_without_handoff_on_error() {
     let resource = unique_resource("native-error-release");
     cleanup_machine_resource(&resource);
     let scope = test_scope(project.path(), "shared-agent");
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
@@ -492,7 +505,7 @@ fn native_embedding_cleanup_failure_preserves_acquired_lock_for_recorded_launch(
     let resource = unique_resource("native-cleanup-failure-preserve");
     cleanup_machine_resource(&resource);
     let scope = test_scope(project.path(), "shared-agent");
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
@@ -624,7 +637,7 @@ fn native_embedding_acquired_post_transfer_cleanup_releases_handed_off_lock() {
 #[test]
 fn native_embedding_reused_post_transfer_cleanup_skips_state_read() {
     let project = tempdir().expect("temp project");
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
@@ -792,7 +805,7 @@ fn machine_resource_reaper_stale_takeover_has_single_winner() {
     for _ in 0..contender_count {
         let resource = resource.clone();
         let barrier = barrier.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_with_test_broker_root(move || {
             barrier.wait();
             try_acquire_machine_resource_reaper_lock(&resource).expect("try reaper")
         }));
@@ -1006,7 +1019,7 @@ fn write_ready_repair_status_file(
     updated_at_epoch_ms: i64,
     phase: &str,
 ) -> PathBuf {
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project,
         codestory_retrieval::SidecarProfile::Agent,
         Some(run_id),
@@ -1261,7 +1274,7 @@ fn machine_resource_lock_contention_has_single_winner_across_threads() {
         let resource = resource.clone();
         let scope = scope.clone();
         let barrier = barrier.clone();
-        handles.push(thread::spawn(move || {
+        handles.push(spawn_with_test_broker_root(move || {
             barrier.wait();
             try_acquire_machine_resource_lock(&resource, &scope).expect("try lock")
         }));
@@ -1298,7 +1311,7 @@ fn refresh_broker_snapshot_final_success_omits_running_ops_after_repair_cleared(
     let project = tempdir().expect("project");
     let cache = tempdir().expect("cache");
     let run_id = "shared-agent";
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
+    let sidecar = test_sidecar_runtime(
         project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some(run_id),
@@ -1385,6 +1398,18 @@ fn observe_broker_snapshot_is_stable_and_does_not_publish() {
     assert_eq!(first.updated_at_epoch_ms, 0);
     assert_eq!(first.persistence_status, "observed");
     assert!(!snapshot_path.exists());
+}
+
+#[test]
+fn broker_unit_test_paths_use_injected_machine_state_root() {
+    let root = broker_cache_root();
+
+    assert!(
+        root.starts_with(std::env::temp_dir().join("codestory-cli-unit-tests")),
+        "broker test root must be process-local: {}",
+        root.display()
+    );
+    assert!(machine_resource_lock_path(NATIVE_EMBEDDING_RESOURCE).starts_with(&root));
 }
 
 #[test]

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -14,7 +14,6 @@ use codestory_runtime::{
     BookmarkService, GroundingService, IndexService, ProjectService, ReadOnlyBrowserService,
     Runtime,
 };
-use directories::ProjectDirs;
 use std::path::{Path, PathBuf};
 
 use crate::args::{ProjectArgs, QuerySelectorOutput, RefreshMode, TargetSelection};
@@ -439,12 +438,8 @@ pub(crate) fn cache_root_for_project(
 ) -> Result<PathBuf> {
     match override_dir {
         Some(path) => Ok(path.to_path_buf()),
-        None => {
-            let base = ProjectDirs::from("dev", "codestory", "codestory")
-                .map(|dirs| dirs.cache_dir().to_path_buf())
-                .unwrap_or_else(|| std::env::temp_dir().join("codestory").join("cache"));
-            Ok(base.join(fnv1a_hex(project_root.to_string_lossy().as_bytes())))
-        }
+        None => Ok(codestory_retrieval::user_cache_root()
+            .join(fnv1a_hex(project_root.to_string_lossy().as_bytes()))),
     }
 }
 

--- a/crates/codestory-cli/tests/cli_error_contracts.rs
+++ b/crates/codestory-cli/tests/cli_error_contracts.rs
@@ -177,7 +177,7 @@ impl AppController {
 }
 
 fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> std::process::Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command
         .args(args)
         .arg("--project")
@@ -265,7 +265,7 @@ fn ambiguous_error_alternatives(json: &Value) -> &Vec<Value> {
 
 #[test]
 fn top_level_help_names_command_purposes() {
-    let help = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let help = test_support::cli_command()
         .arg("--help")
         .output()
         .expect("run top-level help");
@@ -347,7 +347,7 @@ fn smoke_ci_agent_invalid_project_emits_json_failure() {
     let workspace = tempdir().expect("workspace dir");
     let missing = workspace.path().join("missing");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .args([
             "smoke",
             "--profile",
@@ -1191,7 +1191,7 @@ fn ambiguous_query_writes_output_file_even_on_failure() {
 
 #[test]
 fn choose_flag_resolves_by_displayed_alternative_number_when_available() {
-    let help = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let help = test_support::cli_command()
         .args(["symbol", "--help"])
         .output()
         .expect("run symbol help");
@@ -1259,3 +1259,4 @@ fn choose_flag_resolves_by_displayed_alternative_number_when_available() {
         "--choose should resolve the node id displayed as alternative #2"
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/cli_golden_path.rs
+++ b/crates/codestory-cli/tests/cli_golden_path.rs
@@ -85,7 +85,7 @@ fn write_docker_compose_fixture(root: &Path) {
 }
 
 fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> std::process::Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command
         .args(args)
         .arg("--project")
@@ -102,7 +102,7 @@ fn run_cli_with_stdin(
     args: &[&str],
     stdin: &str,
 ) -> std::process::Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let mut child = test_support::cli_command()
         .args(args)
         .arg("--project")
         .arg(workspace)
@@ -129,7 +129,7 @@ fn run_cli_with_embedding_env(
     args: &[&str],
     envs: &[(&str, &str)],
 ) -> std::process::Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command
         .args(args)
         .arg("--project")
@@ -246,7 +246,7 @@ fn install_fake_managed_embeddings(cache_dir: &Path) {
 }
 
 fn run_stdio_request(workspace: &Path, cache_dir: &Path, request: &str) -> Value {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let mut child = test_support::cli_command()
         .arg("serve")
         .arg("--stdio")
         .arg("--refresh")
@@ -2734,3 +2734,4 @@ fn context_json_reports_deep_trace_by_default() {
     );
     assert_sidecar_failure_output(context);
 }
+mod test_support;

--- a/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
+++ b/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
@@ -3,7 +3,6 @@ use serde_json::Value;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::time::Instant;
 use tempfile::tempdir;
 
@@ -501,7 +500,7 @@ fn run_cli_output(
     args: &[String],
 ) -> (f64, Vec<u8>) {
     let started = Instant::now();
-    let output = Command::new(binary)
+    let output = test_support::command(binary)
         .current_dir(project_root)
         .args(args)
         .arg("--project")
@@ -1681,3 +1680,4 @@ fn assert_anchor_summary_usable(repo_json: &Value, anchor: &str) {
         "{anchor} should retain source-truth target pointers"
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/http_transport_contracts.rs
+++ b/crates/codestory-cli/tests/http_transport_contracts.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -140,7 +140,7 @@ fn indexed_fixture() -> HttpFixture {
     let cache_dir = tempfile::tempdir().expect("cache dir");
     write_deep_rust_workspace(workspace.path());
 
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .arg("index")
         .arg("--refresh")
         .arg("full")
@@ -179,7 +179,7 @@ fn http_serve_rejects_non_loopback_addr_before_opening_runtime_state() {
     let cache_dir = tempfile::tempdir().expect("cache dir");
     write_deep_rust_workspace(workspace.path());
 
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .arg("serve")
         .arg("--refresh")
         .arg("none")
@@ -207,7 +207,7 @@ fn http_serve_rejects_non_loopback_addr_before_opening_runtime_state() {
 
 fn spawn_http_server(fixture: &HttpFixture) -> (HttpServer, String) {
     let addr = free_local_addr();
-    let child = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let child = test_support::cli_command()
         .arg("serve")
         .arg("--refresh")
         .arg("none")
@@ -737,3 +737,4 @@ fn http_smoke_keeps_existing_routes_and_default_semantics_against_indexed_repo()
         "/symbols should honor an explicit bounded root limit: {one_symbol}"
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/packet_search_eval.rs
+++ b/crates/codestory-cli/tests/packet_search_eval.rs
@@ -601,13 +601,18 @@ fn packet_search_live_eval_uses_fixed_run_id() {
         ],
     );
     assert_eq!(search.get_program(), live_eval_cli_path().as_os_str());
-    assert_eq!(search.get_envs().count(), live_eval_env().len());
     assert!(
         search
             .get_envs()
             .any(|(name, value)| name == "CODESTORY_SIDECAR_RUN_ID"
                 && value == Some(std::ffi::OsStr::new(LIVE_EVAL_RUN_ID))),
         "search subprocess must inherit the fixed live eval run id"
+    );
+    assert!(
+        search
+            .get_envs()
+            .any(|(name, value)| name == "CODESTORY_CACHE_ROOT" && value.is_some()),
+        "search subprocess must retain the integration-test state root"
     );
     let search_args = search
         .get_args()
@@ -661,7 +666,7 @@ fn packet_search_live_eval_honors_explicit_cli_path() {
     );
     assert_eq!(
         live_eval_cli_path_from(None),
-        PathBuf::from(env!("CARGO_BIN_EXE_codestory-cli"))
+        test_support::cli_binary_path()
     );
 }
 
@@ -855,7 +860,7 @@ fn live_eval_run_cli(project: &Path, args: &[&str]) -> std::process::Output {
 }
 
 fn base_cli_command(project: &Path, args: &[&str]) -> Command {
-    let mut command = Command::new(live_eval_cli_path());
+    let mut command = test_support::command(live_eval_cli_path());
     command.args(args);
     command.arg("--project").arg(project);
     command
@@ -877,7 +882,7 @@ fn live_eval_cli_path_from(explicit: Option<OsString>) -> PathBuf {
     explicit
         .filter(|path| !path.is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(env!("CARGO_BIN_EXE_codestory-cli")))
+        .unwrap_or_else(test_support::cli_binary_path)
 }
 
 fn run_command_with_timeout(
@@ -1076,3 +1081,4 @@ fn hits(json: &Value) -> impl Iterator<Item = &Value> {
         .flatten()
         .chain(json["repo_text_hits"].as_array().into_iter().flatten())
 }
+mod test_support;

--- a/crates/codestory-cli/tests/ready_command.rs
+++ b/crates/codestory-cli/tests/ready_command.rs
@@ -1,7 +1,6 @@
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::tempdir;
 
 #[test]
@@ -299,7 +298,7 @@ fn helper(value: &str) -> String {
 }
 
 fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> String {
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .args(args)
         .arg("--project")
         .arg(workspace)
@@ -345,3 +344,4 @@ fn helper(value: &str) -> String {
     )
     .expect("write lib.rs");
 }
+mod test_support;

--- a/crates/codestory-cli/tests/report_export.rs
+++ b/crates/codestory-cli/tests/report_export.rs
@@ -1,12 +1,11 @@
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use tempfile::tempdir;
 
 #[test]
 fn report_command_help_names_markdown_and_json_exports() {
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .arg("report")
         .arg("--help")
         .output()
@@ -72,7 +71,7 @@ fn report_handoff_profile_renders_handoff_header_and_json_metadata() {
 }
 
 fn run_cli(workspace: &Path, cache_dir: &Path, args: &[&str]) -> String {
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .args(args)
         .arg("--project")
         .arg(workspace)
@@ -118,3 +117,4 @@ fn helper(value: &str) -> String {
     )
     .expect("write lib.rs");
 }
+mod test_support;

--- a/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
+++ b/crates/codestory-cli/tests/retrieval_bootstrap_contracts.rs
@@ -2,11 +2,10 @@
 
 use serde_json::Value;
 use std::fs;
-use std::process::Command;
 use tempfile::tempdir;
 
 fn run_bootstrap(project: &std::path::Path, extra_args: &[&str]) -> Value {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command.env("CODESTORY_EMBED_ALLOW_CPU", "1");
     command.args(["retrieval", "bootstrap", "--project"]);
     command.arg(project);
@@ -21,7 +20,7 @@ fn run_bootstrap(project: &std::path::Path, extra_args: &[&str]) -> Value {
 }
 
 fn run_status(project: &std::path::Path, extra_args: &[&str]) -> Value {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command.env("CODESTORY_EMBED_ALLOW_CPU", "1");
     command.args(["retrieval", "status", "--project"]);
     command.arg(project);
@@ -36,7 +35,7 @@ fn run_status(project: &std::path::Path, extra_args: &[&str]) -> Value {
 }
 
 fn run_down(project: &std::path::Path, extra_args: &[&str]) {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command.env("CODESTORY_EMBED_ALLOW_CPU", "1");
     command.args(["retrieval", "down", "--project"]);
     command.arg(project);
@@ -62,7 +61,7 @@ fn assert_digest_image_pins(json: &Value) {
 }
 
 fn create_valid_cache_with_cli(project: &std::path::Path, cache: &std::path::Path) {
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .env("CODESTORY_EMBED_ALLOW_CPU", "1")
         .args(["index", "--project"])
         .arg(project)
@@ -417,7 +416,7 @@ fn bootstrap_json_surfaces_prune_suppressed_reason_on_scan_errors() {
     fs::create_dir_all(&corrupt_subdir).expect("corrupt subdir");
     fs::write(corrupt_subdir.join("codestory.db"), b"not sqlite").expect("corrupt hashed db");
 
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command.env("CODESTORY_EMBED_ALLOW_CPU", "1");
     command.args([
         "retrieval",
@@ -452,3 +451,4 @@ fn bootstrap_json_surfaces_prune_suppressed_reason_on_scan_errors() {
     );
     assert_eq!(repair["pruned_collections"].as_u64(), Some(0));
 }
+mod test_support;

--- a/crates/codestory-cli/tests/runtime_backed_flows.rs
+++ b/crates/codestory-cli/tests/runtime_backed_flows.rs
@@ -1,7 +1,6 @@
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use tempfile::tempdir;
 
 fn copy_tictactoe_workspace() -> tempfile::TempDir {
@@ -28,7 +27,7 @@ fn copy_tictactoe_workspace() -> tempfile::TempDir {
 }
 
 fn run_cli(workspace: &Path, args: &[&str]) -> std::process::Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command.args(args);
     command.arg("--project").arg(workspace);
     command.output().expect("run codestory-cli")
@@ -235,3 +234,4 @@ fn trail_command_default_width_matches_query_dsl_trail() {
         "trail --query and query trail(...) should expose the same default graph width"
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/search_json_output.rs
+++ b/crates/codestory-cli/tests/search_json_output.rs
@@ -2,7 +2,6 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use std::time::Instant;
 use tempfile::tempdir;
 
@@ -133,7 +132,7 @@ fn write_openapi_route_fixture(root: &Path) {
 }
 
 fn run_cli(workspace: &Path, args: &[&str]) -> std::process::Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command.args(args);
     command.arg("--project").arg(workspace);
     command.env("CODESTORY_HYBRID_RETRIEVAL_ENABLED", "true");
@@ -2027,3 +2026,4 @@ fn search_quality_eval_reports_recall_mrr_and_latency_for_symbols_and_routes() {
         "search latency should stay bounded on eval fixture, got {max_latency_ms}ms"
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/sidecar_status_cli.rs
+++ b/crates/codestory-cli/tests/sidecar_status_cli.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Output;
 use tempfile::tempdir;
 
 fn write_tiny_project(root: &Path) {
@@ -9,7 +9,7 @@ fn write_tiny_project(root: &Path) {
 }
 
 fn run_cli(project: &Path, cache_dir: &Path, args: &[&str]) -> Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command.args(args);
     command.arg("--project").arg(project);
     command.arg("--cache-dir").arg(cache_dir);
@@ -165,3 +165,4 @@ fn unknown_sidecar_subcommand_suggests_status_without_runtime_side_effects() {
         "unknown sidecar subcommand should fail before runtime cache creation"
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -129,7 +129,7 @@ fn write_dirty_marker_fixture(fixture: &StdioFixture, name: &str, marker: Value)
 }
 
 fn refresh_fixture_index(fixture: &StdioFixture) {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command
         .arg("index")
         .arg("--refresh")
@@ -155,7 +155,7 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
     let cache_dir = tempfile::tempdir().expect("cache dir");
     write_tiny_rust_workspace(workspace.path());
 
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command
         .arg("index")
         .arg("--refresh")
@@ -221,7 +221,7 @@ fn full_retrieval_fixture() -> Result<Option<StdioFixture>, String> {
         return Ok(None);
     }
     let fixture = indexed_fixture_with_embedding_mode(false);
-    let output = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let output = test_support::cli_command()
         .arg("retrieval")
         .arg("index")
         .arg("--refresh")
@@ -241,7 +241,7 @@ fn full_retrieval_fixture() -> Result<Option<StdioFixture>, String> {
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    let status = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let status = test_support::cli_command()
         .arg("retrieval")
         .arg("status")
         .arg("--format")
@@ -310,7 +310,7 @@ fn apply_fixture_embedding_env(command: &mut Command, hash_embeddings: bool) {
 }
 
 fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut command = test_support::cli_command();
     command
         .arg("serve")
         .arg("--stdio")
@@ -388,7 +388,7 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
 }
 
 fn spawn_multi_project_stdio_server(cache_root: &Path) -> StdioServer {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_codestory-cli"))
+    let mut child = test_support::cli_command()
         .arg("serve")
         .arg("--stdio")
         .arg("--multi-project")
@@ -885,11 +885,7 @@ fn write_repair_status_fixture(
 ) -> (PathBuf, RemoveDirOnDrop) {
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &canonical_root,
-        codestory_retrieval::SidecarProfile::Agent,
-        Some(run_id),
-    );
+    let sidecar = test_sidecar_runtime(&canonical_root, run_id);
     let status_path = sidecar
         .layout
         .state_file
@@ -924,6 +920,15 @@ fn write_repair_status_fixture(
     )
     .expect("write repair status fixture");
     (status_path, RemoveDirOnDrop(status_dir))
+}
+
+fn test_sidecar_runtime(project: &Path, run_id: &str) -> codestory_retrieval::SidecarRuntimeConfig {
+    codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        Some(project),
+        codestory_retrieval::SidecarProfile::Agent,
+        Some(run_id),
+        &test_support::test_state_root().join("cache"),
+    )
 }
 
 fn continuation_uris_for(node_id: &str) -> Vec<String> {
@@ -3225,11 +3230,8 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
     let policy_path = fixture.cache_dir.path().join("plugin-sidecar-policy.json");
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let repair_sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &canonical_root,
-        codestory_retrieval::SidecarProfile::Agent,
-        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-    );
+    let repair_sidecar =
+        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID);
     let repair_state_dir = repair_sidecar
         .layout
         .state_file
@@ -3415,11 +3417,8 @@ fn tools_call_sidecar_setup_records_successful_worker_terminal_state() {
     fixture.ready_repair_worker_probe_exit_code = Some(0);
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let repair_sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &canonical_root,
-        codestory_retrieval::SidecarProfile::Agent,
-        Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-    );
+    let repair_sidecar =
+        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID);
     let _repair_state_cleanup = RemoveDirOnDrop(
         repair_sidecar
             .layout
@@ -4196,18 +4195,35 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
     fs::remove_file(fixture.workspace.path().join("src").join("alpha.rs"))
         .expect("remove indexed file after indexing");
 
-    let refreshed = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "status-freshness-after-mutation",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let refreshed_result =
-        assert_success_envelope(&refreshed, json!("status-freshness-after-mutation"));
-    let refreshed_status = json_resource_content(refreshed_result, "codestory://status");
+    let refresh_deadline = Instant::now() + Duration::from_secs(15);
+    let mut refresh_attempt = 0;
+    let refreshed_status = loop {
+        let id = format!("status-freshness-after-mutation-{refresh_attempt}");
+        let refreshed = send_json(
+            &mut server,
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "resources/read",
+                "params": {"uri": "codestory://status"}
+            }),
+        );
+        let refreshed_result = assert_success_envelope(&refreshed, json!(id));
+        let status = json_resource_content(refreshed_result, "codestory://status");
+        if find_index_freshness(&status)
+            .and_then(|freshness| freshness.get("status"))
+            .and_then(Value::as_str)
+            == Some("fresh")
+        {
+            break status;
+        }
+        assert!(
+            Instant::now() < refresh_deadline,
+            "background local refresh did not complete within 15 seconds: {status}"
+        );
+        refresh_attempt += 1;
+        thread::sleep(Duration::from_millis(50));
+    };
     assert_fresh_freshness_counts(&refreshed_status, "codestory://status after mutation");
     assert_eq!(
         refreshed_status["local_refresh"]["reason"],
@@ -4274,7 +4290,7 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
         "warm status freshness check p95 should stay under 1s for a small repo, got median={median:?}, p95={p95:?}"
     );
 
-    let mut index_command = Command::new(env!("CARGO_BIN_EXE_codestory-cli"));
+    let mut index_command = test_support::cli_command();
     index_command
         .arg("index")
         .arg("--refresh")
@@ -5666,3 +5682,4 @@ fn unknown_prompt_returns_jsonrpc_error() {
         "unknown prompt message should identify the missing prompt: {response}"
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/stdio_warm_loop_stats.rs
+++ b/crates/codestory-cli/tests/stdio_warm_loop_stats.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStdin, ChildStdout, Stdio};
 use std::time::Instant;
 use tempfile::{TempDir, tempdir};
 
@@ -213,7 +213,7 @@ fn indexed_fixture(binary: &Path) -> (WarmLoopFixture, TimedJson) {
 
 fn run_cli_json(binary: &Path, workspace: &Path, cache_dir: &Path, args: &[String]) -> TimedJson {
     let started = Instant::now();
-    let output = Command::new(binary)
+    let output = test_support::command(binary)
         .args(args)
         .arg("--project")
         .arg(workspace)
@@ -238,7 +238,7 @@ fn run_cli_json(binary: &Path, workspace: &Path, cache_dir: &Path, args: &[Strin
 }
 
 fn spawn_stdio_server(binary: &Path, fixture: &WarmLoopFixture) -> StdioServer {
-    let mut child = Command::new(binary)
+    let mut child = test_support::command(binary)
         .arg("serve")
         .arg("--stdio")
         .arg("--refresh")
@@ -796,3 +796,4 @@ fn warm_stdio_agent_loop_emits_stats_without_protocol_pollution() {
         stats.protocol.first_tool_ms
     );
 }
+mod test_support;

--- a/crates/codestory-cli/tests/test_state_isolation.rs
+++ b/crates/codestory-cli/tests/test_state_isolation.rs
@@ -1,0 +1,153 @@
+mod test_support;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[test]
+fn cli_state_stays_out_of_controlled_user_cache_fallback() {
+    let project = tempfile::tempdir().expect("project");
+    std::fs::write(project.path().join("lib.rs"), "pub fn isolated() {}\n")
+        .expect("project source");
+    let decoy = test_support::os_user_root();
+    // Windows initializes these platform base directories while resolving the
+    // overridden user profile. Include that inert setup in the baseline so the
+    // invariant detects CodeStory state, not OS directory normalization.
+    std::fs::create_dir_all(decoy.join("home").join("AppData").join("Roaming"))
+        .expect("decoy roaming app data");
+    std::fs::create_dir_all(decoy.join("home").join("AppData").join("Local"))
+        .expect("decoy local profile app data");
+    std::fs::create_dir_all(decoy.join("local-app-data")).expect("decoy local app data");
+    std::fs::create_dir_all(decoy.join("app-data")).expect("decoy app data");
+    std::fs::create_dir_all(decoy.join("xdg-cache")).expect("decoy XDG cache");
+    std::fs::create_dir_all(decoy.join("xdg-data")).expect("decoy XDG data");
+    std::fs::write(decoy.join("sentinel.txt"), b"unchanged").expect("decoy sentinel");
+
+    // Some Windows hosts create PowerShell startup-profile metadata while a
+    // retrieval command gathers machine information. Warm that platform-owned
+    // cache, then prove the warmup left no CodeStory-shaped user state before
+    // taking the invariant baseline.
+    let warm = cli_command_with_decoy(&decoy)
+        .args(["retrieval", "status", "--project"])
+        .arg(project.path())
+        .args([
+            "--profile",
+            "agent",
+            "--run-id",
+            "test-state-isolation-warmup",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("warm platform profile state");
+    assert!(warm.status.success(), "warmup status command must succeed");
+    let warmed = inventory(&decoy);
+    assert!(
+        warmed.iter().all(|(path, _)| is_expected_decoy_entry(path)),
+        "warmup leaked state into the decoy user root: {warmed:?}"
+    );
+    let before = inventory(&decoy);
+
+    let output = cli_command_with_decoy(&decoy)
+        .args(["retrieval", "status", "--project"])
+        .arg(project.path())
+        .args([
+            "--profile",
+            "agent",
+            "--run-id",
+            "test-state-isolation",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("run isolated retrieval status");
+
+    assert!(
+        output.status.success(),
+        "isolated status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(inventory(&decoy), before, "decoy user cache changed");
+    assert!(
+        test_support::test_state_root()
+            .join("cache")
+            .join("sidecars")
+            .join("port-allocations.json")
+            .is_file(),
+        "agent port registry must stay under the injected state root"
+    );
+}
+
+fn cli_command_with_decoy(decoy: &Path) -> Command {
+    let mut command = test_support::cli_command();
+    command
+        .env("HOME", decoy.join("home"))
+        .env("USERPROFILE", decoy.join("home"))
+        .env("XDG_CACHE_HOME", decoy.join("xdg-cache"))
+        .env("XDG_DATA_HOME", decoy.join("xdg-data"))
+        .env("LOCALAPPDATA", decoy.join("local-app-data"))
+        .env("APPDATA", decoy.join("app-data"));
+    command
+}
+
+fn is_expected_decoy_entry(path: &Path) -> bool {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    matches!(
+        normalized.as_str(),
+        "app-data"
+            | "home"
+            | "home/AppData"
+            | "home/AppData/Local"
+            | "home/AppData/Roaming"
+            | "local-app-data"
+            | "sentinel.txt"
+            | "xdg-cache"
+            | "xdg-data"
+    ) || normalized.starts_with("home/AppData/Local/Microsoft")
+}
+
+#[test]
+fn integration_cli_processes_use_the_isolated_command_helper() {
+    let tests = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let cli_binary_env = ["CARGO_BIN_EXE_", "codestory-cli"].concat();
+    for entry in std::fs::read_dir(&tests).expect("integration test directory") {
+        let entry = entry.expect("integration test entry");
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path).expect("integration test source");
+        assert!(
+            !source.contains(&cli_binary_env),
+            "{} accesses the CLI binary outside the isolated test helper",
+            path.display()
+        );
+    }
+}
+
+fn inventory(root: &Path) -> Vec<(PathBuf, Option<Vec<u8>>)> {
+    let mut entries = Vec::new();
+    collect_inventory(root, root, &mut entries);
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    entries
+}
+
+fn collect_inventory(root: &Path, path: &Path, entries: &mut Vec<(PathBuf, Option<Vec<u8>>)>) {
+    let mut children: Vec<_> = std::fs::read_dir(path)
+        .unwrap_or_else(|error| panic!("read inventory {}: {error}", path.display()))
+        .map(|entry| entry.expect("inventory entry"))
+        .collect();
+    children.sort_by_key(|entry| entry.file_name());
+    for child in children {
+        let path = child.path();
+        let relative = path.strip_prefix(root).expect("relative inventory path");
+        if child.file_type().expect("inventory file type").is_dir() {
+            entries.push((relative.to_path_buf(), None));
+            collect_inventory(root, &path, entries);
+        } else {
+            entries.push((
+                relative.to_path_buf(),
+                Some(std::fs::read(&path).expect("inventory file")),
+            ));
+        }
+    }
+}

--- a/crates/codestory-cli/tests/test_support/mod.rs
+++ b/crates/codestory-cli/tests/test_support/mod.rs
@@ -1,0 +1,74 @@
+#![allow(dead_code)]
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn cli_command() -> Command {
+    command(cli_binary_path())
+}
+
+pub fn cli_binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_codestory-cli"))
+}
+
+pub fn command(binary: impl AsRef<OsStr>) -> Command {
+    let state = test_state_root();
+    std::fs::create_dir_all(&state).expect("create isolated CodeStory test state root");
+    let mut command = Command::new(binary);
+    command
+        .env("CODESTORY_CACHE_ROOT", state.join("cache"))
+        .env("CODESTORY_STDIO_CACHE_ROOT", state.join("stdio-cache"))
+        .env("CODESTORY_INSTALL_ID", install_id())
+        .env("CODESTORY_PLUGIN_DATA", state.join("plugin-data"));
+    command
+}
+
+pub fn test_state_root() -> PathBuf {
+    test_root().join("codestory-state")
+}
+
+pub fn os_user_root() -> PathBuf {
+    test_root().join("os-user")
+}
+
+fn test_root() -> PathBuf {
+    process_root().join(thread_name())
+}
+
+fn process_root() -> &'static PathBuf {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        let base = option_env!("CARGO_TARGET_TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir);
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        base.join("codestory-integration-tests").join(format!(
+            "{}-{}-{nonce}",
+            env!("CARGO_PKG_NAME"),
+            std::process::id()
+        ))
+    })
+}
+
+fn thread_name() -> String {
+    format!("{:?}", std::thread::current().id())
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn install_id() -> String {
+    format!("integration-{}-{}", std::process::id(), thread_name())
+}

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -267,7 +267,22 @@ impl SidecarRuntimeConfig {
         profile: SidecarProfile,
         run_id: Option<&str>,
     ) -> Self {
-        let base = user_cache_root();
+        Self::for_project_profile_with_run_id_in_cache(
+            project_root,
+            profile,
+            run_id,
+            &user_cache_root(),
+        )
+    }
+
+    #[doc(hidden)]
+    pub fn for_project_profile_with_run_id_in_cache(
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+        cache_root: &Path,
+    ) -> Self {
+        let base = cache_root.to_path_buf();
         let run_id = (profile == SidecarProfile::Agent).then(|| agent_run_id(run_id));
         let namespace = namespace_for(project_root, profile, run_id.as_deref());
         let state_file = match profile {
@@ -1092,9 +1107,69 @@ pub fn user_cache_root() -> PathBuf {
             return PathBuf::from(path);
         }
     }
+    #[cfg(feature = "test-support")]
+    if let Some(path) = active_test_cache_root() {
+        return path;
+    }
+    #[cfg(test)]
+    if let Some(path) = automatic_unit_test_cache_root() {
+        return path;
+    }
     ProjectDirs::from("dev", "codestory", "codestory")
         .map(|dirs| dirs.cache_dir().to_path_buf())
         .unwrap_or_else(|| std::env::temp_dir().join("codestory").join("cache"))
+}
+
+#[cfg(any(test, feature = "test-support"))]
+thread_local! {
+    static TEST_CACHE_ROOT_OVERRIDE: std::cell::RefCell<Option<PathBuf>> = const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn active_test_cache_root() -> Option<PathBuf> {
+    TEST_CACHE_ROOT_OVERRIDE.with(|root| root.borrow().clone())
+}
+
+#[cfg(test)]
+fn automatic_unit_test_cache_root() -> Option<PathBuf> {
+    let thread = std::thread::current();
+    let name = thread.name()?;
+    if name == "main" {
+        return None;
+    }
+    static PROCESS_ROOT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    let process_root = PROCESS_ROOT.get_or_init(|| {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        std::env::temp_dir()
+            .join("codestory-unit-tests")
+            .join(format!("{}-{nonce}", std::process::id()))
+    });
+    let label = normalized_label_component(name)?;
+    let prefix = &label[..label.len().min(32)];
+    let root = process_root.join(format!("{prefix}-{}", &fnv1a_hex(label.as_bytes())[..12]));
+    std::fs::create_dir_all(root.join("sidecars")).ok()?;
+    Some(root)
+}
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn with_test_cache_root<T>(root: &Path, task: impl FnOnce() -> T) -> T {
+    struct Reset(Option<PathBuf>);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_CACHE_ROOT_OVERRIDE.with(|root| {
+                *root.borrow_mut() = self.0.take();
+            });
+        }
+    }
+    let previous =
+        TEST_CACHE_ROOT_OVERRIDE.with(|current| current.replace(Some(root.to_path_buf())));
+    let _reset = Reset(previous);
+    task()
 }
 
 /// Docker compose profile for mandatory sidecars.

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -55,8 +55,10 @@ pub use config::{
     SidecarImagePins, SidecarLayout, SidecarOwnership, SidecarPorts, SidecarProfile,
     SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
     default_sidecar_image_pins, embedding_server_launch_mode, sidecar_runtime_auto,
-    sidecar_runtime_for_project, sidecar_runtime_for_project_with_run_id,
+    sidecar_runtime_for_project, sidecar_runtime_for_project_with_run_id, user_cache_root,
 };
+#[cfg(feature = "test-support")]
+pub use config::{active_test_cache_root, with_test_cache_root};
 pub use embeddings::{
     BGE_BASE_EN_V1_5_GGUF, BGE_QUERY_PREFIX_DEFAULT, EmbeddingRuntimeProbe,
     RETRIEVAL_EMBEDDING_DIM, embedding_backend_label, embedding_runtime_id,

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -55,6 +55,26 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 These are the default broad checks for code changes after the lane picker says
 workspace-wide proof is useful.
 
+CLI integration tests must launch `codestory-cli` through
+`tests/test_support::cli_command` (or `command` for a supplied binary). The
+helper assigns a process-and-test-thread state root and explicitly isolates the
+cache, stdio cache, install identity, and plugin data. Do not serialize the
+workspace suite or clean the real user cache to make a test pass. Broker tests
+that cross a worker-thread boundary must carry their injected test cache root
+into that thread.
+
+Use the isolation contract as the focused regression gate:
+
+```sh
+cargo test -p codestory-cli --test test_state_isolation
+cargo test -p codestory-cli --bin codestory-cli observe_broker_snapshot_
+```
+
+The first command exercises a controlled decoy user profile and fails if CLI
+state escapes the injected root or an integration test constructs the CLI
+directly. The second command keeps the historically competing broker snapshot
+tests in one default-concurrency run.
+
 Do not use `cargo test --workspace --all-targets` as the routine broad test
 gate. `--all-targets` expands into benchmark targets; Criterion benches are
 compiled or run through the bench lane below.


### PR DESCRIPTION
## Context

CodeStory integration and broker tests could resolve user-global cache, install identity, plugin data, managed runtime, and sidecar registry paths. That made default-concurrency tests capable of observing or mutating live developer state and caused cross-test contention.

Closes #907
Refs #899

## What Changed

- Added one shared integration-test command helper with an explicit process-and-test-thread state root for the cache, stdio cache, install identity, and plugin data.
- Routed every integration-test CLI process and direct CLI binary lookup through that helper, with a regression guard that rejects bypasses.
- Centralized runtime and managed-embedding cache resolution on `codestory_retrieval::user_cache_root` so `CODESTORY_CACHE_ROOT` governs every related state surface.
- Added explicit test-only cache injection for sidecar runtime construction and broker worker-thread propagation without changing feature-enabled production thread behavior.
- Moved stdio repair fixtures onto the same isolated root as their child server and made parallel refresh assertions wait for the bounded background contract.
- Added controlled decoy-profile proof that CLI state stays out of OS user cache roots, plus contributor guidance and changelog coverage.

## How To Review

1. Start with `crates/codestory-cli/tests/test_support/mod.rs` and `test_state_isolation.rs` for the integration boundary.
2. Review `codestory-retrieval/src/config.rs` for the explicit test-root API and the separation between `cfg(test)` automatic roots and feature-gated explicit overrides.
3. Review readiness broker paths, snapshot, reconciliation, and tests for worker-thread propagation.
4. Confirm the integration test call sites no longer access `CARGO_BIN_EXE_codestory-cli` outside the helper.

## Verification

- `cargo test --workspace --all-features` (default concurrency): passed.
- `cargo test -p codestory-cli --test test_state_isolation -- --nocapture`: 2 passed.
- `cargo test -p codestory-cli --bin codestory-cli observe_broker_snapshot_ -- --nocapture`: 4 passed.
- `cargo test -p codestory-cli --test stdio_protocol_contracts`: 47 passed, 9 ignored.
- `cargo test -p codestory-retrieval --all-features`: 301 passed across unit/integration tests, 2 ignored.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- `node .github/scripts/check-doc-links.mjs`: passed (70 files, 279 relative links).
- `cargo build --release -p codestory-cli`: passed.
- Required ignored repo-scale attempt ran but could not produce live evidence: `CODESTORY_REAL_REPO_DRILL_CASES` is unset, and this Codex Windows host denied `CREATE_BREAKAWAY_FROM_JOB` with OS error 5 during native embedding bootstrap.

## Risk

The product-facing change is limited to using the existing canonical `CODESTORY_CACHE_ROOT` resolver for CLI storage and managed embeddings. Test-support overrides are thread-local, feature-gated, and inert unless explicitly entered; automatic thread-name isolation is compiled only for retrieval's own unit tests. Live full-sidecar and real-repo drill proof remains unavailable on this host for the reasons above.
