### PR TITLE
Prove prior-version managed CLI upgrade convergence

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -949,12 +949,54 @@ def plugin_stdio_handoff(
     expected_version: str,
     archive_cli: Path,
     empty_model_dir: Path,
+    archive: Path,
 ) -> dict:
     require_plugin_manifest_version(plugin_root, expected_version)
     launcher = plugin_root / "scripts" / "codestory-mcp.cjs"
     require(launcher.is_file(), "managed_plugin_convergence", artifact, f"plugin launcher is missing: {launcher}")
     with temporary_directory_with_retry("codestory-plugin-data-", artifact.parent) as data:
         plugin_data = Path(data)
+        prior_version = "0.0.0"
+        archive_suffix = archive.name.removeprefix(f"codestory-cli-v{expected_version}-")
+        extension = ".zip" if archive_suffix.endswith(".zip") else ".tar.gz"
+        target = archive_suffix.removesuffix(extension)
+        require(
+            target and target != archive_suffix,
+            "managed_plugin_convergence",
+            artifact,
+            f"could not derive release target from {archive.name}",
+        )
+        prior_dir = plugin_data / "codestory-cli" / prior_version
+        prior_bin = prior_dir / "bin" / ("codestory-cli.cmd" if os.name == "nt" else "codestory-cli")
+        prior_bin.parent.mkdir(parents=True)
+        if os.name == "nt":
+            prior_bin.write_text(
+                f"@echo off\r\nif \"%1\"==\"--version\" (echo codestory-cli {prior_version}& exit /b 0)\r\nexit /b 90\r\n",
+                encoding="utf-8",
+            )
+        else:
+            prior_bin.write_text(
+                f"#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codestory-cli {prior_version}'; exit 0; fi\nexit 90\n",
+                encoding="utf-8",
+            )
+            prior_bin.chmod(prior_bin.stat().st_mode | stat.S_IXUSR)
+        prior_archive = f"codestory-cli-v{prior_version}-{target}{extension}"
+        write_json(
+            prior_dir / "manifest.json",
+            {
+                "path": prior_bin.relative_to(prior_dir).as_posix(),
+                "sha256": sha256_file(prior_bin),
+                "version": prior_version,
+                "build_source": "github_release",
+                "repo_ref": f"v{prior_version}",
+                "archive": prior_archive,
+                "archive_url": (release_dir / prior_archive).resolve().as_uri(),
+                "archive_sha256": "0" * 64,
+                "target": target,
+                "provisioned_at": "1970-01-01T00:00:00.000Z",
+                "stdio_initialize_verified": True,
+            },
+        )
         policy_path = plugin_data / "sidecar-setup-policy.json"
         policy_artifact = artifact.with_name("managed-plugin-policy.json")
         try:
@@ -1064,6 +1106,25 @@ def plugin_stdio_handoff(
             cleanup_status_workers=True,
         )
         require_managed_plugin_convergence(status, artifact, expected_version, archive_cli)
+        retention = status.get("plugin_runtime", {}).get("managed_cli_retention", {})
+        retained = retention.get("retained", []) if isinstance(retention, dict) else []
+        require(
+            retention.get("active_version") == expected_version
+            and any(item.get("version") == prior_version and item.get("reason") == "rollback" for item in retained),
+            "managed_plugin_convergence",
+            artifact,
+            "managed upgrade did not retain the verified prior version as rollback",
+        )
+        write_json(
+            artifact.with_name("managed-plugin-upgrade.json"),
+            {
+                "prior_version": prior_version,
+                "requested_version": expected_version,
+                "server_version": status.get("server_version"),
+                "server_executable": status.get("server_executable"),
+                "retention": retention,
+            },
+        )
         return status
 
 
@@ -1769,8 +1830,12 @@ def run_gate(args: argparse.Namespace) -> None:
                 args.expected_version,
                 cli,
                 empty_model_dir,
+                archive,
             )
             summary["artifacts"]["managed_plugin_convergence"] = str(plugin_artifact)
+            summary["artifacts"]["managed_plugin_upgrade"] = str(
+                plugin_artifact.with_name("managed-plugin-upgrade.json")
+            )
             write_json(out_dir / "summary.json", summary)
             return
 
@@ -2975,6 +3040,11 @@ def self_test() -> None:
             managed_summary = read_json_file(Path(managed_args.out_dir) / "summary.json")
             assert "managed_local_ground" in managed_summary["artifacts"]
             assert "managed_plugin_convergence" in managed_summary["artifacts"]
+            assert "managed_plugin_upgrade" in managed_summary["artifacts"]
+            upgrade = read_json_file(Path(managed_args.out_dir) / "managed-plugin-upgrade.json")
+            assert upgrade["prior_version"] == "0.0.0"
+            assert upgrade["requested_version"] == "9.9.9"
+            assert upgrade["server_version"] == "9.9.9"
             observational_artifact = Path(managed_args.out_dir) / "managed-convergence-status-observational.json"
             assert read_json_file(observational_artifact)["status"]["index_freshness"]["status"] == "stale"
             managed_artifact = Path(managed_args.out_dir) / "managed-plugin-convergence.json"
@@ -3016,6 +3086,7 @@ def self_test() -> None:
                     "9.9.9",
                     stage / ("codestory-cli.cmd" if os.name == "nt" else "codestory-cli"),
                     root / "policy-timeout-empty-model",
+                    archive,
                 )
             except GateFailure as exc:
                 assert exc.layer == "managed_plugin_convergence"

--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -1626,20 +1626,37 @@ def require_managed_plugin_convergence(
             f"{request_id} did not return sidecar setup status",
         )
         setup_snapshots.append(setup)
-    attempt_ids = {
-        attempt_id
+    attempt_records = [
+        record
         for setup in setup_snapshots
-        for attempt_id in (
-            (setup.get("active_repair") or {}).get("attempt_id"),
-            (setup.get("last_worker_result") or {}).get("attempt_id"),
-        )
-        if isinstance(attempt_id, str) and attempt_id
-    }
+        for record in (setup.get("active_repair"), setup.get("last_worker_result"))
+        if isinstance(record, dict)
+        and isinstance(record.get("attempt_id"), str)
+        and record.get("attempt_id")
+    ]
+    attempt_ids = {record["attempt_id"] for record in attempt_records}
     require(
         len(attempt_ids) == 1,
         "managed_plugin_convergence",
         artifact,
         f"ground activation did not retain exactly one repair attempt: {sorted(attempt_ids)}",
+    )
+    expected_project = status_before.get("project_root")
+    namespaces = {record.get("namespace") for record in attempt_records}
+    require(
+        isinstance(expected_project, str)
+        and expected_project
+        and len(namespaces) == 1
+        and all(isinstance(namespace, str) and namespace for namespace in namespaces)
+        and all(
+            record.get("project_root") == expected_project
+            and record.get("profile") == "agent"
+            and record.get("run_id") == "shared-agent"
+            for record in attempt_records
+        ),
+        "managed_plugin_convergence",
+        artifact,
+        "ground activation repair records did not preserve one durable project/profile/run/namespace identity",
     )
     terminal = next(
         (
@@ -2231,7 +2248,10 @@ def write_fake_cli(path: Path) -> None:
                                 "active_repair": None,
                                 "last_worker_result": ({
                                     "attempt_id": repair_attempt,
+                                    "project_root": request.get("params", {}).get("arguments", {}).get("project"),
+                                    "profile": "agent",
                                     "run_id": "shared-agent",
+                                    "namespace": "fake-agent-namespace",
                                     "outcome": "failed",
                                     "exit_code": 1,
                                 } if repair_attempt else None),
@@ -2304,13 +2324,23 @@ def write_fake_cli(path: Path) -> None:
                                 "cli_version": "9.9.9",
                                 "plugin_root": os.getcwd(),
                                 "managed_binary_path": server_executable,
+                                "managed_cli_retention": {
+                                    "active_version": "9.9.9",
+                                    "retained": [
+                                        {"version": "9.9.9", "reason": "active"},
+                                        {"version": "0.0.0", "reason": "rollback"},
+                                    ],
+                                },
                             },
                             "sidecar_setup": {
                                 "state": "enabled",
                                 "active_repair": None,
                                 "last_worker_result": ({
                                     "attempt_id": repair_attempt,
+                                    "project_root": request.get("params", {}).get("project", os.getcwd()),
+                                    "profile": "agent",
                                     "run_id": "shared-agent",
+                                    "namespace": "fake-agent-namespace",
                                     "outcome": "failed",
                                     "exit_code": 1,
                                 } if repair_attempt else None),
@@ -3050,8 +3080,18 @@ def self_test() -> None:
             managed_artifact = Path(managed_args.out_dir) / "managed-plugin-convergence.json"
             assert transcript_response(managed_artifact, "ground_activation")["result"]["structuredContent"]["stats"]
             setup = structured_content_from_response(transcript_response(managed_artifact, "setup_poll_1"))
+            assert setup["active_repair"] is None
             assert setup["last_worker_result"]["attempt_id"] == "fake-activation-attempt"
             assert setup["last_worker_result"]["outcome"] == "failed"
+            assert {
+                key: setup["last_worker_result"][key]
+                for key in ("project_root", "profile", "run_id", "namespace")
+            } == {
+                "project_root": managed_summary["managed_convergence_project"],
+                "profile": "agent",
+                "run_id": "shared-agent",
+                "namespace": "fake-agent-namespace",
+            }
             managed_status_after = status_from_resource_response(
                 transcript_response(managed_artifact, "status_after_convergence")
             )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Added deterministic prior-version managed CLI upgrade proof to every native
+  managed-lifecycle cell. The gate now starts with a verified older install,
+  requires the requested packaged binary to serve status and grounding, and
+  retains the older version only as the verified rollback.
 - Launched the managed Windows Vulkan llama.cpp cells with proof verbosity so
   current-launch logs retain the requested device and positive layer-offload
   evidence required by the accelerator smoke gate.

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -162,6 +162,12 @@ state and bounded Qdrant logs before cleanup so the primary failure remains
 diagnosable; cleanup failure is retained as secondary evidence and must not
 replace the primary gate failure.
 
+Each native managed-plugin handoff also starts with a verified prior managed
+CLI whose executable can answer only its version probe. The requested packaged
+version must become the MCP server and active retention entry; the prior version
+must remain only as the verified rollback. This is deterministic upgrade
+convergence proof, not Apple Silicon endpoint-survival or older-glibc evidence.
+
 Release closeout is not complete until every published asset cell passes and
 the corresponding CodeStory plugin-source update is committed or merged in
 `TheGreenCedar/AgentPluginMarketplace`, followed by marketplace refresh and

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -7,7 +7,7 @@ import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { once } from "node:events";
 import { deflateRawSync, gunzipSync, gzipSync } from "node:zlib";
 import { PassThrough, Writable } from "node:stream";
@@ -2904,7 +2904,7 @@ test("enabled sidecar policy defers repair until after MCP startup", async () =>
   }
 });
 
-test("mcp launcher provisions a checksummed release asset into plugin data", async () => {
+test("mcp launcher upgrades a verified prior managed cli to the checksummed release", async () => {
   const version = await readPluginVersion();
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-provisioned-cli-"));
   const releaseDir = await mkdtemp(join(tmpdir(), "codestory-release-"));
@@ -2917,6 +2917,32 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
   const archivePath = join(releaseDir, archiveName);
 
   try {
+    const priorVersion = "0.0.0";
+    const priorRelease = releaseAssetForPlatform(priorVersion);
+    const priorDir = join(dataDir, "codestory-cli", priorVersion);
+    const priorCli = join(priorDir, "bin", cliName);
+    await mkdir(dirname(priorCli), { recursive: true });
+    if (process.platform === "win32") {
+      await writeFile(priorCli, `@echo off\r\nif "%1"=="--version" (echo codestory-cli ${priorVersion}& exit /b 0)\r\nexit /b 90\r\n`, "utf8");
+    } else {
+      await writeFile(priorCli, `#!/bin/sh\nif [ "$1" = "--version" ]; then echo 'codestory-cli ${priorVersion}'; exit 0; fi\nexit 90\n`, "utf8");
+      await chmod(priorCli, 0o755);
+    }
+    const priorSha256 = createHash("sha256").update(await readFile(priorCli)).digest("hex");
+    await writeFile(join(priorDir, "manifest.json"), JSON.stringify({
+      path: `bin/${cliName}`,
+      sha256: priorSha256,
+      version: priorVersion,
+      build_source: "github_release",
+      repo_ref: `v${priorVersion}`,
+      archive: priorRelease.archiveName,
+      archive_url: pathToFileURL(join(releaseDir, priorRelease.archiveName)).toString(),
+      archive_sha256: "0".repeat(64),
+      target: priorRelease.archiveBase.slice(`codestory-cli-v${priorVersion}-`.length),
+      provisioned_at: "1970-01-01T00:00:00.000Z",
+      stdio_initialize_verified: true,
+    }), "utf8");
+
     await mkdir(stageDir, { recursive: true });
     await writeFakeCli(cliPath);
     await writeArchiveFixture(archivePath, `${archiveBase}/${cliName}`, await readFile(cliPath));
@@ -2944,6 +2970,14 @@ test("mcp launcher provisions a checksummed release asset into plugin data", asy
     assert.equal(observed.repoRef, `v${version}`);
     assert.equal(observed.buildSource, "github_release");
     assert.equal(observed.archiveSha256, archiveSha256);
+    assert.notEqual(observed.path, priorCli);
+    const retention = JSON.parse(observed.retention);
+    assert.equal(retention.active_version, version);
+    assert.equal(
+      retention.retained.some((entry) => entry.version === priorVersion && entry.reason === "rollback"),
+      true,
+      JSON.stringify(retention),
+    );
     assert.match(
       observed.path,
       new RegExp(String.raw`codestory-cli[\\/]+${version.replaceAll(".", String.raw`\.`)}[\\/]bin[\\/]codestory-cli`, "u"),


### PR DESCRIPTION
## Context

The six native managed-lifecycle cells proved fresh installation, but #921 still lacked an upgrade path starting from a verified prior managed CLI. Retention had unit coverage in isolation; it was not joined to exact-version publication, managed MCP activation, grounding convergence, durable repair identity, and rollback evidence.

Closes #1036
Refs #921
Refs #887
Refs #1037

## What Changed

- Seed every native managed-convergence cell with a checksummed prior managed CLI whose executable answers only its fixed `--version`; selecting it for MCP exits 90 and fails the gate.
- Require the requested packaged archive to publish and serve MCP with exact executable provenance, then activate through `ground` on a deliberately stale local publication.
- Observe the automatic repair through bounded MCP status polls and require exactly one durable attempt with one matching project/profile/run/namespace identity through terminal completion.
- Require a newer complete local generation while packet/search remain fail-closed without verified accelerator smoke.
- Require the requested version as active and the verified prior version only as rollback, recording `managed-plugin-upgrade.json` in every native cell.
- Upgrade the real launcher static test from fresh provisioning to prior-version convergence.

## How To Review

1. Review `plugin_stdio_handoff` in `.github/scripts/check-packaged-agent-proof.py`: the prior fixture must pass installed-version verification but cannot serve MCP.
2. Review `require_managed_plugin_convergence`: observational status must not mutate ownership; ground is the activation boundary; all durable attempt records must share one attempt and one project/profile/run/namespace identity.
3. Confirm retention requires the packaged version as active and the prior version as rollback.
4. Review the real-launcher regression in `plugins/codestory/tests/plugin-static.test.mjs` for cross-platform fixture behavior.

## Verification

- `python .github/scripts/check-packaged-agent-proof.py --self-test` — passed
- `node --test --test-name-pattern='upgrades a verified prior managed cli' plugins/codestory/tests/plugin-static.test.mjs` — 1 passed
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 72 passed
- `node .github/scripts/check-workflow-policy.mjs` — passed
- `node .github/scripts/check-doc-links.mjs` — 69 files, 281 relative links
- `python -m py_compile .github/scripts/check-packaged-agent-proof.py` — passed
- `git diff --check` — passed
- exact-head packaged and plugin workflow dispatches are running at `1f9e49b8d47e18b9bf7d984ce64984b8f3cd4825`

No local Cargo command was needed because the diff is Python proof code, Node launcher tests, and documentation.

## Risk

The proof adds a prior fixture and bounded convergence polling to every native matrix cell, increasing matrix time slightly. The synthetic prior executable deliberately cannot serve MCP, so false selection fails closed. Native CI remains the final cross-platform execution proof. This PR does not close #921 or #887 and makes no glibc claim.