### PR TITLE
move convergence into project activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
   becoming apparent deletions; incremental planning removes stored projections
   only after a complete inventory, while freshness and cache validation fail
   closed when absence cannot be proven.
+- Made MCP status reads observational. Grounding and other project tools now
+  own local refresh activation and, when the installed sidecar policy is
+  enabled, attach or enqueue agent readiness through the existing
+  project-scoped broker. Automatic repair retries persist a state fingerprint
+  and cooldown across MCP runtimes. Stale heartbeats from a still-live owner
+  remain fail-closed diagnostics surfaced by canonical MCP status; age alone
+  never terminates the process.
 - Renewed live local-refresh ownership during long incremental indexing, with
   token, PID, and process-start checks that prevent stale workers from
   overwriting changed ownership or terminal status.

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -128,6 +128,8 @@ pub(crate) struct ReadyRepairWorkerResult {
     pub(crate) started_at_epoch_ms: i64,
     pub(crate) finished_at_epoch_ms: i64,
     pub(crate) outcome: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) auto_retry_fingerprint: Option<String>,
     pub(crate) exit_code: Option<i32>,
     pub(crate) wait_error: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -329,6 +331,7 @@ pub(crate) fn try_reserve_ready_repair(
                 .unwrap_or(stale.started_at_epoch_ms),
             finished_at_epoch_ms: now_epoch_ms(),
             outcome: "abandoned".to_string(),
+            auto_retry_fingerprint: None,
             exit_code: None,
             wait_error: Some(
                 "repair worker reservation owner exited before recording a terminal result"
@@ -755,6 +758,7 @@ pub(crate) fn cleanup_abandoned_ready_repair_status(
                 started_at_epoch_ms: status.started_at_epoch_ms,
                 finished_at_epoch_ms: now,
                 outcome: "abandoned".to_string(),
+                auto_retry_fingerprint: None,
                 exit_code: None,
                 wait_error: Some(
                     "repair worker process exited without recording a terminal result".to_string(),
@@ -1401,6 +1405,7 @@ mod tests {
             started_at_epoch_ms: 100,
             finished_at_epoch_ms: 200,
             outcome: "succeeded".to_string(),
+            auto_retry_fingerprint: None,
             exit_code: Some(0),
             wait_error: None,
             terminal_envelope: None,
@@ -1518,6 +1523,7 @@ mod tests {
             started_at_epoch_ms: 100,
             finished_at_epoch_ms: 200,
             outcome: "failed".to_string(),
+            auto_retry_fingerprint: None,
             exit_code: Some(17),
             wait_error: None,
             terminal_envelope: Some(CommandFailureEnvelope::new(ApiError::internal(
@@ -1592,6 +1598,7 @@ mod tests {
             started_at_epoch_ms: status.started_at_epoch_ms,
             finished_at_epoch_ms: 200,
             outcome: "succeeded".to_string(),
+            auto_retry_fingerprint: None,
             exit_code: Some(0),
             wait_error: None,
             terminal_envelope: None,
@@ -1979,6 +1986,63 @@ mod tests {
     }
 
     #[test]
+    fn stale_live_repair_with_exact_identity_is_never_terminated_by_age() {
+        let project = tempfile::tempdir().expect("project");
+        let state = tempfile::tempdir().expect("state");
+        let sidecar = test_sidecar_with_run_id(state.path(), "shared-agent");
+        let status_path = ready_repair_status_path(&sidecar);
+        fs::create_dir_all(status_path.parent().expect("repair status parent")).expect("state dir");
+        #[cfg(windows)]
+        let mut child = std::process::Command::new("cmd")
+            .args(["/C", "ping -n 30 127.0.0.1 >nul"])
+            .spawn()
+            .expect("long-lived child");
+        #[cfg(unix)]
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .spawn()
+            .expect("long-lived child");
+        let pid = child.id();
+        let process_start_identity =
+            recorded_process_start_identity(pid).expect("child process start identity");
+        let old = now_epoch_ms() - READY_REPAIR_LOCK_STALE_TTL.as_millis() as i64 - 60_000;
+        let status = ReadyRepairStatus {
+            schema_version: READY_REPAIR_STATUS_SCHEMA_VERSION,
+            status: "repairing".to_string(),
+            project_root: clean_path_text(project.path()),
+            profile: "agent".to_string(),
+            run_id: Some("shared-agent".to_string()),
+            namespace: sidecar.namespace.clone(),
+            compose_project: sidecar.compose_project.clone(),
+            phase: "Embedding documents".to_string(),
+            pid,
+            attempt_id: Some("stale-live-attempt".to_string()),
+            process_start_identity: Some(process_start_identity),
+            started_at_epoch_ms: old,
+            updated_at_epoch_ms: old,
+        };
+        fs::write(
+            &status_path,
+            serde_json::to_string(&status).expect("status json"),
+        )
+        .expect("write stale live status");
+
+        assert_eq!(
+            read_stale_live_ready_repair_status(&status_path, project.path(), now_epoch_ms()),
+            Some(status),
+            "heartbeat age must remain diagnostic while exact process ownership is live"
+        );
+        assert_eq!(
+            read_abandoned_ready_repair_status(&status_path, project.path(), now_epoch_ms()),
+            None,
+            "age alone must never abandon a live exact-identity owner"
+        );
+        assert!(child.try_wait().expect("probe child").is_none());
+        child.kill().expect("stop probe child");
+        child.wait().expect("reap probe child");
+    }
+
+    #[test]
     fn dead_pid_repair_lock_is_reclaimable_immediately() {
         let project = tempfile::tempdir().expect("project");
         let state = tempfile::tempdir().expect("state");
@@ -2131,6 +2195,7 @@ mod tests {
             started_at_epoch_ms: status.started_at_epoch_ms,
             finished_at_epoch_ms: now + 1,
             outcome: "failed".to_string(),
+            auto_retry_fingerprint: None,
             exit_code: Some(17),
             wait_error: None,
             terminal_envelope: None,

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -60,6 +60,7 @@ const STDIO_STATUS_PUBLICATION_ATTEMPTS: usize = 3;
 const STDIO_RECENT_REPAIR_TTL: Duration = Duration::from_secs(30);
 const STDIO_READY_REPAIR_OUTPUT_TAIL_BYTES: usize = 32 * 1024;
 const STDIO_READY_REPAIR_RESERVATION_HEARTBEAT: Duration = Duration::from_secs(5);
+const STDIO_AUTO_REPAIR_RETRY_COOLDOWN: Duration = Duration::from_secs(60);
 const STDIO_LOCAL_REFRESH_FOREGROUND_BUDGET: Duration = Duration::from_secs(5);
 const STDIO_SOURCE_FINGERPRINT_FILE_CAP: usize = 25_000;
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
@@ -83,12 +84,12 @@ struct StdioReleaseMetadataRefreshes {
 /// telemetry on stderr so stdout remains a newline-delimited JSON stream.
 pub(crate) async fn run_stdio_server(
     runtime: Option<RuntimeContext>,
-    refresh: args::RefreshMode,
+    _refresh: args::RefreshMode,
 ) -> Result<()> {
     let stdin = tokio::io::stdin();
     let mut stdin = BufReader::new(stdin);
     let mut stdout = tokio::io::stdout();
-    let mut session = Some(StdioServerSession::new(runtime, refresh));
+    let mut session = Some(StdioServerSession::new(runtime));
     let mut queued = VecDeque::new();
     let mut active: Option<ActiveStdioRequest> = None;
     let mut stdin_closed = false;
@@ -376,23 +377,22 @@ struct StdioServerState {
     packet_cache: StdioPacketCache,
     search_cache: StdioSearchFragmentCache,
     status_cache: Option<StdioStatusCacheEntry>,
+    recent_local_refresh: Option<crate::readiness::LocalRefreshOutput>,
     recent_sidecar_repair: Option<StdioRecentSidecarRepair>,
 }
 
 struct StdioServerSession {
     runtime: Option<RuntimeContext>,
     state: StdioServerState,
-    refresh: args::RefreshMode,
     project_required: bool,
 }
 
 impl StdioServerSession {
-    fn new(runtime: Option<RuntimeContext>, refresh: args::RefreshMode) -> Self {
+    fn new(runtime: Option<RuntimeContext>) -> Self {
         Self {
             project_required: runtime.is_none(),
             runtime,
             state: StdioServerState::default(),
-            refresh,
         }
     }
 
@@ -441,7 +441,7 @@ impl StdioServerSession {
             project: project_root,
             cache_dir,
         })?;
-        runtime.ensure_open(self.refresh)?;
+        runtime.ensure_open(args::RefreshMode::None)?;
         self.runtime = Some(runtime);
         // ponytail: stdio is serialized, so retain only the active project's small caches;
         // add a bounded per-project LRU only if project switching becomes measurably hot.
@@ -571,7 +571,13 @@ fn handle_stdio_message(session: &mut StdioServerSession, line: &str) -> Option<
                 return Some(stdio_jsonrpc_error(id, -32602, error.to_string()));
             }
             let runtime = session.runtime.as_ref().expect("stdio project selected");
-            read_stdio_resource(runtime, &mut session.state, uri)
+            if stdio_resource_activates_project(uri)
+                && let Err(error) = activate_stdio_project(runtime, &mut session.state)
+            {
+                serde_json::json!({"error": format!("Unable to activate CodeStory before reading `{uri}`: {error}")})
+            } else {
+                read_stdio_resource(runtime, &mut session.state, uri)
+            }
         }
         "tools/call" => {
             let Some(name) = request
@@ -616,9 +622,16 @@ fn handle_stdio_message(session: &mut StdioServerSession, line: &str) -> Option<
                 return Some(stdio_jsonrpc_success(id, stdio_tool_call_error(&error)));
             }
             let runtime = session.runtime.as_ref().expect("stdio project selected");
-            // Status is the readiness source. Preflighting it by building another
-            // status snapshot can start a second refresh worker and turn ordinary
-            // publication churn into a spurious cache_busy response.
+            if stdio_tool_reads_publication(name)
+                && let Err(error) = activate_stdio_project(runtime, &mut session.state)
+            {
+                let error = serde_json::json!({
+                    "code": "project_activation_failed",
+                    "message": format!("Unable to activate CodeStory before running `{name}`: {error}"),
+                    "tool": name
+                });
+                return Some(stdio_jsonrpc_success(id, stdio_tool_call_error(&error)));
+            }
             if name != "status" {
                 match stdio_tool_blocked_error(runtime, &mut session.state, name) {
                     Ok(Some(error)) => {
@@ -820,6 +833,124 @@ fn stdio_tool_blocked_error(
     })))
 }
 
+fn activate_stdio_project(runtime: &RuntimeContext, state: &mut StdioServerState) -> Result<()> {
+    if stdio_workspace_mismatch(runtime).is_some() {
+        return Ok(());
+    }
+
+    let project = stdio_project_args(runtime);
+    let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
+    let summary = inspect_runtime.open_project_summary()?;
+    if crate::local_freshness_needs_refresh(&summary)
+        && crate::ready_repair_status::active_ready_repair_status(&runtime.project_root, None)
+            .is_none()
+    {
+        let (_, refresh) = wait_for_stdio_local_freshness(&project, &summary)?;
+        state.recent_local_refresh = refresh;
+    }
+
+    state.status_cache = None;
+    let status = read_stdio_status_resource_cached(runtime, state)?;
+    if stdio_agent_activation_needs_repair(&status) {
+        let fingerprint = stdio_agent_repair_input_fingerprint(&status);
+        if stdio_auto_repair_retry_blocked(
+            &runtime.project_root,
+            &fingerprint,
+            crate::ready_repair_status::now_epoch_ms(),
+            stdio_auto_repair_retry_cooldown(),
+        ) {
+            return Ok(());
+        }
+        let repair = handle_stdio_sidecar_repair(runtime, state, Some(fingerprint));
+        if let Some(error) = repair.get("error") {
+            eprintln!(
+                "[project-activation] project={} agent_repair_start_failed={error}",
+                runtime.project_root.display()
+            );
+        }
+        state.status_cache = None;
+    }
+    Ok(())
+}
+
+fn stdio_agent_repair_input_fingerprint(status: &serde_json::Value) -> String {
+    let input = serde_json::json!({
+        "server_version": status.get("server_version"),
+        "project_root": status.get("project_root"),
+        "index_publication": status.get("index_publication"),
+        "effective_index_freshness": {
+            "status": status.pointer("/effective_index_freshness/status"),
+            "changed_file_count": status.pointer("/effective_index_freshness/changed_file_count"),
+            "new_file_count": status.pointer("/effective_index_freshness/new_file_count"),
+            "removed_file_count": status.pointer("/effective_index_freshness/removed_file_count"),
+            "indexed_file_count": status.pointer("/effective_index_freshness/indexed_file_count")
+        },
+        "sidecar_retrieval": {
+            "retrieval_mode": status.pointer("/sidecar_retrieval/retrieval_mode"),
+            "degraded_reason": status.pointer("/sidecar_retrieval/degraded_reason"),
+            "manifest_generation": status.pointer("/sidecar_retrieval/manifest_generation"),
+            "manifest_input_hash": status.pointer("/sidecar_retrieval/manifest_input_hash")
+        },
+        "sidecar_policy": status.pointer("/sidecar_setup/state"),
+        "embedding_device_policy": status.get("embedding_device_policy")
+    });
+    format!(
+        "{:x}",
+        Sha256::digest(serde_json::to_vec(&input).expect("serialize repair input"))
+    )
+}
+
+fn stdio_auto_repair_retry_blocked(
+    project_root: &Path,
+    fingerprint: &str,
+    now_epoch_ms: i64,
+    cooldown: Duration,
+) -> bool {
+    crate::ready_repair_status::read_ready_repair_worker_result(project_root, None).is_some_and(
+        |result| stdio_auto_repair_result_blocks(&result, fingerprint, now_epoch_ms, cooldown),
+    )
+}
+
+fn stdio_auto_repair_result_blocks(
+    result: &crate::ready_repair_status::ReadyRepairWorkerResult,
+    fingerprint: &str,
+    now_epoch_ms: i64,
+    cooldown: Duration,
+) -> bool {
+    matches!(result.outcome.as_str(), "failed" | "abandoned")
+        && result.auto_retry_fingerprint.as_deref() == Some(fingerprint)
+        && now_epoch_ms.saturating_sub(result.finished_at_epoch_ms)
+            < cooldown.as_millis().min(i64::MAX as u128) as i64
+}
+
+fn stdio_auto_repair_retry_cooldown() -> Duration {
+    std::env::var("CODESTORY_STDIO_AUTO_REPAIR_RETRY_COOLDOWN_MS")
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(STDIO_AUTO_REPAIR_RETRY_COOLDOWN)
+}
+
+fn stdio_agent_activation_needs_repair(status: &serde_json::Value) -> bool {
+    status
+        .pointer("/sidecar_setup/state")
+        .and_then(serde_json::Value::as_str)
+        == Some("enabled")
+        && !stdio_sidecar_setup_has_active_repair(&status["sidecar_setup"])
+        && status
+            .get("readiness")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|verdicts| {
+                verdicts.iter().find(|verdict| {
+                    verdict.get("goal").and_then(serde_json::Value::as_str)
+                        == Some("agent_packet_search")
+                })
+            })
+            .and_then(|verdict| verdict.get("status"))
+            .and_then(serde_json::Value::as_str)
+            != Some("ready")
+}
+
 fn stdio_repair_calls_from_value(
     value: Option<&serde_json::Value>,
     project_root: &Path,
@@ -873,6 +1004,10 @@ fn stdio_jsonrpc_tool_call_from_legacy(
 
 fn stdio_tool_reads_publication(name: &str) -> bool {
     !matches!(name, "status" | "repair_all" | "sidecar_setup")
+}
+
+fn stdio_resource_activates_project(uri: &str) -> bool {
+    !matches!(uri, "codestory://status" | "codestory://agent-guide")
 }
 
 fn stdio_served_publication_meta(
@@ -1293,7 +1428,7 @@ fn handle_stdio_tool_call(
         "repair_all" => {
             state.status_cache = None;
             stdio_deprecated_repair_all_response(
-                handle_stdio_sidecar_repair(runtime, state),
+                handle_stdio_sidecar_repair(runtime, state, None),
                 &runtime.project_root,
             )
         }
@@ -2790,22 +2925,37 @@ fn read_stdio_status_resource_uncached(
     let summary = inspect_runtime.open_project_summary()?;
     let active_agent_repair =
         crate::ready_repair_status::active_ready_repair_status(&runtime.project_root, None);
-    let (summary, local_refresh) = if let Some(active_repair) = active_agent_repair.as_ref() {
+    let recent_local_refresh = state.recent_local_refresh.take();
+    let local_refresh = if let Some(active_repair) = active_agent_repair.as_ref() {
         if crate::local_freshness_needs_refresh(&summary) {
             let mut output = crate::local_refresh_output_from_summary(&summary);
             output.state = crate::readiness::LocalRefreshState::Refreshing;
             output.blocks_local_surfaces = true;
             output.reason = Some(format!("active_ready_repair:{}", active_repair.phase));
             crate::attach_complete_publication(&mut output, &summary);
-            (summary, Some(output))
+            Some(output)
         } else {
-            (summary, None)
+            None
         }
-    } else if crate::local_freshness_needs_refresh(&summary) {
-        wait_for_stdio_local_freshness(&project, &summary)?
     } else {
-        (summary, None)
-    };
+        crate::local_refresh_status::active_local_refresh_status(
+            &runtime.cache_root,
+            &runtime.project_root,
+        )
+        .map(|active| {
+            let mut output = crate::local_refresh_output_from_summary(&summary);
+            output.state = crate::readiness::LocalRefreshState::Refreshing;
+            output.reason = Some("refreshing".to_string());
+            output.phase = Some(active.phase);
+            output.pid = Some(active.pid);
+            output.started_at_epoch_ms = Some(active.started_at_epoch_ms);
+            output.updated_at_epoch_ms = Some(active.updated_at_epoch_ms);
+            output.last_failure_reason = active.last_failure_reason;
+            crate::attach_complete_publication(&mut output, &summary);
+            output
+        })
+    }
+    .or(recent_local_refresh);
     let index_publication = summary
         .publication
         .as_ref()
@@ -4761,7 +4911,7 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
     let prompt_required = matches!(state, "ask");
     let explicit_repair_enabled = matches!(state, "enabled");
     let repair_mode = match state {
-        "enabled" => "explicit_mcp",
+        "enabled" => "activation_or_explicit_mcp",
         "unmanaged" => "explicit_mcp_unmanaged",
         "disabled" => "disabled",
         _ => "consent_required",
@@ -4774,6 +4924,11 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
     let next_repair_command =
         env_nonempty("CODESTORY_PLUGIN_SIDECAR_NEXT_REPAIR_COMMAND").unwrap_or(default_repair);
     let active_repair = crate::ready_repair_status::active_ready_repair_status(project_root, None);
+    let stale_live_repair = active_repair
+        .as_ref()
+        .is_none()
+        .then(|| crate::ready_repair_status::stale_live_ready_repair_status(project_root, None))
+        .flatten();
     let abandoned_repair = active_repair
         .as_ref()
         .is_none()
@@ -4793,8 +4948,9 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
     serde_json::json!({
         "project": project,
         "state": state,
-        "auto_repair": false,
+        "auto_repair": explicit_repair_enabled,
         "status_triggered_repair": false,
+        "activation_triggered_repair": explicit_repair_enabled,
         "explicit_repair_enabled": explicit_repair_enabled,
         "repair_mode": repair_mode,
         "prompt_required": prompt_required,
@@ -4824,6 +4980,7 @@ pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Val
             "attempt_id": &status.attempt_id,
             "updated_at_epoch_ms": status.updated_at_epoch_ms
         })),
+        "stale_live_repair": stale_live_repair.as_ref().map(|status| stdio_ready_repair_status_json(project_root, status, "stale_live")),
         "abandoned_repair": abandoned_repair.as_ref().map(|status| stdio_ready_repair_status_json(project_root, status, "abandoned")),
         "last_worker_result": last_worker_result
     })
@@ -4869,7 +5026,7 @@ fn stdio_ready_repair_status_json(
         .run_id
         .as_deref()
         .unwrap_or(codestory_retrieval::DEFAULT_AGENT_RUN_ID);
-    serde_json::json!({
+    let mut value = serde_json::json!({
         "status": state,
         "recorded_status": &status.status,
         "project_root": &status.project_root,
@@ -4883,7 +5040,13 @@ fn stdio_ready_repair_status_json(
         "age_ms": crate::ready_repair_status::now_epoch_ms().saturating_sub(status.updated_at_epoch_ms),
         "inspect_command": stdio_agent_retrieval_status_command(project_root, run_id),
         "cleanup_command": stdio_agent_retrieval_down_command(project_root, run_id)
-    })
+    });
+    if state == "stale_live"
+        && let Some(object) = value.as_object_mut()
+    {
+        object.remove("cleanup_command");
+    }
+    value
 }
 
 fn stdio_agent_retrieval_status_command(project_root: &Path, run_id: &str) -> String {
@@ -4955,7 +5118,7 @@ fn handle_stdio_sidecar_setup(
                 }});
             }
             state.status_cache = None;
-            handle_stdio_sidecar_repair(runtime, state)
+            handle_stdio_sidecar_repair(runtime, state, None)
         }
         _ => {
             serde_json::json!({"error": "sidecar_setup.action must be status, enable, disable, ask, or repair"})
@@ -5000,6 +5163,7 @@ fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
 fn handle_stdio_sidecar_repair(
     runtime: &RuntimeContext,
     state: &mut StdioServerState,
+    auto_retry_fingerprint: Option<String>,
 ) -> serde_json::Value {
     let project = crate::display::clean_path_string(&runtime.project_root.to_string_lossy());
     if let Some(error) = stdio_workspace_mismatch_error(runtime) {
@@ -5067,20 +5231,6 @@ fn handle_stdio_sidecar_repair(
     ) {
         return stdio_sidecar_repair_machine_busy_result(busy, &sidecar_setup);
     }
-    let mut reservation = match crate::ready_repair_status::try_reserve_ready_repair(
-        &repair_sidecar,
-        &runtime.project_root,
-    ) {
-        Ok(Some(reservation)) => reservation,
-        Ok(None) => {
-            return stdio_sidecar_repair_already_starting_result(
-                &runtime.project_root,
-                &repair_sidecar,
-                &sidecar_setup,
-            );
-        }
-        Err(error) => return serde_json::json!({"error": error.to_string()}),
-    };
     let broker_reconciliation = crate::readiness_broker::reconcile_before_enqueue(
         &runtime.project_root,
         &runtime.cache_root,
@@ -5103,6 +5253,20 @@ fn handle_stdio_sidecar_repair(
     ) {
         return result;
     }
+    let mut reservation = match crate::ready_repair_status::try_reserve_ready_repair(
+        &repair_sidecar,
+        &runtime.project_root,
+    ) {
+        Ok(Some(reservation)) => reservation,
+        Ok(None) => {
+            return stdio_sidecar_repair_already_starting_result(
+                &runtime.project_root,
+                &repair_sidecar,
+                &sidecar_setup,
+            );
+        }
+        Err(error) => return serde_json::json!({"error": error.to_string()}),
+    };
     let exe = match std::env::current_exe() {
         Ok(exe) => exe,
         Err(error) => return serde_json::json!({"error": error.to_string()}),
@@ -5145,6 +5309,7 @@ fn handle_stdio_sidecar_repair(
                 runtime.project_root.clone(),
                 attempt_id.clone(),
                 repair_started_at_epoch_ms,
+                auto_retry_fingerprint,
             );
             let broker_snapshot = crate::readiness_broker::refresh_broker_snapshot(
                 crate::readiness_broker::BrokerSnapshotInput {
@@ -5205,6 +5370,7 @@ fn monitor_stdio_ready_repair_worker(
     project_root: PathBuf,
     attempt_id: String,
     started_at_epoch_ms: i64,
+    auto_retry_fingerprint: Option<String>,
 ) {
     thread::spawn(move || {
         let pid = child.id();
@@ -5256,6 +5422,7 @@ fn monitor_stdio_ready_repair_worker(
             started_at_epoch_ms,
             finished_at_epoch_ms: crate::ready_repair_status::now_epoch_ms(),
             outcome: outcome.to_string(),
+            auto_retry_fingerprint,
             exit_code,
             wait_error,
             terminal_envelope,
@@ -7781,5 +7948,69 @@ starting sidecar setup
             incomplete, finished,
             "publication identity, not volatile WAL metadata, owns status invalidation"
         );
+    }
+
+    #[test]
+    fn project_activation_respects_agent_repair_policy_and_readiness() {
+        let status = |state: &str, readiness: &str| {
+            json!({
+                "sidecar_setup": {"state": state, "active_repair": null},
+                "readiness": [{"goal": "agent_packet_search", "status": readiness}]
+            })
+        };
+
+        assert!(!stdio_tool_reads_publication("status"));
+        assert!(stdio_tool_reads_publication("ground"));
+        assert!(!stdio_resource_activates_project("codestory://status"));
+        assert!(stdio_resource_activates_project("codestory://grounding"));
+        assert!(stdio_agent_activation_needs_repair(&status(
+            "enabled", "blocked"
+        )));
+        assert!(!stdio_agent_activation_needs_repair(&status(
+            "ask", "blocked"
+        )));
+        assert!(!stdio_agent_activation_needs_repair(&status(
+            "enabled", "ready"
+        )));
+
+        let failed: crate::ready_repair_status::ReadyRepairWorkerResult =
+            serde_json::from_value(json!({
+                "schema_version": 1,
+                "attempt_id": "attempt-1",
+                "project_root": "project",
+                "profile": "agent",
+                "run_id": "shared-agent",
+                "namespace": "namespace",
+                "pid": 42,
+                "started_at_epoch_ms": 100,
+                "finished_at_epoch_ms": 200,
+                "outcome": "failed",
+                "auto_retry_fingerprint": "state-a",
+                "exit_code": 17,
+                "wait_error": null,
+                "stdout_tail": "",
+                "stderr_tail": "",
+                "stdout_truncated": false,
+                "stderr_truncated": false
+            }))
+            .expect("failed worker result");
+        assert!(stdio_auto_repair_result_blocks(
+            &failed,
+            "state-a",
+            250,
+            Duration::from_millis(100)
+        ));
+        assert!(!stdio_auto_repair_result_blocks(
+            &failed,
+            "state-b",
+            250,
+            Duration::from_millis(100)
+        ));
+        assert!(!stdio_auto_repair_result_blocks(
+            &failed,
+            "state-a",
+            300,
+            Duration::from_millis(100)
+        ));
     }
 }

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1519,7 +1519,7 @@ fn initialize_preserves_id_and_reports_server_info_and_capabilities() {
 }
 
 #[test]
-fn stdio_starts_without_prebuilt_index_and_reports_status() {
+fn stdio_status_observes_unbuilt_index_and_ground_activates_it() {
     let fixture = unindexed_fixture();
     let mut server = spawn_stdio_server(&fixture);
 
@@ -1550,9 +1550,36 @@ fn stdio_starts_without_prebuilt_index_and_reports_status() {
     let status_result = assert_success_envelope(&status_response, json!("status-unindexed"));
     let status = json_resource_content(status_result, "codestory://status");
 
-    assert_eq!(status["readiness"][0]["status"], json!("ready"));
-    assert_allowed_surface(&status, "ground", true, "local_navigation", "ready");
+    assert_eq!(status["readiness"][0]["status"], json!("repair_index"));
+    assert_allowed_surface(&status, "ground", false, "local_navigation", "repair_index");
     assert_allowed_surface(&status, "search", false, "agent_packet_search", "blocked");
+
+    let ground = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-unindexed",
+            "method": "tools/call",
+            "params": {"name": "ground", "arguments": {"budget": "strict"}}
+        }),
+    );
+    assert_tool_success(&ground, json!("ground-unindexed"));
+
+    let refreshed = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-indexed-after-ground",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let refreshed = json_resource_content(
+        assert_success_envelope(&refreshed, json!("status-indexed-after-ground")),
+        "codestory://status",
+    );
+    assert_eq!(refreshed["readiness"][0]["status"], json!("ready"));
+    assert_allowed_surface(&refreshed, "ground", true, "local_navigation", "ready");
 }
 
 #[test]
@@ -1733,23 +1760,23 @@ fn multi_project_stdio_keeps_project_embedding_endpoints_isolated_across_a_b_a()
 
     let mut server =
         spawn_multi_project_stdio_server_with_project_network_config(cache_root.path());
-    let status_request = |id: &str, project: &Path| {
+    let ground_request = |id: &str, project: &Path| {
         json!({
             "jsonrpc": "2.0",
             "id": id,
             "method": "tools/call",
-            "params": {"name": "status", "arguments": {"project": project}}
+            "params": {"name": "ground", "arguments": {"project": project, "budget": "strict"}}
         })
     };
-    writeln!(server.stdin, "{}", status_request("config-a", first.path()))
-        .expect("queue project A status");
+    writeln!(server.stdin, "{}", ground_request("config-a", first.path()))
+        .expect("queue project A activation");
     writeln!(
         server.stdin,
         "{}",
-        status_request("config-b", second.path())
+        ground_request("config-b", second.path())
     )
-    .expect("queue project B status");
-    server.stdin.flush().expect("flush A/B status requests");
+    .expect("queue project B activation");
+    server.stdin.flush().expect("flush A/B activation requests");
     assert_tool_success(&read_json(&mut server), json!("config-a"));
     assert_tool_success(&read_json(&mut server), json!("config-b"));
 
@@ -1771,7 +1798,7 @@ fn multi_project_stdio_keeps_project_embedding_endpoints_isolated_across_a_b_a()
     );
 
     assert_tool_success(
-        &send_json(&mut server, status_request("config-a-again", first.path())),
+        &send_json(&mut server, ground_request("config-a-again", first.path())),
         json!("config-a-again"),
     );
     let first_after = first_endpoint.snapshot();
@@ -3606,10 +3633,14 @@ fn resources_read_status_recommends_explicit_repair_when_policy_enabled() {
     let status = json_resource_content(result, "codestory://status");
 
     assert_eq!(status["sidecar_setup"]["state"], json!("enabled"));
-    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
+    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(true));
     assert_eq!(
         status["sidecar_setup"]["status_triggered_repair"],
         json!(false)
+    );
+    assert_eq!(
+        status["sidecar_setup"]["activation_triggered_repair"],
+        json!(true)
     );
     assert_eq!(
         status["sidecar_setup"]["explicit_repair_enabled"],
@@ -3617,7 +3648,7 @@ fn resources_read_status_recommends_explicit_repair_when_policy_enabled() {
     );
     assert_eq!(
         status["sidecar_setup"]["repair_mode"],
-        json!("explicit_mcp")
+        json!("activation_or_explicit_mcp")
     );
     let sidecar_repair_command = status["sidecar_setup"]["next_repair_command"]
         .as_str()
@@ -3663,6 +3694,106 @@ fn resources_read_status_recommends_explicit_repair_when_policy_enabled() {
         !next_call_text.contains("\"method\":\"cli\""),
         "enabled policy should not expose CLI as the normal repair path: {status}"
     );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn ground_activation_enqueues_enabled_agent_repair() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("enabled".to_string());
+    fixture.ready_repair_worker_probe_exit_code = Some(0);
+    let canonical_root =
+        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
+    let result_path =
+        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+            .layout
+            .state_file
+            .with_file_name("ready-repair-result.json");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-auto-agent-repair",
+            "method": "tools/call",
+            "params": {"name": "ground", "arguments": {"budget": "strict"}}
+        }),
+    );
+    assert_tool_success(&response, json!("ground-auto-agent-repair"));
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !result_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "enabled grounding activation did not enqueue the broker-backed worker"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    let result: Value = serde_json::from_str(
+        &fs::read_to_string(&result_path).expect("automatic repair worker result"),
+    )
+    .expect("automatic repair worker result json");
+    assert_eq!(result["outcome"], json!("succeeded"), "{result}");
+    assert_eq!(
+        result["run_id"],
+        json!(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn repeated_grounding_cools_down_identical_failed_agent_repair_across_servers() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("enabled".to_string());
+    fixture.ready_repair_worker_probe_exit_code = Some(17);
+    let canonical_root =
+        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
+    let result_path =
+        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID)
+            .layout
+            .state_file
+            .with_file_name("ready-repair-result.json");
+
+    let ground = |server: &mut StdioServer, id: &str| {
+        let response = send_json(
+            server,
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "tools/call",
+                "params": {"name": "ground", "arguments": {"budget": "strict"}}
+            }),
+        );
+        assert_tool_success(&response, json!(id));
+    };
+    let mut first_server = spawn_stdio_server(&fixture);
+    ground(&mut first_server, "ground-failed-repair-first");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !result_path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "first automatic repair did not finish"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    let first: Value = serde_json::from_str(
+        &fs::read_to_string(&result_path).expect("first automatic repair result"),
+    )
+    .expect("first automatic repair result json");
+    assert_eq!(first["outcome"], json!("failed"), "{first}");
+    assert!(first["auto_retry_fingerprint"].is_string(), "{first}");
+    let first_attempt = first["attempt_id"].clone();
+    drop(first_server);
+
+    let mut second_server = spawn_stdio_server(&fixture);
+    ground(&mut second_server, "ground-failed-repair-second");
+    thread::sleep(Duration::from_millis(250));
+    let second: Value = serde_json::from_str(
+        &fs::read_to_string(&result_path).expect("cooled-down automatic repair result"),
+    )
+    .expect("cooled-down automatic repair result json");
+    assert_eq!(second["attempt_id"], first_attempt, "{second}");
 }
 
 #[test]
@@ -4100,6 +4231,75 @@ fn tools_call_sidecar_setup_records_successful_worker_terminal_state() {
             .state_file
             .with_file_name("ready-repair-status.json")
             .exists()
+    );
+}
+
+#[test]
+fn resources_read_status_surfaces_stale_live_repair_without_mutation() {
+    let mut fixture = indexed_fixture();
+    fixture.sidecar_policy_state = Some("enabled".to_string());
+    let status_path = write_stale_live_repair_status_fixture(
+        &fixture,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+        "Embedding documents",
+    );
+    let status_before = fs::read(&status_path).expect("stale-live status before read");
+    let state_dir = status_path.parent().expect("status parent");
+    let reservation_path = state_dir.join("ready-repair-enqueue.lock");
+    let result_path = state_dir.join("ready-repair-result.json");
+    let mut server = spawn_stdio_server(&fixture);
+
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-stale-live-observational",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let status = json_resource_content(
+        assert_success_envelope(&response, json!("status-stale-live-observational")),
+        "codestory://status",
+    );
+
+    assert_eq!(
+        status["sidecar_setup"]["stale_live_repair"]["status"],
+        json!("stale_live"),
+        "{status}"
+    );
+    assert_eq!(
+        status["sidecar_setup"]["stale_live_repair"]["pid"],
+        json!(std::process::id()),
+        "{status}"
+    );
+    assert_eq!(
+        status["sidecar_setup"]["stale_live_repair"]["phase"],
+        json!("Embedding documents"),
+        "{status}"
+    );
+    assert!(
+        status["sidecar_setup"]["stale_live_repair"]
+            .get("cleanup_command")
+            .is_none(),
+        "live ownership must not expose destructive cleanup guidance: {status}"
+    );
+    assert!(
+        status["sidecar_setup"]["stale_live_repair"]["inspect_command"].is_string(),
+        "stale-live evidence should retain read-only inspection guidance: {status}"
+    );
+    assert_eq!(
+        fs::read(&status_path).expect("stale-live status after read"),
+        status_before,
+        "status read must not rewrite stale-live ownership"
+    );
+    assert!(
+        !reservation_path.exists(),
+        "status read must not reserve repair"
+    );
+    assert!(
+        !result_path.exists(),
+        "status read must not record a worker result"
     );
 }
 
@@ -4776,7 +4976,7 @@ fn local_dev_override_does_not_recommend_restart_for_managed_history() {
 }
 
 #[test]
-fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded_latency() {
+fn status_observes_staleness_and_ground_activates_bounded_local_refresh() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);
     let warmup = send_json(
@@ -4813,6 +5013,40 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
     fs::remove_file(fixture.workspace.path().join("src").join("alpha.rs"))
         .expect("remove indexed file after indexing");
 
+    let stale = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-observes-stale",
+            "method": "resources/read",
+            "params": {"uri": "codestory://status"}
+        }),
+    );
+    let stale = json_resource_content(
+        assert_success_envelope(&stale, json!("status-observes-stale")),
+        "codestory://status",
+    );
+    assert_eq!(
+        find_index_freshness(&stale).and_then(|freshness| freshness.get("status")),
+        Some(&json!("stale")),
+        "status must observe source drift without repairing it: {stale}"
+    );
+    assert!(
+        !fixture.cache_dir.path().join("local-refresh.lock").exists(),
+        "status must not acquire refresh ownership"
+    );
+
+    let activation = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "ground-activates-refresh",
+            "method": "tools/call",
+            "params": {"name": "ground", "arguments": {"budget": "strict"}}
+        }),
+    );
+    assert_tool_success(&activation, json!("ground-activates-refresh"));
+
     let refresh_deadline = Instant::now() + Duration::from_secs(15);
     let mut refresh_attempt = 0;
     let refreshed_status = loop {
@@ -4821,7 +5055,7 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
             &mut server,
             json!({
                 "jsonrpc": "2.0",
-                "id": id,
+                "id": id.clone(),
                 "method": "resources/read",
                 "params": {"uri": "codestory://status"}
             }),
@@ -4846,7 +5080,7 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
     assert_eq!(
         refreshed_status["local_refresh"]["reason"],
         json!("refreshed"),
-        "long-lived status must not return the cached warm freshness result after source mutation: {refreshed_status}"
+        "ground activation must invalidate the cached warm freshness result: {refreshed_status}"
     );
     assert_eq!(
         refreshed_status["local_refresh"]["blocks_local_surfaces"],
@@ -4872,7 +5106,9 @@ fn background_local_refresh_status_refreshes_long_lived_stale_index_with_bounded
 
     let mut elapsed = Vec::new();
     let mut last_status = refreshed_status;
-    for index in 0..12 {
+    // Twenty samples are the minimum where this nearest-rank p95 is not just
+    // the single maximum scheduler outlier under the full parallel suite.
+    for index in 0..20 {
         let started = Instant::now();
         let response = send_json(
             &mut server,
@@ -5190,7 +5426,7 @@ fn two_stdio_processes_observe_only_complete_generations_during_real_refresh() {
                 "jsonrpc": "2.0",
                 "id": "writer-start-refresh",
                 "method": "tools/call",
-                "params": {"name": "status", "arguments": {}}
+                "params": {"name": "ground", "arguments": {"budget": "strict"}}
             }),
         );
         (writer_client, response)

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -145,7 +145,7 @@ More pairs, anti-patterns, and language-flavored examples:
 | Status shows `runtime_update.state=available` | Current compatible surfaces keep working; reload when convenient if `restart_recommended=true` |
 | Status shows `repair_setup` | The active runtime could not start or prove compatibility; follow `recommended_next_calls` |
 | Windows terminal refresh says `Access is denied` | Quit stale Codex windows running the old plugin, then refresh from `/plugins` or rerun `codex.cmd plugin add codestory@TheGreenCedar` |
-| Packet/search blocked | Follow `recommended_next_calls`; status reads do not spawn repair, so explicit MCP repair is required when recommended; see [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
+| Packet/search blocked | Follow `recommended_next_calls`. Status reads are observational. A grounding/project tool activation starts or attaches local refresh and automatically enqueues agent repair only when the installed sidecar policy is already enabled; otherwise explicit MCP confirmation/repair remains required. See [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
 | Status/grounding call times out | If status remains visible, reread it and follow its bounded blocker/next call; do not kill or restart managed MCP for index or sidecar readiness. Reload only for host transport/registration failure, plugin/config replacement, or a runtime update whose status says `restart_recommended=true` |
 
 ### Managed platform matrix

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -5,6 +5,15 @@ is the first and canonical runtime truth. Call it before `ground`, `files`,
 `packet`, or `search`, and pass the same project to every tool. The server has no
 global workspace binding.
 
+Status is observational: it reports freshness, active ownership, policy, and
+proof without starting work. Calling a project tool such as `ground` activates
+the selected project, starts or attaches its local refresh, and may enqueue the
+existing broker-backed agent repair when sidecar policy is already enabled.
+Failed automatic repairs are cooldown-gated until the relevant project or
+sidecar state changes. A stale heartbeat from a still-live owner remains
+fail-closed because suspension or starvation is not proof of abandonment;
+CodeStory never terminates a repair process based only on heartbeat age.
+
 Reuse a status result until repository, runtime, or index state changes, or a
 tool reports stale evidence or a freshness failure. A blocked sidecar-backed
 surface does not invalidate an allowed local graph route.
@@ -22,6 +31,7 @@ surface does not invalidate an allowed local graph route.
 | `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `managed_unavailable` as blocked managed setup. |
 | `runtime_truth` | Grouped runtime source, plugin root, managed CLI path, launcher source, and references to canonical readiness fields. | Use as the concise bounded runtime identity summary. Follow its `*_ref` fields into top-level status instead of expecting cloned readiness payloads. |
 | `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Diagnostic sidecar policy detail. For agent repair, follow `recommended_next_calls` and prefer MCP `sidecar_setup` with `action=repair`. |
+| `sidecar_setup.stale_live_repair` | Read-only evidence for a repair whose heartbeat is stale while its recorded process is still live. | Treat it as unresolved ownership. Do not infer abandonment from age, start another repair, or terminate the owner. |
 | `readiness_broker` | Durable repair, local refresh, native embedding resource ownership, stale-lock reconciliation, persistence status, and GPU proof (`proof_status`, `embed_smoke_ok`, `embed_smoke_ms`). | Inspect before retrying repair. A foreign or unverifiable `native_embedding_runtime` busy state blocks repair; a same-project reusable native owner should be followed through `recommended_next_calls`. `gpu_proof.proof_status == "verified"` and `gpu_proof.meaningful_accelerator_work_proven == true` require observed acceleration plus a live timed embed smoke when accelerator is required. |
 | `index_publication` | Durable identity of the complete core database generation currently served at the live path. It is null when the live database is fenced by an incomplete legacy run. | Use its generation, generation ID, run ID, mode, and publication time to distinguish old-or-new complete reads during refresh. |
 | `local_refresh` | Single-flight local refresh state and owner metadata. While `state=refreshing`, `serving_publication` identifies the last complete generation that remains readable. | Continue using local surfaces whose allowed bit is true. Do not treat staged work as live. Read tool-call `_meta.codestory_publication` identifies the exact complete response generation; `served_from=last_complete_publication` means a writer was refreshing concurrently. |


### PR DESCRIPTION
## Context

#897 requires grounding-owned readiness convergence without turning status into a mutating repair command. This PR closes the bounded activation/cooldown child; it deliberately does not claim safe replacement of a stale-but-live owner or live managed-plugin packet/search convergence, which remain in #997 and the parent.

Closes #1001
Refs #897
Refs #997
Refs #899

## What Changed

- Keep dynamic project selection and canonical status observational; publication-backed project activation owns local refresh start/attach.
- With enabled policy, enqueue one project-scoped shared-agent readiness repair through the existing broker; ask/disabled policy does not auto-enqueue.
- Persist stable readiness-input fingerprints for automatic terminal failures and cooldown identical retries across new MCP runtimes; state changes or cooldown expiry allow one retry, while explicit repair remains explicit.
- Preserve stale-live repair owners fail-closed and never terminate or abandon them based on heartbeat age.
- Expose stale-live ownership in canonical status read-only, with inspection guidance but no destructive cleanup command.
- Reset activation state across A/B/A project switches to preserve request-scoped roots, namespaces, and operations.

## How To Review

Review project selection versus activation first, then the automatic repair decision/fingerprint/cooldown path. Finally inspect the stale-live status serialization and non-mutation contract. Safe fencing/replacement of a live stale owner is intentionally not implemented here.

## Verification

- Focused activation, policy, refresh-budget, multi-project A/B/A, cross-server cooldown, stale-live preservation, and real two-process publication tests passed.
- Post-rebase canonical status resource contract passed and proves no ownership/reservation/result mutation.
- `cargo clippy -p codestory-cli --all-targets --all-features -- -D warnings` passed after rebase.
- Docs links, formatting, and diff checks passed.
- Three independent review rounds caught and drove fixes for stale-live deadlock, retry storms, unsafe age-based termination, hidden stale-live status, and destructive cleanup guidance; final review is clean.

## Risk

A stale-but-live repair remains fail-closed because heartbeat age alone cannot prove abandonment safely. #997 retains the installed managed-plugin, multi-platform, accelerator, and stale-local/missing-sidecar convergence proof. This PR does not open packet/search without the existing freshness and accelerator evidence.