### PR TITLE
test publication fault matrix

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -122,3 +122,9 @@ jobs:
 
       - name: Prove multi-project embedding endpoint isolation
         run: cargo test --locked -p codestory-cli --test stdio_protocol_contracts multi_project_stdio_keeps_project_embedding_endpoints_isolated_across_a_b_a -- --nocapture
+
+      - name: Prove publication transition failure and cancellation semantics
+        run: cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture
+
+      - name: Prove staged database recovery after process abort
+        run: cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
   client, and a cross-platform A/B/A stdio contract proves two trusted projects
   cannot cross-route embedding markers or vectors.
 
+- Added a table-driven full and incremental publication fault matrix covering
+  identity persistence, search build/validation/completion, catalog locking,
+  staged database replacement, incremental marker completion, and runtime cache
+  publication. Every boundary now has deterministic failure and cancellation
+  proof, including successful completion when cancellation arrives after the
+  database replacement point of no return. A store-level child process abort
+  after live mutation and before backup cleanup proves retry recovery and
+  artifact cleanup. Promotion-scoped locking prevents healthy backups from
+  being mistaken for abandoned crash recovery state by concurrent readers.
 - Added parser-backed Express route extraction for static module-scope
   registrations on source-ordered app and router bindings constructed from
   explicit `express` imports or `require("express")`. JavaScript, TypeScript,
@@ -104,6 +113,9 @@
   when its complete publication stayed stable, and keyed the cache by durable
   publication identity so concurrent publication cannot produce or retain a
   mixed-generation response.
+- Completed the durable incremental marker before exposing prepared runtime
+  search state or reporting indexing idle. Marker failure now leaves runtime
+  state cleared and the new database generation fenced from readers.
 - Corrected the Codex managed-platform guide to list the restored macOS x64 CLI
   while retaining its no-managed-accelerated-sidecar boundary.
 - Retried packaged-proof temporary directory removal after transient executable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ version = "0.14.3"
 dependencies = [
  "anyhow",
  "codestory-contracts",
+ "fs4",
  "parking_lot",
  "rusqlite",
  "serde",

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -417,7 +417,7 @@ fn runtime_snapshot_lifecycle_flows_through_store_snapshot_surface() {
 }
 
 #[test]
-fn staged_publication_identity_is_schema_backed_and_verified_before_finalization() {
+fn staged_publication_identity_and_fence_are_complete_before_publication() {
     let runtime = read("crates/codestory-runtime/src/lib.rs");
     let store = read("crates/codestory-store/src/storage_impl/mod.rs");
     let schema = read("crates/codestory-store/src/storage_impl/schema.rs");
@@ -435,8 +435,12 @@ fn staged_publication_identity_is_schema_backed_and_verified_before_finalization
     assert!(
         runtime.contains("next_index_publication(")
             && runtime.contains("staged.store_mut().put_index_publication(&publication)")
-            && runtime.contains("Published index generation changed before finalization"),
-        "full and incremental staging should persist and verify one publication identity before clearing compatibility fences"
+            && runtime
+                .matches("staged.store_mut().finish_incremental_run()")
+                .count()
+                >= 2
+            && runtime.matches("staged.publish(storage_path)").count() >= 2,
+        "full and incremental staging should persist publication identity and clear compatibility fences before publishing"
     );
 }
 

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -4214,6 +4214,66 @@ struct SearchGenerationCatalogGuard {
     path: PathBuf,
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublicationTestBoundary {
+    Identity,
+    SearchBuild,
+    SearchValidation,
+    SearchCompletion,
+    CatalogLock,
+    DatabaseReplacement,
+    MarkerCompletion,
+    RuntimeCache,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PublicationTestAction {
+    Fail,
+    Cancel,
+}
+
+#[cfg(test)]
+thread_local! {
+    static PUBLICATION_TEST_FAULT: std::cell::RefCell<Option<(PublicationTestBoundary, PublicationTestAction)>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn arm_publication_test_fault(boundary: PublicationTestBoundary, action: PublicationTestAction) {
+    PUBLICATION_TEST_FAULT.with(|fault| *fault.borrow_mut() = Some((boundary, action)));
+}
+
+#[cfg(test)]
+fn publication_test_checkpoint(
+    boundary: PublicationTestBoundary,
+    cancel_token: Option<&CancellationToken>,
+) -> Result<(), ApiError> {
+    let action = PUBLICATION_TEST_FAULT.with(|fault| {
+        let armed = *fault.borrow();
+        matches!(armed, Some((armed_boundary, _)) if armed_boundary == boundary).then(|| {
+            fault
+                .borrow_mut()
+                .take()
+                .expect("armed publication fault")
+                .1
+        })
+    });
+    match action {
+        Some(PublicationTestAction::Fail) => Err(ApiError::internal(format!(
+            "Injected publication failure at {boundary:?}"
+        ))),
+        Some(PublicationTestAction::Cancel) => {
+            if let Some(token) = cancel_token {
+                token.cancel();
+            }
+            Ok(())
+        }
+        None => Ok(()),
+    }
+}
+
 impl SearchGenerationCatalogGuard {
     fn acquire(storage_path: &Path) -> Result<Self, ApiError> {
         let mut path = search_index_generation_root(storage_path).into_os_string();
@@ -9059,6 +9119,19 @@ impl AppController {
         refresh_runtime_caches: bool,
         _cancel_token: Option<&CancellationToken>,
     ) -> Result<IndexingPhaseTimings, ApiError> {
+        if refresh_runtime_caches {
+            #[cfg(test)]
+            let boundary_result =
+                publication_test_checkpoint(PublicationTestBoundary::RuntimeCache, _cancel_token);
+            #[cfg(not(test))]
+            let boundary_result: Result<(), ApiError> = Ok(());
+            if let Err(error) = boundary_result {
+                tracing::warn!(
+                    error = %error.message,
+                    "Runtime cache publication fault occurred after durable database commit; completing from the prepared generation"
+                );
+            }
+        }
         let cache_refresh_started = Instant::now();
         let cache_stats_result = if let Some(prepared) = summary.prepared_search_state.take() {
             if refresh_runtime_caches {
@@ -9094,6 +9167,7 @@ impl AppController {
                         llm_refresh_scope,
                         false,
                         &self.runtime_config,
+                        None,
                     )
                     .map(|result| CacheRefreshStats {
                         search_stats: result.search_stats,
@@ -9119,11 +9193,6 @@ impl AppController {
             cache_stats.semantic_stats = summary.staged_semantic_stats;
         }
         apply_cache_refresh_stats(&mut summary.phase_timings, cache_stats);
-        if let Err(error) = finish_incremental_run_marker(&summary, storage_path) {
-            self.clear_search_state();
-            self.state.lock().is_indexing = false;
-            return Err(error);
-        }
         Ok(summary.phase_timings)
     }
 
@@ -11468,7 +11537,7 @@ struct IndexingRunSummary {
     phase_timings: IndexingPhaseTimings,
     staged_semantic_stats: SemanticProjectionStats,
     llm_refresh_scope: Option<HashSet<codestory_contracts::graph::NodeId>>,
-    finalize_incremental_run: bool,
+    #[cfg(test)]
     publication: IndexPublicationRecord,
     prepared_search_state: Option<SearchStateBuildResult>,
 }
@@ -11563,28 +11632,6 @@ impl Drop for IndexWriterGuard {
             );
         }
     }
-}
-
-fn finish_incremental_run_marker(
-    summary: &IndexingRunSummary,
-    storage_path: &Path,
-) -> Result<(), ApiError> {
-    let published = Store::database_index_publication(storage_path)
-        .map_err(|e| ApiError::internal(format!("Failed to read publication identity: {e}")))?;
-    if published.as_ref() != Some(&summary.publication) {
-        return Err(ApiError::internal(format!(
-            "Published index generation changed before finalization: expected {} run {}, observed {:?}",
-            summary.publication.generation_id, summary.publication.run_id, published
-        )));
-    }
-    if !summary.finalize_incremental_run {
-        return Ok(());
-    }
-    let storage = Storage::open(storage_path)
-        .map_err(|e| ApiError::internal(format!("Failed to reopen storage: {e}")))?;
-    storage
-        .finish_incremental_run()
-        .map_err(|e| ApiError::internal(format!("Failed to clear incomplete index marker: {e}")))
 }
 
 fn index_full_for_runtime(
@@ -11760,6 +11807,12 @@ fn index_full_for_runtime(
             return Err(error);
         }
     };
+    #[cfg(test)]
+    if let Err(error) = publication_test_checkpoint(PublicationTestBoundary::Identity, cancel_token)
+    {
+        let _ = staged.discard();
+        return Err(error);
+    }
     if let Err(error) = staged.store_mut().put_index_publication(&publication) {
         let _ = staged.discard();
         return Err(ApiError::internal(format!(
@@ -11772,6 +11825,7 @@ fn index_full_for_runtime(
         None,
         false,
         runtime,
+        cancel_token,
     ) {
         Ok(state) => state,
         Err(error) => {
@@ -11787,6 +11841,15 @@ fn index_full_for_runtime(
         return Err(indexing_cancelled_error());
     }
     let staged_path = staged.path().to_path_buf();
+    #[cfg(test)]
+    if let Err(error) =
+        publication_test_checkpoint(PublicationTestBoundary::CatalogLock, cancel_token)
+    {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(error);
+    }
     let _catalog_guard = match SearchGenerationCatalogGuard::acquire(storage_path) {
         Ok(guard) => guard,
         Err(error) => {
@@ -11796,7 +11859,53 @@ fn index_full_for_runtime(
             return Err(error);
         }
     };
+    if is_indexing_cancelled(cancel_token) {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(indexing_cancelled_error());
+    }
+    if recovering_incomplete_run {
+        #[cfg(test)]
+        if let Err(error) =
+            publication_test_checkpoint(PublicationTestBoundary::MarkerCompletion, cancel_token)
+        {
+            drop(prepared_search_state);
+            let _ = staged.discard();
+            discard_unpublished_search_generation(storage_path, &publication);
+            return Err(error);
+        }
+        if is_indexing_cancelled(cancel_token) {
+            drop(prepared_search_state);
+            let _ = staged.discard();
+            discard_unpublished_search_generation(storage_path, &publication);
+            return Err(indexing_cancelled_error());
+        }
+        if let Err(error) = staged.store_mut().finish_incremental_run() {
+            drop(prepared_search_state);
+            let _ = staged.discard();
+            discard_unpublished_search_generation(storage_path, &publication);
+            return Err(ApiError::internal(format!(
+                "Failed to complete staged full-recovery marker: {error}"
+            )));
+        }
+    }
     let publish_started = std::time::Instant::now();
+    #[cfg(test)]
+    if let Err(error) =
+        publication_test_checkpoint(PublicationTestBoundary::DatabaseReplacement, cancel_token)
+    {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(error);
+    }
+    if is_indexing_cancelled(cancel_token) {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(indexing_cancelled_error());
+    }
     if let Err(err) = staged.publish(storage_path) {
         drop(prepared_search_state);
         discard_unpublished_search_generation(storage_path, &publication);
@@ -11900,7 +12009,7 @@ fn index_full_for_runtime(
         },
         staged_semantic_stats,
         llm_refresh_scope: None,
-        finalize_incremental_run: recovering_incomplete_run,
+        #[cfg(test)]
         publication,
         prepared_search_state: Some(prepared_search_state),
     })
@@ -12175,6 +12284,12 @@ where
             return Err(error);
         }
     };
+    #[cfg(test)]
+    if let Err(error) = publication_test_checkpoint(PublicationTestBoundary::Identity, cancel_token)
+    {
+        let _ = staged.discard();
+        return Err(error);
+    }
     if let Err(error) = staged.store_mut().put_index_publication(&publication) {
         let _ = staged.discard();
         return Err(ApiError::internal(format!(
@@ -12187,6 +12302,7 @@ where
         Some(&llm_refresh_scope),
         false,
         runtime,
+        cancel_token,
     ) {
         Ok(state) => state,
         Err(error) => {
@@ -12202,6 +12318,15 @@ where
         return Err(indexing_cancelled_error());
     }
     let staged_path = staged.path().to_path_buf();
+    #[cfg(test)]
+    if let Err(error) =
+        publication_test_checkpoint(PublicationTestBoundary::CatalogLock, cancel_token)
+    {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(error);
+    }
     let _catalog_guard = match SearchGenerationCatalogGuard::acquire(storage_path) {
         Ok(guard) => guard,
         Err(error) => {
@@ -12211,7 +12336,51 @@ where
             return Err(error);
         }
     };
+    if is_indexing_cancelled(cancel_token) {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(indexing_cancelled_error());
+    }
+    #[cfg(test)]
+    if let Err(error) =
+        publication_test_checkpoint(PublicationTestBoundary::MarkerCompletion, cancel_token)
+    {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(error);
+    }
+    if is_indexing_cancelled(cancel_token) {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(indexing_cancelled_error());
+    }
+    if let Err(error) = staged.store_mut().finish_incremental_run() {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(ApiError::internal(format!(
+            "Failed to complete staged incremental marker: {error}"
+        )));
+    }
     let publish_started = Instant::now();
+    #[cfg(test)]
+    if let Err(error) =
+        publication_test_checkpoint(PublicationTestBoundary::DatabaseReplacement, cancel_token)
+    {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(error);
+    }
+    if is_indexing_cancelled(cancel_token) {
+        drop(prepared_search_state);
+        let _ = staged.discard();
+        discard_unpublished_search_generation(storage_path, &publication);
+        return Err(indexing_cancelled_error());
+    }
     if let Err(error) = staged.publish(storage_path) {
         drop(prepared_search_state);
         discard_unpublished_search_generation(storage_path, &publication);
@@ -12315,7 +12484,7 @@ where
         },
         staged_semantic_stats,
         llm_refresh_scope: Some(llm_refresh_scope),
-        finalize_incremental_run: true,
+        #[cfg(test)]
         publication,
         prepared_search_state: Some(prepared_search_state),
     })
@@ -12438,6 +12607,7 @@ fn rebuild_search_state_from_storage(
         llm_refresh_scope,
         hydrate_semantic_docs,
         &codestory_retrieval::SidecarRuntimeConfig::local(),
+        None,
     )
 }
 
@@ -12447,6 +12617,7 @@ fn rebuild_search_state_from_storage_for_runtime(
     llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     hydrate_semantic_docs: bool,
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<SearchStateBuildResult, ApiError> {
     let publication = storage.get_index_publication().map_err(|error| {
         ApiError::internal(format!(
@@ -12474,6 +12645,11 @@ fn rebuild_search_state_from_storage_for_runtime(
         )?,
         None => None,
     };
+    if is_indexing_cancelled(cancel_token) {
+        return Err(indexing_cancelled_error());
+    }
+    #[cfg(test)]
+    publication_test_checkpoint(PublicationTestBoundary::SearchBuild, cancel_token)?;
     let built_new = reused.is_none();
     let mut result = match reused {
         Some(result) => result,
@@ -12490,7 +12666,24 @@ fn rebuild_search_state_from_storage_for_runtime(
             ApiError::internal(format!("Failed to rebuild search state: {}", e.message))
         })?,
     };
+    if is_indexing_cancelled(cancel_token) {
+        return Err(indexing_cancelled_error());
+    }
+    #[cfg(test)]
+    publication_test_checkpoint(PublicationTestBoundary::SearchValidation, cancel_token)?;
+    if result.engine.full_text_doc_count() != result.node_names.len() {
+        return Err(ApiError::internal(format!(
+            "Prepared search generation contains {} searchable symbols for {} core symbols",
+            result.engine.full_text_doc_count(),
+            result.node_names.len()
+        )));
+    }
     if built_new && let Some(publication) = publication.as_ref() {
+        if is_indexing_cancelled(cancel_token) {
+            return Err(indexing_cancelled_error());
+        }
+        #[cfg(test)]
+        publication_test_checkpoint(PublicationTestBoundary::SearchCompletion, cancel_token)?;
         write_search_generation_completion(
             &search_storage_path,
             publication,
@@ -12536,6 +12729,7 @@ fn refresh_caches(
         llm_refresh_scope,
         true,
         &controller.runtime_config,
+        None,
     );
 
     match refreshed {
@@ -18978,7 +19172,6 @@ fn build_llm_symbol_doc_text() -> String {
             phase_timings: IndexingPhaseTimings::default(),
             staged_semantic_stats: SemanticProjectionStats::default(),
             llm_refresh_scope: None,
-            finalize_incremental_run: false,
             publication: IndexPublicationRecord {
                 generation: 1,
                 generation_id: "11111111-1111-4111-8111-111111111111".to_string(),
@@ -19276,55 +19469,6 @@ fn build_llm_symbol_doc_text() -> String {
     }
 
     #[test]
-    fn incremental_cache_rebuild_failure_keeps_incomplete_marker() {
-        let temp = tempdir().expect("create temp dir");
-        let storage_path = temp.path().join("codestory.db");
-        {
-            let mut storage = Storage::open(&storage_path).expect("seed storage");
-            storage
-                .insert_nodes_batch(&[Node {
-                    id: CoreNodeId(1),
-                    kind: NodeKind::FUNCTION,
-                    serialized_name: "value".into(),
-                    ..Default::default()
-                }])
-                .expect("seed node");
-            storage
-                .begin_incremental_run()
-                .expect("mark incremental incomplete");
-            storage
-                .get_connection()
-                .execute_batch(
-                    "CREATE TRIGGER fail_search_projection_rebuild
-                     BEFORE INSERT ON search_symbol_projection
-                     BEGIN SELECT RAISE(ABORT, 'forced search projection failure'); END;",
-                )
-                .expect("install cache rebuild fault");
-        }
-        let controller = AppController::new();
-        controller.state.lock().is_indexing = true;
-        let mut summary = persisted_empty_indexing_run_summary(&storage_path);
-        summary.finalize_incremental_run = true;
-
-        let error = controller
-            .finish_successful_indexing(summary, &storage_path, false, None)
-            .expect_err("cache rebuild failure must fail indexing");
-
-        assert!(error.message.contains("forced search projection failure"));
-        let storage = Storage::open(&storage_path).expect("reopen interrupted storage");
-        assert!(
-            storage
-                .has_incomplete_incremental_run()
-                .expect("marker after cache failure")
-        );
-        assert_ne!(
-            Storage::database_schema_version(&storage_path).expect("schema fence"),
-            codestory_store::CURRENT_SCHEMA_VERSION
-        );
-        assert!(!controller.state.lock().is_indexing);
-    }
-
-    #[test]
     fn staged_recovery_search_failure_preserves_the_marked_live_database() {
         let workspace = tempdir().expect("workspace dir");
         fs::write(
@@ -19444,6 +19588,7 @@ fn build_llm_symbol_doc_text() -> String {
         SemanticDocs,
         SummarySnapshot,
         DetailSnapshot,
+        PublicationIdentity,
         MarkerClear,
     }
 
@@ -19480,6 +19625,11 @@ fn build_llm_symbol_doc_text() -> String {
                  BEFORE INSERT ON grounding_node_snapshot
                  BEGIN SELECT RAISE(ABORT, 'forced detail snapshot failure'); END;"
             }
+            IncrementalFailureBoundary::PublicationIdentity => {
+                "CREATE TRIGGER fail_incremental_boundary
+                 BEFORE INSERT ON index_publication
+                 BEGIN SELECT RAISE(ABORT, 'forced publication identity failure'); END;"
+            }
             IncrementalFailureBoundary::MarkerClear => {
                 "CREATE TRIGGER fail_incremental_boundary
                  BEFORE DELETE ON incomplete_index_run
@@ -19496,6 +19646,9 @@ fn build_llm_symbol_doc_text() -> String {
             IncrementalFailureBoundary::SemanticDocs => "forced semantic doc failure",
             IncrementalFailureBoundary::SummarySnapshot => "forced summary snapshot failure",
             IncrementalFailureBoundary::DetailSnapshot => "forced detail snapshot failure",
+            IncrementalFailureBoundary::PublicationIdentity => {
+                "forced publication identity failure"
+            }
             IncrementalFailureBoundary::MarkerClear => "forced marker clear failure",
         }
     }
@@ -19590,216 +19743,109 @@ fn build_llm_symbol_doc_text() -> String {
             "wrong failure boundary for {boundary:?}: {error:?}"
         );
 
-        let is_pre_publish = !matches!(boundary, IncrementalFailureBoundary::MarkerClear);
-        if is_pre_publish {
-            let storage = Storage::open(&storage_path).expect("reopen live storage");
-            assert!(
-                !storage
-                    .has_incomplete_incremental_run()
-                    .expect("read live marker"),
-                "pre-publish failure must not mark live storage: {boundary:?}"
-            );
-            assert_eq!(
-                Storage::database_schema_version(&storage_path).expect("live schema version"),
-                baseline_schema,
-                "pre-publish failure must not change the live schema: {boundary:?}"
-            );
-            let live_paths = storage
-                .get_files()
-                .expect("read live files")
-                .into_iter()
-                .map(|file| file.path)
-                .collect::<Vec<_>>();
-            assert_eq!(live_paths, baseline_paths, "boundary={boundary:?}");
-            let live_stats = storage.get_stats().expect("read live stats");
-            assert_eq!(live_stats.node_count, baseline_stats.node_count);
-            assert_eq!(live_stats.edge_count, baseline_stats.edge_count);
-            assert_eq!(live_stats.file_count, baseline_stats.file_count);
-            assert_eq!(live_stats.error_count, baseline_stats.error_count);
-            assert_eq!(
-                storage
-                    .snapshots()
-                    .get_metadata()
-                    .expect("read live snapshot metadata"),
-                baseline_snapshots,
-                "pre-publish failure must preserve the complete old snapshot generation"
-            );
-            assert_eq!(
-                storage
-                    .get_index_publication()
-                    .expect("read live publication identity"),
-                Some(baseline_publication.clone()),
-                "pre-publish failure must not advance the live generation"
-            );
-            assert_eq!(
-                persisted_search_generation_names(&storage_path),
-                baseline_search_generations,
-                "pre-publish failure must not create search state for an unpublished generation"
-            );
-            assert_eq!(
-                storage
-                    .get_all_llm_symbol_docs()
-                    .expect("read live semantic docs"),
-                baseline_semantic_docs,
-                "pre-publish failure must preserve the live semantic corpus"
-            );
-            assert_eq!(
-                storage
-                    .get_symbol_search_doc_count()
-                    .expect("read live symbol doc count"),
-                baseline_symbol_doc_count,
-                "pre-publish failure must preserve graph-native semantic docs"
-            );
-            storage
-                .get_connection()
-                .execute_batch("DROP TRIGGER fail_incremental_boundary;")
-                .expect("remove injected live trigger");
-            drop(storage);
-
-            let dry_run = controller
-                .dry_run_index(IndexMode::Incremental)
-                .expect("dry-run direct retry");
-            assert_eq!(dry_run.refresh, IndexMode::Incremental);
-            let timings = controller
-                .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
-                .expect("direct incremental retry");
-            assert!(timings.publish_ms.is_some());
-            let storage = Storage::open(&storage_path).expect("open retried storage");
-            assert!(
-                storage
-                    .get_file_by_path(&old_path)
-                    .expect("read old file after retry")
-                    .is_none()
-            );
-            assert!(
-                storage
-                    .get_file_by_path(&new_path)
-                    .expect("read new file after retry")
-                    .is_some()
-            );
-            assert!(
-                !storage
-                    .has_incomplete_incremental_run()
-                    .expect("marker after direct retry")
-            );
-            let retried_publication = storage
-                .get_index_publication()
-                .expect("read retried publication")
-                .expect("retried publication identity");
-            assert_eq!(
-                retried_publication.generation,
-                baseline_publication.generation + 1
-            );
-            assert_eq!(retried_publication.mode, IndexPublicationMode::Incremental);
-            return;
-        }
-
-        {
-            let storage = Storage::open(&storage_path).expect("reopen published storage");
-            assert!(
-                storage
-                    .has_incomplete_incremental_run()
-                    .expect("read incomplete marker")
-            );
-            assert_ne!(
-                Storage::database_schema_version(&storage_path).expect("schema version"),
-                codestory_store::CURRENT_SCHEMA_VERSION,
-                "late failure must fence the published replacement"
-            );
-            assert!(
-                storage
-                    .get_file_by_path(&new_path)
-                    .expect("read new file")
-                    .is_some()
-            );
-            assert!(
-                storage
-                    .get_file_by_path(&old_path)
-                    .expect("read old file")
-                    .is_none()
-            );
-            assert!(
-                storage
-                    .snapshots()
-                    .has_ready_summary()
-                    .expect("summary readiness")
-            );
-            assert!(
-                storage
-                    .snapshots()
-                    .has_ready_detail()
-                    .expect("detail readiness")
-            );
-            let published = storage
-                .get_index_publication()
-                .expect("read fenced publication")
-                .expect("fenced publication identity");
-            assert_eq!(published.generation, baseline_publication.generation + 1);
-            assert_eq!(published.mode, IndexPublicationMode::Incremental);
-        }
-
-        let recovery = AppController::new();
-        let summary = recovery
-            .open_project_summary_with_storage_path(
-                workspace.path().to_path_buf(),
-                storage_path.clone(),
-            )
-            .expect("open interrupted project");
-        let freshness = summary.freshness.expect("summary freshness");
-        assert_eq!(freshness.status, IndexFreshnessStatusDto::Stale);
-        assert_eq!(
-            freshness.reason.as_deref(),
-            Some("previous_incremental_run_incomplete_full_refresh_required")
-        );
-        let dry_run = recovery
-            .dry_run_index(IndexMode::Incremental)
-            .expect("dry-run recovery");
-        assert_eq!(dry_run.refresh, IndexMode::Full);
-        assert!(
-            Storage::open(&storage_path)
-                .expect("open after dry run")
-                .has_incomplete_incremental_run()
-                .expect("marker after dry run"),
-            "dry-run must not mutate interrupted state"
-        );
-
-        let timings = recovery
-            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
-            .expect("staged full recovery");
-        assert!(
-            timings.publish_ms.is_some(),
-            "recovery must use staged full publish"
-        );
-        let storage = Storage::open(&storage_path).expect("open recovered storage");
+        let storage = Storage::open(&storage_path).expect("reopen live storage");
         assert!(
             !storage
                 .has_incomplete_incremental_run()
-                .expect("marker after recovery")
+                .expect("read live marker"),
+            "pre-publish failure must not mark live storage: {boundary:?}"
         );
         assert_eq!(
-            Storage::database_schema_version(&storage_path).expect("recovered schema"),
-            codestory_store::CURRENT_SCHEMA_VERSION
+            Storage::database_schema_version(&storage_path).expect("live schema version"),
+            baseline_schema,
+            "pre-publish failure must not change the live schema: {boundary:?}"
+        );
+        let live_paths = storage
+            .get_files()
+            .expect("read live files")
+            .into_iter()
+            .map(|file| file.path)
+            .collect::<Vec<_>>();
+        assert_eq!(live_paths, baseline_paths, "boundary={boundary:?}");
+        let live_stats = storage.get_stats().expect("read live stats");
+        assert_eq!(live_stats.node_count, baseline_stats.node_count);
+        assert_eq!(live_stats.edge_count, baseline_stats.edge_count);
+        assert_eq!(live_stats.file_count, baseline_stats.file_count);
+        assert_eq!(live_stats.error_count, baseline_stats.error_count);
+        assert_eq!(
+            storage
+                .snapshots()
+                .get_metadata()
+                .expect("read live snapshot metadata"),
+            baseline_snapshots,
+            "pre-publish failure must preserve the complete old snapshot generation"
         );
         assert_eq!(
-            recovery
-                .index_freshness()
-                .expect("recovered freshness")
-                .status,
-            IndexFreshnessStatusDto::Fresh
+            storage
+                .get_index_publication()
+                .expect("read live publication identity"),
+            Some(baseline_publication.clone()),
+            "pre-publish failure must not advance the live generation"
         );
-        let recovered_publication = storage
+        assert_eq!(
+            persisted_search_generation_names(&storage_path),
+            baseline_search_generations,
+            "pre-publish failure must not create search state for an unpublished generation"
+        );
+        assert_eq!(
+            storage
+                .get_all_llm_symbol_docs()
+                .expect("read live semantic docs"),
+            baseline_semantic_docs,
+            "pre-publish failure must preserve the live semantic corpus"
+        );
+        assert_eq!(
+            storage
+                .get_symbol_search_doc_count()
+                .expect("read live symbol doc count"),
+            baseline_symbol_doc_count,
+            "pre-publish failure must preserve graph-native semantic docs"
+        );
+        storage
+            .get_connection()
+            .execute_batch("DROP TRIGGER fail_incremental_boundary;")
+            .expect("remove injected live trigger");
+        drop(storage);
+
+        let dry_run = controller
+            .dry_run_index(IndexMode::Incremental)
+            .expect("dry-run direct retry");
+        assert_eq!(dry_run.refresh, IndexMode::Incremental);
+        let timings = controller
+            .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
+            .expect("direct incremental retry");
+        assert!(timings.publish_ms.is_some());
+        let storage = Storage::open(&storage_path).expect("open retried storage");
+        assert!(
+            storage
+                .get_file_by_path(&old_path)
+                .expect("read old file after retry")
+                .is_none()
+        );
+        assert!(
+            storage
+                .get_file_by_path(&new_path)
+                .expect("read new file after retry")
+                .is_some()
+        );
+        assert!(
+            !storage
+                .has_incomplete_incremental_run()
+                .expect("marker after direct retry")
+        );
+        let retried_publication = storage
             .get_index_publication()
-            .expect("read recovered publication")
-            .expect("recovered publication identity");
+            .expect("read retried publication")
+            .expect("retried publication identity");
         assert_eq!(
-            recovered_publication.generation,
-            baseline_publication.generation + 2
+            retried_publication.generation,
+            baseline_publication.generation + 1
         );
-        assert_eq!(recovered_publication.mode, IndexPublicationMode::Full);
+        assert_eq!(retried_publication.mode, IndexPublicationMode::Incremental);
     }
 
     #[test]
-    fn incremental_boundaries_publish_atomically_and_late_failure_recovers() {
+    fn incremental_boundaries_preserve_live_state_and_retry_atomically() {
         for boundary in [
             IncrementalFailureBoundary::Projection,
             IncrementalFailureBoundary::Cleanup,
@@ -19807,10 +19853,416 @@ fn build_llm_symbol_doc_text() -> String {
             IncrementalFailureBoundary::SemanticDocs,
             IncrementalFailureBoundary::SummarySnapshot,
             IncrementalFailureBoundary::DetailSnapshot,
+            IncrementalFailureBoundary::PublicationIdentity,
             IncrementalFailureBoundary::MarkerClear,
         ] {
             assert_incremental_boundary_is_atomic(boundary);
         }
+    }
+
+    const PUBLICATION_TRANSITION_BOUNDARIES: [PublicationTestBoundary; 8] = [
+        PublicationTestBoundary::Identity,
+        PublicationTestBoundary::SearchBuild,
+        PublicationTestBoundary::SearchValidation,
+        PublicationTestBoundary::SearchCompletion,
+        PublicationTestBoundary::CatalogLock,
+        PublicationTestBoundary::DatabaseReplacement,
+        PublicationTestBoundary::MarkerCompletion,
+        PublicationTestBoundary::RuntimeCache,
+    ];
+
+    fn assert_no_staged_publication_artifacts(storage_path: &Path) {
+        let parent = storage_path.parent().expect("storage parent");
+        let staged = fs::read_dir(parent)
+            .expect("list storage parent")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .filter(|name| name.contains(".staged."))
+            .collect::<Vec<_>>();
+        assert!(staged.is_empty(), "staged publication debris: {staged:?}");
+    }
+
+    fn storage_has_symbol(storage: &Storage, name: &str) -> bool {
+        storage
+            .get_nodes()
+            .expect("read publication nodes")
+            .iter()
+            .any(|node| node.serialized_name == name)
+    }
+
+    fn copy_publication_fixture_directory(source: &Path, destination: &Path) {
+        fs::create_dir_all(destination).expect("create publication fixture directory");
+        for entry in fs::read_dir(source).expect("list publication fixture directory") {
+            let entry = entry.expect("read publication fixture entry");
+            let target = destination.join(entry.file_name());
+            if entry.file_type().expect("fixture entry type").is_dir() {
+                copy_publication_fixture_directory(&entry.path(), &target);
+            } else {
+                fs::copy(entry.path(), target).expect("copy publication fixture file");
+            }
+        }
+    }
+
+    fn assert_publication_transition_fault_is_atomic(
+        workspace_root: &Path,
+        storage_path: &Path,
+        baseline: &IndexPublicationRecord,
+        baseline_search_generations: &[String],
+        mode: IndexMode,
+        boundary: PublicationTestBoundary,
+        action: PublicationTestAction,
+    ) {
+        let source_path = workspace_root.join("lib.rs");
+        let controller = AppController::new();
+        controller
+            .open_project_summary_with_storage_path(
+                workspace_root.to_path_buf(),
+                storage_path.to_path_buf(),
+            )
+            .expect("open baseline project");
+
+        fs::write(&source_path, "pub fn new_generation() -> i32 { 2 }\n")
+            .expect("write replacement source");
+        let cancel_token = CancellationToken::new();
+        arm_publication_test_fault(boundary, action);
+        let result = controller.run_indexing_blocking_with_cancel(mode, &cancel_token);
+        PUBLICATION_TEST_FAULT.with(|fault| {
+            assert!(
+                fault.borrow().is_none(),
+                "publication fault was not reached: {mode:?} {boundary:?} {action:?}"
+            );
+        });
+        let after_point_of_no_return = boundary == PublicationTestBoundary::RuntimeCache;
+        if after_point_of_no_return {
+            result.expect("post-commit faults must complete the committed publication");
+            assert_eq!(
+                cancel_token.is_cancelled(),
+                action == PublicationTestAction::Cancel
+            );
+        } else {
+            let error = result.expect_err("injected publication transition must fail visibly");
+            match action {
+                PublicationTestAction::Fail => {
+                    assert_eq!(error.code, "internal");
+                    assert!(error.message.contains(&format!("{boundary:?}")));
+                    assert!(!cancel_token.is_cancelled());
+                }
+                PublicationTestAction::Cancel => {
+                    assert_eq!(error.code, "cancelled");
+                    assert!(cancel_token.is_cancelled());
+                }
+            }
+        }
+        let state = controller.state.lock();
+        assert!(!state.is_indexing);
+        if after_point_of_no_return {
+            assert_eq!(
+                state
+                    .search_publication
+                    .as_ref()
+                    .expect("late cancellation published runtime search state")
+                    .generation,
+                baseline.generation + 1
+            );
+        } else {
+            assert_eq!(
+                state
+                    .search_publication
+                    .as_ref()
+                    .expect("failed publication must restore baseline runtime search state")
+                    .generation,
+                baseline.generation
+            );
+        }
+        drop(state);
+        assert_no_staged_publication_artifacts(storage_path);
+
+        let replacement_reached_live = after_point_of_no_return;
+        let publication_completed = replacement_reached_live;
+        {
+            let storage = Storage::open(storage_path).expect("open post-fault storage");
+            let raw = storage
+                .get_index_publication()
+                .expect("read post-fault publication")
+                .expect("post-fault publication identity");
+            if replacement_reached_live {
+                assert_eq!(raw.generation, baseline.generation + 1);
+                assert!(storage_has_symbol(&storage, "new_generation"));
+                assert!(!storage_has_symbol(&storage, "old_generation"));
+                if publication_completed {
+                    assert!(
+                        !storage
+                            .has_incomplete_incremental_run()
+                            .expect("read completed publication fence")
+                    );
+                    assert_eq!(
+                        storage
+                            .get_complete_index_publication()
+                            .expect("read completed publication"),
+                        Some(raw.clone())
+                    );
+                } else {
+                    assert!(
+                        storage
+                            .has_incomplete_incremental_run()
+                            .expect("read post-fault fence")
+                    );
+                    assert_eq!(
+                        storage
+                            .get_complete_index_publication()
+                            .expect("read fenced complete publication"),
+                        None,
+                        "an interrupted incremental replacement must not be served"
+                    );
+                }
+            } else {
+                assert_eq!(&raw, baseline);
+                assert!(storage_has_symbol(&storage, "old_generation"));
+                assert!(!storage_has_symbol(&storage, "new_generation"));
+                assert_eq!(
+                    storage
+                        .get_complete_index_publication()
+                        .expect("read preserved complete publication"),
+                    Some(baseline.clone())
+                );
+                assert_eq!(
+                    persisted_search_generation_names(storage_path),
+                    baseline_search_generations,
+                    "an unpublished generation must be cleaned"
+                );
+            }
+        }
+
+        let restarted = AppController::new();
+        let summary = restarted
+            .open_project_summary_with_storage_path(
+                workspace_root.to_path_buf(),
+                storage_path.to_path_buf(),
+            )
+            .expect("restart against post-fault storage");
+        if publication_completed {
+            assert_eq!(
+                summary
+                    .publication
+                    .expect("restart complete publication")
+                    .generation,
+                baseline.generation + 1
+            );
+        } else if replacement_reached_live {
+            assert!(
+                summary.publication.is_none(),
+                "fenced generation was served"
+            );
+            assert_eq!(
+                restarted
+                    .dry_run_index(IndexMode::Incremental)
+                    .expect("plan fenced recovery")
+                    .refresh,
+                IndexMode::Full
+            );
+            restarted
+                .run_indexing_blocking(IndexMode::Incremental)
+                .expect("restart publication recovery");
+            let storage = Storage::open(storage_path).expect("open recovered storage");
+            let recovered = storage
+                .get_complete_index_publication()
+                .expect("read recovered publication")
+                .expect("complete recovered publication");
+            assert!(recovered.generation > baseline.generation);
+            assert!(storage_has_symbol(&storage, "new_generation"));
+            assert!(!storage_has_symbol(&storage, "old_generation"));
+        } else {
+            assert_eq!(
+                summary
+                    .publication
+                    .expect("restart preserved publication")
+                    .generation,
+                baseline.generation
+            );
+            let storage = Storage::open(storage_path).expect("open restarted baseline");
+            assert!(storage_has_symbol(&storage, "old_generation"));
+            assert!(!storage_has_symbol(&storage, "new_generation"));
+        }
+        assert_no_staged_publication_artifacts(storage_path);
+    }
+
+    fn assert_publication_transition_matrix(mode: IndexMode) {
+        let workspace = tempdir().expect("workspace dir");
+        let source_path = workspace.path().join("lib.rs");
+        fs::write(&source_path, "pub fn old_generation() -> i32 { 1 }\n")
+            .expect("write baseline source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let (baseline, baseline_search_generations) = {
+            let controller = AppController::new();
+            controller
+                .open_project_summary_with_storage_path(
+                    workspace.path().to_path_buf(),
+                    storage_path.clone(),
+                )
+                .expect("open matrix baseline");
+            controller
+                .run_indexing_blocking(IndexMode::Full)
+                .expect("publish matrix baseline");
+            let storage = Storage::open(&storage_path).expect("open matrix baseline storage");
+            assert!(storage_has_symbol(&storage, "old_generation"));
+            (
+                storage
+                    .get_complete_index_publication()
+                    .expect("read matrix baseline publication")
+                    .expect("complete matrix baseline publication"),
+                persisted_search_generation_names(&storage_path),
+            )
+        };
+        let backup = tempdir().expect("baseline backup");
+        let backup_cache = backup.path().join("cache");
+        copy_publication_fixture_directory(
+            storage_path.parent().expect("matrix cache directory"),
+            &backup_cache,
+        );
+
+        for boundary in PUBLICATION_TRANSITION_BOUNDARIES {
+            if boundary == PublicationTestBoundary::MarkerCompletion
+                && mode != IndexMode::Incremental
+            {
+                continue;
+            }
+            for action in [PublicationTestAction::Fail, PublicationTestAction::Cancel] {
+                eprintln!("publication matrix: {mode:?} {boundary:?} {action:?}");
+                fs::remove_dir_all(storage_path.parent().expect("matrix cache directory"))
+                    .expect("reset matrix cache");
+                copy_publication_fixture_directory(
+                    &backup_cache,
+                    storage_path.parent().expect("matrix cache directory"),
+                );
+                fs::write(&source_path, "pub fn old_generation() -> i32 { 1 }\n")
+                    .expect("reset matrix source");
+                assert_publication_transition_fault_is_atomic(
+                    workspace.path(),
+                    &storage_path,
+                    &baseline,
+                    &baseline_search_generations,
+                    mode,
+                    boundary,
+                    action,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn full_recovery_marker_completion_fault_preserves_fenced_live_generation() {
+        let workspace = tempdir().expect("workspace dir");
+        let source_path = workspace.path().join("lib.rs");
+        fs::write(&source_path, "pub fn old_generation() -> i32 { 1 }\n")
+            .expect("write baseline source");
+        let storage_path = workspace.path().join(".cache").join("codestory.db");
+        let baseline = {
+            let controller = AppController::new();
+            controller
+                .open_project_summary_with_storage_path(
+                    workspace.path().to_path_buf(),
+                    storage_path.clone(),
+                )
+                .expect("open recovery baseline");
+            controller
+                .run_indexing_blocking(IndexMode::Full)
+                .expect("publish recovery baseline");
+            Storage::open(&storage_path)
+                .expect("open recovery baseline storage")
+                .get_complete_index_publication()
+                .expect("read recovery baseline")
+                .expect("complete recovery baseline")
+        };
+        let backup = tempdir().expect("baseline backup");
+        let backup_cache = backup.path().join("cache");
+        copy_publication_fixture_directory(
+            storage_path.parent().expect("recovery cache directory"),
+            &backup_cache,
+        );
+
+        for action in [PublicationTestAction::Fail, PublicationTestAction::Cancel] {
+            fs::remove_dir_all(storage_path.parent().expect("recovery cache directory"))
+                .expect("reset recovery cache");
+            copy_publication_fixture_directory(
+                &backup_cache,
+                storage_path.parent().expect("recovery cache directory"),
+            );
+            Storage::open(&storage_path)
+                .expect("open interrupted live storage")
+                .begin_incremental_run()
+                .expect("fence interrupted live storage");
+            fs::write(&source_path, "pub fn new_generation() -> i32 { 2 }\n")
+                .expect("write recovery source");
+            let controller = AppController::new();
+            controller
+                .open_project_summary_with_storage_path(
+                    workspace.path().to_path_buf(),
+                    storage_path.clone(),
+                )
+                .expect("open fenced recovery project");
+            let cancel_token = CancellationToken::new();
+            arm_publication_test_fault(PublicationTestBoundary::MarkerCompletion, action);
+            let error = controller
+                .run_indexing_blocking_with_cancel(IndexMode::Full, &cancel_token)
+                .expect_err("pre-publication marker fault must fail");
+            match action {
+                PublicationTestAction::Fail => assert_eq!(error.code, "internal"),
+                PublicationTestAction::Cancel => assert_eq!(error.code, "cancelled"),
+            }
+            let storage = Storage::open(&storage_path).expect("open preserved fenced live storage");
+            assert_eq!(
+                storage
+                    .get_index_publication()
+                    .expect("read preserved raw publication"),
+                Some(baseline.clone())
+            );
+            assert!(
+                storage
+                    .has_incomplete_incremental_run()
+                    .expect("read preserved incomplete marker")
+            );
+            assert_eq!(
+                storage
+                    .get_complete_index_publication()
+                    .expect("read preserved complete publication"),
+                None
+            );
+            assert!(storage_has_symbol(&storage, "old_generation"));
+            assert!(!storage_has_symbol(&storage, "new_generation"));
+            drop(storage);
+            assert_no_staged_publication_artifacts(&storage_path);
+
+            let restarted = AppController::new();
+            restarted
+                .open_project_summary_with_storage_path(
+                    workspace.path().to_path_buf(),
+                    storage_path.clone(),
+                )
+                .expect("restart fenced recovery project");
+            restarted
+                .run_indexing_blocking(IndexMode::Full)
+                .expect("complete fenced recovery");
+            let storage = Storage::open(&storage_path).expect("open completed recovery");
+            assert_eq!(
+                storage
+                    .get_complete_index_publication()
+                    .expect("read completed recovery")
+                    .expect("complete recovered publication")
+                    .generation,
+                baseline.generation + 1
+            );
+            assert!(storage_has_symbol(&storage, "new_generation"));
+        }
+    }
+
+    #[test]
+    fn full_publication_transitions_fail_or_cancel_atomically() {
+        assert_publication_transition_matrix(IndexMode::Full);
+    }
+
+    #[test]
+    fn incremental_publication_transitions_fail_or_cancel_atomically() {
+        assert_publication_transition_matrix(IndexMode::Incremental);
     }
 
     #[test]

--- a/crates/codestory-store/Cargo.toml
+++ b/crates/codestory-store/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 codestory-contracts = { workspace = true }
 anyhow = { workspace = true }
+fs4 = { workspace = true }
 parking_lot = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -3,6 +3,7 @@ use codestory_contracts::graph::{
     EnumConversionError, Node, NodeId, NodeKind, Occurrence, OccurrenceKind, ResolutionCertainty,
     TrailCallerScope, TrailConfig, TrailDirection, TrailMode, TrailResult,
 };
+use fs4::fs_std::FileExt;
 use parking_lot::RwLock;
 use rusqlite::{
     Connection, MAIN_DB, OpenFlags, Result, Row, params, params_from_iter, types::Value,
@@ -10,7 +11,9 @@ use rusqlite::{
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+#[cfg(test)]
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -48,6 +51,10 @@ const EDGE_SELECT_BASE: &str = "SELECT e.id, e.source_node_id, e.target_node_id,
 const EDGE_NODE_LOOKUP_BATCH_SIZE: usize = 200;
 const NODE_LOOKUP_BATCH_SIZE: usize = 200;
 const OCCURRENCE_LOOKUP_BATCH_SIZE: usize = 200;
+#[cfg(test)]
+const PROMOTION_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_SENTINEL";
+#[cfg(test)]
+const PROMOTION_ABORT_SENTINEL: &[u8] = b"after-live-restore-step\n";
 
 fn clamp_i64_to_u32(value: i64) -> u32 {
     if value <= 0 {
@@ -151,15 +158,110 @@ fn sqlite_sidecar_paths(path: &Path) -> [PathBuf; 3] {
 fn cleanup_sqlite_sidecars(path: &Path) -> Result<(), StorageError> {
     for candidate in sqlite_sidecar_paths(path) {
         if candidate.exists() {
-            fs::remove_file(&candidate).map_err(|err| {
-                StorageError::Other(format!(
-                    "Failed to remove SQLite artifact {}: {err}",
-                    candidate.display()
-                ))
-            })?;
+            match fs::remove_file(&candidate) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    return Err(StorageError::Other(format!(
+                        "Failed to remove SQLite artifact {}: {err}",
+                        candidate.display()
+                    )));
+                }
+            }
         }
     }
     Ok(())
+}
+
+struct PromotionLock {
+    file: File,
+}
+
+fn promotion_lock_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.promotion.lock", path.display()))
+}
+
+impl PromotionLock {
+    fn open(path: &Path) -> Result<File, StorageError> {
+        let lock_path = promotion_lock_path(path);
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                StorageError::Other(format!(
+                    "Failed to create promotion lock directory {}: {error}",
+                    parent.display()
+                ))
+            })?;
+        }
+        OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|error| {
+                StorageError::Other(format!(
+                    "Failed to open promotion lock {}: {error}",
+                    lock_path.display()
+                ))
+            })
+    }
+
+    fn acquire(path: &Path) -> Result<Self, StorageError> {
+        let file = Self::open(path)?;
+        FileExt::lock_exclusive(&file).map_err(|error| {
+            StorageError::Other(format!(
+                "Failed to acquire promotion lock for {}: {error}",
+                path.display()
+            ))
+        })?;
+        Ok(Self { file })
+    }
+
+    fn try_acquire(path: &Path) -> Result<Option<Self>, StorageError> {
+        let file = Self::open(path)?;
+        FileExt::try_lock_exclusive(&file)
+            .map(|locked| locked.then_some(Self { file }))
+            .map_err(|error| {
+                StorageError::Other(format!(
+                    "Failed to inspect promotion lock for {}: {error}",
+                    path.display()
+                ))
+            })
+    }
+}
+
+impl Drop for PromotionLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+fn recover_interrupted_promotion(path: &Path) -> Result<(), StorageError> {
+    if !path.with_extension("sqlite.backup").exists() {
+        return Ok(());
+    }
+    let Some(_lock) = PromotionLock::try_acquire(path)? else {
+        // A healthy promoter owns the lock. SQLite readers may wait for that
+        // transaction, but must never interpret its backup as crash evidence.
+        return Ok(());
+    };
+    recover_interrupted_promotion_locked(path)
+}
+
+fn recover_interrupted_promotion_locked(path: &Path) -> Result<(), StorageError> {
+    let backup_path = path.with_extension("sqlite.backup");
+    if !backup_path.exists() {
+        return Ok(());
+    }
+    let mut live = Connection::open(path)?;
+    let _ = live.busy_timeout(Duration::from_millis(2_500));
+    live.restore(
+        MAIN_DB,
+        &backup_path,
+        None::<fn(rusqlite::backup::Progress)>,
+    )?;
+    drop(live);
+    cleanup_sqlite_sidecars(&backup_path)
 }
 
 fn grounding_display_name_expr(alias: &str) -> String {
@@ -1037,6 +1139,8 @@ impl Storage {
     /// concurrent readers must not contend with a staged refresh merely by
     /// opening the live database.
     pub fn open_read_only<P: AsRef<Path>>(path: P) -> Result<Self, StorageError> {
+        let path = path.as_ref();
+        recover_interrupted_promotion(path)?;
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         conn.busy_timeout(Duration::from_millis(2_500))?;
         conn.pragma_update(None, "foreign_keys", "ON")?;
@@ -1075,6 +1179,9 @@ impl Storage {
         mode: StorageOpenMode,
     ) -> Result<Self, StorageError> {
         let path = path.as_ref();
+        if matches!(mode, StorageOpenMode::Live) {
+            recover_interrupted_promotion(path)?;
+        }
         let conn = Connection::open(path)?;
         // Allow concurrent reads while indexing writes, and avoid flaky "database is locked" errors
         // in app shells when users query mid-index.
@@ -1099,6 +1206,7 @@ impl Storage {
     }
 
     pub fn database_schema_version(path: &Path) -> Result<u32, StorageError> {
+        recover_interrupted_promotion(path)?;
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         Ok(version.max(0) as u32)
@@ -1106,6 +1214,7 @@ impl Storage {
 
     /// Read the incomplete-run fence without migrating or otherwise mutating a live database.
     pub fn database_has_incomplete_incremental_run(path: &Path) -> Result<bool, StorageError> {
+        recover_interrupted_promotion(path)?;
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
         let version = version.max(0) as u32;
@@ -1140,6 +1249,7 @@ impl Storage {
     pub fn database_index_publication(
         path: &Path,
     ) -> Result<Option<IndexPublicationRecord>, StorageError> {
+        recover_interrupted_promotion(path)?;
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         read_index_publication(&conn)
     }
@@ -1149,6 +1259,7 @@ impl Storage {
     pub fn database_complete_index_publication(
         path: &Path,
     ) -> Result<Option<IndexPublicationRecord>, StorageError> {
+        recover_interrupted_promotion(path)?;
         let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         read_complete_index_publication(&conn)
     }
@@ -1157,6 +1268,7 @@ impl Storage {
         source_path: &Path,
         target_path: &Path,
     ) -> Result<(), StorageError> {
+        recover_interrupted_promotion(source_path)?;
         if let Some(parent) = target_path.parent() {
             fs::create_dir_all(parent).map_err(|err| {
                 StorageError::Other(format!(
@@ -2183,6 +2295,8 @@ impl Storage {
         staged_path: &Path,
         live_path: &Path,
     ) -> Result<(), StorageError> {
+        let _promotion_lock = PromotionLock::acquire(live_path)?;
+        recover_interrupted_promotion_locked(live_path)?;
         let backup_path = live_path.with_extension("sqlite.backup");
         let live_exists = live_path.exists();
         cleanup_sqlite_sidecars(&backup_path)?;
@@ -2197,9 +2311,31 @@ impl Storage {
             )?;
         }
 
-        if let Err(err) =
-            live_conn.restore(MAIN_DB, staged_path, None::<fn(rusqlite::backup::Progress)>)
+        #[cfg(test)]
+        let restore_result = if let Some(sentinel_path) =
+            std::env::var_os(PROMOTION_ABORT_SENTINEL_ENV).map(PathBuf::from)
         {
+            live_conn.restore(
+                MAIN_DB,
+                staged_path,
+                Some(move |_progress| {
+                    let mut sentinel = std::fs::File::create(&sentinel_path)
+                        .expect("create promotion abort sentinel");
+                    sentinel
+                        .write_all(PROMOTION_ABORT_SENTINEL)
+                        .expect("write promotion abort sentinel");
+                    sentinel.sync_all().expect("sync promotion abort sentinel");
+                    std::process::abort();
+                }),
+            )
+        } else {
+            live_conn.restore(MAIN_DB, staged_path, None::<fn(rusqlite::backup::Progress)>)
+        };
+        #[cfg(not(test))]
+        let restore_result =
+            live_conn.restore(MAIN_DB, staged_path, None::<fn(rusqlite::backup::Progress)>);
+
+        if let Err(err) = restore_result {
             if live_exists && backup_path.exists() {
                 let _ = live_conn.restore(
                     MAIN_DB,

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -1838,6 +1838,156 @@ fn test_promote_staged_snapshot_replaces_live_db_while_live_reader_is_open()
 }
 
 #[test]
+fn reader_open_during_healthy_promotion_does_not_recover_active_backup() -> Result<(), StorageError>
+{
+    let live_path = unique_temp_db_path("active-promotion-live");
+    let backup_path = live_path.with_extension("sqlite.backup");
+    let lock_path = promotion_lock_path(&live_path);
+    let _ = cleanup_sqlite_sidecars(&live_path);
+    let _ = cleanup_sqlite_sidecars(&backup_path);
+
+    seed_promotion_file(&live_path, 2, "new.rs")?;
+    seed_promotion_file(&backup_path, 1, "old.rs")?;
+    let promotion_lock = PromotionLock::acquire(&live_path)?;
+
+    let during_promotion = Storage::open(&live_path)?;
+    assert_eq!(
+        during_promotion.get_files()?[0].path,
+        PathBuf::from("new.rs")
+    );
+    drop(during_promotion);
+    assert!(
+        backup_path.exists(),
+        "active promoter still owns its backup"
+    );
+
+    drop(promotion_lock);
+    let recovered = Storage::open(&live_path)?;
+    assert_eq!(recovered.get_files()?[0].path, PathBuf::from("old.rs"));
+    drop(recovered);
+    assert!(
+        !backup_path.exists(),
+        "recovery consumes the abandoned backup"
+    );
+
+    let _ = cleanup_sqlite_sidecars(&live_path);
+    let _ = cleanup_sqlite_sidecars(&backup_path);
+    let _ = std::fs::remove_file(lock_path);
+    Ok(())
+}
+
+const PROMOTION_ABORT_LIVE_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_LIVE";
+const PROMOTION_ABORT_STAGED_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_STAGED";
+
+fn seed_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
+    let mut storage = Storage::open(path)?;
+    storage.insert_files_batch(&[FileInfo {
+        id,
+        path: PathBuf::from(name),
+        language: "rust".to_string(),
+        modification_time: id,
+        indexed: true,
+        complete: true,
+        line_count: 1,
+        file_role: FileRole::Source,
+    }])?;
+    storage.finalize_staged_snapshot()
+}
+
+#[test]
+fn staged_promotion_abort_child() {
+    let Some(live_path) = std::env::var_os(PROMOTION_ABORT_LIVE_ENV).map(PathBuf::from) else {
+        return;
+    };
+    let staged_path =
+        PathBuf::from(std::env::var_os(PROMOTION_ABORT_STAGED_ENV).expect("child staged path"));
+    let result = Storage::promote_staged_snapshot(&staged_path, &live_path);
+    panic!("promotion abort hook returned: {result:?}");
+}
+
+#[test]
+fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
+    let live_path = unique_temp_db_path("promotion-abort-live");
+    let staged_path = unique_temp_db_path("promotion-abort-staged");
+    let sentinel_path = unique_temp_db_path("promotion-abort-sentinel");
+    let backup_path = live_path.with_extension("sqlite.backup");
+    seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
+    seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged generation");
+
+    let status =
+        std::process::Command::new(std::env::current_exe().expect("resolve store test executable"))
+            .arg("--exact")
+            .arg("storage_impl::tests::staged_promotion_abort_child")
+            .arg("--nocapture")
+            .env(PROMOTION_ABORT_LIVE_ENV, &live_path)
+            .env(PROMOTION_ABORT_STAGED_ENV, &staged_path)
+            .env(PROMOTION_ABORT_SENTINEL_ENV, &sentinel_path)
+            .status()
+            .expect("run promotion abort child");
+    assert!(
+        !status.success(),
+        "promotion abort child exited successfully"
+    );
+    assert_eq!(
+        std::fs::read(&sentinel_path).expect("read promotion abort sentinel"),
+        PROMOTION_ABORT_SENTINEL,
+        "ordinary child failure must not satisfy the crash proof"
+    );
+
+    let interrupted = Connection::open_with_flags(&live_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open interrupted live generation without recovery");
+    let interrupted_path: String = interrupted
+        .query_row("SELECT path FROM file ORDER BY id LIMIT 1", [], |row| {
+            row.get(0)
+        })
+        .expect("read interrupted live generation");
+    assert_eq!(
+        interrupted_path, "new.rs",
+        "abort hook must run after the live database mutation"
+    );
+    drop(interrupted);
+
+    let live = Storage::open(&live_path).expect("open live generation after abort");
+    assert_eq!(
+        live.get_files().expect("read live generation")[0].path,
+        PathBuf::from("old.rs")
+    );
+    drop(live);
+    assert!(
+        staged_path.exists(),
+        "staged generation must remain retryable"
+    );
+    assert!(
+        !backup_path.exists(),
+        "opening live storage must consume the recovery backup"
+    );
+
+    Storage::promote_staged_snapshot(&staged_path, &live_path)
+        .expect("retry promotion after abort");
+    let live = Storage::open(&live_path).expect("open recovered live generation");
+    assert_eq!(
+        live.get_files().expect("read recovered generation")[0].path,
+        PathBuf::from("new.rs")
+    );
+    drop(live);
+    for artifact in sqlite_sidecar_paths(&staged_path)
+        .into_iter()
+        .chain(sqlite_sidecar_paths(&backup_path))
+    {
+        assert!(
+            !artifact.exists(),
+            "successful retry left promotion artifact {}",
+            artifact.display()
+        );
+    }
+
+    let _ = cleanup_sqlite_sidecars(&live_path);
+    let _ = cleanup_sqlite_sidecars(&staged_path);
+    let _ = cleanup_sqlite_sidecars(&backup_path);
+    let _ = std::fs::remove_file(&sentinel_path);
+}
+
+#[test]
 fn test_resolution_query_plan_prefers_new_indexes() -> Result<(), StorageError> {
     let storage = Storage::new_in_memory()?;
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -36,6 +36,7 @@ Run Cargo commands serially in this repo.
 | Docs only | `git diff --check`, `node .github/scripts/check-doc-links.mjs` |
 | Routine code | `cargo fmt --check`, `cargo check`, `cargo test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` |
 | Concurrent publication | `cargo test -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture`; `rust-ci.yml` repeats this focused contract on Ubuntu, Windows, and macOS |
+| Publication fault recovery | `cargo test -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture`; `cargo test -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture`; `rust-ci.yml` repeats both proofs on Ubuntu, Windows, and macOS |
 | Release-blocking fidelity | `cargo test -p codestory-indexer --test fidelity_regression`, `cargo test -p codestory-indexer --test tictactoe_language_coverage`, `cargo test -p codestory-runtime --test retrieval_eval` |
 | Heavy repo-scale timing | `cargo build --release -p codestory-cli`, then `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture` |
 


### PR DESCRIPTION
## Context

#910 established staged core/search publication, but transition coverage did
not deterministically exercise every identity, search, lock, database-swap, and
runtime-cache failure/cancellation boundary or prove recovery after an actual
process abort.

Closes #955
Refs #910
Refs #956
Refs #975
Refs #899

## What Changed

- Added a test-only fault router and table-driven full/incremental matrix across
  identity, search build/validation/completion, catalog locking, marker
  completion, database replacement, and runtime cache publication.
- Added cancellation checkpoints before the durable point of no return. A
  cancellation or injected cache fault after commit completes the prepared
  generation instead of returning a retryable ordinary failure.
- Clear incomplete-run markers in the staged database before publication, so
  readers never observe an absent generation between old and complete-new.
- Recover a genuinely interrupted SQLite restore from its backup. A persistent
  promotion lock distinguishes abandoned recovery state from a healthy writer,
  preventing concurrent readers from restoring or deleting an active backup.
- Added a child-process abort after live mutation and before backup cleanup,
  restart recovery, active-promoter reader-open, cleanup, and retry proof.
- Added the focused qualification jobs to cross-platform Rust CI and documented
  the contract.

## How To Review

Start with `promote_staged_snapshot` and `recover_interrupted_promotion`: the
promotion lock must cover recovery, backup creation, live restore, and cleanup.
Then review marker completion before staged publication and the post-commit
runtime-cache semantics. Finally inspect the test-only fault router and matrix.

## Verification

- `cargo test -p codestory-runtime incremental_publication_transitions_fail_or_cancel_atomically -- --nocapture` — passed (16 transition cases)
- `cargo test -p codestory-runtime full_publication_transitions_fail_or_cancel_atomically -- --nocapture` — passed (14 applicable transition cases)
- `cargo test -p codestory-runtime full_recovery_marker_completion_fault_preserves_fenced_live_generation -- --nocapture` — passed
- `cargo test -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture` — passed
- `cargo test -p codestory-store reader_open_during_healthy_promotion_does_not_recover_active_backup -- --nocapture` — passed
- `cargo clippy -p codestory-store -p codestory-runtime --all-targets -- -D warnings` — passed
- `cargo fmt --all` and `git diff --check` — passed

The ignored repo-scale timing/evidence lane still requires the live model and
drill manifest unavailable in this environment. No evidence row was fabricated;
#956 and #958 retain that release-proof scope.

## Risk

The fault injection is test-only. The production change adds one persistent
lock file beside the live database and uses the workspace's existing `fs4`
dependency. Readers may briefly wait on SQLite while a healthy restore is in
flight, but they cannot consume or roll back an active writer's backup. No UI
surface changed.
