### PR TITLE
Prove live drill packet parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+- Launched the managed Windows Vulkan llama.cpp cells with proof verbosity so
+  current-launch logs retain the requested device and positive layer-offload
+  evidence required by the accelerator smoke gate.
+- Made agent-facing commands select the Agent sidecar by default, and bound the
+  live packet/drill parity gate plus drill's packet execution to the same
+  explicit Agent run instead of preflighting an unrelated Local generation.
 - Opened the diagnostic MCP immediately on fresh managed-plugin startup while
   the existing single-flight installer provisions the exact CLI version in the
   background. Status now reports the in-process provisioning state, and the

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -986,6 +986,14 @@ pub(crate) struct DrillCommand {
         long_help = DRILL_REFRESH_HELP
     )]
     pub(crate) refresh: RefreshMode,
+    #[arg(long, value_enum)]
+    pub(crate) profile: Option<CliSidecarProfile>,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Agent profile run id to reuse for drill packet retrieval. Passing --run-id implies the agent profile."
+    )]
+    pub(crate) run_id: Option<String>,
     #[arg(long, value_name = "FORMAT", value_parser = parse_read_output_format, default_value = "markdown")]
     pub(crate) format: OutputFormat,
     #[arg(
@@ -2590,6 +2598,8 @@ mod tests {
         assert!(help.contains("--label <LABEL>"));
         assert!(help.contains("--question <QUESTION>"));
         assert!(help.contains("--jobs <N>"));
+        assert!(help.contains("--profile <PROFILE>"));
+        assert!(help.contains("--run-id <ID>"));
         assert!(help.contains("Stored in the report only; it is not interpreted"));
         assert!(help.contains("Drill defaults to `full`"));
     }

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -3502,7 +3502,7 @@ fn execute_drill(cmd: &DrillCommand) -> Result<DrillOutput> {
     let total_timer = Instant::now();
     let setup_timer = Instant::now();
     validate_drill_output_dir(&cmd.output_dir)?;
-    let runtime = RuntimeContext::new(&cmd.project)?;
+    let runtime = new_agent_surface_runtime(&cmd.project, cmd.profile, cmd.run_id.as_deref())?;
     let before = runtime.open_project_summary()?;
     let opened = runtime.ensure_open_from_summary(cmd.refresh, before.clone())?;
     ensure_index_ready(&opened, "drill")?;
@@ -4101,6 +4101,8 @@ fn run_drill_suite_case(
         question: Some(case.question.clone()),
         output_dir: repo_output_dir.clone(),
         refresh: cmd.refresh,
+        profile: None,
+        run_id: None,
         format: cmd.format,
         jobs: drill_jobs,
     };

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -136,23 +136,20 @@ impl RuntimeContext {
         run_id: Option<&str>,
     ) -> Result<Self> {
         let mut context = Self::new_with_startup(args, startup)?;
-        if profile.is_some() || run_id.is_some() {
-            let selected = profile
-                .map(Into::into)
-                .unwrap_or(codestory_retrieval::SidecarProfile::Agent);
-            context.sidecar = context.sidecar.with_profile_and_run_id(
-                Some(&context.project_root),
-                selected,
-                run_id,
-            );
-            let runtime = Runtime::new_with_config(context.sidecar.clone());
-            context.project = runtime.project_service();
-            context.index = runtime.index_service();
-            context.grounding = runtime.grounding_service();
-            context.bookmarks = runtime.bookmark_service();
-            context.browser = runtime.browser_service();
-            context.events = runtime.events();
-        }
+        let selected = profile
+            .map(Into::into)
+            .unwrap_or(codestory_retrieval::SidecarProfile::Agent);
+        context.sidecar =
+            context
+                .sidecar
+                .with_profile_and_run_id(Some(&context.project_root), selected, run_id);
+        let runtime = Runtime::new_with_config(context.sidecar.clone());
+        context.project = runtime.project_service();
+        context.index = runtime.index_service();
+        context.grounding = runtime.grounding_service();
+        context.bookmarks = runtime.bookmark_service();
+        context.browser = runtime.browser_service();
+        context.events = runtime.events();
         Ok(context)
     }
 
@@ -1072,6 +1069,10 @@ mod tests {
         })
         .expect("runtime context");
 
+        assert_eq!(
+            runtime.sidecar.profile,
+            codestory_retrieval::SidecarProfile::Agent
+        );
         assert_eq!(runtime.sidecar.embedding.backend, "llamacpp");
         assert_eq!(env::var("CODESTORY_EMBED_LLAMACPP_URL").ok(), None);
         let sidecar = runtime.sidecar.with_profile_and_run_id(

--- a/crates/codestory-retrieval/assets/llama-sidecar-backends.json
+++ b/crates/codestory-retrieval/assets/llama-sidecar-backends.json
@@ -53,7 +53,9 @@
         "--n-gpu-layers",
         "{n_gpu_layers}",
         "--device",
-        "{device}"
+        "{device}",
+        "--log-verbosity",
+        "4"
       ],
       "device_arg_policy": "request_device",
       "log_markers": ["vulkan", "offloaded"]
@@ -82,7 +84,9 @@
         "--n-gpu-layers",
         "{n_gpu_layers}",
         "--device",
-        "{device}"
+        "{device}",
+        "--log-verbosity",
+        "4"
       ],
       "device_arg_policy": "request_device",
       "log_markers": ["vulkan", "offloaded"]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -2610,6 +2610,12 @@ mod tests {
                 .windows(2)
                 .any(|pair| pair[0] == "--device" && pair[1] == "Vulkan0")
         );
+        assert!(
+            launch
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--log-verbosity" && pair[1] == "4")
+        );
         let metadata = embedding_launch_metadata(
             &launch,
             &runtime,

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -325,13 +325,14 @@ cells must stay labeled as contract-only in PRs, issues, and release notes.
 | Promotion-grade benchmark | Full holdout packet-runtime rows cover cold and warm modes with three repeats, `--jobs 4`, prepared sidecars, `--publishable`, explicit `--max-source-reads-after-packet 0`, no `--allow-failures`, full sidecar provenance, no quality misses, no sufficiency gaps, and no SLA misses. Fixed-baseline A/B rows are supporting diagnostics only unless fingerprint-compatible. | Required for performance or retrieval-quality promotion claims. |
 
 Packet/drill adapter promotion proof is a separate executable gate over one
-already-finalized local sidecar generation:
+already-finalized Agent sidecar generation:
 
 ```sh
 node scripts/prove-drill-packet-parity.mjs \
   --project . \
-  --question "How does indexing feed packet retrieval?" \
-  --anchor WorkspaceIndexer \
+  --run-id drill-packet-parity \
+  --question "RuntimeContext" \
+  --anchor RuntimeContext \
   --output-dir target/drill-packet-parity
 ```
 

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -152,9 +152,10 @@ prewarm the managed Metal cache cell. Set `CODESTORY_EMBED_NATIVE_LLAMA_SERVER`
 only when overriding the managed binary with an absolute path.
 
 On Windows x64, the native llama.cpp resolver selects the manifest-backed b9902
-Vulkan cell by default and launches it with `Vulkan0` plus `99` GPU layers. A
-previous b9058 managed-cache install remains a recognized legacy cell only when
-its install manifest and executable checksum match.
+Vulkan cell by default and launches it with `Vulkan0`, `99` GPU layers, and
+proof verbosity that retains device/offload startup evidence. A previous b9058
+managed-cache install remains a recognized legacy cell only when its install
+manifest and executable checksum match, and uses the same proof verbosity.
 
 On Linux, accelerator-required setup remains Docker Compose based. The supported
 default cells are explicit Vulkan contracts for x64 and arm64, backed by the

--- a/scripts/prove-drill-packet-parity.mjs
+++ b/scripts/prove-drill-packet-parity.mjs
@@ -115,12 +115,13 @@ function main() {
       project: { type: "string", default: repoRoot },
       question: { type: "string" },
       anchor: { type: "string", multiple: true },
+      "run-id": { type: "string" },
       "output-dir": { type: "string" },
     },
     strict: true,
   });
   if (!values.question || !values.anchor?.length || !values["output-dir"]) {
-    throw new Error("usage: prove-drill-packet-parity.mjs --question <text> --anchor <symbol> [--anchor <symbol>] --output-dir <dir> [--cli <path>] [--project <repo>]");
+    throw new Error("usage: prove-drill-packet-parity.mjs --question <text> --anchor <symbol> [--anchor <symbol>] --output-dir <dir> [--run-id <agent-run>] [--cli <path>] [--project <repo>]");
   }
 
   const project = path.resolve(values.project);
@@ -138,17 +139,19 @@ function main() {
   };
 
   try {
-    const statusArgs = ["retrieval", "status", "--project", project, "--profile", "local", "--format", "json"];
+    const agentSelection = ["--profile", "agent"];
+    if (values["run-id"]) agentSelection.push("--run-id", values["run-id"]);
+    const statusArgs = ["retrieval", "status", "--project", project, ...agentSelection, "--format", "json"];
     const beforeStatus = parseJson(runCli(values.cli, statusArgs, transcript, "retrieval-status-before"), "retrieval status before");
     evidence.readiness = { retrieval_mode: beforeStatus.retrieval_mode, degraded_reason: beforeStatus.degraded_reason ?? null, manifest_contract: beforeStatus.manifest_contract ?? null };
     if (beforeStatus.retrieval_mode !== "full") {
       throw new FullSidecarBlockedError(`full-sidecar proof blocked: retrieval_mode=${beforeStatus.retrieval_mode ?? "missing"}; degraded_reason=${beforeStatus.degraded_reason ?? "missing"}`);
     }
 
-    const packetArgs = ["packet", "--project", project, "--question", values.question, "--budget", "standard", "--refresh", "none", "--format", "json"];
+    const packetArgs = ["packet", "--project", project, ...agentSelection, "--question", values.question, "--budget", "standard", "--refresh", "none", "--format", "json"];
     for (const anchor of anchors) packetArgs.push("--extra-probe", anchor);
     const packet = parseJson(runCli(values.cli, packetArgs, transcript, "packet"), "packet");
-    const drillArgs = ["drill", "--project", project, "--question", values.question, "--anchors", anchors.join(","), "--output-dir", drillDir, "--refresh", "none", "--format", "json"];
+    const drillArgs = ["drill", "--project", project, ...agentSelection, "--question", values.question, "--anchors", anchors.join(","), "--output-dir", drillDir, "--refresh", "none", "--format", "json"];
     runCli(values.cli, drillArgs, transcript, "drill");
     const afterStatus = parseJson(runCli(values.cli, statusArgs, transcript, "retrieval-status-after"), "retrieval status after");
     const report = parseJson(readFileSync(path.join(drillDir, "drill-report.json")), "drill report");


### PR DESCRIPTION
## Context

The packet-backed drill adapter had deterministic fixture coverage, but its executable live gate preflighted the Local profile while production packet retrieval requires Agent. The shared agent-surface constructor also left an unspecified profile on Local, and drill created a Local runtime directly. On Windows, the newly required accelerator proof additionally could not finalize a generation because managed Vulkan launches omitted the verbosity that emits device/offload evidence.

Closes #1006
Refs #998
Refs #918
Refs #1039

## What Changed

- Made agent-facing runtime construction default to the Agent sidecar and made drill accept/reuse explicit Agent profile/run selection.
- Updated the existing #1013 parity seam—without adding another harness—to pin status, packet, and drill to the same Agent run.
- Added proof verbosity to the current and supported legacy Windows Vulkan backend manifests so final accelerator validation can observe requested-device layer offload.
- Strengthened the existing Windows launch-contract and drill CLI tests.
- Updated the changelog, operator guidance, and executable promotion command.

## How To Review

1. Review `RuntimeContext::new_agent_sidecar_with_startup_and_selection`: unspecified agent-surface selection now means Agent, while explicit profile/run selection remains preserved.
2. Review `execute_drill` and `DrillCommand`: drill passes the same profile/run identity into the packet-backed runtime.
3. Review `scripts/prove-drill-packet-parity.mjs`: both status reads, packet, and drill share one Agent selection and optional run id.
4. Review the Windows backend manifest and launch test for `--log-verbosity 4`; the proof threshold itself is unchanged.

## Verification

- Focused Rust tests passed:
  - `drill_help_exposes_deterministic_report_controls`
  - `agent_sidecar_runtime_defaults_to_bundled_llamacpp`
  - `native_launch_args_use_model_port_and_default_vulkan_device`
  - `windows_manifest_candidates_prefer_b9902_and_keep_legacy_b9058`
- `node scripts/tests/prove-drill-packet-parity.test.mjs`: 4 passed.
- Release CLI build passed.
- Live Agent repair/finalization passed on run `drill-packet-parity`:
  - generation `1b25a35a2f8df931-32f2dc2c77b90afd`
  - `retrieval_mode=full`
  - GPU proof `verified`, Vulkan0, meaningful accelerator work proven, 14 ms embed smoke
- Existing parity seam passed against that unchanged generation with question/probe `RuntimeContext`:
  - transcript: status-before, packet, drill, status-after
  - sufficiency `partial` matched
  - 7 citations matched
  - explicit probe and both follow-up commands matched
  - drill packet execution count exactly 1
  - retained artifacts: `drill-report.json`, `drill-report.md`, `drill-summary.json`
- `node .github/scripts/check-doc-links.mjs`: 69 files / 281 links.
- `node .github/scripts/check-workflow-policy.mjs` and `git diff --check` passed.
- No screenshot-visible UI change.

## Risk

Agent-facing CLI commands that accidentally fell back to Local now correctly fail or succeed against Agent readiness. Drill gains optional profile/run flags without changing retained report fields. Windows native launch fingerprints intentionally change because proof verbosity is part of the launch contract. A separate cold natural-language stage-deadline failure was retained in #1039; it does not change the demonstrated packet/drill adapter parity on the same full generation.
