### PR TITLE
bound retrieval stage scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@
 
 ### Added
 
+- Added one bounded reusable retrieval-stage scheduler for narrow and broad
+  queries. Request deadlines and cancellation now propagate into sidecar work
+  and query-embedding/Qdrant HTTP work; lexical and graph scans poll the shared
+  token, and synchronous HTTP runs on separate bounded reusable capacity so a
+  cancelled caller releases stage capacity promptly. Timed-out or cancelled
+  results are discarded instead of cached, while traces truthfully separate
+  admission, queue, completed execution, and pending/late completion state.
+
 - Added immutable per-project runtime configuration for multi-project CLI and
   stdio operation. Embedding endpoint provenance, profile/model/prefix contract,
   batching and device policy, retrieval policy, and summary configuration now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tree-sitter-graph = "0.12"
 streaming-iterator = "0.1"
 
 # Storage
-rusqlite = { version = "0.38", features = ["backup", "bundled"] }
+rusqlite = { version = "0.38", features = ["backup", "bundled", "hooks"] }
 
 # Search
 nucleo-matcher = "0.3"

--- a/crates/codestory-contracts/src/api/dto.rs
+++ b/crates/codestory-contracts/src/api/dto.rs
@@ -1692,6 +1692,12 @@ pub struct RetrievalStageTimingDto {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deadline_ms: Option<u32>,
     pub elapsed_ms: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_wait_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_wait_ms: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_ms: Option<u32>,
     #[serde(default)]
     pub candidates_added: u32,
     #[serde(default)]
@@ -1706,6 +1712,12 @@ pub struct RetrievalStageTimingDto {
     pub degraded: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stub_reason: Option<String>,
+    #[serde(default = "completed_stage_status")]
+    pub completion_status: String,
+}
+
+fn completed_stage_status() -> String {
+    "completed".into()
 }
 
 fn is_false(value: &bool) -> bool {
@@ -2156,6 +2168,9 @@ mod packet_tests {
                 stage: "stage1_lexical".to_string(),
                 deadline_ms: Some(120),
                 elapsed_ms: 18,
+                admission_wait_ms: Some(1),
+                queue_wait_ms: Some(2),
+                execution_ms: Some(16),
                 candidates_added: 3,
                 marginal_gain: 0.25,
                 cancel_reason: None,
@@ -2163,6 +2178,7 @@ mod packet_tests {
                 sidecar_latency_ms: Some(18),
                 degraded: false,
                 stub_reason: None,
+                completion_status: "completed".into(),
             }],
             candidates: vec![RetrievalCandidateSummaryDto {
                 rank: 1,

--- a/crates/codestory-retrieval/src/cache.rs
+++ b/crates/codestory-retrieval/src/cache.rs
@@ -90,6 +90,11 @@ impl RetrievalCache {
         }
     }
 
+    pub fn remove(&mut self, key: &RetrievalCacheKey) {
+        self.entries.remove(key);
+        self.order.retain(|existing| existing != key);
+    }
+
     pub fn merge_delta_from(&mut self, baseline: &RetrievalCache, other: RetrievalCache) {
         let RetrievalCache { entries, order, .. } = other;
         for key in order {

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -66,6 +66,10 @@ impl LlamaCppEmbeddingClient {
     }
 
     pub fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
+        self.embed_query_with_timeout(text, HTTP_TIMEOUT)
+    }
+
+    pub fn embed_query_with_timeout(&self, text: &str, timeout: Duration) -> Result<Vec<f32>> {
         let prefix = self.config.query_prefix.as_deref().unwrap_or_else(|| {
             if self.is_llamacpp() {
                 BGE_QUERY_PREFIX_DEFAULT
@@ -73,7 +77,7 @@ impl LlamaCppEmbeddingClient {
                 ""
             }
         });
-        self.embed_prepared(&format!("{prefix}{text}"))
+        self.embed_prepared_with_timeout(&format!("{prefix}{text}"), timeout)
     }
 
     pub fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
@@ -151,12 +155,12 @@ impl LlamaCppEmbeddingClient {
         )
     }
 
-    fn embed_prepared(&self, prepared: &str) -> Result<Vec<f32>> {
+    fn embed_prepared_with_timeout(&self, prepared: &str, timeout: Duration) -> Result<Vec<f32>> {
         if prepared.trim().is_empty() {
             bail!("cannot embed empty text");
         }
         if self.is_llamacpp() {
-            llamacpp_embed_with_timeout(&[prepared.to_string()], &self.config, HTTP_TIMEOUT)?
+            llamacpp_embed_with_timeout(&[prepared.to_string()], &self.config, timeout)?
                 .pop()
                 .ok_or_else(|| anyhow!("llama.cpp returned no embedding vector"))
         } else {
@@ -1312,6 +1316,30 @@ mod tests {
         assert_eq!(vectors[0], vec![1.0, 0.0, 0.0]);
         assert_eq!(vectors[1], vec![0.0, 1.0, 0.0]);
         assert!(request.contains("retained-model-id"), "{request}");
+        Ok(())
+    }
+
+    #[test]
+    fn query_embedding_honors_request_deadline_timeout() -> Result<()> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let url = format!(
+            "http://{}/v1/embeddings",
+            listener.local_addr().expect("embedding server address")
+        );
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept embedding request");
+            thread::sleep(Duration::from_millis(200));
+            drop(stream);
+        });
+        let client = LlamaCppEmbeddingClient::new(&llama_client_config(url))?;
+        let started = Instant::now();
+
+        client
+            .embed_query_with_timeout("deadline", Duration::from_millis(20))
+            .expect_err("request deadline should stop a stalled embedding response");
+
+        assert!(started.elapsed() < Duration::from_millis(150));
+        server.join().expect("embedding server thread");
         Ok(())
     }
 

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -9,18 +9,21 @@ use crate::mode::{RetrievalDegradedMode, derive_degraded_mode};
 use crate::planner::{PlannedStage, RetrievalStageKind};
 use crate::query_features::{QueryFeatures, classify_query};
 use crate::ranker::rank_candidates;
-use crate::sidecar_search::SidecarSearch;
+use crate::sidecar_search::{SearchExecutionContext, SidecarSearch};
 use anyhow::{Result, bail};
 use codestory_store::RetrievalIndexManifest;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::time::{Duration, Instant};
 
-const BROAD_STAGE_WORKER_LIMIT: usize = 16;
-static BROAD_STAGE_WORKERS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+const STAGE_WORKER_LIMIT: usize = 16;
+const STAGE_WAIT_POLL: Duration = Duration::from_millis(5);
+const MAX_RETRIEVAL_BUDGET_MS: u64 = 120_000;
+static STAGE_WORKER_POOL: OnceLock<StageWorkerPool> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Trace for one retrieval stage.
@@ -31,6 +34,12 @@ pub struct StageTrace {
     pub stage: RetrievalStageKind,
     pub budget_ms: u64,
     pub elapsed_ms: u64,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub admission_wait_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_wait_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution_ms: Option<u64>,
     pub candidates_added: usize,
     pub marginal_gain: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,10 +49,27 @@ pub struct StageTrace {
     pub degraded: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stub_reason: Option<String>,
+    #[serde(default)]
+    pub completion_status: StageCompletionStatus,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StageCompletionStatus {
+    #[default]
+    Completed,
+    PendingAfterDeadline,
+    CancelledBeforeStart,
+    CompletedLate,
+    Skipped,
 }
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+fn is_zero(value: &u64) -> bool {
+    *value == 0
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -108,13 +134,24 @@ impl<'a> QueryExecutor<'a> {
             );
         }
 
-        if let Some(manifest) = self.manifest.as_ref() {
+        if !self.cancelled.load(Ordering::Acquire)
+            && let Some(manifest) = self.manifest.as_ref()
+        {
             let key = RetrievalCacheKey::from_manifest(manifest, fingerprint.clone());
             if let Some(cached) = self.cache.get(&key) {
+                let cached = cached.to_vec();
+                if self.cancelled.load(Ordering::Acquire) {
+                    return Ok(cancelled_query_result(
+                        features,
+                        mode,
+                        request_started,
+                        "cancelled",
+                    ));
+                }
                 return Ok(QueryResult {
                     query: features.raw_query.clone(),
                     features,
-                    hits: cached.to_vec(),
+                    hits: cached,
                     trace: QueryTrace {
                         retrieval_mode: mode.as_str().into(),
                         degraded_reason: None,
@@ -134,15 +171,18 @@ impl<'a> QueryExecutor<'a> {
             if is_broad_query(features.shape) && budget < planned_budget_ms {
                 scale_stage_budgets(&mut plan.stages, budget);
             }
-            plan.total_budget_ms = budget;
+            plan.total_budget_ms = budget.min(MAX_RETRIEVAL_BUDGET_MS);
         }
+        plan.total_budget_ms = plan.total_budget_ms.min(MAX_RETRIEVAL_BUDGET_MS);
 
         let started = Instant::now();
-        let deadline = started + Duration::from_millis(plan.total_budget_ms);
+        let deadline = started
+            .checked_add(Duration::from_millis(plan.total_budget_ms))
+            .unwrap_or(started);
         let mut candidates = Vec::new();
         let mut stage_traces = Vec::new();
 
-        let cancel_reason = self.run_stage_sequence(
+        let mut cancel_reason = self.run_stage_sequence(
             &features,
             &plan.stages,
             &mut candidates,
@@ -158,11 +198,25 @@ impl<'a> QueryExecutor<'a> {
         let ranked = rank_candidates(&features, candidates);
         let hits = ranked;
 
+        if self.cancelled.load(Ordering::Acquire) {
+            cancel_reason = Some("cancelled".into());
+        } else if Instant::now() >= deadline && cancel_reason.is_none() {
+            cancel_reason = Some("deadline".into());
+        }
+
         if cancel_reason.is_none()
+            && !self.cancelled.load(Ordering::Acquire)
+            && Instant::now() < deadline
             && let Some(manifest) = self.manifest.as_ref()
         {
             let key = RetrievalCacheKey::from_manifest(manifest, fingerprint);
-            self.cache.insert(key, hits.clone());
+            if !self.cancelled.load(Ordering::Acquire) {
+                self.cache.insert(key.clone(), hits.clone());
+                if self.cancelled.load(Ordering::Acquire) || Instant::now() >= deadline {
+                    self.cache.remove(&key);
+                    cancel_reason = Some(cancellation_reason(&self.cancelled).into());
+                }
+            }
         }
 
         Ok(QueryResult {
@@ -226,13 +280,22 @@ impl<'a> QueryExecutor<'a> {
         stage: &PlannedStage,
         features: &QueryFeatures,
         anchors: &[CandidateHit],
+        context: &SearchExecutionContext,
     ) -> Result<Vec<CandidateHit>> {
         let query = &features.raw_query;
         match stage.kind {
-            RetrievalStageKind::Stage0ScipAnchor => sidecars.scip_anchor(query, stage.top_k),
-            RetrievalStageKind::Stage1Lexical => sidecars.lexical_search(query, stage.top_k),
-            RetrievalStageKind::Stage1bQdrantSemantic => sidecars.qdrant_search(query, stage.top_k),
-            RetrievalStageKind::Stage2ScipExpand => sidecars.scip_expand(anchors, stage.top_k),
+            RetrievalStageKind::Stage0ScipAnchor => {
+                sidecars.scip_anchor_with_context(query, stage.top_k, context)
+            }
+            RetrievalStageKind::Stage1Lexical => {
+                sidecars.lexical_search_with_context(query, stage.top_k, context)
+            }
+            RetrievalStageKind::Stage1bQdrantSemantic => {
+                sidecars.qdrant_search_with_context(query, stage.top_k, context)
+            }
+            RetrievalStageKind::Stage2ScipExpand => {
+                sidecars.scip_expand_with_context(anchors, stage.top_k, context)
+            }
             RetrievalStageKind::Stage3RepoTextFallback => {
                 bail!("repo-text diagnostic stage is unsupported in mandatory sidecar retrieval")
             }
@@ -244,33 +307,88 @@ impl<'a> QueryExecutor<'a> {
         stage: &PlannedStage,
         features: &QueryFeatures,
         anchors: &[CandidateHit],
+        request_deadline: Instant,
     ) -> Result<StageRun> {
-        if !is_broad_query(features.shape) {
-            return Self::run_stage(self.sidecars.as_ref(), stage, features, anchors)
-                .map(StageRun::Completed);
-        }
-
         let stage = stage.clone();
-        let timeout_ms = stage.budget_ms.max(1);
+        let stage_deadline = request_deadline.min(
+            Instant::now()
+                .checked_add(Duration::from_millis(stage.budget_ms.max(1)))
+                .unwrap_or(request_deadline),
+        );
         let features = features.clone();
         let anchors = anchors.to_vec();
         let sidecars = Arc::clone(&self.sidecars);
-        let (sender, receiver) = mpsc::channel();
-        let Some(permit) = BroadStageWorkerPermit::try_acquire() else {
-            return Ok(StageRun::TimedOut("stage_worker_limit"));
+        let stage_cancelled = Arc::new(AtomicBool::new(false));
+        let context = SearchExecutionContext::new(
+            stage_deadline,
+            Arc::clone(&self.cancelled),
+            Arc::clone(&stage_cancelled),
+        );
+        let admission_started = Instant::now();
+        let Some((permit, admission_wait_ms)) =
+            stage_worker_pool().acquire(stage_deadline, self.cancelled.as_ref())
+        else {
+            stage_cancelled.store(true, Ordering::Release);
+            return Ok(StageRun::Cancelled {
+                reason: cancellation_reason(&self.cancelled),
+                admission_wait_ms: admission_started.elapsed().as_millis() as u64,
+                queue_wait_ms: None,
+                execution_ms: None,
+                completion_status: StageCompletionStatus::CancelledBeforeStart,
+            });
         };
-        // ponytail: global cap; use a worker pool if broad-stage timeout volume matters.
-        std::thread::spawn(move || {
-            let _permit = permit;
-            let result = Self::run_stage(sidecars.as_ref(), &stage, &features, &anchors);
-            let _ = sender.send(result);
-        });
+        let state = Arc::new(StageJobState::default());
+        let (sender, receiver) = mpsc::channel();
+        let queued_at = Instant::now();
+        let job = StageJob {
+            queued_at,
+            state: Arc::clone(&state),
+            task: Box::new(move || {
+                Self::run_stage(sidecars.as_ref(), &stage, &features, &anchors, &context)
+            }),
+            sender,
+            _permit: permit,
+        };
+        stage_worker_pool()
+            .sender
+            .send(job)
+            .map_err(|_| anyhow::anyhow!("retrieval stage worker pool disconnected"))?;
 
-        match receiver.recv_timeout(Duration::from_millis(timeout_ms)) {
-            Ok(result) => result.map(StageRun::Completed),
-            Err(mpsc::RecvTimeoutError::Timeout) => Ok(StageRun::TimedOut("stage_deadline")),
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                bail!("sidecar stage worker disconnected")
+        loop {
+            if self.cancelled.load(Ordering::Acquire) || Instant::now() >= stage_deadline {
+                stage_cancelled.store(true, Ordering::Release);
+                return Ok(cancelled_stage_run(
+                    cancellation_reason(&self.cancelled),
+                    admission_wait_ms,
+                    &state,
+                ));
+            }
+            let remaining = stage_deadline.saturating_duration_since(Instant::now());
+            match receiver.recv_timeout(remaining.min(STAGE_WAIT_POLL)) {
+                Ok(completion) => {
+                    let late = completion.finished_at >= stage_deadline
+                        || self.cancelled.load(Ordering::Acquire);
+                    if late {
+                        stage_cancelled.store(true, Ordering::Release);
+                        return Ok(StageRun::Cancelled {
+                            reason: cancellation_reason(&self.cancelled),
+                            admission_wait_ms,
+                            queue_wait_ms: Some(completion.queue_wait_ms),
+                            execution_ms: Some(completion.execution_ms),
+                            completion_status: StageCompletionStatus::CompletedLate,
+                        });
+                    }
+                    return completion.result.map(|hits| StageRun::Completed {
+                        hits,
+                        admission_wait_ms,
+                        queue_wait_ms: Some(completion.queue_wait_ms),
+                        execution_ms: Some(completion.execution_ms),
+                    });
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    bail!("sidecar stage worker disconnected")
+                }
             }
         }
     }
@@ -290,12 +408,12 @@ impl<'a> QueryExecutor<'a> {
             if self.cancelled.load(Ordering::Relaxed) {
                 return Ok(Some("cancelled".into()));
             }
-            if !is_broad_query(features.shape) && Instant::now() >= deadline {
+            if Instant::now() >= deadline {
                 return Ok(Some("deadline".into()));
             }
 
             if should_skip_after_exact_symbol_anchor(stage, features, candidates) {
-                stage_traces.push(stage_trace(
+                let mut trace = stage_trace(
                     stage,
                     0,
                     0,
@@ -303,11 +421,13 @@ impl<'a> QueryExecutor<'a> {
                     Some("exact_symbol_anchor".into()),
                     false,
                     None,
-                ));
+                );
+                trace.completion_status = StageCompletionStatus::Skipped;
+                stage_traces.push(trace);
                 continue;
             }
             if should_skip_zero_dense_stage(stage, self.manifest.as_ref()) {
-                stage_traces.push(stage_trace(
+                let mut trace = stage_trace(
                     stage,
                     0,
                     0,
@@ -315,28 +435,47 @@ impl<'a> QueryExecutor<'a> {
                     Some("zero_dense_anchors".into()),
                     false,
                     None,
-                ));
+                );
+                trace.completion_status = StageCompletionStatus::Skipped;
+                stage_traces.push(trace);
                 continue;
             }
 
             let stage_started = Instant::now();
             let before_score = candidate_mass(candidates);
-            let mut stage_hits = match self.run_stage_bounded(stage, features, candidates)? {
-                StageRun::Completed(hits) => hits,
-                StageRun::TimedOut(reason) => {
-                    stage_traces.push(stage_trace(
-                        stage,
-                        stage.budget_ms,
-                        0,
-                        0.0,
-                        Some(reason.into()),
-                        false,
-                        None,
-                    ));
-                    cancel_reason.get_or_insert_with(|| reason.into());
-                    continue;
-                }
-            };
+            let (mut stage_hits, admission_wait_ms, queue_wait_ms, execution_ms) =
+                match self.run_stage_bounded(stage, features, candidates, deadline)? {
+                    StageRun::Completed {
+                        hits,
+                        admission_wait_ms,
+                        queue_wait_ms,
+                        execution_ms,
+                    } => (hits, admission_wait_ms, queue_wait_ms, execution_ms),
+                    StageRun::Cancelled {
+                        reason,
+                        admission_wait_ms,
+                        queue_wait_ms,
+                        execution_ms,
+                        completion_status,
+                    } => {
+                        let mut trace = stage_trace(
+                            stage,
+                            stage_started.elapsed().as_millis() as u64,
+                            0,
+                            0.0,
+                            Some(reason.into()),
+                            false,
+                            None,
+                        );
+                        trace.admission_wait_ms = admission_wait_ms;
+                        trace.queue_wait_ms = queue_wait_ms;
+                        trace.execution_ms = execution_ms;
+                        trace.completion_status = completion_status;
+                        stage_traces.push(trace);
+                        cancel_reason.get_or_insert_with(|| reason.into());
+                        continue;
+                    }
+                };
             annotate_stage_provenance(stage, &mut stage_hits);
             let (stub_reason, stage_degraded) = stage_stub_metadata(&stage_hits);
             let added = merge_candidates(candidates, stage_hits);
@@ -347,7 +486,7 @@ impl<'a> QueryExecutor<'a> {
                 ((after_score - before_score) / before_score).max(0.0)
             };
 
-            stage_traces.push(stage_trace(
+            let mut trace = stage_trace(
                 stage,
                 stage_started.elapsed().as_millis() as u64,
                 added,
@@ -355,7 +494,11 @@ impl<'a> QueryExecutor<'a> {
                 None,
                 stage_degraded,
                 stub_reason,
-            ));
+            );
+            trace.admission_wait_ms = admission_wait_ms;
+            trace.queue_wait_ms = queue_wait_ms;
+            trace.execution_ms = execution_ms;
+            stage_traces.push(trace);
 
             if let Some(threshold) = options.stop_marginal_gain_threshold {
                 if marginal_gain < threshold && !candidates.is_empty() {
@@ -372,27 +515,212 @@ impl<'a> QueryExecutor<'a> {
     }
 }
 
-enum StageRun {
-    Completed(Vec<CandidateHit>),
-    TimedOut(&'static str),
-}
-
-struct BroadStageWorkerPermit;
-
-impl BroadStageWorkerPermit {
-    fn try_acquire() -> Option<Self> {
-        BROAD_STAGE_WORKERS_IN_FLIGHT
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-                (current < BROAD_STAGE_WORKER_LIMIT).then_some(current + 1)
-            })
-            .ok()
-            .map(|_| Self)
+fn cancelled_query_result(
+    features: QueryFeatures,
+    mode: RetrievalDegradedMode,
+    started: Instant,
+    reason: &str,
+) -> QueryResult {
+    QueryResult {
+        query: features.raw_query.clone(),
+        features,
+        hits: Vec::new(),
+        trace: QueryTrace {
+            retrieval_mode: mode.as_str().into(),
+            degraded_reason: None,
+            total_budget_ms: 0,
+            elapsed_ms: started.elapsed().as_millis() as u64,
+            cancel_reason: Some(reason.into()),
+            cache_hit: false,
+            stages: Vec::new(),
+        },
     }
 }
 
-impl Drop for BroadStageWorkerPermit {
+enum StageRun {
+    Completed {
+        hits: Vec<CandidateHit>,
+        admission_wait_ms: u64,
+        queue_wait_ms: Option<u64>,
+        execution_ms: Option<u64>,
+    },
+    Cancelled {
+        reason: &'static str,
+        admission_wait_ms: u64,
+        queue_wait_ms: Option<u64>,
+        execution_ms: Option<u64>,
+        completion_status: StageCompletionStatus,
+    },
+}
+
+#[derive(Default)]
+struct StageJobState {
+    started: AtomicBool,
+    queue_wait_ms: AtomicU64,
+}
+
+struct StageCompletion {
+    result: Result<Vec<CandidateHit>>,
+    queue_wait_ms: u64,
+    execution_ms: u64,
+    finished_at: Instant,
+}
+
+struct StageJob {
+    queued_at: Instant,
+    state: Arc<StageJobState>,
+    task: Box<dyn FnOnce() -> Result<Vec<CandidateHit>> + Send>,
+    sender: mpsc::Sender<StageCompletion>,
+    _permit: StageAdmissionPermit,
+}
+
+struct StageWorkerPool {
+    sender: mpsc::SyncSender<StageJob>,
+    admission: Arc<StageAdmission>,
+}
+
+struct StageAdmission {
+    in_flight: Mutex<usize>,
+    available: Condvar,
+    capacity: usize,
+}
+
+struct StageAdmissionPermit {
+    admission: Arc<StageAdmission>,
+}
+
+impl Drop for StageAdmissionPermit {
     fn drop(&mut self) {
-        BROAD_STAGE_WORKERS_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+        let mut in_flight = self
+            .admission
+            .in_flight
+            .lock()
+            .expect("stage admission lock");
+        *in_flight = in_flight.saturating_sub(1);
+        self.admission.available.notify_one();
+    }
+}
+
+impl StageWorkerPool {
+    fn new(worker_limit: usize, queue_capacity: usize) -> Self {
+        let (sender, receiver) = mpsc::sync_channel::<StageJob>(queue_capacity);
+        let receiver = Arc::new(Mutex::new(receiver));
+        for index in 0..worker_limit {
+            let receiver = Arc::clone(&receiver);
+            std::thread::Builder::new()
+                .name(format!("codestory-retrieval-{index}"))
+                .spawn(move || stage_worker_loop(&receiver))
+                .expect("spawn bounded retrieval stage worker");
+        }
+        Self {
+            sender,
+            admission: Arc::new(StageAdmission {
+                in_flight: Mutex::new(0),
+                available: Condvar::new(),
+                capacity: worker_limit.saturating_add(queue_capacity),
+            }),
+        }
+    }
+
+    fn acquire(
+        &self,
+        deadline: Instant,
+        cancelled: &AtomicBool,
+    ) -> Option<(StageAdmissionPermit, u64)> {
+        let started = Instant::now();
+        let mut in_flight = self
+            .admission
+            .in_flight
+            .lock()
+            .expect("stage admission lock");
+        loop {
+            if cancelled.load(Ordering::Acquire) || Instant::now() >= deadline {
+                return None;
+            }
+            if *in_flight < self.admission.capacity {
+                *in_flight += 1;
+                return Some((
+                    StageAdmissionPermit {
+                        admission: Arc::clone(&self.admission),
+                    },
+                    started.elapsed().as_millis() as u64,
+                ));
+            }
+            let wait = deadline
+                .saturating_duration_since(Instant::now())
+                .min(STAGE_WAIT_POLL);
+            let (guard, _) = self
+                .admission
+                .available
+                .wait_timeout(in_flight, wait)
+                .expect("stage admission wait");
+            in_flight = guard;
+        }
+    }
+}
+
+fn stage_worker_pool() -> &'static StageWorkerPool {
+    STAGE_WORKER_POOL.get_or_init(|| StageWorkerPool::new(STAGE_WORKER_LIMIT, STAGE_WORKER_LIMIT))
+}
+
+fn stage_worker_loop(receiver: &Mutex<mpsc::Receiver<StageJob>>) {
+    loop {
+        let job = match receiver.lock().expect("stage queue lock").recv() {
+            Ok(job) => job,
+            Err(_) => return,
+        };
+        let queue_wait_ms = job.queued_at.elapsed().as_millis() as u64;
+        job.state
+            .queue_wait_ms
+            .store(queue_wait_ms, Ordering::Release);
+        job.state.started.store(true, Ordering::Release);
+        let started = Instant::now();
+        let result = catch_unwind(AssertUnwindSafe(job.task))
+            .map_err(|_| anyhow::anyhow!("retrieval stage worker panicked"))
+            .and_then(|result| result);
+        let completion = StageCompletion {
+            result,
+            queue_wait_ms,
+            execution_ms: started.elapsed().as_millis() as u64,
+            finished_at: Instant::now(),
+        };
+        if job.sender.send(completion).is_err() {
+            tracing::debug!(
+                late_completion = true,
+                "discarded late retrieval stage result"
+            );
+        }
+    }
+}
+
+fn cancellation_reason(cancelled: &AtomicBool) -> &'static str {
+    if cancelled.load(Ordering::Acquire) {
+        "cancelled"
+    } else {
+        "stage_deadline"
+    }
+}
+
+fn cancelled_stage_run(
+    reason: &'static str,
+    admission_wait_ms: u64,
+    state: &StageJobState,
+) -> StageRun {
+    let started = state.started.load(Ordering::Acquire);
+    StageRun::Cancelled {
+        reason,
+        admission_wait_ms,
+        queue_wait_ms: if started {
+            Some(state.queue_wait_ms.load(Ordering::Acquire))
+        } else {
+            None
+        },
+        execution_ms: None,
+        completion_status: if started {
+            StageCompletionStatus::PendingAfterDeadline
+        } else {
+            StageCompletionStatus::CancelledBeforeStart
+        },
     }
 }
 
@@ -444,12 +772,16 @@ fn stage_trace(
         stage: stage.kind,
         budget_ms: stage.budget_ms,
         elapsed_ms,
+        admission_wait_ms: 0,
+        queue_wait_ms: None,
+        execution_ms: None,
         candidates_added,
         marginal_gain,
         cancel_reason,
         cache_hit: false,
         degraded,
         stub_reason,
+        completion_status: StageCompletionStatus::Completed,
     }
 }
 
@@ -742,6 +1074,12 @@ mod tests {
         assert!(cache.get(&key).is_some());
 
         let mut cancelled_cache = RetrievalCache::new();
+        let cancelled_key =
+            RetrievalCacheKey::from_manifest(&manifest, query_fingerprint("startup"));
+        cancelled_cache.insert(
+            cancelled_key,
+            vec![CandidateHit::lexical_stub("stale-cancelled.rs", 1.0)],
+        );
         let cancelled = cancellation_flag();
         cancelled.store(true, Ordering::Relaxed);
         let mut executor = QueryExecutor {
@@ -754,7 +1092,11 @@ mod tests {
         };
         let result = executor.execute("startup", Some(800)).expect("query");
         assert_eq!(result.trace.cancel_reason.as_deref(), Some("cancelled"));
-        assert_eq!(cancelled_cache.len(), 0);
+        assert!(
+            result.hits.is_empty(),
+            "cancelled requests must not serve cache"
+        );
+        assert_eq!(cancelled_cache.len(), 1);
     }
 
     #[test]
@@ -1328,16 +1670,20 @@ mod tests {
             cancelled: cancellation_flag(),
             mode_override: Some(RetrievalDegradedMode::Full),
         };
-        let result = executor.execute("EventProcessor", Some(1)).expect("query");
+        let result = executor.execute("EventProcessor", Some(10)).expect("query");
 
-        assert_eq!(result.trace.cancel_reason.as_deref(), Some("deadline"));
+        assert!(matches!(
+            result.trace.cancel_reason.as_deref(),
+            Some("deadline" | "stage_deadline")
+        ));
         assert!(
-            result
-                .trace
-                .stages
-                .iter()
-                .any(|stage| stage.stage == RetrievalStageKind::Stage0ScipAnchor),
-            "first non-broad stage should complete before sequence deadline check: {:?}",
+            result.trace.stages.is_empty()
+                || result
+                    .trace
+                    .stages
+                    .iter()
+                    .any(|stage| stage.stage == RetrievalStageKind::Stage0ScipAnchor),
+            "a started non-broad stage should be bounded by the same stage deadline as broad work: {:?}",
             result.trace.stages
         );
         assert!(
@@ -1576,6 +1922,253 @@ mod tests {
         };
         let result = executor.execute("anything", Some(500)).expect("partial ok");
         assert_eq!(result.trace.cancel_reason.as_deref(), Some("cancelled"));
+    }
+
+    #[test]
+    fn executor_caps_untrusted_total_budget_before_instant_arithmetic() {
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(MockSidecarSearch::default()),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: Arc::new(HashMap::new()),
+            cancelled: cancellation_flag(),
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+
+        let result = executor
+            .execute("EventProcessor", Some(u64::MAX))
+            .expect("huge budget should be capped");
+
+        assert_eq!(result.trace.total_budget_ms, MAX_RETRIEVAL_BUDGET_MS);
+    }
+
+    #[test]
+    fn cancellation_after_last_stage_marks_result_and_suppresses_cache_write() {
+        struct CancelOnReturn {
+            cancelled: Arc<AtomicBool>,
+        }
+
+        impl SidecarSearch for CancelOnReturn {
+            fn lexical_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+
+            fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+                self.cancelled.store(true, Ordering::Release);
+                Ok(vec![CandidateHit::with_source(
+                    "src/late.rs",
+                    Some("EventProcessor".into()),
+                    1.0,
+                    CandidateSource::Scip,
+                )])
+            }
+
+            fn scip_expand(
+                &self,
+                _anchors: &[CandidateHit],
+                _limit: usize,
+            ) -> Result<Vec<CandidateHit>> {
+                Ok(Vec::new())
+            }
+        }
+
+        let cancelled = cancellation_flag();
+        let mut cache = RetrievalCache::new();
+        let mut executor = QueryExecutor {
+            sidecars: Arc::new(CancelOnReturn {
+                cancelled: Arc::clone(&cancelled),
+            }),
+            cache: &mut cache,
+            manifest: Some(sample_manifest()),
+            file_roles: Arc::new(HashMap::new()),
+            cancelled,
+            mode_override: Some(RetrievalDegradedMode::Full),
+        };
+
+        let result = executor
+            .execute("EventProcessor", Some(500))
+            .expect("query");
+
+        assert_eq!(result.trace.cancel_reason.as_deref(), Some("cancelled"));
+        assert!(
+            result.hits.is_empty(),
+            "cancelled stage hits must be discarded"
+        );
+        assert!(cache.is_empty());
+    }
+
+    struct CooperativeCancellationSidecars;
+
+    impl CooperativeCancellationSidecars {
+        fn wait_for_cancellation(
+            &self,
+            context: &SearchExecutionContext,
+        ) -> Result<Vec<CandidateHit>> {
+            while !context.is_cancelled() {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            context.check_cancelled()?;
+            unreachable!("cancelled contexts return an error")
+        }
+    }
+
+    impl SidecarSearch for CooperativeCancellationSidecars {
+        fn lexical_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+
+        fn qdrant_search(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+
+        fn scip_anchor(&self, _query: &str, _limit: usize) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+
+        fn scip_expand(
+            &self,
+            _anchors: &[CandidateHit],
+            _limit: usize,
+        ) -> Result<Vec<CandidateHit>> {
+            Ok(Vec::new())
+        }
+
+        fn scip_anchor_with_context(
+            &self,
+            _query: &str,
+            _limit: usize,
+            context: &SearchExecutionContext,
+        ) -> Result<Vec<CandidateHit>> {
+            self.wait_for_cancellation(context)
+        }
+    }
+
+    #[test]
+    fn active_stage_cancellation_returns_promptly_and_is_not_cached() {
+        let cancelled = cancellation_flag();
+        let request_cancelled = Arc::clone(&cancelled);
+        let started = Instant::now();
+        let handle = std::thread::spawn(move || {
+            let mut cache = RetrievalCache::new();
+            let mut executor = QueryExecutor {
+                sidecars: Arc::new(CooperativeCancellationSidecars),
+                cache: &mut cache,
+                manifest: Some(sample_manifest()),
+                file_roles: Arc::new(HashMap::new()),
+                cancelled: request_cancelled,
+                mode_override: Some(RetrievalDegradedMode::Full),
+            };
+            let result = executor
+                .execute("EventProcessor", Some(500))
+                .expect("cancelled work remains diagnostic");
+            (result, cache.len())
+        });
+        std::thread::sleep(Duration::from_millis(15));
+        cancelled.store(true, Ordering::Release);
+        let (result, cache_len) = handle.join().expect("query worker");
+
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "cancellation should not wait for the original stage budget"
+        );
+        assert_eq!(result.trace.cancel_reason.as_deref(), Some("cancelled"));
+        assert_eq!(cache_len, 0, "cancelled results must not be cached");
+        assert!(result.trace.stages.iter().any(|stage| {
+            stage.cancel_reason.as_deref() == Some("cancelled")
+                && match stage.completion_status {
+                    StageCompletionStatus::PendingAfterDeadline => stage.execution_ms.is_none(),
+                    StageCompletionStatus::CompletedLate => stage.execution_ms.is_some(),
+                    _ => false,
+                }
+        }));
+    }
+
+    #[test]
+    fn timeout_storm_cannot_exceed_worker_and_queue_capacity() {
+        let pool = StageWorkerPool::new(1, 1);
+        let cancelled = AtomicBool::new(false);
+        let (first, _) = pool
+            .acquire(Instant::now() + Duration::from_secs(1), &cancelled)
+            .expect("first admission");
+        let (second, _) = pool
+            .acquire(Instant::now() + Duration::from_secs(1), &cancelled)
+            .expect("queued admission");
+        for _ in 0..32 {
+            assert!(
+                pool.acquire(Instant::now() + Duration::from_millis(1), &cancelled)
+                    .is_none(),
+                "one active worker plus one queued job must bound caller admission"
+            );
+        }
+        drop(first);
+        assert!(
+            pool.acquire(Instant::now() + Duration::from_secs(1), &cancelled)
+                .is_some()
+        );
+        drop(second);
+    }
+
+    #[test]
+    fn incomplete_stage_metrics_do_not_invent_queue_or_execution_duration() {
+        let queued = StageJobState::default();
+        let before_start = cancelled_stage_run("stage_deadline", 7, &queued);
+        assert!(matches!(
+            before_start,
+            StageRun::Cancelled {
+                admission_wait_ms: 7,
+                queue_wait_ms: None,
+                execution_ms: None,
+                completion_status: StageCompletionStatus::CancelledBeforeStart,
+                ..
+            }
+        ));
+
+        queued.queue_wait_ms.store(11, Ordering::Release);
+        queued.started.store(true, Ordering::Release);
+        let executing = cancelled_stage_run("stage_deadline", 3, &queued);
+        assert!(matches!(
+            executing,
+            StageRun::Cancelled {
+                admission_wait_ms: 3,
+                queue_wait_ms: Some(11),
+                execution_ms: None,
+                completion_status: StageCompletionStatus::PendingAfterDeadline,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn stage_worker_survives_panicking_job() {
+        let pool = StageWorkerPool::new(1, 1);
+        let cancelled = AtomicBool::new(false);
+        for should_panic in [true, false] {
+            let (permit, _) = pool
+                .acquire(Instant::now() + Duration::from_secs(1), &cancelled)
+                .expect("job admission");
+            let (sender, receiver) = mpsc::channel();
+            pool.sender
+                .send(StageJob {
+                    queued_at: Instant::now(),
+                    state: Arc::new(StageJobState::default()),
+                    task: Box::new(move || {
+                        assert!(!should_panic, "intentional worker panic");
+                        Ok(Vec::new())
+                    }),
+                    sender,
+                    _permit: permit,
+                })
+                .expect("submit job");
+            let completion = receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("worker completion");
+            assert_eq!(completion.result.is_err(), should_panic);
+        }
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lexical_client.rs
+++ b/crates/codestory-retrieval/src/lexical_client.rs
@@ -1,5 +1,5 @@
 use crate::config::SidecarLayout;
-use crate::lexical_index::{search_lexical_index, shard_dir_for};
+use crate::lexical_index::{search_lexical_index_with_cancel, shard_dir_for};
 use anyhow::Result;
 
 #[derive(Debug, Clone, Default)]
@@ -18,12 +18,30 @@ impl LexicalClient {
         query: &str,
         limit: usize,
     ) -> Result<Vec<super::CandidateHit>> {
+        self.search_with_cancel(layout, generation, sidecar_input_hash, query, limit, || {
+            false
+        })
+    }
+
+    pub fn search_with_cancel<F>(
+        &self,
+        layout: &SidecarLayout,
+        generation: &str,
+        sidecar_input_hash: &str,
+        query: &str,
+        limit: usize,
+        cancelled: F,
+    ) -> Result<Vec<super::CandidateHit>>
+    where
+        F: Fn() -> bool + Send + Sync + 'static,
+    {
         use super::candidate::{CandidateHit, CandidateSource};
-        search_lexical_index(
+        search_lexical_index_with_cancel(
             &shard_dir_for(&layout.lexical_data_dir, generation),
             sidecar_input_hash,
             query,
             limit,
+            cancelled,
         )?
         .into_iter()
         .map(|hit| {

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -6,6 +6,7 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 pub const LEXICAL_INDEX_VERSION: &str = "sqlite-fts5-v1";
 pub const LEXICAL_INDEX_FILE: &str = "lexical-index.sqlite3";
@@ -286,12 +287,52 @@ pub fn lexical_shard_coverage(
     .coverage)
 }
 
+#[cfg(test)]
 pub fn search_lexical_index(
     shard_dir: &Path,
     expected_sidecar_input_hash: &str,
     query: &str,
     limit: usize,
 ) -> Result<Vec<LexicalHit>> {
+    search_lexical_index_with_cancel(shard_dir, expected_sidecar_input_hash, query, limit, || {
+        false
+    })
+}
+
+pub fn search_lexical_index_with_cancel<F>(
+    shard_dir: &Path,
+    expected_sidecar_input_hash: &str,
+    query: &str,
+    limit: usize,
+    cancelled: F,
+) -> Result<Vec<LexicalHit>>
+where
+    F: Fn() -> bool + Send + Sync + 'static,
+{
+    let cancelled: Arc<dyn Fn() -> bool + Send + Sync> = Arc::new(cancelled);
+    let result = search_lexical_index_with_cancel_inner(
+        shard_dir,
+        expected_sidecar_input_hash,
+        query,
+        limit,
+        Arc::clone(&cancelled),
+    );
+    if result.is_err() && cancelled() {
+        bail!("lexical search cancelled");
+    }
+    result
+}
+
+fn search_lexical_index_with_cancel_inner(
+    shard_dir: &Path,
+    expected_sidecar_input_hash: &str,
+    query: &str,
+    limit: usize,
+    cancelled: Arc<dyn Fn() -> bool + Send + Sync>,
+) -> Result<Vec<LexicalHit>> {
+    if cancelled() {
+        bail!("lexical search cancelled");
+    }
     if limit == 0 {
         return Ok(Vec::new());
     }
@@ -300,12 +341,15 @@ pub fn search_lexical_index(
     };
     let index_path = shard_dir.join(LEXICAL_INDEX_FILE);
     let connection = open_read_only(&index_path)?;
+    let progress_cancelled = Arc::clone(&cancelled);
+    connection.progress_handler(1_000, Some(move || progress_cancelled()))?;
     let _metadata = validate_open_database(
         &connection,
         project_id,
         expected_sidecar_input_hash,
         None,
         false,
+        cancelled.as_ref(),
     )?;
     let tokens = lexical_query_tokens(query);
     if tokens.is_empty() {
@@ -328,10 +372,13 @@ pub fn search_lexical_index(
         [],
         |row| row.get::<_, u32>(0).map(|count| count as usize),
     )?;
-    let token_frequencies = tokens
-        .iter()
-        .map(|token| fts_document_frequency(&connection, token))
-        .collect::<Result<Vec<_>>>()?;
+    let mut token_frequencies = Vec::with_capacity(tokens.len());
+    for token in &tokens {
+        if cancelled() {
+            bail!("lexical search cancelled");
+        }
+        token_frequencies.push(fts_document_frequency(&connection, token)?);
+    }
     let token_weights = token_frequencies
         .iter()
         .zip(tokens.iter())
@@ -372,7 +419,10 @@ pub fn search_lexical_index(
     })?;
 
     let mut hits = Vec::new();
-    for row in rows {
+    for (index, row) in rows.enumerate() {
+        if index % 64 == 0 && cancelled() {
+            bail!("lexical search cancelled");
+        }
         let document = row?;
         let normalized_path = normalize_lexical_text(&document.path);
         let normalized_content = normalize_lexical_text(&document.content);
@@ -394,6 +444,9 @@ pub fn search_lexical_index(
                 start_line: document.start_line,
             });
         }
+    }
+    if cancelled() {
+        bail!("lexical search cancelled");
     }
     hits.sort_by(|left, right| {
         right
@@ -562,6 +615,7 @@ fn validate_lexical_database(
         expected_sidecar_input_hash,
         expected_lexical,
         quick_check,
+        &|| false,
     )
 }
 
@@ -571,7 +625,11 @@ fn validate_open_database(
     expected_sidecar_input_hash: &str,
     expected_lexical: Option<(u32, &str)>,
     quick_check: bool,
+    cancelled: &dyn Fn() -> bool,
 ) -> Result<LexicalShardMetadata> {
+    if cancelled() {
+        bail!("lexical search cancelled");
+    }
     let schema_version: i32 = connection.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     if schema_version != 1 {
         bail!("lexical SQLite shard schema version is not current");
@@ -673,7 +731,12 @@ fn validate_open_database(
          ORDER BY d.id",
     )?;
     let mut rows = rows.query([])?;
+    let mut row_index = 0_usize;
     while let Some(row) = rows.next()? {
+        if row_index.is_multiple_of(64) && cancelled() {
+            bail!("lexical search cancelled");
+        }
+        row_index += 1;
         let path: String = row.get(0)?;
         let content: String = row.get(1)?;
         let fts_path: Option<String> = row.get(2)?;
@@ -683,6 +746,9 @@ fn validate_open_database(
         {
             bail!("lexical SQLite shard FTS rows do not match immutable documents");
         }
+    }
+    if cancelled() {
+        bail!("lexical search cancelled");
     }
     Ok(metadata)
 }
@@ -1102,6 +1168,7 @@ pub(crate) fn make_test_file_writable(path: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
 
     fn build(project: &Path, data: &Path, generation: &str, input: &str) -> PathBuf {
@@ -1136,6 +1203,34 @@ mod tests {
                 .is_empty()
         );
         assert!(search_lexical_index(&shard_a, "wrong-input", "handler", 8).is_err());
+    }
+
+    #[test]
+    fn sqlite_lexical_search_interrupts_the_sqlite_vm() {
+        let project = TempDir::new().expect("project");
+        std::fs::create_dir_all(project.path().join("src")).expect("src");
+        for index in 0..256 {
+            std::fs::write(
+                project.path().join(format!("src/{index}.rs")),
+                "fn cancellation_needle() {}",
+            )
+            .expect("source");
+        }
+        let data = TempDir::new().expect("data");
+        let shard = build(project.path(), data.path(), "cancel", "input");
+        let polls = Arc::new(AtomicUsize::new(0));
+        let search_polls = Arc::clone(&polls);
+
+        let error = search_lexical_index_with_cancel(&shard, "input", "needle", 8, move || {
+            search_polls.fetch_add(1, Ordering::Relaxed) > 20
+        })
+        .expect_err("SQLite execution should observe cancellation");
+
+        assert!(error.to_string().contains("cancelled"));
+        assert!(
+            polls.load(Ordering::Relaxed) > 20,
+            "the progress handler must poll inside SQLite beyond Rust loop checkpoints"
+        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -71,7 +71,9 @@ pub use embeddings::{
     ensure_product_embedding_backend_for_runtime, probe_product_embedding_runtime,
     probe_product_embedding_runtime_for_runtime, qdrant_vector_dim,
 };
-pub use executor::{QueryExecutor, QueryResult, QueryTrace, StageTrace, cancellation_flag};
+pub use executor::{
+    QueryExecutor, QueryResult, QueryTrace, StageCompletionStatus, StageTrace, cancellation_flag,
+};
 pub use generation::{SIDECAR_SCHEMA_VERSION, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED};
 pub use health::{
     ComponentHealth, ComponentStatus, EmbeddingLaunchMetadata, InfrastructureHealth,

--- a/crates/codestory-retrieval/src/qdrant_client.rs
+++ b/crates/codestory-retrieval/src/qdrant_client.rs
@@ -1,9 +1,12 @@
 use crate::config::{QDRANT_HEALTH_BUDGET, SidecarLayout};
 use crate::embeddings::{self, qdrant_vector_dim as active_vector_dim};
 use crate::outbound_http::{OutboundHttpError, read_text, truncate_http_body};
+use crate::sidecar_search::SearchExecutionContext;
 use anyhow::{Context, Result, bail};
 use codestory_store::FileRole;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
+use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
 use std::time::{Duration, Instant};
 
 /// Back-compat smoke width when semantic vectors are explicitly downgraded.
@@ -16,6 +19,9 @@ const QDRANT_MUTATION_BUDGET: Duration = Duration::from_secs(5);
 const QDRANT_UPSERT_BUDGET: Duration = Duration::from_secs(60);
 const QDRANT_CREATE_POSTCONDITION_ATTEMPTS: usize = 10;
 const QDRANT_CREATE_POSTCONDITION_DELAY: Duration = Duration::from_secs(1);
+const QDRANT_QUERY_WORKER_LIMIT: usize = 4;
+const QDRANT_QUERY_WAIT_POLL: Duration = Duration::from_millis(5);
+static QDRANT_QUERY_POOL: OnceLock<QdrantQueryPool> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub struct QdrantUpsertPoint {
@@ -193,6 +199,39 @@ impl QdrantClient {
         self.search_vector(collection, &vector, limit)
     }
 
+    pub fn search_with_context(
+        &self,
+        collection: &str,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<super::CandidateHit>> {
+        qdrant_query_pool().execute(
+            self.clone(),
+            collection.to_string(),
+            query.to_string(),
+            limit,
+            context.clone(),
+        )
+    }
+
+    fn search_with_context_blocking(
+        &self,
+        collection: &str,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<super::CandidateHit>> {
+        let embedding_timeout = context.timeout(self.timeout)?;
+        let vector = self
+            .embedding
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("qdrant query embedding runtime is not configured"))?
+            .embed_query_with_timeout(query, embedding_timeout)?;
+        context.check_cancelled()?;
+        self.search_vector_with_timeout(collection, &vector, limit, context.timeout(self.timeout)?)
+    }
+
     /// Diagnostic-only vector lookup against Qdrant without query embedding.
     ///
     /// Product retrieval must keep using [`QdrantClient::search`] so query
@@ -212,6 +251,16 @@ impl QdrantClient {
         vector: &[f32],
         limit: usize,
     ) -> Result<Vec<super::CandidateHit>> {
+        self.search_vector_with_timeout(collection, vector, limit, self.timeout)
+    }
+
+    fn search_vector_with_timeout(
+        &self,
+        collection: &str,
+        vector: &[f32],
+        limit: usize,
+        timeout: Duration,
+    ) -> Result<Vec<super::CandidateHit>> {
         let expected_dim = active_vector_dim();
         if vector.len() != expected_dim {
             bail!(
@@ -228,7 +277,7 @@ impl QdrantClient {
         let payload = serde_json::to_string(&body).context("serialize qdrant search body")?;
         match read_text(
             ureq::post(&url)
-                .timeout(self.timeout)
+                .timeout(timeout)
                 .set("Content-Type", "application/json")
                 .send_string(&payload),
         ) {
@@ -448,6 +497,143 @@ impl QdrantClient {
     pub fn is_collection_stubbed(qdrant_data_dir: &Path, collection: &str) -> bool {
         Self::stub_marker_path(qdrant_data_dir, collection).is_file()
             || Self::legacy_stub_marker_path(qdrant_data_dir, collection).is_file()
+    }
+}
+
+struct QdrantQueryJob {
+    client: QdrantClient,
+    collection: String,
+    query: String,
+    limit: usize,
+    context: SearchExecutionContext,
+    sender: mpsc::Sender<Result<Vec<super::CandidateHit>>>,
+    _permit: QdrantQueryPermit,
+}
+
+struct QdrantQueryPool {
+    sender: mpsc::SyncSender<QdrantQueryJob>,
+    admission: Arc<QdrantQueryAdmission>,
+}
+
+struct QdrantQueryAdmission {
+    in_flight: Mutex<usize>,
+    available: Condvar,
+}
+
+struct QdrantQueryPermit {
+    admission: Arc<QdrantQueryAdmission>,
+}
+
+impl Drop for QdrantQueryPermit {
+    fn drop(&mut self) {
+        let mut in_flight = self
+            .admission
+            .in_flight
+            .lock()
+            .expect("qdrant query admission lock");
+        *in_flight = in_flight.saturating_sub(1);
+        self.admission.available.notify_one();
+    }
+}
+
+impl QdrantQueryPool {
+    fn new() -> Self {
+        let (sender, receiver) = mpsc::sync_channel::<QdrantQueryJob>(QDRANT_QUERY_WORKER_LIMIT);
+        let receiver = Arc::new(Mutex::new(receiver));
+        for index in 0..QDRANT_QUERY_WORKER_LIMIT {
+            let receiver = Arc::clone(&receiver);
+            std::thread::Builder::new()
+                .name(format!("codestory-qdrant-query-{index}"))
+                .spawn(move || qdrant_query_worker(&receiver))
+                .expect("spawn qdrant query worker");
+        }
+        Self {
+            sender,
+            admission: Arc::new(QdrantQueryAdmission {
+                in_flight: Mutex::new(0),
+                available: Condvar::new(),
+            }),
+        }
+    }
+
+    fn execute(
+        &self,
+        client: QdrantClient,
+        collection: String,
+        query: String,
+        limit: usize,
+        context: SearchExecutionContext,
+    ) -> Result<Vec<super::CandidateHit>> {
+        let permit = self.acquire(&context)?;
+        let (sender, receiver) = mpsc::channel();
+        self.sender
+            .send(QdrantQueryJob {
+                client,
+                collection,
+                query,
+                limit,
+                context: context.clone(),
+                sender,
+                _permit: permit,
+            })
+            .map_err(|_| anyhow::anyhow!("qdrant query worker pool disconnected"))?;
+        loop {
+            context.check_cancelled()?;
+            match receiver.recv_timeout(context.timeout(QDRANT_QUERY_WAIT_POLL)?) {
+                Ok(result) => return result,
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    bail!("qdrant query worker disconnected")
+                }
+            }
+        }
+    }
+
+    fn acquire(&self, context: &SearchExecutionContext) -> Result<QdrantQueryPermit> {
+        let mut in_flight = self
+            .admission
+            .in_flight
+            .lock()
+            .expect("qdrant query admission lock");
+        loop {
+            context.check_cancelled()?;
+            if *in_flight < QDRANT_QUERY_WORKER_LIMIT * 2 {
+                *in_flight += 1;
+                return Ok(QdrantQueryPermit {
+                    admission: Arc::clone(&self.admission),
+                });
+            }
+            let (guard, _) = self
+                .admission
+                .available
+                .wait_timeout(in_flight, context.timeout(QDRANT_QUERY_WAIT_POLL)?)
+                .expect("qdrant query admission wait");
+            in_flight = guard;
+        }
+    }
+}
+
+fn qdrant_query_pool() -> &'static QdrantQueryPool {
+    QDRANT_QUERY_POOL.get_or_init(QdrantQueryPool::new)
+}
+
+fn qdrant_query_worker(receiver: &Mutex<mpsc::Receiver<QdrantQueryJob>>) {
+    loop {
+        let job = match receiver.lock().expect("qdrant query queue lock").recv() {
+            Ok(job) => job,
+            Err(_) => return,
+        };
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            job.client.search_with_context_blocking(
+                &job.collection,
+                &job.query,
+                job.limit,
+                &job.context,
+            )
+        }))
+        .map_err(|_| anyhow::anyhow!("qdrant query worker panicked"))
+        .and_then(|result| result);
+        let _ = job.sender.send(result);
     }
 }
 
@@ -676,12 +862,84 @@ fn vectors_for_points(
 mod tests {
     use super::*;
     use crate::candidate::CandidateSource;
+    use crate::config::{EmbeddingEndpointOrigin, EmbeddingRuntimeConfig};
+    use std::net::TcpListener;
+    use std::sync::atomic::AtomicBool;
 
     #[test]
     fn label_to_vector_has_fixed_dim() {
         let vector = label_to_vector("handler");
         assert_eq!(vector.len(), QDRANT_VECTOR_DIM);
         assert!(vector.iter().all(|value| (0.0..=1.0).contains(value)));
+    }
+
+    #[test]
+    fn synchronous_http_query_releases_stage_caller_on_cancellation() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding server");
+        let endpoint = format!(
+            "http://{}/v1/embeddings",
+            listener.local_addr().expect("server address")
+        );
+        listener.set_nonblocking(true).expect("nonblocking server");
+        let server = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(1);
+            loop {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        std::thread::sleep(Duration::from_millis(200));
+                        drop(stream);
+                        break;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept request: {error}"),
+                }
+            }
+        });
+        let embedding = embeddings::LlamaCppEmbeddingClient::new(&EmbeddingRuntimeConfig {
+            configuration_error: None,
+            backend: "llamacpp".into(),
+            endpoint,
+            endpoint_origin: EmbeddingEndpointOrigin::TrustedProjectConfig,
+            profile: "custom".into(),
+            model_id: Some("test".into()),
+            pooling: None,
+            query_prefix: None,
+            document_prefix: None,
+            layer_norm: None,
+            truncate_dim: None,
+            expected_dim: Some(3),
+            batch_size: 1,
+            request_count: 1,
+            allow_remote: false,
+            device_policy: "allow_cpu".into(),
+            server_launch: Some("external_endpoint".into()),
+        })
+        .expect("embedding client");
+        let client = QdrantClient {
+            base_url: "http://127.0.0.1:9".into(),
+            timeout: Duration::from_secs(5),
+            embedding: Some(embedding),
+        };
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let context = SearchExecutionContext::new(
+            Instant::now() + Duration::from_millis(500),
+            Arc::clone(&cancelled),
+            Arc::new(AtomicBool::new(false)),
+        );
+        let started = Instant::now();
+        let query = std::thread::spawn(move || {
+            client.search_with_context("collection", "query", 1, &context)
+        });
+        std::thread::sleep(Duration::from_millis(20));
+        cancelled.store(true, std::sync::atomic::Ordering::Release);
+        assert!(query.join().expect("query thread").is_err());
+        assert!(started.elapsed() < Duration::from_millis(100));
+        server.join().expect("embedding server");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -16,7 +16,7 @@ use codestory_store::{FileRole, RetrievalIndexManifest, Store};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 const STRICT_BATCH_WORKER_CAP: usize = 4;
 
@@ -61,6 +61,10 @@ pub fn execute_retrieval_query_with_cache_for_runtime(
     cache: &mut RetrievalCache,
     runtime: &SidecarRuntimeConfig,
 ) -> Result<QueryResult> {
+    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
+    if cancelled.load(Ordering::Acquire) {
+        bail!("retrieval query cancelled before preflight");
+    }
     let QueryContext {
         layout,
         project_id,
@@ -75,7 +79,6 @@ pub fn execute_retrieval_query_with_cache_for_runtime(
         manifest.as_ref(),
         Some(embedding_device),
     )?);
-    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
     let mut executor = QueryExecutor {
         sidecars,
         cache,
@@ -103,6 +106,10 @@ pub fn execute_strict_retrieval_query_batch_with_cache_for_runtime(
     if request.queries.is_empty() {
         return Ok(Vec::new());
     }
+    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
+    if cancelled.load(Ordering::Acquire) {
+        bail!("retrieval query batch cancelled before preflight");
+    }
     let QueryContext {
         layout,
         project_id,
@@ -117,7 +124,6 @@ pub fn execute_strict_retrieval_query_batch_with_cache_for_runtime(
         manifest.as_ref(),
         Some(embedding_device.clone()),
     )?);
-    let cancelled = request.cancelled.unwrap_or_else(cancellation_flag);
     let (mode, degraded_reason) = resolve_batch_mode(
         sidecars.as_ref(),
         manifest.as_ref(),
@@ -160,11 +166,19 @@ fn execute_strict_retrieval_query_batch_against_sidecars(
             mode.as_str()
         );
     }
+    if cancelled.load(Ordering::Acquire) {
+        bail!("retrieval query batch cancelled before cache lookup");
+    }
 
     let mut results = vec![None; queries.len()];
     let mut misses = Vec::new();
     for (index, query) in queries.iter().enumerate() {
-        if let Some(result) = cached_batch_result(manifest.as_ref(), cache, query.query, mode) {
+        if cancelled.load(Ordering::Acquire) {
+            bail!("retrieval query batch cancelled during cache lookup");
+        }
+        if let Some(result) =
+            cached_batch_result(manifest.as_ref(), cache, query.query, mode, &cancelled)
+        {
             results[index] = Some(result);
         } else {
             misses.push((index, query.query.to_string(), query.budget_ms));
@@ -172,6 +186,9 @@ fn execute_strict_retrieval_query_batch_against_sidecars(
     }
 
     for wave in misses.chunks(worker_limit.max(1)) {
+        if cancelled.load(Ordering::Acquire) {
+            bail!("retrieval query batch cancelled before worker wave");
+        }
         let wave_results = std::thread::scope(|scope| {
             let mut handles = Vec::with_capacity(wave.len());
             for (index, query, budget_ms) in wave {
@@ -204,7 +221,10 @@ fn execute_strict_retrieval_query_batch_against_sidecars(
 
         for (index, result) in wave_results {
             let result = result?;
-            cache_completed_batch_result(manifest.as_ref(), cache, &result);
+            if cancelled.load(Ordering::Acquire) {
+                bail!("retrieval query batch cancelled after worker wave");
+            }
+            cache_completed_batch_result(manifest.as_ref(), cache, &result, &cancelled);
             results[index] = Some(result);
         }
     }
@@ -220,14 +240,22 @@ fn cached_batch_result(
     cache: &RetrievalCache,
     query: &str,
     mode: RetrievalDegradedMode,
+    cancelled: &AtomicBool,
 ) -> Option<QueryResult> {
+    if cancelled.load(Ordering::Acquire) {
+        return None;
+    }
     let manifest = manifest?;
     let features = classify_query(query);
     let key = RetrievalCacheKey::from_manifest(manifest, query_fingerprint(&features.raw_query));
-    cache.get(&key).map(|hits| QueryResult {
+    let hits = cache.get(&key)?.to_vec();
+    if cancelled.load(Ordering::Acquire) {
+        return None;
+    }
+    Some(QueryResult {
         query: features.raw_query.clone(),
         features,
-        hits: hits.to_vec(),
+        hits,
         trace: crate::executor::QueryTrace {
             retrieval_mode: mode.as_str().into(),
             degraded_reason: None,
@@ -244,8 +272,9 @@ fn cache_completed_batch_result(
     manifest: Option<&RetrievalIndexManifest>,
     cache: &mut RetrievalCache,
     result: &QueryResult,
+    cancelled: &AtomicBool,
 ) {
-    if result.trace.cancel_reason.is_some() {
+    if result.trace.cancel_reason.is_some() || cancelled.load(Ordering::Acquire) {
         return;
     }
     if let Some(manifest) = manifest {
@@ -253,7 +282,12 @@ fn cache_completed_batch_result(
             manifest,
             query_fingerprint(&result.features.raw_query),
         );
-        cache.insert(key, result.hits.clone());
+        if !cancelled.load(Ordering::Acquire) {
+            cache.insert(key.clone(), result.hits.clone());
+            if cancelled.load(Ordering::Acquire) {
+                cache.remove(&key);
+            }
+        }
     }
 }
 
@@ -544,6 +578,36 @@ mod tests {
         .expect_err("non-full mode must fail before cache use");
 
         assert!(error.to_string().contains("retrieval sidecar is mandatory"));
+    }
+
+    #[test]
+    fn strict_batch_cancellation_preflight_rejects_cache_hits() {
+        let mut cache = RetrievalCache::new();
+        let manifest = manifest_for("testproj", "cafebabedeadbeef", 1);
+        cache.insert(
+            RetrievalCacheKey::from_manifest(&manifest, query_fingerprint("cached")),
+            vec![CandidateHit::lexical_stub("src/cached.rs", 1.0)],
+        );
+        let queries = [QueryBatchItem {
+            query: "cached",
+            budget_ms: Some(100),
+        }];
+        let cancelled = cancellation_flag();
+        cancelled.store(true, Ordering::Release);
+
+        let error = execute_strict_retrieval_query_batch_against_sidecars(
+            Arc::new(crate::sidecar_search::mock::MockSidecarSearch::default()),
+            Some(manifest),
+            Arc::new(HashMap::new()),
+            cancelled,
+            RetrievalDegradedMode::Full,
+            &queries,
+            &mut cache,
+            1,
+        )
+        .expect_err("cancelled batch must not serve cache");
+
+        assert!(error.to_string().contains("cancelled"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/scip_client.rs
+++ b/crates/codestory-retrieval/src/scip_client.rs
@@ -83,6 +83,19 @@ impl ScipClient {
         query: &str,
         limit: usize,
     ) -> anyhow::Result<Vec<super::CandidateHit>> {
+        Self::anchor_search_with_cancel(layout, project_id, query, limit, &|| false)
+    }
+
+    pub fn anchor_search_with_cancel(
+        layout: &SidecarLayout,
+        project_id: &str,
+        query: &str,
+        limit: usize,
+        cancelled: &dyn Fn() -> bool,
+    ) -> anyhow::Result<Vec<super::CandidateHit>> {
+        if cancelled() {
+            anyhow::bail!("SCIP anchor search cancelled");
+        }
         let probe = Self::health_probe(layout, project_id);
         let ScipAvailability::Ready { revision } = probe.availability else {
             return Ok(Vec::new());
@@ -96,11 +109,17 @@ impl ScipClient {
         };
         let profile = ScipQueryProfile::new(query);
         let mut hits = Vec::new();
-        for symbol in index.symbols {
+        for (index, symbol) in index.symbols.into_iter().enumerate() {
+            if index % 64 == 0 && cancelled() {
+                anyhow::bail!("SCIP anchor search cancelled");
+            }
             if symbol_matches_query(&symbol, &profile) {
                 let score = score_symbol_match(&symbol, &profile);
                 hits.push(symbol_to_hit(&symbol, score, 0, provenance));
             }
+        }
+        if cancelled() {
+            anyhow::bail!("SCIP anchor search cancelled");
         }
         hits.sort_by(|left, right| {
             right
@@ -121,6 +140,19 @@ impl ScipClient {
         anchors: &[super::CandidateHit],
         limit: usize,
     ) -> anyhow::Result<Vec<super::CandidateHit>> {
+        Self::expand_graph_with_cancel(layout, project_id, anchors, limit, &|| false)
+    }
+
+    pub fn expand_graph_with_cancel(
+        layout: &SidecarLayout,
+        project_id: &str,
+        anchors: &[super::CandidateHit],
+        limit: usize,
+        cancelled: &dyn Fn() -> bool,
+    ) -> anyhow::Result<Vec<super::CandidateHit>> {
+        if cancelled() {
+            anyhow::bail!("SCIP graph expansion cancelled");
+        }
         let probe = Self::health_probe(layout, project_id);
         let ScipAvailability::Ready { revision } = probe.availability else {
             return Ok(Vec::new());
@@ -135,7 +167,10 @@ impl ScipClient {
         let mut hits = Vec::new();
         for anchor in anchors.iter().take(4) {
             let anchor_symbol = anchor.symbol_name.as_deref().unwrap_or("");
-            for symbol in &index.symbols {
+            for (index, symbol) in index.symbols.iter().enumerate() {
+                if index % 64 == 0 && cancelled() {
+                    anyhow::bail!("SCIP graph expansion cancelled");
+                }
                 if hits.len() >= limit {
                     break;
                 }
@@ -154,6 +189,9 @@ impl ScipClient {
                     ));
                 }
             }
+        }
+        if cancelled() {
+            anyhow::bail!("SCIP graph expansion cancelled");
         }
         hits.truncate(limit);
         Ok(hits)
@@ -420,6 +458,7 @@ mod tests {
         SCIP_IMPORTED_PROOF_PROVENANCE, SCIP_PRECISE_SEMANTIC_IMPORT_PUBLIC_PROVENANCE,
         ScipPackageIdentity, ScipProofAdapterContract, ScipProofRecord, ScipSymbolsIndex,
     };
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use tempfile::TempDir;
 
     fn write_scip_index(
@@ -543,6 +582,44 @@ mod tests {
             "exact SCIP symbol match should survive top-k truncation even when many earlier path-only matches exist"
         );
         assert_eq!(hits[0].file_path, "src/needle/target.ts");
+    }
+
+    #[test]
+    fn anchor_search_polls_cancellation_while_scanning_symbols() {
+        let root = TempDir::new().expect("root");
+        let layout = SidecarLayout {
+            qdrant_http_port: 2,
+            qdrant_grpc_port: 3,
+            lexical_data_dir: root.path().join("lexical"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("state.json"),
+        };
+        let project_dir = layout.scip_project_dir("project");
+        std::fs::create_dir_all(&project_dir).expect("scip dir");
+        write_scip_index(
+            &project_dir,
+            "graph-test",
+            ScipProofAdapterContract::graph_projection("graph-test"),
+            (0..256)
+                .map(|index| ScipSymbolRecord {
+                    path: format!("src/{index}.rs"),
+                    symbol: format!("symbol_{index}"),
+                    start_line: index + 1,
+                    end_line: index + 1,
+                })
+                .collect(),
+            Vec::new(),
+        );
+        let polls = AtomicUsize::new(0);
+
+        let error = ScipClient::anchor_search_with_cancel(&layout, "project", "symbol", 8, &|| {
+            polls.fetch_add(1, AtomicOrdering::Relaxed) > 0
+        })
+        .expect_err("scan should observe cancellation");
+
+        assert!(error.to_string().contains("cancelled"));
+        assert!(polls.load(AtomicOrdering::Relaxed) >= 2);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/sidecar_search.rs
+++ b/crates/codestory-retrieval/src/sidecar_search.rs
@@ -6,6 +6,64 @@ use crate::qdrant_client::QdrantClient;
 use crate::scip_client::ScipClient;
 use anyhow::Result;
 use codestory_store::RetrievalIndexManifest;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+/// Request-scoped deadline and cancellation state shared by retrieval stages and sidecar I/O.
+#[derive(Debug, Clone)]
+pub struct SearchExecutionContext {
+    deadline: Instant,
+    request_cancelled: Arc<AtomicBool>,
+    stage_cancelled: Arc<AtomicBool>,
+}
+
+impl SearchExecutionContext {
+    pub(crate) fn new(
+        deadline: Instant,
+        request_cancelled: Arc<AtomicBool>,
+        stage_cancelled: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            deadline,
+            request_cancelled,
+            stage_cancelled,
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.request_cancelled.load(Ordering::Acquire)
+            || self.stage_cancelled.load(Ordering::Acquire)
+            || Instant::now() >= self.deadline
+    }
+
+    pub fn check_cancelled(&self) -> Result<()> {
+        if self.is_cancelled() {
+            anyhow::bail!("retrieval stage cancelled or deadline exceeded");
+        }
+        Ok(())
+    }
+
+    pub fn timeout(&self, maximum: Duration) -> Result<Duration> {
+        self.check_cancelled()?;
+        let timeout = self
+            .deadline
+            .saturating_duration_since(Instant::now())
+            .min(maximum);
+        if timeout.is_zero() {
+            anyhow::bail!("retrieval stage deadline exceeded");
+        }
+        Ok(timeout)
+    }
+
+    fn run<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+        self.check_cancelled()?;
+        let value = operation()?;
+        self.check_cancelled()?;
+        Ok(value)
+    }
+}
+
 /// Sidecar search surface used by the executor (mockable in unit tests).
 pub trait SidecarSearch: Send + Sync {
     fn layout(&self) -> Option<&SidecarLayout> {
@@ -24,6 +82,42 @@ pub trait SidecarSearch: Send + Sync {
     fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
     fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>>;
     fn scip_expand(&self, anchors: &[CandidateHit], limit: usize) -> Result<Vec<CandidateHit>>;
+
+    fn lexical_search_with_context(
+        &self,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        context.run(|| self.lexical_search(query, limit))
+    }
+
+    fn qdrant_search_with_context(
+        &self,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        context.run(|| self.qdrant_search(query, limit))
+    }
+
+    fn scip_anchor_with_context(
+        &self,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        context.run(|| self.scip_anchor(query, limit))
+    }
+
+    fn scip_expand_with_context(
+        &self,
+        anchors: &[CandidateHit],
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        context.run(|| self.scip_expand(anchors, limit))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -135,16 +229,73 @@ impl SidecarSearch for LiveSidecarSearch {
         )
     }
 
+    fn lexical_search_with_context(
+        &self,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        let context = context.clone();
+        self.lexical.search_with_cancel(
+            &self.layout,
+            &self.sidecar_generation,
+            &self.sidecar_input_hash,
+            query,
+            limit,
+            move || context.is_cancelled(),
+        )
+    }
+
     fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
         self.qdrant.search(&self.qdrant_collection, query, limit)
+    }
+
+    fn qdrant_search_with_context(
+        &self,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        self.qdrant
+            .search_with_context(&self.qdrant_collection, query, limit, context)
     }
 
     fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
         ScipClient::anchor_search(&self.layout, &self.sidecar_generation, query, limit)
     }
 
+    fn scip_anchor_with_context(
+        &self,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        ScipClient::anchor_search_with_cancel(
+            &self.layout,
+            &self.sidecar_generation,
+            query,
+            limit,
+            &|| context.is_cancelled(),
+        )
+    }
+
     fn scip_expand(&self, anchors: &[CandidateHit], limit: usize) -> Result<Vec<CandidateHit>> {
         ScipClient::expand_graph(&self.layout, &self.sidecar_generation, anchors, limit)
+    }
+
+    fn scip_expand_with_context(
+        &self,
+        anchors: &[CandidateHit],
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        ScipClient::expand_graph_with_cancel(
+            &self.layout,
+            &self.sidecar_generation,
+            anchors,
+            limit,
+            &|| context.is_cancelled(),
+        )
     }
 }
 

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -326,7 +326,7 @@ pub(crate) fn sidecar_result_rejection_reason(
 
 fn sidecar_blocking_cancel_reason(query_result: &QueryResult) -> Option<&str> {
     match query_result.trace.cancel_reason.as_deref() {
-        Some("deadline" | "stage_deadline" | "stage_worker_limit" | "cancelled") => {
+        Some("deadline" | "stage_deadline" | "cancelled") => {
             query_result.trace.cancel_reason.as_deref()
         }
         _ => None,
@@ -1207,13 +1207,30 @@ fn retrieval_stage_timings(trace: &QueryTrace) -> Vec<RetrievalStageTimingDto> {
             stage: stage.stage.label().to_string(),
             deadline_ms: u32::try_from(stage.budget_ms).ok(),
             elapsed_ms: u32::try_from(stage.elapsed_ms).unwrap_or(u32::MAX),
+            admission_wait_ms: u32::try_from(stage.admission_wait_ms).ok(),
+            queue_wait_ms: stage.queue_wait_ms.and_then(|ms| u32::try_from(ms).ok()),
+            execution_ms: stage.execution_ms.and_then(|ms| u32::try_from(ms).ok()),
             candidates_added: u32::try_from(stage.candidates_added).unwrap_or(u32::MAX),
             marginal_gain: stage.marginal_gain,
             cancel_reason: stage.cancel_reason.clone(),
             cache_hit: stage.cache_hit,
-            sidecar_latency_ms: stage.stage.sidecar_latency_ms(stage.elapsed_ms),
+            sidecar_latency_ms: stage
+                .execution_ms
+                .and_then(|ms| stage.stage.sidecar_latency_ms(ms)),
             degraded: stage.degraded,
             stub_reason: stage.stub_reason.clone(),
+            completion_status: match stage.completion_status {
+                codestory_retrieval::StageCompletionStatus::Completed => "completed",
+                codestory_retrieval::StageCompletionStatus::PendingAfterDeadline => {
+                    "pending_after_deadline"
+                }
+                codestory_retrieval::StageCompletionStatus::CancelledBeforeStart => {
+                    "cancelled_before_start"
+                }
+                codestory_retrieval::StageCompletionStatus::CompletedLate => "completed_late",
+                codestory_retrieval::StageCompletionStatus::Skipped => "skipped",
+            }
+            .into(),
         })
         .collect()
 }
@@ -1905,12 +1922,16 @@ mod tests {
                     stage: RetrievalStageKind::Stage1Lexical,
                     budget_ms: 120,
                     elapsed_ms: 20,
+                    admission_wait_ms: 0,
+                    queue_wait_ms: Some(1),
+                    execution_ms: Some(19),
                     candidates_added: 2,
                     marginal_gain: 0.4,
                     cancel_reason: None,
                     cache_hit: false,
                     degraded: false,
                     stub_reason: None,
+                    completion_status: codestory_retrieval::StageCompletionStatus::Completed,
                 }],
             },
         });
@@ -2539,12 +2560,7 @@ mod tests {
     fn sidecar_result_rejects_blocking_cancel_reasons_even_with_resolved_hits() {
         use codestory_retrieval::{CandidateSource, classify_query};
 
-        for reason in [
-            "deadline",
-            "stage_deadline",
-            "stage_worker_limit",
-            "cancelled",
-        ] {
+        for reason in ["deadline", "stage_deadline", "cancelled"] {
             let candidate = CandidateHit::with_source(
                 "src/handler.rs",
                 Some("handler".into()),

--- a/docs/testing/retrieval-architecture.md
+++ b/docs/testing/retrieval-architecture.md
@@ -160,6 +160,18 @@ Non-claims:
 | Nucleo policy | `codestory-runtime/src/agent/nucleo_policy.rs` | Suppresses Nucleo O(n) scan on sidecar primary; disabled sidecars are not valid product evidence |
 | Generalization lint | `scripts/lint-retrieval-generalization.mjs` | Derives banned identities, prompts, claims, paths, and query/probe phrases from benchmark manifests, script prompt/query catalogs, and the eval-only probe manifest/source, then scans Rust production retrieval trees after masking test-only items (CI via Rust guard test); missing, malformed, or partially parsed corpora fail closed |
 
+All planned retrieval stages use the same fixed-capacity worker pool, including
+symbol-like and natural-language queries. Each job carries the request deadline
+and cancellation flag into sidecar calls. Lexical and SCIP scans poll that
+context while iterating. Live query embedding and Qdrant requests clamp their
+transport timeout to the remaining deadline and use separate bounded reusable
+HTTP capacity, allowing the stage worker to return promptly when synchronous
+I/O cannot be interrupted in place. Stage traces report admission and queue
+wait separately, report execution duration only after completion, and classify
+completed, skipped, cancelled-before-start, pending-after-deadline, and
+observed-late work. Post-return completions are logged and discarded. Any cancelled or late
+result remains diagnostic and is never inserted into the retrieval cache.
+
 **Modes:** See the canonical
 [mode matrix](../architecture/retrieval-design.md#mode-matrix). Only `full` may
 serve primary packet/search results.


### PR DESCRIPTION
## Context

Issue #916 requires bounded reusable retrieval-stage scheduling with truthful deadlines, cancellation, admission, and telemetry. This branch is rebased onto the merged SQLite lexical engine from #983.

Closes #916
Refs #899

## What Changed

- Add one bounded reusable stage scheduler with fair bounded admission, worker panic containment, and checked/capped deadlines.
- Propagate request and stage cancellation through lexical, SCIP, query embedding, and Qdrant paths.
- Interrupt long SQLite FTS operations inside the SQLite VM with a progress handler, not only between Rust loops.
- Run synchronous embedding/Qdrant HTTP on separate bounded reusable capacity so cancelled callers release stage capacity promptly.
- Prevent cancelled/timed-out/late results from entering cache and report admission, queue, execution, completion, and late state truthfully.
- Preserve worker capacity under timeout storms and panic failures.

## How To Review

Start with the scheduler/executor state machine, then `sidecar_search.rs` and the SQLite lexical cancellation path. Review Qdrant's fixed worker/admission pool and the telemetry DTO changes separately.

## Verification

- `cargo test -p codestory-retrieval` after the final SQLite integration: 321 passed, 2 ignored unit tests; all integration binaries passed, with one live mandatory-sidecar test intentionally ignored.
- `cargo clippy -p codestory-retrieval --all-targets --all-features -- -D warnings` passed.
- Focused SQLite VM interruption, timeout storm, cache suppression, worker panic, cancellation, and synchronous HTTP release tests passed.
- Independent review findings were fixed before the final rebase.

## Risk

Live mandatory-sidecar behavior remains a separate environment proof because this host has no finalized retrieval manifest. Bounded HTTP workers cannot cancel the underlying synchronous socket call, but caller/stage capacity is released promptly and the separate pool is strictly capped.