### PR TITLE
close managed cli publication gaps

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -184,6 +184,11 @@ def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path) -> None:
     shutil.rmtree(cache_root, ignore_errors=True)
 
 
+def local_profile_environment(base: dict[str, str]) -> dict[str, str]:
+    """Keep explicit local commands and their default runtime in one namespace."""
+    return {**base, "CODESTORY_SIDECAR_PROFILE": "local"}
+
+
 def require_plugin_manifest_version(plugin_root: Path, expected_version: str) -> None:
     manifest_path = plugin_root / ".codex-plugin" / "plugin.json"
     require(manifest_path.is_file(), "plugin_manifest", manifest_path, f"plugin manifest is missing: {manifest_path}")
@@ -1138,6 +1143,7 @@ def run_gate(args: argparse.Namespace) -> None:
             write_json(out_dir / "summary.json", summary)
             return
 
+        local_env = local_profile_environment(proof_env)
         local_bootstrap_artifact = out_dir / "local-retrieval-bootstrap.json"
         run_command(
             cli,
@@ -1156,7 +1162,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             local_bootstrap_artifact,
             args.timeout_secs,
-            env=proof_env,
+            env=local_env,
         )
         summary["artifacts"]["local_retrieval_bootstrap"] = str(local_bootstrap_artifact)
         write_json(out_dir / "summary.json", summary)
@@ -1181,7 +1187,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             local_index_artifact,
             args.timeout_secs,
-            env=proof_env,
+            env=local_env,
         )
         require_retrieval_index_ready(local_index, "local_retrieval_index", local_index_artifact)
         summary["artifacts"]["local_retrieval_index"] = str(local_index_artifact)
@@ -1205,7 +1211,7 @@ def run_gate(args: argparse.Namespace) -> None:
             ],
             local_status_artifact,
             args.timeout_secs,
-            env=proof_env,
+            env=local_env,
         )
         require_retrieval_full(local_status, "local_retrieval_status", local_status_artifact)
         summary["artifacts"]["local_retrieval_status"] = str(local_status_artifact)
@@ -1640,6 +1646,12 @@ def write_fake_plugin_launcher(plugin_root: Path) -> None:
 
 
 def self_test() -> None:
+    base_environment = {"KEEP": "value", "CODESTORY_SIDECAR_PROFILE": "agent"}
+    local_environment = local_profile_environment(base_environment)
+    assert local_environment["KEEP"] == "value"
+    assert local_environment["CODESTORY_SIDECAR_PROFILE"] == "local"
+    assert base_environment["CODESTORY_SIDECAR_PROFILE"] == "agent"
+
     with tempfile.TemporaryDirectory(prefix="codestory-packaged-proof-self-test-") as temp:
         root = Path(temp)
         transient_cleanup_attempts = 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Kept packaged local-retrieval proof commands in the local default runtime
+  namespace so the cross-platform gate validates a real local handoff before
+  exercising agent readiness.
+
 ### Removed
 
 - Removed the legacy ONNX diagnostic runtime, asset installer, setup command,
@@ -116,6 +122,12 @@
   reprovisioned, while locked or unmovable targets fail closed. Publication
   states are exposed as redacted plugin-runtime warnings, and native packaged
   proof now includes macOS x64 alongside the existing five release targets.
+- Closed the remaining managed CLI publication gaps: waiters now cover both
+  assets' absolute total configured retry windows, staged binaries must answer
+  the exact MCP stdio `initialize` contract within bounded output and process
+  shutdown limits, stale initialization aliases are inode-and-token revalidated
+  across rename, and resource-capped ZIP/tar.gz extraction uses Node platform
+  APIs instead of an external `tar` executable.
 
 - Extended the retrieval generalization guard from derived query literals to
   direct and split Rust string dependencies on eval/query corpus paths across

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -32,11 +32,17 @@ Ambient `PATH` binaries are reported as diagnostics only; installed plugin
 runtime does not launch them.
 
 After a managed runtime passes archive checksum, executable checksum, manifest,
-and `--version` verification, the adapter retains that active version plus one
-verified pending upgrade or rollback. Same-version launches elect one publisher
+`--version`, and MCP stdio `initialize` verification, the adapter retains that
+active version plus one verified pending upgrade or rollback. ZIP and tar.gz
+release assets are extracted with Node platform APIs, without an external
+archive command, under explicit archive-size, entry-count, per-entry, and total
+output ceilings. Same-version launches elect one publisher
 under an atomically owner-published PID/start-identity/token lock; acquisition
 fails closed without a reliable process-start identity, and waiters reuse its
-atomically renamed staging directory. A corrupt target is quarantined (two
+atomically renamed staging directory. Their wait bound covers both release
+assets' absolute total download retry windows. The staging MCP probe bounds its
+output and waits for child termination with forced-kill escalation. Stale initialization aliases are
+revalidated by inode and owner token after rename before deletion. A corrupt target is quarantined (two
 copies retained) and reprovisioned once. A live owner or unmovable Windows
 executable is never deleted, and publication fails closed when safe quarantine
 or replacement is not possible. Publisher, waiter, reclaimed-lock, quarantine,

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -8,6 +8,7 @@ const http = require('http');
 const https = require('https');
 const os = require('os');
 const path = require('path');
+const zlib = require('zlib');
 const { dirtyMarkerPathForProject } = require('../hooks/codestory-runtime.cjs');
 
 const pluginRoot = path.dirname(__dirname);
@@ -24,9 +25,22 @@ const releaseDownloadAttempts = 3;
 const releaseDownloadRetryDelaysMs = [1000, 3000];
 const managedCliLockStaleMs = 10 * 60 * 1000;
 const managedCliLockMaxAgeMs = 30 * 60 * 1000;
-const managedCliLockWaitMs = 5 * 60 * 1000;
+const releaseAssetRetryBudgetMs =
+  releaseDownloadAttempts * releaseDownloadTimeoutMs +
+  releaseDownloadRetryDelaysMs.slice(0, releaseDownloadAttempts - 1).reduce((sum, delay) => sum + delay, 0);
+const managedCliStagingBudgetMs = 30 * 1000;
+const managedCliLockWaitMs = 2 * releaseAssetRetryBudgetMs + managedCliStagingBudgetMs;
 const managedCliPendingOwnerCleanupLimit = 64;
 const managedCliQuarantineRetention = 2;
+const managedCliArchiveMaxBytes = 256 * 1024 * 1024;
+const managedCliArchiveMaxEntries = 20_000;
+const managedCliArchiveMaxEntryBytes = 256 * 1024 * 1024;
+const managedCliArchiveMaxOutputBytes = 512 * 1024 * 1024;
+const managedCliProbeStdoutMaxBytes = 64 * 1024;
+const managedCliProbeStderrMaxBytes = 4 * 1024;
+const managedCliProbeTerminationGraceMs = 500;
+const managedCliProbeForceKillGraceMs = 1000;
+const managedCliMcpProtocolVersion = '2024-11-05';
 
 function readJson(file) {
   try {
@@ -477,6 +491,7 @@ function sleep(ms) {
 
 function downloadFileOnce(url, destination, options = {}) {
   const timeoutMs = options.timeoutMs || releaseDownloadTimeoutMs;
+  const deadlineMs = options.deadlineMs ?? Date.now() + timeoutMs;
   const redirectsRemaining = options.redirectsRemaining ?? 5;
   const parsedUrl = new URL(url);
   const loopbackHttp = parsedUrl.protocol === 'http:' &&
@@ -486,30 +501,58 @@ function downloadFileOnce(url, destination, options = {}) {
   }
   const get = options.get || (loopbackHttp ? http.get : https.get);
   return new Promise((resolve, reject) => {
+    let settled = false;
+    let output = null;
+    let activeRequest = null;
+    let activeResponse = null;
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadlineTimer);
+      if (error) {
+        if (output) output.destroy();
+        if (activeResponse) activeResponse.destroy();
+        if (activeRequest) activeRequest.destroy();
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    const remainingMs = Math.max(0, deadlineMs - Date.now());
+    const deadlineTimer = setTimeout(
+      () => finish(new Error(`download timed out after ${timeoutMs}ms total: ${url}`)),
+      remainingMs,
+    );
     const request = get(url, (response) => {
+      activeResponse = response;
       if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
         response.resume();
         if (!response.headers.location || redirectsRemaining <= 0) {
-          reject(new Error(`download redirect failed: ${url}`));
+          finish(new Error(`download redirect failed: ${url}`));
           return;
         }
         const nextUrl = new URL(response.headers.location, url).toString();
-        downloadFileOnce(nextUrl, destination, { ...options, redirectsRemaining: redirectsRemaining - 1 })
-          .then(resolve, reject);
+        downloadFileOnce(nextUrl, destination, {
+          ...options,
+          deadlineMs,
+          redirectsRemaining: redirectsRemaining - 1,
+        }).then(() => finish(null), finish);
         return;
       }
       if (response.statusCode !== 200) {
         response.resume();
-        reject(new Error(`download failed ${response.statusCode}: ${url}`));
+        finish(new Error(`download failed ${response.statusCode}: ${url}`));
         return;
       }
-      const output = fs.createWriteStream(destination);
+      output = fs.createWriteStream(destination);
       response.pipe(output);
-      output.on('finish', () => output.close(resolve));
-      output.on('error', reject);
+      output.on('finish', () => output.close((error) => finish(error || null)));
+      output.on('error', finish);
+      response.on('aborted', () => finish(new Error(`download body aborted: ${url}`)));
+      response.on('error', finish);
     });
-    request.setTimeout(timeoutMs, () => request.destroy(new Error(`download timed out after ${timeoutMs}ms: ${url}`)));
-    request.on('error', reject);
+    activeRequest = request;
+    request.on('error', finish);
   });
 }
 
@@ -579,15 +622,266 @@ async function fetchReleaseFile(version, name, destination) {
   return redactedReleaseFileUrl(version, name);
 }
 
-function extractArchive(archivePath, destination) {
-  fs.mkdirSync(destination, { recursive: true });
-  const result = spawnSync('tar', ['-xf', archivePath, '-C', destination], {
-    encoding: 'utf8',
-    windowsHide: true,
-  });
-  if (result.status !== 0) {
-    throw new Error(`tar extract failed: ${result.stderr || result.error?.message || result.status}`);
+function safeArchiveDestination(destination, entryName) {
+  const normalized = String(entryName || '').replace(/\\/gu, '/');
+  if (!normalized || normalized.startsWith('/') || /^[A-Za-z]:\//u.test(normalized)) {
+    throw new Error(`archive_path_invalid:${entryName}`);
   }
+  const parts = normalized.split('/').filter(Boolean);
+  if (parts.some((part) => part === '..')) throw new Error(`archive_path_escape:${entryName}`);
+  const resolved = path.resolve(destination, ...parts);
+  const root = `${path.resolve(destination)}${path.sep}`;
+  if (resolved !== path.resolve(destination) && !resolved.startsWith(root)) {
+    throw new Error(`archive_path_escape:${entryName}`);
+  }
+  return resolved;
+}
+
+function crc32(content) {
+  let crc = 0xffffffff;
+  for (const byte of content) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function tarText(block, start, length) {
+  return block.subarray(start, start + length).toString('utf8').replace(/\0.*$/su, '').trim();
+}
+
+function tarNumber(block, start, length) {
+  const text = tarText(block, start, length);
+  if (!text || !/^[0-7]+$/u.test(text)) throw new Error('tar_numeric_field_invalid');
+  const value = Number.parseInt(text, 8);
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error('tar_numeric_field_invalid');
+  return value;
+}
+
+function paxPath(payload) {
+  let offset = 0;
+  let selected = null;
+  while (offset < payload.length) {
+    const space = payload.indexOf(0x20, offset);
+    if (space < 0) throw new Error('tar_pax_length_missing');
+    const lengthText = payload.subarray(offset, space).toString('ascii');
+    if (!/^\d+$/u.test(lengthText)) throw new Error('tar_pax_length_invalid');
+    const length = Number.parseInt(lengthText, 10);
+    if (!Number.isSafeInteger(length) || length <= 0 || offset + length > payload.length) {
+      throw new Error('tar_pax_length_invalid');
+    }
+    if (payload[offset + length - 1] !== 0x0a) throw new Error('tar_pax_record_unterminated');
+    const record = payload.subarray(space + 1, offset + length - 1).toString('utf8');
+    const separator = record.indexOf('=');
+    if (separator <= 0) throw new Error('tar_pax_record_invalid');
+    if (record.slice(0, separator) === 'path') {
+      selected = record.slice(separator + 1);
+      if (!selected || selected.includes('\0')) throw new Error('tar_pax_path_invalid');
+    }
+    offset += length;
+  }
+  if (offset !== payload.length) throw new Error('tar_pax_trailing_bytes');
+  return selected;
+}
+
+function extractTarGz(archivePath, destination) {
+  const archive = zlib.gunzipSync(fs.readFileSync(archivePath), {
+    maxOutputLength: managedCliArchiveMaxOutputBytes,
+  });
+  let offset = 0;
+  let nextPath = null;
+  let entries = 0;
+  let outputBytes = 0;
+  let terminated = false;
+  while (offset + 512 <= archive.length) {
+    const header = archive.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      if (
+        offset + 1024 > archive.length ||
+        !archive.subarray(offset + 512, offset + 1024).every((byte) => byte === 0)
+      ) {
+        throw new Error('tar_terminator_invalid');
+      }
+      if (!archive.subarray(offset + 1024).every((byte) => byte === 0)) {
+        throw new Error('tar_trailing_bytes');
+      }
+      terminated = true;
+      break;
+    }
+    entries += 1;
+    if (entries > managedCliArchiveMaxEntries) throw new Error('archive_entry_limit_exceeded');
+    const storedChecksum = tarNumber(header, 148, 8);
+    let checksum = 0;
+    for (let index = 0; index < 512; index += 1) {
+      checksum += index >= 148 && index < 156 ? 0x20 : header[index];
+    }
+    if (checksum !== storedChecksum) throw new Error('tar_header_checksum_mismatch');
+    const size = tarNumber(header, 124, 12);
+    if (size > managedCliArchiveMaxEntryBytes) throw new Error('archive_entry_size_limit_exceeded');
+    const type = String.fromCharCode(header[156] || 0);
+    const prefix = tarText(header, 345, 155);
+    const headerName = tarText(header, 0, 100);
+    const name = nextPath || (prefix ? `${prefix}/${headerName}` : headerName);
+    nextPath = null;
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > archive.length) throw new Error('tar_entry_truncated');
+    const payload = archive.subarray(dataStart, dataEnd);
+    if (type === 'x') nextPath = paxPath(payload);
+    else if (type === 'L') {
+      const terminator = payload.indexOf(0);
+      if (terminator < 1 || !payload.subarray(terminator).every((byte) => byte === 0)) {
+        throw new Error('tar_long_name_unterminated');
+      }
+      nextPath = payload.subarray(0, terminator).toString('utf8');
+    }
+    else if (type === '5') fs.mkdirSync(safeArchiveDestination(destination, name), { recursive: true });
+    else if (type === '\0' || type === '0') {
+      if (!name) throw new Error('tar_entry_name_missing');
+      outputBytes += size;
+      if (outputBytes > managedCliArchiveMaxOutputBytes) throw new Error('archive_output_limit_exceeded');
+      const output = safeArchiveDestination(destination, name);
+      fs.mkdirSync(path.dirname(output), { recursive: true });
+      fs.writeFileSync(output, payload, { mode: tarNumber(header, 100, 8) || 0o644 });
+    } else if (type === 'g') {
+      paxPath(payload);
+    } else {
+      throw new Error(`tar_entry_type_unsupported:${type.charCodeAt(0)}`);
+    }
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+  if (!terminated || nextPath) throw new Error(nextPath ? 'tar_extended_name_without_entry' : 'tar_terminator_missing');
+}
+
+function findZipEndOfCentralDirectory(archive) {
+  const minimum = Math.max(0, archive.length - 65557);
+  for (let offset = archive.length - 22; offset >= minimum; offset -= 1) {
+    if (
+      archive.readUInt32LE(offset) === 0x06054b50 &&
+      offset + 22 + archive.readUInt16LE(offset + 20) === archive.length
+    ) return offset;
+  }
+  throw new Error('zip_end_of_central_directory_missing');
+}
+
+function extractZip(archivePath, destination) {
+  const archive = fs.readFileSync(archivePath);
+  const eocd = findZipEndOfCentralDirectory(archive);
+  if (
+    archive.readUInt16LE(eocd + 4) !== 0 || archive.readUInt16LE(eocd + 6) !== 0 ||
+    archive.readUInt16LE(eocd + 8) !== archive.readUInt16LE(eocd + 10)
+  ) throw new Error('zip_multi_disk_unsupported');
+  const entries = archive.readUInt16LE(eocd + 10);
+  if (entries === 0xffff || entries > managedCliArchiveMaxEntries) {
+    throw new Error('archive_entry_limit_exceeded');
+  }
+  const centralSize = archive.readUInt32LE(eocd + 12);
+  const centralOffset = archive.readUInt32LE(eocd + 16);
+  if (
+    centralSize === 0xffffffff || centralOffset === 0xffffffff ||
+    centralOffset + centralSize !== eocd
+  ) throw new Error('zip_central_directory_bounds_invalid');
+  let offset = centralOffset;
+  let outputBytes = 0;
+  const extractedPaths = new Set();
+  for (let index = 0; index < entries; index += 1) {
+    if (offset + 46 > eocd) throw new Error('zip_central_directory_truncated');
+    if (archive.readUInt32LE(offset) !== 0x02014b50) throw new Error('zip_central_directory_invalid');
+    const flags = archive.readUInt16LE(offset + 8);
+    const method = archive.readUInt16LE(offset + 10);
+    const compressedSize = archive.readUInt32LE(offset + 20);
+    const uncompressedSize = archive.readUInt32LE(offset + 24);
+    const nameLength = archive.readUInt16LE(offset + 28);
+    const extraLength = archive.readUInt16LE(offset + 30);
+    const commentLength = archive.readUInt16LE(offset + 32);
+    const externalAttributes = archive.readUInt32LE(offset + 38);
+    const localOffset = archive.readUInt32LE(offset + 42);
+    const centralEnd = offset + 46 + nameLength + extraLength + commentLength;
+    if (centralEnd > eocd) throw new Error('zip_central_entry_bounds_invalid');
+    if (
+      compressedSize === 0xffffffff || uncompressedSize === 0xffffffff ||
+      localOffset === 0xffffffff || uncompressedSize > managedCliArchiveMaxEntryBytes
+    ) throw new Error('archive_entry_size_limit_exceeded');
+    const nameBytes = archive.subarray(offset + 46, offset + 46 + nameLength);
+    const name = nameBytes.toString('utf8');
+    if (!name || name.includes('\0') || name.includes('\ufffd')) throw new Error('zip_entry_name_invalid');
+    if ((flags & 0x1) !== 0) throw new Error('zip_encryption_unsupported');
+    if (((externalAttributes >>> 16) & 0o170000) === 0o120000) throw new Error('zip_symlink_unsupported');
+    if (localOffset + 30 > centralOffset || archive.readUInt32LE(localOffset) !== 0x04034b50) {
+      throw new Error('zip_local_header_invalid');
+    }
+    const localNameLength = archive.readUInt16LE(localOffset + 26);
+    const localExtraLength = archive.readUInt16LE(localOffset + 28);
+    const localName = archive.subarray(localOffset + 30, localOffset + 30 + localNameLength);
+    if (!localName.equals(nameBytes)) throw new Error('zip_local_name_mismatch');
+    const localFlags = archive.readUInt16LE(localOffset + 6);
+    const localMethod = archive.readUInt16LE(localOffset + 8);
+    const localCrc = archive.readUInt32LE(localOffset + 14);
+    const localCompressedSize = archive.readUInt32LE(localOffset + 18);
+    const localUncompressedSize = archive.readUInt32LE(localOffset + 22);
+    if (localFlags !== flags || localMethod !== method) {
+      throw new Error('zip_local_metadata_mismatch');
+    }
+    const usesDataDescriptor = (flags & 0x8) !== 0;
+    if (usesDataDescriptor) {
+      for (const [local, central] of [
+        [localCrc, archive.readUInt32LE(offset + 16)],
+        [localCompressedSize, compressedSize],
+        [localUncompressedSize, uncompressedSize],
+      ]) {
+        if (local !== 0 && local !== central) throw new Error('zip_local_metadata_mismatch');
+      }
+    } else if (
+      localCrc !== archive.readUInt32LE(offset + 16) ||
+      localCompressedSize !== compressedSize || localUncompressedSize !== uncompressedSize
+    ) {
+      throw new Error('zip_local_metadata_mismatch');
+    }
+    const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+    if (dataStart + compressedSize > centralOffset) throw new Error('zip_entry_bounds_invalid');
+    const compressed = archive.subarray(dataStart, dataStart + compressedSize);
+    if (compressed.length !== compressedSize) throw new Error('zip_entry_truncated');
+    if (usesDataDescriptor) {
+      let descriptorOffset = dataStart + compressedSize;
+      if (descriptorOffset + 4 <= centralOffset && archive.readUInt32LE(descriptorOffset) === 0x08074b50) {
+        descriptorOffset += 4;
+      }
+      if (descriptorOffset + 12 > centralOffset) throw new Error('zip_data_descriptor_missing');
+      if (
+        archive.readUInt32LE(descriptorOffset) !== archive.readUInt32LE(offset + 16) ||
+        archive.readUInt32LE(descriptorOffset + 4) !== compressedSize ||
+        archive.readUInt32LE(descriptorOffset + 8) !== uncompressedSize
+      ) throw new Error('zip_data_descriptor_mismatch');
+    }
+    const output = safeArchiveDestination(destination, name);
+    if (extractedPaths.has(output)) throw new Error('archive_duplicate_path');
+    extractedPaths.add(output);
+    if (name.endsWith('/')) {
+      fs.mkdirSync(output, { recursive: true });
+    } else {
+      outputBytes += uncompressedSize;
+      if (outputBytes > managedCliArchiveMaxOutputBytes) throw new Error('archive_output_limit_exceeded');
+      const content = method === 0 ? compressed : method === 8 ? zlib.inflateRawSync(compressed, {
+        maxOutputLength: Math.min(managedCliArchiveMaxEntryBytes, uncompressedSize + 1),
+      }) : null;
+      if (!content) throw new Error(`zip_compression_unsupported:${method}`);
+      if (content.length !== uncompressedSize) throw new Error('zip_entry_size_mismatch');
+      if (crc32(content) !== archive.readUInt32LE(offset + 16)) throw new Error('zip_entry_crc_mismatch');
+      fs.mkdirSync(path.dirname(output), { recursive: true });
+      fs.writeFileSync(output, content, { mode: ((externalAttributes >>> 16) & 0o777) || 0o644 });
+    }
+    offset = centralEnd;
+  }
+  if (offset !== eocd) throw new Error('zip_central_directory_entry_count_mismatch');
+}
+
+function extractArchive(archivePath, destination) {
+  const archiveBytes = fs.statSync(archivePath).size;
+  if (archiveBytes > managedCliArchiveMaxBytes) throw new Error('archive_input_limit_exceeded');
+  fs.mkdirSync(destination, { recursive: true });
+  if (archivePath.endsWith('.zip')) extractZip(archivePath, destination);
+  else if (archivePath.endsWith('.tar.gz')) extractTarGz(archivePath, destination);
+  else throw new Error(`archive_format_unsupported:${path.basename(archivePath)}`);
 }
 
 function processIsAlive(pid) {
@@ -766,16 +1060,72 @@ function reclaimStaleManagedCliPendingOwners(
 
 function reclaimStaleManagedCliInitialization(lockPath, checkProcessIdentity = true) {
   const initializationPath = `${lockPath}.initializing`;
-  const owner = readJson(initializationPath);
-  let stale = managedCliLockOwnerIsStale(owner, checkProcessIdentity);
-  if (stale === null) {
+  return removeManagedCliInitializationIf(initializationPath, (owner, metadata) => {
+    const stale = managedCliLockOwnerIsStale(owner, checkProcessIdentity);
+    return stale === null ? Date.now() - metadata.mtimeMs > managedCliLockStaleMs : stale;
+  });
+}
+
+function sameFileIdentity(left, right) {
+  return left.isFile() && right.isFile() && !left.isSymbolicLink() && !right.isSymbolicLink() &&
+    left.dev === right.dev && left.ino === right.ino && left.size === right.size &&
+    left.mtimeMs === right.mtimeMs;
+}
+
+function restoreMovedInitialization(initializationPath, movedPath) {
+  try {
+    fs.renameSync(movedPath, initializationPath);
+  } catch {
+    // A new contender already owns the canonical alias. Every initializing owner retains its
+    // private hard-linked pending-owner claim, so dropping only this moved alias cannot delete it.
     try {
-      stale = Date.now() - fs.statSync(initializationPath).mtimeMs > managedCliLockStaleMs;
+      fs.unlinkSync(movedPath);
     } catch {
-      return false;
+      // Best effort; the unique artifact is never mistaken for the canonical initialization path.
     }
   }
-  return stale ? removeManagedCliLockArtifact(initializationPath) : false;
+}
+
+function removeManagedCliInitializationIf(initializationPath, shouldRemove, options = {}) {
+  let descriptor;
+  const movedPath = `${initializationPath}.reclaim-${process.pid}-${randomBytes(8).toString('hex')}`;
+  try {
+    const before = fs.lstatSync(initializationPath);
+    if (!before.isFile() || before.isSymbolicLink()) return false;
+    descriptor = fs.openSync(
+      initializationPath,
+      fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0),
+    );
+    const opened = fs.fstatSync(descriptor);
+    if (!sameFileIdentity(before, opened)) return false;
+    let owner = null;
+    try {
+      owner = JSON.parse(fs.readFileSync(descriptor, 'utf8'));
+    } catch {
+      // Malformed artifacts are removable only through the caller's age fallback.
+    }
+    if (!shouldRemove(owner, opened)) return false;
+    const current = fs.lstatSync(initializationPath);
+    if (!sameFileIdentity(opened, current)) return false;
+    fs.renameSync(initializationPath, movedPath);
+    if (options.afterRename) options.afterRename({ initializationPath, movedPath });
+    const moved = fs.lstatSync(movedPath);
+    const movedOwner = readJson(movedPath);
+    if (
+      !sameFileIdentity(opened, moved) ||
+      movedOwner?.pid !== owner?.pid || movedOwner?.token !== owner?.token
+    ) {
+      restoreMovedInitialization(initializationPath, movedPath);
+      return false;
+    }
+    fs.unlinkSync(movedPath);
+    return true;
+  } catch {
+    if (fs.existsSync(movedPath)) restoreMovedInitialization(initializationPath, movedPath);
+    return false;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
 }
 
 function reclaimStaleManagedCliLock(lockPath, checkProcessIdentity = true) {
@@ -798,9 +1148,10 @@ function reclaimStaleManagedCliLock(lockPath, checkProcessIdentity = true) {
 
 function releaseManagedCliInitialization(lockPath, owner) {
   const initializationPath = `${lockPath}.initializing`;
-  const current = readJson(initializationPath);
-  if (!current || current.pid !== owner.pid || current.token !== owner.token) return;
-  fs.rmSync(initializationPath, { force: true });
+  removeManagedCliInitializationIf(
+    initializationPath,
+    (current) => current?.pid === owner.pid && current?.token === owner.token,
+  );
 }
 
 function acquireManagedCliLock(root, purpose, waitMs = 0, options = {}) {
@@ -905,6 +1256,7 @@ function verifyPublishedManagedCli(
     manifest.repo_ref !== `v${version}` ||
     manifest.archive !== expectedAsset ||
     manifest.target !== expectedTarget ||
+    manifest.stdio_initialize_verified !== true ||
     !/^[0-9a-f]{64}$/iu.test(String(manifest.archive_sha256 || '')) ||
     manifest.archive_url !== redactedReleaseFileUrl(version, expectedAsset)
   ) {
@@ -913,6 +1265,127 @@ function verifyPublishedManagedCli(
   const resolved = resolveManifest(path.join(versionDir, 'manifest.json'));
   if (!resolved?.path) return { verified: false, reason: 'manifest_resolution_failed' };
   return { verified: true, reason: null, resolved: { ...resolved, cliVersion: version } };
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function probeManagedCliStdio(cliPath, timeoutMs = 5000, options = {}) {
+  return new Promise((resolve, reject) => {
+    const spawnChild = options.spawn || spawn;
+    const child = spawnChild(cliPath, ['serve', '--stdio', '--multi-project', '--refresh', 'none'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: process.platform === 'win32' && /\.(cmd|bat)$/iu.test(cliPath),
+      windowsHide: true,
+      env: { ...process.env, CODESTORY_PLUGIN_PROVISIONING_PROBE: '1' },
+    });
+    let completed = false;
+    let requestedOutcome = null;
+    let stdout = '';
+    let stderr = '';
+    let forceTimer = null;
+    let terminationTimer = null;
+    const finish = (error) => {
+      if (completed) return;
+      completed = true;
+      clearTimeout(probeTimer);
+      if (forceTimer) clearTimeout(forceTimer);
+      if (terminationTimer) clearTimeout(terminationTimer);
+      if (error) reject(error); else resolve();
+    };
+    const terminate = (error) => {
+      if (requestedOutcome) return;
+      requestedOutcome = { error };
+      clearTimeout(probeTimer);
+      try {
+        child.kill('SIGTERM');
+      } catch (killError) {
+        finish(new Error(`managed_cli_stdio_initialize_terminate:${killError.message}`));
+        return;
+      }
+      forceTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch (killError) {
+          finish(new Error(`managed_cli_stdio_initialize_force_kill:${killError.message}`));
+        }
+      },
+        options.terminationGraceMs ?? managedCliProbeTerminationGraceMs);
+      terminationTimer = setTimeout(
+        () => finish(new Error('managed_cli_stdio_initialize_termination_timeout')),
+        (options.terminationGraceMs ?? managedCliProbeTerminationGraceMs) +
+          (options.forceKillGraceMs ?? managedCliProbeForceKillGraceMs),
+      );
+    };
+    const probeTimer = setTimeout(
+      () => terminate(new Error(`managed_cli_stdio_initialize_timeout:${timeoutMs}`)),
+      timeoutMs,
+    );
+    child.stderr.on('data', (chunk) => {
+      const remaining = managedCliProbeStderrMaxBytes - Buffer.byteLength(stderr, 'utf8');
+      if (remaining > 0) {
+        stderr += Buffer.from(chunk).subarray(0, remaining).toString('utf8');
+      }
+    });
+    child.stderr.on('error', (error) => terminate(new Error(`managed_cli_stdio_initialize_stderr:${error.message}`)));
+    child.stdout.on('data', (chunk) => {
+      const bytes = Buffer.from(chunk);
+      if (Buffer.byteLength(stdout, 'utf8') + bytes.length > managedCliProbeStdoutMaxBytes) {
+        terminate(new Error('managed_cli_stdio_initialize_stdout_limit'));
+        return;
+      }
+      stdout += bytes.toString('utf8');
+      const newline = stdout.indexOf('\n');
+      if (newline < 0) return;
+      let response;
+      try {
+        response = JSON.parse(stdout.slice(0, newline).trim());
+      } catch (error) {
+        terminate(new Error(`managed_cli_stdio_initialize_invalid_json:${error.message}`));
+        return;
+      }
+      if (
+        response?.jsonrpc !== '2.0' || response?.id !== 'managed-cli-staging' ||
+        !isPlainObject(response.result) ||
+        response.result.protocolVersion !== managedCliMcpProtocolVersion ||
+        !isPlainObject(response.result.capabilities) ||
+        !isPlainObject(response.result.serverInfo) ||
+        typeof response.result.serverInfo.name !== 'string' || !response.result.serverInfo.name.trim() ||
+        typeof response.result.serverInfo.version !== 'string' || !response.result.serverInfo.version.trim()
+      ) {
+        terminate(new Error('managed_cli_stdio_initialize_incompatible'));
+        return;
+      }
+      terminate(null);
+    });
+    child.stdout.on('error', (error) => terminate(new Error(`managed_cli_stdio_initialize_stdout:${error.message}`)));
+    child.stdin.on('error', (error) => terminate(new Error(`managed_cli_stdio_initialize_stdin:${error.message}`)));
+    child.on('error', (error) => finish(new Error(`managed_cli_stdio_initialize_spawn:${error.message}`)));
+    child.on('exit', (code, signal) => {
+      if (requestedOutcome) {
+        finish(requestedOutcome.error);
+      } else {
+        finish(new Error(
+          `managed_cli_stdio_initialize_exit:code=${code}:signal=${signal || 'none'}:stderr=${stderr}`,
+        ));
+      }
+    });
+    try {
+      child.stdin.end(`${JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'managed-cli-staging',
+        method: 'initialize',
+        params: {
+          protocolVersion: managedCliMcpProtocolVersion,
+          capabilities: {},
+          clientInfo: { name: 'codestory-managed-cli-staging', version: '1' },
+        },
+      })}\n`);
+    } catch (error) {
+      terminate(new Error(`managed_cli_stdio_initialize_stdin:${error.message}`));
+    }
+  });
 }
 
 function trimManagedCliQuarantines(root, version, options = {}) {
@@ -1021,7 +1494,7 @@ async function provisionManagedCli(dataDir, version, warnings = []) {
     fs.copyFileSync(extracted, destination);
     if (process.platform !== 'win32') fs.chmodSync(destination, 0o755);
     const binarySha256 = fileSha256(destination);
-    fs.writeFileSync(manifestPath, JSON.stringify({
+    const manifest = {
       path: path.relative(stagingDir, destination).replace(/\\/gu, '/'),
       sha256: binarySha256,
       version,
@@ -1032,12 +1505,19 @@ async function provisionManagedCli(dataDir, version, warnings = []) {
       archive_sha256: actual,
       target,
       provisioned_at: new Date().toISOString(),
-    }, null, 2));
+      stdio_initialize_verified: true,
+    };
+    const versionProbe = probeResolvedCli({ path: destination, provisioningProbe: true });
+    if (versionProbe.error || versionProbe.status !== 0 || versionProbe.version !== version) {
+      throw new Error('managed_cli_staging_verification_failed:version_probe_failed');
+    }
+    await probeManagedCliStdio(destination);
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
     const staged = verifyPublishedManagedCli(
       stagingDir,
       version,
       target,
-      (resolved) => probeResolvedCli({ ...resolved, provisioningProbe: true }),
+      () => versionProbe,
     );
     if (!staged.verified) {
       throw new Error(`managed_cli_staging_verification_failed:${staged.reason}`);
@@ -2567,9 +3047,14 @@ if (require.main === module) {
     _test: {
       compareManagedCliVersions,
       downloadFile,
+      extractArchive,
       acquireManagedCliLock,
+      managedCliLockWaitMs,
+      releaseAssetRetryBudgetMs,
       reclaimStaleManagedCliPendingOwners,
+      removeManagedCliInitializationIf,
       processStartIdentity,
+      probeManagedCliStdio,
       provisionManagedCli,
       quarantineManagedCliVersion,
       releaseManagedCliLock,

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
 import { access, chmod, copyFile, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
@@ -8,6 +9,9 @@ import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { once } from "node:events";
+import { deflateRawSync, gunzipSync, gzipSync } from "node:zlib";
+import { PassThrough, Writable } from "node:stream";
+import { EventEmitter } from "node:events";
 
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = dirname(dirname(pluginRoot));
@@ -91,7 +95,125 @@ function managedReleaseManifest(version, executablePath, sha256) {
     archive_url: `https://github.com/TheGreenCedar/CodeStory/releases/download/v${version}/${archiveName}`,
     archive_sha256: "0".repeat(64),
     target,
+    stdio_initialize_verified: true,
   };
+}
+
+function crc32(content) {
+  let crc = 0xffffffff;
+  for (const byte of content) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function tarField(header, offset, length, value) {
+  const encoded = value.toString(8).padStart(length - 1, "0");
+  header.write(encoded, offset, length - 1, "ascii");
+  header[offset + length - 1] = 0;
+}
+
+function tarGzFixture(name, content) {
+  const header = Buffer.alloc(512);
+  header.write(name, 0, 100, "utf8");
+  tarField(header, 100, 8, 0o755);
+  tarField(header, 108, 8, 0);
+  tarField(header, 116, 8, 0);
+  tarField(header, 124, 12, content.length);
+  tarField(header, 136, 12, 315532800);
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii");
+  header[154] = 0;
+  header[155] = 0x20;
+  const padding = Buffer.alloc((512 - (content.length % 512)) % 512);
+  return gzipSync(Buffer.concat([header, content, padding, Buffer.alloc(1024)]), { mtime: 0 });
+}
+
+function rewriteTarChecksum(header) {
+  header.fill(0x20, 148, 156);
+  const checksum = header.reduce((sum, byte) => sum + byte, 0);
+  header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii");
+  header[154] = 0;
+  header[155] = 0x20;
+}
+
+function zipFixture(name, content, options = {}) {
+  const encodedName = Buffer.from(name, "utf8");
+  const compressed = deflateRawSync(content);
+  const checksum = crc32(content);
+  const local = Buffer.alloc(30);
+  local.writeUInt32LE(0x04034b50, 0);
+  local.writeUInt16LE(20, 4);
+  const flags = 0x800 | (options.dataDescriptor ? 0x8 : 0);
+  local.writeUInt16LE(flags, 6);
+  local.writeUInt16LE(8, 8);
+  local.writeUInt32LE(options.dataDescriptor ? 0 : checksum, 14);
+  local.writeUInt32LE(options.dataDescriptor ? 0 : compressed.length, 18);
+  local.writeUInt32LE(options.dataDescriptor ? 0 : content.length, 22);
+  local.writeUInt16LE(encodedName.length, 26);
+  const central = Buffer.alloc(46);
+  central.writeUInt32LE(0x02014b50, 0);
+  central.writeUInt16LE(0x0314, 4);
+  central.writeUInt16LE(20, 6);
+  central.writeUInt16LE(flags, 8);
+  central.writeUInt16LE(8, 10);
+  central.writeUInt32LE(checksum, 16);
+  central.writeUInt32LE(compressed.length, 20);
+  central.writeUInt32LE(content.length, 24);
+  central.writeUInt16LE(encodedName.length, 28);
+  central.writeUInt32LE((0o100755 << 16) >>> 0, 38);
+  const descriptor = options.dataDescriptor ? Buffer.alloc(16) : Buffer.alloc(0);
+  if (options.dataDescriptor) {
+    descriptor.writeUInt32LE(0x08074b50, 0);
+    descriptor.writeUInt32LE(checksum, 4);
+    descriptor.writeUInt32LE(compressed.length, 8);
+    descriptor.writeUInt32LE(content.length, 12);
+  }
+  const centralOffset = local.length + encodedName.length + compressed.length + descriptor.length;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(central.length + encodedName.length, 12);
+  eocd.writeUInt32LE(centralOffset, 16);
+  return Buffer.concat([local, encodedName, compressed, descriptor, central, encodedName, eocd]);
+}
+
+async function writeArchiveFixture(archivePath, entryName, content) {
+  await writeFile(
+    archivePath,
+    archivePath.endsWith(".zip") ? zipFixture(entryName, content) : tarGzFixture(entryName, content),
+  );
+}
+
+function fakeProbeChild(response, options = {}) {
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.killSignals = [];
+  child.kill = (signal = "SIGTERM") => {
+    child.killSignals.push(signal);
+    if (signal === "SIGKILL" && !options.ignoreSigkill) {
+      process.nextTick(() => child.emit("exit", null, signal));
+    }
+    return true;
+  };
+  child.stdin = new Writable({
+    write(_chunk, _encoding, callback) { callback(); },
+    final(callback) {
+      process.nextTick(() => {
+        if (options.stdoutError) child.stdout.emit("error", new Error("synthetic stdout failure"));
+        else child.stdout.write(`${JSON.stringify(response)}\n`);
+      });
+      callback();
+    },
+  });
+  return child;
 }
 
 async function writeReleaseFixture(releaseDir, version) {
@@ -102,11 +224,7 @@ async function writeReleaseFixture(releaseDir, version) {
   const archivePath = join(releaseDir, archiveName);
   await mkdir(stageDir, { recursive: true });
   await writeFakeCli(cliPath);
-  const packArgs = archiveName.endsWith(".zip")
-    ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
-    : ["-czf", archivePath, "-C", releaseDir, archiveBase];
-  const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
-  assert.equal(pack.status, 0, pack.stderr);
+  await writeArchiveFixture(archivePath, `${archiveBase}/${cliName}`, await readFile(cliPath));
   const archiveSha256 = createHash("sha256").update(await readFile(archivePath)).digest("hex");
   const sumsPath = join(releaseDir, "SHA256SUMS.txt");
   await writeFile(sumsPath, `${archiveSha256}  ${archiveName}\n`, "utf8");
@@ -141,7 +259,7 @@ async function waitForPath(pathname, timeoutMs = 10000) {
 }
 
 async function writeFakeCli(cliPath) {
-  const script = "const fs=require('fs');const args=process.argv.slice(1);if(args[0]==='--version'){if(process.env.CODESTORY_PLUGIN_PROVISIONING_PROBE==='1'&&process.env.CODESTORY_TEST_PROBE_LOG)fs.appendFileSync(process.env.CODESTORY_TEST_PROBE_LOG,'probe\\n');const delay=Number(process.env.CODESTORY_TEST_PROBE_DELAY_MS||0);if(delay>0)Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,delay);console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,warnings:process.env.CODESTORY_PLUGIN_CLI_WARNINGS,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,retention:process.env.CODESTORY_PLUGIN_CLI_RETENTION,activeStatePath:process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))";
+  const script = "const fs=require('fs');const args=process.argv.slice(1);if(process.env.CODESTORY_PLUGIN_PROVISIONING_PROBE==='1'&&args[0]==='serve'){let input='';process.stdin.on('data',chunk=>{input+=chunk;const newline=input.indexOf('\\n');if(newline<0)return;const request=JSON.parse(input.slice(0,newline));process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:request.id,result:{protocolVersion:request.params.protocolVersion,capabilities:{},serverInfo:{name:'fixture',version:'1'}}})+'\\n',()=>process.exit(0))})}else{if(args[0]==='--version'){if(process.env.CODESTORY_PLUGIN_PROVISIONING_PROBE==='1'&&process.env.CODESTORY_TEST_PROBE_LOG)fs.appendFileSync(process.env.CODESTORY_TEST_PROBE_LOG,'probe\\n');const delay=Number(process.env.CODESTORY_TEST_PROBE_DELAY_MS||0);if(delay>0)Atomics.wait(new Int32Array(new SharedArrayBuffer(4)),0,0,delay);console.log('codestory-cli '+(process.env.CODESTORY_PLUGIN_CLI_VERSION||process.env.TEST_CODESTORY_VERSION||'0.0.0'));process.exit(0)}if(args[0]==='ready'){if(args.includes('--wait-fresh')&&!args.includes('--repair')&&!args.includes('agent')){console.log(JSON.stringify({verdicts:[{goal:'local_navigation',status:'ready',summary:'ready',minimum_next:[],full_repair:[]}],local_refresh:{state:'fresh',reason:'already_fresh',blocks_local_surfaces:false,readiness_status:'ready',changed_file_count:0,new_file_count:0,removed_file_count:0,fatal_error_count:0}}));process.exit(0)}process.exit(9)}fs.writeFileSync(process.env.TEST_OUT,JSON.stringify({source:process.env.CODESTORY_PLUGIN_CLI_SOURCE,path:process.env.CODESTORY_PLUGIN_CLI_PATH,sha256:process.env.CODESTORY_PLUGIN_CLI_SHA256,version:process.env.CODESTORY_PLUGIN_CLI_VERSION,warnings:process.env.CODESTORY_PLUGIN_CLI_WARNINGS,pluginRoot:process.env.CODESTORY_PLUGIN_ROOT,launchCwd:process.env.CODESTORY_PLUGIN_LAUNCH_CWD,runtimeCwd:process.env.CODESTORY_PLUGIN_RUNTIME_CWD,pluginCacheVersion:process.env.CODESTORY_PLUGIN_CACHE_VERSION,repoRef:process.env.CODESTORY_PLUGIN_CLI_REPO_REF,buildSource:process.env.CODESTORY_PLUGIN_CLI_BUILD_SOURCE,archiveSha256:process.env.CODESTORY_PLUGIN_CLI_ARCHIVE_SHA256,retention:process.env.CODESTORY_PLUGIN_CLI_RETENTION,activeStatePath:process.env.CODESTORY_PLUGIN_ACTIVE_STATE_PATH,sidecarPolicy:process.env.CODESTORY_PLUGIN_SIDECAR_POLICY_STATE,sidecarEnable:process.env.CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND,sidecarRepair:process.env.CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND,dirtyMarkerPath:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PATH,dirtyMarkerRoot:process.env.CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT,args}))}";
   if (process.platform === "win32") {
     await writeFile(
       cliPath,
@@ -165,6 +283,15 @@ async function writeRecordingCli(cliPath) {
     return;
   }
   await writeFile(cliPath, `#!/bin/sh\n${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} -- "$@"\n`, "utf8");
+  await chmod(cliPath, 0o755);
+}
+
+async function writeVersionOnlyCli(cliPath) {
+  if (process.platform === "win32") {
+    await writeFile(cliPath, "@echo off\r\necho codestory-cli %TEST_CODESTORY_VERSION%\r\n", "utf8");
+    return;
+  }
+  await writeFile(cliPath, "#!/bin/sh\necho codestory-cli \"$TEST_CODESTORY_VERSION\"\n", "utf8");
   await chmod(cliPath, 0o755);
 }
 
@@ -789,6 +916,258 @@ test("managed cli pending-owner cleanup protects live and young artifacts", asyn
     await assert.rejects(access(dead));
     await assert.rejects(access(old));
     await assert.rejects(access(reused));
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli waiter covers both configured asset retry windows", () => {
+  assert.ok(launcherTest.releaseAssetRetryBudgetMs > 3 * 60 * 1000);
+  assert.ok(launcherTest.managedCliLockWaitMs >= 2 * launcherTest.releaseAssetRetryBudgetMs);
+});
+
+test("managed cli initializing reclaim preserves a new ABA owner", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-initializing-aba-"));
+  const initializing = join(dataDir, ".retention-lock.initializing");
+  const oldOwner = { pid: 1, token: "old", purpose: "old" };
+  const newOwner = { pid: process.pid, token: "new", purpose: "new" };
+  try {
+    await writeFile(initializing, JSON.stringify(oldOwner));
+    const removed = launcherTest.removeManagedCliInitializationIf(
+      initializing,
+      (owner) => owner?.token === oldOwner.token,
+      {
+        afterRename() {
+          fs.writeFileSync(initializing, JSON.stringify(newOwner), { flag: "wx" });
+        },
+      },
+    );
+    assert.equal(removed, true);
+    assert.deepEqual(JSON.parse(await readFile(initializing, "utf8")), newOwner);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli staging rejects a version-only binary without MCP initialize", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-stdio-probe-"));
+  const cliPath = join(dataDir, process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli");
+  try {
+    await writeVersionOnlyCli(cliPath);
+    await assert.rejects(launcherTest.probeManagedCliStdio(cliPath, 1000), /stdio_initialize_/u);
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli staging requires the exact MCP initialize contract", async () => {
+  const incompatible = {
+    jsonrpc: "2.0",
+    id: "managed-cli-staging",
+    result: {
+      protocolVersion: "2099-01-01",
+      capabilities: [],
+      serverInfo: { name: "", version: 1 },
+    },
+  };
+  await assert.rejects(
+    launcherTest.probeManagedCliStdio("fixture", 100, {
+      spawn: () => fakeProbeChild(incompatible),
+      terminationGraceMs: 5,
+      forceKillGraceMs: 20,
+    }),
+    /stdio_initialize_incompatible/u,
+  );
+});
+
+test("managed cli staging escalates and awaits a stubborn child", async () => {
+  const compatible = {
+    jsonrpc: "2.0",
+    id: "managed-cli-staging",
+    result: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      serverInfo: { name: "fixture", version: "1" },
+    },
+  };
+  const child = fakeProbeChild(compatible);
+  await launcherTest.probeManagedCliStdio("fixture", 100, {
+    spawn: () => child,
+    terminationGraceMs: 5,
+    forceKillGraceMs: 20,
+  });
+  assert.deepEqual(child.killSignals, ["SIGTERM", "SIGKILL"]);
+
+  await assert.rejects(
+    launcherTest.probeManagedCliStdio("fixture", 100, {
+      spawn: () => fakeProbeChild(compatible, { ignoreSigkill: true }),
+      terminationGraceMs: 5,
+      forceKillGraceMs: 10,
+    }),
+    /stdio_initialize_termination_timeout/u,
+  );
+});
+
+test("managed cli staging bounds output and handles stream errors", async () => {
+  await assert.rejects(
+    launcherTest.probeManagedCliStdio("fixture", 100, {
+      spawn: () => fakeProbeChild(null, { stdoutError: true }),
+      terminationGraceMs: 5,
+      forceKillGraceMs: 20,
+    }),
+    /managed_cli_stdio_initialize_stdout/u,
+  );
+  const child = fakeProbeChild(null);
+  child.stdin = new Writable({
+    write(_chunk, _encoding, callback) { callback(); },
+    final(callback) {
+      child.stdout.write("x".repeat(70 * 1024));
+      callback();
+    },
+  });
+  await assert.rejects(
+    launcherTest.probeManagedCliStdio("fixture", 100, {
+      spawn: () => child,
+      terminationGraceMs: 5,
+      forceKillGraceMs: 20,
+    }),
+    /stdio_initialize_stdout_limit/u,
+  );
+});
+
+test("managed cli extracts zip and tar.gz with Node platform APIs", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-native-extract-"));
+  const content = Buffer.from("native archive fixture\n");
+  try {
+    for (const extension of ["zip", "tar.gz"]) {
+      const archive = join(dataDir, `fixture.${extension}`);
+      const destination = join(dataDir, `extract-${extension.replace(".", "-")}`);
+      await writeArchiveFixture(archive, "release/bin/codestory-cli", content);
+      launcherTest.extractArchive(archive, destination);
+      assert.deepEqual(await readFile(join(destination, "release", "bin", "codestory-cli")), content);
+    }
+    const descriptorArchive = join(dataDir, "descriptor.zip");
+    await writeFile(
+      descriptorArchive,
+      zipFixture("release/bin/codestory-cli", content, { dataDescriptor: true }),
+    );
+    const descriptorDestination = join(dataDir, "extract-descriptor");
+    launcherTest.extractArchive(descriptorArchive, descriptorDestination);
+    assert.deepEqual(
+      await readFile(join(descriptorDestination, "release", "bin", "codestory-cli")),
+      content,
+    );
+  } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("managed cli archive extraction fails closed on bombs and malformed metadata", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-managed-bad-archive-"));
+  const content = Buffer.from("fixture\n");
+  const extract = (archive) => launcherTest.extractArchive(archive, join(dataDir, `out-${Math.random()}`));
+  try {
+    const crcArchive = join(dataDir, "crc.zip");
+    const crcBytes = zipFixture("release/codestory-cli", content);
+    const central = crcBytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+    crcBytes.writeUInt32LE(0, 14);
+    crcBytes.writeUInt32LE(0, central + 16);
+    await writeFile(crcArchive, crcBytes);
+    assert.throws(() => extract(crcArchive), /zip_entry_crc_mismatch/u);
+
+    const bombArchive = join(dataDir, "bomb.zip");
+    const bombBytes = zipFixture("release/codestory-cli", content);
+    const bombCentral = bombBytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+    bombBytes.writeUInt32LE(300 * 1024 * 1024, bombCentral + 24);
+    await writeFile(bombArchive, bombBytes);
+    assert.throws(() => extract(bombArchive), /archive_entry_size_limit_exceeded/u);
+
+    const nameArchive = join(dataDir, "name.zip");
+    const nameBytes = zipFixture("release/codestory-cli", content);
+    nameBytes[30] ^= 1;
+    await writeFile(nameArchive, nameBytes);
+    assert.throws(() => extract(nameArchive), /zip_local_name_mismatch/u);
+
+    for (const [label, mutate] of [
+      ["flags", (bytes) => bytes.writeUInt16LE(0x808, 6)],
+      ["method", (bytes) => bytes.writeUInt16LE(0, 8)],
+      ["crc", (bytes) => bytes.writeUInt32LE(0, 14)],
+      ["compressed-size", (bytes) => bytes.writeUInt32LE(1, 18)],
+      ["uncompressed-size", (bytes) => bytes.writeUInt32LE(1, 22)],
+    ]) {
+      const archive = join(dataDir, `local-${label}.zip`);
+      const bytes = zipFixture("release/codestory-cli", content);
+      mutate(bytes);
+      await writeFile(archive, bytes);
+      assert.throws(() => extract(archive), /zip_local_metadata_mismatch/u);
+    }
+
+    const descriptorArchive = join(dataDir, "bad-descriptor.zip");
+    const descriptorBytes = zipFixture("release/codestory-cli", content, { dataDescriptor: true });
+    const descriptorCentral = descriptorBytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+    descriptorBytes.writeUInt32LE(0, descriptorCentral - 12);
+    await writeFile(descriptorArchive, descriptorBytes);
+    assert.throws(() => extract(descriptorArchive), /zip_data_descriptor_mismatch/u);
+
+    const commentArchive = join(dataDir, "comment.zip");
+    const commentBytes = zipFixture("release/codestory-cli", content);
+    commentBytes.writeUInt16LE(4, commentBytes.length - 2);
+    await writeFile(commentArchive, commentBytes);
+    assert.throws(() => extract(commentArchive), /zip_end_of_central_directory_missing/u);
+
+    for (const [name, mode] of [["../escape", 0o100755], ["release/link", 0o120777]]) {
+      const archive = join(dataDir, `${mode}.zip`);
+      const bytes = zipFixture(name, content);
+      const directory = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+      bytes.writeUInt32LE((mode << 16) >>> 0, directory + 38);
+      await writeFile(archive, bytes);
+      assert.throws(
+        () => extract(archive),
+        mode === 0o120777 ? /zip_symlink_unsupported/u : /archive_path_escape/u,
+      );
+    }
+
+    const malformedTar = join(dataDir, "malformed.tar.gz");
+    const malformed = gunzipSync(tarGzFixture("release/codestory-cli", content));
+    malformed.fill("z".charCodeAt(0), 124, 136);
+    rewriteTarChecksum(malformed.subarray(0, 512));
+    await writeFile(malformedTar, gzipSync(malformed));
+    assert.throws(() => extract(malformedTar), /tar_numeric_field_invalid/u);
+
+    const unterminatedTar = join(dataDir, "unterminated.tar.gz");
+    const unterminated = gunzipSync(tarGzFixture("release/codestory-cli", content));
+    await writeFile(unterminatedTar, gzipSync(unterminated.subarray(0, unterminated.length - 512)));
+    assert.throws(() => extract(unterminatedTar), /tar_terminator_invalid|tar_terminator_missing/u);
+
+    const tarBomb = join(dataDir, "bomb.tar.gz");
+    const tarBombBytes = gunzipSync(tarGzFixture("release/codestory-cli", content));
+    tarField(tarBombBytes, 124, 12, 300 * 1024 * 1024);
+    rewriteTarChecksum(tarBombBytes.subarray(0, 512));
+    await writeFile(tarBomb, gzipSync(tarBombBytes));
+    assert.throws(() => extract(tarBomb), /archive_entry_size_limit_exceeded/u);
+
+    for (const [label, type] of [["extended", "x"], ["global", "g"]]) {
+      const paxTar = join(dataDir, `bad-pax-${label}.tar.gz`);
+      const paxBytes = gunzipSync(tarGzFixture("PaxHeader", Buffer.from("8x p=a\n")));
+      paxBytes[156] = type.charCodeAt(0);
+      rewriteTarChecksum(paxBytes.subarray(0, 512));
+      await writeFile(paxTar, gzipSync(paxBytes));
+      assert.throws(() => extract(paxTar), /tar_pax_length_invalid/u);
+    }
+
+    for (const [filename, type, expected] of [
+      ["../escape", "0", /archive_path_escape/u],
+      ["release/link", "2", /tar_entry_type_unsupported/u],
+    ]) {
+      const archive = join(dataDir, `tar-${type.charCodeAt(0)}.tar.gz`);
+      const bytes = gunzipSync(tarGzFixture("release/codestory-cli", content));
+      bytes.fill(0, 0, 100);
+      bytes.write(filename, 0, 100, "utf8");
+      bytes[156] = type.charCodeAt(0);
+      rewriteTarChecksum(bytes.subarray(0, 512));
+      await writeFile(archive, gzipSync(bytes));
+      assert.throws(() => extract(archive), expected);
+    }
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -2477,14 +2856,7 @@ test("enabled sidecar policy defers repair until after MCP startup", async () =>
   }
 });
 
-test("mcp launcher provisions a checksummed release asset into plugin data", async (t) => {
-  const { spawnSync } = await import("node:child_process");
-  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
-  if (tarProbe.status !== 0) {
-    t.skip("tar unavailable for archive fixture");
-    return;
-  }
-
+test("mcp launcher provisions a checksummed release asset into plugin data", async () => {
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
@@ -2499,11 +2871,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   try {
     await mkdir(stageDir, { recursive: true });
     await writeFakeCli(cliPath);
-    const packArgs = archiveName.endsWith(".zip")
-      ? ["-a", "-cf", archivePath, "-C", releaseDir, archiveBase]
-      : ["-czf", archivePath, "-C", releaseDir, archiveBase];
-    const pack = spawnSync("tar", packArgs, { encoding: "utf8" });
-    assert.equal(pack.status, 0, pack.stderr);
+    await writeArchiveFixture(archivePath, `${archiveBase}/${cliName}`, await readFile(cliPath));
     const archiveSha256 = createHash("sha256")
       .update(await readFile(archivePath))
       .digest("hex");
@@ -2546,6 +2914,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     assert.equal(manifest.build_source, "github_release");
     assert.equal(manifest.archive, archiveName);
     assert.equal(manifest.archive_sha256, archiveSha256);
+    assert.equal(manifest.stdio_initialize_verified, true);
     assert.equal(typeof manifest.sha256, "string");
   } finally {
     await rm(dataDir, { recursive: true, force: true });
@@ -2553,12 +2922,7 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   }
 });
 
-test("managed cli publication is single-flight and atomically visible across two processes", { timeout: 30000 }, async (t) => {
-  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
-  if (tarProbe.status !== 0) {
-    t.skip("tar unavailable for archive fixture");
-    return;
-  }
+test("managed cli publication is single-flight and atomically visible across two processes", { timeout: 30000 }, async () => {
   const { createServer } = await import("node:http");
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-publication-contention-"));
@@ -2639,12 +3003,7 @@ test("managed cli publication is single-flight and atomically visible across two
   }
 });
 
-test("managed cli publication reclaims crashes after lock and before publication", { timeout: 45000 }, async (t) => {
-  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
-  if (tarProbe.status !== 0) {
-    t.skip("tar unavailable for archive fixture");
-    return;
-  }
+test("managed cli publication reclaims crashes after lock and before publication", { timeout: 45000 }, async () => {
   const { createServer } = await import("node:http");
   const version = await readPluginVersion();
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-crash-release-"));
@@ -2723,12 +3082,7 @@ test("managed cli publication reclaims crashes after lock and before publication
   }
 });
 
-test("managed cli quarantines corrupt installs, retains two, and fails closed on a locked directory", { timeout: 30000 }, async (t) => {
-  const tarProbe = spawnSync("tar", ["--version"], { encoding: "utf8" });
-  if (tarProbe.status !== 0) {
-    t.skip("tar unavailable for archive fixture");
-    return;
-  }
+test("managed cli quarantines corrupt installs, retains two, and fails closed on a locked directory", { timeout: 30000 }, async () => {
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-corrupt-install-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-corrupt-release-"));
@@ -2935,6 +3289,32 @@ test("release asset downloader retries a transient failure", async () => {
     assert.equal(calls, 2);
     assert.equal(await readFile(destination, "utf8"), "checksum fixture\n");
   } finally {
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("release asset downloader enforces a total body deadline", async () => {
+  const { createServer } = await import("node:http");
+  const dataDir = await mkdtemp(join(tmpdir(), "codestory-download-deadline-"));
+  const destination = join(dataDir, "slow.bin");
+  const server = createServer((_request, response) => {
+    response.writeHead(200);
+    const interval = setInterval(() => response.write("x"), 10);
+    response.on("close", () => clearInterval(interval));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const started = Date.now();
+    await assert.rejects(
+      launcherTest.downloadFile(`http://127.0.0.1:${server.address().port}/slow`, destination, {
+        attempts: 1,
+        timeoutMs: 60,
+      }),
+      /timed out.*total/u,
+    );
+    assert.ok(Date.now() - started < 1000);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
     await rm(dataDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Context

PR #980 shipped the managed CLI publication contract, but exact-head review left four bounded #967 gaps: the waiter budget could expire before both assets exhausted retries, staging proved only `--version`, stale initialization reclaim had an ABA race, and Unix extraction still required external `tar`.

Closes #967
Refs #921
Refs #899

## What Changed

- Bound each download attempt across redirects and body transfer, and size the publication waiter for both release assets plus staging.
- Require an exact MCP stdio `initialize` response and verified child termination before publication.
- Revalidate no-follow file identity and owner token after moving a stale initialization claim.
- Replace external archive commands with bounded Node-native ZIP and tar.gz extraction, including traversal, checksum, metadata, descriptor, entry-count, and expansion limits.
- Update plugin guidance and the changelog.

## How To Review

1. Review the absolute download deadline and derived lock budget.
2. Review the staged stdio probe's protocol validation, stream bounds, and termination path.
3. Review stale initialization compare/move/revalidate behavior.
4. Review the native archive parser's fail-closed format restrictions and negative fixtures.

## Verification

- Full plugin static suite: 69 passed, 0 failed, 0 skipped.
- Focused post-rebase managed-CLI contracts: 8 passed.
- Workflow policy, documentation links, Node syntax, and `git diff --check`: passed.

## Risk

The native extractor intentionally supports only the release formats CodeStory publishes: regular files/directories, non-ZIP64 ZIP, store/deflate, and gzip tar. Encryption, links, multi-disk archives, ZIP64, and unknown tar entry types fail closed.