### PR TITLE
stabilize strict batch concurrency proof

### DIFF
--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -447,12 +447,16 @@ mod tests {
         struct CountingSidecars {
             active: AtomicUsize,
             max_active: AtomicUsize,
+            first_wave: std::sync::Barrier,
         }
 
         impl CountingSidecars {
             fn record(&self, query: &str) -> Vec<CandidateHit> {
                 let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
                 self.max_active.fetch_max(active, Ordering::SeqCst);
+                if matches!(query, "slow" | "fast") {
+                    self.first_wave.wait();
+                }
                 if query == "slow" {
                     std::thread::sleep(Duration::from_millis(30));
                 } else {
@@ -488,6 +492,7 @@ mod tests {
         let sidecars = Arc::new(CountingSidecars {
             active: AtomicUsize::new(0),
             max_active: AtomicUsize::new(0),
+            first_wave: std::sync::Barrier::new(2),
         });
         let mut cache = RetrievalCache::new();
         let manifest = manifest_for("testproj", "cafebabedeadbeef", 3);


### PR DESCRIPTION
## Context

The strict batch concurrency contract repeatedly failed only under full-suite load because its sleep-based witness assumed both scoped workers would be scheduled concurrently. Windows could schedule them serially, reporting a peak of one even though the production wave admitted two workers.

Closes #1026
Refs #1023

## What Changed

- Added a two-party barrier to the test's first `slow`/`fast` worker wave.
- Kept the third `last` query outside the barrier.
- Preserved the exact concurrency bound, result-order, and file-role assertions.
- Changed no production code.

## How To Review

Confirm only the first two query literals wait at the barrier after incrementing the active count, so `max_active == 2` is deterministic and the second wave cannot deadlock.

## Verification

- Focused strict-batch test: 10/10 repeated passes
- `cargo test -p codestory-retrieval`: 332 passed, 2 ignored; integration suites 2/2 bootstrap, 2/2 degraded, 4/4 holdout
- `cargo clippy -p codestory-retrieval --all-targets -- -D warnings`
- Independent review: clean

## Risk

Test-only change. The barrier is intentionally tied to the two first-wave query literals; production scheduling is unchanged.
