### PR TITLE
Add native packaged platform acceptance

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -1264,15 +1264,16 @@ def run_gate(args: argparse.Namespace) -> None:
         summary["artifacts"]["packet"] = str(packet_artifact)
         write_json(out_dir / "summary.json", summary)
 
-        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
-        stdio_attempts = [stdio_status_payload]
-        require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
-        allowed = stdio_status_payload.get("allowed_surfaces", {})
-        if not all(allowed.get(name, {}).get("allowed") is True for name in ("packet", "search", "context")):
-            shutil.copy2(stdio_artifact, out_dir / "serve-stdio-status-initial.json")
+        stdio_attempts = []
+        try:
             stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
             stdio_attempts.append(stdio_status_payload)
-        try:
+            require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
+            allowed = stdio_status_payload.get("allowed_surfaces", {})
+            if not all(allowed.get(name, {}).get("allowed") is True for name in ("packet", "search", "context")):
+                shutil.copy2(stdio_artifact, out_dir / "serve-stdio-status-initial.json")
+                stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
+                stdio_attempts.append(stdio_status_payload)
             require_stdio_ready(stdio_status_payload, stdio_artifact, args.expected_version)
         finally:
             for status_attempt in stdio_attempts:
@@ -1391,7 +1392,7 @@ def write_fake_cli(path: Path) -> None:
             elif layer == "serve":
                 marker = None
                 repair_attempt = None
-                if fail == "serve_first_blocked":
+                if fail in {"serve_first_blocked", "serve_first_blocked_then_timeout"}:
                     try:
                         project = sys.argv[sys.argv.index("--project") + 1]
                         marker = os.path.join(project, ".fake-serve-first-blocked-seen")
@@ -1425,6 +1426,9 @@ def write_fake_cli(path: Path) -> None:
                         repair_attempt = repair["attempt_id"]
                         result = {"content": [{"type": "text", "text": json.dumps(repair)}], "structuredContent": repair}
                     else:
+                        if fail == "serve_first_blocked_then_timeout" and marker is not None and os.path.exists(marker):
+                            time.sleep(60)
+                            continue
                         serve_allowed = True
                         refresh_worker_pid = None
                         if marker is not None and not os.path.exists(marker):
@@ -1666,6 +1670,40 @@ def self_test() -> None:
             assert delayed_status_worker.returncode is not None
         finally:
             terminate_worker_pid(delayed_status_worker.pid)
+            os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+            os.environ.pop("CODESTORY_FAKE_STATUS_WORKER_PID", None)
+
+        retry_timeout_project = root / "repo-retry-timeout"
+        retry_timeout_project.mkdir()
+        retry_timeout_args = argparse.Namespace(**vars(args))
+        retry_timeout_args.project = str(retry_timeout_project)
+        retry_timeout_args.out_dir = str(root / "retry-timeout-out")
+        retry_timeout_args.timeout_secs = 2
+        retry_timeout_worker = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=(
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+                if os.name == "nt"
+                else 0
+            ),
+            start_new_session=os.name != "nt",
+        )
+        os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "serve_first_blocked_then_timeout"
+        os.environ["CODESTORY_FAKE_STATUS_WORKER_PID"] = str(retry_timeout_worker.pid)
+        try:
+            try:
+                run_gate(retry_timeout_args)
+            except GateFailure as exc:
+                assert exc.layer == "serve_stdio"
+                assert "serve-stdio-status.json" in str(exc.artifact)
+            else:
+                raise AssertionError("timed-out stdio readiness retry should fail the gate")
+            retry_timeout_worker.wait(timeout=5)
+            assert retry_timeout_worker.returncode is not None
+        finally:
+            terminate_worker_pid(retry_timeout_worker.pid)
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
             os.environ.pop("CODESTORY_FAKE_STATUS_WORKER_PID", None)
 

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import os
@@ -129,6 +130,32 @@ def verify_archive_checksum(archive: Path, checksum_file: Path, artifact: Path) 
     )
     require(expected is not None, "checksum", artifact, f"checksum file does not list {archive.name}")
     require(actual == expected, "checksum", artifact, f"checksum mismatch for {archive.name}")
+
+
+def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path) -> None:
+    env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
+    for profile, extra in (("local", []), ("agent", ["--run-id", "shared-agent"])):
+        try:
+            subprocess.run(
+                [
+                    str(cli),
+                    "retrieval",
+                    "down",
+                    "--project",
+                    str(project),
+                    "--profile",
+                    profile,
+                    *extra,
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=20,
+                check=False,
+                env=env,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    shutil.rmtree(cache_root, ignore_errors=True)
 
 
 def require_plugin_manifest_version(plugin_root: Path, expected_version: str) -> None:
@@ -941,15 +968,21 @@ def run_gate(args: argparse.Namespace) -> None:
     if args.checksum_file:
         verify_archive_checksum(archive, Path(args.checksum_file).resolve(), checksum_artifact)
 
-    with tempfile.TemporaryDirectory(prefix="codestory-packaged-agent-proof-", dir=out_dir) as temp:
+    with (
+        tempfile.TemporaryDirectory(prefix="codestory-packaged-agent-proof-", dir=out_dir) as temp,
+        contextlib.ExitStack() as cleanup_stack,
+    ):
         unpacked = Path(temp) / "unpacked"
         unpacked.mkdir()
         unpack_archive(archive, unpacked)
         cli = find_cli(unpacked)
         plugin_skill = find_plugin_skill(unpacked)
-        cache_root = Path(temp) / "cache"
+        cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-proof-cache-"))
+        cleanup_stack.callback(cleanup_proof_cache, cli, project, cache_root)
         proof_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
-        stdio_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(Path(temp) / "stdio-cache")}
+        stdio_cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-stdio-cache-"))
+        cleanup_stack.callback(cleanup_proof_cache, cli, project, stdio_cache_root)
+        stdio_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(stdio_cache_root)}
 
         summary = {
             "archive": str(archive),
@@ -1003,8 +1036,6 @@ def run_gate(args: argparse.Namespace) -> None:
                     "--repair",
                     "--project",
                     str(project),
-                    "--cache-dir",
-                    str(cache_root),
                     "--format",
                     "json",
                     "--output-file",
@@ -1024,8 +1055,6 @@ def run_gate(args: argparse.Namespace) -> None:
                     "ground",
                     "--project",
                     str(project),
-                    "--cache-dir",
-                    str(cache_root),
                     "--refresh",
                     "none",
                     "--format",
@@ -1597,7 +1626,7 @@ def self_test() -> None:
         assert (out_dir / "summary.json").is_file()
         stdio_artifact = read_json_file(out_dir / "serve-stdio-status.json")
         full_cache_root = read_json_file(out_dir / "local-retrieval-bootstrap.json")["cache_root"]
-        assert Path(full_cache_root).name == "cache"
+        assert Path(full_cache_root).name.startswith("codestory-packaged-proof-cache-")
         assert stdio_artifact["status"]["cache_root"] == full_cache_root
         status_request = next(
             entry["request"]
@@ -1615,7 +1644,7 @@ def self_test() -> None:
         assert version_only_summary["artifacts"].keys() == {"checksum", "version", "help", "serve_stdio"}
         assert not (version_only_out / "local-retrieval-bootstrap.json").exists()
         version_only_status = read_json_file(version_only_out / "serve-stdio-status.json")["status"]
-        assert Path(version_only_status["cache_root"]).name == "stdio-cache"
+        assert Path(version_only_status["cache_root"]).name.startswith("codestory-packaged-stdio-cache-")
         assert version_only_status["cache_root"] != full_cache_root
 
         bad_checksum = root / "BAD_SHA256SUMS.txt"
@@ -1678,7 +1707,7 @@ def self_test() -> None:
         retry_timeout_args = argparse.Namespace(**vars(args))
         retry_timeout_args.project = str(retry_timeout_project)
         retry_timeout_args.out_dir = str(root / "retry-timeout-out")
-        retry_timeout_args.timeout_secs = 2
+        retry_timeout_args.timeout_secs = 5
         retry_timeout_worker = subprocess.Popen(
             [sys.executable, "-c", "import time; time.sleep(60)"],
             stdout=subprocess.DEVNULL,
@@ -1797,10 +1826,10 @@ def self_test() -> None:
             )
             assert managed_status_after["sidecar_setup"]["active_repair"]["attempt_id"] == "fake-attempt"
             managed_cache_root = read_json_file(Path(managed_args.out_dir) / "managed-local-ground.json")["cache_root"]
-            assert Path(managed_cache_root).name == "cache"
+            assert Path(managed_cache_root).name.startswith("codestory-packaged-proof-cache-")
             assert managed_status_after["cache_root"] == managed_cache_root
             managed_direct_status = read_json_file(Path(managed_args.out_dir) / "serve-stdio-status.json")["status"]
-            assert Path(managed_direct_status["cache_root"]).name == "stdio-cache"
+            assert Path(managed_direct_status["cache_root"]).name.startswith("codestory-packaged-stdio-cache-")
             assert managed_direct_status["cache_root"] != managed_cache_root
         finally:
             os.environ.pop("CODESTORY_FAKE_PLUGIN_MANAGED", None)

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import queue
@@ -96,6 +97,40 @@ def read_json_file(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def captured_text(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value or ""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_archive_checksum(archive: Path, checksum_file: Path, artifact: Path) -> None:
+    lines = checksum_file.read_text(encoding="utf-8").splitlines()
+    expected = next(
+        (
+            line.split(maxsplit=1)[0].lower()
+            for line in lines
+            if len(line.split(maxsplit=1)) == 2
+            and line.split(maxsplit=1)[1].lstrip("*").strip() == archive.name
+        ),
+        None,
+    )
+    actual = sha256_file(archive)
+    write_json(
+        artifact,
+        {"archive": str(archive), "checksum_file": str(checksum_file), "expected": expected, "actual": actual},
+    )
+    require(expected is not None, "checksum", artifact, f"checksum file does not list {archive.name}")
+    require(actual == expected, "checksum", artifact, f"checksum mismatch for {archive.name}")
+
+
 def require_plugin_manifest_version(plugin_root: Path, expected_version: str) -> None:
     manifest_path = plugin_root / ".codex-plugin" / "plugin.json"
     require(manifest_path.is_file(), "plugin_manifest", manifest_path, f"plugin manifest is missing: {manifest_path}")
@@ -117,6 +152,7 @@ def run_command(
     artifact: Path,
     timeout_secs: int,
     parse_json: bool = True,
+    env: dict[str, str] | None = None,
 ) -> object | None:
     stdout_path = artifact.with_suffix(artifact.suffix + ".stdout.txt")
     stderr_path = artifact.with_suffix(artifact.suffix + ".stderr.txt")
@@ -129,16 +165,19 @@ def run_command(
             stderr=subprocess.PIPE,
             timeout=timeout_secs,
             check=False,
+            env=env,
         )
     except subprocess.TimeoutExpired as exc:
-        stdout_path.write_text(exc.stdout or "", encoding="utf-8")
-        stderr_path.write_text(exc.stderr or "", encoding="utf-8")
+        stdout_path.write_text(captured_text(exc.stdout), encoding="utf-8")
+        stderr_path.write_text(captured_text(exc.stderr), encoding="utf-8")
         fail(layer, stdout_path, f"command timed out after {timeout_secs}s: {' '.join(command)}")
 
     stdout_path.write_text(result.stdout, encoding="utf-8")
     stderr_path.write_text(result.stderr, encoding="utf-8")
     if result.returncode != 0:
-        artifact_path = stderr_path if result.stderr.strip() else stdout_path
+        artifact_path = artifact if artifact.is_file() and artifact.stat().st_size > 0 else (
+            stderr_path if result.stderr.strip() else stdout_path
+        )
         fail(layer, artifact_path, f"command exited {result.returncode}: {' '.join(command)}")
 
     if not parse_json:
@@ -310,6 +349,27 @@ def terminate_process_tree(process: subprocess.Popen[str]) -> None:
         process.kill()
 
 
+def terminate_worker_pid(pid: int) -> None:
+    if pid <= 0:
+        return
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    else:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
 def read_stdio_line(stdout_queue: queue.Queue[str | None], timeout_secs: int) -> str | None:
     deadline = time.monotonic() + timeout_secs
     while True:
@@ -326,12 +386,19 @@ def read_stdio_line(stdout_queue: queue.Queue[str | None], timeout_secs: int) ->
             return line
 
 
-def stdio_status(cli: Path, project: Path, artifact: Path, timeout_secs: int) -> dict:
+def stdio_status(
+    cli: Path,
+    project: Path,
+    artifact: Path,
+    timeout_secs: int,
+    env: dict[str, str] | None = None,
+) -> dict:
     return stdio_status_command(
         [str(cli), "serve", "--stdio", "--refresh", "none", "--project", str(project)],
         artifact,
         timeout_secs,
         project,
+        env=env,
     )
 
 
@@ -363,6 +430,94 @@ def plugin_stdio_status(
         )
 
 
+def plugin_stdio_handoff(
+    plugin_root: Path,
+    release_dir: Path,
+    project: Path,
+    cache_root: Path,
+    artifact: Path,
+    timeout_secs: int,
+    expected_version: str,
+    archive_cli: Path,
+) -> dict:
+    require_plugin_manifest_version(plugin_root, expected_version)
+    launcher = plugin_root / "scripts" / "codestory-mcp.cjs"
+    require(launcher.is_file(), "managed_plugin_handoff", artifact, f"plugin launcher is missing: {launcher}")
+    with tempfile.TemporaryDirectory(prefix="codestory-plugin-data-", dir=artifact.parent) as data:
+        plugin_data = Path(data)
+        policy_path = plugin_data / "sidecar-setup-policy.json"
+        policy_artifact = artifact.with_name("managed-plugin-policy.json")
+        try:
+            policy = subprocess.run(
+                ["node", str(launcher), "sidecar-policy", "enable", "--policy-file", str(policy_path)],
+                cwd=project,
+                env={**os.environ, "PLUGIN_DATA": str(plugin_data)},
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout_secs,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            write_json(
+                policy_artifact,
+                {
+                    "error": str(exc),
+                    "stdout": captured_text(getattr(exc, "stdout", None)),
+                    "stderr": captured_text(getattr(exc, "stderr", None)),
+                },
+            )
+            fail("managed_plugin_handoff", policy_artifact, f"plugin sidecar policy enable failed: {exc}")
+        write_json(
+            policy_artifact,
+            {"returncode": policy.returncode, "stdout": policy.stdout, "stderr": policy.stderr},
+        )
+        require(
+            policy.returncode == 0
+            and policy_path.is_file()
+            and read_json_file(policy_path).get("state") == "enabled",
+            "managed_plugin_handoff",
+            policy_artifact,
+            "plugin sidecar policy enable failed",
+        )
+        status_after = {
+            "jsonrpc": "2.0",
+            "id": "status_after_repair",
+            "method": "resources/read",
+            "params": {"uri": STATUS_URI, "project": str(project)},
+        }
+        status = stdio_status_command(
+            ["node", str(launcher)],
+            artifact,
+            timeout_secs,
+            project,
+            layer="managed_plugin_handoff",
+            cwd=project,
+            env={
+                **os.environ,
+                "CODESTORY_CLI": "",
+                "CODESTORY_CACHE_ROOT": str(cache_root),
+                "CODESTORY_PLUGIN_RELEASE_DIR": str(release_dir),
+                "CODESTORY_PLUGIN_SIDECAR_POLICY_PATH": str(policy_path),
+                "PLUGIN_DATA": str(plugin_data),
+            },
+            extra_requests=[
+                {
+                    "jsonrpc": "2.0",
+                    "id": "repair",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "sidecar_setup",
+                        "arguments": {"project": str(project), "action": "repair"},
+                    },
+                },
+                status_after,
+            ],
+        )
+        require_managed_plugin_handoff(status, artifact, expected_version, archive_cli)
+        return status
+
+
 def stdio_status_command(
     command: list[str],
     artifact: Path,
@@ -371,6 +526,7 @@ def stdio_status_command(
     layer: str = "serve_stdio",
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
+    extra_requests: list[dict] | None = None,
 ) -> dict:
     stderr_path = artifact.with_suffix(artifact.suffix + ".stderr.txt")
     process = subprocess.Popen(
@@ -394,6 +550,7 @@ def stdio_status_command(
             "params": {"uri": STATUS_URI, "project": str(project)},
         },
     ]
+    requests.extend(extra_requests or [])
     transcript: list[dict] = []
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
@@ -452,19 +609,23 @@ def stdio_status_command(
             entry["response"] = response
             responses.append(response)
     finally:
+        if not process_terminated:
+            terminate_process_tree(process)
+            process_terminated = True
+        for response in responses:
+            if not isinstance(response, dict) or response.get("id") != "repair":
+                continue
+            worker_pid = response.get("result", {}).get("structuredContent", {}).get("pid")
+            if isinstance(worker_pid, int):
+                terminate_worker_pid(worker_pid)
         try:
             process.stdin.close()
         except OSError:
             pass
-        if not process_terminated:
-            try:
-                process.wait(timeout=0.1)
-            except subprocess.TimeoutExpired:
-                terminate_process_tree(process)
-                try:
-                    process.wait(timeout=0.5)
-                except subprocess.TimeoutExpired:
-                    process.kill()
+        try:
+            process.wait(timeout=0.5)
+        except subprocess.TimeoutExpired:
+            process.kill()
         stdout_thread.join(timeout=0.2)
         stderr_thread.join(timeout=0.2)
 
@@ -567,45 +728,175 @@ def require_stdio_ready(status: dict, artifact: Path, expected_version: str) -> 
         require(allowed is True, "serve_stdio", artifact, f"allowed_surfaces.{name}.allowed is {allowed!r}")
 
 
-def require_plugin_stdio_ready(status: dict, artifact: Path, expected_version: str) -> None:
-    require_stdio_ready(status, artifact, expected_version)
+def require_plugin_provenance(
+    status: dict,
+    artifact: Path,
+    expected_version: str,
+    layer: str,
+) -> None:
+    require_stdio_shape(status, artifact, expected_version, layer)
     plugin_runtime = status.get("plugin_runtime")
-    require(isinstance(plugin_runtime, dict), "plugin_stdio", artifact, "status missing plugin_runtime")
+    require(isinstance(plugin_runtime, dict), layer, artifact, "status missing plugin_runtime")
     require(
         plugin_runtime.get("plugin_version") == expected_version,
-        "plugin_stdio",
+        layer,
         artifact,
         f"plugin_runtime.plugin_version is {plugin_runtime.get('plugin_version')!r}, expected {expected_version!r}",
     )
     require(
         plugin_runtime.get("cli_source") == "managed",
-        "plugin_stdio",
+        layer,
         artifact,
         f"plugin_runtime.cli_source is {plugin_runtime.get('cli_source')!r}, expected 'managed'",
     )
     require(
         plugin_runtime.get("build_source") == "github_release",
-        "plugin_stdio",
+        layer,
         artifact,
         f"plugin_runtime.build_source is {plugin_runtime.get('build_source')!r}, expected 'github_release'",
     )
     require(
         plugin_runtime.get("repo_ref") == f"v{expected_version}",
-        "plugin_stdio",
+        layer,
         artifact,
         f"plugin_runtime.repo_ref is {plugin_runtime.get('repo_ref')!r}, expected 'v{expected_version}'",
     )
     require(
         plugin_runtime.get("cli_version") == expected_version,
-        "plugin_stdio",
+        layer,
         artifact,
         f"plugin_runtime.cli_version is {plugin_runtime.get('cli_version')!r}, expected {expected_version!r}",
     )
     require(
         isinstance(plugin_runtime.get("plugin_root"), str) and len(plugin_runtime.get("plugin_root", "")) > 0,
-        "plugin_stdio",
+        layer,
         artifact,
         "plugin_runtime missing plugin_root",
+    )
+
+
+def require_plugin_stdio_ready(status: dict, artifact: Path, expected_version: str) -> None:
+    require_stdio_ready(status, artifact, expected_version)
+    require_plugin_provenance(status, artifact, expected_version, "plugin_stdio")
+
+
+def transcript_response(artifact: Path, request_id: str) -> dict | None:
+    payload = read_json_file(artifact)
+    if not isinstance(payload, dict):
+        return None
+    for entry in payload.get("transcript", []):
+        if isinstance(entry, dict) and entry.get("request", {}).get("id") == request_id:
+            response = entry.get("response")
+            return response if isinstance(response, dict) else None
+    return None
+
+
+def status_from_resource_response(response: dict) -> dict | None:
+    contents = response.get("result", {}).get("contents", [])
+    content = next(
+        (item for item in contents if isinstance(item, dict) and item.get("uri") == STATUS_URI),
+        None,
+    )
+    if not isinstance(content, dict):
+        return None
+    try:
+        status = json.loads(content.get("text", ""))
+    except json.JSONDecodeError:
+        return None
+    return status if isinstance(status, dict) else None
+
+
+def require_managed_plugin_handoff(
+    status: dict,
+    artifact: Path,
+    expected_version: str,
+    archive_cli: Path,
+) -> None:
+    require_plugin_provenance(status, artifact, expected_version, "managed_plugin_handoff")
+    plugin_runtime = status["plugin_runtime"]
+    managed_binary = Path(plugin_runtime.get("managed_binary_path", ""))
+    server_executable = Path(status.get("server_executable", ""))
+    require(
+        managed_binary.is_file()
+        and server_executable.is_file()
+        and managed_binary.samefile(server_executable),
+        "managed_plugin_handoff",
+        artifact,
+        "managed_binary_path does not identify the executable serving MCP",
+    )
+    archive_sha256 = sha256_file(archive_cli)
+    server_sha256 = sha256_file(server_executable)
+    require(
+        archive_sha256 == server_sha256 == status.get("server_executable_sha256"),
+        "managed_plugin_handoff",
+        artifact,
+        "managed MCP executable does not match the packaged archive binary",
+    )
+    require(
+        status.get("allowed_surfaces", {}).get("ground", {}).get("allowed") is True,
+        "managed_plugin_handoff",
+        artifact,
+        "managed plugin status did not allow local ground",
+    )
+    repair_response = transcript_response(artifact, "repair") or {}
+    repair = repair_response.get("result", {}).get("structuredContent")
+    require(isinstance(repair, dict), "managed_plugin_handoff", artifact, "repair response missing structuredContent")
+    repair_status = repair.get("status")
+    require(
+        repair_status in {"started", "already_running"},
+        "managed_plugin_handoff",
+        artifact,
+        f"repair status is {repair_status!r}, expected started or already_running",
+    )
+    if repair_status == "started":
+        require(
+            isinstance(repair.get("attempt_id"), str)
+            and isinstance(repair.get("pid"), int)
+            and repair.get("reservation_published") is True,
+            "managed_plugin_handoff",
+            artifact,
+            "started repair did not publish an attempt reservation",
+        )
+    repair_setup = repair.get("sidecar_setup") or {}
+    attempt_id = repair.get("attempt_id") or (repair_setup.get("active_repair") or {}).get("attempt_id")
+    require(
+        isinstance(attempt_id, str) and len(attempt_id) > 0,
+        "managed_plugin_handoff",
+        artifact,
+        "repair response did not identify its attempt",
+    )
+    next_calls = repair.get("recommended_next_calls", [])
+    require(
+        any(
+            isinstance(call, dict)
+            and call.get("method") == "tools/call"
+            and call.get("tool") == "status"
+            and call.get("arguments", {}).get("project")
+            for call in next_calls
+        ),
+        "managed_plugin_handoff",
+        artifact,
+        "repair response did not point back to project-scoped status",
+    )
+    status_after_response = transcript_response(artifact, "status_after_repair") or {}
+    status_after = status_from_resource_response(status_after_response)
+    require(
+        isinstance(status_after, dict),
+        "managed_plugin_handoff",
+        artifact,
+        "status read after repair handoff failed",
+    )
+    require_plugin_provenance(status_after, artifact, expected_version, "managed_plugin_handoff")
+    setup = status_after.get("sidecar_setup", {})
+    observed_attempts = {
+        (setup.get("active_repair") or {}).get("attempt_id"),
+        (setup.get("last_worker_result") or {}).get("attempt_id"),
+    }
+    require(
+        attempt_id in observed_attempts,
+        "managed_plugin_handoff",
+        artifact,
+        f"repair attempt {attempt_id!r} was not observable in post-handoff status",
     )
 
 
@@ -615,6 +906,9 @@ def run_gate(args: argparse.Namespace) -> None:
     out_dir = Path(args.out_dir).resolve()
     shutil.rmtree(out_dir, ignore_errors=True)
     out_dir.mkdir(parents=True, exist_ok=True)
+    checksum_artifact = out_dir / "archive-checksum.json"
+    if args.checksum_file:
+        verify_archive_checksum(archive, Path(args.checksum_file).resolve(), checksum_artifact)
 
     with tempfile.TemporaryDirectory(prefix="codestory-packaged-agent-proof-", dir=out_dir) as temp:
         unpacked = Path(temp) / "unpacked"
@@ -622,6 +916,12 @@ def run_gate(args: argparse.Namespace) -> None:
         unpack_archive(archive, unpacked)
         cli = find_cli(unpacked)
         plugin_skill = find_plugin_skill(unpacked)
+        cache_root = Path(temp) / "cache"
+        proof_env = (
+            {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
+            if args.managed_plugin_handoff
+            else None
+        )
 
         summary = {
             "archive": str(archive),
@@ -630,6 +930,8 @@ def run_gate(args: argparse.Namespace) -> None:
             "project": str(project),
             "artifacts": {},
         }
+        if args.checksum_file:
+            summary["artifacts"]["checksum"] = str(checksum_artifact)
         write_json(out_dir / "summary.json", summary)
 
         version_artifact = out_dir / "version.txt"
@@ -645,12 +947,81 @@ def run_gate(args: argparse.Namespace) -> None:
         write_json(out_dir / "summary.json", summary)
 
         stdio_artifact = out_dir / "serve-stdio-status.json"
-        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs)
+        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
         require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
         summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
         write_json(out_dir / "summary.json", summary)
 
         if args.version_only:
+            return
+
+        if args.managed_plugin_handoff:
+            local_ready_artifact = out_dir / "managed-local-ready.json"
+            run_command(
+                cli,
+                "managed_local_ready",
+                [
+                    "ready",
+                    "--goal",
+                    "local",
+                    "--repair",
+                    "--project",
+                    str(project),
+                    "--cache-dir",
+                    str(cache_root),
+                    "--format",
+                    "json",
+                    "--output-file",
+                    str(local_ready_artifact),
+                ],
+                local_ready_artifact,
+                args.timeout_secs,
+                env=proof_env,
+            )
+            summary["artifacts"]["managed_local_ready"] = str(local_ready_artifact)
+
+            local_ground_artifact = out_dir / "managed-local-ground.json"
+            ground = run_command(
+                cli,
+                "managed_local_ground",
+                [
+                    "ground",
+                    "--project",
+                    str(project),
+                    "--cache-dir",
+                    str(cache_root),
+                    "--refresh",
+                    "none",
+                    "--format",
+                    "json",
+                    "--output-file",
+                    str(local_ground_artifact),
+                ],
+                local_ground_artifact,
+                args.timeout_secs,
+                env=proof_env,
+            )
+            require(
+                isinstance(ground, dict) and isinstance(ground.get("stats"), dict),
+                "managed_local_ground",
+                local_ground_artifact,
+                "managed local ground output is missing repository stats",
+            )
+            summary["artifacts"]["managed_local_ground"] = str(local_ground_artifact)
+
+            plugin_artifact = out_dir / "managed-plugin-handoff.json"
+            plugin_status = plugin_stdio_handoff(
+                Path(args.plugin_root).resolve(),
+                archive.parent,
+                project,
+                cache_root,
+                plugin_artifact,
+                args.timeout_secs,
+                args.expected_version,
+                cli,
+            )
+            summary["artifacts"]["managed_plugin_handoff"] = str(plugin_artifact)
+            write_json(out_dir / "summary.json", summary)
             return
 
         local_bootstrap_artifact = out_dir / "local-retrieval-bootstrap.json"
@@ -874,6 +1245,7 @@ def write_fake_cli(path: Path) -> None:
     fake.write_text(
         textwrap.dedent(
             r'''
+            import hashlib
             import json
             import os
             import sys
@@ -949,8 +1321,11 @@ def write_fake_cli(path: Path) -> None:
                     emit({"sufficiency": {"status": "supported"}, "answer": {"retrieval_version": "fallback"}, "retrieval_trace_summary": {}})
                 else:
                     emit({"sufficiency": {"status": "sufficient"}, "answer": {"retrieval_version": "sidecar"}, "retrieval_trace_summary": {}})
+            elif layer == "ground":
+                emit({"root": os.getcwd(), "stats": {"file_count": 1, "node_count": 1}})
             elif layer == "serve":
                 marker = None
+                repair_attempt = None
                 if fail == "serve_first_blocked":
                     try:
                         project = sys.argv[sys.argv.index("--project") + 1]
@@ -963,25 +1338,55 @@ def write_fake_cli(path: Path) -> None:
                         time.sleep(60)
                         continue
                     if request.get("method") == "tools/list":
-                        result = {"tools": [{"name": "packet"}, {"name": "search"}, {"name": "context"}]}
+                        result = {"tools": [{"name": "packet"}, {"name": "search"}, {"name": "context"}, {"name": "sidecar_setup"}]}
                     elif request.get("method") == "resources/list":
                         resources = [{"uri": "codestory://status", "name": "CodeStory runtime status"}]
                         if fail != "resources_hidden":
                             resources.append({"uri": "codestory://agent-guide", "name": "CodeStory agent guide"})
                         result = {"resources": resources}
+                    elif request.get("method") == "tools/call" and request.get("params", {}).get("name") == "sidecar_setup":
+                        repair = {
+                            "status": "started",
+                            "mode": "background",
+                            "pid": os.getpid(),
+                            "attempt_id": "fake-attempt",
+                            "reservation_published": True,
+                            "recommended_next_calls": [{
+                                "method": "tools/call",
+                                "tool": "status",
+                                "arguments": {"project": os.getcwd()},
+                            }],
+                        }
+                        repair_attempt = repair["attempt_id"]
+                        result = {"content": [{"type": "text", "text": json.dumps(repair)}], "structuredContent": repair}
                     else:
                         serve_allowed = True
                         if marker is not None and not os.path.exists(marker):
                             open(marker, "w", encoding="utf-8").write("seen")
                             serve_allowed = False
+                        server_executable = os.environ.get("CODESTORY_FAKE_SERVER_EXECUTABLE", sys.argv[0])
+                        server_sha256 = hashlib.sha256(open(server_executable, "rb").read()).hexdigest()
                         status = {
                             "server_version": "9.9.9",
                             "cli_version": "9.9.9",
-                            "server_executable": sys.argv[0],
-                            "server_executable_sha256": "a" * 64,
+                            "server_executable": server_executable,
+                            "server_executable_sha256": server_sha256,
                             "sidecar_contract_version": 1,
-                            "plugin_runtime": {"cli_source": "direct_cli_launch"},
+                            "plugin_runtime": {
+                                "cli_source": "managed" if os.environ.get("CODESTORY_FAKE_PLUGIN_MANAGED") == "1" else "direct_cli_launch",
+                                "plugin_version": "9.9.9",
+                                "build_source": "github_release",
+                                "repo_ref": "v9.9.9",
+                                "cli_version": "9.9.9",
+                                "plugin_root": os.getcwd(),
+                                "managed_binary_path": server_executable,
+                            },
+                            "sidecar_setup": {
+                                "active_repair": {"attempt_id": repair_attempt} if repair_attempt else None,
+                                "last_worker_result": None,
+                            },
                             "allowed_surfaces": {
+                                "ground": {"allowed": True},
                                 "packet": {"allowed": serve_allowed},
                                 "search": {"allowed": serve_allowed},
                                 "context": {"allowed": serve_allowed},
@@ -1011,11 +1416,35 @@ def write_fake_plugin_launcher(plugin_root: Path) -> None:
         textwrap.dedent(
             r'''
             const { spawn } = require('child_process');
+            const fs = require('fs');
+            const path = require('path');
 
-            const cli = process.env.CODESTORY_FAKE_PLUGIN_CLI;
+            if (process.argv[2] === 'sidecar-policy') {
+              if (process.env.CODESTORY_FAKE_PLUGIN_POLICY_TIMEOUT === '1') {
+                process.stdout.write('policy stdout before timeout\n');
+                process.stderr.write('policy stderr before timeout\n');
+                Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 60_000);
+              }
+              const policyIndex = process.argv.indexOf('--policy-file');
+              if (policyIndex >= 0 && process.argv[policyIndex + 1]) {
+                fs.writeFileSync(process.argv[policyIndex + 1], JSON.stringify({ state: 'enabled' }));
+              }
+              process.exit(0);
+            }
+
+            let cli = process.env.CODESTORY_FAKE_PLUGIN_CLI;
             if (!cli) {
               process.stderr.write('CODESTORY_FAKE_PLUGIN_CLI is required\n');
               process.exit(2);
+            }
+            if (process.env.CODESTORY_FAKE_PLUGIN_MANAGED === '1') {
+              const managedDir = path.join(process.env.PLUGIN_DATA, 'codestory-cli', '9.9.9', 'bin');
+              fs.mkdirSync(managedDir, { recursive: true });
+              const sourceDir = path.dirname(cli);
+              const managedCli = path.join(managedDir, path.basename(cli));
+              fs.copyFileSync(cli, managedCli);
+              fs.copyFileSync(path.join(sourceDir, 'fake_cli.py'), path.join(managedDir, 'fake_cli.py'));
+              cli = managedCli;
             }
 
             const child = spawn(
@@ -1029,6 +1458,7 @@ def write_fake_plugin_launcher(plugin_root: Path) -> None:
                   CODESTORY_FAKE_FAIL_LAYER: process.env.CODESTORY_FAKE_PLUGIN_HIDE_RESOURCES === '1'
                     ? 'resources_hidden'
                     : process.env.CODESTORY_FAKE_FAIL_LAYER || '',
+                  CODESTORY_FAKE_SERVER_EXECUTABLE: cli,
                 },
               },
             );
@@ -1059,6 +1489,8 @@ def self_test() -> None:
         with zipfile.ZipFile(archive, "w") as handle:
             for path in stage.rglob("*"):
                 handle.write(path, path.relative_to(stage.parent).as_posix())
+        checksum_file = root / "SHA256SUMS.txt"
+        checksum_file.write_text(f"{sha256_file(archive)}  {archive.name}\n", encoding="utf-8")
         project = root / "repo"
         project.mkdir()
         out_dir = root / "out"
@@ -1070,9 +1502,11 @@ def self_test() -> None:
             context_query=DEFAULT_QUERY,
             question=DEFAULT_QUESTION,
             expected_version="9.9.9",
+            checksum_file=str(checksum_file),
             plugin_root=None,
             timeout_secs=30,
             version_only=False,
+            managed_plugin_handoff=False,
         )
         run_gate(args)
         assert (out_dir / "summary.json").is_file()
@@ -1090,8 +1524,21 @@ def self_test() -> None:
         version_only_args.version_only = True
         run_gate(version_only_args)
         version_only_summary = read_json_file(version_only_out / "summary.json")
-        assert version_only_summary["artifacts"].keys() == {"version", "help", "serve_stdio"}
+        assert version_only_summary["artifacts"].keys() == {"checksum", "version", "help", "serve_stdio"}
         assert not (version_only_out / "local-retrieval-bootstrap.json").exists()
+
+        bad_checksum = root / "BAD_SHA256SUMS.txt"
+        bad_checksum.write_text(f"{'0' * 64}  {archive.name}\n", encoding="utf-8")
+        bad_checksum_args = argparse.Namespace(**vars(version_only_args))
+        bad_checksum_args.out_dir = str(root / "bad-checksum-out")
+        bad_checksum_args.checksum_file = str(bad_checksum)
+        try:
+            run_gate(bad_checksum_args)
+        except GateFailure as exc:
+            assert exc.layer == "checksum"
+            assert exc.artifact.name == "archive-checksum.json"
+        else:
+            raise AssertionError("mismatched packaged checksum should fail the gate")
 
         stale_out = root / "stale-out"
         stale_out.mkdir()
@@ -1185,6 +1632,59 @@ def self_test() -> None:
             os.environ.pop("CODESTORY_FAKE_PLUGIN_HIDE_RESOURCES", None)
             os.environ.pop("CODESTORY_FAKE_PLUGIN_CLI", None)
 
+        managed_args = argparse.Namespace(**vars(args))
+        managed_args.plugin_root = str(plugin_root)
+        managed_args.out_dir = str(root / "managed-plugin-out")
+        managed_args.managed_plugin_handoff = True
+        os.environ["CODESTORY_FAKE_PLUGIN_CLI"] = str(
+            stage / ("codestory-cli.cmd" if os.name == "nt" else "codestory-cli")
+        )
+        os.environ["CODESTORY_FAKE_PLUGIN_MANAGED"] = "1"
+        try:
+            run_gate(managed_args)
+            managed_summary = read_json_file(Path(managed_args.out_dir) / "summary.json")
+            assert "managed_local_ground" in managed_summary["artifacts"]
+            assert "managed_plugin_handoff" in managed_summary["artifacts"]
+            managed_artifact = Path(managed_args.out_dir) / "managed-plugin-handoff.json"
+            assert transcript_response(managed_artifact, "repair")["result"]["structuredContent"]["status"] == "started"
+            managed_status_after = status_from_resource_response(
+                transcript_response(managed_artifact, "status_after_repair")
+            )
+            assert managed_status_after["sidecar_setup"]["active_repair"]["attempt_id"] == "fake-attempt"
+        finally:
+            os.environ.pop("CODESTORY_FAKE_PLUGIN_MANAGED", None)
+            os.environ.pop("CODESTORY_FAKE_PLUGIN_CLI", None)
+
+        policy_timeout_artifact = root / "policy-timeout" / "managed-plugin-handoff.json"
+        policy_timeout_artifact.parent.mkdir(parents=True)
+        os.environ["CODESTORY_FAKE_PLUGIN_CLI"] = str(
+            stage / ("codestory-cli.cmd" if os.name == "nt" else "codestory-cli")
+        )
+        os.environ["CODESTORY_FAKE_PLUGIN_POLICY_TIMEOUT"] = "1"
+        try:
+            try:
+                plugin_stdio_handoff(
+                    plugin_root,
+                    archive.parent,
+                    project,
+                    root / "policy-timeout-cache",
+                    policy_timeout_artifact,
+                    2,
+                    "9.9.9",
+                    stage / ("codestory-cli.cmd" if os.name == "nt" else "codestory-cli"),
+                )
+            except GateFailure as exc:
+                assert exc.layer == "managed_plugin_handoff"
+                assert exc.artifact.name == "managed-plugin-policy.json"
+                policy_timeout = read_json_file(exc.artifact)
+                assert "policy stdout before timeout" in policy_timeout["stdout"]
+                assert "policy stderr before timeout" in policy_timeout["stderr"]
+            else:
+                raise AssertionError("timed-out plugin policy enable should fail the gate")
+        finally:
+            os.environ.pop("CODESTORY_FAKE_PLUGIN_POLICY_TIMEOUT", None)
+            os.environ.pop("CODESTORY_FAKE_PLUGIN_CLI", None)
+
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "doctor_stderr"
         try:
             try:
@@ -1235,7 +1735,7 @@ def self_test() -> None:
 
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "serve_timeout"
         timeout_args = argparse.Namespace(**vars(args))
-        timeout_args.timeout_secs = 1
+        timeout_args.timeout_secs = 5
         try:
             try:
                 run_gate(timeout_args)
@@ -1271,6 +1771,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--context-query", default=DEFAULT_QUERY, help="Context proof target query.")
     parser.add_argument("--question", default=DEFAULT_QUESTION, help="Packet proof question.")
     parser.add_argument("--expected-version", help="Expected codestory-cli version in the archive.")
+    parser.add_argument("--checksum-file", help="SHA256SUMS file that must contain and match the archive.")
     parser.add_argument("--plugin-root", help="Plugin root to smoke through scripts/codestory-mcp.cjs.")
     parser.add_argument("--timeout-secs", type=int, default=1800, help="Per-layer timeout.")
     parser.add_argument(
@@ -1278,12 +1779,21 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Only run archive, version, help, and stdio status-shape smoke.",
     )
+    parser.add_argument(
+        "--managed-plugin-handoff",
+        action="store_true",
+        help="Prove managed plugin provisioning, local ground, and background repair handoff without requiring full sidecars.",
+    )
     parser.add_argument("--self-test", action="store_true", help="Run script self-tests.")
     args = parser.parse_args()
     if not args.self_test and not args.archive:
         parser.error("--archive is required unless --self-test is set")
     if not args.self_test and not args.expected_version:
         parser.error("--expected-version is required unless --self-test is set")
+    if args.managed_plugin_handoff and not args.plugin_root:
+        parser.error("--plugin-root is required with --managed-plugin-handoff")
+    if args.managed_plugin_handoff and args.version_only:
+        parser.error("--managed-plugin-handoff and --version-only are mutually exclusive")
     return args
 
 

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -370,6 +370,22 @@ def terminate_worker_pid(pid: int) -> None:
             pass
 
 
+def running_status_worker_pids(status: dict) -> set[int]:
+    operations = status.get("readiness_broker", {}).get("operations", [])
+    return {
+        operation["pid"]
+        for operation in operations
+        if isinstance(operation, dict)
+        and operation.get("status") == "running"
+        and isinstance(operation.get("pid"), int)
+    }
+
+
+def terminate_status_workers(status: dict) -> None:
+    for worker_pid in running_status_worker_pids(status):
+        terminate_worker_pid(worker_pid)
+
+
 def read_stdio_line(stdout_queue: queue.Queue[str | None], timeout_secs: int) -> str | None:
     deadline = time.monotonic() + timeout_secs
     while True:
@@ -392,6 +408,7 @@ def stdio_status(
     artifact: Path,
     timeout_secs: int,
     env: dict[str, str] | None = None,
+    cleanup_status_workers: bool = False,
 ) -> dict:
     return stdio_status_command(
         [str(cli), "serve", "--stdio", "--refresh", "none", "--project", str(project)],
@@ -399,6 +416,7 @@ def stdio_status(
         timeout_secs,
         project,
         env=env,
+        cleanup_status_workers=cleanup_status_workers,
     )
 
 
@@ -409,6 +427,7 @@ def plugin_stdio_status(
     artifact: Path,
     timeout_secs: int,
     expected_version: str,
+    cache_root: Path,
 ) -> dict:
     require_plugin_manifest_version(plugin_root, expected_version)
     launcher = plugin_root / "scripts" / "codestory-mcp.cjs"
@@ -424,9 +443,11 @@ def plugin_stdio_status(
             env={
                 **os.environ,
                 "CODESTORY_CLI": "",
+                "CODESTORY_CACHE_ROOT": str(cache_root),
                 "CODESTORY_PLUGIN_RELEASE_DIR": str(release_dir),
                 "PLUGIN_DATA": data,
             },
+            cleanup_status_workers=True,
         )
 
 
@@ -513,6 +534,7 @@ def plugin_stdio_handoff(
                 },
                 status_after,
             ],
+            cleanup_status_workers=True,
         )
         require_managed_plugin_handoff(status, artifact, expected_version, archive_cli)
         return status
@@ -527,6 +549,7 @@ def stdio_status_command(
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
     extra_requests: list[dict] | None = None,
+    cleanup_status_workers: bool = False,
 ) -> dict:
     stderr_path = artifact.with_suffix(artifact.suffix + ".stderr.txt")
     process = subprocess.Popen(
@@ -612,12 +635,20 @@ def stdio_status_command(
         if not process_terminated:
             terminate_process_tree(process)
             process_terminated = True
+        worker_pids: set[int] = set()
         for response in responses:
-            if not isinstance(response, dict) or response.get("id") != "repair":
+            if not isinstance(response, dict):
                 continue
-            worker_pid = response.get("result", {}).get("structuredContent", {}).get("pid")
-            if isinstance(worker_pid, int):
-                terminate_worker_pid(worker_pid)
+            if response.get("id") == "repair":
+                worker_pid = response.get("result", {}).get("structuredContent", {}).get("pid")
+                if isinstance(worker_pid, int):
+                    worker_pids.add(worker_pid)
+            if cleanup_status_workers:
+                status = status_from_resource_response(response)
+                if isinstance(status, dict):
+                    worker_pids.update(running_status_worker_pids(status))
+        for worker_pid in worker_pids:
+            terminate_worker_pid(worker_pid)
         try:
             process.stdin.close()
         except OSError:
@@ -917,11 +948,8 @@ def run_gate(args: argparse.Namespace) -> None:
         cli = find_cli(unpacked)
         plugin_skill = find_plugin_skill(unpacked)
         cache_root = Path(temp) / "cache"
-        proof_env = (
-            {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
-            if args.managed_plugin_handoff
-            else None
-        )
+        proof_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
+        stdio_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(Path(temp) / "stdio-cache")}
 
         summary = {
             "archive": str(archive),
@@ -947,10 +975,18 @@ def run_gate(args: argparse.Namespace) -> None:
         write_json(out_dir / "summary.json", summary)
 
         stdio_artifact = out_dir / "serve-stdio-status.json"
-        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
-        require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
-        summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
-        write_json(out_dir / "summary.json", summary)
+        if args.version_only or args.managed_plugin_handoff:
+            stdio_status_payload = stdio_status(
+                cli,
+                project,
+                stdio_artifact,
+                args.timeout_secs,
+                stdio_env,
+                cleanup_status_workers=True,
+            )
+            require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
+            summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
+            write_json(out_dir / "summary.json", summary)
 
         if args.version_only:
             return
@@ -1042,6 +1078,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             local_bootstrap_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         summary["artifacts"]["local_retrieval_bootstrap"] = str(local_bootstrap_artifact)
         write_json(out_dir / "summary.json", summary)
@@ -1066,6 +1103,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             local_index_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_retrieval_index_ready(local_index, "local_retrieval_index", local_index_artifact)
         summary["artifacts"]["local_retrieval_index"] = str(local_index_artifact)
@@ -1089,6 +1127,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             local_status_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_retrieval_full(local_status, "local_retrieval_status", local_status_artifact)
         summary["artifacts"]["local_retrieval_status"] = str(local_status_artifact)
@@ -1112,6 +1151,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             ready_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_agent_ready(ready, "ready", ready_artifact)
         summary["artifacts"]["ready"] = str(ready_artifact)
@@ -1124,6 +1164,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ["doctor", "--project", str(project), "--format", "json", "--output-file", str(doctor_artifact)],
             doctor_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_retrieval_full(doctor, "doctor", doctor_artifact)
         summary["artifacts"]["doctor"] = str(doctor_artifact)
@@ -1145,6 +1186,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             status_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_retrieval_full(status, "retrieval_status", status_artifact)
         summary["artifacts"]["retrieval_status"] = str(status_artifact)
@@ -1168,6 +1210,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             search_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_search_full(search, search_artifact)
         summary["artifacts"]["search"] = str(search_artifact)
@@ -1190,6 +1233,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             context_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_context_ready(context, context_artifact)
         summary["artifacts"]["context"] = str(context_artifact)
@@ -1214,13 +1258,26 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             packet_artifact,
             args.timeout_secs,
+            env=proof_env,
         )
         require_packet_ready(packet, packet_artifact)
         summary["artifacts"]["packet"] = str(packet_artifact)
         write_json(out_dir / "summary.json", summary)
 
-        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs)
-        require_stdio_ready(stdio_status_payload, stdio_artifact, args.expected_version)
+        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
+        stdio_attempts = [stdio_status_payload]
+        require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
+        allowed = stdio_status_payload.get("allowed_surfaces", {})
+        if not all(allowed.get(name, {}).get("allowed") is True for name in ("packet", "search", "context")):
+            shutil.copy2(stdio_artifact, out_dir / "serve-stdio-status-initial.json")
+            stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
+            stdio_attempts.append(stdio_status_payload)
+        try:
+            require_stdio_ready(stdio_status_payload, stdio_artifact, args.expected_version)
+        finally:
+            for status_attempt in stdio_attempts:
+                terminate_status_workers(status_attempt)
+        summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
         write_json(out_dir / "summary.json", summary)
 
         if args.plugin_root:
@@ -1232,6 +1289,7 @@ def run_gate(args: argparse.Namespace) -> None:
                 plugin_stdio_artifact,
                 args.timeout_secs,
                 args.expected_version,
+                cache_root,
             )
             require_plugin_stdio_ready(plugin_status, plugin_stdio_artifact, args.expected_version)
             summary["artifacts"]["plugin_stdio"] = str(plugin_stdio_artifact)
@@ -1285,7 +1343,10 @@ def write_fake_cli(path: Path) -> None:
             elif layer == "doctor":
                 emit({"retrieval_mode": "full"})
             elif layer == "retrieval_bootstrap":
-                emit({"project_status": {"retrieval_mode": "unavailable"}})
+                emit({
+                    "cache_root": os.environ.get("CODESTORY_CACHE_ROOT"),
+                    "project_status": {"retrieval_mode": "unavailable"},
+                })
             elif layer == "retrieval_index":
                 emit({"zoekt_stubbed": False, "qdrant_stubbed": False, "scip_stubbed": False})
             elif layer == "retrieval_status":
@@ -1322,7 +1383,11 @@ def write_fake_cli(path: Path) -> None:
                 else:
                     emit({"sufficiency": {"status": "sufficient"}, "answer": {"retrieval_version": "sidecar"}, "retrieval_trace_summary": {}})
             elif layer == "ground":
-                emit({"root": os.getcwd(), "stats": {"file_count": 1, "node_count": 1}})
+                emit({
+                    "cache_root": os.environ.get("CODESTORY_CACHE_ROOT"),
+                    "root": os.getcwd(),
+                    "stats": {"file_count": 1, "node_count": 1},
+                })
             elif layer == "serve":
                 marker = None
                 repair_attempt = None
@@ -1361,12 +1426,28 @@ def write_fake_cli(path: Path) -> None:
                         result = {"content": [{"type": "text", "text": json.dumps(repair)}], "structuredContent": repair}
                     else:
                         serve_allowed = True
+                        refresh_worker_pid = None
                         if marker is not None and not os.path.exists(marker):
-                            open(marker, "w", encoding="utf-8").write("seen")
+                            refresh_worker_pid = int(os.environ["CODESTORY_FAKE_STATUS_WORKER_PID"])
+                            open(marker, "w", encoding="utf-8").write(str(refresh_worker_pid))
                             serve_allowed = False
+                        elif marker is not None:
+                            refresh_worker_pid = int(open(marker, encoding="utf-8").read())
+                            try:
+                                os.kill(refresh_worker_pid, 0)
+                            except OSError:
+                                serve_allowed = False
                         server_executable = os.environ.get("CODESTORY_FAKE_SERVER_EXECUTABLE", sys.argv[0])
                         server_sha256 = hashlib.sha256(open(server_executable, "rb").read()).hexdigest()
                         status = {
+                            "cache_root": os.environ.get("CODESTORY_CACHE_ROOT"),
+                            "readiness_broker": {
+                                "operations": ([{
+                                    "operation_kind": "local_graph_refresh",
+                                    "pid": refresh_worker_pid,
+                                    "status": "running",
+                                }] if refresh_worker_pid else []),
+                            },
                             "server_version": "9.9.9",
                             "cli_version": "9.9.9",
                             "server_executable": server_executable,
@@ -1511,6 +1592,9 @@ def self_test() -> None:
         run_gate(args)
         assert (out_dir / "summary.json").is_file()
         stdio_artifact = read_json_file(out_dir / "serve-stdio-status.json")
+        full_cache_root = read_json_file(out_dir / "local-retrieval-bootstrap.json")["cache_root"]
+        assert Path(full_cache_root).name == "cache"
+        assert stdio_artifact["status"]["cache_root"] == full_cache_root
         status_request = next(
             entry["request"]
             for entry in stdio_artifact["transcript"]
@@ -1526,6 +1610,9 @@ def self_test() -> None:
         version_only_summary = read_json_file(version_only_out / "summary.json")
         assert version_only_summary["artifacts"].keys() == {"checksum", "version", "help", "serve_stdio"}
         assert not (version_only_out / "local-retrieval-bootstrap.json").exists()
+        version_only_status = read_json_file(version_only_out / "serve-stdio-status.json")["status"]
+        assert Path(version_only_status["cache_root"]).name == "stdio-cache"
+        assert version_only_status["cache_root"] != full_cache_root
 
         bad_checksum = root / "BAD_SHA256SUMS.txt"
         bad_checksum.write_text(f"{'0' * 64}  {archive.name}\n", encoding="utf-8")
@@ -1556,15 +1643,31 @@ def self_test() -> None:
         delayed_stdio_args = argparse.Namespace(**vars(args))
         delayed_stdio_args.project = str(delayed_stdio_project)
         delayed_stdio_args.out_dir = str(delayed_stdio_out)
+        delayed_status_worker = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            creationflags=(
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+                if os.name == "nt"
+                else 0
+            ),
+            start_new_session=os.name != "nt",
+        )
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "serve_first_blocked"
+        os.environ["CODESTORY_FAKE_STATUS_WORKER_PID"] = str(delayed_status_worker.pid)
         try:
             run_gate(delayed_stdio_args)
             delayed_stdio_status = read_json_file(delayed_stdio_out / "serve-stdio-status.json")
             delayed_status = delayed_stdio_status["status"]
             assert delayed_status["allowed_surfaces"]["packet"]["allowed"] is True
             assert (delayed_stdio_project / ".fake-serve-first-blocked-seen").is_file()
+            delayed_status_worker.wait(timeout=5)
+            assert delayed_status_worker.returncode is not None
         finally:
+            terminate_worker_pid(delayed_status_worker.pid)
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
+            os.environ.pop("CODESTORY_FAKE_STATUS_WORKER_PID", None)
 
         os.environ["CODESTORY_FAKE_FAIL_LAYER"] = "search"
         try:
@@ -1626,6 +1729,10 @@ def self_test() -> None:
                 artifact = read_json_file(exc.artifact)
                 assert artifact["server_advertised_mcp_resources"]["missing"] == ["codestory://agent-guide"]
                 assert artifact["status"]["plugin_runtime"]["cli_source"] == "direct_cli_launch"
+                hidden_cache_root = read_json_file(
+                    Path(plugin_hidden_args.out_dir) / "local-retrieval-bootstrap.json"
+                )["cache_root"]
+                assert artifact["status"]["cache_root"] == hidden_cache_root
             else:
                 raise AssertionError("hidden plugin MCP resources should fail the plugin stdio gate")
         finally:
@@ -1651,6 +1758,12 @@ def self_test() -> None:
                 transcript_response(managed_artifact, "status_after_repair")
             )
             assert managed_status_after["sidecar_setup"]["active_repair"]["attempt_id"] == "fake-attempt"
+            managed_cache_root = read_json_file(Path(managed_args.out_dir) / "managed-local-ground.json")["cache_root"]
+            assert Path(managed_cache_root).name == "cache"
+            assert managed_status_after["cache_root"] == managed_cache_root
+            managed_direct_status = read_json_file(Path(managed_args.out_dir) / "serve-stdio-status.json")["status"]
+            assert Path(managed_direct_status["cache_root"]).name == "stdio-cache"
+            assert managed_direct_status["cache_root"] != managed_cache_root
         finally:
             os.environ.pop("CODESTORY_FAKE_PLUGIN_MANAGED", None)
             os.environ.pop("CODESTORY_FAKE_PLUGIN_CLI", None)

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -13,6 +13,7 @@ const rustCi = path.join(workflowRoot, "rust-ci.yml");
 const releaseWorkflow = path.join(workflowRoot, "release.yml");
 const postPublishReleaseSmoke = path.join(workflowRoot, "post-publish-release-smoke.yml");
 const packagedPlatformPr = path.join(workflowRoot, "packaged-platform-pr.yml");
+const packagedPlatformProof = path.join(workflowRoot, "packaged-platform-proof.yml");
 const mainBranchSourceGuard = path.join(workflowRoot, "main-branch-source-guard.yml");
 
 for (const file of fs
@@ -119,6 +120,7 @@ if (!fs.existsSync(pluginStatic)) {
     ".github/workflows/release.yml",
     ".github/workflows/post-publish-release-smoke.yml",
     ".github/workflows/packaged-platform-pr.yml",
+    ".github/workflows/packaged-platform-proof.yml",
     "scripts/install-codestory.ps1",
   ];
 
@@ -155,16 +157,12 @@ if (!fs.existsSync(releaseWorkflow)) {
   violations.push("release.yml must exist for release automation");
 } else {
   const content = fs.readFileSync(releaseWorkflow, "utf8");
-  if (!content.includes('RELEASE_RUST_TOOLCHAIN: "1.95.0"')) {
-    violations.push("release.yml must pin RELEASE_RUST_TOOLCHAIN to 1.95.0");
-  }
   if (content.includes("rustup toolchain install stable")) {
     violations.push("release.yml release builds must not install floating stable Rust");
   }
   for (const snippet of [
-    "packaged-version-proof-${{ matrix.asset_target }}",
-    "--managed-plugin-handoff",
-    "scripts/install-codestory.ps1 -SelfTest",
+    "uses: ./.github/workflows/packaged-platform-proof.yml",
+    "version: ${{ needs.preflight.outputs.version }}",
     "uses: ./.github/workflows/post-publish-release-smoke.yml",
     "--notes-file target/release-assets/proof-boundaries.md",
     "live managed Metal endpoint survival remains open in #887",
@@ -176,16 +174,41 @@ if (!fs.existsSync(releaseWorkflow)) {
     }
   }
   for (const row of [
+    "needs:\n      - preflight\n      - publish\n    uses: ./.github/workflows/post-publish-release-smoke.yml",
+  ]) {
+    if (!content.includes(row)) {
+      violations.push(`release.yml must preserve release proof block ${row.split("\n")[0]}`);
+    }
+  }
+}
+
+if (!fs.existsSync(packagedPlatformProof)) {
+  violations.push("packaged-platform-proof.yml must own the reusable native package matrix");
+} else {
+  const content = fs.readFileSync(packagedPlatformProof, "utf8");
+  for (const snippet of [
+    "workflow_call:",
+    "contents: read",
+    'RELEASE_RUST_TOOLCHAIN: "1.95.0"',
+    "packaged-version-proof-${{ matrix.asset_target }}",
+    "--managed-plugin-handoff",
+    "scripts/install-codestory.ps1 -SelfTest",
+    "--checksum-file target/release-dist/SHA256SUMS.txt",
+  ]) {
+    if (!content.includes(snippet)) {
+      violations.push(`packaged-platform-proof.yml must include ${snippet}`);
+    }
+  }
+  for (const row of [
     "- os: ubuntu-latest\n            rust_target: x86_64-unknown-linux-gnu\n            asset_target: linux-x64",
     "- os: ubuntu-24.04-arm\n            rust_target: aarch64-unknown-linux-gnu\n            asset_target: linux-arm64",
     "- os: windows-latest\n            rust_target: x86_64-pc-windows-msvc\n            asset_target: windows-x64",
     "- os: windows-11-arm\n            rust_target: aarch64-pc-windows-msvc\n            asset_target: windows-arm64",
     "- os: macos-15\n            rust_target: aarch64-apple-darwin\n            asset_target: macos-arm64",
     "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: pwsh -File scripts/install-codestory.ps1 -SelfTest",
-    "if: ${{ !inputs.proof_only }}\n    needs:\n      - preflight\n      - publish\n    uses: ./.github/workflows/post-publish-release-smoke.yml",
   ]) {
     if (!content.includes(row)) {
-      violations.push(`release.yml must preserve native proof block ${row.split("\n")[0]}`);
+      violations.push(`packaged-platform-proof.yml must preserve native proof block ${row.split("\n")[0]}`);
     }
   }
 }
@@ -239,14 +262,19 @@ if (!fs.existsSync(packagedPlatformPr)) {
   const content = fs.readFileSync(packagedPlatformPr, "utf8");
   for (const snippet of [
     "pull_request:",
-    "uses: ./.github/workflows/release.yml",
-    "proof_only: true",
+    "contents: read",
+    "uses: ./.github/workflows/packaged-platform-proof.yml",
+    "version: ${{ needs.prepare.outputs.version }}",
     ".github/scripts/check-packaged-agent-proof.py",
     ".github/workflows/post-publish-release-smoke.yml",
+    ".github/workflows/packaged-platform-proof.yml",
   ]) {
     if (!content.includes(snippet)) {
       violations.push(`packaged-platform-pr.yml must include ${snippet}`);
     }
+  }
+  if (content.includes("contents: write") || content.includes("uses: ./.github/workflows/release.yml")) {
+    violations.push("packaged-platform-pr.yml must not request release permissions or call the publishing workflow");
   }
 }
 

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -11,6 +11,8 @@ const closeDevIssues = path.join(workflowRoot, "close-dev-issues.yml");
 const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
 const rustCi = path.join(workflowRoot, "rust-ci.yml");
 const releaseWorkflow = path.join(workflowRoot, "release.yml");
+const postPublishReleaseSmoke = path.join(workflowRoot, "post-publish-release-smoke.yml");
+const packagedPlatformPr = path.join(workflowRoot, "packaged-platform-pr.yml");
 const mainBranchSourceGuard = path.join(workflowRoot, "main-branch-source-guard.yml");
 
 for (const file of fs
@@ -109,7 +111,15 @@ if (!fs.existsSync(pluginStatic)) {
     "dev/codestory-next",
     "node --test plugins/codestory/tests/plugin-static.test.mjs",
     "node .github/scripts/check-workflow-policy.mjs",
+    "python .github/scripts/check-packaged-agent-proof.py --self-test",
+    "python .github/scripts/package-codestory-release.py --self-test",
     "python .github/scripts/check-codestory-release.py --version",
+    ".github/scripts/check-packaged-agent-proof.py",
+    ".github/scripts/package-codestory-release.py",
+    ".github/workflows/release.yml",
+    ".github/workflows/post-publish-release-smoke.yml",
+    ".github/workflows/packaged-platform-pr.yml",
+    "scripts/install-codestory.ps1",
   ];
 
   for (const snippet of requiredSnippets) {
@@ -150,6 +160,93 @@ if (!fs.existsSync(releaseWorkflow)) {
   }
   if (content.includes("rustup toolchain install stable")) {
     violations.push("release.yml release builds must not install floating stable Rust");
+  }
+  for (const snippet of [
+    "packaged-version-proof-${{ matrix.asset_target }}",
+    "--managed-plugin-handoff",
+    "scripts/install-codestory.ps1 -SelfTest",
+    "uses: ./.github/workflows/post-publish-release-smoke.yml",
+    "--notes-file target/release-assets/proof-boundaries.md",
+    "live managed Metal endpoint survival remains open in #887",
+    "Older-glibc compatibility is unproven",
+    "--generate-notes",
+  ]) {
+    if (!content.includes(snippet)) {
+      violations.push(`release.yml must include ${snippet}`);
+    }
+  }
+  for (const row of [
+    "- os: ubuntu-latest\n            rust_target: x86_64-unknown-linux-gnu\n            asset_target: linux-x64",
+    "- os: ubuntu-24.04-arm\n            rust_target: aarch64-unknown-linux-gnu\n            asset_target: linux-arm64",
+    "- os: windows-latest\n            rust_target: x86_64-pc-windows-msvc\n            asset_target: windows-x64",
+    "- os: windows-11-arm\n            rust_target: aarch64-pc-windows-msvc\n            asset_target: windows-arm64",
+    "- os: macos-15\n            rust_target: aarch64-apple-darwin\n            asset_target: macos-arm64",
+    "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: pwsh -File scripts/install-codestory.ps1 -SelfTest",
+    "if: ${{ !inputs.proof_only }}\n    needs:\n      - preflight\n      - publish\n    uses: ./.github/workflows/post-publish-release-smoke.yml",
+  ]) {
+    if (!content.includes(row)) {
+      violations.push(`release.yml must preserve native proof block ${row.split("\n")[0]}`);
+    }
+  }
+}
+
+if (!fs.existsSync(postPublishReleaseSmoke)) {
+  violations.push("post-publish-release-smoke.yml must exist for native published-asset proof");
+} else {
+  const content = fs.readFileSync(postPublishReleaseSmoke, "utf8");
+  for (const snippet of [
+    "workflow_call:",
+    "ubuntu-latest",
+    "ubuntu-24.04-arm",
+    "windows-latest",
+    "windows-11-arm",
+    "macos-15",
+    "linux-x64",
+    "linux-arm64",
+    "windows-x64",
+    "windows-arm64",
+    "macos-arm64",
+    "--version-only",
+    "--managed-plugin-handoff",
+    "scripts/install-codestory.ps1 -SelfTest",
+    "--checksum-file \"${{ steps.asset.outputs.checksum }}\"",
+  ]) {
+    if (!content.includes(snippet)) {
+      violations.push(`post-publish-release-smoke.yml must include ${snippet}`);
+    }
+  }
+  for (const row of [
+    "- os: ubuntu-latest\n            asset_target: linux-x64\n            extension: tar.gz",
+    "- os: ubuntu-24.04-arm\n            asset_target: linux-arm64\n            extension: tar.gz",
+    "- os: windows-latest\n            asset_target: windows-x64\n            extension: zip",
+    "- os: windows-11-arm\n            asset_target: windows-arm64\n            extension: zip",
+    "- os: macos-15\n            asset_target: macos-arm64\n            extension: tar.gz",
+    "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: pwsh -File scripts/install-codestory.ps1 -SelfTest",
+    "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: >-\n          python .github/scripts/check-packaged-agent-proof.py",
+  ]) {
+    if (!content.includes(row)) {
+      violations.push(`post-publish-release-smoke.yml must preserve native proof block ${row.split("\n")[0]}`);
+    }
+  }
+  if (content.includes("sha256sum")) {
+    violations.push("post-publish-release-smoke.yml must use the portable Python checksum gate");
+  }
+}
+
+if (!fs.existsSync(packagedPlatformPr)) {
+  violations.push("packaged-platform-pr.yml must run the native package matrix on implementation PRs");
+} else {
+  const content = fs.readFileSync(packagedPlatformPr, "utf8");
+  for (const snippet of [
+    "pull_request:",
+    "uses: ./.github/workflows/release.yml",
+    "proof_only: true",
+    ".github/scripts/check-packaged-agent-proof.py",
+    ".github/workflows/post-publish-release-smoke.yml",
+  ]) {
+    if (!content.includes(snippet)) {
+      violations.push(`packaged-platform-pr.yml must include ${snippet}`);
+    }
   }
 }
 

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -6,6 +6,7 @@ on:
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/package-codestory-release.py
       - .github/workflows/packaged-platform-pr.yml
+      - .github/workflows/packaged-platform-proof.yml
       - .github/workflows/post-publish-release-smoke.yml
       - .github/workflows/release.yml
       - plugins/codestory/**
@@ -16,7 +17,20 @@ permissions:
   contents: read
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: version
+        run: |
+          version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
+          python .github/scripts/check-codestory-release.py --version "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
   native-packaged-proof:
-    uses: ./.github/workflows/release.yml
+    needs: prepare
+    uses: ./.github/workflows/packaged-platform-proof.yml
     with:
-      proof_only: true
+      version: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -1,0 +1,22 @@
+name: Packaged platform acceptance
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/check-packaged-agent-proof.py
+      - .github/scripts/package-codestory-release.py
+      - .github/workflows/packaged-platform-pr.yml
+      - .github/workflows/post-publish-release-smoke.yml
+      - .github/workflows/release.yml
+      - plugins/codestory/**
+      - scripts/install-codestory.ps1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  native-packaged-proof:
+    uses: ./.github/workflows/release.yml
+    with:
+      proof_only: true

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -1,0 +1,218 @@
+name: Packaged platform proof
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release version from crates/codestory-cli/Cargo.toml.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  RELEASE_RUST_TOOLCHAIN: "1.95.0"
+
+jobs:
+  build:
+    name: Build ${{ matrix.asset_target }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rust_target: x86_64-unknown-linux-gnu
+            asset_target: linux-x64
+            exe_suffix: ""
+          - os: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            asset_target: linux-arm64
+            exe_suffix: ""
+          - os: windows-latest
+            rust_target: x86_64-pc-windows-msvc
+            asset_target: windows-x64
+            exe_suffix: ".exe"
+          - os: windows-11-arm
+            rust_target: aarch64-pc-windows-msvc
+            asset_target: windows-arm64
+            exe_suffix: ".exe"
+          # ponytail: ort-sys has no x86_64-apple-darwin prebuilt; add macos-x64
+          # when the release path links a custom ONNX Runtime build.
+          - os: macos-15
+            rust_target: aarch64-apple-darwin
+            asset_target: macos-arm64
+            exe_suffix: ""
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pinned Rust
+        run: |
+          rustup toolchain install "${{ env.RELEASE_RUST_TOOLCHAIN }}" --profile minimal
+          rustup default "${{ env.RELEASE_RUST_TOOLCHAIN }}"
+          rustup target add "${{ matrix.rust_target }}"
+
+      - name: Capture Rust cache key
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Cargo registry, git sources, and build output
+        id: cargo-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-
+
+      - name: Build codestory-cli
+        run: cargo build --release -p codestory-cli --target "${{ matrix.rust_target }}"
+
+      - name: Smoke codestory-cli
+        if: runner.os != 'Windows'
+        run: |
+          bin="target/${{ matrix.rust_target }}/release/codestory-cli"
+          "$bin" --version
+          "$bin" --help
+
+      - name: Smoke codestory-cli on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $bin = Join-Path "target/${{ matrix.rust_target }}/release" "codestory-cli${{ matrix.exe_suffix }}"
+          & $bin --version
+          & $bin --help
+
+      - name: Clear release asset output
+        run: python -c "import shutil; shutil.rmtree('target/release-dist', ignore_errors=True)"
+
+      - name: Package release asset
+        if: runner.os != 'Windows'
+        run: |
+          bin="target/${{ matrix.rust_target }}/release/codestory-cli"
+          python .github/scripts/package-codestory-release.py \
+            --version "${{ inputs.version }}" \
+            --target "${{ matrix.asset_target }}" \
+            --binary "$bin" \
+            --out-dir target/release-dist
+
+      - name: Smoke packaged release asset
+        if: runner.os != 'Windows'
+        run: |
+          python .github/scripts/check-packaged-agent-proof.py \
+            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --checksum-file target/release-dist/SHA256SUMS.txt \
+            --expected-version "${{ inputs.version }}" \
+            --version-only \
+            --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
+
+      - name: Fetch retrieval embedding model
+        if: matrix.asset_target == 'linux-x64'
+        run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
+
+      - name: Packaged full-sidecar agent proof
+        if: matrix.asset_target == 'linux-x64'
+        env:
+          CODESTORY_EMBED_ALLOW_CPU: "1"
+        run: |
+          python .github/scripts/check-packaged-agent-proof.py \
+            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --checksum-file target/release-dist/SHA256SUMS.txt \
+            --expected-version "${{ inputs.version }}" \
+            --project "${{ github.workspace }}" \
+            --plugin-root plugins/codestory \
+            --out-dir target/packaged-agent-proof
+
+      - name: Upload packaged agent proof artifacts
+        if: always() && matrix.asset_target == 'linux-x64'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: packaged-agent-proof-${{ matrix.asset_target }}
+          path: target/packaged-agent-proof
+          if-no-files-found: warn
+
+      - name: Package release asset on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $bin = Join-Path "target/${{ matrix.rust_target }}/release" "codestory-cli${{ matrix.exe_suffix }}"
+          python .github/scripts/package-codestory-release.py `
+            --version "${{ inputs.version }}" `
+            --target "${{ matrix.asset_target }}" `
+            --binary $bin `
+            --out-dir target/release-dist
+
+      - name: Smoke packaged release asset on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          python .github/scripts/check-packaged-agent-proof.py `
+            --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.zip" `
+            --checksum-file target/release-dist/SHA256SUMS.txt `
+            --expected-version "${{ inputs.version }}" `
+            --version-only `
+            --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
+
+      - name: Upload packaged version proof
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: packaged-version-proof-${{ matrix.asset_target }}
+          path: target/packaged-version-smoke/${{ matrix.asset_target }}
+          if-no-files-found: warn
+
+      - name: Run Windows installer ownership self-test
+        if: matrix.asset_target == 'windows-x64'
+        shell: pwsh
+        run: pwsh -File scripts/install-codestory.ps1 -SelfTest
+
+      - name: Prove Windows managed plugin handoff
+        if: matrix.asset_target == 'windows-x64'
+        shell: pwsh
+        run: >-
+          python .github/scripts/check-packaged-agent-proof.py
+          --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.zip"
+          --checksum-file target/release-dist/SHA256SUMS.txt
+          --expected-version "${{ inputs.version }}"
+          --project "${{ github.workspace }}"
+          --plugin-root plugins/codestory
+          --managed-plugin-handoff
+          --out-dir target/packaged-managed-proof
+
+      - name: Upload Windows managed plugin proof
+        if: always() && matrix.asset_target == 'windows-x64'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: packaged-managed-proof-${{ matrix.asset_target }}
+          path: target/packaged-managed-proof
+          if-no-files-found: warn
+
+      - name: Upload release asset
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: codestory-cli-${{ matrix.asset_target }}
+          path: |
+            target/release-dist/*.tar.gz
+            target/release-dist/*.zip
+            target/release-dist/*.sha256
+          if-no-files-found: error
+
+      - name: Save Cargo registry, git sources, and build output
+        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -16,6 +16,7 @@ on:
       - .github/workflows/release.yml
       - .github/workflows/post-publish-release-smoke.yml
       - .github/workflows/packaged-platform-pr.yml
+      - .github/workflows/packaged-platform-proof.yml
       - .github/workflows/plugin-static.yml
       - scripts/install-codestory.ps1
   push:
@@ -36,6 +37,7 @@ on:
       - .github/workflows/release.yml
       - .github/workflows/post-publish-release-smoke.yml
       - .github/workflows/packaged-platform-pr.yml
+      - .github/workflows/packaged-platform-proof.yml
       - .github/workflows/plugin-static.yml
       - scripts/install-codestory.ps1
   workflow_dispatch:

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -7,11 +7,17 @@ on:
       - .github/scripts/detect-codestory-release.py
       - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
+      - .github/scripts/check-packaged-agent-proof.py
+      - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
       - .github/workflows/auto-release.yml
       - .github/workflows/main-branch-source-guard.yml
       - .github/workflows/rust-ci.yml
+      - .github/workflows/release.yml
+      - .github/workflows/post-publish-release-smoke.yml
+      - .github/workflows/packaged-platform-pr.yml
       - .github/workflows/plugin-static.yml
+      - scripts/install-codestory.ps1
   push:
     branches:
       - main
@@ -21,11 +27,17 @@ on:
       - .github/scripts/detect-codestory-release.py
       - .github/scripts/test-detect-codestory-release.py
       - .github/scripts/check-codestory-release.py
+      - .github/scripts/check-packaged-agent-proof.py
+      - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
       - .github/workflows/auto-release.yml
       - .github/workflows/main-branch-source-guard.yml
       - .github/workflows/rust-ci.yml
+      - .github/workflows/release.yml
+      - .github/workflows/post-publish-release-smoke.yml
+      - .github/workflows/packaged-platform-pr.yml
       - .github/workflows/plugin-static.yml
+      - scripts/install-codestory.ps1
   workflow_dispatch:
 
 permissions:
@@ -48,6 +60,12 @@ jobs:
 
       - name: Check workflow policy
         run: node .github/scripts/check-workflow-policy.mjs
+
+      - name: Check packaged proof harness
+        run: python .github/scripts/check-packaged-agent-proof.py --self-test
+
+      - name: Check release packager
+        run: python .github/scripts/package-codestory-release.py --self-test
 
       - name: Check auto-release detector
         run: python .github/scripts/test-detect-codestory-release.py

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -1,6 +1,12 @@
 name: Post-publish release smoke
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release version to smoke, with or without a leading v.
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -13,9 +19,28 @@ permissions:
 
 jobs:
   smoke:
-    name: Published release asset smoke
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    name: Published ${{ matrix.asset_target }} smoke
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_target: linux-x64
+            extension: tar.gz
+          - os: ubuntu-24.04-arm
+            asset_target: linux-arm64
+            extension: tar.gz
+          - os: windows-latest
+            asset_target: windows-x64
+            extension: zip
+          - os: windows-11-arm
+            asset_target: windows-arm64
+            extension: zip
+          - os: macos-15
+            asset_target: macos-arm64
+            extension: tar.gz
     steps:
       - name: Normalize release version
         id: release
@@ -36,52 +61,80 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.tag }}
 
-      - name: Download published release assets
+      - name: Download published asset and checksum
+        id: asset
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.release.outputs.tag }}
           VERSION: ${{ steps.release.outputs.version }}
+          ASSET_TARGET: ${{ matrix.asset_target }}
+          EXTENSION: ${{ matrix.extension }}
         run: |
           set -euo pipefail
-          mkdir -p target/post-publish-release-assets
+          dir="target/post-publish-release-assets"
+          asset="codestory-cli-v${VERSION}-${ASSET_TARGET}.${EXTENSION}"
+          mkdir -p "$dir"
           gh release download "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --pattern "codestory-cli-v${VERSION}-*.tar.gz" \
-            --pattern "codestory-cli-v${VERSION}-*.zip" \
+            --pattern "$asset" \
             --pattern "SHA256SUMS.txt" \
-            --dir target/post-publish-release-assets \
+            --dir "$dir" \
             --clobber
-          shopt -s nullglob
-          assets=(
-            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.tar.gz
-            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.zip
-          )
-          if [ "${#assets[@]}" -ne 5 ]; then
-            echo "::error::Expected five binary archives, found ${#assets[@]}."
-            printf '%s\n' "${assets[@]}"
-            exit 1
-          fi
-          (cd target/post-publish-release-assets && sha256sum -c SHA256SUMS.txt)
+          echo "archive=$dir/$asset" >> "$GITHUB_OUTPUT"
+          echo "checksum=$dir/SHA256SUMS.txt" >> "$GITHUB_OUTPUT"
+
+      - name: Prove packaged version, help, and stdio shape
+        run: >-
+          python .github/scripts/check-packaged-agent-proof.py
+          --archive "${{ steps.asset.outputs.archive }}"
+          --checksum-file "${{ steps.asset.outputs.checksum }}"
+          --expected-version "${{ steps.release.outputs.version }}"
+          --version-only
+          --out-dir "target/post-publish-version-proof/${{ matrix.asset_target }}"
+
+      - name: Run Windows installer ownership self-test
+        if: matrix.asset_target == 'windows-x64'
+        shell: pwsh
+        run: pwsh -File scripts/install-codestory.ps1 -SelfTest
+
+      - name: Prove Windows managed plugin handoff
+        if: matrix.asset_target == 'windows-x64'
+        shell: pwsh
+        run: >-
+          python .github/scripts/check-packaged-agent-proof.py
+          --archive "${{ steps.asset.outputs.archive }}"
+          --checksum-file "${{ steps.asset.outputs.checksum }}"
+          --expected-version "${{ steps.release.outputs.version }}"
+          --project "${{ github.workspace }}"
+          --plugin-root plugins/codestory
+          --managed-plugin-handoff
+          --out-dir target/post-publish-managed-proof
 
       - name: Fetch retrieval embedding model
+        if: matrix.asset_target == 'linux-x64'
         run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
 
-      - name: Prove published Linux agent runtime
+      - name: Prove published Linux full-sidecar agent runtime
+        if: matrix.asset_target == 'linux-x64'
         env:
           CODESTORY_EMBED_ALLOW_CPU: "1"
-        run: |
-          set -euo pipefail
-          python .github/scripts/check-packaged-agent-proof.py \
-            --archive "target/post-publish-release-assets/codestory-cli-v${{ steps.release.outputs.version }}-linux-x64.tar.gz" \
-            --expected-version "${{ steps.release.outputs.version }}" \
-            --project "${{ github.workspace }}" \
-            --plugin-root plugins/codestory \
-            --out-dir target/post-publish-agent-proof
+        run: >-
+          python .github/scripts/check-packaged-agent-proof.py
+          --archive "${{ steps.asset.outputs.archive }}"
+          --checksum-file "${{ steps.asset.outputs.checksum }}"
+          --expected-version "${{ steps.release.outputs.version }}"
+          --project "${{ github.workspace }}"
+          --plugin-root plugins/codestory
+          --out-dir target/post-publish-agent-proof
 
-      - name: Upload post-publish agent proof artifacts
+      - name: Upload post-publish proof artifacts
         if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: post-publish-agent-proof-linux-x64-${{ steps.release.outputs.version }}
-          path: target/post-publish-agent-proof
+          name: post-publish-proof-${{ matrix.asset_target }}-${{ steps.release.outputs.version }}
+          path: |
+            target/post-publish-version-proof/${{ matrix.asset_target }}
+            target/post-publish-managed-proof
+            target/post-publish-agent-proof
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,35 +5,20 @@ on:
     inputs:
       version:
         description: "Release version from crates/codestory-cli/Cargo.toml, for example 0.7.0"
-        required: false
+        required: true
         type: string
-        default: ""
-      proof_only:
-        description: "Build and prove native packaged assets without publishing"
-        required: false
-        type: boolean
-        default: false
   workflow_dispatch:
     inputs:
       version:
         description: "Release version from crates/codestory-cli/Cargo.toml, for example 0.7.0"
-        required: false
+        required: true
         type: string
-        default: ""
-      proof_only:
-        description: "Build and prove native packaged assets without publishing"
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
 
-env:
-  RELEASE_RUST_TOOLCHAIN: "1.95.0"
-
 concurrency:
-  group: release-${{ inputs.proof_only && github.ref || inputs.version }}
+  group: release-${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
@@ -63,7 +48,6 @@ jobs:
           fetch-depth: 0
 
       - name: Refuse non-main release
-        if: ${{ !inputs.proof_only }}
         run: |
           set -euo pipefail
           if [ "$GITHUB_REF_NAME" != "main" ]; then
@@ -75,23 +59,14 @@ jobs:
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
-          PROOF_ONLY: ${{ inputs.proof_only }}
         run: |
           set -euo pipefail
           version="${INPUT_VERSION#v}"
-          if [ -z "$version" ] && [ "$PROOF_ONLY" = "true" ]; then
-            version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
-          fi
-          if [ -z "$version" ]; then
-            echo "::error::version input is required for a publishing release"
-            exit 1
-          fi
           python .github/scripts/check-codestory-release.py --version "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
       - name: Refuse existing tag or release
-        if: ${{ !inputs.proof_only }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
@@ -106,215 +81,17 @@ jobs:
             exit 1
           fi
 
-  build:
-    name: Build ${{ matrix.asset_target }}
+  packaged-proof:
     needs: preflight
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            rust_target: x86_64-unknown-linux-gnu
-            asset_target: linux-x64
-            exe_suffix: ""
-          - os: ubuntu-24.04-arm
-            rust_target: aarch64-unknown-linux-gnu
-            asset_target: linux-arm64
-            exe_suffix: ""
-          - os: windows-latest
-            rust_target: x86_64-pc-windows-msvc
-            asset_target: windows-x64
-            exe_suffix: ".exe"
-          - os: windows-11-arm
-            rust_target: aarch64-pc-windows-msvc
-            asset_target: windows-arm64
-            exe_suffix: ".exe"
-          # ponytail: ort-sys has no x86_64-apple-darwin prebuilt; add macos-x64
-          # when the release path links a custom ONNX Runtime build.
-          - os: macos-15
-            rust_target: aarch64-apple-darwin
-            asset_target: macos-arm64
-            exe_suffix: ""
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install pinned Rust
-        run: |
-          rustup toolchain install "${{ env.RELEASE_RUST_TOOLCHAIN }}" --profile minimal
-          rustup default "${{ env.RELEASE_RUST_TOOLCHAIN }}"
-          rustup target add "${{ matrix.rust_target }}"
-
-      - name: Capture Rust cache key
-        id: rust-cache-key
-        shell: bash
-        run: |
-          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
-
-      - name: Restore Cargo registry, git sources, and build output
-        id: cargo-cache-restore
-        uses: actions/cache/restore@v5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-
-
-      - name: Build codestory-cli
-        run: cargo build --release -p codestory-cli --target "${{ matrix.rust_target }}"
-
-      - name: Smoke codestory-cli
-        if: runner.os != 'Windows'
-        run: |
-          bin="target/${{ matrix.rust_target }}/release/codestory-cli"
-          "$bin" --version
-          "$bin" --help
-
-      - name: Smoke codestory-cli on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $bin = Join-Path "target/${{ matrix.rust_target }}/release" "codestory-cli${{ matrix.exe_suffix }}"
-          & $bin --version
-          & $bin --help
-
-      - name: Clear release asset output
-        run: python -c "import shutil; shutil.rmtree('target/release-dist', ignore_errors=True)"
-
-      - name: Package release asset
-        if: runner.os != 'Windows'
-        run: |
-          bin="target/${{ matrix.rust_target }}/release/codestory-cli"
-          python .github/scripts/package-codestory-release.py \
-            --version "${{ needs.preflight.outputs.version }}" \
-            --target "${{ matrix.asset_target }}" \
-            --binary "$bin" \
-            --out-dir target/release-dist
-
-      - name: Smoke packaged release asset
-        if: runner.os != 'Windows'
-        run: |
-          python .github/scripts/check-packaged-agent-proof.py \
-            --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.tar.gz" \
-            --checksum-file target/release-dist/SHA256SUMS.txt \
-            --expected-version "${{ needs.preflight.outputs.version }}" \
-            --version-only \
-            --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
-
-      - name: Fetch retrieval embedding model
-        if: matrix.asset_target == 'linux-x64'
-        run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
-
-      - name: Packaged full-sidecar agent proof
-        if: matrix.asset_target == 'linux-x64'
-        env:
-          CODESTORY_EMBED_ALLOW_CPU: "1"
-        run: |
-          python .github/scripts/check-packaged-agent-proof.py \
-            --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.tar.gz" \
-            --checksum-file target/release-dist/SHA256SUMS.txt \
-            --expected-version "${{ needs.preflight.outputs.version }}" \
-            --project "${{ github.workspace }}" \
-            --plugin-root plugins/codestory \
-            --out-dir target/packaged-agent-proof
-
-      - name: Upload packaged agent proof artifacts
-        if: always() && matrix.asset_target == 'linux-x64'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: packaged-agent-proof-${{ matrix.asset_target }}
-          path: target/packaged-agent-proof
-          if-no-files-found: warn
-
-      - name: Package release asset on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $bin = Join-Path "target/${{ matrix.rust_target }}/release" "codestory-cli${{ matrix.exe_suffix }}"
-          python .github/scripts/package-codestory-release.py `
-            --version "${{ needs.preflight.outputs.version }}" `
-            --target "${{ matrix.asset_target }}" `
-            --binary $bin `
-            --out-dir target/release-dist
-
-      - name: Smoke packaged release asset on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          python .github/scripts/check-packaged-agent-proof.py `
-            --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.zip" `
-            --checksum-file target/release-dist/SHA256SUMS.txt `
-            --expected-version "${{ needs.preflight.outputs.version }}" `
-            --version-only `
-            --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
-
-      - name: Upload packaged version proof
-        if: always()
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: packaged-version-proof-${{ matrix.asset_target }}
-          path: target/packaged-version-smoke/${{ matrix.asset_target }}
-          if-no-files-found: warn
-
-      - name: Run Windows installer ownership self-test
-        if: matrix.asset_target == 'windows-x64'
-        shell: pwsh
-        run: pwsh -File scripts/install-codestory.ps1 -SelfTest
-
-      - name: Prove Windows managed plugin handoff
-        if: matrix.asset_target == 'windows-x64'
-        shell: pwsh
-        run: >-
-          python .github/scripts/check-packaged-agent-proof.py
-          --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.zip"
-          --checksum-file target/release-dist/SHA256SUMS.txt
-          --expected-version "${{ needs.preflight.outputs.version }}"
-          --project "${{ github.workspace }}"
-          --plugin-root plugins/codestory
-          --managed-plugin-handoff
-          --out-dir target/packaged-managed-proof
-
-      - name: Upload Windows managed plugin proof
-        if: always() && matrix.asset_target == 'windows-x64'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: packaged-managed-proof-${{ matrix.asset_target }}
-          path: target/packaged-managed-proof
-          if-no-files-found: warn
-
-      - name: Upload release asset
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: codestory-cli-${{ matrix.asset_target }}
-          path: |
-            target/release-dist/*.tar.gz
-            target/release-dist/*.zip
-            target/release-dist/*.sha256
-          if-no-files-found: error
-
-      - name: Save Cargo registry, git sources, and build output
-        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}
+    uses: ./.github/workflows/packaged-platform-proof.yml
+    with:
+      version: ${{ needs.preflight.outputs.version }}
 
   publish:
     name: Publish GitHub release
-    if: ${{ !inputs.proof_only }}
     needs:
       - preflight
-      - build
+      - packaged-proof
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -392,7 +169,6 @@ jobs:
 
   post-publish-smoke:
     name: Post-publish release asset smoke
-    if: ${{ !inputs.proof_only }}
     needs:
       - preflight
       - publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,26 @@ on:
     inputs:
       version:
         description: "Release version from crates/codestory-cli/Cargo.toml, for example 0.7.0"
-        required: true
+        required: false
         type: string
+        default: ""
+      proof_only:
+        description: "Build and prove native packaged assets without publishing"
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       version:
         description: "Release version from crates/codestory-cli/Cargo.toml, for example 0.7.0"
-        required: true
+        required: false
         type: string
+        default: ""
+      proof_only:
+        description: "Build and prove native packaged assets without publishing"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -21,7 +33,7 @@ env:
   RELEASE_RUST_TOOLCHAIN: "1.95.0"
 
 concurrency:
-  group: release-${{ inputs.version }}
+  group: release-${{ inputs.proof_only && github.ref || inputs.version }}
   cancel-in-progress: false
 
 jobs:
@@ -51,6 +63,7 @@ jobs:
           fetch-depth: 0
 
       - name: Refuse non-main release
+        if: ${{ !inputs.proof_only }}
         run: |
           set -euo pipefail
           if [ "$GITHUB_REF_NAME" != "main" ]; then
@@ -62,14 +75,23 @@ jobs:
         id: version
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          PROOF_ONLY: ${{ inputs.proof_only }}
         run: |
           set -euo pipefail
           version="${INPUT_VERSION#v}"
+          if [ -z "$version" ] && [ "$PROOF_ONLY" = "true" ]; then
+            version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
+          fi
+          if [ -z "$version" ]; then
+            echo "::error::version input is required for a publishing release"
+            exit 1
+          fi
           python .github/scripts/check-codestory-release.py --version "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
       - name: Refuse existing tag or release
+        if: ${{ !inputs.proof_only }}
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
@@ -180,6 +202,7 @@ jobs:
         run: |
           python .github/scripts/check-packaged-agent-proof.py \
             --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --checksum-file target/release-dist/SHA256SUMS.txt \
             --expected-version "${{ needs.preflight.outputs.version }}" \
             --version-only \
             --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
@@ -195,6 +218,7 @@ jobs:
         run: |
           python .github/scripts/check-packaged-agent-proof.py \
             --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.tar.gz" \
+            --checksum-file target/release-dist/SHA256SUMS.txt \
             --expected-version "${{ needs.preflight.outputs.version }}" \
             --project "${{ github.workspace }}" \
             --plugin-root plugins/codestory \
@@ -225,9 +249,44 @@ jobs:
         run: |
           python .github/scripts/check-packaged-agent-proof.py `
             --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.zip" `
+            --checksum-file target/release-dist/SHA256SUMS.txt `
             --expected-version "${{ needs.preflight.outputs.version }}" `
             --version-only `
             --out-dir "target/packaged-version-smoke/${{ matrix.asset_target }}"
+
+      - name: Upload packaged version proof
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: packaged-version-proof-${{ matrix.asset_target }}
+          path: target/packaged-version-smoke/${{ matrix.asset_target }}
+          if-no-files-found: warn
+
+      - name: Run Windows installer ownership self-test
+        if: matrix.asset_target == 'windows-x64'
+        shell: pwsh
+        run: pwsh -File scripts/install-codestory.ps1 -SelfTest
+
+      - name: Prove Windows managed plugin handoff
+        if: matrix.asset_target == 'windows-x64'
+        shell: pwsh
+        run: >-
+          python .github/scripts/check-packaged-agent-proof.py
+          --archive "target/release-dist/codestory-cli-v${{ needs.preflight.outputs.version }}-${{ matrix.asset_target }}.zip"
+          --checksum-file target/release-dist/SHA256SUMS.txt
+          --expected-version "${{ needs.preflight.outputs.version }}"
+          --project "${{ github.workspace }}"
+          --plugin-root plugins/codestory
+          --managed-plugin-handoff
+          --out-dir target/packaged-managed-proof
+
+      - name: Upload Windows managed plugin proof
+        if: always() && matrix.asset_target == 'windows-x64'
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: packaged-managed-proof-${{ matrix.asset_target }}
+          path: target/packaged-managed-proof
+          if-no-files-found: warn
 
       - name: Upload release asset
         uses: actions/upload-artifact@v7.0.1
@@ -252,6 +311,7 @@ jobs:
 
   publish:
     name: Publish GitHub release
+    if: ${{ !inputs.proof_only }}
     needs:
       - preflight
       - build
@@ -312,71 +372,32 @@ jobs:
             printf '%s\n' "${assets[@]}"
             exit 1
           fi
+          cat > target/release-assets/proof-boundaries.md <<'EOF'
+          ## Platform proof boundaries
+
+          This release ships managed CLI assets for Windows x64/arm64, Linux x64/arm64, and macOS arm64.
+
+          - Windows x64 managed install, local ground, and repair handoff are acceptance-smoked; this is not full sidecar or GPU proof.
+          - Apple Silicon packaging is acceptance-smoked, while live managed Metal endpoint survival remains open in #887.
+          - Windows arm64 ships a CLI asset but has no managed native accelerated embedding cell.
+          - Linux accelerator claims still require the evidence tiers in `docs/contributors/testing-matrix.md`.
+          - Older-glibc compatibility is unproven; execution on the current hosted Ubuntu runner does not establish it.
+          EOF
           gh release create "$TAG" "${assets[@]}" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "CodeStory $TAG" \
+            --notes-file target/release-assets/proof-boundaries.md \
             --generate-notes
 
   post-publish-smoke:
     name: Post-publish release asset smoke
+    if: ${{ !inputs.proof_only }}
     needs:
       - preflight
       - publish
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    uses: ./.github/workflows/post-publish-release-smoke.yml
+    with:
+      version: ${{ needs.preflight.outputs.version }}
     permissions:
       contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Download published release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.preflight.outputs.tag }}
-          VERSION: ${{ needs.preflight.outputs.version }}
-        run: |
-          set -euo pipefail
-          mkdir -p target/post-publish-release-assets
-          gh release download "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern "codestory-cli-v${VERSION}-*.tar.gz" \
-            --pattern "codestory-cli-v${VERSION}-*.zip" \
-            --pattern "SHA256SUMS.txt" \
-            --dir target/post-publish-release-assets \
-            --clobber
-          shopt -s nullglob
-          assets=(
-            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.tar.gz
-            target/post-publish-release-assets/codestory-cli-v${VERSION}-*.zip
-          )
-          if [ "${#assets[@]}" -ne 5 ]; then
-            echo "::error::Expected five binary archives, found ${#assets[@]}."
-            printf '%s\n' "${assets[@]}"
-            exit 1
-          fi
-          (cd target/post-publish-release-assets && sha256sum -c SHA256SUMS.txt)
-
-      - name: Fetch retrieval embedding model
-        run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
-
-      - name: Prove published Linux agent runtime
-        env:
-          CODESTORY_EMBED_ALLOW_CPU: "1"
-        run: |
-          set -euo pipefail
-          python .github/scripts/check-packaged-agent-proof.py \
-            --archive "target/post-publish-release-assets/codestory-cli-v${{ needs.preflight.outputs.version }}-linux-x64.tar.gz" \
-            --expected-version "${{ needs.preflight.outputs.version }}" \
-            --project "${{ github.workspace }}" \
-            --plugin-root plugins/codestory \
-            --out-dir target/post-publish-agent-proof
-
-      - name: Upload post-publish agent proof artifacts
-        if: always()
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: post-publish-agent-proof-linux-x64
-          path: target/post-publish-agent-proof
-          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   handoff, and installer ownership proof. Release notes and contributor
   guidance now preserve Apple Silicon, Windows arm64 acceleration,
   older-glibc, marketplace, and full-sidecar proof boundaries.
+- Kept strict sidecar readiness fail-closed on interrupted index-run markers
+  without globally rejecting completed generations that contain parser-partial
+  files; parser coverage remains visible through file diagnostics.
 - Standardized JSON-mode CLI failures on one versioned error envelope, including
   argument parsing, ambiguity, smoke checks, runtime failures, and background
   repair terminal state. Compacted MCP status by referencing canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- Added native five-asset pre-publish and post-publish acceptance evidence,
+  including Windows x64 managed plugin provisioning, local grounding, repair
+  handoff, and installer ownership proof. Release notes and contributor
+  guidance now preserve Apple Silicon, Windows arm64 acceleration,
+  older-glibc, marketplace, and full-sidecar proof boundaries.
 - Standardized JSON-mode CLI failures on one versioned error envelope, including
   argument parsing, ambiguity, smoke checks, runtime failures, and background
   repair terminal state. Compacted MCP status by referencing canonical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
   older-glibc, marketplace, and full-sidecar proof boundaries.
 - Kept strict sidecar readiness fail-closed on interrupted index-run markers
   without globally rejecting completed generations that contain parser-partial
-  files; parser coverage remains visible through file diagnostics.
+  files or repeatedly refreshing unchanged parser-partial inputs; parser
+  coverage remains visible through file diagnostics.
 - Standardized JSON-mode CLI failures on one versioned error envelope, including
   argument parsing, ambiguity, smoke checks, runtime failures, and background
   repair terminal state. Compacted MCP status by referencing canonical

--- a/crates/codestory-bench/benches/indexing.rs
+++ b/crates/codestory-bench/benches/indexing.rs
@@ -47,17 +47,9 @@ fn open_temp_storage() -> (TempDir, Storage) {
 fn refresh_inputs_from_storage(storage: &Storage) -> codestory_workspace::RefreshInputs {
     codestory_workspace::RefreshInputs {
         stored_files: storage
-            .get_files()
-            .expect("list benchmark storage files")
-            .into_iter()
-            .map(|file| codestory_workspace::StoredFileState {
-                id: file.id,
-                path: file.path,
-                modification_time: file.modification_time,
-                indexed: file.indexed,
-                complete: file.complete,
-            })
-            .collect(),
+            .files()
+            .inventory()
+            .expect("list benchmark storage inventory"),
         inventory: Default::default(),
     }
 }

--- a/crates/codestory-contracts/src/workspace.rs
+++ b/crates/codestory-contracts/src/workspace.rs
@@ -14,6 +14,7 @@ pub struct StoredFileState {
     pub modification_time: i64,
     pub indexed: bool,
     pub complete: bool,
+    pub retry_required: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -28,6 +29,7 @@ pub struct IndexedFileRecord {
     pub modification_time: i64,
     pub indexed: bool,
     pub complete: bool,
+    pub retry_required: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -67,6 +69,7 @@ impl RefreshInputs {
                         modification_time: record.modification_time,
                         indexed: record.indexed,
                         complete: record.complete,
+                        retry_required: record.retry_required,
                     },
                 )
             })

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -902,6 +902,8 @@ impl WorkspaceIndexer {
         // 1. Parallel Indexing (chunked and flushed)
         let mut batched_storage = IntermediateStorage::default();
         let mut all_errors = Vec::new();
+        let mut pending_error_file_ids = HashSet::new();
+        let mut pending_file_errors = Vec::new();
         let mut had_edges = false;
         let full_refresh_defaults =
             IncrementalIndexingConfig::for_mode(codestory_workspace::BuildMode::FullRefresh);
@@ -1028,7 +1030,6 @@ impl WorkspaceIndexer {
             }
 
             for mut local_storage in chunk_results {
-                all_errors.append(&mut local_storage.errors);
                 if let Some(file_info) = local_storage.files.first()
                     && plan.mode == codestory_workspace::BuildMode::Incremental
                     && existing_projection_file_ids.contains(&file_info.id)
@@ -1043,8 +1044,7 @@ impl WorkspaceIndexer {
                         &local_storage.callable_projection_states,
                     );
                     match update_mode {
-                        ProjectionUpdateMode::InsertFresh => {}
-                        ProjectionUpdateMode::NoChanges => {}
+                        ProjectionUpdateMode::InsertFresh | ProjectionUpdateMode::NoChanges => {}
                         ProjectionUpdateMode::Delta { changed_callers } => {
                             storage
                                 .delete_projection_for_callers(file_info.id, &changed_callers)
@@ -1059,6 +1059,15 @@ impl WorkspaceIndexer {
                     stats.cleanup_ms = stats
                         .cleanup_ms
                         .saturating_add(duration_ms_u64(cleanup_started.elapsed()));
+                }
+                pending_error_file_ids.extend(local_storage.files.iter().map(|file| file.id));
+                for error in local_storage.errors.drain(..) {
+                    if let Some(file_id) = error.file_id {
+                        pending_error_file_ids.insert(file_id.0);
+                        pending_file_errors.push(error);
+                    } else {
+                        all_errors.push(error);
+                    }
                 }
                 batched_storage.merge(local_storage);
 
@@ -1087,6 +1096,11 @@ impl WorkspaceIndexer {
                         &mut had_edges,
                     )?;
                     accumulate_flush_breakdown(&mut stats, breakdown);
+                    Self::flush_file_errors(
+                        storage,
+                        &mut pending_error_file_ids,
+                        &mut pending_file_errors,
+                    )?;
                 }
 
                 if all_errors.len() >= batch_config.error_batch_size {
@@ -1099,6 +1113,14 @@ impl WorkspaceIndexer {
             }
 
             if cancelled.load(Ordering::Relaxed) {
+                let breakdown =
+                    Self::flush_projection_batch(storage, &mut batched_storage, &mut had_edges)?;
+                accumulate_flush_breakdown(&mut stats, breakdown);
+                Self::flush_file_errors(
+                    storage,
+                    &mut pending_error_file_ids,
+                    &mut pending_file_errors,
+                )?;
                 event_bus.publish(Event::IndexingComplete { duration_ms: 0 });
                 return Ok(stats);
             }
@@ -1106,6 +1128,14 @@ impl WorkspaceIndexer {
 
         // Check if cancelled during indexing
         if cancelled.load(Ordering::Relaxed) {
+            let breakdown =
+                Self::flush_projection_batch(storage, &mut batched_storage, &mut had_edges)?;
+            accumulate_flush_breakdown(&mut stats, breakdown);
+            Self::flush_file_errors(
+                storage,
+                &mut pending_error_file_ids,
+                &mut pending_file_errors,
+            )?;
             event_bus.publish(Event::IndexingComplete { duration_ms: 0 });
             return Ok(stats);
         }
@@ -1113,6 +1143,11 @@ impl WorkspaceIndexer {
         let breakdown =
             Self::flush_projection_batch(storage, &mut batched_storage, &mut had_edges)?;
         accumulate_flush_breakdown(&mut stats, breakdown);
+        Self::flush_file_errors(
+            storage,
+            &mut pending_error_file_ids,
+            &mut pending_file_errors,
+        )?;
 
         if plan.mode == codestory_workspace::BuildMode::Incremental
             && !plan.files_to_remove.is_empty()
@@ -1505,6 +1540,23 @@ impl WorkspaceIndexer {
         Ok(())
     }
 
+    fn flush_file_errors(
+        storage: &mut Storage,
+        file_ids: &mut HashSet<i64>,
+        errors: &mut Vec<codestory_contracts::graph::ErrorInfo>,
+    ) -> Result<()> {
+        if file_ids.is_empty() {
+            return Ok(());
+        }
+
+        let file_ids = file_ids.drain().collect::<Vec<_>>();
+        storage
+            .replace_errors_for_files_batch(&file_ids, errors)
+            .map_err(|e| anyhow!("Storage file error replacement error: {:?}", e))?;
+        errors.clear();
+        Ok(())
+    }
+
     fn flush_projection_batch(
         storage: &mut Storage,
         batched_storage: &mut IntermediateStorage,
@@ -1533,7 +1585,7 @@ impl WorkspaceIndexer {
     #[allow(clippy::result_large_err)]
     fn prepare_index_work(
         &self,
-        storage: &Storage,
+        storage: &mut Storage,
         path: &PathBuf,
         root: &Path,
         existing_projection_id: Option<i64>,
@@ -1761,6 +1813,24 @@ impl WorkspaceIndexer {
                                     full_path, error
                                 ),
                                 file_id: Some(file_id),
+                                line: None,
+                                column: None,
+                                is_fatal: false,
+                                index_step: codestory_contracts::graph::IndexStep::Indexing,
+                            });
+                            return Err(local_storage);
+                        }
+                        if let Some(file_info) = artifact.files.first()
+                            && let Err(error) =
+                                storage.replace_errors_for_files_batch(&[file_info.id], &[])
+                        {
+                            let mut local_storage = IntermediateStorage::default();
+                            local_storage.add_error(codestory_contracts::graph::ErrorInfo {
+                                message: format!(
+                                    "Failed to replace cached file errors for {:?}: {:?}",
+                                    full_path, error
+                                ),
+                                file_id: Some(NodeId(file_info.id)),
                                 line: None,
                                 column: None,
                                 is_fatal: false,

--- a/crates/codestory-indexer/tests/integration.rs
+++ b/crates/codestory-indexer/tests/integration.rs
@@ -116,6 +116,7 @@ fn test_failed_file_attempt_is_recorded_as_incomplete_with_attached_error() -> a
     let dir = tempdir()?;
     let root = dir.path();
     let file_path = root.join("broken.ts");
+    fs::create_dir(&file_path)?;
 
     let mut storage = Storage::new_in_memory()?;
     run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
@@ -144,6 +145,25 @@ fn test_failed_file_attempt_is_recorded_as_incomplete_with_attached_error() -> a
         "reindexing the same failed file should replace, not duplicate, its error"
     );
     assert_eq!(errors[0].file_id, Some(NodeId(file.id)));
+
+    fs::remove_dir(&file_path)?;
+    fs::write(&file_path, "function broken( {\n")?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+
+    let files = storage.get_files()?;
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].id, file.id);
+    assert!(files[0].indexed);
+    assert!(
+        !files[0].complete,
+        "malformed source should remain visible as parser-partial coverage"
+    );
+    assert!(
+        storage.get_errors(None)?.is_empty(),
+        "a successful parser-partial retry should clear the historical file error"
+    );
+    let inventory = storage.files().inventory()?;
+    assert!(!inventory[0].retry_required);
 
     Ok(())
 }
@@ -269,6 +289,36 @@ fn test_incremental_indexing_second_run_reuses_unchanged_extraction_cache_and_re
 
     let nodes = storage.get_nodes()?;
     assert!(nodes.iter().any(|node| node.serialized_name == "run"));
+
+    Ok(())
+}
+
+#[test]
+fn test_cached_parser_partial_retry_clears_transient_file_error() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+    let file_path = root.join("broken.ts");
+    let malformed_source = "function broken( {\n";
+    fs::write(&file_path, malformed_source)?;
+
+    let mut storage = Storage::new_in_memory()?;
+    let first_stats = run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+    assert_eq!(first_stats.artifact_cache_writes, 1);
+    assert!(!storage.get_files()?[0].complete);
+    assert!(storage.get_errors(None)?.is_empty());
+
+    fs::remove_file(&file_path)?;
+    fs::create_dir(&file_path)?;
+    run_incremental_indexing(root, &mut storage, vec![file_path.clone()])?;
+    assert_eq!(storage.get_errors(None)?.len(), 1);
+    assert!(storage.files().inventory()?[0].retry_required);
+
+    fs::remove_dir(&file_path)?;
+    fs::write(&file_path, malformed_source)?;
+    let retry_stats = run_incremental_indexing(root, &mut storage, vec![file_path])?;
+    assert_eq!(retry_stats.artifact_cache_hits, 1);
+    assert!(storage.get_errors(None)?.is_empty());
+    assert!(!storage.files().inventory()?[0].retry_required);
 
     Ok(())
 }

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -863,13 +863,6 @@ fn strict_readiness_unavailable_reason(
     {
         return Ok(None);
     }
-    if let Some(path) = storage
-        .first_incomplete_file_path()
-        .context("inspect incomplete indexed files")?
-    {
-        return Ok(Some(format!("indexed_file_incomplete: {}", path.display())));
-    }
-
     let embedding_backend = crate::embeddings::embedding_runtime_id();
     let expected_doc_backend = crate::embeddings::embedding_backend_label();
     if let Ok(stats) = storage.get_llm_symbol_doc_stats() {
@@ -1487,7 +1480,9 @@ mod tests {
     }
 
     #[test]
-    fn strict_readiness_rejects_unchanged_incomplete_indexed_file() {
+    fn strict_readiness_does_not_conflate_parser_partial_file_with_interrupted_run() {
+        let _lock = crate::test_support::env_lock();
+        let _backend = EnvGuard::set("CODESTORY_EMBED_BACKEND", "llamacpp");
         let project = TempDir::new().expect("project");
         let storage_dir = TempDir::new().expect("storage");
         let storage_path = storage_dir.path().join("codestory.db");
@@ -1495,8 +1490,7 @@ mod tests {
         std::fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
         let indexed_mtime = live_mtime_millis(&source_path);
         let project_id = project_id_for_root(project.path());
-        let manifest = retrieval_manifest_fixture(&project_id, "current");
-        let storage = Store::open(&storage_path).expect("open db");
+        let mut storage = Store::open(&storage_path).expect("open db");
         storage
             .insert_file(&FileInfo {
                 id: 1,
@@ -1509,22 +1503,29 @@ mod tests {
                 file_role: FileRole::Source,
             })
             .expect("insert incomplete file");
-
-        let reason = strict_readiness_unavailable_reason(
-            project.path(),
-            &storage_path,
+        let input = compute_sidecar_input_fingerprint(
             &storage,
+            &storage_path,
+            project.path(),
             &project_id,
-            &manifest,
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
         )
-        .expect("strict readiness")
-        .expect("incomplete file must degrade");
+        .expect("sidecar input");
+        let mut manifest = retrieval_manifest_fixture(&project_id, &input.hash);
+        manifest.built_at_epoch_ms = indexed_mtime;
+        manifest.projection_count = Some(input.projection_count);
+        manifest.symbol_doc_count = Some(input.symbol_doc_count);
+        manifest.dense_projection_count = Some(input.dense_projection_count);
+        manifest.semantic_policy_version = input.semantic_policy_version;
+        manifest.graph_artifact_hash = Some(input.graph_artifact_hash);
+        manifest.dense_reason_counts_json = Some(input.dense_reason_counts_json);
+        storage
+            .upsert_retrieval_index_manifest(&manifest)
+            .expect("manifest");
 
-        assert!(
-            reason.contains("indexed_file_incomplete"),
-            "unexpected reason: {reason}"
-        );
-        assert!(reason.contains(&source_path.display().to_string()));
+        validate_strict_sidecar_readiness(project.path(), &storage_path, &storage)
+            .expect("parser coverage must not masquerade as an interrupted transaction");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -16,7 +16,7 @@ use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext,
 };
 use codestory_store::Store;
-use codestory_workspace::{RefreshInputs, StoredFileState, WorkspaceManifest};
+use codestory_workspace::{RefreshInputs, WorkspaceManifest};
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "linux")]
 use std::fs;
@@ -892,6 +892,16 @@ fn strict_readiness_unavailable_reason(
         embedding_dim,
     )
     .context("compute strict sidecar input fingerprint")?;
+    let stored_files = storage
+        .files()
+        .inventory()
+        .context("load indexed file inventory")?;
+    if let Some(file) = stored_files.iter().find(|file| file.retry_required) {
+        return Ok(Some(format!(
+            "indexed_file_error_retry_required: {}",
+            file.path.display()
+        )));
+    }
     if manifest.sidecar_input_hash.as_deref() == Some(current_input.hash.as_str())
         && manifest.projection_count == Some(current_input.projection_count)
         && manifest.symbol_doc_count == Some(current_input.symbol_doc_count)
@@ -907,18 +917,8 @@ fn strict_readiness_unavailable_reason(
 
     let workspace = WorkspaceManifest::open(project_root.to_path_buf())
         .context("open workspace manifest for strict sidecar readiness")?;
-    let files = storage.files().get_files().context("load indexed files")?;
     let refresh_inputs = RefreshInputs {
-        stored_files: files
-            .into_iter()
-            .map(|file| StoredFileState {
-                id: file.id,
-                path: file.path,
-                modification_time: file.modification_time,
-                indexed: file.indexed,
-                complete: file.complete,
-            })
-            .collect(),
+        stored_files,
         inventory: Default::default(),
     };
     let plan = workspace
@@ -1017,7 +1017,7 @@ mod tests {
     };
     use crate::index::{compute_sidecar_input_fingerprint, project_id_for_root};
     use crate::test_support::retrieval_manifest_fixture;
-    use codestory_contracts::graph::{Node, NodeId, NodeKind};
+    use codestory_contracts::graph::{ErrorInfo, IndexStep, Node, NodeId, NodeKind};
     use codestory_store::{FileInfo, FileRole, LlmSymbolDoc};
     use std::collections::BTreeMap;
     use std::ffi::OsString;
@@ -1480,7 +1480,7 @@ mod tests {
     }
 
     #[test]
-    fn strict_readiness_does_not_conflate_parser_partial_file_with_interrupted_run() {
+    fn strict_readiness_distinguishes_parser_partial_from_file_error() {
         let _lock = crate::test_support::env_lock();
         let _backend = EnvGuard::set("CODESTORY_EMBED_BACKEND", "llamacpp");
         let project = TempDir::new().expect("project");
@@ -1526,6 +1526,33 @@ mod tests {
 
         validate_strict_sidecar_readiness(project.path(), &storage_path, &storage)
             .expect("parser coverage must not masquerade as an interrupted transaction");
+
+        storage
+            .insert_error(&ErrorInfo {
+                message: "read failed".into(),
+                file_id: Some(NodeId(1)),
+                line: None,
+                column: None,
+                is_fatal: true,
+                index_step: IndexStep::Indexing,
+            })
+            .expect("file error");
+        let reason = strict_readiness_unavailable_reason(
+            project.path(),
+            &storage_path,
+            &storage,
+            &project_id,
+            &manifest,
+        )
+        .expect("strict readiness")
+        .expect("file error must degrade");
+        assert_eq!(
+            reason,
+            format!(
+                "indexed_file_error_retry_required: {}",
+                source_path.display()
+            )
+        );
     }
 
     #[test]

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -47,9 +47,7 @@ use codestory_store::{
     LlmSymbolDocStats, SearchSymbolProjection, SnapshotStore, Store, SymbolSearchDoc,
     SymbolSummaryRecord,
 };
-use codestory_workspace::{
-    IndexedFileRecord, RefreshExecutionPlan, RefreshInputs, WorkspaceInventory, WorkspaceManifest,
-};
+use codestory_workspace::{RefreshExecutionPlan, RefreshInputs, WorkspaceManifest};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use fs4::fs_std::FileExt;
 use parking_lot::Mutex;
@@ -3479,37 +3477,6 @@ fn not_checked_index_freshness(
     }
 }
 
-fn refresh_inputs_from_files(files: Vec<FileInfo>) -> RefreshInputs {
-    let inventory = files
-        .iter()
-        .map(|file| {
-            (
-                file.path.clone(),
-                IndexedFileRecord {
-                    file_id: file.id,
-                    modification_time: file.modification_time,
-                    indexed: file.indexed,
-                    complete: file.complete,
-                },
-            )
-        })
-        .collect::<Vec<_>>();
-    let stored_files = files
-        .into_iter()
-        .map(|file| codestory_workspace::StoredFileState {
-            id: file.id,
-            path: file.path,
-            modification_time: file.modification_time,
-            indexed: file.indexed,
-            complete: file.complete,
-        });
-
-    RefreshInputs {
-        stored_files: stored_files.collect(),
-        inventory: WorkspaceInventory::from_records(inventory),
-    }
-}
-
 fn indexable_source_path(path: &Path) -> bool {
     let tree_sitter_supported = path
         .extension()
@@ -3594,11 +3561,24 @@ fn index_freshness_from_storage(
         );
     }
 
+    let stored_files = match storage.files().inventory() {
+        Ok(files) => files,
+        Err(error) => {
+            return not_checked_index_freshness(
+                format!("failed to read refresh inventory: {error}"),
+                indexed_file_count,
+                started_at,
+            );
+        }
+    };
     let removed_paths = files
         .iter()
         .map(|file| (file.id, file.path.clone()))
         .collect::<HashMap<_, _>>();
-    let refresh_inputs = refresh_inputs_from_files(files);
+    let refresh_inputs = RefreshInputs {
+        stored_files,
+        inventory: Default::default(),
+    };
     let plan = match workspace
         .build_execution_plan_bounded(&refresh_inputs, INDEX_FRESHNESS_CURRENT_FILE_CAP)
     {
@@ -11108,11 +11088,13 @@ fn indexing_cancelled_error() -> ApiError {
 }
 
 fn workspace_refresh_inputs(store: &Store) -> Result<RefreshInputs, ApiError> {
-    let files = store
-        .files()
-        .get_files()
-        .map_err(|e| ApiError::internal(format!("Failed to read workspace inventory: {e}")))?;
-    Ok(refresh_inputs_from_files(files))
+    Ok(RefreshInputs {
+        stored_files: store
+            .files()
+            .inventory()
+            .map_err(|e| ApiError::internal(format!("Failed to read workspace inventory: {e}")))?,
+        inventory: Default::default(),
+    })
 }
 
 fn rebuild_search_state_from_storage(
@@ -11273,6 +11255,53 @@ mod tests {
             !indexable_source_path(Path::new("target/run-output.log")),
             "runtime freshness should not count unsupported output artifacts"
         );
+    }
+
+    #[test]
+    fn parser_partial_freshness_distinguishes_file_level_errors() {
+        let project = tempdir().expect("project");
+        let source_path = project.path().join("lib.rs");
+        fs::write(&source_path, "pub fn indexed() {}\n").expect("write source");
+        let modification_time = fs::metadata(&source_path)
+            .expect("metadata")
+            .modified()
+            .expect("mtime")
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("mtime since epoch")
+            .as_millis()
+            .min(i64::MAX as u128) as i64;
+        let workspace = WorkspaceManifest::open(project.path().to_path_buf()).expect("workspace");
+        let storage = Storage::new_in_memory().expect("storage");
+        storage
+            .insert_file(&FileInfo {
+                id: 1,
+                path: source_path,
+                language: "rust".into(),
+                modification_time,
+                indexed: true,
+                complete: false,
+                line_count: 1,
+                file_role: codestory_store::FileRole::Source,
+            })
+            .expect("insert parser-partial file");
+
+        let freshness = index_freshness_from_storage(project.path(), &workspace, &storage);
+        assert_eq!(freshness.status, IndexFreshnessStatusDto::Fresh);
+        assert_eq!(freshness.changed_file_count, 0);
+
+        storage
+            .insert_error(&codestory_contracts::graph::ErrorInfo {
+                message: "read failed".into(),
+                file_id: Some(codestory_contracts::graph::NodeId(1)),
+                line: None,
+                column: None,
+                is_fatal: true,
+                index_step: codestory_contracts::graph::IndexStep::Indexing,
+            })
+            .expect("file error");
+        let retry = index_freshness_from_storage(project.path(), &workspace, &storage);
+        assert_eq!(retry.status, IndexFreshnessStatusDto::Stale);
+        assert_eq!(retry.changed_file_count, 1);
     }
 
     struct HybridTestEnv {

--- a/crates/codestory-store/src/file_store.rs
+++ b/crates/codestory-store/src/file_store.rs
@@ -1,6 +1,6 @@
 use crate::{FileInfo, StorageError, Store};
 use codestory_contracts::workspace::StoredFileRecord;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Read-only file inventory facade.
@@ -38,6 +38,12 @@ impl<'a> FileStore<'a> {
 
     /// Return the compact inventory contract consumed by refresh planning.
     pub fn inventory(&self) -> Result<Vec<StoredFileRecord>, StorageError> {
+        let retry_required_file_ids = self
+            .storage
+            .get_errors(None)?
+            .into_iter()
+            .filter_map(|error| error.file_id.map(|id| id.0))
+            .collect::<HashSet<_>>();
         self.storage
             .get_files()?
             .into_iter()
@@ -48,8 +54,61 @@ impl<'a> FileStore<'a> {
                     modification_time: file.modification_time,
                     indexed: file.indexed,
                     complete: file.complete,
+                    retry_required: !file.complete && retry_required_file_ids.contains(&file.id),
                 })
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FileRole;
+    use codestory_contracts::graph::{ErrorInfo, IndexStep, NodeId};
+
+    #[test]
+    fn inventory_retries_file_errors_but_not_parser_partial_coverage() {
+        let storage = Store::new_in_memory().expect("storage");
+        for id in [1, 2] {
+            storage
+                .insert_file(&FileInfo {
+                    id,
+                    path: PathBuf::from(format!("src/{id}.rs")),
+                    language: "rust".into(),
+                    modification_time: 1,
+                    indexed: true,
+                    complete: false,
+                    line_count: 1,
+                    file_role: FileRole::Source,
+                })
+                .expect("file");
+        }
+        storage
+            .insert_error(&ErrorInfo {
+                message: "read failed".into(),
+                file_id: Some(NodeId(2)),
+                line: None,
+                column: None,
+                is_fatal: true,
+                index_step: IndexStep::Indexing,
+            })
+            .expect("error");
+
+        let inventory = storage.files().inventory().expect("inventory");
+        assert!(
+            !inventory
+                .iter()
+                .find(|file| file.id == 1)
+                .unwrap()
+                .retry_required
+        );
+        assert!(
+            inventory
+                .iter()
+                .find(|file| file.id == 2)
+                .unwrap()
+                .retry_required
+        );
     }
 }

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -5534,6 +5534,54 @@ impl Storage {
         Ok(())
     }
 
+    /// Replace errors for reprocessed files after their latest projection is durable.
+    pub fn replace_errors_for_files_batch(
+        &mut self,
+        file_ids: &[i64],
+        errors: &[codestory_contracts::graph::ErrorInfo],
+    ) -> Result<(), StorageError> {
+        if file_ids.is_empty() {
+            return Ok(());
+        }
+
+        let file_ids = file_ids.iter().copied().collect::<HashSet<_>>();
+        debug_assert!(errors.iter().all(|error| {
+            error
+                .file_id
+                .is_some_and(|file_id| file_ids.contains(&file_id.0))
+        }));
+
+        let tx = self.conn.transaction()?;
+        let mut removed_error_count = 0;
+        {
+            let mut delete = tx.prepare("DELETE FROM error WHERE file_id = ?1")?;
+            for file_id in &file_ids {
+                removed_error_count += delete.execute(params![file_id])?;
+            }
+        }
+        {
+            let mut insert = tx.prepare(
+                "INSERT INTO error (message, file_id, line, column, fatal, indexed)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )?;
+            for error in errors {
+                insert.execute(params![
+                    error.message,
+                    error.file_id.map(|id| id.0),
+                    error.line,
+                    error.column,
+                    error.is_fatal as i32,
+                    (error.index_step == codestory_contracts::graph::IndexStep::Indexing) as i32,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        if removed_error_count > 0 || !errors.is_empty() {
+            self.invalidate_grounding_snapshots()?;
+        }
+        Ok(())
+    }
+
     // ========================================================================
     // Bookmark Management
     // ========================================================================

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -5108,17 +5108,6 @@ impl Storage {
         }
     }
 
-    pub fn first_incomplete_file_path(&self) -> Result<Option<PathBuf>, StorageError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path FROM file WHERE complete = 0 ORDER BY id LIMIT 1")?;
-        let mut rows = stmt.query([])?;
-        match rows.next()? {
-            Some(row) => Ok(Some(PathBuf::from(row.get::<_, String>(0)?))),
-            None => Ok(None),
-        }
-    }
-
     pub fn get_node_kinds_for_files(
         &self,
         file_ids: &[i64],

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -370,8 +370,9 @@ impl WorkspaceManifest {
 
     /// Build an incremental refresh plan from stored file inventory.
     ///
-    /// A file is scheduled when it is new, unreadable, previously unindexed, or
-    /// its filesystem mtime differs from the stored millisecond timestamp.
+    /// A file is scheduled when it is new, unreadable, previously unindexed,
+    /// carries a retryable file-level error, or its filesystem mtime differs
+    /// from the stored millisecond timestamp.
     /// Stored file ids absent from current discovery are scheduled for removal.
     pub fn build_execution_plan(&self, inputs: &RefreshInputs) -> Result<RefreshPlan> {
         WorkspaceDiscovery.build_refresh_plan(self, inputs)
@@ -537,7 +538,7 @@ impl WorkspaceDiscovery {
                     existing_file_ids.insert(path.clone(), file.id);
                     match modification_time_millis(&path) {
                         Ok(mtime) => {
-                            mtime != file.modification_time || !file.indexed || !file.complete
+                            mtime != file.modification_time || !file.indexed || file.retry_required
                         }
                         Err(_) => true,
                     }
@@ -924,6 +925,7 @@ mod tests {
                     modification_time: 0,
                     indexed: true,
                     complete: true,
+                    retry_required: false,
                 }],
                 inventory: WorkspaceInventory::default(),
             },
@@ -953,6 +955,7 @@ mod tests {
                     modification_time: modification_time_millis(&file)?,
                     indexed: true,
                     complete: true,
+                    retry_required: false,
                 }],
                 inventory: WorkspaceInventory::default(),
             },
@@ -967,8 +970,7 @@ mod tests {
     }
 
     #[test]
-    fn incremental_refresh_retries_unchanged_incomplete_files_from_both_inventories() -> Result<()>
-    {
+    fn incremental_refresh_does_not_spin_on_unchanged_parser_partial_files() -> Result<()> {
         let temp = tempdir()?;
         let root = temp.path().join("repo");
         fs::create_dir_all(&root)?;
@@ -985,6 +987,7 @@ mod tests {
                     modification_time,
                     indexed: true,
                     complete: false,
+                    retry_required: false,
                 }],
                 inventory: WorkspaceInventory::default(),
             },
@@ -997,6 +1000,54 @@ mod tests {
                         modification_time,
                         indexed: true,
                         complete: false,
+                        retry_required: false,
+                    },
+                )]),
+            },
+        ];
+
+        for input in inputs {
+            let plan = WorkspaceDiscovery.build_refresh_plan(&manifest, &input)?;
+            assert!(
+                plan.files_to_index.is_empty(),
+                "parser coverage is diagnostic state, not source freshness"
+            );
+            assert_eq!(plan.existing_file_ids.get(&file), Some(&7));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn incremental_refresh_retries_unchanged_file_level_failures() -> Result<()> {
+        let temp = tempdir()?;
+        let root = temp.path().join("repo");
+        fs::create_dir_all(&root)?;
+        let file = root.join("main.rs");
+        fs::write(&file, "fn main() {}\n")?;
+        let modification_time = modification_time_millis(&file)?;
+        let manifest = WorkspaceManifest::open(root)?;
+        let inputs = [
+            RefreshInputs {
+                stored_files: vec![StoredFileState {
+                    id: 7,
+                    path: file.clone(),
+                    modification_time,
+                    indexed: true,
+                    complete: false,
+                    retry_required: true,
+                }],
+                inventory: WorkspaceInventory::default(),
+            },
+            RefreshInputs {
+                stored_files: Vec::new(),
+                inventory: WorkspaceInventory::from_records([(
+                    file.clone(),
+                    IndexedFileRecord {
+                        file_id: 7,
+                        modification_time,
+                        indexed: true,
+                        complete: false,
+                        retry_required: true,
                     },
                 )]),
             },
@@ -1033,6 +1084,7 @@ mod tests {
                             modification_time: modification_time_millis(&file)?,
                             indexed: true,
                             complete: true,
+                            retry_required: false,
                         },
                     ),
                     (
@@ -1042,6 +1094,7 @@ mod tests {
                             modification_time: 0,
                             indexed: true,
                             complete: true,
+                            retry_required: false,
                         },
                     ),
                 ]),

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -120,6 +120,32 @@ the active plugin runtime plus observed and missing server-advertised MCP
 resources. This proves the installed plugin launcher advertises the resources;
 it is not Codex host/model visibility proof.
 
+Packaged acceptance uses the same five native hosted-runner cells before and
+after publication. Pull requests that change release, packaging, installer, or
+plugin-launch surfaces call the same release build in non-publishing
+`proof_only` mode, so the native matrix is reviewed before a release:
+
+| Asset | Native runner | Required packaged proof |
+| --- | --- | --- |
+| Linux x64 | `ubuntu-latest` | Version, help, stdio shape, and the full-sidecar agent proof |
+| Linux arm64 | `ubuntu-24.04-arm` | Version, help, and stdio shape |
+| Windows x64 | `windows-latest` | Version, help, stdio shape, installer ownership self-test, managed provisioning, local ground, and repair handoff |
+| Windows arm64 | `windows-11-arm` | Version, help, and stdio shape |
+| macOS arm64 | `macos-15` | Version, help, and stdio shape |
+
+The Windows managed handoff proves that the packaged CLI can be installed by
+the plugin, serve status, use the local graph, and publish a background repair
+reservation. It does not prove full sidecars or GPU execution. macOS arm64
+package execution does not close #887; live managed Metal endpoint survival
+still needs reporter or equivalent Apple Silicon hardware evidence. Current
+Ubuntu execution does not prove older-glibc compatibility.
+
+Release closeout is not complete until every published asset cell passes and
+the corresponding CodeStory plugin-source update is committed or merged in
+`TheGreenCedar/AgentPluginMarketplace`, followed by marketplace refresh and
+managed-plugin version/status readback. Source CI cannot substitute for that
+external pointer and installed-runtime proof.
+
 ## Docs-Only Fast Path
 
 If you only changed documentation or plugin doc surfaces, use the smallest credible

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -122,8 +122,9 @@ it is not Codex host/model visibility proof.
 
 Packaged acceptance uses the same five native hosted-runner cells before and
 after publication. Pull requests that change release, packaging, installer, or
-plugin-launch surfaces call the same release build in non-publishing
-`proof_only` mode, so the native matrix is reviewed before a release:
+plugin-launch surfaces call the same read-only reusable packaged-proof workflow
+as the release, so the native matrix is reviewed before publication without
+granting release permissions to pull-request code:
 
 | Asset | Native runner | Required packaged proof |
 | --- | --- | --- |


### PR DESCRIPTION
## Context

The v0.14.3 release needs native packaged acceptance evidence before publication and the same evidence against published assets afterward. The existing release workflow built five assets but retained only Linux x64 full-sidecar proof, duplicated its post-publish lane, and did not prove the Windows managed-plugin handoff.

Closes #934
Refs #909
Refs #887

## What Changed

- Added a pull-request `proof_only` lane that reuses the release workflow across Linux x64/arm64, Windows x64/arm64, and macOS arm64 without publishing.
- Reworked post-publish smoke into the same five-cell native matrix and made the release workflow call it directly.
- Extended the packaged proof helper with portable checksum verification and Windows x64 managed-plugin provisioning, local-ground, executable-provenance, repair-reservation, post-status, and cleanup evidence.
- Added Windows installer ownership proof, per-cell artifacts, exact workflow policy assertions, contributor guidance, and honest release-note boundaries.
- Kept live Apple Silicon Metal endpoint proof (#887), Windows arm64 acceleration, older-glibc compatibility, and marketplace readback outside source-CI claims.

## How To Review

1. Review `.github/workflows/packaged-platform-pr.yml` and the `proof_only` gates in `.github/workflows/release.yml`.
2. Compare the release build matrix with `.github/workflows/post-publish-release-smoke.yml`; both must retain the same five native runner/asset pairs.
3. Review `plugin_stdio_handoff` and `require_managed_plugin_handoff` in the packaged proof helper for provenance, repair observability, and worker cleanup.
4. Confirm `.github/scripts/check-workflow-policy.mjs` pins the workflow contract rather than accepting partial string matches.
5. Confirm documentation and release notes do not claim the remaining live-hardware or external-marketplace proof.

## Verification

- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `python .github/scripts/package-codestory-release.py --self-test`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` (47 passed)
- `node .github/scripts/check-workflow-policy.mjs`
- `scripts/install-codestory.ps1 -SelfTest`
- `node .github/scripts/check-doc-links.mjs` (70 files, 279 links)
- Python compilation and YAML parsing for all four touched workflows
- `git diff --check`
- Two independent read-only review passes found no remaining actionable findings

## Risk

The new native PR matrix is intentionally expensive because it exercises the actual release packaging surfaces. It proves package execution on hosted native runners, but it does not close live managed Metal endpoint survival on Apple Silicon, Windows arm64 accelerated retrieval, older-glibc compatibility, or external marketplace pointer/readback. Those remain explicit release closeout work under #909/#887.
