### PR TITLE
renew local refresh ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Renewed live local-refresh ownership during long incremental indexing, with
+  token, PID, and process-start checks that prevent stale workers from
+  overwriting changed ownership or terminal status.
 - Kept packaged local-retrieval proof commands in the local default runtime
   namespace so the cross-platform gate validates a real local handoff before
   exercising agent readiness.

--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -1,15 +1,20 @@
 use anyhow::Result;
+use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const LOCAL_REFRESH_STATUS_FILE: &str = "local-refresh-status.json";
 const LOCAL_REFRESH_LOCK_FILE: &str = "local-refresh.lock";
+const LOCAL_REFRESH_STATE_GUARD_FILE: &str = "local-refresh-state.guard";
 const LOCAL_REFRESH_STATUS_SCHEMA_VERSION: u32 = 1;
 const LOCAL_REFRESH_STATUS_TTL: Duration = Duration::from_secs(30);
 const LOCAL_REFRESH_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
+const LOCAL_REFRESH_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct LocalRefreshStatus {
@@ -20,6 +25,8 @@ pub(crate) struct LocalRefreshStatus {
     pub(crate) pid: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) process_start_identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) owner_token: Option<String>,
     pub(crate) started_at_epoch_ms: i64,
     pub(crate) updated_at_epoch_ms: i64,
     #[serde(default)]
@@ -68,11 +75,91 @@ pub(crate) struct LocalRefreshLock {
     path: PathBuf,
     token: String,
     pid: u32,
+    process_start_identity: Option<String>,
+    started_at_epoch_ms: i64,
+}
+
+#[derive(Debug)]
+struct LocalRefreshStateGuard {
+    file: File,
+}
+
+impl Drop for LocalRefreshStateGuard {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct LocalRefreshHeartbeat {
+    stop: Option<Sender<()>>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl LocalRefreshHeartbeat {
+    pub(crate) fn start(lock: &LocalRefreshLock, project_root: &Path, phase: &str) -> Self {
+        Self::start_with_interval(lock, project_root, phase, LOCAL_REFRESH_HEARTBEAT_INTERVAL)
+    }
+
+    fn start_with_interval(
+        lock: &LocalRefreshLock,
+        project_root: &Path,
+        phase: &str,
+        interval: Duration,
+    ) -> Self {
+        let owner = lock.owner();
+        let cache_root = lock.cache_root().to_path_buf();
+        let project_root = project_root.to_path_buf();
+        let phase = phase.to_string();
+        let (stop, receiver) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            while let Err(RecvTimeoutError::Timeout) = receiver.recv_timeout(interval) {
+                match renew_local_refresh_status(&cache_root, &project_root, &phase, &owner) {
+                    Ok(true) | Err(_) => {}
+                    Ok(false) => break,
+                }
+            }
+        });
+        Self {
+            stop: Some(stop),
+            worker: Some(worker),
+        }
+    }
+
+    pub(crate) fn stop(mut self) {
+        self.join();
+    }
+
+    fn join(&mut self) {
+        self.stop.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+impl Drop for LocalRefreshHeartbeat {
+    fn drop(&mut self) {
+        self.join();
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LocalRefreshOwner {
+    token: String,
+    pid: u32,
+    process_start_identity: Option<String>,
     started_at_epoch_ms: i64,
 }
 
 impl Drop for LocalRefreshLock {
     fn drop(&mut self) {
+        let Some(cache_root) = self.path.parent() else {
+            return;
+        };
+        let Ok(_guard) = acquire_local_refresh_state_guard(cache_root) else {
+            return;
+        };
         let Some(lock) = read_local_refresh_lock_file(&self.path) else {
             return;
         };
@@ -97,6 +184,45 @@ impl LocalRefreshLock {
     pub(crate) fn pid(&self) -> u32 {
         self.pid
     }
+
+    pub(crate) fn write_status(
+        &self,
+        project_root: &Path,
+        status: &str,
+        phase: &str,
+        last_failure_reason: Option<String>,
+    ) -> Result<bool> {
+        let cache_root = self.cache_root();
+        let _guard = acquire_local_refresh_state_guard(cache_root)?;
+        let owner = self.owner();
+        if !local_refresh_lock_matches(&self.path, project_root, &owner) {
+            return Ok(false);
+        }
+        write_local_refresh_status_for_owner(
+            cache_root,
+            project_root,
+            status,
+            phase,
+            &owner,
+            last_failure_reason,
+        )?;
+        Ok(true)
+    }
+
+    fn owner(&self) -> LocalRefreshOwner {
+        LocalRefreshOwner {
+            token: self.token.clone(),
+            pid: self.pid,
+            process_start_identity: self.process_start_identity.clone(),
+            started_at_epoch_ms: self.started_at_epoch_ms,
+        }
+    }
+
+    fn cache_root(&self) -> &Path {
+        self.path
+            .parent()
+            .expect("local refresh lock path always has a cache root")
+    }
 }
 
 pub(crate) fn try_acquire_local_refresh_lock(
@@ -107,6 +233,7 @@ pub(crate) fn try_acquire_local_refresh_lock(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
+    let _guard = acquire_local_refresh_state_guard(cache_root)?;
 
     let started_at_epoch_ms = now_epoch_ms();
     let pid = std::process::id();
@@ -116,7 +243,7 @@ pub(crate) fn try_acquire_local_refresh_lock(
         schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
         project_root: clean_path_text(project_root),
         pid,
-        process_start_identity,
+        process_start_identity: process_start_identity.clone(),
         started_at_epoch_ms,
         token: token.clone(),
     };
@@ -128,6 +255,7 @@ pub(crate) fn try_acquire_local_refresh_lock(
                 path,
                 token,
                 pid,
+                process_start_identity,
                 started_at_epoch_ms,
             }));
         }
@@ -160,6 +288,7 @@ pub(crate) fn try_acquire_local_refresh_lock(
             path,
             token,
             pid,
+            process_start_identity,
             started_at_epoch_ms,
         })),
         Err(error) if error.kind() == ErrorKind::AlreadyExists => {
@@ -175,6 +304,7 @@ pub(crate) fn try_acquire_local_refresh_lock(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn write_local_refresh_status(
     cache_root: &Path,
     project_root: &Path,
@@ -184,6 +314,7 @@ pub(crate) fn write_local_refresh_status(
     pid: u32,
     last_failure_reason: Option<String>,
 ) -> Result<()> {
+    let _guard = acquire_local_refresh_state_guard(cache_root)?;
     let path = local_refresh_status_path(cache_root);
     let status = LocalRefreshStatus {
         schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
@@ -192,11 +323,91 @@ pub(crate) fn write_local_refresh_status(
         phase: phase.to_string(),
         pid,
         process_start_identity: crate::ready_repair_status::recorded_process_start_identity(pid),
+        owner_token: None,
         started_at_epoch_ms,
         updated_at_epoch_ms: now_epoch_ms(),
         last_failure_reason,
     };
     crate::file_state::write_json_atomic(&path, "local-refresh-status", &status)
+}
+
+fn write_local_refresh_status_for_owner(
+    cache_root: &Path,
+    project_root: &Path,
+    status: &str,
+    phase: &str,
+    owner: &LocalRefreshOwner,
+    last_failure_reason: Option<String>,
+) -> Result<()> {
+    let value = LocalRefreshStatus {
+        schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
+        status: status.to_string(),
+        project_root: clean_path_text(project_root),
+        phase: phase.to_string(),
+        pid: owner.pid,
+        process_start_identity: owner.process_start_identity.clone(),
+        owner_token: Some(owner.token.clone()),
+        started_at_epoch_ms: owner.started_at_epoch_ms,
+        updated_at_epoch_ms: now_epoch_ms(),
+        last_failure_reason,
+    };
+    crate::file_state::write_json_atomic(
+        &local_refresh_status_path(cache_root),
+        "local-refresh-status",
+        &value,
+    )
+}
+
+fn renew_local_refresh_status(
+    cache_root: &Path,
+    project_root: &Path,
+    phase: &str,
+    owner: &LocalRefreshOwner,
+) -> Result<bool> {
+    renew_local_refresh_status_with_hook(cache_root, project_root, phase, owner, || {})
+}
+
+fn renew_local_refresh_status_with_hook(
+    cache_root: &Path,
+    project_root: &Path,
+    phase: &str,
+    owner: &LocalRefreshOwner,
+    before_write: impl FnOnce(),
+) -> Result<bool> {
+    let _guard = acquire_local_refresh_state_guard(cache_root)?;
+    if !local_refresh_lock_matches(&local_refresh_lock_path(cache_root), project_root, owner) {
+        return Ok(false);
+    }
+    let path = local_refresh_status_path(cache_root);
+    let Some(mut status) = read_local_refresh_status_file(&path) else {
+        return Ok(false);
+    };
+    if status.schema_version != LOCAL_REFRESH_STATUS_SCHEMA_VERSION
+        || status.status != "refreshing"
+        || status.phase != phase
+        || !same_path_text(Path::new(&status.project_root), project_root)
+        || status.pid != owner.pid
+        || status.process_start_identity != owner.process_start_identity
+        || status.owner_token.as_deref() != Some(owner.token.as_str())
+        || status.started_at_epoch_ms != owner.started_at_epoch_ms
+    {
+        return Ok(false);
+    }
+    before_write();
+    status.updated_at_epoch_ms = now_epoch_ms();
+    crate::file_state::write_json_atomic(&path, "local-refresh-status", &status)?;
+    Ok(true)
+}
+
+fn local_refresh_lock_matches(path: &Path, project_root: &Path, owner: &LocalRefreshOwner) -> bool {
+    read_local_refresh_lock_file(path).is_some_and(|lock| {
+        lock.schema_version == LOCAL_REFRESH_STATUS_SCHEMA_VERSION
+            && same_path_text(Path::new(&lock.project_root), project_root)
+            && lock.token == owner.token
+            && lock.pid == owner.pid
+            && lock.process_start_identity == owner.process_start_identity
+            && lock.started_at_epoch_ms == owner.started_at_epoch_ms
+    })
 }
 
 pub(crate) fn active_local_refresh_status(
@@ -211,6 +422,7 @@ pub(crate) fn cleanup_stale_local_refresh_state(
     cache_root: &Path,
     project_root: &Path,
 ) -> Option<LocalRefreshCleanup> {
+    let _guard = acquire_local_refresh_state_guard(cache_root).ok()?;
     let status_path = local_refresh_status_path(cache_root);
     let lock_path = local_refresh_lock_path(cache_root);
     let now = now_epoch_ms();
@@ -233,11 +445,18 @@ pub(crate) fn cleanup_stale_local_refresh_state(
         .is_some_and(|state| state != crate::ready_repair_status::ProcessOwnerState::GoneOrReused);
     let status_owner_dead = status_owner_state
         .is_some_and(|state| state == crate::ready_repair_status::ProcessOwnerState::GoneOrReused);
+    let status_lock_mismatch = status.as_ref().is_some_and(|status| {
+        status.owner_token.is_some()
+            && lock
+                .as_ref()
+                .is_none_or(|lock| !local_refresh_status_matches_lock(status, lock, project_root))
+    });
     let status_age_stale = status.as_ref().is_some_and(|status| {
         now.saturating_sub(status.updated_at_epoch_ms)
             > LOCAL_REFRESH_LOCK_STALE_TTL.as_millis() as i64
     });
-    let status_stale = status_owner_dead || (status_age_stale && !status_owner_live);
+    let status_stale =
+        status_owner_dead || status_lock_mismatch || (status_age_stale && !status_owner_live);
     let live_status_heartbeat_stale = status_age_stale && status_owner_live;
     let active_status = status.as_ref().filter(|_| !status_stale);
     let lock_stale = lock
@@ -259,7 +478,7 @@ pub(crate) fn cleanup_stale_local_refresh_state(
             .as_ref()
             .zip(lock.as_ref())
             .is_some_and(|(status, lock)| {
-                status.pid == lock.pid && status.started_at_epoch_ms == lock.started_at_epoch_ms
+                local_refresh_status_matches_lock(status, lock, project_root)
             });
     let removed_status_path =
         status_stale && status.is_some() && fs::remove_file(&status_path).is_ok();
@@ -291,6 +510,51 @@ pub(crate) fn local_refresh_status_cache_fingerprint(cache_root: &Path) -> Strin
 
 fn create_local_refresh_lock_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
     crate::file_state::write_synced_new_file(path, content)
+}
+
+fn acquire_local_refresh_state_guard(cache_root: &Path) -> Result<LocalRefreshStateGuard> {
+    fs::create_dir_all(cache_root)?;
+    let path = cache_root.join(LOCAL_REFRESH_STATE_GUARD_FILE);
+    let file = open_local_refresh_state_guard_file(&path)?;
+    FileExt::lock_exclusive(&file)?;
+    anyhow::ensure!(
+        locked_guard_path_matches(&file, &path),
+        "local refresh state guard was replaced at {}",
+        path.display()
+    );
+    Ok(LocalRefreshStateGuard { file })
+}
+
+fn open_local_refresh_state_guard_file(path: &Path) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // A guard handle may be shared by contenders, but never for deletion:
+        // replacing this persistent inode would split the serialization domain.
+        const FILE_SHARE_READ_WRITE: u32 = 0x1 | 0x2;
+        options.share_mode(FILE_SHARE_READ_WRITE);
+    }
+    Ok(options.open(path)?)
+}
+
+#[cfg(unix)]
+fn locked_guard_path_matches(file: &File, path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    file.metadata()
+        .ok()
+        .zip(fs::metadata(path).ok())
+        .is_some_and(|(locked, current)| {
+            locked.dev() == current.dev() && locked.ino() == current.ino()
+        })
+}
+
+#[cfg(not(unix))]
+fn locked_guard_path_matches(_file: &File, path: &Path) -> bool {
+    // Windows opens deny delete sharing above, so the locked handle cannot be
+    // unlinked or replaced. Other supported hosts at least require the path.
+    path.is_file()
 }
 
 fn local_refresh_status_path(cache_root: &Path) -> PathBuf {
@@ -338,7 +602,26 @@ fn read_local_refresh_status(
     {
         return None;
     }
+    if status.owner_token.is_some()
+        && read_local_refresh_lock_file(&path.with_file_name(LOCAL_REFRESH_LOCK_FILE))
+            .is_none_or(|lock| !local_refresh_status_matches_lock(&status, &lock, project_root))
+    {
+        return None;
+    }
     Some(status)
+}
+
+fn local_refresh_status_matches_lock(
+    status: &LocalRefreshStatus,
+    lock: &LocalRefreshLockFile,
+    project_root: &Path,
+) -> bool {
+    lock.schema_version == LOCAL_REFRESH_STATUS_SCHEMA_VERSION
+        && same_path_text(Path::new(&lock.project_root), project_root)
+        && status.owner_token.as_deref() == Some(lock.token.as_str())
+        && status.pid == lock.pid
+        && status.process_start_identity == lock.process_start_identity
+        && status.started_at_epoch_ms == lock.started_at_epoch_ms
 }
 
 fn read_local_refresh_status_file(path: &Path) -> Option<LocalRefreshStatus> {
@@ -532,6 +815,226 @@ mod tests {
     }
 
     #[test]
+    fn local_refresh_heartbeat_renews_owner_and_stops_before_terminal_status() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let lock = match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("lock attempt")
+        {
+            LocalRefreshLockAttempt::Acquired(lock) => lock,
+            LocalRefreshLockAttempt::Busy(_) => panic!("lock should be acquired"),
+        };
+        assert!(
+            lock.write_status(project.path(), "refreshing", "incremental_index", None,)
+                .expect("initial status")
+        );
+        let path = local_refresh_status_path(cache.path());
+        let initial = read_local_refresh_status_file(&path).expect("initial status");
+        let heartbeat = LocalRefreshHeartbeat::start_with_interval(
+            &lock,
+            project.path(),
+            "incremental_index",
+            Duration::from_millis(5),
+        );
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        loop {
+            let current = read_local_refresh_status_file(&path).expect("renewed status");
+            if current.updated_at_epoch_ms > initial.updated_at_epoch_ms {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "heartbeat did not renew"
+            );
+            thread::yield_now();
+        }
+        heartbeat.stop();
+        assert!(
+            lock.write_status(project.path(), "refreshed", "incremental_index", None,)
+                .expect("terminal status")
+        );
+        thread::sleep(Duration::from_millis(20));
+        assert_eq!(
+            read_local_refresh_status_file(&path)
+                .expect("terminal status remains")
+                .status,
+            "refreshed"
+        );
+    }
+
+    #[test]
+    fn local_refresh_renewal_rejects_changed_token_pid_or_start_identity() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let lock = match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("lock attempt")
+        {
+            LocalRefreshLockAttempt::Acquired(lock) => lock,
+            LocalRefreshLockAttempt::Busy(_) => panic!("lock should be acquired"),
+        };
+        assert!(
+            lock.write_status(project.path(), "refreshing", "incremental_index", None,)
+                .expect("initial status")
+        );
+        let owner = lock.owner();
+        let path = local_refresh_status_path(cache.path());
+        let baseline = read_local_refresh_status_file(&path).expect("baseline status");
+
+        for changed in ["token", "pid", "start_identity", "terminal"] {
+            let mut status = baseline.clone();
+            match changed {
+                "token" => status.owner_token = Some("different-owner".to_string()),
+                "pid" => status.pid = status.pid.saturating_add(1),
+                "start_identity" => {
+                    status.process_start_identity = Some("different-process-start".to_string())
+                }
+                "terminal" => status.status = "refreshed".to_string(),
+                _ => unreachable!(),
+            }
+            crate::file_state::write_json_atomic(&path, "local-refresh-status", &status)
+                .expect("changed status");
+            assert!(
+                !renew_local_refresh_status(
+                    cache.path(),
+                    project.path(),
+                    "incremental_index",
+                    &owner,
+                )
+                .expect("renewal result"),
+                "renewal should reject changed {changed}"
+            );
+            assert_eq!(read_local_refresh_status_file(&path), Some(status));
+        }
+
+        crate::file_state::write_json_atomic(&path, "local-refresh-status", &baseline)
+            .expect("restore owned status");
+        let lock_path = local_refresh_lock_path(cache.path());
+        let mut changed_lock = read_local_refresh_lock_file(&lock_path).expect("owner lock");
+        changed_lock.token = "replacement-owner".to_string();
+        crate::file_state::write_json_atomic(&lock_path, "local-refresh-lock", &changed_lock)
+            .expect("replace lock owner");
+        assert!(
+            !renew_local_refresh_status(cache.path(), project.path(), "incremental_index", &owner,)
+                .expect("changed lock renewal")
+        );
+        assert!(active_local_refresh_status(cache.path(), project.path()).is_none());
+        let cleanup = cleanup_stale_local_refresh_state(cache.path(), project.path())
+            .expect("mismatched status cleanup");
+        assert_eq!(cleanup.reason, "stale_status");
+        assert!(cleanup.removed_status_path);
+        assert!(!cleanup.removed_lock_path);
+        assert!(lock_path.exists());
+    }
+
+    #[test]
+    fn paused_stale_renewal_cannot_overwrite_replacement_owner_terminal_status() {
+        let project = tempfile::tempdir().expect("project");
+        let cache = tempfile::tempdir().expect("cache");
+        let lock = match try_acquire_local_refresh_lock(cache.path(), project.path())
+            .expect("lock attempt")
+        {
+            LocalRefreshLockAttempt::Acquired(lock) => lock,
+            LocalRefreshLockAttempt::Busy(_) => panic!("lock should be acquired"),
+        };
+        assert!(
+            lock.write_status(project.path(), "refreshing", "incremental_index", None,)
+                .expect("initial status")
+        );
+
+        let owner = lock.owner();
+        let stale_cache = cache.path().to_path_buf();
+        let stale_project = project.path().to_path_buf();
+        let (paused_tx, paused_rx) = std::sync::mpsc::channel();
+        let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+        let stale_writer = thread::spawn(move || {
+            renew_local_refresh_status_with_hook(
+                &stale_cache,
+                &stale_project,
+                "incremental_index",
+                &owner,
+                || {
+                    paused_tx.send(()).expect("announce paused writer");
+                    resume_rx.recv().expect("resume paused writer");
+                },
+            )
+            .expect("stale renewal")
+        });
+        paused_rx.recv().expect("writer paused after validation");
+
+        let replacement_cache = cache.path().to_path_buf();
+        let replacement_project = project.path().to_path_buf();
+        let replacement_start = lock.started_at_epoch_ms().saturating_add(1);
+        let replacement_pid = lock.pid();
+        let replacement_identity = lock.process_start_identity.clone();
+        let (replacement_attempt_tx, replacement_attempt_rx) = std::sync::mpsc::channel();
+        let (contention_tx, contention_rx) = std::sync::mpsc::channel();
+        let (retry_tx, retry_rx) = std::sync::mpsc::channel();
+        let replacement_writer = thread::spawn(move || {
+            let guard_path = replacement_cache.join(LOCAL_REFRESH_STATE_GUARD_FILE);
+            let guard_file =
+                open_local_refresh_state_guard_file(&guard_path).expect("open replacement guard");
+            replacement_attempt_tx
+                .send(())
+                .expect("announce replacement lock attempt");
+            contention_tx
+                .send(FileExt::try_lock_exclusive(&guard_file).expect("try replacement guard"))
+                .expect("report replacement contention");
+            retry_rx.recv().expect("retry replacement guard");
+            FileExt::lock_exclusive(&guard_file).expect("acquire replacement guard");
+            let replacement_token = "replacement-owner".to_string();
+            crate::file_state::write_json_atomic(
+                &local_refresh_lock_path(&replacement_cache),
+                "local-refresh-lock",
+                &LocalRefreshLockFile {
+                    schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
+                    project_root: clean_path_text(&replacement_project),
+                    pid: replacement_pid,
+                    process_start_identity: replacement_identity.clone(),
+                    started_at_epoch_ms: replacement_start,
+                    token: replacement_token.clone(),
+                },
+            )
+            .expect("replace owner lock");
+            crate::file_state::write_json_atomic(
+                &local_refresh_status_path(&replacement_cache),
+                "local-refresh-status",
+                &LocalRefreshStatus {
+                    schema_version: LOCAL_REFRESH_STATUS_SCHEMA_VERSION,
+                    status: "refreshed".to_string(),
+                    project_root: clean_path_text(&replacement_project),
+                    phase: "incremental_index".to_string(),
+                    pid: replacement_pid,
+                    process_start_identity: replacement_identity,
+                    owner_token: Some(replacement_token),
+                    started_at_epoch_ms: replacement_start,
+                    updated_at_epoch_ms: now_epoch_ms(),
+                    last_failure_reason: None,
+                },
+            )
+            .expect("replacement terminal status");
+            FileExt::unlock(&guard_file).expect("unlock replacement guard");
+        });
+        replacement_attempt_rx
+            .recv()
+            .expect("replacement reached lock attempt");
+        assert!(
+            !contention_rx.recv().expect("replacement contention result"),
+            "replacement try-lock must fail while renewal owns the guard"
+        );
+
+        resume_tx.send(()).expect("resume stale writer");
+        assert!(stale_writer.join().expect("stale writer joined"));
+        retry_tx.send(()).expect("retry replacement writer");
+        replacement_writer.join().expect("replacement joined");
+
+        let terminal = read_local_refresh_status_file(&local_refresh_status_path(cache.path()))
+            .expect("terminal status");
+        assert_eq!(terminal.status, "refreshed");
+        assert_eq!(terminal.owner_token.as_deref(), Some("replacement-owner"));
+        assert!(cache.path().join(LOCAL_REFRESH_STATE_GUARD_FILE).exists());
+    }
+
+    #[test]
     fn local_refresh_lock_reclaims_stale_file_and_expires_status() {
         let project = tempfile::tempdir().expect("project");
         let cache = tempfile::tempdir().expect("cache");
@@ -558,6 +1061,7 @@ mod tests {
                 phase: "incremental_index".to_string(),
                 pid: std::process::id(),
                 process_start_identity: Some("different-process-start".to_string()),
+                owner_token: None,
                 started_at_epoch_ms: old_started,
                 updated_at_epoch_ms: now_epoch_ms()
                     - LOCAL_REFRESH_STATUS_TTL.as_millis() as i64
@@ -612,6 +1116,7 @@ mod tests {
                 phase: "incremental_index".to_string(),
                 pid: u32::MAX,
                 process_start_identity: None,
+                owner_token: None,
                 started_at_epoch_ms: old_started,
                 updated_at_epoch_ms: old_started,
                 last_failure_reason: None,
@@ -620,6 +1125,11 @@ mod tests {
         )
         .expect("write stale status");
 
+        drop(acquire_local_refresh_state_guard(cache.path()).expect("persistent guard"));
+        let guard_path = cache.path().join(LOCAL_REFRESH_STATE_GUARD_FILE);
+        let guard_identity_alias = cache.path().join("local-refresh-state.guard.identity-test");
+        fs::hard_link(&guard_path, &guard_identity_alias).expect("guard identity alias");
+
         let cleanup = cleanup_stale_local_refresh_state(cache.path(), project.path())
             .expect("stale local refresh cleanup");
         assert_eq!(cleanup.reason, "stale_status_and_lock");
@@ -627,6 +1137,12 @@ mod tests {
         assert!(cleanup.removed_lock_path);
         assert!(!local_refresh_status_path(cache.path()).exists());
         assert!(!local_refresh_lock_path(cache.path()).exists());
+        assert!(guard_path.exists(), "cleanup must preserve the guard inode");
+        assert!(
+            codestory_workspace::same_workspace_path(&guard_path, &guard_identity_alias),
+            "cleanup must not replace the persistent guard inode"
+        );
+        fs::remove_file(guard_identity_alias).expect("remove guard identity alias");
     }
 
     #[test]
@@ -656,6 +1172,7 @@ mod tests {
                 phase: "incremental_index".to_string(),
                 pid: std::process::id(),
                 process_start_identity: None,
+                owner_token: None,
                 started_at_epoch_ms: old_started,
                 updated_at_epoch_ms: old_started,
                 last_failure_reason: None,
@@ -709,6 +1226,7 @@ mod tests {
                 phase: "incremental_index".to_string(),
                 pid: std::process::id(),
                 process_start_identity: None,
+                owner_token: None,
                 started_at_epoch_ms: old_started,
                 updated_at_epoch_ms: now_epoch_ms(),
                 last_failure_reason: None,
@@ -759,6 +1277,7 @@ mod tests {
                 phase: "incremental_index".to_string(),
                 pid: u32::MAX,
                 process_start_identity: None,
+                owner_token: None,
                 started_at_epoch_ms: old_started,
                 updated_at_epoch_ms: old_started,
                 last_failure_reason: None,
@@ -808,6 +1327,7 @@ mod tests {
                 phase: "incremental_index".to_string(),
                 pid,
                 process_start_identity: reused_identity,
+                owner_token: None,
                 started_at_epoch_ms: old,
                 updated_at_epoch_ms: old,
                 last_failure_reason: None,

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -2487,26 +2487,29 @@ pub(crate) fn wait_for_local_freshness(
     let refresh_started_at_epoch_ms = lock.started_at_epoch_ms();
     let refresh_pid = lock.pid();
     let refresh_phase = "incremental_index";
-    local_refresh_status::write_local_refresh_status(
-        &inspect_runtime.cache_root,
+    if !lock.write_status(
         &inspect_runtime.project_root,
         "refreshing",
         refresh_phase,
-        refresh_started_at_epoch_ms,
-        refresh_pid,
         None,
-    )?;
+    )? {
+        anyhow::bail!("local refresh ownership changed before indexing");
+    }
+    let heartbeat = local_refresh_status::LocalRefreshHeartbeat::start(
+        &lock,
+        &inspect_runtime.project_root,
+        refresh_phase,
+    );
 
     let index_runtime = RuntimeContext::new(project)?;
-    match index_runtime.ensure_open(args::RefreshMode::Incremental) {
+    let refresh_result = index_runtime.ensure_open(args::RefreshMode::Incremental);
+    heartbeat.stop();
+    match refresh_result {
         Ok(opened) => {
-            let _ = local_refresh_status::write_local_refresh_status(
-                &inspect_runtime.cache_root,
+            let _ = lock.write_status(
                 &inspect_runtime.project_root,
                 "refreshed",
                 refresh_phase,
-                refresh_started_at_epoch_ms,
-                refresh_pid,
                 None,
             );
             let mut output = local_refresh_output_from_summary(&opened.summary);
@@ -2526,13 +2529,10 @@ pub(crate) fn wait_for_local_freshness(
         }
         Err(error) => {
             let error_text = error.to_string();
-            let _ = local_refresh_status::write_local_refresh_status(
-                &inspect_runtime.cache_root,
+            let _ = lock.write_status(
                 &inspect_runtime.project_root,
                 "failed",
                 refresh_phase,
-                refresh_started_at_epoch_ms,
-                refresh_pid,
                 Some(error_text.clone()),
             );
             let mut output = local_refresh_output_from_summary(&summary);

--- a/crates/codestory-cli/src/readiness_broker/tests.rs
+++ b/crates/codestory-cli/src/readiness_broker/tests.rs
@@ -1174,6 +1174,10 @@ fn reconcile_before_enqueue_cleans_stale_local_refresh() {
     );
     assert!(!cache.path().join("local-refresh-status.json").exists());
     assert!(!cache.path().join("local-refresh.lock").exists());
+    assert!(
+        cache.path().join("local-refresh-state.guard").exists(),
+        "compatibility cleanup must preserve the persistent guard inode"
+    );
 }
 
 #[test]
@@ -1258,6 +1262,49 @@ fn reconcile_before_enqueue_reports_live_stale_local_refresh_without_cleanup() {
         reconciliation.unresolved_orphan_reason.as_deref(),
         Some("local_refresh_cleanup_blocked:live_status_heartbeat_stale")
     );
+}
+
+#[test]
+fn reconcile_before_enqueue_preserves_renewed_live_local_refresh_owner() {
+    let project = tempdir().expect("project");
+    let cache = tempdir().expect("cache");
+    let old = now_epoch_ms() - 180_000;
+    fs::write(
+        cache.path().join("local-refresh-status.json"),
+        serde_json::to_string(&serde_json::json!({
+            "schema_version": 1,
+            "status": "refreshing",
+            "project_root": clean_path_text(project.path()),
+            "phase": "incremental_index",
+            "pid": std::process::id(),
+            "owner_token": "renewed-live",
+            "started_at_epoch_ms": old,
+            "updated_at_epoch_ms": now_epoch_ms(),
+            "last_failure_reason": null
+        }))
+        .expect("status json"),
+    )
+    .expect("write renewed local refresh status");
+    fs::write(
+        cache.path().join("local-refresh.lock"),
+        serde_json::to_string(&serde_json::json!({
+            "schema_version": 1,
+            "project_root": clean_path_text(project.path()),
+            "pid": std::process::id(),
+            "started_at_epoch_ms": old,
+            "token": "renewed-live"
+        }))
+        .expect("lock json"),
+    )
+    .expect("write renewed local refresh lock");
+
+    let reconciliation =
+        reconcile_before_enqueue(project.path(), cache.path(), Some("shared-agent"), "9.9.9");
+
+    assert!(reconciliation.local_refresh_cleanups.is_empty());
+    assert_ne!(reconciliation.status, "orphan_unresolved");
+    assert!(cache.path().join("local-refresh-status.json").exists());
+    assert!(cache.path().join("local-refresh.lock").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Context

Long local refreshes publish one ownership heartbeat before blocking incremental
indexing. After 30 seconds, reconciliation can mistake that still-live owner for
abandoned work and block #897 convergence with
`local_refresh_cleanup_blocked:live_status_heartbeat_stale`.

Closes #994
Refs #897
Refs #884
Refs #899

## What Changed

- Added a local-refresh-specific heartbeat that renews the existing durable
  owner record every 10 seconds while incremental indexing runs.
- Bound renewal and terminal publication to project, owner token, PID, process
  start identity, and original start time.
- Added one persistent fs4 state guard that serializes owner acquisition,
  replacement, cleanup, renewal, terminal status, and release. Unix validates
  the locked device/inode; Windows denies delete sharing, preventing guard-path
  replacement from splitting ownership.
- Stop and join the heartbeat before publishing refreshed/failed terminal state.
- Reconciliation rejects status whose owner no longer matches the lock and
  preserves a renewed healthy owner.
- Added deterministic contention, PID-reuse, stale cleanup, atomic JSON, and
  terminal-state preservation tests.

## How To Review

Review `LocalRefreshStateGuard` and lock acquisition/release first. Then follow
`LocalRefreshHeartbeat` from `wait_for_local_freshness` through stop/join and
terminal publication. Finally inspect the channel-coordinated stale-writer vs
replacement-owner test; it must prove lock contention without timing alone.

## Verification

- `cargo test -p codestory-cli local_refresh -- --test-threads=1` — passed (16 focused unit/broker tests plus matching CLI/stdio contracts)
- `cargo test -p codestory-cli readiness_broker -- --test-threads=1` — passed (46 broker tests plus matching doctor contract)
- `cargo clippy -p codestory-cli --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check origin/dev/codestory-next...HEAD` — passed
- Independent final review — clean after TOCTOU and guard-inode corrections

## Risk

The persistent guard adds brief cross-process serialization only around tiny
local-refresh state-file operations; indexing itself does not hold it. Legacy
status without an owner token retains its prior fail-closed compatibility
behavior. This slice does not start sidecars, mutate observational `status`, or
claim #897 complete. No UI changed.
