### PR TITLE
[codex] route CI proof by maturity

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -16,6 +16,9 @@ const packagedPlatformPr = path.join(workflowRoot, "packaged-platform-pr.yml");
 const packagedPlatformProof = path.join(workflowRoot, "packaged-platform-proof.yml");
 const macosMetalProof = path.join(workflowRoot, "macos-metal-proof.yml");
 const mainBranchSourceGuard = path.join(workflowRoot, "main-branch-source-guard.yml");
+const sourceProof = path.join(workflowRoot, "source-proof.yml");
+const repoScaleStats = path.join(workflowRoot, "repo-scale-stats.yml");
+const retrievalSidecarSmoke = path.join(workflowRoot, "retrieval-sidecar-smoke.yml");
 
 function yamlJob(content, name) {
   const lines = content.split(/\r?\n/u);
@@ -53,7 +56,11 @@ function managedPluginMatrixIsRequired(content, jobName, archiveLine) {
     job.length === 0 ||
     job.some((line) => /^    (?:if|continue-on-error):/u.test(line)) ||
     !job.includes("      fail-fast: false") ||
-    job.some((line) => /^\s+exclude:/u.test(line)) ||
+    job.some(
+      (line) =>
+        /^\s+exclude:/u.test(line) &&
+        !line.includes("fromJSON(inputs.scope == 'macos'"),
+    ) ||
     step.length === 0 ||
     step.some((line) => /^        (?:if|continue-on-error):/u.test(line)) ||
     required.some((line) => !step.includes(line))
@@ -101,7 +108,16 @@ for (const file of fs
   const workflowPath = path.join(workflowRoot, file);
   const content = fs.readFileSync(workflowPath, "utf8");
 
+  if (/^  pull_request(?:_target)?:/mu.test(content)) {
+    if (!/^concurrency:/mu.test(content) || !/^  cancel-in-progress: true$/mu.test(content)) {
+      violations.push(`${file} pull-request runs must cancel stale work`);
+    }
+  }
+
   content.split(/\r?\n/).forEach((line, index) => {
+    if (/^\s+key:/u.test(line) && line.includes("github.sha")) {
+      violations.push(`${file}:${index + 1} Cargo cache keys must not include commit SHA`);
+    }
     const match = line.match(/\buses:\s*['"]?([^'"\s#]+)['"]?/);
     if (!match) return;
 
@@ -187,25 +203,23 @@ if (!fs.existsSync(pluginStatic)) {
     "dev/codestory-next",
     "node --test plugins/codestory/tests/plugin-static.test.mjs",
     "node .github/scripts/check-workflow-policy.mjs",
+    "node .github/scripts/route-ci-proof.mjs --self-test",
     "python .github/scripts/check-packaged-agent-proof.py --self-test",
     "python .github/scripts/package-codestory-release.py --self-test",
     "python .github/scripts/check-codestory-release.py --version",
     ".github/scripts/check-packaged-agent-proof.py",
     ".github/scripts/package-codestory-release.py",
+    ".github/scripts/route-ci-proof.mjs",
     ".github/workflows/release.yml",
     ".github/workflows/post-publish-release-smoke.yml",
     ".github/workflows/packaged-platform-pr.yml",
     ".github/workflows/packaged-platform-proof.yml",
     ".github/workflows/macos-metal-proof.yml",
+    ".github/workflows/source-proof.yml",
+    ".github/workflows/repo-scale-stats.yml",
     "scripts/codex-worktree-setup.*",
     "scripts/tests/codex-worktree-setup.test.mjs",
     "scripts/setup-retrieval-env.*",
-    "macos-setup-static:",
-    "runs-on: macos-15",
-    "node scripts/setup-retrieval-env.mjs --self-test",
-    "node --test scripts/tests/codex-worktree-setup.test.mjs",
-    "node scripts/codex-worktree-setup.mjs --self-test",
-    "test -x plugins/codestory/skills/codestory-grounding/scripts/setup.sh",
     "scripts/install-codestory.ps1",
   ];
 
@@ -220,19 +234,37 @@ if (!fs.existsSync(rustCi)) {
     "Cargo.lock",
     "Cargo.toml",
     "crates/**",
-    "dev/codestory-next",
     "cargo fmt --check",
     "cargo check --workspace --locked",
-    "cargo test --locked",
-    "cargo clippy --workspace --all-targets --all-features -- -D warnings",
-    "macos-workspace:",
-    "macos-15",
-    "macos-15-intel",
-    "asset_target: macos-arm64",
-    "asset_target: macos-x64",
+    "cargo clippy --workspace --lib --locked -- -D warnings",
+    "Prove focused publication contracts",
+    "workspace-default-features",
+    "cancel-in-progress: true",
   ];
 
   requireContent(content, requiredSnippets, snippet => `rust-ci.yml must include ${snippet}`);
+  if (content.includes("macos-") || content.includes("windows-") || content.includes("push:")) {
+    violations.push("rust-ci.yml draft pushes must use one Ubuntu-only lane");
+  }
+}
+
+if (!fs.existsSync(sourceProof)) {
+  violations.push("source-proof.yml must own exact-head full source proof");
+} else {
+  const content = fs.readFileSync(sourceProof, "utf8");
+  requireContent(content, [
+    "types: [labeled, synchronize]",
+    "review-accepted",
+    'test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY"',
+    'test "$current_head" = "$EVENT_HEAD_SHA"',
+    "name: full-source-gate",
+    "cargo test --workspace --locked",
+    "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+    "cancel-in-progress: true",
+  ], snippet => `source-proof.yml must include ${snippet}`);
+  if (content.includes("pull_request_target:")) {
+    violations.push("source-proof.yml must not execute pull-request code through pull_request_target");
+  }
 }
 
 if (!fs.existsSync(releaseWorkflow)) {
@@ -312,6 +344,12 @@ if (!fs.existsSync(packagedPlatformProof)) {
     "if: matrix.asset_target == 'macos-x64'",
     "scripts/install-codestory.ps1 -SelfTest",
     "--checksum-file target/release-dist/SHA256SUMS.txt",
+    "scope:",
+    "proof_key:",
+    "ref:",
+    "cancel-in-progress: true",
+    "codestory-cli-default-features",
+    "exclude: ${{ fromJSON(inputs.scope == 'macos'",
   ], snippet => `packaged-platform-proof.yml must include ${snippet}`);
   const releaseAssetStart = content.indexOf("- name: Upload release asset");
   const notarizationProofStart = content.indexOf("- name: Upload macOS notarization proof");
@@ -394,30 +432,42 @@ if (!fs.existsSync(postPublishReleaseSmoke)) {
 }
 
 if (!fs.existsSync(packagedPlatformPr)) {
-  violations.push("packaged-platform-pr.yml must run the native package matrix on implementation PRs");
+  violations.push("packaged-platform-pr.yml must orchestrate explicitly promoted platform proof");
 } else {
   const content = fs.readFileSync(packagedPlatformPr, "utf8");
   requireContent(content, [
-    "pull_request:",
-    "contents: read",
+    "types: [labeled, synchronize]",
+    "platform-proof",
+    "workflow_dispatch:",
+    "options: [platform, integration]",
+    "expected_head_sha:",
+    "actions: read",
+    'test "$head_repo" = "$GITHUB_REPOSITORY"',
+    'test "$current_head" = "$expected_head"',
+    "actions/runs?head_sha=$HEAD_SHA",
+    '.path == ".github/workflows/source-proof.yml"',
+    ".head_repository.full_name == $repo",
+    '.name == "full-source-gate" and .conclusion == "success"',
+    'test "$INPUT_HEAD_SHA" = "$dev_head"',
+    "node .github/scripts/route-ci-proof.mjs --stdin",
+    "scope=full",
+    "uses: ./.github/workflows/source-proof.yml",
+    "uses: ./.github/workflows/repo-scale-stats.yml",
     "uses: ./.github/workflows/packaged-platform-proof.yml",
-    "version: ${{ needs.prepare.outputs.version }}",
-    ".github/scripts/check-packaged-agent-proof.py",
-    ".github/scripts/check-linux-glibc-baseline.sh",
-    ".github/scripts/check-workflow-policy.mjs",
-    ".github/workflows/macos-metal-proof.yml",
-    ".github/workflows/post-publish-release-smoke.yml",
-    ".github/workflows/packaged-platform-proof.yml",
-    ".github/workflows/rust-ci.yml",
-    "Cargo.toml",
-    "Cargo.lock",
-    "crates/**",
-    "scripts/codex-worktree-setup.*",
-    "scripts/tests/codex-worktree-setup.test.mjs",
-    "scripts/setup-retrieval-env.*",
-    ".codex/environments/environment.toml",
+    "scope: ${{ needs.route.outputs.scope }}",
+    "sign_macos: true",
+    "uses: ./.github/workflows/macos-metal-proof.yml",
+    "use_packaged_artifact: true",
+    "dev/codestory-next moved from proved head",
   ], snippet => `packaged-platform-pr.yml must include ${snippet}`);
-  if (content.includes("contents: write") || content.includes("uses: ./.github/workflows/release.yml")) {
+  if ((content.match(/branches\/dev\/codestory-next/gu) ?? []).length < 2) {
+    violations.push("packaged-platform-pr.yml must verify the dev head before and after integration proof");
+  }
+  if (
+    content.includes("contents: write") ||
+    content.includes("uses: ./.github/workflows/release.yml") ||
+    content.includes("pull_request_target:")
+  ) {
     violations.push("packaged-platform-pr.yml must not request release permissions or call the publishing workflow");
   }
 }
@@ -445,7 +495,36 @@ if (!fs.existsSync(macosMetalProof)) {
     "CODESTORY_EMBED_DEVICE_PROVIDER: metal",
     "CODESTORY_EMBED_ALLOW_CPU: \"0\"",
     "macos-arm64-metal-proof-${{ inputs.version }}",
+    "proof_key:",
+    "cancel-in-progress: true",
   ], snippet => `macos-metal-proof.yml must include ${snippet}`);
+}
+
+if (!fs.existsSync(repoScaleStats)) {
+  violations.push("repo-scale-stats.yml must own promoted-head stats proof");
+} else {
+  const content = fs.readFileSync(repoScaleStats, "utf8");
+  requireContent(content, [
+    "workflow_call:",
+    "cargo build --release --locked -p codestory-cli",
+    "cargo test --locked -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture",
+    "repo-scale-stats-${{ inputs.proof_key }}",
+    "actions/upload-artifact@v7.0.1",
+    "codestory-cli-default-features",
+    "cancel-in-progress: true",
+  ], snippet => `repo-scale-stats.yml must include ${snippet}`);
+}
+
+if (!fs.existsSync(retrievalSidecarSmoke)) {
+  violations.push("retrieval-sidecar-smoke.yml must exist");
+} else {
+  const windowsJob = yamlJob(fs.readFileSync(retrievalSidecarSmoke, "utf8"), "windows-manifest-missing");
+  if (
+    !windowsJob.includes("    if: github.event_name == 'workflow_dispatch'") ||
+    windowsJob.some(line => line.includes("labels"))
+  ) {
+    violations.push("retrieval-sidecar-smoke.yml Windows proof must be workflow_dispatch-only");
+  }
 }
 
 if (!fs.existsSync(mainBranchSourceGuard)) {

--- a/.github/scripts/route-ci-proof.mjs
+++ b/.github/scripts/route-ci-proof.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const scopeRank = new Map([
+  ["none", 0],
+  ["macos", 1],
+  ["full", 2],
+]);
+
+const macosSurfaces = [
+  /^\.github\/workflows\/macos-/u,
+  /^backend\/.*(?:darwin|macos|metal)/iu,
+  /^scripts\/setup-retrieval-env\./u,
+  /^scripts\/codex-worktree-setup\.(?:mjs|sh)$/u,
+  /^scripts\/tests\/codex-worktree-setup\.test\.mjs$/u,
+  /^plugins\/codestory\/.*(?:darwin|macos|metal)/iu,
+];
+
+const crossPlatformRuntimeSurfaces = [
+  /^(?:Cargo\.toml|Cargo\.lock)$/u,
+  /^crates\/[^/]+\/Cargo\.toml$/u,
+  /^crates\/codestory-cli\/src\/readiness_broker\//u,
+  /^crates\/codestory-retrieval\/src\/(?:config|index|inventory|lib|query|sidecar)\.rs$/u,
+  /^scripts\/install-codestory\.ps1$/u,
+];
+
+const proofNeutralSurfaces = [
+  /^CHANGELOG\.md$/u,
+  /^docs\//u,
+  /^\.github\/workflows\/retrieval-sidecar-smoke\.yml$/u,
+  /^crates\/codestory-runtime\/tests\/retrieval_generalization_guard\.rs$/u,
+  /^scripts\/(?:codestory-agent-ab-benchmark|codestory-evidence-provenance|codestory-release-evidence-gate|lint-retrieval-generalization)\.mjs$/u,
+];
+
+function cleanPaths(paths) {
+  return [...new Set(paths.map(value => value.trim().replaceAll("\\", "/")).filter(Boolean))];
+}
+
+export function classifyProofScope(paths) {
+  const changed = cleanPaths(paths);
+  if (changed.length === 0) return "none";
+  if (changed.some(file => crossPlatformRuntimeSurfaces.some(pattern => pattern.test(file)))) {
+    return "full";
+  }
+  if (changed.some(file => macosSurfaces.some(pattern => pattern.test(file)))) {
+    return "macos";
+  }
+  if (changed.every(file => proofNeutralSurfaces.some(pattern => pattern.test(file)))) {
+    return "none";
+  }
+  return "full";
+}
+
+export function selectProofScope(paths, requested = "auto") {
+  const inferred = classifyProofScope(paths);
+  if (requested === "auto" || requested === "") return inferred;
+  if (!scopeRank.has(requested)) {
+    throw new Error(`unsupported proof scope: ${requested}`);
+  }
+  return scopeRank.get(requested) > scopeRank.get(inferred) ? requested : inferred;
+}
+
+function selfTest() {
+  const fixtures = [
+    {
+      name: "script and guard tests do not package",
+      expected: "none",
+      paths: [
+        ".github/workflows/retrieval-sidecar-smoke.yml",
+        "crates/codestory-runtime/tests/retrieval_generalization_guard.rs",
+        "scripts/lint-retrieval-generalization.mjs",
+        "docs/testing/retrieval-architecture.md",
+        "CHANGELOG.md",
+      ],
+    },
+    {
+      name: "Mac lifecycle changes stay on Mac",
+      expected: "macos",
+      paths: [
+        ".github/scripts/check-packaged-agent-proof.py",
+        ".github/workflows/macos-metal-proof.yml",
+        "crates/codestory-cli/src/ready_repair_status.rs",
+        "crates/codestory-cli/src/stdio_transport.rs",
+        "crates/codestory-retrieval/src/embeddings.rs",
+      ],
+    },
+    {
+      name: "runtime identity changes use every platform",
+      expected: "full",
+      paths: [
+        "Cargo.lock",
+        "crates/codestory-cli/src/readiness_broker/native_lease.rs",
+        "crates/codestory-retrieval/src/inventory.rs",
+        "crates/codestory-retrieval/src/sidecar.rs",
+      ],
+    },
+  ];
+  for (const fixture of fixtures) {
+    const actual = classifyProofScope(fixture.paths);
+    if (actual !== fixture.expected) {
+      throw new Error(`${fixture.name}: expected ${fixture.expected}, got ${actual}`);
+    }
+  }
+  if (selectProofScope(fixtures[0].paths, "macos") !== "macos") {
+    throw new Error("explicit promotion must be able to widen an inferred scope");
+  }
+  if (selectProofScope(fixtures[2].paths, "macos") !== "full") {
+    throw new Error("explicit promotion must not narrow an inferred scope");
+  }
+}
+
+function main(argv) {
+  const args = [...argv];
+  if (args.includes("--self-test")) {
+    selfTest();
+    console.log("CI proof routing fixtures passed.");
+    return;
+  }
+  const requestedIndex = args.indexOf("--requested");
+  const requested = requestedIndex >= 0 ? args.splice(requestedIndex, 2)[1] : "auto";
+  const stdin = args.includes("--stdin") ? fs.readFileSync(0, "utf8").split(/\r?\n/u) : [];
+  const paths = args.filter(arg => arg !== "--stdin");
+  console.log(selectProofScope([...stdin, ...paths], requested));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/.github/workflows/macos-metal-proof.yml
+++ b/.github/workflows/macos-metal-proof.yml
@@ -11,6 +11,11 @@ on:
         description: Git ref to check out. Defaults to the caller SHA.
         required: false
         type: string
+      proof_key:
+        description: Stable PR, integration, or release identity for cancellation.
+        required: false
+        default: ""
+        type: string
       use_packaged_artifact:
         description: Download the signed macOS arm64 artifact produced by packaged-platform-proof.
         required: false
@@ -26,13 +31,17 @@ on:
         description: Git ref to check out. Defaults to the current SHA.
         required: false
         type: string
+      proof_key:
+        description: Stable proof identity for cancellation.
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: macos-metal-proof
-  cancel-in-progress: false
+  group: macos-metal-proof-${{ inputs.proof_key || inputs.ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   packaged-metal-lifecycle:

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -1,47 +1,309 @@
-name: Packaged platform acceptance
+name: Platform and integration proof
 
 on:
   pull_request:
-    paths:
-      - .github/scripts/check-packaged-agent-proof.py
-      - .github/scripts/check-linux-glibc-baseline.sh
-      - .github/scripts/check-workflow-policy.mjs
-      - .github/scripts/package-codestory-release.py
-      - .github/workflows/macos-metal-proof.yml
-      - .github/workflows/packaged-platform-pr.yml
-      - .github/workflows/packaged-platform-proof.yml
-      - .github/workflows/post-publish-release-smoke.yml
-      - .github/workflows/release.yml
-      - .github/workflows/rust-ci.yml
-      - Cargo.toml
-      - Cargo.lock
-      - crates/**
-      - plugins/codestory/**
-      - scripts/install-codestory.ps1
-      - scripts/codex-worktree-setup.*
-      - scripts/tests/codex-worktree-setup.test.mjs
-      - scripts/setup-retrieval-env.*
-      - .codex/environments/environment.toml
+    types: [labeled, synchronize]
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Prove an accepted PR head or the current dev integration head.
+        required: true
+        default: platform
+        type: choice
+        options: [platform, integration]
+      pr_number:
+        description: Same-repository pull request for platform mode.
+        required: false
+        type: string
+      expected_head_sha:
+        description: Exact accepted head SHA.
+        required: true
+        type: string
+      scope:
+        description: Auto-detect proof scope or widen it explicitly.
+        required: true
+        default: auto
+        type: choice
+        options: [auto, macos, full]
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
+
+concurrency:
+  group: proof-${{ inputs.mode || 'platform' }}-${{ inputs.pr_number || github.event.pull_request.number || 'dev' }}-${{ github.event.action == 'labeled' && github.event.label.name != 'platform-proof' && github.event.label.name || 'candidate' }}
+  cancel-in-progress: true
 
 jobs:
-  prepare:
+  route:
+    if: github.event_name != 'pull_request' || (github.event.action == 'labeled' && github.event.label.name == 'platform-proof')
     runs-on: ubuntu-latest
     outputs:
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      mode: ${{ steps.resolve.outputs.mode }}
+      proof_key: ${{ steps.resolve.outputs.proof_key }}
+      scope: ${{ steps.scope.outputs.scope }}
       version: ${{ steps.version.outputs.version }}
     steps:
+      - name: Resolve trusted exact head
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          INPUT_MODE: ${{ inputs.mode }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          mode="${INPUT_MODE:-platform}"
+          if [ "$mode" = "integration" ]; then
+            test "$GITHUB_EVENT_NAME" = "workflow_dispatch"
+            test -n "$INPUT_HEAD_SHA"
+            dev_head="$(gh api "repos/$GITHUB_REPOSITORY/branches/dev/codestory-next" --jq '.commit.sha')"
+            test "$INPUT_HEAD_SHA" = "$dev_head" || {
+              echo "::error::Integration proof requires current dev head $dev_head, not $INPUT_HEAD_SHA."
+              exit 1
+            }
+            {
+              echo "head_sha=$dev_head"
+              echo "base_sha="
+              echo "mode=integration"
+              echo "proof_key=integration-$dev_head"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          test "$mode" = "platform"
+          pr_number="${EVENT_PR_NUMBER:-$INPUT_PR_NUMBER}"
+          expected_head="${EVENT_HEAD_SHA:-$INPUT_HEAD_SHA}"
+          test -n "$pr_number" && test -n "$expected_head"
+          pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number")"
+          head_repo="$(jq -r '.head.repo.full_name' <<<"$pr")"
+          current_head="$(jq -r '.head.sha' <<<"$pr")"
+          base_sha="$(jq -r '.base.sha' <<<"$pr")"
+          test "$head_repo" = "$GITHUB_REPOSITORY" || {
+            echo "::error::Platform proof does not execute fork pull requests."
+            exit 1
+          }
+          if [ -n "$EVENT_HEAD_REPO" ]; then
+            test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY" || exit 1
+          fi
+          test "$current_head" = "$expected_head" || {
+            echo "::error::PR #$pr_number moved from promoted head $expected_head to $current_head."
+            exit 1
+          }
+          {
+            echo "head_sha=$current_head"
+            echo "base_sha=$base_sha"
+            echo "mode=platform"
+            echo "proof_key=pr-$pr_number-$current_head"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Require successful exact-head source proof
+        if: steps.resolve.outputs.mode == 'platform'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          accepted=false
+          while IFS= read -r run_id; do
+            if gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs?per_page=100" \
+              --jq '.jobs[] | select(.name == "full-source-gate" and .conclusion == "success") | .id' \
+              | grep -q .
+            then
+              accepted=true
+              echo "Accepted exact-head source proof run $run_id for $HEAD_SHA."
+              break
+            fi
+          done < <(
+            gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&status=completed&per_page=100" \
+              | jq -r --arg repo "$GITHUB_REPOSITORY" \
+                '.workflow_runs[] | select(.path == ".github/workflows/source-proof.yml" and .head_repository.full_name == $repo and (.event == "pull_request" or .event == "workflow_dispatch") and .conclusion == "success") | .id'
+          )
+          test "$accepted" = true || {
+            echo "::error::No successful full-source-gate job exists for exact head $HEAD_SHA."
+            exit 1
+          }
+
       - uses: actions/checkout@v5
-      - id: version
+        with:
+          ref: ${{ steps.resolve.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Select change-aware proof scope
+        id: scope
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
+          REQUESTED_SCOPE: ${{ inputs.scope || 'auto' }}
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.resolve.outputs.mode }}" = "integration" ]; then
+            scope=full
+          else
+            scope="$(git diff --name-only "$BASE_SHA...$HEAD_SHA" | node .github/scripts/route-ci-proof.mjs --stdin --requested "$REQUESTED_SCOPE")"
+          fi
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+          echo "Selected $scope platform proof."
+
+      - name: Verify package version surfaces
+        id: version
+        shell: bash
         run: |
           version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
           python .github/scripts/check-codestory-release.py --version "$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-  native-packaged-proof:
-    needs: prepare
+  macos-source:
+    if: needs.route.outputs.scope == 'macos'
+    needs: route
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            target: aarch64-apple-darwin
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.route.outputs.head_sha }}
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - name: Capture Rust cache identity
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-macos-source-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.target }}-workspace-default-features-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-macos-source-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.target }}-workspace-default-features-
+      - run: cargo check --workspace --locked
+      - run: node scripts/setup-retrieval-env.mjs --self-test
+      - run: node --test scripts/tests/codex-worktree-setup.test.mjs
+      - run: node scripts/codex-worktree-setup.mjs --self-test
+      - run: test -x plugins/codestory/skills/codestory-grounding/scripts/setup.sh
+
+  repo-scale-stats:
+    needs: route
+    uses: ./.github/workflows/repo-scale-stats.yml
+    with:
+      ref: ${{ needs.route.outputs.head_sha }}
+      proof_key: ${{ needs.route.outputs.proof_key }}
+
+  source-proof:
+    if: needs.route.outputs.mode == 'integration'
+    needs: route
+    uses: ./.github/workflows/source-proof.yml
+    with:
+      ref: ${{ needs.route.outputs.head_sha }}
+      proof_key: ${{ needs.route.outputs.proof_key }}
+
+  packaged-proof:
+    if: >-
+      always() &&
+      needs.route.result == 'success' &&
+      needs.route.outputs.scope != 'none' &&
+      (needs.macos-source.result == 'success' || needs.macos-source.result == 'skipped') &&
+      (needs.source-proof.result == 'success' || (needs.route.outputs.mode == 'platform' && needs.source-proof.result == 'skipped'))
+    needs:
+      - route
+      - macos-source
+      - source-proof
     uses: ./.github/workflows/packaged-platform-proof.yml
     with:
-      version: ${{ needs.prepare.outputs.version }}
+      version: ${{ needs.route.outputs.version }}
+      ref: ${{ needs.route.outputs.head_sha }}
+      scope: ${{ needs.route.outputs.scope }}
+      proof_key: ${{ needs.route.outputs.proof_key }}
+      sign_macos: true
+    secrets: inherit
+
+  macos-metal-proof:
+    if: needs.route.outputs.scope == 'macos' || needs.route.outputs.scope == 'full'
+    needs:
+      - route
+      - packaged-proof
+    uses: ./.github/workflows/macos-metal-proof.yml
+    with:
+      version: ${{ needs.route.outputs.version }}
+      ref: ${{ needs.route.outputs.head_sha }}
+      proof_key: ${{ needs.route.outputs.proof_key }}
+      use_packaged_artifact: true
+
+  closeout:
+    if: always() && needs.route.result != 'skipped'
+    needs:
+      - route
+      - macos-source
+      - source-proof
+      - repo-scale-stats
+      - packaged-proof
+      - macos-metal-proof
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require one coherent accepted proof
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.route.outputs.head_sha }}
+          MODE: ${{ needs.route.outputs.mode }}
+          SCOPE: ${{ needs.route.outputs.scope }}
+          ROUTE_RESULT: ${{ needs.route.result }}
+          MACOS_SOURCE_RESULT: ${{ needs.macos-source.result }}
+          SOURCE_RESULT: ${{ needs.source-proof.result }}
+          STATS_RESULT: ${{ needs.repo-scale-stats.result }}
+          PACKAGE_RESULT: ${{ needs.packaged-proof.result }}
+          METAL_RESULT: ${{ needs.macos-metal-proof.result }}
+        run: |
+          set -euo pipefail
+          require_result() {
+            test "$1" = "$2" || {
+              echo "::error::$3 finished $1; expected $2."
+              exit 1
+            }
+          }
+          require_result "$ROUTE_RESULT" success routing
+          require_result "$STATS_RESULT" success repo-scale-stats
+          if [ "$MODE" = integration ]; then
+            require_result "$SOURCE_RESULT" success source-proof
+          else
+            require_result "$SOURCE_RESULT" skipped source-proof
+          fi
+          if [ "$SCOPE" = macos ]; then
+            require_result "$MACOS_SOURCE_RESULT" success macos-source
+          else
+            require_result "$MACOS_SOURCE_RESULT" skipped macos-source
+          fi
+          if [ "$SCOPE" = none ]; then
+            require_result "$PACKAGE_RESULT" skipped packaged-proof
+            require_result "$METAL_RESULT" skipped macos-metal-proof
+          else
+            require_result "$PACKAGE_RESULT" success packaged-proof
+            require_result "$METAL_RESULT" success macos-metal-proof
+          fi
+          if [ "$MODE" = integration ]; then
+            current_dev="$(gh api "repos/$GITHUB_REPOSITORY/branches/dev/codestory-next" --jq '.commit.sha')"
+            test "$HEAD_SHA" = "$current_dev" || {
+              echo "::error::dev/codestory-next moved from proved head $HEAD_SHA to $current_dev."
+              exit 1
+            }
+          fi

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -7,6 +7,21 @@ on:
         description: Release version from crates/codestory-cli/Cargo.toml.
         required: true
         type: string
+      ref:
+        description: Exact source SHA to package.
+        required: false
+        default: ""
+        type: string
+      scope:
+        description: Native package matrix scope (macos or full).
+        required: false
+        default: full
+        type: string
+      proof_key:
+        description: Stable PR or integration identity for concurrency cancellation.
+        required: false
+        default: ""
+        type: string
       sign_macos:
         description: Require Developer ID signing and Apple notarization for macOS assets.
         required: false
@@ -28,6 +43,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: packaged-platform-proof-${{ inputs.proof_key || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   RELEASE_RUST_TOOLCHAIN: "1.95.0"
@@ -77,9 +96,12 @@ jobs:
             asset_target: macos-arm64
             exe_suffix: ""
             extension: tar.gz
+        exclude: ${{ fromJSON(inputs.scope == 'macos' && '[{"asset_target":"linux-x64"},{"asset_target":"linux-arm64"},{"asset_target":"windows-x64"},{"asset_target":"windows-arm64"}]' || '[]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Install pinned Rust
         run: |
@@ -102,9 +124,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-default-features-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-
+            ${{ runner.os }}-release-${{ env.RELEASE_RUST_TOOLCHAIN }}-${{ steps.rust-cache-key.outputs.version }}-${{ matrix.rust_target }}-codestory-cli-default-features-
 
       - name: Build codestory-cli
         if: matrix.asset_target != 'linux-x64'
@@ -219,6 +241,12 @@ jobs:
             exit 1
           fi
           grep -F "source=Notarized Developer ID" "$proof_dir/spctl.txt"
+
+      - name: Execute notarized macOS CLI without signing credentials
+        if: runner.os == 'macOS' && inputs.sign_macos
+        shell: bash
+        run: |
+          work_dir="$RUNNER_TEMP/codestory-notary-${{ matrix.asset_target }}"
           "$work_dir/codestory-cli-quarantined" --version
           "$work_dir/codestory-cli-quarantined" --help >/dev/null
 

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -10,6 +10,7 @@ on:
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/route-ci-proof.mjs
       - .github/workflows/auto-release.yml
       - .github/workflows/main-branch-source-guard.yml
       - .github/workflows/rust-ci.yml
@@ -18,6 +19,8 @@ on:
       - .github/workflows/packaged-platform-pr.yml
       - .github/workflows/packaged-platform-proof.yml
       - .github/workflows/macos-metal-proof.yml
+      - .github/workflows/source-proof.yml
+      - .github/workflows/repo-scale-stats.yml
       - .github/workflows/plugin-static.yml
       - scripts/install-codestory.ps1
       - scripts/codex-worktree-setup.*
@@ -36,6 +39,7 @@ on:
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/route-ci-proof.mjs
       - .github/workflows/auto-release.yml
       - .github/workflows/main-branch-source-guard.yml
       - .github/workflows/rust-ci.yml
@@ -44,6 +48,8 @@ on:
       - .github/workflows/packaged-platform-pr.yml
       - .github/workflows/packaged-platform-proof.yml
       - .github/workflows/macos-metal-proof.yml
+      - .github/workflows/source-proof.yml
+      - .github/workflows/repo-scale-stats.yml
       - .github/workflows/plugin-static.yml
       - scripts/install-codestory.ps1
       - scripts/codex-worktree-setup.*
@@ -73,6 +79,9 @@ jobs:
       - name: Check workflow policy
         run: node .github/scripts/check-workflow-policy.mjs
 
+      - name: Check CI proof routing fixtures
+        run: node .github/scripts/route-ci-proof.mjs --self-test
+
       - name: Check packaged proof harness
         run: python .github/scripts/check-packaged-agent-proof.py --self-test
 
@@ -87,22 +96,3 @@ jobs:
         run: |
           version="$(python -c "import tomllib; print(tomllib.load(open('crates/codestory-cli/Cargo.toml', 'rb'))['package']['version'])")"
           python .github/scripts/check-codestory-release.py --version "$version"
-
-  macos-setup-static:
-    name: macOS setup self-tests
-    runs-on: macos-15
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Check retrieval setup contracts
-        run: node scripts/setup-retrieval-env.mjs --self-test
-
-      - name: Check worktree setup dispatcher contracts
-        run: node --test scripts/tests/codex-worktree-setup.test.mjs
-
-      - name: Check POSIX worktree setup implementation
-        run: node scripts/codex-worktree-setup.mjs --self-test
-
-      - name: Check shipped grounding setup executable mode
-        run: test -x plugins/codestory/skills/codestory-grounding/scripts/setup.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
     uses: ./.github/workflows/packaged-platform-proof.yml
     with:
       version: ${{ needs.preflight.outputs.version }}
+      ref: ${{ github.sha }}
+      scope: full
+      proof_key: release-${{ needs.preflight.outputs.version }}
       sign_macos: true
     # Provision these names as environment secrets on macos-release-signing.
     # That protected environment is selected by the called macOS matrix jobs,
@@ -106,6 +109,7 @@ jobs:
     with:
       version: ${{ needs.preflight.outputs.version }}
       ref: ${{ github.sha }}
+      proof_key: release-${{ needs.preflight.outputs.version }}
       use_packaged_artifact: true
 
   publish:

--- a/.github/workflows/repo-scale-stats.yml
+++ b/.github/workflows/repo-scale-stats.yml
@@ -1,0 +1,70 @@
+name: Promoted repo-scale stats
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      proof_key:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-scale-stats-${{ inputs.proof_key }}
+  cancel-in-progress: true
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - name: Capture Rust cache identity
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-repo-scale-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-codestory-cli-default-features-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-repo-scale-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-codestory-cli-default-features-
+      - name: Fetch the checksum-pinned embedding model
+        env:
+          CODESTORY_EMBED_MODEL_DIR: ${{ runner.temp }}/codestory-stats-models
+        run: node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-only
+      - name: Build the release CLI
+        run: cargo build --release --locked -p codestory-cli
+      - name: Run mandatory repo-scale stats once
+        shell: bash
+        env:
+          CODESTORY_ALLOW_SKIP_REAL_REPO_DRILL_CASES: "1"
+          CODESTORY_EMBED_ALLOW_CPU: "1"
+          CODESTORY_EMBED_MODEL_DIR: ${{ runner.temp }}/codestory-stats-models
+        run: |
+          set -euo pipefail
+          mkdir -p target/repo-scale-stats
+          cargo test --locked -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture \
+            2>&1 | tee target/repo-scale-stats/output.txt
+      - name: Upload repo-scale stats output
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: repo-scale-stats-${{ inputs.proof_key }}
+          path: target/repo-scale-stats
+          if-no-files-found: error

--- a/.github/workflows/retrieval-sidecar-smoke.yml
+++ b/.github/workflows/retrieval-sidecar-smoke.yml
@@ -100,6 +100,7 @@ jobs:
         shell: bash
         run: |
           echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"
 
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
@@ -110,10 +111,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
-            ${{ runner.os }}-cargo-stable-
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-contracts-default-features-
 
       - name: Runtime sidecar and packet contract tests
         run: |
@@ -148,7 +148,7 @@ jobs:
           key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}
 
   windows-manifest-missing:
-    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'ci:windows-smoke')
+    if: github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -163,7 +163,9 @@ jobs:
         id: rust-cache-key
         run: |
           $release = rustc -Vv | Select-String '^release: ' | ForEach-Object { $_.ToString().Substring(9) }
+          $target = rustc -Vv | Select-String '^host: ' | ForEach-Object { $_.ToString().Substring(6) }
           "version=$release" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "target=$target" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
@@ -174,10 +176,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-bootstrap-default-features-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
-            ${{ runner.os }}-cargo-stable-
+            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-retrieval-bootstrap-default-features-
 
       - name: Retrieval bootstrap manifest-missing contract
         run: cargo test -p codestory-cli --test retrieval_bootstrap_contracts

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,4 +1,4 @@
-name: rust ci
+name: Draft source checks
 
 on:
   pull_request:
@@ -6,22 +6,11 @@ on:
       - Cargo.lock
       - Cargo.toml
       - crates/**
-      - docs/contributors/testing-matrix.md
-      - .github/scripts/check-workflow-policy.mjs
       - .github/scripts/check-runtime-config-boundary.mjs
-      - .github/workflows/rust-ci.yml
-  push:
-    branches:
-      - main
-      - dev/codestory-next
-    paths:
-      - Cargo.lock
-      - Cargo.toml
-      - crates/**
-      - docs/contributors/testing-matrix.md
       - .github/scripts/check-workflow-policy.mjs
-      - .github/scripts/check-runtime-config-boundary.mjs
+      - .github/scripts/route-ci-proof.mjs
       - .github/workflows/rust-ci.yml
+      - .github/workflows/source-proof.yml
   workflow_dispatch:
 
 permissions:
@@ -32,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  workspace:
-    name: workspace cargo checks
+  linux-draft:
+    name: Ubuntu draft source checks
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -44,13 +33,14 @@ jobs:
           rustup toolchain install stable --profile minimal --component clippy --component rustfmt
           rustup default stable
 
-      - name: Capture Rust cache key
+      - name: Capture Rust cache identity
         id: rust-cache-key
         shell: bash
         run: |
           echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Cargo registry, git sources, and build output
+      - name: Restore Cargo inputs and output
         id: cargo-cache-restore
         uses: actions/cache/restore@v5
         continue-on-error: true
@@ -59,11 +49,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-rust-ci-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-draft-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-rust-ci-stable-${{ steps.rust-cache-key.outputs.version }}-
-            ${{ runner.os }}-cargo-stable-${{ steps.rust-cache-key.outputs.version }}-
-            ${{ runner.os }}-cargo-stable-
+            ${{ runner.os }}-draft-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-default-features-
 
       - name: Check formatting
         run: cargo fmt --check
@@ -71,16 +59,19 @@ jobs:
       - name: Check immutable runtime configuration boundary
         run: node .github/scripts/check-runtime-config-boundary.mjs
 
-      - name: Check workspace
+      - name: Check the workspace
         run: cargo check --workspace --locked
 
-      - name: Test workspace
-        run: cargo test --locked
+      - name: Lint workspace libraries
+        run: cargo clippy --workspace --lib --locked -- -D warnings
 
-      - name: Lint workspace
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Prove focused publication contracts
+        run: |
+          cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture
+          cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture
+          cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture
 
-      - name: Save Cargo registry, git sources, and build output
+      - name: Save Cargo inputs and output
         if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
         uses: actions/cache/save@v5
         continue-on-error: true
@@ -90,100 +81,3 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}
-
-  macos-workspace:
-    name: macOS workspace cargo checks (${{ matrix.asset_target }})
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-15
-            asset_target: macos-arm64
-          - os: macos-15-intel
-            asset_target: macos-x64
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust stable
-        run: |
-          rustup toolchain install stable --profile minimal --component clippy
-          rustup default stable
-
-      - name: Capture Rust cache key
-        id: rust-cache-key
-        shell: bash
-        run: |
-          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
-
-      - name: Restore Cargo registry, git sources, and build output
-        id: cargo-cache-restore
-        uses: actions/cache/restore@v5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ matrix.asset_target }}-cargo-rust-ci-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.asset_target }}-cargo-rust-ci-stable-${{ steps.rust-cache-key.outputs.version }}-
-
-      - name: Check workspace
-        run: cargo check --workspace --locked
-
-      - name: Test workspace
-        run: cargo test --locked
-
-      - name: Lint workspace
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-      - name: Save Cargo registry, git sources, and build output
-        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
-        uses: actions/cache/save@v5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}
-
-  concurrent-publication:
-    name: concurrent publication (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust stable
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-
-      - name: Restore Cargo source cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-concurrent-publication-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-concurrent-publication-
-
-      - name: Prove old-or-new publication reads across MCP processes
-        run: cargo test --locked -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture
-
-      - name: Prove multi-project embedding endpoint isolation
-        run: cargo test --locked -p codestory-cli --test stdio_protocol_contracts multi_project_stdio_keeps_project_embedding_endpoints_isolated_across_a_b_a -- --nocapture
-
-      - name: Prove publication transition failure and cancellation semantics
-        run: cargo test --locked -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture
-
-      - name: Prove staged database recovery after process abort
-        run: cargo test --locked -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -48,6 +48,7 @@ jobs:
         shell: bash
         run: |
           echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"
 
       - name: Restore Cargo registry, git sources, and build output
         id: cargo-cache-restore
@@ -58,10 +59,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-doc-default-features-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-
-            ${{ runner.os }}-rustdoc-stable-
+            ${{ runner.os }}-rustdoc-stable-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-doc-default-features-
 
       - name: Deny rustdoc warnings
         env:

--- a/.github/workflows/saga-issue-link-guard.yml
+++ b/.github/workflows/saga-issue-link-guard.yml
@@ -8,6 +8,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: saga-issue-link-guard-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   require-closing-issue-link:
     name: require closing issue link

--- a/.github/workflows/source-proof.yml
+++ b/.github/workflows/source-proof.yml
@@ -1,0 +1,135 @@
+name: Exact-head source proof
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      proof_key:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Same-repository pull request accepted by exact-head review.
+        required: true
+        type: string
+      expected_head_sha:
+        description: Exact reviewed head SHA. The gate refuses a newer or older head.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: source-proof-${{ inputs.proof_key || inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ github.event.action == 'labeled' && github.event.label.name != 'review-accepted' && github.event.label.name || 'candidate' }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    if: github.event_name != 'pull_request' || (github.event.action == 'labeled' && github.event.label.name == 'review-accepted')
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - name: Resolve trusted exact head
+        id: resolve
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          CALLER_REF: ${{ inputs.ref }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "$EVENT_PR_NUMBER" ]; then
+            test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY" || {
+              echo "::error::Exact-head proof does not execute fork pull requests."
+              exit 1
+            }
+            pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$EVENT_PR_NUMBER")"
+            current_head="$(jq -r '.head.sha' <<<"$pr")"
+            test "$current_head" = "$EVENT_HEAD_SHA" || {
+              echo "::error::PR #$EVENT_PR_NUMBER moved after the review-accepted label event."
+              exit 1
+            }
+            echo "ref=$EVENT_HEAD_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$PR_NUMBER" ]; then
+            pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+            head_repo="$(jq -r '.head.repo.full_name' <<<"$pr")"
+            head_sha="$(jq -r '.head.sha' <<<"$pr")"
+            test "$head_repo" = "$GITHUB_REPOSITORY" || {
+              echo "::error::Exact-head proof does not execute fork pull requests."
+              exit 1
+            }
+            test "$head_sha" = "$EXPECTED_HEAD_SHA" || {
+              echo "::error::PR #$PR_NUMBER moved from reviewed head $EXPECTED_HEAD_SHA to $head_sha."
+              exit 1
+            }
+            echo "ref=$head_sha" >> "$GITHUB_OUTPUT"
+          else
+            test -n "$CALLER_REF"
+            echo "ref=$CALLER_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+  full-source-gate:
+    name: full-source-gate
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve.outputs.ref }}
+
+      - name: Install Rust stable
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy
+          rustup default stable
+
+      - name: Capture Rust cache identity
+        id: rust-cache-key
+        shell: bash
+        run: |
+          echo "version=$(rustc -Vv | sed -n 's/^release: //p')" >> "$GITHUB_OUTPUT"
+          echo "target=$(rustc -Vv | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Cargo inputs and output
+        id: cargo-cache-restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-source-proof-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-all-targets-all-features-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-source-proof-${{ steps.rust-cache-key.outputs.version }}-${{ steps.rust-cache-key.outputs.target }}-workspace-all-targets-all-features-
+
+      - name: Test the complete workspace once
+        run: cargo test --workspace --locked
+
+      - name: Lint every workspace target and feature once
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Save Cargo inputs and output
+        if: always() && steps.cargo-cache-restore.outputs.cache-hit != 'true' && steps.cargo-cache-restore.outputs.cache-primary-key != ''
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ steps.cargo-cache-restore.outputs.cache-primary-key }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,10 @@
 
 ## Testing Guidelines
 - Tests live in `#[cfg(test)]` blocks or `*_tests.rs`; name them `test_*`.
-- Before committing, run the repo-scale CLI e2e stats test and append the emitted stats to `docs/testing/codestory-e2e-stats-log.md`:
+- On the final merge-ready head, run the repo-scale CLI e2e stats test once and
+  append the emitted stats to `docs/testing/codestory-e2e-stats-log.md`.
+  Intermediate checkpoint commits use focused verification and do not append
+  telemetry rows:
   - `cargo build --release -p codestory-cli`
   - `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture`
 - To exercise indexing fidelity and coverage, you must explicitly run full test binaries, not just filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Changed
+
+- Staged CI proof by pull-request maturity and changed surface. Draft pushes
+  now stay on one Ubuntu source lane, exact-head review promotion runs the full
+  workspace test and clippy gate once, and explicit platform promotion selects
+  no package matrix, the two Mac targets, or all six native targets. Promoted
+  heads run repo-scale stats once; signed package artifacts are built once per
+  target and reused by package smoke, notarization, install, and protected
+  Apple Silicon proof. Per-proof concurrency cancels stale heads, while the
+  integrated platform dispatcher verifies successful exact-head source proof,
+  and its integration mode proves the current `dev/codestory-next` merge result
+  before rechecking that dev did not move during the gate.
+
 ### Fixed
 
 - Made incremental freshness compare verified parser source hashes when file

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -18,13 +18,13 @@ flowchart TD
     change --> bench["Bench or perf-surface work"]
     change --> e2e["Repo-scale semantic or cold-start behavior"]
     docs --> docs_checks["readback + git diff --check + check-doc-links.mjs"]
-    always --> workspace["fmt, check, targeted tests, clippy"]
+    always --> workspace["draft: fmt, check, lib clippy, focused tests"]
     indexer --> fidelity["fidelity_regression, tictactoe_language_coverage, integration"]
     store --> store_tests["cargo test -p codestory-store"]
     runtime --> runtime_tests["cargo test -p codestory-runtime and retrieval_eval"]
     cli --> cli_tests["cargo test -p codestory-cli"]
     bench --> bench_checks["cargo check -p codestory-bench --bench name"]
-    e2e --> e2e_stats["release build + codestory_repo_e2e_stats"]
+    e2e --> e2e_stats["final merge-ready head: release build + repo-scale stats"]
 ```
 
 ## Verification Lane Summary
@@ -34,12 +34,13 @@ Run Cargo commands serially in this repo.
 | Lane | Commands |
 | --- | --- |
 | Docs only | `git diff --check`, `node .github/scripts/check-doc-links.mjs` |
-| Routine code | `cargo fmt --check`, `cargo check`, `cargo test`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` |
-| macOS workspace | On both `macos-15` and `macos-15-intel`: `cargo check --workspace --locked`, `cargo test --locked`, then `cargo clippy --workspace --all-targets --all-features -- -D warnings`; keep commands serialized within each job |
-| Concurrent publication | `cargo test -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture`; `rust-ci.yml` repeats this focused contract on Ubuntu, Windows, and macOS |
-| Publication fault recovery | `cargo test -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture`; `cargo test -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture`; `rust-ci.yml` repeats both proofs on Ubuntu, Windows, and macOS |
+| Draft code | On Ubuntu: `cargo fmt --check`, `cargo check --workspace --locked`, library clippy, and focused publication contracts |
+| Exact-head source proof | After independent review accepts the current head: `cargo test --workspace --locked`, then `cargo clippy --workspace --all-targets --all-features -- -D warnings`, once |
+| Scoped macOS source proof | On both `macos-15` and `macos-15-intel`: `cargo check --workspace --locked` plus setup self-tests, only for an explicitly promoted Mac-scoped head |
+| Concurrent publication | `cargo test -p codestory-cli --test stdio_protocol_contracts two_stdio_processes_observe_only_complete_generations_during_real_refresh -- --nocapture`; draft CI runs this focused contract on Ubuntu |
+| Publication fault recovery | `cargo test -p codestory-runtime publication_transitions_fail_or_cancel_atomically -- --nocapture`; `cargo test -p codestory-store staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts -- --nocapture`; draft CI runs both focused proofs on Ubuntu |
 | Release-blocking fidelity | `cargo test -p codestory-indexer --test fidelity_regression`, `cargo test -p codestory-indexer --test tictactoe_language_coverage`, `cargo test -p codestory-runtime --test retrieval_eval` |
-| Heavy repo-scale timing | `cargo build --release -p codestory-cli`, then `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture` |
+| Heavy repo-scale timing | Once on a promoted final merge-ready head: `cargo build --release -p codestory-cli`, then `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture`; upload the output and append its metrics before the final commit |
 
 Append fresh headline rows to
 [`codestory-e2e-stats-log.md`](../testing/codestory-e2e-stats-log.md) when
@@ -86,11 +87,11 @@ Do not use `cargo test --workspace --all-targets` as the routine broad test
 gate. `--all-targets` expands into benchmark targets; Criterion benches are
 compiled or run through the bench lane below.
 
-The macOS CI merge bar runs the complete workspace lane independently on
-Apple Silicon (`macos-15`) and Intel (`macos-15-intel`). Mac setup changes must
-also pass the retrieval setup self-test, the Node dispatcher test, and the POSIX
-worktree setup self-test. Run locally from an isolated cache when changing these
-surfaces:
+An explicitly promoted Mac-scoped head runs source checks independently on
+Apple Silicon (`macos-15`) and Intel (`macos-15-intel`) before packaging. Mac
+setup changes also pass the retrieval setup self-test, the Node dispatcher
+test, and the POSIX worktree setup self-test. Draft pushes stay on Ubuntu. Run
+locally from an isolated cache when changing these surfaces:
 
 ```sh
 node scripts/setup-retrieval-env.mjs --self-test
@@ -142,16 +143,26 @@ the active plugin runtime plus observed and missing server-advertised MCP
 resources. This proves the installed plugin launcher advertises the resources;
 it is not Codex host/model visibility proof.
 
-Packaged acceptance uses the same six native hosted-runner cells before and
-after publication. Pull requests that change release, packaging, installer, or
-plugin-launch surfaces call the same read-only reusable packaged-proof workflow
-as the release, so the native matrix is reviewed before publication without
-granting release permissions to pull-request code:
+Packaged acceptance builds each selected native target once and reuses that
+artifact for package smoke, signing/notarization, install checks, and the
+protected Apple Silicon lifecycle. Draft pushes never start this matrix. A
+same-repository `platform-proof` label or coordinator dispatch rechecks the
+exact PR head and requires a completed successful `full-source-gate` job for
+that SHA, then routes script/test-guard-only changes to `none`, Mac
+lifecycle changes to the two Mac targets, and cross-platform runtime or
+packaging changes to all six targets. Forks are rejected before checkout and no
+proof lane uses `pull_request_target` to execute PR code. Mac package promotion
+uses the protected signing environment; unavailable credentials fail the proof.
 
-Pull-request cells do not receive the protected Apple signing credentials, so
-their Mac archives prove packaging and runtime behavior but remain unsigned.
-Developer ID signing, notarization, and Gatekeeper checks apply to the release
-and post-publish cells only.
+The `review-accepted` label runs the full Ubuntu source gate once for that exact
+head; the persistent label alone does not authorize later heads. After merge,
+the coordinator selects integration mode in the same dispatcher for the
+current `dev/codestory-next` SHA. That mode forces the full source, six-target
+package, repo-scale stats, and packaged Metal workflows, then rechecks that dev
+did not move while they ran.
+Every lane cancels an older run for the same PR or proof identity. Cargo cache
+keys use the toolchain, lockfile, feature set, and target triple, never a commit
+SHA.
 
 | Asset | Native runner | Required packaged proof |
 | --- | --- | --- |
@@ -372,8 +383,9 @@ cargo test -p codestory-runtime --test integration test_repo_scale_call_resoluti
 
 ## Repo-Scale Semantic And Cold-Start Checks
 
-Run this lane when default `index` behavior, symbol-doc persistence, dense-anchor
-persistence/reuse, embedding reuse, or cold-start performance changes:
+Run this lane once on the final merge-ready head when default `index` behavior,
+symbol-doc persistence, dense-anchor persistence/reuse, embedding reuse, or
+cold-start performance changes. Intermediate checkpoints do not append rows:
 
 ```sh
 cargo build --release -p codestory-cli

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -539,9 +539,8 @@ expansion lanes are skipped for that query.
 path and not a full sidecar proof. Linux carries generic
 lint/runtime/search/retrieval contract slices plus the non-live packet/search
 fixture and baseline gate (`cargo test -p codestory-cli --test packet_search_eval`).
-Windows carries the
-manifest-missing bootstrap/status shape only when manually dispatched or when a
-PR has the `ci:windows-smoke` label.
+Windows carries the manifest-missing bootstrap/status shape only when manually
+dispatched; persistent PR labels do not allocate a Windows runner.
 
 The reduced CI sequence does not start real sidecars, fetch
 `bge-base-en-v1.5.Q8_0.gguf`, build the project manifest required for full mode,


### PR DESCRIPTION
## Summary

- keep draft and checkpoint pushes on one Ubuntu source lane plus focused docs/plugin checks
- promote exact reviewed heads once for full workspace tests and clippy
- route explicit platform proof by changed surface: no package matrix for #1056-shaped guard changes, Mac-only proof for #1058-shaped lifecycle work, and the full native matrix for #1059-shaped runtime identity changes
- cancel stale PR runs, reuse each packaged binary through smoke/signing/notarization/install/Metal proof, and key caches by toolchain, lockfile, features, and target
- move repo-scale stats to the final promoted head and make integration proof an explicit current-dev dispatch

## Verification

- `actionlint -no-color .github/workflows/*.yml`
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/route-ci-proof.mjs --self-test`
- real PR routing: #1056 `none`, #1058 `macos`, #1059 `full`
- plugin static tests: 72 passed, 1 platform skip
- docs links, packaged proof/packager self-tests, release detector, version synchronization, and `git diff --check`

No Cargo lane was run for this workflow-only checkpoint. The commit carries `[skip ci]` so the old broad PR workflows do not fan out before this router is merged.

Closes #1060
Refs #1046
