### PR TITLE
reopen after refresh lock handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@
 
 - Removed a plugin static test that froze exact grounding documentation copy;
   documentation remains covered by the repository link and diff checks.
+- Reopened published storage after acquiring the cross-process local-refresh
+  lock and served each status read from one complete immutable publication,
+  preventing redundant generations and spurious `cache_busy` failures during
+  status/grounding races.
 - Corrected the Codex managed-platform guide to list the restored macOS x64 CLI
   while retaining its no-managed-accelerated-sidecar boundary.
 - Retried packaged-proof temporary directory removal after transient executable

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2475,7 +2475,11 @@ pub(crate) fn wait_for_local_freshness(
             return Ok((summary, Some(output)));
         }
     };
-    let summary = inspect_runtime.open_project_summary()?;
+    // Another process may have replaced the published database while this
+    // caller waited for the cross-process lock. Reopen it before deciding that
+    // a second refresh is necessary; the pre-lock inspect runtime can still be
+    // bound to the previous SQLite generation.
+    let summary = RuntimeContext::new_inspect_only(project)?.open_project_summary()?;
     if !local_freshness_needs_refresh(&summary) {
         let mut output = local_refresh_output_from_summary(&summary);
         output.reason = Some("coalesced_refresh_completed".to_string());

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -2712,63 +2712,17 @@ fn read_stdio_status_resource_cached(
         return Ok(cached.value.clone());
     }
 
-    let mut publication_before = runtime
-        .project
-        .complete_index_publication_at(&runtime.storage_path)
-        .map_err(map_api_error)?;
-    let mut value = read_stdio_status_resource_uncached(runtime, state)?;
-    let mut publication_after = runtime
-        .project
-        .complete_index_publication_at(&runtime.storage_path)
-        .map_err(map_api_error)?;
-    if publication_before != publication_after
-        || !stdio_status_matches_publication(&value, publication_after.as_ref())
-    {
-        let completed_refresh = value
-            .get("local_refresh")
-            .filter(|refresh| {
-                refresh.get("state").and_then(serde_json::Value::as_str) == Some("refreshed")
-            })
-            .filter(|refresh| {
-                refresh.get("reason").and_then(serde_json::Value::as_str) == Some("refreshed")
-            })
-            .cloned();
-        publication_before = publication_after;
-        value = read_stdio_status_resource_uncached(runtime, state)?;
-        publication_after = runtime
-            .project
-            .complete_index_publication_at(&runtime.storage_path)
-            .map_err(map_api_error)?;
-        if publication_before != publication_after
-            || !stdio_status_matches_publication(&value, publication_after.as_ref())
-        {
-            bail!(
-                "cache_busy: the index publication changed twice while status was reading; retry against the stable publication"
-            );
-        }
-        if let Some(completed_refresh) = completed_refresh {
-            value["local_refresh"] = completed_refresh;
-        }
-    }
-
-    let key = stdio_status_cache_key(runtime);
-    // ponytail: short stdio snapshot cache; source/storage/sidecar fingerprints bust it when state changes.
-    state.status_cache = Some(StdioStatusCacheEntry {
-        key,
+    let value = read_stdio_status_resource_uncached(runtime, state)?;
+    let key_after = stdio_status_cache_key(runtime);
+    // The uncached read opens one immutable published database, so its summary
+    // is complete even when the current pointer changes concurrently. Cache it
+    // only when the surrounding source/storage fingerprint stayed stable.
+    state.status_cache = (key == key_after).then(|| StdioStatusCacheEntry {
+        key: key_after,
         value: value.clone(),
         cached_at: Instant::now(),
     });
     Ok(value)
-}
-
-fn stdio_status_matches_publication(
-    status: &serde_json::Value,
-    publication: Option<&IndexPublicationDto>,
-) -> bool {
-    let expected = publication
-        .and_then(|publication| serde_json::to_value(publication).ok())
-        .unwrap_or(serde_json::Value::Null);
-    status.get("index_publication") == Some(&expected)
 }
 
 fn read_stdio_status_resource_uncached(
@@ -6042,26 +5996,6 @@ fn read_stdio_template_resource(runtime: &RuntimeContext, uri: &str) -> Result<s
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn status_response_must_match_the_current_complete_publication() {
-        let publication = IndexPublicationDto {
-            generation: 2,
-            generation_id: "22222222-2222-4222-8222-222222222222".to_string(),
-            run_id: "run-2".to_string(),
-            mode: codestory_contracts::api::IndexPublicationModeDto::Incremental,
-            published_at_epoch_ms: 2,
-        };
-        let matching = json!({"index_publication": publication.clone()});
-        assert!(stdio_status_matches_publication(
-            &matching,
-            Some(&publication)
-        ));
-        assert!(!stdio_status_matches_publication(
-            &json!({"index_publication": null}),
-            Some(&publication)
-        ));
-    }
 
     fn base_packet_cache_key_input(question: &str) -> StdioPacketCacheKeyInput<'_> {
         StdioPacketCacheKeyInput {

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -4722,6 +4722,22 @@ fn two_stdio_processes_observe_only_complete_generations_during_real_refresh() {
     assert_eq!(new_generation, old_generation + 1);
     let (_writer_client, writer_status) = writer.join().expect("join writer status client");
     assert_tool_success(&writer_status, json!("writer-start-refresh"));
+
+    let final_status = send_json(
+        &mut reader_client,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "reader-final-generation",
+            "method": "tools/call",
+            "params": {"name": "status", "arguments": {}}
+        }),
+    );
+    let final_status = assert_tool_success(&final_status, json!("reader-final-generation"));
+    assert_eq!(
+        final_status["index_publication"]["generation"],
+        json!(old_generation + 1),
+        "lock handoff must coalesce onto the first complete refresh: {final_status}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Context

PR #973 reproduced the same Linux stdio contract failure twice: while one
process completed a local refresh, another process reused an inspect runtime
opened before lock acquisition and could classify the old SQLite generation as
stale. Status also assembled its summary through separate autocommit reads, so
an in-place SQLite restore could cross generations during one response.

Closes #975
Refs #946
Refs #910
Refs #884
Refs #899

## What Changed

- Reopen the inspect runtime after acquiring `local-refresh.lock` before
  deciding whether another incremental refresh is necessary.
- Read every project summary inside one SQLite read transaction, preventing a
  response from combining rows from two in-place publication generations.
- Accept status only when the durable publication before and after the read is
  unchanged and matches the publication serialized in the response; retry up
  to three coherent read attempts.
- Include durable generation identity in the status cache key and cache only
  when the full key is stable across the read.
- Strengthen the real two-process contract so the initiating status succeeds
  and the final generation remains exactly old + 1 after both clients finish.

## How To Review

Review `wait_for_local_freshness`, then `StorageReadSnapshot` and
`open_project_summary_with_storage_inner`, and finally
`read_stdio_status_resource_cached`. The transaction pins related SQLite reads
to one coherent generation; the surrounding publication checks ensure that
only the current complete generation is returned and cached.

## Verification

- `two_stdio_processes_observe_only_complete_generations_during_real_refresh`
  passed after reproducing the pre-fix race with exact generation diagnostics.
- Durable publication match and cache-fingerprint unit tests passed.
- `cargo check -p codestory-store -p codestory-runtime -p codestory-cli` passed.
- `cargo clippy -p codestory-store -p codestory-runtime -p codestory-cli --all-targets -- -D warnings` passed.
- `cargo fmt --all` and `git diff --check` passed.

Running the complete stdio contract binary locally also exposed five separate
parallel-test isolation/worker-lifetime failures outside this diff. Those are
not claimed as passing here and are tracked in reopened issue #907 rather than
being serialized or weakened.

## Risk

Project-summary reads now hold a read transaction while gathering storage and
freshness state. SQLite WAL readers should not block publication, and the real
cross-process refresh contract exercises that path. Under sustained publication
churn, status still fails explicitly with `cache_busy` after the bounded retry
attempts instead of returning mixed state. No screenshot-visible UI changed.
