### PR TITLE
harden managed cli publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,20 @@
 - Retried packaged-proof temporary directory removal after transient executable
   locks while keeping persistent cleanup failures fail-closed, preventing a
   successful Windows managed-plugin handoff from failing during teardown.
+- Made managed CLI provisioning cross-process single-flight: one publisher now
+  downloads, extracts, checksum-validates, probes, and atomically publishes a
+  release while waiters reuse the verified result. Lock ownership is published
+  atomically with process-start identity, acquisition fails closed when that
+  identity cannot be established, and incomplete initialization is
+  reclaimed only after its owner exits. Orphaned pending-owner files are
+  removed with the same process-identity checks, deferring expensive identity
+  probes until the stale threshold while live and young malformed artifacts
+  remain protected; malformed, wrong-version, or
+  checksum-mismatched installs are quarantined with bounded retention and
+  reprovisioned, while locked or unmovable targets fail closed. Publication
+  states are exposed as redacted plugin-runtime warnings, and native packaged
+  proof now includes macOS x64 alongside the existing five release targets.
+
 - Extended the retrieval generalization guard from derived query literals to
   direct and split Rust string dependencies on eval/query corpus paths across
   production crates, including benchmark manifests, query catalogs, packet

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -31,14 +31,18 @@ and stay up with diagnostic `codestory://status` when managed setup fails.
 Ambient `PATH` binaries are reported as diagnostics only; installed plugin
 runtime does not launch them.
 
-After a managed runtime passes checksum and `--version` verification, the
-adapter retains that active version plus one verified pending upgrade or
-rollback. New installs publish from a verified staging directory under a
-PID/token lock. Older version directories are removed best-effort; live Windows
-executables, active installs, links, malformed manifests, and concurrent runs
-are preserved, while abandoned locks/staging are safely reclaimed. Results are
-reported under `managed_cli_retention` in `codestory://status`, including
-retained, removed, and reclaimable byte totals.
+After a managed runtime passes archive checksum, executable checksum, manifest,
+and `--version` verification, the adapter retains that active version plus one
+verified pending upgrade or rollback. Same-version launches elect one publisher
+under an atomically owner-published PID/start-identity/token lock; acquisition
+fails closed without a reliable process-start identity, and waiters reuse its
+atomically renamed staging directory. A corrupt target is quarantined (two
+copies retained) and reprovisioned once. A live owner or unmovable Windows
+executable is never deleted, and publication fails closed when safe quarantine
+or replacement is not possible. Publisher, waiter, reclaimed-lock, quarantine,
+reprovision, and terminal-failure states appear in `plugin_runtime.warnings`;
+retained, removed, and reclaimable byte totals remain under
+`managed_cli_retention`.
 
 ## Codex install (summary)
 

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -4,6 +4,7 @@ const { spawn } = require('child_process');
 const { spawnSync } = require('child_process');
 const { createHash, randomBytes } = require('crypto');
 const fs = require('fs');
+const http = require('http');
 const https = require('https');
 const os = require('os');
 const path = require('path');
@@ -23,7 +24,9 @@ const releaseDownloadAttempts = 3;
 const releaseDownloadRetryDelaysMs = [1000, 3000];
 const managedCliLockStaleMs = 10 * 60 * 1000;
 const managedCliLockMaxAgeMs = 30 * 60 * 1000;
-const managedCliLockWaitMs = 120000;
+const managedCliLockWaitMs = 5 * 60 * 1000;
+const managedCliPendingOwnerCleanupLimit = 64;
+const managedCliQuarantineRetention = 2;
 
 function readJson(file) {
   try {
@@ -475,7 +478,13 @@ function sleep(ms) {
 function downloadFileOnce(url, destination, options = {}) {
   const timeoutMs = options.timeoutMs || releaseDownloadTimeoutMs;
   const redirectsRemaining = options.redirectsRemaining ?? 5;
-  const get = options.get || https.get;
+  const parsedUrl = new URL(url);
+  const loopbackHttp = parsedUrl.protocol === 'http:' &&
+    ['127.0.0.1', '::1', '[::1]', 'localhost'].includes(parsedUrl.hostname);
+  if (!options.get && parsedUrl.protocol !== 'https:' && !loopbackHttp) {
+    return Promise.reject(new Error('download transport must be HTTPS'));
+  }
+  const get = options.get || (loopbackHttp ? http.get : https.get);
   return new Promise((resolve, reject) => {
     const request = get(url, (response) => {
       if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
@@ -533,6 +542,24 @@ function releaseAssetFetchFailure(name, startedAt, attempts, error) {
   return `managed_cli_asset_fetch_failed:${name}:elapsed_ms=${elapsedMs}:attempts=${attempts}:retry=restart_reload_status:last_error=${error.message}`;
 }
 
+function releaseFileUrl(version, name) {
+  if (process.env.CODESTORY_PLUGIN_RELEASE_DIR) {
+    return `file://${path.join(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name)}`;
+  }
+  const baseUrl = process.env.CODESTORY_PLUGIN_RELEASE_BASE_URL ||
+    `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}`;
+  return `${baseUrl.replace(/\/$/u, '')}/${name}`;
+}
+
+function redactedReleaseFileUrl(version, name) {
+  const url = new URL(releaseFileUrl(version, name));
+  url.username = '';
+  url.password = '';
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
 async function fetchReleaseFile(version, name, destination) {
   const startedAt = Date.now();
   if (process.env.CODESTORY_PLUGIN_RELEASE_DIR) {
@@ -541,17 +568,15 @@ async function fetchReleaseFile(version, name, destination) {
     } catch (error) {
       throw new Error(releaseAssetFetchFailure(name, startedAt, 1, error));
     }
-    return `file://${path.join(process.env.CODESTORY_PLUGIN_RELEASE_DIR, name)}`;
+    return redactedReleaseFileUrl(version, name);
   }
-  const baseUrl = process.env.CODESTORY_PLUGIN_RELEASE_BASE_URL ||
-    `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}`;
-  const url = `${baseUrl.replace(/\/$/u, '')}/${name}`;
+  const url = releaseFileUrl(version, name);
   try {
     await downloadFile(url, destination);
   } catch (error) {
     throw new Error(releaseAssetFetchFailure(name, startedAt, releaseDownloadAttempts, error));
   }
-  return url;
+  return redactedReleaseFileUrl(version, name);
 }
 
 function extractArchive(archivePath, destination) {
@@ -576,6 +601,46 @@ function processIsAlive(pid) {
   }
 }
 
+function processStartIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    if (process.platform === 'linux') {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const fields = stat.slice(stat.lastIndexOf(') ') + 2).trim().split(/\s+/u);
+      const bootId = fs.readFileSync('/proc/sys/kernel/random/boot_id', 'utf8').trim();
+      return `linux:${bootId}:${fields[19]}`;
+    }
+    if (process.platform === 'darwin') {
+      const result = spawnSync('/bin/ps', ['-o', 'lstart=', '-p', String(pid)], {
+        encoding: 'utf8',
+        windowsHide: true,
+      });
+      const started = result.status === 0 ? result.stdout.trim().replace(/\s+/gu, ' ') : '';
+      return started ? `darwin:${started}` : null;
+    }
+    if (process.platform === 'win32') {
+      const powershell = path.join(
+        process.env.SystemRoot || process.env.WINDIR || 'C:\\Windows',
+        'System32',
+        'WindowsPowerShell',
+        'v1.0',
+        'powershell.exe',
+      );
+      const result = spawnSync(powershell, [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ], { encoding: 'utf8', windowsHide: true });
+      const started = result.status === 0 ? result.stdout.trim() : '';
+      return /^\d+$/u.test(started) ? `win32:${started}` : null;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 function sleepSync(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
@@ -593,25 +658,25 @@ function managedCliRoot(dataDir, create = false) {
   return root;
 }
 
-function reclaimStaleManagedCliLock(lockPath) {
-  let stale = false;
-  const ownerPath = path.join(lockPath, 'owner.json');
-  const owner = readJson(ownerPath);
-  if (owner && Number.isInteger(owner.pid)) {
-    const startedAt = Date.parse(owner.started_at || '');
-    const tooOld = Number.isFinite(startedAt) && Date.now() - startedAt > managedCliLockMaxAgeMs;
-    stale = !processIsAlive(owner.pid) || tooOld;
-  } else {
-    try {
-      stale = Date.now() - fs.statSync(lockPath).mtimeMs > managedCliLockStaleMs;
-    } catch {
-      return true;
-    }
-  }
-  if (!stale) return false;
-  const stalePath = `${lockPath}.stale-${process.pid}-${randomBytes(6).toString('hex')}`;
+function managedCliLockOwnerIsStale(
+  owner,
+  checkProcessIdentity = true,
+  processStartIdentityFor = processStartIdentity,
+) {
+  if (!owner || !Number.isInteger(owner.pid)) return null;
+  const alive = processIsAlive(owner.pid);
+  const observedIdentity = alive && checkProcessIdentity ? processStartIdentityFor(owner.pid) : null;
+  return !alive || Boolean(
+    owner.process_start_identity &&
+    observedIdentity &&
+    owner.process_start_identity !== observedIdentity
+  );
+}
+
+function removeManagedCliLockArtifact(artifactPath) {
+  const stalePath = `${artifactPath}.stale-${process.pid}-${randomBytes(6).toString('hex')}`;
   try {
-    fs.renameSync(lockPath, stalePath);
+    fs.renameSync(artifactPath, stalePath);
     fs.rmSync(stalePath, { recursive: true, force: true });
     return true;
   } catch {
@@ -619,38 +684,281 @@ function reclaimStaleManagedCliLock(lockPath) {
   }
 }
 
-function acquireManagedCliLock(root, purpose, waitMs = 0) {
-  const lockPath = path.join(root, '.retention-lock');
-  const deadline = Date.now() + waitMs;
-  while (true) {
+function reclaimStaleManagedCliPendingOwners(
+  root,
+  checkProcessIdentity = true,
+  processStartIdentityFor = processStartIdentity,
+) {
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let removed = 0;
+  let inspected = 0;
+  for (const entry of entries) {
+    if (!entry.isFile() || entry.isSymbolicLink()) {
+      continue;
+    }
+    const match = entry.name.match(/^\.retention-lock\.owner-(\d+)-([0-9a-f]{32})$/u);
+    if (!match) continue;
+    if (inspected >= managedCliPendingOwnerCleanupLimit) break;
+    inspected += 1;
+    const artifactPath = path.join(root, entry.name);
+    let descriptor;
     try {
-      fs.mkdirSync(lockPath);
-      const token = randomBytes(16).toString('hex');
-      try {
-        fs.writeFileSync(path.join(lockPath, 'owner.json'), JSON.stringify({
-          pid: process.pid,
-          purpose,
-          token,
-          started_at: new Date().toISOString(),
-        }));
-      } catch (error) {
-        fs.rmSync(lockPath, { recursive: true, force: true });
-        throw error;
+      const before = fs.lstatSync(artifactPath);
+      if (!before.isFile() || before.isSymbolicLink()) continue;
+      descriptor = fs.openSync(
+        artifactPath,
+        fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0),
+      );
+      const metadata = fs.fstatSync(descriptor);
+      if (
+        !metadata.isFile() || metadata.dev !== before.dev || metadata.ino !== before.ino ||
+        metadata.size !== before.size || metadata.mtimeMs !== before.mtimeMs
+      ) {
+        continue;
       }
-      return { lockPath, token };
-    } catch (error) {
-      if (error.code !== 'EEXIST') throw error;
-      if (reclaimStaleManagedCliLock(lockPath)) continue;
-      if (Date.now() >= deadline) return null;
-      sleepSync(50);
+      let owner = null;
+      try {
+        owner = JSON.parse(fs.readFileSync(descriptor, 'utf8'));
+      } catch {
+        // A young partial/malformed artifact remains protected by the age fallback.
+      }
+      const pid = Number(match[1]);
+      const completeOwner = owner &&
+        owner.pid === pid &&
+        owner.token === match[2] &&
+        typeof owner.purpose === 'string' && owner.purpose.length > 0 &&
+        typeof owner.process_start_identity === 'string' && owner.process_start_identity.length > 0 &&
+        typeof owner.started_at === 'string' && Number.isFinite(Date.parse(owner.started_at));
+      const ageMs = Date.now() - metadata.mtimeMs;
+      // Fresh live claims cannot be stale yet; defer expensive identity probes until the
+      // existing ten-minute stale threshold makes PID reuse relevant.
+      const stale = completeOwner
+        ? managedCliLockOwnerIsStale(
+          owner,
+          checkProcessIdentity && ageMs > managedCliLockStaleMs,
+          processStartIdentityFor,
+        )
+        : ageMs > managedCliLockStaleMs;
+      if (!stale) continue;
+      const current = fs.lstatSync(artifactPath);
+      if (
+        current.isSymbolicLink() || !current.isFile() ||
+        current.dev !== metadata.dev || current.ino !== metadata.ino ||
+        current.size !== metadata.size || current.mtimeMs !== metadata.mtimeMs
+      ) {
+        continue;
+      }
+      fs.unlinkSync(artifactPath);
+      removed += 1;
+    } catch {
+      // Another contender may publish or remove the artifact concurrently.
+    } finally {
+      if (descriptor !== undefined) fs.closeSync(descriptor);
     }
   }
+  return removed;
+}
+
+function reclaimStaleManagedCliInitialization(lockPath, checkProcessIdentity = true) {
+  const initializationPath = `${lockPath}.initializing`;
+  const owner = readJson(initializationPath);
+  let stale = managedCliLockOwnerIsStale(owner, checkProcessIdentity);
+  if (stale === null) {
+    try {
+      stale = Date.now() - fs.statSync(initializationPath).mtimeMs > managedCliLockStaleMs;
+    } catch {
+      return false;
+    }
+  }
+  return stale ? removeManagedCliLockArtifact(initializationPath) : false;
+}
+
+function reclaimStaleManagedCliLock(lockPath, checkProcessIdentity = true) {
+  const ownerPath = path.join(lockPath, 'owner.json');
+  const owner = readJson(ownerPath);
+  const initializationOwner = owner ? null : readJson(`${lockPath}.initializing`);
+  let stale = managedCliLockOwnerIsStale(owner || initializationOwner, checkProcessIdentity);
+  if (stale === null) {
+    try {
+      stale = Date.now() - fs.statSync(lockPath).mtimeMs > managedCliLockStaleMs;
+    } catch {
+      return false;
+    }
+  }
+  if (!stale) return false;
+  const removed = removeManagedCliLockArtifact(lockPath);
+  if (removed) reclaimStaleManagedCliInitialization(lockPath, checkProcessIdentity);
+  return removed;
+}
+
+function releaseManagedCliInitialization(lockPath, owner) {
+  const initializationPath = `${lockPath}.initializing`;
+  const current = readJson(initializationPath);
+  if (!current || current.pid !== owner.pid || current.token !== owner.token) return;
+  fs.rmSync(initializationPath, { force: true });
+}
+
+function acquireManagedCliLock(root, purpose, waitMs = 0, options = {}) {
+  const lockPath = path.join(root, '.retention-lock');
+  const ownerPath = path.join(lockPath, 'owner.json');
+  const initializationPath = `${lockPath}.initializing`;
+  const token = randomBytes(16).toString('hex');
+  const processStartIdentityFor = options.processStartIdentity || processStartIdentity;
+  const selfIdentity = processStartIdentityFor(process.pid);
+  if (!selfIdentity) throw new Error('managed_cli_process_identity_unavailable');
+  const owner = {
+    pid: process.pid,
+    purpose,
+    token,
+    process_start_identity: selfIdentity,
+    started_at: new Date().toISOString(),
+  };
+  const pendingOwnerPath = `${lockPath}.owner-${process.pid}-${token}`;
+  const deadline = Date.now() + waitMs;
+  let waited = false;
+  let reclaimed = false;
+  let nextIdentityCheckAt = 0;
+  reclaimStaleManagedCliPendingOwners(root);
+  fs.writeFileSync(pendingOwnerPath, JSON.stringify(owner), { flag: 'wx', mode: 0o600 });
+  try {
+    while (true) {
+      let createdLock = false;
+      let ownsInitialization = false;
+      let publishedOwner = false;
+      try {
+        fs.linkSync(pendingOwnerPath, initializationPath);
+        ownsInitialization = true;
+        try {
+          fs.mkdirSync(lockPath);
+          createdLock = true;
+          fs.linkSync(initializationPath, ownerPath);
+          publishedOwner = true;
+        } catch (error) {
+          if (createdLock) fs.rmSync(lockPath, { recursive: true, force: true });
+          throw error;
+        }
+        try {
+          releaseManagedCliInitialization(lockPath, owner);
+        } catch {
+          // The owner-bearing directory is authoritative; release retries this alias.
+        }
+        reclaimStaleManagedCliPendingOwners(root);
+        return { lockPath, token, waited, reclaimed };
+      } catch (error) {
+        if (ownsInitialization && !publishedOwner) {
+          releaseManagedCliInitialization(lockPath, owner);
+        }
+        if (error.code !== 'EEXIST') throw error;
+        waited = true;
+        const checkProcessIdentity = Date.now() >= nextIdentityCheckAt;
+        if (checkProcessIdentity) nextIdentityCheckAt = Date.now() + 2000;
+        if (checkProcessIdentity) reclaimStaleManagedCliPendingOwners(root);
+        if (
+          reclaimStaleManagedCliLock(lockPath, checkProcessIdentity) ||
+          reclaimStaleManagedCliInitialization(lockPath, checkProcessIdentity)
+        ) {
+          reclaimed = true;
+          continue;
+        }
+        if (Date.now() >= deadline) return null;
+        sleepSync(50);
+      }
+    }
+  } finally {
+    fs.rmSync(pendingOwnerPath, { force: true });
+  }
+}
+
+function managedCliFailureCode(error) {
+  return String(error?.message || error || 'unknown_failure').match(/^[a-z0-9_]+/iu)?.[0] || 'unknown_failure';
+}
+
+function verifyPublishedManagedCli(
+  versionDir,
+  version,
+  expectedTarget = assetTarget(),
+  probeVersion = probeResolvedCli,
+) {
+  let bytes = 0;
+  try {
+    bytes = managedPathSize(versionDir);
+  } catch (error) {
+    return { verified: false, reason: `version_unreadable:${error.code || managedCliFailureCode(error)}` };
+  }
+  const verified = verifyManagedCliVersion({
+    version,
+    versionDir,
+    bytes,
+    scanError: null,
+    provisioning: false,
+  }, probeVersion);
+  if (!verified.verified) return verified;
+  const manifest = readJson(path.join(versionDir, 'manifest.json'));
+  const expectedAsset = archiveName(version, expectedTarget);
+  if (
+    manifest.build_source !== 'github_release' ||
+    manifest.repo_ref !== `v${version}` ||
+    manifest.archive !== expectedAsset ||
+    manifest.target !== expectedTarget ||
+    !/^[0-9a-f]{64}$/iu.test(String(manifest.archive_sha256 || '')) ||
+    manifest.archive_url !== redactedReleaseFileUrl(version, expectedAsset)
+  ) {
+    return { verified: false, reason: 'manifest_release_metadata_invalid' };
+  }
+  const resolved = resolveManifest(path.join(versionDir, 'manifest.json'));
+  if (!resolved?.path) return { verified: false, reason: 'manifest_resolution_failed' };
+  return { verified: true, reason: null, resolved: { ...resolved, cliVersion: version } };
+}
+
+function trimManagedCliQuarantines(root, version, options = {}) {
+  const rmSync = options.rmSync || fs.rmSync;
+  const candidates = fs.readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.name.startsWith(`.quarantine-${version}-`));
+  if (candidates.some((entry) => !entry.isDirectory() || entry.isSymbolicLink())) {
+    throw new Error('managed_cli_quarantine_not_direct');
+  }
+  const quarantines = candidates
+    .map((entry) => path.join(root, entry.name))
+    .sort()
+    .reverse();
+  for (const stale of quarantines.slice(managedCliQuarantineRetention)) {
+    try {
+      rmSync(stale, { recursive: true, force: false });
+    } catch (error) {
+      throw new Error(`managed_cli_quarantine_retention_failed:${error.code || managedCliFailureCode(error)}`);
+    }
+  }
+}
+
+function quarantineManagedCliVersion(root, versionDir, version, reason, options = {}) {
+  const renameSync = options.renameSync || fs.renameSync;
+  const metadata = fs.lstatSync(versionDir);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new Error('managed_cli_quarantine_not_direct');
+  }
+  const quarantine = path.join(
+    root,
+    `.quarantine-${version}-${Date.now()}-${randomBytes(6).toString('hex')}`,
+  );
+  try {
+    renameSync(versionDir, quarantine);
+  } catch (error) {
+    throw new Error(`managed_cli_quarantine_failed:${error.code || managedCliFailureCode(error)}`);
+  }
+  trimManagedCliQuarantines(root, version, options);
+  return { reason, quarantine };
 }
 
 function releaseManagedCliLock(lock) {
   if (!lock) return;
   const owner = readJson(path.join(lock.lockPath, 'owner.json'));
   if (!owner || owner.token !== lock.token || owner.pid !== process.pid) return;
+  releaseManagedCliInitialization(lock.lockPath, owner);
   try {
     fs.rmSync(lock.lockPath, { recursive: true, force: true });
   } catch (error) {
@@ -666,7 +974,7 @@ function releaseManagedCliLock(lock) {
   }
 }
 
-async function provisionManagedCli(dataDir, version) {
+async function provisionManagedCli(dataDir, version, warnings = []) {
   if (!dataDir || !version || process.env.CODESTORY_PLUGIN_DISABLE_PROVISION === '1') return null;
   const target = assetTarget();
   const asset = archiveName(version, target);
@@ -674,12 +982,26 @@ async function provisionManagedCli(dataDir, version) {
 
   const root = managedCliRoot(dataDir, true);
   const versionDir = path.join(root, version);
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codestory-plugin-cli-'));
-  const sumsPath = path.join(tempRoot, 'SHA256SUMS.txt');
-  const archivePath = path.join(tempRoot, asset);
-  const extractDir = path.join(tempRoot, 'extract');
+  const lock = acquireManagedCliLock(root, `provision:${version}`, managedCliLockWaitMs);
+  if (!lock) throw new Error('managed_cli_publish_locked');
+  if (lock.waited) warnings.push('managed_cli_publication:waiter');
+  if (lock.reclaimed) warnings.push('managed_cli_publication:reclaimed_lock');
+  let tempRoot = null;
   let stagingDir = null;
   try {
+    trimManagedCliQuarantines(root, version);
+    if (fs.existsSync(versionDir)) {
+      const existing = verifyPublishedManagedCli(versionDir, version, target);
+      if (existing.verified) return existing.resolved;
+      quarantineManagedCliVersion(root, versionDir, version, existing.reason);
+      warnings.push(`managed_cli_publication:quarantine:${existing.reason}`);
+      warnings.push(`managed_cli_publication:reprovision:${existing.reason}`);
+    }
+    warnings.push('managed_cli_publication:publisher');
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codestory-plugin-cli-'));
+    const sumsPath = path.join(tempRoot, 'SHA256SUMS.txt');
+    const archivePath = path.join(tempRoot, asset);
+    const extractDir = path.join(tempRoot, 'extract');
     await fetchReleaseFile(version, 'SHA256SUMS.txt', sumsPath);
     const archiveUrl = await fetchReleaseFile(version, asset, archivePath);
     const expected = expectedArchiveHash(fs.readFileSync(sumsPath, 'utf8'), asset);
@@ -711,42 +1033,23 @@ async function provisionManagedCli(dataDir, version) {
       target,
       provisioned_at: new Date().toISOString(),
     }, null, 2));
-    const staged = resolveManifest(manifestPath);
-    if (!staged) {
-      throw new Error(`managed_cli_staging_verification_failed:${version}`);
+    const staged = verifyPublishedManagedCli(
+      stagingDir,
+      version,
+      target,
+      (resolved) => probeResolvedCli({ ...resolved, provisioningProbe: true }),
+    );
+    if (!staged.verified) {
+      throw new Error(`managed_cli_staging_verification_failed:${staged.reason}`);
     }
-    const stagedProbe = probeResolvedCli({ ...staged, source: 'managed', version });
-    if (stagedProbe.error || stagedProbe.status !== 0 || stagedProbe.version !== version) {
-      throw new Error(`managed_cli_staging_version_probe_failed:${version}`);
-    }
-
-    const lock = acquireManagedCliLock(root, 'provision', managedCliLockWaitMs);
-    if (!lock) throw new Error('managed_cli_publish_locked');
-    try {
-      const existing = resolveManifest(path.join(versionDir, 'manifest.json'));
-      if (existing) return existing;
-      let replacedDir = null;
-      if (fs.existsSync(versionDir)) {
-        replacedDir = path.join(root, `.replaced-${version}-${process.pid}-${randomBytes(6).toString('hex')}`);
-        fs.renameSync(versionDir, replacedDir);
-      }
-      try {
-        fs.renameSync(stagingDir, versionDir);
-        stagingDir = null;
-      } catch (error) {
-        if (replacedDir && !fs.existsSync(versionDir) && fs.existsSync(replacedDir)) {
-          fs.renameSync(replacedDir, versionDir);
-        }
-        throw error;
-      }
-      if (replacedDir) fs.rmSync(replacedDir, { recursive: true, force: true });
-      return resolveManifest(path.join(versionDir, 'manifest.json'));
-    } finally {
-      releaseManagedCliLock(lock);
-    }
+    if (fs.existsSync(versionDir)) throw new Error('managed_cli_publish_target_reappeared');
+    fs.renameSync(stagingDir, versionDir);
+    stagingDir = null;
+    return resolveManifest(path.join(versionDir, 'manifest.json'));
   } finally {
     if (stagingDir) fs.rmSync(stagingDir, { recursive: true, force: true });
-    fs.rmSync(tempRoot, { recursive: true, force: true });
+    if (tempRoot) fs.rmSync(tempRoot, { recursive: true, force: true });
+    releaseManagedCliLock(lock);
   }
 }
 
@@ -758,30 +1061,17 @@ async function resolveManagedCli(dataDir, version, warnings) {
     warnings.push(`managed_cli_root_invalid:${error.message}`);
     return null;
   }
-  for (const manifestPath of [
-    path.join(dataDir, 'codestory-cli', version, 'manifest.json'),
-    path.join(dataDir, 'codestory-cli', 'manifest.json'),
-  ]) {
-    if (managedProvisioningState(path.dirname(manifestPath)).active) continue;
-    const resolved = resolveManifest(manifestPath);
-    if (resolved) return resolved;
-  }
-
-  for (const cliPath of [
-    path.join(dataDir, 'codestory-cli', version, binaryName),
-    path.join(dataDir, 'codestory-cli', version, 'bin', binaryName),
-  ]) {
-    if (fs.existsSync(cliPath)
-        && !fs.existsSync(path.join(dataDir, 'codestory-cli', version, '.provisioning'))) {
-      return { path: cliPath, sha256: fileSha256(cliPath), manifestPath: null };
-    }
+  const versionDir = path.join(dataDir, 'codestory-cli', version);
+  if (fs.existsSync(versionDir)) {
+    const existing = verifyPublishedManagedCli(versionDir, version);
+    if (existing.verified) return existing.resolved;
   }
   try {
-    return await provisionManagedCli(dataDir, version);
+    return await provisionManagedCli(dataDir, version, warnings);
   } catch (error) {
-    warnings.push(`managed_cli_provision_failed:${error.message}`);
-    const concurrent = resolveManifest(path.join(dataDir, 'codestory-cli', version, 'manifest.json'));
-    if (concurrent) return concurrent;
+    const code = managedCliFailureCode(error);
+    warnings.push(`managed_cli_publication:terminal_failure:${code}`);
+    warnings.push(`managed_cli_provision_failed:${code}`);
   }
   return null;
 }
@@ -849,6 +1139,9 @@ function probeResolvedCli(resolved) {
   }
   const result = spawnSync(resolved.path, ['--version'], {
     encoding: 'utf8',
+    env: resolved.provisioningProbe
+      ? { ...process.env, CODESTORY_PLUGIN_PROVISIONING_PROBE: '1' }
+      : process.env,
     shell: process.platform === 'win32' && /\.(cmd|bat)$/i.test(resolved.path),
     timeout: 3000,
     windowsHide: true,
@@ -2274,9 +2567,17 @@ if (require.main === module) {
     _test: {
       compareManagedCliVersions,
       downloadFile,
+      acquireManagedCliLock,
+      reclaimStaleManagedCliPendingOwners,
+      processStartIdentity,
+      provisionManagedCli,
+      quarantineManagedCliVersion,
+      releaseManagedCliLock,
+      resolveManagedCli,
       managedCliRetentionReport,
       managedCliVersionEntries,
       removeManagedCliVersion,
+      verifyPublishedManagedCli,
       verifyManagedCliVersion,
     },
   };

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { spawn, spawnSync } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { access, chmod, copyFile, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -59,7 +59,7 @@ function releaseAssetForPlatform(version) {
       ? "windows-arm64"
       : process.platform === "linux" && process.arch === "x64"
         ? "linux-x64"
-        : process.platform === "linux" && process.arch === "arm64"
+      : process.platform === "linux" && process.arch === "arm64"
           ? "linux-arm64"
           : process.platform === "darwin" && process.arch === "x64"
             ? "macos-x64"
@@ -72,8 +72,70 @@ function releaseAssetForPlatform(version) {
   return { archiveBase, archiveName };
 }
 
+function managedReleaseManifest(version, executablePath, sha256) {
+  const { archiveName } = releaseAssetForPlatform(version);
+  const target = archiveName.slice(`codestory-cli-v${version}-`.length).replace(/\.(?:zip|tar\.gz)$/u, "");
+  return {
+    path: executablePath,
+    sha256,
+    version,
+    build_source: "github_release",
+    repo_ref: `v${version}`,
+    archive: archiveName,
+    archive_url: `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}/${archiveName}`,
+    archive_sha256: "0".repeat(64),
+    target,
+  };
+}
+
+async function writeReleaseFixture(releaseDir, version) {
+  const { archiveBase, archiveName } = releaseAssetForPlatform(version);
+  const stageDir = join(releaseDir, archiveBase);
+  const cliName = process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli";
+  const cliPath = join(stageDir, cliName);
+  const archivePath = join(releaseDir, archiveName);
+  await mkdir(stageDir, { recursive: true });
+  await writeFakeCli(cliPath);
+  const packArgs = archiveName.endsWith(".zip")
+    ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
+    : ["-czf", archivePath, "-C", releaseDir, archiveBase];
+  const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
+  assert.equal(pack.status, 0, pack.stderr);
+  const archiveSha256 = createHash("sha256").update(await readFile(archivePath)).digest("hex");
+  const sumsPath = join(releaseDir, "SHA256SUMS.txt");
+  await writeFile(sumsPath, `${archiveSha256}  ${archiveName}\n`, "utf8");
+  return { archiveName, archivePath, archiveSha256, cliName, sumsPath };
+}
+
+function spawnLauncher(launcher, env) {
+  const child = spawn(process.execPath, [launcher], {
+    env: { ...process.env, CODESTORY_CLI: "", ...env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.stdin.end(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "resources/read", params: { uri: "codestory://status" } })}\n`);
+  const completed = once(child, "close").then(([status, signal]) => ({ status, signal, stdout, stderr }));
+  return { child, completed };
+}
+
+async function waitForPath(pathname, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await access(pathname);
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  assert.fail(`timed out waiting for ${pathname}`);
+}
+
 async function writeFakeCli(cliPath) {
-  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,retention:process.env.CODESTORY_PLUGIN_CLI_RETENTION,activeStatePath:process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){if(process.env.CODESTORY_PLUGIN_PROVISIONING_PROBE==='1'&&process.env.CODESTORY_TEST_PROBE_LOG)fs.appendFileSync(process.env.CODESTORY_TEST_PROBE_LOG,'probe\\n');const delay=Number(process.env.CODESTORY_TEST_PROBE_DELAY_MS||0);if(delay>0)Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,delay);console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,warnings:process.env.CODESTORY_PLUGIN_CLI_WARNINGS,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,retention:process.env.CODESTORY_PLUGIN_CLI_RETENTION,activeStatePath:process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
@@ -391,7 +453,11 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
       .digest("hex");
     await writeFile(
       join(cliDir, "manifest.json"),
-      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256, version }),
+      JSON.stringify(managedReleaseManifest(
+        version,
+        process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+        sha256,
+      )),
       "utf8",
     );
     const result = spawnSync(process.execPath, [launcher], {
@@ -597,9 +663,10 @@ test("managed cli retention reclaims an abandoned lock and provisioning sentinel
     await writeFile(
       join(lockDir, "owner.json"),
       JSON.stringify({
-        pid: process.pid,
+        pid: 2147483647,
         token: "abandoned",
         purpose: "retention",
+        process_start_identity: "dead:process",
         started_at: "2000-01-01T00:00:00.000Z",
       }),
       "utf8",
@@ -622,6 +689,264 @@ test("managed cli retention reclaims an abandoned lock and provisioning sentinel
     await assert.rejects(access(stale.versionDir));
     await assert.rejects(access(lockDir));
   } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli retention never reclaims an old lock owned by the live process", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-retention-live-lock-"));
+  try {
+    const processStartIdentity = launcherTest.processStartIdentity(process.pid);
+    assert.ok(processStartIdentity, `process start identity unavailable on ${process.platform}`);
+    const stale = await writeManagedCliFixture(dataDir, "0.13.9");
+    await writeManagedCliFixture(dataDir, "0.14.0");
+    const active = await writeManagedCliFixture(dataDir, "0.14.1");
+    const lockDir = join(dataDir, "codestory-cli", ".retention-lock");
+    await mkdir(lockDir);
+    await writeFile(join(lockDir, "owner.json"), JSON.stringify({
+      pid: process.pid,
+      token: "live",
+      purpose: "retention",
+      process_start_identity: processStartIdentity,
+      started_at: "2000-01-01T00:00:00.000Z",
+    }), "utf8");
+    const probeVersion = (resolved) => ({ status: 0, error: null, version: resolved.version });
+    const report = launcherTest.managedCliRetentionReport(
+      { source: "managed", version: "0.14.1", path: active.cliPath, warnings: [] },
+      probeVersion({ version: "0.14.1" }),
+      { dataDir, probeVersion },
+    );
+    assert.deepEqual(report.removed, []);
+    assert.equal(report.warnings.includes("managed_cli_retention_locked"), true);
+    await access(lockDir);
+    await access(stale.versionDir);
+
+    await writeFile(join(lockDir, "owner.json"), JSON.stringify({
+      pid: process.pid,
+      token: "reused-pid",
+      purpose: "retention",
+      process_start_identity: "different-process-start",
+      started_at: "2000-01-01T00:00:00.000Z",
+    }), "utf8");
+    const reclaimed = launcherTest.managedCliRetentionReport(
+      { source: "managed", version: "0.14.1", path: active.cliPath, warnings: [] },
+      probeVersion({ version: "0.14.1" }),
+      { dataDir, probeVersion },
+    );
+    assert.deepEqual(reclaimed.removed.map((entry) => entry.version), ["0.13.9"]);
+    await assert.rejects(access(lockDir));
+    await assert.rejects(access(stale.versionDir));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli lock fails closed when self process identity is unavailable", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-lock-no-identity-"));
+  const root = join(dataDir, "codestory-cli");
+  await mkdir(root);
+  try {
+    assert.throws(
+      () => launcherTest.acquireManagedCliLock(root, "no-identity", 0, {
+        processStartIdentity: () => null,
+      }),
+      /managed_cli_process_identity_unavailable/u,
+    );
+    assert.deepEqual(await readdir(root), []);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli pending-owner cleanup protects live and young artifacts", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-pending-owner-"));
+  const root = join(dataDir, "codestory-cli");
+  await mkdir(root);
+  const identity = launcherTest.processStartIdentity(process.pid);
+  assert.ok(identity, `process start identity unavailable on ${process.platform}`);
+  const liveToken = "1".repeat(32);
+  const deadToken = "2".repeat(32);
+  const youngToken = "3".repeat(32);
+  const oldToken = "4".repeat(32);
+  const reusedToken = "5".repeat(32);
+  const live = join(root, `.retention-lock.owner-${process.pid}-${liveToken}`);
+  const dead = join(root, `.retention-lock.owner-2147483647-${deadToken}`);
+  const young = join(root, `.retention-lock.owner-8-${youngToken}`);
+  const old = join(root, `.retention-lock.owner-9-${oldToken}`);
+  const reused = join(root, `.retention-lock.owner-${process.pid}-${reusedToken}`);
+  try {
+    await writeFile(live, JSON.stringify({
+      pid: process.pid,
+      purpose: "waiter",
+      token: liveToken,
+      process_start_identity: identity,
+      started_at: "2000-01-01T00:00:00.000Z",
+    }));
+    await writeFile(dead, JSON.stringify({
+      pid: 2147483647,
+      purpose: "waiter",
+      token: deadToken,
+      process_start_identity: "dead:process",
+      started_at: new Date().toISOString(),
+    }));
+    await writeFile(young, "{partial");
+    await writeFile(old, "{malformed");
+    await writeFile(reused, JSON.stringify({
+      pid: process.pid,
+      purpose: "waiter",
+      token: reusedToken,
+      process_start_identity: "different-process-start",
+      started_at: "2000-01-01T00:00:00.000Z",
+    }));
+    const staleTime = new Date(Date.now() - 11 * 60 * 1000);
+    await utimes(old, staleTime, staleTime);
+    await utimes(reused, staleTime, staleTime);
+
+    assert.equal(launcherTest.reclaimStaleManagedCliPendingOwners(root), 3);
+    await access(live);
+    await access(young);
+    await assert.rejects(access(dead));
+    await assert.rejects(access(old));
+    await assert.rejects(access(reused));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli pending-owner cleanup skips identity probes for 64 young live records", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-young-pending-"));
+  const root = join(dataDir, "codestory-cli");
+  await mkdir(root);
+  let identityProbes = 0;
+  try {
+    for (let index = 0; index < 64; index += 1) {
+      const token = index.toString(16).padStart(32, "0");
+      await writeFile(
+        join(root, `.retention-lock.owner-${process.pid}-${token}`),
+        JSON.stringify({
+          pid: process.pid,
+          purpose: "waiter",
+          token,
+          process_start_identity: "young-live-owner",
+          started_at: new Date().toISOString(),
+        }),
+      );
+    }
+
+    assert.equal(launcherTest.reclaimStaleManagedCliPendingOwners(root, true, () => {
+      identityProbes += 1;
+      return "young-live-owner";
+    }), 0);
+    assert.equal(identityProbes, 0);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli publication removes a killed waiter's pending owner", { timeout: 15000 }, async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-killed-waiter-"));
+  const root = join(dataDir, "codestory-cli");
+  const launcherPath = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  await mkdir(root);
+  const held = launcherTest.acquireManagedCliLock(root, "holder");
+  assert.ok(held);
+  const childScript = String.raw`
+    require(process.argv[1])._test.acquireManagedCliLock(process.argv[2], 'waiter', 60000);
+  `;
+  const waiter = spawn(process.execPath, ["-e", childScript, launcherPath, root], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let waiterStderr = "";
+  waiter.stderr.on("data", (chunk) => { waiterStderr += chunk; });
+  const completed = once(waiter, "close");
+  try {
+    const prefix = `.retention-lock.owner-${waiter.pid}-`;
+    const deadline = Date.now() + 5000;
+    let pending;
+    while (Date.now() < deadline && !pending) {
+      pending = (await readdir(root)).find((name) => name.startsWith(prefix));
+      if (!pending) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.ok(pending, waiterStderr);
+    waiter.kill("SIGKILL");
+    await completed;
+    await access(join(root, pending));
+
+    launcherTest.releaseManagedCliLock(held);
+    const recovered = launcherTest.acquireManagedCliLock(root, "recovered");
+    assert.ok(recovered);
+    launcherTest.releaseManagedCliLock(recovered);
+    assert.equal(
+      (await readdir(root)).some((name) => name.startsWith(".retention-lock.owner-")),
+      false,
+    );
+  } finally {
+    waiter.kill("SIGKILL");
+    await completed;
+    try { launcherTest.releaseManagedCliLock(held); } catch {}
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli publication recovers a killed initializer before owner publication", { timeout: 15000 }, async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-lock-initialization-"));
+  const root = join(dataDir, "codestory-cli");
+  const lockPath = join(root, ".retention-lock");
+  const readyPath = join(dataDir, "initializer-ready");
+  const launcherPath = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const childScript = String.raw`
+    const fs = require('fs');
+    const path = require('path');
+    const launcher = require(process.argv[1])._test;
+    const root = process.argv[2];
+    const ready = process.argv[3];
+    const linkSync = fs.linkSync;
+    fs.linkSync = (existing, destination) => {
+      if (path.basename(destination) === 'owner.json') {
+        fs.writeFileSync(ready, 'ready');
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 60000);
+      }
+      return linkSync(existing, destination);
+    };
+    launcher.acquireManagedCliLock(root, 'initializer', 1000);
+  `;
+  await mkdir(root, { recursive: true });
+  const initializer = spawn(process.execPath, ["-e", childScript, launcherPath, root, readyPath], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let initializerStderr = "";
+  initializer.stderr.on("data", (chunk) => { initializerStderr += chunk; });
+  const completed = once(initializer, "close");
+  try {
+    await waitForPath(readyPath);
+    await access(lockPath);
+    await assert.rejects(access(join(lockPath, "owner.json")));
+    const initializationOwner = JSON.parse(await readFile(`${lockPath}.initializing`, "utf8"));
+    assert.equal(initializationOwner.pid, initializer.pid);
+
+    const blocked = launcherTest.acquireManagedCliLock(root, "live-contender", 100);
+    assert.equal(blocked, null, "a live initializer must retain its claim");
+    await access(`${lockPath}.initializing`);
+    await assert.rejects(access(join(lockPath, "owner.json")));
+
+    initializer.kill("SIGKILL");
+    await completed;
+    const startedAt = Date.now();
+    const recovered = launcherTest.acquireManagedCliLock(root, "recovered", 2000);
+    assert.ok(recovered, initializerStderr);
+    assert.equal(recovered.waited, true);
+    assert.equal(recovered.reclaimed, true);
+    assert.ok(Date.now() - startedAt < 2000, "recovery must beat the waiter timeout");
+    launcherTest.releaseManagedCliLock(recovered);
+    await assert.rejects(access(lockPath));
+    await assert.rejects(access(`${lockPath}.initializing`));
+    assert.equal(
+      (await readdir(root)).some((name) => name.startsWith(".retention-lock.owner-")),
+      false,
+    );
+  } finally {
+    initializer.kill("SIGKILL");
+    await completed;
     await rm(dataDir, { recursive: true, force: true });
   }
 });
@@ -1693,7 +2018,11 @@ test("mcp launcher infers Codex managed data from installed cache without env", 
       .digest("hex");
     await writeFile(
       join(cliDir, "manifest.json"),
-      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      JSON.stringify(managedReleaseManifest(
+        version,
+        process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+        sha256,
+      )),
       "utf8",
     );
     await writeFile(
@@ -1710,6 +2039,7 @@ test("mcp launcher infers Codex managed data from installed cache without env", 
         PLUGIN_DATA: "",
         COPILOT_PLUGIN_DATA: "",
         TEST_OUT: outFile,
+        TEST_CODESTORY_VERSION: version,
         PATH: pathDir,
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
@@ -2025,13 +2355,18 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
       .digest("hex");
     await writeFile(
       join(cliDir, "manifest.json"),
-      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      JSON.stringify(managedReleaseManifest(
+        version,
+        process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+        sha256,
+      )),
       "utf8",
     );
 
     const result = spawnSync(process.execPath, [launcher], {
       env: {
         PLUGIN_DATA: dataDir,
+        CODESTORY_PLUGIN_RELEASE_DIR: join(dataDir, "missing-release"),
         PATH: "",
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
@@ -2045,7 +2380,7 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
     const status = JSON.parse(response.result.contents[0].text);
     assert.equal(
       status.readiness[0].repair_reason,
-      "managed_cli_unspawnable",
+      "managed_cli_provision_failed:managed_cli_asset_fetch_failed",
     );
     assert.equal(
       status.plugin_runtime.plugin_version,
@@ -2113,7 +2448,11 @@ test("enabled sidecar policy defers repair until after MCP startup", async () =>
       .digest("hex");
     await writeFile(
       join(cliDir, "manifest.json"),
-      JSON.stringify({ path: process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli", sha256 }),
+      JSON.stringify(managedReleaseManifest(
+        version,
+        process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
+        sha256,
+      )),
       "utf8",
     );
     await writeFile(
@@ -2126,6 +2465,7 @@ test("enabled sidecar policy defers repair until after MCP startup", async () =>
       env: {
         PLUGIN_DATA: dataDir,
         TEST_LOG: logFile,
+        TEST_CODESTORY_VERSION: version,
         PATH: "",
         ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
       },
@@ -2229,6 +2569,303 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli publication is single-flight and atomically visible across two processes", { timeout: 30000 }, async (t) => {
+  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
+  if (tarProbe.status !== 0) {
+    t.skip("tar unavailable for archive fixture");
+    return;
+  }
+  const { createServer } = await import("node:http");
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-publication-contention-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-publication-release-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  const outA = join(dataDir, "a.json");
+  const outB = join(dataDir, "b.json");
+  const probeLog = join(dataDir, "probes.log");
+  let server;
+  try {
+    const fixture = await writeReleaseFixture(releaseDir, version);
+    const assets = new Map([
+      ["/SHA256SUMS.txt", await readFile(fixture.sumsPath)],
+      [`/${fixture.archiveName}`, await readFile(fixture.archivePath)],
+    ]);
+    const requests = [];
+    server = createServer((request, response) => {
+      requests.push(request.url);
+      const body = assets.get(request.url);
+      if (!body) {
+        response.writeHead(404).end();
+        return;
+      }
+      setTimeout(() => response.writeHead(200).end(body), requests.length === 1 ? 250 : 0);
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const baseUrl = `http://publication-secret@127.0.0.1:${server.address().port}`;
+    const common = {
+      CODESTORY_PLUGIN_RELEASE_BASE_URL: baseUrl,
+      PLUGIN_DATA: dataDir,
+      TEST_CODESTORY_VERSION: version,
+      CODESTORY_TEST_PROBE_LOG: probeLog,
+    };
+    const first = spawnLauncher(launcher, { ...common, TEST_OUT: outA });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const second = spawnLauncher(launcher, { ...common, TEST_OUT: outB });
+    const versionDir = join(dataDir, "codestory-cli", version);
+    let finished = false;
+    const visibility = (async () => {
+      while (!finished) {
+        try {
+          await access(versionDir);
+        } catch (error) {
+          if (error.code === "ENOENT") {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            continue;
+          }
+          throw error;
+        }
+        const manifest = JSON.parse(await readFile(join(versionDir, "manifest.json"), "utf8"));
+        const executable = join(versionDir, ...manifest.path.split("/"));
+        const actual = createHash("sha256").update(await readFile(executable)).digest("hex");
+        assert.equal(actual, manifest.sha256);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+    })();
+    const results = await Promise.all([first.completed, second.completed]);
+    finished = true;
+    await visibility;
+    for (const result of results) assert.equal(result.status, 0, result.stderr);
+    for (const file of [outA, outB]) {
+      await access(file).catch(() => assert.fail(JSON.stringify(results)));
+    }
+    const observed = await Promise.all([outA, outB].map(async (file) => JSON.parse(await readFile(file, "utf8"))));
+    assert.equal(observed[0].path, observed[1].path);
+    assert.equal(observed[0].sha256, observed[1].sha256);
+    const publishedManifest = JSON.parse(await readFile(join(versionDir, "manifest.json"), "utf8"));
+    assert.doesNotMatch(publishedManifest.archive_url, /publication-secret/u);
+    assert.equal(requests.filter((url) => url === "/SHA256SUMS.txt").length, 1, JSON.stringify(requests));
+    assert.equal(requests.filter((url) => url === `/${fixture.archiveName}`).length, 1, JSON.stringify(requests));
+    assert.equal((await readFile(probeLog, "utf8")).trim().split(/\r?\n/u).filter(Boolean).length, 1);
+    assert.equal(observed.some((entry) => entry.warnings.includes("managed_cli_publication:publisher")), true);
+    assert.equal(observed.some((entry) => entry.warnings.includes("managed_cli_publication:waiter")), true);
+  } finally {
+    if (server) await new Promise((resolve) => server.close(resolve));
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli publication reclaims crashes after lock and before publication", { timeout: 45000 }, async (t) => {
+  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
+  if (tarProbe.status !== 0) {
+    t.skip("tar unavailable for archive fixture");
+    return;
+  }
+  const { createServer } = await import("node:http");
+  const version = await readPluginVersion();
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-crash-release-"));
+  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
+  let server;
+  try {
+    const fixture = await writeReleaseFixture(releaseDir, version);
+    const assets = new Map([
+      ["/SHA256SUMS.txt", await readFile(fixture.sumsPath)],
+      [`/${fixture.archiveName}`, await readFile(fixture.archivePath)],
+    ]);
+    let holdResponses = true;
+    server = createServer((request, response) => {
+      const body = assets.get(request.url);
+      if (!body) return response.writeHead(404).end();
+      const send = () => response.writeHead(200).end(body);
+      if (holdResponses) setTimeout(send, 5000);
+      else send();
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const baseUrl = `http://127.0.0.1:${server.address().port}`;
+
+    for (const crashPoint of ["after-lock", "before-publication"]) {
+      const dataDir = await mkdtemp(join(tmpdir(), `codestory-${crashPoint}-`));
+      try {
+        const failedOut = join(dataDir, "failed.json");
+        const recoveredOut = join(dataDir, "recovered.json");
+        holdResponses = crashPoint === "after-lock";
+        const crashed = spawnLauncher(launcher, {
+          CODESTORY_PLUGIN_RELEASE_BASE_URL: baseUrl,
+          PLUGIN_DATA: dataDir,
+          TEST_CODESTORY_VERSION: version,
+          TEST_OUT: failedOut,
+          CODESTORY_TEST_PROBE_DELAY_MS: crashPoint === "before-publication" ? "5000" : "0",
+        });
+        if (crashPoint === "after-lock") {
+          await waitForPath(join(dataDir, "codestory-cli", ".retention-lock", "owner.json"));
+        } else {
+          const root = join(dataDir, "codestory-cli");
+          const deadline = Date.now() + 15000;
+          while (Date.now() < deadline) {
+            const children = await readdir(root).catch(() => []);
+            if (children.some((name) => name.startsWith(`.provisioning-${version}-`))) break;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          assert.equal((await readdir(root)).some((name) => name.startsWith(`.provisioning-${version}-`)), true);
+        }
+        crashed.child.kill("SIGKILL");
+        await crashed.completed;
+        holdResponses = false;
+        const recovered = spawnLauncher(launcher, {
+          CODESTORY_PLUGIN_RELEASE_BASE_URL: baseUrl,
+          PLUGIN_DATA: dataDir,
+          TEST_CODESTORY_VERSION: version,
+          TEST_OUT: recoveredOut,
+          CODESTORY_TEST_PROBE_DELAY_MS: "0",
+        });
+        const result = await recovered.completed;
+        assert.equal(result.status, 0, result.stderr);
+        await access(recoveredOut).catch(() => assert.fail(JSON.stringify(result)));
+        const observed = JSON.parse(await readFile(recoveredOut, "utf8"));
+        assert.match(observed.warnings, /managed_cli_publication:reclaimed_lock/u);
+        const root = join(dataDir, "codestory-cli");
+        await access(join(root, version, "manifest.json"));
+        assert.equal(
+          (await readdir(root)).some((name) => name.startsWith(".retention-lock.owner-")),
+          false,
+        );
+      } finally {
+        await rm(dataDir, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    if (server) await new Promise((resolve) => server.close(resolve));
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli quarantines corrupt installs, retains two, and fails closed on a locked directory", { timeout: 30000 }, async (t) => {
+  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
+  if (tarProbe.status !== 0) {
+    t.skip("tar unavailable for archive fixture");
+    return;
+  }
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-corrupt-install-"));
+  const releaseDir = await mkdtemp(join(tmpdir(), "codestory-corrupt-release-"));
+  const root = join(dataDir, "codestory-cli");
+  const versionDir = join(root, version);
+  const previousReleaseDir = process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+  const previousTestVersion = process.env.TEST_CODESTORY_VERSION;
+  try {
+    await writeReleaseFixture(releaseDir, version);
+    process.env.CODESTORY_PLUGIN_RELEASE_DIR = releaseDir;
+    process.env.TEST_CODESTORY_VERSION = version;
+    await launcherTest.provisionManagedCli(dataDir, version, []);
+    const corruptions = [
+      async () => writeFile(join(versionDir, "manifest.json"), "{", "utf8"),
+      async () => {
+        const manifest = JSON.parse(await readFile(join(versionDir, "manifest.json"), "utf8"));
+        manifest.version = "0.0.0";
+        await writeFile(join(versionDir, "manifest.json"), JSON.stringify(manifest), "utf8");
+      },
+      async () => {
+        const manifest = JSON.parse(await readFile(join(versionDir, "manifest.json"), "utf8"));
+        manifest.sha256 = "f".repeat(64);
+        await writeFile(join(versionDir, "manifest.json"), JSON.stringify(manifest), "utf8");
+      },
+      async () => {
+        const manifestPath = join(versionDir, "manifest.json");
+        const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+        const executable = join(versionDir, ...manifest.path.split("/"));
+        if (process.platform === "win32") {
+          await writeFile(executable, "@echo off\r\necho codestory-cli 0.0.0\r\n", "utf8");
+        } else {
+          await writeFile(executable, "#!/bin/sh\necho codestory-cli 0.0.0\n", "utf8");
+          await chmod(executable, 0o755);
+        }
+        manifest.sha256 = createHash("sha256").update(await readFile(executable)).digest("hex");
+        await writeFile(manifestPath, JSON.stringify(manifest), "utf8");
+      },
+    ];
+    for (const corrupt of corruptions) {
+      await corrupt();
+      const warnings = [];
+      const resolved = await launcherTest.provisionManagedCli(dataDir, version, warnings);
+      assert.ok(resolved.path);
+      assert.equal(warnings.some((warning) => warning.startsWith("managed_cli_publication:quarantine:")), true);
+      assert.equal(warnings.some((warning) => warning.startsWith("managed_cli_publication:reprovision:")), true);
+    }
+    const quarantines = (await readdir(root)).filter((name) => name.startsWith(`.quarantine-${version}-`));
+    assert.equal(quarantines.length, 2, JSON.stringify(quarantines));
+
+    const lockedDir = join(root, "locked");
+    await mkdir(lockedDir);
+    assert.throws(
+      () => launcherTest.quarantineManagedCliVersion(root, lockedDir, version, "locked", {
+        renameSync() {
+          const error = new Error("locked");
+          error.code = "EPERM";
+          throw error;
+        },
+      }),
+      /managed_cli_quarantine_failed:EPERM/u,
+    );
+    await access(lockedDir);
+  } finally {
+    if (previousReleaseDir === undefined) delete process.env.CODESTORY_PLUGIN_RELEASE_DIR;
+    else process.env.CODESTORY_PLUGIN_RELEASE_DIR = previousReleaseDir;
+    if (previousTestVersion === undefined) delete process.env.TEST_CODESTORY_VERSION;
+    else process.env.TEST_CODESTORY_VERSION = previousTestVersion;
+    await rm(dataDir, { recursive: true, force: true });
+    await rm(releaseDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli resolution fails closed on a running Windows executable", { timeout: 15000 }, async (t) => {
+  if (process.platform !== "win32") {
+    t.skip("Windows executable locking semantics");
+    return;
+  }
+  const version = await readPluginVersion();
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-locked-windows-cli-"));
+  const versionDir = join(dataDir, "codestory-cli", version);
+  const cliPath = join(versionDir, "bin", "codestory-cli.exe");
+  const readyPath = join(dataDir, "ready");
+  let locked;
+  try {
+    await mkdir(dirname(cliPath), { recursive: true });
+    await copyFile(process.execPath, cliPath);
+    const sha256 = createHash("sha256").update(await readFile(cliPath)).digest("hex");
+    await writeFile(
+      join(versionDir, "manifest.json"),
+      JSON.stringify(managedReleaseManifest(version, "bin/codestory-cli.exe", sha256)),
+      "utf8",
+    );
+    locked = spawn(cliPath, ["-e", `require('fs').writeFileSync(${JSON.stringify(readyPath)}, 'ready');Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,60000)`], {
+      cwd: dirname(cliPath),
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    await waitForPath(readyPath);
+    await assert.rejects(
+      rm(cliPath),
+      (error) => ["EACCES", "EBUSY", "EPERM"].includes(error.code),
+    );
+
+    const warnings = [];
+    const resolved = await launcherTest.resolveManagedCli(dataDir, version, warnings);
+    assert.equal(resolved, null);
+    assert.equal(
+      warnings.some((warning) => warning.startsWith("managed_cli_publication:terminal_failure:managed_cli_quarantine_failed")),
+      true,
+      JSON.stringify(warnings),
+    );
+    await access(cliPath);
+  } finally {
+    if (locked) {
+      locked.kill("SIGKILL");
+      await once(locked, "close");
+    }
+    await rm(dataDir, { recursive: true, force: true });
   }
 });
 
@@ -2352,9 +2989,11 @@ test("mcp launcher keeps managed provision failures primary", async () => {
     assert.equal(result.status, 0, result.stderr);
     const response = JSON.parse(result.stdout.trim());
     const status = JSON.parse(response.result.contents[0].text);
-    assert.match(
-      status.degraded_reason,
-      /^managed_cli_provision_failed:managed_cli_asset_fetch_failed:SHA256SUMS\.txt:elapsed_ms=\d+:attempts=1:retry=restart_reload_status:/u,
+    assert.equal(status.degraded_reason, "managed_cli_provision_failed:managed_cli_asset_fetch_failed");
+    assert.doesNotMatch(JSON.stringify(status), new RegExp(releaseDir.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
+    assert.equal(
+      status.plugin_runtime.warnings.includes("managed_cli_publication:terminal_failure:managed_cli_asset_fetch_failed"),
+      true,
     );
     assert.equal(status.plugin_runtime.cli_source, "managed_unavailable");
     assert.equal(


### PR DESCRIPTION
## Context

Multiple Codex tasks can start the managed plugin adapter concurrently. The
0.14.3 launcher could let independent processes provision, replace, or clean the
same version directory without one authoritative publication transaction, and
could trust a manifest without proving the exact requested CLI version.

Closes #967
Refs #921
Refs #899

## What Changed

- Added a cross-process, PID/start-identity-owned publication lock with atomic
  initialization ownership, bounded waiting, stale-owner recovery, and exact
  live-owner protection.
- Added bounded reclamation for killed waiters' pending-owner artifacts without
  following links or deleting young/live ownership records.
- Elect one publisher; waiters reuse only the checksum- and exact-version-
  verified result.
- Stage and probe the complete release before atomic visibility, then fail
  closed on target reappearance or version mismatch.
- Quarantine invalid published versions with bounded retention; preserve a
  locked Windows executable and surface terminal quarantine failure rather than
  hiding it with a partial replacement.
- Redact release URL credentials/query/fragment metadata and require HTTPS
  outside explicit loopback test transport.
- Document publication roles, recovery, terminal failures, and retention.

## How To Review

Review the lock protocol in this order: process identity, pending-owner cleanup,
initialization claim, owner publication, stale recovery, release. Then review
`verifyPublishedManagedCli`, quarantine/retention, provisioning, and
`resolveManagedCli`. Finish with the real two-process kill/crash and Windows
locked-executable tests; injected filesystem failures supplement but do not
replace those OS-level proofs.

## Verification

- Full plugin static suite: 58/58 passed
- Focused crash/owner lifecycle suite: 4/4 passed
- 64 young live pending owners: zero process-start identity probes; 82.9ms
- Real two-process publisher/waiter election and exact-version reuse
- Real killed initializer and killed waiter recovery with no orphan owner files
- Real Windows locked executable through `resolveManagedCli`
- `node --check` on launcher and plugin test modules
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/check-doc-links.mjs` (69 files, 279 links)
- `git diff --check origin/dev/codestory-next...HEAD`

## Risk

Managed CLI installation is intentionally more fail-closed: filesystems that
cannot provide the required atomic ownership primitives or process identity now
produce a terminal managed-runtime diagnostic instead of racing publication.
Cleanup is root-scoped, exact-name filtered, capped at 64 candidates per pass,
and protects live or young ambiguous owners. No screenshot-visible UI changed.
