### PR TITLE
qualify hook routing evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,10 @@
   Local navigation remains explicitly weaker than full packet/search proof.
 - Added a test-only hook qualification matrix for orientation, ownership, call
   flow, change impact, broad retrieval, blocked-deep fallback, and non-repo
-  suppression, including an executable comparison with the former generic
-  status-first behavior and representative recorded agent drill traces.
+  suppression. The former prompt-agnostic policy's first prompt emission and
+  current hook both run as processes; qualification scores structured route
+  categories and exact tool tokens. Separately sourced observed MCP drill
+  artifacts remain explicitly non-executable test evidence.
 - Replaced generic status-only lifecycle guidance with compact repository-task
   routing for orientation, symbol ownership, call flow, change impact, and broad
   questions. Prompt hooks no longer echo user text, suppress non-repository

--- a/plugins/codestory/docs/agent-portability.md
+++ b/plugins/codestory/docs/agent-portability.md
@@ -23,3 +23,17 @@ Adapter layout, MCP script, hooks, and plugin checks:
 
 Keep adapters thin: point hook-capable hosts at `hooks/` and `skills/`; align
 rule-only hosts with the grounding skill contract.
+
+## Hook qualification evidence
+
+The deterministic [route matrix](../tests/fixtures/hook-route-qualification.json)
+runs both the current hook and a test-only reproduction of the former policy's
+first `UserPromptSubmit` emission as child processes. It scores route categories
+and exact tool-name tokens, not rendered prose fragments; historical hook-state
+deduplication is outside this comparison.
+
+The separate [observed MCP drills](../tests/fixtures/hook-observed-mcp-drills.json)
+record sourced orientation, symbol, call-flow, change-impact, and blocked
+fallback observations. Static tests validate those artifacts and the matching
+hook category; they do not execute MCP or promote recorded observations into
+live proof.

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -31,7 +31,7 @@ function routeForPrompt(prompt) {
     || /\breview\b[^.!?]*\b(?:diff|changes?|pull request)\b/u.test(text)
     || /\b(?:review\b[^.!?]*\bpr|pr\b[^.!?]*\breview)\b/u.test(text)
   ) {
-    return 'Review/change impact: use affected only with explicit git-changed paths, then inspect relevant symbols or traces; affected is planning evidence, not proof.';
+    return 'Review/change impact: use affected only with explicit git-changed paths, then inspect relevant symbol or trace evidence; affected is planning evidence, not proof.';
   }
   if (/\b(?:where is|defined|definition|owns?|ownership|symbol|class|function|method)\b/u.test(text)) {
     return 'Symbol ownership: use symbol, then definition; add callers/callees only when the question asks for flow.';
@@ -42,6 +42,24 @@ function routeForPrompt(prompt) {
   return 'Repository orientation: use ground; use files only for language, role, path, or coverage questions.';
 }
 
+function selectedPlan(route, prompt) {
+  const label = route.split(':', 1)[0];
+  const blockedDeep = /\b(?:packet(?:\s*\/\s*|\s+and\s+)search|packet|search)\b[^.!?]*\bblocked\b|\bblocked\b[^.!?]*\b(?:packet|search)\b/u.test(
+    normalizePrompt(prompt).toLowerCase(),
+  );
+  const plans = {
+    'Repository orientation': ['orientation', ['ground', 'files']],
+    'Symbol ownership': ['symbol_ownership', ['symbol', 'definition']],
+    'Call flow': ['call_flow', ['symbol', 'callers', 'callees', 'trace']],
+    'Review/change impact': ['change_impact', ['affected', 'symbol', 'trace']],
+    'Broad question': blockedDeep
+      ? ['broad_question', ['ground', 'symbol', 'trace']]
+      : ['broad_question', ['packet']],
+  };
+  const [category, tools] = plans[label];
+  return `Plan: category=${category}; tools=${tools.join(',')}`;
+}
+
 function eventHeader(event, input = {}) {
   if (event === 'UserPromptSubmit') {
     const route = routeForPrompt(input.prompt);
@@ -50,6 +68,7 @@ function eventHeader(event, input = {}) {
       'CODESTORY REQUEST ROUTING ACTIVE',
       '',
       `Route: ${route}`,
+      selectedPlan(route, input.prompt),
       '',
     ].join('\n');
   }

--- a/plugins/codestory/tests/fixtures/hook-generic-baseline.cjs
+++ b/plugins/codestory/tests/fixtures/hook-generic-baseline.cjs
@@ -1,16 +1,51 @@
-// Test-only executable model of the pre-router UserPromptSubmit policy: every
-// prompt received the same grounding instruction and none were suppressed.
-function emitGenericUserPromptPolicy() {
-  return {
-    hookSpecificOutput: {
-      additionalContext: [
-        'CODESTORY REQUEST GROUNDING ACTIVE',
-        '',
-        'Use CodeStory before source files for this user prompt.',
-        'Call status with the target repository before manual source reads.',
-      ].join('\n'),
-    },
-  };
+#!/usr/bin/env node
+
+// Test-only executable reproduction of ca351218^ first-emission
+// UserPromptSubmit output. Historical hook-state deduplication is out of scope.
+const MAX_PROMPT_CHARS = 600;
+const MCP_RESOURCE_TEXT = 'If mcp__codestory tools are not initially visible and tool_search is available, query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools before manual source reads.';
+
+function compactPrompt(prompt) {
+  const text = String(prompt || '').replace(/\s+/g, ' ').trim();
+  return text.length <= MAX_PROMPT_CHARS ? text : `${text.slice(0, MAX_PROMPT_CHARS)}...`;
 }
 
-module.exports = { emitGenericUserPromptPolicy };
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  let hookInput = {};
+  try {
+    hookInput = JSON.parse(input.replace(/^\uFEFF/, '') || '{}');
+  } catch {
+    // The former hook treated malformed input as an empty event.
+  }
+  const event = hookInput.hook_event_name || 'UserPromptSubmit';
+  const prompt = compactPrompt(hookInput.prompt);
+  const cwd = hookInput.cwd || process.cwd();
+  const header = [
+    'CODESTORY REQUEST GROUNDING ACTIVE',
+    '',
+    'Use CodeStory before source files for this user prompt.',
+    MCP_RESOURCE_TEXT,
+    prompt ? `Prompt: ${prompt}` : 'Prompt: unavailable from hook input.',
+  ].join('\n');
+  const mcpInstructions = [
+    'CodeStory MCP startup path:',
+    '1. Use live CodeStory MCP before manual source reads for repository work.',
+    `2. If mcp__codestory tools are visible, call status with project=${JSON.stringify(cwd)}, then pass that same project to every CodeStory tool call.`,
+    '3. If mcp__codestory is not visible and tool_search is available, query "codestory mcp ground status packet search", then use the loaded CodeStory MCP tools.',
+    '4. The MCP is multi-project and request-scoped. Never infer workspace from another thread or a global active-state file.',
+    '5. Do not treat hook text as grounding evidence; only live MCP results or verified source reads count.',
+  ].join('\n');
+  const context = `${header}\n\n${mcpInstructions}`;
+  process.stdout.write(JSON.stringify({
+    systemMessage: 'CODESTORY:BACKGROUND',
+    hookSpecificOutput: {
+      hookEventName: event,
+      additionalContext: context.length <= 1200
+        ? context
+        : `${context.slice(0, 1200)}\n\n... CodeStory hook output truncated.`,
+    },
+  }));
+});

--- a/plugins/codestory/tests/fixtures/hook-observed-mcp-drills.json
+++ b/plugins/codestory/tests/fixtures/hook-observed-mcp-drills.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": 1,
+  "artifact_kind": "sourced_observed_mcp_drill_traces",
+  "test_execution": {
+    "executes_mcp": false,
+    "statement": "These are sourced observations. Static tests validate their schema and hook category, not MCP execution."
+  },
+  "observations": [
+    {
+      "slug": "orientation",
+      "prompt": "List the languages and major areas in this repository.",
+      "category": "orientation",
+      "source": {
+        "kind": "agent_observation",
+        "url": "https://github.com/TheGreenCedar/CodeStory/pull/982",
+        "location": "Verification: recorded live drills",
+        "commit": "4fcbab22c6a41fcfaef7d995ce5ff91f38cc3c68",
+        "observed_at": "2026-07-12"
+      },
+      "steps": [
+        { "tool": "status", "outcome": "current project status reused" },
+        { "tool": "ground", "outcome": "repository orientation returned" },
+        { "tool": "files", "outcome": "language and area coverage inspected" }
+      ],
+      "source_fallback": { "used": false },
+      "repair_attempted": false
+    },
+    {
+      "slug": "symbol_lookup",
+      "prompt": "Where is RuntimeContext defined?",
+      "category": "symbol_ownership",
+      "source": {
+        "kind": "agent_observation",
+        "url": "https://github.com/TheGreenCedar/CodeStory/pull/982",
+        "location": "Verification: recorded live drills",
+        "commit": "4fcbab22c6a41fcfaef7d995ce5ff91f38cc3c68",
+        "observed_at": "2026-07-12"
+      },
+      "steps": [
+        { "tool": "status", "outcome": "current project status reused" },
+        { "tool": "symbol", "outcome": "RuntimeContext selected" },
+        { "tool": "definition", "outcome": "definition anchor returned" }
+      ],
+      "source_fallback": { "used": false },
+      "repair_attempted": false
+    },
+    {
+      "slug": "call_flow",
+      "prompt": "Who calls wait_for_local_freshness?",
+      "category": "call_flow",
+      "source": {
+        "kind": "agent_observation",
+        "url": "https://github.com/TheGreenCedar/CodeStory/pull/982",
+        "location": "Verification: recorded live drills",
+        "commit": "4fcbab22c6a41fcfaef7d995ce5ff91f38cc3c68",
+        "observed_at": "2026-07-12"
+      },
+      "steps": [
+        { "tool": "status", "outcome": "current project status reused" },
+        { "tool": "symbol", "outcome": "wait_for_local_freshness selected" },
+        { "tool": "callers", "outcome": "incoming flow inspected" },
+        { "tool": "callees", "outcome": "outgoing flow inspected" }
+      ],
+      "source_fallback": { "used": false },
+      "repair_attempted": false
+    },
+    {
+      "slug": "change_impact",
+      "prompt": "Review the changed hook files and identify affected tests.",
+      "category": "change_impact",
+      "source": {
+        "kind": "agent_observation",
+        "url": "https://github.com/TheGreenCedar/CodeStory/pull/982",
+        "location": "Verification: recorded live drills",
+        "commit": "4fcbab22c6a41fcfaef7d995ce5ff91f38cc3c68",
+        "observed_at": "2026-07-12"
+      },
+      "steps": [
+        { "tool": "status", "outcome": "current project status reused" },
+        {
+          "tool": "affected",
+          "arguments": {
+            "paths": [
+              "plugins/codestory/hooks/codestory-activate.cjs",
+              "plugins/codestory/tests/plugin-static.test.mjs"
+            ]
+          },
+          "result_kind": "explicit_path_match",
+          "outcome": "both explicit paths matched; plugin-static.test.mjs was impacted"
+        }
+      ],
+      "source_fallback": { "used": false },
+      "repair_attempted": false
+    },
+    {
+      "slug": "blocked_broad_fallback",
+      "prompt": "Explain the AppController codebase architecture while packet/search is blocked.",
+      "category": "broad_question",
+      "source": {
+        "kind": "agent_observation",
+        "url": "https://github.com/TheGreenCedar/CodeStory/pull/982",
+        "location": "Verification: recorded live drills",
+        "commit": "4fcbab22c6a41fcfaef7d995ce5ff91f38cc3c68",
+        "observed_at": "2026-07-12"
+      },
+      "steps": [
+        {
+          "tool": "status",
+          "outcome": "packet and search blocked by retrieval_manifest_missing"
+        },
+        { "tool": "ground", "outcome": "allowed local orientation used" },
+        { "tool": "symbol", "outcome": "AppController selected" },
+        { "tool": "trace", "outcome": "focused graph flow inspected" },
+        { "tool": "source", "outcome": "source fallback followed graph evidence" }
+      ],
+      "blocked_tools": ["packet", "search"],
+      "source_fallback": {
+        "used": true,
+        "after_graph": true,
+        "reason": "retrieval_manifest_missing"
+      },
+      "repair_attempted": false
+    }
+  ]
+}

--- a/plugins/codestory/tests/fixtures/hook-route-qualification.json
+++ b/plugins/codestory/tests/fixtures/hook-route-qualification.json
@@ -1,54 +1,54 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "cases": [
     {
       "slug": "orientation",
       "prompt": "List the languages and major areas in this repository.",
-      "route": "Repository orientation",
-      "required_surfaces": ["ground", "files"]
+      "category": "orientation",
+      "instructed_tools": ["ground", "files"]
     },
     {
       "slug": "symbol_lookup",
       "prompt": "Where is RequestContext defined?",
-      "route": "Symbol ownership",
-      "required_surfaces": ["symbol", "definition"]
+      "category": "symbol_ownership",
+      "instructed_tools": ["symbol", "definition"]
     },
     {
       "slug": "call_flow",
       "prompt": "Who calls RequestContext::open?",
-      "route": "Call flow",
-      "required_surfaces": ["symbol", "callers", "callees", "trace"]
+      "category": "call_flow",
+      "instructed_tools": ["symbol", "callers", "callees", "trace"]
     },
     {
       "slug": "change_impact",
       "prompt": "Review crates/codestory-runtime/src/lib.rs and identify affected tests.",
-      "route": "Review/change impact",
-      "required_surfaces": ["affected", "symbols", "traces"]
+      "category": "change_impact",
+      "instructed_tools": ["affected", "symbol", "trace"]
     },
     {
       "slug": "snake_case_change",
       "prompt": "Fix the refresh_index race.",
-      "route": "Review/change impact",
-      "required_surfaces": ["affected", "symbols", "traces"]
+      "category": "change_impact",
+      "instructed_tools": ["affected", "symbol", "trace"]
     },
     {
       "slug": "camel_case_change",
       "prompt": "Refactor routeForPrompt.",
-      "route": "Review/change impact",
-      "required_surfaces": ["affected", "symbols", "traces"]
+      "category": "change_impact",
+      "instructed_tools": ["affected", "symbol", "trace"]
     },
     {
       "slug": "broad_architecture_full",
       "prompt": "Explain the broad architecture of this codebase.",
-      "route": "Broad question",
-      "required_surfaces": ["packet"]
+      "category": "broad_question",
+      "instructed_tools": ["packet"]
     },
     {
       "slug": "broad_architecture_blocked",
       "prompt": "Explain the codebase architecture when packet/search is blocked.",
-      "route": "Broad question",
-      "required_surfaces": ["ground", "symbol", "trace"],
-      "forbidden_surfaces": ["sidecar_setup"]
+      "category": "broad_question",
+      "instructed_tools": ["ground", "symbol", "trace"],
+      "forbidden_tools": ["sidecar_setup"]
     },
     {
       "slug": "non_repository_review",
@@ -74,60 +74,6 @@
       "slug": "issue_workflow",
       "prompt": "Create an issue for the hook initiative.",
       "suppressed": true
-    }
-  ],
-  "drills": [
-    {
-      "slug": "live_orientation",
-      "prompt": "List the languages and major areas in this repository.",
-      "route": "Repository orientation",
-      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
-      "surface_trace": ["status", "ground", "files"],
-      "status_reused": true,
-      "repair_attempted": false
-    },
-    {
-      "slug": "live_symbol_lookup",
-      "prompt": "Where is RuntimeContext defined?",
-      "route": "Symbol ownership",
-      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
-      "surface_trace": ["status", "symbol", "definition"],
-      "status_reused": true,
-      "repair_attempted": false
-    },
-    {
-      "slug": "live_call_flow",
-      "prompt": "Who calls wait_for_local_freshness?",
-      "route": "Call flow",
-      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
-      "surface_trace": ["status", "symbol", "callers", "callees"],
-      "status_reused": true,
-      "repair_attempted": false
-    },
-    {
-      "slug": "live_change_impact",
-      "prompt": "Review the changed hook files and identify affected tests.",
-      "route": "Review/change impact",
-      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
-      "surface_trace": ["status", "affected"],
-      "affected_paths": [
-        "plugins/codestory/hooks/codestory-activate.cjs",
-        "plugins/codestory/tests/plugin-static.test.mjs"
-      ],
-      "affected_outcome": "both paths matched; plugin-static.test.mjs was impacted",
-      "status_reused": true,
-      "repair_attempted": false
-    },
-    {
-      "slug": "live_blocked_broad",
-      "prompt": "Explain the AppController codebase architecture while packet/search is blocked.",
-      "route": "Broad question",
-      "evidence_source": "Codex parent saga live MCP trace for issue 965 on 2026-07-12",
-      "status_outcome": "packet/search blocked: retrieval_manifest_missing",
-      "surface_trace": ["status", "ground", "symbol", "trace", "source"],
-      "blocked_surfaces": ["packet", "search"],
-      "status_reused": true,
-      "repair_attempted": false
     }
   ]
 }

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -20,12 +20,7 @@ const {
   uninstallDirtyHooks,
   writeDirtyMarker,
 } = require(join(pluginRoot, "hooks", "codestory-runtime.cjs"));
-const { emitGenericUserPromptPolicy } = require(join(
-  pluginRoot,
-  "tests",
-  "fixtures",
-  "hook-generic-baseline.cjs",
-));
+const genericBaselineHook = join(pluginRoot, "tests", "fixtures", "hook-generic-baseline.cjs");
 
 function threadActiveStatePath(dataDir, threadId) {
   const key = createHash("sha256").update(String(threadId)).digest("hex").slice(0, 16);
@@ -3097,8 +3092,8 @@ async function writeNodeCli(binDir, source) {
   return cliPath;
 }
 
-function runCodexHook(input, env) {
-  const result = spawnSync(process.execPath, [join(pluginRoot, "hooks", "codestory-activate.cjs")], {
+function runHookProcess(script, input, env) {
+  const result = spawnSync(process.execPath, [script], {
     env: {
       ...process.env,
       COPILOT_PLUGIN_DATA: "",
@@ -3109,6 +3104,10 @@ function runCodexHook(input, env) {
   });
   assert.equal(result.status, 0, result.stderr);
   return JSON.parse(result.stdout);
+}
+
+function runCodexHook(input, env) {
+  return runHookProcess(join(pluginRoot, "hooks", "codestory-activate.cjs"), input, env);
 }
 
 async function runCodexHookAsync(input, env) {
@@ -3195,49 +3194,43 @@ test("hook routing is stateless across repeated and parallel processes", async (
   }
 });
 
-test("hook qualification records emitted routes and observed drill surfaces", async (t) => {
+test("hook qualification compares executable policies with sourced MCP observations", async (t) => {
   const fixture = JSON.parse(await readFile(
     join(pluginRoot, "tests", "fixtures", "hook-route-qualification.json"),
     "utf8",
   ));
+  const observedDrills = JSON.parse(await readFile(
+    join(pluginRoot, "tests", "fixtures", "hook-observed-mcp-drills.json"),
+    "utf8",
+  ));
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-qualification-"));
-  const surfacePatterns = new Map([
-    ["status", /\bstatus\b/u],
-    ["ground", /\bground\b/u],
-    ["files", /\buse files\b/u],
-    ["symbol", /\bsymbols?\b/u],
-    ["definition", /\bdefinition\b/u],
-    ["callers", /\bcallers\b/u],
-    ["callees", /\bcallees\b/u],
-    ["trace", /\btraces?\b/u],
-    ["trail", /\btrails?\b/u],
-    ["affected", /\baffected\b/u],
-    ["packet", /\bpacket\b/u],
-    ["search", /\bsearch\b/u],
-    ["sidecar_setup", /\bsidecar_setup\b/u],
+  const toolVocabulary = new Set([
+    "affected", "callees", "callers", "definition", "files", "ground", "packet",
+    "search", "sidecar_setup", "snippet", "status", "symbol", "trace", "trail",
   ]);
   const record = (output) => {
     const context = output.hookSpecificOutput?.additionalContext || "";
-    const routeInstruction = context.match(/^Route: (.+)$/mu)?.[1] || "";
-    const surfaceText = routeInstruction || context;
+    const plan = context.match(/^Plan: category=([a-z_]+); tools=([a-z_,]+)$/mu);
+    const instructedTools = plan
+      ? [...new Set(plan[2].split(","))].sort()
+      : [];
+    assert.ok(instructedTools.every((tool) => toolVocabulary.has(tool)));
     return {
       suppressed: !context,
-      route: routeInstruction.match(/^([^:]+):/u)?.[1] || null,
-      instructed_surfaces: [...surfacePatterns]
-        .filter(([, pattern]) => pattern.test(surfaceText))
-        .map(([surface]) => surface),
+      category: plan?.[1] || null,
+      instructed_tools: instructedTools,
     };
   };
   const failures = (actual, expected) => {
     const result = [];
     if (actual.suppressed !== Boolean(expected.suppressed)) result.push("suppression");
-    if (!expected.suppressed && actual.route !== expected.route) result.push("route");
-    for (const surface of expected.required_surfaces || []) {
-      const normalized = { symbols: "symbol", traces: "trace" }[surface] || surface;
-      if (!actual.instructed_surfaces.includes(normalized)) result.push(`missing:${surface}`);
+    if (!expected.suppressed && actual.category !== expected.category) result.push("category");
+    const expectedTools = [...(expected.instructed_tools || [])].sort();
+    if (!expected.suppressed && actual.instructed_tools.join("\0") !== expectedTools.join("\0")) {
+      result.push(`tools:${actual.instructed_tools.join(",")}`);
     }
-    for (const surface of expected.forbidden_surfaces || []) {
-      if (actual.instructed_surfaces.includes(surface)) result.push(`forbidden:${surface}`);
+    for (const tool of expected.forbidden_tools || []) {
+      if (actual.instructed_tools.includes(tool)) result.push(`forbidden:${tool}`);
     }
     return result;
   };
@@ -3254,7 +3247,11 @@ test("hook qualification records emitted routes and observed drill surfaces", as
       assert.equal(context.includes(entry.prompt), false);
       assert.doesNotMatch(context, /hook output truncated/u);
       const current = record(currentOutput);
-      const baseline = record(emitGenericUserPromptPolicy(entry.prompt));
+      const baseline = record(runHookProcess(genericBaselineHook, {
+        hook_event_name: "UserPromptSubmit",
+        prompt: entry.prompt,
+        cwd: repoRoot,
+      }, { PLUGIN_DATA: dataDir, PATH: "" }));
       return {
         slug: entry.slug,
         current,
@@ -3264,49 +3261,63 @@ test("hook qualification records emitted routes and observed drill surfaces", as
       };
     });
 
-    const requiredTraceSurfaces = {
-      "Repository orientation": ["ground", "files"],
-      "Symbol ownership": ["symbol", "definition"],
-      "Call flow": ["symbol", "callers", "callees"],
-      "Review/change impact": ["affected"],
-      "Broad question": ["ground", "symbol", "trace"],
+    const requiredObservedTools = {
+      orientation: ["ground", "files"],
+      symbol_ownership: ["symbol", "definition"],
+      call_flow: ["symbol", "callers", "callees"],
+      change_impact: ["affected"],
+      broad_question: ["ground", "symbol", "trace"],
     };
-    for (const drill of fixture.drills) {
+    assert.equal(observedDrills.artifact_kind, "sourced_observed_mcp_drill_traces");
+    assert.equal(observedDrills.test_execution.executes_mcp, false);
+    for (const drill of observedDrills.observations) {
       const emitted = record(runCodexHook({
         hook_event_name: "UserPromptSubmit",
         prompt: drill.prompt,
         cwd: repoRoot,
       }, { PLUGIN_DATA: dataDir, PATH: "" }));
-      const sourceIndex = drill.surface_trace.indexOf("source");
-      const graphIndex = drill.surface_trace.findIndex((surface) =>
-        ["ground", "symbol", "callers", "callees", "trace", "trail", "affected"].includes(surface));
-      assert.equal(emitted.route, drill.route);
-      assert.equal(drill.surface_trace[0], "status");
-      assert.equal(drill.status_reused, true);
-      assert.ok(drill.evidence_source.includes("live MCP trace"));
-      assert.ok(requiredTraceSurfaces[drill.route].every((surface) =>
-        drill.surface_trace.includes(surface)), drill.evidence_source);
-      if (sourceIndex >= 0) assert.ok(graphIndex > 0 && sourceIndex > graphIndex, drill.evidence_source);
-      if (drill.blocked_surfaces) {
-        assert.ok(drill.blocked_surfaces.every((surface) => drill.status_outcome.includes(surface)));
+      const observedTools = drill.steps.map(({ tool }) => tool);
+      const sourceIndex = observedTools.indexOf("source");
+      const graphIndex = observedTools.findIndex((tool) =>
+        ["ground", "symbol", "callers", "callees", "trace", "trail", "affected"].includes(tool));
+      assert.ok(
+        observedTools.every((tool) => tool === "source" || toolVocabulary.has(tool)),
+        drill.source.location,
+      );
+      assert.equal(drill.source_fallback.used, sourceIndex >= 0, drill.source.location);
+      assert.equal(emitted.category, drill.category);
+      assert.equal(observedTools[0], "status");
+      assert.equal(drill.source.kind, "agent_observation");
+      assert.equal(drill.source.url, "https://github.com/TheGreenCedar/CodeStory/pull/982");
+      assert.match(drill.source.commit, /^[0-9a-f]{40}$/u);
+      assert.ok(requiredObservedTools[drill.category].every((tool) =>
+        observedTools.includes(tool)), drill.source.location);
+      if (sourceIndex >= 0) {
+        assert.equal(drill.source_fallback.used, true);
+        assert.equal(drill.source_fallback.after_graph, true);
+        assert.ok(graphIndex > 0 && sourceIndex > graphIndex, drill.source.location);
       }
-      if (drill.affected_paths) {
-        assert.deepEqual(drill.affected_paths, [
+      if (drill.blocked_tools) {
+        assert.deepEqual([...drill.blocked_tools].sort(), ["packet", "search"]);
+      }
+      const affected = drill.steps.find(({ tool }) => tool === "affected");
+      if (affected) {
+        assert.deepEqual(affected.arguments.paths, [
           "plugins/codestory/hooks/codestory-activate.cjs",
           "plugins/codestory/tests/plugin-static.test.mjs",
         ]);
-        assert.match(drill.affected_outcome, /both paths matched/u);
+        assert.equal(affected.result_kind, "explicit_path_match");
       }
-      assert.equal(drill.surface_trace.includes("sidecar_setup"), false);
+      assert.equal(observedTools.includes("sidecar_setup"), false);
       assert.equal(drill.repair_attempted, false);
     }
 
     t.diagnostic(JSON.stringify({
       cases,
-      drills: fixture.drills.map(({ slug, evidence_source, surface_trace }) => ({
+      observed_drills: observedDrills.observations.map(({ slug, source, steps }) => ({
         slug,
-        evidence_source,
-        observed_surfaces: surface_trace,
+        source,
+        observed_tools: steps.map(({ tool }) => tool),
       })),
     }));
     assert.deepEqual(cases.flatMap(({ slug, current_failures }) =>


### PR DESCRIPTION
## Context

PR #982 merged a deterministic hook fixture, but its baseline score was
hard-coded and its qualification inspected classifier prose rather than
executable policies and sourced drill evidence. #965 was reopened so that the
proof matches the behavior being claimed.

## What Changed

- Added an executable test-only reproduction of the exact former first-emission
  UserPromptSubmit output, including prompt echo, MCP discovery/status context,
  cap, and truncation. Historical deduplication is explicitly out of scope.
- Ran current qualification cases through the real `codestory-activate.cjs`
  child process.
- Added a structured hook plan with category and exact selected tool set.
- Compared complete tool sets, distinguishing full broad `packet` from explicit
  blocked broad `ground,symbol,trace` without prose-substring false passes.
- Moved five observed MCP drills into a separately sourced artifact anchored to
  PR #982 and its exact commit, explicitly labeled `executes_mcp:false`.
- Validated observation structure (`blocked_tools`, exact affected arguments and
  result kind) while leaving human outcome prose diagnostic-only.
- Updated portability guidance and the changelog.

## How To Review

Review the former-policy fixture against `ca351218^`, then compare the v2 case
fixture with the `Plan:` line emitted by `codestory-instructions.cjs`. Confirm
the observed drill file is evidence input, not a test claim that MCP ran.

## Verification

- Full plugin static suite: 60/60.
- Current routing qualification: 13/13.
- Executable former baseline: 0/13, with its actual instructed discovery/status
  tokens retained rather than weakened.
- Documentation links: 69 files, 281 links.
- Workflow policy, Node syntax checks, and `git diff --check`: passed.

## Risk

Low. Runtime change is one structured plan line derived from the existing route;
the remaining changes are test/evidence/docs. Observed drills remain explicitly
non-executable and do not claim current live MCP proof.

Closes #965
Refs #962
Refs #899
