### PR TITLE
remove grounding prose test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
 
 ### Fixed
 
+- Removed a plugin static test that froze exact grounding documentation copy;
+  documentation remains covered by the repository link and diff checks.
 - Corrected the Codex managed-platform guide to list the restored macOS x64 CLI
   while retaining its no-managed-accelerated-sidecar boundary.
 - Retried packaged-proof temporary directory removal after transient executable

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -169,31 +169,6 @@ test("agent-facing guidance does not send agents to CLI fallback repair", async 
   }
 });
 
-test("grounding guidance preserves local graph fallback and repair boundaries", async () => {
-  const skill = await readFile(
-    join(pluginRoot, "skills", "codestory-grounding", "SKILL.md"),
-    "utf8",
-  );
-  const statusContract = await readFile(
-    join(pluginRoot, "skills", "codestory-grounding", "references", "status-contract.md"),
-    "utf8",
-  );
-  const guidance = `${skill}\n${statusContract}`;
-
-  for (const surface of [
-    "ground", "files", "symbol", "definition", "callers", "callees",
-    "trace", "trail", "references", "snippet", "affected", "symbols",
-    "get_node", "neighbors", "shortest_path", "query_subgraph",
-  ]) {
-    assert.equal(guidance.includes(`\`${surface}\``), true, surface);
-  }
-  assert.match(guidance, /Reuse (?:that |a )?status result until repository, runtime, or index state changes/u);
-  assert.match(guidance, /task requires (?:a |the )?blocked surface/u);
-  assert.match(guidance, /Local graph output is navigation evidence/u);
-  assert.match(guidance, /does not prove full\s+packet\/search readiness/u);
-  assert.match(statusContract, /use it without repairing packet\/search\/context/u);
-});
-
 test("plugin package version tracks the codestory-cli release version", async () => {
   const cliManifest = await readFile(
     join(repoRoot, "crates", "codestory-cli", "Cargo.toml"),


### PR DESCRIPTION
## Context

PR #972 added a static test that froze exact wording in the grounding skill and
status documentation. Repository policy reserves documentation proof for link
and diff checks rather than unit tests asserting copy.

## What Changed

- Removed only the grounding prose-freezing static test.
- Preserved the shipped grounding guidance and every behavior/manifest test.
- Recorded the testing-policy correction in the changelog.

## How To Review

Confirm the removed block is the only plugin-test change and that no grounding
documentation changed.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` (47 passed)
- `node .github/scripts/check-doc-links.mjs` (69 files, 279 links)
- `git diff --check`

## Risk

Low. This removes a policy-violating documentation-copy assertion without
changing runtime or plugin behavior.

Closes #976
Refs #964
Refs #972
Refs #899
