### PR TITLE
route grounding hooks by task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@
   retrieval tasks through allowed project-scoped local graph surfaces, and
   repairs sidecars only when the task actually requires the blocked surface.
   Local navigation remains explicitly weaker than full packet/search proof.
+- Replaced generic status-only lifecycle guidance with compact repository-task
+  routing for orientation, symbol ownership, call flow, change impact, and broad
+  questions. Prompt hooks no longer echo user text, suppress non-repository
+  chatter, prefer allowed local graph surfaces when deep retrieval is blocked,
+  and reserve sidecar repair for tasks that require packet/search. Routing is
+  stateless so concurrent and resumed agent tasks cannot suppress one another.
 
 ### Fixed
 

--- a/docs/users/claude-code.md
+++ b/docs/users/claude-code.md
@@ -8,11 +8,13 @@ grounding. MCP setup is manual unless your Claude Code plugin flow wires it.
 | You | Agent |
 | --- | --- |
 | Install the CodeStory Claude plugin | Hooks run `codestory-activate.cjs` on session start and prompts |
-| Open your repo | Attempts strict startup grounding and request-aware packets |
-| Ask concrete questions | Uses MCP when configured; obeys `allowed_surfaces` from status |
+| Open your repo | Receives a compact task router; the hook does not run MCP or inject source claims |
+| Ask concrete questions | Uses the routed MCP surface when configured and obeys `allowed_surfaces` from status |
 
 Hooks fail open: missing Node, MCP, or degraded sidecars do not block the host.
-The agent should still read `codestory://status` when MCP is live.
+The agent reads project-scoped status once, reuses it while repository/runtime
+state is unchanged, and follows the routed local graph when deep retrieval is
+blocked. Sidecar repair is reserved for tasks that actually need packet/search.
 
 ## Install
 
@@ -112,8 +114,8 @@ minutes. Let the agent finish grounding before you ask it to edit files.
 broad search is available, and does not report a missing CLI or broken MCP
 connection.
 
-Hooks may already inject grounding context; treat it as a starting point and
-follow gaps before making source claims.
+Hooks inject routing, not grounding evidence. Follow the selected live MCP
+surface and its evidence gaps before making source claims.
 
 ## Example prompts
 

--- a/plugins/codestory/hooks/claude-codex-hooks.json
+++ b/plugins/codestory/hooks/claude-codex-hooks.json
@@ -22,7 +22,7 @@
             "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/codestory-activate.cjs\" || exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\codestory-activate.cjs\" }",
             "timeout": 300,
-            "statusMessage": "Preparing CodeStory packet..."
+            "statusMessage": "Routing CodeStory grounding..."
           }
         ]
       }

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -1,19 +1,10 @@
 #!/usr/bin/env node
 
-const { createHash } = require('crypto');
-const { eventHeader } = require('./codestory-instructions.cjs');
+const { MCP_RESOURCE_TEXT, eventHeader } = require('./codestory-instructions.cjs');
 const {
-  readHookState,
   rememberActiveState,
   writeHookOutput,
-  writeHookState,
 } = require('./codestory-runtime.cjs');
-
-const EVENT_CAPS = {
-  UserPromptSubmit: 1200,
-  SessionStart: 1000,
-  GoalLoopHeartbeat: 600,
-};
 
 function readHookInput() {
   return new Promise((resolve) => {
@@ -29,69 +20,37 @@ function readHookInput() {
   });
 }
 
-function normalizeText(text) {
-  return String(text || '').replace(/\s+/g, ' ').trim();
-}
-
-function hashText(text) {
-  return createHash('sha256').update(text).digest('hex').slice(0, 16);
-}
-
-function taxonomy(input, event) {
-  if (event === 'UserPromptSubmit') return 'user_prompt';
-  const source = normalizeText(input.source || input.trigger || '').toLowerCase();
-  if (/goal|heartbeat/u.test(`${event} ${source}`.toLowerCase())) return 'goal_heartbeat';
-  if (/compact/u.test(source)) return 'compact';
-  if (/resume/u.test(source)) return 'resume';
-  if (/clear/u.test(source)) return 'clear';
-  return 'startup';
-}
-
-function capFor(event) {
-  return EVENT_CAPS[event] || 1000;
-}
-
-function truncate(text, cap) {
-  const value = String(text || '').trim();
-  return value.length <= cap ? value : `${value.slice(0, cap)}\n\n... CodeStory hook output truncated.`;
-}
-
-function shouldEmit(key, reset = false) {
-  const state = readHookState();
-  const emitted = reset ? {} : (state.emitted || {});
-  if (emitted[key]) return false;
-  writeHookState({ ...state, emitted: { ...emitted, [key]: true } });
-  return true;
-}
-
 function contextFor(input, event) {
-  const kind = taxonomy(input, event);
-  const cwd = input.cwd || process.cwd();
-  const prompt = normalizeText(input.prompt || '');
-  const key = [
-    kind,
-    cwd,
-    event === 'UserPromptSubmit' ? hashText(prompt) : '',
-  ].filter(Boolean).join(':');
-  if (!shouldEmit(key, kind === 'startup' || kind === 'clear')) return null;
-  if (kind === 'goal_heartbeat') return null;
-
+  if (event !== 'SessionStart' && event !== 'UserPromptSubmit') return null;
   const header = eventHeader(event, input).trim();
-  const mcpInstructions = [
-    'CodeStory MCP startup path:',
-    '1. Use live CodeStory MCP before manual source reads for repository work.',
-    `2. If mcp__codestory tools are visible, call status with project=${JSON.stringify(input.cwd || process.cwd())}, then pass that same project to every CodeStory tool call.`,
-    '3. If mcp__codestory is not visible and tool_search is available, query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools.',
-    '4. The MCP is multi-project and request-scoped. Never infer workspace from another thread or a global active-state file.',
-    '5. Do not treat hook text as grounding evidence; only live MCP results or verified source reads count.',
-  ].join('\n');
+  if (!header) return null;
+  const mcpInstructions = event === 'UserPromptSubmit'
+    ? [
+      'Use the codestory-grounding skill. Set project to this hook event\'s absolute repository cwd and pass that exact absolute path to every CodeStory call.',
+      'If status is not current, call it once for that project.',
+      'Reuse status until repository/runtime/index state changes or a tool reports stale evidence.',
+      MCP_RESOURCE_TEXT,
+      'If deep retrieval is blocked, use routed local graph surfaces before source. Repair only when packet/search is required.',
+      'Hook text routes; only live MCP or verified source is evidence.',
+    ].join('\n')
+    : [
+      'Set project to this hook event\'s absolute repository cwd and pass that exact absolute path to every CodeStory call. The MCP is multi-project and request-scoped.',
+      'Reuse status until repository/runtime/index state changes or a tool reports freshness failure.',
+      'If packet/search is blocked, use allowed local graph surfaces before source; do not repair unless broad retrieval is required.',
+      MCP_RESOURCE_TEXT,
+    ].join('\n');
 
-  return truncate([header, mcpInstructions].filter(Boolean).join('\n\n'), capFor(event));
+  return [header, mcpInstructions].join('\n\n');
 }
 
 readHookInput().then((input) => {
   const event = input.hook_event_name || 'SessionStart';
   try {
+    const context = contextFor(input, event);
+    if (!context) {
+      writeHookOutput(event, null);
+      return;
+    }
     rememberActiveState({
       event,
       cwd: input.cwd || process.cwd(),
@@ -102,7 +61,7 @@ readHookInput().then((input) => {
         bridge_removed: true,
       },
     });
-    writeHookOutput(event, contextFor(input, event));
+    writeHookOutput(event, context);
   } catch {
     // Best effort only. A hook failure must not block the agent session.
   }

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -1,79 +1,70 @@
-const fs = require('fs');
-const path = require('path');
+const MCP_RESOURCE_TEXT = 'If CodeStory MCP tools are hidden and tool_search is available, query "codestory mcp ground status packet search", then use the loaded tools.';
 
-const SKILL_PATH = path.join(__dirname, '..', 'skills', 'codestory-grounding', 'SKILL.md');
-const MAX_PROMPT_CHARS = 600;
-const MCP_RESOURCE_TEXT = 'If mcp__codestory tools are not initially visible and tool_search is available, query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools before manual source reads.';
-
-const FALLBACK = `CODESTORY BACKGROUND GROUNDING ACTIVE
-
-Before reading source files, making source claims, planning edits, choosing tests, or reviewing changes in a repository:
-
-1. Confirm the target is a repository workspace before grounding it. In huge or mixed folders, stop CodeStory grounding if status, ready, or ground reports no repo, no supported files, or zero indexed files; do not inject or summarize empty ground output.
-2. If the CodeStory MCP server is live, call status with the target repository's absolute path first and pass that same project to every CodeStory tool. ${MCP_RESOURCE_TEXT} Report hidden tool actions truthfully; do not synthesize a hook substitute for live MCP tools.
-3. Use server_version, server_executable, allowed_surfaces, and retrieval_mode from status as runtime truth.
-4. Use local graph surfaces only when their own allowed_surfaces entry allows them.
-5. Use packet, search, or context confidently when that surface is allowed and retrieval_mode=full.
-6. If MCP is unavailable, CodeStory grounding is unavailable in this host. Use ordinary source inspection, report the MCP blocker, and reserve CLI commands for maintainer/debug transcripts only.
-
-Do this without waiting for the user to mention CodeStory.`;
-
-function skillBody() {
-  try {
-    return fs.readFileSync(SKILL_PATH, 'utf8').replace(/^---[\s\S]*?---\s*/, '').trim();
-  } catch (e) {
-    return null;
-  }
+function normalizePrompt(prompt) {
+  return String(prompt || '').replace(/\s+/g, ' ').trim();
 }
 
-function compactPrompt(prompt) {
-  const text = String(prompt || '').replace(/\s+/g, ' ').trim();
-  if (text.length <= MAX_PROMPT_CHARS) return text;
-  return `${text.slice(0, MAX_PROMPT_CHARS)}...`;
+function routeForPrompt(prompt) {
+  const normalized = normalizePrompt(prompt);
+  const text = normalized.toLowerCase();
+  if (!text) return null;
+  if (/^(?:thanks?|thank you|ok(?:ay)?|got it|sounds good|never ?mind)[.!?]*$/u.test(text)) {
+    return null;
+  }
+  const explicitRepositoryIntent = /\b(?:codestory|repo(?:sitory)?|codebase|source code|source files?|pull request|worktree|mcp|grounding|git|commit|rebase|cherry-pick|merge conflict|current branch|this branch|feature branch|branch (?:name|head)|code review|changed files?|diff|build (?:the )?(?:code|repo|repository|project)|unit tests?|integration tests?|test suite|test files?|callers?|callees?|crates?)\b|\b(?:review|fix|update|merge)\b[^.!?]*\bpr\b|\bpr\b[^.!?]*\b(?:review|changes?|diff)\b|\b(?:cargo|npm|pnpm|yarn|go) test\b|\bpytest\b|\bdotnet test\b|\bwhere is [a-z_$][\w$]* (?:defined|implemented)\b|(?:^|[\s"'`])(?:src|crates|plugins|scripts|tests?|docs?)[/\\][\w./\\-]+|(?:^|[\s"'`])[\w./\\-]+\.(?:rs|js|cjs|mjs|ts|tsx|jsx|py|go|cs|cpp|c|h|toml|json|ya?ml|md)(?:\b|$)/u;
+  const codeShapedIdentifier = /\b[a-z][a-z\d]*_[a-z\d_]+\b|\b[a-z]+[A-Z][A-Za-z\d]*\b/u.test(normalized);
+  const identifierIntent = codeShapedIdentifier && /\b(?:fix|refactor|review|change|edit|debug|implement|test|define|defined|definition|trace|trail|caller|callee|invokes?|called by)\b|\b(?:where is|who calls)\b/u.test(text);
+  const qualifiedIdentifier = /[A-Za-z_$][\w$]*::[A-Za-z_$][\w$]*/u.test(normalized);
+  const codeChangeIntent = /\b(?:fix|refactor|review|change|edit|debug|implement|test)\b[^.!?]*\b(?:function|method|class|module|runtime|compiler|plugin|hook|symbol)s?\b/u.test(text);
+  const repositoryIntent = explicitRepositoryIntent.test(text) || identifierIntent || qualifiedIdentifier || codeChangeIntent;
+  if (
+    !repositoryIntent
+    && /\b(?:create|open|close|assign|organize|triage|label|comment on|update|status of)\b[^.!?]*\b(?:issue|initiative|epic|project (?:board|item))\b/u.test(text)
+  ) return null;
+  if (!repositoryIntent) return null;
+
+  if (/\b(?:caller|callee|call path|call flow|trace|trail|invokes?|called by)\b|\bwho calls\b/u.test(text)) {
+    return 'Call flow: use symbol, then callers/callees or trace/trail; use snippet only after the graph selects a concrete target.';
+  }
+  if (
+    /\b(?:diff|changed files?|edit|refactor|bug|fix|impact|tests? should|affected|rebase|cherry-pick|merge)\b/u.test(text)
+    || /\breview\b[^.!?]*\b(?:diff|changes?|pull request)\b/u.test(text)
+    || /\b(?:review\b[^.!?]*\bpr|pr\b[^.!?]*\breview)\b/u.test(text)
+  ) {
+    return 'Review/change impact: use affected only with explicit git-changed paths, then inspect relevant symbols or traces; affected is planning evidence, not proof.';
+  }
+  if (/\b(?:where is|defined|definition|owns?|ownership|symbol|class|function|method)\b/u.test(text)) {
+    return 'Symbol ownership: use symbol, then definition; add callers/callees only when the question asks for flow.';
+  }
+  if (/\b(?:whole|entire|broad|architecture|subsystem|data flow|how does|how do|explain|codebase review)\b/u.test(text)) {
+    return 'Broad question: use packet only when status allows it and retrieval_mode=full; otherwise use ground, then focused symbol/trace evidence before source.';
+  }
+  return 'Repository orientation: use ground; use files only for language, role, path, or coverage questions.';
 }
 
 function eventHeader(event, input = {}) {
   if (event === 'UserPromptSubmit') {
-    const prompt = compactPrompt(input.prompt);
+    const route = routeForPrompt(input.prompt);
+    if (!route) return '';
     return [
-      'CODESTORY REQUEST GROUNDING ACTIVE',
+      'CODESTORY REQUEST ROUTING ACTIVE',
       '',
-      'Use CodeStory before source files for this user prompt.',
-      MCP_RESOURCE_TEXT,
-      prompt ? `Prompt: ${prompt}` : 'Prompt: unavailable from hook input.',
+      `Route: ${route}`,
       '',
     ].join('\n');
   }
 
-  const source = input.source ? ` (${input.source})` : '';
   return [
-    `CODESTORY SESSION GROUNDING ACTIVE${source}`,
+    'CODESTORY SESSION ROUTING ACTIVE',
     '',
-    'Keep CodeStory ambient in this session. Before source reads, claims, edits, reviews, or test choices, check CodeStory status and use allowed grounding surfaces first.',
-    MCP_RESOURCE_TEXT,
+    'For repository work, use the codestory-grounding skill and call status once for the explicit project.',
+    'Task router: orientation -> ground/files; symbol -> symbol/definition; flow -> callers/callees/trace; review/change -> affected with explicit paths plus focused graph evidence; broad -> packet only when allowed/full.',
     '',
   ].join('\n');
 }
 
-function getCodeStoryInstructions(event = 'SessionStart', input = {}) {
-  const body = skillBody();
-  if (!body) return `${eventHeader(event, input)}${FALLBACK}`;
-
-  return `${eventHeader(event, input)}CODESTORY BACKGROUND GROUNDING RULES
-
-Use CodeStory proactively for repository grounding. Do not wait for the user to call it by name.
-Before manually opening source files, first call status with the target repository's absolute path when MCP is live. Pass that same project to every CodeStory tool call; the server is multi-project and has no global workspace binding. When CodeStory is not initially model-visible, use host deferred discovery/tool_search to load the registered CodeStory MCP. When MCP is unavailable, CodeStory grounding is unavailable in this host; use ordinary source inspection and report the MCP blocker.
-For broad user requests, prefer a packet tied to the user's actual question. For concrete symbols, files, or routes, use search/context/trail/snippet. For no request context, use a compact ground snapshot only after confirming the target repo is indexable.
-Avoid no-op grounding context in huge or non-code folders.
-When retrieval sidecars are full and allowed, use packet, search, and context confidently.
-Use status recommended_next_calls as the setup path once a repository target is known: call MCP sidecar_setup with the same project and action=repair when recommended, then call project-scoped status again.
-
-${body}`;
-}
-
 module.exports = {
-  FALLBACK,
-  compactPrompt,
+  MCP_RESOURCE_TEXT,
   eventHeader,
-  getCodeStoryInstructions,
+  routeForPrompt,
 };

--- a/plugins/codestory/hooks/codestory-runtime.cjs
+++ b/plugins/codestory/hooks/codestory-runtime.cjs
@@ -7,7 +7,6 @@ const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 const STATE_FILE = '.codestory-active';
 const THREAD_STATE_PREFIX = '.codestory-active-thread-';
-const HOOK_STATE_FILE = '.codestory-hook-output-state.json';
 const DIRTY_MARKER_SCHEMA_VERSION = 1;
 const DIRTY_MARKER_SAMPLE_LIMIT = 20;
 const DIRTY_HOOK_NAMES = ['post-checkout', 'post-merge', 'post-rewrite'];
@@ -84,27 +83,6 @@ function rememberActiveState(state) {
     if (threadFile) {
       fs.writeFileSync(threadFile, JSON.stringify(nextState));
     }
-  } catch (e) {
-    // Best effort only. Hook state must not block the host session.
-  }
-}
-
-function readHookState() {
-  const stateDir = pluginDataDir();
-  if (!stateDir) return {};
-  return readJson(path.join(stateDir, HOOK_STATE_FILE)) || {};
-}
-
-function writeHookState(state) {
-  const stateDir = pluginDataDir();
-  if (!stateDir) return;
-
-  try {
-    fs.mkdirSync(stateDir, { recursive: true });
-    fs.writeFileSync(path.join(stateDir, HOOK_STATE_FILE), JSON.stringify({
-      ...state,
-      updatedAt: new Date().toISOString(),
-    }));
   } catch (e) {
     // Best effort only. Hook state must not block the host session.
   }
@@ -346,10 +324,8 @@ module.exports = {
   dirtyHookStatus,
   installDirtyHooks,
   readActiveState,
-  readHookState,
   rememberActiveState,
   uninstallDirtyHooks,
   writeDirtyMarker,
-  writeHookState,
   writeHookOutput,
 };

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -2257,8 +2257,8 @@ test("startup hook records active project without runtime bootstrap", async () =
     const output = JSON.parse(result.stdout);
     const context = output.hookSpecificOutput.additionalContext;
     assert.equal(output.systemMessage, "CODESTORY:BACKGROUND");
-    assert.match(context, /CODESTORY SESSION GROUNDING ACTIVE/u);
-    assert.match(context, /CodeStory MCP startup path/u);
+    assert.match(context, /CODESTORY SESSION ROUTING ACTIVE/u);
+    assert.match(context, /Task router: orientation/u);
     assert.match(context, /tool_search/u);
     assert.doesNotMatch(context, /HOOK MCP BRIDGE/u);
     assert.doesNotMatch(context, /managed_bootstrap/u);
@@ -2491,6 +2491,27 @@ function runCodexHook(input, env) {
   return JSON.parse(result.stdout);
 }
 
+async function runCodexHookAsync(input, env) {
+  const child = spawn(process.execPath, [join(pluginRoot, "hooks", "codestory-activate.cjs")], {
+    env: {
+      ...process.env,
+      COPILOT_PLUGIN_DATA: "",
+      ...env,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.stdin.end(JSON.stringify(input));
+  const [status] = await once(child, "close");
+  assert.equal(status, 0, stderr);
+  return JSON.parse(stdout);
+}
+
 test("hook emits MCP activation guidance without running CLI", async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-mcp-guidance-"));
   const binDir = await mkdtemp(join(tmpdir(), "codestory-hook-unused-cli-"));
@@ -2511,10 +2532,14 @@ test("hook emits MCP activation guidance without running CLI", async () => {
 
     const context = output.hookSpecificOutput.additionalContext;
     assert.equal(output.systemMessage, "CODESTORY:BACKGROUND");
-    assert.match(context, /CODESTORY REQUEST GROUNDING ACTIVE/u);
-    assert.match(context, /CodeStory MCP startup path/u);
+    assert.match(context, /CODESTORY REQUEST ROUTING ACTIVE/u);
+    assert.match(context, /Route: Symbol ownership/u);
     assert.match(context, /codestory mcp ground status packet search/u);
-    assert.match(context, /Do not treat hook text as grounding evidence/u);
+    assert.match(context, /absolute repository cwd/u);
+    assert.match(context, /local graph surfaces before source/u);
+    assert.match(context, /Repair only when packet\/search is required/u);
+    assert.match(context, /Hook text routes; only live MCP or verified source is evidence/u);
+    assert.doesNotMatch(context, /CodeStory hook output truncated/u);
     assert.doesNotMatch(context, /HOOK MCP BRIDGE/u);
     assert.doesNotMatch(context, /managed_bootstrap/u);
     assert.doesNotMatch(context, /packet ok/u);
@@ -2525,36 +2550,157 @@ test("hook emits MCP activation guidance without running CLI", async () => {
   }
 });
 
-test("hook dedupes repeated request prompts without storing prompt text", async () => {
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-prompt-dedupe-"));
+test("hook routing is stateless across repeated and parallel processes", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-stateless-"));
+  const input = {
+    hook_event_name: "UserPromptSubmit",
+    prompt: "Where is RefreshMode defined?",
+    cwd: repoRoot,
+  };
 
   try {
-    const first = runCodexHook({
-      hook_event_name: "UserPromptSubmit",
-      prompt: "Where is RefreshMode defined?",
-      cwd: repoRoot,
-    }, { PLUGIN_DATA: dataDir, PATH: "" });
-    const second = runCodexHook({
-      hook_event_name: "UserPromptSubmit",
-      prompt: "Where is RefreshMode defined?",
-      cwd: repoRoot,
-    }, { PLUGIN_DATA: dataDir, PATH: "" });
-    const third = runCodexHook({
-      hook_event_name: "UserPromptSubmit",
-      prompt: "Where is strict_sidecar_status defined?",
-      cwd: repoRoot,
-    }, { PLUGIN_DATA: dataDir, PATH: "" });
+    const serial = [runCodexHook(input, { PLUGIN_DATA: dataDir, PATH: "" }), runCodexHook(input, { PLUGIN_DATA: dataDir, PATH: "" })];
+    const parallel = await Promise.all(Array.from({ length: 6 }, () => runCodexHookAsync(input, {
+      CODEX_THREAD_ID: "shared-task",
+      PLUGIN_DATA: dataDir,
+      PATH: "",
+    })));
+    for (const output of [...serial, ...parallel]) {
+      assert.match(output.hookSpecificOutput.additionalContext, /Route: Symbol ownership/u);
+      assert.doesNotMatch(output.hookSpecificOutput.additionalContext, /Where is RefreshMode defined/u);
+    }
+    await assert.rejects(access(join(dataDir, ".codestory-hook-output-state.json")), /ENOENT/u);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
 
-    assert.match(first.hookSpecificOutput.additionalContext, /Where is RefreshMode defined?/u);
-    assert.equal(Object.hasOwn(second, "hookSpecificOutput"), false);
-    assert.match(third.hookSpecificOutput.additionalContext, /Where is strict_sidecar_status defined?/u);
-    const stateText = await readFile(join(dataDir, ".codestory-hook-output-state.json"), "utf8");
-    const promptHash = createHash("sha256")
-      .update("Where is RefreshMode defined?")
-      .digest("hex")
-      .slice(0, 16);
-    assert.match(stateText, new RegExp(promptHash, "u"));
-    assert.doesNotMatch(stateText, /Where is RefreshMode defined/u);
+test("hook routes repository prompts and suppresses non-repository chatter", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-route-matrix-"));
+
+  try {
+    const prompts = [
+      ["Give me a broad architecture review of this codebase", /Route: Broad question/u],
+      ["Who calls RuntimeContext::open?", /Route: Call flow/u],
+      ["Explain who calls RuntimeContext::open across the architecture", /Route: Call flow/u],
+      ["Where is RuntimeContext defined?", /Route: Symbol ownership/u],
+      ["Explain where RuntimeContext is defined in this codebase", /Route: Symbol ownership/u],
+      ["Review the changed files and tell me what tests are affected", /Route: Review\/change impact/u],
+      ["Review this PR", /Route: Review\/change impact/u],
+      ["Run cargo test", /Route: Repository orientation/u],
+      ["Run npm test", /Route: Repository orientation/u],
+      ["Fix the refresh_index race", /Route: Review\/change impact/u],
+      ["Refactor routeForPrompt", /Route: Review\/change impact/u],
+      ["Use CodeStory", /Route: Repository orientation/u],
+      ["Rebase this branch onto dev", /Route: Review\/change impact/u],
+      ["Fix function", /Route: Review\/change impact/u],
+      ["Refactor method", /Route: Review\/change impact/u],
+      ["Review class changes", /Route: Review\/change impact/u],
+      ["How does CodeStory grounding work?", /Route: Broad question/u],
+      ["Show the current branch", /Route: Repository orientation/u],
+      ["List the languages in this repository", /Route: Repository orientation/u],
+    ];
+    for (const [prompt, expected] of prompts) {
+      const output = runCodexHook({
+        hook_event_name: "UserPromptSubmit",
+        prompt,
+        cwd: repoRoot,
+      }, { PLUGIN_DATA: dataDir, PATH: "" });
+      const context = output.hookSpecificOutput.additionalContext;
+      assert.match(context, expected);
+      assert.ok(context.length <= 900, `hook output was ${context.length} characters`);
+      assert.equal(context.includes(prompt), false);
+      assert.doesNotMatch(context, /hook output truncated/u);
+    }
+
+    for (const prompt of [
+      "Thanks, that answers it.",
+      "Can you review this restaurant?",
+      "Explain the egg method.",
+      "I registered for semester classes.",
+      "Tell me about compiler design.",
+      "What is the movie runtime?",
+      "I bought an iPhone.",
+      "Search for eBay.",
+      "Please update my social_security_number.",
+      "Help me build a birdhouse.",
+      "Explain liver function tests.",
+      "Organize my grocery list.",
+      "Create an issue for the hook initiative.",
+      "What is the status of issue #963?",
+      "Update issue #897.",
+    ]) {
+      const chatter = runCodexHook({
+        hook_event_name: "UserPromptSubmit",
+        prompt,
+        cwd: repoRoot,
+      }, { PLUGIN_DATA: dataDir, PATH: "" });
+      assert.equal(Object.hasOwn(chatter, "hookSpecificOutput"), false);
+    }
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("suppressed hook events write no active or thread state", async () => {
+  for (const input of [
+    { hook_event_name: "UserPromptSubmit", prompt: "Can you review this restaurant?", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Explain the egg method.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "I registered for semester classes.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Tell me about compiler design.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "What is the movie runtime?", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "I bought an iPhone.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Search for eBay.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Please update my social_security_number.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Help me build a birdhouse.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Explain liver function tests.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Organize my grocery list.", cwd: repoRoot },
+    { hook_event_name: "UserPromptSubmit", prompt: "Update issue #897.", cwd: repoRoot },
+    { hook_event_name: "GoalLoopHeartbeat", cwd: repoRoot },
+  ]) {
+    const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-no-state-"));
+    try {
+      const output = runCodexHook(input, {
+        CODEX_THREAD_ID: "suppressed-task",
+        PLUGIN_DATA: dataDir,
+        PATH: "",
+      });
+      assert.equal(Object.hasOwn(output, "hookSpecificOutput"), false);
+      await assert.rejects(access(join(dataDir, ".codestory-active")), /ENOENT/u);
+      await assert.rejects(access(threadActiveStatePath(dataDir, "suppressed-task")), /ENOENT/u);
+      await assert.rejects(access(join(dataDir, ".codestory-hook-output-state.json")), /ENOENT/u);
+    } finally {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("compact and resume session starts re-inject complete bounded routing", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-reinject-"));
+  const longCwd = `C:\\${"very-long-directory\\".repeat(200)}repo`;
+  try {
+    for (const source of ["compact", "resume", "compact"]) {
+      const output = runCodexHook({
+        hook_event_name: "SessionStart",
+        source,
+        cwd: longCwd,
+      }, { PLUGIN_DATA: dataDir, PATH: "" });
+      const context = output.hookSpecificOutput.additionalContext;
+      assert.ok(context.length <= 900, `hook output was ${context.length} characters`);
+      assert.match(context, /absolute repository cwd/u);
+      assert.match(context, /codestory mcp ground status packet search/u);
+      assert.doesNotMatch(context, /truncated/u);
+      assert.equal(context.endsWith("tools."), true);
+    }
+    const promptContext = runCodexHook({
+      hook_event_name: "UserPromptSubmit",
+      prompt: "Where is RuntimeContext defined?",
+      cwd: longCwd,
+    }, { PLUGIN_DATA: dataDir, PATH: "" }).hookSpecificOutput.additionalContext;
+    assert.ok(promptContext.length <= 900, `hook output was ${promptContext.length} characters`);
+    assert.match(promptContext, /absolute repository cwd/u);
+    assert.doesNotMatch(promptContext, /truncated/u);
+    assert.equal(promptContext.endsWith("evidence."), true);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -2622,7 +2768,7 @@ test("hook script executes under Codex home module scope", async () => {
         },
         input: JSON.stringify({
           hook_event_name: "UserPromptSubmit",
-          prompt: "Explain hook loading.",
+          prompt: "Explain CodeStory hook loading.",
           cwd: repoRoot,
         }),
         encoding: "utf8",
@@ -2633,7 +2779,7 @@ test("hook script executes under Codex home module scope", async () => {
     assert.doesNotMatch(result.stderr, /require is not defined/u);
     assert.match(
       JSON.parse(result.stdout).hookSpecificOutput.additionalContext,
-      /CODESTORY REQUEST GROUNDING ACTIVE/u,
+      /CODESTORY REQUEST ROUTING ACTIVE/u,
     );
   } finally {
     await rm(codexHome, { recursive: true, force: true });


### PR DESCRIPTION
## Context

The lifecycle hook emitted the same status-first prompt for every user request,
echoed user text, and could make successful CodeStory usage look like reading
status without using the graph. It also emitted for unrelated conversation.

Closes #963
Refs #962
Refs #899

## What Changed

- Route repository prompts into orientation, symbol ownership, call flow,
  change-impact, or broad-question CodeStory surfaces, with specific call-flow
  and change routes taking precedence over broad or generic symbol routing.
- Require explicit repository signals, commands, or code-shaped identifiers
  paired with a change, definition, or flow cue before routing; ambiguous words
  and ordinary camel/snake-case text no longer activate CodeStory by themselves.
- Suppress empty, acknowledgement, general, and issue-only coordination prompts
  before writing active or thread state.
- Remove prompt hashes and persistent dedupe entirely so repeated, resumed, and
  concurrent hook processes cannot suppress one another or retain prompt data.
- Reuse current status and prefer allowed local graph surfaces when deep
  retrieval is blocked; repair remains conditional on packet/search need.
- Remove dead skill-file loading and generic prompt echoing from the hook path.
- Emit complete SessionStart and UserPromptSubmit guidance under 900 characters
  without including an unbounded cwd literal; unsupported events stay quiet.

## How To Review

Start with `routeForPrompt` and `contextFor`, then review the route/suppression,
parallel-process, resume/compact, no-state, and long-cwd cases in
`plugin-static.test.mjs`. Confirm that hook text only selects a live MCP route
and never claims source evidence.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` (51/51)
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/check-doc-links.mjs` (69 files, 279 links)
- `node --check` for all three changed hook modules
- `git diff --check origin/dev/codestory-next...HEAD`
- Live managed 0.14.3 drill on this repository: local graph fresh at 296 files,
  140151 nodes, and 117759 edges; used `ground`, `symbol`, `callers`, and
  `affected` while packet/search were blocked by `retrieval_manifest_missing`,
  without starting sidecar repair.

## Risk

Prompt classification is intentionally conservative and deterministic; an
ambiguous prompt may receive no hook route, in which case the grounding skill
and ordinary agent judgment remain available. No source claims or MCP calls are
performed by the hook itself. This is prompt-visible behavior, not a rendered
dashboard/UI change, so screenshot evidence is not applicable.
