### PR TITLE
Prepare CodeStory 0.14.3 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.14.3
+
 ### Fixed
 
 - Added native five-asset pre-publish and post-publish acceptance evidence,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "codestory-bench"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-cli"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-contracts"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-indexer"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-retrieval"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-runtime"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-store"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "codestory-workspace"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",

--- a/crates/codestory-bench/Cargo.toml
+++ b/crates/codestory-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-bench"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 publish = false
 

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-cli"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 description = "Local repository evidence and grounding CLI for source-backed coding workflows."
 license = "Apache-2.0"

--- a/crates/codestory-contracts/Cargo.toml
+++ b/crates/codestory-contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-contracts"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-indexer/Cargo.toml
+++ b/crates/codestory-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-indexer"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 
 [dev-dependencies]

--- a/crates/codestory-retrieval/Cargo.toml
+++ b/crates/codestory-retrieval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-retrieval"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 
 [features]

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-runtime"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-store"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codestory-workspace"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 
 [dependencies]

--- a/plugins/codestory/.claude-plugin/plugin.json
+++ b/plugins/codestory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.codex-plugin/plugin.json
+++ b/plugins/codestory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codestory",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "CodeStory grounding for Codex over the local codestory-cli stdio server.",
   "author": {
     "name": "The Green Cedar",

--- a/plugins/codestory/.github/plugin/plugin.json
+++ b/plugins/codestory/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codestory",
   "description": "CodeStory grounding for coding agents over the local codestory-cli runtime.",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "author": {
     "name": "The Green Cedar",
     "url": "https://github.com/TheGreenCedar"


### PR DESCRIPTION
## Context

The native packaged-platform source lane is merged and green. This PR performs the narrow, reviewable v0.14.3 metadata synchronization required before the release promotion lane.

Closes #937
Refs #909
Refs #887
Refs #899

## What Changed

- Updated all eight `codestory-*` workspace crates to `0.14.3`.
- Regenerated `Cargo.lock` with synchronized workspace package versions.
- Updated the Codex, Claude, and GitHub CodeStory plugin manifests to `0.14.3`.
- Promoted the accumulated Unreleased notes to the `0.14.3` changelog section.

This does not claim that v0.14.3 is published, installed, or marketplace-visible. Those proofs remain in #909. Issue #887 remains open pending real Apple Silicon managed Metal endpoint-survival evidence.

## How To Review

1. Run `python .github/scripts/check-codestory-release.py --version 0.14.3`.
2. Confirm the diff is limited to eight crate manifests, Cargo.lock, three plugin manifests, and CHANGELOG.md.
3. Confirm the changelog preserves the Apple Silicon and other platform-proof boundaries.

## Verification

Passed:

- `python .github/scripts/check-codestory-release.py --version 0.14.3`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` - 47 passed
- `node .github/scripts/check-doc-links.mjs` - 70 files, 279 links
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo build --workspace --locked`
- `cargo test --workspace --locked -q`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo build --release -p codestory-cli --locked`
- `git diff --check`

Attempted but environment-blocked:

- `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture`
  - `CODESTORY_REAL_REPO_DRILL_CASES` is not set.
  - The Codex Windows host job object denies `CREATE_BREAKAWAY_FROM_JOB`, so native embedding bootstrap fails with `Access is denied. (os error 5)`.
  - No stats were emitted, so nothing was appended to the stats log.

## Risk

Low metadata risk. The main operational risk is downstream: release publication, five-asset verification, marketplace pointer update, and managed installed-runtime readback still must succeed in #909 before v0.14.3 is treated as shipped.