### PR TITLE
[codex] make windows native embedding start identity reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Fixed
 
+- Replaced the Windows native embedding process-start identity CIM probe with
+  the native process creation time. Immediate post-spawn identity reads no
+  longer depend on CIM convergence and retain the existing serialized format.
 - Made incremental freshness compare verified parser source hashes when file
   mtimes match. Same-timestamp edits now schedule reindexing instead of leaving
   stale graph data current, while legacy and non-parser rows retain the

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -802,6 +802,9 @@ fn normalized_identity_path(path: &str) -> String {
 
 #[cfg(windows)]
 pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String>> {
+    if pid == 0 {
+        bail!("native embedding process pid must be greater than zero");
+    }
     let raw_handle = unsafe { OpenProcess(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
     if raw_handle.is_null() {
         let error = io::Error::last_os_error();
@@ -836,7 +839,10 @@ pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String
 fn windows_datetime_ticks_from_filetime(filetime: &WindowsFileTime) -> Result<u64> {
     let filetime_ticks =
         (u64::from(filetime.high_date_time) << 32) | u64::from(filetime.low_date_time);
-    filetime_ticks
+    // Win32_Process.CreationDate exposes microseconds, so discard sub-microsecond
+    // FILETIME ticks to preserve identities serialized by the previous CIM query.
+    let legacy_filetime_ticks = filetime_ticks / 10 * 10;
+    legacy_filetime_ticks
         .checked_add(WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH)
         .context("convert Windows process creation time to DateTime ticks")
 }
@@ -2011,14 +2017,16 @@ mod tests {
         const WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH: u64 = 116_444_736_000_000_000;
         const DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH: u64 = 621_355_968_000_000_000;
 
+        let unix_epoch_with_sub_microsecond_ticks = WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH + 8;
         let unix_epoch = WindowsFileTime {
-            low_date_time: WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH as u32,
-            high_date_time: (WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH >> 32) as u32,
+            low_date_time: unix_epoch_with_sub_microsecond_ticks as u32,
+            high_date_time: (unix_epoch_with_sub_microsecond_ticks >> 32) as u32,
         };
         assert_eq!(
             windows_datetime_ticks_from_filetime(&unix_epoch)?,
             DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH
         );
+        assert!(native_embedding_process_start_identity(0).is_err());
 
         let mut child = Command::new("cmd.exe")
             .args(["/D", "/S", "/C", "ping -n 30 127.0.0.1 > nul"])

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -20,6 +20,10 @@ use codestory_workspace::{RefreshInputs, WorkspaceManifest};
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "linux")]
 use std::fs;
+#[cfg(windows)]
+use std::io;
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
 use std::path::Path;
 use std::process::Command;
 #[cfg(not(windows))]
@@ -47,7 +51,34 @@ unsafe extern "C" {
     ) -> std::ffi::c_int;
 }
 
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Default)]
+struct WindowsFileTime {
+    low_date_time: u32,
+    high_date_time: u32,
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> RawHandle;
+    fn GetProcessTimes(
+        process: RawHandle,
+        creation_time: *mut WindowsFileTime,
+        exit_time: *mut WindowsFileTime,
+        kernel_time: *mut WindowsFileTime,
+        user_time: *mut WindowsFileTime,
+    ) -> i32;
+}
+
 const NATIVE_EMBEDDING_PROCESS_START_TOLERANCE_MS: i64 = 5 * 1000;
+#[cfg(windows)]
+const WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+#[cfg(windows)]
+const WINDOWS_ERROR_INVALID_PARAMETER: i32 = 87;
+#[cfg(windows)]
+const WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH: u64 = 504_911_232_000_000_000;
 #[cfg(target_os = "macos")]
 const MACOS_CTL_KERN: std::ffi::c_int = 1;
 #[cfg(target_os = "macos")]
@@ -771,24 +802,43 @@ fn normalized_identity_path(path: &str) -> String {
 
 #[cfg(windows)]
 pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String>> {
-    let script = format!(
-        "$p=Get-CimInstance Win32_Process -Filter 'ProcessId = {pid}'; if ($null -eq $p) {{ exit 2 }}; [Console]::Out.Write($p.CreationDate.ToUniversalTime().Ticks)"
-    );
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-Command", &script])
-        .output()
-        .with_context(|| format!("query native embedding start identity for pid {pid}"))?;
-    if output.status.code() == Some(2) {
-        return Ok(None);
+    let raw_handle = unsafe { OpenProcess(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if raw_handle.is_null() {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(WINDOWS_ERROR_INVALID_PARAMETER) {
+            return Ok(None);
+        }
+        return Err(error).with_context(|| format!("open native embedding process {pid}"));
     }
-    if !output.status.success() {
-        bail!(
-            "query native embedding start identity for pid {pid} failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
+    let process = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
+    let mut creation_time = WindowsFileTime::default();
+    let mut exit_time = WindowsFileTime::default();
+    let mut kernel_time = WindowsFileTime::default();
+    let mut user_time = WindowsFileTime::default();
+    if unsafe {
+        GetProcessTimes(
+            process.as_raw_handle(),
+            &mut creation_time,
+            &mut exit_time,
+            &mut kernel_time,
+            &mut user_time,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error())
+            .with_context(|| format!("query native embedding start identity for pid {pid}"));
     }
-    let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok((!identity.is_empty()).then(|| format!("windows:{identity}")))
+    let ticks = windows_datetime_ticks_from_filetime(&creation_time)?;
+    Ok(Some(format!("windows:{ticks}")))
+}
+
+#[cfg(windows)]
+fn windows_datetime_ticks_from_filetime(filetime: &WindowsFileTime) -> Result<u64> {
+    let filetime_ticks =
+        (u64::from(filetime.high_date_time) << 32) | u64::from(filetime.low_date_time);
+    filetime_ticks
+        .checked_add(WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH)
+        .context("convert Windows process creation time to DateTime ticks")
 }
 
 #[cfg(target_os = "linux")]
@@ -1953,6 +2003,39 @@ mod tests {
             log_path: Some("C:/cache/llama-server-native.log".to_string()),
             requested_device: None,
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_native_embedding_start_identity_is_stable_and_compatible() -> Result<()> {
+        const WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH: u64 = 116_444_736_000_000_000;
+        const DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH: u64 = 621_355_968_000_000_000;
+
+        let unix_epoch = WindowsFileTime {
+            low_date_time: WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH as u32,
+            high_date_time: (WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH >> 32) as u32,
+        };
+        assert_eq!(
+            windows_datetime_ticks_from_filetime(&unix_epoch)?,
+            DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH
+        );
+
+        let mut child = Command::new("cmd.exe")
+            .args(["/D", "/S", "/C", "ping -n 30 127.0.0.1 > nul"])
+            .spawn()
+            .context("spawn Windows identity test child")?;
+        let result = (|| -> Result<()> {
+            let first = native_embedding_process_start_identity(child.id())?
+                .context("read Windows child process start identity immediately after spawn")?;
+            let second = native_embedding_process_start_identity(child.id())?
+                .context("repeat Windows child process start identity read")?;
+            assert!(first.starts_with("windows:"));
+            assert_eq!(first, second);
+            Ok(())
+        })();
+        let _ = child.kill();
+        let _ = child.wait();
+        result
     }
 
     #[test]


### PR DESCRIPTION
## Context

Windows native embedding startup records an exact process-start identity before the readiness broker accepts or reuses a managed llama-server process. The existing implementation obtained that identity through a fresh PowerShell/CIM query immediately after spawn. On the packaged Windows x64 Vulkan proof for #1052, that query failed to converge twice even though the process was live and offloaded all 13 layers to Vulkan.

This PR fixes the shared Windows identity source without changing #1052's scheduler work or #1059's identity-V3 migration.

Closes #1067
Refs #1039
Refs #1052

## What Changed

- Replaced the Windows PowerShell/CIM start-identity probe with `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` and `GetProcessTimes`.
- Owns the process handle with `std::os::windows::io::OwnedHandle` so cleanup remains RAII-managed and no dependency is added.
- Converts Windows `FILETIME` creation ticks to the existing .NET `DateTime.Ticks` epoch, truncates the sub-microsecond remainder exposed only by the native API, and preserves values previously serialized through CIM as `windows:<ticks>`.
- Returns `None` only when Windows reports that the PID no longer exists; process access and query failures remain fail-closed errors.
- Kept the existing before/snapshot/after PID-reuse checks and the CIM snapshot used for executable, arguments, and approximate start time.
- Added one Windows regression test for the known epoch conversion and repeated identity reads immediately after child spawn.
- Added an Unreleased changelog entry.

Exact implementation head: `6d3e3e2e5a319021fbd57a3579e4b7f6cae342bc`

## How To Review

1. In `crates/codestory-retrieval/src/sidecar.rs`, verify the Win32 declarations match the documented signatures and the process handle is adopted exactly once by `OwnedHandle`.
2. Verify `WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH` preserves the old PowerShell `.CreationDate.ToUniversalTime().Ticks` value space and that the conversion removes only `FILETIME`'s sub-microsecond remainder.
3. Confirm that only `ERROR_INVALID_PARAMETER` maps to a missing process and every access/query failure is returned.
4. Confirm the existing process snapshot and double start-identity check are unchanged.
5. Run the Windows regression and focused identity/readiness lanes below.

## Verification

Passed locally on Windows x64 at `6d3e3e2e5a319021fbd57a3579e4b7f6cae342bc`:

- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-retrieval --lib windows_native_embedding_start_identity_is_stable_and_compatible`
- `cargo test --locked -p codestory-retrieval --lib native_embedding` (21 passed)
- `cargo test --locked -p codestory-cli readiness_broker` with an isolated test temp root outside `%USERPROFILE%` (43 relevant tests passed across unit and integration targets)
- `cargo check --locked -p codestory-retrieval -p codestory-cli`
- `cargo clippy --locked -p codestory-retrieval --lib -- -D warnings`
- `git diff --check`

The first readiness-broker run placed its injected root under the normal `%USERPROFILE%\AppData\Local\Temp` path and triggered the existing test's platform-cache prefix assertion. Rerunning with `TEMP` and `TMP` set to the isolated `C:\codestory-test-temp-1067` root passed; that root was removed afterward.

## Risk

- The change is Windows-only and preserves the public identity format, but the packaged Windows x64 Vulkan acceptance proof is still required before merge.
- Exact-head source CI, independent re-review, and the Windows x64/ARM64 package cells are pending.
- After merge, #1052 must rebase and rerun its unchanged-generation packet/drill parity proof; this PR does not claim that downstream acceptance yet.
