### PR TITLE
correct macOS x64 managed guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 ### Fixed
 
+- Corrected the Codex managed-platform guide to list the restored macOS x64 CLI
+  while retaining its no-managed-accelerated-sidecar boundary.
 - Extended the retrieval generalization guard from derived query literals to
   direct and split Rust string dependencies on eval/query corpus paths across
   production crates, including benchmark manifests, query catalogs, packet

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -156,7 +156,7 @@ More pairs, anti-patterns, and language-flavored examples:
 | Windows arm64 | Yes | No managed accelerated sidecar cell; use a proven external endpoint or explicit degraded CPU opt-in |
 | Linux x64 / arm64 | Yes | Docker Vulkan with a verified `/dev/dri` render node |
 | macOS arm64 | Yes | Native Metal |
-| macOS x64 | No release asset; managed plugin runtime unsupported | Build or provide an explicit compatible `CODESTORY_CLI` first; then use a proven external embedding endpoint or explicit degraded CPU opt-in |
+| macOS x64 | Yes | No managed accelerated sidecar cell; use a proven external embedding endpoint or explicit degraded CPU opt-in |
 
 Linux CUDA, HIP/ROCm, SYCL, and OpenVINO remain contract-only until packaging,
 launch, and live GPU evidence exist. A compatible version difference is


### PR DESCRIPTION
## Context

PR #960 restored and proved the macOS x64 managed CLI asset, but the user
platform matrix still said that asset did not exist.

Closes #969
Refs #957
Refs #921
Refs #899

## What Changed

- Marked macOS x64 managed CLI support as available.
- Retained the honest boundary that macOS x64 has no managed accelerated
  sidecar cell and requires a proven external endpoint or explicit degraded CPU
  opt-in.
- Recorded the guidance correction in the changelog.

## How To Review

Compare the platform row with #960's packaged and post-publish matrices.

## Verification

- Documentation links: 69 files, 279 relative links passed.
- `git diff --check`: passed.
- The source packaged matrix and PR #960 CI prove the macOS x64 asset.

## Risk

Documentation-only; no runtime behavior changes.
