### PR TITLE
qualify managed lifecycle on every platform

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -162,6 +162,7 @@ def proof_environment(base: dict[str, str]) -> dict[str, str]:
     env = dict(base)
     if hasattr(os, "getuid") and hasattr(os, "getgid"):
         env["CODESTORY_QDRANT_USER"] = f"{os.getuid()}:{os.getgid()}"
+        env["CODESTORY_QDRANT_SNAPSHOTS_PATH"] = "/qdrant/storage/snapshots"
     return env
 
 
@@ -189,10 +190,8 @@ def validated_proof_compose_state(cache_root: Path, project: Path, read_state) -
     for name, expected in expected_identity.items():
         if state.get(name) != expected:
             raise RuntimeError(f"proof sidecar state {name} does not match {expected!r}: {state_file}")
-    for name, expected in (
-        ("qdrant_data_dir", cache_root / "qdrant"),
-        ("lexical_data_dir", cache_root / "lexical"),
-    ):
+    state = dict(state)
+    for name, expected in (("qdrant_data_dir", cache_root / "qdrant"),):
         value = state.get(name)
         if not isinstance(value, str) or not value:
             raise TypeError(f"proof sidecar state {name} is not a path string: {state_file}")
@@ -200,6 +199,18 @@ def validated_proof_compose_state(cache_root: Path, project: Path, read_state) -
         expected = expected.resolve(strict=True)
         if observed != expected or observed.is_symlink() or observed.resolve(strict=True) != expected:
             raise RuntimeError(f"proof sidecar state {name} escaped its cache root: {state_file}")
+    lexical_expected = cache_root / "lexical"
+    lexical_value = state.get("lexical_data_dir")
+    if lexical_value is None:
+        lexical_value = state.get("zoekt_data_dir")
+    if not isinstance(lexical_value, str) or not lexical_value:
+        raise TypeError(f"proof sidecar state lexical_data_dir or legacy zoekt_data_dir is not a path string: {state_file}")
+    observed = Path(lexical_value)
+    if observed != lexical_expected or observed.is_symlink():
+        raise RuntimeError(f"proof sidecar state lexical_data_dir escaped its cache root: {state_file}")
+    if observed.exists() and observed.resolve(strict=True) != lexical_expected:
+        raise RuntimeError(f"proof sidecar state lexical_data_dir escaped its cache root: {state_file}")
+    state["lexical_data_dir"] = str(lexical_expected)
     compose_value = state.get("compose_file")
     if not isinstance(compose_value, str) or not compose_value:
         raise TypeError(f"proof sidecar compose_file is not a path string: {state_file}")
@@ -248,7 +259,6 @@ def cleanup_proof_compose(
         **env,
         "CODESTORY_SIDECAR_NAMESPACE": state["namespace"],
         "CODESTORY_QDRANT_DATA_DIR": state["qdrant_data_dir"],
-        "CODESTORY_ZOEKT_DATA_DIR": state["lexical_data_dir"],
         "CODESTORY_EMBED_MODEL_DIR": state["qdrant_data_dir"],
     }
     command = [
@@ -285,6 +295,58 @@ def cleanup_proof_compose(
     )
     if result.returncode != 0:
         raise RuntimeError(f"proof-owned Compose cleanup exited {result.returncode}")
+
+
+def capture_proof_compose_diagnostics(
+    cache_root: Path,
+    project: Path,
+    env: dict[str, str],
+    artifact: Path,
+    run=subprocess.run,
+    read_state=read_json_file,
+) -> None:
+    payload = {"state_file": str(cache_root / "retrieval-sidecars.json"), "commands": []}
+    try:
+        validated = validated_proof_compose_state(cache_root, project, read_state)
+        if validated is None:
+            payload["error"] = "proof-owned Compose state is absent"
+            write_json(artifact, payload)
+            return
+        _, state = validated
+        compose_env = {
+            **env,
+            "CODESTORY_SIDECAR_NAMESPACE": state["namespace"],
+            "CODESTORY_QDRANT_DATA_DIR": state["qdrant_data_dir"],
+            "CODESTORY_EMBED_MODEL_DIR": state["qdrant_data_dir"],
+        }
+        base = ["docker", "compose", "-p", state["compose_project"], "-f", state["compose_file"]]
+        for kind, extra in (
+            ("compose_ps", ["ps", "--all"]),
+            ("qdrant_logs", ["logs", "--no-color", "--tail", "200", "qdrant"]),
+        ):
+            try:
+                result = run(
+                    [*base, *extra],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=20,
+                    check=False,
+                    env=compose_env,
+                    text=True,
+                )
+                payload["commands"].append(
+                    {
+                        "kind": kind,
+                        "returncode": result.returncode,
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                    }
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                payload["commands"].append({"kind": kind, "error": f"{type(exc).__name__}: {exc}"})
+    except Exception as exc:
+        payload["error"] = f"{type(exc).__name__}: {exc}"
+    write_json(artifact, payload)
 
 
 def cleanup_proof_cache(
@@ -353,6 +415,27 @@ def cleanup_proof_cache(
     write_json(artifact, {"cache_root": str(cache_root), "commands": results, "removed": removed})
     if not removed:
         raise RuntimeError(f"proof cache still exists after cleanup: {cache_root}")
+
+
+def cleanup_proof_cache_on_exit(
+    cli: Path,
+    project: Path,
+    cache_root: Path,
+    artifact: Path,
+    run=subprocess.run,
+    read_state=read_json_file,
+):
+    def cleanup(exc_type, exc, traceback) -> bool:
+        try:
+            cleanup_proof_cache(cli, project, cache_root, artifact, run, read_state)
+        except Exception as cleanup_exc:
+            if exc is None:
+                raise
+            if hasattr(exc, "add_note"):
+                exc.add_note(f"proof cleanup also failed: {type(cleanup_exc).__name__}: {cleanup_exc}")
+        return False
+
+    return cleanup
 
 
 def local_profile_environment(base: dict[str, str]) -> dict[str, str]:
@@ -586,49 +669,126 @@ def terminate_process_tree(process: subprocess.Popen[str]) -> None:
         process.kill()
 
 
-def require_windows_process_exit(process_handle, pid: int, timeout_ms: int = 10_000) -> None:
-    wait_result = ctypes.windll.kernel32.WaitForSingleObject(process_handle, timeout_ms)
-    if wait_result != 0:
-        raise RuntimeError(f"worker process {pid} did not terminate before cleanup (wait result {wait_result})")
+def windows_process_api():
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong]
+    kernel32.OpenProcess.restype = ctypes.c_void_p
+    kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+    kernel32.TerminateProcess.argtypes = [ctypes.c_void_p, ctypes.c_uint]
+    kernel32.TerminateProcess.restype = ctypes.c_int
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    kernel32.CloseHandle.restype = ctypes.c_int
+    return kernel32
 
 
-def terminate_worker_pid(pid: int) -> None:
-    if pid <= 0:
+def windows_last_error(kernel32) -> int:
+    return int(getattr(kernel32, "last_error", ctypes.get_last_error()))
+
+
+def require_windows_process_exit(process_handle, pid: int, timeout_ms: int = 10_000, kernel32=None) -> None:
+    kernel32 = kernel32 or windows_process_api()
+    wait_result = kernel32.WaitForSingleObject(process_handle, timeout_ms)
+    if wait_result == 0:
         return
-    if os.name == "nt":
+    if wait_result == 0xFFFFFFFF:
+        raise RuntimeError(f"could not wait for worker process {pid} (Windows error {windows_last_error(kernel32)})")
+    raise RuntimeError(f"worker process {pid} did not terminate before cleanup (wait result {wait_result})")
+
+
+def terminate_worker_pid(
+    pid: int,
+    diagnostics: dict | None = None,
+    *,
+    kernel32=None,
+    run=subprocess.run,
+    platform: str | None = None,
+) -> None:
+    diagnostics = diagnostics if diagnostics is not None else {}
+    platform = platform or os.name
+    diagnostics.update({"pid": pid, "platform": platform, "attempts": []})
+    if pid <= 0:
+        diagnostics["status"] = "invalid_pid"
+        return
+    if platform == "nt":
+        kernel32 = kernel32 or windows_process_api()
         process_handle = None
         open_error = 0
         try:
-            process_handle = ctypes.windll.kernel32.OpenProcess(0x00100001, False, pid)
+            process_handle = kernel32.OpenProcess(0x00100001, False, pid)
             if not process_handle:
-                open_error = ctypes.windll.kernel32.GetLastError()
+                open_error = windows_last_error(kernel32)
         except (AttributeError, OSError):
             process_handle = None
+        diagnostics["attempts"].append(
+            {"kind": "open_process", "success": bool(process_handle), "windows_error": open_error}
+        )
+        if not process_handle:
+            if open_error == 87:
+                diagnostics["status"] = "already_exited"
+                return
+            raise RuntimeError(
+                f"could not open worker process {pid} for termination proof (Windows error {open_error})"
+            )
+        taskkill_evidence = "not run"
         try:
-            subprocess.run(
+            taskkill = run(
                 ["taskkill", "/PID", str(pid), "/T", "/F"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 timeout=10,
                 check=False,
+                text=True,
             )
-        except (OSError, subprocess.TimeoutExpired):
-            pass
-        if process_handle:
+            taskkill_evidence = (
+                f"exit={taskkill.returncode} stdout={taskkill.stdout.strip()!r} stderr={taskkill.stderr.strip()!r}"
+            )
+            diagnostics["attempts"].append(
+                {
+                    "kind": "taskkill",
+                    "returncode": taskkill.returncode,
+                    "stdout": taskkill.stdout,
+                    "stderr": taskkill.stderr,
+                }
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            taskkill_evidence = f"{type(exc).__name__}: {exc}"
+            diagnostics["attempts"].append({"kind": "taskkill", "error": taskkill_evidence})
+        try:
             try:
+                require_windows_process_exit(process_handle, pid, kernel32=kernel32)
+                diagnostics["status"] = "terminated_after_taskkill"
+            except RuntimeError as wait_error:
+                diagnostics["attempts"].append({"kind": "initial_wait", "error": str(wait_error)})
+                terminated = bool(kernel32.TerminateProcess(process_handle, 1))
+                terminate_error = 0 if terminated else windows_last_error(kernel32)
+                diagnostics["attempts"].append(
+                    {"kind": "terminate_process", "success": terminated, "windows_error": terminate_error}
+                )
+                if not terminated:
+                    try:
+                        require_windows_process_exit(process_handle, pid, timeout_ms=0, kernel32=kernel32)
+                    except RuntimeError:
+                        raise RuntimeError(
+                            f"could not terminate worker process {pid} (Windows error {terminate_error}; "
+                            f"taskkill {taskkill_evidence}; initial wait: {wait_error})"
+                        ) from wait_error
                 try:
-                    require_windows_process_exit(process_handle, pid)
-                except RuntimeError:
-                    ctypes.windll.kernel32.TerminateProcess(process_handle, 1)
-                    require_windows_process_exit(process_handle, pid)
-            finally:
-                ctypes.windll.kernel32.CloseHandle(process_handle)
-        elif open_error != 87:
-            raise RuntimeError(f"could not prove worker process {pid} terminated")
+                    require_windows_process_exit(process_handle, pid, timeout_ms=30_000, kernel32=kernel32)
+                    diagnostics["status"] = "terminated_after_direct_termination"
+                except RuntimeError as final_wait_error:
+                    diagnostics["attempts"].append({"kind": "final_wait", "error": str(final_wait_error)})
+                    raise RuntimeError(
+                        f"worker process {pid} remained alive after direct termination; "
+                        f"taskkill {taskkill_evidence}; initial wait: {wait_error}; final wait: {final_wait_error}"
+                    ) from final_wait_error
+        finally:
+            kernel32.CloseHandle(process_handle)
     else:
         try:
             os.kill(pid, signal.SIGKILL)
         except ProcessLookupError:
+            diagnostics["status"] = "already_exited"
             return
         except PermissionError as exc:
             raise RuntimeError(f"could not terminate worker process {pid}") from exc
@@ -637,12 +797,14 @@ def terminate_worker_pid(pid: int) -> None:
             try:
                 exited = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
                 if exited is not None:
+                    diagnostics["status"] = "terminated"
                     return
             except ChildProcessError:
                 pass
             try:
                 os.kill(pid, 0)
             except ProcessLookupError:
+                diagnostics["status"] = "terminated"
                 return
             except PermissionError as exc:
                 raise RuntimeError(f"could not prove worker process {pid} terminated") from exc
@@ -651,20 +813,26 @@ def terminate_worker_pid(pid: int) -> None:
             time.sleep(0.1)
 
 
-def running_status_worker_pids(status: dict) -> set[int]:
-    operations = status.get("readiness_broker", {}).get("operations", [])
-    return {
-        operation["pid"]
-        for operation in operations
-        if isinstance(operation, dict)
-        and operation.get("status") == "running"
-        and isinstance(operation.get("pid"), int)
+def proof_started_repair_workers(responses: list[dict]) -> list[dict]:
+    responses_by_id = {response.get("id"): response for response in responses if isinstance(response, dict)}
+    repair = responses_by_id.get("repair", {}).get("result", {}).get("structuredContent", {})
+    if not isinstance(repair, dict) or repair.get("status") != "started":
+        return []
+    pid = repair.get("pid")
+    attempt_id = repair.get("attempt_id")
+    if not isinstance(pid, int) or not isinstance(attempt_id, str) or not attempt_id:
+        return []
+    status = status_from_resource_response(responses_by_id.get("status_after_repair", {}))
+    if not isinstance(status, dict):
+        return []
+    setup = status.get("sidecar_setup", {})
+    observed_attempts = {
+        (setup.get("active_repair") or {}).get("attempt_id"),
+        (setup.get("last_worker_result") or {}).get("attempt_id"),
     }
-
-
-def terminate_status_workers(status: dict) -> None:
-    for worker_pid in running_status_worker_pids(status):
-        terminate_worker_pid(worker_pid)
+    if attempt_id not in observed_attempts:
+        return []
+    return [{"pid": pid, "attempt_id": attempt_id, "source": "proof_started_repair_response"}]
 
 
 def read_stdio_line(stdout_queue: queue.Queue[str | None], timeout_secs: int) -> str | None:
@@ -1000,20 +1168,19 @@ def stdio_status_command(
             except subprocess.TimeoutExpired:
                 terminate_process_tree(process)
             process_terminated = True
-        worker_pids: set[int] = set()
-        for response in responses:
-            if not isinstance(response, dict):
-                continue
-            if response.get("id") == "repair":
-                worker_pid = response.get("result", {}).get("structuredContent", {}).get("pid")
-                if isinstance(worker_pid, int):
-                    worker_pids.add(worker_pid)
-            if cleanup_status_workers:
-                status = status_from_resource_response(response)
-                if isinstance(status, dict):
-                    worker_pids.update(running_status_worker_pids(status))
-        for worker_pid in worker_pids:
-            terminate_worker_pid(worker_pid)
+        worker_cleanup_artifact = artifact.with_name(f"{artifact.stem}-worker-cleanup.json")
+        worker_cleanup = []
+        owned_workers = proof_started_repair_workers(responses) if cleanup_status_workers else []
+        for worker in owned_workers:
+            evidence = dict(worker)
+            worker_cleanup.append(evidence)
+            try:
+                terminate_worker_pid(worker["pid"], evidence)
+            except Exception as exc:
+                evidence["error"] = f"{type(exc).__name__}: {exc}"
+                write_json(worker_cleanup_artifact, {"workers": worker_cleanup})
+                raise
+            write_json(worker_cleanup_artifact, {"workers": worker_cleanup})
         if process.poll() is None:
             process.kill()
             process.wait(timeout=2)
@@ -1315,11 +1482,11 @@ def run_gate(args: argparse.Namespace) -> None:
         plugin_skill = find_plugin_skill(unpacked)
         cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-proof-cache-"))
         proof_cleanup_artifact = out_dir / "proof-cache-cleanup.json"
-        cleanup_stack.callback(cleanup_proof_cache, cli, project, cache_root, proof_cleanup_artifact)
+        cleanup_stack.push(cleanup_proof_cache_on_exit(cli, project, cache_root, proof_cleanup_artifact))
         proof_env = proof_environment({**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)})
         stdio_cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-stdio-cache-"))
         stdio_cleanup_artifact = out_dir / "stdio-cache-cleanup.json"
-        cleanup_stack.callback(cleanup_proof_cache, cli, project, stdio_cache_root, stdio_cleanup_artifact)
+        cleanup_stack.push(cleanup_proof_cache_on_exit(cli, project, stdio_cache_root, stdio_cleanup_artifact))
         stdio_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(stdio_cache_root)}
 
         summary = {
@@ -1455,28 +1622,35 @@ def run_gate(args: argparse.Namespace) -> None:
         write_json(out_dir / "summary.json", summary)
 
         local_index_artifact = out_dir / "local-retrieval-index.json"
-        local_index = run_command(
-            cli,
-            "local_retrieval_index",
-            [
-                "retrieval",
-                "index",
-                "--project",
-                str(project),
-                "--profile",
-                "local",
-                "--refresh",
-                "full",
-                "--format",
-                "json",
-                "--output-file",
-                str(local_index_artifact),
-            ],
-            local_index_artifact,
-            args.timeout_secs,
-            env=local_env,
-        )
-        require_retrieval_index_ready(local_index, "local_retrieval_index", local_index_artifact)
+        try:
+            local_index = run_command(
+                cli,
+                "local_retrieval_index",
+                [
+                    "retrieval",
+                    "index",
+                    "--project",
+                    str(project),
+                    "--profile",
+                    "local",
+                    "--refresh",
+                    "full",
+                    "--format",
+                    "json",
+                    "--output-file",
+                    str(local_index_artifact),
+                ],
+                local_index_artifact,
+                args.timeout_secs,
+                env=local_env,
+            )
+            require_retrieval_index_ready(local_index, "local_retrieval_index", local_index_artifact)
+        except GateFailure:
+            compose_diagnostics_artifact = out_dir / "local-retrieval-compose-diagnostics.json"
+            capture_proof_compose_diagnostics(cache_root, project, local_env, compose_diagnostics_artifact)
+            summary["artifacts"]["local_retrieval_compose_diagnostics"] = str(compose_diagnostics_artifact)
+            write_json(out_dir / "summary.json", summary)
+            raise
         summary["artifacts"]["local_retrieval_index"] = str(local_index_artifact)
         write_json(out_dir / "summary.json", summary)
 
@@ -1635,20 +1809,13 @@ def run_gate(args: argparse.Namespace) -> None:
         summary["artifacts"]["packet"] = str(packet_artifact)
         write_json(out_dir / "summary.json", summary)
 
-        stdio_attempts = []
-        try:
+        stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
+        require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
+        allowed = stdio_status_payload.get("allowed_surfaces", {})
+        if not all(allowed.get(name, {}).get("allowed") is True for name in ("packet", "search", "context")):
+            shutil.copy2(stdio_artifact, out_dir / "serve-stdio-status-initial.json")
             stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
-            stdio_attempts.append(stdio_status_payload)
-            require_stdio_shape(stdio_status_payload, stdio_artifact, args.expected_version)
-            allowed = stdio_status_payload.get("allowed_surfaces", {})
-            if not all(allowed.get(name, {}).get("allowed") is True for name in ("packet", "search", "context")):
-                shutil.copy2(stdio_artifact, out_dir / "serve-stdio-status-initial.json")
-                stdio_status_payload = stdio_status(cli, project, stdio_artifact, args.timeout_secs, proof_env)
-                stdio_attempts.append(stdio_status_payload)
-            require_stdio_ready(stdio_status_payload, stdio_artifact, args.expected_version)
-        finally:
-            for status_attempt in stdio_attempts:
-                terminate_status_workers(status_attempt)
+        require_stdio_ready(stdio_status_payload, stdio_artifact, args.expected_version)
         summary["artifacts"]["serve_stdio"] = str(stdio_artifact)
         write_json(out_dir / "summary.json", summary)
 
@@ -1984,6 +2151,7 @@ def self_test() -> None:
     owned_environment = proof_environment(base_environment)
     if hasattr(os, "getuid") and hasattr(os, "getgid"):
         assert owned_environment["CODESTORY_QDRANT_USER"] == f"{os.getuid()}:{os.getgid()}"
+        assert owned_environment["CODESTORY_QDRANT_SNAPSHOTS_PATH"] == "/qdrant/storage/snapshots"
     local_environment = local_profile_environment(base_environment)
     assert local_environment["KEEP"] == "value"
     assert local_environment["CODESTORY_SIDECAR_PROFILE"] == "local"
@@ -2054,17 +2222,96 @@ def self_test() -> None:
         assert unclassified_attempts == 1
 
         if os.name == "nt":
-            process_handle = ctypes.windll.kernel32.OpenProcess(0x00100000, False, os.getpid())
+            kernel32 = windows_process_api()
+            process_handle = kernel32.OpenProcess(0x00100000, False, os.getpid())
             assert process_handle
             try:
                 try:
-                    require_windows_process_exit(process_handle, os.getpid(), timeout_ms=0)
+                    require_windows_process_exit(process_handle, os.getpid(), timeout_ms=0, kernel32=kernel32)
                 except RuntimeError:
                     pass
                 else:
                     raise AssertionError("an unterminated worker must remain a cleanup failure")
             finally:
-                ctypes.windll.kernel32.CloseHandle(process_handle)
+                kernel32.CloseHandle(process_handle)
+
+            class FakeKernel32:
+                def __init__(self, waits, *, handle=123, terminate=True, last_error=5):
+                    self.waits = list(waits)
+                    self.handle = handle
+                    self.terminate = terminate
+                    self.last_error = last_error
+
+                def OpenProcess(self, _access, _inherit, _pid):
+                    return self.handle
+
+                def WaitForSingleObject(self, _handle, _timeout):
+                    return self.waits.pop(0)
+
+                def TerminateProcess(self, _handle, _exit_code):
+                    return self.terminate
+
+                def CloseHandle(self, _handle):
+                    return True
+
+            failed_wait = FakeKernel32([0xFFFFFFFF], last_error=6)
+            try:
+                require_windows_process_exit(123, 42, timeout_ms=0, kernel32=failed_wait)
+            except RuntimeError as exc:
+                assert "Windows error 6" in str(exc)
+            else:
+                raise AssertionError("WAIT_FAILED must remain a cleanup failure")
+
+            open_failure = FakeKernel32([], handle=None, last_error=5)
+            open_diagnostics = {}
+            try:
+                terminate_worker_pid(
+                    42,
+                    open_diagnostics,
+                    kernel32=open_failure,
+                    run=lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 128, "", "not found"),
+                    platform="nt",
+                )
+            except RuntimeError as exc:
+                assert "Windows error 5" in str(exc)
+            else:
+                raise AssertionError("OpenProcess access failure must remain fail closed")
+            assert open_diagnostics["attempts"] == [
+                {"kind": "open_process", "success": False, "windows_error": 5}
+            ]
+
+            async_exit = FakeKernel32([258, 0])
+            async_diagnostics = {}
+
+            def timed_out_taskkill(*_args, **_kwargs):
+                raise subprocess.TimeoutExpired("taskkill", 10)
+
+            terminate_worker_pid(
+                42,
+                async_diagnostics,
+                kernel32=async_exit,
+                run=timed_out_taskkill,
+                platform="nt",
+            )
+            assert async_diagnostics["status"] == "terminated_after_direct_termination"
+            assert "TimeoutExpired" in async_diagnostics["attempts"][1]["error"]
+
+            terminate_failure = FakeKernel32([258, 258], terminate=False, last_error=5)
+            terminate_diagnostics = {}
+            try:
+                terminate_worker_pid(
+                    42,
+                    terminate_diagnostics,
+                    kernel32=terminate_failure,
+                    run=lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1, "", "denied"),
+                    platform="nt",
+                )
+            except RuntimeError as exc:
+                assert "Windows error 5" in str(exc)
+            else:
+                raise AssertionError("TerminateProcess failure must remain fail closed")
+            assert terminate_diagnostics["attempts"][1]["returncode"] == 1
+            assert terminate_diagnostics["attempts"][-1]["success"] is False
 
         stage = root / "pkg" / "codestory-cli-v9.9.9-test"
         stage.mkdir(parents=True)
@@ -2117,6 +2364,31 @@ def self_test() -> None:
         assert compose_cleanup["removed"] is True
         assert compose_cleanup["commands"][0]["kind"] == "compose_down"
 
+        optional_lexical_root = root / "compose-cleanup-optional-lexical"
+        write_proof_compose_state(optional_lexical_root, {"lexical_data_dir": None})
+        optional_lexical_artifact = root / "compose-cleanup-optional-lexical.json"
+        try:
+            cleanup_proof_cache(fake_cli, root, optional_lexical_root, optional_lexical_artifact)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("missing canonical and legacy lexical ownership must fail closed")
+        assert read_json_file(optional_lexical_artifact)["commands"][0]["kind"] == "compose_state_validation"
+        remove_tree_with_retry(optional_lexical_root)
+
+        legacy_lexical_root = root / "compose-cleanup-legacy-lexical"
+        write_proof_compose_state(
+            legacy_lexical_root,
+            {"lexical_data_dir": None, "zoekt_data_dir": str(legacy_lexical_root / "lexical")},
+        )
+        cleanup_proof_cache(
+            fake_cli,
+            root,
+            legacy_lexical_root,
+            root / "compose-cleanup-legacy-lexical.json",
+            successful_compose_cleanup,
+        )
+
         failed_compose_root = root / "compose-cleanup-failed"
         write_proof_compose_state(failed_compose_root)
         failed_compose_artifact = root / "compose-cleanup-failed.json"
@@ -2142,6 +2414,30 @@ def self_test() -> None:
         assert read_json_file(failed_compose_artifact)["removed"] is False
         remove_tree_with_retry(failed_compose_root)
 
+        masked_failure_root = root / "compose-cleanup-primary-failure"
+        write_proof_compose_state(masked_failure_root)
+        masked_failure_artifact = root / "compose-cleanup-primary-failure.json"
+        primary_artifact = root / "primary-failure.json"
+        try:
+            with contextlib.ExitStack() as stack:
+                stack.push(
+                    cleanup_proof_cache_on_exit(
+                        fake_cli,
+                        root,
+                        masked_failure_root,
+                        masked_failure_artifact,
+                        failed_compose_cleanup,
+                    )
+                )
+                raise GateFailure("primary", primary_artifact, "primary gate failed")
+        except GateFailure as exc:
+            assert exc.layer == "primary"
+            assert any("proof cleanup also failed" in note for note in getattr(exc, "__notes__", []))
+        else:
+            raise AssertionError("proof cleanup must not mask the primary gate failure")
+        assert read_json_file(masked_failure_artifact)["removed"] is False
+        remove_tree_with_retry(masked_failure_root)
+
         altered_compose_file = root / "altered-compose.yml"
         altered_compose_file.write_text("services: {}\n", encoding="utf-8")
         altered_qdrant = root / "altered-qdrant"
@@ -2150,7 +2446,9 @@ def self_test() -> None:
             ("project", {"compose_project": "not-codestory"}),
             ("file", {"compose_file": str(altered_compose_file)}),
             ("path", {"qdrant_data_dir": str(altered_qdrant)}),
+            ("lexical-path", {"lexical_data_dir": str(altered_qdrant)}),
             ("non-string", {"namespace": 7}),
+            ("lexical-non-string", {"lexical_data_dir": 7}),
         ]
         for label, overrides in validation_cases:
             cache_root = root / f"compose-validation-{label}"
@@ -2331,8 +2629,7 @@ def self_test() -> None:
             delayed_status = delayed_stdio_status["status"]
             assert delayed_status["allowed_surfaces"]["packet"]["allowed"] is True
             assert (delayed_stdio_project / ".fake-serve-first-blocked-seen").is_file()
-            delayed_status_worker.wait(timeout=5)
-            assert delayed_status_worker.returncode is not None
+            assert delayed_status_worker.poll() is None
         finally:
             terminate_worker_pid(delayed_status_worker.pid)
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
@@ -2365,8 +2662,7 @@ def self_test() -> None:
                 assert "serve-stdio-status.json" in str(exc.artifact)
             else:
                 raise AssertionError("timed-out stdio readiness retry should fail the gate")
-            retry_timeout_worker.wait(timeout=5)
-            assert retry_timeout_worker.returncode is not None
+            assert retry_timeout_worker.poll() is None
         finally:
             terminate_worker_pid(retry_timeout_worker.pid)
             os.environ.pop("CODESTORY_FAKE_FAIL_LAYER", None)
@@ -2462,6 +2758,17 @@ def self_test() -> None:
                 transcript_response(managed_artifact, "status_after_repair")
             )
             assert managed_status_after["sidecar_setup"]["active_repair"]["attempt_id"] == "fake-attempt"
+            worker_cleanup = read_json_file(
+                Path(managed_args.out_dir) / "managed-plugin-handoff-worker-cleanup.json"
+            )["workers"]
+            assert worker_cleanup[0]["source"] == "proof_started_repair_response"
+            assert worker_cleanup[0]["attempt_id"] == "fake-attempt"
+            assert worker_cleanup[0]["status"] in {
+                "already_exited",
+                "terminated",
+                "terminated_after_taskkill",
+                "terminated_after_direct_termination",
+            }
             managed_cache_root = read_json_file(Path(managed_args.out_dir) / "managed-local-ground.json")["cache_root"]
             assert Path(managed_cache_root).name.startswith("codestory-packaged-proof-cache-")
             assert managed_status_after["cache_root"] == managed_cache_root

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -158,12 +158,80 @@ def verify_archive_checksum(archive: Path, checksum_file: Path, artifact: Path) 
     require(actual == expected, "checksum", artifact, f"checksum mismatch for {archive.name}")
 
 
-def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path, artifact: Path) -> None:
+def proof_environment(base: dict[str, str]) -> dict[str, str]:
+    env = dict(base)
+    if hasattr(os, "getuid") and hasattr(os, "getgid"):
+        env["CODESTORY_QDRANT_USER"] = f"{os.getuid()}:{os.getgid()}"
+    return env
+
+
+def cleanup_proof_compose(cache_root: Path, env: dict[str, str], results: list[dict], run) -> None:
+    for state_file in sorted(cache_root.rglob("retrieval-sidecars.json")):
+        state = read_json_file(state_file)
+        if not isinstance(state, dict) or state.get("owner") != "codestory":
+            raise RuntimeError(f"proof sidecar state has unexpected ownership: {state_file}")
+        if state.get("profile") != "local" or not state.get("compose_file"):
+            continue
+        required = ("compose_project", "namespace", "qdrant_data_dir", "lexical_data_dir")
+        if any(not isinstance(state.get(name), str) or not state[name] for name in required):
+            raise RuntimeError(f"proof sidecar state is missing compose ownership: {state_file}")
+        compose_file = Path(state["compose_file"])
+        if not compose_file.is_file():
+            raise RuntimeError(f"proof sidecar compose file is missing: {compose_file}")
+        compose_env = {
+            **env,
+            "CODESTORY_SIDECAR_NAMESPACE": state["namespace"],
+            "CODESTORY_QDRANT_DATA_DIR": state["qdrant_data_dir"],
+            "CODESTORY_ZOEKT_DATA_DIR": state["lexical_data_dir"],
+            "CODESTORY_EMBED_MODEL_DIR": state["qdrant_data_dir"],
+        }
+        command = [
+            "docker",
+            "compose",
+            "-p",
+            state["compose_project"],
+            "-f",
+            str(compose_file),
+            "down",
+            "--remove-orphans",
+        ]
+        try:
+            result = run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+                check=False,
+                env=compose_env,
+                text=True,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            results.append({"kind": "compose_down", "state_file": str(state_file), "error": str(exc)})
+            raise RuntimeError(f"could not stop proof-owned Compose sidecars: {exc}") from exc
+        results.append(
+            {
+                "kind": "compose_down",
+                "state_file": str(state_file),
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"proof-owned Compose cleanup exited {result.returncode}")
+
+
+def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path, artifact: Path, run=subprocess.run) -> None:
     env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
     results = []
+    try:
+        cleanup_proof_compose(cache_root, env, results, run)
+    except RuntimeError as exc:
+        write_json(artifact, {"cache_root": str(cache_root), "commands": results, "removed": False})
+        raise
     for profile, extra in (("local", []), ("agent", ["--run-id", "shared-agent"])):
         try:
-            result = subprocess.run(
+            result = run(
                 [
                     str(cli),
                     "retrieval",
@@ -187,6 +255,7 @@ def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path, artifact: Pa
             raise RuntimeError(f"could not stop {profile} proof sidecars: {exc}") from exc
         results.append(
             {
+                "kind": "retrieval_down",
                 "profile": profile,
                 "returncode": result.returncode,
                 "stdout": result.stdout,
@@ -576,13 +645,13 @@ def plugin_stdio_status(
             project,
             layer="plugin_stdio",
             cwd=project,
-            env={
+            env=proof_environment({
                 **os.environ,
                 "CODESTORY_CLI": "",
                 "CODESTORY_CACHE_ROOT": str(cache_root),
                 "CODESTORY_PLUGIN_RELEASE_DIR": str(release_dir),
                 "PLUGIN_DATA": data,
-            },
+            }),
             cleanup_status_workers=True,
         )
 
@@ -650,14 +719,14 @@ def plugin_stdio_handoff(
             project,
             layer="managed_plugin_handoff",
             cwd=project,
-            env={
+            env=proof_environment({
                 **os.environ,
                 "CODESTORY_CLI": "",
                 "CODESTORY_CACHE_ROOT": str(cache_root),
                 "CODESTORY_PLUGIN_RELEASE_DIR": str(release_dir),
                 "CODESTORY_PLUGIN_SIDECAR_POLICY_PATH": str(policy_path),
                 "PLUGIN_DATA": str(plugin_data),
-            },
+            }),
             extra_requests=[
                 {
                     "jsonrpc": "2.0",
@@ -1171,7 +1240,7 @@ def run_gate(args: argparse.Namespace) -> None:
         cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-proof-cache-"))
         proof_cleanup_artifact = out_dir / "proof-cache-cleanup.json"
         cleanup_stack.callback(cleanup_proof_cache, cli, project, cache_root, proof_cleanup_artifact)
-        proof_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
+        proof_env = proof_environment({**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)})
         stdio_cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-stdio-cache-"))
         stdio_cleanup_artifact = out_dir / "stdio-cache-cleanup.json"
         cleanup_stack.callback(cleanup_proof_cache, cli, project, stdio_cache_root, stdio_cleanup_artifact)
@@ -1836,6 +1905,9 @@ def write_fake_plugin_launcher(plugin_root: Path) -> None:
 
 def self_test() -> None:
     base_environment = {"KEEP": "value", "CODESTORY_SIDECAR_PROFILE": "agent"}
+    owned_environment = proof_environment(base_environment)
+    if hasattr(os, "getuid") and hasattr(os, "getgid"):
+        assert owned_environment["CODESTORY_QDRANT_USER"] == f"{os.getuid()}:{os.getgid()}"
     local_environment = local_profile_environment(base_environment)
     assert local_environment["KEEP"] == "value"
     assert local_environment["CODESTORY_SIDECAR_PROFILE"] == "local"
@@ -1921,6 +1993,78 @@ def self_test() -> None:
         stage = root / "pkg" / "codestory-cli-v9.9.9-test"
         stage.mkdir(parents=True)
         write_fake_cli(stage)
+        fake_cli = find_cli(stage)
+        compose_file = root / "retrieval-compose.yml"
+        compose_file.write_text("services: {}\n", encoding="utf-8")
+
+        def write_proof_compose_state(cache_root: Path) -> None:
+            state_dir = cache_root / "sidecars" / "proof-local"
+            state_dir.mkdir(parents=True)
+            (cache_root / "qdrant").mkdir()
+            (cache_root / "lexical").mkdir()
+            write_json(
+                state_dir / "retrieval-sidecars.json",
+                {
+                    "owner": "codestory",
+                    "profile": "local",
+                    "namespace": "proof-local",
+                    "compose_project": "proof-local",
+                    "compose_file": str(compose_file),
+                    "qdrant_data_dir": str(cache_root / "qdrant"),
+                    "lexical_data_dir": str(cache_root / "lexical"),
+                },
+            )
+
+        compose_cleanup_root = root / "compose-cleanup"
+        write_proof_compose_state(compose_cleanup_root)
+        compose_cleanup_artifact = root / "compose-cleanup.json"
+        compose_calls = []
+
+        def successful_compose_cleanup(command, **kwargs):
+            if command[0] == "docker":
+                compose_calls.append((command, kwargs["env"]))
+                return subprocess.CompletedProcess(command, 0, "stopped", "")
+            return subprocess.run(command, **kwargs)
+
+        cleanup_proof_cache(
+            fake_cli,
+            root,
+            compose_cleanup_root,
+            compose_cleanup_artifact,
+            successful_compose_cleanup,
+        )
+        assert not compose_cleanup_root.exists()
+        assert compose_calls[0][0][-2:] == ["down", "--remove-orphans"]
+        assert compose_calls[0][1]["CODESTORY_SIDECAR_NAMESPACE"] == "proof-local"
+        compose_cleanup = read_json_file(compose_cleanup_artifact)
+        assert compose_cleanup["removed"] is True
+        assert compose_cleanup["commands"][0]["kind"] == "compose_down"
+
+        failed_compose_root = root / "compose-cleanup-failed"
+        write_proof_compose_state(failed_compose_root)
+        failed_compose_artifact = root / "compose-cleanup-failed.json"
+
+        def failed_compose_cleanup(command, **kwargs):
+            if command[0] == "docker":
+                return subprocess.CompletedProcess(command, 17, "", "forced failure")
+            return subprocess.run(command, **kwargs)
+
+        try:
+            cleanup_proof_cache(
+                fake_cli,
+                root,
+                failed_compose_root,
+                failed_compose_artifact,
+                failed_compose_cleanup,
+            )
+        except RuntimeError as exc:
+            assert "Compose cleanup exited 17" in str(exc)
+        else:
+            raise AssertionError("failed proof-owned Compose cleanup must remain fail-closed")
+        assert failed_compose_root.exists()
+        assert read_json_file(failed_compose_artifact)["removed"] is False
+        remove_tree_with_retry(failed_compose_root)
+
         skill = stage / PLUGIN_SKILL_RELATIVE
         skill.parent.mkdir(parents=True)
         skill.write_text("name: codestory-grounding\n", encoding="utf-8")

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -165,69 +165,145 @@ def proof_environment(base: dict[str, str]) -> dict[str, str]:
     return env
 
 
-def cleanup_proof_compose(cache_root: Path, env: dict[str, str], results: list[dict], run) -> None:
-    for state_file in sorted(cache_root.rglob("retrieval-sidecars.json")):
-        state = read_json_file(state_file)
-        if not isinstance(state, dict) or state.get("owner") != "codestory":
-            raise RuntimeError(f"proof sidecar state has unexpected ownership: {state_file}")
-        if state.get("profile") != "local" or not state.get("compose_file"):
+def validated_proof_compose_state(cache_root: Path, project: Path, read_state) -> tuple[Path, dict] | None:
+    if cache_root.is_symlink() or project.is_symlink():
+        raise RuntimeError("proof cache and project roots must not be symlinks")
+    cache_root = cache_root.resolve(strict=True)
+    project = project.resolve(strict=True)
+    state_file = cache_root / "retrieval-sidecars.json"
+    if state_file.is_symlink():
+        raise RuntimeError(f"proof sidecar state must not be a symlink: {state_file}")
+    if not state_file.exists():
+        return None
+    if not state_file.is_file():
+        raise RuntimeError(f"proof sidecar state is not a regular file: {state_file}")
+    state = read_state(state_file)
+    if not isinstance(state, dict):
+        raise TypeError(f"proof sidecar state is not an object: {state_file}")
+    expected_identity = {
+        "owner": "codestory",
+        "profile": "local",
+        "namespace": "codestory",
+        "compose_project": "codestory",
+    }
+    for name, expected in expected_identity.items():
+        if state.get(name) != expected:
+            raise RuntimeError(f"proof sidecar state {name} does not match {expected!r}: {state_file}")
+    for name, expected in (
+        ("qdrant_data_dir", cache_root / "qdrant"),
+        ("lexical_data_dir", cache_root / "lexical"),
+    ):
+        value = state.get(name)
+        if not isinstance(value, str) or not value:
+            raise TypeError(f"proof sidecar state {name} is not a path string: {state_file}")
+        observed = Path(value)
+        expected = expected.resolve(strict=True)
+        if observed != expected or observed.is_symlink() or observed.resolve(strict=True) != expected:
+            raise RuntimeError(f"proof sidecar state {name} escaped its cache root: {state_file}")
+    compose_value = state.get("compose_file")
+    if not isinstance(compose_value, str) or not compose_value:
+        raise TypeError(f"proof sidecar compose_file is not a path string: {state_file}")
+    compose_file = Path(compose_value)
+    if compose_file.is_symlink() or not compose_file.is_file():
+        raise RuntimeError(f"proof sidecar compose file is not a regular canonical file: {compose_file}")
+    allowed_compose_files = set()
+    for candidate in (
+        project / "docker" / "retrieval-compose.yml",
+        cache_root / "retrieval-compose.yml",
+    ):
+        if not candidate.is_file() or candidate.is_symlink():
             continue
-        required = ("compose_project", "namespace", "qdrant_data_dir", "lexical_data_dir")
-        if any(not isinstance(state.get(name), str) or not state[name] for name in required):
-            raise RuntimeError(f"proof sidecar state is missing compose ownership: {state_file}")
-        compose_file = Path(state["compose_file"])
-        if not compose_file.is_file():
-            raise RuntimeError(f"proof sidecar compose file is missing: {compose_file}")
-        compose_env = {
-            **env,
-            "CODESTORY_SIDECAR_NAMESPACE": state["namespace"],
-            "CODESTORY_QDRANT_DATA_DIR": state["qdrant_data_dir"],
-            "CODESTORY_ZOEKT_DATA_DIR": state["lexical_data_dir"],
-            "CODESTORY_EMBED_MODEL_DIR": state["qdrant_data_dir"],
-        }
-        command = [
-            "docker",
-            "compose",
-            "-p",
-            state["compose_project"],
-            "-f",
-            str(compose_file),
-            "down",
-            "--remove-orphans",
-        ]
-        try:
-            result = run(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                timeout=30,
-                check=False,
-                env=compose_env,
-                text=True,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            results.append({"kind": "compose_down", "state_file": str(state_file), "error": str(exc)})
-            raise RuntimeError(f"could not stop proof-owned Compose sidecars: {exc}") from exc
+        canonical_candidate = candidate.resolve(strict=True)
+        if candidate == canonical_candidate:
+            allowed_compose_files.add(canonical_candidate)
+    canonical_compose_file = compose_file.resolve(strict=True)
+    if compose_file != canonical_compose_file or canonical_compose_file not in allowed_compose_files:
+        raise RuntimeError(f"proof sidecar compose file is outside the allowed roots: {compose_file}")
+    return state_file, state
+
+
+def cleanup_proof_compose(
+    cache_root: Path,
+    project: Path,
+    env: dict[str, str],
+    results: list[dict],
+    run,
+    read_state,
+) -> None:
+    try:
+        validated = validated_proof_compose_state(cache_root, project, read_state)
+    except Exception as exc:
         results.append(
             {
-                "kind": "compose_down",
-                "state_file": str(state_file),
-                "returncode": result.returncode,
-                "stdout": result.stdout,
-                "stderr": result.stderr,
+                "kind": "compose_state_validation",
+                "state_file": str(cache_root / "retrieval-sidecars.json"),
+                "error": f"{type(exc).__name__}: {exc}",
             }
         )
-        if result.returncode != 0:
-            raise RuntimeError(f"proof-owned Compose cleanup exited {result.returncode}")
+        raise RuntimeError(f"proof-owned Compose state validation failed: {exc}") from exc
+    if validated is None:
+        return
+    state_file, state = validated
+    compose_env = {
+        **env,
+        "CODESTORY_SIDECAR_NAMESPACE": state["namespace"],
+        "CODESTORY_QDRANT_DATA_DIR": state["qdrant_data_dir"],
+        "CODESTORY_ZOEKT_DATA_DIR": state["lexical_data_dir"],
+        "CODESTORY_EMBED_MODEL_DIR": state["qdrant_data_dir"],
+    }
+    command = [
+        "docker",
+        "compose",
+        "-p",
+        state["compose_project"],
+        "-f",
+        state["compose_file"],
+        "down",
+        "--remove-orphans",
+    ]
+    try:
+        result = run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+            check=False,
+            env=compose_env,
+            text=True,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        results.append({"kind": "compose_down", "state_file": str(state_file), "error": str(exc)})
+        raise RuntimeError(f"could not stop proof-owned Compose sidecars: {exc}") from exc
+    results.append(
+        {
+            "kind": "compose_down",
+            "state_file": str(state_file),
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"proof-owned Compose cleanup exited {result.returncode}")
 
 
-def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path, artifact: Path, run=subprocess.run) -> None:
+def cleanup_proof_cache(
+    cli: Path,
+    project: Path,
+    cache_root: Path,
+    artifact: Path,
+    run=subprocess.run,
+    read_state=read_json_file,
+) -> None:
     env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
     results = []
     try:
-        cleanup_proof_compose(cache_root, env, results, run)
-    except RuntimeError as exc:
-        write_json(artifact, {"cache_root": str(cache_root), "commands": results, "removed": False})
+        cleanup_proof_compose(cache_root, project, env, results, run, read_state)
+    except Exception as exc:
+        write_json(
+            artifact,
+            {"cache_root": str(cache_root), "commands": results, "removed": False, "error": str(exc)},
+        )
         raise
     for profile, extra in (("local", []), ("agent", ["--run-id", "shared-agent"])):
         try:
@@ -1994,26 +2070,27 @@ def self_test() -> None:
         stage.mkdir(parents=True)
         write_fake_cli(stage)
         fake_cli = find_cli(stage)
-        compose_file = root / "retrieval-compose.yml"
+        compose_file = root / "docker" / "retrieval-compose.yml"
+        compose_file.parent.mkdir()
         compose_file.write_text("services: {}\n", encoding="utf-8")
 
-        def write_proof_compose_state(cache_root: Path) -> None:
-            state_dir = cache_root / "sidecars" / "proof-local"
-            state_dir.mkdir(parents=True)
+        def write_proof_compose_state(cache_root: Path, overrides: dict | None = None) -> Path:
+            cache_root.mkdir()
             (cache_root / "qdrant").mkdir()
             (cache_root / "lexical").mkdir()
-            write_json(
-                state_dir / "retrieval-sidecars.json",
-                {
-                    "owner": "codestory",
-                    "profile": "local",
-                    "namespace": "proof-local",
-                    "compose_project": "proof-local",
-                    "compose_file": str(compose_file),
-                    "qdrant_data_dir": str(cache_root / "qdrant"),
-                    "lexical_data_dir": str(cache_root / "lexical"),
-                },
-            )
+            state = {
+                "owner": "codestory",
+                "profile": "local",
+                "namespace": "codestory",
+                "compose_project": "codestory",
+                "compose_file": str(compose_file),
+                "qdrant_data_dir": str(cache_root / "qdrant"),
+                "lexical_data_dir": str(cache_root / "lexical"),
+            }
+            state.update(overrides or {})
+            state_file = cache_root / "retrieval-sidecars.json"
+            write_json(state_file, state)
+            return state_file
 
         compose_cleanup_root = root / "compose-cleanup"
         write_proof_compose_state(compose_cleanup_root)
@@ -2035,7 +2112,7 @@ def self_test() -> None:
         )
         assert not compose_cleanup_root.exists()
         assert compose_calls[0][0][-2:] == ["down", "--remove-orphans"]
-        assert compose_calls[0][1]["CODESTORY_SIDECAR_NAMESPACE"] == "proof-local"
+        assert compose_calls[0][1]["CODESTORY_SIDECAR_NAMESPACE"] == "codestory"
         compose_cleanup = read_json_file(compose_cleanup_artifact)
         assert compose_cleanup["removed"] is True
         assert compose_cleanup["commands"][0]["kind"] == "compose_down"
@@ -2064,6 +2141,85 @@ def self_test() -> None:
         assert failed_compose_root.exists()
         assert read_json_file(failed_compose_artifact)["removed"] is False
         remove_tree_with_retry(failed_compose_root)
+
+        altered_compose_file = root / "altered-compose.yml"
+        altered_compose_file.write_text("services: {}\n", encoding="utf-8")
+        altered_qdrant = root / "altered-qdrant"
+        altered_qdrant.mkdir()
+        validation_cases = [
+            ("project", {"compose_project": "not-codestory"}),
+            ("file", {"compose_file": str(altered_compose_file)}),
+            ("path", {"qdrant_data_dir": str(altered_qdrant)}),
+            ("non-string", {"namespace": 7}),
+        ]
+        for label, overrides in validation_cases:
+            cache_root = root / f"compose-validation-{label}"
+            write_proof_compose_state(cache_root, overrides)
+            artifact = root / f"compose-validation-{label}.json"
+            try:
+                cleanup_proof_cache(fake_cli, root, cache_root, artifact)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError(f"altered proof Compose {label} must fail closed")
+            validation = read_json_file(artifact)
+            assert validation["removed"] is False
+            assert validation["commands"][0]["kind"] == "compose_state_validation"
+            assert validation["commands"][0]["error"]
+            remove_tree_with_retry(cache_root)
+
+        malformed_root = root / "compose-validation-malformed"
+        malformed_state = write_proof_compose_state(malformed_root)
+        malformed_state.write_text("{", encoding="utf-8")
+        malformed_artifact = root / "compose-validation-malformed.json"
+        try:
+            cleanup_proof_cache(fake_cli, root, malformed_root, malformed_artifact)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("malformed proof Compose state must fail closed")
+        assert "JSONDecodeError" in read_json_file(malformed_artifact)["commands"][0]["error"]
+        remove_tree_with_retry(malformed_root)
+
+        unreadable_root = root / "compose-validation-unreadable"
+        write_proof_compose_state(unreadable_root)
+        unreadable_artifact = root / "compose-validation-unreadable.json"
+
+        def unreadable_state(_path):
+            raise PermissionError("forced unreadable state")
+
+        try:
+            cleanup_proof_cache(
+                fake_cli,
+                root,
+                unreadable_root,
+                unreadable_artifact,
+                read_state=unreadable_state,
+            )
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("unreadable proof Compose state must fail closed")
+        assert "PermissionError" in read_json_file(unreadable_artifact)["commands"][0]["error"]
+        remove_tree_with_retry(unreadable_root)
+
+        symlink_root = root / "compose-validation-symlink"
+        symlink_root.mkdir()
+        (symlink_root / "qdrant").mkdir()
+        (symlink_root / "lexical").mkdir()
+        symlink_target = root / "compose-validation-symlink-target.json"
+        write_json(symlink_target, {"owner": "codestory"})
+        (symlink_root / "retrieval-sidecars.json").symlink_to(symlink_target)
+        symlink_artifact = root / "compose-validation-symlink.json"
+        try:
+            cleanup_proof_cache(fake_cli, root, symlink_root, symlink_artifact)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("symlinked proof Compose state must fail closed")
+        assert "symlink" in read_json_file(symlink_artifact)["commands"][0]["error"]
+        remove_tree_with_retry(symlink_root)
+        symlink_target.unlink()
 
         skill = stage / PLUGIN_SKILL_RELATIVE
         skill.parent.mkdir(parents=True)

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -158,11 +158,12 @@ def verify_archive_checksum(archive: Path, checksum_file: Path, artifact: Path) 
     require(actual == expected, "checksum", artifact, f"checksum mismatch for {archive.name}")
 
 
-def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path) -> None:
+def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path, artifact: Path) -> None:
     env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
+    results = []
     for profile, extra in (("local", []), ("agent", ["--run-id", "shared-agent"])):
         try:
-            subprocess.run(
+            result = subprocess.run(
                 [
                     str(cli),
                     "retrieval",
@@ -173,15 +174,40 @@ def cleanup_proof_cache(cli: Path, project: Path, cache_root: Path) -> None:
                     profile,
                     *extra,
                 ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 timeout=20,
                 check=False,
                 env=env,
+                text=True,
             )
-        except (OSError, subprocess.TimeoutExpired):
-            pass
-    shutil.rmtree(cache_root, ignore_errors=True)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            results.append({"profile": profile, "error": str(exc)})
+            write_json(artifact, {"cache_root": str(cache_root), "commands": results, "removed": False})
+            raise RuntimeError(f"could not stop {profile} proof sidecars: {exc}") from exc
+        results.append(
+            {
+                "profile": profile,
+                "returncode": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        )
+        if result.returncode != 0:
+            write_json(artifact, {"cache_root": str(cache_root), "commands": results, "removed": False})
+            raise RuntimeError(f"{profile} proof sidecar cleanup exited {result.returncode}")
+    try:
+        remove_tree_with_retry(cache_root)
+    except OSError as exc:
+        write_json(
+            artifact,
+            {"cache_root": str(cache_root), "commands": results, "removed": False, "error": str(exc)},
+        )
+        raise
+    removed = not cache_root.exists()
+    write_json(artifact, {"cache_root": str(cache_root), "commands": results, "removed": removed})
+    if not removed:
+        raise RuntimeError(f"proof cache still exists after cleanup: {cache_root}")
 
 
 def local_profile_environment(base: dict[str, str]) -> dict[str, str]:
@@ -457,8 +483,27 @@ def terminate_worker_pid(pid: int) -> None:
     else:
         try:
             os.kill(pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            pass
+        except ProcessLookupError:
+            return
+        except PermissionError as exc:
+            raise RuntimeError(f"could not terminate worker process {pid}") from exc
+        deadline = time.monotonic() + 10
+        while True:
+            try:
+                exited = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+                if exited is not None:
+                    return
+            except ChildProcessError:
+                pass
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            except PermissionError as exc:
+                raise RuntimeError(f"could not prove worker process {pid} terminated") from exc
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f"worker process {pid} did not terminate before cleanup")
+            time.sleep(0.1)
 
 
 def running_status_worker_pids(status: dict) -> set[int]:
@@ -1124,10 +1169,12 @@ def run_gate(args: argparse.Namespace) -> None:
         cli = find_cli(unpacked)
         plugin_skill = find_plugin_skill(unpacked)
         cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-proof-cache-"))
-        cleanup_stack.callback(cleanup_proof_cache, cli, project, cache_root)
+        proof_cleanup_artifact = out_dir / "proof-cache-cleanup.json"
+        cleanup_stack.callback(cleanup_proof_cache, cli, project, cache_root, proof_cleanup_artifact)
         proof_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
         stdio_cache_root = Path(tempfile.mkdtemp(prefix="codestory-packaged-stdio-cache-"))
-        cleanup_stack.callback(cleanup_proof_cache, cli, project, stdio_cache_root)
+        stdio_cleanup_artifact = out_dir / "stdio-cache-cleanup.json"
+        cleanup_stack.callback(cleanup_proof_cache, cli, project, stdio_cache_root, stdio_cleanup_artifact)
         stdio_env = {**os.environ, "CODESTORY_CACHE_ROOT": str(stdio_cache_root)}
 
         summary = {
@@ -1135,7 +1182,10 @@ def run_gate(args: argparse.Namespace) -> None:
             "cli": str(cli),
             "plugin_skill": str(plugin_skill),
             "project": str(project),
-            "artifacts": {},
+            "artifacts": {
+                "proof_cache_cleanup": str(proof_cleanup_artifact),
+                "stdio_cache_cleanup": str(stdio_cleanup_artifact),
+            },
         }
         if args.checksum_file:
             summary["artifacts"]["checksum"] = str(checksum_artifact)
@@ -1532,6 +1582,8 @@ def write_fake_cli(path: Path) -> None:
                 })
             elif layer == "retrieval_status":
                 emit({"retrieval_mode": "full"})
+            elif layer == "retrieval_down":
+                emit({"stopped": True})
             elif layer == "search":
                 emit({"retrieval_shadow": {"retrieval_mode": "full"}, "indexed_symbol_hits": [{"node_id": "1"}]})
             elif layer == "context":
@@ -1897,6 +1949,8 @@ def self_test() -> None:
         )
         run_gate(args)
         assert (out_dir / "summary.json").is_file()
+        assert read_json_file(out_dir / "proof-cache-cleanup.json")["removed"] is True
+        assert read_json_file(out_dir / "stdio-cache-cleanup.json")["removed"] is True
         stdio_artifact = read_json_file(out_dir / "serve-stdio-status.json")
         full_cache_root = read_json_file(out_dir / "local-retrieval-bootstrap.json")["cache_root"]
         assert Path(full_cache_root).name.startswith("codestory-packaged-proof-cache-")
@@ -1914,7 +1968,16 @@ def self_test() -> None:
         version_only_args.version_only = True
         run_gate(version_only_args)
         version_only_summary = read_json_file(version_only_out / "summary.json")
-        assert version_only_summary["artifacts"].keys() == {"checksum", "version", "help", "serve_stdio"}
+        assert version_only_summary["artifacts"].keys() == {
+            "checksum",
+            "version",
+            "help",
+            "serve_stdio",
+            "proof_cache_cleanup",
+            "stdio_cache_cleanup",
+        }
+        assert read_json_file(Path(version_only_args.out_dir) / "proof-cache-cleanup.json")["removed"] is True
+        assert read_json_file(Path(version_only_args.out_dir) / "stdio-cache-cleanup.json")["removed"] is True
         assert not (version_only_out / "local-retrieval-bootstrap.json").exists()
         version_only_status = read_json_file(version_only_out / "serve-stdio-status.json")["status"]
         assert Path(version_only_status["cache_root"]).name.startswith("codestory-packaged-stdio-cache-")

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -16,6 +16,76 @@ const packagedPlatformPr = path.join(workflowRoot, "packaged-platform-pr.yml");
 const packagedPlatformProof = path.join(workflowRoot, "packaged-platform-proof.yml");
 const mainBranchSourceGuard = path.join(workflowRoot, "main-branch-source-guard.yml");
 
+function yamlJob(content, name) {
+  const lines = content.split(/\r?\n/u);
+  const start = lines.indexOf(`  ${name}:`);
+  if (start < 0) return [];
+  const end = lines.findIndex((line, index) => index > start && /^  \S/iu.test(line));
+  return lines.slice(start, end < 0 ? undefined : end);
+}
+
+function namedStep(job, name) {
+  const start = job.indexOf(`      - name: ${name}`);
+  if (start < 0) return [];
+  const relativeEnd = job.slice(start + 1).findIndex((line) => /^      - /u.test(line));
+  return job.slice(start, relativeEnd < 0 ? undefined : start + 1 + relativeEnd);
+}
+
+function managedPluginMatrixIsRequired(content, jobName, archiveLine) {
+  const job = yamlJob(content, jobName);
+  const step = namedStep(job, "Prove managed plugin handoff");
+  const required = [
+    "        run: >-",
+    "          python .github/scripts/check-packaged-agent-proof.py",
+    archiveLine,
+    "          --managed-plugin-handoff",
+  ];
+  return !(
+    job.length === 0 ||
+    job.some((line) => /^    (?:if|continue-on-error):/u.test(line)) ||
+    !job.includes("      fail-fast: false") ||
+    job.some((line) => /^\s+exclude:/u.test(line)) ||
+    step.length === 0 ||
+    step.some((line) => /^        (?:if|continue-on-error):/u.test(line)) ||
+    required.some((line) => !step.includes(line))
+  );
+}
+
+function requireManagedPluginStep(content, jobName, workflowName, archiveLine) {
+  if (!managedPluginMatrixIsRequired(content, jobName, archiveLine)) {
+    violations.push(`${workflowName} must run the managed plugin handoff unconditionally in every matrix cell`);
+  }
+  const policyBypasses = [
+    ["fail-fast", content.replace("      fail-fast: false\n", "")],
+    ["matrix exclude", content.replace("      matrix:\n", "      matrix:\n        exclude:\n          - os: never\n")],
+    ["job if", content.replace(`  ${jobName}:\n`, `  ${jobName}:\n    if: always()\n`)],
+    [
+      "job continue-on-error",
+      content.replace(`  ${jobName}:\n`, `  ${jobName}:\n    continue-on-error: true\n`),
+    ],
+    [
+      "step if",
+      content.replace(
+        "      - name: Prove managed plugin handoff\n",
+        "      - name: Prove managed plugin handoff\n        if: always()\n",
+      ),
+    ],
+    [
+      "step continue-on-error",
+      content.replace(
+        "      - name: Prove managed plugin handoff\n",
+        "      - name: Prove managed plugin handoff\n        continue-on-error: true\n",
+      ),
+    ],
+  ];
+  const acceptedBypasses = policyBypasses
+    .filter(([, candidate]) => managedPluginMatrixIsRequired(candidate, jobName, archiveLine))
+    .map(([name]) => name);
+  if (acceptedBypasses.length > 0) {
+    violations.push(`${workflowName} managed matrix policy accepted bypasses: ${acceptedBypasses.join(", ")}`);
+  }
+}
+
 for (const file of fs
   .readdirSync(workflowRoot)
   .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))) {
@@ -194,6 +264,9 @@ if (!fs.existsSync(packagedPlatformProof)) {
     "contents: read",
     'RELEASE_RUST_TOOLCHAIN: "1.95.0"',
     "packaged-version-proof-${{ matrix.asset_target }}",
+    "packaged-managed-proof-${{ matrix.asset_target }}",
+    "- name: Prove managed plugin handoff",
+    "--archive \"target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}\"",
     "--managed-plugin-handoff",
     "scripts/install-codestory.ps1 -SelfTest",
     "--checksum-file target/release-dist/SHA256SUMS.txt",
@@ -203,18 +276,24 @@ if (!fs.existsSync(packagedPlatformProof)) {
     }
   }
   for (const row of [
-    "- os: ubuntu-latest\n            rust_target: x86_64-unknown-linux-gnu\n            asset_target: linux-x64",
-    "- os: ubuntu-24.04-arm\n            rust_target: aarch64-unknown-linux-gnu\n            asset_target: linux-arm64",
-    "- os: windows-latest\n            rust_target: x86_64-pc-windows-msvc\n            asset_target: windows-x64",
-    "- os: windows-11-arm\n            rust_target: aarch64-pc-windows-msvc\n            asset_target: windows-arm64",
-    "- os: macos-15-intel\n            rust_target: x86_64-apple-darwin\n            asset_target: macos-x64",
-    "- os: macos-15\n            rust_target: aarch64-apple-darwin\n            asset_target: macos-arm64",
+    "- os: ubuntu-latest\n            rust_target: x86_64-unknown-linux-gnu\n            asset_target: linux-x64\n            exe_suffix: \"\"\n            extension: tar.gz",
+    "- os: ubuntu-24.04-arm\n            rust_target: aarch64-unknown-linux-gnu\n            asset_target: linux-arm64\n            exe_suffix: \"\"\n            extension: tar.gz",
+    "- os: windows-latest\n            rust_target: x86_64-pc-windows-msvc\n            asset_target: windows-x64\n            exe_suffix: \".exe\"\n            extension: zip",
+    "- os: windows-11-arm\n            rust_target: aarch64-pc-windows-msvc\n            asset_target: windows-arm64\n            exe_suffix: \".exe\"\n            extension: zip",
+    "- os: macos-15-intel\n            rust_target: x86_64-apple-darwin\n            asset_target: macos-x64\n            exe_suffix: \"\"\n            extension: tar.gz",
+    "- os: macos-15\n            rust_target: aarch64-apple-darwin\n            asset_target: macos-arm64\n            exe_suffix: \"\"\n            extension: tar.gz",
     "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: pwsh -File scripts/install-codestory.ps1 -SelfTest",
   ]) {
     if (!content.includes(row)) {
       violations.push(`packaged-platform-proof.yml must preserve native proof block ${row.split("\n")[0]}`);
     }
   }
+  requireManagedPluginStep(
+    content,
+    "build",
+    "packaged-platform-proof.yml",
+    '          --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}"',
+  );
 }
 
 if (!fs.existsSync(postPublishReleaseSmoke)) {
@@ -235,6 +314,7 @@ if (!fs.existsSync(postPublishReleaseSmoke)) {
     "macos-x64",
     "macos-arm64",
     "--version-only",
+    "- name: Prove managed plugin handoff",
     "--managed-plugin-handoff",
     "scripts/install-codestory.ps1 -SelfTest",
     "--checksum-file \"${{ steps.asset.outputs.checksum }}\"",
@@ -251,7 +331,6 @@ if (!fs.existsSync(postPublishReleaseSmoke)) {
     "- os: macos-15-intel\n            asset_target: macos-x64\n            extension: tar.gz",
     "- os: macos-15\n            asset_target: macos-arm64\n            extension: tar.gz",
     "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: pwsh -File scripts/install-codestory.ps1 -SelfTest",
-    "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: >-\n          python .github/scripts/check-packaged-agent-proof.py",
   ]) {
     if (!content.includes(row)) {
       violations.push(`post-publish-release-smoke.yml must preserve native proof block ${row.split("\n")[0]}`);
@@ -260,6 +339,12 @@ if (!fs.existsSync(postPublishReleaseSmoke)) {
   if (content.includes("sha256sum")) {
     violations.push("post-publish-release-smoke.yml must use the portable Python checksum gate");
   }
+  requireManagedPluginStep(
+    content,
+    "smoke",
+    "post-publish-release-smoke.yml",
+    '          --archive "${{ steps.asset.outputs.archive }}"',
+  );
 }
 
 if (!fs.existsSync(packagedPlatformPr)) {

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -27,26 +27,32 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
             asset_target: linux-x64
             exe_suffix: ""
+            extension: tar.gz
           - os: ubuntu-24.04-arm
             rust_target: aarch64-unknown-linux-gnu
             asset_target: linux-arm64
             exe_suffix: ""
+            extension: tar.gz
           - os: windows-latest
             rust_target: x86_64-pc-windows-msvc
             asset_target: windows-x64
             exe_suffix: ".exe"
+            extension: zip
           - os: windows-11-arm
             rust_target: aarch64-pc-windows-msvc
             asset_target: windows-arm64
             exe_suffix: ".exe"
+            extension: zip
           - os: macos-15-intel
             rust_target: x86_64-apple-darwin
             asset_target: macos-x64
             exe_suffix: ""
+            extension: tar.gz
           - os: macos-15
             rust_target: aarch64-apple-darwin
             asset_target: macos-arm64
             exe_suffix: ""
+            extension: tar.gz
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -177,12 +183,10 @@ jobs:
         shell: pwsh
         run: pwsh -File scripts/install-codestory.ps1 -SelfTest
 
-      - name: Prove Windows managed plugin handoff
-        if: matrix.asset_target == 'windows-x64'
-        shell: pwsh
+      - name: Prove managed plugin handoff
         run: >-
           python .github/scripts/check-packaged-agent-proof.py
-          --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.zip"
+          --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}"
           --checksum-file target/release-dist/SHA256SUMS.txt
           --expected-version "${{ inputs.version }}"
           --project "${{ github.workspace }}"
@@ -190,8 +194,8 @@ jobs:
           --managed-plugin-handoff
           --out-dir target/packaged-managed-proof
 
-      - name: Upload Windows managed plugin proof
-        if: always() && matrix.asset_target == 'windows-x64'
+      - name: Upload managed plugin proof
+        if: always()
         uses: actions/upload-artifact@v7.0.1
         with:
           name: packaged-managed-proof-${{ matrix.asset_target }}

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -101,9 +101,7 @@ jobs:
         shell: pwsh
         run: pwsh -File scripts/install-codestory.ps1 -SelfTest
 
-      - name: Prove Windows managed plugin handoff
-        if: matrix.asset_target == 'windows-x64'
-        shell: pwsh
+      - name: Prove managed plugin handoff
         run: >-
           python .github/scripts/check-packaged-agent-proof.py
           --archive "${{ steps.asset.outputs.archive }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
   restart.
 - Expanded managed-plugin provisioning, local grounding, repair handoff, and
   proof cleanup from Windows x64 to every shipped native release asset in both
-  pre-publish and post-publish matrices.
+  pre-publish and post-publish matrices. Linux proof containers now write
+  bind-mounted Qdrant data as the proof owner, and cleanup explicitly stops the
+  proof-owned local Compose namespace before verifying cache removal.
 - Made sidecar generation GC root every current and rollback manifest across
   the shared cache scope instead of collapsing rollback evidence to one latest
   generation. Inventory now reports active, rollback, building, and reclaimable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   background. Status now reports the in-process provisioning state, and the
   launcher hands the next request to the verified stdio runtime without a host
   restart.
+- Expanded managed-plugin provisioning, local grounding, repair handoff, and
+  proof cleanup from Windows x64 to every shipped native release asset in both
+  pre-publish and post-publish matrices.
 - Made sidecar generation GC root every current and rollback manifest across
   the shared cache scope instead of collapsing rollback evidence to one latest
   generation. Inventory now reports active, rollback, building, and reclaimable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,18 @@
 - Expanded managed-plugin provisioning, local grounding, repair handoff, and
   proof cleanup from Windows x64 to every shipped native release asset in both
   pre-publish and post-publish matrices. Linux proof containers now write
-  bind-mounted Qdrant data as the proof owner, and cleanup explicitly stops the
-  proof-owned local Compose namespace before verifying cache removal.
+  bind-mounted Qdrant data as the proof owner, keep Qdrant snapshots inside that
+  owned mount, and capture Compose/Qdrant diagnostics before cleanup on failure.
+  Cleanup explicitly stops the proof-owned local Compose namespace before
+  verifying cache removal and preserves the original gate failure if cleanup
+  also fails.
+- Stopped new sidecar state from emitting removed Zoekt path, port, and image
+  keys. State now writes `lexical_data_dir`, accepts `zoekt_data_dir` only while
+  reading legacy state, and keeps legacy cleanup bounded to state that proves
+  ownership of the old Zoekt directory. Legacy retrieval state remains readable
+  and the next owned sidecar publication rewrites it in canonical form;
+  rebuilding remains the fail-closed recovery when legacy state does not match
+  the current cache.
 - Made sidecar generation GC root every current and rollback manifest across
   the shared cache scope instead of collapsing rollback evidence to one latest
   generation. Inventory now reports active, rollback, building, and reclaimable

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -27,8 +27,6 @@ use std::time::{Duration, Instant};
 
 const NATIVE_EMBEDDING_PROCESS_START_TOLERANCE_MS: i64 = 5 * 60 * 1000;
 const LEGACY_ZOEKT_CLEANUP_ENTRY_LIMIT: usize = 4_096;
-const LEGACY_ZOEKT_HTTP_PORT: u16 = 6070;
-const LEGACY_ZOEKT_IMAGE_PIN: &str = "sourcegraph/zoekt-webserver:0.0.0-20250506123554-490422d1adb4@sha256:34c77a62bcafc41ce3ee193e44f42aa84690d9ec51b953e7efae4dfdfae80aff";
 #[cfg(not(windows))]
 const NATIVE_EMBEDDING_STOP_WAIT: Duration = Duration::from_secs(5);
 #[cfg(not(windows))]
@@ -88,7 +86,7 @@ pub struct SidecarStateFile {
     pub embedding_launch: Option<EmbeddingLaunchMetadata>,
     #[serde(default = "default_sidecar_image_pins")]
     pub sidecar_images: SidecarImagePins,
-    #[serde(rename = "zoekt_data_dir", alias = "lexical_data_dir")]
+    #[serde(alias = "zoekt_data_dir")]
     pub lexical_data_dir: String,
     pub qdrant_data_dir: String,
     pub scip_artifacts_root: String,
@@ -157,17 +155,7 @@ pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
         cleanup_command: runtime.cleanup_command.clone(),
         started_at_epoch_ms: chrono::Utc::now().timestamp_millis(),
     };
-    let mut value = serde_json::to_value(&state).context("serialize sidecar state")?;
-    let object = value
-        .as_object_mut()
-        .context("sidecar state must serialize as an object")?;
-    object.insert("zoekt_http_port".into(), LEGACY_ZOEKT_HTTP_PORT.into());
-    object
-        .get_mut("sidecar_images")
-        .and_then(serde_json::Value::as_object_mut)
-        .context("sidecar image pins must serialize as an object")?
-        .insert("zoekt".into(), LEGACY_ZOEKT_IMAGE_PIN.into());
-    let json = serde_json::to_vec_pretty(&value).context("serialize sidecar state")?;
+    let json = serde_json::to_vec_pretty(&state).context("serialize sidecar state")?;
     codestory_workspace::atomic_file::write_bytes_atomic(
         &layout.state_file,
         "retrieval-sidecars",
@@ -192,12 +180,7 @@ fn cleanup_owned_legacy_zoekt(layout: &SidecarLayout) -> Result<()> {
         .get("zoekt_data_dir")
         .and_then(|value| value.as_str())
         .is_some_and(|path| Path::new(path) == legacy_root);
-    let current_state_matches = state
-        .get("lexical_data_dir")
-        .or_else(|| state.get("zoekt_data_dir"))
-        .and_then(|value| value.as_str())
-        .is_some_and(|path| Path::new(path) == layout.lexical_data_dir);
-    if !legacy_state_matches && !current_state_matches {
+    if !legacy_state_matches {
         return Ok(());
     }
     let mut remaining = LEGACY_ZOEKT_CLEANUP_ENTRY_LIMIT;
@@ -1261,22 +1244,33 @@ mod tests {
         let raw: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&runtime.layout.state_file).expect("read state"))
                 .expect("state json");
-        assert_eq!(
-            raw.get("zoekt_http_port").and_then(|value| value.as_u64()),
-            Some(u64::from(LEGACY_ZOEKT_HTTP_PORT))
-        );
-        assert!(raw.get("zoekt_data_dir").is_some());
-        assert_eq!(
-            raw.pointer("/sidecar_images/zoekt")
-                .and_then(|value| value.as_str()),
-            Some(LEGACY_ZOEKT_IMAGE_PIN)
-        );
+        assert!(raw.get("lexical_data_dir").is_some());
+        assert!(raw.get("zoekt_data_dir").is_none());
+        assert!(raw.get("zoekt_http_port").is_none());
+        assert!(raw.pointer("/sidecar_images/zoekt").is_none());
         assert!(
             std::fs::read_dir(root.path())
                 .expect("read root")
                 .flatten()
                 .all(|entry| !entry.file_name().to_string_lossy().ends_with(".tmp"))
         );
+    }
+
+    #[test]
+    fn sidecar_state_reads_legacy_zoekt_data_dir_without_reemitting_it() {
+        let root = TempDir::new().expect("root");
+        let runtime = test_runtime(&root);
+        let state = sidecar_up_with_runtime(&runtime, None).expect("state");
+        let mut raw = serde_json::to_value(&state).expect("serialize state");
+        let object = raw.as_object_mut().expect("state object");
+        let lexical = object.remove("lexical_data_dir").expect("lexical path");
+        object.insert("zoekt_data_dir".to_string(), lexical);
+
+        let migrated: SidecarStateFile = serde_json::from_value(raw).expect("read legacy state");
+        let rewritten = serde_json::to_value(migrated).expect("rewrite state");
+
+        assert!(rewritten.get("lexical_data_dir").is_some());
+        assert!(rewritten.get("zoekt_data_dir").is_none());
     }
 
     #[test]

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -13,6 +13,8 @@ services:
     image: qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-qdrant
     user: "${CODESTORY_QDRANT_USER:-0:0}"
+    environment:
+      QDRANT__STORAGE__SNAPSHOTS_PATH: "${CODESTORY_QDRANT_SNAPSHOTS_PATH:-/qdrant/snapshots}"
     restart: unless-stopped
     labels:
       dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}

--- a/docker/retrieval-compose.yml
+++ b/docker/retrieval-compose.yml
@@ -12,6 +12,7 @@ services:
   qdrant:
     image: qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae
     container_name: ${CODESTORY_SIDECAR_NAMESPACE:-codestory}-qdrant
+    user: "${CODESTORY_QDRANT_USER:-0:0}"
     restart: unless-stopped
     labels:
       dev.codestory.owner: ${CODESTORY_SIDECAR_OWNER:-codestory}

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -150,6 +150,14 @@ package execution does not close #887; live managed Metal endpoint survival
 still needs reporter or equivalent Apple Silicon hardware evidence. Current
 Ubuntu execution does not prove older-glibc compatibility.
 
+Proof cleanup validates the exact current `lexical_data_dir` and accepts the
+legacy `zoekt_data_dir` spelling only as read compatibility for an otherwise
+proof-owned state file. New state must never emit Zoekt path, port, or image
+keys. When local retrieval indexing fails, the proof records Compose process
+state and bounded Qdrant logs before cleanup so the primary failure remains
+diagnosable; cleanup failure is retained as secondary evidence and must not
+replace the primary gate failure.
+
 Release closeout is not complete until every published asset cell passes and
 the corresponding CodeStory plugin-source update is committed or merged in
 `TheGreenCedar/AgentPluginMarketplace`, followed by marketplace refresh and

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -134,16 +134,17 @@ granting release permissions to pull-request code:
 
 | Asset | Native runner | Required packaged proof |
 | --- | --- | --- |
-| Linux x64 | `ubuntu-latest` | Version, help, stdio shape, and the full-sidecar agent proof |
-| Linux arm64 | `ubuntu-24.04-arm` | Version, help, and stdio shape |
-| Windows x64 | `windows-latest` | Version, help, stdio shape, installer ownership self-test, managed provisioning, local ground, and repair handoff |
-| Windows arm64 | `windows-11-arm` | Version, help, and stdio shape |
-| macOS x64 | `macos-15-intel` | Version, help, and stdio shape |
-| macOS arm64 | `macos-15` | Version, help, and stdio shape |
+| Linux x64 | `ubuntu-latest` | Version, help, stdio shape, managed provisioning, local ground, repair handoff, cleanup, and the full-sidecar agent proof |
+| Linux arm64 | `ubuntu-24.04-arm` | Version, help, stdio shape, managed provisioning, local ground, repair handoff, and cleanup |
+| Windows x64 | `windows-latest` | Version, help, stdio shape, installer ownership self-test, managed provisioning, local ground, repair handoff, and cleanup |
+| Windows arm64 | `windows-11-arm` | Version, help, stdio shape, managed provisioning, local ground, repair handoff, and cleanup |
+| macOS x64 | `macos-15-intel` | Version, help, stdio shape, managed provisioning, local ground, repair handoff, and cleanup |
+| macOS arm64 | `macos-15` | Version, help, stdio shape, managed provisioning, local ground, repair handoff, and cleanup |
 
-The Windows managed handoff proves that the packaged CLI can be installed by
-the plugin, serve status, use the local graph, and publish a background repair
-reservation. It does not prove full sidecars or GPU execution. macOS x64
+The managed handoff on every native runner proves that the packaged CLI can be
+installed by the plugin, serve status, use the local graph, publish a background
+repair reservation, and clean up its proof-owned processes and cache. It does
+not prove full sidecars or GPU execution. macOS x64
 package execution does not make Apple Silicon acceleration claims. macOS arm64
 package execution does not close #887; live managed Metal endpoint survival
 still needs reporter or equivalent Apple Silicon hardware evidence. Current


### PR DESCRIPTION
## Context

The six-cell release matrices executed every shipped archive, but managed-plugin provisioning, local grounding, repair handoff, and cleanup were only qualified on Windows x64. The other five supported targets stopped at version/help/stdio shape, leaving #921's managed lifecycle claim incomplete.

PR #986 merged as squash commit `a2f0938a`. This branch contains four #1031 commits on that exact base and changes only the eight lifecycle, proof, state-contract, documentation, and workflow files listed by the PR.

Closes #1030
Refs #921

## What Changed

- Run the managed-plugin handoff gate unconditionally on all six native pre-publish and post-publish cells, with explicit archive extensions, per-target evidence artifacts, `fail-fast: false`, and workflow-policy checks that reject exclusions, conditions, and `continue-on-error` bypasses.
- Make proof cleanup fail closed while preserving the primary gate failure. It validates the exact proof-owned state/Compose identity, records retrieval-down and Compose teardown, requires cache absence, and captures bounded `compose ps` plus Qdrant logs before cleanup whenever retrieval indexing fails, including exit-zero contract failures.
- Scope non-root Qdrant execution to proof environments. The proof passes its UID/GID and places Qdrant snapshots under the proof-owned storage mount; normal runtime Compose retains the root user and `/qdrant/snapshots` defaults.
- Harden Windows repair-worker cleanup with typed 64-bit Win32 bindings, checked `taskkill`, `WaitForSingleObject`, and `TerminateProcess` outcomes, and persisted per-PID source/attempt/kill diagnostics before failure. Only the repair PID started by this proof and observed with the same attempt ID is eligible; arbitrary PIDs merely visible in status are never swept.
- Correct the sidecar-state migration direction. New state writes `lexical_data_dir` and no longer emits Zoekt path, port, or image keys. `zoekt_data_dir` remains a read-only legacy alias, and bounded legacy cleanup requires exact state-proven ownership of the old Zoekt directory.
- Update the changelog and contributor testing matrix without widening Linux-x64 full-sidecar, Apple Metal/#887, GPU, or older-glibc claims.

## CI Failures and Root Causes

Run `29210464288`, Linux x64 job `86697247949`:

- `retrieval index` exited 1 because Qdrant refused connections.
- The cleanup validator then masked that primary `GateFailure` because it expected the test-only `lexical_data_dir` spelling while production state serialized `zoekt_data_dir`.
- The Qdrant 1.12.5 image failure was reproduced with the proof UID: it exited 101 because the non-root process could not create `/qdrant/snapshots`. Pointing snapshots at `/qdrant/storage/snapshots` under the already-owned bind mount kept the same pinned image running.
- Cleanup now accepts only an exact canonical path or exact legacy alias, never synthesizes missing ownership, preserves the primary failure, and records pre-cleanup Compose/Qdrant diagnostics.

Run `29210464288`, Windows x64 job `86697247985`:

- The managed repair worker PID 2628 remained nonsignaled after the old blind `taskkill` and `TerminateProcess` sequence (`WAIT_TIMEOUT` 258).
- The old proof discarded taskkill return/output, Win32 errors, and cleanup provenance, and used untyped ctypes calls. The historical runner evidence therefore cannot prove which termination sub-operation failed.
- The fix pins the process identity with `OpenProcess` before killing, uses typed `HANDLE`/DWORD/BOOL/UINT signatures, classifies wait results, checks all termination outcomes, persists diagnostics before raising, and limits cleanup authority to the proof-started matching repair attempt.

## How To Review

1. Confirm both workflow matrices retain exactly six native target rows and the managed handoff step has no condition.
2. Review `validated_proof_compose_state`, `capture_proof_compose_diagnostics`, `cleanup_proof_compose`, and `cleanup_proof_cache_on_exit` for exact ownership and primary-error preservation.
3. Review `proof_started_repair_workers` and `terminate_worker_pid` for attempt-ID ownership, typed Win32 calls, checked outcomes, and persisted diagnostics.
4. Review `SidecarStateFile` serialization and migration tests: canonical writes use `lexical_data_dir`; legacy `zoekt_data_dir` is read-only compatibility; new state has no Zoekt port/image/path output.
5. Confirm the testing matrix preserves the narrower sidecar and accelerator proof boundaries.

## Verification

On exact head `3056c1d2` over exact merge-base `a2f0938a`:

- `python .github/scripts/check-packaged-agent-proof.py --self-test` on Windows — passed
- The same packaged-proof self-test under Ubuntu/WSL — passed
- `python -m py_compile .github/scripts/check-packaged-agent-proof.py` — passed
- `cargo test -p codestory-retrieval sidecar_state_ -- --nocapture` — 2 passed
- `cargo test -p codestory-retrieval` — 333 unit tests passed, 2 measurement/live-sidecar tests ignored; all non-live integration binaries passed
- `cargo fmt --all --check` — passed
- `node .github/scripts/check-workflow-policy.mjs` — passed
- `node .github/scripts/check-doc-links.mjs` — 69 files, 281 relative links
- `docker compose -f docker/retrieval-compose.yml config` with proof UID and snapshots path — passed with `user: 1000:1000` and `/qdrant/storage/snapshots`
- Direct pinned Qdrant repro: default non-root snapshots path exited 101 with permission denied; proof snapshots path remained running
- `git diff --check` — passed
- Independent review found two proof gaps; both were fixed, and the focused re-review was CLEAN

CodeStory managed runtime status was available on 0.14.3. Its local `affected` graph remained blocked while a local reindex was still refreshing, so no graph-impact claim is made from that unavailable surface.

## Risk

The change increases native matrix work by running the existing managed proof on five additional targets. Cleanup is intentionally strict: missing, ambiguous, forged, or escaping state blocks teardown rather than targeting Docker. Historical Windows evidence cannot identify the exact old Win32 sub-operation because the old gate discarded it; the new artifact makes any recurrence diagnosable. Full sidecars remain Linux-x64-only. There is no screenshot-visible UI change.