### PR TITLE
fix repository identity clippy

### DIFF
--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -693,9 +693,11 @@ fn normalize_windows_lexical_path(path: &Path) -> Vec<u16> {
         .as_os_str()
         .encode_wide()
         .map(|unit| {
-            (unit == u16::from(b'/'))
-                .then_some(u16::from(b'\\'))
-                .unwrap_or(unit)
+            if unit == u16::from(b'/') {
+                u16::from(b'\\')
+            } else {
+                unit
+            }
         })
         .collect::<Vec<_>>();
     let separator = u16::from(b'\\');


### PR DESCRIPTION
## Context

PR #985 left strict clippy failing on the new Windows repository-identity path
normalization expression, making every feature branch rebased onto
`dev/codestory-next` red for an unrelated base-branch lint.

Closes #989
Refs #913
Refs #985
Refs #899

## What Changed

- Replaced the flagged boolean `then_some(...).unwrap_or(...)` expression with
  the direct `if/else` form requested by clippy.
- Preserved slash-to-backslash normalization exactly.

## How To Review

The PR is one expression in `normalize_windows_lexical_path`; compare both
branches of the old and new forms.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codestory-workspace repository_identity` — 19 passed
- `cargo clippy -p codestory-workspace --all-targets -- -D warnings`
- `git diff --check`

## Risk

Minimal. This is a behavior-preserving expression rewrite. No UI changed.
