### PR TITLE
qualify hook task routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@
   retrieval tasks through allowed project-scoped local graph surfaces, and
   repairs sidecars only when the task actually requires the blocked surface.
   Local navigation remains explicitly weaker than full packet/search proof.
+- Added a test-only hook qualification matrix for orientation, ownership, call
+  flow, change impact, broad retrieval, blocked-deep fallback, and non-repo
+  suppression, including an executable comparison with the former generic
+  status-first behavior and representative recorded agent drill traces.
 - Replaced generic status-only lifecycle guidance with compact repository-task
   routing for orientation, symbol ownership, call flow, change impact, and broad
   questions. Prompt hooks no longer echo user text, suppress non-repository

--- a/plugins/codestory/tests/fixtures/hook-generic-baseline.cjs
+++ b/plugins/codestory/tests/fixtures/hook-generic-baseline.cjs
@@ -1,0 +1,16 @@
+// Test-only executable model of the pre-router UserPromptSubmit policy: every
+// prompt received the same grounding instruction and none were suppressed.
+function emitGenericUserPromptPolicy() {
+  return {
+    hookSpecificOutput: {
+      additionalContext: [
+        'CODESTORY REQUEST GROUNDING ACTIVE',
+        '',
+        'Use CodeStory before source files for this user prompt.',
+        'Call status with the target repository before manual source reads.',
+      ].join('\n'),
+    },
+  };
+}
+
+module.exports = { emitGenericUserPromptPolicy };

--- a/plugins/codestory/tests/fixtures/hook-route-qualification.json
+++ b/plugins/codestory/tests/fixtures/hook-route-qualification.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "slug": "orientation",
+      "prompt": "List the languages and major areas in this repository.",
+      "route": "Repository orientation",
+      "required_surfaces": ["ground", "files"]
+    },
+    {
+      "slug": "symbol_lookup",
+      "prompt": "Where is RequestContext defined?",
+      "route": "Symbol ownership",
+      "required_surfaces": ["symbol", "definition"]
+    },
+    {
+      "slug": "call_flow",
+      "prompt": "Who calls RequestContext::open?",
+      "route": "Call flow",
+      "required_surfaces": ["symbol", "callers", "callees", "trace"]
+    },
+    {
+      "slug": "change_impact",
+      "prompt": "Review crates/codestory-runtime/src/lib.rs and identify affected tests.",
+      "route": "Review/change impact",
+      "required_surfaces": ["affected", "symbols", "traces"]
+    },
+    {
+      "slug": "snake_case_change",
+      "prompt": "Fix the refresh_index race.",
+      "route": "Review/change impact",
+      "required_surfaces": ["affected", "symbols", "traces"]
+    },
+    {
+      "slug": "camel_case_change",
+      "prompt": "Refactor routeForPrompt.",
+      "route": "Review/change impact",
+      "required_surfaces": ["affected", "symbols", "traces"]
+    },
+    {
+      "slug": "broad_architecture_full",
+      "prompt": "Explain the broad architecture of this codebase.",
+      "route": "Broad question",
+      "required_surfaces": ["packet"]
+    },
+    {
+      "slug": "broad_architecture_blocked",
+      "prompt": "Explain the codebase architecture when packet/search is blocked.",
+      "route": "Broad question",
+      "required_surfaces": ["ground", "symbol", "trace"],
+      "forbidden_surfaces": ["sidecar_setup"]
+    },
+    {
+      "slug": "non_repository_review",
+      "prompt": "Can you review this restaurant?",
+      "suppressed": true
+    },
+    {
+      "slug": "ambiguous_compiler",
+      "prompt": "Tell me about compiler design.",
+      "suppressed": true
+    },
+    {
+      "slug": "camel_case_chatter",
+      "prompt": "I bought an iPhone.",
+      "suppressed": true
+    },
+    {
+      "slug": "snake_case_chatter",
+      "prompt": "Please update my social_security_number.",
+      "suppressed": true
+    },
+    {
+      "slug": "issue_workflow",
+      "prompt": "Create an issue for the hook initiative.",
+      "suppressed": true
+    }
+  ],
+  "drills": [
+    {
+      "slug": "live_orientation",
+      "prompt": "List the languages and major areas in this repository.",
+      "route": "Repository orientation",
+      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
+      "surface_trace": ["status", "ground", "files"],
+      "status_reused": true,
+      "repair_attempted": false
+    },
+    {
+      "slug": "live_symbol_lookup",
+      "prompt": "Where is RuntimeContext defined?",
+      "route": "Symbol ownership",
+      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
+      "surface_trace": ["status", "symbol", "definition"],
+      "status_reused": true,
+      "repair_attempted": false
+    },
+    {
+      "slug": "live_call_flow",
+      "prompt": "Who calls wait_for_local_freshness?",
+      "route": "Call flow",
+      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
+      "surface_trace": ["status", "symbol", "callers", "callees"],
+      "status_reused": true,
+      "repair_attempted": false
+    },
+    {
+      "slug": "live_change_impact",
+      "prompt": "Review the changed hook files and identify affected tests.",
+      "route": "Review/change impact",
+      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
+      "surface_trace": ["status", "affected"],
+      "affected_paths": [
+        "plugins/codestory/hooks/codestory-activate.cjs",
+        "plugins/codestory/tests/plugin-static.test.mjs"
+      ],
+      "affected_outcome": "both paths matched; plugin-static.test.mjs was impacted",
+      "status_reused": true,
+      "repair_attempted": false
+    },
+    {
+      "slug": "live_blocked_broad",
+      "prompt": "Explain the AppController codebase architecture while packet/search is blocked.",
+      "route": "Broad question",
+      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
+      "status_outcome": "packet/search blocked: retrieval_manifest_missing",
+      "surface_trace": ["status", "ground", "symbol", "trace", "source"],
+      "blocked_surfaces": ["packet", "search"],
+      "status_reused": true,
+      "repair_attempted": false
+    }
+  ]
+}

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -20,6 +20,12 @@ const {
   uninstallDirtyHooks,
   writeDirtyMarker,
 } = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
+const { emitGenericUserPromptPolicy } = require(join(
+  pluginRoot,
+  "tests",
+  "fixtures",
+  "hook-generic-baseline.cjs",
+));
 
 function threadActiveStatePath(dataDir, threadId) {
   const key = createHash("sha256").update(String(threadId)).digest("hex").slice(0, 16);
@@ -2550,68 +2556,123 @@ test("hook routing is stateless across repeated and parallel processes", async (
   }
 });
 
-test("hook routes repository prompts and suppresses non-repository chatter", async () => {
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-route-matrix-"));
+test("hook qualification records emitted routes and observed drill surfaces", async (t) => {
+  const fixture = JSON.parse(await readFile(
+    join(pluginRoot, "tests", "fixtures", "hook-route-qualification.json"),
+    "utf8",
+  ));
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-qualification-"));
+  const surfacePatterns = new Map([
+    ["status", /\bstatus\b/u],
+    ["ground", /\bground\b/u],
+    ["files", /\buse files\b/u],
+    ["symbol", /\bsymbols?\b/u],
+    ["definition", /\bdefinition\b/u],
+    ["callers", /\bcallers\b/u],
+    ["callees", /\bcallees\b/u],
+    ["trace", /\btraces?\b/u],
+    ["trail", /\btrails?\b/u],
+    ["affected", /\baffected\b/u],
+    ["packet", /\bpacket\b/u],
+    ["search", /\bsearch\b/u],
+    ["sidecar_setup", /\bsidecar_setup\b/u],
+  ]);
+  const record = (output) => {
+    const context = output.hookSpecificOutput?.additionalContext || "";
+    const routeInstruction = context.match(/^Route: (.+)$/mu)?.[1] || "";
+    const surfaceText = routeInstruction || context;
+    return {
+      suppressed: !context,
+      route: routeInstruction.match(/^([^:]+):/u)?.[1] || null,
+      instructed_surfaces: [...surfacePatterns]
+        .filter(([, pattern]) => pattern.test(surfaceText))
+        .map(([surface]) => surface),
+    };
+  };
+  const failures = (actual, expected) => {
+    const result = [];
+    if (actual.suppressed !== Boolean(expected.suppressed)) result.push("suppression");
+    if (!expected.suppressed && actual.route !== expected.route) result.push("route");
+    for (const surface of expected.required_surfaces || []) {
+      const normalized = { symbols: "symbol", traces: "trace" }[surface] || surface;
+      if (!actual.instructed_surfaces.includes(normalized)) result.push(`missing:${surface}`);
+    }
+    for (const surface of expected.forbidden_surfaces || []) {
+      if (actual.instructed_surfaces.includes(surface)) result.push(`forbidden:${surface}`);
+    }
+    return result;
+  };
 
   try {
-    const prompts = [
-      ["Give me a broad architecture review of this codebase", /Route: Broad question/u],
-      ["Who calls RuntimeContext::open?", /Route: Call flow/u],
-      ["Explain who calls RuntimeContext::open across the architecture", /Route: Call flow/u],
-      ["Where is RuntimeContext defined?", /Route: Symbol ownership/u],
-      ["Explain where RuntimeContext is defined in this codebase", /Route: Symbol ownership/u],
-      ["Review the changed files and tell me what tests are affected", /Route: Review\/change impact/u],
-      ["Review this PR", /Route: Review\/change impact/u],
-      ["Run cargo test", /Route: Repository orientation/u],
-      ["Run npm test", /Route: Repository orientation/u],
-      ["Fix the refresh_index race", /Route: Review\/change impact/u],
-      ["Refactor routeForPrompt", /Route: Review\/change impact/u],
-      ["Use CodeStory", /Route: Repository orientation/u],
-      ["Rebase this branch onto dev", /Route: Review\/change impact/u],
-      ["Fix function", /Route: Review\/change impact/u],
-      ["Refactor method", /Route: Review\/change impact/u],
-      ["Review class changes", /Route: Review\/change impact/u],
-      ["How does CodeStory grounding work?", /Route: Broad question/u],
-      ["Show the current branch", /Route: Repository orientation/u],
-      ["List the languages in this repository", /Route: Repository orientation/u],
-    ];
-    for (const [prompt, expected] of prompts) {
-      const output = runCodexHook({
+    const cases = fixture.cases.map((entry) => {
+      const currentOutput = runCodexHook({
         hook_event_name: "UserPromptSubmit",
-        prompt,
+        prompt: entry.prompt,
         cwd: repoRoot,
       }, { PLUGIN_DATA: dataDir, PATH: "" });
-      const context = output.hookSpecificOutput.additionalContext;
-      assert.match(context, expected);
+      const context = currentOutput.hookSpecificOutput?.additionalContext || "";
       assert.ok(context.length <= 900, `hook output was ${context.length} characters`);
-      assert.equal(context.includes(prompt), false);
+      assert.equal(context.includes(entry.prompt), false);
       assert.doesNotMatch(context, /hook output truncated/u);
+      const current = record(currentOutput);
+      const baseline = record(emitGenericUserPromptPolicy(entry.prompt));
+      return {
+        slug: entry.slug,
+        current,
+        baseline,
+        current_failures: failures(current, entry),
+        baseline_failures: failures(baseline, entry),
+      };
+    });
+
+    const requiredTraceSurfaces = {
+      "Repository orientation": ["ground", "files"],
+      "Symbol ownership": ["symbol", "definition"],
+      "Call flow": ["symbol", "callers", "callees"],
+      "Review/change impact": ["affected"],
+      "Broad question": ["ground", "symbol", "trace"],
+    };
+    for (const drill of fixture.drills) {
+      const emitted = record(runCodexHook({
+        hook_event_name: "UserPromptSubmit",
+        prompt: drill.prompt,
+        cwd: repoRoot,
+      }, { PLUGIN_DATA: dataDir, PATH: "" }));
+      const sourceIndex = drill.surface_trace.indexOf("source");
+      const graphIndex = drill.surface_trace.findIndex((surface) =>
+        ["ground", "symbol", "callers", "callees", "trace", "trail", "affected"].includes(surface));
+      assert.equal(emitted.route, drill.route);
+      assert.equal(drill.surface_trace[0], "status");
+      assert.equal(drill.status_reused, true);
+      assert.ok(drill.evidence_source.includes("live MCP trace"));
+      assert.ok(requiredTraceSurfaces[drill.route].every((surface) =>
+        drill.surface_trace.includes(surface)), drill.evidence_source);
+      if (sourceIndex >= 0) assert.ok(graphIndex > 0 && sourceIndex > graphIndex, drill.evidence_source);
+      if (drill.blocked_surfaces) {
+        assert.ok(drill.blocked_surfaces.every((surface) => drill.status_outcome.includes(surface)));
+      }
+      if (drill.affected_paths) {
+        assert.deepEqual(drill.affected_paths, [
+          "plugins/codestory/hooks/codestory-activate.cjs",
+          "plugins/codestory/tests/plugin-static.test.mjs",
+        ]);
+        assert.match(drill.affected_outcome, /both paths matched/u);
+      }
+      assert.equal(drill.surface_trace.includes("sidecar_setup"), false);
+      assert.equal(drill.repair_attempted, false);
     }
 
-    for (const prompt of [
-      "Thanks, that answers it.",
-      "Can you review this restaurant?",
-      "Explain the egg method.",
-      "I registered for semester classes.",
-      "Tell me about compiler design.",
-      "What is the movie runtime?",
-      "I bought an iPhone.",
-      "Search for eBay.",
-      "Please update my social_security_number.",
-      "Help me build a birdhouse.",
-      "Explain liver function tests.",
-      "Organize my grocery list.",
-      "Create an issue for the hook initiative.",
-      "What is the status of issue #963?",
-      "Update issue #897.",
-    ]) {
-      const chatter = runCodexHook({
-        hook_event_name: "UserPromptSubmit",
-        prompt,
-        cwd: repoRoot,
-      }, { PLUGIN_DATA: dataDir, PATH: "" });
-      assert.equal(Object.hasOwn(chatter, "hookSpecificOutput"), false);
-    }
+    t.diagnostic(JSON.stringify({
+      cases,
+      drills: fixture.drills.map(({ slug, evidence_source, surface_trace }) => ({
+        slug,
+        evidence_source,
+        observed_surfaces: surface_trace,
+      })),
+    }));
+    assert.deepEqual(cases.flatMap(({ slug, current_failures }) =>
+      current_failures.map((failure) => `${slug}:${failure}`)), []);
+    assert.deepEqual(cases.filter(({ baseline_failures }) => baseline_failures.length === 0), []);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

The task router shipped by #963 replaces generic status-first hook guidance, but
it needs qualification evidence that separates emitted instructions from graph
tools an agent actually used.

Closes #965
Refs #962
Refs #899

## What Changed

- Consolidated the existing inline route matrix into one 13-case test fixture
  covering route selection, instructed graph surfaces, and non-repo suppression.
- Added a small executable test-only adapter for the former generic
  UserPromptSubmit policy instead of constructing a `status` result inside the
  assertion.
- Emit per-case current/baseline route, suppression, instructed surfaces, and
  exact failures as the test diagnostic.
- Recorded five representative parent-saga MCP drills separately as source
  evidence: orientation, symbol ownership, call flow, explicit-path change
  impact, and blocked broad fallback.
- Kept the adapter, prompts, scoring, and drill trace test-only.

## How To Review

1. Inspect `hook-generic-baseline.cjs` as the executable semantic model of the
   old prompt-agnostic policy: it emits generic grounding with `status` for
   every prompt and suppresses none.
2. Inspect `hook-route-qualification.json` for expected emitted routes and the
   five explicitly sourced live drill traces.
3. Inspect the consolidated plugin test: route scoring uses real hook process
   output; the MCP trace is recorded evidence, not fabricated tool execution.

## Verification

- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 50/50 passed.
- Current router — 13/13 cases had no route, suppression, required-surface, or
  forbidden-surface failures.
- Executable generic baseline — 0/13 cases qualified; the diagnostic emits the
  exact per-case reason (`route`, `suppression`, or missing instructed surface).
- Recorded live drills — orientation used `status -> ground -> files`; symbol
  ownership used `status -> symbol -> definition`; call flow used `status ->
  symbol -> callers -> callees`; change impact used `status -> affected` with
  both explicit hook/test paths matched; blocked broad used `status -> ground ->
  symbol -> trace -> source`. Status was reused, packet/search were blocked by
  `retrieval_manifest_missing`, and no repair was attempted.
- `node .github/scripts/check-doc-links.mjs` — 69 files / 279 links passed.
- `node .github/scripts/check-workflow-policy.mjs` — passed.
- `git diff --check` — passed.

The deterministic test does not claim to execute MCP graph calls. It qualifies
the hook's emitted route and instructed surfaces, then validates the shape of
the separately recorded live agent evidence.

## Risk

Low. The change is test-only plus changelog and replaces a duplicate inline
matrix. It freezes route categories and tool names, not full hook prose. No
screenshot-visible UI changed, so visual evidence is not applicable.
