### PR TITLE
Migrate broker and repair ownership to project identity v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@
   metadata only after a matching verification read, and leave an incomplete
   retry error instead of accepting stale output even when the file's timestamp
   is restored.
+- Migrated readiness-broker scopes, operation IDs, machine locks, snapshots,
+  and GPU-runtime binding to lossless project identity schema 3. Legacy broker
+  state is reused only when its workspace and repository provenance map
+  unambiguously; case-distinct Unix roots no longer collide, while Windows
+  aliases still share their existing workspace. Refresh/repair and stdio path
+  ownership now use the shared filesystem-aware path comparator, and new
+  refresh/repair state preserves native path case.
 - Opened the diagnostic MCP immediately on fresh managed-plugin startup while
   the existing single-flight installer provisions the exact CLI version in the
   background. Status now reports the in-process provisioning state, and the

--- a/crates/codestory-cli/src/local_refresh_status.rs
+++ b/crates/codestory-cli/src/local_refresh_status.rs
@@ -385,7 +385,7 @@ fn renew_local_refresh_status_with_hook(
     if status.schema_version != LOCAL_REFRESH_STATUS_SCHEMA_VERSION
         || status.status != "refreshing"
         || status.phase != phase
-        || !same_path_text(Path::new(&status.project_root), project_root)
+        || !codestory_workspace::same_workspace_path(Path::new(&status.project_root), project_root)
         || status.pid != owner.pid
         || status.process_start_identity != owner.process_start_identity
         || status.owner_token.as_deref() != Some(owner.token.as_str())
@@ -402,7 +402,7 @@ fn renew_local_refresh_status_with_hook(
 fn local_refresh_lock_matches(path: &Path, project_root: &Path, owner: &LocalRefreshOwner) -> bool {
     read_local_refresh_lock_file(path).is_some_and(|lock| {
         lock.schema_version == LOCAL_REFRESH_STATUS_SCHEMA_VERSION
-            && same_path_text(Path::new(&lock.project_root), project_root)
+            && codestory_workspace::same_workspace_path(Path::new(&lock.project_root), project_root)
             && lock.token == owner.token
             && lock.pid == owner.pid
             && lock.process_start_identity == owner.process_start_identity
@@ -429,11 +429,14 @@ pub(crate) fn cleanup_stale_local_refresh_state(
     let status = read_local_refresh_status_file(&status_path).filter(|status| {
         status.schema_version == LOCAL_REFRESH_STATUS_SCHEMA_VERSION
             && status.status == "refreshing"
-            && same_path_text(Path::new(&status.project_root), project_root)
+            && codestory_workspace::same_workspace_path(
+                Path::new(&status.project_root),
+                project_root,
+            )
     });
     let lock = read_local_refresh_lock_file(&lock_path).filter(|lock| {
         lock.schema_version == LOCAL_REFRESH_STATUS_SCHEMA_VERSION
-            && same_path_text(Path::new(&lock.project_root), project_root)
+            && codestory_workspace::same_workspace_path(Path::new(&lock.project_root), project_root)
     });
     let status_owner_state = status.as_ref().map(|status| {
         crate::ready_repair_status::process_owner_state(
@@ -587,7 +590,7 @@ fn read_local_refresh_status(
     let status = read_local_refresh_status_file(path)?;
     if status.schema_version != LOCAL_REFRESH_STATUS_SCHEMA_VERSION
         || status.status != "refreshing"
-        || !same_path_text(Path::new(&status.project_root), project_root)
+        || !codestory_workspace::same_workspace_path(Path::new(&status.project_root), project_root)
     {
         return None;
     }
@@ -617,7 +620,7 @@ fn local_refresh_status_matches_lock(
     project_root: &Path,
 ) -> bool {
     lock.schema_version == LOCAL_REFRESH_STATUS_SCHEMA_VERSION
-        && same_path_text(Path::new(&lock.project_root), project_root)
+        && codestory_workspace::same_workspace_path(Path::new(&lock.project_root), project_root)
         && status.owner_token.as_deref() == Some(lock.token.as_str())
         && status.pid == lock.pid
         && status.process_start_identity == lock.process_start_identity
@@ -641,11 +644,7 @@ fn clean_path_text(path: &Path) -> String {
         .trim_start_matches(r"\\?\")
         .replace('\\', "/")
         .trim_end_matches('/')
-        .to_ascii_lowercase()
-}
-
-fn same_path_text(left: &Path, right: &Path) -> bool {
-    clean_path_text(left) == clean_path_text(right)
+        .to_string()
 }
 
 fn path_fingerprint(path: &Path) -> String {
@@ -1341,5 +1340,14 @@ mod tests {
         assert_eq!(cleanup.reason, "stale_status_and_lock");
         assert!(cleanup.removed_status_path);
         assert!(cleanup.removed_lock_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_local_refresh_root_preserves_unix_case() {
+        let parent = tempfile::tempdir().expect("parent");
+        let project = parent.path().join("CaseSensitiveProject");
+        fs::create_dir_all(&project).expect("project");
+        assert!(clean_path_text(&project).ends_with("CaseSensitiveProject"));
     }
 }

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -9500,6 +9500,7 @@ mod tests {
 
     #[test]
     fn ready_repair_waits_for_native_log_before_liveness_failure() {
+        let _env_lock = crate::config::config_env_test_lock();
         let _env = EnvVarSnapshot::clear(&[
             "CODESTORY_EMBED_SERVER_LAUNCH",
             "CODESTORY_EMBED_ALLOW_CPU",

--- a/crates/codestory-cli/src/readiness_broker/machine_lock.rs
+++ b/crates/codestory-cli/src/readiness_broker/machine_lock.rs
@@ -12,10 +12,14 @@ use super::paths::{
     machine_resource_reaper_takeover_lock_path, now_epoch_ms,
 };
 use super::scope::broker_operation_id;
-use super::scope::{BROKER_SCHEMA_VERSION, LEGACY_BROKER_SCHEMA_VERSION, effective_scope_identity};
+use super::scope::{
+    BROKER_SCHEMA_VERSION, BROKER_SCHEMA_VERSION_V2, LEGACY_BROKER_SCHEMA_VERSION,
+    effective_scope_identity,
+};
 use super::types::{BrokerResourceSnapshot, BrokerScope};
 
-pub(crate) const MACHINE_LOCK_SCHEMA_VERSION: u32 = 2;
+pub(crate) const MACHINE_LOCK_SCHEMA_VERSION: u32 = 3;
+pub(crate) const MACHINE_LOCK_SCHEMA_VERSION_V2: u32 = 2;
 pub(crate) const MACHINE_LOCK_STALE_TTL: Duration = Duration::from_secs(20 * 60);
 pub(crate) const MACHINE_REAPER_LOCK_STALE_TTL: Duration = Duration::from_secs(2 * 60);
 pub(crate) const NATIVE_EMBEDDING_RESOURCE: &str = "native_embedding_runtime";
@@ -454,6 +458,7 @@ fn machine_lock_has_valid_identity(lock: &BrokerMachineResourceLockFile) -> bool
     }
     match lock.schema_version {
         MACHINE_LOCK_SCHEMA_VERSION => lock.scope.schema_version == BROKER_SCHEMA_VERSION,
+        MACHINE_LOCK_SCHEMA_VERSION_V2 => lock.scope.schema_version == BROKER_SCHEMA_VERSION_V2,
         LEGACY_BROKER_SCHEMA_VERSION => lock.scope.schema_version == LEGACY_BROKER_SCHEMA_VERSION,
         _ => false,
     }
@@ -468,7 +473,9 @@ pub(crate) fn read_machine_resource_reaper_lock_file(
         .filter(|lock: &BrokerMachineResourceReaperLockFile| {
             matches!(
                 lock.schema_version,
-                LEGACY_BROKER_SCHEMA_VERSION | MACHINE_LOCK_SCHEMA_VERSION
+                LEGACY_BROKER_SCHEMA_VERSION
+                    | MACHINE_LOCK_SCHEMA_VERSION_V2
+                    | MACHINE_LOCK_SCHEMA_VERSION
             )
         })
 }

--- a/crates/codestory-cli/src/readiness_broker/native_lease.rs
+++ b/crates/codestory-cli/src/readiness_broker/native_lease.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use std::fs;
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use super::machine_lock::{
@@ -375,9 +376,12 @@ pub(crate) fn reusable_native_embedding_resource_pid(
     else {
         return Ok(None);
     };
-    let same_normalized_root = super::scope::normalized_workspace_root(owner_workspace_root)
-        == super::scope::normalized_workspace_root(&scope.workspace_root);
-    if owner_identity.workspace_id != scope_identity.workspace_id || !same_normalized_root {
+    if owner_identity.workspace_id != scope_identity.workspace_id
+        || !codestory_workspace::same_workspace_path(
+            Path::new(owner_workspace_root),
+            Path::new(&scope.workspace_root),
+        )
+    {
         return Ok(None);
     }
     let Some(state) = read_sidecar_state_file(sidecar)? else {

--- a/crates/codestory-cli/src/readiness_broker/operations.rs
+++ b/crates/codestory-cli/src/readiness_broker/operations.rs
@@ -47,7 +47,7 @@ pub(crate) fn operation_from_local_refresh_status(
     operation_status: &str,
     degraded_reason: Option<String>,
 ) -> BrokerOperationSnapshot {
-    let identity = codestory_workspace::project_identity_v2(project_root);
+    let identity = codestory_workspace::project_identity_v3(project_root);
     let project_id = identity.project_id;
     let workspace_id = identity.workspace_id;
     BrokerOperationSnapshot {
@@ -76,7 +76,7 @@ pub(crate) fn operation_from_local_refresh_lock_cleanup(
     cli_version: &str,
     cleanup: local_refresh_status::LocalRefreshCleanup,
 ) -> BrokerOperationSnapshot {
-    let identity = codestory_workspace::project_identity_v2(project_root);
+    let identity = codestory_workspace::project_identity_v3(project_root);
     let project_id = identity.project_id;
     let workspace_id = identity.workspace_id;
     BrokerOperationSnapshot {

--- a/crates/codestory-cli/src/readiness_broker/scope.rs
+++ b/crates/codestory-cli/src/readiness_broker/scope.rs
@@ -1,13 +1,14 @@
 use std::path::Path;
 
-use codestory_workspace::{ProjectIdentityV2, project_identity_v2};
+use codestory_workspace::{ProjectIdentityV3, project_identity_v2, project_identity_v3};
 
 use crate::display;
 
 use super::paths::{clean_path_text, hash_text, install_id};
 use super::types::BrokerScope;
 
-pub(crate) const BROKER_SCHEMA_VERSION: u32 = 2;
+pub(crate) const BROKER_SCHEMA_VERSION: u32 = 3;
+pub(crate) const BROKER_SCHEMA_VERSION_V2: u32 = 2;
 pub(crate) const LEGACY_BROKER_SCHEMA_VERSION: u32 = 1;
 
 pub(crate) fn agent_repair_scope(
@@ -32,9 +33,8 @@ pub(crate) fn operation_scope(
     cli_version: &str,
 ) -> BrokerScope {
     let install_id = install_id();
-    let canonical_root = clean_path_text(project_root);
-    let canonical_root_hash = hash_text(&canonical_root);
-    let identity = project_identity_v2(project_root);
+    let identity = project_identity_v3(project_root);
+    let canonical_root_hash = identity.workspace_id.clone();
     let run_id = run_id
         .filter(|value| !value.trim().is_empty())
         .map(str::to_string);
@@ -64,52 +64,139 @@ pub(crate) fn broker_operation_id(scope: &BrokerScope) -> String {
     )
 }
 
-pub(crate) fn effective_scope_identity(scope: &BrokerScope) -> Option<ProjectIdentityV2> {
-    let identity = effective_identity(
+pub(crate) fn effective_scope_identity(scope: &BrokerScope) -> Option<ProjectIdentityV3> {
+    effective_record_identity(
         scope.schema_version,
         scope.identity.as_ref(),
+        &scope.project_id,
+        &scope.canonical_root_hash,
         &scope.workspace_root,
-    )?;
-    if scope.schema_version == BROKER_SCHEMA_VERSION && scope.project_id != identity.project_id {
-        return None;
+    )
+}
+
+pub(crate) fn effective_record_identity(
+    schema_version: u32,
+    stored_identity: Option<&ProjectIdentityV3>,
+    project_id: &str,
+    canonical_root_hash: &str,
+    workspace_root: &str,
+) -> Option<ProjectIdentityV3> {
+    let identity = effective_identity(schema_version, stored_identity, workspace_root)?;
+    match schema_version {
+        BROKER_SCHEMA_VERSION => {
+            if project_id != identity.project_id || canonical_root_hash != identity.workspace_id {
+                return None;
+            }
+        }
+        BROKER_SCHEMA_VERSION_V2 => {
+            let legacy = stored_identity?;
+            if project_id != legacy.project_id
+                || canonical_root_hash != legacy_canonical_root_hash(workspace_root)?
+            {
+                return None;
+            }
+        }
+        LEGACY_BROKER_SCHEMA_VERSION => {
+            let legacy_hash = legacy_canonical_root_hash(workspace_root)?;
+            if stored_identity.is_some()
+                || canonical_root_hash != legacy_hash
+                || project_id != format!("codestory-{}", &legacy_hash[..16])
+            {
+                return None;
+            }
+        }
+        _ => return None,
     }
     Some(identity)
 }
 
 pub(crate) fn effective_identity(
     schema_version: u32,
-    identity: Option<&ProjectIdentityV2>,
+    identity: Option<&ProjectIdentityV3>,
     workspace_root: &str,
-) -> Option<ProjectIdentityV2> {
+) -> Option<ProjectIdentityV3> {
     match schema_version {
         BROKER_SCHEMA_VERSION => {
             let identity = identity?.clone();
-            identity_matches_workspace_root(&identity, workspace_root).then_some(identity)
+            identity_v3_matches_workspace_root(&identity, workspace_root).then_some(identity)
+        }
+        BROKER_SCHEMA_VERSION_V2 => {
+            let identity = identity?;
+            identity_v2_matches_workspace_root(identity, workspace_root)
+                .then(|| identity_from_workspace_root(workspace_root))?
         }
         LEGACY_BROKER_SCHEMA_VERSION => identity_from_workspace_root(workspace_root),
         _ => None,
     }
 }
 
-pub(crate) fn identity_from_workspace_root(workspace_root: &str) -> Option<ProjectIdentityV2> {
+pub(crate) fn identity_from_workspace_root(workspace_root: &str) -> Option<ProjectIdentityV3> {
     let root = Path::new(workspace_root.trim());
     if workspace_root.trim().is_empty() || !root.is_absolute() {
         return None;
     }
-    Some(project_identity_v2(root))
+    Some(project_identity_v3(root))
 }
 
-pub(crate) fn normalized_workspace_root(workspace_root: &str) -> Option<String> {
+pub(crate) fn legacy_canonical_root_hash(workspace_root: &str) -> Option<String> {
     let root = Path::new(workspace_root.trim());
     if workspace_root.trim().is_empty() || !root.is_absolute() {
         return None;
     }
-    Some(clean_path_text(root))
+    Some(hash_text(&clean_path_text(root)))
 }
 
-fn identity_matches_workspace_root(identity: &ProjectIdentityV2, workspace_root: &str) -> bool {
+fn identity_v3_matches_workspace_root(identity: &ProjectIdentityV3, workspace_root: &str) -> bool {
     let root = Path::new(workspace_root.trim());
-    !workspace_root.trim().is_empty()
-        && root.is_absolute()
-        && codestory_workspace::workspace_id_for_root(root) == identity.workspace_id
+    if workspace_root.trim().is_empty() || !root.is_absolute() {
+        return false;
+    }
+    let current = project_identity_v3(root);
+    identity.project_identity_schema_version
+        == codestory_workspace::PROJECT_IDENTITY_V3_SCHEMA_VERSION
+        && identity.workspace_id == current.workspace_id
+        && identity.canonical_repository_id == current.canonical_repository_id
+        && identity.legacy_canonical_repository_id == current.legacy_canonical_repository_id
+        && identity_has_consistent_scope(
+            &identity.project_id,
+            &identity.artifact_scope_id,
+            &identity.workspace_id,
+            identity.canonical_repository_id.as_deref(),
+            identity.portable_reuse_eligible,
+        )
+}
+
+fn identity_v2_matches_workspace_root(identity: &ProjectIdentityV3, workspace_root: &str) -> bool {
+    let root = Path::new(workspace_root.trim());
+    if workspace_root.trim().is_empty() || !root.is_absolute() {
+        return false;
+    }
+    let current = project_identity_v2(root);
+    identity.project_identity_schema_version == codestory_workspace::PROJECT_IDENTITY_SCHEMA_VERSION
+        && identity.legacy_canonical_repository_id.is_none()
+        && identity.workspace_id == current.workspace_id
+        && identity.canonical_repository_id == current.canonical_repository_id
+        && identity_has_consistent_scope(
+            &identity.project_id,
+            &identity.artifact_scope_id,
+            &identity.workspace_id,
+            identity.canonical_repository_id.as_deref(),
+            identity.portable_reuse_eligible,
+        )
+}
+
+fn identity_has_consistent_scope(
+    project_id: &str,
+    artifact_scope_id: &str,
+    workspace_id: &str,
+    canonical_repository_id: Option<&str>,
+    portable_reuse_eligible: bool,
+) -> bool {
+    let portable_id = canonical_repository_id.unwrap_or(workspace_id);
+    let expected = if portable_reuse_eligible {
+        portable_id
+    } else {
+        workspace_id
+    };
+    project_id == expected && artifact_scope_id == expected
 }

--- a/crates/codestory-cli/src/readiness_broker/snapshot.rs
+++ b/crates/codestory-cli/src/readiness_broker/snapshot.rs
@@ -9,10 +9,9 @@ use super::gpu_proof::{bind_verified_runtime_identity, gpu_proof, inherit_verifi
 use super::machine_lock::{NATIVE_EMBEDDING_RESOURCE, machine_resource_snapshot};
 use super::operations::{operation_from_local_refresh, operation_from_ready_status};
 use super::paths::{
-    BROKER_SNAPSHOT_FILE, broker_snapshot_path, clean_path, clean_path_text, hash_text, install_id,
-    now_epoch_ms,
+    BROKER_SNAPSHOT_FILE, broker_snapshot_path, clean_path, install_id, now_epoch_ms,
 };
-use super::scope::BROKER_SCHEMA_VERSION;
+use super::scope::{BROKER_SCHEMA_VERSION, effective_record_identity, legacy_canonical_root_hash};
 use super::types::{
     BrokerGpuRuntimeIdentity, BrokerReconciliationSnapshot, BrokerSnapshotInput,
     ReadinessBrokerSnapshot,
@@ -26,14 +25,14 @@ pub(crate) fn refresh_broker_snapshot(input: BrokerSnapshotInput) -> ReadinessBr
 }
 
 fn refresh_broker_snapshot_inner(input: BrokerSnapshotInput) -> ReadinessBrokerSnapshot {
-    let identity = codestory_workspace::project_identity_v2(&input.project_root);
+    let identity = codestory_workspace::project_identity_v3(&input.project_root);
     let runtime_identity = current_gpu_runtime_identity(&input, &identity);
     refresh_broker_snapshot_with_identity(input, identity, runtime_identity.as_ref(), None)
 }
 
 fn refresh_broker_snapshot_with_identity(
     input: BrokerSnapshotInput,
-    identity: codestory_workspace::ProjectIdentityV2,
+    identity: codestory_workspace::ProjectIdentityV3,
     runtime_identity: Option<&BrokerGpuRuntimeIdentity>,
     sidecar: Option<&codestory_retrieval::SidecarRuntimeConfig>,
 ) -> ReadinessBrokerSnapshot {
@@ -91,8 +90,9 @@ fn observe_broker_snapshot_for_sidecar_inner(
     input: BrokerSnapshotInput,
     sidecar: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> ReadinessBrokerSnapshot {
-    let identity = codestory_workspace::cached_project_identity_v2(&input.project_root);
-    let runtime_identity = gpu_runtime_identity_for_sidecar(sidecar, &identity);
+    let identity = codestory_workspace::cached_project_identity_v3(&input.project_root);
+    let runtime_identity =
+        gpu_runtime_identity_for_sidecar(sidecar, &input.project_root, &identity);
     observe_broker_snapshot_with_identity(input, identity, runtime_identity.as_ref(), Some(sidecar))
 }
 
@@ -100,23 +100,25 @@ fn refresh_broker_snapshot_for_sidecar_inner(
     input: BrokerSnapshotInput,
     sidecar: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> ReadinessBrokerSnapshot {
-    let identity = codestory_workspace::project_identity_v2(&input.project_root);
-    let runtime_identity = gpu_runtime_identity_for_sidecar(sidecar, &identity);
+    let identity = codestory_workspace::project_identity_v3(&input.project_root);
+    let runtime_identity =
+        gpu_runtime_identity_for_sidecar(sidecar, &input.project_root, &identity);
     refresh_broker_snapshot_with_identity(input, identity, runtime_identity.as_ref(), Some(sidecar))
 }
 
 fn observe_broker_snapshot_inner(input: BrokerSnapshotInput) -> ReadinessBrokerSnapshot {
-    let identity = codestory_workspace::cached_project_identity_v2(&input.project_root);
+    let identity = codestory_workspace::cached_project_identity_v3(&input.project_root);
     let runtime_identity = current_gpu_runtime_identity(&input, &identity);
     observe_broker_snapshot_with_identity(input, identity, runtime_identity.as_ref(), None)
 }
 
 fn observe_broker_snapshot_with_identity(
     input: BrokerSnapshotInput,
-    identity: codestory_workspace::ProjectIdentityV2,
+    identity: codestory_workspace::ProjectIdentityV3,
     runtime_identity: Option<&BrokerGpuRuntimeIdentity>,
     sidecar: Option<&codestory_retrieval::SidecarRuntimeConfig>,
 ) -> ReadinessBrokerSnapshot {
+    let project_root = input.project_root.clone();
     let mut snapshot = build_broker_snapshot(input, identity, sidecar);
     if let Some(proof) = snapshot.gpu_proof.as_mut() {
         bind_verified_runtime_identity(proof, runtime_identity);
@@ -124,7 +126,11 @@ fn observe_broker_snapshot_with_identity(
     let path = broker_snapshot_path(&snapshot.canonical_root_hash);
     snapshot.snapshot_path = Some(clean_path(&path));
 
-    if let Some(persisted) = read_snapshot_file(&path) {
+    let persisted = read_snapshot_file(&path, &project_root).or_else(|| {
+        let legacy_hash = legacy_canonical_root_hash(&project_root.to_string_lossy())?;
+        read_snapshot_file(&broker_snapshot_path(&legacy_hash), &project_root)
+    });
+    if let Some(persisted) = persisted {
         if let (Some(observed_proof), Some(persisted_proof)) =
             (snapshot.gpu_proof.as_mut(), persisted.gpu_proof.as_ref())
         {
@@ -149,7 +155,7 @@ pub(super) fn refresh_broker_snapshot_with_runtime_identity(
     runtime_identity: Option<&BrokerGpuRuntimeIdentity>,
 ) -> ReadinessBrokerSnapshot {
     super::paths::with_test_broker_root(|| {
-        let identity = codestory_workspace::project_identity_v2(&input.project_root);
+        let identity = codestory_workspace::project_identity_v3(&input.project_root);
         refresh_broker_snapshot_with_identity(input, identity, runtime_identity, None)
     })
 }
@@ -160,14 +166,14 @@ pub(super) fn observe_broker_snapshot_with_runtime_identity(
     runtime_identity: Option<&BrokerGpuRuntimeIdentity>,
 ) -> ReadinessBrokerSnapshot {
     super::paths::with_test_broker_root(|| {
-        let identity = codestory_workspace::cached_project_identity_v2(&input.project_root);
+        let identity = codestory_workspace::cached_project_identity_v3(&input.project_root);
         observe_broker_snapshot_with_identity(input, identity, runtime_identity, None)
     })
 }
 
 fn current_gpu_runtime_identity(
     input: &BrokerSnapshotInput,
-    expected_project_identity: &codestory_workspace::ProjectIdentityV2,
+    expected_project_identity: &codestory_workspace::ProjectIdentityV3,
 ) -> Option<BrokerGpuRuntimeIdentity> {
     let profile = if input.agent_run_id.is_some() {
         codestory_retrieval::SidecarProfile::Agent
@@ -188,12 +194,13 @@ fn current_gpu_runtime_identity(
             input.agent_run_id.as_deref(),
             &super::paths::broker_cache_root(),
         );
-    gpu_runtime_identity_for_sidecar(&runtime, expected_project_identity)
+    gpu_runtime_identity_for_sidecar(&runtime, &input.project_root, expected_project_identity)
 }
 
 fn gpu_runtime_identity_for_sidecar(
     runtime: &codestory_retrieval::SidecarRuntimeConfig,
-    expected_project_identity: &codestory_workspace::ProjectIdentityV2,
+    project_root: &std::path::Path,
+    expected_project_identity: &codestory_workspace::ProjectIdentityV3,
 ) -> Option<BrokerGpuRuntimeIdentity> {
     let state: codestory_retrieval::SidecarStateFile =
         serde_json::from_slice(&fs::read(&runtime.layout.state_file).ok()?).ok()?;
@@ -201,7 +208,11 @@ fn gpu_runtime_identity_for_sidecar(
         return None;
     }
     let state_project_identity = state.project_identity.as_ref()?;
-    if state_project_identity.workspace_id != expected_project_identity.workspace_id
+    let legacy_identity = codestory_workspace::project_identity_v2(project_root);
+    if runtime.project_identity.as_ref()? != &legacy_identity
+        || state_project_identity != &legacy_identity
+        || expected_project_identity.workspace_id
+            != codestory_workspace::workspace_id_v3_for_root(project_root)
         || state.started_at_epoch_ms <= 0
     {
         return None;
@@ -217,7 +228,7 @@ fn gpu_runtime_identity_for_sidecar(
         }
     }
     Some(BrokerGpuRuntimeIdentity {
-        workspace_id: state_project_identity.workspace_id.clone(),
+        workspace_id: expected_project_identity.workspace_id.clone(),
         profile: state.profile,
         run_id: state.run_id,
         namespace: state.namespace,
@@ -230,11 +241,10 @@ fn gpu_runtime_identity_for_sidecar(
 
 fn build_broker_snapshot(
     input: BrokerSnapshotInput,
-    identity: codestory_workspace::ProjectIdentityV2,
+    identity: codestory_workspace::ProjectIdentityV3,
     sidecar: Option<&codestory_retrieval::SidecarRuntimeConfig>,
 ) -> ReadinessBrokerSnapshot {
-    let canonical_root = clean_path_text(&input.project_root);
-    let canonical_root_hash = hash_text(&canonical_root);
+    let canonical_root_hash = identity.workspace_id.clone();
     let project_id = identity.project_id.clone();
     let cli_version = input.cli_version;
     let mut operations = Vec::new();
@@ -325,23 +335,43 @@ fn build_broker_snapshot(
     }
 }
 
-fn read_snapshot_file(path: &std::path::Path) -> Option<ReadinessBrokerSnapshot> {
-    let snapshot: ReadinessBrokerSnapshot = serde_json::from_slice(&fs::read(path).ok()?).ok()?;
-    snapshot.effective_identity()?;
+fn read_snapshot_file(
+    path: &std::path::Path,
+    expected_project_root: &std::path::Path,
+) -> Option<ReadinessBrokerSnapshot> {
+    let mut snapshot: ReadinessBrokerSnapshot =
+        serde_json::from_slice(&fs::read(path).ok()?).ok()?;
+    let identity = snapshot.effective_identity()?;
+    if identity.workspace_id != codestory_workspace::workspace_id_v3_for_root(expected_project_root)
+        || !codestory_workspace::same_workspace_path(
+            std::path::Path::new(&snapshot.workspace_root),
+            expected_project_root,
+        )
+    {
+        return None;
+    }
+    if snapshot.schema_version != BROKER_SCHEMA_VERSION
+        && let Some(runtime_identity) = snapshot
+            .gpu_proof
+            .as_mut()
+            .and_then(|proof| proof.runtime_identity.as_mut())
+        && runtime_identity.workspace_id
+            == codestory_workspace::workspace_id_for_root(expected_project_root)
+    {
+        runtime_identity.workspace_id = identity.workspace_id;
+    }
     Some(snapshot)
 }
 
 impl ReadinessBrokerSnapshot {
-    pub(crate) fn effective_identity(&self) -> Option<codestory_workspace::ProjectIdentityV2> {
-        let identity = super::scope::effective_identity(
+    pub(crate) fn effective_identity(&self) -> Option<codestory_workspace::ProjectIdentityV3> {
+        effective_record_identity(
             self.schema_version,
             self.identity.as_ref(),
+            &self.project_id,
+            &self.canonical_root_hash,
             &self.workspace_root,
-        )?;
-        if self.schema_version == BROKER_SCHEMA_VERSION && self.project_id != identity.project_id {
-            return None;
-        }
-        Some(identity)
+        )
     }
 }
 

--- a/crates/codestory-cli/src/readiness_broker/tests.rs
+++ b/crates/codestory-cli/src/readiness_broker/tests.rs
@@ -767,7 +767,7 @@ fn machine_resource_lock_reclaims_dead_owner() {
     cleanup_machine_resource(&resource);
     let old_scope = test_scope(project.path(), "dead");
     let new_scope = test_scope(project.path(), "new");
-    write_machine_lock(&resource, &old_scope, u32::MAX);
+    write_machine_lock(&resource, &old_scope, exited_process_id());
 
     let acquired =
         try_acquire_machine_resource_lock(&resource, &new_scope).expect("reclaim dead owner");
@@ -1167,10 +1167,27 @@ fn producer_path_text(path: &Path) -> String {
         .to_string()
 }
 
+fn exited_process_id() -> u32 {
+    #[cfg(windows)]
+    let mut child = std::process::Command::new("cmd")
+        .args(["/C", "exit", "0"])
+        .spawn()
+        .expect("spawn short-lived process");
+    #[cfg(not(windows))]
+    let mut child = std::process::Command::new("sh")
+        .args(["-c", "exit 0"])
+        .spawn()
+        .expect("spawn short-lived process");
+    let pid = child.id();
+    child.wait().expect("wait for short-lived process");
+    pid
+}
+
 fn write_stale_local_refresh(cache_root: &Path, project: &Path) {
     let status_path = cache_root.join("local-refresh-status.json");
     let lock_path = cache_root.join("local-refresh.lock");
     let old_started = now_epoch_ms() - 180_000;
+    let dead_pid = exited_process_id();
     fs::write(
         &status_path,
         serde_json::to_string(&serde_json::json!({
@@ -1178,7 +1195,7 @@ fn write_stale_local_refresh(cache_root: &Path, project: &Path) {
             "status": "refreshing",
             "project_root": producer_path_text(project),
             "phase": "incremental_index",
-            "pid": u32::MAX,
+            "pid": dead_pid,
             "started_at_epoch_ms": old_started,
             "updated_at_epoch_ms": old_started,
             "last_failure_reason": null
@@ -1191,7 +1208,7 @@ fn write_stale_local_refresh(cache_root: &Path, project: &Path) {
         serde_json::to_string(&serde_json::json!({
             "schema_version": 1,
             "project_root": producer_path_text(project),
-            "pid": u32::MAX,
+            "pid": dead_pid,
             "started_at_epoch_ms": old_started,
             "token": "stale"
         }))
@@ -1234,7 +1251,7 @@ fn reconcile_before_enqueue_cleans_abandoned_repair_for_dead_pid() {
     let status_path = write_ready_repair_status_file(
         project.path(),
         run_id,
-        u32::MAX,
+        exited_process_id(),
         now_epoch_ms(),
         "graph artifact",
     );
@@ -1292,7 +1309,7 @@ fn reconcile_before_enqueue_for_sidecar_keeps_abandoned_cleanup_in_retained_root
             "namespace": retained_sidecar.namespace,
             "compose_project": retained_sidecar.compose_project,
             "phase": "graph artifact",
-            "pid": u32::MAX,
+            "pid": exited_process_id(),
             "started_at_epoch_ms": now_epoch_ms(),
             "updated_at_epoch_ms": now_epoch_ms()
         }))

--- a/crates/codestory-cli/src/readiness_broker/tests.rs
+++ b/crates/codestory-cli/src/readiness_broker/tests.rs
@@ -8,6 +8,7 @@ use super::*;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::thread;
 use std::time::{Duration, SystemTime};
 use tempfile::tempdir;
@@ -20,6 +21,33 @@ fn cleanup_machine_resource(resource: &str) {
     let _ = fs::remove_file(machine_resource_lock_path(resource));
     let _ = fs::remove_file(machine_resource_reaper_lock_path(resource));
     let _ = fs::remove_file(machine_resource_reaper_takeover_lock_path(resource));
+}
+
+fn run_git(project: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(project)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_git_project(project: &Path, remote: &str) {
+    run_git(project, &["init", "--quiet"]);
+    run_git(
+        project,
+        &["config", "user.email", "codestory@example.invalid"],
+    );
+    run_git(project, &["config", "user.name", "CodeStory Test"]);
+    run_git(
+        project,
+        &["commit", "--allow-empty", "--quiet", "-m", "initial"],
+    );
+    run_git(project, &["remote", "add", "origin", remote]);
 }
 
 fn test_scope(project: &Path, run_id: &str) -> BrokerScope {
@@ -112,13 +140,13 @@ fn set_file_age(path: &Path, age: Duration) {
 }
 
 fn sample_snapshot(project: &Path) -> ReadinessBrokerSnapshot {
-    let canonical_root = clean_path_text(project);
-    let canonical_root_hash = hash_text(&canonical_root);
+    let identity = codestory_workspace::project_identity_v3(project);
+    let canonical_root_hash = identity.workspace_id.clone();
     ReadinessBrokerSnapshot {
         schema_version: BROKER_SCHEMA_VERSION,
-        identity: Some(codestory_workspace::project_identity_v2(project)),
+        identity: Some(identity.clone()),
         install_id: "test-install".to_string(),
-        project_id: codestory_workspace::project_identity_v2(project).project_id,
+        project_id: identity.project_id,
         canonical_root_hash,
         workspace_root: clean_path(project),
         cli_version: "9.9.9".to_string(),
@@ -207,7 +235,7 @@ fn verified_gpu_proof_input(embed_smoke_ok: Option<bool>) -> BrokerGpuProofInput
 
 fn gpu_runtime_identity(project: &Path, started_at_epoch_ms: i64) -> BrokerGpuRuntimeIdentity {
     BrokerGpuRuntimeIdentity {
-        workspace_id: codestory_workspace::workspace_id_for_root(project),
+        workspace_id: codestory_workspace::workspace_id_v3_for_root(project),
         profile: "agent".to_string(),
         run_id: Some("shared-agent".to_string()),
         namespace: "codestory-test".to_string(),
@@ -346,9 +374,57 @@ fn broker_scope_carries_project_and_run_identity() {
     assert_eq!(scope.project_id, identity.project_id);
     assert_eq!(
         identity.workspace_id,
-        codestory_workspace::workspace_id_for_root(project.path())
+        codestory_workspace::workspace_id_v3_for_root(project.path())
     );
     assert_eq!(scope.cli_version, "9.9.9");
+}
+
+#[test]
+fn broker_persistence_preserves_non_default_repository_ports() {
+    let first = tempdir().expect("first project");
+    let second = tempdir().expect("second project");
+    init_git_project(
+        first.path(),
+        "ssh://git@example.com:2222/Org/CaseSensitive.git",
+    );
+    init_git_project(
+        second.path(),
+        "ssh://git@example.com:2200/Org/CaseSensitive.git",
+    );
+
+    let first = test_scope(first.path(), "shared-agent");
+    let second = test_scope(second.path(), "shared-agent");
+    assert_ne!(first.project_id, second.project_id);
+    assert_ne!(
+        first.identity.unwrap().canonical_repository_id,
+        second.identity.unwrap().canonical_repository_id
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn broker_scope_keeps_case_distinct_unix_roots_separate() {
+    let parent = tempdir().expect("parent");
+    let upper = parent.path().join("Project");
+    let lower = parent.path().join("project");
+    fs::create_dir_all(&upper).expect("upper project");
+    fs::create_dir_all(&lower).expect("lower project");
+
+    let upper = test_scope(&upper, "shared-agent");
+    let lower = test_scope(&lower, "shared-agent");
+    assert_ne!(upper.canonical_root_hash, lower.canonical_root_hash);
+    assert_ne!(broker_operation_id(&upper), broker_operation_id(&lower));
+}
+
+#[cfg(windows)]
+#[test]
+fn broker_scope_treats_windows_case_alias_as_one_workspace() {
+    let project = tempdir().expect("project");
+    let alias = PathBuf::from(project.path().to_string_lossy().to_ascii_uppercase());
+    let original = test_scope(project.path(), "shared-agent");
+    let alias = test_scope(&alias, "shared-agent");
+    assert_eq!(original.canonical_root_hash, alias.canonical_root_hash);
+    assert_eq!(broker_operation_id(&original), broker_operation_id(&alias));
 }
 
 #[test]
@@ -984,6 +1060,36 @@ fn snapshot_file_round_trips_json() {
 }
 
 #[test]
+fn v2_snapshot_identity_maps_only_to_its_proven_workspace() {
+    let project = tempdir().expect("project");
+    let other = tempdir().expect("other project");
+    let legacy_identity = codestory_workspace::project_identity_v2(project.path());
+    let legacy_hash = hash_text(&clean_path_text(project.path()));
+    let mut value = serde_json::to_value(sample_snapshot(project.path())).expect("snapshot json");
+    value["schema_version"] = BROKER_SCHEMA_VERSION_V2.into();
+    value["identity"] = serde_json::to_value(&legacy_identity).expect("legacy identity json");
+    value["project_id"] = legacy_identity.project_id.clone().into();
+    value["canonical_root_hash"] = legacy_hash.into();
+
+    let parsed: ReadinessBrokerSnapshot =
+        serde_json::from_value(value.clone()).expect("parse v2 snapshot");
+    let effective = parsed.effective_identity().expect("map v2 identity");
+    assert_eq!(
+        effective.workspace_id,
+        codestory_workspace::workspace_id_v3_for_root(project.path())
+    );
+    assert_eq!(
+        effective.project_identity_schema_version,
+        codestory_workspace::PROJECT_IDENTITY_V3_SCHEMA_VERSION
+    );
+
+    value["workspace_root"] = clean_path(other.path()).into();
+    let mismatched: ReadinessBrokerSnapshot =
+        serde_json::from_value(value).expect("parse mismatched v2 snapshot");
+    assert!(mismatched.effective_identity().is_none());
+}
+
+#[test]
 fn snapshot_file_uses_unique_temp_names_for_same_process_writers() {
     let dir = tempdir().expect("temp dir");
     let path = dir.path().join("snapshot.json");
@@ -1492,7 +1598,7 @@ fn refresh_broker_snapshot_final_success_omits_running_ops_after_repair_cleared(
 fn observe_broker_snapshot_is_stable_and_does_not_publish() {
     let project = tempdir().expect("project");
     let cache = tempdir().expect("cache");
-    let canonical_root_hash = hash_text(&clean_path_text(project.path()));
+    let canonical_root_hash = codestory_workspace::workspace_id_v3_for_root(project.path());
     let snapshot_path = broker_snapshot_path(&canonical_root_hash);
     let _ = fs::remove_file(&snapshot_path);
 
@@ -1514,6 +1620,31 @@ fn observe_broker_snapshot_is_stable_and_does_not_publish() {
     assert_eq!(first.updated_at_epoch_ms, 0);
     assert_eq!(first.persistence_status, "observed");
     assert!(!snapshot_path.exists());
+}
+
+#[test]
+fn broker_snapshot_a_b_a_keeps_workspace_state_isolated() {
+    let project_a = tempdir().expect("project a");
+    let project_b = tempdir().expect("project b");
+    let cache = tempdir().expect("cache");
+    let input = |project: &Path| BrokerSnapshotInput {
+        project_root: project.to_path_buf(),
+        cache_root: cache.path().to_path_buf(),
+        agent_run_id: Some("shared-agent".to_string()),
+        cli_version: "9.9.9".to_string(),
+        gpu_proof: None,
+        reconciliation: None,
+    };
+
+    let first_a = refresh_broker_snapshot(input(project_a.path()));
+    let snapshot_b = refresh_broker_snapshot(input(project_b.path()));
+    let second_a = observe_broker_snapshot(input(project_a.path()));
+
+    assert_ne!(first_a.canonical_root_hash, snapshot_b.canonical_root_hash);
+    assert_ne!(first_a.snapshot_path, snapshot_b.snapshot_path);
+    assert_eq!(second_a.persistence_status, "persisted");
+    assert_eq!(second_a.canonical_root_hash, first_a.canonical_root_hash);
+    assert_eq!(second_a.updated_at_epoch_ms, first_a.updated_at_epoch_ms);
 }
 
 #[test]
@@ -1647,19 +1778,23 @@ fn observe_broker_snapshot_invalidates_verified_smoke_for_changed_runtime_identi
 }
 
 #[test]
-fn legacy_snapshot_observation_is_read_only_and_refresh_migrates_to_v2() {
+fn legacy_snapshot_observation_is_read_only_and_refresh_migrates_to_v3() {
     let project = tempdir().expect("project");
     let cache = tempdir().expect("cache");
     let canonical_root_hash = hash_text(&clean_path_text(project.path()));
-    let snapshot_path = broker_snapshot_path(&canonical_root_hash);
-    fs::create_dir_all(snapshot_path.parent().expect("snapshot parent"))
+    let legacy_snapshot_path = broker_snapshot_path(&canonical_root_hash);
+    let snapshot_path = broker_snapshot_path(&codestory_workspace::workspace_id_v3_for_root(
+        project.path(),
+    ));
+    fs::create_dir_all(legacy_snapshot_path.parent().expect("snapshot parent"))
         .expect("create snapshot parent");
     let mut legacy = sample_snapshot(project.path());
     legacy.schema_version = LEGACY_BROKER_SCHEMA_VERSION;
     legacy.identity = None;
     legacy.project_id = format!("codestory-{}", &canonical_root_hash[..16]);
+    legacy.canonical_root_hash = canonical_root_hash;
     let legacy_json = serde_json::to_vec_pretty(&legacy).expect("serialize legacy snapshot");
-    fs::write(&snapshot_path, &legacy_json).expect("write legacy snapshot");
+    fs::write(&legacy_snapshot_path, &legacy_json).expect("write legacy snapshot");
     let input = || BrokerSnapshotInput {
         project_root: project.path().to_path_buf(),
         cache_root: cache.path().to_path_buf(),
@@ -1673,7 +1808,7 @@ fn legacy_snapshot_observation_is_read_only_and_refresh_migrates_to_v2() {
     assert_eq!(observed.schema_version, BROKER_SCHEMA_VERSION);
     assert_eq!(observed.persistence_status, "observed");
     assert_eq!(
-        fs::read(&snapshot_path).expect("legacy snapshot remains"),
+        fs::read(&legacy_snapshot_path).expect("legacy snapshot remains"),
         legacy_json,
         "observational reads must not migrate persisted state"
     );
@@ -1686,9 +1821,14 @@ fn legacy_snapshot_observation_is_read_only_and_refresh_migrates_to_v2() {
     assert_eq!(migrated["schema_version"], BROKER_SCHEMA_VERSION);
     assert_eq!(
         migrated["identity"]["workspace_id"],
-        codestory_workspace::workspace_id_for_root(project.path())
+        codestory_workspace::workspace_id_v3_for_root(project.path())
+    );
+    assert_eq!(
+        fs::read(&legacy_snapshot_path).expect("legacy snapshot remains isolated"),
+        legacy_json
     );
     let _ = fs::remove_file(snapshot_path);
+    let _ = fs::remove_file(legacy_snapshot_path);
 }
 
 #[test]
@@ -1699,10 +1839,8 @@ fn legacy_machine_lock_derives_identity_without_rewriting() {
     let mut scope = test_scope(project.path(), "shared-agent");
     scope.schema_version = LEGACY_BROKER_SCHEMA_VERSION;
     scope.identity = None;
-    scope.project_id = format!(
-        "codestory-{}",
-        &hash_text(&clean_path_text(project.path()))[..16]
-    );
+    scope.canonical_root_hash = hash_text(&clean_path_text(project.path()));
+    scope.project_id = format!("codestory-{}", &scope.canonical_root_hash[..16]);
     let lock = BrokerMachineResourceLockFile {
         schema_version: LEGACY_BROKER_SCHEMA_VERSION,
         resource: resource.clone(),
@@ -1722,7 +1860,50 @@ fn legacy_machine_lock_derives_identity_without_rewriting() {
     let identity = effective_scope_identity(&parsed.scope).expect("derive legacy identity");
     assert_eq!(
         identity.workspace_id,
-        codestory_workspace::workspace_id_for_root(project.path())
+        codestory_workspace::workspace_id_v3_for_root(project.path())
+    );
+    assert_eq!(fs::read(&path).expect("lock remains"), legacy_json);
+    cleanup_machine_resource(&resource);
+}
+
+#[test]
+fn v2_machine_lock_maps_to_v3_without_rewriting() {
+    let project = tempdir().expect("project");
+    let resource = unique_resource("v2-identity");
+    cleanup_machine_resource(&resource);
+    let legacy_identity = codestory_workspace::project_identity_v2(project.path());
+    let mut scope = test_scope(project.path(), "shared-agent");
+    scope.schema_version = BROKER_SCHEMA_VERSION_V2;
+    scope.identity = Some(
+        serde_json::from_value(serde_json::to_value(&legacy_identity).expect("v2 identity json"))
+            .expect("v2 identity compatibility"),
+    );
+    scope.project_id = legacy_identity.project_id;
+    scope.canonical_root_hash = hash_text(&clean_path_text(project.path()));
+    let lock = BrokerMachineResourceLockFile {
+        schema_version: MACHINE_LOCK_SCHEMA_VERSION_V2,
+        resource: resource.clone(),
+        operation_id: broker_operation_id(&scope),
+        scope,
+        pid: std::process::id(),
+        started_at_epoch_ms: now_epoch_ms(),
+        token: "v2-token".to_string(),
+        native_embedding_launch: None,
+    };
+    let path = machine_resource_lock_path(&resource);
+    fs::create_dir_all(path.parent().expect("lock parent")).expect("create lock parent");
+    let legacy_json = serde_json::to_vec_pretty(&lock).expect("serialize v2 lock");
+    fs::write(&path, &legacy_json).expect("write v2 lock");
+
+    let parsed = read_machine_resource_lock_file(&path).expect("read v2 machine lock");
+    let identity = effective_scope_identity(&parsed.scope).expect("map v2 identity");
+    assert_eq!(
+        identity.workspace_id,
+        codestory_workspace::workspace_id_v3_for_root(project.path())
+    );
+    assert_eq!(
+        identity.project_identity_schema_version,
+        codestory_workspace::PROJECT_IDENTITY_V3_SCHEMA_VERSION
     );
     assert_eq!(fs::read(&path).expect("lock remains"), legacy_json);
     cleanup_machine_resource(&resource);

--- a/crates/codestory-cli/src/readiness_broker/tests.rs
+++ b/crates/codestory-cli/src/readiness_broker/tests.rs
@@ -1139,7 +1139,7 @@ fn write_ready_repair_status_file(
     let status = serde_json::json!({
         "schema_version": 1,
         "status": "repairing",
-        "project_root": clean_path_text(project),
+        "project_root": producer_path_text(project),
         "profile": "agent",
         "run_id": run_id,
         "namespace": sidecar.namespace,
@@ -1157,6 +1157,16 @@ fn write_ready_repair_status_file(
     path
 }
 
+fn producer_path_text(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string()
+}
+
 fn write_stale_local_refresh(cache_root: &Path, project: &Path) {
     let status_path = cache_root.join("local-refresh-status.json");
     let lock_path = cache_root.join("local-refresh.lock");
@@ -1166,7 +1176,7 @@ fn write_stale_local_refresh(cache_root: &Path, project: &Path) {
         serde_json::to_string(&serde_json::json!({
             "schema_version": 1,
             "status": "refreshing",
-            "project_root": clean_path_text(project),
+            "project_root": producer_path_text(project),
             "phase": "incremental_index",
             "pid": u32::MAX,
             "started_at_epoch_ms": old_started,
@@ -1180,7 +1190,7 @@ fn write_stale_local_refresh(cache_root: &Path, project: &Path) {
         &lock_path,
         serde_json::to_string(&serde_json::json!({
             "schema_version": 1,
-            "project_root": clean_path_text(project),
+            "project_root": producer_path_text(project),
             "pid": u32::MAX,
             "started_at_epoch_ms": old_started,
             "token": "stale"
@@ -1276,7 +1286,7 @@ fn reconcile_before_enqueue_for_sidecar_keeps_abandoned_cleanup_in_retained_root
         serde_json::to_vec_pretty(&serde_json::json!({
             "schema_version": 1,
             "status": "repairing",
-            "project_root": clean_path_text(project.path()),
+            "project_root": producer_path_text(project.path()),
             "profile": "agent",
             "run_id": run_id,
             "namespace": retained_sidecar.namespace,
@@ -1398,7 +1408,7 @@ fn reconcile_before_enqueue_reports_live_stale_local_refresh_without_cleanup() {
         serde_json::to_string(&serde_json::json!({
             "schema_version": 1,
             "status": "refreshing",
-            "project_root": clean_path_text(project.path()),
+            "project_root": producer_path_text(project.path()),
             "phase": "incremental_index",
             "pid": std::process::id(),
             "started_at_epoch_ms": old,
@@ -1412,7 +1422,7 @@ fn reconcile_before_enqueue_reports_live_stale_local_refresh_without_cleanup() {
         cache.path().join("local-refresh.lock"),
         serde_json::to_string(&serde_json::json!({
             "schema_version": 1,
-            "project_root": clean_path_text(project.path()),
+            "project_root": producer_path_text(project.path()),
             "pid": std::process::id(),
             "started_at_epoch_ms": old,
             "token": "live-stale"
@@ -1449,7 +1459,7 @@ fn reconcile_before_enqueue_preserves_renewed_live_local_refresh_owner() {
         serde_json::to_string(&serde_json::json!({
             "schema_version": 1,
             "status": "refreshing",
-            "project_root": clean_path_text(project.path()),
+            "project_root": producer_path_text(project.path()),
             "phase": "incremental_index",
             "pid": std::process::id(),
             "owner_token": "renewed-live",
@@ -1464,7 +1474,7 @@ fn reconcile_before_enqueue_preserves_renewed_live_local_refresh_owner() {
         cache.path().join("local-refresh.lock"),
         serde_json::to_string(&serde_json::json!({
             "schema_version": 1,
-            "project_root": clean_path_text(project.path()),
+            "project_root": producer_path_text(project.path()),
             "pid": std::process::id(),
             "started_at_epoch_ms": old,
             "token": "renewed-live"

--- a/crates/codestory-cli/src/readiness_broker/types.rs
+++ b/crates/codestory-cli/src/readiness_broker/types.rs
@@ -1,4 +1,4 @@
-use codestory_workspace::ProjectIdentityV2;
+use codestory_workspace::ProjectIdentityV3;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct BrokerScope {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) identity: Option<ProjectIdentityV2>,
+    pub(crate) identity: Option<ProjectIdentityV3>,
     pub(crate) install_id: String,
     pub(crate) project_id: String,
     pub(crate) canonical_root_hash: String,
@@ -25,7 +25,7 @@ pub(crate) struct BrokerScope {
 pub(crate) struct ReadinessBrokerSnapshot {
     pub(crate) schema_version: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) identity: Option<ProjectIdentityV2>,
+    pub(crate) identity: Option<ProjectIdentityV3>,
     pub(crate) install_id: String,
     pub(crate) project_id: String,
     pub(crate) canonical_root_hash: String,

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -1005,7 +1005,7 @@ fn read_ready_repair_status(
     if status.schema_version != READY_REPAIR_STATUS_SCHEMA_VERSION
         || status.status != "repairing"
         || status.profile != SidecarProfile::Agent.as_str()
-        || !same_path_text(Path::new(&status.project_root), project_root)
+        || !codestory_workspace::same_workspace_path(Path::new(&status.project_root), project_root)
     {
         return None;
     }
@@ -1030,7 +1030,7 @@ fn read_abandoned_ready_repair_status(
     if status.schema_version != READY_REPAIR_STATUS_SCHEMA_VERSION
         || status.status != "repairing"
         || status.profile != SidecarProfile::Agent.as_str()
-        || !same_path_text(Path::new(&status.project_root), project_root)
+        || !codestory_workspace::same_workspace_path(Path::new(&status.project_root), project_root)
     {
         return None;
     }
@@ -1051,7 +1051,7 @@ fn read_stale_live_ready_repair_status(
     if status.schema_version != READY_REPAIR_STATUS_SCHEMA_VERSION
         || status.status != "repairing"
         || status.profile != SidecarProfile::Agent.as_str()
-        || !same_path_text(Path::new(&status.project_root), project_root)
+        || !codestory_workspace::same_workspace_path(Path::new(&status.project_root), project_root)
     {
         return None;
     }
@@ -1315,11 +1315,7 @@ fn clean_path_text(path: &Path) -> String {
         .trim_start_matches(r"\\?\")
         .replace('\\', "/")
         .trim_end_matches('/')
-        .to_ascii_lowercase()
-}
-
-fn same_path_text(left: &Path, right: &Path) -> bool {
-    clean_path_text(left) == clean_path_text(right)
+        .to_string()
 }
 
 fn path_fingerprint(path: &Path) -> String {
@@ -2335,5 +2331,14 @@ mod tests {
             Some(terminal),
             "cleanup must preserve an existing matching terminal result"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_ready_repair_root_preserves_unix_case() {
+        let parent = tempfile::tempdir().expect("parent");
+        let project = parent.path().join("CaseSensitiveProject");
+        fs::create_dir_all(&project).expect("project");
+        assert!(clean_path_text(&project).ends_with("CaseSensitiveProject"));
     }
 }

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -470,19 +470,6 @@ fn write_ready_repair_worker_result_locked(
     )
 }
 
-#[cfg(test)]
-pub(crate) fn read_ready_repair_worker_result(
-    project_root: &Path,
-    run_id: Option<&str>,
-) -> Option<ReadyRepairWorkerResult> {
-    let sidecar = sidecar_runtime_for_project_with_run_id(
-        project_root,
-        SidecarProfile::Agent,
-        run_id.or(Some(DEFAULT_AGENT_RUN_ID)),
-    );
-    read_ready_repair_worker_result_for_sidecar(&sidecar)
-}
-
 pub(crate) fn read_ready_repair_worker_result_for_sidecar(
     sidecar: &SidecarRuntimeConfig,
 ) -> Option<ReadyRepairWorkerResult> {
@@ -1618,6 +1605,7 @@ mod tests {
 
     #[test]
     fn ready_repair_worker_result_round_trips() {
+        let _env_lock = crate::config::config_env_test_lock();
         let project = tempfile::tempdir().expect("project");
         let sidecar = sidecar_runtime_for_project_with_run_id(
             project.path(),
@@ -1656,7 +1644,7 @@ mod tests {
             "terminal result should invalidate cached MCP status"
         );
         assert_eq!(
-            read_ready_repair_worker_result(project.path(), Some(DEFAULT_AGENT_RUN_ID)),
+            read_ready_repair_worker_result_for_sidecar(&sidecar),
             Some(result)
         );
         let _ = fs::remove_dir_all(
@@ -1670,6 +1658,7 @@ mod tests {
 
     #[test]
     fn concurrent_terminal_write_and_abandoned_cleanup_preserve_terminal_result() {
+        let _env_lock = crate::config::config_env_test_lock();
         let project = tempfile::tempdir().expect("project");
         let sidecar = sidecar_runtime_for_project_with_run_id(
             project.path(),
@@ -1742,7 +1731,7 @@ mod tests {
         cleaner.join().expect("abandoned cleaner");
 
         assert_eq!(
-            read_ready_repair_worker_result(project.path(), Some(DEFAULT_AGENT_RUN_ID)),
+            read_ready_repair_worker_result_for_sidecar(&sidecar),
             Some(terminal),
             "terminal success must win regardless of cleanup ordering"
         );
@@ -2217,6 +2206,7 @@ mod tests {
 
     #[test]
     fn cleanup_abandoned_ready_repair_status_removes_dead_pid_status_and_stale_locks() {
+        let _env_lock = crate::config::config_env_test_lock();
         let project = tempfile::tempdir().expect("project");
         let sidecar = sidecar_runtime_for_project_with_run_id(
             project.path(),
@@ -2273,7 +2263,7 @@ mod tests {
         )
         .expect("write stale project lock");
 
-        let cleanups = cleanup_abandoned_ready_repair_status(project.path(), Some("shared-agent"));
+        let cleanups = cleanup_abandoned_ready_repair_status_for_sidecar(project.path(), &sidecar);
 
         assert_eq!(cleanups.len(), 1);
         assert!(cleanups[0].removed_status_path);
@@ -2291,7 +2281,7 @@ mod tests {
             active_ready_repair_status(project.path(), Some("shared-agent")).is_none(),
             "abandoned cleanup must leave no active repair"
         );
-        let result = read_ready_repair_worker_result(project.path(), Some("shared-agent"))
+        let result = read_ready_repair_worker_result_for_sidecar(&sidecar)
             .expect("abandoned cleanup terminal result");
         assert_eq!(result.attempt_id, "abandoned-test");
         assert_eq!(result.outcome, "abandoned");
@@ -2323,11 +2313,11 @@ mod tests {
         )
         .expect("recreate abandoned status");
 
-        let repeated = cleanup_abandoned_ready_repair_status(project.path(), Some("shared-agent"));
+        let repeated = cleanup_abandoned_ready_repair_status_for_sidecar(project.path(), &sidecar);
 
         assert_eq!(repeated.len(), 1);
         assert_eq!(
-            read_ready_repair_worker_result(project.path(), Some("shared-agent")),
+            read_ready_repair_worker_result_for_sidecar(&sidecar),
             Some(terminal),
             "cleanup must preserve an existing matching terminal result"
         );

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -888,6 +888,7 @@ mod tests {
         let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
         let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
         let _device = EnvGuard::remove("CODESTORY_EMBED_DEVICE_STATE");
+        let _host_detection = EnvGuard::set("CODESTORY_EMBED_DISABLE_HOST_GPU_DETECT", "1");
         let sidecar = SidecarRuntimeConfig::local();
 
         let error = ensure_retrieval_index_embedding_policy(&sidecar)

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -3333,7 +3333,7 @@ fn stdio_dirty_marker_env_path(project_root: &Path) -> Option<PathBuf> {
     let env_root = std::env::var_os("CODESTORY_PLUGIN_DIRTY_MARKER_PROJECT_ROOT")
         .map(PathBuf::from)
         .unwrap_or_else(|| project_root.to_path_buf());
-    if !stdio_same_path_text(&env_root, project_root) {
+    if !codestory_workspace::same_workspace_path(&env_root, project_root) {
         return None;
     }
     Some(path)
@@ -3391,7 +3391,7 @@ fn stdio_dirty_marker_status(project_root: &Path, storage_path: &Path) -> StdioD
             reason: Some("schema_version_unsupported".to_string()),
         };
     }
-    if !stdio_same_path_text(Path::new(&marker.project_root), project_root) {
+    if !codestory_workspace::same_workspace_path(Path::new(&marker.project_root), project_root) {
         return StdioDirtyMarkerStatus {
             path: Some(path),
             marker: Some(marker),
@@ -3438,18 +3438,6 @@ fn stdio_dirty_marker_status(project_root: &Path, storage_path: &Path) -> StdioD
     }
 }
 
-fn stdio_same_path_text(left: &Path, right: &Path) -> bool {
-    let clean = |path: &Path| {
-        let path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-        path.to_string_lossy()
-            .trim_start_matches(r"\\?\")
-            .replace('\\', "/")
-            .trim_end_matches('/')
-            .to_ascii_lowercase()
-    };
-    clean(left) == clean(right)
-}
-
 fn stdio_workspace_mismatch(runtime: &RuntimeContext) -> Option<StdioWorkspaceMismatch> {
     if env_nonempty("CODESTORY_PLUGIN_MULTI_PROJECT").is_some() {
         return None;
@@ -3457,7 +3445,7 @@ fn stdio_workspace_mismatch(runtime: &RuntimeContext) -> Option<StdioWorkspaceMi
     let active_state_path =
         std::env::var_os("CODESTORY_PLUGIN_ACTIVE_STATE_PATH").map(PathBuf::from)?;
     let active_root = stdio_active_state_root(&active_state_path)?;
-    if stdio_same_path_text(&active_root, &runtime.project_root) {
+    if codestory_workspace::same_workspace_path(&active_root, &runtime.project_root) {
         return None;
     }
     Some(StdioWorkspaceMismatch {
@@ -4517,8 +4505,9 @@ fn stdio_validate_managed_cli_candidate(
     let manifest_dir = fs::canonicalize(candidate.manifest_path.parent()?).ok()?;
     let executable = fs::canonicalize(manifest_dir.join(candidate.executable)).ok()?;
     if !executable.starts_with(&manifest_dir)
-        || server_executable
-            .is_some_and(|active| stdio_same_path_text(&executable, Path::new(active)))
+        || server_executable.is_some_and(|active| {
+            codestory_workspace::same_workspace_path(&executable, Path::new(active))
+        })
         || !candidate
             .expected_sha256
             .eq_ignore_ascii_case(&sha256_file(&executable).ok()?)

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -710,6 +710,7 @@ fn apply_fixture_embedding_env(command: &mut Command, hash_embeddings: bool) {
 }
 
 fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
+    let state_root = fixture.cache_dir.path().join("test-state");
     let mut command = test_support::cli_command();
     command
         .arg("serve")
@@ -722,7 +723,10 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
         .arg(fixture.cache_dir.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stderr(Stdio::piped())
+        .env("CODESTORY_CACHE_ROOT", state_root.join("cache"))
+        .env("CODESTORY_STDIO_CACHE_ROOT", state_root.join("stdio-cache"))
+        .env("CODESTORY_PLUGIN_DATA", state_root.join("plugin-data"));
     apply_fixture_embedding_env(&mut command, fixture.hash_embeddings);
     if let Some(version) = &fixture.latest_release_version {
         command.env("CODESTORY_LATEST_RELEASE_VERSION", version);
@@ -784,10 +788,7 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
         child,
         stdin,
         stdout,
-        worker_roots: vec![
-            test_support::test_state_root(),
-            fixture.cache_dir.path().to_path_buf(),
-        ],
+        worker_roots: vec![fixture.cache_dir.path().to_path_buf()],
         preserve_fixture_roots: Some(Arc::clone(&fixture.workspace.preserve)),
     }
 }
@@ -813,7 +814,7 @@ fn spawn_multi_project_stdio_server(cache_root: &Path) -> StdioServer {
         child,
         stdin,
         stdout,
-        worker_roots: vec![test_support::test_state_root(), cache_root.to_path_buf()],
+        worker_roots: vec![cache_root.to_path_buf()],
         preserve_fixture_roots: None,
     }
 }
@@ -840,7 +841,7 @@ fn spawn_multi_project_stdio_server_with_project_network_config(cache_root: &Pat
         child,
         stdin,
         stdout,
-        worker_roots: vec![test_support::test_state_root(), cache_root.to_path_buf()],
+        worker_roots: vec![cache_root.to_path_buf()],
         preserve_fixture_roots: None,
     }
 }
@@ -1323,7 +1324,7 @@ fn write_repair_status_fixture(
 ) -> PathBuf {
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let sidecar = test_sidecar_runtime(&canonical_root, run_id);
+    let sidecar = test_sidecar_runtime(fixture, &canonical_root, run_id);
     let status_path = sidecar
         .layout
         .state_file
@@ -1360,12 +1361,20 @@ fn write_repair_status_fixture(
     status_path
 }
 
-fn test_sidecar_runtime(project: &Path, run_id: &str) -> codestory_retrieval::SidecarRuntimeConfig {
+fn test_sidecar_runtime(
+    fixture: &StdioFixture,
+    project: &Path,
+    run_id: &str,
+) -> codestory_retrieval::SidecarRuntimeConfig {
     codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
         Some(project),
         codestory_retrieval::SidecarProfile::Agent,
         Some(run_id),
-        &test_support::test_state_root().join("stdio-cache"),
+        &fixture
+            .cache_dir
+            .path()
+            .join("test-state")
+            .join("stdio-cache"),
     )
 }
 
@@ -3776,11 +3785,14 @@ fn ground_activation_enqueues_enabled_agent_repair() {
     fixture.ready_repair_worker_probe_exit_code = Some(0);
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let result_path =
-        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID)
-            .layout
-            .state_file
-            .with_file_name("ready-repair-result.json");
+    let result_path = test_sidecar_runtime(
+        &fixture,
+        &canonical_root,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+    )
+    .layout
+    .state_file
+    .with_file_name("ready-repair-result.json");
     let mut server = spawn_stdio_server(&fixture);
 
     let response = send_json(
@@ -3821,11 +3833,14 @@ fn repeated_grounding_cools_down_identical_failed_agent_repair_across_servers() 
     fixture.ready_repair_worker_probe_exit_code = Some(17);
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let result_path =
-        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID)
-            .layout
-            .state_file
-            .with_file_name("ready-repair-result.json");
+    let result_path = test_sidecar_runtime(
+        &fixture,
+        &canonical_root,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+    )
+    .layout
+    .state_file
+    .with_file_name("ready-repair-result.json");
 
     let ground = |server: &mut StdioServer, id: &str| {
         let response = send_json(
@@ -4053,8 +4068,11 @@ fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
     let policy_path = fixture.cache_dir.path().join("plugin-sidecar-policy.json");
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let repair_sidecar =
-        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID);
+    let repair_sidecar = test_sidecar_runtime(
+        &fixture,
+        &canonical_root,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+    );
     let mut server = spawn_stdio_server(&fixture);
 
     let response = send_json(
@@ -4247,14 +4265,17 @@ fn tools_call_sidecar_setup_records_successful_worker_terminal_state() {
     fixture.ready_repair_worker_probe_exit_code = Some(0);
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let repair_sidecar =
-        test_sidecar_runtime(&canonical_root, codestory_retrieval::DEFAULT_AGENT_RUN_ID);
+    let repair_sidecar = test_sidecar_runtime(
+        &fixture,
+        &canonical_root,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+    );
     let mutable_cache_sidecar =
         codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
             Some(&canonical_root),
             codestory_retrieval::SidecarProfile::Agent,
             Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-            &test_support::test_state_root().join("cache"),
+            &fixture.cache_dir.path().join("test-state").join("cache"),
         );
     assert_ne!(
         repair_sidecar.layout.state_file, mutable_cache_sidecar.layout.state_file,

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1338,7 +1338,7 @@ fn write_repair_status_fixture(
         .trim_start_matches(r"\\?\")
         .replace('\\', "/")
         .trim_end_matches('/')
-        .to_ascii_lowercase();
+        .to_string();
     fs::write(
         &status_path,
         json!({
@@ -5376,7 +5376,7 @@ fn independent_clients_serve_one_complete_generation_while_refresh_is_owned() {
         .trim_start_matches(r"\\?\")
         .replace('\\', "/")
         .trim_end_matches('/')
-        .to_ascii_lowercase();
+        .to_string();
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock")

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -27,9 +27,9 @@ pub use repository_identity::{
     PROJECT_IDENTITY_SCHEMA_VERSION, PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV2,
     ProjectIdentityV3, REPOSITORY_IDENTITY_SCHEMA_VERSION, REPOSITORY_IDENTITY_V2_SCHEMA_VERSION,
     RepositoryIdentity, RepositoryIdentityV2, SidecarProjectIdentity, cached_project_identity_v2,
-    inspect_repository_identity, inspect_repository_identity_v2, project_identity_v2,
-    project_identity_v3, same_workspace_path, sidecar_project_identity, workspace_id_for_root,
-    workspace_id_v3_for_root,
+    cached_project_identity_v3, inspect_repository_identity, inspect_repository_identity_v2,
+    project_identity_v2, project_identity_v3, same_workspace_path, sidecar_project_identity,
+    workspace_id_for_root, workspace_id_v3_for_root,
 };
 
 /// Source-group language selector used during workspace discovery.

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -20,6 +20,9 @@ const PROJECT_IDENTITY_OBSERVATION_CACHE_TTL: Duration = Duration::from_secs(1);
 static PROJECT_IDENTITY_OBSERVATION_CACHE: OnceLock<
     Mutex<HashMap<PathBuf, (Instant, ProjectIdentityV2)>>,
 > = OnceLock::new();
+static PROJECT_IDENTITY_V3_OBSERVATION_CACHE: OnceLock<
+    Mutex<HashMap<PathBuf, (Instant, ProjectIdentityV3)>>,
+> = OnceLock::new();
 
 /// Git-derived identity used to decide whether portable sidecar cache reuse is
 /// safe for a project root.
@@ -74,6 +77,7 @@ pub struct ProjectIdentityV3 {
     pub workspace_id: String,
     pub artifact_scope_id: String,
     pub canonical_repository_id: Option<String>,
+    #[serde(default)]
     pub legacy_canonical_repository_id: Option<String>,
     pub legacy_raw_root_project_id: Option<String>,
     pub normalized_root_project_id_alias: Option<String>,
@@ -223,6 +227,26 @@ pub fn cached_project_identity_v2(project_root: &Path) -> ProjectIdentityV2 {
         return identity.clone();
     }
     let identity = project_identity_v2(project_root);
+    cache.insert(key, (Instant::now(), identity.clone()));
+    identity
+}
+
+/// Resolve lossless identity for repeated observational status reads.
+///
+/// Mutating paths must use `project_identity_v3` so dirtiness changes are
+/// observed immediately.
+pub fn cached_project_identity_v3(project_root: &Path) -> ProjectIdentityV3 {
+    let key = fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let cache = PROJECT_IDENTITY_V3_OBSERVATION_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some((cached_at, identity)) = cache.get(&key)
+        && cached_at.elapsed() < PROJECT_IDENTITY_OBSERVATION_CACHE_TTL
+    {
+        return identity.clone();
+    }
+    let identity = project_identity_v3(project_root);
     cache.insert(key, (Instant::now(), identity.clone()));
     identity
 }

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -175,6 +175,14 @@ replacement and host reload.
 
 ### Readiness broker fields
 
+Broker schema 3 scopes processes, operations, locks, snapshots, and verified
+GPU runtime evidence with the lossless workspace identity. On case-sensitive
+filesystems, roots that differ only by case remain separate; Windows aliases
+for the same existing path remain one workspace. Schema 1/2 state is consulted
+only when its recorded root and repository provenance map unambiguously to the
+requested workspace. Otherwise CodeStory leaves that state isolated and
+publishes a fresh schema-3 snapshot.
+
 | Field | Healthy value | Action value |
 | --- | --- | --- |
 | `readiness_broker.reconciliation.status` | `clean` or `observed` | `active_repair` means wait and reread status; `stale_state_cleaned` means retry repair once |


### PR DESCRIPTION
## Context

Broker and repair ownership still used project identity v2 and universally case-folded path text after lossless identity v3 landed in #974. That allowed case-distinct Unix roots to collide and left scopes, locks, snapshots, operation IDs, and GPU proof binding on the legacy contract.

Closes #1033
Refs #1032
Refs #913
Refs #899

## What Changed

- Migrated broker scopes, snapshots, operation IDs, machine locks, and GPU runtime binding to `ProjectIdentityV3` and lossless workspace IDs.
- Added fail-closed v1/v2 provenance mapping. Legacy snapshots remain read-only at their old path; verified state can inform observation, while refresh publishes only to the v3 path.
- Replaced duplicate refresh, repair, stdio, and native-lease path case-folding with the shared filesystem-aware comparator.
- Added v1/v2 migration, A/B/A isolation, non-default-port, Unix case-sensitive, Windows alias, lock, snapshot, and GPU-binding coverage.
- Documented schema-3 behavior and added the unreleased changelog entry.

## How To Review

1. Review `readiness_broker/scope.rs` for current/v2/v1 provenance validation.
2. Review `readiness_broker/snapshot.rs` for v3 path selection, legacy read fallback, cross-root rejection, and sidecar-v2 to broker-v3 GPU binding.
3. Review machine-lock schema pairing and the shared path-comparison replacements.
4. Review the migration and platform tests in `readiness_broker/tests.rs`.

## Verification

- `cargo test -p codestory-cli readiness_broker` — 53 broker unit tests plus broker CLI integration passed.
- `cargo test -p codestory-workspace repository_identity` — 19 passed.
- Focused local-refresh and ready-repair suites — 16 and 35 passed.
- `cargo clippy -p codestory-cli -p codestory-workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check`, `git diff --check`, docs links (69 files / 281 links), and workflow policy — passed.
- Full local CLI suite reached 285/293. The hardware-sensitive unknown-device test observed this machine's live accelerator instead of the test's expected unknown state; its panic poisoned the shared config lock and caused seven dependent failures. The failing test is outside this diff; all changed ownership and identity surfaces pass independently.
- Independent read-only review found no actionable issue in v1/v2 mapping, snapshot isolation, machine-lock schema pairing, or GPU identity migration.

## Risk

The migration deliberately leaves old snapshot files in place because a legacy case-folded path can be ambiguous on case-sensitive filesystems. Only state whose stored root, project identity, and legacy workspace identity map unambiguously is read. Screenshot evidence is not applicable; this change has no visual UI surface.