### PR TITLE
[codex] route Windows-only package proof

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -399,7 +399,7 @@ if (!fs.existsSync(packagedPlatformProof)) {
     "ref:",
     "cancel-in-progress: true",
     "codestory-cli-default-features",
-    "matrix: ${{ fromJSON(inputs.scope == 'macos'",
+    "matrix: ${{ fromJSON(inputs.scope == 'windows'",
   ], snippet => `packaged-platform-proof.yml must include ${snippet}`);
   const macosSigningStep = namedStep(yamlJob(content, "build"), "Sign and notarize macOS CLI").join("\n");
   const blockingNotaryWait = /^\s+--wait(?:\s|\\|$)/mu;
@@ -425,7 +425,7 @@ if (!fs.existsSync(packagedPlatformProof)) {
     violations.push("packaged-platform-proof.yml must include SHA256SUMS.txt in each reusable package artifact");
   }
   const matrixMatch = content.match(
-    /^      matrix: \$\{\{ fromJSON\(inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\) \}\}$/mu,
+    /^      matrix: \$\{\{ fromJSON\(inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\) \}\}$/mu,
   );
   const expectedFullMatrix = {
     include: [
@@ -440,9 +440,16 @@ if (!fs.existsSync(packagedPlatformProof)) {
   const expectedMacMatrix = {
     include: expectedFullMatrix.include.filter(row => row.asset_target.startsWith("macos-")),
   };
+  const expectedWindowsMatrix = {
+    include: expectedFullMatrix.include.filter(row => row.asset_target === "windows-x64"),
+  };
   try {
-    const macMatrix = matrixMatch && JSON.parse(matrixMatch[1]);
-    const fullMatrix = matrixMatch && JSON.parse(matrixMatch[2]);
+    const windowsMatrix = matrixMatch && JSON.parse(matrixMatch[1]);
+    const macMatrix = matrixMatch && JSON.parse(matrixMatch[2]);
+    const fullMatrix = matrixMatch && JSON.parse(matrixMatch[3]);
+    if (JSON.stringify(windowsMatrix) !== JSON.stringify(expectedWindowsMatrix)) {
+      violations.push("packaged-platform-proof.yml windows scope must contain exactly the Windows x64 package row");
+    }
     if (JSON.stringify(macMatrix) !== JSON.stringify(expectedMacMatrix)) {
       violations.push("packaged-platform-proof.yml macos scope must contain exactly the two Mac package rows");
     }
@@ -527,6 +534,7 @@ if (!fs.existsSync(packagedPlatformPr)) {
     "platform-proof",
     "workflow_dispatch:",
     "options: [platform, integration]",
+    "options: [auto, windows, macos, full]",
     "expected_head_sha:",
     "actions: read",
     'test "$head_repo" = "$GITHUB_REPOSITORY"',

--- a/.github/scripts/route-ci-proof.mjs
+++ b/.github/scripts/route-ci-proof.mjs
@@ -7,6 +7,7 @@ const scopeRank = new Map([
   ["macos", 1],
   ["full", 2],
 ]);
+const coordinatorScopes = new Set(["windows", ...scopeRank.keys()]);
 
 const macosSurfaces = [
   /^\.github\/workflows\/macos-/u,
@@ -55,9 +56,10 @@ export function classifyProofScope(paths) {
 export function selectProofScope(paths, requested = "auto") {
   const inferred = classifyProofScope(paths);
   if (requested === "auto" || requested === "") return inferred;
-  if (!scopeRank.has(requested)) {
+  if (!coordinatorScopes.has(requested)) {
     throw new Error(`unsupported proof scope: ${requested}`);
   }
+  if (requested === "windows") return requested;
   return scopeRank.get(requested) > scopeRank.get(inferred) ? requested : inferred;
 }
 
@@ -107,6 +109,9 @@ function selfTest() {
   }
   if (selectProofScope(fixtures[2].paths, "macos") !== "full") {
     throw new Error("explicit promotion must not narrow an inferred scope");
+  }
+  if (selectProofScope(fixtures[2].paths, "windows") !== "windows") {
+    throw new Error("coordinator Windows proof must select only Windows x64 packaging");
   }
 }
 

--- a/.github/workflows/packaged-platform-pr.yml
+++ b/.github/workflows/packaged-platform-pr.yml
@@ -20,11 +20,11 @@ on:
         required: true
         type: string
       scope:
-        description: Auto-detect proof scope or widen it explicitly.
+        description: Auto-detect proof scope or select a coordinator package scope.
         required: true
         default: auto
         type: choice
-        options: [auto, macos, full]
+        options: [auto, windows, macos, full]
 
 permissions:
   actions: read
@@ -301,7 +301,11 @@ jobs:
             require_result "$METAL_RESULT" skipped macos-metal-proof
           else
             require_result "$PACKAGE_RESULT" success packaged-proof
-            require_result "$METAL_RESULT" success macos-metal-proof
+            if [ "$SCOPE" = windows ]; then
+              require_result "$METAL_RESULT" skipped macos-metal-proof
+            else
+              require_result "$METAL_RESULT" success macos-metal-proof
+            fi
           fi
           if [ "$MODE" = integration ]; then
             current_dev="$(gh api "repos/$GITHUB_REPOSITORY/branches/dev/codestory-next" --jq '.commit.sha')"

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -13,7 +13,7 @@ on:
         default: ""
         type: string
       scope:
-        description: Native package matrix scope (macos or full).
+        description: Native package matrix scope (windows, macos, or full).
         required: false
         default: full
         type: string
@@ -67,7 +67,7 @@ jobs:
       # GitHub applies matrix exclusions before includes, so an include-only
       # matrix must select the complete row set rather than trying to exclude
       # rows after the fact.
-      matrix: ${{ fromJSON(inputs.scope == 'macos' && '{"include":[{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"},{"os":"ubuntu-24.04-arm","rust_target":"aarch64-unknown-linux-gnu","asset_target":"linux-arm64","exe_suffix":"","extension":"tar.gz"},{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"},{"os":"windows-11-arm","rust_target":"aarch64-pc-windows-msvc","asset_target":"windows-arm64","exe_suffix":".exe","extension":"zip"},{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}') }}
+      matrix: ${{ fromJSON(inputs.scope == 'windows' && '{"include":[{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"}]}' || inputs.scope == 'macos' && '{"include":[{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}' || '{"include":[{"os":"ubuntu-latest","rust_target":"x86_64-unknown-linux-gnu","asset_target":"linux-x64","exe_suffix":"","extension":"tar.gz"},{"os":"ubuntu-24.04-arm","rust_target":"aarch64-unknown-linux-gnu","asset_target":"linux-arm64","exe_suffix":"","extension":"tar.gz"},{"os":"windows-latest","rust_target":"x86_64-pc-windows-msvc","asset_target":"windows-x64","exe_suffix":".exe","extension":"zip"},{"os":"windows-11-arm","rust_target":"aarch64-pc-windows-msvc","asset_target":"windows-arm64","exe_suffix":".exe","extension":"zip"},{"os":"macos-15-intel","rust_target":"x86_64-apple-darwin","asset_target":"macos-x64","exe_suffix":"","extension":"tar.gz"},{"os":"macos-15","rust_target":"aarch64-apple-darwin","asset_target":"macos-arm64","exe_suffix":"","extension":"tar.gz"}]}') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- Added a Windows-x64-only promoted proof scope so coordinator runs can produce
+  the Vulkan package without starting Mac source, signing, notarization, or
+  Metal jobs.
 - Reduced the packaged macOS proof to one check per release boundary. The
   protected run still covers managed Metal cold/warm/recovery, exact process
   reuse, dead-endpoint blocking, Intel CPU/external labelling, and proof-owned

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -155,8 +155,10 @@ same-repository `platform-proof` label or coordinator dispatch rechecks the
 exact PR head and requires a completed successful `full-source-gate` job for
 that SHA, then routes script/test-guard-only changes to `none`, Mac lifecycle
 changes to the two Mac targets, and cross-platform runtime or packaging changes
-to all six targets. Forks are rejected before checkout and no proof lane uses
-`pull_request_target` to execute PR code.
+to all six targets. A coordinator can explicitly select `windows` to build only
+the Windows x64 package for an external Windows proof; that scope skips Mac
+source and Metal jobs and receives no signing credentials. Forks are rejected
+before checkout and no proof lane uses `pull_request_target` to execute PR code.
 
 The `review-accepted` label runs the full Ubuntu source gate once for that exact
 head; the persistent label alone does not authorize later heads. After merge,


### PR DESCRIPTION
## Context

Closes #1063
Refs #1039

CodeStory's promoted platform workflow normally infers either no package work, the two Mac targets, or the complete six-target native matrix. A Windows acceptance run sometimes needs only the hosted Windows x64 package before a separate physical Windows/Vulkan proof. Running the Mac source, Metal, and other package cells cannot strengthen that Windows claim and consumes scarce runners.

This branch is refreshed directly onto `dev/codestory-next` at `e7cfa0e7afaed870321dc11666bb5127c00feace`.

## Outcome

A coordinator can explicitly select `windows` for an accepted exact PR head. The reusable package workflow then builds exactly `windows-x64`, while Mac source and Metal jobs skip and the PR workflow receives no signing credentials.

## What changed

- Added the coordinator-only `windows` routing choice without changing automatic scope inference.
- Added a one-row Windows x64 package matrix alongside the existing two-target Mac and six-target full matrices.
- Made closeout require a successful Windows package and a skipped Metal job for this scope.
- Added policy coverage for the exact target sets and documented the new proof boundary in the testing matrix and changelog.

## How to review

1. Check `.github/scripts/route-ci-proof.mjs`: automatic routing is unchanged; only an explicit coordinator request can narrow to `windows`.
2. Check `.github/workflows/packaged-platform-proof.yml`: the Windows scope contains exactly `windows-latest` / `windows-x64`.
3. Check `.github/workflows/packaged-platform-pr.yml`: Mac source and Metal skip, `sign_macos` remains `false`, and no caller secrets are inherited.

## Verification

- `node .github/scripts/route-ci-proof.mjs --self-test` — passed
- `node .github/scripts/check-workflow-policy.mjs` — passed
- `actionlint .github/workflows/packaged-platform-pr.yml .github/workflows/packaged-platform-proof.yml` — passed
- `node .github/scripts/check-doc-links.mjs` — passed, 69 files / 281 relative links
- `git diff --check origin/dev/codestory-next...HEAD` — passed

## Risk or follow-up

- This PR does not claim a Windows hardware pass. After independent review and successful exact-head source proof, the coordinator can dispatch the Windows scope and hand its single artifact to the external Windows x64 Vulkan proof.
- Keep the PR draft until that exact-head review boundary is accepted. Do not trigger Mac, signing, notarization, or Metal proof for this lane.
