### PR TITLE
parse FastAPI routes with tree-sitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 - Added an opt-in `diagnostic-onnx` Cargo feature for maintainers who still need
   the legacy ONNX asset diagnostics. Default CLI builds no longer compile or
   link ONNX Runtime, DirectML, ndarray, or tokenizer support.
-- Added parser-backed FastAPI decorator route extraction for receivers locally
-  constructed from imported `FastAPI` or `APIRouter` constructors, including
-  exact handler, method, path, provenance, and claim-tier metadata. Multiline
-  and raw-string routes are supported; imported but unowned receivers remain
-  structural, while dynamic templates, nested path builders, ordinary escaped
-  literals, and unrelated-error lexical candidates do not become exact route
-  claims. Error-local syntax recovery stays explicitly structural and
+- Added parser-backed FastAPI decorator route extraction for module-scope
+  receivers whose latest preceding assignment constructs an imported `FastAPI`
+  or `APIRouter`, including exact handler, method, path, provenance, and
+  claim-tier metadata. Reassignment invalidates ownership. Multiline and raw
+  string routes are supported; unmatched or nested-scope receivers are not
+  labeled as FastAPI, while dynamic templates, nested path builders, ordinary
+  escaped literals, and unrelated-error lexical candidates do not become exact
+  route claims. Error-local syntax recovery stays explicitly structural and
   low-confidence.
 - Added a schema-backed publication generation and run identity to every staged
   full and incremental core database. Typed store and runtime reads now expose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@
 - Added parser-backed FastAPI decorator route extraction for module-scope
   receivers whose latest preceding assignment constructs an imported `FastAPI`
   or `APIRouter`, including exact handler, method, path, provenance, and
-  claim-tier metadata. Reassignment invalidates ownership. Multiline and raw
-  string routes are supported; unmatched or nested-scope receivers are not
-  labeled as FastAPI, while dynamic templates, nested path builders, ordinary
-  escaped literals, and unrelated-error lexical candidates do not become exact
-  route claims. Error-local syntax recovery stays explicitly structural and
-  low-confidence.
+  claim-tier metadata. Later assignments, imports, functions, and classes
+  invalidate shadowed ownership. Multiline and raw string routes are supported;
+  unmatched or nested-scope receivers are not labeled as FastAPI, while dynamic
+  templates, nested path builders, ordinary escaped literals, and
+  unrelated-error lexical candidates do not become exact route claims.
+  Error-local syntax recovery stays explicitly structural and low-confidence.
 - Added a schema-backed publication generation and run identity to every staged
   full and incremental core database. Typed store and runtime reads now expose
   the generation that owns the live graph, and cache finalization verifies that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Added an opt-in `diagnostic-onnx` Cargo feature for maintainers who still need
   the legacy ONNX asset diagnostics. Default CLI builds no longer compile or
   link ONNX Runtime, DirectML, ndarray, or tokenizer support.
+- Added parser-backed FastAPI decorator route extraction with exact handler,
+  method, path, provenance, and claim-tier metadata. Multiline and raw-string
+  routes are supported; dynamic templates and nested path builders no longer
+  become exact endpoint claims, while syntax-error fallback stays explicitly
+  structural and low-confidence.
 - Added a schema-backed publication generation and run identity to every staged
   full and incremental core database. Typed store and runtime reads now expose
   the generation that owns the live graph, and cache finalization verifies that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
 - Added an opt-in `diagnostic-onnx` Cargo feature for maintainers who still need
   the legacy ONNX asset diagnostics. Default CLI builds no longer compile or
   link ONNX Runtime, DirectML, ndarray, or tokenizer support.
-- Added parser-backed FastAPI decorator route extraction with exact handler,
-  method, path, provenance, and claim-tier metadata. Multiline and raw-string
-  routes are supported; dynamic templates and nested path builders no longer
-  become exact endpoint claims, while syntax-error fallback stays explicitly
-  structural and low-confidence.
+- Added parser-backed FastAPI decorator route extraction for receivers locally
+  constructed from imported `FastAPI` or `APIRouter` constructors, including
+  exact handler, method, path, provenance, and claim-tier metadata. Multiline
+  and raw-string routes are supported; imported but unowned receivers remain
+  structural, while dynamic templates, nested path builders, ordinary escaped
+  literals, and unrelated-error lexical candidates do not become exact route
+  claims. Error-local syntax recovery stays explicitly structural and
+  low-confidence.
 - Added a schema-backed publication generation and run identity to every staged
   full and incremental core database. Typed store and runtime reads now expose
   the generation that owns the live graph, and cache finalization verifies that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@
 - Added an opt-in `diagnostic-onnx` Cargo feature for maintainers who still need
   the legacy ONNX asset diagnostics. Default CLI builds no longer compile or
   link ONNX Runtime, DirectML, ndarray, or tokenizer support.
-- Added parser-backed FastAPI decorator route extraction for module-scope
-  receivers whose latest preceding assignment constructs an imported `FastAPI`
-  or `APIRouter`, including exact handler, method, path, provenance, and
-  claim-tier metadata. Later assignments, imports, functions, and classes
-  invalidate shadowed ownership. Multiline and raw string routes are supported;
-  unmatched or nested-scope receivers are not labeled as FastAPI, while dynamic
-  templates, nested path builders, ordinary escaped literals, and
-  unrelated-error lexical candidates do not become exact route claims.
-  Error-local syntax recovery stays explicitly structural and low-confidence.
+- Added parser-backed FastAPI decorator route extraction for single-target,
+  module-scope receivers whose latest preceding assignment constructs an
+  imported `FastAPI` or `APIRouter`, including exact handler, method, path,
+  provenance, and claim-tier metadata. Later assignments, imports, functions,
+  and classes invalidate shadowed ownership; chained or multi-target
+  construction is conservatively not promoted. Multiline and raw string routes
+  are supported; unmatched or nested-scope receivers are not labeled as
+  FastAPI, while dynamic templates, nested path builders, ordinary escaped
+  literals, and unrelated-error lexical candidates do not become exact route
+  claims. Error-local syntax recovery stays explicitly structural and
+  low-confidence.
 - Added a schema-backed publication generation and run identity to every staged
   full and incremental core database. Typed store and runtime reads now expose
   the generation that owns the live graph, and cache finalization verifies that

--- a/crates/codestory-indexer/src/framework_routes.rs
+++ b/crates/codestory-indexer/src/framework_routes.rs
@@ -21,7 +21,7 @@ const PYTHON_FASTAPI_QUERY: &str = r#"
 static PYTHON_FASTAPI_COMPILED_QUERY: OnceLock<Result<Query, String>> = OnceLock::new();
 
 #[derive(Default)]
-struct FastApiOwnership {
+struct FastApiBindings {
     constructors: HashSet<String>,
     modules: HashSet<String>,
     receivers: HashSet<String>,
@@ -32,10 +32,6 @@ pub(super) fn collect_python_fastapi_routes(
     tree: &Tree,
     source: &str,
 ) -> Result<Vec<FrameworkRoute>> {
-    let ownership = fastapi_ownership(tree, source);
-    if ownership.constructors.is_empty() && ownership.modules.is_empty() {
-        return Ok(Vec::new());
-    }
     let query = PYTHON_FASTAPI_COMPILED_QUERY
         .get_or_init(|| {
             Query::new(language, PYTHON_FASTAPI_QUERY).map_err(|error| error.to_string())
@@ -59,6 +55,8 @@ pub(super) fn collect_python_fastapi_routes(
         let mut path = None;
         let mut handler = None;
         let mut line = None;
+        let mut route_start_byte = None;
+        let mut module_scope = false;
 
         for capture in query_match.captures {
             let name = capture_names
@@ -70,17 +68,32 @@ pub(super) fn collect_python_fastapi_routes(
                 "method" => method = node_text(capture.node, source),
                 "path" => path = python_static_string(capture.node, source),
                 "handler" => handler = node_text(capture.node, source),
-                "decorator" => line = Some(capture.node.start_position().row as u32 + 1),
+                "decorator" => {
+                    line = Some(capture.node.start_position().row as u32 + 1);
+                    route_start_byte = Some(capture.node.start_byte());
+                    module_scope = capture
+                        .node
+                        .parent()
+                        .and_then(|node| node.parent())
+                        .is_some_and(|node| node.kind() == "module");
+                }
                 _ => {}
             }
         }
 
-        let (Some(receiver), Some(method), Some(path), Some(handler), Some(line)) =
-            (receiver, method, path, handler, line)
+        let (
+            Some(receiver),
+            Some(method),
+            Some(path),
+            Some(handler),
+            Some(line),
+            Some(route_start_byte),
+        ) = (receiver, method, path, handler, line, route_start_byte)
         else {
             continue;
         };
-        if !matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete") {
+        if !module_scope || !matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete")
+        {
             continue;
         }
         let route = FrameworkRoute::new(
@@ -91,13 +104,9 @@ pub(super) fn collect_python_fastapi_routes(
             line,
             "decorator",
         );
-        routes.push(if ownership.receivers.contains(&receiver) {
-            route.with_claim_evidence("tree_sitter_query", "parser_backed")
-        } else {
-            route
-                .with_confidence("heuristic")
-                .with_claim_evidence("tree_sitter_query_unowned", "structural")
-        });
+        if module_fastapi_receiver_owned_at(tree, source, &receiver, route_start_byte) {
+            routes.push(route.with_claim_evidence("tree_sitter_query", "parser_backed"));
+        }
     }
 
     Ok(routes)
@@ -122,19 +131,18 @@ pub(super) fn allow_python_fastapi_lexical_fallback(
     let direct_static = raw || argument.starts_with('"') || argument.starts_with('\'');
     direct_static
         && (raw || !route.raw_path.contains('\\'))
-        && fastapi_ownership(tree, source).receivers.contains(receiver)
+        && module_fastapi_receiver_owned_at(
+            tree,
+            source,
+            receiver,
+            source_byte_at_line(source, route.line),
+        )
         && syntax_error_near_line(tree.root_node(), route.line)
+        && line_is_module_scope(tree, line, route.line)
         && !line_is_inside_python_string_or_comment(tree, line, route.line)
 }
 
-fn fastapi_ownership(tree: &Tree, source: &str) -> FastApiOwnership {
-    let mut ownership = FastApiOwnership::default();
-    collect_fastapi_imports(tree.root_node(), source, &mut ownership);
-    collect_fastapi_receivers(tree.root_node(), source, &mut ownership);
-    ownership
-}
-
-fn collect_fastapi_imports(node: Node<'_>, source: &str, ownership: &mut FastApiOwnership) {
+fn apply_fastapi_import(node: Node<'_>, source: &str, bindings: &mut FastApiBindings) {
     match node.kind() {
         "import_from_statement" => {
             let module = node
@@ -159,7 +167,7 @@ fn collect_fastapi_imports(node: Node<'_>, source: &str, ownership: &mut FastApi
                         _ => name,
                     };
                     if matches!(name, "FastAPI" | "APIRouter") {
-                        ownership.constructors.insert(alias.to_string());
+                        bindings.constructors.insert(alias.to_string());
                     }
                 }
             }
@@ -177,32 +185,71 @@ fn collect_fastapi_imports(node: Node<'_>, source: &str, ownership: &mut FastApi
                         (Some("as"), Some(alias)) => alias,
                         _ => "fastapi",
                     };
-                    ownership.modules.insert(alias.to_string());
+                    bindings.modules.insert(alias.to_string());
                 }
             }
         }
         _ => {}
     }
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        collect_fastapi_imports(child, source, ownership);
+}
+
+fn module_fastapi_receiver_owned_at(
+    tree: &Tree,
+    source: &str,
+    receiver: &str,
+    before_byte: usize,
+) -> bool {
+    let mut bindings = FastApiBindings::default();
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    for statement in root.named_children(&mut cursor) {
+        if statement.start_byte() >= before_byte {
+            break;
+        }
+        apply_fastapi_import(statement, source, &mut bindings);
+        if let Some(assignment) = module_assignment(statement) {
+            apply_fastapi_assignment(assignment, source, &mut bindings);
+        }
+    }
+    bindings.receivers.contains(receiver)
+}
+
+fn module_assignment(node: Node<'_>) -> Option<Node<'_>> {
+    if node.kind() == "assignment" {
+        return Some(node);
+    }
+    (node.kind() == "expression_statement")
+        .then(|| node.named_child(0))
+        .flatten()
+        .filter(|node| node.kind() == "assignment")
+}
+
+fn apply_fastapi_assignment(node: Node<'_>, source: &str, bindings: &mut FastApiBindings) {
+    if let Some(receiver) = node
+        .child_by_field_name("left")
+        .filter(|node| node.kind() == "identifier")
+        .and_then(|node| node_text(node, source))
+    {
+        let constructs_fastapi = assignment_constructs_fastapi(node, source, bindings);
+        bindings.receivers.remove(&receiver);
+        bindings.constructors.remove(&receiver);
+        bindings.modules.remove(&receiver);
+        if constructs_fastapi {
+            bindings.receivers.insert(receiver);
+        }
     }
 }
 
-fn collect_fastapi_receivers(node: Node<'_>, source: &str, ownership: &mut FastApiOwnership) {
+fn assignment_constructs_fastapi(node: Node<'_>, source: &str, bindings: &FastApiBindings) -> bool {
     if node.kind() == "assignment"
-        && let Some(receiver) = node
-            .child_by_field_name("left")
-            .filter(|node| node.kind() == "identifier")
-            .and_then(|node| node_text(node, source))
         && let Some(call) = node
             .child_by_field_name("right")
             .filter(|node| node.kind() == "call")
         && let Some(function) = call.child_by_field_name("function")
     {
-        let owned = match function.kind() {
+        return match function.kind() {
             "identifier" => node_text(function, source)
-                .is_some_and(|name| ownership.constructors.contains(&name)),
+                .is_some_and(|name| bindings.constructors.contains(&name)),
             "attribute" => {
                 let module = function
                     .child_by_field_name("object")
@@ -210,21 +257,37 @@ fn collect_fastapi_receivers(node: Node<'_>, source: &str, ownership: &mut FastA
                 let constructor = function
                     .child_by_field_name("attribute")
                     .and_then(|node| node_text(node, source));
-                module.is_some_and(|module| ownership.modules.contains(&module))
+                module.is_some_and(|module| bindings.modules.contains(&module))
                     && constructor
                         .as_deref()
                         .is_some_and(|name| matches!(name, "FastAPI" | "APIRouter"))
             }
             _ => false,
         };
-        if owned {
-            ownership.receivers.insert(receiver);
+    }
+    false
+}
+
+fn line_is_module_scope(tree: &Tree, line: &str, line_number: u32) -> bool {
+    let mut node = node_at_line_start(tree, line, line_number);
+    while let Some(current) = node {
+        if matches!(
+            current.kind(),
+            "function_definition" | "class_definition" | "lambda"
+        ) {
+            return false;
         }
+        node = current.parent();
     }
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        collect_fastapi_receivers(child, source, ownership);
-    }
+    true
+}
+
+fn source_byte_at_line(source: &str, line: u32) -> usize {
+    source
+        .split_inclusive('\n')
+        .take(line.saturating_sub(1) as usize)
+        .map(str::len)
+        .sum()
 }
 
 fn fastapi_decorator_receiver_and_argument<'a>(
@@ -255,10 +318,7 @@ fn syntax_error_near_line(node: Node<'_>, line: u32) -> bool {
 }
 
 fn line_is_inside_python_string_or_comment(tree: &Tree, line: &str, line_number: u32) -> bool {
-    let row = line_number.saturating_sub(1) as usize;
-    let col = line.len().saturating_sub(line.trim_start().len());
-    let point = Point::new(row, col);
-    let mut node = tree.root_node().descendant_for_point_range(point, point);
+    let mut node = node_at_line_start(tree, line, line_number);
     while let Some(current) = node {
         if matches!(current.kind(), "string" | "comment") {
             return true;
@@ -266,6 +326,17 @@ fn line_is_inside_python_string_or_comment(tree: &Tree, line: &str, line_number:
         node = current.parent();
     }
     false
+}
+
+fn node_at_line_start<'tree>(
+    tree: &'tree Tree,
+    line: &str,
+    line_number: u32,
+) -> Option<Node<'tree>> {
+    let row = line_number.saturating_sub(1) as usize;
+    let col = line.len().saturating_sub(line.trim_start().len());
+    let point = Point::new(row, col);
+    tree.root_node().descendant_for_point_range(point, point)
 }
 
 fn node_text(node: Node<'_>, source: &str) -> Option<String> {
@@ -468,7 +539,7 @@ async def broken(
     }
 
     #[test]
-    fn test_fastapi_unowned_receiver_stays_structural_and_unrelated_app_is_ignored() -> Result<()> {
+    fn test_fastapi_unowned_receiver_and_unrelated_app_are_ignored() -> Result<()> {
         let imported = r#"
 from fastapi import APIRouter
 
@@ -482,17 +553,12 @@ async def external_router(): pass
             None,
             None,
         )?;
-        let route = imported_result
-            .nodes
-            .iter()
-            .find(|node| {
-                node.serialized_name
-                    == "GET /factory-owned-elsewhere (fastapi route; confidence=heuristic)"
-            })
-            .expect("unowned imported FastAPI receiver stays structural");
-        let canonical_id = route.canonical_id.as_deref().expect("route metadata");
-        assert!(canonical_id.contains(r#""extraction_provenance":"tree_sitter_query_unowned""#));
-        assert!(canonical_id.contains(r#""claim_tier":"structural""#));
+        assert!(imported_result.nodes.iter().all(|node| {
+            !node
+                .canonical_id
+                .as_deref()
+                .is_some_and(|value| value.contains(r#""framework":"fastapi""#))
+        }));
 
         let unrelated = r#"
 app = OtherFramework()
@@ -513,6 +579,58 @@ async def unrelated_handler(): pass
                 .as_deref()
                 .is_some_and(|value| value.contains(r#""framework":"fastapi""#))
         }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fastapi_receiver_ownership_is_module_scoped_and_invalidated_by_reassignment()
+    -> Result<()> {
+        let nested_scopes = r#"
+from fastapi import FastAPI
+
+def build_fastapi():
+    app = FastAPI()
+    @app.get("/inside-one")
+    async def inside_one(): pass
+
+def build_other():
+    app = OtherFramework()
+    @app.get("/inside-two")
+    async def inside_two(): pass
+"#;
+        let reassigned = r#"
+from fastapi import FastAPI
+
+app = FastAPI()
+app = OtherFramework()
+
+@app.get("/after-reassignment")
+async def after_reassignment(): pass
+"#;
+        let constructor_reassigned = r#"
+from fastapi import FastAPI
+
+FastAPI = OtherFactory
+app = FastAPI()
+
+@app.get("/after-constructor-reassignment")
+async def after_constructor_reassignment(): pass
+"#;
+        for source in [nested_scopes, reassigned, constructor_reassigned] {
+            let result = super::super::index_file(
+                Path::new("scopes.py"),
+                source,
+                &super::super::get_language_for_ext("py").expect("python config"),
+                None,
+                None,
+            )?;
+            assert!(result.nodes.iter().all(|node| {
+                !node
+                    .canonical_id
+                    .as_deref()
+                    .is_some_and(|value| value.contains(r#""framework":"fastapi""#))
+            }));
+        }
         Ok(())
     }
 

--- a/crates/codestory-indexer/src/framework_routes.rs
+++ b/crates/codestory-indexer/src/framework_routes.rs
@@ -206,12 +206,166 @@ fn module_fastapi_receiver_owned_at(
         if statement.start_byte() >= before_byte {
             break;
         }
-        apply_fastapi_import(statement, source, &mut bindings);
         if let Some(assignment) = module_assignment(statement) {
             apply_fastapi_assignment(assignment, source, &mut bindings);
+        } else {
+            invalidate_module_statement_bindings(statement, source, &mut bindings);
+            apply_fastapi_import(statement, source, &mut bindings);
         }
     }
     bindings.receivers.contains(receiver)
+}
+
+fn invalidate_module_statement_bindings(
+    statement: Node<'_>,
+    source: &str,
+    bindings: &mut FastApiBindings,
+) {
+    if node_is_star_import(statement, source) {
+        bindings.receivers.clear();
+        bindings.constructors.clear();
+        bindings.modules.clear();
+        return;
+    }
+    let mut names = HashSet::new();
+    collect_module_bound_names(statement, source, &mut names);
+    for name in names {
+        bindings.receivers.remove(&name);
+        bindings.constructors.remove(&name);
+        bindings.modules.remove(&name);
+    }
+}
+
+fn node_is_star_import(node: Node<'_>, source: &str) -> bool {
+    node.kind() == "import_from_statement"
+        && node_text(node, source).is_some_and(|statement| {
+            statement
+                .rsplit_once(" import ")
+                .is_some_and(|(_, imported)| imported.trim() == "*")
+        })
+}
+
+fn collect_module_bound_names(node: Node<'_>, source: &str, names: &mut HashSet<String>) {
+    match node.kind() {
+        "function_definition" | "class_definition" => {
+            if let Some(name) = node
+                .child_by_field_name("name")
+                .and_then(|node| node_text(node, source))
+            {
+                names.insert(name);
+            }
+            return;
+        }
+        "decorated_definition" => {
+            if let Some(definition) = node.child_by_field_name("definition") {
+                collect_module_bound_names(definition, source, names);
+            }
+            return;
+        }
+        "lambda" => return,
+        "assignment" | "augmented_assignment" | "named_expression" => {
+            if let Some(target) = node.child_by_field_name("left") {
+                collect_python_binding_target(target, source, names);
+            }
+        }
+        "delete_statement" => {
+            let mut cursor = node.walk();
+            for target in node.named_children(&mut cursor) {
+                collect_python_binding_target(target, source, names);
+            }
+            return;
+        }
+        "type_alias_statement" => {
+            if let Some(target) = node.child_by_field_name("name") {
+                collect_python_binding_target(target, source, names);
+            }
+        }
+        "for_statement" => {
+            if let Some(target) = node.child_by_field_name("left") {
+                collect_python_binding_target(target, source, names);
+            }
+        }
+        "with_item" => {
+            if let Some(target) = node.child_by_field_name("alias") {
+                collect_python_binding_target(target, source, names);
+            }
+        }
+        "except_clause" => {
+            if let Some(target) = node.child_by_field_name("name") {
+                collect_python_binding_target(target, source, names);
+            }
+        }
+        "import_from_statement" => collect_import_from_bound_names(node, source, names),
+        "import_statement" => collect_import_bound_names(node, source, names),
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_module_bound_names(child, source, names);
+    }
+}
+
+fn collect_python_binding_target(node: Node<'_>, source: &str, names: &mut HashSet<String>) {
+    if node.kind() == "identifier" {
+        if let Some(name) = node_text(node, source) {
+            names.insert(name);
+        }
+        return;
+    }
+    if matches!(node.kind(), "attribute" | "subscript") {
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_python_binding_target(child, source, names);
+    }
+}
+
+fn collect_import_from_bound_names(node: Node<'_>, source: &str, names: &mut HashSet<String>) {
+    let Some(statement) = node_text(node, source) else {
+        return;
+    };
+    let Some((_, imported)) = statement.rsplit_once(" import ") else {
+        return;
+    };
+    for spec in imported
+        .trim_matches(|ch: char| ch == '(' || ch == ')' || ch.is_whitespace())
+        .split(',')
+    {
+        let mut parts = spec.split_whitespace();
+        let Some(imported_name) = parts.next() else {
+            continue;
+        };
+        if imported_name == "*" {
+            continue;
+        }
+        let bound = match (parts.next(), parts.next()) {
+            (Some("as"), Some(alias)) => alias,
+            _ => imported_name,
+        };
+        names.insert(bound.to_string());
+    }
+}
+
+fn collect_import_bound_names(node: Node<'_>, source: &str, names: &mut HashSet<String>) {
+    let Some(statement) = node_text(node, source) else {
+        return;
+    };
+    let Some(imported) = statement.strip_prefix("import ") else {
+        return;
+    };
+    for spec in imported.split(',') {
+        let mut parts = spec.split_whitespace();
+        let Some(module) = parts.next() else {
+            continue;
+        };
+        let bound = match (parts.next(), parts.next()) {
+            (Some("as"), Some(alias)) => alias,
+            _ => module.split('.').next().unwrap_or(module),
+        };
+        names.insert(bound.to_string());
+    }
 }
 
 fn module_assignment(node: Node<'_>) -> Option<Node<'_>> {
@@ -616,7 +770,47 @@ app = FastAPI()
 @app.get("/after-constructor-reassignment")
 async def after_constructor_reassignment(): pass
 "#;
-        for source in [nested_scopes, reassigned, constructor_reassigned] {
+        let imported_constructor_shadowed = r#"
+from fastapi import FastAPI
+from other_framework import FastAPI
+
+app = FastAPI()
+@app.get("/shadowed-import")
+async def shadowed_import(): pass
+"#;
+        let imported_module_shadowed = r#"
+import fastapi as framework
+import other_framework as framework
+
+app = framework.FastAPI()
+@app.get("/shadowed-module")
+async def shadowed_module(): pass
+"#;
+        let class_shadowed = r#"
+from fastapi import FastAPI
+
+class FastAPI: pass
+app = FastAPI()
+@app.get("/shadowed-class")
+async def shadowed_class(): pass
+"#;
+        let function_shadowed = r#"
+from fastapi import FastAPI
+
+def FastAPI(): return OtherFramework()
+app = FastAPI()
+@app.get("/shadowed-function")
+async def shadowed_function(): pass
+"#;
+        for source in [
+            nested_scopes,
+            reassigned,
+            constructor_reassigned,
+            imported_constructor_shadowed,
+            imported_module_shadowed,
+            class_shadowed,
+            function_shadowed,
+        ] {
             let result = super::super::index_file(
                 Path::new("scopes.py"),
                 source,

--- a/crates/codestory-indexer/src/framework_routes.rs
+++ b/crates/codestory-indexer/src/framework_routes.rs
@@ -379,26 +379,39 @@ fn module_assignment(node: Node<'_>) -> Option<Node<'_>> {
 }
 
 fn apply_fastapi_assignment(node: Node<'_>, source: &str, bindings: &mut FastApiBindings) {
-    if let Some(receiver) = node
-        .child_by_field_name("left")
-        .filter(|node| node.kind() == "identifier")
-        .and_then(|node| node_text(node, source))
+    let mut targets = HashSet::new();
+    collect_assignment_binding_targets(node, source, &mut targets);
+    let constructs_fastapi = assignment_constructs_fastapi(node, source, bindings);
+    for target in &targets {
+        bindings.receivers.remove(target);
+        bindings.constructors.remove(target);
+        bindings.modules.remove(target);
+    }
+    if constructs_fastapi
+        && targets.len() == 1
+        && let Some(receiver) = targets.into_iter().next()
     {
-        let constructs_fastapi = assignment_constructs_fastapi(node, source, bindings);
-        bindings.receivers.remove(&receiver);
-        bindings.constructors.remove(&receiver);
-        bindings.modules.remove(&receiver);
-        if constructs_fastapi {
-            bindings.receivers.insert(receiver);
-        }
+        bindings.receivers.insert(receiver);
+    }
+}
+
+fn collect_assignment_binding_targets(node: Node<'_>, source: &str, targets: &mut HashSet<String>) {
+    if let Some(left) = node.child_by_field_name("left") {
+        collect_python_binding_target(left, source, targets);
+    }
+    if let Some(right) = node.child_by_field_name("right")
+        && right.kind() == "assignment"
+    {
+        collect_assignment_binding_targets(right, source, targets);
     }
 }
 
 fn assignment_constructs_fastapi(node: Node<'_>, source: &str, bindings: &FastApiBindings) -> bool {
-    if node.kind() == "assignment"
-        && let Some(call) = node
-            .child_by_field_name("right")
-            .filter(|node| node.kind() == "call")
+    let mut value = node.child_by_field_name("right");
+    while let Some(assignment) = value.filter(|node| node.kind() == "assignment") {
+        value = assignment.child_by_field_name("right");
+    }
+    if let Some(call) = value.filter(|node| node.kind() == "call")
         && let Some(function) = call.child_by_field_name("function")
     {
         return match function.kind() {
@@ -802,6 +815,37 @@ app = FastAPI()
 @app.get("/shadowed-function")
 async def shadowed_function(): pass
 "#;
+        let tuple_reassigned = r#"
+from fastapi import FastAPI
+
+app = FastAPI()
+app, other = OtherFramework(), None
+@app.get("/after-tuple-reassignment")
+async def after_tuple_reassignment(): pass
+"#;
+        let nested_destructuring_reassigned = r#"
+from fastapi import FastAPI
+
+app = FastAPI()
+(app, (other,)) = (OtherFramework(), (None,))
+@app.get("/after-nested-reassignment")
+async def after_nested_reassignment(): pass
+"#;
+        let chained_reassigned = r#"
+from fastapi import APIRouter
+
+router = APIRouter()
+app = router = OtherFramework()
+@router.get("/after-chained-reassignment")
+async def after_chained_reassignment(): pass
+"#;
+        let chained_fastapi_construction = r#"
+from fastapi import FastAPI
+
+app = router = FastAPI()
+@app.get("/ambiguous-chained-construction")
+async def ambiguous_chained_construction(): pass
+"#;
         for source in [
             nested_scopes,
             reassigned,
@@ -810,6 +854,10 @@ async def shadowed_function(): pass
             imported_module_shadowed,
             class_shadowed,
             function_shadowed,
+            tuple_reassigned,
+            nested_destructuring_reassigned,
+            chained_reassigned,
+            chained_fastapi_construction,
         ] {
             let result = super::super::index_file(
                 Path::new("scopes.py"),

--- a/crates/codestory-indexer/src/framework_routes.rs
+++ b/crates/codestory-indexer/src/framework_routes.rs
@@ -1,8 +1,9 @@
 use super::FrameworkRoute;
 use anyhow::{Result, anyhow};
+use std::collections::HashSet;
 use std::sync::OnceLock;
 use streaming_iterator::StreamingIterator;
-use tree_sitter::{Language, Node, Query, QueryCursor, Tree};
+use tree_sitter::{Language, Node, Point, Query, QueryCursor, Tree};
 
 const PYTHON_FASTAPI_QUERY: &str = r#"
 (decorated_definition
@@ -19,11 +20,22 @@ const PYTHON_FASTAPI_QUERY: &str = r#"
 
 static PYTHON_FASTAPI_COMPILED_QUERY: OnceLock<Result<Query, String>> = OnceLock::new();
 
+#[derive(Default)]
+struct FastApiOwnership {
+    constructors: HashSet<String>,
+    modules: HashSet<String>,
+    receivers: HashSet<String>,
+}
+
 pub(super) fn collect_python_fastapi_routes(
     language: &Language,
     tree: &Tree,
     source: &str,
 ) -> Result<Vec<FrameworkRoute>> {
+    let ownership = fastapi_ownership(tree, source);
+    if ownership.constructors.is_empty() && ownership.modules.is_empty() {
+        return Ok(Vec::new());
+    }
     let query = PYTHON_FASTAPI_COMPILED_QUERY
         .get_or_init(|| {
             Query::new(language, PYTHON_FASTAPI_QUERY).map_err(|error| error.to_string())
@@ -68,25 +80,192 @@ pub(super) fn collect_python_fastapi_routes(
         else {
             continue;
         };
-        if !matches!(receiver.as_str(), "app" | "router")
-            || !matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete")
-        {
+        if !matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete") {
             continue;
         }
-        routes.push(
-            FrameworkRoute::new(
-                "fastapi",
-                method.to_ascii_uppercase(),
-                path,
-                Some(handler),
-                line,
-                "decorator",
-            )
-            .with_claim_evidence("tree_sitter_query", "parser_backed"),
+        let route = FrameworkRoute::new(
+            "fastapi",
+            method.to_ascii_uppercase(),
+            path,
+            Some(handler),
+            line,
+            "decorator",
         );
+        routes.push(if ownership.receivers.contains(&receiver) {
+            route.with_claim_evidence("tree_sitter_query", "parser_backed")
+        } else {
+            route
+                .with_confidence("heuristic")
+                .with_claim_evidence("tree_sitter_query_unowned", "structural")
+        });
     }
 
     Ok(routes)
+}
+
+pub(super) fn allow_python_fastapi_lexical_fallback(
+    tree: &Tree,
+    source: &str,
+    route: &FrameworkRoute,
+) -> bool {
+    let Some(line) = source.lines().nth(route.line.saturating_sub(1) as usize) else {
+        return false;
+    };
+    let Some((receiver, argument)) = fastapi_decorator_receiver_and_argument(line, &route.method)
+    else {
+        return false;
+    };
+    let raw = argument.starts_with("r\"")
+        || argument.starts_with("r'")
+        || argument.starts_with("R\"")
+        || argument.starts_with("R'");
+    let direct_static = raw || argument.starts_with('"') || argument.starts_with('\'');
+    direct_static
+        && (raw || !route.raw_path.contains('\\'))
+        && fastapi_ownership(tree, source).receivers.contains(receiver)
+        && syntax_error_near_line(tree.root_node(), route.line)
+        && !line_is_inside_python_string_or_comment(tree, line, route.line)
+}
+
+fn fastapi_ownership(tree: &Tree, source: &str) -> FastApiOwnership {
+    let mut ownership = FastApiOwnership::default();
+    collect_fastapi_imports(tree.root_node(), source, &mut ownership);
+    collect_fastapi_receivers(tree.root_node(), source, &mut ownership);
+    ownership
+}
+
+fn collect_fastapi_imports(node: Node<'_>, source: &str, ownership: &mut FastApiOwnership) {
+    match node.kind() {
+        "import_from_statement" => {
+            let module = node
+                .child_by_field_name("module_name")
+                .and_then(|node| node_text(node, source));
+            if module
+                .as_deref()
+                .is_some_and(|module| module == "fastapi" || module.starts_with("fastapi."))
+                && let Some(statement) = node_text(node, source)
+                && let Some((_, imported)) = statement.rsplit_once(" import ")
+            {
+                for spec in imported
+                    .trim_matches(|ch: char| ch == '(' || ch == ')' || ch.is_whitespace())
+                    .split(',')
+                {
+                    let mut parts = spec.split_whitespace();
+                    let Some(name) = parts.next() else {
+                        continue;
+                    };
+                    let alias = match (parts.next(), parts.next()) {
+                        (Some("as"), Some(alias)) => alias,
+                        _ => name,
+                    };
+                    if matches!(name, "FastAPI" | "APIRouter") {
+                        ownership.constructors.insert(alias.to_string());
+                    }
+                }
+            }
+        }
+        "import_statement" => {
+            if let Some(statement) = node_text(node, source)
+                && let Some(imported) = statement.strip_prefix("import ")
+            {
+                for spec in imported.split(',') {
+                    let mut parts = spec.split_whitespace();
+                    if parts.next() != Some("fastapi") {
+                        continue;
+                    }
+                    let alias = match (parts.next(), parts.next()) {
+                        (Some("as"), Some(alias)) => alias,
+                        _ => "fastapi",
+                    };
+                    ownership.modules.insert(alias.to_string());
+                }
+            }
+        }
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_fastapi_imports(child, source, ownership);
+    }
+}
+
+fn collect_fastapi_receivers(node: Node<'_>, source: &str, ownership: &mut FastApiOwnership) {
+    if node.kind() == "assignment"
+        && let Some(receiver) = node
+            .child_by_field_name("left")
+            .filter(|node| node.kind() == "identifier")
+            .and_then(|node| node_text(node, source))
+        && let Some(call) = node
+            .child_by_field_name("right")
+            .filter(|node| node.kind() == "call")
+        && let Some(function) = call.child_by_field_name("function")
+    {
+        let owned = match function.kind() {
+            "identifier" => node_text(function, source)
+                .is_some_and(|name| ownership.constructors.contains(&name)),
+            "attribute" => {
+                let module = function
+                    .child_by_field_name("object")
+                    .and_then(|node| node_text(node, source));
+                let constructor = function
+                    .child_by_field_name("attribute")
+                    .and_then(|node| node_text(node, source));
+                module.is_some_and(|module| ownership.modules.contains(&module))
+                    && constructor
+                        .as_deref()
+                        .is_some_and(|name| matches!(name, "FastAPI" | "APIRouter"))
+            }
+            _ => false,
+        };
+        if owned {
+            ownership.receivers.insert(receiver);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_fastapi_receivers(child, source, ownership);
+    }
+}
+
+fn fastapi_decorator_receiver_and_argument<'a>(
+    line: &'a str,
+    method: &str,
+) -> Option<(&'a str, &'a str)> {
+    let trimmed = line.trim_start().strip_prefix('@')?;
+    let (receiver, tail) = trimmed.split_once('.')?;
+    let argument = tail.strip_prefix(&format!("{}(", method.to_ascii_lowercase()))?;
+    Some((receiver, argument.trim_start()))
+}
+
+fn syntax_error_near_line(node: Node<'_>, line: u32) -> bool {
+    let start = node.start_position().row as u32 + 1;
+    let end = node.end_position().row as u32 + 1;
+    if (node.is_error() || node.is_missing())
+        && start <= line.saturating_add(2)
+        && end.saturating_add(2) >= line
+    {
+        return true;
+    }
+    if !node.has_error() {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .any(|child| syntax_error_near_line(child, line))
+}
+
+fn line_is_inside_python_string_or_comment(tree: &Tree, line: &str, line_number: u32) -> bool {
+    let row = line_number.saturating_sub(1) as usize;
+    let col = line.len().saturating_sub(line.trim_start().len());
+    let point = Point::new(row, col);
+    let mut node = tree.root_node().descendant_for_point_range(point, point);
+    while let Some(current) = node {
+        if matches!(current.kind(), "string" | "comment") {
+            return true;
+        }
+        node = current.parent();
+    }
+    false
 }
 
 fn node_text(node: Node<'_>, source: &str) -> Option<String> {
@@ -121,8 +300,11 @@ fn python_static_string(node: Node<'_>, source: &str) -> Option<String> {
     };
     let content_start = quote_start + delimiter_len;
     let content_end = text.len().checked_sub(delimiter_len)?;
-    (content_end >= content_start && text[content_end..].chars().all(|ch| ch == quote))
-        .then(|| text[content_start..content_end].to_string())
+    let content = (content_end >= content_start
+        && text[content_end..].chars().all(|ch| ch == quote))
+    .then(|| &text[content_start..content_end])?;
+    let raw = prefix.chars().any(|ch| matches!(ch, 'r' | 'R'));
+    (raw || !content.contains('\\')).then(|| content.to_string())
 }
 
 #[cfg(test)]
@@ -218,7 +400,11 @@ async def example(): pass
     #[test]
     fn test_fastapi_indexed_route_records_parser_claim_and_handler_edge() -> Result<()> {
         let source = r#"
-@router.get(
+from fastapi import APIRouter
+
+api = APIRouter()
+
+@api.get(
     r"/users/{user_id}",
 )
 async def show_user():
@@ -256,7 +442,11 @@ async def show_user():
 
     #[test]
     fn test_fastapi_syntax_error_fallback_stays_structural() -> Result<()> {
-        let source = "@app.get(\"/fallback\")\nasync def broken(\n";
+        let source = r#"from fastapi import FastAPI
+app = FastAPI()
+@app.get("/fallback")
+async def broken(
+"#;
         let result = super::super::index_file(
             Path::new("routes.py"),
             source,
@@ -274,6 +464,137 @@ async def show_user():
         let canonical_id = route.canonical_id.as_deref().expect("route metadata");
         assert!(canonical_id.contains(r#""extraction_provenance":"lexical_fallback""#));
         assert!(canonical_id.contains(r#""claim_tier":"structural""#));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fastapi_unowned_receiver_stays_structural_and_unrelated_app_is_ignored() -> Result<()> {
+        let imported = r#"
+from fastapi import APIRouter
+
+@router.get("/factory-owned-elsewhere")
+async def external_router(): pass
+"#;
+        let imported_result = super::super::index_file(
+            Path::new("imported.py"),
+            imported,
+            &super::super::get_language_for_ext("py").expect("python config"),
+            None,
+            None,
+        )?;
+        let route = imported_result
+            .nodes
+            .iter()
+            .find(|node| {
+                node.serialized_name
+                    == "GET /factory-owned-elsewhere (fastapi route; confidence=heuristic)"
+            })
+            .expect("unowned imported FastAPI receiver stays structural");
+        let canonical_id = route.canonical_id.as_deref().expect("route metadata");
+        assert!(canonical_id.contains(r#""extraction_provenance":"tree_sitter_query_unowned""#));
+        assert!(canonical_id.contains(r#""claim_tier":"structural""#));
+
+        let unrelated = r#"
+app = OtherFramework()
+
+@app.get("/not-fastapi")
+async def unrelated_handler(): pass
+"#;
+        let unrelated_result = super::super::index_file(
+            Path::new("unrelated.py"),
+            unrelated,
+            &super::super::get_language_for_ext("py").expect("python config"),
+            None,
+            None,
+        )?;
+        assert!(unrelated_result.nodes.iter().all(|node| {
+            !node
+                .canonical_id
+                .as_deref()
+                .is_some_and(|value| value.contains(r#""framework":"fastapi""#))
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fastapi_unsupported_decorators_and_nonliteral_paths_do_not_emit_exact_routes()
+    -> Result<()> {
+        let source = r#"
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get(path="/keyword")
+async def keyword_path(): pass
+
+@app.get("/escaped\x2fpath")
+async def escaped_path(): pass
+
+@app.head("/head")
+async def head_path(): pass
+
+@app.options("/options")
+async def options_path(): pass
+
+@app.api_route("/api-route", methods=["GET"])
+async def api_route_path(): pass
+
+@app.websocket("/socket")
+async def websocket_path(): pass
+"#;
+        let routes = collect_python_fastapi_routes(
+            &tree_sitter_python::LANGUAGE.into(),
+            &parse_python(source),
+            source,
+        )?;
+        assert!(
+            routes.is_empty(),
+            "unsupported shapes must not emit exact routes"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_fastapi_unrelated_parse_error_does_not_restore_dynamic_or_docstring_routes()
+    -> Result<()> {
+        let cases = [
+            r#"
+from fastapi import FastAPI
+app = FastAPI()
+EXAMPLE = """
+@app.get("/docstring-only")
+async def documented(): pass
+"""
+broken = (
+"#,
+            r#"
+from fastapi import FastAPI
+app = FastAPI()
+@app.get(f"/dynamic/{item_id}")
+async def broken(
+"#,
+            r#"
+from fastapi import FastAPI
+app = FastAPI()
+@app.get(build_path("/nested"))
+async def broken(
+"#,
+        ];
+        for source in cases {
+            let result = super::super::index_file(
+                Path::new("broken.py"),
+                source,
+                &super::super::get_language_for_ext("py").expect("python config"),
+                None,
+                None,
+            )?;
+            assert!(result.nodes.iter().all(|node| {
+                !node
+                    .canonical_id
+                    .as_deref()
+                    .is_some_and(|value| value.contains(r#""framework":"fastapi""#))
+            }));
+        }
         Ok(())
     }
 }

--- a/crates/codestory-indexer/src/framework_routes.rs
+++ b/crates/codestory-indexer/src/framework_routes.rs
@@ -1,0 +1,279 @@
+use super::FrameworkRoute;
+use anyhow::{Result, anyhow};
+use std::sync::OnceLock;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Language, Node, Query, QueryCursor, Tree};
+
+const PYTHON_FASTAPI_QUERY: &str = r#"
+(decorated_definition
+  (decorator
+    (call
+      function: (attribute
+        object: (identifier) @receiver
+        attribute: (identifier) @method)
+      arguments: (argument_list
+        . (string) @path))) @decorator
+  definition: (function_definition
+    name: (identifier) @handler))
+"#;
+
+static PYTHON_FASTAPI_COMPILED_QUERY: OnceLock<Result<Query, String>> = OnceLock::new();
+
+pub(super) fn collect_python_fastapi_routes(
+    language: &Language,
+    tree: &Tree,
+    source: &str,
+) -> Result<Vec<FrameworkRoute>> {
+    let query = PYTHON_FASTAPI_COMPILED_QUERY
+        .get_or_init(|| {
+            Query::new(language, PYTHON_FASTAPI_QUERY).map_err(|error| error.to_string())
+        })
+        .as_ref()
+        .map_err(|message| anyhow!(message.clone()))?;
+    let capture_names = query.capture_names();
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(query, tree.root_node(), source.as_bytes());
+    let mut routes = Vec::new();
+
+    while {
+        matches.advance();
+        matches.get().is_some()
+    } {
+        let Some(query_match) = matches.get() else {
+            continue;
+        };
+        let mut receiver = None;
+        let mut method = None;
+        let mut path = None;
+        let mut handler = None;
+        let mut line = None;
+
+        for capture in query_match.captures {
+            let name = capture_names
+                .get(capture.index as usize)
+                .copied()
+                .unwrap_or_default();
+            match name {
+                "receiver" => receiver = node_text(capture.node, source),
+                "method" => method = node_text(capture.node, source),
+                "path" => path = python_static_string(capture.node, source),
+                "handler" => handler = node_text(capture.node, source),
+                "decorator" => line = Some(capture.node.start_position().row as u32 + 1),
+                _ => {}
+            }
+        }
+
+        let (Some(receiver), Some(method), Some(path), Some(handler), Some(line)) =
+            (receiver, method, path, handler, line)
+        else {
+            continue;
+        };
+        if !matches!(receiver.as_str(), "app" | "router")
+            || !matches!(method.as_str(), "get" | "post" | "put" | "patch" | "delete")
+        {
+            continue;
+        }
+        routes.push(
+            FrameworkRoute::new(
+                "fastapi",
+                method.to_ascii_uppercase(),
+                path,
+                Some(handler),
+                line,
+                "decorator",
+            )
+            .with_claim_evidence("tree_sitter_query", "parser_backed"),
+        );
+    }
+
+    Ok(routes)
+}
+
+fn node_text(node: Node<'_>, source: &str) -> Option<String> {
+    node.utf8_text(source.as_bytes())
+        .ok()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn python_static_string(node: Node<'_>, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    if node
+        .named_children(&mut cursor)
+        .any(|child| child.kind() == "interpolation")
+    {
+        return None;
+    }
+    let text = node.utf8_text(source.as_bytes()).ok()?.trim();
+    let quote_start = text.find(['\'', '"'])?;
+    let prefix = &text[..quote_start];
+    if prefix.chars().any(|ch| matches!(ch, 'f' | 'F' | 'b' | 'B'))
+        || !prefix.chars().all(|ch| matches!(ch, 'r' | 'R' | 'u' | 'U'))
+    {
+        return None;
+    }
+    let quote = text.as_bytes()[quote_start] as char;
+    let delimiter_len = if text[quote_start..].starts_with(&format!("{quote}{quote}{quote}")) {
+        3
+    } else {
+        1
+    };
+    let content_start = quote_start + delimiter_len;
+    let content_end = text.len().checked_sub(delimiter_len)?;
+    (content_end >= content_start && text[content_end..].chars().all(|ch| ch == quote))
+        .then(|| text[content_start..content_end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::path::Path;
+    use tree_sitter::Parser;
+
+    fn parse_python(source: &str) -> Tree {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_python::LANGUAGE.into())
+            .expect("python grammar");
+        parser.parse(source, None).expect("python tree")
+    }
+
+    #[test]
+    fn test_fastapi_query_fixture_matrix_and_line_scan_comparison() -> Result<()> {
+        let source = r#"
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+@app.get("/simple")
+async def simple(): pass
+
+@app.post(r"/raw/{item_id}")
+async def raw_path(): pass
+
+@app.put(
+    "/multiline",
+)
+async def multiline(): pass
+
+@app.patch("/nested-dependency", dependencies=[Depends(require_user())])
+async def nested_dependency(): pass
+
+@app.get(f"/users/{user_id}")
+async def dynamic_template(): pass
+
+@app.get(build_path("/nested-path"))
+async def nested_path(): pass
+
+# @app.delete("/comment-only")
+
+EXAMPLE = """
+@app.get("/docstring-only")
+async def example(): pass
+"""
+"#;
+        let expected = HashSet::from([
+            ("GET".to_string(), "/simple".to_string()),
+            ("POST".to_string(), "/raw/:item_id".to_string()),
+            ("PUT".to_string(), "/multiline".to_string()),
+            ("PATCH".to_string(), "/nested-dependency".to_string()),
+        ]);
+        let lexical =
+            super::super::collect_framework_routes(Path::new("routes.py"), "python", source)
+                .into_iter()
+                .filter(|route| route.framework == "fastapi")
+                .map(|route| (route.method, route.path))
+                .collect::<HashSet<_>>();
+        let tree = parse_python(source);
+        let parser_routes =
+            collect_python_fastapi_routes(&tree_sitter_python::LANGUAGE.into(), &tree, source)?;
+        let parser = parser_routes
+            .iter()
+            .map(|route| (route.method.clone(), route.path.clone()))
+            .collect::<HashSet<_>>();
+
+        let lexical_tp = lexical.intersection(&expected).count();
+        let lexical_fp = lexical.difference(&expected).count();
+        let lexical_fn = expected.difference(&lexical).count();
+        let parser_tp = parser.intersection(&expected).count();
+        let parser_fp = parser.difference(&expected).count();
+        let parser_fn = expected.difference(&parser).count();
+        eprintln!(
+            "fastapi route matrix: line_scan tp={lexical_tp} fp={lexical_fp} fn={lexical_fn}; tree_sitter_query tp={parser_tp} fp={parser_fp} fn={parser_fn}"
+        );
+
+        assert_eq!((lexical_tp, lexical_fp, lexical_fn), (3, 3, 1));
+        assert_eq!((parser_tp, parser_fp, parser_fn), (4, 0, 0));
+        assert!(parser_routes.iter().all(|route| {
+            route.extraction_provenance == "tree_sitter_query"
+                && route.claim_tier == "parser_backed"
+                && route.confidence == "decorator"
+                && route.handler.is_some()
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fastapi_indexed_route_records_parser_claim_and_handler_edge() -> Result<()> {
+        let source = r#"
+@router.get(
+    r"/users/{user_id}",
+)
+async def show_user():
+    return None
+"#;
+        let result = super::super::index_file(
+            Path::new("routes.py"),
+            source,
+            &super::super::get_language_for_ext("py").expect("python config"),
+            None,
+            None,
+        )?;
+        let route = result
+            .nodes
+            .iter()
+            .find(|node| {
+                node.serialized_name == "GET /users/:user_id (fastapi route; confidence=decorator)"
+            })
+            .expect("parser-backed FastAPI route");
+        let handler = result
+            .nodes
+            .iter()
+            .find(|node| node.serialized_name == "show_user")
+            .expect("decorated handler");
+        let canonical_id = route.canonical_id.as_deref().expect("route metadata");
+        assert!(canonical_id.contains(r#""extraction_provenance":"tree_sitter_query""#));
+        assert!(canonical_id.contains(r#""claim_tier":"parser_backed""#));
+        assert!(result.edges.iter().any(|edge| {
+            edge.kind == codestory_contracts::graph::EdgeKind::CALL
+                && edge.source == route.id
+                && edge.target == handler.id
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn test_fastapi_syntax_error_fallback_stays_structural() -> Result<()> {
+        let source = "@app.get(\"/fallback\")\nasync def broken(\n";
+        let result = super::super::index_file(
+            Path::new("routes.py"),
+            source,
+            &super::super::get_language_for_ext("py").expect("python config"),
+            None,
+            None,
+        )?;
+        let route = result
+            .nodes
+            .iter()
+            .find(|node| {
+                node.serialized_name == "GET /fallback (fastapi route; confidence=heuristic)"
+            })
+            .expect("structural FastAPI fallback");
+        let canonical_id = route.canonical_id.as_deref().expect("route metadata");
+        assert!(canonical_id.contains(r#""extraction_provenance":"lexical_fallback""#));
+        assert!(canonical_id.contains(r#""claim_tier":"structural""#));
+        Ok(())
+    }
+}

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -16970,6 +16970,9 @@ fn append_framework_routes(
                     .into_iter()
                     .filter(|route| {
                         !parser_keys.contains(&(route.method.clone(), route.path.clone()))
+                            && framework_routes::allow_python_fastapi_lexical_fallback(
+                                tree, source, route,
+                            )
                     })
                     .map(|route| {
                         route

--- a/crates/codestory-indexer/src/lib.rs
+++ b/crates/codestory-indexer/src/lib.rs
@@ -35,6 +35,7 @@ use tree_sitter_graph::{ExecutionConfig, NoCancellation, Variables};
 mod cache;
 pub mod cancellation;
 pub mod compilation_database;
+mod framework_routes;
 pub mod intermediate_storage;
 mod language_configs;
 pub mod resolution;
@@ -14597,6 +14598,7 @@ struct FrameworkRoute {
     confidence: &'static str,
     source_convention: &'static str,
     extraction_provenance: &'static str,
+    claim_tier: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14645,11 +14647,28 @@ impl FrameworkRoute {
             confidence,
             source_convention: confidence,
             extraction_provenance: "line_scan",
+            claim_tier: "structural",
         }
     }
 
     fn with_extraction_provenance(mut self, extraction_provenance: &'static str) -> Self {
         self.extraction_provenance = extraction_provenance;
+        self
+    }
+
+    fn with_claim_evidence(
+        mut self,
+        extraction_provenance: &'static str,
+        claim_tier: &'static str,
+    ) -> Self {
+        self.extraction_provenance = extraction_provenance;
+        self.claim_tier = claim_tier;
+        self
+    }
+
+    fn with_confidence(mut self, confidence: &'static str) -> Self {
+        self.confidence = confidence;
+        self.source_convention = confidence;
         self
     }
 }
@@ -16685,9 +16704,11 @@ fn framework_route_canonical_id(route: &FrameworkRoute) -> String {
             "confidence": route.confidence,
             "source_convention": route.source_convention,
             "extraction_provenance": route.extraction_provenance,
+            "claim_tier": route.claim_tier,
             "provenance": [
                 format!("framework:{}", route.framework),
                 format!("extraction:{}", route.extraction_provenance),
+                format!("claim_tier:{}", route.claim_tier),
             ],
         })
     )
@@ -16916,14 +16937,50 @@ struct FrameworkRouteSinks<'a> {
 
 fn append_framework_routes(
     path: &Path,
-    language_name: &str,
+    language_config: &LanguageConfig,
+    tree: &Tree,
     source: &str,
     file_id: NodeId,
     flags: IndexFeatureFlags,
     sinks: &mut FrameworkRouteSinks<'_>,
-) {
-    for route in collect_framework_routes(path, language_name, source) {
-        let route = route.with_extraction_provenance("ast_indexed");
+) -> Result<()> {
+    let mut routes = collect_framework_routes(path, language_config.language_name, source)
+        .into_iter()
+        .map(|route| route.with_extraction_provenance("ast_indexed"))
+        .collect::<Vec<_>>();
+
+    if language_config.language_name == "python" {
+        let lexical_fastapi = routes
+            .extract_if(.., |route| route.framework == "fastapi")
+            .collect::<Vec<_>>();
+        let parser_routes = framework_routes::collect_python_fastapi_routes(
+            &language_config.language,
+            tree,
+            source,
+        )?;
+        let parser_keys = parser_routes
+            .iter()
+            .map(|route| (route.method.clone(), route.path.clone()))
+            .collect::<HashSet<_>>();
+        routes.extend(parser_routes);
+
+        if tree.root_node().has_error() {
+            routes.extend(
+                lexical_fastapi
+                    .into_iter()
+                    .filter(|route| {
+                        !parser_keys.contains(&(route.method.clone(), route.path.clone()))
+                    })
+                    .map(|route| {
+                        route
+                            .with_confidence("heuristic")
+                            .with_claim_evidence("lexical_fallback", "structural")
+                    }),
+            );
+        }
+    }
+
+    for route in routes {
         let route_node = framework_route_node(file_id, &route);
         let route_node_id = route_node.id;
         sinks
@@ -16977,6 +17034,7 @@ fn append_framework_routes(
         call_edge.id = EdgeId(generate_edge_id_for_edge(&call_edge, flags));
         sinks.result_edges.push(call_edge);
     }
+    Ok(())
 }
 
 fn find_framework_route_handler(
@@ -18596,7 +18654,8 @@ pub fn index_file(
     );
     append_framework_routes(
         path,
-        language_config.language_name,
+        language_config,
+        &tree,
         source,
         file_id,
         flags,
@@ -18608,7 +18667,7 @@ pub fn index_file(
             edge_keys: &mut edge_keys,
             callsite_ordinals: &mut callsite_ordinals,
         },
-    );
+    )?;
 
     if language_config.language_name == "rust" {
         apply_rust_receiver_call_hints(&tree, source, &mut unique_nodes);

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -194,19 +194,28 @@ fn route_endpoint_extraction_score_adjustment(canonical_id: Option<&str>) -> f32
         return 0.0;
     };
 
-    if canonical
-        .provenance
-        .iter()
-        .any(|entry| entry == "extraction:ast_indexed")
-    {
+    if canonical.provenance.iter().any(|entry| {
+        matches!(
+            entry.as_str(),
+            "extraction:ast_indexed" | "extraction:tree_sitter_query"
+        )
+    }) {
         return 0.025;
+    }
+    if canonical.provenance.iter().any(|entry| {
+        matches!(
+            entry.as_str(),
+            "extraction:text_only" | "extraction:lexical_fallback"
+        )
+    }) {
+        return -0.025;
     }
     if canonical
         .provenance
         .iter()
-        .any(|entry| entry == "extraction:text_only")
+        .any(|entry| entry == "extraction:tree_sitter_query_unowned")
     {
-        return -0.025;
+        return -0.01;
     }
     0.0
 }
@@ -544,10 +553,14 @@ const FRAMEWORK_ROUTE_COVERAGE_ENTRIES: &[FrameworkRouteCoverageEntry] = &[
         framework: "fastapi",
         language: "python",
         status: "partial",
-        coverage_evidence: "validated_by_indexer_regression",
-        confidence_floor: "decorator",
-        handler_link_support: "not_claimed",
-        unsupported_patterns: &["router prefixes and dependency-driven routing are partial"],
+        coverage_evidence: "validated_by_tree_sitter_query_regression",
+        confidence_floor: "heuristic",
+        handler_link_support: "probable_for_decorated_handler",
+        unsupported_patterns: &[
+            "path= keyword arguments and escaped non-raw string literals are not exact routes",
+            "head/options/api_route/websocket decorators are not indexed",
+            "factory-returned or injected router receivers without local construction stay structural",
+        ],
         known_gaps: &["include_router prefix propagation is not modeled"],
         promotable: true,
     },
@@ -12657,6 +12670,32 @@ mod tests {
                 .filter(|entry| entry.language == "go")
                 .all(|entry| entry.handler_link_support == "not_claimed_text_only")
         );
+        let fastapi = coverage
+            .iter()
+            .find(|entry| entry.framework == "fastapi")
+            .expect("FastAPI coverage entry");
+        assert_eq!(
+            fastapi.coverage_evidence,
+            "validated_by_tree_sitter_query_regression"
+        );
+        assert_eq!(
+            fastapi.handler_link_support,
+            "probable_for_decorated_handler"
+        );
+        assert_eq!(fastapi.confidence_floor, "heuristic");
+        for unsupported in [
+            "path= keyword arguments",
+            "head/options/api_route/websocket",
+            "without local construction stay structural",
+        ] {
+            assert!(
+                fastapi
+                    .unsupported_patterns
+                    .iter()
+                    .any(|pattern| pattern.contains(unsupported)),
+                "FastAPI coverage should record {unsupported}"
+            );
+        }
     }
 
     #[test]
@@ -15551,12 +15590,42 @@ fn build_llm_symbol_doc_text() -> String {
                     start_line: Some(8),
                     ..Default::default()
                 },
+                Node {
+                    id: CoreNodeId(25),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "GET /api/users".to_string(),
+                    file_node_id: Some(CoreNodeId(20)),
+                    canonical_id: Some(route_canonical_id("tree_sitter_query")),
+                    start_line: Some(4),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(26),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "GET /api/users".to_string(),
+                    file_node_id: Some(CoreNodeId(20)),
+                    canonical_id: Some(route_canonical_id("lexical_fallback")),
+                    start_line: Some(5),
+                    ..Default::default()
+                },
+                Node {
+                    id: CoreNodeId(27),
+                    kind: NodeKind::FUNCTION,
+                    serialized_name: "GET /api/users".to_string(),
+                    file_node_id: Some(CoreNodeId(20)),
+                    canonical_id: Some(route_canonical_id("tree_sitter_query_unowned")),
+                    start_line: Some(6),
+                    ..Default::default()
+                },
             ])
             .expect("insert route nodes");
         let node_names = HashMap::from([
             (CoreNodeId(22), "GET /api/users".to_string()),
             (CoreNodeId(23), "GET /api/users".to_string()),
             (CoreNodeId(24), "plain_handler".to_string()),
+            (CoreNodeId(25), "GET /api/users".to_string()),
+            (CoreNodeId(26), "GET /api/users".to_string()),
+            (CoreNodeId(27), "GET /api/users".to_string()),
         ]);
 
         let ast = AppController::build_search_hit(&storage, &node_names, CoreNodeId(22), 1.0)
@@ -15565,6 +15634,14 @@ fn build_llm_symbol_doc_text() -> String {
             .expect("text-only route hit");
         let normal = AppController::build_search_hit(&storage, &node_names, CoreNodeId(24), 1.0)
             .expect("normal hit");
+        let tree_sitter =
+            AppController::build_search_hit(&storage, &node_names, CoreNodeId(25), 1.0)
+                .expect("tree-sitter route hit");
+        let lexical_fallback =
+            AppController::build_search_hit(&storage, &node_names, CoreNodeId(26), 1.0)
+                .expect("lexical fallback route hit");
+        let unowned = AppController::build_search_hit(&storage, &node_names, CoreNodeId(27), 1.0)
+            .expect("unowned query route hit");
 
         assert!(
             ast.score > text_only.score,
@@ -15572,6 +15649,10 @@ fn build_llm_symbol_doc_text() -> String {
         );
         assert!(ast.score > normal.score);
         assert!(text_only.score < normal.score);
+        assert_eq!(tree_sitter.score, ast.score);
+        assert_eq!(lexical_fallback.score, text_only.score);
+        assert!(unowned.score < normal.score);
+        assert!(unowned.score > lexical_fallback.score);
         assert_eq!(normal.score, 1.0);
 
         let mut hits = [text_only, ast.clone()];

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -552,6 +552,7 @@ const FRAMEWORK_ROUTE_COVERAGE_ENTRIES: &[FrameworkRouteCoverageEntry] = &[
         unsupported_patterns: &[
             "path= keyword arguments and escaped non-raw string literals are not exact routes",
             "head/options/api_route/websocket decorators are not indexed",
+            "chained or multi-target FastAPI/APIRouter construction is not promoted",
             "factory-returned or injected router receivers without module-scope construction are not claimed",
         ],
         known_gaps: &["include_router prefix propagation is not modeled"],
@@ -12679,6 +12680,7 @@ mod tests {
         for unsupported in [
             "path= keyword arguments",
             "head/options/api_route/websocket",
+            "chained or multi-target FastAPI/APIRouter construction",
             "without module-scope construction are not claimed",
         ] {
             assert!(

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -210,13 +210,6 @@ fn route_endpoint_extraction_score_adjustment(canonical_id: Option<&str>) -> f32
     }) {
         return -0.025;
     }
-    if canonical
-        .provenance
-        .iter()
-        .any(|entry| entry == "extraction:tree_sitter_query_unowned")
-    {
-        return -0.01;
-    }
     0.0
 }
 
@@ -559,7 +552,7 @@ const FRAMEWORK_ROUTE_COVERAGE_ENTRIES: &[FrameworkRouteCoverageEntry] = &[
         unsupported_patterns: &[
             "path= keyword arguments and escaped non-raw string literals are not exact routes",
             "head/options/api_route/websocket decorators are not indexed",
-            "factory-returned or injected router receivers without local construction stay structural",
+            "factory-returned or injected router receivers without module-scope construction are not claimed",
         ],
         known_gaps: &["include_router prefix propagation is not modeled"],
         promotable: true,
@@ -12686,7 +12679,7 @@ mod tests {
         for unsupported in [
             "path= keyword arguments",
             "head/options/api_route/websocket",
-            "without local construction stay structural",
+            "without module-scope construction are not claimed",
         ] {
             assert!(
                 fastapi
@@ -15608,15 +15601,6 @@ fn build_llm_symbol_doc_text() -> String {
                     start_line: Some(5),
                     ..Default::default()
                 },
-                Node {
-                    id: CoreNodeId(27),
-                    kind: NodeKind::FUNCTION,
-                    serialized_name: "GET /api/users".to_string(),
-                    file_node_id: Some(CoreNodeId(20)),
-                    canonical_id: Some(route_canonical_id("tree_sitter_query_unowned")),
-                    start_line: Some(6),
-                    ..Default::default()
-                },
             ])
             .expect("insert route nodes");
         let node_names = HashMap::from([
@@ -15625,7 +15609,6 @@ fn build_llm_symbol_doc_text() -> String {
             (CoreNodeId(24), "plain_handler".to_string()),
             (CoreNodeId(25), "GET /api/users".to_string()),
             (CoreNodeId(26), "GET /api/users".to_string()),
-            (CoreNodeId(27), "GET /api/users".to_string()),
         ]);
 
         let ast = AppController::build_search_hit(&storage, &node_names, CoreNodeId(22), 1.0)
@@ -15640,8 +15623,6 @@ fn build_llm_symbol_doc_text() -> String {
         let lexical_fallback =
             AppController::build_search_hit(&storage, &node_names, CoreNodeId(26), 1.0)
                 .expect("lexical fallback route hit");
-        let unowned = AppController::build_search_hit(&storage, &node_names, CoreNodeId(27), 1.0)
-            .expect("unowned query route hit");
 
         assert!(
             ast.score > text_only.score,
@@ -15651,8 +15632,6 @@ fn build_llm_symbol_doc_text() -> String {
         assert!(text_only.score < normal.score);
         assert_eq!(tree_sitter.score, ast.score);
         assert_eq!(lexical_fallback.score, text_only.score);
-        assert!(unowned.score < normal.score);
-        assert!(unowned.score > lexical_fallback.score);
         assert_eq!(normal.score, 1.0);
 
         let mut hits = [text_only, ast.clone()];

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -151,12 +151,13 @@ language can have parser-backed graph support while a framework remains partial
 or heuristic. A route claim needs fixture or real-repo route evidence, not just a
 language parser. FastAPI decorator routes are parser-backed only when a
 tree-sitter query captures a static string path and decorated handler on a
-module-scope receiver whose latest preceding binding constructs an imported
-`FastAPI` or `APIRouter`. Later assignments, imports, functions, and classes
-invalidate shadowed ownership; unmatched, injected, factory-returned, and
-nested-scope receivers are not labeled as FastAPI. Error-local line-scan
-recovery remains structural evidence. Dynamic paths and ordinary escaped
-literals do not become exact route claims.
+single-target module-scope receiver whose latest preceding binding constructs
+an imported `FastAPI` or `APIRouter`. Later assignments, imports, functions,
+and classes invalidate shadowed ownership. Chained or multi-target constructor
+assignments are conservatively not promoted; unmatched, injected,
+factory-returned, and nested-scope receivers are not labeled as FastAPI.
+Error-local line-scan recovery remains structural evidence. Dynamic paths and
+ordinary escaped literals do not become exact route claims.
 
 ## Expansion Checklist
 

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -149,7 +149,10 @@ Framework route extraction has its own confidence labels in
 [framework-route-coverage.md](../testing/framework-route-coverage.md). A
 language can have parser-backed graph support while a framework remains partial
 or heuristic. A route claim needs fixture or real-repo route evidence, not just a
-language parser.
+language parser. FastAPI decorator routes are parser-backed only when a
+tree-sitter query captures a static string path and its decorated handler;
+syntax-error line-scan recovery remains structural evidence and dynamic path
+expressions do not become exact route claims.
 
 ## Expansion Checklist
 

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -151,11 +151,12 @@ language can have parser-backed graph support while a framework remains partial
 or heuristic. A route claim needs fixture or real-repo route evidence, not just a
 language parser. FastAPI decorator routes are parser-backed only when a
 tree-sitter query captures a static string path and decorated handler on a
-module-scope receiver whose latest preceding assignment constructs an imported
-`FastAPI` or `APIRouter`. Reassignment invalidates ownership; unmatched,
-injected, factory-returned, and nested-scope receivers are not labeled as
-FastAPI. Error-local line-scan recovery remains structural evidence. Dynamic
-paths and ordinary escaped literals do not become exact route claims.
+module-scope receiver whose latest preceding binding constructs an imported
+`FastAPI` or `APIRouter`. Later assignments, imports, functions, and classes
+invalidate shadowed ownership; unmatched, injected, factory-returned, and
+nested-scope receivers are not labeled as FastAPI. Error-local line-scan
+recovery remains structural evidence. Dynamic paths and ordinary escaped
+literals do not become exact route claims.
 
 ## Expansion Checklist
 

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -150,9 +150,11 @@ Framework route extraction has its own confidence labels in
 language can have parser-backed graph support while a framework remains partial
 or heuristic. A route claim needs fixture or real-repo route evidence, not just a
 language parser. FastAPI decorator routes are parser-backed only when a
-tree-sitter query captures a static string path and its decorated handler;
-syntax-error line-scan recovery remains structural evidence and dynamic path
-expressions do not become exact route claims.
+tree-sitter query captures a static string path and decorated handler on a
+receiver locally constructed from an imported `FastAPI` or `APIRouter`.
+Imported but unowned receivers and error-local line-scan recovery remain
+structural evidence. Dynamic paths and ordinary escaped literals do not become
+exact route claims.
 
 ## Expansion Checklist
 

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -151,10 +151,11 @@ language can have parser-backed graph support while a framework remains partial
 or heuristic. A route claim needs fixture or real-repo route evidence, not just a
 language parser. FastAPI decorator routes are parser-backed only when a
 tree-sitter query captures a static string path and decorated handler on a
-receiver locally constructed from an imported `FastAPI` or `APIRouter`.
-Imported but unowned receivers and error-local line-scan recovery remain
-structural evidence. Dynamic paths and ordinary escaped literals do not become
-exact route claims.
+module-scope receiver whose latest preceding assignment constructs an imported
+`FastAPI` or `APIRouter`. Reassignment invalidates ownership; unmatched,
+injected, factory-returned, and nested-scope receivers are not labeled as
+FastAPI. Error-local line-scan recovery remains structural evidence. Dynamic
+paths and ordinary escaped literals do not become exact route claims.
 
 ## Expansion Checklist
 

--- a/docs/testing/framework-route-coverage.md
+++ b/docs/testing/framework-route-coverage.md
@@ -70,11 +70,12 @@ be checked with `files --path <fragment>` or a fresh index.
 FastAPI route metadata records `claim_tier=parser_backed` with
 `extraction_provenance=tree_sitter_query`. Its syntax-error fallback records
 `claim_tier=structural`, `extraction_provenance=lexical_fallback`, and
-`confidence=heuristic`. Keyword `path=` arguments, ordinary escaped string
-literals, and `head`, `options`, `api_route`, and `websocket` decorators are not
-exact route claims in this slice. Factory-returned, injected, and nested-scope
-routers are not labeled as FastAPI until receiver-specific provenance is
-resolved.
+  `confidence=heuristic`. Keyword `path=` arguments, ordinary escaped string
+  literals, and `head`, `options`, `api_route`, and `websocket` decorators are not
+  exact route claims in this slice. Chained or multi-target constructor
+  assignments, including `app = router = FastAPI()`, are not promoted.
+  Factory-returned, injected, and nested-scope routers are not labeled as
+  FastAPI until receiver-specific provenance is resolved.
 
 ## Verification Playbook
 

--- a/docs/testing/framework-route-coverage.md
+++ b/docs/testing/framework-route-coverage.md
@@ -18,10 +18,10 @@ status, confidence floor, handler-link support, known gaps, and promotability.
 - Astro/Vue: Astro and Nuxt file-convention routes, plus Vue Router object
   routes.
 - Python: Django and Flask retain structural collectors. FastAPI decorators on
-  locally constructed `FastAPI`/`APIRouter` receivers use a tree-sitter query
-  for static string paths and handler links. Imported but unowned receivers and
-  error-local malformed-file recovery are explicitly structural and
-  low-confidence.
+  source-ordered module bindings constructed from imported
+  `FastAPI`/`APIRouter` constructors use a tree-sitter query for static string
+  paths and handler links. Error-local malformed-file recovery is explicitly
+  structural and low-confidence; unmatched receivers are not FastAPI claims.
 - Ruby/PHP/Java/C#: Rails, Laravel, Spring, ASP.NET.
 - Rust: Axum, Actix, Rocket.
 - Go: Gin, Chi, Echo, Fiber as text-only partial route extraction until Go
@@ -69,11 +69,11 @@ be checked with `files --path <fragment>` or a fresh index.
 FastAPI route metadata records `claim_tier=parser_backed` with
 `extraction_provenance=tree_sitter_query`. Its syntax-error fallback records
 `claim_tier=structural`, `extraction_provenance=lexical_fallback`, and
-`confidence=heuristic`; imported receivers without a local constructor record
-`tree_sitter_query_unowned` at the structural tier. Keyword `path=` arguments,
-ordinary escaped string literals, and `head`, `options`, `api_route`, and
-`websocket` decorators are not exact route claims in this slice. Factory-returned
-or injected routers remain structural until receiver provenance is resolved.
+`confidence=heuristic`. Keyword `path=` arguments, ordinary escaped string
+literals, and `head`, `options`, `api_route`, and `websocket` decorators are not
+exact route claims in this slice. Factory-returned, injected, and nested-scope
+routers are not labeled as FastAPI until receiver-specific provenance is
+resolved.
 
 ## Verification Playbook
 

--- a/docs/testing/framework-route-coverage.md
+++ b/docs/testing/framework-route-coverage.md
@@ -17,7 +17,9 @@ status, confidence floor, handler-link support, known gaps, and promotability.
   Remix, Fastify, Koa, Hono, NestJS.
 - Astro/Vue: Astro and Nuxt file-convention routes, plus Vue Router object
   routes.
-- Python: Django, Flask, FastAPI.
+- Python: Django and Flask retain structural collectors. FastAPI decorators use
+  a tree-sitter query for static string paths and handler links; malformed-file
+  lexical recovery is explicitly structural and low-confidence.
 - Ruby/PHP/Java/C#: Rails, Laravel, Spring, ASP.NET.
 - Rust: Axum, Actix, Rocket.
 - Go: Gin, Chi, Echo, Fiber as text-only partial route extraction until Go
@@ -61,6 +63,11 @@ be checked with `files --path <fragment>` or a fresh index.
   annotation, C# attribute, or Rust attribute.
 - `heuristic`: route comes from text/tree-sitter pattern matching and needs
   source review before claiming handler parity.
+
+FastAPI route metadata records `claim_tier=parser_backed` with
+`extraction_provenance=tree_sitter_query`. Its syntax-error fallback records
+`claim_tier=structural`, `extraction_provenance=lexical_fallback`, and
+`confidence=heuristic`; it must not be promoted as parser-backed evidence.
 
 ## Verification Playbook
 

--- a/docs/testing/framework-route-coverage.md
+++ b/docs/testing/framework-route-coverage.md
@@ -17,9 +17,11 @@ status, confidence floor, handler-link support, known gaps, and promotability.
   Remix, Fastify, Koa, Hono, NestJS.
 - Astro/Vue: Astro and Nuxt file-convention routes, plus Vue Router object
   routes.
-- Python: Django and Flask retain structural collectors. FastAPI decorators use
-  a tree-sitter query for static string paths and handler links; malformed-file
-  lexical recovery is explicitly structural and low-confidence.
+- Python: Django and Flask retain structural collectors. FastAPI decorators on
+  locally constructed `FastAPI`/`APIRouter` receivers use a tree-sitter query
+  for static string paths and handler links. Imported but unowned receivers and
+  error-local malformed-file recovery are explicitly structural and
+  low-confidence.
 - Ruby/PHP/Java/C#: Rails, Laravel, Spring, ASP.NET.
 - Rust: Axum, Actix, Rocket.
 - Go: Gin, Chi, Echo, Fiber as text-only partial route extraction until Go
@@ -67,7 +69,11 @@ be checked with `files --path <fragment>` or a fresh index.
 FastAPI route metadata records `claim_tier=parser_backed` with
 `extraction_provenance=tree_sitter_query`. Its syntax-error fallback records
 `claim_tier=structural`, `extraction_provenance=lexical_fallback`, and
-`confidence=heuristic`; it must not be promoted as parser-backed evidence.
+`confidence=heuristic`; imported receivers without a local constructor record
+`tree_sitter_query_unowned` at the structural tier. Keyword `path=` arguments,
+ordinary escaped string literals, and `head`, `options`, `api_route`, and
+`websocket` decorators are not exact route claims in this slice. Factory-returned
+or injected routers remain structural until receiver provenance is resolved.
 
 ## Verification Playbook
 

--- a/docs/testing/framework-route-coverage.md
+++ b/docs/testing/framework-route-coverage.md
@@ -20,7 +20,8 @@ status, confidence floor, handler-link support, known gaps, and promotability.
 - Python: Django and Flask retain structural collectors. FastAPI decorators on
   source-ordered module bindings constructed from imported
   `FastAPI`/`APIRouter` constructors use a tree-sitter query for static string
-  paths and handler links. Error-local malformed-file recovery is explicitly
+  paths and handler links. Later assignment, import, function, or class bindings
+  invalidate stale ownership. Error-local malformed-file recovery is explicitly
   structural and low-confidence; unmatched receivers are not FastAPI claims.
 - Ruby/PHP/Java/C#: Rails, Laravel, Spring, ASP.NET.
 - Rust: Axum, Actix, Rocket.


### PR DESCRIPTION
## Context

FastAPI route collection scanned stripped source lines and quoted strings, which produced false claims from comments, docstrings, dynamic templates, and unrelated receivers while missing multiline decorators. This is the first PR-sized parser-backed family migration under #920.

Closes #950
Refs #920, #899

## What Changed

- Added a Python tree-sitter query adapter for FastAPI decorators and decorated handlers.
- Requires source-ordered module ownership from imported `FastAPI`/`APIRouter` constructors before parser-backed promotion.
- Invalidates ownership across imports, assignments, definitions, deletes, tuple/destructuring targets, and chained bindings.
- Keeps malformed-source recovery structural, heuristic, locally owned, error-local, and limited to direct static literals.
- Gives query and lexical-fallback provenance distinct ranking treatment.
- Updates the canonical coverage matrix and documents unsupported patterns, including chained/multi-target construction.

```mermaid
flowchart LR
    Source[Python source] --> Query[tree-sitter FastAPI query]
    Query --> Ownership[source-ordered module ownership]
    Ownership -->|owned + static| Parser[parser-backed route + handler]
    Ownership -->|unowned or unsupported| None[no FastAPI claim]
    Source -->|near syntax error| Fallback[structural lexical fallback]
```

## How To Review

1. Review binding and extraction rules in `framework_routes.rs`, especially reassignment and compound targets.
2. Review provenance plumbing and fallback routing in the indexer.
3. Confirm runtime ranking and coverage metadata agree with the documented claim boundary.
4. Compare the measured matrix: old line scan TP=3/FP=3/FN=1; query TP=4/FP=0/FN=0.

## Verification

- Framework-route tests: 13 passed.
- Full indexer library: 163 passed.
- Fidelity regression binary: 8 passed.
- Language coverage binary: 12 passed.
- Focused runtime ranking and coverage tests: passed.
- Indexer/runtime Clippy with `-D warnings`: passed.
- Release CLI build: passed.
- Formatting, documentation links, and diff checks: passed.

The ignored repository-scale e2e was attempted but could not emit a stats row because the real-repo drill manifest and embedding model assets were unavailable. No row was fabricated.

## Risk

- The extractor is deliberately conservative: injected/factory receivers, escaped ordinary literals, `path=` keyword routes, several method families, and chained/multi-target construction remain unclaimed rather than guessed.
- Other framework families are unchanged and remain tracked by #920.
