### PR TITLE
[codex] make generation GC manifest-rooted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- Made sidecar generation GC root every current and rollback manifest across
+  the shared cache scope instead of collapsing rollback evidence to one latest
+  generation. Inventory now reports active, rollback, building, and reclaimable
+  bytes separately and treats unrooted artifacts as building while a
+  publication or cleanup writer owns the retention lock.
 - Made sidecar generation fingerprinting snapshot-coherent and current-manifest
   promotion fail closed when any graph, semantic, or lexical input changes
   during a build. Filesystem input is hashed before locking SQLite; final stored

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -716,8 +716,13 @@ fn emit_retrieval_inventory(
     }
     if let Some(retention) = report.generation_retention.as_ref() {
         markdown.push_str(&format!(
-            "- generation_retention_retained_bytes: {}\n- generation_retention_reclaimable_bytes: {}\n- generation_retention_pruning_suppressed: {}\n",
-            retention.retained_bytes, retention.reclaimable_bytes, retention.pruning_suppressed
+            "- generation_retention_active_bytes: {}\n- generation_retention_rollback_bytes: {}\n- generation_retention_building_bytes: {}\n- generation_retention_retained_bytes: {}\n- generation_retention_reclaimable_bytes: {}\n- generation_retention_pruning_suppressed: {}\n",
+            retention.active_bytes,
+            retention.rollback_bytes,
+            retention.building_bytes,
+            retention.retained_bytes,
+            retention.reclaimable_bytes,
+            retention.pruning_suppressed
         ));
         if !retention.errors.is_empty() {
             markdown.push_str(&format!(
@@ -787,7 +792,10 @@ fn emit_retrieval_gc(
     }
     if let Some(retention) = report.generation_retention.as_ref() {
         markdown.push_str(&format!(
-            "- generation_retention_retained_bytes: {}\n- generation_retention_reclaimable_bytes: {}\n- generation_retention_removed_bytes: {}\n- generation_retention_remaining_reclaimable_bytes: {}\n- generation_retention_pruning_suppressed: {}\n",
+            "- generation_retention_active_bytes: {}\n- generation_retention_rollback_bytes: {}\n- generation_retention_building_bytes: {}\n- generation_retention_retained_bytes: {}\n- generation_retention_reclaimable_bytes: {}\n- generation_retention_removed_bytes: {}\n- generation_retention_remaining_reclaimable_bytes: {}\n- generation_retention_pruning_suppressed: {}\n",
+            retention.active_bytes,
+            retention.rollback_bytes,
+            retention.building_bytes,
             retention.retained_bytes,
             retention.reclaimable_bytes,
             retention.removed_bytes,

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -6,9 +6,9 @@ use crate::generation::{
 use crate::qdrant_client::QdrantClient;
 use crate::retention::{
     FsQdrantGenerationRemover, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport,
-    GenerationRetentionLock, GenerationRetentionPlan, apply_generation_retention,
-    global_generation_gc_state_file, plan_generation_retention_with_qdrant_collections,
-    scan_retention_protection,
+    GenerationRetentionLock, GenerationRetentionPlan, GenerationRetentionState,
+    apply_generation_retention, global_generation_gc_state_file,
+    plan_generation_retention_with_unrooted_state, scan_retention_protection,
 };
 use crate::sidecar::SidecarStateFile;
 use anyhow::{Context, Result};
@@ -393,14 +393,28 @@ fn generation_retention_plan_for_storage(
     let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
     let layout = &runtime.layout;
     let project_id = crate::index::sidecar_project_id_for_root(project_root);
-    let _lock = GenerationRetentionLock::acquire(&layout.state_file, &project_id)
-        .context("lock sidecar generation inventory")?;
+    let (_lock, unrooted_state) = inventory_retention_view(layout, &project_id)?;
     Ok(build_generation_retention_plan(
         storage_path,
         cache_root,
         &runtime,
         &project_id,
+        unrooted_state,
     ))
+}
+
+fn inventory_retention_view(
+    layout: &crate::config::SidecarLayout,
+    project_id: &str,
+) -> Result<(Option<GenerationRetentionLock>, GenerationRetentionState)> {
+    let lock = GenerationRetentionLock::try_acquire_shared(&layout.state_file, project_id)
+        .context("observe sidecar generation inventory lock")?;
+    let state = if lock.is_some() {
+        GenerationRetentionState::Reclaimable
+    } else {
+        GenerationRetentionState::Building
+    };
+    Ok((lock, state))
 }
 
 fn apply_generation_retention_for_storage(
@@ -412,7 +426,13 @@ fn apply_generation_retention_for_storage(
     let project_id = crate::index::sidecar_project_id_for_root(project_root);
     let _lock = GenerationRetentionLock::acquire(&runtime.layout.state_file, &project_id)
         .context("lock sidecar generation retention apply")?;
-    let plan = build_generation_retention_plan(storage_path, cache_root, &runtime, &project_id);
+    let plan = build_generation_retention_plan(
+        storage_path,
+        cache_root,
+        &runtime,
+        &project_id,
+        GenerationRetentionState::Reclaimable,
+    );
     let mut remover = FsQdrantGenerationRemover::new(&runtime.layout);
     Ok(apply_generation_retention(&plan, &mut remover))
 }
@@ -422,6 +442,7 @@ fn build_generation_retention_plan(
     cache_root: &Path,
     runtime: &SidecarRuntimeConfig,
     project_id: &str,
+    unrooted_state: GenerationRetentionState,
 ) -> GenerationRetentionPlan {
     let layout = &runtime.layout;
     let mut protection =
@@ -492,11 +513,12 @@ fn build_generation_retention_plan(
             Vec::new()
         }
     };
-    plan_generation_retention_with_qdrant_collections(
+    plan_generation_retention_with_unrooted_state(
         layout,
         project_id,
         &protection,
         &live_qdrant_collections,
+        unrooted_state,
     )
 }
 
@@ -1038,6 +1060,77 @@ mod tests {
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("active retrieval manifest is stale; pruning suppressed"));
         assert!(errors[0].contains("sidecar_embedding_dim_changed"));
+    }
+
+    #[test]
+    fn inventory_reports_unrooted_bytes_as_building_while_writer_is_active() {
+        let root = tempdir().expect("root");
+        let project_id = "repo-v1-project";
+        let mut runtime = SidecarRuntimeConfig::local();
+        runtime.layout = crate::config::SidecarLayout {
+            qdrant_http_port: 9,
+            qdrant_grpc_port: 10,
+            lexical_data_dir: root.path().join("lexical"),
+            qdrant_data_dir: root.path().join("qdrant"),
+            scip_artifacts_root: root.path().join("scip"),
+            state_file: root.path().join("retrieval-sidecars.json"),
+        };
+        for suffix in ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"] {
+            let generation = format!("{project_id}-{suffix}");
+            for path in [
+                runtime
+                    .layout
+                    .lexical_data_dir
+                    .join("shards")
+                    .join(&generation),
+                runtime.layout.scip_artifacts_root.join(&generation),
+                runtime
+                    .layout
+                    .qdrant_data_dir
+                    .join("collections")
+                    .join(format!("codestory_{project_id}_{suffix}")),
+            ] {
+                std::fs::create_dir_all(&path).expect("generation dir");
+                std::fs::write(path.join("data"), b"x").expect("generation bytes");
+            }
+        }
+        let protection = crate::retention::RetentionProtectionScan {
+            authoritative_active: vec![crate::test_support::retrieval_manifest_fixture(
+                project_id,
+                "aaaaaaaaaaaaaaaa",
+            )],
+            ..crate::retention::RetentionProtectionScan::default()
+        };
+        let writer = GenerationRetentionLock::acquire(&runtime.layout.state_file, project_id)
+            .expect("writer");
+
+        let (shared, state) = inventory_retention_view(&runtime.layout, project_id).expect("view");
+        assert!(shared.is_none());
+        let plan = plan_generation_retention_with_unrooted_state(
+            &runtime.layout,
+            project_id,
+            &protection,
+            &[],
+            state,
+        );
+        assert_eq!(plan.active_bytes, 3);
+        assert_eq!(plan.building_bytes, 3);
+        assert_eq!(plan.reclaimable_bytes, 0);
+        assert!(plan.pruning_suppressed);
+
+        drop(writer);
+        let (_shared, state) =
+            inventory_retention_view(&runtime.layout, project_id).expect("stable view");
+        let plan = plan_generation_retention_with_unrooted_state(
+            &runtime.layout,
+            project_id,
+            &protection,
+            &[],
+            state,
+        );
+        assert_eq!(plan.building_bytes, 0);
+        assert_eq!(plan.reclaimable_bytes, 3);
+        assert!(!plan.pruning_suppressed);
     }
 
     fn write_state(path: &Path, state: &SidecarStateFile) {

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -86,6 +86,25 @@ impl GenerationRetentionLock {
         Self::acquire_with_mode(state_file, scope_id, true)
     }
 
+    pub fn try_acquire_shared(state_file: &Path, scope_id: &str) -> Result<Option<Self>> {
+        let path = retention_lock_path(state_file, scope_id)?;
+        ensure_retention_dir(state_file)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("open generation retention lock {}", path.display()))?;
+        match FileExt::try_lock_shared(&file) {
+            Ok(true) => Ok(Some(Self { file })),
+            Ok(false) => Ok(None),
+            Err(error) => Err(error).with_context(|| {
+                format!("try lock shared generation retention {}", path.display())
+            }),
+        }
+    }
+
     fn acquire_with_mode(state_file: &Path, scope_id: &str, shared: bool) -> Result<Self> {
         let path = retention_lock_path(state_file, scope_id)?;
         ensure_retention_dir(state_file)?;
@@ -282,6 +301,7 @@ pub fn scan_retention_protection(
 pub enum GenerationRetentionState {
     Active,
     Rollback,
+    Building,
     Reclaimable,
 }
 
@@ -316,6 +336,9 @@ pub struct GenerationRetentionPlan {
     pub dry_run: bool,
     pub project_id: String,
     pub pruning_suppressed: bool,
+    pub active_bytes: u64,
+    pub rollback_bytes: u64,
+    pub building_bytes: u64,
     pub retained_bytes: u64,
     pub reclaimable_bytes: u64,
     pub bundles: Vec<GenerationBundle>,
@@ -340,6 +363,26 @@ pub fn plan_generation_retention_with_qdrant_collections(
     protection: &RetentionProtectionScan,
     live_qdrant_collections: &[String],
 ) -> GenerationRetentionPlan {
+    plan_generation_retention_with_unrooted_state(
+        layout,
+        project_id,
+        protection,
+        live_qdrant_collections,
+        GenerationRetentionState::Reclaimable,
+    )
+}
+
+pub(crate) fn plan_generation_retention_with_unrooted_state(
+    layout: &SidecarLayout,
+    project_id: &str,
+    protection: &RetentionProtectionScan,
+    live_qdrant_collections: &[String],
+    unrooted_state: GenerationRetentionState,
+) -> GenerationRetentionPlan {
+    debug_assert!(matches!(
+        unrooted_state,
+        GenerationRetentionState::Building | GenerationRetentionState::Reclaimable
+    ));
     let mut errors = protection.errors.clone();
     let mut blocked = Vec::new();
     let mut builders = BTreeMap::<String, BundleBuilder>::new();
@@ -399,17 +442,19 @@ pub fn plan_generation_retention_with_qdrant_collections(
         &mut errors,
         "shared active",
     );
-    let rollback_evidence = if protection.authoritative_rollback.is_empty() {
-        &protection.rollback
-    } else {
-        &protection.authoritative_rollback
-    };
-    collect_latest_protected_generation(
+    collect_protected_generations(
         project_id,
-        rollback_evidence,
+        &protection.rollback,
         &mut rollback,
         &mut errors,
-        "rollback",
+        "shared rollback",
+    );
+    collect_protected_generations(
+        project_id,
+        &protection.authoritative_rollback,
+        &mut rollback,
+        &mut errors,
+        "authoritative rollback",
     );
     if active.is_empty() {
         errors.push(format!(
@@ -420,6 +465,12 @@ pub fn plan_generation_retention_with_qdrant_collections(
         builders.entry(generation.clone()).or_default();
     }
 
+    let effective_unrooted_state = if errors.is_empty() {
+        unrooted_state
+    } else {
+        GenerationRetentionState::Building
+    };
+
     let mut bundles = builders
         .into_iter()
         .map(|(generation, builder)| {
@@ -428,25 +479,33 @@ pub fn plan_generation_retention_with_qdrant_collections(
             } else if rollback.contains(&generation) {
                 GenerationRetentionState::Rollback
             } else {
-                GenerationRetentionState::Reclaimable
+                effective_unrooted_state
             };
             builder.finish(project_id, generation, state)
         })
         .collect::<Vec<_>>();
     bundles.sort_by(|left, right| left.generation.cmp(&right.generation));
-    let retained_bytes = bundles
-        .iter()
-        .filter(|bundle| bundle.state != GenerationRetentionState::Reclaimable)
-        .fold(0_u64, |total, bundle| total.saturating_add(bundle.bytes));
-    let reclaimable_bytes = bundles
-        .iter()
-        .filter(|bundle| bundle.state == GenerationRetentionState::Reclaimable)
-        .fold(0_u64, |total, bundle| total.saturating_add(bundle.bytes));
+    let bytes_for = |state| {
+        bundles
+            .iter()
+            .filter(|bundle| bundle.state == state)
+            .fold(0_u64, |total, bundle| total.saturating_add(bundle.bytes))
+    };
+    let active_bytes = bytes_for(GenerationRetentionState::Active);
+    let rollback_bytes = bytes_for(GenerationRetentionState::Rollback);
+    let building_bytes = bytes_for(GenerationRetentionState::Building);
+    let reclaimable_bytes = bytes_for(GenerationRetentionState::Reclaimable);
+    let retained_bytes = active_bytes
+        .saturating_add(rollback_bytes)
+        .saturating_add(building_bytes);
 
     GenerationRetentionPlan {
         dry_run: true,
         project_id: project_id.to_string(),
-        pruning_suppressed: !errors.is_empty(),
+        pruning_suppressed: effective_unrooted_state == GenerationRetentionState::Building,
+        active_bytes,
+        rollback_bytes,
+        building_bytes,
         retained_bytes,
         reclaimable_bytes,
         bundles,
@@ -523,6 +582,9 @@ pub struct GenerationRetentionApplyReport {
     pub dry_run: bool,
     pub project_id: String,
     pub pruning_suppressed: bool,
+    pub active_bytes: u64,
+    pub rollback_bytes: u64,
+    pub building_bytes: u64,
     pub retained_bytes: u64,
     pub reclaimable_bytes: u64,
     pub removed_bytes: u64,
@@ -540,6 +602,9 @@ pub fn apply_generation_retention(
             dry_run: false,
             project_id: plan.project_id.clone(),
             pruning_suppressed: true,
+            active_bytes: plan.active_bytes,
+            rollback_bytes: plan.rollback_bytes,
+            building_bytes: plan.building_bytes,
             retained_bytes: plan.retained_bytes,
             reclaimable_bytes: plan.reclaimable_bytes,
             removed_bytes: 0,
@@ -608,6 +673,9 @@ pub fn apply_generation_retention(
         dry_run: false,
         project_id: plan.project_id.clone(),
         pruning_suppressed: false,
+        active_bytes: plan.active_bytes,
+        rollback_bytes: plan.rollback_bytes,
+        building_bytes: plan.building_bytes,
         retained_bytes: plan.retained_bytes,
         reclaimable_bytes: plan.reclaimable_bytes,
         removed_bytes,
@@ -898,32 +966,6 @@ fn collect_protected_generations(
                 "{role} manifest for {project_id} is not safe retention evidence: {error:#}"
             )),
         }
-    }
-}
-
-fn collect_latest_protected_generation(
-    project_id: &str,
-    manifests: &[RetrievalIndexManifest],
-    generations: &mut BTreeSet<String>,
-    errors: &mut Vec<String>,
-    role: &str,
-) {
-    let mut candidates = manifests
-        .iter()
-        .filter(|manifest| manifest.project_id == project_id)
-        .filter_map(|manifest| match canonical_manifest_generation(manifest) {
-            Ok(generation) => Some((manifest.built_at_epoch_ms, generation)),
-            Err(error) => {
-                errors.push(format!(
-                    "{role} manifest for {project_id} is not safe retention evidence: {error:#}"
-                ));
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-    candidates.sort();
-    if let Some((_, generation)) = candidates.pop() {
-        generations.insert(generation);
     }
 }
 
@@ -1313,6 +1355,9 @@ mod tests {
         let plan = plan_generation_retention(&layout, project, &protection);
 
         assert!(!plan.pruning_suppressed);
+        assert_eq!(plan.active_bytes, 6);
+        assert_eq!(plan.rollback_bytes, 15);
+        assert_eq!(plan.building_bytes, 0);
         assert_eq!(plan.retained_bytes, 21);
         assert_eq!(plan.reclaimable_bytes, 24);
         assert_eq!(
@@ -1344,7 +1389,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_active_manifests_remain_protected_while_rollback_is_bounded() {
+    fn every_shared_active_and_rollback_manifest_is_a_gc_root() {
         let root = tempdir().expect("root");
         let layout = layout(root.path());
         let project = "repo-v1-project";
@@ -1354,21 +1399,31 @@ mod tests {
             "cccccccccccccccc",
             "dddddddddddddddd",
             "eeeeeeeeeeeeeeee",
+            "ffffffffffffffff",
         ] {
             write_bundle(&layout, project, suffix, [1, 1, 1]);
         }
-        let protection = RetentionProtectionScan {
-            authoritative_active: vec![manifest(project, "aaaaaaaaaaaaaaaa", 10)],
-            active: vec![
-                manifest(project, "bbbbbbbbbbbbbbbb", 20),
-                manifest(project, "cccccccccccccccc", 30),
-            ],
-            rollback: vec![
-                manifest(project, "bbbbbbbbbbbbbbbb", 20),
-                manifest(project, "dddddddddddddddd", 40),
-            ],
-            ..RetentionProtectionScan::default()
-        };
+        let state_file = root.path().join("retrieval-sidecars.json");
+        for (workspace, active, rollback) in [
+            ("workspace_a", "aaaaaaaaaaaaaaaa", "dddddddddddddddd"),
+            ("workspace_b", "bbbbbbbbbbbbbbbb", "eeeeeeeeeeeeeeee"),
+        ] {
+            let marker = GenerationRetentionMarker::next(
+                workspace,
+                manifest(project, active, 10),
+                Some(VerifiedRollbackManifest {
+                    manifest: manifest(project, rollback, 5),
+                    verified_at_epoch_ms: 10,
+                }),
+                10,
+            )
+            .expect("marker");
+            write_retention_marker(&state_file, &marker).expect("write marker");
+        }
+        let mut protection = scan_retention_protection(root.path(), None, &state_file);
+        protection
+            .authoritative_active
+            .push(manifest(project, "cccccccccccccccc", 30));
 
         let plan = plan_generation_retention(&layout, project, &protection);
 
@@ -1395,6 +1450,10 @@ mod tests {
                     "repo-v1-project-dddddddddddddddd".to_string(),
                     GenerationRetentionState::Rollback,
                 ),
+                (
+                    "repo-v1-project-eeeeeeeeeeeeeeee".to_string(),
+                    GenerationRetentionState::Rollback,
+                ),
             ]
         );
         assert_eq!(
@@ -1403,8 +1462,36 @@ mod tests {
                 .filter(|bundle| bundle.state == GenerationRetentionState::Reclaimable)
                 .map(|bundle| bundle.generation.as_str())
                 .collect::<Vec<_>>(),
-            vec!["repo-v1-project-eeeeeeeeeeeeeeee"]
+            vec!["repo-v1-project-ffffffffffffffff"]
         );
+    }
+
+    #[test]
+    fn unrooted_bytes_are_building_until_the_retention_view_is_stable() {
+        let root = tempdir().expect("root");
+        let layout = layout(root.path());
+        let project = "repo-v1-project";
+        write_bundle(&layout, project, "aaaaaaaaaaaaaaaa", [1, 2, 3]);
+        write_bundle(&layout, project, "bbbbbbbbbbbbbbbb", [4, 5, 6]);
+        let protection = RetentionProtectionScan {
+            authoritative_active: vec![manifest(project, "aaaaaaaaaaaaaaaa", 1)],
+            ..RetentionProtectionScan::default()
+        };
+
+        let plan = plan_generation_retention_with_unrooted_state(
+            &layout,
+            project,
+            &protection,
+            &[],
+            GenerationRetentionState::Building,
+        );
+
+        assert_eq!(plan.active_bytes, 6);
+        assert_eq!(plan.rollback_bytes, 0);
+        assert_eq!(plan.building_bytes, 15);
+        assert_eq!(plan.reclaimable_bytes, 0);
+        assert_eq!(plan.retained_bytes, 21);
+        assert!(plan.pruning_suppressed);
     }
 
     #[test]
@@ -1447,7 +1534,8 @@ mod tests {
         let report = apply_generation_retention(&plan, &mut remover);
 
         assert!(plan.pruning_suppressed);
-        assert_eq!(plan.reclaimable_bytes, 9);
+        assert_eq!(plan.building_bytes, 9);
+        assert_eq!(plan.reclaimable_bytes, 0);
         assert!(report.pruning_suppressed);
         assert_eq!(report.removed_bytes, 0);
         assert!(remover.removed_paths.is_empty());
@@ -1473,7 +1561,8 @@ mod tests {
         let report = apply_generation_retention(&plan, &mut remover);
 
         assert!(plan.pruning_suppressed);
-        assert_eq!(plan.reclaimable_bytes, 9);
+        assert_eq!(plan.building_bytes, 9);
+        assert_eq!(plan.reclaimable_bytes, 0);
         assert!(report.pruning_suppressed);
         assert!(remover.removed_paths.is_empty());
         assert!(remover.removed_collections.is_empty());

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -107,6 +107,14 @@ manifest together. Graph or semantic input drift during a build therefore
 leaves the previous current manifest untouched without holding the write lock
 during workspace discovery.
 
+Generation cleanup is a reachability pass. Every canonical generation named by
+a readable current manifest or active/rollback retention marker in the shared
+cache scope is a root. GC obtains the exclusive publication/retention locks and
+may delete only generation artifacts outside that root set. Inventory uses a shared
+view when available; if a writer owns the lock, it does not wait or infer that
+new artifacts are garbage, and instead reports all unrooted bytes as building.
+Status exposes active, rollback, building, and reclaimable bytes separately.
+
 ## AST-First Semantic Contract
 
 Code structure is graph-native first. Runtime writes a deterministic

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -283,8 +283,8 @@ codestory-cli retrieval inventory --project <repo> --format json
 The inventory lists CodeStory-owned sidecar namespaces, state paths, cleanup
 commands, Compose projects, matching containers/networks, visible ports, and
 the required `bge-base-en-v1.5.Q8_0.gguf` model check. It also reports the
-project's generation bundles as active, verified rollback, or reclaimable with
-retained and reclaimable byte totals. It classifies namespaces as `live`,
+project's generation bundles as active, verified rollback, building, or
+reclaimable with separate byte totals for each state. It classifies namespaces as `live`,
 `stale`, `orphaned`, `incomplete`, or `unknown` with safe-candidate and blocking
 reasons. The default command is a dry-run: it does not run Docker prune, remove
 containers, delete networks, clear state files, or delete generations. When
@@ -303,10 +303,12 @@ codestory-cli retrieval inventory --project <repo> --apply --format json
 
 `--apply` removes only namespaces classified as inventory safe candidates and
 applies the generation plan shown by the dry-run. Generation cleanup requires a
-fully healthy active manifest, retains every manifest-referenced active
-generation sharing that sidecar scope plus at most one health-verified
-rollback, and removes only matching stale Qdrant, SCIP, and lexical artifacts
-under the per-project publication lock. Live namespaces,
+fully healthy active manifest, retains every generation referenced by a current
+or rollback manifest in the shared sidecar scope, and removes only unreachable
+Qdrant, SCIP, and lexical artifacts under the per-project publication lock.
+If inventory cannot obtain a stable shared view because a publication or GC
+writer is active, unrooted bytes are reported as `building` and reclaimable
+bytes remain zero. Live namespaces,
 incomplete state, unknown ownership, protection-scan errors, and malformed
 generation entries stay blocked with explicit reasons. The apply path does not
 run Docker prune, broad Docker cleanup, or host/global network deletion.


### PR DESCRIPTION
## Context

Generation retention rooted current manifests but collapsed rollback evidence to one latest generation across the shared sidecar scope. That made another workspace's explicit rollback generation eligible for reclamation. Inventory also reported only aggregate retained bytes and waited for publication, so it could not distinguish live building artifacts from stable garbage.

Closes #1019
Refs #914

## What Changed

- Union every readable current, active-marker, and rollback-marker generation into the GC root set.
- Treat unrooted artifacts as reclaimable only while inventory owns a stable shared retention view; a live publication/cleanup writer or any incomplete protection scan classifies them as building with zero reclaimable bytes.
- Keep apply under the existing exclusive coordination locks and delete only bundles in the explicit reclaimable state.
- Report active, rollback, building, retained, and reclaimable bytes in inventory/apply JSON and Markdown.
- Add realistic multi-workspace marker scanning and writer-contention byte-accounting tests, plus operator and architecture documentation.

```mermaid
flowchart LR
    M["Current and rollback manifests"] --> R["Root generation set"]
    L{"Stable shared lock view?"} -->|"yes"| U["Unrooted = reclaimable"]
    L -->|"no"| B["Unrooted = building"]
    R --> P["Reachability plan"]
    U --> P
    B --> P
    P --> G["Exclusive-lock GC deletes reclaimable only"]
```

## How To Review

1. Trace `scan_retention_protection` through both active and rollback marker collection.
2. Confirm planner errors and a busy writer both force the effective unrooted state to `Building` and `reclaimable_bytes=0`.
3. Confirm `apply_generation_retention` still filters exclusively on `Reclaimable`.
4. Inspect the real marker scan and busy-lock inventory tests for the cross-workspace and concurrency boundaries.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codestory-retrieval retention::tests -- --nocapture` — 12 passed
- `cargo test -p codestory-retrieval inventory_reports_unrooted_bytes_as_building_while_writer_is_active -- --nocapture` — 1 passed
- `cargo test -p codestory-retrieval` — 331 passed, 2 ignored; integration binaries 2/2, 2/2, 4/4; live full-sidecar fixture ignored by design
- `cargo clippy -p codestory-retrieval -p codestory-cli --all-targets -- -D warnings`
- `node .github/scripts/check-doc-links.mjs` — 69 files, 281 relative links
- `git diff --check`
- Independent review: initial P1/P2 fixed; final re-review CLEAN, including the final fs4 API correction

## Risk

Conservative inventory may temporarily classify stale bytes as building while any writer owns the project lock or root discovery is incomplete. This intentionally delays reclamation instead of risking deletion. The manifest promotion transaction and generation fingerprint are unchanged. No screenshot-visible UI changed.
