### PR TITLE
version repository identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@
 
 ### Changed
 
+- Added staged repository-v2/project-v3 identity contracts that preserve
+  transport schemes, effective and non-default remote ports, and case-sensitive
+  repository paths, distinguish absolute and home-relative SCP paths, reject
+  ambiguous local remotes, hash canonical workspace paths without lossy UTF-8
+  conversion, and never guess schema-1 ownership without persisted provenance.
+  A shared path comparator uses full filesystem identity for existing paths and
+  normalized platform lexical rules only for missing paths; current persisted
+  v1/v2 consumers stay unchanged until the coordinated identity migration.
 - Grounding skill guidance now reuses current status, routes blocked deep
   retrieval tasks through allowed project-scoped local graph surfaces, and
   repairs sidecars only when the task actually requires the blocked surface.

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -24,10 +24,12 @@ use uuid::Uuid;
 pub mod atomic_file;
 mod repository_identity;
 pub use repository_identity::{
-    PROJECT_IDENTITY_SCHEMA_VERSION, ProjectIdentityV2, REPOSITORY_IDENTITY_SCHEMA_VERSION,
-    RepositoryIdentity, SidecarProjectIdentity, cached_project_identity_v2,
-    inspect_repository_identity, project_identity_v2, sidecar_project_identity,
-    workspace_id_for_root,
+    PROJECT_IDENTITY_SCHEMA_VERSION, PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV2,
+    ProjectIdentityV3, REPOSITORY_IDENTITY_SCHEMA_VERSION, REPOSITORY_IDENTITY_V2_SCHEMA_VERSION,
+    RepositoryIdentity, RepositoryIdentityV2, SidecarProjectIdentity, cached_project_identity_v2,
+    inspect_repository_identity, inspect_repository_identity_v2, project_identity_v2,
+    project_identity_v3, same_workspace_path, sidecar_project_identity, workspace_id_for_root,
+    workspace_id_v3_for_root,
 };
 
 /// Source-group language selector used during workspace discovery.

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -8,9 +8,13 @@ use std::time::{Duration, Instant};
 
 /// Version of the repository identity hashing contract.
 pub const REPOSITORY_IDENTITY_SCHEMA_VERSION: u32 = 1;
+/// Lossless repository identity hashing contract available for migration.
+pub const REPOSITORY_IDENTITY_V2_SCHEMA_VERSION: u32 = 2;
 
 /// Shared project identity contract version.
 pub const PROJECT_IDENTITY_SCHEMA_VERSION: u32 = 2;
+/// Lossless shared project identity contract available for migration.
+pub const PROJECT_IDENTITY_V3_SCHEMA_VERSION: u32 = 3;
 const PROJECT_IDENTITY_OBSERVATION_CACHE_TTL: Duration = Duration::from_secs(1);
 
 static PROJECT_IDENTITY_OBSERVATION_CACHE: OnceLock<
@@ -22,6 +26,19 @@ static PROJECT_IDENTITY_OBSERVATION_CACHE: OnceLock<
 #[derive(Debug, Clone, Serialize)]
 pub struct RepositoryIdentity {
     pub canonical_repository_id: Option<String>,
+    pub repository_identity_schema_version: u32,
+    pub normalized_repository_identity: Option<String>,
+    pub git_remote: Option<String>,
+    pub git_tree: Option<String>,
+    pub portable_reuse_eligible: bool,
+    pub portable_reuse_reason: String,
+}
+
+/// Lossless repository identity contract for staged schema-2 migrations.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositoryIdentityV2 {
+    pub canonical_repository_id: Option<String>,
+    pub legacy_canonical_repository_id: Option<String>,
     pub repository_identity_schema_version: u32,
     pub normalized_repository_identity: Option<String>,
     pub git_remote: Option<String>,
@@ -49,6 +66,21 @@ pub struct ProjectIdentityV2 {
     pub portable_reuse_reason: String,
 }
 
+/// Lossless project identity contract for staged schema-3 migrations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectIdentityV3 {
+    pub project_identity_schema_version: u32,
+    pub project_id: String,
+    pub workspace_id: String,
+    pub artifact_scope_id: String,
+    pub canonical_repository_id: Option<String>,
+    pub legacy_canonical_repository_id: Option<String>,
+    pub legacy_raw_root_project_id: Option<String>,
+    pub normalized_root_project_id_alias: Option<String>,
+    pub portable_reuse_eligible: bool,
+    pub portable_reuse_reason: String,
+}
+
 /// Project id decision for sidecar artifacts.
 ///
 /// Clean, identifiable Git repositories use a stable repository-derived id.
@@ -70,8 +102,8 @@ pub fn inspect_repository_identity(project_root: &Path) -> RepositoryIdentity {
     let dirty = git_output(project_root, &["status", "--porcelain"])
         .map(|status| !status.trim().is_empty())
         .unwrap_or(true);
-    let normalized = remote.as_deref().and_then(normalize_repository_identity);
-    let canonical_repository_id = normalized.as_deref().map(canonical_repository_id);
+    let normalized = remote.as_deref().and_then(normalize_repository_identity_v1);
+    let canonical_repository_id = normalized.as_deref().map(legacy_canonical_repository_id);
     let (portable_reuse_eligible, portable_reuse_reason) =
         portable_reuse_status(normalized.as_deref(), tree.as_deref(), dirty);
 
@@ -79,6 +111,40 @@ pub fn inspect_repository_identity(project_root: &Path) -> RepositoryIdentity {
         canonical_repository_id,
         repository_identity_schema_version: REPOSITORY_IDENTITY_SCHEMA_VERSION,
         normalized_repository_identity: normalized,
+        git_remote: remote,
+        git_tree: tree,
+        portable_reuse_eligible,
+        portable_reuse_reason,
+    }
+}
+
+/// Inspect the lossless repository identity without migrating current consumers.
+pub fn inspect_repository_identity_v2(project_root: &Path) -> RepositoryIdentityV2 {
+    let remote = git_output(project_root, &["config", "--get", "remote.origin.url"]).ok();
+    let tree = git_output(project_root, &["rev-parse", "HEAD^{tree}"]).ok();
+    let dirty = git_output(project_root, &["status", "--porcelain"])
+        .map(|status| !status.trim().is_empty())
+        .unwrap_or(true);
+    let normalized = remote.as_deref().and_then(parse_repository_identity_v2);
+    let canonical_repository_id = normalized
+        .as_ref()
+        .map(|identity| canonical_repository_id_v2(&identity.canonical));
+    // A current remote spelling cannot prove which schema-1 identity owns
+    // persisted artifacts. Parent #913 will supply provenance during migration.
+    let legacy_canonical_repository_id = None;
+    let (portable_reuse_eligible, portable_reuse_reason) = portable_reuse_status(
+        normalized
+            .as_ref()
+            .map(|identity| identity.canonical.as_str()),
+        tree.as_deref(),
+        dirty,
+    );
+
+    RepositoryIdentityV2 {
+        canonical_repository_id,
+        legacy_canonical_repository_id,
+        repository_identity_schema_version: REPOSITORY_IDENTITY_V2_SCHEMA_VERSION,
+        normalized_repository_identity: normalized.map(|identity| identity.canonical),
         git_remote: remote,
         git_tree: tree,
         portable_reuse_eligible,
@@ -113,6 +179,34 @@ pub fn project_identity_v2(project_root: &Path) -> ProjectIdentityV2 {
     }
 }
 
+/// Resolve the lossless V3 identity without migrating current consumers.
+pub fn project_identity_v3(project_root: &Path) -> ProjectIdentityV3 {
+    let repository_identity = inspect_repository_identity_v2(project_root);
+    let root_identity = workspace_root_identity_v3(project_root);
+    let project_id = repository_identity
+        .canonical_repository_id
+        .clone()
+        .unwrap_or_else(|| root_identity.workspace_id.clone());
+    let artifact_scope_id = if repository_identity.portable_reuse_eligible {
+        project_id.clone()
+    } else {
+        root_identity.workspace_id.clone()
+    };
+
+    ProjectIdentityV3 {
+        project_identity_schema_version: PROJECT_IDENTITY_V3_SCHEMA_VERSION,
+        project_id,
+        workspace_id: root_identity.workspace_id,
+        artifact_scope_id,
+        canonical_repository_id: repository_identity.canonical_repository_id,
+        legacy_canonical_repository_id: repository_identity.legacy_canonical_repository_id,
+        legacy_raw_root_project_id: root_identity.legacy_raw_root_project_id,
+        normalized_root_project_id_alias: root_identity.normalized_root_project_id_alias,
+        portable_reuse_eligible: repository_identity.portable_reuse_eligible,
+        portable_reuse_reason: repository_identity.portable_reuse_reason,
+    }
+}
+
 /// Resolve identity for repeated observational status reads.
 ///
 /// Mutating/indexing paths must use `project_identity_v2` so dirtiness changes
@@ -136,6 +230,11 @@ pub fn cached_project_identity_v2(project_root: &Path) -> ProjectIdentityV2 {
 /// Return the canonical-root FNV identity used to scope one workspace.
 pub fn workspace_id_for_root(project_root: &Path) -> String {
     workspace_root_identity(project_root).workspace_id
+}
+
+/// Return the schema-3 workspace id hashed from native path data.
+pub fn workspace_id_v3_for_root(project_root: &Path) -> String {
+    workspace_root_identity_v3(project_root).workspace_id
 }
 
 /// Choose the sidecar project id while preserving the fallback reason.
@@ -173,6 +272,24 @@ fn workspace_root_identity(project_root: &Path) -> WorkspaceRootIdentity {
         .to_string_lossy()
         .into_owned();
     workspace_root_identity_from_text(&raw_root, &canonical_root)
+}
+
+fn workspace_root_identity_v3(project_root: &Path) -> WorkspaceRootIdentity {
+    let canonical_root =
+        fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let workspace_id = fnv1a_path_hex(&canonical_root);
+    let legacy_raw_root_project_id = project_root
+        .to_str()
+        .and_then(|root| fnv_alias(root, &workspace_id));
+    let normalized_root_project_id_alias = canonical_root
+        .to_str()
+        .and_then(|root| fnv_alias(&normalize_root_identity_text(root), &workspace_id));
+
+    WorkspaceRootIdentity {
+        workspace_id,
+        legacy_raw_root_project_id,
+        normalized_root_project_id_alias,
+    }
 }
 
 fn workspace_root_identity_from_text(
@@ -262,22 +379,33 @@ fn portable_reuse_status(
     (true, "eligible".into())
 }
 
-fn canonical_repository_id(normalized_repository_identity: &str) -> String {
-    let mut state = 0xcbf29ce484222325_u64;
-    mix_str(&mut state, "codestory-repository-identity");
-    mix_u32(&mut state, REPOSITORY_IDENTITY_SCHEMA_VERSION);
-    mix_str(&mut state, normalized_repository_identity);
-    format!("repo-v{REPOSITORY_IDENTITY_SCHEMA_VERSION}-{state:016x}")
+fn canonical_repository_id_v2(normalized_repository_identity: &str) -> String {
+    versioned_repository_id(
+        REPOSITORY_IDENTITY_V2_SCHEMA_VERSION,
+        normalized_repository_identity,
+    )
 }
 
-fn normalize_repository_identity(remote: &str) -> Option<String> {
+fn legacy_canonical_repository_id(normalized_repository_identity: &str) -> String {
+    versioned_repository_id(1, normalized_repository_identity)
+}
+
+fn versioned_repository_id(schema_version: u32, normalized_repository_identity: &str) -> String {
+    let mut state = 0xcbf29ce484222325_u64;
+    mix_str(&mut state, "codestory-repository-identity");
+    mix_u32(&mut state, schema_version);
+    mix_str(&mut state, normalized_repository_identity);
+    format!("repo-v{schema_version}-{state:016x}")
+}
+
+fn normalize_repository_identity_v1(remote: &str) -> Option<String> {
     let value = remote.trim().replace('\\', "/");
     if value.is_empty() {
         return None;
     }
 
     if let Some((_, rest)) = value.split_once("://") {
-        return normalize_url_repository_identity(rest);
+        return normalize_url_repository_identity_v1(rest);
     }
 
     let without_user = strip_userinfo(&value);
@@ -289,23 +417,19 @@ fn normalize_repository_identity(remote: &str) -> Option<String> {
     } else {
         without_user.to_string()
     };
-    normalize_repository_path(&normalized)
+    normalize_repository_path_v1(&normalized)
 }
 
-fn normalize_url_repository_identity(rest: &str) -> Option<String> {
+fn normalize_url_repository_identity_v1(rest: &str) -> Option<String> {
     let rest = strip_userinfo(rest);
     let (authority, path) = rest.split_once('/')?;
     let host = authority
         .split_once(':')
         .map_or(authority, |(host, _)| host);
-    normalize_repository_path(&format!("{host}/{path}"))
+    normalize_repository_path_v1(&format!("{host}/{path}"))
 }
 
-fn strip_userinfo(value: &str) -> &str {
-    value.split_once('@').map(|(_, rest)| rest).unwrap_or(value)
-}
-
-fn normalize_repository_path(value: &str) -> Option<String> {
+fn normalize_repository_path_v1(value: &str) -> Option<String> {
     let lower = value.to_ascii_lowercase();
     let normalized = lower
         .trim_start_matches('/')
@@ -314,6 +438,363 @@ fn normalize_repository_path(value: &str) -> Option<String> {
         .trim_end_matches('/')
         .to_string();
     (!normalized.is_empty()).then_some(normalized)
+}
+
+#[cfg(test)]
+fn normalize_repository_identity_v2(remote: &str) -> Option<String> {
+    parse_repository_identity_v2(remote).map(|identity| identity.canonical)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedRepositoryIdentity {
+    canonical: String,
+}
+
+fn parse_repository_identity_v2(remote: &str) -> Option<NormalizedRepositoryIdentity> {
+    let value = remote.trim().replace('\\', "/");
+    if value.is_empty()
+        || value.starts_with('/')
+        || value.starts_with("./")
+        || value.starts_with("../")
+        || (value
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphabetic)
+            && value.as_bytes().get(1) == Some(&b':'))
+    {
+        return None;
+    }
+
+    let (scheme, host, port, path, is_url) = if let Some((scheme, rest)) = value.split_once("://") {
+        let (scheme, host, port, path) = normalize_url_repository_identity(scheme, rest)?;
+        (scheme, host, port, path, true)
+    } else {
+        let (scheme, host, port, path) = normalize_scp_repository_identity(&value)?;
+        (scheme, host, port, path, false)
+    };
+    let host = host.to_ascii_lowercase();
+    if host.is_empty() {
+        return None;
+    }
+    let path = normalize_repository_path(if is_url {
+        &path
+    } else {
+        path.strip_prefix('/').unwrap_or(&path)
+    })?;
+    let scheme = scheme.to_ascii_lowercase();
+    let canonical = match port.as_deref() {
+        Some(port) => format!("{scheme}://{host}:{port}/{path}"),
+        None => format!("{scheme}://{host}/{path}"),
+    };
+
+    Some(NormalizedRepositoryIdentity { canonical })
+}
+
+fn normalize_scp_repository_identity(
+    value: &str,
+) -> Option<(String, String, Option<String>, String)> {
+    let without_user = strip_userinfo(value);
+    if let Some((host, path)) = split_scp_host_path(without_user) {
+        let path = if path.starts_with('/') || path.starts_with('~') {
+            path.to_string()
+        } else {
+            format!("~/{path}")
+        };
+        return Some(("ssh".into(), host.into(), Some("22".into()), path));
+    }
+    None
+}
+
+fn split_scp_host_path(value: &str) -> Option<(&str, &str)> {
+    if value.starts_with('[') {
+        let end = value.find(']')?;
+        let host = &value[..=end];
+        let path = value[end + 1..].strip_prefix(':')?;
+        return (!path.is_empty()).then_some((host, path));
+    }
+    let (host, path) = value.split_once(':')?;
+    (!host.contains('/') && !path.is_empty()).then_some((host, path))
+}
+
+fn normalize_url_repository_identity(
+    scheme: &str,
+    rest: &str,
+) -> Option<(String, String, Option<String>, String)> {
+    let scheme = scheme.to_ascii_lowercase();
+    if scheme == "file" {
+        return None;
+    }
+    let rest = strip_userinfo(rest);
+    let (authority, path) = rest.split_once('/')?;
+    let (host, explicit_port) = split_host_port(authority)?;
+    let default_port = match scheme.as_str() {
+        "http" => Some("80"),
+        "https" => Some("443"),
+        "ssh" => Some("22"),
+        "git" => Some("9418"),
+        _ => None,
+    };
+    let port = explicit_port.or_else(|| default_port.map(str::to_string));
+    Some((scheme, host.to_string(), port, path.to_string()))
+}
+
+fn split_host_port(authority: &str) -> Option<(&str, Option<String>)> {
+    if authority.starts_with('[') {
+        let end = authority.find(']')?;
+        let host = &authority[..=end];
+        let suffix = &authority[end + 1..];
+        if suffix.is_empty() {
+            return Some((host, None));
+        }
+        let port = suffix.strip_prefix(':')?;
+        return valid_port(port).map(|port| (host, Some(port)));
+    }
+
+    match authority.rsplit_once(':') {
+        Some((host, port)) => valid_port(port).map(|port| (host, Some(port))),
+        None => Some((authority, None)),
+    }
+}
+
+fn valid_port(port: &str) -> Option<String> {
+    let port = port.parse::<u16>().ok()?;
+    (port != 0).then(|| port.to_string())
+}
+
+fn strip_userinfo(value: &str) -> &str {
+    value.split_once('@').map(|(_, rest)| rest).unwrap_or(value)
+}
+
+fn normalize_repository_path(value: &str) -> Option<String> {
+    let mut normalized = value.trim_end_matches('/').to_string();
+    if normalized.ends_with(".git") {
+        normalized.truncate(normalized.len() - 4);
+        normalized = normalized.trim_end_matches('/').to_string();
+    }
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+/// Compare workspace paths without merging distinct case-sensitive roots.
+///
+/// Existing paths use the filesystem's stable file identity. Only two missing
+/// paths use platform lexical rules. Windows missing-path comparison normalizes
+/// separators and dot segments and uses ordinal Unicode case comparison, but
+/// cannot observe a missing path's future per-directory case-sensitivity flag.
+pub fn same_workspace_path(left: &Path, right: &Path) -> bool {
+    match (fs::metadata(left), fs::metadata(right)) {
+        (Ok(left_metadata), Ok(right_metadata)) => {
+            same_existing_path(left, &left_metadata, right, &right_metadata)
+        }
+        (Err(left_error), Err(right_error))
+            if left_error.kind() == std::io::ErrorKind::NotFound
+                && right_error.kind() == std::io::ErrorKind::NotFound =>
+        {
+            same_missing_path(left, right)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(unix)]
+fn same_existing_path(
+    _left_path: &Path,
+    left: &fs::Metadata,
+    _right_path: &Path,
+    right: &fs::Metadata,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(windows)]
+fn same_existing_path(
+    left_path: &Path,
+    _left: &fs::Metadata,
+    right_path: &Path,
+    _right: &fs::Metadata,
+) -> bool {
+    windows_file_identity(left_path)
+        .zip(windows_file_identity(right_path))
+        .is_some_and(|(left, right)| left == right)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn same_existing_path(
+    _left_path: &Path,
+    _left: &fs::Metadata,
+    _right_path: &Path,
+    _right: &fs::Metadata,
+) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn windows_file_identity(path: &Path) -> Option<(u64, [u8; 16])> {
+    use std::ffi::c_void;
+    use std::mem::MaybeUninit;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+
+    #[repr(C)]
+    struct FileIdInfo {
+        volume_serial_number: u64,
+        file_id: [u8; 16],
+    }
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn GetFileInformationByHandleEx(
+            file: *mut c_void,
+            information_class: i32,
+            information: *mut c_void,
+            information_size: u32,
+        ) -> i32;
+    }
+
+    const FILE_ID_INFO_CLASS: i32 = 18;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    let file = fs::OpenOptions::new()
+        .access_mode(0)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)
+        .ok()?;
+    let mut information = MaybeUninit::<FileIdInfo>::uninit();
+    // SAFETY: `file` owns a valid handle for the duration of the call and the
+    // output points to correctly sized, writable storage.
+    if unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle().cast(),
+            FILE_ID_INFO_CLASS,
+            information.as_mut_ptr().cast(),
+            std::mem::size_of::<FileIdInfo>() as u32,
+        )
+    } == 0
+    {
+        return None;
+    }
+    // SAFETY: a successful `GetFileInformationByHandleEx` initializes all fields.
+    let information = unsafe { information.assume_init() };
+    Some((information.volume_serial_number, information.file_id))
+}
+
+#[cfg(windows)]
+fn same_missing_path(left: &Path, right: &Path) -> bool {
+    windows_ordinal_case_eq(
+        &normalize_windows_lexical_path(left),
+        &normalize_windows_lexical_path(right),
+    )
+}
+
+#[cfg(windows)]
+fn normalize_windows_lexical_path(path: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+
+    let mut units = path
+        .as_os_str()
+        .encode_wide()
+        .map(|unit| {
+            (unit == u16::from(b'/'))
+                .then_some(u16::from(b'\\'))
+                .unwrap_or(unit)
+        })
+        .collect::<Vec<_>>();
+    let separator = u16::from(b'\\');
+    let extended = [separator, separator, u16::from(b'?'), separator];
+    if units.starts_with(&extended) {
+        units.drain(..extended.len());
+        let unc = [u16::from(b'U'), u16::from(b'N'), u16::from(b'C'), separator];
+        if units
+            .get(..unc.len())
+            .is_some_and(|prefix| windows_ordinal_case_eq(prefix, &unc))
+        {
+            units.splice(..unc.len(), [separator, separator]);
+        }
+    }
+
+    let unc = units.starts_with(&[separator, separator]);
+    let drive = units.len() >= 2 && units[1] == u16::from(b':');
+    let rooted =
+        unc || units.first() == Some(&separator) || (drive && units.get(2) == Some(&separator));
+    let prefix_len = if unc {
+        2
+    } else if drive {
+        2 + if rooted { 1 } else { 0 }
+    } else {
+        if rooted { 1 } else { 0 }
+    };
+    let prefix = units[..prefix_len.min(units.len())].to_vec();
+    let protected_segments = if unc { 2 } else { 0 };
+    let mut segments = Vec::<Vec<u16>>::new();
+    for segment in units[prefix_len.min(units.len())..]
+        .split(|unit| *unit == separator)
+        .filter(|segment| !segment.is_empty())
+    {
+        if segment == [u16::from(b'.')] {
+            continue;
+        }
+        if segment == [u16::from(b'.'), u16::from(b'.')] {
+            if segments.len() > protected_segments
+                && segments
+                    .last()
+                    .is_some_and(|last| last.as_slice() != segment)
+            {
+                segments.pop();
+            } else if !rooted {
+                segments.push(segment.to_vec());
+            }
+            continue;
+        }
+        segments.push(segment.to_vec());
+    }
+
+    let mut normalized = prefix;
+    for (index, segment) in segments.into_iter().enumerate() {
+        if !normalized.is_empty()
+            && normalized.last() != Some(&separator)
+            && !(drive && !rooted && index == 0)
+        {
+            normalized.push(separator);
+        }
+        normalized.extend(segment);
+    }
+    normalized
+}
+
+#[cfg(windows)]
+fn windows_ordinal_case_eq(left: &[u16], right: &[u16]) -> bool {
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn CompareStringOrdinal(
+            left: *const u16,
+            left_len: i32,
+            right: *const u16,
+            right_len: i32,
+            ignore_case: i32,
+        ) -> i32;
+    }
+
+    if left == right {
+        return true;
+    }
+    if left.is_empty() || right.is_empty() {
+        return false;
+    }
+    let (Ok(left_len), Ok(right_len)) = (i32::try_from(left.len()), i32::try_from(right.len()))
+    else {
+        return false;
+    };
+    const CSTR_EQUAL: i32 = 2;
+    // SAFETY: both pointers remain valid for their supplied lengths, and the
+    // API only reads them. Windows ordinal ignore-case is the closest lexical
+    // fallback available when a missing path has no filesystem identity.
+    unsafe {
+        CompareStringOrdinal(left.as_ptr(), left_len, right.as_ptr(), right_len, 1) == CSTR_EQUAL
+    }
+}
+
+#[cfg(not(windows))]
+fn same_missing_path(left: &Path, right: &Path) -> bool {
+    left == right
 }
 
 fn git_output(project: &Path, args: &[&str]) -> Result<String, ()> {
@@ -352,6 +833,30 @@ fn fnv1a_hex(bytes: &[u8]) -> String {
     format!("{hash:016x}")
 }
 
+#[cfg(unix)]
+fn fnv1a_path_hex(path: &Path) -> String {
+    use std::os::unix::ffi::OsStrExt;
+    fnv1a_hex(path.as_os_str().as_bytes())
+}
+
+#[cfg(windows)]
+fn fnv1a_path_hex(path: &Path) -> String {
+    use std::os::windows::ffi::OsStrExt;
+    let mut state = 0xcbf29ce484222325_u64;
+    for unit in path.as_os_str().encode_wide() {
+        for byte in unit.to_le_bytes() {
+            state ^= u64::from(byte);
+            state = state.wrapping_mul(0x100000001b3);
+        }
+    }
+    format!("{state:016x}")
+}
+
+#[cfg(not(any(unix, windows)))]
+fn fnv1a_path_hex(path: &Path) -> String {
+    fnv1a_hex(path.as_os_str().as_encoded_bytes())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -360,38 +865,206 @@ mod tests {
 
     #[test]
     fn normalizes_common_git_remote_forms() {
-        for (remote, expected) in [
-            (
-                "https://github.com/TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "ssh://git@github.com/TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "ssh://git@github.com:22/TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "git@github.com:TheGreenCedar/CodeStory.git",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "https://github.com/TheGreenCedar/CodeStory.git/",
-                "github.com/thegreencedar/codestory",
-            ),
-            (
-                "HTTPS://GITHUB.COM/TheGreenCedar/CodeStory.GIT",
-                "github.com/thegreencedar/codestory",
-            ),
+        let https =
+            normalize_repository_identity_v2("https://github.com/TheGreenCedar/CodeStory.git");
+        assert_eq!(
+            https.as_deref(),
+            Some("https://github.com:443/TheGreenCedar/CodeStory")
+        );
+        assert_eq!(
+            https,
+            normalize_repository_identity_v2("HTTPS://GITHUB.COM:443/TheGreenCedar/CodeStory.git/")
+        );
+
+        let ssh =
+            normalize_repository_identity_v2("ssh://git@github.com/TheGreenCedar/CodeStory.git");
+        assert_eq!(
+            ssh.as_deref(),
+            Some("ssh://github.com:22/TheGreenCedar/CodeStory")
+        );
+        assert_eq!(
+            ssh,
+            normalize_repository_identity_v2("ssh://git@github.com:22/TheGreenCedar/CodeStory.git")
+        );
+        assert_eq!(
+            ssh,
+            normalize_repository_identity_v2("git@github.com:/TheGreenCedar/CodeStory.git")
+        );
+        assert_ne!(https, ssh);
+    }
+
+    #[test]
+    fn repository_identity_preserves_meaningful_ports_and_path_case() {
+        assert_eq!(
+            normalize_repository_identity_v2("ssh://git@EXAMPLE.com:2222/Team/Repo.git").as_deref(),
+            Some("ssh://example.com:2222/Team/Repo")
+        );
+        assert_eq!(
+            normalize_repository_identity_v2("https://example.com:8443/Team/Repo.git").as_deref(),
+            Some("https://example.com:8443/Team/Repo")
+        );
+        assert_ne!(
+            normalize_repository_identity_v2("https://example.com/Team/Repo.git"),
+            normalize_repository_identity_v2("https://example.com/team/repo.git")
+        );
+        assert_ne!(
+            normalize_repository_identity_v2("https://example.com:443/team/repo.git"),
+            normalize_repository_identity_v2("ssh://git@example.com:22/team/repo.git")
+        );
+        assert_eq!(
+            normalize_repository_identity_v2("ssh://git@example.com:22/team/repo.git"),
+            normalize_repository_identity_v2("git@example.com:/team/repo.git")
+        );
+        assert_ne!(
+            normalize_repository_identity_v2("custom-a://example.com/team/repo.git"),
+            normalize_repository_identity_v2("custom-b://example.com/team/repo.git")
+        );
+        assert_eq!(
+            normalize_repository_identity_v2("https://example.com/team/repo.GIT").as_deref(),
+            Some("https://example.com:443/team/repo.GIT")
+        );
+    }
+
+    #[test]
+    fn bracketed_scp_ipv6_matches_ssh_url() {
+        assert_eq!(
+            normalize_repository_identity_v2("git@[2001:DB8::1]:/team/repo.git"),
+            normalize_repository_identity_v2("ssh://git@[2001:db8::1]:22/team/repo.git")
+        );
+    }
+
+    #[test]
+    fn rejects_unqualified_local_remote_paths() {
+        for remote in [
+            "repos/origin.git",
+            "~/repo.git",
+            "github.com/org/repo.git",
+            "C:/source/repo.git",
+            r"C:\source\repo.git",
+            "C:repo.git",
+            "file://localhost/source/repo.git",
+            "file://server/share/repo.git",
         ] {
+            assert!(
+                normalize_repository_identity_v2(remote).is_none(),
+                "local remote must fail closed: {remote}"
+            );
+        }
+    }
+
+    #[test]
+    fn scp_absolute_and_home_relative_paths_remain_distinct() {
+        let absolute = normalize_repository_identity_v2("git@example.com:/team/repo.git");
+        let relative = normalize_repository_identity_v2("git@example.com:team/repo.git");
+
+        assert_eq!(
+            absolute,
+            normalize_repository_identity_v2("ssh://git@example.com:22/team/repo.git")
+        );
+        assert_eq!(
+            relative,
+            normalize_repository_identity_v2("ssh://git@example.com:22/~/team/repo.git")
+        );
+        assert_ne!(absolute, relative);
+    }
+
+    #[test]
+    fn url_path_leading_slashes_remain_distinct() {
+        let standard = normalize_repository_identity_v2("https://example.com/org/repo.git");
+        let doubled = normalize_repository_identity_v2("https://example.com//org/repo.git");
+
+        assert_eq!(
+            standard.as_deref(),
+            Some("https://example.com:443/org/repo")
+        );
+        assert_eq!(
+            doubled.as_deref(),
+            Some("https://example.com:443//org/repo")
+        );
+        assert_ne!(standard, doubled);
+    }
+
+    #[test]
+    fn repository_v2_never_guesses_a_legacy_alias_without_provenance() {
+        let Some(project) = git_project() else {
+            return;
+        };
+        for remote in [
+            "https://example.com/team/repo.git",
+            "https://example.com/Team/Repo.git",
+            "ssh://example.com:2222/team/repo.git",
+            "ssh://[::1]/team/repo.git",
+        ] {
+            git(project.path(), &["remote", "set-url", "origin", remote]);
             assert_eq!(
-                normalize_repository_identity(remote).as_deref(),
-                Some(expected),
+                inspect_repository_identity_v2(project.path()).legacy_canonical_repository_id,
+                None,
                 "remote: {remote}"
             );
         }
+        assert!(parse_repository_identity_v2("C:/source/repo").is_none());
+    }
+
+    #[test]
+    fn identity_schema_migration_changes_repository_id_without_guessing_alias() {
+        assert_eq!(REPOSITORY_IDENTITY_SCHEMA_VERSION, 1);
+        assert_eq!(PROJECT_IDENTITY_SCHEMA_VERSION, 2);
+        assert_eq!(REPOSITORY_IDENTITY_V2_SCHEMA_VERSION, 2);
+        assert_eq!(PROJECT_IDENTITY_V3_SCHEMA_VERSION, 3);
+        let normalized = "example.com/team/repo";
+        assert_ne!(
+            canonical_repository_id_v2(normalized),
+            legacy_canonical_repository_id(normalized)
+        );
+        assert!(canonical_repository_id_v2(normalized).starts_with("repo-v2-"));
+        assert!(legacy_canonical_repository_id(normalized).starts_with("repo-v1-"));
+    }
+
+    #[test]
+    fn legacy_entrypoints_remain_on_the_existing_contract() {
+        assert_eq!(
+            normalize_repository_identity_v1("ssh://git@EXAMPLE.com:2222/Team/Repo.git").as_deref(),
+            Some("example.com/team/repo")
+        );
+        let Some(project) = git_project() else {
+            return;
+        };
+        let repository = inspect_repository_identity(project.path());
+        assert_eq!(repository.repository_identity_schema_version, 1);
+        assert_eq!(
+            repository.normalized_repository_identity.as_deref(),
+            Some("github.com/thegreencedar/codestory")
+        );
+        assert_eq!(
+            repository.canonical_repository_id.as_deref(),
+            Some("repo-v1-670ad7db4da1546b")
+        );
+        assert_eq!(repository.portable_reuse_reason, "eligible");
+
+        let project_identity = project_identity_v2(project.path());
+        assert_eq!(project_identity.project_identity_schema_version, 2);
+        assert_eq!(project_identity.project_id, "repo-v1-670ad7db4da1546b");
+        assert_eq!(
+            project_identity.canonical_repository_id.as_deref(),
+            Some("repo-v1-670ad7db4da1546b")
+        );
+        assert_eq!(
+            project_identity.artifact_scope_id,
+            project_identity.project_id
+        );
+        assert_eq!(project_identity.portable_reuse_reason, "eligible");
+
+        let root =
+            workspace_root_identity_from_text(r"C:\Source\CodeStory\", r"\\?\C:\Source\CodeStory\");
+        assert_eq!(root.workspace_id, "f6a770b628e5f7f2");
+        assert_eq!(
+            root.legacy_raw_root_project_id.as_deref(),
+            Some("914a8e53209dde45")
+        );
+        assert_eq!(
+            root.normalized_root_project_id_alias.as_deref(),
+            Some("e2562715b2c4b441")
+        );
     }
 
     #[test]
@@ -433,9 +1106,9 @@ mod tests {
             return;
         };
 
-        let clean = project_identity_v2(project.path());
+        let clean = project_identity_v3(project.path());
         fs::write(project.path().join("lib.rs"), "pub fn dirty() {}\n").expect("dirty source");
-        let dirty = project_identity_v2(project.path());
+        let dirty = project_identity_v3(project.path());
 
         assert_eq!(clean.project_id, dirty.project_id);
         assert_eq!(clean.workspace_id, dirty.workspace_id);
@@ -461,8 +1134,8 @@ mod tests {
             ],
         );
 
-        let first = project_identity_v2(project.path());
-        let second = project_identity_v2(&worktree);
+        let first = project_identity_v3(project.path());
+        let second = project_identity_v3(&worktree);
 
         assert_eq!(first.project_id, second.project_id);
         assert_ne!(first.workspace_id, second.workspace_id);
@@ -473,10 +1146,10 @@ mod tests {
     fn workspace_id_matches_existing_canonical_root_fnv_contract() {
         let project = tempdir().expect("project");
         let canonical = fs::canonicalize(project.path()).expect("canonical project root");
-        let expected = fnv1a_hex(canonical.to_string_lossy().as_bytes());
+        let expected = fnv1a_path_hex(&canonical);
 
-        assert_eq!(workspace_id_for_root(project.path()), expected);
-        assert_eq!(project_identity_v2(project.path()).workspace_id, expected);
+        assert_eq!(workspace_id_v3_for_root(project.path()), expected);
+        assert_eq!(project_identity_v3(project.path()).workspace_id, expected);
     }
 
     #[test]
@@ -485,9 +1158,87 @@ mod tests {
         let dotted = project.path().join(".");
 
         assert_eq!(
-            workspace_id_for_root(project.path()),
-            workspace_id_for_root(&dotted)
+            workspace_id_v3_for_root(project.path()),
+            workspace_id_v3_for_root(&dotted)
         );
+    }
+
+    #[test]
+    fn existing_path_equality_uses_file_identity() {
+        let project = tempdir().expect("project");
+        let file = project.path().join("identity");
+        let alias = project.path().join("identity-alias");
+        fs::write(&file, "identity").expect("identity file");
+        fs::hard_link(&file, &alias).expect("hard-link alias");
+
+        assert!(same_workspace_path(&file, &alias));
+        assert!(!same_workspace_path(&file, &project.path().join("missing")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_paths_preserve_case_and_non_utf8_bytes() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let project = tempdir().expect("project");
+        let upper = project.path().join("Repo");
+        let lower = project.path().join("repo");
+        fs::create_dir(&upper).expect("upper-case path");
+        fs::create_dir(&lower).expect("lower-case path");
+        assert!(!same_workspace_path(&upper, &lower));
+        assert_ne!(
+            workspace_id_v3_for_root(&upper),
+            workspace_id_v3_for_root(&lower)
+        );
+
+        let first = project.path().join(OsString::from_vec(vec![b'r', 0x80]));
+        let second = project.path().join(OsString::from_vec(vec![b'r', 0x81]));
+        fs::create_dir(&first).expect("first non-UTF-8 path");
+        fs::create_dir(&second).expect("second non-UTF-8 path");
+        assert_ne!(
+            workspace_id_v3_for_root(&first),
+            workspace_id_v3_for_root(&second)
+        );
+        assert!(
+            workspace_root_identity_v3(&first)
+                .legacy_raw_root_project_id
+                .is_none()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_existing_and_missing_aliases_compare_case_insensitively() {
+        let project = tempdir().expect("project");
+        let existing = project.path().join("CodeStory");
+        fs::create_dir(&existing).expect("mixed-case path");
+        let existing_alias = project.path().join("codestory");
+        assert!(same_workspace_path(&existing, &existing_alias));
+
+        let missing = project.path().join("Missing");
+        let missing_alias = project.path().join("missing");
+        assert!(same_workspace_path(&missing, &missing_alias));
+
+        let dotted = project
+            .path()
+            .join("Missing")
+            .join(".")
+            .join("child")
+            .join("..")
+            .join("Älias");
+        let normalized = project.path().join("missing").join("äLIAS");
+        assert!(same_workspace_path(&dotted, &normalized));
+
+        let extended = PathBuf::from(format!(r"\\?\{}", project.path().display()));
+        assert!(same_workspace_path(
+            &extended.join("missing"),
+            &project.path().join("MISSING")
+        ));
+        assert!(!same_missing_path(
+            Path::new(r"C:missing"),
+            Path::new(r"C:\missing")
+        ));
     }
 
     #[test]
@@ -514,9 +1265,9 @@ mod tests {
             return;
         };
 
-        let clean = project_identity_v2(project.path());
+        let clean = project_identity_v3(project.path());
         fs::write(project.path().join("lib.rs"), "pub fn dirty() {}\n").expect("dirty source");
-        let dirty = project_identity_v2(project.path());
+        let dirty = project_identity_v3(project.path());
 
         assert_eq!(clean.artifact_scope_id, clean.project_id);
         assert_eq!(dirty.artifact_scope_id, dirty.workspace_id);

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -66,6 +66,26 @@ back to `workspace_id`; `canonical_root_hash` is only a local broker snapshot
 locator. The 0.14 migration records these identities without renaming existing
 namespace or artifact paths.
 
+Repository identity schema 2 lowercases only the remote host, normalizes an
+omitted port to that scheme's effective default, and preserves the transport
+scheme, repository path case, and meaningful ports. SCP spellings normalize to
+SSH while preserving absolute versus home-relative paths; unqualified local
+remotes fail closed. HTTPS, SSH, Git, and unknown schemes remain distinct.
+Project identity schema 3 hashes canonical workspace paths from native OS
+bytes/code units rather than a lossy UTF-8 rendering. Existing paths are
+compared by filesystem file identity; only missing paths use platform lexical
+rules. On Windows that fallback normalizes separators and dot segments and uses
+ordinal Unicode ignore-case;
+because the target does not exist, it cannot observe a future directory's
+case-sensitivity flag. A schema-1 repository id is never inferred from the
+current remote spelling alone; migration requires persisted provenance.
+
+The schema-2/schema-3 contract is exposed through
+`inspect_repository_identity_v2` and `project_identity_v3`. Existing
+repository-v1/project-v2 broker, repair, and sidecar entrypoints remain
+unchanged until the parent identity migration can move their persisted state
+and ownership checks together.
+
 The hash includes local lexical input, graph-native `symbol_search_doc` rows,
 dense-anchor rows, semantic file-role metadata, sidecar schema version, Zoekt
 version pin, embedding backend, embedding dimension, semantic policy version,


### PR DESCRIPTION
## Context

Current repository identity lowercases meaningful path data, drops port/scheme
semantics, and hashes normalized text for workspace identity. That can merge
distinct case-sensitive repositories and cannot represent native paths
losslessly. #974 introduces the versioned contract without silently migrating
existing readiness/sidecar consumers.

## What Changed

- Added explicit repository-v2 and project-v3 identity APIs while preserving
  current repository-v1/project-v2 entrypoints and exact outputs.
- Canonicalized network remotes with scheme, effective port, host case-folding,
  path case, SCP absolute/home-relative semantics, bracketed IPv6, and exact
  lowercase `.git` suffix handling.
- Failed closed for local/unqualified remotes and for legacy-v1 alias adoption
  without persisted provenance.
- Hashed native path data for new workspace IDs.
- Compared existing paths by filesystem identity: device/inode on Unix and
  `FileIdInfo` volume + 128-bit file ID on Windows/ReFS.
- Added Windows lexical fallback for missing paths using normalized separators,
  dot segments, and ordinal Unicode case comparison, with the per-directory
  case-sensitivity ceiling documented.
- Documented the staged #913 consumer migration and updated the changelog.

## How To Review

Review `repository_identity.rs` in three passes: unchanged legacy entrypoints,
new remote canonicalization, then native workspace/path identity. Confirm no
runtime, broker, retrieval, CLI, or plugin consumer moved to v3 in this PR.

## Verification

- `cargo test -p codestory-workspace`: 38/38 plus doc-tests, rerun after the
  final collision fixes.
- `cargo build --release -p codestory-cli`: passed.
- `cargo fmt --all -- --check`: passed.
- Documentation links: 69 files, 279 links passed.
- Workflow policy and `git diff --check`: passed.
- The required ignored repo e2e stats binary was invoked but could not emit
  stats: `CODESTORY_REAL_REPO_DRILL_CASES` is unset and no
  `bge-base-en-v1.5.Q8_0.gguf` model directory exists. Retrieval bootstrap
  failed explicitly; no e2e success or stats are claimed.

## Risk

The new contract is intentionally opt-in. Existing consumers retain their
current IDs until parent #913 migrates them with persisted provenance. Remaining
risk is platform-specific path behavior; focused Unix, Windows, ReFS-safe API,
non-UTF-8, worktree, port, case, IPv6, SCP, and legacy-output regressions cover
the supported boundaries.

Closes #974
Refs #913
Refs #899
