### PR TITLE
pin status summaries to one publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@
 
 - Removed a plugin static test that froze exact grounding documentation copy;
   documentation remains covered by the repository link and diff checks.
+- Pinned each status summary to one SQLite read transaction, accepted it only
+  when its complete publication stayed stable, and keyed the cache by durable
+  publication identity so concurrent publication cannot produce or retain a
+  mixed-generation response.
 - Corrected the Codex managed-platform guide to list the restored macOS x64 CLI
   while retaining its no-managed-accelerated-sidecar boundary.
 - Retried packaged-proof temporary directory removal after transient executable

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2518,6 +2518,7 @@ pub(crate) fn wait_for_local_freshness(
                 output.blocks_local_surfaces = true;
                 output.reason = Some("refresh_did_not_reach_fresh".to_string());
             }
+            attach_complete_publication(&mut output, &opened.summary);
             Ok((opened.summary, Some(output)))
         }
         Err(error) => {

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -57,6 +57,7 @@ use std::time::{Duration, Instant};
 
 const STDIO_PACKET_CACHE_CAPACITY: usize = 8;
 const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
+const STDIO_STATUS_PUBLICATION_ATTEMPTS: usize = 3;
 const STDIO_RECENT_REPAIR_TTL: Duration = Duration::from_secs(30);
 const STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES: usize = 32 * 1024;
 const STDIO_READY_REPAIR_RESERVATION_HEARTBEAT: Duration = Duration::from_secs(5);
@@ -2712,53 +2713,63 @@ fn read_stdio_status_resource_cached(
         return Ok(cached.value.clone());
     }
 
-    let mut publication_before = runtime
-        .project
-        .complete_index_publication_at(&runtime.storage_path)
-        .map_err(map_api_error)?;
-    let mut value = read_stdio_status_resource_uncached(runtime, state)?;
-    let mut publication_after = runtime
-        .project
-        .complete_index_publication_at(&runtime.storage_path)
-        .map_err(map_api_error)?;
-    if publication_before != publication_after
-        || !stdio_status_matches_publication(&value, publication_after.as_ref())
-    {
-        let completed_refresh = value
-            .get("local_refresh")
-            .filter(|refresh| {
-                refresh.get("state").and_then(serde_json::Value::as_str) == Some("refreshed")
-            })
-            .filter(|refresh| {
-                refresh.get("reason").and_then(serde_json::Value::as_str) == Some("refreshed")
-            })
-            .cloned();
-        publication_before = publication_after;
-        value = read_stdio_status_resource_uncached(runtime, state)?;
-        publication_after = runtime
+    let mut completed_refresh = None;
+    for attempt in 1..=STDIO_STATUS_PUBLICATION_ATTEMPTS {
+        let publication_before = runtime
             .project
             .complete_index_publication_at(&runtime.storage_path)
             .map_err(map_api_error)?;
-        if publication_before != publication_after
-            || !stdio_status_matches_publication(&value, publication_after.as_ref())
+        let mut value = read_stdio_status_resource_uncached(runtime, state)?;
+        completed_refresh = completed_refresh.or_else(|| {
+            value
+                .get("local_refresh")
+                .filter(|refresh| {
+                    refresh.get("reason").and_then(serde_json::Value::as_str) == Some("refreshed")
+                })
+                .cloned()
+        });
+        let publication_after = runtime
+            .project
+            .complete_index_publication_at(&runtime.storage_path)
+            .map_err(map_api_error)?;
+        let cache_key = stdio_status_cache_key_with_publication(
+            runtime,
+            &stdio_publication_fingerprint(publication_after.as_ref()),
+        );
+        if publication_before == publication_after
+            && stdio_status_matches_publication(&value, publication_after.as_ref())
         {
+            if let Some(refresh) = completed_refresh
+                .as_ref()
+                .filter(|refresh| stdio_refresh_matches_publication(refresh, &value))
+            {
+                value["local_refresh"] = refresh.clone();
+            }
+            state.status_cache = Some(StdioStatusCacheEntry {
+                key: cache_key,
+                value: value.clone(),
+                cached_at: Instant::now(),
+            });
+            return Ok(value);
+        }
+        state.status_cache = None;
+        if attempt == STDIO_STATUS_PUBLICATION_ATTEMPTS {
+            let status_generation = value
+                .pointer("/index_publication/generation")
+                .and_then(serde_json::Value::as_u64);
             bail!(
-                "cache_busy: the index publication changed twice while status was reading; retry against the stable publication"
+                "cache_busy: status could not observe one stable complete publication after {STDIO_STATUS_PUBLICATION_ATTEMPTS} attempts (before={:?}, status={status_generation:?}, after={:?})",
+                publication_before
+                    .as_ref()
+                    .map(|publication| publication.generation),
+                publication_after
+                    .as_ref()
+                    .map(|publication| publication.generation)
             );
         }
-        if let Some(completed_refresh) = completed_refresh {
-            value["local_refresh"] = completed_refresh;
-        }
+        thread::sleep(Duration::from_millis(5));
     }
-
-    let key = stdio_status_cache_key(runtime);
-    // ponytail: short stdio snapshot cache; source/storage/sidecar fingerprints bust it when state changes.
-    state.status_cache = Some(StdioStatusCacheEntry {
-        key,
-        value: value.clone(),
-        cached_at: Instant::now(),
-    });
-    Ok(value)
+    unreachable!("status publication attempt loop always returns or errors")
 }
 
 fn stdio_status_matches_publication(
@@ -2769,6 +2780,13 @@ fn stdio_status_matches_publication(
         .and_then(|publication| serde_json::to_value(publication).ok())
         .unwrap_or(serde_json::Value::Null);
     status.get("index_publication") == Some(&expected)
+}
+
+fn stdio_refresh_matches_publication(
+    refresh: &serde_json::Value,
+    status: &serde_json::Value,
+) -> bool {
+    refresh.get("serving_publication") == status.get("index_publication")
 }
 
 fn read_stdio_status_resource_uncached(
@@ -2969,15 +2987,48 @@ fn stdio_project_args(runtime: &RuntimeContext) -> args::ProjectArgs {
     }
 }
 
+fn stdio_complete_publication_fingerprint(runtime: &RuntimeContext) -> String {
+    match runtime
+        .project
+        .complete_index_publication_at(&runtime.storage_path)
+    {
+        Ok(publication) => stdio_publication_fingerprint(publication.as_ref()),
+        Err(error) => format!("error:{error:?}"),
+    }
+}
+
+fn stdio_publication_fingerprint(publication: Option<&IndexPublicationDto>) -> String {
+    publication.map_or_else(
+        || "missing".to_string(),
+        |publication| {
+            format!(
+                "{}:{}:{}:{}",
+                publication.generation,
+                publication.generation_id,
+                publication.run_id,
+                publication.published_at_epoch_ms
+            )
+        },
+    )
+}
+
 fn stdio_status_cache_key(runtime: &RuntimeContext) -> String {
+    // Opening SQLite can touch WAL/SHM metadata, so read publication before the
+    // helper fingerprints storage.
+    let publication = stdio_complete_publication_fingerprint(runtime);
+    stdio_status_cache_key_with_publication(runtime, &publication)
+}
+
+fn stdio_status_cache_key_with_publication(runtime: &RuntimeContext, publication: &str) -> String {
     let layout = SidecarLayout::from_env_for_project(&runtime.project_root);
     let marker_path = stdio_dirty_marker_env_path(&runtime.project_root);
     [
         format!("project:{}", runtime.project_root.display()),
         format!("storage:{}", runtime.storage_path.display()),
+        format!("complete_publication:{publication}"),
         format!(
             "storage_state:{}",
-            stdio_storage_fingerprint(&runtime.storage_path)
+            stdio_path_fingerprint(&runtime.storage_path)
         ),
         format!(
             "sidecar_state:{}",
@@ -6063,6 +6114,37 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn status_cache_publication_fingerprint_includes_durable_identity() {
+        let publication = |generation| IndexPublicationDto {
+            generation,
+            generation_id: format!("generation-{generation}"),
+            run_id: format!("run-{generation}"),
+            mode: codestory_contracts::api::IndexPublicationModeDto::Incremental,
+            published_at_epoch_ms: generation as i64,
+        };
+        let first = publication(1);
+        let second = publication(2);
+        assert_ne!(
+            stdio_publication_fingerprint(Some(&first)),
+            stdio_publication_fingerprint(Some(&second))
+        );
+        assert_eq!(stdio_publication_fingerprint(None), "missing");
+    }
+
+    #[test]
+    fn completed_refresh_is_reused_only_for_the_same_publication() {
+        let refresh = json!({"serving_publication": {"generation": 2}});
+        assert!(stdio_refresh_matches_publication(
+            &refresh,
+            &json!({"index_publication": {"generation": 2}})
+        ));
+        assert!(!stdio_refresh_matches_publication(
+            &refresh,
+            &json!({"index_publication": {"generation": 3}})
+        ));
+    }
+
     fn base_packet_cache_key_input(question: &str) -> StdioPacketCacheKeyInput<'_> {
         StdioPacketCacheKeyInput {
             storage_fingerprint: "snapshot-a".to_string(),
@@ -7683,7 +7765,7 @@ starting sidecar setup
     }
 
     #[test]
-    fn stdio_status_cache_key_tracks_wal_changes() {
+    fn stdio_status_cache_key_uses_publication_instead_of_volatile_wal_metadata() {
         let project = tempfile::tempdir().expect("project");
         let cache = tempfile::tempdir().expect("cache");
         let runtime = crate::runtime::RuntimeContext::new_inspect_only(&crate::args::ProjectArgs {
@@ -7694,19 +7776,23 @@ starting sidecar setup
         std::fs::create_dir_all(runtime.storage_path.parent().expect("storage parent"))
             .expect("create storage parent");
         std::fs::write(&runtime.storage_path, b"db").expect("write db");
-        let clean = stdio_status_cache_key(&runtime);
+        let publication = "2:generation-2:run-2:200";
+        let clean = stdio_status_cache_key_with_publication(&runtime, publication);
 
         let wal_path = runtime.storage_path.with_extension("db-wal");
         std::fs::write(&wal_path, b"incomplete-marker-frame").expect("write marker WAL frame");
-        let incomplete = stdio_status_cache_key(&runtime);
-        assert_ne!(clean, incomplete, "WAL write must bust cached fresh status");
+        let incomplete = stdio_status_cache_key_with_publication(&runtime, publication);
+        assert_eq!(
+            clean, incomplete,
+            "observer-induced WAL metadata must not invalidate a durable publication key"
+        );
 
         std::fs::write(&wal_path, b"incomplete-marker-frame-cleared")
             .expect("write marker-clear WAL frame");
-        let finished = stdio_status_cache_key(&runtime);
-        assert_ne!(
+        let finished = stdio_status_cache_key_with_publication(&runtime, publication);
+        assert_eq!(
             incomplete, finished,
-            "marker clear must bust cached stale status"
+            "publication identity, not volatile WAL metadata, owns status invalidation"
         );
     }
 }

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -4678,6 +4678,12 @@ fn two_stdio_processes_observe_only_complete_generations_during_real_refresh() {
             generation == old_generation || generation == old_generation + 1,
             "reader observed an unexpected publication generation: {status}"
         );
+        let expected_status_file_count = if generation == old_generation { 5 } else { 101 };
+        assert_eq!(
+            status["index_freshness"]["indexed_file_count"],
+            json!(expected_status_file_count),
+            "status mixed publication metadata and summary contents: {status}"
+        );
         let ground_response = send_json(
             &mut reader_client,
             json!({

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -8555,7 +8555,16 @@ impl AppController {
         storage_path: PathBuf,
     ) -> Result<ProjectSummary, ApiError> {
         let storage = open_storage_for_read(&storage_path)?;
-        let summary = self.project_summary_from_storage(&root, &storage_path, &storage)?;
+        let snapshot = storage.read_snapshot().map_err(|error| {
+            ApiError::internal(format!("Failed to begin project summary snapshot: {error}"))
+        })?;
+        let summary =
+            self.project_summary_from_storage(&root, &storage_path, snapshot.storage())?;
+        snapshot.finish().map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to finish project summary snapshot: {error}"
+            ))
+        })?;
 
         {
             let mut s = self.state.lock();

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -293,6 +293,35 @@ pub struct Storage {
     deferred_secondary_indexes: bool,
 }
 
+/// One coherent read view of a live SQLite store.
+///
+/// Publication replaces the live database in place. Grouping related reads in
+/// one transaction prevents a reader from combining rows from two generations.
+pub struct StorageReadSnapshot<'a> {
+    storage: &'a Storage,
+    active: bool,
+}
+
+impl StorageReadSnapshot<'_> {
+    pub fn storage(&self) -> &Storage {
+        self.storage
+    }
+
+    pub fn finish(mut self) -> Result<(), StorageError> {
+        self.storage.conn.execute_batch("COMMIT")?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for StorageReadSnapshot<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = self.storage.conn.execute_batch("ROLLBACK");
+        }
+    }
+}
+
 /// Opening mode for a SQLite store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StorageOpenMode {
@@ -1022,6 +1051,14 @@ impl Storage {
             conn,
             cache: StorageCache::default(),
             deferred_secondary_indexes: false,
+        })
+    }
+
+    pub fn read_snapshot(&self) -> Result<StorageReadSnapshot<'_>, StorageError> {
+        self.conn.execute_batch("BEGIN DEFERRED TRANSACTION")?;
+        Ok(StorageReadSnapshot {
+            storage: self,
+            active: true,
         })
     }
 


### PR DESCRIPTION
## Context

Status assembled its project summary through separate autocommit reads. Because
publication restores a staged SQLite database into the live database in place,
one response could combine rows from two complete generations. The status cache
also relied on file length and millisecond mtime without durable publication
identity.

Closes #988
Refs #975
Refs #946
Refs #910
Refs #884
Refs #899

## What Changed

- Read every project summary inside one SQLite read transaction, preventing a
  response from combining rows from two in-place publication generations.
- Accept status only when the durable publication before and after the read is
  unchanged and matches the publication serialized in the response; retry up
  to three coherent read attempts.
- Include durable generation identity in the status cache key and cache only
  after the returned publication is stable. Volatile WAL/SHM mtimes no longer
  invalidate the durable publication key merely because a reader opened SQLite.

## How To Review

Review `StorageReadSnapshot` and `open_project_summary_with_storage_inner`, then
`read_stdio_status_resource_cached`. The transaction pins related SQLite reads
to one coherent generation; the surrounding publication checks ensure that
only the current complete generation is returned and cached.

## Verification

- `two_stdio_processes_observe_only_complete_generations_during_real_refresh`
  passed after reproducing the pre-fix race with exact generation diagnostics.
- `background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded_latency`
  passed with the refreshed provenance and warm-cache latency contracts intact.
- Durable publication match and cache-fingerprint unit tests passed.
- `cargo check -p codestory-store -p codestory-runtime -p codestory-cli` passed.
- `cargo clippy -p codestory-store -p codestory-runtime -p codestory-cli --all-targets -- -D warnings` passed.
- `cargo fmt --all` and `git diff --check` passed.

The distinct atomic marker/publication failure remains in #955/#973. The stale
runtime premise in #975 was disproved, so this PR deliberately does not reopen
that issue or retain its ineffective lock-handoff change. Running the complete
stdio contract binary locally also exposed five separate parallel-test
isolation/worker-lifetime failures tracked in reopened issue #907.

## Risk

Project-summary reads now hold a read transaction while gathering storage and
freshness state. SQLite WAL readers should not block publication, and the real
cross-process refresh contract exercises that path. Under sustained publication
churn, status still fails explicitly with `cache_busy` after the bounded retry
attempts instead of returning mixed state. No screenshot-visible UI changed.
