### PR TITLE
route blocked grounding locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@
   Retention keeps the active generation plus one verified rollback, skips locked
   readers, and preserves the legacy path for databases without an identity.
 
+### Changed
+
+- Grounding skill guidance now reuses current status, routes blocked deep
+  retrieval tasks through allowed project-scoped local graph surfaces, and
+  repairs sidecars only when the task actually requires the blocked surface.
+  Local navigation remains explicitly weaker than full packet/search proof.
+
 ### Fixed
 
 - Corrected the Codex managed-platform guide to list the restored macOS x64 CLI

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -36,9 +36,12 @@ When the plugin MCP server is available:
 
 1. Resolve `<target-workspace>` explicitly.
 2. Call `status` with `project=<target-workspace>` — field meanings in [status-contract](references/status-contract.md). If `mcp__codestory__*` tools are not initially visible and tool_search is available, query `codestory mcp ground status packet search`, then use the loaded CodeStory MCP tools.
-3. Obey `allowed_surfaces` and `retrieval_mode`.
-4. Call the allowed surface that fits the task; preserve cited anchors in answers.
-5. Follow project-scoped `recommended_next_calls` from status when setup or repair is needed.
+3. Reuse that status result until repository, runtime, or index state changes, or
+   a tool reports stale/freshness failure.
+4. Obey `allowed_surfaces` and `retrieval_mode`.
+5. Call the allowed surface that fits the task; preserve cited anchors in answers.
+6. Follow project-scoped `recommended_next_calls` only when the task requires a
+   blocked surface or setup is otherwise necessary.
 
 If the skill is visible but no `mcp__codestory` tools are exposed, call it a
 plugin MCP visibility failure. Unscoped resources cannot identify the caller's
@@ -55,12 +58,15 @@ MCP tools were not visible.
 | Trace: "Who calls this?" | `callers`, `callees`, `trace`, or `trail --story --hide-speculative`. |
 | Impact: "What might this change touch?" | `affected` with changed files from git; planning hints only, not proof. |
 | Broad question | `packet`, `search`, or `context` only when allowed and `retrieval_mode=full`. |
-| Blocked surface | Follow `recommended_next_calls` from status; normally call MCP `sidecar_setup` with the same `project` and `action=repair`, then call project-scoped `status` again. |
+| Blocked packet/search/context, local route available | Do not repair. Route by task through allowed `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trace`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`, then use focused source only for remaining evidence gaps. |
+| Blocked surface required by the task | Follow `recommended_next_calls`; normally call MCP `sidecar_setup` with the same `project` and `action=repair`, then call project-scoped `status` again. |
 
 ## Evidence Rules
 
 - Treat CodeStory output as evidence, not omniscience.
 - Preserve cited file, symbol, trail, and snippet anchors in user-facing claims.
+- Local graph output is navigation evidence. It does not prove full
+  packet/search readiness or substitute for sidecar-backed evidence claims.
 - When `packet` reports `sufficient` with no `follow_up_commands`, answer from the packet.
 - When `packet` reports `partial`, run named follow-up commands before proof claims.
 - `retrieval_mode=full` is infrastructure eligibility, not answer-quality proof;
@@ -85,8 +91,8 @@ Supported agent repair is MCP-only:
 1. Call `status` with `project=<target-workspace>`.
 2. Inspect `readiness_broker` and `sidecar_setup`; status reads report state
    but do not start repairs.
-3. If `recommended_next_calls` says so and the `mcp__codestory__sidecar_setup`
-   tool is visible, call MCP `sidecar_setup` with
+3. If the task requires the blocked surface, `recommended_next_calls` says so,
+   and the `mcp__codestory__sidecar_setup` tool is visible, call MCP `sidecar_setup` with
    `project=<target-workspace>, action=repair`.
 4. Call `status` again with the same project.
 5. Use only the surfaces allowed by the refreshed status.

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -5,6 +5,10 @@ is the first and canonical runtime truth. Call it before `ground`, `files`,
 `packet`, or `search`, and pass the same project to every tool. The server has no
 global workspace binding.
 
+Reuse a status result until repository, runtime, or index state changes, or a
+tool reports stale evidence or a freshness failure. A blocked sidecar-backed
+surface does not invalidate an allowed local graph route.
+
 ## Status Fields
 
 | Status field | Meaning | Agent action |
@@ -43,8 +47,10 @@ provisions from `github_release` when needed, and records the launch source in
 `plugin_runtime`. If the managed runtime cannot spawn or be provisioned, the
 adapter stays up with `repair_setup` diagnostics instead of closing transport.
 
-If project-scoped `status` reports a repairable state, run the MCP
-`recommended_next_calls` loop: call `sidecar_setup` with the same `project` and
-`action=repair` when recommended, then call `status` again before local
-navigation, packet, search, or context. Do not ask the human to install the binary unless network,
+If project-scoped `status` reports a repairable state and the task requires the
+blocked surface, run the MCP `recommended_next_calls` loop: call
+`sidecar_setup` with the same `project` and `action=repair` when recommended,
+then call `status` again before using that surface. When an allowed local graph
+surface satisfies the task, use it without repairing packet/search/context and
+do not represent local navigation as full retrieval proof. Do not ask the human to install the binary unless network,
 permissions, host reload, or release assets block the repair.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -169,6 +169,31 @@ test("agent-facing guidance does not send agents to CLI fallback repair", async 
   }
 });
 
+test("grounding guidance preserves local graph fallback and repair boundaries", async () => {
+  const skill = await readFile(
+    join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"),
+    "utf8",
+  );
+  const statusContract = await readFile(
+    join(pluginRoot, "skills", "codestory-grounding", "references", "status-contract.md"),
+    "utf8",
+  );
+  const guidance = `${skill}\n${statusContract}`;
+
+  for (const surface of [
+    "ground", "files", "symbol", "definition", "callers", "callees",
+    "trace", "trail", "references", "snippet", "affected", "symbols",
+    "get_node", "neighbors", "shortest_path", "query_subgraph",
+  ]) {
+    assert.equal(guidance.includes(`\`${surface}\``), true, surface);
+  }
+  assert.match(guidance, /Reuse (?:that |a )?status result until repository, runtime, or index state changes/u);
+  assert.match(guidance, /task requires (?:a |the )?blocked surface/u);
+  assert.match(guidance, /Local graph output is navigation evidence/u);
+  assert.match(guidance, /does not prove full\s+packet\/search readiness/u);
+  assert.match(statusContract, /use it without repairing packet\/search\/context/u);
+});
+
 test("plugin package version tracks the codestory-cli release version", async () => {
   const cliManifest = await readFile(
     join(repoRoot, "crates", "codestory-cli", "Cargo.toml"),


### PR DESCRIPTION
## Context

The grounding skill treated any blocked surface as a reason to follow repair,
even when an allowed local graph route could satisfy the task. That encouraged
unnecessary sidecar work and obscured the evidence boundary between local
navigation and full packet/search proof.

Closes #964
Refs #962
Refs #899

## What Changed

- Reuse project-scoped status until repository, runtime, or index state changes
  or a tool reports freshness failure.
- Enumerate the allowed local graph fallback set and route through it without
  repair when it satisfies the task.
- Gate `sidecar_setup` repair on the task actually requiring the blocked
  surface.
- State explicitly that local graph output is navigation evidence, not full
  packet/search proof.
- Add a semantic contract test for the local-route and repair boundary.

## How To Review

Review the Quick Loop, Task Router, Evidence Rules, and Repair Loop together
with `references/status-contract.md`; then verify the contract test checks tool
and decision semantics rather than exact prose copy.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` (48/48)
- `node .github/scripts/check-doc-links.mjs` (69 files, 279 links)
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check origin/dev/codestory-next...HEAD`

## Risk

The change affects agent guidance only. It preserves explicit project scope and
fail-closed evidence tiers; a task that genuinely needs packet/search still
follows the status-recommended repair loop. No screenshot-visible UI changed.
