### PR TITLE
[codex] make sidecar manifest promotion atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Made sidecar generation fingerprinting snapshot-coherent and current-manifest
+  promotion fail closed when any graph, semantic, or lexical input changes
+  during a build. Filesystem input is hashed before locking SQLite; final stored
+  input validation and pointer replacement commit in one immediate transaction.
 - Renewed live local-refresh ownership during long incremental indexing, with
   token, PID, and process-start checks that prevent stale workers from
   overwriting changed ownership or terminal status.

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -7,7 +7,8 @@ use crate::generation::{
 };
 use crate::health::probe_sidecar_health_for_runtime;
 use crate::lexical_index::{
-    LEXICAL_INDEX_VERSION, LexicalInputFingerprint, build_lexical_shard, lexical_input_fingerprint,
+    LEXICAL_INDEX_VERSION, LexicalInputFingerprint, build_lexical_shard,
+    finish_lexical_input_for_store, lexical_source_input,
 };
 use crate::qdrant_client::{QDRANT_INDEX_UPSERT_BATCH_SIZE, QdrantClient, QdrantUpsertPoint};
 use crate::retention::{
@@ -73,7 +74,6 @@ struct SidecarStubFlags {
 
 struct LexicalGenerationOutcome {
     version: String,
-    rebuilt_fingerprint: Option<LexicalInputFingerprint>,
 }
 
 struct GenerationRetentionContext<'a> {
@@ -247,15 +247,22 @@ pub fn finalize_index_for_runtime_with_progress(
     let mut storage =
         Store::open(storage_path).context("open storage for retrieval sidecar input")?;
     ensure_search_symbol_projection(&mut storage)?;
-    let sidecar_input = compute_sidecar_input_fingerprint_for_runtime(
-        &storage,
-        storage_path,
+    let lexical_source = lexical_source_input(project_root).context("hash lexical source input")?;
+    let input_snapshot = storage
+        .read_snapshot()
+        .context("open coherent sidecar input snapshot")?;
+    let sidecar_input = compute_sidecar_input_fingerprint_with_lexical_source(
+        input_snapshot.storage(),
         project_root,
         &project_id,
         &embedding_backend,
         embedding_dim,
         &runtime.embedding,
+        lexical_source,
     )?;
+    input_snapshot
+        .finish()
+        .context("finish coherent sidecar input snapshot")?;
     let previous_manifest = storage
         .get_retrieval_index_manifest(&project_id)
         .context("load previous retrieval_index_manifest")?;
@@ -313,7 +320,6 @@ pub fn finalize_index_for_runtime_with_progress(
                                 qdrant_stubbed,
                                 scip_stubbed,
                             },
-                            None,
                         );
                     }
                 }
@@ -337,7 +343,6 @@ pub fn finalize_index_for_runtime_with_progress(
                         qdrant_stubbed,
                         scip_stubbed,
                     },
-                    None,
                 );
             }
             warn!(
@@ -414,7 +419,6 @@ pub fn finalize_index_for_runtime_with_progress(
                     qdrant_stubbed,
                     scip_stubbed,
                 },
-                None,
             );
         }
     }
@@ -479,7 +483,6 @@ pub fn finalize_index_for_runtime_with_progress(
                 scip_stubbed,
             },
             &embedding_device,
-            lexical_outcome.rebuilt_fingerprint.as_ref(),
         )
     })
 }
@@ -502,7 +505,6 @@ fn ensure_lexical_generation(
     sidecar_input_hash: &str,
     mut lexical_ready: bool,
 ) -> Result<LexicalGenerationOutcome> {
-    let mut rebuilt_fingerprint = None;
     if lexical_ready {
         info!(sidecar_generation = %generation, "SQLite lexical shard reused");
     } else {
@@ -514,9 +516,8 @@ fn ensure_lexical_generation(
             expected,
             sidecar_input_hash,
         ) {
-            Ok(rebuilt) => {
+            Ok(_) => {
                 lexical_ready = true;
-                rebuilt_fingerprint = Some(rebuilt);
                 info!(sidecar_generation = %generation, "SQLite lexical shard built");
             }
             Err(error) => {
@@ -537,7 +538,6 @@ fn ensure_lexical_generation(
     }
     Ok(LexicalGenerationOutcome {
         version: LEXICAL_INDEX_VERSION.to_string(),
-        rebuilt_fingerprint,
     })
 }
 
@@ -719,7 +719,6 @@ fn finalize_manifest_after_health_check(
     degraded_modes: Vec<String>,
     stub_flags: SidecarStubFlags,
     embedding_device: &crate::embeddings::EmbeddingDeviceReadiness,
-    rebuilt_lexical_input: Option<&LexicalInputFingerprint>,
 ) -> Result<FinalizeIndexOutcome> {
     let generation = manifest
         .sidecar_generation
@@ -765,38 +764,7 @@ fn finalize_manifest_after_health_check(
         manifest,
         degraded_modes,
         stub_flags,
-        rebuilt_lexical_input,
     )
-}
-
-fn ensure_lexical_input_unchanged(
-    project_root: &Path,
-    storage_path: &Path,
-    expected: &SidecarInputFingerprint,
-) -> Result<()> {
-    let current = lexical_input_fingerprint(project_root, Some(storage_path))?;
-    if current.file_count != expected.lexical_file_count || current.hash != expected.lexical_hash {
-        bail!("lexical input changed before sidecar manifest publication");
-    }
-    Ok(())
-}
-
-fn ensure_lexical_freshness_for_publication(
-    project_root: &Path,
-    storage_path: &Path,
-    expected: &SidecarInputFingerprint,
-    rebuilt: Option<&LexicalInputFingerprint>,
-) -> Result<()> {
-    if let Some(rebuilt) = rebuilt {
-        if rebuilt.file_count == expected.lexical_file_count
-            && rebuilt.hash == expected.lexical_hash
-            && rebuilt.coverage == expected.lexical_coverage
-        {
-            return Ok(());
-        }
-        bail!("rebuilt lexical fingerprint does not match sidecar input");
-    }
-    ensure_lexical_input_unchanged(project_root, storage_path, expected)
 }
 
 #[allow(dead_code)] // Phase 2 cache keys
@@ -937,32 +905,38 @@ fn persist_finalized_manifest(
     mut manifest: RetrievalIndexManifest,
     degraded_modes: Vec<String>,
     stub_flags: SidecarStubFlags,
-    rebuilt_lexical_input: Option<&LexicalInputFingerprint>,
 ) -> Result<FinalizeIndexOutcome> {
     manifest.built_at_epoch_ms = Utc::now().timestamp_millis();
     manifest.degraded_modes_json =
         serde_json::to_string(&degraded_modes).unwrap_or_else(|_| "[]".into());
+    let lexical_source = lexical_source_input(project_root).context("hash lexical source input")?;
     let mut storage = Store::open(storage_path).context("open storage for retrieval manifest")?;
-    if let Some(reason) = manifest_unavailable_reason_for_runtime(
-        &project_id,
-        &storage,
-        &manifest,
-        retention_context.runtime,
-    ) {
-        bail!(
-            "mandatory retrieval sidecar manifest would be unavailable immediately for {project_id}: {reason}"
-        );
-    }
-    ensure_lexical_freshness_for_publication(
-        project_root,
-        storage_path,
-        sidecar_input,
-        rebuilt_lexical_input,
-    )?;
-    storage
-        .upsert_retrieval_index_manifest(&manifest)
-        .context("persist retrieval_index_manifest")?;
-    drop(storage);
+    let embedding_backend =
+        crate::embeddings::embedding_runtime_id_for_runtime(retention_context.runtime);
+    let embedding_dim = i32::try_from(crate::embeddings::qdrant_vector_dim())
+        .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
+    promote_retrieval_manifest(&mut storage, sidecar_input, &manifest, |storage| {
+        let current_input = compute_sidecar_input_fingerprint_with_lexical_source(
+            storage,
+            project_root,
+            &project_id,
+            &embedding_backend,
+            embedding_dim,
+            &retention_context.runtime.embedding,
+            lexical_source,
+        )?;
+        if let Some(reason) = manifest_unavailable_reason_for_runtime(
+            &project_id,
+            storage,
+            &manifest,
+            retention_context.runtime,
+        ) {
+            bail!(
+                "mandatory retrieval sidecar manifest would be unavailable immediately for {project_id}: {reason}"
+            );
+        }
+        Ok(current_input)
+    })?;
 
     let (generation_retention_plan, generation_retention) =
         retain_published_generations(storage_path, retention_context, &project_id, &manifest);
@@ -985,6 +959,36 @@ fn persist_finalized_manifest(
         generation_retention_plan,
         generation_retention,
     })
+}
+
+fn ensure_sidecar_input_unchanged(
+    expected: &SidecarInputFingerprint,
+    current: &SidecarInputFingerprint,
+) -> Result<()> {
+    if current != expected {
+        bail!("sidecar generation input changed before manifest publication");
+    }
+    Ok(())
+}
+
+fn promote_retrieval_manifest(
+    storage: &mut Store,
+    expected: &SidecarInputFingerprint,
+    manifest: &RetrievalIndexManifest,
+    current_input: impl FnOnce(&Store) -> Result<SidecarInputFingerprint>,
+) -> Result<()> {
+    let mut publication = storage
+        .write_transaction()
+        .context("lock sidecar input and manifest publication")?;
+    let current = current_input(publication.storage())?;
+    ensure_sidecar_input_unchanged(expected, &current)?;
+    publication
+        .storage_mut()
+        .upsert_retrieval_index_manifest(manifest)
+        .context("persist retrieval_index_manifest")?;
+    publication
+        .finish()
+        .context("commit retrieval manifest publication")
 }
 
 fn retain_published_generations(
@@ -1104,15 +1108,36 @@ pub(crate) fn compute_sidecar_input_fingerprint(
 
 pub(crate) fn compute_sidecar_input_fingerprint_for_runtime(
     storage: &Store,
-    storage_path: &Path,
+    _storage_path: &Path,
     project_root: &Path,
     project_id: &str,
     embedding_backend: &str,
     embedding_dim: i32,
     embedding: &crate::config::EmbeddingRuntimeConfig,
 ) -> Result<SidecarInputFingerprint> {
-    let lexical = lexical_input_fingerprint(project_root, Some(storage_path))
-        .context("hash lexical sidecar input")?;
+    let lexical_source = lexical_source_input(project_root).context("hash lexical source input")?;
+    compute_sidecar_input_fingerprint_with_lexical_source(
+        storage,
+        project_root,
+        project_id,
+        embedding_backend,
+        embedding_dim,
+        embedding,
+        lexical_source,
+    )
+}
+
+fn compute_sidecar_input_fingerprint_with_lexical_source(
+    storage: &Store,
+    project_root: &Path,
+    project_id: &str,
+    embedding_backend: &str,
+    embedding_dim: i32,
+    embedding: &crate::config::EmbeddingRuntimeConfig,
+    lexical_source: crate::lexical_index::LexicalSourceInput,
+) -> Result<SidecarInputFingerprint> {
+    let lexical = finish_lexical_input_for_store(lexical_source, project_root, storage)
+        .context("hash lexical symbol input")?;
     let mut hasher = Sha256::new();
     let mut graph_hasher = Sha256::new();
     hash_part(&mut hasher, "codestory-sidecar-input-v5");
@@ -1463,47 +1488,6 @@ mod tests {
     }
 
     #[test]
-    fn just_built_lexical_fingerprint_skips_only_the_redundant_final_scan() {
-        let expected = SidecarInputFingerprint {
-            hash: "sidecar".into(),
-            symbol_doc_count: 0,
-            projection_count: 0,
-            dense_projection_count: 0,
-            semantic_policy_version: None,
-            graph_artifact_hash: "graph".into(),
-            dense_reason_counts_json: "{}".into(),
-            lexical_file_count: 0,
-            lexical_hash: "lexical".into(),
-            lexical_coverage: Default::default(),
-        };
-        let rebuilt = LexicalInputFingerprint {
-            file_count: 0,
-            hash: "lexical".into(),
-            coverage: Default::default(),
-        };
-        let root = TempDir::new().expect("root");
-        let missing = root.path().join("missing");
-
-        ensure_lexical_freshness_for_publication(
-            &missing,
-            Path::new("missing.db"),
-            &expected,
-            Some(&rebuilt),
-        )
-        .expect("matching just-built fingerprint avoids a third scan");
-        assert!(
-            ensure_lexical_freshness_for_publication(
-                &missing,
-                Path::new("missing.db"),
-                &expected,
-                None,
-            )
-            .is_err(),
-            "reused shards must retain the final freshness scan"
-        );
-    }
-
-    #[test]
     fn qdrant_semantic_smoke_gate_succeeds_first_attempt() {
         let mut calls = 0usize;
         ensure_qdrant_semantic_smoke_with(
@@ -1838,7 +1822,7 @@ mod tests {
     }
 
     #[test]
-    fn sidecar_input_hash_changes_when_embedding_values_change() {
+    fn manifest_promotion_rejects_same_count_content_drift_and_preserves_current() {
         let project = TempDir::new().expect("project dir");
         std::fs::write(project.path().join("lib.rs"), "pub fn do_work() {}\n")
             .expect("project file");
@@ -1886,10 +1870,23 @@ mod tests {
             crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
         )
         .expect("first fingerprint");
-        doc.embedding[0] = 0.02;
+        let old_manifest = retrieval_manifest_for_sidecar(
+            "proj",
+            &sidecar_generation_id("proj", &first.hash),
+            &crate::generation::sidecar_qdrant_collection("proj", &first.hash),
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            &first,
+        );
         storage
+            .upsert_retrieval_index_manifest(&old_manifest)
+            .expect("old manifest");
+        doc.embedding[0] = 0.02;
+        let mut concurrent = Store::open(&storage_path).expect("concurrent store");
+        concurrent
             .upsert_llm_symbol_docs_batch(&[doc])
             .expect("second doc");
+        drop(concurrent);
         let second = compute_sidecar_input_fingerprint(
             &storage,
             &storage_path,
@@ -1905,6 +1902,64 @@ mod tests {
         assert_eq!(first.dense_projection_count, 1);
         assert_eq!(first.dense_reason_counts_json, "{\"public_api\":1}");
         assert_ne!(first.hash, second.hash);
+
+        let mut rejected_manifest = retrieval_manifest_for_sidecar(
+            "proj",
+            &sidecar_generation_id("proj", &first.hash),
+            &crate::generation::sidecar_qdrant_collection("proj", &first.hash),
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            &first,
+        );
+        rejected_manifest.built_at_epoch_ms += 1;
+        let lexical_source = lexical_source_input(project.path()).expect("lexical source");
+        let rejected =
+            promote_retrieval_manifest(&mut storage, &first, &rejected_manifest, |snapshot| {
+                compute_sidecar_input_fingerprint_with_lexical_source(
+                    snapshot,
+                    project.path(),
+                    "proj",
+                    crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+                    crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+                    &crate::config::SidecarRuntimeConfig::local().embedding,
+                    lexical_source,
+                )
+            });
+        assert!(rejected.is_err());
+        assert_eq!(
+            storage
+                .get_retrieval_index_manifest("proj")
+                .expect("current manifest"),
+            Some(old_manifest)
+        );
+
+        let new_manifest = retrieval_manifest_for_sidecar(
+            "proj",
+            &sidecar_generation_id("proj", &second.hash),
+            &crate::generation::sidecar_qdrant_collection("proj", &second.hash),
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            &second,
+        );
+        let lexical_source = lexical_source_input(project.path()).expect("lexical source");
+        promote_retrieval_manifest(&mut storage, &second, &new_manifest, |snapshot| {
+            compute_sidecar_input_fingerprint_with_lexical_source(
+                snapshot,
+                project.path(),
+                "proj",
+                crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+                crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+                &crate::config::SidecarRuntimeConfig::local().embedding,
+                lexical_source,
+            )
+        })
+        .expect("unchanged input promotes manifest");
+        assert_eq!(
+            storage
+                .get_retrieval_index_manifest("proj")
+                .expect("current manifest"),
+            Some(new_manifest)
+        );
     }
 
     fn insert_matching_semantic_doc(storage: &mut Store, project_root: &Path) {

--- a/crates/codestory-retrieval/src/lexical_index.rs
+++ b/crates/codestory-retrieval/src/lexical_index.rs
@@ -123,6 +123,13 @@ pub struct LexicalHit {
     pub score: f32,
 }
 
+pub(crate) struct LexicalSourceInput {
+    hasher: Sha256,
+    file_count: u32,
+    coverage: LexicalCoverage,
+}
+
+#[cfg(test)]
 pub fn lexical_input_fingerprint(
     project_root: &Path,
     storage_path: Option<&Path>,
@@ -138,6 +145,38 @@ pub fn lexical_input_fingerprint(
         file_count,
         hash: finish_lexical_documents_hash(hasher, &coverage),
         coverage,
+    })
+}
+
+pub(crate) fn lexical_source_input(project_root: &Path) -> Result<LexicalSourceInput> {
+    let mut hasher = lexical_documents_hasher();
+    let mut file_count = 0_u32;
+    let coverage = scan_lexical_documents(project_root, None, &mut |document| {
+        hash_lexical_document(&mut hasher, document);
+        file_count = file_count.saturating_add(1);
+        Ok(())
+    })?;
+    Ok(LexicalSourceInput {
+        hasher,
+        file_count,
+        coverage,
+    })
+}
+
+pub(crate) fn finish_lexical_input_for_store(
+    mut source: LexicalSourceInput,
+    project_root: &Path,
+    storage: &Store,
+) -> Result<LexicalInputFingerprint> {
+    scan_symbol_documents_from_store(project_root, storage, &mut |document| {
+        hash_lexical_document(&mut source.hasher, document);
+        source.file_count = source.file_count.saturating_add(1);
+        Ok(())
+    })?;
+    Ok(LexicalInputFingerprint {
+        file_count: source.file_count,
+        hash: finish_lexical_documents_hash(source.hasher, &source.coverage),
+        coverage: source.coverage,
     })
 }
 
@@ -845,6 +884,14 @@ fn scan_symbol_documents(
         return Ok(());
     };
     let storage = Store::open(storage_path).context("open storage for lexical symbol docs")?;
+    scan_symbol_documents_from_store(project_root, &storage, visit)
+}
+
+fn scan_symbol_documents_from_store(
+    project_root: &Path,
+    storage: &Store,
+    visit: &mut dyn FnMut(&LexicalDocument) -> Result<()>,
+) -> Result<()> {
     let mut after = None;
     loop {
         let batch = storage

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -404,6 +404,12 @@ pub struct StorageReadSnapshot<'a> {
     active: bool,
 }
 
+/// One exclusive write view used when validation and publication must commit together.
+pub struct StorageWriteTransaction<'a> {
+    storage: &'a mut Storage,
+    active: bool,
+}
+
 impl StorageReadSnapshot<'_> {
     pub fn storage(&self) -> &Storage {
         self.storage
@@ -417,6 +423,30 @@ impl StorageReadSnapshot<'_> {
 }
 
 impl Drop for StorageReadSnapshot<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = self.storage.conn.execute_batch("ROLLBACK");
+        }
+    }
+}
+
+impl StorageWriteTransaction<'_> {
+    pub fn storage(&self) -> &Storage {
+        self.storage
+    }
+
+    pub fn storage_mut(&mut self) -> &mut Storage {
+        self.storage
+    }
+
+    pub fn finish(mut self) -> Result<(), StorageError> {
+        self.storage.conn.execute_batch("COMMIT")?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for StorageWriteTransaction<'_> {
     fn drop(&mut self) {
         if self.active {
             let _ = self.storage.conn.execute_batch("ROLLBACK");
@@ -1161,6 +1191,14 @@ impl Storage {
     pub fn read_snapshot(&self) -> Result<StorageReadSnapshot<'_>, StorageError> {
         self.conn.execute_batch("BEGIN DEFERRED TRANSACTION")?;
         Ok(StorageReadSnapshot {
+            storage: self,
+            active: true,
+        })
+    }
+
+    pub fn write_transaction(&mut self) -> Result<StorageWriteTransaction<'_>, StorageError> {
+        self.conn.execute_batch("BEGIN IMMEDIATE TRANSACTION")?;
+        Ok(StorageWriteTransaction {
             storage: self,
             active: true,
         })

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rusqlite::OptionalExtension;
 
 #[test]
 fn file_role_classification_ignores_materialized_repo_cache_prefix() {
@@ -35,6 +36,49 @@ fn unique_temp_db_path(label: &str) -> PathBuf {
         "codestory-store-{label}-{}-{stamp}.sqlite",
         std::process::id()
     ))
+}
+
+#[test]
+fn write_transaction_commits_or_rolls_back_as_one_unit() {
+    let path = unique_temp_db_path("write-transaction");
+    let mut storage = Storage::open(&path).expect("open storage");
+
+    {
+        let mut transaction = storage.write_transaction().expect("begin transaction");
+        transaction
+            .storage_mut()
+            .conn
+            .execute("CREATE TABLE publication_probe (value INTEGER)", [])
+            .expect("create rollback probe");
+    }
+    assert!(
+        storage
+            .conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'publication_probe'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .expect("query rollback probe")
+            .is_none()
+    );
+
+    let mut transaction = storage.write_transaction().expect("begin transaction");
+    transaction
+        .storage_mut()
+        .conn
+        .execute("CREATE TABLE publication_probe (value INTEGER)", [])
+        .expect("create commit probe");
+    transaction.finish().expect("commit transaction");
+    assert!(
+        storage
+            .conn
+            .execute("DROP TABLE publication_probe", [])
+            .is_ok()
+    );
+    drop(storage);
+    let _ = std::fs::remove_file(path);
 }
 
 #[test]

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -100,6 +100,12 @@ dense reason counts, and SCIP artifact contract inputs.
 `retrieval index --refresh auto` should reuse an unchanged healthy generation.
 If inputs match but health is not `full`, CodeStory rebuilds the unhealthy
 component and persists the manifest only after the full stack is healthy.
+Generation fingerprint reads use one SQLite snapshot. Promotion hashes source
+files before taking the database lock, then takes an immediate SQLite write
+transaction to hash stored symbol/semantic inputs and update the current
+manifest together. Graph or semantic input drift during a build therefore
+leaves the previous current manifest untouched without holding the write lock
+during workspace discovery.
 
 ## AST-First Semantic Contract
 


### PR DESCRIPTION
## Context

A sidecar candidate was fingerprinted through independent SQLite reads, then only lexical files were rechecked before the current retrieval manifest row was replaced. Same-count graph or semantic content drift could therefore publish a manifest for a superseded or mixed SQLite state. This is the first atomic generation identity/current-pointer slice under #914.

Closes #1014
Refs #914

## What Changed

- Split lexical fingerprinting so filesystem discovery/content hashing completes before the SQLite writer lock, while stored symbol documents extend the exact same hash inside a coherent database view.
- Added a rollback-on-drop `BEGIN IMMEDIATE` store transaction and made final stored-input fingerprint comparison, manifest availability validation, current-manifest upsert, and commit one atomic publication unit.
- Removed the former lexical-only final scan; the promotion gate now compares the complete `SidecarInputFingerprint`, including same-count content changes.
- Added transaction commit/rollback coverage plus a two-connection regression that mutates one embedding without changing counts, proves the stale candidate is rejected and the old pointer remains, then proves unchanged input promotes the new pointer.
- Documented the transaction boundary and recorded the behavior in the changelog.

```mermaid
flowchart LR
    A["Hash workspace files"] --> B["BEGIN IMMEDIATE"]
    B --> C["Hash stored symbol and semantic rows"]
    C --> D{"Full fingerprint unchanged?"}
    D -- "no" --> E["ROLLBACK; keep current manifest"]
    D -- "yes" --> F["Validate and upsert current manifest"]
    F --> G["COMMIT"]
```

## How To Review

1. Confirm `lexical_source_input` runs before `promote_retrieval_manifest` acquires the write transaction.
2. Trace the closure passed to `promote_retrieval_manifest`: stored input hashing and manifest availability checks run on the locked store, then the manifest upsert commits through the same guard.
3. Inspect `manifest_promotion_rejects_same_count_content_drift_and_preserves_current` for the stale rejection and unchanged commit assertions.
4. Confirm the split lexical hash preserves source-first then node-id-ordered symbol document hashing and the existing coverage finalizer.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codestory-store write_transaction_commits_or_rolls_back_as_one_unit` — 1 passed
- `cargo test -p codestory-retrieval manifest_promotion_rejects_same_count_content_drift_and_preserves_current` — 1 passed
- `cargo test -p codestory-retrieval` — 329 passed, 2 ignored; integration binaries: bootstrap 2/2, degraded 2/2, holdout 4/4; live full-sidecar fixture ignored by design
- `cargo clippy -p codestory-store -p codestory-retrieval --all-targets -- -D warnings`
- `node .github/scripts/check-doc-links.mjs` — 69 files, 281 links
- `git diff --check`
- Independent review: initial two P1 findings fixed; post-fix re-review CLEAN

## Risk

The immediate transaction intentionally holds SQLite's writer lock while stored symbol and semantic rows are hashed. Workspace discovery and file reads stay outside that lock. Cross-filesystem source locking remains out of scope; final source hashing is performed immediately before the database transaction and any later source drift is handled by existing freshness checks/rebuild flow.