### PR TITLE
build attested release evidence pipeline

### DIFF
--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -1,0 +1,187 @@
+name: Release candidate evidence
+
+on:
+  workflow_call:
+    inputs:
+      profile:
+        required: true
+        type: string
+      drill_manifest:
+        required: false
+        type: string
+        default: ""
+      embedding_model_dir:
+        required: false
+        type: string
+        default: ""
+      source_run_id:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON:
+        required: false
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Approved release-eligible profile id.
+        required: true
+        type: string
+      drill_manifest:
+        description: Absolute path to the prepared real-repo drill manifest on the evidence runner.
+        required: false
+        type: string
+      embedding_model_dir:
+        description: Absolute path containing bge-base-en-v1.5.Q8_0.gguf on the evidence runner.
+        required: false
+        type: string
+      source_run_id:
+        description: Optional prior rejected evidence run id to re-evaluate without re-measuring.
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  measure:
+    name: Measure release candidate
+    runs-on: [self-hosted, linux, codestory-release-evidence]
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Record and validate runner provisioning
+        if: inputs.source_run_id == ''
+        shell: python
+        env:
+          PROFILE: ${{ inputs.profile }}
+          DRILL_MANIFEST: ${{ inputs.drill_manifest }}
+          EMBEDDING_MODEL_DIR: ${{ inputs.embedding_model_dir }}
+        run: |
+          import json, os, pathlib, shutil
+          out = pathlib.Path("target/release-evidence")
+          out.mkdir(parents=True, exist_ok=True)
+          drill = pathlib.Path(os.environ["DRILL_MANIFEST"])
+          model = pathlib.Path(os.environ["EMBEDDING_MODEL_DIR"]) / "bge-base-en-v1.5.Q8_0.gguf"
+          memory_gib = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES") / 2**30
+          disk_gib = shutil.disk_usage(".").free / 2**30
+          proof = {
+              "profile": os.environ["PROFILE"],
+              "runner_labels": ["self-hosted", "linux", "codestory-release-evidence"],
+              "drill_manifest": str(drill),
+              "drill_manifest_exists": drill.is_file(),
+              "embedding_model": str(model),
+              "embedding_model_exists": model.is_file(),
+              "memory_gib": round(memory_gib, 2),
+              "free_disk_gib": round(disk_gib, 2),
+          }
+          (out / "provisioning.json").write_text(json.dumps(proof, indent=2) + "\n")
+          assert proof["profile"]
+          assert proof["drill_manifest_exists"]
+          assert proof["embedding_model_exists"]
+          assert memory_gib >= 16
+          assert disk_gib >= 20
+
+      - name: Build release CLI
+        if: inputs.source_run_id == ''
+        run: cargo build --release -p codestory-cli
+
+      - name: Capture machine fingerprint
+        if: inputs.source_run_id == ''
+        id: machine
+        shell: bash
+        run: echo "fingerprint=$(node scripts/codestory-release-evidence-gate.mjs fingerprint)" >> "$GITHUB_OUTPUT"
+
+      - name: Produce full-sidecar repo evidence
+        if: inputs.source_run_id == ''
+        shell: bash
+        env:
+          CODESTORY_RELEASE_EVIDENCE_STATS_PATH: ${{ github.workspace }}/target/release-evidence/stats.json
+          CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ github.sha }}
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v1
+          CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-full-sidecar-v1
+          CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
+          CODESTORY_REAL_REPO_DRILL_CASES: ${{ inputs.drill_manifest }}
+          CODESTORY_EMBED_MODEL_DIR: ${{ inputs.embedding_model_dir }}
+        run: cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture
+
+      - name: Produce publishable packet evidence
+        if: inputs.source_run_id == ''
+        shell: bash
+        env:
+          CODESTORY_RELEASE_EVIDENCE_COMMIT: ${{ github.sha }}
+          CODESTORY_RELEASE_EVIDENCE_PROFILE: ${{ inputs.profile }}
+          CODESTORY_RELEASE_EVIDENCE_CORPUS_ID: codestory-release-corpus-v1
+          CODESTORY_RELEASE_EVIDENCE_CACHE_ID: cold-full-sidecar-v1
+          CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT: ${{ steps.machine.outputs.fingerprint }}
+          CODESTORY_EMBED_MODEL_DIR: ${{ inputs.embedding_model_dir }}
+        run: |
+          node scripts/codestory-agent-ab-benchmark.mjs \
+            --packet-runtime \
+            --packet-runtime-mode cold-cli \
+            --task-suite holdout-retrieval \
+            --materialize-repos \
+            --repeats 3 \
+            --publishable \
+            --max-source-reads-after-packet 0 \
+            --codestory-cli target/release/codestory-cli \
+            --timeout-ms 180000 \
+            --out-dir target/release-evidence/packet
+
+      - name: Download prior rejected evidence for approval re-evaluation
+        if: inputs.source_run_id != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          mkdir -p target/release-evidence
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "release-evidence-$GITHUB_SHA" \
+            --dir target/release-evidence
+
+      - name: Produce and evaluate same-SHA candidate
+        shell: bash
+        env:
+          PROFILE: ${{ inputs.profile }}
+          APPROVAL_JSON: ${{ secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SOURCE_RUN_ID" ]; then
+            node scripts/codestory-release-evidence-gate.mjs produce \
+              --baseline benchmarks/release-evidence/approved-baselines.json \
+              --profile "$PROFILE" \
+              --stats target/release-evidence/stats.json \
+              --packet target/release-evidence/packet/packet-runtime-summary.json \
+              --out target/release-evidence/candidate.json \
+              --expected-sha "$GITHUB_SHA" \
+              --mode release \
+              --repo "$GITHUB_WORKSPACE"
+          fi
+          approval_args=()
+          if [ -n "$APPROVAL_JSON" ]; then
+            printf '%s' "$APPROVAL_JSON" > target/release-evidence/approval.json
+            approval_args=(--approval target/release-evidence/approval.json)
+          fi
+          node scripts/codestory-release-evidence-gate.mjs evaluate \
+            --baseline benchmarks/release-evidence/approved-baselines.json \
+            --candidate target/release-evidence/candidate.json \
+            --out target/release-evidence/report.json \
+            --expected-sha "$GITHUB_SHA" \
+            --mode release \
+            --repo "$GITHUB_WORKSPACE" \
+            "${approval_args[@]}"
+
+      - name: Upload release evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-evidence-${{ github.sha }}
+          path: target/release-evidence
+          if-no-files-found: warn

--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -24,6 +24,9 @@ on:
       - crates/codestory-indexer/Cargo.toml
       - crates/codestory-indexer/src/lib.rs
       - scripts/lint-retrieval-generalization.mjs
+      - scripts/codestory-release-evidence-gate.mjs
+      - scripts/tests/codestory-release-evidence-gate.test.mjs
+      - benchmarks/release-evidence/**
       - scripts/**retrieval**
       - docs/ops/retrieval-sidecars.md
       - docs/architecture/retrieval-*.md
@@ -54,6 +57,9 @@ on:
       - crates/codestory-indexer/Cargo.toml
       - crates/codestory-indexer/src/lib.rs
       - scripts/lint-retrieval-generalization.mjs
+      - scripts/codestory-release-evidence-gate.mjs
+      - scripts/tests/codestory-release-evidence-gate.test.mjs
+      - benchmarks/release-evidence/**
       - scripts/**retrieval**
       - docs/ops/retrieval-sidecars.md
       - docs/architecture/retrieval-*.md
@@ -80,6 +86,9 @@ jobs:
 
       - name: Generalization lint (production paths)
         run: node scripts/lint-retrieval-generalization.mjs
+
+      - name: Release evidence gate contracts
+        run: node --test scripts/tests/codestory-release-evidence-gate.test.mjs
 
       - name: Install Rust stable
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
   literals, and unrelated-error lexical candidates do not become exact route
   claims. Error-local syntax recovery stays explicitly structural and
   low-confidence.
+- Added a fail-closed, machine-profiled release evidence gate with pinned
+  approved references and separate budgets for status, local grounding,
+  convergence, packet, search, indexing, and storage growth. Decision reports
+  retain metric status, release decision, full commits, rationale, and artifact
+  hashes; an appended telemetry row cannot become its own baseline. A
+  provisioned same-SHA manual/reusable workflow now produces raw repo/packet
+  evidence without changing the current release path before a live profile is
+  approved.
 - Added a schema-backed publication generation and run identity to every staged
   full and incremental core database. Typed store and runtime reads now expose
   the generation that owns the live graph, and cache finalization verifies that
@@ -30,6 +38,11 @@
   readers, and preserves the legacy path for databases without an identity.
 
 ### Fixed
+
+- Extended the retrieval generalization guard from derived query literals to
+  direct and split Rust string dependencies on eval/query corpus paths across
+  production crates, including benchmark manifests, query catalogs, packet
+  fixtures, agent-quality fixtures, and eval probes.
 
 - Kept project-scoped MCP reads available during a single-flight local refresh
   by opening published SQLite generations read-only, serving the last complete

--- a/benchmarks/release-evidence/approved-baselines.json
+++ b/benchmarks/release-evidence/approved-baselines.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 2,
+  "profiles": {
+    "ci-contract-v1": {
+      "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
+      "status": "approved",
+      "release_eligible": false,
+      "commit": "1111111111111111111111111111111111111111",
+      "git_state": "clean",
+      "identity": {
+        "corpus_id": "ci-contract-corpus-v1",
+        "cache_id": "cold-full-sidecar-v1",
+        "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB"
+      },
+      "approval": {
+        "owner": "CodeStory CI contract",
+        "approved_at": "2026-07-11",
+        "rationale": "Deterministic checked-in contract fixture only; deliberately ineligible for product release evidence."
+      },
+      "artifacts": [
+        {
+          "path": "fixtures/baseline-raw.json",
+          "sha256": "045099bc10d243f1f94ccf8a853fdce11fda012c90fe52bbc7302dce373073fc"
+        }
+      ],
+      "metrics": {
+        "status_seconds": { "reference": 1, "threshold": 1.25, "unit": "seconds", "aggregation": "full-sidecar command wall time", "direction": "max", "source": "baseline-raw.json" },
+        "local_grounding_seconds": { "reference": 1, "threshold": 1.25, "unit": "seconds", "aggregation": "full-sidecar command wall time", "direction": "max", "source": "baseline-raw.json" },
+        "convergence_seconds": { "reference": 10, "threshold": 11.5, "unit": "seconds", "aggregation": "unchanged-corpus repeat full-refresh wall time", "direction": "max", "source": "baseline-raw.json" },
+        "packet_seconds": { "reference": 1, "threshold": 1.1, "unit": "seconds", "aggregation": "worst quality-gated packet median wall time", "direction": "max", "source": "baseline-raw.json" },
+        "search_seconds": { "reference": 1, "threshold": 1.25, "unit": "seconds", "aggregation": "full-sidecar command wall time", "direction": "max", "source": "baseline-raw.json" },
+        "indexing_seconds": { "reference": 10, "threshold": 12.5, "unit": "seconds", "aggregation": "cold full-refresh wall time", "direction": "max", "source": "baseline-raw.json" },
+        "storage_growth_ratio": { "reference": 1, "threshold": 1.1, "reference_bytes": 1000, "unit": "ratio", "aggregation": "candidate bytes divided by approved same-corpus bytes", "direction": "max", "source": "baseline-raw.json" }
+      }
+    }
+  }
+}

--- a/benchmarks/release-evidence/fixtures/baseline-raw.json
+++ b/benchmarks/release-evidence/fixtures/baseline-raw.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "commit": "1111111111111111111111111111111111111111",
+  "evidence_identity": {
+    "corpus_id": "ci-contract-corpus-v1",
+    "cache_id": "cold-full-sidecar-v1",
+    "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB"
+  },
+  "metrics": {
+    "status_seconds": 1,
+    "local_grounding_seconds": 1,
+    "convergence_seconds": 10,
+    "packet_seconds": 1,
+    "search_seconds": 1,
+    "indexing_seconds": 10,
+    "storage_bytes": 1000
+  }
+}

--- a/benchmarks/release-evidence/fixtures/candidate-packet.json
+++ b/benchmarks/release-evidence/fixtures/candidate-packet.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 1,
+  "modes": ["cold-cli"],
+  "repeats": 3,
+  "release_evidence": {
+    "commit": "2222222222222222222222222222222222222222",
+    "profile": "ci-contract-v1",
+    "evidence_identity": {
+      "corpus_id": "ci-contract-corpus-v1",
+      "cache_id": "cold-full-sidecar-v1",
+      "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB"
+    },
+    "publishable": true,
+    "repeats": 3,
+    "quality_gate_status": "pass",
+    "publishable_blockers": [],
+    "rows": [
+      {
+        "repo": "fixture",
+        "task_id": "quality-contract",
+        "mode": "cold-cli",
+        "repeat": 1,
+        "status": "pass",
+        "quality": { "pass": true },
+        "sufficiency": { "status": "sufficient", "sufficient_quality_mismatch": false },
+        "packet_latency": { "sla_missed": false, "retrieval_shadow": { "retrieval_mode": "full" } },
+        "repo_provenance": {
+          "manifest_overridden_by_builtin": false,
+          "configured": { "url": "https://github.com/example/fixture.git", "ref": "9999999999999999999999999999999999999999" },
+          "manifest": { "url": "https://github.com/example/fixture.git", "ref": "9999999999999999999999999999999999999999" },
+          "git_head": "9999999999999999999999999999999999999999",
+          "git_origin": "https://github.com/example/fixture.git",
+          "git_dirty": false
+        },
+        "codestory_cache_provenance": {
+          "doctor_status": "pass", "storage_path": "fixture/codestory.db",
+          "cache_policy": "prepared-sidecar-cache-read-only", "retrieval_mode": "full",
+          "sidecar_generation": "fixture-generation", "manifest_embedding_backend": "llamacpp:bge-base-en-v1.5",
+          "semantic_backend": "llamacpp", "local_only": true, "locality_kind": "local_model_files",
+          "indexed": true, "freshness_status": "fresh", "semantic_ready": true, "indexing_in_timed_run": false
+        }
+      },
+      {
+        "repo": "fixture",
+        "task_id": "quality-contract",
+        "mode": "cold-cli",
+        "repeat": 2,
+        "status": "pass",
+        "quality": { "pass": true },
+        "sufficiency": { "status": "sufficient", "sufficient_quality_mismatch": false },
+        "packet_latency": { "sla_missed": false, "retrieval_shadow": { "retrieval_mode": "full" } },
+        "repo_provenance": {
+          "manifest_overridden_by_builtin": false,
+          "configured": { "url": "https://github.com/example/fixture.git", "ref": "9999999999999999999999999999999999999999" },
+          "manifest": { "url": "https://github.com/example/fixture.git", "ref": "9999999999999999999999999999999999999999" },
+          "git_head": "9999999999999999999999999999999999999999",
+          "git_origin": "https://github.com/example/fixture.git",
+          "git_dirty": false
+        },
+        "codestory_cache_provenance": {
+          "doctor_status": "pass", "storage_path": "fixture/codestory.db",
+          "cache_policy": "prepared-sidecar-cache-read-only", "retrieval_mode": "full",
+          "sidecar_generation": "fixture-generation", "manifest_embedding_backend": "llamacpp:bge-base-en-v1.5",
+          "semantic_backend": "llamacpp", "local_only": true, "locality_kind": "local_model_files",
+          "indexed": true, "freshness_status": "fresh", "semantic_ready": true, "indexing_in_timed_run": false
+        }
+      },
+      {
+        "repo": "fixture",
+        "task_id": "quality-contract",
+        "mode": "cold-cli",
+        "repeat": 3,
+        "status": "pass",
+        "quality": { "pass": true },
+        "sufficiency": { "status": "sufficient", "sufficient_quality_mismatch": false },
+        "packet_latency": { "sla_missed": false, "retrieval_shadow": { "retrieval_mode": "full" } },
+        "repo_provenance": {
+          "manifest_overridden_by_builtin": false,
+          "configured": { "url": "https://github.com/example/fixture.git", "ref": "9999999999999999999999999999999999999999" },
+          "manifest": { "url": "https://github.com/example/fixture.git", "ref": "9999999999999999999999999999999999999999" },
+          "git_head": "9999999999999999999999999999999999999999",
+          "git_origin": "https://github.com/example/fixture.git",
+          "git_dirty": false
+        },
+        "codestory_cache_provenance": {
+          "doctor_status": "pass", "storage_path": "fixture/codestory.db",
+          "cache_policy": "prepared-sidecar-cache-read-only", "retrieval_mode": "full",
+          "sidecar_generation": "fixture-generation", "manifest_embedding_backend": "llamacpp:bge-base-en-v1.5",
+          "semantic_backend": "llamacpp", "local_only": true, "locality_kind": "local_model_files",
+          "indexed": true, "freshness_status": "fresh", "semantic_ready": true, "indexing_in_timed_run": false
+        }
+      }
+    ]
+  },
+  "summary": [
+    { "task": "one", "median_e2e_wall_ms": 800 },
+    { "task": "two", "median_e2e_wall_ms": 900 }
+  ]
+}

--- a/benchmarks/release-evidence/fixtures/candidate-stats.json
+++ b/benchmarks/release-evidence/fixtures/candidate-stats.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "commit": "2222222222222222222222222222222222222222",
+  "evidence_identity": {
+    "corpus_id": "ci-contract-corpus-v1",
+    "cache_id": "cold-full-sidecar-v1",
+    "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB"
+  },
+  "retrieval_status_seconds": 0.8,
+  "ground_seconds": 0.8,
+  "repeat_full_refresh_seconds": 8,
+  "repeat_graph_phase_seconds": 10,
+  "repeat_semantic_phase_seconds": 2,
+  "stats_baseline": {
+    "repeat_full_refresh_seconds": 10
+  },
+  "search_seconds": 0.8,
+  "index_seconds": 8,
+  "storage_bytes": 1020,
+  "proof_tier": "full_sidecar",
+  "repeat_semantic_docs_embedded": 0,
+  "index": {
+    "error_count": 0,
+    "sidecar_status_after_retrieval_index": "full"
+  },
+  "ground": {
+    "sidecar_status_after_retrieval_index": "full"
+  },
+  "search": {
+    "sidecar_shadow_retrieval_mode": "full"
+  },
+  "sidecar_manifest": {
+    "symbol_doc_count": 10,
+    "dense_projection_count": 4,
+    "projection_count": 4,
+    "semantic_policy_version": "graph_first_v1",
+    "graph_artifact_hash_present": true,
+    "dense_reason_count_total": 4
+  }
+}

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 2,
+  "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
+  "baseline_sha256": "e7488c0625620ebeaf669fab3b9d4150a29b60d08398a3c6a005b2ee4c152642",
+  "commit": "2222222222222222222222222222222222222222",
+  "git_state": "clean",
+  "profile": "ci-contract-v1",
+  "identity": {
+    "corpus_id": "ci-contract-corpus-v1",
+    "cache_id": "cold-full-sidecar-v1",
+    "machine_fingerprint": "ci-contract/windows-x64/8/test-cpu/16GiB"
+  },
+  "artifacts": {
+    "stats": {
+      "path": "candidate-stats.json",
+      "sha256": "f65c55078260a4ee6a6e1c0c73346317aeb972c8fe10c0c9580cab7c963da30a",
+      "bytes": 1106
+    },
+    "packet": {
+      "path": "candidate-packet.json",
+      "sha256": "ff3bb834b3e473e2f099dbbf8a52651622039dddb60a2ce2b9b2e0bd40c21a0f",
+      "bytes": 4911
+    }
+  },
+  "metrics": {
+    "status_seconds": {
+      "value": 0.8,
+      "unit": "seconds",
+      "aggregation": "full-sidecar command wall time"
+    },
+    "local_grounding_seconds": {
+      "value": 0.8,
+      "unit": "seconds",
+      "aggregation": "full-sidecar command wall time"
+    },
+    "convergence_seconds": {
+      "value": 8,
+      "unit": "seconds",
+      "aggregation": "unchanged-corpus repeat full-refresh wall time"
+    },
+    "packet_seconds": {
+      "value": 0.9,
+      "unit": "seconds",
+      "aggregation": "worst quality-gated packet median wall time"
+    },
+    "search_seconds": {
+      "value": 0.8,
+      "unit": "seconds",
+      "aggregation": "full-sidecar command wall time"
+    },
+    "indexing_seconds": {
+      "value": 8,
+      "unit": "seconds",
+      "aggregation": "cold full-refresh wall time"
+    },
+    "storage_growth_ratio": {
+      "value": 1.02,
+      "unit": "ratio",
+      "aggregation": "candidate bytes divided by approved same-corpus bytes"
+    }
+  }
+}

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 2,
+  "status": "pass",
+  "decision": "accept_contract",
+  "commit": "2222222222222222222222222222222222222222",
+  "profile": "ci-contract-v1",
+  "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
+  "baseline_sha256": "e7488c0625620ebeaf669fab3b9d4150a29b60d08398a3c6a005b2ee4c152642",
+  "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
+  "candidate_sha256": "6e34aa50106f6cac5ac66b9deb464575d285f2d110cd640336541b51e9f56937",
+  "artifact_paths": [
+    {
+      "path": "candidate-stats.json",
+      "sha256": "f65c55078260a4ee6a6e1c0c73346317aeb972c8fe10c0c9580cab7c963da30a",
+      "bytes": 1106
+    },
+    {
+      "path": "candidate-packet.json",
+      "sha256": "ff3bb834b3e473e2f099dbbf8a52651622039dddb60a2ce2b9b2e0bd40c21a0f",
+      "bytes": 4911
+    }
+  ],
+  "metrics": [
+    {
+      "status": "pass",
+      "metric": "status_seconds",
+      "decision": "accept",
+      "measured_value": 0.8,
+      "reference": 1,
+      "threshold": 1.25,
+      "unit": "seconds",
+      "aggregation": "full-sidecar command wall time",
+      "source": "baseline-raw.json"
+    },
+    {
+      "status": "pass",
+      "metric": "local_grounding_seconds",
+      "decision": "accept",
+      "measured_value": 0.8,
+      "reference": 1,
+      "threshold": 1.25,
+      "unit": "seconds",
+      "aggregation": "full-sidecar command wall time",
+      "source": "baseline-raw.json"
+    },
+    {
+      "status": "pass",
+      "metric": "convergence_seconds",
+      "decision": "accept",
+      "measured_value": 8,
+      "reference": 10,
+      "threshold": 11.5,
+      "unit": "seconds",
+      "aggregation": "unchanged-corpus repeat full-refresh wall time",
+      "source": "baseline-raw.json"
+    },
+    {
+      "status": "pass",
+      "metric": "packet_seconds",
+      "decision": "accept",
+      "measured_value": 0.9,
+      "reference": 1,
+      "threshold": 1.1,
+      "unit": "seconds",
+      "aggregation": "worst quality-gated packet median wall time",
+      "source": "baseline-raw.json"
+    },
+    {
+      "status": "pass",
+      "metric": "search_seconds",
+      "decision": "accept",
+      "measured_value": 0.8,
+      "reference": 1,
+      "threshold": 1.25,
+      "unit": "seconds",
+      "aggregation": "full-sidecar command wall time",
+      "source": "baseline-raw.json"
+    },
+    {
+      "status": "pass",
+      "metric": "indexing_seconds",
+      "decision": "accept",
+      "measured_value": 8,
+      "reference": 10,
+      "threshold": 12.5,
+      "unit": "seconds",
+      "aggregation": "cold full-refresh wall time",
+      "source": "baseline-raw.json"
+    },
+    {
+      "status": "pass",
+      "metric": "storage_growth_ratio",
+      "decision": "accept",
+      "measured_value": 1.02,
+      "reference": 1,
+      "threshold": 1.1,
+      "unit": "ratio",
+      "aggregation": "candidate bytes divided by approved same-corpus bytes",
+      "source": "baseline-raw.json"
+    }
+  ]
+}

--- a/benchmarks/release-evidence/repo-stats-contract.json
+++ b/benchmarks/release-evidence/repo-stats-contract.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "repeat_graph_phase_seconds_max": 20,
+  "repeat_semantic_phase_seconds_max": 3,
+  "repeat_full_refresh_regression_factor": 1.25
+}

--- a/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
+++ b/crates/codestory-cli/tests/codestory_repo_e2e_stats.rs
@@ -13,10 +13,13 @@ const REPEAT_SEMANTIC_PHASE_SECONDS_BUDGET: f64 = 3.0;
 
 #[derive(Debug, Serialize)]
 struct RepoE2eStats {
+    commit: String,
+    evidence_identity: EvidenceIdentity,
     project_root: String,
     cache_dir: String,
     storage_path: String,
     search_dir: String,
+    storage_bytes: u64,
     proof_tier: String,
     warnings: Vec<String>,
     stats_baseline: StatsLogBaseline,
@@ -70,6 +73,13 @@ struct RepoE2eStats {
     trail: TrailStats,
     snippet: SnippetStats,
     report: ReportStats,
+}
+
+#[derive(Debug, Serialize)]
+struct EvidenceIdentity {
+    corpus_id: String,
+    cache_id: String,
+    machine_fingerprint: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -164,6 +174,26 @@ struct ReportStats {
 const PROOF_TIER_STATS_ONLY: &str = "stats_only";
 const PROOF_TIER_FULL_SIDECAR: &str = "full_sidecar";
 const RELEASE_WARNING_REGRESSION_FACTOR: f64 = 1.25;
+
+#[test]
+fn shared_release_stats_contract_matches_harness_thresholds() {
+    let contract: Value = serde_json::from_str(include_str!(
+        "../../../benchmarks/release-evidence/repo-stats-contract.json"
+    ))
+    .expect("parse shared release stats contract");
+    assert_eq!(
+        contract["repeat_graph_phase_seconds_max"].as_f64(),
+        Some(REPEAT_GRAPH_PHASE_SECONDS_BUDGET)
+    );
+    assert_eq!(
+        contract["repeat_semantic_phase_seconds_max"].as_f64(),
+        Some(REPEAT_SEMANTIC_PHASE_SECONDS_BUDGET)
+    );
+    assert_eq!(
+        contract["repeat_full_refresh_regression_factor"].as_f64(),
+        Some(RELEASE_WARNING_REGRESSION_FACTOR)
+    );
+}
 
 fn release_readiness_proof_tier(
     sidecar_status_after_retrieval_index: &str,
@@ -478,6 +508,21 @@ fn search_dir_for_storage(storage_path: &Path) -> PathBuf {
         .and_then(|value| value.to_str())
         .expect("storage file stem");
     parent.join(format!("{stem}.search"))
+}
+
+fn path_bytes(path: &Path) -> u64 {
+    let Ok(metadata) = fs::metadata(path) else {
+        return 0;
+    };
+    if metadata.is_file() {
+        return metadata.len();
+    }
+    fs::read_dir(path)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|entry| path_bytes(&entry.path()))
+        .sum()
 }
 
 fn run_cli_json(
@@ -983,10 +1028,21 @@ fn codestory_repo_release_e2e_emits_stats() {
     );
 
     let stats = RepoE2eStats {
+        commit: env::var("CODESTORY_RELEASE_EVIDENCE_COMMIT")
+            .unwrap_or_else(|_| "unbound-local-run".to_string()),
+        evidence_identity: EvidenceIdentity {
+            corpus_id: env::var("CODESTORY_RELEASE_EVIDENCE_CORPUS_ID")
+                .unwrap_or_else(|_| "unbound-local-run".to_string()),
+            cache_id: env::var("CODESTORY_RELEASE_EVIDENCE_CACHE_ID")
+                .unwrap_or_else(|_| "unbound-local-run".to_string()),
+            machine_fingerprint: env::var("CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT")
+                .unwrap_or_else(|_| "unbound-local-run".to_string()),
+        },
         project_root: project_root.display().to_string(),
         cache_dir: cache_dir.path().display().to_string(),
         storage_path: storage_path.display().to_string(),
         search_dir: search_dir.display().to_string(),
+        storage_bytes: path_bytes(cache_dir.path()),
         proof_tier,
         warnings,
         stats_baseline,
@@ -1154,10 +1210,16 @@ fn codestory_repo_release_e2e_emits_stats() {
         },
     };
 
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&stats).expect("serialize stats")
-    );
+    let stats_json = serde_json::to_string_pretty(&stats).expect("serialize stats");
+    println!("{stats_json}");
+    if let Ok(output_path) = env::var("CODESTORY_RELEASE_EVIDENCE_STATS_PATH") {
+        let output_path = PathBuf::from(output_path);
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent).expect("create release evidence stats parent");
+        }
+        fs::write(output_path, format!("{stats_json}\n"))
+            .expect("write release evidence stats artifact");
+    }
 
     assert_eq!(
         stats.index.error_count, 0,

--- a/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
+++ b/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
@@ -338,6 +338,55 @@ pub const LEAKED_EVAL_SOURCE_PROBE: &str = "createCacheHelper";
 }
 
 #[test]
+fn linter_structurally_rejects_production_dependencies_on_eval_corpora() {
+    let output = run_lint_with_fixture(
+        r#"
+pub const LEAKED_TASK_CORPUS: &str = "benchmarks/tasks/holdout-retrieval/axios-request-dispatch.task.json";
+pub const LEAKED_QUERY_CORPUS: &str = "scripts/cross-repo-sourcetrail-queries.mjs";
+pub const LEAKED_EVAL_PROBES: &str = "benchmarks/tasks/eval-probes.json";
+"#,
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "production references to eval/query corpora must fail lint; stderr={stderr}"
+    );
+    for expected in [
+        "benchmarks/tasks",
+        "scripts/cross-repo-sourcetrail-queries.mjs",
+        "benchmarks/tasks/eval-probes.json",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "lint failure should identify corpus boundary {expected}; stderr={stderr}"
+        );
+    }
+}
+
+#[test]
+fn linter_rejects_constructed_eval_corpus_dependencies() {
+    let output = run_lint_with_fixture(
+        r#"
+pub const LEAKED_TASK_CORPUS: &str = concat!("benchmarks", "/tasks", "/eval-probes.json");
+pub const LEAKED_PACKET_FIXTURE: &str = concat!("crates/codestory-cli/tests/fixtures/", "packet_search_eval");
+pub const LEAKED_QUALITY_FIXTURE: &str = concat!("crates/codestory-cli/tests/", "fixtures/agent_quality");
+pub const LEAKED_DEPENDENCY: &str = include_str!(concat!("../../benchmarks/", "tasks/eval-probes.json"));
+"#,
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "constructed production corpus dependencies must fail lint; stderr={stderr}"
+    );
+    for expected in ["benchmarkstasks", "packetsearcheval", "agentquality"] {
+        assert!(
+            stderr.to_lowercase().contains(expected),
+            "lint failure should identify constructed boundary {expected}; stderr={stderr}"
+        );
+    }
+}
+
+#[test]
 fn linter_fails_closed_when_one_prompt_corpus_entry_is_not_a_literal() {
     let output = run_lint_with_prompt_script_fixture(
         r#"

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -283,12 +283,14 @@ seconds, symbol docs written, dense docs skipped, dense reason counts, dense
 docs reused, dense docs embedded, total index seconds,
 `repeat_full_refresh_seconds`, repeat graph/semantic/cache/search timings,
 `retrieval_index_seconds`, `retrieval_status_seconds`, `report_seconds`,
-`proof_tier`, any `warnings`, and whether
+`proof_tier`, and whether
 `sidecar_status_after_retrieval_index` plus `search.sidecar_shadow_retrieval_mode`
-were `full`. The release stats harness reads the latest valid `Phase Metrics`
-row in that log as its living warning baseline and reads that row's
-`repeat full refresh <seconds>s` scenario text as the repeat full-refresh
-blocker baseline.
+were `full`. The log is telemetry only and cannot become a release baseline by
+appending a row. Use the approved profile and release decision command in
+[`performance-review-playbook.md`](../testing/performance-review-playbook.md).
+The harness still emits its prior latest-row warnings and repeat-refresh
+blocker during the transition; release workflow authorization comes only from
+the attested gate below.
 
 Release-readiness evidence is tiered:
 
@@ -311,29 +313,22 @@ skip env vars used. The stats JSON reports `proof_tier` as the highest tier
 proven by that stats object. If `CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES=1`
 was used, record that the real-repo drill was intentionally skipped, but preserve
 the stats JSON tier exactly; for example, a passing full-sidecar stats object
-remains `full_sidecar`, not `stats_only`. Warning-free full-sidecar stats must
+remains `full_sidecar`, not `stats_only`. Full-sidecar stats must
 not be promoted to real-repo drill or promotion-grade evidence by themselves.
 
-The stats JSON also reports `warnings` for performance thresholds that should
-stay visible in logged evidence. Total index time and semantic phase warnings
-are computed against the latest `Phase Metrics` row in
-[`codestory-e2e-stats-log.md`](../testing/codestory-e2e-stats-log.md), not
-against older hard-coded timing rows:
-
-| Warning | Threshold |
-| --- | --- |
-| Total index time | `index_seconds` is more than 25% above the latest stats-log phase baseline |
-| Semantic phase time | `semantic_phase_seconds` is more than 25% above the latest stats-log phase baseline |
-| AST-first cold index gate | cold CodeStory product index is not under 180s or `semantic_embedding_ms` is not at least 70% below same-run baseline |
-
-Preserve those warning strings when copying the run into release evidence. An
-empty `warnings` array only means the measured run stayed under these warning
-thresholds; it does not raise the proof tier.
-
-For the current repo-scale baseline, use the latest row in
-[`codestory-e2e-stats-log.md`](../testing/codestory-e2e-stats-log.md). Older
-rows, including the 2026-04-18 durable-scope measurements, are historical
-examples only; do not copy them into current performance claims.
+Release-significant performance decisions are fail-closed. Normalize the raw
+stats and packet-runtime artifacts into the seven-metric candidate described in
+the performance playbook, then run
+`scripts/codestory-release-evidence-gate.mjs`. The selected machine profile
+must be approved, release-eligible, pinned to attested raw evidence, and match
+the candidate's corpus, cache, and machine fingerprint. Candidate artifacts can
+be produced on the same clean full SHA by the explicit manual/reusable
+`release-candidate-evidence.yml` workflow. This infrastructure is not wired to
+the release workflow until a live eligible baseline exists. A rejected metric
+blocks the release unless a non-expired exception binds the exact candidate
+hash, baseline id/hash, profile, metric, measured value, threshold, owner, ISO
+date, and rationale. Preserve the emitted decision JSON; it carries status,
+metric, decision, commit, and artifact paths/hashes.
 
 ## CLI Boundary And Output Changes
 

--- a/docs/testing/codestory-e2e-stats-log.md
+++ b/docs/testing/codestory-e2e-stats-log.md
@@ -9,7 +9,16 @@ cargo build --release -p codestory-cli
 cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture
 ```
 
-Keep the full emitted JSON in the test output when reviewing locally, and add the headline metrics here so search/index reuse trends are visible over time. The release stats harness reads the latest valid `Phase Metrics` row below as its living warning baseline, so append the phase row with the same evidence update. For performance branches, capture the baseline and no-regression threshold from [performance-review-playbook.md](performance-review-playbook.md) before tuning.
+Keep the full emitted JSON in the test output when reviewing locally, and add
+the headline metrics here so search/index reuse trends are visible over time.
+Rows in this log are telemetry only: appending a row never promotes it to a
+release baseline. Approved references and per-metric budgets live in
+[`approved-baselines.json`](../../benchmarks/release-evidence/approved-baselines.json),
+and release decisions use the gate in the
+[performance review playbook](performance-review-playbook.md).
+The repo-scale harness temporarily retains its prior warning strings and repeat
+refresh blocker as defense in depth; those legacy comparisons are not baseline
+approval or release authorization.
 
 Rows whose commit cell ends in `+wt` were run from the working tree based on that commit before the proof row itself was committed. When a row names the later commit in the result text, the runtime/code state under test is the working tree that became that commit; proof-only commits after the run still need fresh `ready`/`doctor` checks because docs change the sidecar input hash.
 

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -80,7 +80,7 @@ regression risk, but it is not answer-quality proof.
 
 | Gate | Current metric or threshold | Command that proves it | Source |
 | --- | --- | --- | --- |
-| Repeat refresh | `repeat_semantic_docs_embedded == 0`; repeat graph phase `< 20s`; repeat semantic reuse phase `< 3s`; repeat full-refresh process smoke stays within 25% of the latest stats-log phase-row baseline | `cargo build --release -p codestory-cli`, then `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture` | `crates/codestory-cli/tests/codestory_repo_e2e_stats.rs`, `docs/testing/codestory-e2e-stats-log.md` |
+| Repeat refresh | `repeat_semantic_docs_embedded == 0`; repeat graph phase `< 20s`; repeat semantic reuse phase `< 3s`; release-significant convergence changes use the approved machine-profile budget | `cargo build --release -p codestory-cli`, then `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture`; release gate below | `crates/codestory-cli/tests/codestory_repo_e2e_stats.rs`, `benchmarks/release-evidence/approved-baselines.json` |
 | Retrieval status | After sidecar indexing, `retrieval_mode == "full"` and `retrieval status --format json` reports current manifest provenance: source root, input hash, generation, schema, graph hash, symbol-doc count, dense-anchor count, degraded modes, and lane provenance. Non-`full` status is diagnostic only. | `codestory-cli retrieval bootstrap --project <repo> --format json`; `codestory-cli retrieval index --project <repo> --refresh full --format json`; `codestory-cli retrieval status --project <repo> --format json` | `docs/ops/retrieval-sidecars.md`, `crates/codestory-retrieval/src/sidecar.rs`, `crates/codestory-runtime/src/agent/retrieval_primary.rs` |
 | Packet runtime | Product sidecar query budget defaults to `1,000ms`; packet batch budget defaults to `18,000ms` and is capped at `120,000ms`; packet runs must report `packet_latency.sla_missed == false` for product evidence. North-star targets are retrieval p50 `<= 250ms`, p90 `<= 600ms`, p99 `<= 1,000ms`, and worst-case packet wall `<= 1,500ms`, but those targets become promotion proof only inside a quality-gated benchmark run. | `node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --task-suite local-real --repeats 1 --codestory-cli target/release/codestory-cli --timeout-ms 300000` | `crates/codestory-runtime/src/agent/retrieval_primary.rs`, `crates/codestory-retrieval/src/planner.rs`, `scripts/codestory-agent-ab-benchmark.mjs`, `docs/testing/retrieval-architecture.md` |
 | Benchmark promotion | `--publishable` requires at least 3 repeats, sidecar-primary retrieval, no diagnostic extra probes, no failed rows, token usage, clean preludes, manifest quality gates when present, packet-first compliance, sufficient packets with no unresolved diagnostics, and the explicit `--max-source-reads-after-packet` budget. Holdout/local task quality thresholds live in the task manifests; stats-log timing rows do not promote answer quality. | `node scripts/codestory-agent-ab-benchmark.mjs --packet-runtime --packet-runtime-mode cold-cli --task-suite holdout-retrieval --materialize-repos --repeats 3 --publishable --max-source-reads-after-packet 0 --codestory-cli target/release/codestory-cli --timeout-ms 180000` | `scripts/codestory-agent-ab-benchmark.mjs`, `scripts/codestory-benchmark-contract.mjs`, `benchmarks/tasks/`, `docs/testing/retrieval-architecture.md` |
@@ -91,6 +91,85 @@ Current telemetry snapshot from `docs/testing/codestory-e2e-stats-log.md`
 refresh `29.45s` with `750` reused and `0` embedded, index `75.36s`, semantic
 phase `49.45s`. This row is useful regression telemetry; it does not prove
 answer quality because the real drill was intentionally skipped.
+
+## Release Evidence Gate
+
+The stats log is append-only telemetry, not a baseline selector. Release
+candidates must use a named machine profile from
+`benchmarks/release-evidence/approved-baselines.json`; the profile pins its
+accepted commit, approval rationale, source artifacts, and a separate budget
+for status, local grounding, convergence, packet, search, indexing, and
+same-corpus storage growth. This avoids applying one timing to dissimilar
+machines while preventing a slower appended row from becoming its own
+reference.
+
+Do not hand-author candidate metrics. The provisioned
+`release-candidate-evidence.yml` workflow runs the full repo-scale and
+publishable packet producers on the same clean SHA, records the corpus, cache,
+and machine fingerprint, hashes both non-empty raw artifacts, and derives the
+candidate. It refuses contract-only profiles during release runs. The release
+workflow is not yet activated; legacy warnings and blockers remain authoritative
+until the activation child has a provisioned release-eligible baseline and live
+candidate report.
+
+For maintainer reproduction, produce and evaluate from real raw artifacts:
+
+```sh
+node scripts/codestory-release-evidence-gate.mjs produce \
+  --baseline benchmarks/release-evidence/approved-baselines.json \
+  --profile <approved-release-profile> \
+  --stats target/release-evidence/stats.json \
+  --packet target/release-evidence/packet/packet-runtime-summary.json \
+  --out target/release-evidence/candidate.json \
+  --expected-sha <full-40-character-sha> --mode release --repo .
+node scripts/codestory-release-evidence-gate.mjs evaluate \
+  --baseline benchmarks/release-evidence/approved-baselines.json \
+  --candidate target/release-evidence/candidate.json \
+  --out target/release-evidence/decision.json \
+  --expected-sha <full-40-character-sha> --mode release --repo .
+```
+
+Production and evaluation both reject missing, empty, changed, or all-zero raw
+artifacts; short or dirty Git identities; self-baselining; identity drift; and
+unit or aggregation changes. The normalized report records the candidate and
+baseline hashes, full commits, artifact hashes and sizes, and every metric's
+status and decision. A regression exits nonzero. Each exception is bound to the
+exact candidate hash, baseline id/hash, full commit, profile, metric, measured
+value, threshold, owner, ISO approval date, rationale, and unexpired date.
+Approval never updates the pinned baseline.
+
+Packet provenance is finalized only after publishable blockers are calculated.
+The evaluator does not trust its status label: it requires an empty blocker
+list and independently checks every embedded row for pass/quality/sufficiency,
+full retrieval shadow, SLA, the benchmark's shared pinned-repository and
+local-cache provenance validators, and distinct exact `1..N` repeats matching
+the top-level modes/repeat contract. It also
+rechecks the raw stats object's `full_sidecar` tier, index/ground/search modes,
+manifest counts/hash/policy, zero index errors, and zero repeat embeddings.
+Repeat graph, semantic, and full-refresh limits are re-evaluated from the shared
+`repo-stats-contract.json`, whose values are asserted against the Rust harness
+constants so the downloaded-artifact gate cannot drift from the surviving
+release assertions.
+
+On rejection, the workflow uploads provisioning, raw, candidate, approval (when
+provided), and report files with `if: always()`. Author an exception against the
+reported hashes and values in the
+`CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON` secret, then dispatch the same SHA
+with `source_run_id=<rejected-run-id>`. That path downloads and re-evaluates the
+exact candidate without re-running measurements; any SHA, hash, value, profile,
+baseline, threshold, date, or expiry drift still fails.
+
+The checked-in `ci-contract-v1` fixture and report exercise this trust chain in
+ordinary CI but are explicitly `release_eligible: false`. A product profile must
+be created from provisioned raw evidence and explicitly approved before a
+release workflow can adopt this gate.
+
+The corpus boundary is deliberately precise: it scans Rust production files in
+all non-benchmark crates for direct path strings and adjacent/split literal
+construction such as `concat!` and `include_str!`. It does not prove arbitrary
+runtime path generation, non-Rust production surfaces, environment/config
+indirection, or dependencies hidden behind external processes. Those surfaces
+remain explicit follow-up audit scope rather than being claimed as covered.
 
 Do not promote importable or rebuildable graph/sidecar artifacts in this slice.
 A follow-up PR for that idea must require provenance before reuse: source root,
@@ -122,6 +201,9 @@ verification plan in the PR or final notes:
 cargo build --release -p codestory-cli
 cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture
 ```
+
+Appending those rows is never a release decision. Assemble the candidate
+artifact and run the release evidence gate after the raw producers complete.
 
 ## Parallelization Candidate Gate
 

--- a/scripts/codestory-agent-ab-benchmark.mjs
+++ b/scripts/codestory-agent-ab-benchmark.mjs
@@ -5258,6 +5258,7 @@ async function runPacketRuntimeBenchmark(opts, tasks) {
   }
   await writeJsonlRows(path.join(outDir, "packet-runtime-runs.jsonl"), results);
   const summary = summarizePacketRuntimeRuns(results);
+  const blockers = packetRuntimePublishableBlockers(results, opts);
   const payload = {
     generated_at: new Date().toISOString(),
     benchmark_run_id: benchmarkId,
@@ -5275,6 +5276,33 @@ async function runPacketRuntimeBenchmark(opts, tasks) {
       scorerPath: benchmarkScorerPath,
       cliIdentity: opts.codestoryCli ?? process.env.CODESTORY_CLI ?? null,
     }),
+    ...(process.env.CODESTORY_RELEASE_EVIDENCE_COMMIT
+      ? {
+          release_evidence: {
+            commit: process.env.CODESTORY_RELEASE_EVIDENCE_COMMIT,
+            profile: process.env.CODESTORY_RELEASE_EVIDENCE_PROFILE,
+            evidence_identity: {
+              corpus_id: process.env.CODESTORY_RELEASE_EVIDENCE_CORPUS_ID,
+              cache_id: process.env.CODESTORY_RELEASE_EVIDENCE_CACHE_ID,
+              machine_fingerprint:
+                process.env.CODESTORY_RELEASE_EVIDENCE_MACHINE_FINGERPRINT,
+            },
+            publishable: opts.publishable === true,
+            repeats: opts.repeats,
+            quality_gate_status:
+              opts.publishable === true && blockers.length === 0 ? "pass" : "fail",
+            publishable_blockers: blockers.map((blocker) => ({
+              repo: blocker.result.repo,
+              task_id: blocker.result.task_id,
+              mode: blocker.result.mode,
+              repeat: blocker.result.repeat,
+              category: blocker.category,
+              reasons: blocker.reasons,
+            })),
+            rows: results,
+          },
+        }
+      : {}),
     summary,
   };
   const packetRuntimeSummaryPath = path.join(outDir, "packet-runtime-summary.json");
@@ -5353,7 +5381,6 @@ async function runPacketRuntimeBenchmark(opts, tasks) {
   );
   console.log(`ARTIFACT packet_runtime_artifacts=${packetRuntimeArtifactManifestPath}`);
 
-  const blockers = packetRuntimePublishableBlockers(results, opts);
   if (opts.publishable && blockers.length) {
     console.error(
       "--publishable failed: packet runtime rows must pass, include passing manifest quality gates, report sufficient packets with zero follow-ups or unresolved diagnostics, and use pinned clean repo provenance.",
@@ -6840,6 +6867,7 @@ export {
   packetRuntimeCacheObservations,
   packetRuntimePublishableBlockers,
   packetRuntimeQualityGateRequired,
+  cacheProvenanceBlockers,
   PACKET_COMPOSITION_WEIGHTS,
   MAX_REUSED_ARTIFACT_BYTES,
   packetCompositionFileScore,

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import {
+  cacheProvenanceBlockers,
+  repoProvenanceBlockers,
+} from "./codestory-agent-ab-benchmark.mjs";
+
+const METRICS = [
+  "status_seconds", "local_grounding_seconds", "convergence_seconds",
+  "packet_seconds", "search_seconds", "indexing_seconds", "storage_growth_ratio",
+];
+const SHA = /^[0-9a-f]{40}$/;
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function fail(message) { throw new Error(message); }
+function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail(`${label} must be an object`);
+  return value;
+}
+function text(value, label) {
+  if (typeof value !== "string" || value.trim() === "") fail(`${label} must be a non-empty string`);
+  return value;
+}
+function number(value, label) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) fail(`${label} must be a finite positive number`);
+  return value;
+}
+function fullSha(value, label) {
+  const normalized = text(value, label).toLowerCase();
+  if (!SHA.test(normalized)) fail(`${label} must be a full 40-character Git SHA`);
+  return normalized;
+}
+function sha256(bytes) { return createHash("sha256").update(bytes).digest("hex"); }
+function readJson(filePath, label) {
+  try { return JSON.parse(readFileSync(filePath, "utf8")); }
+  catch (error) { fail(`failed to read ${label} ${filePath}: ${error.message}`); }
+}
+function fileAttestation(filePath, baseDir) {
+  const absolute = path.resolve(baseDir, filePath);
+  if (!existsSync(absolute) || !statSync(absolute).isFile()) fail(`artifact does not exist: ${filePath}`);
+  const bytes = readFileSync(absolute);
+  if (bytes.length === 0) fail(`artifact is empty: ${filePath}`);
+  return { path: path.relative(baseDir, absolute).replaceAll(path.sep, "/"), sha256: sha256(bytes), bytes: bytes.length };
+}
+function git(args, cwd) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  return result.stdout.trim();
+}
+function machineFingerprint() {
+  const cpu = os.cpus()[0]?.model?.trim() ?? "unknown";
+  const memoryGiB = Math.round(os.totalmem() / 2 ** 30);
+  return `${process.platform}/${process.arch}/${os.cpus().length}/${cpu}/${memoryGiB}GiB`;
+}
+function profileFrom(document, name, mode, baselineDir) {
+  if (document.schema_version !== 2) fail("baseline schema_version must be 2");
+  const profile = object(object(document.profiles, "baseline.profiles")[name], `profile ${name}`);
+  text(profile.baseline_id, "baseline_id");
+  fullSha(profile.commit, "baseline.commit");
+  if (profile.git_state !== "clean") fail("baseline git_state must be clean");
+  if (profile.status !== "approved") fail("baseline status must be approved");
+  if (mode === "release" && profile.release_eligible !== true) fail(`profile ${name} is not release eligible`);
+  const identity = object(profile.identity, "baseline.identity");
+  for (const key of ["corpus_id", "cache_id", "machine_fingerprint"]) text(identity[key], `baseline.identity.${key}`);
+  const approval = object(profile.approval, "baseline.approval");
+  for (const key of ["owner", "approved_at", "rationale"]) text(approval[key], `baseline.approval.${key}`);
+  if (!DATE.test(approval.approved_at)) fail("baseline approval date must be ISO YYYY-MM-DD");
+  if (!Array.isArray(profile.artifacts) || profile.artifacts.length === 0) fail("baseline artifacts must be non-empty");
+  for (const artifact of profile.artifacts) {
+    const actual = fileAttestation(artifact.path, baselineDir);
+    if (actual.sha256 !== artifact.sha256) fail(`baseline artifact hash changed: ${artifact.path}`);
+  }
+  for (const metric of METRICS) {
+    const budget = object(object(profile.metrics, "baseline.metrics")[metric], `baseline metric ${metric}`);
+    number(budget.reference, `${metric}.reference`);
+    number(budget.threshold, `${metric}.threshold`);
+    for (const key of ["unit", "aggregation", "source"]) text(budget[key], `${metric}.${key}`);
+    if (budget.direction !== "max") fail(`${metric}.direction must be max`);
+    if (metric === "storage_growth_ratio") number(budget.reference_bytes, `${metric}.reference_bytes`);
+  }
+  const raw = readJson(path.resolve(baselineDir, profile.artifacts[0].path), "baseline raw artifact");
+  if (fullSha(raw.commit, "baseline raw commit") !== profile.commit) fail("baseline raw commit does not match profile");
+  if (JSON.stringify(raw.evidence_identity) !== JSON.stringify(identity)) fail("baseline raw identity does not match profile");
+  for (const metric of METRICS.filter((name) => name !== "storage_growth_ratio")) {
+    if (raw.metrics?.[metric] !== profile.metrics[metric].reference) fail(`baseline raw metric ${metric} does not match profile`);
+  }
+  if (raw.metrics?.storage_bytes !== profile.metrics.storage_growth_ratio.reference_bytes) fail("baseline raw storage bytes do not match profile");
+  return profile;
+}
+function candidateCommit(expectedSha, mode, repoRoot) {
+  const expected = fullSha(expectedSha, "expected SHA");
+  if (mode === "release") {
+    const actual = fullSha(git(["rev-parse", "HEAD"], repoRoot), "Git HEAD");
+    if (actual !== expected) fail(`Git HEAD ${actual} does not match expected SHA ${expected}`);
+    if (git(["status", "--porcelain"], repoRoot) !== "") fail("release evidence requires a clean Git worktree");
+  }
+  return expected;
+}
+function packetMaximum(packet) {
+  const rows = packet.summary;
+  if (!Array.isArray(rows) || rows.length === 0) fail("packet artifact summary must be a non-empty array");
+  return Math.max(...rows.map((row, index) => number(row.median_e2e_wall_ms, `packet summary[${index}].median_e2e_wall_ms`))) / 1000;
+}
+function metricsFrom(stats, packet, profile) {
+  const values = {
+    status_seconds: stats.retrieval_status_seconds,
+    local_grounding_seconds: stats.ground_seconds,
+    convergence_seconds: stats.repeat_full_refresh_seconds,
+    packet_seconds: packetMaximum(packet),
+    search_seconds: stats.search_seconds,
+    indexing_seconds: stats.index_seconds,
+    storage_growth_ratio: stats.storage_bytes / profile.metrics.storage_growth_ratio.reference_bytes,
+  };
+  for (const metric of METRICS) number(values[metric], `candidate metric ${metric}`);
+  return values;
+}
+
+function statsContractFrom(repoRoot) {
+  const contract = readJson(path.join(repoRoot, "benchmarks/release-evidence/repo-stats-contract.json"), "stats contract");
+  if (contract.schema_version !== 1) fail("stats contract schema_version must be 1");
+  for (const field of ["repeat_graph_phase_seconds_max", "repeat_semantic_phase_seconds_max", "repeat_full_refresh_regression_factor"]) {
+    number(contract[field], `stats contract ${field}`);
+  }
+  return contract;
+}
+
+function validateRawProvenance(stats, packet, commit, profileName, identity, statsContract) {
+  if (fullSha(stats.commit, "stats.commit") !== commit) fail("raw stats commit does not match candidate");
+  if (JSON.stringify(stats.evidence_identity) !== JSON.stringify(identity)) fail("raw stats identity does not match profile");
+  if (stats.proof_tier !== "full_sidecar"
+      || stats.index?.error_count !== 0
+      || stats.index?.sidecar_status_after_retrieval_index !== "full"
+      || stats.ground?.sidecar_status_after_retrieval_index !== "full"
+      || stats.search?.sidecar_shadow_retrieval_mode !== "full"
+      || !(stats.sidecar_manifest?.symbol_doc_count > 0)
+      || !(stats.sidecar_manifest?.dense_projection_count > 0)
+      || stats.sidecar_manifest?.dense_projection_count !== stats.sidecar_manifest?.projection_count
+      || stats.sidecar_manifest?.semantic_policy_version !== "graph_first_v1"
+      || stats.sidecar_manifest?.graph_artifact_hash_present !== true
+      || stats.sidecar_manifest?.dense_reason_count_total !== stats.sidecar_manifest?.dense_projection_count
+      || stats.repeat_semantic_docs_embedded !== 0) {
+    fail("raw stats artifact does not prove the full-sidecar readiness contract");
+  }
+  const repeatBaseline = stats.stats_baseline?.repeat_full_refresh_seconds;
+  if (!(stats.repeat_graph_phase_seconds < statsContract.repeat_graph_phase_seconds_max)
+      || !(stats.repeat_semantic_phase_seconds < statsContract.repeat_semantic_phase_seconds_max)
+      || !(repeatBaseline > 0)
+      || !(stats.repeat_full_refresh_seconds < repeatBaseline * statsContract.repeat_full_refresh_regression_factor)) {
+    fail("raw stats artifact does not satisfy the shared repeat-refresh release contract");
+  }
+  const packetProvenance = object(packet.release_evidence, "packet.release_evidence");
+  if (fullSha(packetProvenance.commit, "packet commit") !== commit) fail("raw packet commit does not match candidate");
+  if (packetProvenance.profile !== profileName) fail("raw packet profile does not match candidate");
+  if (JSON.stringify(packetProvenance.evidence_identity) !== JSON.stringify(identity)) fail("raw packet identity does not match profile");
+  if (packetProvenance.publishable !== true || packetProvenance.repeats < 3 || packetProvenance.quality_gate_status !== "pass") fail("raw packet artifact is not publishable three-repeat quality-gated evidence");
+  if (packet.repeats !== packetProvenance.repeats || !Array.isArray(packet.modes) || packet.modes.length === 0) fail("raw packet top-level modes/repeats do not match provenance");
+  if (!Array.isArray(packetProvenance.publishable_blockers) || packetProvenance.publishable_blockers.length !== 0) fail("raw packet artifact contains publishable blockers");
+  const rows = packetProvenance.rows;
+  if (!Array.isArray(rows) || rows.length === 0) fail("raw packet artifact has no quality rows");
+  const repeats = new Map();
+  for (const [index, row] of rows.entries()) {
+    const sufficiency = row.sufficiency;
+    const latency = row.packet_latency;
+    const invalid = row.status !== "pass"
+      || row.quality?.pass !== true
+      || sufficiency?.status !== "sufficient"
+      || sufficiency?.sufficient_quality_mismatch === true
+      || ["follow_up_commands_count", "open_next_count", "gaps_count", "coverage_unresolved_blocking_count"]
+        .some((field) => Number(sufficiency?.[field] ?? 0) > 0)
+      || latency?.sla_missed !== false
+      || latency?.retrieval_shadow?.retrieval_mode !== "full";
+    if (invalid) fail(`raw packet quality row ${index} does not satisfy the publishable contract`);
+    const provenanceFailures = [
+      ...repoProvenanceBlockers(row),
+      ...cacheProvenanceBlockers(row),
+    ];
+    if (provenanceFailures.length > 0) {
+      fail(`raw packet provenance row ${index} failed: ${provenanceFailures.join("; ")}`);
+    }
+    if (!Number.isInteger(row.repeat) || row.repeat < 1 || row.repeat > packetProvenance.repeats) fail(`raw packet row ${index} has invalid repeat`);
+    const key = `${row.repo}/${row.task_id}/${row.mode}`;
+    const values = repeats.get(key) ?? new Set();
+    if (values.has(row.repeat)) fail(`raw packet rows contain duplicate repeat ${row.repeat} for ${key}`);
+    values.add(row.repeat);
+    repeats.set(key, values);
+  }
+  if ([...repeats.values()].some((values) => values.size !== packetProvenance.repeats)) fail("raw packet rows do not exactly cover the declared repeat count");
+  const rowModes = [...new Set(rows.map((row) => row.mode))].sort();
+  if (JSON.stringify(rowModes) !== JSON.stringify([...packet.modes].sort())) fail("raw packet row modes do not match top-level modes");
+}
+
+export function produceCandidate({ baselineDocument, baselineDir, profileName, statsPath, packetPath, outPath, expectedSha, mode, repoRoot }) {
+  const profile = profileFrom(baselineDocument, profileName, mode, baselineDir);
+  const commit = candidateCommit(expectedSha, mode, repoRoot);
+  if (commit === profile.commit) fail("candidate and baseline commits are identical");
+  const statsAbsolute = path.resolve(repoRoot, statsPath);
+  const packetAbsolute = path.resolve(repoRoot, packetPath);
+  const stats = readJson(statsAbsolute, "stats artifact");
+  const packet = readJson(packetAbsolute, "packet artifact");
+  const identity = object(stats.evidence_identity, "stats.evidence_identity");
+  for (const key of ["corpus_id", "cache_id", "machine_fingerprint"]) {
+    if (identity[key] !== profile.identity[key]) fail(`candidate ${key} does not match approved profile`);
+  }
+  const statsContract = statsContractFrom(repoRoot);
+  validateRawProvenance(stats, packet, commit, profileName, identity, statsContract);
+  const baseDir = path.dirname(path.resolve(outPath));
+  const measured = metricsFrom(stats, packet, profile);
+  const candidate = {
+    schema_version: 2,
+    baseline_id: profile.baseline_id,
+    baseline_sha256: sha256(Buffer.from(JSON.stringify(profile))),
+    commit,
+    git_state: "clean",
+    profile: profileName,
+    identity,
+    artifacts: {
+      stats: fileAttestation(statsAbsolute, baseDir),
+      packet: fileAttestation(packetAbsolute, baseDir),
+    },
+    metrics: Object.fromEntries(METRICS.map((metric) => [metric, {
+      value: measured[metric],
+      unit: profile.metrics[metric].unit,
+      aggregation: profile.metrics[metric].aggregation,
+    }])),
+  };
+  mkdirSync(baseDir, { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(candidate, null, 2)}\n`);
+  return candidate;
+}
+
+function strictDate(value, label) {
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (!DATE.test(text(value, label)) || Number.isNaN(parsed.valueOf()) || parsed.toISOString().slice(0, 10) !== value) fail(`${label} must be a valid ISO date`);
+  return value;
+}
+function exceptionFor(approval, context) {
+  if (!approval) return null;
+  for (const [key, expected] of Object.entries(context.bindings)) {
+    if (approval[key] !== expected) fail(`approval ${key} does not match measured evidence`);
+  }
+  strictDate(approval.approved_at, "approval.approved_at");
+  strictDate(approval.expires_at, "approval.expires_at");
+  if (approval.expires_at < approval.approved_at || approval.expires_at < new Date().toISOString().slice(0, 10)) fail("approval is expired or expires before approval date");
+  text(approval.owner, "approval.owner");
+  text(approval.rationale, "approval.rationale");
+  return approval;
+}
+
+export function evaluateCandidate({ baselineDocument, baselineDir, candidatePath, approvalDocument = null, outPath, expectedSha, mode, repoRoot }) {
+  const bytes = readFileSync(candidatePath);
+  const candidateHash = sha256(bytes);
+  const candidate = JSON.parse(bytes);
+  if (candidate.schema_version !== 2) fail("candidate schema_version must be 2");
+  const profile = profileFrom(baselineDocument, candidate.profile, mode, baselineDir);
+  const commit = candidateCommit(expectedSha, mode, repoRoot);
+  if (candidate.commit !== commit || candidate.git_state !== "clean") fail("candidate is not bound to the clean expected commit");
+  if (candidate.commit === profile.commit) fail("candidate and baseline commits are identical");
+  const baselineHash = sha256(Buffer.from(JSON.stringify(profile)));
+  if (candidate.baseline_id !== profile.baseline_id || candidate.baseline_sha256 !== baselineHash) fail("candidate baseline identity/hash does not match");
+  if (JSON.stringify(candidate.identity) !== JSON.stringify(profile.identity)) fail("candidate identity does not match profile");
+  const baseDir = path.dirname(path.resolve(candidatePath));
+  for (const artifact of Object.values(object(candidate.artifacts, "candidate.artifacts"))) {
+    const actual = fileAttestation(artifact.path, baseDir);
+    if (actual.sha256 !== artifact.sha256 || actual.bytes !== artifact.bytes) fail(`artifact attestation changed: ${artifact.path}`);
+  }
+  const statsPath = path.resolve(baseDir, candidate.artifacts.stats.path);
+  const packetPath = path.resolve(baseDir, candidate.artifacts.packet.path);
+  const stats = readJson(statsPath, "stats artifact");
+  const packet = readJson(packetPath, "packet artifact");
+  const statsContract = statsContractFrom(repoRoot);
+  validateRawProvenance(stats, packet, commit, candidate.profile, profile.identity, statsContract);
+  const measured = metricsFrom(stats, packet, profile);
+  if (approvalDocument && approvalDocument.schema_version !== 2) fail("approval schema_version must be 2");
+  const approvals = approvalDocument?.metrics ?? {};
+  const rows = METRICS.map((metric) => {
+    const recorded = object(candidate.metrics[metric], `candidate metric ${metric}`);
+    const budget = profile.metrics[metric];
+    if (recorded.value !== measured[metric] || recorded.unit !== budget.unit || recorded.aggregation !== budget.aggregation) fail(`candidate metric ${metric} is not derived with the approved unit/aggregation`);
+    const passed = measured[metric] <= budget.threshold;
+    const bindings = {
+      candidate_sha256: candidateHash, commit, profile: candidate.profile,
+      baseline_id: profile.baseline_id, baseline_sha256: baselineHash, metric,
+      measured_value: measured[metric], threshold: budget.threshold,
+    };
+    const exception = passed ? null : exceptionFor(approvals[metric], { bindings });
+    return { status: passed ? "pass" : exception ? "approved_exception" : "fail", metric,
+      decision: passed ? "accept" : exception ? "accept_with_rationale" : "reject",
+      measured_value: measured[metric], reference: budget.reference, threshold: budget.threshold,
+      unit: budget.unit, aggregation: budget.aggregation, source: budget.source,
+      ...(exception ? { approval: exception } : {}) };
+  });
+  const rejected = rows.some((row) => row.decision === "reject");
+  const report = { schema_version: 2, status: rejected ? "fail" : "pass", decision: rejected ? "reject_release" : mode === "release" ? "accept_release" : "accept_contract",
+    commit, profile: candidate.profile, baseline_id: profile.baseline_id, baseline_sha256: baselineHash,
+    candidate_path: path.relative(repoRoot, path.resolve(candidatePath)).replaceAll(path.sep, "/"), candidate_sha256: candidateHash,
+    artifact_paths: Object.values(candidate.artifacts), metrics: rows };
+  mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`);
+  return report;
+}
+
+function args(argv) {
+  const command = argv.shift();
+  const values = {};
+  while (argv.length) { const key = argv.shift(); const value = argv.shift(); if (!key?.startsWith("--") || value == null) fail("arguments must be --key value pairs"); values[key.slice(2)] = value; }
+  return { command, values };
+}
+function main() {
+  const { command, values } = args(process.argv.slice(2));
+  if (command === "fingerprint") {
+    console.log(machineFingerprint());
+    return;
+  }
+  const repoRoot = path.resolve(values.repo ?? path.resolve(path.dirname(new URL(import.meta.url).pathname), ".."));
+  const baselineDocument = readJson(values.baseline, "baseline");
+  const baselineDir = path.dirname(path.resolve(values.baseline));
+  const mode = values.mode ?? "contract";
+  if (command === "produce") produceCandidate({ baselineDocument, baselineDir, profileName: values.profile, statsPath: values.stats, packetPath: values.packet, outPath: values.out, expectedSha: values["expected-sha"], mode, repoRoot });
+  else if (command === "evaluate") {
+    const report = evaluateCandidate({ baselineDocument, baselineDir, candidatePath: values.candidate, approvalDocument: values.approval ? readJson(values.approval, "approval") : null, outPath: values.out, expectedSha: values["expected-sha"], mode, repoRoot });
+    if (!report.decision.startsWith("accept_")) process.exitCode = 1;
+  } else fail("command must be produce or evaluate");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) main();

--- a/scripts/lint-retrieval-generalization.mjs
+++ b/scripts/lint-retrieval-generalization.mjs
@@ -25,17 +25,17 @@ const explicitScanRoots = (
   .split(path.delimiter)
   .filter(Boolean);
 
+const structuralScanDirs = readdirSync(path.join(repoRoot, "crates"), { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && entry.name !== "codestory-bench")
+  .map((entry) => path.join(repoRoot, "crates", entry.name, "src"))
+  .filter(existsSync);
+
 const requiredScanDirs = [
   path.join(repoRoot, "crates", "codestory-runtime", "src", "agent"),
   path.join(repoRoot, "crates", "codestory-retrieval", "src"),
 ];
 
-const requiredProductionOnlyFiles = [
-  path.join(repoRoot, "crates", "codestory-runtime", "src", "agent", "orchestrator.rs"),
-  path.join(repoRoot, "crates", "codestory-runtime", "src", "lib.rs"),
-  path.join(repoRoot, "crates", "codestory-runtime", "src", "semantic_doc_text.rs"),
-  path.join(repoRoot, "crates", "codestory-retrieval", "src", "ranker.rs"),
-];
+const requiredProductionOnlyFiles = [];
 
 const usesDefaultScanRoots = explicitScanRoots.length === 0;
 const missingRequiredPaths = usesDefaultScanRoots
@@ -89,12 +89,18 @@ const benchmarkEvalProbeSourcePath = path.join(
   "agent",
   "eval_probes.rs",
 );
+const evalCorpusRoots = [
+  benchmarkTaskRoot,
+  path.join(repoRoot, "crates", "codestory-cli", "tests", "fixtures", "packet_search_eval"),
+  path.join(repoRoot, "crates", "codestory-cli", "tests", "fixtures", "agent_quality"),
+];
 
 const missingBenchmarkBoundaryFiles = [
   ...benchmarkIdentityScriptFiles,
   ...benchmarkPromptScriptFiles.map(({ filePath }) => filePath),
   benchmarkEvalProbeManifestPath,
   benchmarkEvalProbeSourcePath,
+  ...evalCorpusRoots,
 ].filter((scriptPath, index, paths) =>
   paths.indexOf(scriptPath) === index && !existsSync(scriptPath)
 );
@@ -200,6 +206,7 @@ const bannedPatterns = [
   "nvm",
   "install\\.sh\\s+nvm",
   "bash_completion\\s+__nvm",
+  ...evalCorpusBoundaryPatterns(),
   ...benchmarkManifestDerivedPatterns(),
   ...benchmarkEvalProbeDerivedPatterns(),
   ...benchmarkScriptPromptDerivedPatterns(),
@@ -227,6 +234,7 @@ const bannedCompactPatterns = [
   "datarequest",
   "sessiondelegate",
   "sourceanimatecss",
+  ...evalCorpusCompactPatterns(),
 ];
 
 const allowedPatternLines = [
@@ -241,6 +249,27 @@ const allowedPatternLines = [
 ];
 
 const rankerFilenameLiteralPattern = /["'`][a-z0-9][a-z0-9._-]*\.[a-z0-9]+["'`]/i;
+
+function evalCorpusBoundaryPatterns() {
+  const corpusFiles = [
+    ...evalCorpusRoots.flatMap((root) => walkFiles(root, () => true)),
+    ...benchmarkIdentityScriptFiles,
+    benchmarkEvalProbeSourcePath,
+  ];
+  if (corpusFiles.length === 0) {
+    throw new Error("eval/query corpus boundary contains no files");
+  }
+  return [
+    ...evalCorpusRoots.map((root) => path.relative(repoRoot, root).replaceAll(path.sep, "/")),
+    ...corpusFiles.map((filePath) => path.relative(repoRoot, filePath).replaceAll(path.sep, "/")),
+  ].map(escapeRegExp);
+}
+
+function evalCorpusCompactPatterns() {
+  return evalCorpusBoundaryPatterns()
+    .map((pattern) => compactProductionSource(pattern.replaceAll("\\", "")))
+    .filter((pattern) => pattern.length >= 12);
+}
 
 function benchmarkManifestDerivedPatterns() {
   if (!existsSync(benchmarkTaskRoot)) {
@@ -1255,6 +1284,38 @@ for (const filePath of [...scanFiles].sort()) {
   }
 }
 
+const corpusRegexPatterns = evalCorpusBoundaryPatterns().map((pattern) => ({
+  pattern,
+  re: new RegExp(pattern, "i"),
+}));
+const corpusCombinedRegex = new RegExp(
+  corpusRegexPatterns.map(({ pattern }) => `(?:${pattern})`).join("|"),
+  "i",
+);
+const structuralFiles = new Set();
+for (const root of structuralScanDirs) {
+  for (const filePath of walkRustProductionFiles(root)) structuralFiles.add(filePath);
+}
+for (const filePath of [...structuralFiles].sort()) {
+  if (isEvalOnlyProductionFile(filePath)) continue;
+  const prepared = prepareProductionFile(filePath);
+  const hitsByPattern = scanProductionFile(prepared, corpusRegexPatterns, corpusCombinedRegex);
+  for (const { pattern } of corpusRegexPatterns) {
+    const hits = hitsByPattern.get(pattern) ?? [];
+    if (hits.length > 0) {
+      console.error(`Production dependency on eval/query corpus /${pattern}/ in ${path.relative(repoRoot, filePath)}:\n${hits.join("\n")}\n`);
+      failed = true;
+    }
+  }
+  for (const pattern of evalCorpusCompactPatterns()) {
+    const hits = scanProductionCompactPatterns(prepared, pattern);
+    if (hits.length > 0) {
+      console.error(`Constructed production dependency on eval/query corpus /${pattern}/ in ${path.relative(repoRoot, filePath)}:\n${hits.join("\n")}\n`);
+      failed = true;
+    }
+  }
+}
+
 if (failed) {
   console.error(
     "retrieval generalization lint failed: remove repo-specific literals from retrieval integration code",
@@ -1263,5 +1324,5 @@ if (failed) {
 }
 
 console.log(
-  `lint-retrieval-generalization: ok (${scanDirs.length} dir(s), ${scanFiles.size} production file(s), ${bannedPatterns.length} patterns)`,
+  `lint-retrieval-generalization: ok (${scanDirs.length} retrieval dir(s), ${scanFiles.size} retrieval file(s), ${structuralFiles.size} production file(s), ${bannedPatterns.length} patterns)`,
 );

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const script = path.join(root, "scripts/codestory-release-evidence-gate.mjs");
+const fixture = path.join(root, "benchmarks/release-evidence/fixtures");
+const baseline = path.join(root, "benchmarks/release-evidence/approved-baselines.json");
+const candidateSha = "2222222222222222222222222222222222222222";
+
+function run(command, extra = []) {
+  return spawnSync(process.execPath, [script, command, "--baseline", baseline, "--expected-sha", candidateSha, "--mode", "contract", "--repo", root, ...extra], { encoding: "utf8" });
+}
+function workspace() {
+  const dir = mkdtempSync(path.join(tmpdir(), "codestory-release-evidence-"));
+  copyFileSync(path.join(fixture, "candidate-stats.json"), path.join(dir, "stats.json"));
+  copyFileSync(path.join(fixture, "candidate-packet.json"), path.join(dir, "packet.json"));
+  return dir;
+}
+function produce(dir) {
+  const result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "stats.json"), "--packet", path.join(dir, "packet.json"), "--out", path.join(dir, "candidate.json")]);
+  assert.equal(result.status, 0, result.stderr);
+}
+function reattest(candidate, artifact, filePath) {
+  const bytes = readFileSync(filePath);
+  candidate.artifacts[artifact].sha256 = createHash("sha256").update(bytes).digest("hex");
+  candidate.artifacts[artifact].bytes = bytes.length;
+}
+
+test("checked-in candidate and report are deterministic and fully attested", () => {
+  const dir = workspace();
+  const out = path.join(dir, "report.json");
+  const result = run("evaluate", ["--candidate", path.join(fixture, "candidate.json"), "--out", out]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(readFileSync(out)), JSON.parse(readFileSync(path.join(fixture, "report.json"))));
+  const report = JSON.parse(readFileSync(out));
+  assert.equal(report.decision, "accept_contract");
+  assert.ok(report.artifact_paths.every(({ sha256, bytes }) => /^[0-9a-f]{64}$/.test(sha256) && bytes > 0));
+});
+
+test("missing and all-zero raw artifacts fail production", () => {
+  const dir = workspace();
+  let result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "missing.json"), "--packet", path.join(dir, "packet.json"), "--out", path.join(dir, "candidate.json")]);
+  assert.notEqual(result.status, 0);
+  const stats = JSON.parse(readFileSync(path.join(dir, "stats.json")));
+  for (const key of ["retrieval_status_seconds", "ground_seconds", "repeat_full_refresh_seconds", "search_seconds", "index_seconds", "storage_bytes"]) stats[key] = 0;
+  writeFileSync(path.join(dir, "stats.json"), JSON.stringify(stats));
+  result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "stats.json"), "--packet", path.join(dir, "packet.json"), "--out", path.join(dir, "candidate.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /finite positive number/);
+});
+
+test("artifact mutation, identity drift, and short SHA are rejected", () => {
+  const dir = workspace();
+  produce(dir);
+  writeFileSync(path.join(dir, "packet.json"), JSON.stringify({ summary: [{ median_e2e_wall_ms: 1 }] }));
+  let result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--out", path.join(dir, "report.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /artifact attestation changed/);
+  result = spawnSync(process.execPath, [script, "evaluate", "--baseline", baseline, "--candidate", path.join(fixture, "candidate.json"), "--out", path.join(dir, "report.json"), "--expected-sha", candidateSha.slice(0, 8), "--mode", "contract", "--repo", root], { encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /full 40-character Git SHA/);
+  const stats = JSON.parse(readFileSync(path.join(fixture, "candidate-stats.json")));
+  stats.evidence_identity.cache_id = "different-cache";
+  writeFileSync(path.join(dir, "stats.json"), JSON.stringify(stats));
+  result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "stats.json"), "--packet", path.join(fixture, "candidate-packet.json"), "--out", path.join(dir, "candidate-2.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /cache_id does not match/);
+
+  stats.commit = "1111111111111111111111111111111111111111";
+  stats.evidence_identity.cache_id = "cold-full-sidecar-v1";
+  writeFileSync(path.join(dir, "stats.json"), JSON.stringify(stats));
+  result = spawnSync(process.execPath, [script, "produce", "--baseline", baseline, "--profile", "ci-contract-v1", "--stats", path.join(dir, "stats.json"), "--packet", path.join(fixture, "candidate-packet.json"), "--out", path.join(dir, "candidate-3.json"), "--expected-sha", stats.commit, "--mode", "contract", "--repo", root], { encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /identical/);
+});
+
+test("regression approval is bound to candidate hash, value, threshold, baseline, profile, and expiry", () => {
+  const dir = workspace();
+  const stats = JSON.parse(readFileSync(path.join(dir, "stats.json")));
+  stats.retrieval_status_seconds = 2;
+  writeFileSync(path.join(dir, "stats.json"), JSON.stringify(stats));
+  produce(dir);
+  const reportPath = path.join(dir, "report.json");
+  let result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--out", reportPath]);
+  assert.equal(result.status, 1, result.stderr);
+  const report = JSON.parse(readFileSync(reportPath));
+  const row = report.metrics.find(({ metric }) => metric === "status_seconds");
+  const approval = {
+    schema_version: 2,
+    metrics: {
+      status_seconds: {
+        candidate_sha256: report.candidate_sha256,
+        commit: report.commit,
+        profile: report.profile,
+        baseline_id: report.baseline_id,
+        baseline_sha256: report.baseline_sha256,
+        metric: row.metric,
+        measured_value: row.measured_value,
+        threshold: row.threshold,
+        owner: "release owner",
+        approved_at: "2026-07-11",
+        expires_at: "2099-07-11",
+        rationale: "Bound contract exception"
+      }
+    }
+  };
+  const approvalPath = path.join(dir, "approval.json");
+  writeFileSync(approvalPath, JSON.stringify(approval));
+  result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--approval", approvalPath, "--out", reportPath]);
+  assert.equal(result.status, 0, result.stderr);
+  approval.metrics.status_seconds.measured_value = 1.9;
+  writeFileSync(approvalPath, JSON.stringify(approval));
+  result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--approval", approvalPath, "--out", reportPath]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /does not match measured evidence/);
+  approval.metrics.status_seconds.measured_value = row.measured_value;
+  approval.metrics.status_seconds.approved_at = "2026-02-31";
+  writeFileSync(approvalPath, JSON.stringify(approval));
+  result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--approval", approvalPath, "--out", reportPath]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /valid ISO date/);
+});
+
+test("evaluation independently rejects reattested raw commit and packet provenance drift", () => {
+  const dir = workspace();
+  produce(dir);
+  let candidate = JSON.parse(readFileSync(path.join(dir, "candidate.json")));
+  const statsPath = path.join(dir, "stats.json");
+  const stats = JSON.parse(readFileSync(statsPath));
+  stats.commit = "3333333333333333333333333333333333333333";
+  writeFileSync(statsPath, JSON.stringify(stats));
+  reattest(candidate, "stats", statsPath);
+  writeFileSync(path.join(dir, "candidate.json"), JSON.stringify(candidate));
+  let result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--out", path.join(dir, "report.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /raw stats commit/);
+
+  const dir2 = workspace();
+  produce(dir2);
+  candidate = JSON.parse(readFileSync(path.join(dir2, "candidate.json")));
+  const packetPath = path.join(dir2, "packet.json");
+  const packet = JSON.parse(readFileSync(packetPath));
+  packet.release_evidence.publishable = false;
+  packet.release_evidence.repeats = 1;
+  packet.release_evidence.quality_gate_status = "fail";
+  writeFileSync(packetPath, JSON.stringify(packet));
+  reattest(candidate, "packet", packetPath);
+  writeFileSync(path.join(dir2, "candidate.json"), JSON.stringify(candidate));
+  result = run("evaluate", ["--candidate", path.join(dir2, "candidate.json"), "--out", path.join(dir2, "report.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /not publishable three-repeat quality-gated/);
+});
+
+test("failed packet quality and non-full stats cannot produce or evaluate a passing candidate", () => {
+  const dir = workspace();
+  const packetPath = path.join(dir, "packet.json");
+  const packet = JSON.parse(readFileSync(packetPath));
+  packet.release_evidence.rows[0].quality.pass = false;
+  writeFileSync(packetPath, JSON.stringify(packet));
+  let result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "stats.json"), "--packet", packetPath, "--out", path.join(dir, "candidate.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /quality row 0/);
+
+  const dir2 = workspace();
+  produce(dir2);
+  const statsPath = path.join(dir2, "stats.json");
+  const stats = JSON.parse(readFileSync(statsPath));
+  stats.proof_tier = "stats_only";
+  writeFileSync(statsPath, JSON.stringify(stats));
+  const candidate = JSON.parse(readFileSync(path.join(dir2, "candidate.json")));
+  reattest(candidate, "stats", statsPath);
+  writeFileSync(path.join(dir2, "candidate.json"), JSON.stringify(candidate));
+  result = run("evaluate", ["--candidate", path.join(dir2, "candidate.json"), "--out", path.join(dir2, "report.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /full-sidecar readiness contract/);
+});
+
+test("forged provenance, duplicate repeats, and omitted repeat budgets fail", () => {
+  const dir = workspace();
+  let packet = JSON.parse(readFileSync(path.join(dir, "packet.json")));
+  packet.release_evidence.rows[0].repo_provenance = {};
+  packet.release_evidence.rows[0].codestory_cache_provenance = {};
+  writeFileSync(path.join(dir, "packet.json"), JSON.stringify(packet));
+  let result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "stats.json"), "--packet", path.join(dir, "packet.json"), "--out", path.join(dir, "candidate.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /provenance row 0 failed/);
+
+  const dir2 = workspace();
+  packet = JSON.parse(readFileSync(path.join(dir2, "packet.json")));
+  packet.release_evidence.rows[1].repeat = 1;
+  writeFileSync(path.join(dir2, "packet.json"), JSON.stringify(packet));
+  result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir2, "stats.json"), "--packet", path.join(dir2, "packet.json"), "--out", path.join(dir2, "candidate.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /duplicate repeat 1/);
+
+  const dir3 = workspace();
+  produce(dir3);
+  const statsPath = path.join(dir3, "stats.json");
+  const stats = JSON.parse(readFileSync(statsPath));
+  delete stats.repeat_semantic_phase_seconds;
+  writeFileSync(statsPath, JSON.stringify(stats));
+  const candidate = JSON.parse(readFileSync(path.join(dir3, "candidate.json")));
+  reattest(candidate, "stats", statsPath);
+  writeFileSync(path.join(dir3, "candidate.json"), JSON.stringify(candidate));
+  result = run("evaluate", ["--candidate", path.join(dir3, "candidate.json"), "--out", path.join(dir3, "report.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /repeat-refresh release contract/);
+});


### PR DESCRIPTION
## Context

The repo-scale harness treated the latest Markdown stats row as the next baseline and emitted warnings for many release-significant regressions. That allowed a slower candidate to become its own future reference. #922 also requires production code to remain structurally separated from eval/query corpora.

This PR builds the attested candidate/evaluator infrastructure without activating it in current release workflows. Live baseline approval and release activation remain on #922.

Closes #952
Refs #922, #899

## What Changed

- Added versioned, machine-profiled baseline and shared stats contracts with seven metric budgets.
- Added a fail-closed candidate producer/evaluator that re-derives metrics from hashed raw artifacts and validates Git, repository/cache provenance, full-sidecar proof, publishable packet quality, exact repeats, units, aggregation, storage, and repeat-performance limits.
- Added tightly bound, expiring approval exceptions and exact prior-run re-evaluation.
- Added a manual/reusable provisioned workflow with explicit drill/model/profile inputs and `if: always()` evidence upload.
- Kept `release.yml`, `auto-release.yml`, and the legacy warning/repeat-refresh enforcement unchanged until a live eligible profile exists.
- Expanded the Rust production boundary guard for inventoried eval/query corpora and documented its non-Rust/runtime-indirection limits.

```mermaid
flowchart LR
    Provision[Provisioned runner inputs] --> Raw[Raw repo + packet artifacts]
    Raw --> Attest[SHA/bytes/identity attestation]
    Attest --> Candidate[Same-SHA candidate]
    Candidate --> Evaluate[Independent re-evaluation]
    Evaluate -->|pass| Report[Auditable decision report]
    Evaluate -->|reject| Evidence[Durable rejection artifacts]
    Approval[Bound, expiring approval] --> Evaluate
```

## How To Review

1. Start with `codestory-release-evidence-gate.mjs` and its trust tests.
2. Confirm benchmark and evaluator share repository/cache provenance validation and stats budget contracts.
3. Review the manual/reusable workflow provisioning and rejection-artifact paths.
4. Confirm current release workflows are unchanged and the checked profile is non-release.
5. Review the exact scope of the Rust corpus boundary; it deliberately does not claim runtime-generated or non-Rust indirection coverage.

## Verification

- Release evidence trust tests: 7 passed.
- Benchmark analyzer: 79 passed.
- Repo e2e non-ignored contract tests: 5 passed; 2 heavy tests intentionally ignored.
- Retrieval generalization guard: 15 passed.
- Generalization lint: 56 retrieval files, 179 production Rust files, 1,429 patterns.
- Focused Clippy `-D warnings`, release build, formatting, workflow policy, YAML parse, docs links, and diff checks passed.

The provisioned live benchmark was unavailable locally because the real-repo drill manifest and embedding model are absent. No live report or stats row was fabricated; the checked fixtures are explicitly contract-only.

## Risk

- This infrastructure intentionally cannot authorize a release yet: no checked profile is release-eligible.
- The manual workflow requires the documented self-hosted label, model, drill manifest, and capacity inputs.
- Current releases retain their existing enforcement until #922 provisions a live baseline and activates the proven gate.
