### PR TITLE
Make runtime configuration project scoped

### DIFF
--- a/.github/scripts/check-runtime-config-boundary.mjs
+++ b/.github/scripts/check-runtime-config-boundary.mjs
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const roots = [
+  "crates/codestory-cli/src",
+  "crates/codestory-retrieval/src",
+  "crates/codestory-runtime/src",
+];
+const forbidden = [
+  "std::env::set_var",
+  "std::env::remove_var",
+  "activate_embed_url",
+  "prepare_bundled_llamacpp_client_env_defaults",
+  "activate_retrieval_profile_env",
+  "CODESTORY_EMBED_LLAMACPP_URL_MANAGED",
+];
+
+function rustFiles(root) {
+  return fs.readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const child = path.join(root, entry.name);
+    return entry.isDirectory() ? rustFiles(child) : entry.name.endsWith(".rs") ? [child] : [];
+  });
+}
+
+const violations = [];
+for (const file of roots.flatMap(rustFiles)) {
+  const source = fs.readFileSync(file, "utf8");
+  const production = source.split(/\r?\n#\[cfg\(test\)\]\r?\nmod tests\s*\{/u, 1)[0];
+  for (const token of forbidden) {
+    if (production.includes(token)) violations.push(`${file}: ${token}`);
+  }
+}
+
+if (violations.length) {
+  console.error("Production runtime configuration must remain immutable:\n" + violations.join("\n"));
+  process.exit(1);
+}
+console.log("runtime config boundary ok");

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,6 +8,7 @@ on:
       - crates/**
       - docs/contributors/testing-matrix.md
       - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/check-runtime-config-boundary.mjs
       - .github/workflows/rust-ci.yml
   push:
     branches:
@@ -19,6 +20,7 @@ on:
       - crates/**
       - docs/contributors/testing-matrix.md
       - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/check-runtime-config-boundary.mjs
       - .github/workflows/rust-ci.yml
   workflow_dispatch:
 
@@ -65,6 +67,9 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --check
+
+      - name: Check immutable runtime configuration boundary
+        run: node .github/scripts/check-runtime-config-boundary.mjs
 
       - name: Check workspace
         run: cargo check --workspace --locked
@@ -114,3 +119,6 @@ jobs:
 
       - name: Prove old-or-new publication reads across MCP processes
         run: cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture
+
+      - name: Prove multi-project embedding endpoint isolation
+        run: cargo test --locked -p codestory-cli --test stdio_protocol_contracts multi_project_stdio_keeps_project_embedding_endpoints_isolated_across_a_b_a -- --nocapture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ### Added
 
+- Added immutable per-project runtime configuration for multi-project CLI and
+  stdio operation. Embedding endpoint provenance, profile/model/prefix contract,
+  batching and device policy, retrieval policy, and summary configuration now
+  travel with retained project state instead of being published through process
+  environment mutation. Retrieval and runtime share the concrete llama.cpp HTTP
+  client, and a cross-platform A/B/A stdio contract proves two trusted projects
+  cannot cross-route embedding markers or vectors.
+
 - Added parser-backed Express route extraction for static module-scope
   registrations on source-ordered app and router bindings constructed from
   explicit `express` imports or `require("express")`. JavaScript, TypeScript,
@@ -77,6 +85,13 @@
 
 ### Fixed
 
+- Hardened project-scoped embedding requests by retaining the configured model
+  identity, validating and ordering OpenAI response rows by their explicit
+  indices, deriving named-profile dimensions, refusing redirects, and
+  redacting endpoint credentials and query secrets from failures. Ready,
+  report, drill, stdio cache/readiness, and profile-selection paths now reuse
+  the captured runtime instead of rebuilding configuration from changed
+  process environment state.
 - Removed a plugin static test that froze exact grounding documentation copy;
   documentation remains covered by the repository link and diff checks.
 - Pinned each status summary to one SQLite read transaction, accepted it only

--- a/crates/codestory-cli/Cargo.toml
+++ b/crates/codestory-cli/Cargo.toml
@@ -31,4 +31,5 @@ ratatui = { workspace = true }
 
 [dev-dependencies]
 codestory-retrieval = { workspace = true, features = ["test-support"] }
+codestory-runtime = { workspace = true, features = ["test-support"] }
 tempfile = { workspace = true }

--- a/crates/codestory-cli/src/config.rs
+++ b/crates/codestory-cli/src/config.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
+#[cfg(not(test))]
+use std::sync::OnceLock;
 
 const PROJECT_NETWORK_CONFIG_OPT_IN_ENV: &str = "CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG";
 
@@ -12,11 +14,15 @@ pub(crate) struct CliConfig {
     #[serde(default)]
     pub(crate) embedding_model: Option<String>,
     pub(crate) embedding_endpoint: Option<String>,
+    pub(crate) embedding_query_prefix: Option<String>,
+    pub(crate) embedding_document_prefix: Option<String>,
     pub(crate) hybrid_retrieval_enabled: Option<bool>,
     pub(crate) semantic_doc_scope: Option<String>,
     pub(crate) semantic_doc_alias_mode: Option<String>,
     pub(crate) summary_endpoint: Option<String>,
     pub(crate) summary_model: Option<String>,
+    #[serde(skip)]
+    embedding_endpoint_source: Option<ConfigSource>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,8 +48,21 @@ pub(crate) fn load_config(project_root: &Path) -> Result<CliConfig> {
         &project_root.join(".codestory.toml"),
         ConfigSource::Project,
     )?;
-    apply_env_defaults(&config);
     Ok(config)
+}
+
+pub(crate) fn process_runtime_defaults() -> codestory_retrieval::SidecarRuntimeDefaults {
+    #[cfg(test)]
+    {
+        codestory_retrieval::SidecarRuntimeDefaults::from_process_env()
+    }
+    #[cfg(not(test))]
+    {
+        static DEFAULTS: OnceLock<codestory_retrieval::SidecarRuntimeDefaults> = OnceLock::new();
+        DEFAULTS
+            .get_or_init(codestory_retrieval::SidecarRuntimeDefaults::from_process_env)
+            .clone()
+    }
 }
 
 fn merge_config_file(config: &mut CliConfig, path: &Path, source: ConfigSource) -> Result<()> {
@@ -68,6 +87,13 @@ fn merge_config_file(config: &mut CliConfig, path: &Path, source: ConfigSource) 
     }
     if file_config.embedding_endpoint.is_some() {
         config.embedding_endpoint = file_config.embedding_endpoint;
+        config.embedding_endpoint_source = Some(source);
+    }
+    if file_config.embedding_query_prefix.is_some() {
+        config.embedding_query_prefix = file_config.embedding_query_prefix;
+    }
+    if file_config.embedding_document_prefix.is_some() {
+        config.embedding_document_prefix = file_config.embedding_document_prefix;
     }
     if file_config.hybrid_retrieval_enabled.is_some() {
         config.hybrid_retrieval_enabled = file_config.hybrid_retrieval_enabled;
@@ -117,47 +143,27 @@ fn project_network_config_allowed() -> bool {
         .unwrap_or(false)
 }
 
-fn apply_env_defaults(config: &CliConfig) {
-    set_env_if_absent(
-        "CODESTORY_EMBED_PROFILE",
-        config.embedding_profile.as_deref(),
-    );
-    set_env_if_absent(
-        "CODESTORY_EMBED_MODEL_ID",
-        config.embedding_model_id.as_deref(),
-    );
-    set_env_if_absent(
-        "CODESTORY_EMBED_LLAMACPP_URL",
-        config.embedding_endpoint.as_deref(),
-    );
-    set_env_if_absent(
-        "CODESTORY_HYBRID_RETRIEVAL_ENABLED",
-        config
-            .hybrid_retrieval_enabled
-            .map(|value| if value { "true" } else { "false" }),
-    );
-    set_env_if_absent(
-        "CODESTORY_SEMANTIC_DOC_SCOPE",
-        config.semantic_doc_scope.as_deref(),
-    );
-    set_env_if_absent(
-        "CODESTORY_SEMANTIC_DOC_ALIAS_MODE",
-        config.semantic_doc_alias_mode.as_deref(),
-    );
-    set_env_if_absent(
-        "CODESTORY_SUMMARY_ENDPOINT",
-        config.summary_endpoint.as_deref(),
-    );
-    set_env_if_absent("CODESTORY_SUMMARY_MODEL", config.summary_model.as_deref());
-}
-
-fn set_env_if_absent(name: &str, value: Option<&str>) {
-    if std::env::var_os(name).is_some() {
-        return;
-    }
-    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
-        unsafe {
-            std::env::set_var(name, value);
+impl CliConfig {
+    pub(crate) fn runtime_overrides(&self) -> codestory_retrieval::SidecarRuntimeOverrides {
+        codestory_retrieval::SidecarRuntimeOverrides {
+            embedding_profile: self.embedding_profile.clone(),
+            embedding_model_id: self.embedding_model_id.clone(),
+            embedding_endpoint: self.embedding_endpoint.clone(),
+            embedding_endpoint_origin: self.embedding_endpoint_source.map(|source| match source {
+                ConfigSource::TrustedUser => {
+                    codestory_retrieval::EmbeddingEndpointOrigin::TrustedUserConfig
+                }
+                ConfigSource::Project => {
+                    codestory_retrieval::EmbeddingEndpointOrigin::TrustedProjectConfig
+                }
+            }),
+            embedding_query_prefix: self.embedding_query_prefix.clone(),
+            embedding_document_prefix: self.embedding_document_prefix.clone(),
+            hybrid_retrieval_enabled: self.hybrid_retrieval_enabled,
+            semantic_doc_scope: self.semantic_doc_scope.clone(),
+            semantic_doc_alias_mode: self.semantic_doc_alias_mode.clone(),
+            summary_endpoint: self.summary_endpoint.clone(),
+            summary_model: self.summary_model.clone(),
         }
     }
 }
@@ -219,7 +225,7 @@ mod tests {
     }
 
     #[test]
-    fn config_sets_embedding_profile_and_model_id_runtime_env_defaults() -> Result<()> {
+    fn config_retains_embedding_profile_and_model_without_mutating_environment() -> Result<()> {
         let _env = EnvRestore::capture(&[
             "USERPROFILE",
             "HOME",
@@ -254,14 +260,8 @@ embedding_model_id = "BAAI/bge-small-en-v1.5-local"
             config.embedding_model_id.as_deref(),
             Some("BAAI/bge-small-en-v1.5-local")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_PROFILE").as_deref(),
-            Ok("bge-small-en-v1.5")
-        );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_MODEL_ID").as_deref(),
-            Ok("BAAI/bge-small-en-v1.5-local")
-        );
+        assert!(std::env::var("CODESTORY_EMBED_PROFILE").is_err());
+        assert!(std::env::var("CODESTORY_EMBED_MODEL_ID").is_err());
         assert!(std::env::var_os("CODESTORY_EMBEDDING_MODEL").is_none());
 
         Ok(())
@@ -294,10 +294,7 @@ embedding_model_id = "BAAI/bge-small-en-v1.5-local"
             config.embedding_model_id.as_deref(),
             Some("legacy/model-id")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_MODEL_ID").as_deref(),
-            Ok("legacy/model-id")
-        );
+        assert!(std::env::var("CODESTORY_EMBED_MODEL_ID").is_err());
         assert!(std::env::var_os("CODESTORY_EMBEDDING_MODEL").is_none());
 
         Ok(())
@@ -333,10 +330,7 @@ embedding_model_id = "current/model-id"
             config.embedding_model_id.as_deref(),
             Some("current/model-id")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_MODEL_ID").as_deref(),
-            Ok("current/model-id")
-        );
+        assert!(std::env::var("CODESTORY_EMBED_MODEL_ID").is_err());
 
         Ok(())
     }
@@ -424,14 +418,8 @@ embedding_model_id = "project/model-id"
             config.embedding_model_id.as_deref(),
             Some("project/model-id")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_PROFILE").as_deref(),
-            Ok("project-profile")
-        );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_MODEL_ID").as_deref(),
-            Ok("project/model-id")
-        );
+        assert!(std::env::var("CODESTORY_EMBED_PROFILE").is_err());
+        assert!(std::env::var("CODESTORY_EMBED_MODEL_ID").is_err());
 
         Ok(())
     }
@@ -470,10 +458,7 @@ embedding_model_id = "project/model-id"
             config.embedding_model_id.as_deref(),
             Some("project/legacy-model-id")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_MODEL_ID").as_deref(),
-            Ok("project/legacy-model-id")
-        );
+        assert!(std::env::var("CODESTORY_EMBED_MODEL_ID").is_err());
         assert!(std::env::var_os("CODESTORY_EMBEDDING_MODEL").is_none());
 
         Ok(())
@@ -604,10 +589,7 @@ embedding_model_id = "project/model-id"
             config.summary_endpoint.as_deref(),
             Some("https://example.invalid/v1/chat/completions")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_SUMMARY_ENDPOINT").as_deref(),
-            Ok("https://example.invalid/v1/chat/completions")
-        );
+        assert!(std::env::var("CODESTORY_SUMMARY_ENDPOINT").is_err());
 
         Ok(())
     }
@@ -637,10 +619,7 @@ embedding_model_id = "project/model-id"
             config.embedding_endpoint.as_deref(),
             Some("http://127.0.0.1:8080/v1/embeddings")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_LLAMACPP_URL").as_deref(),
-            Ok("http://127.0.0.1:8080/v1/embeddings")
-        );
+        assert!(std::env::var("CODESTORY_EMBED_LLAMACPP_URL").is_err());
 
         Ok(())
     }
@@ -691,18 +670,9 @@ embedding_endpoint = "http://127.0.0.1:8080/v1/embeddings"
             config.embedding_endpoint.as_deref(),
             Some("http://127.0.0.1:8080/v1/embeddings")
         );
-        assert_eq!(
-            std::env::var("CODESTORY_SUMMARY_ENDPOINT").as_deref(),
-            Ok("https://example.invalid/v1/chat/completions")
-        );
-        assert_eq!(
-            std::env::var("CODESTORY_SUMMARY_MODEL").as_deref(),
-            Ok("trusted/model")
-        );
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_LLAMACPP_URL").as_deref(),
-            Ok("http://127.0.0.1:8080/v1/embeddings")
-        );
+        assert!(std::env::var("CODESTORY_SUMMARY_ENDPOINT").is_err());
+        assert!(std::env::var("CODESTORY_SUMMARY_MODEL").is_err());
+        assert!(std::env::var("CODESTORY_EMBED_LLAMACPP_URL").is_err());
 
         Ok(())
     }

--- a/crates/codestory-cli/src/embedding_config.rs
+++ b/crates/codestory-cli/src/embedding_config.rs
@@ -1,30 +1,3 @@
-const BUNDLED_LLAMACPP_BACKEND_LABEL: &str = "llamacpp";
-
-pub(crate) fn prepare_bundled_llamacpp_client_env_defaults() {
-    unsafe {
-        if env_value_is_unset("CODESTORY_EMBED_RUNTIME_MODE")
-            && env_value_is_unset("CODESTORY_EMBED_BACKEND")
-        {
-            set_env_default_str("CODESTORY_EMBED_BACKEND", BUNDLED_LLAMACPP_BACKEND_LABEL);
-        }
-    }
-}
-
-fn env_value_is_unset(name: &str) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| value.trim().is_empty())
-        .unwrap_or(true)
-}
-
-unsafe fn set_env_default_str(key: &str, value: &str) {
-    if std::env::var_os(key).is_none() {
-        unsafe {
-            std::env::set_var(key, value);
-        }
-    }
-}
-
 pub(crate) fn redact_url_for_display(value: &str) -> String {
     let Some((scheme, rest)) = value.split_once("://") else {
         return value.to_string();

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -379,8 +379,12 @@ fn run_sidecar(cmd: SidecarCommand) -> Result<()> {
     }
 }
 
-fn new_agent_surface_runtime(project: &ProjectArgs) -> Result<RuntimeContext> {
-    RuntimeContext::new_agent_sidecar(project)
+fn new_agent_surface_runtime(
+    project: &ProjectArgs,
+    profile: Option<args::CliSidecarProfile>,
+    run_id: Option<&str>,
+) -> Result<RuntimeContext> {
+    RuntimeContext::new_agent_sidecar_with_selection(project, profile, run_id)
 }
 
 fn run_cache(cmd: CacheCommand) -> Result<()> {
@@ -1338,7 +1342,7 @@ struct ResolvedContextTarget {
 fn run_context(cmd: ContextCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "context")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = new_agent_surface_runtime(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project, None, None)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "context")?;
 
@@ -1385,8 +1389,7 @@ fn run_context(cmd: ContextCommand) -> Result<()> {
 fn run_packet(cmd: PacketCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "packet")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    retrieval::activate_retrieval_profile_env(cmd.profile, cmd.run_id.as_deref());
-    let runtime = new_agent_surface_runtime(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project, cmd.profile, cmd.run_id.as_deref())?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "packet")?;
 
@@ -1418,7 +1421,7 @@ fn run_task(cmd: TaskCommand) -> Result<()> {
 fn run_task_brief(cmd: TaskBriefCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "task brief")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = new_agent_surface_runtime(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project, None, None)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "task brief")?;
 
@@ -2331,7 +2334,7 @@ fn run_fix(cmd: FixCommand) -> Result<()> {
 fn build_ready_output(cmd: &ReadyCommand) -> Result<ReadyOutput> {
     let runtime = if cmd.repair {
         if matches!(cmd.goal, None | Some(args::ReadyGoal::Agent)) {
-            new_agent_surface_runtime(&cmd.project)?
+            new_agent_surface_runtime(&cmd.project, None, None)?
         } else {
             RuntimeContext::new(&cmd.project)?
         }
@@ -2708,8 +2711,8 @@ fn repair_ready_state(
 ) -> Result<Option<codestory_retrieval::SidecarRuntimeConfig>> {
     let agent_goal = matches!(goal, None | Some(args::ReadyGoal::Agent));
     let sidecar = agent_goal.then(|| {
-        codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-            &runtime.project_root,
+        runtime.sidecar.with_profile_and_run_id(
+            Some(&runtime.project_root),
             codestory_retrieval::SidecarProfile::Agent,
             run_id,
         )
@@ -2979,7 +2982,7 @@ fn run_ready_repair_with_native_embedding_lease(
                 &runtime.storage_path,
                 sidecar,
             );
-            let embed_smoke = ensure_ready_repair_embed_liveness(&infrastructure)?;
+            let embed_smoke = ensure_ready_repair_embed_liveness(&infrastructure, sidecar)?;
             let gpu_proof =
                 broker_gpu_proof_input_from_infrastructure_with_smoke(&infrastructure, embed_smoke);
             let _ =
@@ -3040,9 +3043,10 @@ struct ReadyRepairEmbedSmoke {
 
 fn ensure_ready_repair_embed_liveness(
     infrastructure: &codestory_retrieval::InfrastructureHealth,
+    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<ReadyRepairEmbedSmoke> {
     ensure_ready_repair_embed_liveness_with_probe(infrastructure, || {
-        codestory_retrieval::probe_product_embedding_runtime()
+        codestory_retrieval::probe_product_embedding_runtime_for_runtime(sidecar)
     })
 }
 
@@ -3439,8 +3443,7 @@ fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> Strin
 fn run_search(cmd: SearchCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "search")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    retrieval::activate_retrieval_profile_env(cmd.profile, cmd.run_id.as_deref());
-    let runtime = new_agent_surface_runtime(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project, cmd.profile, cmd.run_id.as_deref())?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "search")?;
     let search_results = runtime
@@ -3483,9 +3486,10 @@ fn execute_drill(cmd: &DrillCommand) -> Result<DrillOutput> {
         retrieval::finalize_retrieval_index_for_runtime(&runtime)
             .context("drill retrieval index finalize")?;
     }
-    let sidecar_retrieval_mode = codestory_retrieval::strict_sidecar_status(
+    let sidecar_retrieval_mode = codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
+        runtime.sidecar.clone(),
     )
     .ok()
     .map(|status| status.retrieval_mode);
@@ -10901,7 +10905,7 @@ async fn run_serve(cmd: ServeCommand) -> Result<()> {
     if cmd.multi_project {
         return stdio_transport::run_stdio_server(None, cmd.refresh).await;
     }
-    let runtime = new_agent_surface_runtime(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project, None, None)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     if cmd.stdio {
         return stdio_transport::run_stdio_server(Some(runtime), cmd.refresh).await;
@@ -11350,7 +11354,7 @@ fn readiness_sidecar_input(
 }
 
 fn doctor_sidecar_status(runtime: &RuntimeContext) -> DoctorSidecarStatusOutput {
-    let sidecar = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    let sidecar = runtime.sidecar.clone();
     match codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
@@ -11379,8 +11383,8 @@ fn ready_sidecar_status(
     if matches!(goal, Some(args::ReadyGoal::Agent))
         && let Some(run_id) = run_id
     {
-        let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-            &runtime.project_root,
+        let sidecar = runtime.sidecar.with_profile_and_run_id(
+            Some(&runtime.project_root),
             codestory_retrieval::SidecarProfile::Agent,
             Some(run_id),
         );
@@ -11493,7 +11497,11 @@ pub(crate) fn selected_agent_readiness_sidecar_status(
     run_id: Option<&str>,
     fallback: &DoctorSidecarStatusOutput,
 ) -> DoctorSidecarStatusOutput {
-    let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, run_id);
+    let agent_runtime = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
+        codestory_retrieval::SidecarProfile::Agent,
+        run_id,
+    );
     let agent_status = doctor_sidecar_status_for_runtime(runtime, agent_runtime);
     lane_scoped_agent_readiness_sidecar(fallback, agent_status)
 }
@@ -11525,11 +11533,16 @@ pub(crate) fn build_readiness_lanes_for_runtime(
 ) -> BTreeMap<String, ReadinessLaneOutput> {
     let project = display::clean_path_string(&runtime.project_root.to_string_lossy());
     let project_arg = display::quote_command_argument_value(&project);
-    let local_runtime = codestory_retrieval::sidecar_runtime_for_project(
-        &runtime.project_root,
+    let local_runtime = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
         codestory_retrieval::SidecarProfile::Local,
+        None,
     );
-    let agent_runtime = agent_readiness_sidecar_runtime(&runtime.project_root, agent_run_id);
+    let agent_runtime = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
+        codestory_retrieval::SidecarProfile::Agent,
+        agent_run_id,
+    );
     let local_status = doctor_sidecar_status_for_runtime(runtime, local_runtime);
     let agent_status = selected_agent_status
         .cloned()
@@ -11590,6 +11603,7 @@ fn apply_broker_ready_repair_overlay(
     ));
 }
 
+#[cfg(test)]
 fn agent_readiness_sidecar_runtime(
     project_root: &Path,
     run_id: Option<&str>,
@@ -11744,7 +11758,7 @@ fn apply_sidecar_profile_handoff(
 }
 
 fn doctor_sidecar_profile_handoff_failure(runtime: &RuntimeContext) -> Option<String> {
-    let active = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    let active = runtime.sidecar.clone();
     if active.profile == codestory_retrieval::SidecarProfile::Local {
         return None;
     }
@@ -13569,8 +13583,10 @@ mod tests {
             embed_detail: "llama.cpp embeddings reachable dim=768".into(),
         };
 
-        let error = ensure_ready_repair_embed_liveness(&infrastructure)
-            .expect_err("unknown device should stop ready repair before indexing");
+        let error = ensure_ready_repair_embed_liveness_with_probe(&infrastructure, || {
+            unreachable!("device policy must fail before probing")
+        })
+        .expect_err("unknown device should stop ready repair before indexing");
         let message = format!("{error:#}");
 
         assert!(message.contains("embedding device policy failed before long semantic indexing"));
@@ -13610,6 +13626,7 @@ mod tests {
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".into(),
             labels: BTreeMap::new(),
+            ..codestory_retrieval::SidecarRuntimeConfig::local()
         };
         let state_dir = sidecar.layout.state_file.parent().expect("state parent");
         fs::create_dir_all(state_dir).expect("create state dir");

--- a/crates/codestory-cli/src/readiness_broker/native_lease.rs
+++ b/crates/codestory-cli/src/readiness_broker/native_lease.rs
@@ -312,7 +312,7 @@ fn acquire_native_embedding_resource_lease_if_needed_with_validator(
     poll: Duration,
     mut validate_launch: impl FnMut(&codestory_retrieval::EmbeddingLaunchMetadata) -> Result<u32>,
 ) -> Result<Option<BrokerNativeEmbeddingResourceLease>> {
-    if codestory_retrieval::embedding_server_launch_mode()?
+    if codestory_retrieval::embedding_server_launch_mode_for_runtime(sidecar)?
         != codestory_retrieval::EmbeddingServerLaunchMode::NativeSpawned
     {
         return Ok(None);

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -1249,6 +1249,7 @@ mod tests {
             embed_http_port: 8080,
             cleanup_command: "codestory-cli retrieval down".to_string(),
             labels: Default::default(),
+            ..SidecarRuntimeConfig::local()
         }
     }
 

--- a/crates/codestory-cli/src/report.rs
+++ b/crates/codestory-cli/src/report.rs
@@ -114,9 +114,10 @@ struct ReportSidecarStatus {
 }
 
 fn report_sidecar_status(runtime: &RuntimeContext) -> ReportSidecarStatus {
-    match codestory_retrieval::strict_sidecar_status(
+    match codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
         Some(&runtime.storage_path),
+        runtime.sidecar.clone(),
     ) {
         Ok(report) => {
             let manifest_generation = report

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use codestory_retrieval::{
     BootstrapStorageScope, FinalizeIndexOutcome, ProjectQdrantRepairOutcome, QueryRequest,
     RetrievalIndexManifest, RetrievalStatusReport, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    SidecarProfile, SidecarRuntimeConfig, bootstrap_sidecars_with_runtime, execute_retrieval_query,
-    sidecar_down_for_runtime, sidecar_up_with_runtime_preserving_launch, strict_sidecar_status,
+    SidecarProfile, SidecarRuntimeConfig, bootstrap_sidecars_with_runtime,
+    sidecar_down_for_runtime, sidecar_up_with_runtime_preserving_launch,
     strict_sidecar_status_for_runtime,
 };
 
@@ -39,8 +39,8 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
         Some(runtime.cache_root.as_path()),
     );
     let sidecar_profile = cmd.profile;
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &runtime.project_root,
+    let sidecar = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
         sidecar_profile.into(),
         cmd.run_id.as_deref(),
     );
@@ -74,7 +74,6 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
             },
             |report| &report.state,
             |report| {
-                activate_retrieval_profile_env(Some(sidecar_profile), sidecar.run_id.as_deref());
                 let project_qdrant_repair =
                     codestory_retrieval::repair_project_qdrant_collection_for_runtime(
                         &runtime.project_root,
@@ -113,8 +112,8 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
 
 fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &runtime.project_root,
+    let sidecar = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
         cmd.profile.into(),
         cmd.run_id.as_deref(),
     );
@@ -126,8 +125,8 @@ fn run_retrieval_up(cmd: RetrievalSidecarStateCommand) -> Result<()> {
 
 fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &runtime.project_root,
+    let sidecar = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
         cmd.profile.into(),
         cmd.run_id.as_deref(),
     );
@@ -159,8 +158,8 @@ pub(crate) fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
         .or_else(|| cmd.run_id.as_ref().map(|_| CliSidecarProfile::Agent));
     let mut agent_run_id = None;
     let report = if let Some(profile) = profile {
-        let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-            &runtime.project_root,
+        let sidecar = runtime.sidecar.with_profile_and_run_id(
+            Some(&runtime.project_root),
             profile.into(),
             cmd.run_id.as_deref(),
         );
@@ -173,7 +172,11 @@ pub(crate) fn run_retrieval_status(cmd: RetrievalStatusCommand) -> Result<()> {
             sidecar,
         )
     } else {
-        strict_sidecar_status(&runtime.project_root, Some(&runtime.storage_path))
+        strict_sidecar_status_for_runtime(
+            &runtime.project_root,
+            Some(&runtime.storage_path),
+            runtime.sidecar.clone(),
+        )
     }
     .context("retrieval status")?;
     let readiness_broker = crate::readiness_broker::observe_broker_snapshot(
@@ -216,13 +219,17 @@ pub(crate) fn run_retrieval_inventory(cmd: RetrievalInventoryCommand) -> Result<
 fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let result = execute_retrieval_query(QueryRequest {
-        project_root: &runtime.project_root,
-        storage_path: &runtime.storage_path,
-        query: &cmd.query,
-        budget_ms: cmd.budget_ms,
-        cancelled: None,
-    })
+    let result = codestory_retrieval::execute_retrieval_query_with_cache_for_runtime(
+        QueryRequest {
+            project_root: &runtime.project_root,
+            storage_path: &runtime.storage_path,
+            query: &cmd.query,
+            budget_ms: cmd.budget_ms,
+            cancelled: None,
+        },
+        &mut codestory_retrieval::RetrievalCache::new(),
+        &runtime.sidecar,
+    )
     .context("retrieval query")?;
     emit_retrieval_query(cmd.format, &result, cmd.output_file.as_deref())
 }
@@ -230,15 +237,12 @@ fn run_retrieval_query(cmd: RetrievalQueryCommand) -> Result<()> {
 fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
     preflight_output(cmd.output_file.as_deref())?;
     let sidecar_profile = cmd.profile.unwrap_or(CliSidecarProfile::Local);
-    activate_retrieval_profile_env(Some(sidecar_profile), cmd.run_id.as_deref());
-    prepare_retrieval_index_embedding_env(sidecar_profile);
     let runtime = RuntimeContext::new_inspect_only(&cmd.project)?;
-    let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &runtime.project_root,
+    let sidecar = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
         sidecar_profile.into(),
         cmd.run_id.as_deref(),
     );
-    prepare_retrieval_index_sidecar_env(&sidecar);
     let summary = runtime.open_project_summary()?;
     let refresh_mode = resolve_refresh_request(cmd.refresh, &summary);
     ensure_retrieval_index_embedding_policy(&sidecar)?;
@@ -262,39 +266,6 @@ fn run_retrieval_index(cmd: RetrievalIndexCommand) -> Result<()> {
 fn ensure_retrieval_index_embedding_policy(sidecar: &SidecarRuntimeConfig) -> Result<()> {
     codestory_retrieval::ensure_product_embedding_backend_for_runtime(sidecar)
         .context("retrieval index embedding device policy")
-}
-
-fn prepare_retrieval_index_embedding_env(profile: CliSidecarProfile) {
-    if matches!(profile, CliSidecarProfile::Agent) {
-        crate::embedding_config::prepare_bundled_llamacpp_client_env_defaults();
-    }
-}
-
-fn prepare_retrieval_index_sidecar_env(sidecar: &SidecarRuntimeConfig) {
-    sidecar.activate_embed_url();
-}
-
-pub(crate) fn activate_retrieval_profile_env(
-    profile: Option<crate::args::CliSidecarProfile>,
-    run_id: Option<&str>,
-) {
-    if profile.is_some() || run_id.is_some() {
-        let profile = match profile {
-            Some(crate::args::CliSidecarProfile::Local) => "local",
-            Some(crate::args::CliSidecarProfile::Agent) | None => "agent",
-        };
-        // SAFETY: retrieval CLI commands are short-lived processes and set this before sidecar
-        // layout resolution or worker threads are started.
-        unsafe {
-            std::env::set_var("CODESTORY_RETRIEVAL_PROFILE", profile);
-        }
-    }
-    if let Some(run_id) = run_id {
-        // SAFETY: see the profile environment setup above.
-        unsafe {
-            std::env::set_var("CODESTORY_SIDECAR_RUN_ID", run_id);
-        }
-    }
 }
 
 fn run_retrieval_index_refresh(
@@ -326,8 +297,7 @@ fn run_retrieval_index_refresh(
 pub(crate) fn finalize_retrieval_index_for_runtime(
     runtime: &RuntimeContext,
 ) -> Result<FinalizeIndexOutcome> {
-    let sidecar = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
-    finalize_retrieval_index_for_sidecar_runtime(runtime, &sidecar)
+    finalize_retrieval_index_for_sidecar_runtime(runtime, &runtime.sidecar)
 }
 
 pub(crate) fn finalize_retrieval_index_for_sidecar_runtime(
@@ -352,7 +322,7 @@ fn ensure_local_profile_handoff(
     if indexed_sidecar.profile != SidecarProfile::Local {
         return Ok(());
     }
-    let default_sidecar = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    let default_sidecar = runtime.sidecar.clone();
     if let Some(mismatch) = sidecar_runtime_mismatch(indexed_sidecar, &default_sidecar) {
         anyhow::bail!("{mismatch}");
     }
@@ -928,34 +898,11 @@ mod tests {
     }
 
     #[test]
-    fn agent_retrieval_index_defaults_to_llamacpp_backend() {
+    fn sidecar_runtime_retains_backend_endpoint_profile_and_run_without_env_mutation() {
         let _lock = crate::config::config_env_test_lock();
         let _runtime_mode = EnvGuard::remove("CODESTORY_EMBED_RUNTIME_MODE");
         let _backend = EnvGuard::remove("CODESTORY_EMBED_BACKEND");
 
-        prepare_retrieval_index_embedding_env(CliSidecarProfile::Agent);
-
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_BACKEND").as_deref(),
-            Ok("llamacpp")
-        );
-    }
-
-    #[test]
-    fn local_retrieval_index_does_not_force_llamacpp_backend() {
-        let _lock = crate::config::config_env_test_lock();
-        let _runtime_mode = EnvGuard::remove("CODESTORY_EMBED_RUNTIME_MODE");
-        let _backend = EnvGuard::remove("CODESTORY_EMBED_BACKEND");
-
-        prepare_retrieval_index_embedding_env(CliSidecarProfile::Local);
-
-        assert!(std::env::var("CODESTORY_EMBED_BACKEND").is_err());
-    }
-
-    #[test]
-    fn retrieval_index_activates_selected_sidecar_embed_url_default() {
-        let _lock = crate::config::config_env_test_lock();
-        let _url = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
         let project = tempfile::TempDir::new().expect("project");
         let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
             project.path(),
@@ -964,45 +911,12 @@ mod tests {
         );
         let expected = codestory_retrieval::SidecarLayout::embed_base_url(sidecar.embed_http_port);
 
-        prepare_retrieval_index_sidecar_env(&sidecar);
-
-        assert_eq!(
-            std::env::var("CODESTORY_EMBED_LLAMACPP_URL").as_deref(),
-            Ok(expected.as_str())
-        );
-    }
-
-    #[test]
-    fn run_id_without_profile_selects_agent_over_ambient_local_profile() {
-        let _lock = crate::config::config_env_test_lock();
-        let _retrieval_profile = EnvGuard::set("CODESTORY_RETRIEVAL_PROFILE", "local");
-        let _sidecar_profile = EnvGuard::set("CODESTORY_SIDECAR_PROFILE", "local");
-        let _run_id = EnvGuard::remove("CODESTORY_SIDECAR_RUN_ID");
-
-        activate_retrieval_profile_env(None, Some("packet-search-eval"));
-
-        assert_eq!(
-            std::env::var("CODESTORY_RETRIEVAL_PROFILE").as_deref(),
-            Ok("agent")
-        );
-        assert_eq!(
-            std::env::var("CODESTORY_SIDECAR_RUN_ID").as_deref(),
-            Ok("packet-search-eval")
-        );
-
-        activate_retrieval_profile_env(
-            Some(crate::args::CliSidecarProfile::Local),
-            Some("explicit-local"),
-        );
-
-        assert_eq!(
-            std::env::var("CODESTORY_RETRIEVAL_PROFILE").as_deref(),
-            Ok("local")
-        );
-        assert_eq!(
-            std::env::var("CODESTORY_SIDECAR_RUN_ID").as_deref(),
-            Ok("explicit-local")
-        );
+        assert_eq!(sidecar.embedding.backend, "llamacpp");
+        assert_eq!(sidecar.embedding.endpoint, expected);
+        assert_eq!(sidecar.profile, SidecarProfile::Agent);
+        assert_eq!(sidecar.run_id.as_deref(), Some("packet-search-eval"));
+        assert!(std::env::var("CODESTORY_EMBED_BACKEND").is_err());
+        assert!(std::env::var("CODESTORY_EMBED_LLAMACPP_URL").is_err());
     }
 
     #[test]

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -55,6 +55,7 @@ pub(crate) struct RuntimeContext {
     pub(crate) project_root: PathBuf,
     pub(crate) cache_root: PathBuf,
     pub(crate) storage_path: PathBuf,
+    pub(crate) sidecar: codestory_retrieval::SidecarRuntimeConfig,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -104,8 +105,33 @@ impl RuntimeContext {
 
     /// Open runtime services for agent-facing packet/search commands.
     pub(crate) fn new_agent_sidecar(args: &ProjectArgs) -> Result<Self> {
-        crate::embedding_config::prepare_bundled_llamacpp_client_env_defaults();
-        Self::new(args)
+        Self::new_agent_sidecar_with_selection(args, None, None)
+    }
+
+    pub(crate) fn new_agent_sidecar_with_selection(
+        args: &ProjectArgs,
+        profile: Option<crate::args::CliSidecarProfile>,
+        run_id: Option<&str>,
+    ) -> Result<Self> {
+        let mut context = Self::new(args)?;
+        if profile.is_some() || run_id.is_some() {
+            let selected = profile
+                .map(Into::into)
+                .unwrap_or(codestory_retrieval::SidecarProfile::Agent);
+            context.sidecar = context.sidecar.with_profile_and_run_id(
+                Some(&context.project_root),
+                selected,
+                run_id,
+            );
+            let runtime = Runtime::new_with_config(context.sidecar.clone());
+            context.project = runtime.project_service();
+            context.index = runtime.index_service();
+            context.grounding = runtime.grounding_service();
+            context.bookmarks = runtime.bookmark_service();
+            context.browser = runtime.browser_service();
+            context.events = runtime.events();
+        }
+        Ok(context)
     }
 
     /// Open runtime services without starting managed embedding processes.
@@ -115,10 +141,17 @@ impl RuntimeContext {
 
     fn new_with_startup(args: &ProjectArgs) -> Result<Self> {
         let project_root = canonicalize_project_root(&args.project)?;
-        let cache_override = trusted_cache_override(&project_root, args.cache_dir.as_deref())?;
+        let config = crate::config::load_config(&project_root)?;
+        let cache_override = args.cache_dir.clone().or_else(|| config.cache_dir.clone());
         let cache_root = cache_root_for_project(&project_root, cache_override.as_deref())?;
         let storage_path = cache_root.join("codestory.db");
-        let runtime = Runtime::new();
+        let defaults = crate::config::process_runtime_defaults();
+        let sidecar = codestory_retrieval::SidecarRuntimeConfig::for_project_auto_with_defaults(
+            &project_root,
+            &defaults,
+            &config.runtime_overrides(),
+        );
+        let runtime = Runtime::new_with_config(sidecar.clone());
         let events = runtime.events();
         Ok(Self {
             project: runtime.project_service(),
@@ -130,6 +163,7 @@ impl RuntimeContext {
             project_root,
             cache_root,
             storage_path,
+            sidecar,
         })
     }
 
@@ -437,14 +471,6 @@ pub(crate) fn cache_root_for_project(
         None => Ok(codestory_retrieval::user_cache_root()
             .join(fnv1a_hex(project_root.to_string_lossy().as_bytes()))),
     }
-}
-
-pub(crate) fn trusted_cache_override(
-    project_root: &Path,
-    cli_cache_dir: Option<&Path>,
-) -> Result<Option<PathBuf>> {
-    let config = crate::config::load_config(project_root)?;
-    Ok(cli_cache_dir.map(Path::to_path_buf).or(config.cache_dir))
 }
 
 /// Small stable hash used for path-derived cache directory names.
@@ -922,29 +948,22 @@ mod tests {
         let cache = temp.path().join("cache");
         fs::create_dir_all(&project).expect("create project");
 
-        RuntimeContext::new_agent_sidecar(&ProjectArgs {
+        let runtime = RuntimeContext::new_agent_sidecar(&ProjectArgs {
             project: project.clone(),
             cache_dir: Some(cache),
         })
         .expect("runtime context");
 
-        assert_eq!(
-            env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
-            Some("llamacpp")
-        );
+        assert_eq!(runtime.sidecar.embedding.backend, "llamacpp");
         assert_eq!(env::var("CODESTORY_EMBED_LLAMACPP_URL").ok(), None);
-        let sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-            &project,
+        let sidecar = runtime.sidecar.with_profile_and_run_id(
+            Some(&project),
             codestory_retrieval::SidecarProfile::Agent,
             Some("ready-repair-test"),
         );
         let expected_url =
             codestory_retrieval::SidecarLayout::embed_base_url(sidecar.embed_http_port);
-        sidecar.activate_embed_url_default();
-        assert_eq!(
-            env::var("CODESTORY_EMBED_LLAMACPP_URL").ok().as_deref(),
-            Some(expected_url.as_str())
-        );
+        assert_eq!(sidecar.embedding.endpoint.as_str(), expected_url.as_str());
         assert_ne!(expected_url, "http://127.0.0.1:8080/v1/embeddings");
     }
 
@@ -960,15 +979,20 @@ mod tests {
             );
         }
 
-        crate::embedding_config::prepare_bundled_llamacpp_client_env_defaults();
+        let project = tempfile::tempdir().expect("project");
+        let runtime = RuntimeContext::new_agent_sidecar(&ProjectArgs {
+            project: project.path().to_path_buf(),
+            cache_dir: None,
+        })
+        .expect("runtime context");
 
         assert_eq!(
             env::var("CODESTORY_EMBED_BACKEND").ok().as_deref(),
             Some("llamacpp")
         );
         assert_eq!(
-            env::var("CODESTORY_EMBED_LLAMACPP_URL").ok().as_deref(),
-            Some("http://127.0.0.1:18080/v1/embeddings")
+            runtime.sidecar.embedding.endpoint.as_str(),
+            "http://127.0.0.1:18080/v1/embeddings"
         );
     }
 }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -17,7 +17,6 @@ use codestory_contracts::api::{
     ReadinessStatusDto, ReadinessVerdictDto, SearchRepoTextMode, SearchRequest, TrailCallerScope,
     TrailDirection, TrailMode,
 };
-use codestory_retrieval::SidecarLayout;
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -1584,10 +1583,7 @@ fn handle_stdio_packet(
         .unwrap_or(true);
     let cache_key = stdio_packet_cache_key(StdioPacketCacheKeyInput {
         storage_fingerprint: stdio_storage_fingerprint(&runtime.storage_path),
-        sidecar_fingerprint: stdio_mandatory_sidecar_fingerprint(
-            &runtime.project_root,
-            &runtime.storage_path,
-        ),
+        sidecar_fingerprint: stdio_mandatory_sidecar_fingerprint(runtime),
         question,
         budget,
         task_class,
@@ -1763,30 +1759,29 @@ fn stdio_storage_modified(
     newest.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "storage state missing"))
 }
 
-fn stdio_mandatory_sidecar_fingerprint(
-    project_root: &std::path::Path,
-    storage_path: &std::path::Path,
-) -> String {
-    let layout = SidecarLayout::from_env_for_project(project_root);
-    let status = codestory_retrieval::strict_sidecar_status(project_root, Some(storage_path)).map(
-        |report| StdioSidecarStatusFingerprint {
-            retrieval_mode: report.retrieval_mode,
-            degraded_reason: report.degraded_reason,
-            embedding_device_policy: report.embedding_device_policy,
-            embedding_device_state: report.embedding_device_state,
-            embedding_device_observation_source: report.embedding_device_observation_source,
-            embedding_detected_provider: report.embedding_detected_provider,
-            embedding_detected_gpu: report.embedding_detected_gpu,
-            embedding_accelerator_requested: report.embedding_accelerator_requested,
-            embedding_accelerator_request_provider: report.embedding_accelerator_request_provider,
-            embedding_accelerator_request_device: report.embedding_accelerator_request_device,
-            embedding_cpu_allowed: report.embedding_cpu_allowed,
-            manifest: report.manifest,
-        },
-    );
+fn stdio_mandatory_sidecar_fingerprint(runtime: &RuntimeContext) -> String {
+    let status = codestory_retrieval::strict_sidecar_status_for_runtime(
+        &runtime.project_root,
+        Some(&runtime.storage_path),
+        runtime.sidecar.clone(),
+    )
+    .map(|report| StdioSidecarStatusFingerprint {
+        retrieval_mode: report.retrieval_mode,
+        degraded_reason: report.degraded_reason,
+        embedding_device_policy: report.embedding_device_policy,
+        embedding_device_state: report.embedding_device_state,
+        embedding_device_observation_source: report.embedding_device_observation_source,
+        embedding_detected_provider: report.embedding_detected_provider,
+        embedding_detected_gpu: report.embedding_detected_gpu,
+        embedding_accelerator_requested: report.embedding_accelerator_requested,
+        embedding_accelerator_request_provider: report.embedding_accelerator_request_provider,
+        embedding_accelerator_request_device: report.embedding_accelerator_request_device,
+        embedding_cpu_allowed: report.embedding_cpu_allowed,
+        manifest: report.manifest,
+    });
     stdio_mandatory_sidecar_fingerprint_from_status(
-        codestory_retrieval::embedding_runtime_id(),
-        stdio_path_fingerprint(&layout.state_file),
+        codestory_retrieval::embedding_runtime_id_for_runtime(&runtime.sidecar),
+        stdio_path_fingerprint(&runtime.sidecar.layout.state_file),
         status,
     )
 }
@@ -2034,10 +2029,7 @@ fn handle_stdio_search(
         .unwrap_or(10);
     let cache_key = StdioSearchFragmentCacheKey {
         storage_fingerprint: stdio_storage_fingerprint(&runtime.storage_path),
-        sidecar_fingerprint: stdio_mandatory_sidecar_fingerprint(
-            &runtime.project_root,
-            &runtime.storage_path,
-        ),
+        sidecar_fingerprint: stdio_mandatory_sidecar_fingerprint(runtime),
         query: query.trim().to_ascii_lowercase(),
         repo_text: match repo_text {
             SearchRepoTextMode::On => "on",
@@ -3020,7 +3012,6 @@ fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
 }
 
 fn stdio_status_cache_key_with_publication(runtime: &RuntimeContext, publication: &str) -> String {
-    let layout = SidecarLayout::from_env_for_project(&runtime.project_root);
     let marker_path = stdio_dirty_marker_env_path(&runtime.project_root);
     [
         format!("project:{}", runtime.project_root.display()),
@@ -3032,7 +3023,7 @@ fn stdio_status_cache_key_with_publication(runtime: &RuntimeContext, publication
         ),
         format!(
             "sidecar_state:{}",
-            stdio_path_fingerprint(&layout.state_file)
+            stdio_path_fingerprint(&runtime.sidecar.layout.state_file)
         ),
         format!(
             "native_embedding_broker:{}",
@@ -3072,7 +3063,7 @@ fn stdio_status_cache_key_with_publication(runtime: &RuntimeContext, publication
         ),
         format!(
             "release_metadata:{}",
-            stdio_path_fingerprint(&stdio_release_metadata_cache_path())
+            stdio_path_fingerprint(&stdio_release_metadata_cache_path(runtime))
         ),
         format!(
             "release_override:{}",
@@ -3081,7 +3072,7 @@ fn stdio_status_cache_key_with_publication(runtime: &RuntimeContext, publication
         ),
         format!(
             "active_embedding_backend:{}",
-            codestory_retrieval::embedding_runtime_id()
+            codestory_retrieval::embedding_runtime_id_for_runtime(&runtime.sidecar)
         ),
     ]
     .join("|")
@@ -3608,7 +3599,7 @@ fn read_stdio_status_resource(
     let sidecar = build_stdio_status_sidecar(runtime);
     let (server_executable, server_executable_sha256, server_warnings) =
         stdio_server_executable_status();
-    let runtime_update = stdio_runtime_update_advisory(server_executable.as_deref());
+    let runtime_update = stdio_runtime_update_advisory(server_executable.as_deref(), runtime);
     let source_checkout_version = stdio_source_checkout_version(&runtime.project_root);
     let plugin_runtime = stdio_plugin_runtime_status();
     let broker = build_stdio_status_broker(runtime, &sidecar.selected_agent_sidecar);
@@ -3680,7 +3671,7 @@ fn read_stdio_status_resource(
 }
 
 fn build_stdio_status_sidecar(runtime: &RuntimeContext) -> StdioSidecarStatusParts {
-    let sidecar_runtime = codestory_retrieval::sidecar_runtime_auto(&runtime.project_root);
+    let sidecar_runtime = runtime.sidecar.clone();
     let (
         retrieval_mode,
         degraded_reason,
@@ -3939,8 +3930,8 @@ fn build_stdio_status_surfaces(
     selected_agent_sidecar: &args::DoctorSidecarStatusOutput,
     plugin_runtime: &serde_json::Value,
 ) -> StdioStatusSurfacesParts {
-    let selected_agent_runtime = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &runtime.project_root,
+    let selected_agent_runtime = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
         codestory_retrieval::SidecarProfile::Agent,
         selected_agent_sidecar.run_id.as_deref(),
     );
@@ -4044,9 +4035,12 @@ struct StdioLatestReleaseMetadata {
     refresh_scheduled: bool,
 }
 
-fn stdio_runtime_update_advisory(server_executable: Option<&str>) -> serde_json::Value {
+fn stdio_runtime_update_advisory(
+    server_executable: Option<&str>,
+    runtime: &RuntimeContext,
+) -> serde_json::Value {
     let active_version = env!("CARGO_PKG_VERSION");
-    let metadata = stdio_latest_release_metadata();
+    let metadata = stdio_latest_release_metadata(runtime);
     let newer_installed = (env_nonempty("CODESTORY_PLUGIN_CLI_SOURCE").as_deref()
         == Some("managed"))
     .then(|| stdio_newer_installed_cli(active_version, server_executable))
@@ -4118,7 +4112,7 @@ fn stdio_runtime_update_advisory_from(
     })
 }
 
-fn stdio_latest_release_metadata() -> StdioLatestReleaseMetadata {
+fn stdio_latest_release_metadata(runtime: &RuntimeContext) -> StdioLatestReleaseMetadata {
     if let Ok(version) = std::env::var("CODESTORY_LATEST_RELEASE_VERSION")
         && let Some(version) = normalize_release_version(&version)
     {
@@ -4131,7 +4125,7 @@ fn stdio_latest_release_metadata() -> StdioLatestReleaseMetadata {
         };
     }
     let release_probe_disabled = std::env::var_os("CODESTORY_DISABLE_RELEASE_PROBE").is_some();
-    let path = stdio_release_metadata_cache_path();
+    let path = stdio_release_metadata_cache_path(runtime);
     let cache = stdio_read_release_metadata_cache(&path);
     let now = crate::ready_repair_status::now_epoch_ms();
     let due = cache
@@ -4159,17 +4153,10 @@ fn stdio_latest_release_metadata() -> StdioLatestReleaseMetadata {
     }
 }
 
-fn stdio_release_metadata_cache_path() -> PathBuf {
+fn stdio_release_metadata_cache_path(runtime: &RuntimeContext) -> PathBuf {
     env_nonempty("CODESTORY_PLUGIN_DATA")
         .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            codestory_retrieval::SidecarRuntimeConfig::local()
-                .layout
-                .state_file
-                .parent()
-                .map(Path::to_path_buf)
-                .unwrap_or_else(std::env::temp_dir)
-        })
+        .unwrap_or_else(|| runtime.cache_root.clone())
         .join("release-metadata.json")
 }
 
@@ -5058,8 +5045,8 @@ fn handle_stdio_sidecar_repair(
     if let Some(result) = stdio_sidecar_repair_policy_block_result(&sidecar_setup) {
         return result;
     }
-    let repair_sidecar = codestory_retrieval::sidecar_runtime_for_project_with_run_id(
-        &runtime.project_root,
+    let repair_sidecar = runtime.sidecar.with_profile_and_run_id(
+        Some(&runtime.project_root),
         codestory_retrieval::SidecarProfile::Agent,
         Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
     );

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -79,8 +79,9 @@ fn direct_cli_and_stdio_agent_surfaces_share_runtime_constructor() {
     let main = read("crates/codestory-cli/src/main.rs");
     let helper = source_between(&main, "fn new_agent_surface_runtime", "fn run_cache");
     assert!(
-        helper.contains("RuntimeContext::new_agent_sidecar(project)"),
-        "shared agent surface runtime must keep ready/direct CLI/stdio on the agent-sidecar constructor"
+        helper
+            .contains("RuntimeContext::new_agent_sidecar_with_selection(project, profile, run_id)"),
+        "shared agent surface runtime must retain the selected profile and run id"
     );
 
     for (start, end, surface) in [
@@ -96,14 +97,14 @@ fn direct_cli_and_stdio_agent_surfaces_share_runtime_constructor() {
     ] {
         let body = source_between(&main, start, end);
         assert!(
-            body.contains("new_agent_surface_runtime(&cmd.project)?"),
+            body.contains("new_agent_surface_runtime(&cmd.project,"),
             "{surface} must use the same agent-sidecar runtime constructor as stdio status/ready"
         );
     }
 
     let ready = source_between(&main, "fn run_ready", "fn run_agent");
     assert!(
-        ready.contains("new_agent_surface_runtime(&cmd.project)?"),
+        ready.contains("new_agent_surface_runtime(&cmd.project,"),
         "ready --goal agent --repair must stay on the shared agent-sidecar runtime constructor"
     );
 }

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -2,9 +2,12 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
@@ -33,6 +36,111 @@ struct StdioServer {
 }
 
 struct RemoveDirOnDrop(PathBuf);
+
+struct FakeEmbeddingEndpoint {
+    url: String,
+    response_vector: Vec<f32>,
+    requests: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl FakeEmbeddingEndpoint {
+    fn spawn(vector: Vec<f32>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake embedding endpoint");
+        listener
+            .set_nonblocking(true)
+            .expect("set fake endpoint nonblocking");
+        let address = listener.local_addr().expect("fake endpoint address");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_requests = Arc::clone(&requests);
+        let worker_stop = Arc::clone(&stop);
+        let response_vector = vector.clone();
+        let worker = thread::spawn(move || {
+            while !worker_stop.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("make accepted fake endpoint stream blocking");
+                        let body = read_http_request_body(&mut stream);
+                        let input_count = serde_json::from_str::<Value>(&body)
+                            .ok()
+                            .and_then(|request| {
+                                request.get("input").and_then(Value::as_array).map(Vec::len)
+                            })
+                            .expect("embedding request input array");
+                        worker_requests.lock().expect("request log").push(body);
+                        let response_body = json!({
+                            "data": (0..input_count)
+                                .map(|index| json!({"index": index, "embedding": &vector}))
+                                .collect::<Vec<_>>(),
+                        })
+                        .to_string();
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            response_body.len(),
+                            response_body
+                        )
+                        .expect("write fake embedding response");
+                        stream.flush().expect("flush fake embedding response");
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept fake embedding request: {error}"),
+                }
+            }
+        });
+        Self {
+            url: format!("http://{address}/v1/embeddings"),
+            response_vector,
+            requests,
+            stop,
+            worker: Some(worker),
+        }
+    }
+
+    fn snapshot(&self) -> Vec<String> {
+        self.requests.lock().expect("request log").clone()
+    }
+}
+
+impl Drop for FakeEmbeddingEndpoint {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            worker.join().expect("join fake embedding endpoint");
+        }
+    }
+}
+
+fn read_http_request_body(stream: &mut TcpStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set fake endpoint read timeout");
+    let mut request = Vec::new();
+    let mut byte = [0_u8; 1];
+    while !request.ends_with(b"\r\n\r\n") {
+        stream.read_exact(&mut byte).expect("read request header");
+        request.push(byte[0]);
+        assert!(request.len() < 64 * 1024, "request header too large");
+    }
+    let header = String::from_utf8_lossy(&request);
+    let content_length = header
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().expect("content length"))
+        })
+        .unwrap_or(0);
+    let mut body = vec![0_u8; content_length];
+    stream.read_exact(&mut body).expect("read request body");
+    String::from_utf8(body).expect("embedding request utf8")
+}
 
 impl Drop for RemoveDirOnDrop {
     fn drop(&mut self) {
@@ -402,6 +510,31 @@ fn spawn_multi_project_stdio_server(cache_root: &Path) -> StdioServer {
         .env("CODESTORY_PLUGIN_MULTI_PROJECT", "1")
         .spawn()
         .expect("spawn multi-project stdio server");
+    let stdin = child.stdin.take().expect("multi-project stdio stdin");
+    let stdout = BufReader::new(child.stdout.take().expect("multi-project stdio stdout"));
+    StdioServer {
+        child,
+        stdin,
+        stdout,
+    }
+}
+
+fn spawn_multi_project_stdio_server_with_project_network_config(cache_root: &Path) -> StdioServer {
+    let mut child = test_support::cli_command()
+        .arg("serve")
+        .arg("--stdio")
+        .arg("--multi-project")
+        .arg("--refresh")
+        .arg("full")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG", "1")
+        .env("CODESTORY_EMBED_ALLOW_CPU", "1")
+        .env("CODESTORY_STDIO_CACHE_ROOT", cache_root)
+        .env("CODESTORY_PLUGIN_MULTI_PROJECT", "1")
+        .spawn()
+        .expect("spawn multi-project network-config stdio server");
     let stdin = child.stdin.take().expect("multi-project stdio stdin");
     let stdout = BufReader::new(child.stdout.take().expect("multi-project stdio stdout"));
     StdioServer {
@@ -1269,6 +1402,158 @@ fn multi_project_stdio_routes_interleaved_requests_by_explicit_project() {
     );
     assert_eq!(first_snapshot["root"], first_again["root"]);
     assert_ne!(first_snapshot["root"], second_snapshot["root"]);
+}
+
+#[test]
+fn multi_project_stdio_keeps_project_embedding_endpoints_isolated_across_a_b_a() {
+    let first = tempfile::tempdir().expect("first workspace");
+    let second = tempfile::tempdir().expect("second workspace");
+    let cache_root = tempfile::tempdir().expect("multi-project cache root");
+    let first_endpoint = FakeEmbeddingEndpoint::spawn(vec![1.0; 768]);
+    let second_endpoint = FakeEmbeddingEndpoint::spawn(vec![-1.0; 768]);
+    write_tiny_rust_workspace(first.path());
+    write_tiny_rust_workspace(second.path());
+    fs::write(
+        first.path().join(".codestory.toml"),
+        format!(
+            "embedding_endpoint = {:?}\nembedding_query_prefix = \"project-a:\"\nembedding_document_prefix = \"project-a:\"\n",
+            first_endpoint.url
+        ),
+    )
+    .expect("write first runtime config");
+    fs::write(
+        second.path().join(".codestory.toml"),
+        format!(
+            "embedding_endpoint = {:?}\nembedding_query_prefix = \"project-b:\"\nembedding_document_prefix = \"project-b:\"\n",
+            second_endpoint.url
+        ),
+    )
+    .expect("write second runtime config");
+
+    let mut server =
+        spawn_multi_project_stdio_server_with_project_network_config(cache_root.path());
+    let status_request = |id: &str, project: &Path| {
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {"name": "status", "arguments": {"project": project}}
+        })
+    };
+    writeln!(server.stdin, "{}", status_request("config-a", first.path()))
+        .expect("queue project A status");
+    writeln!(
+        server.stdin,
+        "{}",
+        status_request("config-b", second.path())
+    )
+    .expect("queue project B status");
+    server.stdin.flush().expect("flush A/B status requests");
+    assert_tool_success(&read_json(&mut server), json!("config-a"));
+    assert_tool_success(&read_json(&mut server), json!("config-b"));
+
+    let first_before = first_endpoint.snapshot();
+    let second_before = second_endpoint.snapshot();
+    assert!(!first_before.is_empty(), "project A endpoint was not used");
+    assert!(!second_before.is_empty(), "project B endpoint was not used");
+    assert!(
+        first_before
+            .iter()
+            .all(|request| request.contains("project-a:") && !request.contains("project-b:")),
+        "project A endpoint received cross-project input: {first_before:?}"
+    );
+    assert!(
+        second_before
+            .iter()
+            .all(|request| request.contains("project-b:") && !request.contains("project-a:")),
+        "project B endpoint received cross-project input: {second_before:?}"
+    );
+
+    assert_tool_success(
+        &send_json(&mut server, status_request("config-a-again", first.path())),
+        json!("config-a-again"),
+    );
+    let first_after = first_endpoint.snapshot();
+    let second_after = second_endpoint.snapshot();
+    assert!(
+        first_after.len() > first_before.len(),
+        "A again must reuse project A's retained endpoint"
+    );
+    assert_eq!(
+        second_after.len(),
+        second_before.len(),
+        "A again must not touch project B's endpoint"
+    );
+
+    let persisted_embeddings = |project: &Path| {
+        let canonical = fs::canonicalize(project).expect("canonical project");
+        let mut hash = 0xcbf29ce484222325_u64;
+        for byte in canonical.to_string_lossy().as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        let storage_path = cache_root
+            .path()
+            .join(format!("{hash:016x}"))
+            .join("codestory.db");
+        codestory_runtime::stored_semantic_embeddings_for_test(&storage_path)
+            .expect("read persisted semantic documents through runtime boundary")
+    };
+    let first_vectors = persisted_embeddings(first.path());
+    let second_vectors = persisted_embeddings(second.path());
+    assert!(
+        !first_vectors.is_empty(),
+        "project A persisted no embeddings"
+    );
+    assert!(
+        !second_vectors.is_empty(),
+        "project B persisted no embeddings"
+    );
+    assert!(
+        first_vectors
+            .iter()
+            .all(|vector| vector.len() == 768 && vector.iter().all(|value| *value > 0.0)),
+        "project A did not persist vectors returned by endpoint A"
+    );
+    assert!(
+        second_vectors
+            .iter()
+            .all(|vector| vector.len() == 768 && vector.iter().all(|value| *value < 0.0)),
+        "project B did not persist vectors returned by endpoint B"
+    );
+
+    assert!(
+        first_after
+            .iter()
+            .any(|request| request.contains("project-a:codestory health probe")),
+        "project A retained config never routed its semantic health query"
+    );
+    assert!(
+        second_after
+            .iter()
+            .any(|request| request.contains("project-b:codestory health probe")),
+        "project B retained config never routed its semantic health query"
+    );
+    let first_query = &first_endpoint.response_vector;
+    let second_query = &second_endpoint.response_vector;
+    let cosine = |left: &[f32], right: &[f32]| {
+        let dot = left
+            .iter()
+            .zip(right)
+            .map(|(left, right)| left * right)
+            .sum::<f32>();
+        let left_norm = left.iter().map(|value| value * value).sum::<f32>().sqrt();
+        let right_norm = right.iter().map(|value| value * value).sum::<f32>().sqrt();
+        dot / (left_norm * right_norm)
+    };
+    assert!(
+        cosine(first_query, &first_vectors[0]) > cosine(first_query, &second_vectors[0]),
+        "project A semantic query must prefer project A's persisted vectors"
+    );
+    assert!(
+        cosine(second_query, &second_vectors[0]) > cosine(second_query, &first_vectors[0]),
+        "project B semantic query must prefer project B's persisted vectors"
+    );
 }
 
 #[test]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -1,7 +1,7 @@
 use crate::config::{
     EmbeddingServerLaunchMode, NATIVE_LLAMA_MANAGED_CACHE_REL_PATH,
     NATIVE_LLAMA_SOURCE_CACHE_REL_PATH, SidecarLayout, SidecarProfile, SidecarRuntimeConfig,
-    embedding_server_launch_mode, retrieval_compose_profile, user_cache_root,
+    retrieval_compose_profile, user_cache_root,
 };
 use crate::health::{InfrastructureHealth, probe_infrastructure_health};
 use crate::outbound_http::read_bytes;
@@ -273,8 +273,7 @@ pub fn bootstrap_sidecars_with_runtime_progress(
     layout.ensure_data_dirs()?;
     let storage_repair =
         repair_qdrant_storage(&layout, &storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?;
-    let launch_mode = embedding_server_launch_mode()?;
-    runtime.activate_embed_url_default();
+    let launch_mode = crate::config::embedding_server_launch_mode_for_runtime(runtime)?;
     let native_embedding = (launch_mode == EmbeddingServerLaunchMode::NativeSpawned)
         .then(|| native_embedding_server_launch(repo_root, runtime))
         .transpose()?;
@@ -472,7 +471,7 @@ fn docker_compose_up(
     let mut command = docker_compose_command()?;
     let compose_profile = retrieval_compose_profile();
     remove_container_if_present("codestory-zoekt-stub")?;
-    let embedding_device = crate::embeddings::embedding_device_readiness();
+    let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
     let accelerator_request = crate::embeddings::embedding_accelerator_request();
     let vulkan_override = maybe_write_vulkan_compose_override(
         &user_cache_root(),
@@ -516,10 +515,7 @@ fn docker_compose_up(
             docker_bind_path(&embed_model_dir(repo_root, layout)?),
         )
         .env("CODESTORY_EMBED_PORT", runtime.embed_http_port.to_string())
-        .env(
-            "CODESTORY_EMBED_LLAMACPP_URL",
-            SidecarLayout::embed_base_url(runtime.embed_http_port),
-        )
+        .env("CODESTORY_EMBED_LLAMACPP_URL", &runtime.embedding.endpoint)
         .env(
             "CODESTORY_EMBED_DEVICE_STATE",
             embedding_device.observed_state,
@@ -729,7 +725,7 @@ fn native_embedding_server_launch(
     repo_root: Option<&Path>,
     runtime: &SidecarRuntimeConfig,
 ) -> Result<NativeEmbeddingServerLaunch> {
-    ensure_native_launch_backend_supported()?;
+    ensure_native_launch_backend_supported(runtime)?;
     ensure_selected_managed_native_llama_server(repo_root)?;
     let executable = native_llama_server_path(repo_root)?;
     let model_path =
@@ -993,8 +989,10 @@ fn matching_native_llama_backends(provider: &str) -> Vec<crate::config::LlamaSid
         .collect()
 }
 
-fn ensure_native_launch_backend_supported() -> Result<()> {
-    if crate::config::embedding_server_launch_mode()? != EmbeddingServerLaunchMode::NativeSpawned {
+fn ensure_native_launch_backend_supported(runtime: &SidecarRuntimeConfig) -> Result<()> {
+    if crate::config::embedding_server_launch_mode_for_runtime(runtime)?
+        != EmbeddingServerLaunchMode::NativeSpawned
+    {
         return Ok(());
     }
     let Some(request) = crate::embeddings::embedding_accelerator_request() else {
@@ -1455,7 +1453,7 @@ fn spawn_native_embedding_server(
     runtime: &SidecarRuntimeConfig,
     allow_spawn: bool,
 ) -> Result<Option<NativeEmbeddingSpawn>> {
-    let probe = crate::embeddings::probe_product_embedding_runtime();
+    let probe = crate::embeddings::probe_product_embedding_runtime_for_runtime(runtime);
     spawn_native_embedding_server_with_probe(launch, runtime, allow_spawn, probe)
 }
 
@@ -1828,6 +1826,7 @@ mod tests {
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".to_string(),
             labels: std::collections::BTreeMap::new(),
+            ..SidecarRuntimeConfig::local()
         }
     }
 

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -48,6 +48,54 @@ pub const NATIVE_LLAMA_SOURCE_CACHE_REL_PATH: &str = "target/llamacpp/b8840/llam
 const LLAMA_SIDECAR_BACKENDS_JSON: &str = include_str!("../assets/llama-sidecar-backends.json");
 const TEST_HOST_PLATFORM_ENV: &str = "CODESTORY_TEST_HOST_PLATFORM";
 const AGENT_PORT_RESERVATION_GRACE: Duration = Duration::from_secs(10 * 60);
+const RUNTIME_ENV_KEYS: &[&str] = &[
+    "CODESTORY_RETRIEVAL_PROFILE",
+    "CODESTORY_SIDECAR_PROFILE",
+    "CODESTORY_SIDECAR_RUN_ID",
+    "CODESTORY_AGENT_RUN_ID",
+    "CODESTORY_AGENT",
+    "CODESTORY_AGENT_RUN",
+    "CI",
+    "GITHUB_ACTIONS",
+    "CODESTORY_ZOEKT_PORT",
+    "CODESTORY_QDRANT_HTTP_PORT",
+    "CODESTORY_QDRANT_GRPC_PORT",
+    "CODESTORY_EMBED_PORT",
+    "CODESTORY_EMBED_BACKEND",
+    "CODESTORY_EMBED_RUNTIME_MODE",
+    "CODESTORY_EMBED_LLAMACPP_URL",
+    "CODESTORY_EMBED_PROFILE",
+    "CODESTORY_EMBED_MODEL_ID",
+    "CODESTORY_EMBED_POOLING",
+    "CODESTORY_EMBED_QUERY_PREFIX",
+    "CODESTORY_EMBED_DOCUMENT_PREFIX",
+    "CODESTORY_EMBED_LAYER_NORM",
+    "CODESTORY_EMBED_TRUNCATE_DIM",
+    "CODESTORY_EMBED_EXPECTED_DIM",
+    "CODESTORY_EMBED_LLAMACPP_BATCH_SIZE",
+    "CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT",
+    "CODESTORY_ALLOW_REMOTE_EMBEDDINGS",
+    "CODESTORY_EMBED_DEVICE_POLICY",
+    "CODESTORY_EMBED_ALLOW_CPU",
+    "CODESTORY_EMBED_SERVER_LAUNCH",
+    "CODESTORY_EMBED_ONNX_MODEL",
+    "CODESTORY_EMBED_ONNX_TOKENIZER",
+    "CODESTORY_EMBED_ONNX_PROVIDER",
+    "CODESTORY_EMBED_ONNX_THREADS",
+    "CODESTORY_EMBED_ONNX_BATCH_TOKENS",
+    "CODESTORY_HYBRID_RETRIEVAL_ENABLED",
+    "CODESTORY_SEMANTIC_DOC_SCOPE",
+    "CODESTORY_SEMANTIC_DOC_ALIAS_MODE",
+    "CODESTORY_SEMANTIC_DOC_MAX_TOKENS",
+    "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE",
+    "CODESTORY_SEMANTIC_STREAM_PENDING_DOCS",
+    "CODESTORY_SEMANTIC_STREAM_SORT_WINDOW_BATCHES",
+    "CODESTORY_SUMMARY_ENDPOINT",
+    "CODESTORY_SUMMARY_MODEL",
+    "CODESTORY_SUMMARY_API_KEY",
+    "CODESTORY_SUMMARY_MAX_TOKENS",
+    "CODESTORY_SUMMARY_TIMEOUT_SECS",
+];
 
 pub const ZOEKT_HEALTH_BUDGET: Duration = Duration::from_millis(100);
 pub const QDRANT_HEALTH_BUDGET: Duration = Duration::from_millis(200);
@@ -159,6 +207,97 @@ pub enum EmbeddingServerLaunchMode {
     ExternalEndpoint,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingEndpointOrigin {
+    #[default]
+    ManagedSidecar,
+    ProcessEnvironment,
+    TrustedUserConfig,
+    TrustedProjectConfig,
+    BuiltInDefault,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddingRuntimeConfig {
+    pub configuration_error: Option<String>,
+    pub backend: String,
+    pub endpoint: String,
+    pub endpoint_origin: EmbeddingEndpointOrigin,
+    pub profile: String,
+    pub model_id: Option<String>,
+    pub pooling: Option<String>,
+    pub query_prefix: Option<String>,
+    pub document_prefix: Option<String>,
+    pub layer_norm: Option<bool>,
+    pub truncate_dim: Option<usize>,
+    pub expected_dim: Option<usize>,
+    pub batch_size: usize,
+    pub request_count: usize,
+    pub allow_remote: bool,
+    pub device_policy: String,
+    pub server_launch: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SidecarRuntimeDefaults {
+    values: BTreeMap<String, String>,
+}
+
+impl SidecarRuntimeDefaults {
+    pub fn from_process_env() -> Self {
+        Self {
+            values: RUNTIME_ENV_KEYS
+                .iter()
+                .filter_map(|name| {
+                    std::env::var(name)
+                        .ok()
+                        .map(|value| ((*name).to_string(), value))
+                })
+                .collect(),
+        }
+    }
+
+    fn get(&self, name: &str) -> Option<&str> {
+        self.values.get(name).map(String::as_str)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetrievalRuntimeConfig {
+    pub hybrid_enabled: bool,
+    pub semantic_doc_scope: String,
+    pub semantic_doc_alias_mode: String,
+    pub semantic_doc_max_tokens: usize,
+    pub llm_doc_embed_batch_size: usize,
+    pub stream_pending_docs: bool,
+    pub stream_sort_window_batches: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SummaryRuntimeConfig {
+    pub endpoint: Option<String>,
+    pub model: String,
+    pub api_key: Option<String>,
+    pub max_tokens: Option<usize>,
+    pub timeout: Duration,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SidecarRuntimeOverrides {
+    pub embedding_profile: Option<String>,
+    pub embedding_model_id: Option<String>,
+    pub embedding_endpoint: Option<String>,
+    pub embedding_endpoint_origin: Option<EmbeddingEndpointOrigin>,
+    pub embedding_query_prefix: Option<String>,
+    pub embedding_document_prefix: Option<String>,
+    pub hybrid_retrieval_enabled: Option<bool>,
+    pub semantic_doc_scope: Option<String>,
+    pub semantic_doc_alias_mode: Option<String>,
+    pub summary_endpoint: Option<String>,
+    pub summary_model: Option<String>,
+}
+
 impl EmbeddingServerLaunchMode {
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -189,6 +328,8 @@ pub struct SidecarOwnership {
     pub state_file: String,
     pub cleanup_command: String,
     pub ports: SidecarPorts,
+    #[serde(default)]
+    pub embedding_endpoint_origin: EmbeddingEndpointOrigin,
     pub labels: BTreeMap<String, String>,
 }
 
@@ -203,6 +344,9 @@ pub struct SidecarRuntimeConfig {
     pub embed_http_port: u16,
     pub cleanup_command: String,
     pub labels: BTreeMap<String, String>,
+    pub embedding: EmbeddingRuntimeConfig,
+    pub retrieval: RetrievalRuntimeConfig,
+    pub summary: SummaryRuntimeConfig,
 }
 
 impl SidecarLayout {
@@ -211,9 +355,7 @@ impl SidecarLayout {
     }
 
     pub fn from_env_for_project(project_root: &Path) -> Self {
-        let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
-        runtime.activate_embed_url_default();
-        runtime.layout
+        SidecarRuntimeConfig::for_project_auto(project_root).layout
     }
 
     fn from_env_for_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
@@ -221,10 +363,7 @@ impl SidecarLayout {
     }
 
     pub fn from_env_agent(project_root: &Path) -> Self {
-        let runtime =
-            SidecarRuntimeConfig::for_project_profile(Some(project_root), SidecarProfile::Agent);
-        runtime.activate_embed_url_default();
-        runtime.layout
+        SidecarRuntimeConfig::for_project_profile(Some(project_root), SidecarProfile::Agent).layout
     }
 
     pub fn from_env_local(project_root: Option<&Path>) -> Self {
@@ -242,8 +381,27 @@ impl SidecarRuntimeConfig {
     }
 
     pub fn for_project_auto(project_root: &Path) -> Self {
-        let explicit_profile = env_profile();
-        let env_run_id = env_agent_run_id();
+        Self::for_project_auto_with_overrides(project_root, &SidecarRuntimeOverrides::default())
+    }
+
+    pub fn for_project_auto_with_overrides(
+        project_root: &Path,
+        overrides: &SidecarRuntimeOverrides,
+    ) -> Self {
+        Self::for_project_auto_with_defaults(
+            project_root,
+            &SidecarRuntimeDefaults::from_process_env(),
+            overrides,
+        )
+    }
+
+    pub fn for_project_auto_with_defaults(
+        project_root: &Path,
+        defaults: &SidecarRuntimeDefaults,
+        overrides: &SidecarRuntimeOverrides,
+    ) -> Self {
+        let explicit_profile = env_profile(defaults);
+        let env_run_id = env_agent_run_id(defaults);
         let latest_run_id = if explicit_profile.is_none() && env_run_id.is_none() {
             latest_agent_run_id(project_root)
         } else {
@@ -253,9 +411,15 @@ impl SidecarRuntimeConfig {
             explicit_profile,
             env_run_id,
             latest_run_id,
-            running_in_ci_agent(),
+            running_in_ci_agent(defaults),
         );
-        Self::for_project_profile_with_run_id(Some(project_root), profile, run_id.as_deref())
+        Self::for_project_profile_with_run_id_defaults_and_overrides(
+            Some(project_root),
+            profile,
+            run_id.as_deref(),
+            defaults,
+            overrides,
+        )
     }
 
     pub fn for_project_profile(project_root: Option<&Path>, profile: SidecarProfile) -> Self {
@@ -267,11 +431,43 @@ impl SidecarRuntimeConfig {
         profile: SidecarProfile,
         run_id: Option<&str>,
     ) -> Self {
-        Self::for_project_profile_with_run_id_in_cache(
+        Self::for_project_profile_with_run_id_and_overrides(
+            project_root,
+            profile,
+            run_id,
+            &SidecarRuntimeOverrides::default(),
+        )
+    }
+
+    pub fn for_project_profile_with_run_id_and_overrides(
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+        overrides: &SidecarRuntimeOverrides,
+    ) -> Self {
+        Self::for_project_profile_with_run_id_defaults_and_overrides(
+            project_root,
+            profile,
+            run_id,
+            &SidecarRuntimeDefaults::from_process_env(),
+            overrides,
+        )
+    }
+
+    fn for_project_profile_with_run_id_defaults_and_overrides(
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+        defaults: &SidecarRuntimeDefaults,
+        overrides: &SidecarRuntimeOverrides,
+    ) -> Self {
+        Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
             project_root,
             profile,
             run_id,
             &user_cache_root(),
+            defaults,
+            overrides,
         )
     }
 
@@ -282,8 +478,44 @@ impl SidecarRuntimeConfig {
         run_id: Option<&str>,
         cache_root: &Path,
     ) -> Self {
+        Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
+            project_root,
+            profile,
+            run_id,
+            cache_root,
+            &SidecarRuntimeDefaults::from_process_env(),
+            &SidecarRuntimeOverrides::default(),
+        )
+    }
+
+    #[doc(hidden)]
+    pub fn for_project_profile_with_run_id_in_cache_and_overrides(
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+        cache_root: &Path,
+        overrides: &SidecarRuntimeOverrides,
+    ) -> Self {
+        Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
+            project_root,
+            profile,
+            run_id,
+            cache_root,
+            &SidecarRuntimeDefaults::from_process_env(),
+            overrides,
+        )
+    }
+
+    fn for_project_profile_with_run_id_in_cache_defaults_and_overrides(
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+        cache_root: &Path,
+        defaults: &SidecarRuntimeDefaults,
+        overrides: &SidecarRuntimeOverrides,
+    ) -> Self {
         let base = cache_root.to_path_buf();
-        let run_id = (profile == SidecarProfile::Agent).then(|| agent_run_id(run_id));
+        let run_id = (profile == SidecarProfile::Agent).then(|| agent_run_id(run_id, defaults));
         let namespace = namespace_for(project_root, profile, run_id.as_deref());
         let state_file = match profile {
             SidecarProfile::Local => base.join("retrieval-sidecars.json"),
@@ -295,10 +527,18 @@ impl SidecarRuntimeConfig {
         let stored = read_ports_from_state(&state_file);
         let dynamic = profile == SidecarProfile::Agent && stored.is_none();
         let configured_ports = [
-            env_port("CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT),
-            env_port("CODESTORY_QDRANT_HTTP_PORT", DEFAULT_QDRANT_HTTP_PORT),
-            env_port("CODESTORY_QDRANT_GRPC_PORT", DEFAULT_QDRANT_GRPC_PORT),
-            env_port("CODESTORY_EMBED_PORT", DEFAULT_EMBED_HTTP_PORT),
+            env_port(defaults, "CODESTORY_ZOEKT_PORT", DEFAULT_ZOEKT_HTTP_PORT),
+            env_port(
+                defaults,
+                "CODESTORY_QDRANT_HTTP_PORT",
+                DEFAULT_QDRANT_HTTP_PORT,
+            ),
+            env_port(
+                defaults,
+                "CODESTORY_QDRANT_GRPC_PORT",
+                DEFAULT_QDRANT_GRPC_PORT,
+            ),
+            env_port(defaults, "CODESTORY_EMBED_PORT", DEFAULT_EMBED_HTTP_PORT),
         ];
         let dynamic_ports =
             dynamic.then(|| dynamic_agent_ports(&base, &namespace, configured_ports));
@@ -394,6 +634,9 @@ impl SidecarRuntimeConfig {
             labels.insert("dev.codestory.run_id".into(), run_id.to_string());
             labels.insert("dev.codestory.agent_id".into(), run_id.to_string());
         }
+        let embedding = embedding_runtime_config(embed_http_port, defaults, overrides);
+        let retrieval = retrieval_runtime_config(defaults, overrides);
+        let summary = summary_runtime_config(defaults, overrides);
         Self {
             project_identity,
             layout,
@@ -404,6 +647,9 @@ impl SidecarRuntimeConfig {
             embed_http_port,
             cleanup_command,
             labels,
+            embedding,
+            retrieval,
+            summary,
         }
     }
 
@@ -421,8 +667,9 @@ impl SidecarRuntimeConfig {
                 qdrant_http: self.layout.qdrant_http_port,
                 qdrant_grpc: self.layout.qdrant_grpc_port,
                 embed_http: self.embed_http_port,
-                embed_url: SidecarLayout::embed_base_url(self.embed_http_port),
+                embed_url: redacted_embedding_endpoint(&self.embedding.endpoint),
             },
+            embedding_endpoint_origin: self.embedding.endpoint_origin,
             labels: self.labels.clone(),
         }
     }
@@ -444,33 +691,37 @@ impl SidecarRuntimeConfig {
         Ok(())
     }
 
-    pub fn activate_embed_url_default(&self) {
-        let url_missing_or_blank = std::env::var("CODESTORY_EMBED_LLAMACPP_URL")
-            .ok()
-            .is_none_or(|value| value.trim().is_empty());
-        let managed_url = std::env::var(MANAGED_LLAMACPP_URL_ENV).is_ok();
-
-        if url_missing_or_blank || managed_url {
-            // SAFETY: this is command-local setup before sidecar probes/query embedding calls.
-            unsafe {
-                std::env::set_var(
-                    "CODESTORY_EMBED_LLAMACPP_URL",
-                    SidecarLayout::embed_base_url(self.embed_http_port),
-                );
-                std::env::set_var(MANAGED_LLAMACPP_URL_ENV, "1");
-            }
+    pub fn with_profile_and_run_id(
+        &self,
+        project_root: Option<&Path>,
+        profile: SidecarProfile,
+        run_id: Option<&str>,
+    ) -> Self {
+        let cache_root = match self.profile {
+            SidecarProfile::Local => self.layout.state_file.parent(),
+            SidecarProfile::Agent => self
+                .layout
+                .state_file
+                .parent()
+                .and_then(Path::parent)
+                .and_then(Path::parent),
         }
-    }
-
-    pub fn activate_embed_url(&self) {
-        // SAFETY: this is command-local setup before sidecar probes/query embedding calls.
-        unsafe {
-            std::env::set_var(
-                "CODESTORY_EMBED_LLAMACPP_URL",
-                SidecarLayout::embed_base_url(self.embed_http_port),
-            );
-            std::env::set_var(MANAGED_LLAMACPP_URL_ENV, "1");
+        .unwrap_or_else(|| Path::new("."));
+        let mut selected = Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
+            project_root,
+            profile,
+            run_id,
+            cache_root,
+            &SidecarRuntimeDefaults::default(),
+            &SidecarRuntimeOverrides::default(),
+        );
+        selected.embedding = self.embedding.clone();
+        if selected.embedding.endpoint_origin == EmbeddingEndpointOrigin::ManagedSidecar {
+            selected.embedding.endpoint = SidecarLayout::embed_base_url(selected.embed_http_port);
         }
+        selected.retrieval = self.retrieval.clone();
+        selected.summary = self.summary.clone();
+        selected
     }
 }
 
@@ -519,10 +770,229 @@ pub fn sidecar_runtime_auto(project_root: &Path) -> SidecarRuntimeConfig {
     SidecarRuntimeConfig::for_project_auto(project_root)
 }
 
-fn env_profile() -> Option<SidecarProfile> {
-    std::env::var("CODESTORY_RETRIEVAL_PROFILE")
-        .ok()
-        .or_else(|| std::env::var("CODESTORY_SIDECAR_PROFILE").ok())
+fn embedding_runtime_config(
+    embed_http_port: u16,
+    defaults: &SidecarRuntimeDefaults,
+    overrides: &SidecarRuntimeOverrides,
+) -> EmbeddingRuntimeConfig {
+    const REMOVED_ONNX_ENV_VARS: &[&str] = &[
+        "CODESTORY_EMBED_ONNX_MODEL",
+        "CODESTORY_EMBED_ONNX_TOKENIZER",
+        "CODESTORY_EMBED_ONNX_PROVIDER",
+        "CODESTORY_EMBED_ONNX_THREADS",
+        "CODESTORY_EMBED_ONNX_BATCH_TOKENS",
+    ];
+    let configured_backend = default_nonempty(defaults, "CODESTORY_EMBED_BACKEND")
+        .or_else(|| default_nonempty(defaults, "CODESTORY_EMBED_RUNTIME_MODE"))
+        .unwrap_or_else(|| "llamacpp".to_string());
+    let configuration_error = REMOVED_ONNX_ENV_VARS
+        .iter()
+        .find(|name| defaults.get(name).is_some())
+        .map(|name| {
+            format!(
+                "{name} is no longer supported; CodeStory retrieval requires the llama.cpp sidecar"
+            )
+        })
+        .or_else(|| {
+            matches!(
+                configured_backend.trim().to_ascii_lowercase().as_str(),
+                "onnx" | "ort" | "onnxruntime" | "onnx-runtime"
+            )
+            .then(|| {
+                format!(
+                    "embedding backend `{configured_backend}` is no longer supported; CodeStory retrieval requires the llama.cpp sidecar"
+                )
+            })
+        });
+    let env_endpoint = default_nonempty(defaults, "CODESTORY_EMBED_LLAMACPP_URL");
+    let (mut endpoint, mut endpoint_origin) = if let Some(endpoint) = env_endpoint {
+        (endpoint, EmbeddingEndpointOrigin::ProcessEnvironment)
+    } else if let Some(endpoint) = overrides.embedding_endpoint.clone() {
+        (
+            endpoint,
+            overrides
+                .embedding_endpoint_origin
+                .unwrap_or(EmbeddingEndpointOrigin::TrustedUserConfig),
+        )
+    } else {
+        (
+            SidecarLayout::embed_base_url(embed_http_port),
+            EmbeddingEndpointOrigin::ManagedSidecar,
+        )
+    };
+    let mut server_launch = default_nonempty(defaults, "CODESTORY_EMBED_SERVER_LAUNCH");
+    if endpoint_origin != EmbeddingEndpointOrigin::ManagedSidecar {
+        let native_selected = server_launch.as_deref().is_some_and(|mode| {
+            matches!(
+                mode.trim().to_ascii_lowercase().as_str(),
+                "native" | "native_spawned"
+            )
+        });
+        if native_selected {
+            endpoint = SidecarLayout::embed_base_url(embed_http_port);
+            endpoint_origin = EmbeddingEndpointOrigin::ManagedSidecar;
+        } else {
+            server_launch = Some("external_endpoint".to_string());
+        }
+    }
+    EmbeddingRuntimeConfig {
+        configuration_error,
+        backend: configured_backend,
+        endpoint,
+        endpoint_origin,
+        profile: default_nonempty(defaults, "CODESTORY_EMBED_PROFILE")
+            .or_else(|| overrides.embedding_profile.clone())
+            .unwrap_or_else(|| "bge-base-en-v1.5".to_string()),
+        model_id: default_nonempty(defaults, "CODESTORY_EMBED_MODEL_ID")
+            .or_else(|| overrides.embedding_model_id.clone()),
+        pooling: default_nonempty(defaults, "CODESTORY_EMBED_POOLING"),
+        query_prefix: defaults
+            .get("CODESTORY_EMBED_QUERY_PREFIX")
+            .map(str::to_string)
+            .or_else(|| overrides.embedding_query_prefix.clone()),
+        document_prefix: defaults
+            .get("CODESTORY_EMBED_DOCUMENT_PREFIX")
+            .map(str::to_string)
+            .or_else(|| overrides.embedding_document_prefix.clone()),
+        layer_norm: default_optional_bool(defaults, "CODESTORY_EMBED_LAYER_NORM"),
+        truncate_dim: default_bounded_usize(defaults, "CODESTORY_EMBED_TRUNCATE_DIM", 1, 8192),
+        expected_dim: default_bounded_usize(defaults, "CODESTORY_EMBED_EXPECTED_DIM", 1, 8192),
+        batch_size: default_bounded_usize(defaults, "CODESTORY_EMBED_LLAMACPP_BATCH_SIZE", 1, 1024)
+            .unwrap_or(128),
+        request_count: default_bounded_usize(
+            defaults,
+            "CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT",
+            1,
+            16,
+        )
+        .unwrap_or_else(|| {
+            defaults
+                .get("CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT")
+                .filter(|value| {
+                    matches!(
+                        value.trim().to_ascii_lowercase().as_str(),
+                        "auto" | "available_parallelism"
+                    )
+                })
+                .and_then(|_| std::thread::available_parallelism().ok())
+                .map(|value| value.get().clamp(1, 16))
+                .unwrap_or(1)
+        }),
+        allow_remote: default_flag(defaults, "CODESTORY_ALLOW_REMOTE_EMBEDDINGS", false),
+        device_policy: if default_flag(defaults, "CODESTORY_EMBED_ALLOW_CPU", false) {
+            "allow_cpu".to_string()
+        } else {
+            default_nonempty(defaults, "CODESTORY_EMBED_DEVICE_POLICY")
+                .unwrap_or_else(|| "accelerator_required".to_string())
+        },
+        server_launch,
+    }
+}
+
+fn retrieval_runtime_config(
+    defaults: &SidecarRuntimeDefaults,
+    overrides: &SidecarRuntimeOverrides,
+) -> RetrievalRuntimeConfig {
+    RetrievalRuntimeConfig {
+        hybrid_enabled: default_optional_bool(defaults, "CODESTORY_HYBRID_RETRIEVAL_ENABLED")
+            .or(overrides.hybrid_retrieval_enabled)
+            .unwrap_or(true),
+        semantic_doc_scope: default_nonempty(defaults, "CODESTORY_SEMANTIC_DOC_SCOPE")
+            .or_else(|| overrides.semantic_doc_scope.clone())
+            .unwrap_or_else(|| "durable".to_string()),
+        semantic_doc_alias_mode: default_nonempty(defaults, "CODESTORY_SEMANTIC_DOC_ALIAS_MODE")
+            .or_else(|| overrides.semantic_doc_alias_mode.clone())
+            .unwrap_or_else(|| "alias_variant".to_string()),
+        semantic_doc_max_tokens: default_bounded_usize(
+            defaults,
+            "CODESTORY_SEMANTIC_DOC_MAX_TOKENS",
+            16,
+            8192,
+        )
+        .unwrap_or(128),
+        llm_doc_embed_batch_size: default_bounded_usize(
+            defaults,
+            "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE",
+            1,
+            2048,
+        )
+        .unwrap_or(128),
+        stream_pending_docs: default_optional_bool(
+            defaults,
+            "CODESTORY_SEMANTIC_STREAM_PENDING_DOCS",
+        )
+        .unwrap_or(true),
+        stream_sort_window_batches: default_bounded_usize(
+            defaults,
+            "CODESTORY_SEMANTIC_STREAM_SORT_WINDOW_BATCHES",
+            1,
+            16,
+        )
+        .unwrap_or(1),
+    }
+}
+
+fn summary_runtime_config(
+    defaults: &SidecarRuntimeDefaults,
+    overrides: &SidecarRuntimeOverrides,
+) -> SummaryRuntimeConfig {
+    SummaryRuntimeConfig {
+        endpoint: default_nonempty(defaults, "CODESTORY_SUMMARY_ENDPOINT")
+            .or_else(|| overrides.summary_endpoint.clone()),
+        model: default_nonempty(defaults, "CODESTORY_SUMMARY_MODEL")
+            .or_else(|| overrides.summary_model.clone())
+            .unwrap_or_else(|| "codestory-symbol-summary".to_string()),
+        api_key: default_nonempty(defaults, "CODESTORY_SUMMARY_API_KEY"),
+        max_tokens: default_bounded_usize(
+            defaults,
+            "CODESTORY_SUMMARY_MAX_TOKENS",
+            1,
+            u32::MAX as usize,
+        ),
+        timeout: Duration::from_secs(
+            default_bounded_usize(defaults, "CODESTORY_SUMMARY_TIMEOUT_SECS", 1, 300).unwrap_or(30)
+                as u64,
+        ),
+    }
+}
+
+fn default_nonempty(defaults: &SidecarRuntimeDefaults, name: &str) -> Option<String> {
+    defaults
+        .get(name)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn default_optional_bool(defaults: &SidecarRuntimeDefaults, name: &str) -> Option<bool> {
+    defaults
+        .get(name)
+        .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        })
+}
+
+fn default_bounded_usize(
+    defaults: &SidecarRuntimeDefaults,
+    name: &str,
+    min: usize,
+    max: usize,
+) -> Option<usize> {
+    defaults
+        .get(name)
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .map(|value| value.clamp(min, max))
+}
+
+fn default_flag(defaults: &SidecarRuntimeDefaults, name: &str, default: bool) -> bool {
+    default_optional_bool(defaults, name).unwrap_or(default)
+}
+
+fn env_profile(defaults: &SidecarRuntimeDefaults) -> Option<SidecarProfile> {
+    defaults
+        .get("CODESTORY_RETRIEVAL_PROFILE")
+        .or_else(|| defaults.get("CODESTORY_SIDECAR_PROFILE"))
         .and_then(|value| match value.trim().to_ascii_lowercase().as_str() {
             "agent" | "ci" => Some(SidecarProfile::Agent),
             "local" | "dev" => Some(SidecarProfile::Local),
@@ -530,18 +1000,18 @@ fn env_profile() -> Option<SidecarProfile> {
         })
 }
 
-fn env_agent_run_id() -> Option<String> {
-    std::env::var("CODESTORY_SIDECAR_RUN_ID")
-        .ok()
-        .or_else(|| std::env::var("CODESTORY_AGENT_RUN_ID").ok())
-        .and_then(|value| normalized_label_component(&value))
+fn env_agent_run_id(defaults: &SidecarRuntimeDefaults) -> Option<String> {
+    defaults
+        .get("CODESTORY_SIDECAR_RUN_ID")
+        .or_else(|| defaults.get("CODESTORY_AGENT_RUN_ID"))
+        .and_then(normalized_label_component)
 }
 
-fn running_in_ci_agent() -> bool {
-    env_flag("CODESTORY_AGENT", false)
-        || env_flag("CODESTORY_AGENT_RUN", false)
-        || env_flag("CI", false)
-        || env_flag("GITHUB_ACTIONS", false)
+fn running_in_ci_agent(defaults: &SidecarRuntimeDefaults) -> bool {
+    default_flag(defaults, "CODESTORY_AGENT", false)
+        || default_flag(defaults, "CODESTORY_AGENT_RUN", false)
+        || default_flag(defaults, "CI", false)
+        || default_flag(defaults, "GITHUB_ACTIONS", false)
 }
 
 fn auto_runtime_selection(
@@ -627,11 +1097,25 @@ fn latest_agent_run_id(project_root: &Path) -> Option<String> {
     newest.map(|(_, run_id)| run_id)
 }
 
-fn agent_run_id(explicit: Option<&str>) -> String {
+fn agent_run_id(explicit: Option<&str>, defaults: &SidecarRuntimeDefaults) -> String {
     explicit
         .and_then(normalized_label_component)
-        .or_else(env_agent_run_id)
+        .or_else(|| env_agent_run_id(defaults))
         .unwrap_or_else(default_agent_run_id)
+}
+
+pub(crate) fn redacted_embedding_endpoint(endpoint: &str) -> String {
+    let Some((scheme, rest)) = endpoint.split_once("://") else {
+        return "[invalid embedding endpoint]".to_string();
+    };
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let path = &rest[authority_end..];
+    let path_end = path.find(['?', '#']).unwrap_or(path.len());
+    format!("{scheme}://{host}{}", &path[..path_end])
 }
 
 fn default_agent_run_id() -> String {
@@ -1177,18 +1661,17 @@ pub fn retrieval_compose_profile() -> String {
     "real".to_string()
 }
 
-const MANAGED_LLAMACPP_URL_ENV: &str = "CODESTORY_EMBED_LLAMACPP_URL_MANAGED";
-
-fn operator_explicit_llamacpp_endpoint_configured() -> bool {
-    std::env::var("CODESTORY_EMBED_LLAMACPP_URL")
-        .ok()
-        .is_some_and(|value| !value.trim().is_empty())
-        && std::env::var(MANAGED_LLAMACPP_URL_ENV).is_err()
+pub fn embedding_server_launch_mode() -> Result<EmbeddingServerLaunchMode> {
+    embedding_server_launch_mode_for_runtime(&SidecarRuntimeConfig::local())
 }
 
-pub fn embedding_server_launch_mode() -> Result<EmbeddingServerLaunchMode> {
-    if let Some(mode) = std::env::var("CODESTORY_EMBED_SERVER_LAUNCH")
-        .ok()
+pub fn embedding_server_launch_mode_for_runtime(
+    runtime: &SidecarRuntimeConfig,
+) -> Result<EmbeddingServerLaunchMode> {
+    if let Some(mode) = runtime
+        .embedding
+        .server_launch
+        .as_deref()
         .map(|value| value.trim().to_ascii_lowercase())
         .and_then(|value| match value.as_str() {
             "native_spawned" | "native" => Some(EmbeddingServerLaunchMode::NativeSpawned),
@@ -1196,10 +1679,8 @@ pub fn embedding_server_launch_mode() -> Result<EmbeddingServerLaunchMode> {
                 Some(EmbeddingServerLaunchMode::DockerComposeEmbed)
             }
             "external_endpoint" | "external" | "endpoint"
-                if !std::env::var("CODESTORY_EMBED_LLAMACPP_URL")
-                    .unwrap_or_default()
-                    .trim()
-                    .is_empty() =>
+                if runtime.embedding.endpoint_origin != EmbeddingEndpointOrigin::ManagedSidecar
+                    && !runtime.embedding.endpoint.trim().is_empty() =>
             {
                 Some(EmbeddingServerLaunchMode::ExternalEndpoint)
             }
@@ -1208,12 +1689,12 @@ pub fn embedding_server_launch_mode() -> Result<EmbeddingServerLaunchMode> {
     {
         return Ok(mode);
     }
-    if std::env::var("CODESTORY_EMBED_SERVER_LAUNCH").is_ok() {
+    if runtime.embedding.server_launch.is_some() {
         anyhow::bail!(
             "CODESTORY_EMBED_SERVER_LAUNCH must be docker_compose_embed, native_spawned, or external_endpoint"
         );
     }
-    if operator_explicit_llamacpp_endpoint_configured() {
+    if runtime.embedding.endpoint_origin != EmbeddingEndpointOrigin::ManagedSidecar {
         return Ok(EmbeddingServerLaunchMode::ExternalEndpoint);
     }
     let request = crate::embeddings::embedding_accelerator_request();
@@ -1226,24 +1707,14 @@ pub fn embedding_server_launch_mode() -> Result<EmbeddingServerLaunchMode> {
     }
 }
 
-fn env_port(name: &str, default: u16) -> Option<u16> {
-    std::env::var(name).ok().map(|value| {
+fn env_port(defaults: &SidecarRuntimeDefaults, name: &str, default: u16) -> Option<u16> {
+    defaults.get(name).map(|value| {
         value
             .parse()
             .ok()
             .filter(|port| *port != 0)
             .unwrap_or(default)
     })
-}
-
-fn env_flag(name: &str, default: bool) -> bool {
-    match std::env::var(name) {
-        Ok(value) => matches!(
-            value.trim(),
-            "1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON"
-        ),
-        Err(_) => default,
-    }
 }
 
 pub fn dir_size_bytes(path: &Path) -> u64 {
@@ -1777,7 +2248,6 @@ mod tests {
     fn explicit_llamacpp_url_selects_external_endpoint_launch() {
         let _lock = crate::test_support::env_lock();
         let _mode = EnvGuard::remove("CODESTORY_EMBED_SERVER_LAUNCH");
-        let _managed = EnvGuard::remove(MANAGED_LLAMACPP_URL_ENV);
         let _url = EnvGuard::set(
             "CODESTORY_EMBED_LLAMACPP_URL",
             "http://127.0.0.1:37040/v1/embeddings",
@@ -1793,7 +2263,6 @@ mod tests {
     fn blank_llamacpp_url_does_not_select_external_endpoint_launch() {
         let _lock = crate::test_support::env_lock();
         let _mode = EnvGuard::remove("CODESTORY_EMBED_SERVER_LAUNCH");
-        let _managed = EnvGuard::remove(MANAGED_LLAMACPP_URL_ENV);
         let _url = EnvGuard::set("CODESTORY_EMBED_LLAMACPP_URL", " ");
         let _host = EnvGuard::set(TEST_HOST_PLATFORM_ENV, "linux/x86_64");
         let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
@@ -1822,40 +2291,161 @@ mod tests {
     }
 
     #[test]
-    fn managed_llamacpp_url_after_activation_keeps_native_launch() {
+    fn managed_llamacpp_url_keeps_native_launch_without_environment_activation() {
         let _lock = crate::test_support::env_lock();
         let _mode = EnvGuard::remove("CODESTORY_EMBED_SERVER_LAUNCH");
         let _url = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
-        let _managed = EnvGuard::remove(MANAGED_LLAMACPP_URL_ENV);
         let _host = EnvGuard::set(TEST_HOST_PLATFORM_ENV, "windows/x86_64");
         let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
         let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
         let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
 
-        runtime.activate_embed_url_default();
+        assert_eq!(
+            embedding_server_launch_mode_for_runtime(&runtime).expect("launch mode"),
+            EmbeddingServerLaunchMode::NativeSpawned
+        );
+        assert_eq!(
+            runtime.embedding.endpoint,
+            SidecarLayout::embed_base_url(runtime.embed_http_port)
+        );
+    }
+
+    #[test]
+    fn managed_llamacpp_url_is_retained_in_runtime_without_environment_mutation() {
+        let _lock = crate::test_support::env_lock();
+        let _mode = EnvGuard::remove("CODESTORY_EMBED_SERVER_LAUNCH");
+        let _url = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
+        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
 
         assert_eq!(
-            embedding_server_launch_mode().expect("launch mode"),
+            runtime.embedding.endpoint,
+            SidecarLayout::embed_base_url(runtime.embed_http_port)
+        );
+        assert!(std::env::var_os("CODESTORY_EMBED_LLAMACPP_URL").is_none());
+    }
+
+    #[test]
+    fn retained_runtime_profile_selection_does_not_reparse_process_environment() {
+        let _lock = crate::test_support::env_lock();
+        let cache = tempdir().expect("cache");
+        let poison_cache = tempdir().expect("poison cache");
+        let _cache = EnvGuard::remove("CODESTORY_CACHE_ROOT");
+        let _zoekt = EnvGuard::remove("CODESTORY_ZOEKT_PORT");
+        let _endpoint = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
+        let retained = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+            None,
+            SidecarProfile::Local,
+            None,
+            cache.path(),
+        );
+        let _cache = EnvGuard::set(
+            "CODESTORY_CACHE_ROOT",
+            poison_cache.path().to_str().expect("utf8 poison cache"),
+        );
+        let _zoekt = EnvGuard::set("CODESTORY_ZOEKT_PORT", "39999");
+        let _endpoint = EnvGuard::set(
+            "CODESTORY_EMBED_LLAMACPP_URL",
+            "http://127.0.0.1:39998/v1/embeddings",
+        );
+        let _run_id = EnvGuard::set("CODESTORY_AGENT_RUN_ID", "poison-run-id");
+
+        let selected = retained.with_profile_and_run_id(None, SidecarProfile::Local, None);
+        let selected_agent = retained.with_profile_and_run_id(None, SidecarProfile::Agent, None);
+
+        assert_eq!(selected.layout.zoekt_http_port, DEFAULT_ZOEKT_HTTP_PORT);
+        assert_eq!(
+            selected.layout.state_file,
+            cache.path().join("retrieval-sidecars.json")
+        );
+        assert_eq!(selected.embedding, retained.embedding);
+        assert!(!selected.layout.state_file.starts_with(poison_cache.path()));
+        assert_eq!(selected_agent.run_id.as_deref(), Some(DEFAULT_AGENT_RUN_ID));
+        assert!(!selected_agent.namespace.contains("poison-run-id"));
+    }
+
+    #[test]
+    fn retained_runtime_captures_removed_onnx_configuration_error() {
+        let _lock = crate::test_support::env_lock();
+        let _legacy = EnvGuard::set("CODESTORY_EMBED_ONNX_MODEL", "legacy.onnx");
+
+        let runtime = SidecarRuntimeConfig::local();
+
+        let error = runtime
+            .embedding
+            .configuration_error
+            .as_deref()
+            .expect("removed ONNX configuration error");
+        assert!(error.contains("CODESTORY_EMBED_ONNX_MODEL"), "{error}");
+        assert!(error.contains("no longer supported"), "{error}");
+    }
+
+    #[test]
+    fn ownership_redacts_external_embedding_endpoint_secrets() {
+        let mut runtime = SidecarRuntimeConfig::local();
+        runtime.embedding.endpoint =
+            "http://username-secret:password-secret@127.0.0.1:8080/v1/embeddings?token=query-secret#fragment-secret"
+                .into();
+
+        let ownership = runtime.ownership();
+
+        assert_eq!(
+            ownership.ports.embed_url,
+            "http://127.0.0.1:8080/v1/embeddings"
+        );
+        for secret in [
+            "username-secret",
+            "password-secret",
+            "query-secret",
+            "fragment-secret",
+        ] {
+            assert!(!ownership.ports.embed_url.contains(secret));
+        }
+    }
+
+    #[test]
+    fn explicit_native_launch_rewrites_external_endpoint_to_managed_sidecar() {
+        let _lock = crate::test_support::env_lock();
+        let _mode = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "native_spawned");
+        let _url = EnvGuard::set(
+            "CODESTORY_EMBED_LLAMACPP_URL",
+            "http://127.0.0.1:37040/v1/embeddings",
+        );
+        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
+
+        assert_eq!(
+            runtime.embedding.endpoint_origin,
+            EmbeddingEndpointOrigin::ManagedSidecar
+        );
+        assert_eq!(
+            runtime.embedding.endpoint,
+            SidecarLayout::embed_base_url(runtime.embed_http_port)
+        );
+        assert_eq!(
+            embedding_server_launch_mode_for_runtime(&runtime).expect("native launch"),
             EmbeddingServerLaunchMode::NativeSpawned
         );
     }
 
     #[test]
-    fn managed_llamacpp_url_after_activation_retargets_runtime_url() {
+    fn external_endpoint_forces_external_launch_instead_of_managed_launch() {
         let _lock = crate::test_support::env_lock();
-        let _mode = EnvGuard::remove("CODESTORY_EMBED_SERVER_LAUNCH");
-        let _url = EnvGuard::set(
-            "CODESTORY_EMBED_LLAMACPP_URL",
-            "http://127.0.0.1:11111/v1/embeddings",
-        );
-        let _managed = EnvGuard::set(MANAGED_LLAMACPP_URL_ENV, "1");
+        let _mode = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "docker_compose_embed");
+        let endpoint = "http://127.0.0.1:37040/v1/embeddings";
+        let _url = EnvGuard::set("CODESTORY_EMBED_LLAMACPP_URL", endpoint);
         let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
 
-        runtime.activate_embed_url_default();
-
+        assert_eq!(runtime.embedding.endpoint, endpoint);
         assert_eq!(
-            std::env::var("CODESTORY_EMBED_LLAMACPP_URL").expect("managed embed url"),
-            SidecarLayout::embed_base_url(runtime.embed_http_port)
+            runtime.embedding.endpoint_origin,
+            EmbeddingEndpointOrigin::ProcessEnvironment
+        );
+        assert_eq!(
+            runtime.embedding.server_launch.as_deref(),
+            Some("external_endpoint")
+        );
+        assert_eq!(
+            embedding_server_launch_mode_for_runtime(&runtime).expect("external launch"),
+            EmbeddingServerLaunchMode::ExternalEndpoint
         );
     }
 

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -4,7 +4,7 @@
 //! uses **BAAI/bge-base-en-v1.5** (768-dim) via llama.cpp `/v1/embeddings` for query vectors and
 //! semantic smoke checks.
 
-use crate::outbound_http::read_text;
+use crate::outbound_http::read_bytes;
 use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -27,13 +27,7 @@ pub const BGE_QUERY_PREFIX_DEFAULT: &str =
     "Represent this sentence for searching relevant passages: ";
 pub const PRODUCT_EMBEDDING_RUNTIME_ID: &str = "llamacpp:bge-base-en-v1.5";
 
-const LLAMACPP_URL_ENV: &str = "CODESTORY_EMBED_LLAMACPP_URL";
-const DEFAULT_LLAMACPP_URL: &str = "http://127.0.0.1:8080/v1/embeddings";
 const EMBEDDING_BACKEND_ENV: &str = "CODESTORY_EMBED_BACKEND";
-const QUERY_PREFIX_ENV: &str = "CODESTORY_EMBED_QUERY_PREFIX";
-const DOCUMENT_PREFIX_ENV: &str = "CODESTORY_EMBED_DOCUMENT_PREFIX";
-const LLAMACPP_BATCH_SIZE_ENV: &str = "CODESTORY_EMBED_LLAMACPP_BATCH_SIZE";
-const LLAMACPP_REQUEST_COUNT_ENV: &str = "CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT";
 const ALLOW_REMOTE_EMBEDDINGS_ENV: &str = "CODESTORY_ALLOW_REMOTE_EMBEDDINGS";
 const DEVICE_POLICY_ENV: &str = "CODESTORY_EMBED_DEVICE_POLICY";
 const DEVICE_STATE_ENV: &str = "CODESTORY_EMBED_DEVICE_STATE";
@@ -50,9 +44,164 @@ const RUNTIME_EMBED_DEVICE_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(1
 const RUNTIME_EMBED_DEVICE_OBSERVATION_POLL: Duration = Duration::from_millis(250);
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(120);
-const HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
-const DEFAULT_LLAMACPP_BATCH_SIZE: usize = 128;
-const DEFAULT_LLAMACPP_REQUEST_COUNT: usize = 6;
+
+#[derive(Debug, Clone)]
+pub struct LlamaCppEmbeddingClient {
+    config: crate::config::EmbeddingRuntimeConfig,
+}
+
+impl LlamaCppEmbeddingClient {
+    pub fn new(config: &crate::config::EmbeddingRuntimeConfig) -> Result<Self> {
+        if let Some(error) = config.configuration_error.as_deref() {
+            bail!(error.to_string());
+        }
+        ensure_llamacpp_url_allowed_with_policy(&config.endpoint, config.allow_remote)?;
+        Ok(Self {
+            config: config.clone(),
+        })
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.config.endpoint
+    }
+
+    pub fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
+        let prefix = self.config.query_prefix.as_deref().unwrap_or_else(|| {
+            if self.is_llamacpp() {
+                BGE_QUERY_PREFIX_DEFAULT
+            } else {
+                ""
+            }
+        });
+        self.embed_prepared(&format!("{prefix}{text}"))
+    }
+
+    pub fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let prefix = self.config.document_prefix.as_deref().unwrap_or_default();
+        let prepared = texts
+            .iter()
+            .map(|text| format!("{prefix}{text}"))
+            .collect::<Vec<_>>();
+        if prepared.iter().any(|text| text.trim().is_empty()) {
+            bail!("cannot embed empty text");
+        }
+        if self.is_llamacpp() {
+            self.embed_llamacpp_batched(&prepared)
+        } else {
+            Ok(prepared
+                .iter()
+                .map(|text| hash_projection_embed(text, RETRIEVAL_EMBEDDING_DIM))
+                .collect())
+        }
+    }
+
+    pub fn embed_prepared_texts(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        if texts.iter().any(|text| text.trim().is_empty()) {
+            bail!("cannot embed empty text");
+        }
+        if self.is_llamacpp() {
+            self.embed_llamacpp_batched(texts)
+        } else {
+            Ok(texts
+                .iter()
+                .map(|text| hash_projection_embed(text, RETRIEVAL_EMBEDDING_DIM))
+                .collect())
+        }
+    }
+
+    pub fn probe(&self) -> EmbeddingRuntimeProbe {
+        let started = Instant::now();
+        let result = self
+            .embed_query("codestory health probe")
+            .map(|embedding| vec![embedding]);
+        let elapsed_ms = Some(started.elapsed().as_millis().min(u64::MAX as u128) as u64);
+        match result {
+            Ok(vectors) => EmbeddingRuntimeProbe {
+                reachable: true,
+                detail: format!(
+                    "{} embeddings reachable dim={}",
+                    self.backend_label(),
+                    vectors.first().map(|vector| vector.len()).unwrap_or(0)
+                ),
+                elapsed_ms,
+            },
+            Err(error) => EmbeddingRuntimeProbe {
+                reachable: false,
+                detail: format!("{} embeddings unavailable: {error}", self.backend_label()),
+                elapsed_ms,
+            },
+        }
+    }
+
+    pub fn backend_label(&self) -> &'static str {
+        if self.is_llamacpp() {
+            "llamacpp"
+        } else {
+            "hash"
+        }
+    }
+
+    fn is_llamacpp(&self) -> bool {
+        matches!(
+            self.config.backend.trim().to_ascii_lowercase().as_str(),
+            "" | "auto" | "llamacpp" | "llama_cpp" | "llama.cpp" | "llama-cpp" | "gguf"
+        )
+    }
+
+    fn embed_prepared(&self, prepared: &str) -> Result<Vec<f32>> {
+        if prepared.trim().is_empty() {
+            bail!("cannot embed empty text");
+        }
+        if self.is_llamacpp() {
+            llamacpp_embed_with_timeout(&[prepared.to_string()], &self.config, HTTP_TIMEOUT)?
+                .pop()
+                .ok_or_else(|| anyhow!("llama.cpp returned no embedding vector"))
+        } else {
+            Ok(hash_projection_embed(prepared, RETRIEVAL_EMBEDDING_DIM))
+        }
+    }
+
+    fn embed_llamacpp_batched(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        if texts.len() <= self.config.batch_size {
+            return llamacpp_embed_with_timeout(texts, &self.config, HTTP_TIMEOUT);
+        }
+        let batches = texts
+            .chunks(self.config.batch_size)
+            .map(|chunk| chunk.to_vec())
+            .collect::<Vec<_>>();
+        let mut output = Vec::with_capacity(texts.len());
+        for (wave_index, wave) in batches.chunks(self.config.request_count).enumerate() {
+            let mut wave_results = thread::scope(|scope| {
+                let mut handles = Vec::with_capacity(wave.len());
+                for (index, batch) in wave.iter().cloned().enumerate() {
+                    let config = self.config.clone();
+                    handles.push(scope.spawn(move || {
+                        llamacpp_embed_with_timeout(&batch, &config, HTTP_TIMEOUT)
+                            .map(|vectors| (index, vectors))
+                    }));
+                }
+                let mut joined = Vec::with_capacity(handles.len());
+                for handle in handles {
+                    joined.push(
+                        handle
+                            .join()
+                            .map_err(|_| anyhow!("llama.cpp embedding worker panicked"))??,
+                    );
+                }
+                Ok::<_, anyhow::Error>(joined)
+            })
+            .with_context(|| format!("embed llama.cpp request wave {wave_index}"))?;
+            wave_results.sort_by_key(|(index, _)| *index);
+            for (_, vectors) in wave_results {
+                output.extend(vectors);
+            }
+        }
+        Ok(output)
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct EmbeddingRuntimeProbe {
@@ -96,7 +245,16 @@ struct NativeEmbeddingDeviceLaunch {
 
 /// Stable id stored on retrieval manifest rows (backend + model family).
 pub fn embedding_runtime_id() -> String {
-    if llamacpp_backend_selected() {
+    embedding_runtime_id_for_runtime(&crate::config::SidecarRuntimeConfig::local())
+}
+
+pub fn embedding_runtime_id_for_runtime(runtime: &crate::config::SidecarRuntimeConfig) -> String {
+    if runtime
+        .embedding
+        .backend
+        .trim()
+        .eq_ignore_ascii_case("llamacpp")
+    {
         PRODUCT_EMBEDDING_RUNTIME_ID.into()
     } else {
         "hash-projection:768".into()
@@ -114,7 +272,14 @@ pub fn ensure_product_embedding_backend() -> Result<()> {
 pub fn ensure_product_embedding_backend_for_runtime(
     runtime: &crate::config::SidecarRuntimeConfig,
 ) -> Result<()> {
-    ensure_product_embedding_backend_static()?;
+    if !runtime
+        .embedding
+        .backend
+        .trim()
+        .eq_ignore_ascii_case("llamacpp")
+    {
+        bail!("llama.cpp embedding sidecar is mandatory");
+    }
     let deadline = Instant::now() + RUNTIME_EMBED_DEVICE_OBSERVATION_TIMEOUT;
     let mut device = embedding_device_readiness_for_runtime(runtime);
     loop {
@@ -148,19 +313,30 @@ fn ensure_product_embedding_backend_static() -> Result<()> {
 }
 
 pub fn embedding_device_readiness() -> EmbeddingDeviceReadiness {
-    embedding_device_readiness_with_observed_state(None)
+    embedding_device_readiness_with_observed_state(None, None)
 }
 
 pub fn embedding_device_readiness_for_runtime(
     runtime: &crate::config::SidecarRuntimeConfig,
 ) -> EmbeddingDeviceReadiness {
-    embedding_device_readiness_with_observed_state(observe_sidecar_embedding_device_state(runtime))
+    embedding_device_readiness_with_observed_state(
+        observe_sidecar_embedding_device_state(runtime),
+        Some(runtime),
+    )
 }
 
 fn embedding_device_readiness_with_observed_state(
     sidecar_observed_state: Option<EmbeddingDeviceObservation>,
+    runtime: Option<&crate::config::SidecarRuntimeConfig>,
 ) -> EmbeddingDeviceReadiness {
-    let cpu_allowed = explicit_cpu_allowed();
+    let cpu_allowed = runtime
+        .map(|runtime| {
+            runtime
+                .embedding
+                .device_policy
+                .eq_ignore_ascii_case("allow_cpu")
+        })
+        .unwrap_or_else(explicit_cpu_allowed);
     let detection = host_embedding_device_detection();
     let accelerator_request = (!cpu_allowed).then(default_embedding_accelerator_request);
     let accelerator_requested = accelerator_request.is_some();
@@ -205,7 +381,7 @@ fn embedding_device_readiness_with_observed_state(
 fn observe_sidecar_embedding_device_state(
     runtime: &crate::config::SidecarRuntimeConfig,
 ) -> Option<EmbeddingDeviceObservation> {
-    if crate::config::embedding_server_launch_mode()
+    if crate::config::embedding_server_launch_mode_for_runtime(runtime)
         .ok()
         .is_some_and(|mode| mode == crate::config::EmbeddingServerLaunchMode::NativeSpawned)
     {
@@ -636,8 +812,15 @@ fn env_truthy(name: &str) -> bool {
 }
 
 pub fn embed_query(text: &str) -> Result<Vec<f32>> {
-    let prefix = query_prefix();
-    embed_prepared(&format!("{prefix}{text}"))
+    LlamaCppEmbeddingClient::new(&crate::config::SidecarRuntimeConfig::local().embedding)?
+        .embed_query(text)
+}
+
+pub fn embed_query_for_runtime(
+    runtime: &crate::config::SidecarRuntimeConfig,
+    text: &str,
+) -> Result<Vec<f32>> {
+    LlamaCppEmbeddingClient::new(&runtime.embedding)?.embed_query(text)
 }
 
 /// Active embedding backend label for ops/status (`hash`, `llamacpp`).
@@ -649,51 +832,32 @@ pub fn embedding_backend_label() -> &'static str {
     }
 }
 
-pub fn embed_documents(texts: &[String]) -> Result<Vec<Vec<f32>>> {
-    if texts.is_empty() {
-        return Ok(Vec::new());
-    }
-    let prefix = std::env::var(DOCUMENT_PREFIX_ENV).unwrap_or_default();
-    let prepared = texts
-        .iter()
-        .map(|text| format!("{prefix}{text}"))
-        .collect::<Vec<_>>();
-    if prepared.iter().any(|text| text.trim().is_empty()) {
-        bail!("cannot embed empty text");
-    }
-    if llamacpp_backend_selected() {
-        llamacpp_embed_batched(&prepared)
-    } else {
-        Ok(prepared
-            .iter()
-            .map(|text| hash_projection_embed(text, RETRIEVAL_EMBEDDING_DIM))
-            .collect())
-    }
-}
-
-fn query_prefix() -> String {
-    if let Ok(value) = std::env::var(QUERY_PREFIX_ENV)
-        && (!value.is_empty() || !llamacpp_backend_selected())
+pub fn embedding_backend_label_for_runtime(
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> &'static str {
+    if runtime
+        .embedding
+        .backend
+        .trim()
+        .eq_ignore_ascii_case("llamacpp")
     {
-        return value;
+        "llamacpp"
+    } else {
+        "hash"
     }
-    if llamacpp_backend_selected() {
-        return BGE_QUERY_PREFIX_DEFAULT.to_string();
-    }
-    String::new()
 }
 
-fn embed_prepared(prepared: &str) -> Result<Vec<f32>> {
-    if prepared.trim().is_empty() {
-        bail!("cannot embed empty text");
-    }
-    if llamacpp_backend_selected() {
-        llamacpp_embed(&[prepared.to_string()])?
-            .pop()
-            .ok_or_else(|| anyhow!("llama.cpp returned no embedding vector"))
-    } else {
-        Ok(hash_projection_embed(prepared, RETRIEVAL_EMBEDDING_DIM))
-    }
+#[cfg(test)]
+pub fn embed_documents(texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    LlamaCppEmbeddingClient::new(&crate::config::SidecarRuntimeConfig::local().embedding)?
+        .embed_documents(texts)
+}
+
+pub fn embed_documents_for_runtime(
+    runtime: &crate::config::SidecarRuntimeConfig,
+    texts: &[String],
+) -> Result<Vec<Vec<f32>>> {
+    LlamaCppEmbeddingClient::new(&runtime.embedding)?.embed_documents(texts)
 }
 
 fn llamacpp_backend_selected() -> bool {
@@ -706,106 +870,29 @@ fn llamacpp_backend_selected() -> bool {
     }
 }
 
-fn llamacpp_embed(texts: &[String]) -> Result<Vec<Vec<f32>>> {
-    let url = llamacpp_url()?;
-    llamacpp_embed_with_timeout(texts, &url, HTTP_TIMEOUT)
-}
-
-fn llamacpp_embed_batched(texts: &[String]) -> Result<Vec<Vec<f32>>> {
-    let batch_size = env_usize(
-        LLAMACPP_BATCH_SIZE_ENV,
-        DEFAULT_LLAMACPP_BATCH_SIZE,
-        1,
-        1024,
-    );
-    let request_count = env_usize(
-        LLAMACPP_REQUEST_COUNT_ENV,
-        DEFAULT_LLAMACPP_REQUEST_COUNT,
-        1,
-        16,
-    );
-    if texts.len() <= batch_size {
-        return llamacpp_embed(texts);
-    }
-
-    let url = llamacpp_url()?;
-    let batches = texts
-        .chunks(batch_size)
-        .map(|chunk| chunk.to_vec())
-        .collect::<Vec<_>>();
-    let mut output = Vec::with_capacity(texts.len());
-    for (wave_index, wave) in batches.chunks(request_count).enumerate() {
-        let mut wave_results = thread::scope(|scope| {
-            let mut handles = Vec::with_capacity(wave.len());
-            for (index, batch) in wave.iter().cloned().enumerate() {
-                let url = url.clone();
-                handles.push(scope.spawn(move || {
-                    llamacpp_embed_with_timeout(&batch, &url, HTTP_TIMEOUT)
-                        .map(|vectors| (index, vectors))
-                }));
-            }
-            let mut joined = Vec::with_capacity(handles.len());
-            for handle in handles {
-                joined.push(
-                    handle
-                        .join()
-                        .map_err(|_| anyhow!("llama.cpp embedding worker panicked"))??,
-                );
-            }
-            Ok::<_, anyhow::Error>(joined)
-        })
-        .with_context(|| format!("embed llama.cpp request wave {wave_index}"))?;
-        wave_results.sort_by_key(|(index, _)| *index);
-        for (_, vectors) in wave_results {
-            output.extend(vectors);
-        }
-    }
-    Ok(output)
-}
-
-fn env_usize(name: &str, default: usize, min: usize, max: usize) -> usize {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .map(|value| value.clamp(min, max))
-        .unwrap_or(default)
-}
-
 pub fn probe_product_embedding_runtime() -> EmbeddingRuntimeProbe {
-    let started = Instant::now();
-    let result = llamacpp_url().and_then(|url| {
-        llamacpp_embed_with_timeout(
-            &["codestory health probe".to_string()],
-            &url,
-            HEALTH_TIMEOUT,
-        )
-    });
-    let elapsed_ms = Some(started.elapsed().as_millis().min(u64::MAX as u128) as u64);
-    match result {
-        Ok(vectors) => EmbeddingRuntimeProbe {
-            reachable: true,
-            detail: format!(
-                "llama.cpp embeddings reachable dim={}",
-                vectors.first().map(|vector| vector.len()).unwrap_or(0)
-            ),
-            elapsed_ms,
-        },
-        Err(error) => EmbeddingRuntimeProbe {
+    probe_product_embedding_runtime_for_runtime(&crate::config::SidecarRuntimeConfig::local())
+}
+
+pub fn probe_product_embedding_runtime_for_runtime(
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> EmbeddingRuntimeProbe {
+    LlamaCppEmbeddingClient::new(&runtime.embedding)
+        .map(|client| client.probe())
+        .unwrap_or_else(|error| EmbeddingRuntimeProbe {
             reachable: false,
             detail: format!("llama.cpp embeddings unavailable: {error}"),
-            elapsed_ms,
-        },
-    }
+            elapsed_ms: None,
+        })
 }
 
-fn llamacpp_url() -> Result<String> {
-    let url = std::env::var(LLAMACPP_URL_ENV).unwrap_or_else(|_| DEFAULT_LLAMACPP_URL.to_string());
-    ensure_llamacpp_url_allowed(&url)?;
-    Ok(url)
-}
-
+#[cfg(test)]
 fn ensure_llamacpp_url_allowed(url: &str) -> Result<()> {
-    if !allow_remote_embeddings() && !is_loopback_embedding_url(url) {
+    ensure_llamacpp_url_allowed_with_policy(url, allow_remote_embeddings())
+}
+
+fn ensure_llamacpp_url_allowed_with_policy(url: &str, allow_remote: bool) -> Result<()> {
+    if !allow_remote && !is_loopback_embedding_url(url) {
         bail!(
             "remote embedding URL is disabled; use a loopback URL or set {ALLOW_REMOTE_EMBEDDINGS_ENV}=1"
         );
@@ -813,6 +900,7 @@ fn ensure_llamacpp_url_allowed(url: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn allow_remote_embeddings() -> bool {
     std::env::var(ALLOW_REMOTE_EMBEDDINGS_ENV)
         .ok()
@@ -849,26 +937,42 @@ fn http_url_host(url: &str) -> Option<&str> {
 
 fn llamacpp_embed_with_timeout(
     texts: &[String],
-    url: &str,
+    config: &crate::config::EmbeddingRuntimeConfig,
     timeout: Duration,
 ) -> Result<Vec<Vec<f32>>> {
+    let model = config
+        .model_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&config.profile);
     let body = serde_json::json!({
         "input": texts,
-        "model": "bge-base-en-v1.5",
+        "model": model,
     });
     let payload = serde_json::to_string(&body).context("serialize embeddings request")?;
-    let response = read_text(
-        ureq::post(url)
+    let display_endpoint = crate::config::redacted_embedding_endpoint(&config.endpoint);
+    let agent = ureq::builder().redirects(0).build();
+    let response = read_bytes(
+        agent
+            .post(&config.endpoint)
             .timeout(timeout)
             .set("Content-Type", "application/json")
             .send_string(&payload),
     )
-    .map_err(|error| anyhow!("llama.cpp embeddings request failed: {error}"))?;
+    .map_err(|error| {
+        anyhow!(
+            "llama.cpp embeddings request to {display_endpoint} failed: {}",
+            redact_embedding_error(&config.endpoint, &error.to_string())
+        )
+    })?;
     let status = response.status;
     if !(200..300).contains(&status) {
-        bail!("llama.cpp embeddings http {status}");
+        bail!("llama.cpp embeddings endpoint {display_endpoint} returned HTTP {status}");
     }
-    parse_openai_embeddings(&response.body, true)
+    let response_body = std::str::from_utf8(&response.body)
+        .with_context(|| format!("decode UTF-8 JSON from llama.cpp endpoint {display_endpoint}"))?;
+    parse_openai_embeddings(response_body, texts.len(), expected_embedding_dim(config))
+        .with_context(|| format!("parse response from llama.cpp endpoint {display_endpoint}"))
 }
 
 #[derive(Deserialize)]
@@ -878,27 +982,118 @@ struct OpenAiEmbeddingsResponse {
 
 #[derive(Deserialize)]
 struct OpenAiEmbeddingRow {
+    index: Option<usize>,
     embedding: Vec<f32>,
 }
 
-fn parse_openai_embeddings(body: &str, require_llamacpp_dim: bool) -> Result<Vec<Vec<f32>>> {
+fn parse_openai_embeddings(
+    body: &str,
+    expected_count: usize,
+    expected_dim: Option<usize>,
+) -> Result<Vec<Vec<f32>>> {
     let parsed: OpenAiEmbeddingsResponse =
         serde_json::from_str(body).context("parse llama.cpp embeddings json")?;
-    if parsed.data.is_empty() {
-        bail!("llama.cpp embeddings response had no data rows");
+    if parsed.data.len() != expected_count {
+        bail!(
+            "llama.cpp embeddings response returned {} vectors for {expected_count} inputs",
+            parsed.data.len()
+        );
     }
-    let mut vectors = Vec::with_capacity(parsed.data.len());
+    let mut indexed = Vec::with_capacity(parsed.data.len());
+    let mut seen = std::collections::BTreeSet::new();
     for row in parsed.data {
-        if require_llamacpp_dim && row.embedding.len() != RETRIEVAL_EMBEDDING_DIM {
+        let index = row
+            .index
+            .ok_or_else(|| anyhow!("llama.cpp embeddings response row missing `index`"))?;
+        if index >= expected_count {
+            bail!("llama.cpp embeddings response index {index} is outside 0..{expected_count}");
+        }
+        if !seen.insert(index) {
+            bail!("llama.cpp embeddings response duplicated index {index}");
+        }
+        if expected_dim.is_some_and(|expected| row.embedding.len() != expected) {
+            let expected_dim = expected_dim.expect("checked above");
             bail!(
-                "llama.cpp embedding dim {} != expected {} (bge-base-en-v1.5); check model GGUF and CODESTORY_EMBED_BACKEND",
+                "llama.cpp embedding dim {} != expected {}; check the configured model profile and GGUF",
                 row.embedding.len(),
-                RETRIEVAL_EMBEDDING_DIM
+                expected_dim
             );
         }
-        vectors.push(row.embedding);
+        indexed.push((index, row.embedding));
     }
-    Ok(vectors)
+    indexed.sort_by_key(|(index, _)| *index);
+    Ok(indexed.into_iter().map(|(_, vector)| vector).collect())
+}
+
+fn expected_embedding_dim(config: &crate::config::EmbeddingRuntimeConfig) -> Option<usize> {
+    config
+        .expected_dim
+        .or(config.truncate_dim)
+        .or_else(|| named_embedding_profile_dim(&config.profile))
+}
+
+fn named_embedding_profile_dim(profile: &str) -> Option<usize> {
+    match profile.trim().to_ascii_lowercase().as_str() {
+        "minilm" | "minilm-l6-v2" | "all-minilm-l6-v2" | "bge-small" | "bge-small-en-v1.5" => {
+            Some(384)
+        }
+        "bge-base"
+        | "bge-base-en-v1.5"
+        | "baai/bge-base-en-v1.5"
+        | "embeddinggemma"
+        | "embeddinggemma-300m"
+        | "gemma"
+        | "gemma-embedding-300m"
+        | "google/embeddinggemma-300m"
+        | "nomic"
+        | "nomic-v1.5"
+        | "nomic-embed-text-v1.5"
+        | "nomic-v2"
+        | "nomic-embed-text-v2"
+        | "nomic-embed-text-v2-moe" => Some(768),
+        "qwen" | "qwen3" | "qwen3-embedding-0.6b" | "qwen/qwen3-embedding-0.6b" => Some(1024),
+        _ => None,
+    }
+}
+
+fn redact_embedding_error(endpoint: &str, error: &str) -> String {
+    let display = crate::config::redacted_embedding_endpoint(endpoint);
+    let mut redacted = error.replace(endpoint, &display);
+    let rest = endpoint
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(endpoint);
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    if let Some((userinfo, host)) = authority.rsplit_once('@') {
+        redacted = redacted
+            .replace(authority, host)
+            .replace(userinfo, "[redacted]");
+        for secret in userinfo.split(':') {
+            if !secret.is_empty() {
+                redacted = redacted.replace(secret, "[redacted]");
+            }
+        }
+    }
+    if let Some(query) = endpoint.split_once('?').map(|(_, value)| value) {
+        let query = query.split('#').next().unwrap_or_default();
+        if !query.is_empty() {
+            redacted = redacted.replace(query, "[redacted]");
+        }
+        for value in query
+            .split('&')
+            .filter_map(|pair| pair.split_once('=').map(|(_, value)| value))
+            .filter(|value| !value.is_empty())
+        {
+            redacted = redacted.replace(value, "[redacted]");
+        }
+    }
+    if let Some(fragment) = endpoint.split_once('#').map(|(_, value)| value)
+        && !fragment.is_empty()
+    {
+        redacted = redacted.replace(fragment, "[redacted]");
+    }
+    redacted
 }
 
 /// Same algorithm as `codestory_runtime::search::engine::embed_text_with_hash_projection`.
@@ -952,6 +1147,271 @@ mod tests {
     use super::*;
     use crate::config::{SidecarLayout, SidecarProfile, SidecarRuntimeConfig};
     use std::collections::BTreeMap;
+    use std::io::Write;
+    use std::net::TcpListener;
+
+    fn llama_client_config(endpoint: String) -> crate::config::EmbeddingRuntimeConfig {
+        crate::config::EmbeddingRuntimeConfig {
+            configuration_error: None,
+            backend: "llamacpp".into(),
+            endpoint,
+            endpoint_origin: crate::config::EmbeddingEndpointOrigin::TrustedProjectConfig,
+            profile: "custom".into(),
+            model_id: Some("retained-model-id".into()),
+            pooling: None,
+            query_prefix: None,
+            document_prefix: None,
+            layer_norm: None,
+            truncate_dim: None,
+            expected_dim: Some(3),
+            batch_size: 128,
+            request_count: 1,
+            allow_remote: false,
+            device_policy: "allow_cpu".into(),
+            server_launch: Some("external_endpoint".into()),
+        }
+    }
+
+    fn one_shot_embedding_server(
+        status: &str,
+        headers: &str,
+        body: String,
+    ) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding server");
+        let url = format!(
+            "http://{}/v1/embeddings",
+            listener.local_addr().expect("embedding server address")
+        );
+        let status = status.to_string();
+        let headers = headers.to_string();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept embedding request");
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            loop {
+                let read = stream.read(&mut buffer).expect("read embedding request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                let Some(header_end) = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|index| index + 4)
+                else {
+                    continue;
+                };
+                let header = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = header
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+                if request.len().saturating_sub(header_end) >= content_length {
+                    break;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 {status}\r\n{headers}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write embedding response");
+            String::from_utf8(request).expect("embedding request utf8")
+        });
+        (url, handle)
+    }
+
+    #[test]
+    fn openai_embedding_rows_are_sorted_by_index() {
+        let body = serde_json::json!({"data": [
+            {"index": 1, "embedding": [0.0, 1.0, 0.0]},
+            {"index": 0, "embedding": [1.0, 0.0, 0.0]}
+        ]})
+        .to_string();
+
+        let vectors = parse_openai_embeddings(&body, 2, Some(3)).expect("parse rows");
+
+        assert_eq!(vectors[0], vec![1.0, 0.0, 0.0]);
+        assert_eq!(vectors[1], vec![0.0, 1.0, 0.0]);
+    }
+
+    #[test]
+    fn openai_embedding_rows_reject_invalid_index_sets_and_counts() {
+        for (body, expected_count, expected) in [
+            (
+                serde_json::json!({"data": [
+                    {"index": 0, "embedding": [1.0]},
+                    {"index": 0, "embedding": [2.0]}
+                ]})
+                .to_string(),
+                2,
+                "duplicated index 0",
+            ),
+            (
+                serde_json::json!({"data": [{"embedding": [1.0]}]}).to_string(),
+                1,
+                "missing `index`",
+            ),
+            (
+                serde_json::json!({"data": [{"index": 2, "embedding": [1.0]}]}).to_string(),
+                1,
+                "outside 0..1",
+            ),
+            (
+                serde_json::json!({"data": [{"index": 0, "embedding": [1.0]}]}).to_string(),
+                2,
+                "1 vectors for 2 inputs",
+            ),
+            (
+                serde_json::json!({"data": [
+                    {"index": 0, "embedding": [1.0]},
+                    {"index": 1, "embedding": [2.0]}
+                ]})
+                .to_string(),
+                1,
+                "2 vectors for 1 inputs",
+            ),
+        ] {
+            let error = parse_openai_embeddings(&body, expected_count, None)
+                .expect_err("invalid response must fail");
+            assert!(error.to_string().contains(expected), "{error:#}");
+        }
+    }
+
+    #[test]
+    fn named_embedding_profiles_supply_dimensions_with_explicit_precedence() {
+        let mut config = llama_client_config("http://127.0.0.1:8080/v1/embeddings".into());
+        config.expected_dim = None;
+        config.profile = "qwen3-embedding-0.6b".into();
+        assert_eq!(expected_embedding_dim(&config), Some(1024));
+        config.truncate_dim = Some(256);
+        assert_eq!(expected_embedding_dim(&config), Some(256));
+        config.expected_dim = Some(128);
+        assert_eq!(expected_embedding_dim(&config), Some(128));
+    }
+
+    #[test]
+    fn production_llamacpp_client_uses_retained_model_and_sorted_rows() -> Result<()> {
+        let response = serde_json::json!({"data": [
+            {"index": 1, "embedding": [0.0, 1.0, 0.0]},
+            {"index": 0, "embedding": [1.0, 0.0, 0.0]}
+        ]})
+        .to_string();
+        let (url, request) = one_shot_embedding_server("200 OK", "", response);
+        let client = LlamaCppEmbeddingClient::new(&llama_client_config(url))?;
+
+        let vectors = client.embed_prepared_texts(&["alpha".into(), "beta".into()])?;
+        let request = request.join().expect("embedding server thread");
+
+        assert_eq!(vectors[0], vec![1.0, 0.0, 0.0]);
+        assert_eq!(vectors[1], vec![0.0, 1.0, 0.0]);
+        assert!(request.contains("retained-model-id"), "{request}");
+        Ok(())
+    }
+
+    #[test]
+    fn production_llamacpp_client_rejects_redirects_and_redacts_endpoint_secrets() -> Result<()> {
+        let (url, request) = one_shot_embedding_server(
+            "302 Found",
+            "Location: http://127.0.0.1:9/redirected\r\n",
+            "redirect".into(),
+        );
+        let secret_url = format!(
+            "{}?token=query-secret#fragment-secret",
+            url.replacen("http://", "http://username-secret:password-secret@", 1)
+        );
+        let error = LlamaCppEmbeddingClient::new(&llama_client_config(secret_url))?
+            .embed_prepared_texts(&["alpha".into()])
+            .expect_err("redirect must not be followed");
+        request.join().expect("embedding server thread");
+
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("302"), "{rendered}");
+        for secret in [
+            "username-secret",
+            "password-secret",
+            "query-secret",
+            "fragment-secret",
+        ] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn production_llamacpp_transport_errors_redact_endpoint_secrets() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let address = listener.local_addr()?;
+        drop(listener);
+        let endpoint = format!(
+            "http://username-secret:password-secret@{address}/v1/embeddings?token=query-secret#fragment-secret"
+        );
+        let error = LlamaCppEmbeddingClient::new(&llama_client_config(endpoint))?
+            .embed_prepared_texts(&["alpha".into()])
+            .expect_err("closed endpoint must fail");
+
+        let rendered = format!("{error:#}");
+        for secret in [
+            "username-secret",
+            "password-secret",
+            "query-secret",
+            "fragment-secret",
+        ] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn production_llamacpp_invalid_json_errors_redact_endpoint_secrets() -> Result<()> {
+        let (url, request) = one_shot_embedding_server("200 OK", "", "invalid".into());
+        let endpoint = format!(
+            "{}?token=query-secret#fragment-secret",
+            url.replacen("http://", "http://username-secret:password-secret@", 1)
+        );
+        let error = LlamaCppEmbeddingClient::new(&llama_client_config(endpoint))?
+            .embed_prepared_texts(&["alpha".into()])
+            .expect_err("invalid JSON must fail");
+        request.join().expect("embedding server thread");
+
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("parse llama.cpp embeddings json"),
+            "{rendered}"
+        );
+        for secret in [
+            "username-secret",
+            "password-secret",
+            "query-secret",
+            "fragment-secret",
+        ] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn production_llamacpp_client_accepts_json_over_ten_mib() -> Result<()> {
+        let response = serde_json::json!({
+            "padding": "x".repeat(10 * 1024 * 1024 + 1),
+            "data": [{"index": 0, "embedding": [1.0, 0.0, 0.0]}]
+        })
+        .to_string();
+        let (url, request) = one_shot_embedding_server("200 OK", "", response);
+
+        let vectors = LlamaCppEmbeddingClient::new(&llama_client_config(url))?
+            .embed_prepared_texts(&["alpha".into()])?;
+        request.join().expect("embedding server thread");
+
+        assert_eq!(vectors, vec![vec![1.0, 0.0, 0.0]]);
+        Ok(())
+    }
 
     #[test]
     fn hash_projection_dim_matches_retrieval_embedding_dim() {
@@ -1306,11 +1766,13 @@ mod tests {
         let observed = observed_embedding_device_state_from_text(
             "llama_model_load: offloaded 33/33 layers to GPU\n",
         );
-        let readiness =
-            embedding_device_readiness_with_observed_state(Some(EmbeddingDeviceObservation {
+        let readiness = embedding_device_readiness_with_observed_state(
+            Some(EmbeddingDeviceObservation {
                 state: observed,
                 source: "sidecar_log",
-            }));
+            }),
+            None,
+        );
 
         assert_eq!(observed, "accelerated");
         assert_eq!(readiness.requested_policy, "accelerator_required");
@@ -1345,7 +1807,7 @@ mod tests {
         let _host_detect = EnvGuard::remove(DISABLE_HOST_GPU_DETECT_ENV);
 
         let observed = observed_embedding_device_state_from_text("server listening on 0.0.0.0");
-        let readiness = embedding_device_readiness_with_observed_state(None);
+        let readiness = embedding_device_readiness_with_observed_state(None, None);
 
         assert_eq!(observed, "unknown");
         assert_eq!(readiness.requested_policy, "accelerator_required");
@@ -1369,11 +1831,13 @@ mod tests {
         let _name = EnvGuard::set(DEVICE_NAME_ENV, "AMD Radeon RX 7900 XT");
         let _host_detect = EnvGuard::remove(DISABLE_HOST_GPU_DETECT_ENV);
 
-        let readiness =
-            embedding_device_readiness_with_observed_state(Some(EmbeddingDeviceObservation {
+        let readiness = embedding_device_readiness_with_observed_state(
+            Some(EmbeddingDeviceObservation {
                 state: "accelerated",
                 source: "native_log",
-            }));
+            }),
+            None,
+        );
 
         assert_eq!(readiness.observed_state, "accelerated");
         assert_eq!(readiness.observation_source, "native_log");
@@ -1411,11 +1875,13 @@ mod tests {
         let _name = EnvGuard::set(DEVICE_NAME_ENV, "AMD Radeon RX 7900 XT");
         let _host_detect = EnvGuard::remove(DISABLE_HOST_GPU_DETECT_ENV);
 
-        let readiness =
-            embedding_device_readiness_with_observed_state(Some(EmbeddingDeviceObservation {
+        let readiness = embedding_device_readiness_with_observed_state(
+            Some(EmbeddingDeviceObservation {
                 state: "accelerated",
                 source: "native_device_list",
-            }));
+            }),
+            None,
+        );
 
         assert_eq!(readiness.observed_state, "accelerated");
         assert_eq!(readiness.observation_source, "native_device_list");
@@ -1612,6 +2078,7 @@ mod tests {
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".into(),
             labels: BTreeMap::new(),
+            ..SidecarRuntimeConfig::local()
         };
         std::fs::create_dir_all(runtime.layout.state_file.parent().expect("state parent"))
             .expect("create state dir");
@@ -1662,6 +2129,7 @@ mod tests {
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".into(),
             labels: BTreeMap::new(),
+            ..SidecarRuntimeConfig::local()
         };
         std::fs::create_dir_all(runtime.layout.state_file.parent().expect("state parent"))
             .expect("create state dir");

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -1,6 +1,9 @@
 use crate::cache::{RetrievalCache, RetrievalCacheKey};
 use crate::candidate::CandidateHit;
-use crate::health::{probe_sidecar_health, probe_sidecar_health_with_embedding_device};
+use crate::health::{
+    probe_sidecar_health, probe_sidecar_health_for_runtime,
+    probe_sidecar_health_with_embedding_device,
+};
 use crate::index::query_fingerprint;
 use crate::mode::{RetrievalDegradedMode, derive_degraded_mode};
 use crate::planner::{PlannedStage, RetrievalStageKind};
@@ -189,8 +192,18 @@ impl<'a> QueryExecutor<'a> {
                     Some("sidecar_layout_missing".into()),
                 );
             };
-            let report = if let Some(embedding_device) = self.sidecars.embedding_device_readiness()
-            {
+            let report = if let (Some(embedding_device), Some(runtime)) = (
+                self.sidecars.embedding_device_readiness(),
+                self.sidecars.runtime_config(),
+            ) {
+                probe_sidecar_health_for_runtime(
+                    layout,
+                    &manifest.project_id,
+                    Some(manifest.clone()),
+                    embedding_device,
+                    runtime,
+                )
+            } else if let Some(embedding_device) = self.sidecars.embedding_device_readiness() {
                 probe_sidecar_health_with_embedding_device(
                     layout,
                     &manifest.project_id,

--- a/crates/codestory-retrieval/src/generation.rs
+++ b/crates/codestory-retrieval/src/generation.rs
@@ -45,11 +45,24 @@ pub fn manifest_has_current_sidecar_contract(
         && manifest.dense_reason_counts_json.is_some()
 }
 
+#[cfg(test)]
 pub fn manifest_staleness_reason(
     storage: &Store,
     manifest: &RetrievalIndexManifest,
 ) -> Option<String> {
-    let embedding_backend = crate::embeddings::embedding_runtime_id();
+    manifest_staleness_reason_for_runtime(
+        storage,
+        manifest,
+        &crate::config::SidecarRuntimeConfig::local(),
+    )
+}
+
+pub fn manifest_staleness_reason_for_runtime(
+    storage: &Store,
+    manifest: &RetrievalIndexManifest,
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> Option<String> {
+    let embedding_backend = crate::embeddings::embedding_runtime_id_for_runtime(runtime);
     if manifest.embedding_backend.as_deref() != Some(embedding_backend.as_str()) {
         return Some(format!(
             "sidecar_embedding_backend_changed: manifest={} current={embedding_backend}",
@@ -156,15 +169,30 @@ pub fn manifest_staleness_reason(
     }
 }
 
+#[cfg(test)]
 pub fn manifest_unavailable_reason(
     project_id: &str,
     storage: &Store,
     manifest: &RetrievalIndexManifest,
 ) -> Option<String> {
+    manifest_unavailable_reason_for_runtime(
+        project_id,
+        storage,
+        manifest,
+        &crate::config::SidecarRuntimeConfig::local(),
+    )
+}
+
+pub fn manifest_unavailable_reason_for_runtime(
+    project_id: &str,
+    storage: &Store,
+    manifest: &RetrievalIndexManifest,
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> Option<String> {
     if !manifest_has_current_sidecar_contract(project_id, manifest) {
         return Some("sidecar_manifest_generation_contract_missing".into());
     }
-    manifest_staleness_reason(storage, manifest)
+    manifest_staleness_reason_for_runtime(storage, manifest, runtime)
         .map(|reason| format!("sidecar_manifest_stale: {reason}"))
 }
 

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -473,6 +473,7 @@ struct QdrantCapabilityProbe {
     semantic_failure_reason: String,
 }
 
+#[cfg(test)]
 fn qdrant_capabilities(
     layout: &SidecarLayout,
     collection: &str,
@@ -480,6 +481,26 @@ fn qdrant_capabilities(
     expected_points: Option<u64>,
     product_embedding_backend: bool,
     current_product_embedding_backend: bool,
+) -> QdrantCapabilityProbe {
+    qdrant_capabilities_for_runtime(
+        layout,
+        collection,
+        probe,
+        expected_points,
+        product_embedding_backend,
+        current_product_embedding_backend,
+        &crate::config::SidecarRuntimeConfig::local(),
+    )
+}
+
+fn qdrant_capabilities_for_runtime(
+    layout: &SidecarLayout,
+    collection: &str,
+    probe: &crate::qdrant_client::QdrantHealthProbe,
+    expected_points: Option<u64>,
+    product_embedding_backend: bool,
+    current_product_embedding_backend: bool,
+    runtime: &crate::config::SidecarRuntimeConfig,
 ) -> QdrantCapabilityProbe {
     if !probe.reachable || !probe.collection_exists {
         return qdrant_capability_failure("qdrant_unreachable");
@@ -496,7 +517,12 @@ fn qdrant_capabilities(
     if !current_product_embedding_backend {
         return qdrant_capability_failure("qdrant_current_embedding_backend_not_product");
     }
-    let client = QdrantClient::new(layout);
+    let client = match QdrantClient::for_runtime(runtime) {
+        Ok(client) => client,
+        Err(error) => {
+            return qdrant_capability_failure(format!("embedding_runtime_unavailable: {error:#}"));
+        }
+    };
     match client.semantic_search_smoke_result(collection) {
         Ok(()) => QdrantCapabilityProbe {
             capabilities: SidecarCapabilities {
@@ -588,6 +614,17 @@ pub fn probe_sidecar_health_with_embedding_device(
     manifest: Option<codestory_store::RetrievalIndexManifest>,
     embedding_device: &EmbeddingDeviceReadiness,
 ) -> RetrievalStatusReport {
+    let runtime = crate::config::SidecarRuntimeConfig::local();
+    probe_sidecar_health_for_runtime(layout, project_id, manifest, embedding_device, &runtime)
+}
+
+pub fn probe_sidecar_health_for_runtime(
+    layout: &SidecarLayout,
+    project_id: &str,
+    manifest: Option<codestory_store::RetrievalIndexManifest>,
+    embedding_device: &EmbeddingDeviceReadiness,
+    runtime: &crate::config::SidecarRuntimeConfig,
+) -> RetrievalStatusReport {
     if let Some(manifest) = manifest.as_ref() {
         if !manifest_has_current_sidecar_contract(project_id, manifest) {
             return unavailable_status_report_with_embedding_device(
@@ -637,7 +674,7 @@ pub fn probe_sidecar_health_with_embedding_device(
         capabilities: zoekt_capabilities,
     };
 
-    let current_embedding_backend = crate::embeddings::embedding_runtime_id();
+    let current_embedding_backend = crate::embeddings::embedding_runtime_id_for_runtime(runtime);
     let dense_anchor_count = manifest
         .dense_projection_count
         .or(manifest.projection_count)
@@ -654,13 +691,14 @@ pub fn probe_sidecar_health_with_embedding_device(
             manifest_embedding_backend_is_product(manifest.embedding_backend.as_deref());
         let current_product_embedding_backend =
             manifest_embedding_backend_is_product(Some(current_embedding_backend.as_str()));
-        let qdrant_capability_probe = qdrant_capabilities(
+        let qdrant_capability_probe = qdrant_capabilities_for_runtime(
             layout,
             &collection,
             &qdrant_probe,
             expected_qdrant_points,
             product_embedding_backend,
             current_product_embedding_backend,
+            runtime,
         );
         let qdrant_semantic_stub = qdrant_probe.reachable
             && qdrant_probe.collection_exists

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1,9 +1,11 @@
 use crate::config::{SidecarLayout, SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, dir_size_bytes};
+#[cfg(test)]
+use crate::generation::manifest_unavailable_reason;
 use crate::generation::{
-    SIDECAR_SCHEMA_VERSION, manifest_has_current_sidecar_contract, manifest_unavailable_reason,
-    sidecar_generation_id,
+    SIDECAR_SCHEMA_VERSION, manifest_has_current_sidecar_contract,
+    manifest_unavailable_reason_for_runtime, sidecar_generation_id,
 };
-use crate::health::probe_sidecar_health_with_embedding_device;
+use crate::health::probe_sidecar_health_for_runtime;
 use crate::qdrant_client::{QDRANT_INDEX_UPSERT_BATCH_SIZE, QdrantClient, QdrantUpsertPoint};
 use crate::retention::{
     FsQdrantGenerationRemover, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport,
@@ -70,6 +72,7 @@ struct SidecarStubFlags {
 }
 
 struct GenerationRetentionContext<'a> {
+    runtime: &'a SidecarRuntimeConfig,
     layout: &'a SidecarLayout,
     workspace_id: &'a str,
     previous_manifest: Option<&'a RetrievalIndexManifest>,
@@ -113,7 +116,9 @@ pub fn repair_project_qdrant_collection_for_runtime(
     else {
         return Ok(None);
     };
-    if let Some(reason) = manifest_unavailable_reason(&project_id, &storage, &manifest) {
+    if let Some(reason) =
+        manifest_unavailable_reason_for_runtime(&project_id, &storage, &manifest, runtime)
+    {
         return Ok(Some(ProjectQdrantRepairOutcome {
             project_id,
             qdrant_collection: manifest.qdrant_collection,
@@ -127,7 +132,7 @@ pub fn repair_project_qdrant_collection_for_runtime(
 
     let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
-    let qdrant_client = QdrantClient::new(layout);
+    let qdrant_client = QdrantClient::for_runtime(runtime)?;
     let probe = qdrant_client.health_probe(&manifest.qdrant_collection);
     if !probe.reachable {
         return Ok(Some(ProjectQdrantRepairOutcome {
@@ -207,7 +212,6 @@ pub fn finalize_index_for_runtime_with_progress(
     runtime: &SidecarRuntimeConfig,
     mut progress: impl FnMut(&'static str),
 ) -> Result<FinalizeIndexOutcome> {
-    runtime.activate_embed_url_default();
     let layout = runtime.layout.clone();
     let project_id = sidecar_project_id_for_root(project_root);
     let workspace_id = runtime
@@ -239,8 +243,8 @@ pub fn finalize_index_for_runtime_with_progress(
         );
     }
 
-    let qdrant_client = QdrantClient::new(&layout);
-    let embedding_backend = crate::embeddings::embedding_runtime_id();
+    let qdrant_client = QdrantClient::for_runtime(runtime)?;
+    let embedding_backend = crate::embeddings::embedding_runtime_id_for_runtime(runtime);
     let embedding_dim = i32::try_from(crate::embeddings::qdrant_vector_dim())
         .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
     crate::embeddings::ensure_product_embedding_backend_for_runtime(runtime)?;
@@ -249,22 +253,24 @@ pub fn finalize_index_for_runtime_with_progress(
     let mut storage =
         Store::open(storage_path).context("open storage for retrieval sidecar input")?;
     ensure_search_symbol_projection(&mut storage)?;
-    let sidecar_input = compute_sidecar_input_fingerprint(
+    let sidecar_input = compute_sidecar_input_fingerprint_for_runtime(
         &storage,
         storage_path,
         project_root,
         &project_id,
         &embedding_backend,
         embedding_dim,
+        &runtime.embedding,
     )?;
     let previous_manifest = storage
         .get_retrieval_index_manifest(&project_id)
         .context("load previous retrieval_index_manifest")?;
-    let previous_manifest_unavailable_reason = previous_manifest
-        .as_ref()
-        .and_then(|manifest| manifest_unavailable_reason(&project_id, &storage, manifest));
+    let previous_manifest_unavailable_reason = previous_manifest.as_ref().and_then(|manifest| {
+        manifest_unavailable_reason_for_runtime(&project_id, &storage, manifest, runtime)
+    });
     drop(storage);
     let retention_context = GenerationRetentionContext {
+        runtime,
         layout: &layout,
         workspace_id: &workspace_id,
         previous_manifest: previous_manifest.as_ref(),
@@ -284,11 +290,12 @@ pub fn finalize_index_for_runtime_with_progress(
             &embedding_backend,
             embedding_dim,
         ) {
-            let status = probe_sidecar_health_with_embedding_device(
+            let status = probe_sidecar_health_for_runtime(
                 &layout,
                 &project_id,
                 Some(previous.clone()),
                 &embedding_device,
+                runtime,
             );
             let qdrant_point_count = qdrant_ready_point_count(
                 &qdrant_client,
@@ -362,11 +369,12 @@ pub fn finalize_index_for_runtime_with_progress(
     );
     manifest.scip_revision = read_scip_revision(&scip_dir);
 
-    let existing_status = probe_sidecar_health_with_embedding_device(
+    let existing_status = probe_sidecar_health_for_runtime(
         &layout,
         &project_id,
         Some(manifest.clone()),
         &embedding_device,
+        runtime,
     );
     let zoekt_ready = existing_status.zoekt.capabilities.lexical
         && crate::zoekt_index::shard_matches_lexical_input(
@@ -386,11 +394,12 @@ pub fn finalize_index_for_runtime_with_progress(
     if zoekt_ready && qdrant_ready_points.is_some() && scip_ready {
         update_precise_semantic_import_status(&scip_dir, &mut manifest)?;
         manifest.disk_bytes = sidecar_disk_bytes(&layout, &generation, &collection, &scip_dir);
-        let status = probe_sidecar_health_with_embedding_device(
+        let status = probe_sidecar_health_for_runtime(
             &layout,
             &project_id,
             Some(manifest.clone()),
             &embedding_device,
+            runtime,
         );
         if status.retrieval_mode == "full" {
             info!(
@@ -725,11 +734,12 @@ fn finalize_manifest_after_health_check(
     ) {
         bail!("mandatory Zoekt lexical shard is incomplete for {project_id}");
     }
-    let status = probe_sidecar_health_with_embedding_device(
+    let status = probe_sidecar_health_for_runtime(
         layout,
         &project_id,
         Some(manifest.clone()),
         embedding_device,
+        retention_context.runtime,
     );
     if status.retrieval_mode != "full" {
         bail!(
@@ -913,7 +923,12 @@ fn persist_finalized_manifest(
     manifest.degraded_modes_json =
         serde_json::to_string(&degraded_modes).unwrap_or_else(|_| "[]".into());
     let mut storage = Store::open(storage_path).context("open storage for retrieval manifest")?;
-    if let Some(reason) = manifest_unavailable_reason(&project_id, &storage, &manifest) {
+    if let Some(reason) = manifest_unavailable_reason_for_runtime(
+        &project_id,
+        &storage,
+        &manifest,
+        retention_context.runtime,
+    ) {
         bail!(
             "mandatory retrieval sidecar manifest would be unavailable immediately for {project_id}: {reason}"
         );
@@ -983,11 +998,12 @@ fn retain_published_generations(
     candidates.sort_by_key(|candidate| candidate.built_at_epoch_ms);
     candidates.dedup_by(|left, right| left.sidecar_generation == right.sidecar_generation);
     let verified_previous = candidates.into_iter().rev().find_map(|candidate| {
-        let status = probe_sidecar_health_with_embedding_device(
+        let status = probe_sidecar_health_for_runtime(
             context.layout,
             project_id,
             Some(candidate.clone()),
             context.embedding_device,
+            context.runtime,
         );
         (status.retrieval_mode == "full").then_some(VerifiedRollbackManifest {
             manifest: candidate,
@@ -1042,6 +1058,7 @@ fn retain_published_generations(
     (plan, apply)
 }
 
+#[cfg(test)]
 pub(crate) fn compute_sidecar_input_fingerprint(
     storage: &Store,
     storage_path: &Path,
@@ -1049,6 +1066,26 @@ pub(crate) fn compute_sidecar_input_fingerprint(
     project_id: &str,
     embedding_backend: &str,
     embedding_dim: i32,
+) -> Result<SidecarInputFingerprint> {
+    compute_sidecar_input_fingerprint_for_runtime(
+        storage,
+        storage_path,
+        project_root,
+        project_id,
+        embedding_backend,
+        embedding_dim,
+        &crate::config::SidecarRuntimeConfig::local().embedding,
+    )
+}
+
+pub(crate) fn compute_sidecar_input_fingerprint_for_runtime(
+    storage: &Store,
+    storage_path: &Path,
+    project_root: &Path,
+    project_id: &str,
+    embedding_backend: &str,
+    embedding_dim: i32,
+    embedding: &crate::config::EmbeddingRuntimeConfig,
 ) -> Result<SidecarInputFingerprint> {
     let lexical = lexical_input_fingerprint(project_root, Some(storage_path))
         .context("hash lexical sidecar input")?;
@@ -1063,17 +1100,10 @@ pub(crate) fn compute_sidecar_input_fingerprint(
     hash_part(&mut hasher, &lexical.hash);
     hash_part(&mut hasher, embedding_backend);
     hash_part(&mut hasher, &embedding_dim.to_string());
+    hash_part(&mut hasher, embedding.query_prefix.as_deref().unwrap_or(""));
     hash_part(
         &mut hasher,
-        std::env::var("CODESTORY_EMBED_QUERY_PREFIX")
-            .as_deref()
-            .unwrap_or(""),
-    );
-    hash_part(
-        &mut hasher,
-        std::env::var("CODESTORY_EMBED_DOCUMENT_PREFIX")
-            .as_deref()
-            .unwrap_or(""),
+        embedding.document_prefix.as_deref().unwrap_or(""),
     );
     hash_part(&mut hasher, "qdrant-semantic-vectors");
     hash_part(&mut hasher, "scip-symbols-json-v1");
@@ -1542,6 +1572,7 @@ mod tests {
             embed_http_port: 11,
             cleanup_command: "codestory-cli retrieval down".into(),
             labels: BTreeMap::new(),
+            ..SidecarRuntimeConfig::local()
         };
 
         let repair =

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -1,7 +1,8 @@
 use crate::compose::{EmbedModelInventory, embed_model_inventory};
 use crate::config::{SidecarRuntimeConfig, user_cache_root};
-use crate::generation::{manifest_has_current_sidecar_contract, manifest_unavailable_reason};
-use crate::health::probe_sidecar_health_with_embedding_device;
+use crate::generation::{
+    manifest_has_current_sidecar_contract, manifest_unavailable_reason_for_runtime,
+};
 use crate::qdrant_client::QdrantClient;
 use crate::retention::{
     FsQdrantGenerationRemover, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport,
@@ -433,6 +434,7 @@ fn build_generation_retention_plan(
                         &store,
                         project_id,
                         &manifest,
+                        runtime,
                         &mut protection.errors,
                     );
                     Some(manifest)
@@ -458,11 +460,12 @@ fn build_generation_retention_plan(
     match manifest {
         Some(manifest) if manifest_has_current_sidecar_contract(project_id, &manifest) => {
             let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
-            let health = probe_sidecar_health_with_embedding_device(
+            let health = crate::health::probe_sidecar_health_for_runtime(
                 layout,
                 project_id,
                 Some(manifest),
                 &embedding_device,
+                runtime,
             );
             if health.retrieval_mode != "full" {
                 protection.errors.push(format!(
@@ -501,9 +504,12 @@ fn record_manifest_retention_freshness(
     store: &Store,
     project_id: &str,
     manifest: &codestory_store::RetrievalIndexManifest,
+    runtime: &SidecarRuntimeConfig,
     errors: &mut Vec<String>,
 ) {
-    if let Some(reason) = manifest_unavailable_reason(project_id, store, manifest) {
+    if let Some(reason) =
+        manifest_unavailable_reason_for_runtime(project_id, store, manifest, runtime)
+    {
         errors.push(format!(
             "active retrieval manifest is stale; pruning suppressed: {reason}"
         ));
@@ -1022,8 +1028,12 @@ mod tests {
         let mut manifest = crate::test_support::retrieval_manifest_fixture(project_id, "input");
         manifest.embedding_dim = Some(1);
         let mut errors = Vec::new();
+        let mut runtime = SidecarRuntimeConfig::local();
+        runtime.embedding.backend = "llamacpp".into();
+        runtime.embedding.profile = "bge-base-en-v1.5".into();
+        runtime.embedding.model_id = None;
 
-        record_manifest_retention_freshness(&store, project_id, &manifest, &mut errors);
+        record_manifest_retention_freshness(&store, project_id, &manifest, &runtime, &mut errors);
 
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("active retrieval manifest is stale; pruning suppressed"));

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -51,19 +51,23 @@ pub use compose::{
 };
 pub use config::{
     DEFAULT_AGENT_RUN_ID, DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT,
-    DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, EmbeddingServerLaunchMode, QDRANT_IMAGE_PIN,
+    DEFAULT_QDRANT_HTTP_PORT, DEFAULT_ZOEKT_HTTP_PORT, EmbeddingEndpointOrigin,
+    EmbeddingRuntimeConfig, EmbeddingServerLaunchMode, QDRANT_IMAGE_PIN, RetrievalRuntimeConfig,
     SidecarImagePins, SidecarLayout, SidecarOwnership, SidecarPorts, SidecarProfile,
-    SidecarRuntimeConfig, ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN,
-    default_sidecar_image_pins, embedding_server_launch_mode, sidecar_runtime_auto,
+    SidecarRuntimeConfig, SidecarRuntimeDefaults, SidecarRuntimeOverrides, SummaryRuntimeConfig,
+    ZOEKT_REAL_VERSION_PIN, ZOEKT_WEBSERVER_IMAGE_PIN, default_sidecar_image_pins,
+    embedding_server_launch_mode, embedding_server_launch_mode_for_runtime, sidecar_runtime_auto,
     sidecar_runtime_for_project, sidecar_runtime_for_project_with_run_id, user_cache_root,
 };
 #[cfg(feature = "test-support")]
 pub use config::{active_test_cache_root, with_test_cache_root};
 pub use embeddings::{
     BGE_BASE_EN_V1_5_GGUF, BGE_QUERY_PREFIX_DEFAULT, EmbeddingRuntimeProbe,
-    RETRIEVAL_EMBEDDING_DIM, embedding_backend_label, embedding_runtime_id,
-    ensure_product_embedding_backend, ensure_product_embedding_backend_for_runtime,
-    probe_product_embedding_runtime, qdrant_vector_dim,
+    LlamaCppEmbeddingClient, RETRIEVAL_EMBEDDING_DIM, embed_documents_for_runtime,
+    embed_query_for_runtime, embedding_backend_label, embedding_backend_label_for_runtime,
+    embedding_runtime_id, embedding_runtime_id_for_runtime, ensure_product_embedding_backend,
+    ensure_product_embedding_backend_for_runtime, probe_product_embedding_runtime,
+    probe_product_embedding_runtime_for_runtime, qdrant_vector_dim,
 };
 pub use executor::{QueryExecutor, QueryResult, QueryTrace, StageTrace, cancellation_flag};
 pub use generation::{SIDECAR_SCHEMA_VERSION, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED};
@@ -97,7 +101,9 @@ pub use qdrant_storage::{
 };
 pub use query::{
     QueryBatchItem, QueryBatchRequest, QueryRequest, execute_retrieval_query,
-    execute_retrieval_query_with_cache, execute_strict_retrieval_query_batch_with_cache,
+    execute_retrieval_query_with_cache, execute_retrieval_query_with_cache_for_runtime,
+    execute_strict_retrieval_query_batch_with_cache,
+    execute_strict_retrieval_query_batch_with_cache_for_runtime,
 };
 pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;

--- a/crates/codestory-retrieval/src/qdrant_client.rs
+++ b/crates/codestory-retrieval/src/qdrant_client.rs
@@ -47,6 +47,7 @@ pub(crate) enum QdrantDeleteOutcome {
 pub struct QdrantClient {
     base_url: String,
     timeout: Duration,
+    embedding: Option<embeddings::LlamaCppEmbeddingClient>,
 }
 
 impl QdrantClient {
@@ -54,7 +55,18 @@ impl QdrantClient {
         Self {
             base_url: layout.qdrant_base_url(),
             timeout: QDRANT_HEALTH_BUDGET,
+            embedding: None,
         }
+    }
+
+    pub fn for_runtime(runtime: &crate::config::SidecarRuntimeConfig) -> Result<Self> {
+        Ok(Self {
+            base_url: runtime.layout.qdrant_base_url(),
+            timeout: QDRANT_HEALTH_BUDGET,
+            embedding: Some(embeddings::LlamaCppEmbeddingClient::new(
+                &runtime.embedding,
+            )?),
+        })
     }
 
     pub fn collection_name(project_id: &str) -> String {
@@ -173,7 +185,11 @@ impl QdrantClient {
         query: &str,
         limit: usize,
     ) -> Result<Vec<super::CandidateHit>> {
-        let vector = query_vector(query)?;
+        let vector = self
+            .embedding
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("qdrant query embedding runtime is not configured"))?
+            .embed_query(query)?;
         self.search_vector(collection, &vector, limit)
     }
 
@@ -316,7 +332,7 @@ impl QdrantClient {
         );
         let mut written = 0usize;
         for chunk in points.chunks(QDRANT_INDEX_UPSERT_BATCH_SIZE) {
-            let vectors = vectors_for_points(chunk)?;
+            let vectors = vectors_for_points(chunk, self.embedding.as_ref())?;
             if vectors.len() != chunk.len() {
                 bail!(
                     "embedding batch returned {} vector(s) for {} qdrant point(s)",
@@ -623,11 +639,10 @@ pub fn diagnostic_query_vector(query: &str) -> Result<Vec<f32>> {
     query_vector(query)
 }
 
-fn document_vectors(labels: &[String]) -> Result<Vec<Vec<f32>>> {
-    embeddings::embed_documents(labels)
-}
-
-fn vectors_for_points(points: &[QdrantUpsertPoint]) -> Result<Vec<Vec<f32>>> {
+fn vectors_for_points(
+    points: &[QdrantUpsertPoint],
+    embedding: Option<&embeddings::LlamaCppEmbeddingClient>,
+) -> Result<Vec<Vec<f32>>> {
     let provided = points.iter().filter(|point| point.vector.is_some()).count();
     if provided == points.len() {
         return Ok(points
@@ -645,13 +660,16 @@ fn vectors_for_points(points: &[QdrantUpsertPoint]) -> Result<Vec<Vec<f32>>> {
         .iter()
         .map(|point| point.display_name.clone())
         .collect::<Vec<_>>();
-    document_vectors(&labels).with_context(|| {
-        format!(
-            "embed qdrant document batch size={} first={}",
-            labels.len(),
-            labels.first().map(String::as_str).unwrap_or("<empty>")
-        )
-    })
+    embedding
+        .ok_or_else(|| anyhow::anyhow!("qdrant document embedding runtime is not configured"))?
+        .embed_documents(&labels)
+        .with_context(|| {
+            format!(
+                "embed qdrant document batch size={} first={}",
+                labels.len(),
+                labels.first().map(String::as_str).unwrap_or("<empty>")
+            )
+        })
 }
 
 #[cfg(test)]

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -3,8 +3,8 @@ use crate::cache::RetrievalCacheKey;
 use crate::config::{SidecarLayout, SidecarRuntimeConfig};
 use crate::embeddings::{EmbeddingDeviceReadiness, embedding_device_readiness_for_runtime};
 use crate::executor::{QueryExecutor, QueryResult, cancellation_flag};
-use crate::generation::manifest_unavailable_reason;
-use crate::health::probe_sidecar_health_with_embedding_device;
+use crate::generation::manifest_unavailable_reason_for_runtime;
+use crate::health::probe_sidecar_health_for_runtime;
 use crate::index::{query_fingerprint, sidecar_project_id_for_root};
 use crate::mode::{RetrievalDegradedMode, derive_degraded_mode};
 use crate::query_features::classify_query;
@@ -52,19 +52,29 @@ pub fn execute_retrieval_query_with_cache(
     request: QueryRequest<'_>,
     cache: &mut RetrievalCache,
 ) -> Result<QueryResult> {
+    let runtime = SidecarRuntimeConfig::for_project_auto(request.project_root);
+    execute_retrieval_query_with_cache_for_runtime(request, cache, &runtime)
+}
+
+pub fn execute_retrieval_query_with_cache_for_runtime(
+    request: QueryRequest<'_>,
+    cache: &mut RetrievalCache,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<QueryResult> {
     let QueryContext {
         layout,
         project_id,
         manifest,
         file_roles,
         embedding_device,
-    } = load_query_context(request.project_root, request.storage_path)?;
-    let sidecars = Arc::new(LiveSidecarSearch::new_with_embedding_device(
+    } = load_query_context(request.project_root, request.storage_path, runtime)?;
+    let sidecars = Arc::new(LiveSidecarSearch::new_for_runtime_with_embedding_device(
+        runtime,
         layout,
         project_id,
         manifest.as_ref(),
         Some(embedding_device),
-    ));
+    )?);
     let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
     let mut executor = QueryExecutor {
         sidecars,
@@ -81,6 +91,15 @@ pub fn execute_strict_retrieval_query_batch_with_cache(
     request: QueryBatchRequest<'_>,
     cache: &mut RetrievalCache,
 ) -> Result<Vec<QueryResult>> {
+    let runtime = SidecarRuntimeConfig::for_project_auto(request.project_root);
+    execute_strict_retrieval_query_batch_with_cache_for_runtime(request, cache, &runtime)
+}
+
+pub fn execute_strict_retrieval_query_batch_with_cache_for_runtime(
+    request: QueryBatchRequest<'_>,
+    cache: &mut RetrievalCache,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<Vec<QueryResult>> {
     if request.queries.is_empty() {
         return Ok(Vec::new());
     }
@@ -90,16 +109,21 @@ pub fn execute_strict_retrieval_query_batch_with_cache(
         manifest,
         file_roles,
         embedding_device,
-    } = load_query_context(request.project_root, request.storage_path)?;
-    let sidecars = Arc::new(LiveSidecarSearch::new_with_embedding_device(
+    } = load_query_context(request.project_root, request.storage_path, runtime)?;
+    let sidecars = Arc::new(LiveSidecarSearch::new_for_runtime_with_embedding_device(
+        runtime,
         layout,
         project_id,
         manifest.as_ref(),
         Some(embedding_device.clone()),
-    ));
+    )?);
     let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
-    let (mode, degraded_reason) =
-        resolve_batch_mode(sidecars.as_ref(), manifest.as_ref(), &embedding_device);
+    let (mode, degraded_reason) = resolve_batch_mode(
+        sidecars.as_ref(),
+        manifest.as_ref(),
+        &embedding_device,
+        runtime,
+    );
     if mode != RetrievalDegradedMode::Full {
         bail!(
             "retrieval sidecar is mandatory; project is not in full mode (mode={}, reason={})",
@@ -252,10 +276,12 @@ struct QueryContext {
     embedding_device: EmbeddingDeviceReadiness,
 }
 
-fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryContext> {
-    let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
-    runtime.activate_embed_url_default();
-    let embedding_device = embedding_device_readiness_for_runtime(&runtime);
+fn load_query_context(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<QueryContext> {
+    let embedding_device = embedding_device_readiness_for_runtime(runtime);
     let layout = runtime.layout.clone();
     let project_id = sidecar_project_id_for_root(project_root);
     let (manifest, file_roles) = if storage_path.exists() {
@@ -271,7 +297,9 @@ fn load_query_context(project_root: &Path, storage_path: &Path) -> Result<QueryC
                     "retrieval sidecar manifest is unavailable ({error}); run retrieval index for project {project_id}"
                 );
             }
-            if let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest) {
+            if let Some(reason) =
+                manifest_unavailable_reason_for_runtime(&project_id, &storage, manifest, runtime)
+            {
                 bail!(
                     "retrieval sidecar manifest is unavailable ({reason}); run retrieval index for project {project_id}"
                 );
@@ -308,6 +336,7 @@ fn resolve_batch_mode(
     sidecars: &dyn SidecarSearch,
     manifest: Option<&RetrievalIndexManifest>,
     embedding_device: &EmbeddingDeviceReadiness,
+    runtime: &SidecarRuntimeConfig,
 ) -> (RetrievalDegradedMode, Option<String>) {
     if let Some(manifest) = manifest {
         let Some(layout) = sidecars.layout() else {
@@ -316,11 +345,12 @@ fn resolve_batch_mode(
                 Some("sidecar_layout_missing".into()),
             );
         };
-        let report = probe_sidecar_health_with_embedding_device(
+        let report = probe_sidecar_health_for_runtime(
             layout,
             &manifest.project_id,
             Some(manifest.clone()),
             embedding_device,
+            runtime,
         );
         return derive_degraded_mode(&report.zoekt, &report.qdrant, &report.scip);
     }

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -1238,6 +1238,7 @@ mod tests {
             embed_http_port: 0,
             cleanup_command: String::new(),
             labels: BTreeMap::new(),
+            ..SidecarRuntimeConfig::local()
         };
         let local = runtime(
             SidecarProfile::Local,

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -4,13 +4,13 @@ use crate::config::{
 };
 use crate::generation::{
     SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
-    manifest_staleness_reason, manifest_unavailable_reason,
+    manifest_staleness_reason_for_runtime, manifest_unavailable_reason_for_runtime,
 };
 use crate::health::{
     EmbeddingLaunchMetadata, RetrievalStatusReport, attach_manifest_contract, attach_repair_hint,
-    probe_sidecar_health_with_embedding_device, unavailable_status_report_with_embedding_device,
+    probe_sidecar_health_for_runtime, unavailable_status_report_with_embedding_device,
 };
-use crate::index::{compute_sidecar_input_fingerprint, sidecar_project_id_for_root};
+use crate::index::{compute_sidecar_input_fingerprint_for_runtime, sidecar_project_id_for_root};
 use anyhow::{Context, Result, bail};
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext,
@@ -123,7 +123,7 @@ pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
     runtime.ensure_ports_allocated()?;
     let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
-    let embedding_device = crate::embeddings::embedding_device_readiness();
+    let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
     let state = SidecarStateFile {
         project_identity: runtime.project_identity.clone(),
         owner: "codestory".into(),
@@ -689,8 +689,15 @@ fn sidecar_status_inner_with_runtime(
     strict: bool,
     runtime: SidecarRuntimeConfig,
 ) -> Result<RetrievalStatusReport> {
-    runtime.activate_embed_url_default();
     let layout = runtime.layout.clone();
+    if runtime.embedding.endpoint_origin != crate::config::EmbeddingEndpointOrigin::ManagedSidecar {
+        let probe = crate::embeddings::probe_product_embedding_runtime_for_runtime(&runtime);
+        tracing::debug!(
+            reachable = probe.reachable,
+            detail = %probe.detail,
+            "Probed explicit embedding endpoint for retained project runtime"
+        );
+    }
     let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(&runtime);
     let project_id = sidecar_project_id_for_root(project_root);
     let manifest = if let Some(path) = storage_path.filter(|path| path.exists()) {
@@ -700,12 +707,13 @@ fn sidecar_status_inner_with_runtime(
             .context("load retrieval manifest")?;
         if strict
             && let Some(manifest) = manifest.as_ref()
-            && let Some(reason) = strict_readiness_unavailable_reason(
+            && let Some(reason) = strict_readiness_unavailable_reason_for_runtime(
                 project_root,
                 path,
                 &storage,
                 &project_id,
                 manifest,
+                &runtime,
             )
             .context("check strict sidecar readiness")?
         {
@@ -729,7 +737,8 @@ fn sidecar_status_inner_with_runtime(
             ));
         }
         if let Some(manifest) = manifest.as_ref()
-            && let Some(reason) = manifest_unavailable_reason(&project_id, &storage, manifest)
+            && let Some(reason) =
+                manifest_unavailable_reason_for_runtime(&project_id, &storage, manifest, &runtime)
         {
             return Ok(attach_status_ownership(
                 enrich_status_with_semantic_doc_stats(
@@ -750,11 +759,12 @@ fn sidecar_status_inner_with_runtime(
                 &runtime,
             ));
         }
-        let report = probe_sidecar_health_with_embedding_device(
+        let report = probe_sidecar_health_for_runtime(
             &layout,
             &project_id,
             manifest,
             &embedding_device,
+            &runtime,
         );
         return Ok(attach_status_ownership(
             enrich_status_with_semantic_doc_stats(
@@ -773,11 +783,12 @@ fn sidecar_status_inner_with_runtime(
     Ok(attach_status_ownership(
         attach_repair_hint(
             attach_manifest_contract(
-                probe_sidecar_health_with_embedding_device(
+                probe_sidecar_health_for_runtime(
                     &layout,
                     &project_id,
                     manifest,
                     &embedding_device,
+                    &runtime,
                 ),
                 project_root,
             ),
@@ -793,6 +804,7 @@ fn attach_status_ownership(
     runtime: &SidecarRuntimeConfig,
 ) -> RetrievalStatusReport {
     report.ownership = Some(runtime.ownership());
+    report.query_embedding_backend = crate::embeddings::embedding_runtime_id_for_runtime(runtime);
     if let Some(state) = read_sidecar_state(&runtime.layout.state_file) {
         report.embedding_launch = state.embedding_launch.or(report.embedding_launch);
         report.sidecar_images = state.sidecar_images;
@@ -849,6 +861,25 @@ fn strict_readiness_unavailable_reason(
     project_id: &str,
     manifest: &codestory_store::RetrievalIndexManifest,
 ) -> Result<Option<String>> {
+    let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
+    strict_readiness_unavailable_reason_for_runtime(
+        project_root,
+        storage_path,
+        storage,
+        project_id,
+        manifest,
+        &runtime,
+    )
+}
+
+fn strict_readiness_unavailable_reason_for_runtime(
+    project_root: &Path,
+    storage_path: &Path,
+    storage: &Store,
+    project_id: &str,
+    manifest: &codestory_store::RetrievalIndexManifest,
+    runtime: &SidecarRuntimeConfig,
+) -> Result<Option<String>> {
     if storage
         .has_incomplete_incremental_run()
         .context("inspect incomplete incremental index marker")?
@@ -858,13 +889,13 @@ fn strict_readiness_unavailable_reason(
     if !manifest_has_current_sidecar_contract(project_id, manifest) {
         return Ok(None);
     }
-    if let Some(reason) = manifest_staleness_reason(storage, manifest)
+    if let Some(reason) = manifest_staleness_reason_for_runtime(storage, manifest, runtime)
         && manifest_contract_drift_should_win(&reason)
     {
         return Ok(None);
     }
-    let embedding_backend = crate::embeddings::embedding_runtime_id();
-    let expected_doc_backend = crate::embeddings::embedding_backend_label();
+    let embedding_backend = crate::embeddings::embedding_runtime_id_for_runtime(runtime);
+    let expected_doc_backend = crate::embeddings::embedding_backend_label_for_runtime(runtime);
     if let Ok(stats) = storage.get_llm_symbol_doc_stats() {
         if stats.mixed_embedding_backends {
             return Ok(Some("sidecar_symbol_docs_mixed_embedding_backends".into()));
@@ -883,13 +914,14 @@ fn strict_readiness_unavailable_reason(
     }
     let embedding_dim = i32::try_from(crate::embeddings::qdrant_vector_dim())
         .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
-    let current_input = compute_sidecar_input_fingerprint(
+    let current_input = compute_sidecar_input_fingerprint_for_runtime(
         storage,
         storage_path,
         project_root,
         project_id,
         &embedding_backend,
         embedding_dim,
+        &runtime.embedding,
     )
     .context("compute strict sidecar input fingerprint")?;
     let stored_files = storage
@@ -1015,7 +1047,7 @@ mod tests {
     use crate::generation::{
         SIDECAR_SCHEMA_VERSION, sidecar_generation_id, sidecar_qdrant_collection,
     };
-    use crate::index::{compute_sidecar_input_fingerprint, project_id_for_root};
+    use crate::index::project_id_for_root;
     use crate::test_support::retrieval_manifest_fixture;
     use codestory_contracts::graph::{ErrorInfo, IndexStep, Node, NodeId, NodeKind};
     use codestory_store::{FileInfo, FileRole, LlmSymbolDoc};
@@ -1042,6 +1074,7 @@ mod tests {
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".to_string(),
             labels: BTreeMap::new(),
+            ..SidecarRuntimeConfig::local()
         }
     }
 
@@ -1503,7 +1536,7 @@ mod tests {
                 file_role: FileRole::Source,
             })
             .expect("insert incomplete file");
-        let input = compute_sidecar_input_fingerprint(
+        let input = crate::index::compute_sidecar_input_fingerprint(
             &storage,
             &storage_path,
             project.path(),
@@ -1821,7 +1854,7 @@ mod tests {
                 file_role: FileRole::Source,
             })
             .expect("insert indexed file");
-        let input = compute_sidecar_input_fingerprint(
+        let input = crate::index::compute_sidecar_input_fingerprint(
             &storage,
             &storage_path,
             project.path(),

--- a/crates/codestory-retrieval/src/sidecar_search.rs
+++ b/crates/codestory-retrieval/src/sidecar_search.rs
@@ -1,5 +1,5 @@
 use crate::candidate::CandidateHit;
-use crate::config::SidecarLayout;
+use crate::config::{SidecarLayout, SidecarRuntimeConfig};
 use crate::embeddings::EmbeddingDeviceReadiness;
 use crate::qdrant_client::QdrantClient;
 use crate::scip_client::ScipClient;
@@ -16,6 +16,10 @@ pub trait SidecarSearch: Send + Sync {
         None
     }
 
+    fn runtime_config(&self) -> Option<&SidecarRuntimeConfig> {
+        None
+    }
+
     fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
     fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
     fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
@@ -24,6 +28,7 @@ pub trait SidecarSearch: Send + Sync {
 
 #[derive(Debug, Clone)]
 pub struct LiveSidecarSearch {
+    runtime: SidecarRuntimeConfig,
     layout: SidecarLayout,
     project_id: String,
     sidecar_generation: String,
@@ -49,8 +54,29 @@ impl LiveSidecarSearch {
         manifest: Option<&RetrievalIndexManifest>,
         embedding_device: Option<EmbeddingDeviceReadiness>,
     ) -> Self {
+        let runtime = crate::config::SidecarRuntimeConfig::for_project_profile(
+            None,
+            crate::config::SidecarProfile::Local,
+        );
+        Self::new_for_runtime_with_embedding_device(
+            &runtime,
+            layout,
+            project_id,
+            manifest,
+            embedding_device,
+        )
+        .expect("default embedding runtime configuration must be valid")
+    }
+
+    pub fn new_for_runtime_with_embedding_device(
+        runtime: &crate::config::SidecarRuntimeConfig,
+        layout: SidecarLayout,
+        project_id: String,
+        manifest: Option<&RetrievalIndexManifest>,
+        embedding_device: Option<EmbeddingDeviceReadiness>,
+    ) -> Result<Self> {
         let zoekt = ZoektClient::new(&layout);
-        let qdrant = QdrantClient::new(&layout);
+        let qdrant = QdrantClient::for_runtime(runtime)?;
         let sidecar_generation = manifest
             .and_then(|manifest| manifest.sidecar_generation.clone())
             .unwrap_or_else(|| format!("{project_id}-missing-manifest"));
@@ -60,7 +86,8 @@ impl LiveSidecarSearch {
         let qdrant_collection = manifest
             .map(|manifest| manifest.qdrant_collection.clone())
             .unwrap_or_else(|| format!("codestory_{project_id}_missing_manifest"));
-        Self {
+        Ok(Self {
+            runtime: runtime.clone(),
             layout,
             project_id,
             sidecar_generation,
@@ -69,7 +96,7 @@ impl LiveSidecarSearch {
             embedding_device,
             zoekt,
             qdrant,
-        }
+        })
     }
 
     pub fn layout(&self) -> &SidecarLayout {
@@ -92,6 +119,10 @@ impl SidecarSearch for LiveSidecarSearch {
 
     fn embedding_device_readiness(&self) -> Option<&EmbeddingDeviceReadiness> {
         self.embedding_device.as_ref()
+    }
+
+    fn runtime_config(&self) -> Option<&SidecarRuntimeConfig> {
+        Some(&self.runtime)
     }
 
     fn zoekt_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {

--- a/crates/codestory-runtime/Cargo.toml
+++ b/crates/codestory-runtime/Cargo.toml
@@ -3,6 +3,9 @@ name = "codestory-runtime"
 version = "0.14.3"
 edition = "2024"
 
+[features]
+test-support = []
+
 [dependencies]
 anyhow = { workspace = true }
 codestory-contracts = { workspace = true }

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -10,11 +10,13 @@ use codestory_contracts::api::{
     RetrievalStageTimingDto, SearchHit,
 };
 use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
+#[cfg(test)]
+use codestory_retrieval::sidecar_runtime_auto;
 use codestory_retrieval::{
     CandidateHit, CandidateSource, QueryBatchItem, QueryBatchRequest, QueryRequest, QueryResult,
-    QueryTrace, SidecarProfile, execute_retrieval_query_with_cache,
-    execute_strict_retrieval_query_batch_with_cache, is_phantom_sidecar_hit,
-    sidecar_project_id_for_root, sidecar_runtime_auto, strict_sidecar_status_for_runtime,
+    QueryTrace, SidecarProfile, execute_retrieval_query_with_cache_for_runtime,
+    execute_strict_retrieval_query_batch_with_cache_for_runtime, is_phantom_sidecar_hit,
+    sidecar_project_id_for_root, strict_sidecar_status_for_runtime,
 };
 use codestory_store::Store;
 use std::collections::{BTreeMap, HashMap};
@@ -107,7 +109,8 @@ pub(crate) fn sidecar_retrieval_unavailable_reason(controller: &AppController) -
     let Ok(storage_path) = controller.require_storage_path() else {
         return Some("sidecar retrieval primary requires an index storage path".into());
     };
-    let status = sidecar_mode_status_for_project(&project_root, &storage_path);
+    let status =
+        sidecar_mode_status_for_runtime(&project_root, &storage_path, &controller.runtime_config);
     let reason = status
         .degraded_reason
         .map(|reason| format!("; reason={reason}"))
@@ -130,13 +133,20 @@ pub(crate) fn sidecar_retrieval_unavailable_error(
         .unwrap_or_else(|| "<project>".to_string());
     let recovery_commands = project_root
         .as_deref()
-        .map(sidecar_retrieval_recovery_commands)
+        .map(|project_root| {
+            sidecar_retrieval_recovery_commands_for_runtime(
+                project_root,
+                &controller.runtime_config,
+            )
+        })
         .unwrap_or_else(|| sidecar_retrieval_recovery_commands_for_project(&project, None));
     ApiError::retrieval_unavailable(reason, project.clone(), recovery_commands)
 }
 
-fn sidecar_retrieval_recovery_commands(project_root: &Path) -> Vec<String> {
-    let runtime = sidecar_runtime_auto(project_root);
+fn sidecar_retrieval_recovery_commands_for_runtime(
+    project_root: &Path,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+) -> Vec<String> {
     let agent_run_id = (runtime.profile == SidecarProfile::Agent)
         .then_some(runtime.run_id.as_deref())
         .flatten();
@@ -243,9 +253,10 @@ fn sidecar_mode_is_required_full(controller: &AppController) -> bool {
     let Ok(storage_path) = controller.require_storage_path() else {
         return false;
     };
-    sidecar_status_can_serve_primary(&sidecar_mode_status_for_project(
+    sidecar_status_can_serve_primary(&sidecar_mode_status_for_runtime(
         &project_root,
         &storage_path,
+        &controller.runtime_config,
     ))
 }
 
@@ -264,9 +275,18 @@ struct SidecarModeStatus {
     degraded_reason: Option<String>,
 }
 
+#[cfg(test)]
 fn sidecar_mode_status_for_project(project_root: &Path, storage_path: &Path) -> SidecarModeStatus {
     let runtime = sidecar_runtime_auto(project_root);
-    match strict_sidecar_status_for_runtime(project_root, Some(storage_path), runtime) {
+    sidecar_mode_status_for_runtime(project_root, storage_path, &runtime)
+}
+
+fn sidecar_mode_status_for_runtime(
+    project_root: &Path,
+    storage_path: &Path,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+) -> SidecarModeStatus {
+    match strict_sidecar_status_for_runtime(project_root, Some(storage_path), runtime.clone()) {
         Ok(report) => SidecarModeStatus {
             profile: report
                 .ownership
@@ -356,7 +376,7 @@ pub(crate) fn run_sidecar_query(
         .require_storage_path()
         .map_err(|error| anyhow::anyhow!("storage path required: {}", error.message))?;
     with_detached_sidecar_query_cache(controller, |cache| {
-        execute_retrieval_query_with_cache(
+        execute_retrieval_query_with_cache_for_runtime(
             QueryRequest {
                 project_root: &project_root,
                 storage_path: &storage_path,
@@ -365,6 +385,7 @@ pub(crate) fn run_sidecar_query(
                 cancelled: None,
             },
             cache,
+            &controller.runtime_config,
         )
     })
 }
@@ -387,7 +408,7 @@ pub(crate) fn run_sidecar_query_batch(
         })
         .collect::<Vec<_>>();
     with_detached_sidecar_query_cache(controller, |cache| {
-        execute_strict_retrieval_query_batch_with_cache(
+        execute_strict_retrieval_query_batch_with_cache_for_runtime(
             QueryBatchRequest {
                 project_root: &project_root,
                 storage_path: &storage_path,
@@ -395,6 +416,7 @@ pub(crate) fn run_sidecar_query_batch(
                 cancelled: None,
             },
             cache,
+            &controller.runtime_config,
         )
     })
 }

--- a/crates/codestory-runtime/src/grounding.rs
+++ b/crates/codestory-runtime/src/grounding.rs
@@ -842,7 +842,8 @@ impl AppController {
         }
 
         let total_file_count = dto_stats.file_count;
-        let retrieval = retrieval_state_from_storage(&storage).ok();
+        let retrieval =
+            retrieval_state_from_storage_for_runtime(&storage, &self.runtime_config).ok();
         if let Some(state) = retrieval.as_ref() {
             let mode = match state.mode {
                 codestory_contracts::api::RetrievalModeDto::Hybrid => "hybrid",

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -110,6 +110,16 @@ pub use services::{
     AgentService, BookmarkService, GroundingService, IndexService, ProjectService, SearchService,
     TrailService,
 };
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub fn stored_semantic_embeddings_for_test(storage_path: &Path) -> anyhow::Result<Vec<Vec<f32>>> {
+    Ok(Store::open_read_only(storage_path)?
+        .get_all_llm_symbol_docs()?
+        .into_iter()
+        .map(|document| document.embedding)
+        .collect())
+}
 pub(crate) use support::{
     FocusedSourceContext, HYBRID_RETRIEVAL_ENABLED_ENV, SEMANTIC_FILE_TEXT_CACHE_MAX_BYTES,
     SEMANTIC_FILE_TEXT_MAX_BYTES, aggregate_symbol_matches, clamp_i64_to_u32, clamp_u64_to_u32,
@@ -2696,6 +2706,12 @@ impl Runtime {
         }
     }
 
+    pub fn new_with_config(config: codestory_retrieval::SidecarRuntimeConfig) -> Self {
+        Self {
+            controller: AppController::new_with_config(config),
+        }
+    }
+
     pub fn project_service(&self) -> ProjectService {
         ProjectService::new(self.controller.clone())
     }
@@ -3353,6 +3369,7 @@ fn apply_cache_refresh_stats(timings: &mut IndexingPhaseTimings, stats: CacheRef
     apply_semantic_projection_stats(timings, stats.semantic_stats);
 }
 
+#[cfg(test)]
 fn build_search_state(
     storage: &mut Storage,
     search_storage_path: Option<&Path>,
@@ -3360,6 +3377,26 @@ fn build_search_state(
     llm_refresh_file_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     semantic_projection_mode: SemanticProjectionMode,
     hydrate_semantic_docs: bool,
+) -> Result<SearchStateBuildResult, ApiError> {
+    build_search_state_for_runtime(
+        storage,
+        search_storage_path,
+        nodes,
+        llm_refresh_file_scope,
+        semantic_projection_mode,
+        hydrate_semantic_docs,
+        &codestory_retrieval::SidecarRuntimeConfig::local(),
+    )
+}
+
+fn build_search_state_for_runtime(
+    storage: &mut Storage,
+    search_storage_path: Option<&Path>,
+    nodes: Vec<codestory_contracts::graph::Node>,
+    llm_refresh_file_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
+    semantic_projection_mode: SemanticProjectionMode,
+    hydrate_semantic_docs: bool,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<SearchStateBuildResult, ApiError> {
     let projection_started = Instant::now();
     match llm_refresh_file_scope {
@@ -3402,7 +3439,7 @@ fn build_search_state(
         search_symbol_index_ms,
     };
     let semantic_stats = match semantic_projection_mode {
-        SemanticProjectionMode::PersistBackedDocs => sync_llm_symbol_projection(
+        SemanticProjectionMode::PersistBackedDocs => sync_llm_symbol_projection_for_runtime(
             storage,
             &nodes,
             &node_names,
@@ -3413,10 +3450,14 @@ fn build_search_state(
             },
             hydrate_semantic_docs,
             None,
+            runtime,
         )?,
-        SemanticProjectionMode::LoadPersistedDocs => {
-            load_persisted_semantic_docs(storage, &mut engine, hydrate_semantic_docs)?
-        }
+        SemanticProjectionMode::LoadPersistedDocs => load_persisted_semantic_docs_for_runtime(
+            storage,
+            &mut engine,
+            hydrate_semantic_docs,
+            runtime,
+        )?,
         SemanticProjectionMode::SkipPersistence => {
             tracing::debug!("Skipping semantic docs for transient search-state build");
             engine.index_llm_symbol_docs(Vec::new());
@@ -3811,6 +3852,7 @@ fn summarize_symbol_doc(
     endpoint: &str,
     model: &str,
     doc: &LlmSymbolDoc,
+    config: &codestory_retrieval::SummaryRuntimeConfig,
 ) -> Result<String, ApiError> {
     if endpoint.eq_ignore_ascii_case("local") || endpoint.eq_ignore_ascii_case("mock") {
         return Ok(local_symbol_summary(doc));
@@ -3831,9 +3873,7 @@ fn summarize_symbol_doc(
         "temperature": 0
     });
     if let Some(object) = request.as_object_mut()
-        && let Ok(max_tokens) = std::env::var("CODESTORY_SUMMARY_MAX_TOKENS")
-            .unwrap_or_default()
-            .parse::<u32>()
+        && let Some(max_tokens) = config.max_tokens
     {
         object.insert("max_tokens".to_string(), serde_json::json!(max_tokens));
     }
@@ -3841,11 +3881,9 @@ fn summarize_symbol_doc(
     let body = serde_json::to_string(&request)
         .map_err(|e| ApiError::internal(format!("Failed to build summary request: {e}")))?;
     let mut request = ureq::post(endpoint)
-        .timeout(summary_endpoint_timeout())
+        .timeout(config.timeout)
         .set("Content-Type", "application/json");
-    if let Ok(api_key) = std::env::var("CODESTORY_SUMMARY_API_KEY")
-        && !api_key.trim().is_empty()
-    {
+    if let Some(api_key) = config.api_key.as_deref() {
         request = request.set("Authorization", &format!("Bearer {}", api_key.trim()));
     }
     let response_body = codestory_retrieval::outbound_http::read_text(request.send_string(&body))
@@ -3869,15 +3907,6 @@ fn summarize_symbol_doc(
             )
         })?;
     Ok(summary.lines().next().unwrap_or(summary).trim().to_string())
-}
-
-fn summary_endpoint_timeout() -> Duration {
-    let seconds = std::env::var("CODESTORY_SUMMARY_TIMEOUT_SECS")
-        .ok()
-        .and_then(|value| value.trim().parse::<u64>().ok())
-        .filter(|seconds| (1..=300).contains(seconds))
-        .unwrap_or(30);
-    Duration::from_secs(seconds)
 }
 
 fn summary_endpoint_http_error(
@@ -3913,15 +3942,24 @@ const LLM_SYMBOL_DOC_VERSION_PREFIX: &str = "semantic_doc_version:";
 const SEARCH_NODE_BATCH_SIZE: usize = 8_192;
 const SEARCH_SYMBOL_PROJECTION_BATCH_SIZE: usize = 4_096;
 const LLM_DOC_RELOAD_BATCH_SIZE: usize = 512;
+#[cfg(test)]
 const LLM_DOC_EMBED_BATCH_SIZE: usize = 128;
+#[cfg(test)]
 const LLM_DOC_EMBED_BATCH_SIZE_ENV: &str = "CODESTORY_LLM_DOC_EMBED_BATCH_SIZE";
+#[cfg(test)]
 const SEMANTIC_DOC_SCOPE_ENV: &str = "CODESTORY_SEMANTIC_DOC_SCOPE";
+#[cfg(test)]
 const SEMANTIC_DOC_ALIAS_MODE_ENV: &str = "CODESTORY_SEMANTIC_DOC_ALIAS_MODE";
+#[cfg(test)]
 const SEMANTIC_DOC_MAX_TOKENS_ENV: &str = "CODESTORY_SEMANTIC_DOC_MAX_TOKENS";
+#[cfg(test)]
 const SEMANTIC_DOC_DEFAULT_MAX_TOKENS: usize = 128;
+#[cfg(test)]
 const SEMANTIC_STREAM_PENDING_DOCS_ENV: &str = "CODESTORY_SEMANTIC_STREAM_PENDING_DOCS";
+#[cfg(test)]
 const SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV: &str =
     "CODESTORY_SEMANTIC_STREAM_SORT_WINDOW_BATCHES";
+#[cfg(test)]
 const SEMANTIC_STREAM_SORT_WINDOW_BATCHES: usize = 1;
 const SEMANTIC_POLICY_VERSION: &str = "graph_first_v1";
 const SYMBOL_SEARCH_DOC_PROVENANCE: &str = "extracted";
@@ -3983,6 +4021,7 @@ impl SemanticDocAliasMode {
     }
 }
 
+#[cfg(test)]
 fn semantic_doc_shape_contract() -> String {
     let max_tokens = semantic_doc_max_tokens_from_env();
     format!(
@@ -3994,9 +4033,38 @@ fn semantic_doc_shape_contract() -> String {
     )
 }
 
+fn semantic_doc_shape_contract_for_runtime(
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+) -> String {
+    format!(
+        "semantic_doc_version={};scope={};alias_mode={};max_tokens={}",
+        LLM_SYMBOL_DOC_SCHEMA_VERSION,
+        semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope).as_str(),
+        semantic_doc_alias_mode_from_value(&runtime.retrieval.semantic_doc_alias_mode).as_str(),
+        runtime.retrieval.semantic_doc_max_tokens,
+    )
+}
+
+#[cfg(test)]
 fn current_embedding_contract_from_env() -> Option<EmbeddingProfileContractDto> {
     let doc_shape = semantic_doc_shape_contract();
     embedding_profile_contract_from_env()
+        .ok()
+        .map(|contract| EmbeddingProfileContractDto {
+            profile: contract.profile,
+            backend: contract.backend,
+            model_id: contract.model_id,
+            cache_key: contract.cache_key,
+            dimension: contract.dimension,
+            doc_shape,
+        })
+}
+
+fn current_embedding_contract_for_runtime(
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+) -> Option<EmbeddingProfileContractDto> {
+    let doc_shape = semantic_doc_shape_contract_for_runtime(runtime);
+    crate::search_runtime::embedding_profile_contract_from_config(&runtime.embedding)
         .ok()
         .map(|contract| EmbeddingProfileContractDto {
             profile: contract.profile,
@@ -4378,9 +4446,22 @@ struct LoadedSearchState {
     engine: SearchEngine,
 }
 
+#[cfg(test)]
 fn load_persisted_search_state(
     storage: &mut Storage,
     storage_path: &Path,
+) -> Result<LoadedSearchState, ApiError> {
+    load_persisted_search_state_for_runtime(
+        storage,
+        storage_path,
+        &codestory_retrieval::SidecarRuntimeConfig::local(),
+    )
+}
+
+fn load_persisted_search_state_for_runtime(
+    storage: &mut Storage,
+    storage_path: &Path,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<LoadedSearchState, ApiError> {
     let _catalog_guard = SearchGenerationCatalogGuard::acquire(storage_path)?;
     *storage = open_storage_for_read(storage_path)?;
@@ -4408,7 +4489,7 @@ fn load_persisted_search_state(
         engine.index_nodes(search_nodes).map_err(|error| {
             ApiError::internal(format!("Failed to index legacy search nodes: {error}"))
         })?;
-        load_persisted_semantic_docs(storage, &mut engine, false)?;
+        load_persisted_semantic_docs_for_runtime(storage, &mut engine, false, runtime)?;
         return Ok(LoadedSearchState {
             publication: None,
             node_names,
@@ -4509,6 +4590,7 @@ fn reload_llm_docs_from_storage(
     Ok(())
 }
 
+#[cfg(test)]
 fn llm_doc_embed_batch_size() -> usize {
     std::env::var(LLM_DOC_EMBED_BATCH_SIZE_ENV)
         .ok()
@@ -4517,6 +4599,7 @@ fn llm_doc_embed_batch_size() -> usize {
         .unwrap_or(LLM_DOC_EMBED_BATCH_SIZE)
 }
 
+#[cfg(test)]
 fn retrieval_state_from_parts(
     semantic_doc_count: u32,
     embedding_model: Option<String>,
@@ -4526,7 +4609,29 @@ fn retrieval_state_from_parts(
     stored_embedding: Option<StoredSemanticDocsContractDto>,
     runtime_degraded: bool,
 ) -> RetrievalStateDto {
-    let hybrid_configured = hybrid_retrieval_enabled();
+    retrieval_state_from_parts_with_hybrid(
+        semantic_doc_count,
+        embedding_model,
+        embedding_runtime_available,
+        fallback_message,
+        current_embedding,
+        stored_embedding,
+        runtime_degraded,
+        hybrid_retrieval_enabled(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn retrieval_state_from_parts_with_hybrid(
+    semantic_doc_count: u32,
+    embedding_model: Option<String>,
+    embedding_runtime_available: bool,
+    fallback_message: Option<String>,
+    current_embedding: Option<EmbeddingProfileContractDto>,
+    stored_embedding: Option<StoredSemanticDocsContractDto>,
+    runtime_degraded: bool,
+    hybrid_configured: bool,
+) -> RetrievalStateDto {
     let fallback_reason = if !hybrid_configured {
         Some(RetrievalFallbackReasonDto::DisabledByConfig)
     } else if runtime_degraded {
@@ -4617,12 +4722,23 @@ fn retrieval_state_from_engine_with_storage_contract(
     retrieval
 }
 
+#[cfg(test)]
 fn retrieval_state_from_storage(storage: &Storage) -> Result<RetrievalStateDto, ApiError> {
+    retrieval_state_from_storage_for_runtime(
+        storage,
+        &codestory_retrieval::SidecarRuntimeConfig::local(),
+    )
+}
+
+fn retrieval_state_from_storage_for_runtime(
+    storage: &Storage,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+) -> Result<RetrievalStateDto, ApiError> {
     let stats = storage
         .get_llm_symbol_doc_stats()
         .map_err(|e| ApiError::internal(format!("Failed to query LLM symbol doc stats: {e}")))?;
-    let probe = embedding_runtime_availability_from_env();
-    let current_embedding = current_embedding_contract_from_env();
+    let probe = embedding_runtime_availability_from_config(&runtime.embedding);
+    let current_embedding = current_embedding_contract_for_runtime(runtime);
     let stored_embedding = stored_semantic_docs_contract_from_stats(&stats);
     let contract_mismatch = stats.doc_count > 0
         && probe.available
@@ -4635,7 +4751,7 @@ fn retrieval_state_from_storage(storage: &Storage) -> Result<RetrievalStateDto, 
                 .to_string()
         })
     });
-    Ok(retrieval_state_from_parts(
+    Ok(retrieval_state_from_parts_with_hybrid(
         stats.doc_count,
         stats
             .embedding_model
@@ -4651,6 +4767,7 @@ fn retrieval_state_from_storage(storage: &Storage) -> Result<RetrievalStateDto, 
         current_embedding,
         Some(stored_embedding),
         contract_mismatch,
+        runtime.retrieval.hybrid_enabled,
     ))
 }
 
@@ -4701,6 +4818,7 @@ fn stored_semantic_docs_contract_from_stats(
     }
 }
 
+#[cfg(test)]
 fn semantic_doc_scope_from_env() -> SemanticDocScope {
     semantic_doc_scope_from_value(&std::env::var(SEMANTIC_DOC_SCOPE_ENV).unwrap_or_default())
 }
@@ -4712,6 +4830,7 @@ fn semantic_doc_scope_from_value(value: &str) -> SemanticDocScope {
     }
 }
 
+#[cfg(test)]
 fn semantic_doc_alias_mode_from_env() -> SemanticDocAliasMode {
     semantic_doc_alias_mode_from_value(
         &std::env::var(SEMANTIC_DOC_ALIAS_MODE_ENV).unwrap_or_default(),
@@ -4730,6 +4849,7 @@ fn semantic_doc_alias_mode_from_value(value: &str) -> SemanticDocAliasMode {
     }
 }
 
+#[cfg(test)]
 fn semantic_doc_max_tokens_from_env() -> usize {
     std::env::var(SEMANTIC_DOC_MAX_TOKENS_ENV)
         .ok()
@@ -4739,6 +4859,7 @@ fn semantic_doc_max_tokens_from_env() -> usize {
         .unwrap_or(SEMANTIC_DOC_DEFAULT_MAX_TOKENS)
 }
 
+#[cfg(test)]
 fn stream_pending_llm_symbol_docs_from_env() -> bool {
     !matches!(
         std::env::var(SEMANTIC_STREAM_PENDING_DOCS_ENV)
@@ -4750,6 +4871,7 @@ fn stream_pending_llm_symbol_docs_from_env() -> bool {
     )
 }
 
+#[cfg(test)]
 fn semantic_stream_sort_window_batches_from_env() -> usize {
     std::env::var(SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV)
         .ok()
@@ -4788,6 +4910,7 @@ fn llm_indexable_kind_for_scope(
     }
 }
 
+#[cfg(test)]
 fn llm_indexable_kind(kind: codestory_contracts::graph::NodeKind) -> bool {
     llm_indexable_kind_for_scope(kind, semantic_doc_scope_from_env())
 }
@@ -4899,10 +5022,25 @@ struct SemanticDocGraphContext {
 }
 
 impl SemanticDocGraphContext {
+    #[cfg(test)]
     fn build(
         storage: &Storage,
         semantic_nodes: &[&GraphNode],
         all_nodes: &[GraphNode],
+    ) -> Result<Self, ApiError> {
+        Self::build_for_scope(
+            storage,
+            semantic_nodes,
+            all_nodes,
+            semantic_doc_scope_from_env(),
+        )
+    }
+
+    fn build_for_scope(
+        storage: &Storage,
+        semantic_nodes: &[&GraphNode],
+        all_nodes: &[GraphNode],
+        scope: SemanticDocScope,
     ) -> Result<Self, ApiError> {
         let nodes_by_id = all_nodes
             .iter()
@@ -4944,11 +5082,11 @@ impl SemanticDocGraphContext {
                 .unwrap_or(&[]);
             context.child_labels.insert(
                 node.id,
-                child_symbol_labels_from_edges(node, edges, &nodes_by_id, 6),
+                child_symbol_labels_from_edges(node, edges, &nodes_by_id, 6, scope),
             );
             context.referenced_labels.insert(
                 node.id,
-                referenced_symbol_labels_from_edges(node, edges, &nodes_by_id, 6),
+                referenced_symbol_labels_from_edges(node, edges, &nodes_by_id, 6, scope),
             );
             context
                 .edge_digests
@@ -5063,6 +5201,7 @@ fn referenced_symbol_labels_from_edges(
     edges: &[GraphEdge],
     nodes_by_id: &HashMap<GraphNodeId, &GraphNode>,
     limit: usize,
+    scope: SemanticDocScope,
 ) -> Vec<String> {
     let mut labels = Vec::new();
 
@@ -5078,7 +5217,7 @@ fn referenced_symbol_labels_from_edges(
         let Some(other_node) = nodes_by_id.get(&other) else {
             continue;
         };
-        if !llm_indexable_kind(other_node.kind) {
+        if !llm_indexable_kind_for_scope(other_node.kind, scope) {
             continue;
         }
         let label = node_display_name(other_node);
@@ -5099,13 +5238,14 @@ fn child_symbol_labels_from_edges(
     edges: &[GraphEdge],
     nodes_by_id: &HashMap<GraphNodeId, &GraphNode>,
     limit: usize,
+    scope: SemanticDocScope,
 ) -> Vec<String> {
     edges
         .iter()
         .filter(|edge| edge.kind == codestory_contracts::graph::EdgeKind::MEMBER)
         .filter(|edge| edge.source == node.id)
         .filter_map(|edge| nodes_by_id.get(&edge.target).copied())
-        .filter(|child| llm_indexable_kind(child.kind))
+        .filter(|child| llm_indexable_kind_for_scope(child.kind, scope))
         .map(node_display_name)
         .filter(|label| !label.is_empty())
         .take(limit)
@@ -5234,6 +5374,7 @@ fn symbol_excerpt(
     (signature, comments, body)
 }
 
+#[cfg(test)]
 fn build_llm_symbol_doc_text(
     graph_context: &SemanticDocGraphContext,
     node: &GraphNode,
@@ -5241,7 +5382,26 @@ fn build_llm_symbol_doc_text(
     file_path: Option<&str>,
     file_text_cache: &HashMap<String, Option<String>>,
 ) -> String {
-    let alias_mode = semantic_doc_alias_mode_from_env();
+    build_llm_symbol_doc_text_with_policy(
+        graph_context,
+        node,
+        display_name,
+        file_path,
+        file_text_cache,
+        semantic_doc_alias_mode_from_env(),
+        semantic_doc_max_tokens_from_env(),
+    )
+}
+
+fn build_llm_symbol_doc_text_with_policy(
+    graph_context: &SemanticDocGraphContext,
+    node: &GraphNode,
+    display_name: &str,
+    file_path: Option<&str>,
+    file_text_cache: &HashMap<String, Option<String>>,
+    alias_mode: SemanticDocAliasMode,
+    max_tokens: usize,
+) -> String {
     let mut out = String::new();
     let _ = writeln!(
         out,
@@ -5336,7 +5496,7 @@ fn build_llm_symbol_doc_text(
         out.push('\n');
     }
 
-    out = truncate_semantic_doc_text_to_token_budget(&out, semantic_doc_max_tokens_from_env());
+    out = truncate_semantic_doc_text_to_token_budget(&out, max_tokens);
 
     out
 }
@@ -5467,12 +5627,16 @@ impl SemanticVectorReuseKey {
     }
 }
 
+#[cfg(test)]
 fn llm_symbol_doc_hash(doc_text: &str) -> String {
+    llm_symbol_doc_hash_with_alias(doc_text, semantic_doc_alias_mode_from_env())
+}
+
+fn llm_symbol_doc_hash_with_alias(doc_text: &str, alias_mode: SemanticDocAliasMode) -> String {
     const FNV_OFFSET: u64 = 0xcbf29ce484222325;
     const FNV_PRIME: u64 = 0x100000001b3;
 
     let mut hash = FNV_OFFSET;
-    let alias_mode = semantic_doc_alias_mode_from_env();
     for byte in LLM_SYMBOL_DOC_SCHEMA_VERSION
         .to_le_bytes()
         .into_iter()
@@ -5866,12 +6030,33 @@ fn is_retrieval_artifact_node(node: &GraphNode) -> bool {
             .is_some_and(|canonical_id| canonical_id.starts_with("codestory:component_report:"))
 }
 
+#[cfg(test)]
 fn build_component_report_docs(
     graph_context: &SemanticDocGraphContext,
     semantic_nodes: &[&GraphNode],
     existing_docs: &HashMap<GraphNodeId, LlmSymbolDocReuseMetadata>,
     embedding_contract: Option<&EmbeddingProfileContractDto>,
     updated_at_epoch_ms: i64,
+) -> Vec<BuiltLlmSymbolDoc> {
+    build_component_report_docs_with_policy(
+        graph_context,
+        semantic_nodes,
+        existing_docs,
+        embedding_contract,
+        updated_at_epoch_ms,
+        semantic_doc_alias_mode_from_env(),
+        semantic_doc_max_tokens_from_env(),
+    )
+}
+
+fn build_component_report_docs_with_policy(
+    graph_context: &SemanticDocGraphContext,
+    semantic_nodes: &[&GraphNode],
+    existing_docs: &HashMap<GraphNodeId, LlmSymbolDocReuseMetadata>,
+    embedding_contract: Option<&EmbeddingProfileContractDto>,
+    updated_at_epoch_ms: i64,
+    alias_mode: SemanticDocAliasMode,
+    max_tokens: usize,
 ) -> Vec<BuiltLlmSymbolDoc> {
     let mut components = BTreeMap::<String, Vec<&GraphNode>>::new();
     for node in semantic_nodes {
@@ -5941,11 +6126,8 @@ fn build_component_report_docs(
             for line in god_nodes {
                 let _ = writeln!(doc_text, "{line}");
             }
-            doc_text = truncate_semantic_doc_text_to_token_budget(
-                &doc_text,
-                semantic_doc_max_tokens_from_env(),
-            );
-            let doc_hash = llm_symbol_doc_hash(&doc_text);
+            doc_text = truncate_semantic_doc_text_to_token_budget(&doc_text, max_tokens);
+            let doc_hash = llm_symbol_doc_hash_with_alias(&doc_text, alias_mode);
             let node_id = virtual_component_report_node_id(&component_key);
             let display_name = format!("component_report:{component_key}");
             let qualified_name = Some(format!("codestory::component_report::{component_key}"));
@@ -6090,7 +6272,8 @@ fn persist_embedded_llm_symbol_docs(
     Ok(())
 }
 
-fn sync_llm_symbol_projection(
+#[allow(clippy::too_many_arguments)]
+fn sync_llm_symbol_projection_for_runtime(
     storage: &mut Storage,
     nodes: &[codestory_contracts::graph::Node],
     node_names: &HashMap<codestory_contracts::graph::NodeId, String>,
@@ -6098,6 +6281,7 @@ fn sync_llm_symbol_projection(
     refresh_scope: SemanticRefreshScope<'_>,
     hydrate_semantic_docs: bool,
     cancel_token: Option<&CancellationToken>,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<SemanticProjectionStats, ApiError> {
     let mut stats = SemanticProjectionStats {
         reported: true,
@@ -6107,15 +6291,15 @@ fn sync_llm_symbol_projection(
         return Err(indexing_cancelled_error());
     }
 
-    if !hybrid_retrieval_enabled() {
+    if !runtime.retrieval.hybrid_enabled {
         if hydrate_semantic_docs {
             engine.index_llm_symbol_docs(Vec::new());
         }
         return Ok(stats);
     }
 
-    let embedding_contract = match engine.set_embedding_runtime_from_env() {
-        Ok(()) => Some(current_embedding_contract_from_env().ok_or_else(|| {
+    let embedding_contract = match engine.set_embedding_runtime_from_config(&runtime.embedding) {
+        Ok(()) => Some(current_embedding_contract_for_runtime(runtime).ok_or_else(|| {
             ApiError::internal(
                 "Failed to resolve current embedding profile contract after configuring runtime",
             )
@@ -6164,9 +6348,12 @@ fn sync_llm_symbol_projection(
     } else {
         refresh_scope.file_ids
     };
-    let embed_batch_size = llm_doc_embed_batch_size();
-    let stream_pending_docs = stream_pending_llm_symbol_docs_from_env();
-    let stream_sort_window_batches = semantic_stream_sort_window_batches_from_env();
+    let embed_batch_size = runtime.retrieval.llm_doc_embed_batch_size;
+    let semantic_alias_mode =
+        semantic_doc_alias_mode_from_value(&runtime.retrieval.semantic_doc_alias_mode);
+    let semantic_max_tokens = runtime.retrieval.semantic_doc_max_tokens;
+    let stream_pending_docs = runtime.retrieval.stream_pending_docs;
+    let stream_sort_window_batches = runtime.retrieval.stream_sort_window_batches;
     let stream_sort_window_size = embed_batch_size.saturating_mul(stream_sort_window_batches);
     tracing::debug!(embed_batch_size, "Using semantic doc embedding batch size");
     let mut pending_docs = Vec::<PendingLlmSymbolDoc>::new();
@@ -6177,7 +6364,12 @@ fn sync_llm_symbol_projection(
     let mut doc_build_ns = 0_u128;
     let all_semantic_nodes = nodes
         .iter()
-        .filter(|node| llm_indexable_kind(node.kind))
+        .filter(|node| {
+            llm_indexable_kind_for_scope(
+                node.kind,
+                semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope),
+            )
+        })
         .filter(|node| !is_retrieval_artifact_node(node))
         .collect::<Vec<_>>();
     let semantic_nodes = all_semantic_nodes
@@ -6276,7 +6468,12 @@ fn sync_llm_symbol_projection(
     let component_access = storage
         .get_component_access_map_for_nodes(&semantic_node_ids)
         .map_err(|e| ApiError::internal(format!("Failed to load symbol access metadata: {e}")))?;
-    let graph_context = SemanticDocGraphContext::build(storage, &context_nodes, nodes)?;
+    let graph_context = SemanticDocGraphContext::build_for_scope(
+        storage,
+        &context_nodes,
+        nodes,
+        semantic_doc_scope_from_value(&runtime.retrieval.semantic_doc_scope),
+    )?;
     let file_cache_started = Instant::now();
     let file_text_cache = build_semantic_file_text_cache(&graph_context, &semantic_nodes);
     doc_build_ns = doc_build_ns.saturating_add(file_cache_started.elapsed().as_nanos());
@@ -6296,14 +6493,16 @@ fn sync_llm_symbol_projection(
                 let file_path = graph_context
                     .file_path_for_node(node)
                     .map(ToString::to_string);
-                let doc_text = build_llm_symbol_doc_text(
+                let doc_text = build_llm_symbol_doc_text_with_policy(
                     &graph_context,
                     node,
                     &display_name,
                     file_path.as_deref(),
                     &file_text_cache,
+                    semantic_alias_mode,
+                    semantic_max_tokens,
                 );
-                let doc_hash = llm_symbol_doc_hash(&doc_text);
+                let doc_hash = llm_symbol_doc_hash_with_alias(&doc_text, semantic_alias_mode);
                 let dense_reason = dense_anchor_reason_for_node(
                     &graph_context,
                     node,
@@ -6430,12 +6629,14 @@ fn sync_llm_symbol_projection(
             return Err(indexing_cancelled_error());
         }
         let report_build_started = Instant::now();
-        let built_reports = build_component_report_docs(
+        let built_reports = build_component_report_docs_with_policy(
             &graph_context,
             &report_semantic_nodes,
             &existing_docs,
             embedding_contract.as_ref(),
             updated_at_epoch_ms,
+            semantic_alias_mode,
+            semantic_max_tokens,
         );
         doc_build_ns = doc_build_ns.saturating_add(report_build_started.elapsed().as_nanos());
         if is_indexing_cancelled(cancel_token) {
@@ -6600,11 +6801,28 @@ fn sync_llm_symbol_projection(
     Ok(stats)
 }
 
+#[cfg(test)]
 fn finalize_staged_semantic_docs(
     storage: &mut Storage,
     llm_refresh_file_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     component_report_refresh: Option<&ComponentReportRefreshScope>,
     cancel_token: Option<&CancellationToken>,
+) -> Result<SemanticProjectionStats, ApiError> {
+    finalize_staged_semantic_docs_for_runtime(
+        storage,
+        llm_refresh_file_scope,
+        component_report_refresh,
+        cancel_token,
+        &codestory_retrieval::SidecarRuntimeConfig::local(),
+    )
+}
+
+fn finalize_staged_semantic_docs_for_runtime(
+    storage: &mut Storage,
+    llm_refresh_file_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
+    component_report_refresh: Option<&ComponentReportRefreshScope>,
+    cancel_token: Option<&CancellationToken>,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<SemanticProjectionStats, ApiError> {
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
@@ -6618,7 +6836,7 @@ fn finalize_staged_semantic_docs(
         .collect::<HashMap<_, _>>();
     let mut engine = SearchEngine::new(None)
         .map_err(|error| ApiError::internal(format!("Failed to init semantic engine: {error}")))?;
-    sync_llm_symbol_projection(
+    sync_llm_symbol_projection_for_runtime(
         storage,
         &nodes,
         &node_names,
@@ -6629,28 +6847,30 @@ fn finalize_staged_semantic_docs(
         },
         false,
         cancel_token,
+        runtime,
     )
 }
 
-fn load_persisted_semantic_docs(
+fn load_persisted_semantic_docs_for_runtime(
     storage: &Storage,
     engine: &mut SearchEngine,
     hydrate_semantic_docs: bool,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<SemanticProjectionStats, ApiError> {
     let mut stats = SemanticProjectionStats {
         reported: true,
         ..Default::default()
     };
-    if !hydrate_semantic_docs || !hybrid_retrieval_enabled() {
+    if !hydrate_semantic_docs || !runtime.retrieval.hybrid_enabled {
         return Ok(stats);
     }
-    if let Err(error) = engine.set_embedding_runtime_from_env() {
+    if let Err(error) = engine.set_embedding_runtime_from_config(&runtime.embedding) {
         tracing::warn!(
             "embedding runtime unavailable while hydrating completed semantic docs: {error}"
         );
         return Ok(stats);
     }
-    let current_contract = current_embedding_contract_from_env().ok_or_else(|| {
+    let current_contract = current_embedding_contract_for_runtime(runtime).ok_or_else(|| {
         ApiError::internal(
             "Failed to resolve current embedding profile contract after configuring runtime",
         )
@@ -7756,6 +7976,7 @@ pub struct AppController {
     sidecar_query_cache: Arc<Mutex<SidecarQueryCacheState>>,
     events_tx: Sender<AppEventPayload>,
     events_rx: Receiver<AppEventPayload>,
+    runtime_config: Arc<codestory_retrieval::SidecarRuntimeConfig>,
 }
 
 #[derive(Debug)]
@@ -7820,6 +8041,10 @@ impl Default for AppController {
 
 impl AppController {
     pub fn new() -> Self {
+        Self::new_with_config(codestory_retrieval::SidecarRuntimeConfig::local())
+    }
+
+    pub fn new_with_config(config: codestory_retrieval::SidecarRuntimeConfig) -> Self {
         let (events_tx, events_rx) = unbounded();
         Self {
             state: Arc::new(Mutex::new(AppState {
@@ -7836,6 +8061,7 @@ impl AppController {
             sidecar_query_cache: Arc::new(Mutex::new(SidecarQueryCacheState::new())),
             events_tx,
             events_rx,
+            runtime_config: Arc::new(config),
         }
     }
 
@@ -7969,7 +8195,11 @@ impl AppController {
         let mut attempts = 0;
         let loaded = loop {
             let mut storage = open_storage_for_read(&storage_path)?;
-            match load_persisted_search_state(&mut storage, &storage_path) {
+            match load_persisted_search_state_for_runtime(
+                &mut storage,
+                &storage_path,
+                &self.runtime_config,
+            ) {
                 Ok(state) => break state,
                 Err(error) if error.code == "cache_busy" && attempts == 0 => attempts += 1,
                 Err(error) => return Err(error),
@@ -7987,7 +8217,7 @@ impl AppController {
 
     pub fn retrieval_state(&self) -> Result<RetrievalStateDto, ApiError> {
         let storage = self.open_storage_read_only()?;
-        retrieval_state_from_storage(&storage)
+        retrieval_state_from_storage_for_runtime(&storage, &self.runtime_config)
     }
 
     fn file_path_for_node(
@@ -8527,7 +8757,10 @@ impl AppController {
             root: root.to_string_lossy().to_string(),
             stats: dto_stats,
             members,
-            retrieval: Some(retrieval_state_from_storage(storage)?),
+            retrieval: Some(retrieval_state_from_storage_for_runtime(
+                storage,
+                &self.runtime_config,
+            )?),
             freshness: Some(freshness),
             publication,
         })
@@ -8584,9 +8817,16 @@ impl AppController {
         storage_path: PathBuf,
     ) -> Result<ProjectSummary, ApiError> {
         let mut storage = open_storage_for_read(&storage_path)?;
-        let loaded = load_persisted_search_state(&mut storage, &storage_path)?;
+        let loaded = load_persisted_search_state_for_runtime(
+            &mut storage,
+            &storage_path,
+            &self.runtime_config,
+        )?;
         let mut summary = self.project_summary_from_storage(&root, &storage_path, &storage)?;
-        summary.retrieval = Some(retrieval_state_from_storage(&storage)?);
+        summary.retrieval = Some(retrieval_state_from_storage_for_runtime(
+            &storage,
+            &self.runtime_config,
+        )?);
 
         {
             let mut s = self.state.lock();
@@ -8710,10 +8950,20 @@ impl AppController {
             let result = match IndexWriterGuard::try_acquire(&storage_path) {
                 Ok(_writer_guard) => {
                     let result = match req.mode {
-                        IndexMode::Full => index_full(&root, &storage_path, &events_tx, None),
-                        IndexMode::Incremental => {
-                            index_incremental(&root, &storage_path, &events_tx, None)
-                        }
+                        IndexMode::Full => index_full_for_runtime(
+                            &root,
+                            &storage_path,
+                            &events_tx,
+                            None,
+                            &controller.runtime_config,
+                        ),
+                        IndexMode::Incremental => index_incremental_for_runtime(
+                            &root,
+                            &storage_path,
+                            &events_tx,
+                            None,
+                            &controller.runtime_config,
+                        ),
                     };
                     result.and_then(|summary| {
                         controller.finish_successful_indexing(summary, &storage_path, true, None)
@@ -8772,10 +9022,20 @@ impl AppController {
         };
 
         let result = match mode {
-            IndexMode::Full => index_full(&root, &storage_path, &self.events_tx, cancel_token),
-            IndexMode::Incremental => {
-                index_incremental(&root, &storage_path, &self.events_tx, cancel_token)
-            }
+            IndexMode::Full => index_full_for_runtime(
+                &root,
+                &storage_path,
+                &self.events_tx,
+                cancel_token,
+                &self.runtime_config,
+            ),
+            IndexMode::Incremental => index_incremental_for_runtime(
+                &root,
+                &storage_path,
+                &self.events_tx,
+                cancel_token,
+                &self.runtime_config,
+            ),
         };
 
         match result {
@@ -8828,11 +9088,12 @@ impl AppController {
                 storage_path,
                 summary.llm_refresh_scope.as_ref(),
                 |storage, llm_refresh_scope| {
-                    rebuild_search_state_from_storage(
+                    rebuild_search_state_from_storage_for_runtime(
                         storage,
                         storage_path,
                         llm_refresh_scope,
                         false,
+                        &self.runtime_config,
                     )
                     .map(|result| CacheRefreshStats {
                         search_stats: result.search_stats,
@@ -8968,20 +9229,17 @@ impl AppController {
     }
 
     pub fn summarize_symbols_blocking(&self) -> Result<SummaryGenerationDto, ApiError> {
-        let endpoint = std::env::var("CODESTORY_SUMMARY_ENDPOINT")
-            .ok()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
+        let endpoint = self
+            .runtime_config
+            .summary
+            .endpoint
+            .clone()
             .ok_or_else(|| {
                 ApiError::invalid_argument(
                     "--summarize requires CODESTORY_SUMMARY_ENDPOINT to be configured.",
                 )
             })?;
-        let model = std::env::var("CODESTORY_SUMMARY_MODEL")
-            .ok()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_else(|| "codestory-symbol-summary".to_string());
+        let model = self.runtime_config.summary.model.clone();
         let storage_path = self.require_storage_path()?;
         let mut storage = Store::open(&storage_path)
             .map_err(|e| ApiError::internal(format!("Failed to open storage: {e}")))?;
@@ -9005,7 +9263,8 @@ impl AppController {
                 skipped = skipped.saturating_add(1);
                 continue;
             }
-            let summary = summarize_symbol_doc(&endpoint, &model, &doc)?;
+            let summary =
+                summarize_symbol_doc(&endpoint, &model, &doc, &self.runtime_config.summary)?;
             pending.push(SymbolSummaryRecord {
                 node_id: doc.node_id,
                 content_hash: doc.doc_hash,
@@ -9567,7 +9826,7 @@ impl AppController {
         annotate_search_hit_match_quality(&query, &mut indexed_symbol_hits);
 
         let storage = self.open_storage_read_only()?;
-        let retrieval = retrieval_state_from_storage(&storage)?;
+        let retrieval = retrieval_state_from_storage_for_runtime(&storage, &self.runtime_config)?;
         let freshness = self.index_freshness().ok();
         let mut repo_text_hits = Vec::new();
         let suggestions = Vec::new();
@@ -10465,7 +10724,8 @@ impl AppController {
                 && engine.semantic_doc_count() == 0
             {
                 if !engine.embedding_runtime_configured()
-                    && let Err(error) = engine.set_embedding_runtime_from_env()
+                    && let Err(error) =
+                        engine.set_embedding_runtime_from_config(&self.runtime_config.embedding)
                 {
                     tracing::warn!(
                         "Search embedding runtime unavailable during hybrid load: {error}"
@@ -11327,11 +11587,12 @@ fn finish_incremental_run_marker(
         .map_err(|e| ApiError::internal(format!("Failed to clear incomplete index marker: {e}")))
 }
 
-fn index_full(
+fn index_full_for_runtime(
     root: &Path,
     storage_path: &Path,
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<IndexingRunSummary, ApiError> {
     let previous_publication = if storage_path.exists() {
         Store::database_index_publication(storage_path).map_err(|error| {
@@ -11442,14 +11703,19 @@ fn index_full(
             }
         }
     }
-    let staged_semantic_stats =
-        match finalize_staged_semantic_docs(staged.store_mut(), None, None, cancel_token) {
-            Ok(stats) => stats,
-            Err(error) => {
-                let _ = staged.discard();
-                return Err(error);
-            }
-        };
+    let staged_semantic_stats = match finalize_staged_semantic_docs_for_runtime(
+        staged.store_mut(),
+        None,
+        None,
+        cancel_token,
+        runtime,
+    ) {
+        Ok(stats) => stats,
+        Err(error) => {
+            let _ = staged.discard();
+            return Err(error);
+        }
+    };
     if is_indexing_cancelled(cancel_token) {
         let _ = staged.discard();
         return Err(indexing_cancelled_error());
@@ -11500,15 +11766,20 @@ fn index_full(
             "Failed to persist staged full publication identity: {error}"
         )));
     }
-    let prepared_search_state =
-        match rebuild_search_state_from_storage(staged.store_mut(), storage_path, None, false) {
-            Ok(state) => state,
-            Err(error) => {
-                let _ = staged.discard();
-                discard_unpublished_search_generation(storage_path, &publication);
-                return Err(error);
-            }
-        };
+    let prepared_search_state = match rebuild_search_state_from_storage_for_runtime(
+        staged.store_mut(),
+        storage_path,
+        None,
+        false,
+        runtime,
+    ) {
+        Ok(state) => state,
+        Err(error) => {
+            let _ = staged.discard();
+            discard_unpublished_search_generation(storage_path, &publication);
+            return Err(error);
+        }
+    };
     if is_indexing_cancelled(cancel_token) {
         drop(prepared_search_state);
         let _ = staged.discard();
@@ -11635,17 +11906,35 @@ fn index_full(
     })
 }
 
+#[cfg(test)]
 fn index_incremental(
     root: &Path,
     storage_path: &Path,
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
 ) -> Result<IndexingRunSummary, ApiError> {
+    index_incremental_for_runtime(
+        root,
+        storage_path,
+        events_tx,
+        cancel_token,
+        &codestory_retrieval::SidecarRuntimeConfig::local(),
+    )
+}
+
+fn index_incremental_for_runtime(
+    root: &Path,
+    storage_path: &Path,
+    events_tx: &Sender<AppEventPayload>,
+    cancel_token: Option<&CancellationToken>,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+) -> Result<IndexingRunSummary, ApiError> {
     run_incremental_indexing_common(
         root,
         storage_path,
         events_tx,
         cancel_token,
+        runtime,
         |workspace, inputs| {
             workspace
                 .build_execution_plan(inputs)
@@ -11681,6 +11970,7 @@ fn run_incremental_indexing_common<F>(
     storage_path: &Path,
     events_tx: &Sender<AppEventPayload>,
     cancel_token: Option<&CancellationToken>,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
     refresh_builder: F,
 ) -> Result<IndexingRunSummary, ApiError>
 where
@@ -11696,7 +11986,7 @@ where
             message: "A prior incremental index run was interrupted; rebuilding through staged full recovery."
                 .to_string(),
         });
-        return index_full(root, storage_path, events_tx, cancel_token);
+        return index_full_for_runtime(root, storage_path, events_tx, cancel_token, runtime);
     }
     if is_indexing_cancelled(cancel_token) {
         return Err(indexing_cancelled_error());
@@ -11820,11 +12110,12 @@ where
             for file_id in &execution_plan.files_to_remove {
                 llm_refresh_scope.insert(codestory_contracts::graph::NodeId(*file_id));
             }
-            let staged_semantic_stats = finalize_staged_semantic_docs(
+            let staged_semantic_stats = finalize_staged_semantic_docs_for_runtime(
                 staged.store_mut(),
                 Some(&llm_refresh_scope),
                 Some(&component_report_refresh),
                 cancel_token,
+                runtime,
             )?;
             if is_indexing_cancelled(cancel_token) {
                 return Err(indexing_cancelled_error());
@@ -11890,11 +12181,12 @@ where
             "Failed to persist staged incremental publication identity: {error}"
         )));
     }
-    let prepared_search_state = match rebuild_search_state_from_storage(
+    let prepared_search_state = match rebuild_search_state_from_storage_for_runtime(
         staged.store_mut(),
         storage_path,
         Some(&llm_refresh_scope),
         false,
+        runtime,
     ) {
         Ok(state) => state,
         Err(error) => {
@@ -12056,6 +12348,7 @@ fn reuse_completed_search_state(
     nodes: &[codestory_contracts::graph::Node],
     llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     hydrate_semantic_docs: bool,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<Option<SearchStateBuildResult>, ApiError> {
     let generation_id = Uuid::parse_str(&publication.generation_id)
         .map_err(|error| {
@@ -12114,7 +12407,12 @@ fn reuse_completed_search_state(
         return Ok(None);
     }
     let search_symbol_index_ms = clamp_u128_to_u32(search_index_started.elapsed().as_millis());
-    let semantic_stats = load_persisted_semantic_docs(storage, &mut engine, hydrate_semantic_docs)?;
+    let semantic_stats = load_persisted_semantic_docs_for_runtime(
+        storage,
+        &mut engine,
+        hydrate_semantic_docs,
+        runtime,
+    )?;
     Ok(Some(SearchStateBuildResult {
         publication: Some(publication.clone()),
         node_names,
@@ -12127,11 +12425,28 @@ fn reuse_completed_search_state(
     }))
 }
 
+#[cfg(test)]
 fn rebuild_search_state_from_storage(
     storage: &mut Storage,
     storage_path: &Path,
     llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
     hydrate_semantic_docs: bool,
+) -> Result<SearchStateBuildResult, ApiError> {
+    rebuild_search_state_from_storage_for_runtime(
+        storage,
+        storage_path,
+        llm_refresh_scope,
+        hydrate_semantic_docs,
+        &codestory_retrieval::SidecarRuntimeConfig::local(),
+    )
+}
+
+fn rebuild_search_state_from_storage_for_runtime(
+    storage: &mut Storage,
+    storage_path: &Path,
+    llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
+    hydrate_semantic_docs: bool,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> Result<SearchStateBuildResult, ApiError> {
     let publication = storage.get_index_publication().map_err(|error| {
         ApiError::internal(format!(
@@ -12155,19 +12470,21 @@ fn rebuild_search_state_from_storage(
             &nodes,
             llm_refresh_scope,
             hydrate_semantic_docs,
+            runtime,
         )?,
         None => None,
     };
     let built_new = reused.is_none();
     let mut result = match reused {
         Some(result) => result,
-        None => build_search_state(
+        None => build_search_state_for_runtime(
             storage,
             Some(search_storage_path.as_path()),
             nodes,
             llm_refresh_scope,
             SemanticProjectionMode::LoadPersistedDocs,
             hydrate_semantic_docs,
+            runtime,
         )
         .map_err(|e| {
             ApiError::internal(format!("Failed to rebuild search state: {}", e.message))
@@ -12213,8 +12530,13 @@ fn refresh_caches(
     storage_path: &Path,
     llm_refresh_scope: Option<&HashSet<codestory_contracts::graph::NodeId>>,
 ) -> Result<CacheRefreshStats, ApiError> {
-    let refreshed =
-        rebuild_search_state_from_storage(storage, storage_path, llm_refresh_scope, true);
+    let refreshed = rebuild_search_state_from_storage_for_runtime(
+        storage,
+        storage_path,
+        llm_refresh_scope,
+        true,
+        &controller.runtime_config,
+    );
 
     match refreshed {
         Ok(result) => Ok(publish_prepared_search_state(controller, result)),
@@ -16556,7 +16878,15 @@ fn build_llm_symbol_doc_text() -> String {
         );
 
         env.push(EnvGuard::set(EMBEDDING_EXPECTED_DIM_ENV, "384"));
-        let repair_timings = controller
+        let repair_controller =
+            AppController::new_with_config(codestory_retrieval::SidecarRuntimeConfig::local());
+        repair_controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary with updated runtime");
+        let repair_timings = repair_controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Full)
             .expect("second full index after dimension change");
         assert!(
@@ -16851,7 +17181,15 @@ fn build_llm_symbol_doc_text() -> String {
         source.push_str("\nfn codestory_contract_drift_added_hint() -> i32 { 7 }\n");
         fs::write(&rust_fixture, source).expect("write changed rust fixture");
 
-        let incremental_timings = controller
+        let repair_controller =
+            AppController::new_with_config(codestory_retrieval::SidecarRuntimeConfig::local());
+        repair_controller
+            .open_project_summary_with_storage_path(
+                workspace.path().to_path_buf(),
+                storage_path.clone(),
+            )
+            .expect("open project summary with updated runtime");
+        let incremental_timings = repair_controller
             .run_indexing_blocking_without_runtime_refresh(IndexMode::Incremental)
             .expect("incremental index after contract drift");
         assert!(

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -7,13 +7,11 @@ use fs4::fs_std::FileExt;
 use nucleo_matcher::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config as NucleoConfig, Matcher, Utf32String};
 use rayon::prelude::*;
-use serde_json::{Value as JsonValue, json};
 use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
 use tantivy::collector::TopDocs;
 use tantivy::doc;
 use tantivy::query::QueryParser;
@@ -33,6 +31,7 @@ pub const EMBEDDING_DOCUMENT_PREFIX_ENV: &str = "CODESTORY_EMBED_DOCUMENT_PREFIX
 pub const EMBEDDING_LAYER_NORM_ENV: &str = "CODESTORY_EMBED_LAYER_NORM";
 pub const EMBEDDING_TRUNCATE_DIM_ENV: &str = "CODESTORY_EMBED_TRUNCATE_DIM";
 pub const EMBEDDING_EXPECTED_DIM_ENV: &str = "CODESTORY_EMBED_EXPECTED_DIM";
+#[cfg(test)]
 const REMOVED_ONNX_ENV_VARS: &[&str] = &[
     "CODESTORY_EMBED_ONNX_MODEL",
     "CODESTORY_EMBED_ONNX_TOKENIZER",
@@ -44,9 +43,6 @@ pub const LLAMACPP_EMBEDDINGS_URL_ENV: &str = "CODESTORY_EMBED_LLAMACPP_URL";
 pub const LLAMACPP_REQUEST_COUNT_ENV: &str = "CODESTORY_EMBED_LLAMACPP_REQUEST_COUNT";
 pub const STORED_VECTOR_ENCODING_ENV: &str = "CODESTORY_STORED_VECTOR_ENCODING";
 pub const SYMBOL_FULL_TEXT_INDEX_ENV: &str = "CODESTORY_SYMBOL_FULL_TEXT_INDEX";
-const DEFAULT_LLAMACPP_EMBEDDINGS_URL: &str = "http://127.0.0.1:8080/v1/embeddings";
-const DEFAULT_LLAMACPP_REQUEST_COUNT: usize = 1;
-const MAX_LLAMACPP_REQUEST_COUNT: usize = 16;
 #[cfg(test)]
 const SEMANTIC_QUANTIZED_RESCORE_MULTIPLIER: usize = 4;
 
@@ -74,13 +70,6 @@ pub struct EmbeddingProfileContract {
     pub dimension: Option<u32>,
 }
 
-fn env_usize(key: &str, min: usize, max: usize) -> Option<usize> {
-    std::env::var(key)
-        .ok()
-        .and_then(|raw| raw.trim().parse::<usize>().ok())
-        .map(|value| value.clamp(min, max))
-}
-
 fn env_bool_override(key: &str) -> Option<bool> {
     std::env::var(key).ok().and_then(|raw| {
         let normalized = raw.trim().to_ascii_lowercase();
@@ -96,26 +85,10 @@ fn symbol_full_text_index_enabled_from_env() -> bool {
     env_bool_override(SYMBOL_FULL_TEXT_INDEX_ENV).unwrap_or(true)
 }
 
+#[cfg(test)]
 fn embedding_parallel_chunk_size(text_count: usize, worker_count: usize) -> usize {
     let workers = worker_count.max(1).min(text_count.max(1));
     text_count.max(1).div_ceil(workers).max(1)
-}
-
-fn llamacpp_request_count_from_env() -> usize {
-    let Ok(raw) = std::env::var(LLAMACPP_REQUEST_COUNT_ENV) else {
-        return DEFAULT_LLAMACPP_REQUEST_COUNT;
-    };
-    let normalized = raw.trim().to_ascii_lowercase();
-    if matches!(normalized.as_str(), "auto" | "available_parallelism") {
-        return std::thread::available_parallelism()
-            .map(|workers| workers.get())
-            .unwrap_or(DEFAULT_LLAMACPP_REQUEST_COUNT)
-            .clamp(1, MAX_LLAMACPP_REQUEST_COUNT);
-    }
-    normalized
-        .parse::<usize>()
-        .map(|value| value.clamp(1, MAX_LLAMACPP_REQUEST_COUNT))
-        .unwrap_or(DEFAULT_LLAMACPP_REQUEST_COUNT)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,6 +98,7 @@ enum EmbeddingBackendSelection {
 }
 
 impl EmbeddingBackendSelection {
+    #[cfg(test)]
     fn from_env() -> Result<Self> {
         if let Some(name) = REMOVED_ONNX_ENV_VARS
             .iter()
@@ -134,13 +108,21 @@ impl EmbeddingBackendSelection {
                 "{name} is no longer supported; CodeStory retrieval requires the llama.cpp sidecar"
             );
         }
-        let runtime_mode_raw = std::env::var(EMBEDDING_RUNTIME_MODE_ENV).ok();
-        let backend_raw = std::env::var(EMBEDDING_BACKEND_ENV).ok();
-        let runtime_mode = runtime_mode_raw
-            .as_deref()
-            .unwrap_or("llamacpp")
-            .trim()
-            .to_ascii_lowercase();
+        if let Ok(runtime_mode) = std::env::var(EMBEDDING_RUNTIME_MODE_ENV)
+            && matches!(
+                runtime_mode.trim().to_ascii_lowercase().as_str(),
+                "onnx" | "ort" | "onnxruntime" | "onnx-runtime"
+            )
+        {
+            bail!(
+                "{EMBEDDING_RUNTIME_MODE_ENV}={runtime_mode} is no longer supported; CodeStory retrieval requires the llama.cpp sidecar"
+            );
+        }
+        Self::from_config(&codestory_retrieval::SidecarRuntimeConfig::local().embedding)
+    }
+
+    fn from_config(config: &codestory_retrieval::EmbeddingRuntimeConfig) -> Result<Self> {
+        let runtime_mode = config.backend.trim().to_ascii_lowercase();
         if matches!(
             runtime_mode.as_str(),
             "onnx" | "ort" | "onnxruntime" | "onnx-runtime"
@@ -153,35 +135,10 @@ impl EmbeddingBackendSelection {
             return Ok(Self::HashProjection);
         }
 
-        let backend = backend_raw
-            .as_deref()
-            .unwrap_or(&runtime_mode)
-            .trim()
-            .to_ascii_lowercase();
-        if backend_is_auto_or_default(&backend)
-            && runtime_mode_raw
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .is_none()
-            && backend_raw
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .is_none()
-            && std::env::var(LLAMACPP_EMBEDDINGS_URL_ENV)
-                .ok()
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .is_some()
-        {
-            return Ok(Self::LlamaCpp);
-        }
-        match backend.as_str() {
+        match runtime_mode.as_str() {
             "" | "auto" => Ok(Self::LlamaCpp),
             "onnx" | "ort" | "onnxruntime" | "onnx-runtime" => Err(anyhow!(
-                "embedding backend `{backend}` is no longer supported; CodeStory retrieval requires the llama.cpp sidecar"
+                "embedding backend `{runtime_mode}` is no longer supported; CodeStory retrieval requires the llama.cpp sidecar"
             )),
             "llamacpp" | "llama.cpp" | "llama-cpp" | "gguf" => Ok(Self::LlamaCpp),
             "hash" | "hash_projection" => Ok(Self::HashProjection),
@@ -197,10 +154,6 @@ impl EmbeddingBackendSelection {
             Self::HashProjection => "hash",
         }
     }
-}
-
-fn backend_is_auto_or_default(value: &str) -> bool {
-    matches!(value, "" | "auto")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -234,11 +187,13 @@ struct EmbeddingProfile {
 }
 
 impl EmbeddingProfile {
+    #[cfg(test)]
     fn from_env() -> Result<Self> {
-        let name = std::env::var(EMBEDDING_PROFILE_ENV)
-            .unwrap_or_else(|_| "bge-base-en-v1.5".to_string())
-            .trim()
-            .to_ascii_lowercase();
+        Self::from_config(&codestory_retrieval::SidecarRuntimeConfig::local().embedding)
+    }
+
+    fn from_config(config: &codestory_retrieval::EmbeddingRuntimeConfig) -> Result<Self> {
+        let name = config.profile.trim().to_ascii_lowercase();
 
         let mut profile = match name.as_str() {
             "" | "minilm" | "all-minilm-l6-v2" => Self {
@@ -332,29 +287,27 @@ impl EmbeddingProfile {
             }
         };
 
-        if let Ok(model_id) = std::env::var(EMBEDDING_MODEL_ID_ENV)
-            && !model_id.trim().is_empty()
-        {
-            profile.model_id = model_id;
+        if let Some(model_id) = config.model_id.as_ref() {
+            profile.model_id = model_id.clone();
         }
-        if let Ok(raw) = std::env::var(EMBEDDING_POOLING_ENV) {
-            profile.pooling = EmbeddingPooling::from_value(&raw)
+        if let Some(raw) = config.pooling.as_ref() {
+            profile.pooling = EmbeddingPooling::from_value(raw)
                 .ok_or_else(|| anyhow!("unsupported {EMBEDDING_POOLING_ENV} value `{raw}`"))?;
         }
-        if let Ok(prefix) = std::env::var(EMBEDDING_QUERY_PREFIX_ENV) {
-            profile.query_prefix = prefix;
+        if let Some(prefix) = config.query_prefix.as_ref() {
+            profile.query_prefix = prefix.clone();
         }
-        if let Ok(prefix) = std::env::var(EMBEDDING_DOCUMENT_PREFIX_ENV) {
-            profile.document_prefix = prefix;
+        if let Some(prefix) = config.document_prefix.as_ref() {
+            profile.document_prefix = prefix.clone();
         }
-        if let Some(layer_norm) = env_bool_override(EMBEDDING_LAYER_NORM_ENV) {
+        if let Some(layer_norm) = config.layer_norm {
             profile.layer_norm = layer_norm;
         }
-        if let Some(truncate_dim) = env_usize(EMBEDDING_TRUNCATE_DIM_ENV, 1, 8192) {
+        if let Some(truncate_dim) = config.truncate_dim {
             profile.truncate_dim = Some(truncate_dim);
             profile.expected_dim = Some(truncate_dim);
         }
-        if let Some(expected_dim) = env_usize(EMBEDDING_EXPECTED_DIM_ENV, 1, 8192) {
+        if let Some(expected_dim) = config.expected_dim {
             profile.expected_dim = Some(expected_dim);
         }
 
@@ -381,13 +334,21 @@ impl EmbeddingProfile {
 }
 
 pub fn embedding_runtime_availability_from_env() -> EmbeddingRuntimeAvailability {
-    let profile = match EmbeddingProfile::from_env() {
+    embedding_runtime_availability_from_config(
+        &codestory_retrieval::SidecarRuntimeConfig::local().embedding,
+    )
+}
+
+pub fn embedding_runtime_availability_from_config(
+    config: &codestory_retrieval::EmbeddingRuntimeConfig,
+) -> EmbeddingRuntimeAvailability {
+    let profile = match EmbeddingProfile::from_config(config) {
         Ok(profile) => profile,
         Err(error) => {
             return unavailable_embedding_runtime(None, error);
         }
     };
-    let backend = match EmbeddingBackendSelection::from_env() {
+    let backend = match EmbeddingBackendSelection::from_config(config) {
         Ok(backend) => backend,
         Err(error) => {
             return unavailable_embedding_runtime(Some(profile.model_id.clone()), error);
@@ -399,7 +360,7 @@ pub fn embedding_runtime_availability_from_env() -> EmbeddingRuntimeAvailability
         return available_embedding_runtime(model_id);
     }
 
-    if let Err(error) = ensure_embedding_backend_available(backend) {
+    if let Err(error) = ensure_embedding_backend_available(backend, config) {
         return unavailable_embedding_runtime(Some(model_id), error);
     }
 
@@ -425,18 +386,34 @@ fn unavailable_embedding_runtime(
     }
 }
 
-fn ensure_embedding_backend_available(backend: EmbeddingBackendSelection) -> Result<()> {
+fn ensure_embedding_backend_available(
+    backend: EmbeddingBackendSelection,
+    config: &codestory_retrieval::EmbeddingRuntimeConfig,
+) -> Result<()> {
     match backend {
         EmbeddingBackendSelection::LlamaCpp => {
-            LlamaCppEndpoint::from_env().and_then(|endpoint| endpoint.ensure_reachable())
+            let probe = codestory_retrieval::LlamaCppEmbeddingClient::new(config)?.probe();
+            if probe.reachable {
+                Ok(())
+            } else {
+                bail!("{}", probe.detail)
+            }
         }
         EmbeddingBackendSelection::HashProjection => Ok(()),
     }
 }
 
 pub fn embedding_profile_contract_from_env() -> Result<EmbeddingProfileContract> {
-    let profile = EmbeddingProfile::from_env()?;
-    let backend = EmbeddingBackendSelection::from_env()?;
+    embedding_profile_contract_from_config(
+        &codestory_retrieval::SidecarRuntimeConfig::local().embedding,
+    )
+}
+
+pub fn embedding_profile_contract_from_config(
+    config: &codestory_retrieval::EmbeddingRuntimeConfig,
+) -> Result<EmbeddingProfileContract> {
+    let profile = EmbeddingProfile::from_config(config)?;
+    let backend = EmbeddingBackendSelection::from_config(config)?;
     let cache_key = profile.cache_model_id(backend);
     Ok(EmbeddingProfileContract {
         profile: profile.name.clone(),
@@ -677,234 +654,22 @@ enum EmbeddingBackend {
     HashProjection,
 }
 
-#[derive(Debug, Clone)]
-struct LlamaCppEndpoint {
-    host: String,
-    port: u16,
-    path: String,
-}
-
-impl LlamaCppEndpoint {
-    fn from_env() -> Result<Self> {
-        let raw = std::env::var(LLAMACPP_EMBEDDINGS_URL_ENV)
-            .unwrap_or_else(|_| DEFAULT_LLAMACPP_EMBEDDINGS_URL.to_string());
-        Self::parse(&raw)
-    }
-
-    fn parse(raw: &str) -> Result<Self> {
-        let trimmed = raw.trim();
-        let rest = trimmed
-            .strip_prefix("http://")
-            .ok_or_else(|| anyhow!("{LLAMACPP_EMBEDDINGS_URL_ENV} must be an http:// URL"))?;
-        let (authority, path) = rest
-            .split_once('/')
-            .map(|(authority, path)| (authority, format!("/{path}")))
-            .unwrap_or((rest, "/v1/embeddings".to_string()));
-        let (host, port) = if let Some((host, raw_port)) = authority.rsplit_once(':') {
-            let port = raw_port
-                .parse::<u16>()
-                .with_context(|| format!("invalid port in {LLAMACPP_EMBEDDINGS_URL_ENV}"))?;
-            (host.to_string(), port)
-        } else {
-            (authority.to_string(), 80)
-        };
-        if host.trim().is_empty() {
-            return Err(anyhow!("{LLAMACPP_EMBEDDINGS_URL_ENV} must include a host"));
-        }
-        Ok(Self { host, port, path })
-    }
-
-    fn url(&self) -> String {
-        format!("http://{}:{}{}", self.host, self.port, self.path)
-    }
-
-    fn display_url(&self) -> String {
-        let host = self
-            .host
-            .rsplit_once('@')
-            .map_or(self.host.as_str(), |(_, host)| host);
-        let path = self
-            .path
-            .split_once('#')
-            .map_or(self.path.as_str(), |(path, _)| path);
-        let path = path.split_once('?').map_or(path, |(path, _)| path);
-        format!("http://{host}:{}{path}", self.port)
-    }
-
-    fn redact_error_text(&self, text: &str) -> String {
-        let mut redacted = text.replace(&self.url(), &self.display_url());
-        if let Some((userinfo, host)) = self.host.rsplit_once('@') {
-            redacted = redacted
-                .replace(&self.host, host)
-                .replace(userinfo, "[redacted]");
-            if let Some((username, password)) = userinfo.split_once(':') {
-                for secret in [username, password] {
-                    if !secret.is_empty() {
-                        redacted = redacted.replace(secret, "[redacted]");
-                    }
-                }
-            }
-        }
-        if let Some((_, query_and_fragment)) = self.path.split_once('?') {
-            redacted = redacted.replace(query_and_fragment, "[redacted]");
-            for pair in query_and_fragment
-                .split('#')
-                .next()
-                .unwrap_or_default()
-                .split('&')
-            {
-                if let Some((_, value)) = pair.split_once('=')
-                    && !value.is_empty()
-                {
-                    redacted = redacted.replace(value, "[redacted]");
-                }
-            }
-        }
-        if let Some((_, fragment)) = self.path.split_once('#')
-            && !fragment.is_empty()
-        {
-            redacted = redacted.replace(fragment, "[redacted]");
-        }
-        redacted
-    }
-
-    fn ensure_reachable(&self) -> Result<()> {
-        match ureq::get(&self.url())
-            .timeout(Duration::from_millis(750))
-            .call()
-        {
-            Ok(_) | Err(ureq::Error::Status(_, _)) => Ok(()),
-            Err(error) => Err(anyhow!(
-                "failed to connect to llama.cpp endpoint {}: {}",
-                self.display_url(),
-                self.redact_error_text(&error.to_string())
-            )),
-        }
-    }
-}
-
 #[derive(Debug)]
 struct LlamaCppEmbeddingRuntime {
-    endpoint: LlamaCppEndpoint,
-    request_count: usize,
+    client: codestory_retrieval::LlamaCppEmbeddingClient,
 }
 
 impl LlamaCppEmbeddingRuntime {
     fn embed_texts(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
-        if texts.is_empty() {
-            return Ok(Vec::new());
-        }
-        if self.request_count > 1 && texts.len() > 1 {
-            let chunk_size = embedding_parallel_chunk_size(texts.len(), self.request_count);
-            let chunks = texts
-                .par_chunks(chunk_size)
-                .map(|chunk| self.embed_texts_serial(chunk))
-                .collect::<Result<Vec<_>>>()?;
-            return Ok(chunks.into_iter().flatten().collect());
-        }
-        self.embed_texts_serial(texts)
+        self.client.embed_prepared_texts(texts)
     }
-
-    fn embed_texts_serial(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
-        let request = json!({
-            "input": texts,
-            "model": "codestory-local-embedding"
-        });
-        let response = post_json_to_http_endpoint(&self.endpoint, &request)?;
-        parse_openai_embeddings_response(response, texts.len())
-    }
-}
-
-fn post_json_to_http_endpoint(
-    endpoint: &LlamaCppEndpoint,
-    request: &JsonValue,
-) -> Result<JsonValue> {
-    let body = serde_json::to_string(request).context("failed to serialize llama.cpp request")?;
-    let endpoint_url = endpoint.url();
-    let display_url = endpoint.display_url();
-    let agent = ureq::builder().redirects(0).build();
-    let response = codestory_retrieval::outbound_http::read_bytes(
-        agent
-            .post(&endpoint_url)
-            .timeout(Duration::from_secs(300))
-            .set("Content-Type", "application/json")
-            .set("Accept", "application/json")
-            .send_bytes(body.as_bytes()),
-    )
-    .map_err(|error| {
-        anyhow!(
-            "llama.cpp embeddings request to {display_url} failed: {}",
-            endpoint.redact_error_text(&error.to_string())
-        )
-    })?;
-    if !(200..300).contains(&response.status) {
-        let response_body = String::from_utf8_lossy(&response.body);
-        bail!(
-            "llama.cpp embeddings endpoint {} returned HTTP {}: {}",
-            display_url,
-            response.status,
-            codestory_retrieval::outbound_http::truncate_http_body(
-                &endpoint.redact_error_text(&response_body)
-            )
-        );
-    }
-
-    serde_json::from_slice(&response.body).with_context(|| {
-        format!(
-            "failed to parse JSON response from llama.cpp endpoint {}",
-            display_url
-        )
-    })
-}
-
-fn parse_openai_embeddings_response(
-    response: JsonValue,
-    expected_count: usize,
-) -> Result<Vec<Vec<f32>>> {
-    let data = response
-        .get("data")
-        .and_then(JsonValue::as_array)
-        .ok_or_else(|| anyhow!("llama.cpp embeddings response missing `data` array"))?;
-    if data.len() != expected_count {
-        return Err(anyhow!(
-            "llama.cpp embeddings response returned {} vectors for {} inputs",
-            data.len(),
-            expected_count
-        ));
-    }
-
-    let mut indexed = Vec::with_capacity(data.len());
-    for (fallback_index, item) in data.iter().enumerate() {
-        let index = item
-            .get("index")
-            .and_then(JsonValue::as_u64)
-            .map(|value| value as usize)
-            .unwrap_or(fallback_index);
-        let embedding = item
-            .get("embedding")
-            .and_then(JsonValue::as_array)
-            .ok_or_else(|| anyhow!("llama.cpp embeddings response item missing `embedding`"))?
-            .iter()
-            .map(|value| {
-                value
-                    .as_f64()
-                    .map(|number| number as f32)
-                    .ok_or_else(|| anyhow!("llama.cpp embedding contained a non-numeric value"))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        indexed.push((index, embedding));
-    }
-    indexed.sort_by_key(|(index, _)| *index);
-    Ok(indexed
-        .into_iter()
-        .map(|(_, embedding)| embedding)
-        .collect())
 }
 
 impl EmbeddingRuntime {
     pub fn probe_from_env() -> Result<EmbeddingRuntimeProbe> {
-        let profile = EmbeddingProfile::from_env()?;
-        let backend = EmbeddingBackendSelection::from_env()?;
+        let config = codestory_retrieval::SidecarRuntimeConfig::local().embedding;
+        let profile = EmbeddingProfile::from_config(&config)?;
+        let backend = EmbeddingBackendSelection::from_config(&config)?;
         let model_id = profile.cache_model_id(backend);
 
         if backend == EmbeddingBackendSelection::HashProjection {
@@ -915,10 +680,13 @@ impl EmbeddingRuntime {
         }
 
         if backend == EmbeddingBackendSelection::LlamaCpp {
-            let endpoint = LlamaCppEndpoint::from_env()?;
-            endpoint.ensure_reachable()?;
+            let client = codestory_retrieval::LlamaCppEmbeddingClient::new(&config)?;
+            let probe = client.probe();
+            if !probe.reachable {
+                bail!("{}", probe.detail);
+            }
             return Ok(EmbeddingRuntimeProbe {
-                model_path: PathBuf::from(endpoint.url()),
+                model_path: PathBuf::from(client.endpoint()),
                 model_id,
             });
         }
@@ -927,8 +695,12 @@ impl EmbeddingRuntime {
     }
 
     pub fn from_env() -> Result<Self> {
-        let profile = EmbeddingProfile::from_env()?;
-        let backend = EmbeddingBackendSelection::from_env()?;
+        Self::from_config(&codestory_retrieval::SidecarRuntimeConfig::local().embedding)
+    }
+
+    pub fn from_config(config: &codestory_retrieval::EmbeddingRuntimeConfig) -> Result<Self> {
+        let profile = EmbeddingProfile::from_config(config)?;
+        let backend = EmbeddingBackendSelection::from_config(config)?;
         let model_id = profile.cache_model_id(backend);
 
         match backend {
@@ -939,15 +711,17 @@ impl EmbeddingRuntime {
                 backend: EmbeddingBackend::HashProjection,
             }),
             EmbeddingBackendSelection::LlamaCpp => {
-                let endpoint = LlamaCppEndpoint::from_env()?;
-                endpoint.ensure_reachable()?;
+                let client = codestory_retrieval::LlamaCppEmbeddingClient::new(config)?;
+                let probe = client.probe();
+                if !probe.reachable {
+                    bail!("{}", probe.detail);
+                }
                 Ok(Self {
-                    model_path: PathBuf::from(endpoint.url()),
+                    model_path: PathBuf::from(client.endpoint()),
                     model_id,
                     profile,
                     backend: EmbeddingBackend::LlamaCpp(Arc::new(LlamaCppEmbeddingRuntime {
-                        endpoint,
-                        request_count: llamacpp_request_count_from_env(),
+                        client,
                     })),
                 })
             }
@@ -1409,9 +1183,11 @@ impl SearchEngine {
         self.embedding_runtime = Some(runtime);
     }
 
-    pub fn set_embedding_runtime_from_env(&mut self) -> Result<()> {
-        let runtime = EmbeddingRuntime::from_env()?;
-        self.embedding_runtime = Some(runtime);
+    pub fn set_embedding_runtime_from_config(
+        &mut self,
+        config: &codestory_retrieval::EmbeddingRuntimeConfig,
+    ) -> Result<()> {
+        self.embedding_runtime = Some(EmbeddingRuntime::from_config(config)?);
         Ok(())
     }
 
@@ -2465,13 +2241,18 @@ mod tests {
             truncate_dim: None,
             expected_dim: Some(3),
         };
+        let mut client_config = codestory_retrieval::SidecarRuntimeConfig::local().embedding;
+        client_config.endpoint = url.clone();
+        client_config.endpoint_origin =
+            codestory_retrieval::EmbeddingEndpointOrigin::TrustedProjectConfig;
+        client_config.expected_dim = Some(3);
+        client_config.request_count = 1;
         let runtime = EmbeddingRuntime {
             model_path: PathBuf::from(&url),
             model_id: profile.cache_model_id(EmbeddingBackendSelection::LlamaCpp),
             profile,
             backend: EmbeddingBackend::LlamaCpp(Arc::new(LlamaCppEmbeddingRuntime {
-                endpoint: LlamaCppEndpoint::parse(&url)?,
-                request_count: 1,
+                client: codestory_retrieval::LlamaCppEmbeddingClient::new(&client_config)?,
             })),
         };
         let embeddings = runtime.embed_texts(&["alpha".to_string(), "beta".to_string()])?;
@@ -2488,112 +2269,6 @@ mod tests {
             runtime.model_id(),
             "custom-local|backend=llamacpp|pool=Mean|query_prefix=|document_prefix=doc: |layer_norm=false|truncate_dim=None|expected_dim=Some(3)"
         );
-        Ok(())
-    }
-
-    #[test]
-    fn llamacpp_embedding_post_rejects_redirects() -> Result<()> {
-        let (url, handle) = run_one_fake_embedding_server(
-            "302 Found",
-            "Location: http://127.0.0.1:9/redirected\r\n",
-            "redirect-secret query-secret".to_string(),
-        )?;
-        let url = format!(
-            "{}?token=query-secret#fragment-secret",
-            url.replacen("http://", "http://user:redirect-secret@", 1)
-        );
-        let endpoint = LlamaCppEndpoint::parse(&url)?;
-
-        let error = post_json_to_http_endpoint(
-            &endpoint,
-            &json!({"input": ["alpha"], "model": "codestory-local-embedding"}),
-        )
-        .expect_err("embedding POST must not follow redirects");
-        handle.join().expect("fake embedding server should finish");
-
-        let rendered = format!("{error:#}");
-        assert!(rendered.contains("HTTP 302"), "{rendered}");
-        assert!(rendered.contains(&endpoint.display_url()), "{rendered}");
-        for secret in ["redirect-secret", "query-secret", "fragment-secret"] {
-            assert!(!rendered.contains(secret), "{rendered}");
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn llamacpp_runtime_transport_errors_redact_endpoint_secrets() -> Result<()> {
-        let listener = TcpListener::bind("127.0.0.1:0")?;
-        let addr = listener.local_addr()?;
-        drop(listener);
-        let endpoint = LlamaCppEndpoint::parse(&format!(
-            "http://user:transport-secret@{addr}/v1/embeddings?token=query-secret#fragment-secret"
-        ))?;
-
-        let errors = [
-            endpoint.ensure_reachable().expect_err("endpoint is closed"),
-            post_json_to_http_endpoint(
-                &endpoint,
-                &json!({"input": ["alpha"], "model": "codestory-local-embedding"}),
-            )
-            .expect_err("endpoint is closed"),
-        ];
-
-        for error in errors {
-            let rendered = format!("{error:#}");
-            assert!(rendered.contains(&endpoint.display_url()), "{rendered}");
-            for secret in ["transport-secret", "query-secret", "fragment-secret"] {
-                assert!(!rendered.contains(secret), "{rendered}");
-            }
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn llamacpp_invalid_json_error_redacts_endpoint_secrets() -> Result<()> {
-        let (url, handle) = run_one_fake_embedding_server(
-            "200 OK",
-            "",
-            "invalid json-secret query-secret fragment-secret".to_string(),
-        )?;
-        let url = format!(
-            "{}?token=query-secret#fragment-secret",
-            url.replacen("http://", "http://user:json-secret@", 1)
-        );
-        let endpoint = LlamaCppEndpoint::parse(&url)?;
-
-        let error = post_json_to_http_endpoint(
-            &endpoint,
-            &json!({"input": ["alpha"], "model": "codestory-local-embedding"}),
-        )
-        .expect_err("response is not JSON");
-        handle.join().expect("fake embedding server should finish");
-
-        let rendered = format!("{error:#}");
-        assert!(rendered.contains(&endpoint.display_url()), "{rendered}");
-        for secret in ["json-secret", "query-secret", "fragment-secret"] {
-            assert!(!rendered.contains(secret), "{rendered}");
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn llamacpp_embedding_post_accepts_json_over_ten_mib() -> Result<()> {
-        let response = json!({
-            "padding": "x".repeat(10 * 1024 * 1024 + 1),
-            "data": [{"index": 0, "embedding": [1.0, 0.0, 0.0]}]
-        })
-        .to_string();
-        assert!(response.len() > 10 * 1024 * 1024);
-        let (url, handle) = run_one_fake_embedding_server("200 OK", "", response)?;
-        let endpoint = LlamaCppEndpoint::parse(&url)?;
-
-        let response = post_json_to_http_endpoint(
-            &endpoint,
-            &json!({"input": ["alpha"], "model": "codestory-local-embedding"}),
-        )?;
-        handle.join().expect("fake embedding server should finish");
-
-        assert_eq!(parse_openai_embeddings_response(response, 1)?.len(), 1);
         Ok(())
     }
 
@@ -2710,16 +2385,6 @@ mod tests {
     fn l2_normalized(vector: &[f32]) -> bool {
         let norm = vector.iter().map(|value| value * value).sum::<f32>().sqrt();
         (norm - 1.0).abs() <= 0.05
-    }
-
-    #[test]
-    fn llamacpp_endpoint_parse_accepts_openai_embeddings_url() -> Result<()> {
-        let endpoint = LlamaCppEndpoint::parse("http://127.0.0.1:8080/v1/embeddings")?;
-
-        assert_eq!(endpoint.host, "127.0.0.1");
-        assert_eq!(endpoint.port, 8080);
-        assert_eq!(endpoint.path, "/v1/embeddings");
-        Ok(())
     }
 
     #[test]

--- a/crates/codestory-runtime/src/search_runtime.rs
+++ b/crates/codestory-runtime/src/search_runtime.rs
@@ -5,7 +5,8 @@ pub use crate::search::engine::{
     EMBEDDING_QUERY_PREFIX_ENV, EMBEDDING_RUNTIME_MODE_ENV, EMBEDDING_TRUNCATE_DIM_ENV,
     EmbeddingProfileContract, EmbeddingRuntimeAvailability, HybridSearchConfig, HybridSearchHit,
     LLAMACPP_EMBEDDINGS_URL_ENV, LLAMACPP_REQUEST_COUNT_ENV, LlmSearchDoc,
-    STORED_VECTOR_ENCODING_ENV, embedding_profile_contract_from_env,
+    STORED_VECTOR_ENCODING_ENV, embedding_profile_contract_from_config,
+    embedding_profile_contract_from_env, embedding_runtime_availability_from_config,
     embedding_runtime_availability_from_env,
 };
 

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -55,6 +55,12 @@ Runtime rules:
   an older retrieval path.
 - Repo-text, hash, stub, and old local search surfaces may be used only as
   explicitly labeled diagnostics.
+- Each opened project owns one immutable `SidecarRuntimeConfig`. Retrieval
+  indexing, query embedding, readiness/status, runtime search, and summary
+  generation consume that retained value. Managed sidecar endpoints are
+  derived from the selected profile/run ports; external endpoints retain their
+  trusted origin. Request handlers never activate endpoints by mutating process
+  environment variables.
 
 ## Generation And Reuse
 

--- a/docs/architecture/subsystems/cli.md
+++ b/docs/architecture/subsystems/cli.md
@@ -38,7 +38,19 @@ index path when embedding assets are available.
 
 ## Configuration Files
 
-The CLI loads optional `.codestory.toml` defaults from the user home directory and then from the selected project root. Project config may override home config for project-safe preferences. Cache roots, network endpoints, model selectors for source-egress calls, credentials, and source-text egress settings must come from trusted user config, explicit environment variables, or CLI options; project files cannot set `cache_dir`, `summary_endpoint`, `summary_model`, or embedding endpoint fields unless `CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG=1` is set deliberately for that run. Explicit environment variables override both config files because config values are only applied when the matching runtime env var is absent.
+The CLI captures process environment defaults once, then loads optional
+`.codestory.toml` defaults from the user home directory and the selected project
+root. It merges those values into an immutable `SidecarRuntimeConfig` retained
+by that project runtime; it never publishes project choices back through the
+process environment. This is required for multi-project stdio: switching A/B/A
+must keep each project's endpoint, model, prefix, retrieval policy, and summary
+settings isolated. Cache roots, network endpoints, model selectors for
+source-egress calls, credentials, and source-text egress settings must come from
+trusted user config, explicit environment variables, or CLI options; project
+files cannot set `cache_dir`, `summary_endpoint`, `summary_model`, or embedding
+endpoint fields unless `CODESTORY_ALLOW_PROJECT_NETWORK_CONFIG=1` is set
+deliberately for that process. Explicit environment values have highest
+precedence without being mutated.
 
 Embedding config keys map to the runtime env names:
 
@@ -48,8 +60,12 @@ Embedding config keys map to the runtime env names:
 | `embedding_model_id` | `CODESTORY_EMBED_MODEL_ID` | Overrides the resolved model id for the selected profile. |
 | `embedding_model` | `CODESTORY_EMBED_MODEL_ID` | Deprecated alias for `embedding_model_id`; prefer the explicit key in new config. |
 | `embedding_endpoint` | `CODESTORY_EMBED_LLAMACPP_URL` | Trusted-only endpoint for the product llama.cpp embedding sidecar. |
+| `embedding_query_prefix` | `CODESTORY_EMBED_QUERY_PREFIX` | Per-project query prefix retained with the embedding contract. |
+| `embedding_document_prefix` | `CODESTORY_EMBED_DOCUMENT_PREFIX` | Per-project document prefix retained with the embedding contract. |
 
-The CLI should not set stale embedding env aliases that the runtime does not read.
+Runtime status reports distinguish a managed sidecar endpoint from an explicit
+process, trusted-user, or trusted-project endpoint. The CLI must not set runtime
+environment variables after startup.
 
 Index output should expose:
 

--- a/docs/users/cli-reference.md
+++ b/docs/users/cli-reference.md
@@ -101,6 +101,12 @@ Team or user defaults: `.codestory.toml` at project root or user home. Home
 file loads first; project file overrides for project-safe preferences.
 Environment variables win over files.
 
+Configuration is resolved independently for each project and retained for the
+life of that project runtime. Multi-project stdio does not rewrite process
+environment variables when requests switch repositories. Trusted project files
+may also set `embedding_query_prefix` and `embedding_document_prefix` as part of
+their per-project embedding contract.
+
 Project `.codestory.toml` cannot choose cache roots or network egress settings.
 Put `cache_dir` in user home `.codestory.toml` or pass `--cache-dir`.
 


### PR DESCRIPTION
## Context

Multi-project stdio retained project roots but still let embedding and
retrieval selection drift through process-global environment reads. One
project could therefore change another project's endpoint, model, dimensions,
prefixes, device/launch policy, status, and cache identity.

Closes #961
Refs #912
Refs #884
Refs #897
Refs #899

## What Changed

- Added immutable `SidecarRuntimeConfig` snapshots and threaded retained
  project configuration through CLI selection, indexing, readiness, report,
  drill, status, cache fingerprints, semantic hydration, and query clients.
- Reused the production llama.cpp client, retained the configured model and
  named-profile dimensions, validated exact OpenAI row counts/indices, refused
  redirects, redacted endpoint credentials/query/fragment secrets, and kept
  removed ONNX configuration as an explicit captured validation error.
- Enforced external-versus-managed launch provenance instead of spawning a
  local server against an external endpoint.
- Removed duplicated runtime HTTP/parser code and added a production mutation
  guard.
- Strengthened the serialized A/B/A stdio proof: trusted project configs route
  queries to two independent endpoints, and each exact served query vector
  prefers embeddings persisted in the matching project's SQLite store.

```mermaid
flowchart LR
    A["Project A config"] --> RA["Retained runtime A"] --> EA["Endpoint A"]
    B["Project B config"] --> RB["Retained runtime B"] --> EB["Endpoint B"]
    RA --> SA["Index, status, query, summary A"]
    RB --> SB["Index, status, query, summary B"]
```

## How To Review

1. Start with `crates/codestory-retrieval/src/config.rs` for immutable selection
   and endpoint provenance.
2. Review `crates/codestory-retrieval/src/embeddings.rs` for the single
   production client, response ordering, dimensions, redirect policy, and
   redaction.
3. Follow retained config through CLI/runtime callers and cache/status paths.
4. Finish with the runtime-config boundary script and the A/B/A stdio test.

## Verification

- `cargo test -p codestory-retrieval --lib` — 305 passed, 1 ignored
- `cargo test -p codestory-cli --test architecture_contracts` — 12 passed
- `cargo test -p codestory-cli --test cli_golden_path doctor_reports_removed_onnx_configuration_as_unsupported -- --exact --nocapture` — passed
- `cargo test -p codestory-cli --test stdio_protocol_contracts multi_project_stdio_keeps_project_embedding_endpoints_isolated_across_a_b_a -- --exact --nocapture` — passed after rebase
- `cargo check -p codestory-retrieval -p codestory-runtime -p codestory-cli`
- `cargo clippy -p codestory-retrieval -p codestory-runtime -p codestory-cli --all-targets -- -D warnings` — passed after rebase
- runtime-config boundary, workflow policy, docs links, formatting, and diff checks passed

The ignored real-repo e2e stats command was attempted earlier but could not
emit a row because `CODESTORY_REAL_REPO_DRILL_CASES` and the required local
GGUF model were unavailable. This PR does not claim live sidecar e2e proof.

## Risk

This is a broad configuration-boundary refactor. Legacy compatibility wrappers
still snapshot process defaults when callers do not supply a retained runtime;
production CLI and stdio paths now pass explicit project state. The A/B/A proof
is intentionally serialized and does not claim concurrent execution. No UI
changed.
