### PR TITLE
persist publication generation identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Added a schema-backed publication generation and run identity to every staged
+  full and incremental core database. Typed store and runtime reads now expose
+  the generation that owns the live graph, and cache finalization verifies that
+  identity before clearing the incomplete-run compatibility fence.
+
 ### Fixed
 
 - Staged incremental graph projection, removed-file cleanup, resolution,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "tokenizers",
  "tracing",
  "ureq 2.12.1",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -416,6 +416,30 @@ fn runtime_snapshot_lifecycle_flows_through_store_snapshot_surface() {
 }
 
 #[test]
+fn staged_publication_identity_is_schema_backed_and_verified_before_finalization() {
+    let runtime = read("crates/codestory-runtime/src/lib.rs");
+    let store = read("crates/codestory-store/src/storage_impl/mod.rs");
+    let schema = read("crates/codestory-store/src/storage_impl/schema.rs");
+
+    assert!(
+        store.contains("pub struct IndexPublicationRecord")
+            && store.contains("pub fn database_index_publication")
+            && store.contains("pub fn put_index_publication"),
+        "publication identity should be a typed store contract with read-only and staged-write surfaces"
+    );
+    assert!(
+        schema.contains("CREATE TABLE IF NOT EXISTS index_publication"),
+        "publication identity should survive process restarts in the SQLite schema"
+    );
+    assert!(
+        runtime.contains("next_index_publication(")
+            && runtime.contains("staged.store_mut().put_index_publication(&publication)")
+            && runtime.contains("Published index generation changed before finalization"),
+        "full and incremental staging should persist and verify one publication identity before clearing compatibility fences"
+    );
+}
+
+#[test]
 fn legacy_crates_are_removed_from_the_workspace() {
     let members = workspace_members();
     for legacy in [

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -23,6 +23,7 @@ tantivy = { workspace = true }
 tokenizers = { workspace = true }
 tracing = { workspace = true }
 ureq = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 codestory-retrieval = { workspace = true, features = ["test-support"] }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -43,9 +43,9 @@ use codestory_indexer::{
     CancellationToken, IncrementalIndexingStats, WorkspaceIndexer as V2WorkspaceIndexer,
 };
 use codestory_store::{
-    FileInfo, GroundingEdgeKindCount, GroundingNodeRecord, LlmSymbolDoc, LlmSymbolDocReuseMetadata,
-    LlmSymbolDocStats, SearchSymbolProjection, SnapshotStore, Store, SymbolSearchDoc,
-    SymbolSummaryRecord,
+    FileInfo, GroundingEdgeKindCount, GroundingNodeRecord, IndexPublicationMode,
+    IndexPublicationRecord, LlmSymbolDoc, LlmSymbolDocReuseMetadata, LlmSymbolDocStats,
+    SearchSymbolProjection, SnapshotStore, Store, SymbolSearchDoc, SymbolSummaryRecord,
 };
 use codestory_workspace::{RefreshExecutionPlan, RefreshInputs, WorkspaceManifest};
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -59,6 +59,7 @@ use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use uuid::Uuid;
 
 mod agent;
 pub use agent::packet_step_trace_json;
@@ -9615,6 +9616,16 @@ impl AppController {
         Ok(freshness)
     }
 
+    /// Return the durable identity of the core database generation at the live path.
+    pub fn index_publication(&self) -> Result<Option<IndexPublicationRecord>, ApiError> {
+        let storage_path = self.require_storage_path()?;
+        Store::database_index_publication(&storage_path).map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to read index publication identity: {error}"
+            ))
+        })
+    }
+
     fn cached_index_freshness_from_storage(
         &self,
         root: &Path,
@@ -10527,6 +10538,26 @@ struct IndexingRunSummary {
     phase_timings: IndexingPhaseTimings,
     llm_refresh_scope: Option<HashSet<codestory_contracts::graph::NodeId>>,
     finalize_incremental_run: bool,
+    publication: IndexPublicationRecord,
+}
+
+fn next_index_publication(
+    previous: Option<&IndexPublicationRecord>,
+    mode: IndexPublicationMode,
+    run_id: &str,
+) -> Result<IndexPublicationRecord, ApiError> {
+    let generation = previous
+        .map(|publication| publication.generation)
+        .unwrap_or_default()
+        .checked_add(1)
+        .ok_or_else(|| ApiError::internal("Index publication generation overflow"))?;
+    Ok(IndexPublicationRecord {
+        generation,
+        generation_id: Uuid::new_v4().to_string(),
+        run_id: run_id.to_string(),
+        mode,
+        published_at_epoch_ms: current_epoch_ms(),
+    })
 }
 
 struct IndexWriterGuard {
@@ -10593,6 +10624,14 @@ fn finish_incremental_run_marker(
     summary: &IndexingRunSummary,
     storage_path: &Path,
 ) -> Result<(), ApiError> {
+    let published = Store::database_index_publication(storage_path)
+        .map_err(|e| ApiError::internal(format!("Failed to read publication identity: {e}")))?;
+    if published.as_ref() != Some(&summary.publication) {
+        return Err(ApiError::internal(format!(
+            "Published index generation changed before finalization: expected {} run {}, observed {:?}",
+            summary.publication.generation_id, summary.publication.run_id, published
+        )));
+    }
     if !summary.finalize_incremental_run {
         return Ok(());
     }
@@ -10609,6 +10648,16 @@ fn index_full(
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
 ) -> Result<IndexingRunSummary, ApiError> {
+    let previous_publication = if storage_path.exists() {
+        Store::database_index_publication(storage_path).map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to inspect live publication identity: {error}"
+            ))
+        })?
+    } else {
+        None
+    };
+    let publication_run_id = Uuid::new_v4().to_string();
     let recovering_incomplete_run = if storage_path.exists() {
         match Storage::database_schema_version(storage_path) {
             Ok(version) if version > codestory_store::CURRENT_SCHEMA_VERSION => {
@@ -10741,6 +10790,23 @@ fn index_full(
             "Failed to preserve incomplete marker through staged recovery: {err}"
         )));
     }
+    let publication = match next_index_publication(
+        previous_publication.as_ref(),
+        IndexPublicationMode::Full,
+        &publication_run_id,
+    ) {
+        Ok(publication) => publication,
+        Err(error) => {
+            let _ = staged.discard();
+            return Err(error);
+        }
+    };
+    if let Err(error) = staged.store_mut().put_index_publication(&publication) {
+        let _ = staged.discard();
+        return Err(ApiError::internal(format!(
+            "Failed to persist staged full publication identity: {error}"
+        )));
+    }
     let staged_path = staged.path().to_path_buf();
     let publish_started = std::time::Instant::now();
     if let Err(err) = staged.publish(storage_path) {
@@ -10844,6 +10910,7 @@ fn index_full(
         },
         llm_refresh_scope: None,
         finalize_incremental_run: recovering_incomplete_run,
+        publication,
     })
 }
 
@@ -10925,6 +10992,16 @@ where
             ApiError::internal(format!("Failed to open staged incremental storage: {e}"))
         })?
     };
+    let previous_publication = match staged.store_mut().get_index_publication() {
+        Ok(publication) => publication,
+        Err(error) => {
+            let _ = staged.discard();
+            return Err(ApiError::internal(format!(
+                "Failed to read staged publication identity: {error}"
+            )));
+        }
+    };
+    let publication_run_id = Uuid::new_v4().to_string();
     let staged_result = (|| {
         staged.store_mut().begin_incremental_run().map_err(|e| {
             ApiError::internal(format!(
@@ -11026,6 +11103,23 @@ where
     if is_indexing_cancelled(cancel_token) {
         let _ = staged.discard();
         return Err(indexing_cancelled_error());
+    }
+    let publication = match next_index_publication(
+        previous_publication.as_ref(),
+        IndexPublicationMode::Incremental,
+        &publication_run_id,
+    ) {
+        Ok(publication) => publication,
+        Err(error) => {
+            let _ = staged.discard();
+            return Err(error);
+        }
+    };
+    if let Err(error) = staged.store_mut().put_index_publication(&publication) {
+        let _ = staged.discard();
+        return Err(ApiError::internal(format!(
+            "Failed to persist staged incremental publication identity: {error}"
+        )));
     }
     let staged_path = staged.path().to_path_buf();
     let publish_started = Instant::now();
@@ -11130,6 +11224,7 @@ where
         },
         llm_refresh_scope: Some(llm_refresh_scope),
         finalize_incremental_run: true,
+        publication,
     })
 }
 
@@ -16842,7 +16937,23 @@ fn build_llm_symbol_doc_text() -> String {
             phase_timings: IndexingPhaseTimings::default(),
             llm_refresh_scope: None,
             finalize_incremental_run: false,
+            publication: IndexPublicationRecord {
+                generation: 1,
+                generation_id: "test-generation".to_string(),
+                run_id: "test-run".to_string(),
+                mode: IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            },
         }
+    }
+
+    fn persisted_empty_indexing_run_summary(storage_path: &Path) -> IndexingRunSummary {
+        let summary = empty_indexing_run_summary();
+        Storage::open(storage_path)
+            .expect("open storage for publication identity")
+            .put_index_publication(&summary.publication)
+            .expect("persist test publication identity");
+        summary
     }
 
     #[test]
@@ -16857,8 +16968,9 @@ fn build_llm_symbol_doc_text() -> String {
             state.is_indexing = true;
         }
 
+        let summary = persisted_empty_indexing_run_summary(&storage_path);
         let timings = controller
-            .finish_successful_indexing(empty_indexing_run_summary(), &storage_path, true, None)
+            .finish_successful_indexing(summary, &storage_path, true, None)
             .expect("cache refresh should succeed");
 
         assert!(timings.cache_refresh_ms.is_some());
@@ -16918,6 +17030,116 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
+    fn full_and_incremental_publications_advance_one_durable_generation() {
+        let workspace = tempdir().expect("workspace dir");
+        fs::write(
+            workspace.path().join("lib.rs"),
+            "pub fn first_value() -> i32 { 1 }\n",
+        )
+        .expect("write initial source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project");
+
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("first full publication");
+        let first = controller
+            .index_publication()
+            .expect("read first publication")
+            .expect("first publication identity");
+        assert_eq!(first.generation, 1);
+        assert_eq!(first.mode, IndexPublicationMode::Full);
+
+        fs::write(
+            workspace.path().join("second.rs"),
+            "pub fn second_value() -> i32 { 2 }\n",
+        )
+        .expect("write incremental source");
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect("incremental publication");
+        let second = controller
+            .index_publication()
+            .expect("read second publication")
+            .expect("second publication identity");
+        assert_eq!(second.generation, 2);
+        assert_eq!(second.mode, IndexPublicationMode::Incremental);
+        assert_ne!(second.generation_id, first.generation_id);
+        assert_ne!(second.run_id, first.run_id);
+
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
+            .expect("second full publication");
+        let third = controller
+            .index_publication()
+            .expect("read third publication")
+            .expect("third publication identity");
+        assert_eq!(third.generation, 3);
+        assert_eq!(third.mode, IndexPublicationMode::Full);
+        assert_ne!(third.generation_id, second.generation_id);
+        assert_ne!(third.run_id, second.run_id);
+        assert!(third.published_at_epoch_ms >= second.published_at_epoch_ms);
+    }
+
+    #[test]
+    fn legacy_schema_18_incomplete_marker_recovers_to_first_publication() {
+        let workspace = tempdir().expect("workspace dir");
+        fs::write(
+            workspace.path().join("lib.rs"),
+            "pub fn legacy_value() -> i32 { 18 }\n",
+        )
+        .expect("write source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project");
+        {
+            let storage = Storage::open(&storage_path).expect("open legacy seed storage");
+            storage
+                .get_connection()
+                .execute_batch("DROP TABLE index_publication;")
+                .expect("remove post-v18 publication table");
+            storage
+                .get_connection()
+                .pragma_update(None, "user_version", 18)
+                .expect("stamp schema 18");
+            storage
+                .begin_incremental_run()
+                .expect("install legacy incomplete marker");
+        }
+
+        assert!(
+            Storage::database_index_publication(&storage_path)
+                .expect("read legacy publication")
+                .is_none()
+        );
+        controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect("recover legacy marker");
+
+        assert_eq!(
+            Storage::database_schema_version(&storage_path).expect("recovered schema"),
+            codestory_store::CURRENT_SCHEMA_VERSION
+        );
+        let publication = controller
+            .index_publication()
+            .expect("read recovered publication")
+            .expect("recovered publication identity");
+        assert_eq!(publication.generation, 1);
+        assert_eq!(publication.mode, IndexPublicationMode::Full);
+    }
+
+    #[test]
     fn incremental_cache_rebuild_failure_keeps_incomplete_marker() {
         let temp = tempdir().expect("create temp dir");
         let storage_path = temp.path().join("codestory.db");
@@ -16945,7 +17167,7 @@ fn build_llm_symbol_doc_text() -> String {
         }
         let controller = AppController::new();
         controller.state.lock().is_indexing = true;
-        let mut summary = empty_indexing_run_summary();
+        let mut summary = persisted_empty_indexing_run_summary(&storage_path);
         summary.finalize_incremental_run = true;
 
         let error = controller
@@ -17150,7 +17372,13 @@ fn build_llm_symbol_doc_text() -> String {
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
             .expect("initial full index");
 
-        let (baseline_paths, baseline_stats, baseline_snapshots, baseline_schema) = {
+        let (
+            baseline_paths,
+            baseline_stats,
+            baseline_snapshots,
+            baseline_schema,
+            baseline_publication,
+        ) = {
             let storage = Storage::open(&storage_path).expect("open baseline storage");
             let paths = storage
                 .get_files()
@@ -17165,7 +17393,11 @@ fn build_llm_symbol_doc_text() -> String {
                 .expect("read baseline snapshot metadata");
             let schema = Storage::database_schema_version(&storage_path)
                 .expect("read baseline schema version");
-            (paths, stats, snapshots, schema)
+            let publication = storage
+                .get_index_publication()
+                .expect("read baseline publication")
+                .expect("baseline publication identity");
+            (paths, stats, snapshots, schema, publication)
         };
 
         fs::remove_file(&old_path).expect("remove old source");
@@ -17227,6 +17459,13 @@ fn build_llm_symbol_doc_text() -> String {
                 baseline_snapshots,
                 "pre-publish failure must preserve the complete old snapshot generation"
             );
+            assert_eq!(
+                storage
+                    .get_index_publication()
+                    .expect("read live publication identity"),
+                Some(baseline_publication.clone()),
+                "pre-publish failure must not advance the live generation"
+            );
             storage
                 .get_connection()
                 .execute_batch("DROP TRIGGER fail_incremental_boundary;")
@@ -17259,6 +17498,15 @@ fn build_llm_symbol_doc_text() -> String {
                     .has_incomplete_incremental_run()
                     .expect("marker after direct retry")
             );
+            let retried_publication = storage
+                .get_index_publication()
+                .expect("read retried publication")
+                .expect("retried publication identity");
+            assert_eq!(
+                retried_publication.generation,
+                baseline_publication.generation + 1
+            );
+            assert_eq!(retried_publication.mode, IndexPublicationMode::Incremental);
             return;
         }
 
@@ -17298,6 +17546,12 @@ fn build_llm_symbol_doc_text() -> String {
                     .has_ready_detail()
                     .expect("detail readiness")
             );
+            let published = storage
+                .get_index_publication()
+                .expect("read fenced publication")
+                .expect("fenced publication identity");
+            assert_eq!(published.generation, baseline_publication.generation + 1);
+            assert_eq!(published.mode, IndexPublicationMode::Incremental);
         }
 
         let recovery = AppController::new();
@@ -17349,6 +17603,15 @@ fn build_llm_symbol_doc_text() -> String {
                 .status,
             IndexFreshnessStatusDto::Fresh
         );
+        let recovered_publication = storage
+            .get_index_publication()
+            .expect("read recovered publication")
+            .expect("recovered publication identity");
+        assert_eq!(
+            recovered_publication.generation,
+            baseline_publication.generation + 2
+        );
+        assert_eq!(recovered_publication.mode, IndexPublicationMode::Full);
     }
 
     #[test]
@@ -17458,7 +17721,7 @@ fn build_llm_symbol_doc_text() -> String {
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
             .expect("initial full index");
 
-        let (baseline_stats, baseline_snapshots) = {
+        let (baseline_stats, baseline_snapshots, baseline_publication) = {
             let storage = Storage::open(&storage_path).expect("open baseline storage");
             (
                 storage.get_stats().expect("baseline stats"),
@@ -17466,6 +17729,10 @@ fn build_llm_symbol_doc_text() -> String {
                     .snapshots()
                     .get_metadata()
                     .expect("baseline snapshot metadata"),
+                storage
+                    .get_index_publication()
+                    .expect("baseline publication read")
+                    .expect("baseline publication identity"),
             )
         };
         fs::write(
@@ -17517,6 +17784,12 @@ fn build_llm_symbol_doc_text() -> String {
                 .get_metadata()
                 .expect("cancelled snapshot metadata"),
             baseline_snapshots
+        );
+        assert_eq!(
+            storage
+                .get_index_publication()
+                .expect("cancelled live publication"),
+            Some(baseline_publication)
         );
         assert!(
             storage

--- a/crates/codestory-store/src/lib.rs
+++ b/crates/codestory-store/src/lib.rs
@@ -19,10 +19,11 @@ pub use snapshot_store::{
 pub use storage_impl::{
     CURRENT_SCHEMA_VERSION, CallerProjectionRemovalSummary, DenseReasonCounts, FileInfo,
     FileProjectionRemovalSummary, FileRole, GroundingEdgeKindCount, GroundingFileSummary,
-    GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState, LlmSymbolDoc,
-    LlmSymbolDocReuseMetadata, LlmSymbolDocStats, ProjectionFlushBreakdown, RetrievalIndexManifest,
-    SearchSymbolProjection, SearchSymbolProjectionDetail, Storage as Store, StorageError,
-    StorageOpenMode, StorageStats, SymbolSearchDoc, SymbolSummaryRecord,
+    GroundingNodeRecord, GroundingSnapshotMetadata, GroundingSnapshotState, IndexPublicationMode,
+    IndexPublicationRecord, LlmSymbolDoc, LlmSymbolDocReuseMetadata, LlmSymbolDocStats,
+    ProjectionFlushBreakdown, RetrievalIndexManifest, SearchSymbolProjection,
+    SearchSymbolProjectionDetail, Storage as Store, StorageError, StorageOpenMode, StorageStats,
+    SymbolSearchDoc, SymbolSummaryRecord,
 };
 
 impl Store {

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -424,6 +424,14 @@ mod tests {
                 },
             ])
             .expect("seed old generation");
+            live.put_index_publication(&crate::IndexPublicationRecord {
+                generation: 1,
+                generation_id: "old-generation".to_string(),
+                run_id: "old-run".to_string(),
+                mode: crate::IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            })
+            .expect("identify old generation");
             live.snapshots()
                 .refresh_all()
                 .expect("finalize old snapshots");
@@ -473,6 +481,16 @@ mod tests {
             .snapshots()
             .refresh_all()
             .expect("finalize new snapshots");
+        staged
+            .store_mut()
+            .put_index_publication(&crate::IndexPublicationRecord {
+                generation: 2,
+                generation_id: "new-generation".to_string(),
+                run_id: "new-run".to_string(),
+                mode: crate::IndexPublicationMode::Incremental,
+                published_at_epoch_ms: 2,
+            })
+            .expect("identify new generation");
         let staged_path = staged.path().to_path_buf();
         let racing_live_path = live_path.clone();
         let (old_observed_tx, old_observed_rx) = mpsc::channel();
@@ -501,6 +519,10 @@ mod tests {
                         .snapshots()
                         .has_ready_detail()
                         .expect("racing detail readiness");
+                let publication = reader
+                    .get_index_publication()
+                    .expect("racing publication read")
+                    .expect("racing publication identity");
                 reader
                     .get_connection()
                     .execute_batch("COMMIT;")
@@ -510,11 +532,13 @@ mod tests {
                     "racing reader observed unready snapshots for {paths:?}"
                 );
                 if paths == old_generation {
+                    assert_eq!(publication.generation, 1);
                     if !announced_old {
                         old_observed_tx.send(()).expect("announce old generation");
                         announced_old = true;
                     }
                 } else if paths == new_generation {
+                    assert_eq!(publication.generation, 2);
                     assert!(announced_old, "racing reader must span publication");
                     return;
                 } else {
@@ -538,6 +562,14 @@ mod tests {
             old_paths,
             vec![PathBuf::from("old_a.rs"), PathBuf::from("old_b.rs")]
         );
+        assert_eq!(
+            old_reader
+                .get_index_publication()
+                .expect("held reader publication")
+                .expect("held reader publication identity")
+                .generation,
+            1
+        );
 
         let new_reader = Store::open(&live_path).expect("open fresh reader");
         let new_paths = new_reader
@@ -549,6 +581,14 @@ mod tests {
         assert_eq!(
             new_paths,
             vec![PathBuf::from("new_a.rs"), PathBuf::from("new_b.rs")]
+        );
+        assert_eq!(
+            new_reader
+                .get_index_publication()
+                .expect("new reader publication")
+                .expect("new reader publication identity")
+                .generation,
+            2
         );
         assert!(
             new_reader

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -28,7 +28,7 @@ use helpers::{
     numbered_placeholders, question_placeholders, serialize_candidate_targets,
 };
 
-const SCHEMA_VERSION: u32 = 18;
+const SCHEMA_VERSION: u32 = 19;
 // Reserved outside the sequential migration range so a future real schema version cannot
 // accidentally be treated as an interrupted run from this release.
 const INCOMPLETE_INCREMENTAL_SCHEMA_VERSION: u32 = 0x4353_0001;
@@ -498,6 +498,117 @@ pub struct StorageStats {
     pub fatal_error_count: i64,
 }
 
+/// Indexing mode that produced one durable core database generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexPublicationMode {
+    Full,
+    Incremental,
+}
+
+impl IndexPublicationMode {
+    fn db_value(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Incremental => "incremental",
+        }
+    }
+
+    fn from_db(value: &str) -> Result<Self, StorageError> {
+        match value {
+            "full" => Ok(Self::Full),
+            "incremental" => Ok(Self::Incremental),
+            _ => Err(StorageError::Other(format!(
+                "Unsupported index publication mode: {value}"
+            ))),
+        }
+    }
+}
+
+/// Durable identity of the complete core database generation at the live path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexPublicationRecord {
+    pub generation: u64,
+    pub generation_id: String,
+    pub run_id: String,
+    pub mode: IndexPublicationMode,
+    pub published_at_epoch_ms: i64,
+}
+
+fn index_publication_record_from_values(
+    generation: i64,
+    generation_id: String,
+    run_id: String,
+    mode: String,
+    published_at_epoch_ms: i64,
+) -> Result<IndexPublicationRecord, StorageError> {
+    let generation = u64::try_from(generation).map_err(|_| {
+        StorageError::Other(format!(
+            "Invalid index publication generation: {generation}"
+        ))
+    })?;
+    if generation == 0
+        || generation_id.trim().is_empty()
+        || run_id.trim().is_empty()
+        || published_at_epoch_ms < 0
+    {
+        return Err(StorageError::Other(
+            "Index publication identity contains an empty or zero field".to_string(),
+        ));
+    }
+    Ok(IndexPublicationRecord {
+        generation,
+        generation_id,
+        run_id,
+        mode: IndexPublicationMode::from_db(&mode)?,
+        published_at_epoch_ms,
+    })
+}
+
+fn read_index_publication(
+    conn: &Connection,
+) -> Result<Option<IndexPublicationRecord>, StorageError> {
+    let table_exists: i64 = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master
+            WHERE type = 'table' AND name = 'index_publication'
+        )",
+        [],
+        |row| row.get(0),
+    )?;
+    if table_exists == 0 {
+        return Ok(None);
+    }
+    let values = conn.query_row(
+        "SELECT generation, generation_id, run_id, mode, published_at_epoch_ms
+         FROM index_publication WHERE id = 1",
+        [],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+            ))
+        },
+    );
+    match values {
+        Ok((generation, generation_id, run_id, mode, published_at_epoch_ms)) => {
+            index_publication_record_from_values(
+                generation,
+                generation_id,
+                run_id,
+                mode,
+                published_at_epoch_ms,
+            )
+            .map(Some)
+        }
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
 fn is_framework_synthetic_node(node: &Node) -> bool {
     node.canonical_id.as_deref().is_some_and(|canonical_id| {
         canonical_id.starts_with("tauri:command:")
@@ -930,6 +1041,14 @@ impl Storage {
         Ok(marked)
     }
 
+    /// Read the durable publication identity without migrating or mutating the database.
+    pub fn database_index_publication(
+        path: &Path,
+    ) -> Result<Option<IndexPublicationRecord>, StorageError> {
+        let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        read_index_publication(&conn)
+    }
+
     pub fn copy_database_snapshot(
         source_path: &Path,
         target_path: &Path,
@@ -1290,6 +1409,47 @@ impl Storage {
         transaction.execute("DELETE FROM incomplete_index_run WHERE id = 1", [])?;
         transaction.pragma_update(None, "user_version", SCHEMA_VERSION.to_string())?;
         transaction.commit()?;
+        Ok(())
+    }
+
+    /// Return the durable identity of the currently stored core generation.
+    pub fn get_index_publication(&self) -> Result<Option<IndexPublicationRecord>, StorageError> {
+        read_index_publication(&self.conn)
+    }
+
+    /// Store the identity that will describe this database once it is published.
+    pub fn put_index_publication(
+        &self,
+        publication: &IndexPublicationRecord,
+    ) -> Result<(), StorageError> {
+        if publication.generation == 0
+            || publication.generation > i64::MAX as u64
+            || publication.generation_id.trim().is_empty()
+            || publication.run_id.trim().is_empty()
+            || publication.published_at_epoch_ms < 0
+        {
+            return Err(StorageError::Other(
+                "Index publication identity contains an invalid field".to_string(),
+            ));
+        }
+        self.conn.execute(
+            "INSERT INTO index_publication (
+                id, generation, generation_id, run_id, mode, published_at_epoch_ms
+             ) VALUES (1, ?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(id) DO UPDATE SET
+                generation = excluded.generation,
+                generation_id = excluded.generation_id,
+                run_id = excluded.run_id,
+                mode = excluded.mode,
+                published_at_epoch_ms = excluded.published_at_epoch_ms",
+            params![
+                publication.generation as i64,
+                publication.generation_id.as_str(),
+                publication.run_id.as_str(),
+                publication.mode.db_value(),
+                publication.published_at_epoch_ms,
+            ],
+        )?;
         Ok(())
     }
 

--- a/crates/codestory-store/src/storage_impl/schema.rs
+++ b/crates/codestory-store/src/storage_impl/schema.rs
@@ -56,6 +56,14 @@ const TABLE_STATEMENTS: &[&str] = &[
         id INTEGER PRIMARY KEY CHECK (id = 1),
         started_at_epoch_ms INTEGER NOT NULL
     )",
+    "CREATE TABLE IF NOT EXISTS index_publication (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        generation INTEGER NOT NULL CHECK (generation > 0),
+        generation_id TEXT NOT NULL UNIQUE CHECK (length(generation_id) > 0),
+        run_id TEXT NOT NULL CHECK (length(run_id) > 0),
+        mode TEXT NOT NULL CHECK (mode IN ('full', 'incremental')),
+        published_at_epoch_ms INTEGER NOT NULL CHECK (published_at_epoch_ms >= 0)
+    )",
     "CREATE TABLE IF NOT EXISTS local_symbol (
         id INTEGER PRIMARY KEY,
         name TEXT NOT NULL,

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -68,6 +68,68 @@ fn incomplete_incremental_run_marker_survives_reopen_until_success() -> Result<(
 }
 
 #[test]
+fn index_publication_identity_round_trips_through_typed_and_read_only_reads()
+-> Result<(), StorageError> {
+    let path = unique_temp_db_path("index-publication-round-trip");
+    let publication = IndexPublicationRecord {
+        generation: 7,
+        generation_id: "generation-7".to_string(),
+        run_id: "run-7".to_string(),
+        mode: IndexPublicationMode::Incremental,
+        published_at_epoch_ms: 1234,
+    };
+    {
+        let storage = Storage::open(&path)?;
+        assert!(storage.get_index_publication()?.is_none());
+        storage.put_index_publication(&publication)?;
+        assert_eq!(storage.get_index_publication()?, Some(publication.clone()));
+    }
+    assert_eq!(
+        Storage::database_index_publication(&path)?,
+        Some(publication)
+    );
+
+    let _ = cleanup_sqlite_sidecars(&path);
+    Ok(())
+}
+
+#[test]
+fn index_publication_identity_rejects_negative_published_timestamp() {
+    assert!(
+        index_publication_record_from_values(
+            1,
+            "generation-1".to_string(),
+            "run-1".to_string(),
+            "full".to_string(),
+            -1,
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn schema_18_migrates_to_empty_publication_identity_without_synthesis() -> Result<(), StorageError>
+{
+    let path = unique_temp_db_path("index-publication-v18-migration");
+    {
+        let storage = Storage::open(&path)?;
+        storage
+            .get_connection()
+            .execute_batch("DROP TABLE index_publication;")?;
+        storage.set_schema_version(18)?;
+    }
+
+    assert!(Storage::database_index_publication(&path)?.is_none());
+    let storage = Storage::open(&path)?;
+    assert_eq!(Storage::database_schema_version(&path)?, SCHEMA_VERSION);
+    assert!(storage.get_index_publication()?.is_none());
+
+    drop(storage);
+    let _ = cleanup_sqlite_sidecars(&path);
+    Ok(())
+}
+
+#[test]
 fn incomplete_incremental_begin_failure_keeps_clean_schema_and_no_marker()
 -> Result<(), StorageError> {
     let path = unique_temp_db_path("incomplete-begin-rollback");


### PR DESCRIPTION
## Context

The staged core database from #936 has no durable identity that later persisted search, semantic state, sidecar manifests, or runtime in-memory snapshots can bind to. Paths and timestamps are not a safe cross-process join key.

Closes #941
Refs #910

## What Changed

- advance the SQLite schema from 18 to 19 with a singleton `index_publication` record
- persist a monotonic generation number, generation UUID, run UUID, full/incremental mode, and publication timestamp in every staged core database before promotion
- read the prior identity without migrating or mutating the live database
- expose typed store reads plus `AppController::index_publication`
- carry the expected publication through indexing finalization and refuse to clear the incomplete-run fence if the live identity changed
- preserve schema-18 marked-cache recovery: the first recovered full generation becomes generation 1 and finishes on schema 19
- bind fault, cancellation, direct-retry, late-recovery, held-reader, and racing-reader tests to the durable identity
- validate nonzero/nonempty/nonnegative identity fields in typed decoding, staged writes, and SQLite constraints

## How To Review

1. Review the schema and `IndexPublicationRecord` typed contract in `codestory-store`.
2. Follow `next_index_publication` through staged full and incremental publication.
3. Confirm `finish_incremental_run_marker` verifies the published identity before clearing the fence.
4. Review schema-18 migration, monotonic full/incremental tests, and the A/B racing-reader assertions.

## Verification

Passed locally on the final diff:

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p codestory-indexer --test fidelity_regression`
- `cargo test -p codestory-indexer --test tictactoe_language_coverage`
- `cargo build --release -p codestory-cli`
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` (47 passed)
- `git diff --check`

Independent read-only review finished clean after tightening negative timestamp validation.

The required ignored repo-scale harness was attempted again. It emitted no timing row because `CODESTORY_REAL_REPO_DRILL_CASES` is unset and this Codex Windows job denies native embedding `CREATE_BREAKAWAY_FROM_JOB` (`Access is denied`, os error 5).

## Risk

Schema 19 is intentionally forward-only for this v0.15 development lane; v0.14.3 runtimes will reject a completed schema-19 cache instead of silently reading unknown state. The publication record identifies only the core SQLite generation in this slice. Persisted `.search`, semantic completion, sidecars, and runtime in-memory swaps remain deferred #910 work and must bind to this identity before #910 closes.