### PR TITLE
[codex] migrate retrieval manifest to lexical schema

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -243,7 +243,7 @@ def validated_proof_compose_state(cache_root: Path, project: Path, read_state) -
     if lexical_value is None:
         lexical_value = state.get("zoekt_data_dir")
     if not isinstance(lexical_value, str) or not lexical_value:
-        raise TypeError(f"proof sidecar state lexical_data_dir or legacy zoekt_data_dir is not a path string: {state_file}")
+        raise TypeError(f"proof sidecar state canonical or legacy lexical data directory is not a path string: {state_file}")
     observed = Path(lexical_value)
     if observed != lexical_expected or observed.is_symlink():
         raise RuntimeError(f"proof sidecar state lexical_data_dir escaped its cache root: {state_file}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   managed-lifecycle cell. The gate now starts with a verified older install,
   requires the requested packaged binary to serve status and grounding, and
   retains the older version only as the verified rollback.
+- Migrated retrieval manifests to schema 21 with a canonical
+  `lexical_version` column. Existing schema-19 and schema-20 rows are renamed
+  in place, and all reads and writes now use the lexical column without
+  recreating the removed legacy field. Non-persistent response/cache aliases
+  were removed; only the v0.15 owned-state and legacy-compose cleanup window
+  remains.
 - Launched the managed Windows Vulkan llama.cpp cells with proof verbosity so
   current-launch logs retain the requested device and positive layer-offload
   evidence required by the accelerator smoke gate.

--- a/crates/codestory-retrieval/src/cache.rs
+++ b/crates/codestory-retrieval/src/cache.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, VecDeque};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RetrievalCacheKey {
     pub project_id: String,
-    #[serde(alias = "zoekt_version")]
     pub lexical_version: String,
     pub qdrant_collection: String,
     pub scip_revision: Option<String>,

--- a/crates/codestory-retrieval/src/candidate.rs
+++ b/crates/codestory-retrieval/src/candidate.rs
@@ -41,7 +41,6 @@ pub struct CandidateHit {
 #[serde(rename_all = "snake_case")]
 /// Sidecar lane that produced a retrieval candidate.
 pub enum CandidateSource {
-    #[serde(alias = "zoekt")]
     Lexical,
     Qdrant,
     Scip,
@@ -51,7 +50,6 @@ pub enum CandidateSource {
 /// Dev-only synthetic hit prefix (`lexical:`, `semantic:`, `scip:`).
 pub fn is_phantom_sidecar_hit(hit: &CandidateHit) -> bool {
     hit.file_path.starts_with("lexical:")
-        || hit.file_path.starts_with("zoekt:") // migration-only cached synthetic prefix
         || hit.file_path.starts_with("semantic:")
         || hit.file_path.starts_with("scip:")
 }

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -700,16 +700,11 @@ pub fn docker_compose_down_for_state(state: &SidecarStateFile) -> Result<()> {
 }
 
 fn compose_down_environment(state: &SidecarStateFile) -> Vec<(&'static str, String)> {
-    vec![
+    let mut environment = vec![
         ("CODESTORY_SIDECAR_NAMESPACE", state.namespace.clone()),
         (
             "CODESTORY_QDRANT_DATA_DIR",
             docker_bind_path(Path::new(&state.qdrant_data_dir)),
-        ),
-        // Migration-only: old compose files require this interpolation while `down` parses them.
-        (
-            "CODESTORY_ZOEKT_DATA_DIR",
-            docker_bind_path(Path::new(&state.lexical_data_dir)),
         ),
         // Compose requires this variable while parsing the file. `down` does not
         // access the model mount, so an existing owned data path is sufficient.
@@ -717,7 +712,21 @@ fn compose_down_environment(state: &SidecarStateFile) -> Vec<(&'static str, Stri
             "CODESTORY_EMBED_MODEL_DIR",
             docker_bind_path(Path::new(&state.qdrant_data_dir)),
         ),
-    ]
+    ];
+    // Migration-only: emit the removed interpolation variable solely while parsing an
+    // owned legacy compose file that still references it. Current compose files never do.
+    if state
+        .compose_file
+        .as_deref()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .is_some_and(|compose| compose.contains("CODESTORY_ZOEKT_DATA_DIR"))
+    {
+        environment.push((
+            "CODESTORY_ZOEKT_DATA_DIR",
+            docker_bind_path(Path::new(&state.lexical_data_dir)),
+        ));
+    }
+    environment
 }
 
 fn docker_compose_command() -> Result<Command> {
@@ -1882,13 +1891,44 @@ mod tests {
             environment.get("CODESTORY_QDRANT_DATA_DIR"),
             Some(&docker_bind_path(Path::new(&state.qdrant_data_dir)))
         );
-        assert_eq!(
-            environment.get("CODESTORY_ZOEKT_DATA_DIR"),
-            Some(&docker_bind_path(Path::new(&state.lexical_data_dir)))
-        );
+        assert!(!environment.contains_key("CODESTORY_ZOEKT_DATA_DIR"));
         assert_eq!(
             environment.get("CODESTORY_EMBED_MODEL_DIR"),
             Some(&docker_bind_path(Path::new(&state.qdrant_data_dir)))
+        );
+    }
+
+    #[test]
+    fn compose_down_emits_removed_interpolation_only_for_legacy_compose_input() {
+        let root = tempdir().expect("root");
+        let compose_file = root.path().join("legacy-compose.yml");
+        std::fs::write(
+            &compose_file,
+            "volumes:\n  - ${CODESTORY_ZOEKT_DATA_DIR}:/data\n",
+        )
+        .expect("write legacy compose fixture");
+        let state: SidecarStateFile = serde_json::from_value(serde_json::json!({
+            "owner": "codestory",
+            "profile": "agent",
+            "namespace": "codestory-agent-test",
+            "compose_project": "codestory-agent-test",
+            "qdrant_http_port": 16333,
+            "qdrant_grpc_port": 16334,
+            "lexical_data_dir": root.path().join("lexical"),
+            "qdrant_data_dir": root.path().join("qdrant"),
+            "scip_artifacts_root": root.path().join("scip"),
+            "compose_file": compose_file,
+            "cleanup_command": "codestory-cli retrieval down",
+            "started_at_epoch_ms": 1
+        }))
+        .expect("state");
+
+        let environment = compose_down_environment(&state)
+            .into_iter()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(
+            environment.get("CODESTORY_ZOEKT_DATA_DIR"),
+            Some(&docker_bind_path(Path::new(&state.lexical_data_dir)))
         );
     }
 

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -130,7 +130,6 @@ pub struct RetrievalStatusReport {
     pub embedding_cpu_allowed: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding_launch: Option<EmbeddingLaunchMetadata>,
-    #[serde(alias = "zoekt")]
     pub lexical: ComponentHealth,
     pub qdrant: ComponentHealth,
     pub scip: ComponentHealth,

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum RetrievalStageKind {
     Stage0ScipAnchor,
-    #[serde(alias = "stage1_zoekt_lexical")]
     Stage1Lexical,
     Stage1bQdrantSemantic,
     Stage2ScipExpand,

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -26,7 +26,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 const NATIVE_EMBEDDING_PROCESS_START_TOLERANCE_MS: i64 = 5 * 60 * 1000;
-const LEGACY_ZOEKT_CLEANUP_ENTRY_LIMIT: usize = 4_096;
+const LEGACY_LEXICAL_MIGRATION_ENTRY_LIMIT: usize = 4_096;
 #[cfg(not(windows))]
 const NATIVE_EMBEDDING_STOP_WAIT: Duration = Duration::from_secs(5);
 #[cfg(not(windows))]
@@ -86,6 +86,7 @@ pub struct SidecarStateFile {
     pub embedding_launch: Option<EmbeddingLaunchMetadata>,
     #[serde(default = "default_sidecar_image_pins")]
     pub sidecar_images: SidecarImagePins,
+    // v0.15 migration-only read alias; serialization is canonical. Remove the alias in v0.16.
     #[serde(alias = "zoekt_data_dir")]
     pub lexical_data_dir: String,
     pub qdrant_data_dir: String,
@@ -123,7 +124,7 @@ pub(crate) fn sidecar_up_with_runtime_and_launch_metadata(
 ) -> Result<SidecarStateFile> {
     runtime.ensure_ports_allocated()?;
     let layout = &runtime.layout;
-    cleanup_owned_legacy_zoekt(layout)?;
+    cleanup_owned_legacy_lexical_artifacts(layout)?;
     layout.ensure_data_dirs()?;
     let embedding_device = crate::embeddings::embedding_device_readiness_for_runtime(runtime);
     let state = SidecarStateFile {
@@ -179,7 +180,7 @@ pub(crate) fn persist_embedding_container_identity(path: &Path, identity: &str) 
         .context("persist embedding container identity")
 }
 
-fn cleanup_owned_legacy_zoekt(layout: &SidecarLayout) -> Result<()> {
+fn cleanup_owned_legacy_lexical_artifacts(layout: &SidecarLayout) -> Result<()> {
     let Ok(raw) = std::fs::read_to_string(&layout.state_file) else {
         return Ok(());
     };
@@ -197,11 +198,11 @@ fn cleanup_owned_legacy_zoekt(layout: &SidecarLayout) -> Result<()> {
     if !legacy_state_matches {
         return Ok(());
     }
-    let mut remaining = LEGACY_ZOEKT_CLEANUP_ENTRY_LIMIT;
+    let mut remaining = LEGACY_LEXICAL_MIGRATION_ENTRY_LIMIT;
     if !remove_tree_bounded(&legacy_root, &mut remaining)? {
         eprintln!(
-            "CodeStory legacy Zoekt cleanup reached its {}-entry limit; remaining owned data will be retried",
-            LEGACY_ZOEKT_CLEANUP_ENTRY_LIMIT
+            "CodeStory legacy lexical migration cleanup reached its {}-entry limit; remaining owned data will be retried",
+            LEGACY_LEXICAL_MIGRATION_ENTRY_LIMIT
         );
     }
     Ok(())
@@ -219,12 +220,12 @@ fn remove_tree_bounded(path: &Path, remaining: &mut usize) -> Result<bool> {
     *remaining -= 1;
     if !metadata.is_dir() || metadata.file_type().is_symlink() {
         std::fs::remove_file(path)
-            .with_context(|| format!("remove legacy Zoekt artifact {}", path.display()))?;
+            .with_context(|| format!("remove legacy lexical artifact {}", path.display()))?;
         return Ok(true);
     }
     let mut complete = true;
     for entry in std::fs::read_dir(path)
-        .with_context(|| format!("read legacy Zoekt directory {}", path.display()))?
+        .with_context(|| format!("read legacy lexical directory {}", path.display()))?
     {
         if !remove_tree_bounded(&entry?.path(), remaining)? {
             complete = false;
@@ -233,7 +234,7 @@ fn remove_tree_bounded(path: &Path, remaining: &mut usize) -> Result<bool> {
     }
     if complete {
         std::fs::remove_dir(path)
-            .with_context(|| format!("remove empty legacy Zoekt directory {}", path.display()))?;
+            .with_context(|| format!("remove empty legacy lexical directory {}", path.display()))?;
     }
     Ok(complete)
 }
@@ -1331,7 +1332,7 @@ mod tests {
     }
 
     #[test]
-    fn sidecar_state_reads_legacy_zoekt_data_dir_without_reemitting_it() {
+    fn sidecar_state_reads_legacy_lexical_data_dir_without_reemitting_it() {
         let root = TempDir::new().expect("root");
         let runtime = test_runtime(&root);
         let state = sidecar_up_with_runtime(&runtime, None).expect("state");
@@ -1348,7 +1349,7 @@ mod tests {
     }
 
     #[test]
-    fn upgrade_removes_only_state_proven_owned_legacy_zoekt_data() {
+    fn upgrade_removes_only_state_proven_owned_legacy_lexical_data() {
         let root = TempDir::new().expect("root");
         let runtime = test_runtime(&root);
         let legacy = root.path().join("zoekt");
@@ -1364,7 +1365,7 @@ mod tests {
         )
         .expect("state");
 
-        cleanup_owned_legacy_zoekt(&runtime.layout).expect("cleanup");
+        cleanup_owned_legacy_lexical_artifacts(&runtime.layout).expect("cleanup");
 
         assert!(!legacy.exists());
 
@@ -1378,7 +1379,7 @@ mod tests {
             .expect("foreign state json"),
         )
         .expect("foreign state");
-        cleanup_owned_legacy_zoekt(&runtime.layout).expect("skip foreign");
+        cleanup_owned_legacy_lexical_artifacts(&runtime.layout).expect("skip foreign");
         assert!(legacy.exists());
     }
 

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -32,7 +32,7 @@ use helpers::{
     numbered_placeholders, question_placeholders, serialize_candidate_targets,
 };
 
-const SCHEMA_VERSION: u32 = 20;
+const SCHEMA_VERSION: u32 = 21;
 // Reserved outside the sequential migration range so a future real schema version cannot
 // accidentally be treated as an interrupted run from this release.
 const INCOMPLETE_INCREMENTAL_SCHEMA_VERSION: u32 = 0x4353_0001;

--- a/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
+++ b/crates/codestory-store/src/storage_impl/retrieval_manifest.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 const MANIFEST_SELECT: &str = "
     SELECT
         project_id,
-        zoekt_version,
+        lexical_version,
         qdrant_collection,
         scip_revision,
         built_at_epoch_ms,
@@ -37,7 +37,6 @@ const MANIFEST_SELECT: &str = "
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RetrievalIndexManifest {
     pub project_id: String,
-    #[serde(alias = "zoekt_version")]
     pub lexical_version: String,
     pub qdrant_collection: String,
     pub scip_revision: Option<String>,
@@ -77,7 +76,7 @@ impl Storage {
         self.conn.execute(
             "INSERT INTO retrieval_index_manifest (
                 project_id,
-                zoekt_version,
+                lexical_version,
                 qdrant_collection,
                 scip_revision,
                 built_at_epoch_ms,
@@ -100,7 +99,7 @@ impl Storage {
                 precise_semantic_import_producer
             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)
             ON CONFLICT(project_id) DO UPDATE SET
-                zoekt_version = excluded.zoekt_version,
+                lexical_version = excluded.lexical_version,
                 qdrant_collection = excluded.qdrant_collection,
                 scip_revision = excluded.scip_revision,
                 built_at_epoch_ms = excluded.built_at_epoch_ms,

--- a/crates/codestory-store/src/storage_impl/schema.rs
+++ b/crates/codestory-store/src/storage_impl/schema.rs
@@ -241,7 +241,7 @@ const TABLE_STATEMENTS: &[&str] = &[
     ) VALUES (1, 0, 0, NULL, NULL)",
     "CREATE TABLE IF NOT EXISTS retrieval_index_manifest (
         project_id TEXT PRIMARY KEY,
-        zoekt_version TEXT NOT NULL,
+        lexical_version TEXT NOT NULL,
         qdrant_collection TEXT NOT NULL,
         scip_revision TEXT,
         built_at_epoch_ms INTEGER NOT NULL,
@@ -455,6 +455,12 @@ pub(super) fn apply_schema_migrations(storage: &Storage) -> Result<(), StorageEr
         if stored_version != INCOMPLETE_INCREMENTAL_SCHEMA_VERSION {
             storage.set_schema_version(20)?;
         }
+    }
+    // The interrupted-incremental sentinel sits outside the sequential version range, so inspect
+    // the actual columns instead of skipping this idempotent rename while an older run recovers.
+    migrate_v21_retrieval_manifest_lexical_version(&storage.conn)?;
+    if stored_version < 21 {
+        storage.set_schema_version(21)?;
     }
     create_llm_symbol_doc_reuse_index(&storage.conn)?;
     create_symbol_summary_indexes(&storage.conn)?;
@@ -684,6 +690,30 @@ pub(super) fn migrate_v14_retrieval_index_manifest(conn: &Connection) -> Result<
         [],
     )?;
     Ok(())
+}
+
+pub(super) fn migrate_v21_retrieval_manifest_lexical_version(
+    conn: &Connection,
+) -> Result<(), StorageError> {
+    let columns = table_columns(conn, "retrieval_index_manifest")?;
+    let has_legacy = columns.iter().any(|column| column == "zoekt_version");
+    let has_lexical = columns.iter().any(|column| column == "lexical_version");
+    match (has_legacy, has_lexical) {
+        (true, false) => {
+            conn.execute(
+                "ALTER TABLE retrieval_index_manifest RENAME COLUMN zoekt_version TO lexical_version",
+                [],
+            )?;
+            Ok(())
+        }
+        (false, true) => Ok(()),
+        (true, true) => Err(StorageError::Other(
+            "retrieval_index_manifest contains both legacy and lexical version columns".to_string(),
+        )),
+        (false, false) => Err(StorageError::Other(
+            "retrieval_index_manifest is missing lexical_version".to_string(),
+        )),
+    }
 }
 
 fn create_symbol_summary_indexes(conn: &Connection) -> Result<(), StorageError> {
@@ -962,17 +992,23 @@ pub(super) fn try_add_column(
         .split_whitespace()
         .next()
         .ok_or_else(|| StorageError::Other("missing column name in migration".to_string()))?;
-    let pragma = format!("PRAGMA table_info({table})");
-    let mut stmt = conn.prepare(&pragma)?;
-    let mut rows = stmt.query([])?;
-    while let Some(row) = rows.next()? {
-        let existing_name: String = row.get(1)?;
-        if existing_name == column_name {
-            return Ok(());
-        }
+    if table_columns(conn, table)?
+        .iter()
+        .any(|existing| existing == column_name)
+    {
+        return Ok(());
     }
 
     let sql = format!("ALTER TABLE {table} ADD COLUMN {column_sql}");
     conn.execute(&sql, [])?;
     Ok(())
+}
+
+fn table_columns(conn: &Connection, table: &str) -> Result<Vec<String>, StorageError> {
+    let pragma = format!("PRAGMA table_info({table})");
+    let mut stmt = conn.prepare(&pragma)?;
+    let columns = stmt
+        .query_map([], |row| row.get(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(columns)
 }

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -197,7 +197,7 @@ fn schema_19_adds_nullable_file_content_hash_without_losing_rows() -> Result<(),
     }
 
     let storage = Storage::open(&path)?;
-    assert_eq!(storage.schema_version()?, 20);
+    assert_eq!(storage.schema_version()?, 21);
     assert_eq!(storage.get_files()?.len(), 1);
     assert_eq!(storage.get_file_content_hash(7)?, None);
 
@@ -246,6 +246,40 @@ fn transient_incomplete_schema_fence_requires_marker() -> Result<(), StorageErro
     let _ = std::fs::remove_file(&path);
     let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
     let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    Ok(())
+}
+
+#[test]
+fn interrupted_v19_run_migrates_manifest_column_without_clearing_fence() -> Result<(), StorageError>
+{
+    let path = unique_temp_db_path("interrupted-v19-manifest-migration");
+    {
+        let storage = Storage::open(&path)?;
+        storage.get_connection().execute(
+            "ALTER TABLE retrieval_index_manifest RENAME COLUMN lexical_version TO zoekt_version",
+            [],
+        )?;
+        storage.begin_incremental_run()?;
+    }
+
+    let storage = Storage::open(&path)?;
+    assert_eq!(
+        Storage::database_schema_version(&path)?,
+        INCOMPLETE_INCREMENTAL_SCHEMA_VERSION
+    );
+    assert!(storage.has_incomplete_incremental_run()?);
+    let columns = storage
+        .conn
+        .prepare("PRAGMA table_info(retrieval_index_manifest)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    assert!(columns.iter().any(|column| column == "lexical_version"));
+    assert!(!columns.iter().any(|column| column == "zoekt_version"));
+    storage.finish_incremental_run()?;
+    assert_eq!(Storage::database_schema_version(&path)?, SCHEMA_VERSION);
+
+    drop(storage);
+    let _ = cleanup_sqlite_sidecars(&path);
     Ok(())
 }
 
@@ -1780,7 +1814,8 @@ fn live_open_migrates_v17_llm_doc_columns_before_secondary_indexes() -> Result<(
 }
 
 #[test]
-fn live_open_repairs_v18_manifest_precise_semantic_columns() -> Result<(), StorageError> {
+fn live_open_migrates_v18_manifest_to_lexical_schema_without_losing_rows()
+-> Result<(), StorageError> {
     let db_path = unique_temp_db_path("v18-precise-semantic-manifest-repair");
     let _ = std::fs::remove_file(&db_path);
     {
@@ -1815,7 +1850,7 @@ fn live_open_repairs_v18_manifest_precise_semantic_columns() -> Result<(), Stora
                 qdrant_collection,
                 built_at_epoch_ms,
                 degraded_modes_json
-            ) VALUES ('proj', 'zoekt', 'collection', 1, '[]')",
+            ) VALUES ('proj', 'legacy-v1', 'collection', 1, '[]')",
             [],
         )?;
         conn.pragma_update(None, "user_version", 18)?;
@@ -1828,7 +1863,7 @@ fn live_open_repairs_v18_manifest_precise_semantic_columns() -> Result<(), Stora
         .query_map([], |row| row.get::<_, String>(1))?
         .collect::<Result<Vec<_>, _>>()?;
     for column in [
-        "zoekt_version",
+        "lexical_version",
         "precise_semantic_import_status",
         "precise_semantic_import_reason",
         "precise_semantic_import_revision",
@@ -1836,12 +1871,12 @@ fn live_open_repairs_v18_manifest_precise_semantic_columns() -> Result<(), Stora
     ] {
         assert!(columns.iter().any(|existing| existing == column));
     }
-    assert!(!columns.iter().any(|existing| existing == "lexical_version"));
+    assert!(!columns.iter().any(|existing| existing == "zoekt_version"));
     let manifest = storage
         .get_retrieval_index_manifest("proj")?
         .expect("manifest survives repair");
     assert_eq!(manifest.project_id, "proj");
-    assert_eq!(manifest.lexical_version, "zoekt");
+    assert_eq!(manifest.lexical_version, "legacy-v1");
     assert_eq!(manifest.precise_semantic_import_status, None);
 
     drop(storage);
@@ -1850,21 +1885,93 @@ fn live_open_repairs_v18_manifest_precise_semantic_columns() -> Result<(), Stora
 }
 
 #[test]
-fn current_schema_keeps_manifest_column_rollback_compatible() -> Result<(), StorageError> {
-    let db_path = unique_temp_db_path("current-manifest-rollback-contract");
+fn current_schema_uses_only_lexical_manifest_column() -> Result<(), StorageError> {
+    let db_path = unique_temp_db_path("v21-lexical-manifest-contract");
     let _ = std::fs::remove_file(&db_path);
     let storage = Storage::open(&db_path)?;
-    assert_eq!(storage.schema_version()?, 20);
+    assert_eq!(storage.schema_version()?, 21);
     let columns = storage
         .conn
         .prepare("PRAGMA table_info(retrieval_index_manifest)")?
         .query_map([], |row| row.get::<_, String>(1))?
         .collect::<Result<Vec<_>, _>>()?;
-    assert!(columns.iter().any(|column| column == "zoekt_version"));
-    assert!(!columns.iter().any(|column| column == "lexical_version"));
+    assert!(columns.iter().any(|column| column == "lexical_version"));
+    assert!(!columns.iter().any(|column| column == "zoekt_version"));
 
     drop(storage);
     let _ = std::fs::remove_file(&db_path);
+    Ok(())
+}
+
+#[test]
+fn v19_and_v20_manifests_migrate_once_and_new_writes_do_not_recreate_legacy_column()
+-> Result<(), StorageError> {
+    for source_version in [19, 20] {
+        let db_path = unique_temp_db_path(&format!("v{source_version}-lexical-manifest-migration"));
+        let _ = std::fs::remove_file(&db_path);
+        {
+            let conn = rusqlite::Connection::open(&db_path)?;
+            conn.execute_batch(
+                "CREATE TABLE retrieval_index_manifest (
+                project_id TEXT PRIMARY KEY,
+                zoekt_version TEXT NOT NULL,
+                qdrant_collection TEXT NOT NULL,
+                scip_revision TEXT,
+                built_at_epoch_ms INTEGER NOT NULL,
+                disk_bytes INTEGER,
+                degraded_modes_json TEXT NOT NULL DEFAULT '[]',
+                embedding_backend TEXT,
+                embedding_dim INTEGER,
+                sidecar_schema_version INTEGER,
+                sidecar_input_hash TEXT,
+                sidecar_generation TEXT,
+                projection_count INTEGER,
+                symbol_doc_count INTEGER,
+                dense_projection_count INTEGER,
+                semantic_policy_version TEXT,
+                graph_artifact_hash TEXT,
+                dense_reason_counts_json TEXT,
+                precise_semantic_import_status TEXT,
+                precise_semantic_import_reason TEXT,
+                precise_semantic_import_revision TEXT,
+                precise_semantic_import_producer TEXT
+            );
+            INSERT INTO retrieval_index_manifest (
+                project_id, zoekt_version, qdrant_collection,
+                built_at_epoch_ms, degraded_modes_json
+            ) VALUES ('proj', 'legacy-v1', 'collection', 1, '[]');",
+            )?;
+            conn.pragma_update(None, "user_version", source_version)?;
+        }
+
+        let mut storage = Storage::open(&db_path)?;
+        let mut manifest = storage
+            .get_retrieval_index_manifest("proj")?
+            .expect("legacy manifest row survives migration");
+        assert_eq!(manifest.lexical_version, "legacy-v1");
+        manifest.lexical_version = "sqlite-fts5-v1".into();
+        storage.upsert_retrieval_index_manifest(&manifest)?;
+        drop(storage);
+
+        let storage = Storage::open(&db_path)?;
+        let columns = storage
+            .conn
+            .prepare("PRAGMA table_info(retrieval_index_manifest)")?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert!(columns.iter().any(|column| column == "lexical_version"));
+        assert!(!columns.iter().any(|column| column == "zoekt_version"));
+        assert_eq!(
+            storage
+                .get_retrieval_index_manifest("proj")?
+                .expect("updated manifest")
+                .lexical_version,
+            "sqlite-fts5-v1"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_file(&db_path);
+    }
     Ok(())
 }
 
@@ -1876,7 +1983,7 @@ fn live_open_preserves_correct_v18_manifest_precise_semantic_values() -> Result<
         let mut storage = Storage::open(&db_path)?;
         storage.upsert_retrieval_index_manifest(&RetrievalIndexManifest {
             project_id: "proj".into(),
-            lexical_version: "zoekt".into(),
+            lexical_version: "legacy-v1".into(),
             qdrant_collection: "collection".into(),
             scip_revision: None,
             built_at_epoch_ms: 1,

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -16,15 +16,20 @@ with `retrieval_mode=full`.
   selects zero dense anchors, Qdrant is explicitly not required for that
   generation.
 - SCIP graph artifacts exist and are not stub markers.
-- The SQLite `retrieval_index_manifest` has the current schema version,
-  sidecar input hash, sidecar generation, Qdrant collection, embedding backend,
-  embedding dimension, symbol-doc count, dense-anchor count, semantic policy
-  version, graph artifact hash, and dense reason counts.
+- The SQLite `retrieval_index_manifest` has the current schema version and
+  canonical `lexical_version`, sidecar input hash, sidecar generation, Qdrant
+  collection, embedding backend, embedding dimension, symbol-doc count,
+  dense-anchor count, semantic policy version, graph artifact hash, and dense
+  reason counts.
 
 Everything else is diagnostic only. `no_scip`, `no_semantic`, `lexical_only`,
 `unavailable`, stale manifests, stub markers, disabled sidecars, hash vectors,
 removed ONNX configuration, old env aliases, and `CODESTORY_RETRIEVAL=0` fail
 closed for agent-facing packet/search.
+
+Schema 21 renames the former lexical producer column in place, preserving every
+manifest row while removing the legacy column from both fresh and upgraded
+databases. Current code reads and writes only `lexical_version`.
 
 ## Ownership
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -154,13 +154,13 @@ package execution does not close #887; live managed Metal endpoint survival
 still needs reporter or equivalent Apple Silicon hardware evidence. Current
 Ubuntu execution does not prove older-glibc compatibility.
 
-Proof cleanup validates the exact current `lexical_data_dir` and accepts the
-legacy `zoekt_data_dir` spelling only as read compatibility for an otherwise
-proof-owned state file. New state must never emit Zoekt path, port, or image
-keys. When local retrieval indexing fails, the proof records Compose process
-state and bounded Qdrant logs before cleanup so the primary failure remains
-diagnosable; cleanup failure is retained as secondary evidence and must not
-replace the primary gate failure.
+Proof cleanup validates the exact current `lexical_data_dir`. During the v0.15
+migration window it accepts the removed `zoekt_data_dir` spelling only as
+read compatibility for an otherwise proof-owned state file; remove that alias
+in v0.16. New state must emit only lexical path fields. When local retrieval
+indexing fails, the proof records Compose process state and bounded Qdrant logs
+before cleanup so the primary failure remains diagnosable; cleanup failure is
+retained as secondary evidence and must not replace the primary gate failure.
 
 Each native managed-plugin handoff also starts with a verified prior managed
 CLI whose executable can answer only its version probe. The requested packaged

--- a/docs/testing/retrieval-architecture.md
+++ b/docs/testing/retrieval-architecture.md
@@ -154,7 +154,7 @@ Non-claims:
 |-------|----------|------|
 | Retrieval clients | `crates/codestory-retrieval/` (`lexical_client`, `qdrant_client`, `scip_client`, `health`) | SQLite FTS candidate selection, HTTP probes, staged search, timeouts |
 | Planner / executor / ranker | `codestory-retrieval` (`planner`, `executor`, `ranker`, `query_features`, `mode`) | Repo-agnostic staged plan, deadlines, degraded modes |
-| Index manifest | `codestory-store` `retrieval_index_manifest` + `codestory-retrieval::index` | Version pins, sidecar input hash, generation id, symbol-doc count, dense-anchor count, semantic policy version, graph artifact hash, dense reason counts, mandatory real sidecar artifact paths, and derived status `manifest_contract` provenance |
+| Index manifest | `codestory-store` `retrieval_index_manifest` + `codestory-retrieval::index` | Canonical `lexical_version`, sidecar input hash, generation id, symbol-doc count, dense-anchor count, semantic policy version, graph artifact hash, dense reason counts, mandatory real sidecar artifact paths, and derived status `manifest_contract` provenance |
 | CLI lifecycle | `codestory-cli` `retrieval up\|down\|status\|index\|query` | Local data dirs, health JSON, standalone query |
 | Packet integration | `codestory-runtime/src/agent/retrieval_primary.rs` | Primary sidecar path, diagnostic traces, promotion warnings |
 | Nucleo policy | `codestory-runtime/src/agent/nucleo_policy.rs` | Suppresses Nucleo O(n) scan on sidecar primary; disabled sidecars are not valid product evidence |


### PR DESCRIPTION
## Context

PR #996 replaced the removed lexical sidecar with project-local SQLite FTS, but `retrieval_index_manifest` still physically stored and updated the producer version through the legacy column. Several response-only serde aliases and an unconditional legacy Compose interpolation also kept removed vocabulary active.

Closes #1043
Refs #983
Refs #899

## What Changed

- Added schema 21 after #978's schema-20 file-content migration and renamed the manifest column in place to `lexical_version`.
- Switched manifest SELECT and UPSERT paths to the canonical column; fresh databases now create only that column.
- Preserved schema-19, schema-20, and interrupted-incremental rows while keeping the sentinel fence intact.
- Removed non-persistent legacy serde aliases and synthetic-hit handling.
- Limited the removed Compose interpolation to owned legacy compose files that actually reference it; current files emit no legacy variable.
- Kept the v0.15 state alias and bounded, ownership-checked artifact cleanup as migration-only input, with v0.16 removal documented.
- Updated the changelog and v0.15 architecture/testing documentation.

## How To Review

1. Review the schema order in `storage_impl/schema.rs`: v20 adds `file.content_hash`; v21 performs the idempotent manifest rename.
2. Check that `retrieval_manifest.rs` reads and writes only `lexical_version`.
3. Review the v18/v19/v20 and interrupted-fence tests for row preservation and repeat writes.
4. Confirm current sidecar serialization/Compose state emits lexical names while legacy cleanup remains ownership checked.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codestory-store` — 86 passed
- `cargo test -p codestory-retrieval compose_down_` — 2 passed
- `cargo test -p codestory-retrieval legacy_lexical` — 2 passed
- `cargo test -p codestory-retrieval` — 341 unit tests passed, 2 explicitly ignored; integration suites passed 2 + 2 + 4, with 1 live-sidecar test explicitly ignored
- `cargo clippy -p codestory-store -p codestory-retrieval --all-targets -- -D warnings`
- `node .github/scripts/check-doc-links.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `python -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `git diff --check`

## Risk

- Schema 21 intentionally makes older binaries fail closed instead of reopening a database whose column contract they do not understand; the rename preserves every row.
- Legacy state/Compose reads remain only for the documented v0.15 migration window and should be deleted in v0.16.
- Live sidecar integration was not exercised locally; this change was covered by full retrieval tests and CI owns cross-platform publication/runtime checks.
