### PR TITLE
rewrite agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,102 +1,240 @@
-# Repository Guidelines
+# CodeStory Agent Guide
 
-**Audience:** Contributors — workspace layout, verification lanes, and merge bar.
+**Audience:** agents and contributors changing CodeStory. This file contains the
+decisions that must remain visible while working; generated help, architecture
+pages, runbooks, and workflows own detailed mechanics.
 
-## Project Structure & Module Organization
-- Rust workspace is defined in `Cargo.toml`; crates live under `crates/`.
-- Primary runtime surface is `crates/codestory-cli`; the canonical agent skill ships with the plugin under `plugins/codestory/skills/codestory-grounding`.
-- Workspace crates: `codestory-contracts`, `codestory-workspace`, `codestory-store`, `codestory-indexer`, `codestory-retrieval`, `codestory-runtime`, `codestory-cli`, `codestory-bench`.
-- Runtime artifacts: user-cache SQLite grounding indexes keyed by repo path; build outputs in `target/`.
+## Start Here
 
-## Architecture Overview
-- `codestory-runtime` is the headless orchestrator used by the CLI and skill scripts.
-- `codestory-contracts` holds the shared graph model, DTOs, grounding/trail types, and shared events.
-- Indexing pipeline: `codestory-workspace` discovers files and refresh plans, `codestory-indexer` extracts symbols/edges via tree-sitter + semantic resolution, and `codestory-store` persists graph/search/snapshot state to SQLite.
-- `codestory-bench` contains Criterion benches for indexing, grounding, resolution, and cleanup work.
+- Establish current truth before choosing work: inspect the current branch and
+  integration head, active worktrees, open PR or issue ownership, and the
+  release state. Do not reuse an active lane or implement routine work directly
+  on `dev/codestory-next`.
+- Run `node scripts/codex-worktree-setup.mjs` for a delegated worktree. Treat
+  its printed base, child head, PR head, and proof target as authoritative
+  before cache repair, readiness work, or verification. When changing setup,
+  keep the PowerShell and POSIX implementations behaviorally aligned and run
+  the setup self-tests from the testing matrix.
+- Before source claims, planning edits, choosing tests, or reviewing changes,
+  use the canonical CodeStory grounding skill when its MCP tools are visible.
+  Every MCP call must carry the target repository's absolute `project` root.
+  Reuse current status until repository, runtime, or index state changes.
+- Obey `allowed_surfaces` and `retrieval_mode`. Use `packet`, `search`, or
+  `context` only when that surface is allowed and retrieval is `full`. If the
+  MCP tools are not visible, use ordinary source inspection and report the
+  visibility gap. CLI diagnostics do not prove that the packaged plugin MCP is
+  live in the agent host.
+- For a large change, read `docs/architecture/overview.md`, the owning
+  subsystem page, `docs/contributors/debugging.md`, and
+  `docs/contributors/testing-matrix.md` before editing.
 
-## Build, Test, and Development Commands
-- Backend build/test: `cargo build`, `cargo test`, `cargo check`, `cargo fmt`, `cargo clippy`.
-- CLI runtime: `cargo run --release -p codestory-cli -- index --project .`.
-- Skill-first grounding: `cargo run --release -p codestory-cli -- ground --project .`.
-- Codex worktree setup runs `node scripts/codex-worktree-setup.mjs` before the
-  thread starts. The dispatcher uses the existing PowerShell implementation on
-  Windows and `scripts/codex-worktree-setup.sh` on macOS/Linux. Both resolve a
-  version-matched CLI from `CODESTORY_CLI`, PATH, the CodeStory install
-  directory, this worktree, or a sibling worktree before trying the current
-  release and then a release build with optional `sccache`; they then try
-  `cache rehydrate`, refresh the SQLite index, and best-effort repair/report
-  sidecar readiness.
-- Release version checks: `python .github/scripts/check-codestory-release.py --version <version>` and `node .github/scripts/check-workflow-policy.mjs`.
-- On Windows, the Codex npm shim should be invoked as `codex.cmd` (typically under `%APPDATA%\\npm`); using the extensionless `codex` shim can fail with `os error 193`.
-- In this PowerShell environment, large parallel file reads can truncate output; when investigating a single large file, prefer one direct read command (for example `Get-Content` or `cmd /c type`) before parallelizing.
-- Public GitHub status comments should go through `node scripts/github-status-comment.mjs --issue <n> --body-file <file>` or stdin; the helper rejects literal `\\n` text before posting.
+## Ownership Boundaries
 
-## Coding Style & Naming Conventions
-- Rust edition is `2024` across workspace crates.
-- Rust naming: `snake_case` for functions/modules, `PascalCase` for types, `SCREAMING_SNAKE_CASE` for constants.
+- `codestory-contracts`: shared DTOs, graph types, events, grounding and trail
+  contracts.
+- `codestory-workspace`: project discovery, inventories, refresh planning, and
+  repository/project identity.
+- `codestory-indexer`: parsing, extraction, intermediate projections, and
+  semantic resolution.
+- `codestory-store`: SQLite source of truth, snapshots, projections, and core
+  publication.
+- `codestory-retrieval`: lexical, semantic, and SCIP artifacts; immutable
+  sidecar generations; manifests; health; and fail-closed query execution.
+- `codestory-runtime`: the only product orchestration layer. Indexing,
+  grounding, search, packet construction, and agent flows belong here.
+- `codestory-cli`: command and transport parsing, output rendering, process
+  configuration capture, readiness-broker integration, and managed sidecar
+  lifecycle boundaries. Do not move product orchestration into adapters.
+- `plugins/codestory`: host hooks, the packaged launcher, MCP routing, and the
+  canonical agent skill. Plugin routing selects a project per request and
+  reaches product behavior through the version-matched CLI.
+- `codestory-bench`: measurement and benchmark support only; it does not own
+  product contracts.
 
-## Testing Guidelines
-- Tests live in `#[cfg(test)]` blocks or `*_tests.rs`; name them `test_*`.
-- On the final merge-ready head, run the repo-scale CLI e2e stats test once and
-  append the emitted stats to `docs/testing/codestory-e2e-stats-log.md`.
-  Intermediate checkpoint commits use focused verification and do not append
-  telemetry rows:
-  - `cargo build --release -p codestory-cli`
-  - `cargo test -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture`
-- To exercise indexing fidelity and coverage, you must explicitly run full test binaries, not just filters:
+Dependency direction is
+`contracts -> workspace/store/indexer/retrieval -> runtime -> cli/adapters`.
+Change the owning source-of-truth layer first; do not patch a derived view or
+adapter to compensate for incorrect upstream state.
+
+## Product Invariants
+
+### Identity and configuration
+
+- Keep logical project, workspace, artifact scope, publication generation,
+  task/request, run, lease, and process identity distinct. Never replace these
+  contracts with a path spelling, PID, mutable environment variable, or global
+  active-project value.
+- Every MCP or plugin request selects its project explicitly. Hook-written
+  active-state files are diagnostic only and must not route a runtime.
+- Compare existing paths and executables by native filesystem identity. Use
+  platform lexical rules only for missing paths; Unix path equality remains
+  case-sensitive and Windows path equality case-insensitive.
+- Capture user home, network trust, cache root, and runtime defaults once at
+  process start. Retain immutable configuration per project. Switching projects
+  must not mutate or re-read the process environment, and project config must
+  not silently choose cache roots, credentials, or network-egress endpoints.
+
+### Reads, activation, and publication
+
+- Status, doctor, and other read surfaces are observational. They must not
+  download assets, refresh indexes, start repair, or mutate sidecar state.
+  Grounding and explicit project-scoped setup or repair operations own
+  activation.
+- Writers stage and validate a complete generation before publishing it.
+  Current and rollback pointers change atomically; readers pin one complete
+  old-or-new generation. Failure, cancellation, or concurrent source drift
+  leaves the previous publication usable and schedules or reports a retry.
+- Freshness depends on verified source/content and publication identity, not
+  timestamps alone. Partial, unreadable, or bounded discovery cannot prove
+  absence and must never schedule deletion.
+- Cleanup may remove only resources proven CodeStory-owned by a current token,
+  lease, manifest, generation, or proof marker. Do not perform broad Docker,
+  process, port, or user-cache cleanup.
+- Agent-facing packet/search/context must fail closed on stale or partial
+  publications, ambiguous migration, changed runtime identity, non-`full`
+  sidecars, dead required infrastructure, or missing required accelerator/embed
+  proof. `retrieval_mode=full` proves infrastructure eligibility, not answer
+  quality or claim sufficiency.
+
+### Evaluation and surface boundaries
+
+- Production packet/search behavior must not contain holdout repository names,
+  fixture paths, expected-answer shapes, or benchmark-family steering.
+- Benchmark-shaped probe catalogs and claim/source-truth scoring stay behind
+  test-only evaluation boundaries.
+- Language claims must name their tier: parser-backed graph coverage,
+  structural source collectors, or agent-facing packet quality.
+- `packet` owns broad retrieval. `drill` adapts that packet path and must not
+  create a second search, readiness, bridge, or scoring system.
+- Browser and HTTP adapters remain read-only and loopback-bound by default.
+  Any broader browser, UI, or network surface must satisfy the browser surface
+  gate in the testing documentation.
+- Generated CLI help is the option source of truth. Keep user docs
+  workflow-oriented instead of duplicating complete flag matrices.
+
+## Verification By Change
+
+- Choose the smallest credible lane from
+  `docs/contributors/testing-matrix.md` before running broad checks. Run
+  separate Cargo build, check, test, and clippy commands serially because this
+  workspace shares build locks. Use locked dependency resolution in proof
+  lanes.
+- Do not use `cargo test --workspace --all-targets` as the routine broad gate;
+  it expands Criterion targets. Draft work uses focused checks. The full
+  workspace test and all-target/all-feature clippy gate run once on an
+  independently accepted exact head.
+- CLI integration tests must launch through
+  `tests/test_support::cli_command` or its supplied-binary variant, use
+  isolated cache/install/plugin state roots, and drain spawned repair workers.
+  Never clean or write the real user cache to make a test pass, and never
+  serialize the suite to hide state leakage.
+- Docs-only scope is `README.md`, `docs/**`, `plugins/codestory/README.md`,
+  `plugins/codestory/docs/**`, and `plugins/codestory/skills/**`. Read changed
+  pages back, then run `git diff --check` and
+  `node .github/scripts/check-doc-links.mjs`. Do not add tests that assert prose.
+  Plugin adapter changes also run
+  `node --test plugins/codestory/tests/plugin-static.test.mjs`.
+- Indexer fidelity or language coverage requires the full binaries, not name
+  filters:
   - `cargo test -p codestory-indexer --test fidelity_regression`
   - `cargo test -p codestory-indexer --test tictactoe_language_coverage`
-  - Note: Using `cargo test -p codestory-index fidelity_regression` will just filter tests instead of running the targeted suites.
-- Cargo verifications (build, check, test) should be serialized when working in this repo because parallel `cargo` commands will contend on the shared package and build locks.
-- For graph perf and fidelity checks, use Criterion benches in `crates/codestory-bench`.
-- Operator documentation lives in `docs/users/`. Docs-only proof: `git diff --check` and `node .github/scripts/check-doc-links.mjs`. Do not add unit tests that assert documentation copy or required phrases.
+- Publication, identity, packaging, or platform changes require their named
+  concurrency, fault, package, and native proof lanes from the testing matrix.
+  Draft CI, exact-head source proof, platform proof, and integration proof are
+  distinct stages. A persistent label never authorizes an unreviewed later SHA.
+- Run the repo-scale CLI stats lane once on the promoted final merge-ready head
+  only when default indexing, symbol/dense persistence, embedding reuse, or
+  cold-start behavior changed. Intermediate commits do not append telemetry.
+  `docs/testing/codestory-e2e-stats-log.md` is telemetry only and cannot
+  authorize a release; release-significant decisions use the approved,
+  attested profile and `scripts/codestory-release-evidence-gate.mjs`.
 
-## Commit & Pull Request Guidelines
-- Commit messages are short, lowercase, imperative (e.g., `fix minimap`, `refactor graph style`).
-- Before staging or committing, update `CHANGELOG.md` whenever the diff changes
-  shipped behavior, operator guidance, release automation, packaging, or version
-  metadata. If the work modifies the current latest unreleased version or
-  creates the next latest version heading, keep the entry under `Unreleased` or
-  that new release heading in the same commit.
-- PRs should include a summary, tests run, linked issues, and relevant artifacts for behavior changes.
-- Routine implementation PRs branch from and target `dev/codestory-next`. Do not target `main` directly unless the lane is an explicit release, hotfix, final comparison/review artifact, or promotion.
-- Agent branches should use the `codex/` prefix by default. Saga comparison/review branches may use `review/codestory-saga-*` when the branch exists only to support a reviewer comparison.
-- The saga issue-link guard applies to `codex/*` heads, `review/codestory-saga-*` heads, `[codex]` PR titles, and PRs labeled `saga:codestory-intelligence`. Guarded PRs must include a closing issue reference (`Closes #123`, `Fixes #123`, `Resolves #123`, or the full GitHub issue URL) for the PR-sized issue. Use `Refs #...` only for broader parents or related context. For PRs targeting `dev/codestory-next`, add both the issue and PR to the Project because GitHub's computed Linked pull requests field may not populate until default-branch promotion.
-- If a slice is partial under a larger saga, create or use a PR-sized child issue and close that issue in the PR body; do not close the parent until its acceptance criteria are actually met.
-- Keep release comparisons, ledgers, and generated pre-release evidence in PR bodies, issue comments, project updates, or external artifacts. Do not commit generated comparison docs/CSVs/SVGs into the repo unless they are intended to become durable product documentation.
+## Git, PR, and Evidence Workflow
 
-## Release Guidelines
-- `crates/codestory-cli/Cargo.toml` is the release version source.
-- Update every `codestory-*` workspace crate version and `Cargo.lock` together.
-- Before committing a change that modifies the current unreleased version or
-  creates the next latest version, update `CHANGELOG.md` under `Unreleased` or
-  the new release heading so release contents are tracked while the work is
-  still reviewable.
-- Do not create or push `v*` release tags manually. A synchronized version bump on `main` triggers GitHub Actions to create the tag, GitHub release, cross-platform `codestory-cli` binary assets, and `SHA256SUMS.txt`.
-- After merging a `dev/codestory-next` promotion PR into `main`, verify
-  `dev/codestory-next` still exists and matches `main` with
-  `git ls-remote --heads origin main dev/codestory-next` and
-  `git rev-list --left-right --count origin/main...origin/dev/codestory-next`.
-  If GitHub deletes the head branch, restore it from the promoted `main` commit
-  before treating the release as complete.
-- After a plugin release or plugin-source update that Codex must detect through
-  the marketplace, push a corresponding change to
-  `TheGreenCedar/AgentPluginMarketplace`; Codex observes the marketplace repo
-  state, not only the CodeStory repo release.
-- CI binary assets prove build/package smoke only. Packet/search readiness still requires the sidecar evidence tiers in `docs/contributors/testing-matrix.md`.
+- Routine implementation branches start from and target
+  `dev/codestory-next`. Agent branches use `codex/` by default. Comparison-only
+  reviewer branches may use `review/codestory-saga-*`.
+- Every PR into `main` must come from the same repository's
+  `dev/codestory-next` branch. Release, promotion, hotfix, and review work does
+  not bypass this source-branch guard.
+- Guarded PRs (`codex/*`, `review/codestory-saga-*`, `[codex]` titles, or the
+  saga label) must close a PR-sized issue with `Closes`, `Fixes`, or `Resolves`.
+  Use `Refs` for broader parents. A partial slice closes only its child issue;
+  keep the parent open until its acceptance criteria are met.
+- For PRs targeting `dev/codestory-next`, add both the issue and PR to the
+  Project; computed linked-PR fields may not populate before default-branch
+  promotion.
+- Keep active ownership visible through the issue/PR lane: worktree, branch,
+  base SHA, current head, role, checks, blockers, and next proof target. Keep
+  PRs draft through implementation, independent review, exact-head re-review,
+  and required CI. Ready means mergeable now.
+- PRs should explain context, what changed, how to review, verification, risk,
+  and follow-up. Include exact SHAs and distinguish completed proof from
+  non-claims.
+- Public GitHub status comments must use
+  `node scripts/github-status-comment.mjs --issue <n> --body-file <file>` or
+  stdin; the helper rejects literal `\\n` text.
+- Keep generated comparisons, ledgers, CSVs, SVGs, and pre-release evidence in
+  PR bodies, issue comments, Project updates, CI artifacts, or external
+  storage unless they are intended as durable product documentation.
+- Update `CHANGELOG.md` in the same change when shipped behavior, operator or
+  contributor guidance, release automation, packaging, or version metadata
+  changes. Keep current work under `Unreleased` until release preparation.
+- Commit messages are short, lowercase, and imperative.
 
-## Retrieval documentation
-- Canonical sidecar retrieval docs are `docs/architecture/retrieval-design.md`, `docs/testing/retrieval-architecture.md`, and `docs/ops/retrieval-sidecars.md`. Parser compatibility records live in `docs/architecture/language-support.md`.
+## Release Rules
 
-## Coding & Design Constraints
+- `crates/codestory-cli/Cargo.toml` is the release version source. Synchronize
+  every `codestory-*` workspace crate, `Cargo.lock`, and these plugin manifests:
+  - `plugins/codestory/.codex-plugin/plugin.json`
+  - `plugins/codestory/.claude-plugin/plugin.json`
+  - `plugins/codestory/.github/plugin/plugin.json`
+- Validate release changes with
+  `python .github/scripts/check-codestory-release.py --version <version>` and
+  `node .github/scripts/check-workflow-policy.mjs`.
+- Never create or push `v*` tags manually. A synchronized version bump on
+  `main` triggers the release workflow that creates the tag, GitHub release,
+  native archives, and `SHA256SUMS.txt`.
+- Source checks, built binaries, packaged archives, installed plugin launchers,
+  fresh host sessions, and live full-sidecar behavior are distinct proof tiers.
+  A lower tier cannot support a higher-tier claim. Use the named testing-matrix
+  lane for packet/search readiness, accelerator execution, signing/notarization
+  and Gatekeeper, restart survival, host visibility, or another architecture.
+- After promoting `dev/codestory-next` into `main`, verify the dev branch still
+  exists and matches `main` with:
+  - `git ls-remote --heads origin main dev/codestory-next`
+  - `git rev-list --left-right --count origin/main...origin/dev/codestory-next`
+  Restore a deleted dev branch from the promoted `main` commit before declaring
+  the release complete.
+- Release closeout includes the required source, package, native, protected
+  hardware, post-publish, installed-runtime, and live behavior evidence for the
+  claims being shipped. A merge, tag, or downloadable archive alone is not
+  release completion.
+- When Codex must observe a plugin-source change, publish the corresponding
+  update to `TheGreenCedar/AgentPluginMarketplace`, refresh the marketplace,
+  and verify the installed managed runtime path/version plus project-scoped
+  status. CodeStory repository state alone does not update the marketplace.
 
-Current merge bar for production changes:
+## Platform and Security Notes
 
-1. No holdout literals in production paths — packet/search code must not depend on benchmark holdout repo names, fixture paths, or expected-answer shapes.
-2. Eval probes stay test-only — benchmark-shaped probe catalogs remain behind the test-only eval-probe boundary.
-3. Language support claims match claim tier definitions — distinguish parser-backed graph coverage, structural collectors, and agent-facing packet quality.
-4. Benchmark assertions reference living stats, not hard-coded baselines — repo-scale timing belongs in `docs/testing/codestory-e2e-stats-log.md`.
-5. Retrieval mode changes require sidecar evidence — agent packet/search readiness must report full sidecar retrieval, not semantic-only fallback.
+- On Windows, invoke the Codex npm shim as `codex.cmd`; the extensionless shim
+  can fail with `os error 193`.
+- Keep secrets out of the repository. Pass credentials through approved
+  environment or protected CI secret surfaces, and keep private material out
+  of logs, fixtures, generated artifacts, and comments.
 
-## Security & Configuration Tips
-- Keep secrets out of the repo; pass credentials via environment variables.
+## Canonical References
+
+- Architecture and ownership: `docs/architecture/overview.md` and
+  `docs/architecture/subsystems/`
+- Contributor setup and debugging: `docs/contributors/getting-started.md` and
+  `docs/contributors/debugging.md`
+- Verification, CI maturity, release proof, and evidence tiers:
+  `docs/contributors/testing-matrix.md`
+- Retrieval design and operations: `docs/architecture/retrieval-design.md`,
+  `docs/testing/retrieval-architecture.md`, and
+  `docs/ops/retrieval-sidecars.md`
+- Language claim tiers: `docs/architecture/language-support.md`
+- Agent operational contract:
+  `plugins/codestory/skills/codestory-grounding/SKILL.md` and its references
+- Current CLI syntax: `codestory-cli --help` and subcommand help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Rewrote the repository agent guide around the current request-scoped MCP
+  workflow, crate ownership, identity/publication invariants, isolated test
+  contract, maturity-routed verification, and claim-specific release proof.
 - Staged CI proof by pull-request maturity and changed surface. Draft pushes
   now stay on one Ubuntu source lane, exact-head review promotion runs the full
   workspace test and clippy gate once, and explicit platform promotion selects


### PR DESCRIPTION
## Context

The root agent guide had drifted behind the current request-scoped MCP, identity, publication, verification, and release contracts. It also contained stale test naming, crate, branch-target, cache-identity, and benchmark-baseline guidance.

Closes #1065

## What changed

- Reframed AGENTS.md as the operating contract for agents and contributors.
- Put current-truth discovery and MCP-first self-hosting first.
- Documented crate ownership and dependency direction.
- Added durable identity, immutable configuration, observational-read, atomic-publication, cleanup, retrieval, and evaluation invariants.
- Routed verification through the maturity-based testing matrix and isolated-state contract.
- Corrected the main source-branch guard, synchronized plugin version surfaces, release proof tiers, and telemetry-only stats rule.
- Removed obsolete test naming, package, and session-specific PowerShell guidance.
- Recorded the contributor-guidance change under Unreleased.

## How to review

Read AGENTS.md as a cold-start contract and compare its boundaries with the grounding skill, architecture overview, testing matrix, main source guard, and release checker. The important review question is whether the root file now contains durable decisions while detailed mechanics remain routed to their canonical documents.

## Verification

- `git diff --check`
- `node .github/scripts/check-doc-links.mjs` — 69 files, 281 relative links
- `python .github/scripts/check-codestory-release.py --version 0.14.3` — 8 workspace crates, Cargo.lock, and 3 plugin manifests synchronized
- `node .github/scripts/check-workflow-policy.mjs`

## Risk or follow-up

Documentation and contributor policy only; no runtime, workflow, package, or release-version behavior changed. The main risk is future drift between this decision document and the canonical architecture/testing surfaces, which the rewrite reduces by linking rather than duplicating detailed mechanics.