### PR TITLE
activate release evidence gate

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -10,6 +10,7 @@ const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
 const closeDevIssues = path.join(workflowRoot, "close-dev-issues.yml");
 const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
 const rustCi = path.join(workflowRoot, "rust-ci.yml");
+const autoRelease = path.join(workflowRoot, "auto-release.yml");
 const releaseWorkflow = path.join(workflowRoot, "release.yml");
 const releaseCandidateEvidence = path.join(workflowRoot, "release-candidate-evidence.yml");
 const releaseNotesExtractor = path.join(".github", "scripts", "extract-codestory-release-notes.mjs");
@@ -316,6 +317,8 @@ if (!fs.existsSync(releaseWorkflow)) {
     violations.push("release.yml release builds must not install floating stable Rust");
   }
   requireContent(content, [
+    "actions: read",
+    "uses: ./.github/workflows/release-candidate-evidence.yml",
     "uses: ./.github/workflows/packaged-platform-proof.yml",
     "sign_macos: true",
     "APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}",
@@ -338,6 +341,25 @@ if (!fs.existsSync(releaseWorkflow)) {
     "gated on packaged managed-Metal cold/warm reuse, dead-endpoint blocking, recovery, packet, and search proof",
     "Linux x64 is packaged and executed at the glibc 2.31 baseline; this does not claim musl support or Linux arm64 baseline parity.",
   ], snippet => `release.yml must include ${snippet}`);
+  const releaseEvidenceJob = yamlJob(content, "release-evidence");
+  requireContent(releaseEvidenceJob.join("\n"), [
+    "needs: preflight",
+    "ref: ${{ github.sha }}",
+    "proof_key: release-${{ needs.preflight.outputs.version }}",
+    "profile: codestory-release-evidence-linux-arm64-v1",
+    "drill_manifest: /srv/codestory-release-evidence/drills/real-repo-drill-cases.json",
+    "embedding_model_dir: /srv/codestory-release-evidence/models",
+    "source_run_id: ${{ inputs.source_run_id }}",
+  ], snippet => `release.yml release-evidence job must include ${snippet}`);
+  const packagedProofJob = yamlJob(content, "packaged-proof");
+  if (!packagedProofJob.includes("      - release-evidence")) {
+    violations.push("release.yml packaged-proof must wait for release-evidence");
+  }
+  const sourceRunInputDescription =
+    'description: "Optional rejected release-evidence run to re-evaluate without measuring again"';
+  if ((content.match(new RegExp(sourceRunInputDescription, "gu")) ?? []).length !== 2) {
+    violations.push("release.yml must expose optional source_run_id inputs for calls and dispatches");
+  }
   if (!fs.existsSync(releaseNotesExtractor)) {
     violations.push("release.yml must use the checked-in versioned changelog extractor");
   }
@@ -370,6 +392,29 @@ if (!fs.existsSync(releaseWorkflow)) {
     "needs:\n      - preflight\n      - packaged-proof\n      - macos-metal-proof\n    runs-on: ubuntu-latest",
     "needs:\n      - preflight\n      - publish\n    uses: ./.github/workflows/post-publish-release-smoke.yml",
   ], row => `release.yml must preserve release proof block ${row.split("\n")[0]}`);
+}
+
+if (!fs.existsSync(autoRelease)) {
+  violations.push("auto-release.yml must exist for main release detection");
+} else {
+  const content = fs.readFileSync(autoRelease, "utf8");
+  requireContent(content, [
+    ".github/workflows/release-candidate-evidence.yml",
+    "benchmarks/release-evidence/**",
+    "benchmarks/tasks/manifest.schema.json",
+    "benchmarks/tasks/holdout-retrieval/**",
+    "scripts/codestory-agent-ab-benchmark.mjs",
+    "scripts/codestory-agent-value-score.mjs",
+    "scripts/codestory-benchmark-contract.mjs",
+    "scripts/codestory-evidence-provenance.mjs",
+    "scripts/codestory-release-evidence-gate.mjs",
+    "scripts/codestory-release-evidence-runner.sh",
+    "scripts/release-evidence/**",
+  ], snippet => `auto-release.yml must trigger for ${snippet}`);
+  const releaseJob = yamlJob(content, "release");
+  if (!releaseJob.includes("      actions: read")) {
+    violations.push("auto-release.yml release job must allow prior-run evidence download");
+  }
 }
 
 if (!fs.existsSync(packagedPlatformProof)) {

--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -23,12 +23,18 @@ const sourceProof = path.join(workflowRoot, "source-proof.yml");
 const repoScaleStats = path.join(workflowRoot, "repo-scale-stats.yml");
 const retrievalSidecarSmoke = path.join(workflowRoot, "retrieval-sidecar-smoke.yml");
 
-function yamlJob(content, name) {
+function yamlMapping(content, name, indent) {
   const lines = content.split(/\r?\n/u);
-  const start = lines.indexOf(`  ${name}:`);
+  const padding = " ".repeat(indent);
+  const start = lines.indexOf(`${padding}${name}:`);
   if (start < 0) return [];
-  const end = lines.findIndex((line, index) => index > start && /^  \S/iu.test(line));
+  const sibling = new RegExp(`^${padding}\\S`, "u");
+  const end = lines.findIndex((line, index) => index > start && sibling.test(line));
   return lines.slice(start, end < 0 ? undefined : end);
+}
+
+function yamlJob(content, name) {
+  return yamlMapping(content, name, 2);
 }
 
 function namedStep(job, name) {
@@ -318,7 +324,6 @@ if (!fs.existsSync(releaseWorkflow)) {
   }
   requireContent(content, [
     "actions: read",
-    "uses: ./.github/workflows/release-candidate-evidence.yml",
     "uses: ./.github/workflows/packaged-platform-proof.yml",
     "sign_macos: true",
     "APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}",
@@ -355,10 +360,15 @@ if (!fs.existsSync(releaseWorkflow)) {
   if (!packagedProofJob.includes("      - release-evidence")) {
     violations.push("release.yml packaged-proof must wait for release-evidence");
   }
-  const sourceRunInputDescription =
-    'description: "Optional rejected release-evidence run to re-evaluate without measuring again"';
-  if ((content.match(new RegExp(sourceRunInputDescription, "gu")) ?? []).length !== 2) {
-    violations.push("release.yml must expose optional source_run_id inputs for calls and dispatches");
+  for (const trigger of ["workflow_call", "workflow_dispatch"]) {
+    const triggerBlock = yamlMapping(content, trigger, 2).join("\n");
+    const inputsBlock = yamlMapping(triggerBlock, "inputs", 4).join("\n");
+    const sourceRunInput = yamlMapping(inputsBlock, "source_run_id", 6).join("\n");
+    requireContent(
+      sourceRunInput,
+      ["required: false", "type: string", 'default: ""'],
+      field => `release.yml ${trigger} source_run_id input must include ${field}`,
+    );
   }
   if (!fs.existsSync(releaseNotesExtractor)) {
     violations.push("release.yml must use the checked-in versioned changelog extractor");
@@ -398,19 +408,6 @@ if (!fs.existsSync(autoRelease)) {
   violations.push("auto-release.yml must exist for main release detection");
 } else {
   const content = fs.readFileSync(autoRelease, "utf8");
-  requireContent(content, [
-    ".github/workflows/release-candidate-evidence.yml",
-    "benchmarks/release-evidence/**",
-    "benchmarks/tasks/manifest.schema.json",
-    "benchmarks/tasks/holdout-retrieval/**",
-    "scripts/codestory-agent-ab-benchmark.mjs",
-    "scripts/codestory-agent-value-score.mjs",
-    "scripts/codestory-benchmark-contract.mjs",
-    "scripts/codestory-evidence-provenance.mjs",
-    "scripts/codestory-release-evidence-gate.mjs",
-    "scripts/codestory-release-evidence-runner.sh",
-    "scripts/release-evidence/**",
-  ], snippet => `auto-release.yml must trigger for ${snippet}`);
   const releaseJob = yamlJob(content, "release");
   if (!releaseJob.includes("      actions: read")) {
     violations.push("auto-release.yml release job must allow prior-run evidence download");
@@ -696,6 +693,8 @@ if (!fs.existsSync(releaseCandidateEvidence)) {
     "environment: release-evidence",
     "runs-on: [self-hosted, Linux, ARM64, codestory-release-evidence]",
     "ref: ${{ inputs.ref }}",
+    "validate-source-run",
+    "actions/runs/$SOURCE_RUN_ID",
     "--test-threads=1",
     "release-evidence-${{ inputs.ref }}",
   ], snippet => `release evidence workflow must include ${snippet}`);

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,9 +11,20 @@ on:
       - AGENTS.md
       - docs/contributors/testing-matrix.md
       - .github/workflows/auto-release.yml
+      - .github/workflows/release-candidate-evidence.yml
       - .github/workflows/release.yml
       - .github/scripts/**
+      - benchmarks/release-evidence/**
+      - benchmarks/tasks/manifest.schema.json
+      - benchmarks/tasks/holdout-retrieval/**
       - plugins/codestory/**
+      - scripts/codestory-agent-ab-benchmark.mjs
+      - scripts/codestory-agent-value-score.mjs
+      - scripts/codestory-benchmark-contract.mjs
+      - scripts/codestory-evidence-provenance.mjs
+      - scripts/codestory-release-evidence-gate.mjs
+      - scripts/codestory-release-evidence-runner.sh
+      - scripts/release-evidence/**
 
 permissions:
   contents: read
@@ -69,6 +80,7 @@ jobs:
     needs: detect-version
     if: needs.detect-version.outputs.should_release == 'true'
     permissions:
+      actions: read
       contents: write
     uses: ./.github/workflows/release.yml
     with:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,20 +11,9 @@ on:
       - AGENTS.md
       - docs/contributors/testing-matrix.md
       - .github/workflows/auto-release.yml
-      - .github/workflows/release-candidate-evidence.yml
       - .github/workflows/release.yml
       - .github/scripts/**
-      - benchmarks/release-evidence/**
-      - benchmarks/tasks/manifest.schema.json
-      - benchmarks/tasks/holdout-retrieval/**
       - plugins/codestory/**
-      - scripts/codestory-agent-ab-benchmark.mjs
-      - scripts/codestory-agent-value-score.mjs
-      - scripts/codestory-benchmark-contract.mjs
-      - scripts/codestory-evidence-provenance.mjs
-      - scripts/codestory-release-evidence-gate.mjs
-      - scripts/codestory-release-evidence-runner.sh
-      - scripts/release-evidence/**
 
 permissions:
   contents: read

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -134,7 +134,14 @@ jobs:
           EVIDENCE_SHA: ${{ inputs.ref }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
         run: |
+          set -euo pipefail
           mkdir -p target/release-evidence
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
+            > target/release-evidence/source-run.json
+          node scripts/codestory-release-evidence-gate.mjs validate-source-run \
+            --run target/release-evidence/source-run.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --expected-sha "$EVIDENCE_SHA"
           gh run download "$SOURCE_RUN_ID" \
             --repo "$GITHUB_REPOSITORY" \
             --name "release-evidence-$EVIDENCE_SHA" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,25 @@ on:
         description: "Release version from crates/codestory-cli/Cargo.toml, for example 0.7.0"
         required: true
         type: string
+      source_run_id:
+        description: "Optional rejected release-evidence run to re-evaluate without measuring again"
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       version:
         description: "Release version from crates/codestory-cli/Cargo.toml, for example 0.7.0"
         required: true
         type: string
+      source_run_id:
+        description: "Optional rejected release-evidence run to re-evaluate without measuring again"
+        required: false
+        type: string
+        default: ""
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -89,8 +100,21 @@ jobs:
             exit 1
           fi
 
-  packaged-proof:
+  release-evidence:
     needs: preflight
+    uses: ./.github/workflows/release-candidate-evidence.yml
+    with:
+      ref: ${{ github.sha }}
+      proof_key: release-${{ needs.preflight.outputs.version }}
+      profile: codestory-release-evidence-linux-arm64-v1
+      drill_manifest: /srv/codestory-release-evidence/drills/real-repo-drill-cases.json
+      embedding_model_dir: /srv/codestory-release-evidence/models
+      source_run_id: ${{ inputs.source_run_id }}
+
+  packaged-proof:
+    needs:
+      - preflight
+      - release-evidence
     uses: ./.github/workflows/packaged-platform-proof.yml
     with:
       version: ${{ needs.preflight.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   search, indexing, and storage budgets.
 - Wired releases through protected Linux ARM64 release evidence after preflight
   and before packaged proof, with optional same-SHA prior-run re-evaluation and
-  auto-release routing for every release-evidence contract surface.
+  the same gate for manual and main-triggered releases.
 - GitHub releases now use the exact matching version section from this
   changelog before the existing platform proof-boundary appendix. Publication
   fails when that version section is missing, duplicated, or empty instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Approved the first protected Linux ARM64 release-evidence baseline with
   pinned machine identity and explicit status, grounding, convergence, packet,
   search, indexing, and storage budgets.
+- Wired releases through protected Linux ARM64 release evidence after preflight
+  and before packaged proof, with optional same-SHA prior-run re-evaluation and
+  auto-release routing for every release-evidence contract surface.
 - GitHub releases now use the exact matching version section from this
   changelog before the existing platform proof-boundary appendix. Publication
   fails when that version section is missing, duplicated, or empty instead of

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -135,18 +135,25 @@ scripts/codestory-release-evidence-runner.sh destroy
 
 ## Release workflow handoff
 
-Dispatch `.github/workflows/release-candidate-evidence.yml` only from a trusted,
-exact release head. The first measurement uses:
+`release.yml` calls `release-candidate-evidence.yml` on the exact release head
+after preflight and before packaged proof. The automatic path measures fresh
+evidence with:
 
 | Input | Value |
 | --- | --- |
-| `profile` | the release-eligible profile created from the approved baseline |
+| `profile` | `codestory-release-evidence-linux-arm64-v1` |
 | `drill_manifest` | `/srv/codestory-release-evidence/drills/real-repo-drill-cases.json` |
 | `embedding_model_dir` | `/srv/codestory-release-evidence/models` |
 | `source_run_id` | empty for measurement; a rejected run ID only for exact-artifact re-evaluation |
+
+If a measured candidate is rejected and receives an exact, expiring approval,
+manually dispatch `release.yml` on the same SHA and version with
+`source_run_id=<rejected-run-id>`. The reusable workflow downloads that run's
+artifact and evaluates it again without producing new measurements.
 
 The workflow uploads `release-evidence-<full SHA>` from
 `target/release-evidence`, including provisioning, raw stats, packet summary,
 candidate, approval when supplied, and report files that exist. Runner
 provisioning alone does not establish a baseline, execute the real-repo drill,
-or prove a candidate acceptable.
+or prove a candidate acceptable. The release remains blocked until the selected
+profile exists as an approved, release-eligible baseline.

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -149,7 +149,9 @@ evidence with:
 If a measured candidate is rejected and receives an exact, expiring approval,
 manually dispatch `release.yml` on the same SHA and version with
 `source_run_id=<rejected-run-id>`. The reusable workflow downloads that run's
-artifact and evaluates it again without producing new measurements.
+artifact and evaluates it again without producing new measurements. Before the
+download, it requires a failed trusted evidence workflow from this repository
+whose head is the exact evidence SHA.
 
 The workflow uploads `release-evidence-<full SHA>` from
 `target/release-evidence`, including provisioning, raw stats, packet summary,

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -430,8 +430,8 @@ were `full`. The log is telemetry only and cannot become a release baseline by
 appending a row. Use the approved profile and release decision command in
 [`performance-review-playbook.md`](../testing/performance-review-playbook.md).
 The harness still emits its prior latest-row warnings and repeat-refresh
-blocker during the transition; release workflow authorization comes only from
-the attested gate below.
+blocker as diagnostics; release workflow authorization comes only from the
+attested gate below.
 
 Release-readiness evidence is tiered:
 
@@ -485,14 +485,14 @@ stats and packet-runtime artifacts into the seven-metric candidate described in
 the performance playbook, then run
 `scripts/codestory-release-evidence-gate.mjs`. The selected machine profile
 must be approved, release-eligible, pinned to attested raw evidence, and match
-the candidate's corpus, cache, and machine fingerprint. Candidate artifacts can
-be produced on the same clean full SHA by the explicit manual/reusable
-`release-candidate-evidence.yml` workflow. This infrastructure is not wired to
-the release workflow until a live eligible baseline exists. A rejected metric
-blocks the release unless a non-expired exception binds the exact candidate
-hash, baseline id/hash, profile, metric, measured value, threshold, owner, ISO
-date, and rationale. Preserve the emitted decision JSON; it carries status,
-metric, decision, commit, and artifact paths/hashes.
+the candidate's corpus, cache, and machine fingerprint. Candidate artifacts are
+produced on the same clean full SHA by the reusable
+`release-candidate-evidence.yml` workflow. `release.yml` calls it after
+preflight and requires it to pass before packaged proof starts. A rejected
+metric blocks the release unless a non-expired exception binds the exact
+candidate hash, baseline id/hash, profile, metric, measured value, threshold,
+owner, ISO date, and rationale. Preserve the emitted decision JSON; it carries
+status, metric, decision, commit, and artifact paths/hashes.
 
 The dedicated Linux ARM64 evidence profile explicitly allows CPU embeddings
 from its checksum-verified preseeded model. Fresh measurements retain the raw
@@ -500,13 +500,14 @@ repo-scale log, stats JSON, and complete real-repo drill tree. Before a distinct
 release-eligible baseline exists, artifact production succeeds but evaluation
 must reject the first run; retained output alone is not acceptance.
 
-Only the manual `release-evidence` mode of the registered platform-proof
-coordinator can reach that self-hosted runner. Its hosted resolver first requires
-a same-repository PR into `dev/codestory-next`, its exact expected head, the
-`review-accepted` label, and a successful exact-head source proof. It then calls
-the reusable evidence workflow with fixed profile and runner paths. The resolved
-SHA is checked out behind the protected `release-evidence` environment; the
-ambient dispatch ref is never measured. Runner groups are unavailable for this
+The main-triggered release and the manual `release-evidence` mode of the
+registered platform-proof coordinator can reach that self-hosted runner. The
+coordinator's hosted resolver first requires a same-repository PR into
+`dev/codestory-next`, its exact expected head, the `review-accepted` label, and
+a successful exact-head source proof. Both entry points call the reusable
+evidence workflow with fixed profile and runner paths. The selected SHA is
+checked out behind the protected `release-evidence` environment; an ambient
+dispatch ref is never substituted. Runner groups are unavailable for this
 personal-account repository, so environment approval is the allocation guard.
 The two live tests run serially and must prove their owned sidecars are gone
 before the packet benchmark starts.

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -108,9 +108,8 @@ Do not hand-author candidate metrics. The provisioned
 publishable packet producers on the same clean SHA, records the corpus, cache,
 and machine fingerprint, hashes both non-empty raw artifacts, and derives the
 candidate. It refuses contract-only profiles during release runs. The release
-workflow is not yet activated; legacy warnings and blockers remain authoritative
-until the activation child has a provisioned release-eligible baseline and live
-candidate report.
+workflow calls this gate after preflight and does not start packaged proof until
+the evidence decision passes.
 
 Provision, verify, recover, and unregister the dedicated Linux host using the
 [release-evidence runner runbook](../contributors/release-evidence-runner.md).
@@ -161,15 +160,16 @@ artifact can become release-eligible.
 On rejection, the workflow uploads provisioning, raw, candidate, approval (when
 provided), and report files with `if: always()`. Author an exception against the
 reported hashes and values in the
-`CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON` secret, then dispatch the same SHA
-with `source_run_id=<rejected-run-id>`. That path downloads and re-evaluates the
+`CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON` secret, then dispatch the Release
+workflow on the same SHA and version with
+`source_run_id=<rejected-run-id>`. That path downloads and re-evaluates the
 exact candidate without re-running measurements; any SHA, hash, value, profile,
 baseline, threshold, date, or expiry drift still fails.
 
 The checked-in `ci-contract-v1` fixture and report exercise this trust chain in
-ordinary CI but are explicitly `release_eligible: false`. A product profile must
-be created from provisioned raw evidence and explicitly approved before a
-release workflow can adopt this gate.
+ordinary CI but are explicitly `release_eligible: false`. The release path uses
+only a product profile created from provisioned raw evidence and explicitly
+approved in the baseline document.
 
 The corpus boundary is deliberately precise. The generalization lint scans Rust
 production files in all non-benchmark crates for copied corpus content, direct

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -19,6 +19,11 @@ const SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const MACHINE_FINGERPRINT = /^[A-Za-z0-9][A-Za-z0-9._:/+-]{2,199}$/;
+const SOURCE_RUN_PRODUCERS = new Map([
+  [".github/workflows/packaged-platform-pr.yml", new Set(["workflow_dispatch"])],
+  [".github/workflows/release.yml", new Set(["workflow_dispatch"])],
+  [".github/workflows/auto-release.yml", new Set(["push"])],
+]);
 
 function fail(message) { throw new Error(message); }
 function object(value, label) {
@@ -84,6 +89,25 @@ function machineFingerprint() {
   const cpu = os.cpus()[0]?.model?.trim() ?? "unknown";
   const memoryGiB = Math.round(os.totalmem() / 2 ** 30);
   return `${process.platform}/${process.arch}/${os.cpus().length}/${cpu}/${memoryGiB}GiB`;
+}
+
+export function validateSourceRunMetadata({ run, expectedRepo, expectedSha }) {
+  object(run, "source run");
+  const repo = text(expectedRepo, "expected repository");
+  const sha = fullSha(expectedSha, "expected SHA");
+  if (run.repository?.full_name !== repo || run.head_repository?.full_name !== repo) {
+    fail("source run must come from the current repository");
+  }
+  if (fullSha(run.head_sha, "source run head SHA") !== sha) {
+    fail("source run head SHA does not match the evidence SHA");
+  }
+  if (run.conclusion !== "failure") {
+    fail("source run must be a rejected failed evidence run");
+  }
+  const events = SOURCE_RUN_PRODUCERS.get(run.path);
+  if (!events?.has(run.event)) {
+    fail("source run workflow and event are not trusted evidence producers");
+  }
 }
 function profileFrom(document, name, mode, baselineDir) {
   if (document.schema_version !== 2) fail("baseline schema_version must be 2");
@@ -344,6 +368,14 @@ function main() {
     console.log(machineFingerprint());
     return;
   }
+  if (command === "validate-source-run") {
+    validateSourceRunMetadata({
+      run: readJson(values.run, "source run"),
+      expectedRepo: values.repo,
+      expectedSha: values["expected-sha"],
+    });
+    return;
+  }
   const repoRoot = path.resolve(values.repo ?? path.resolve(path.dirname(new URL(import.meta.url).pathname), ".."));
   const baselineDocument = readJson(values.baseline, "baseline");
   const baselineDir = path.dirname(path.resolve(values.baseline));
@@ -352,7 +384,7 @@ function main() {
   else if (command === "evaluate") {
     const report = evaluateCandidate({ baselineDocument, baselineDir, candidatePath: values.candidate, approvalDocument: values.approval ? readJson(values.approval, "approval") : null, outPath: values.out, expectedSha: values["expected-sha"], mode, repoRoot });
     if (!report.decision.startsWith("accept_")) process.exitCode = 1;
-  } else fail("command must be produce or evaluate");
+  } else fail("command must be fingerprint, validate-source-run, produce, or evaluate");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) main();

--- a/scripts/lint-retrieval-generalization.mjs
+++ b/scripts/lint-retrieval-generalization.mjs
@@ -131,6 +131,11 @@ const allowedHarnessReferences = [
     "uses: ./.github/workflows/release-candidate-evidence.yml",
   ],
   [
+    path.join(".github", "workflows", "release.yml"),
+    ".github/workflows/release-candidate-evidence.yml",
+    "uses: ./.github/workflows/release-candidate-evidence.yml",
+  ],
+  [
     path.join(".github", "scripts", "route-ci-proof.mjs"),
     ".github/workflows/retrieval-sidecar-smoke.yml",
     "\".github/workflows/retrieval-sidecar-smoke.yml\",",

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -65,6 +65,38 @@ test("fingerprint prefers a validated provisioned machine identity", () => {
   assert.match(result.stderr, /observed identity attestation changed/);
 });
 
+test("prior-run reuse requires an exact failed trusted producer", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "codestory-source-run-"));
+  const runPath = path.join(dir, "run.json");
+  const run = {
+    path: ".github/workflows/packaged-platform-pr.yml",
+    event: "workflow_dispatch",
+    conclusion: "failure",
+    head_sha: candidateSha,
+    repository: { full_name: "TheGreenCedar/CodeStory" },
+    head_repository: { full_name: "TheGreenCedar/CodeStory" },
+  };
+  const validate = () => spawnSync(process.execPath, [
+    script,
+    "validate-source-run",
+    "--run", runPath,
+    "--repo", "TheGreenCedar/CodeStory",
+    "--expected-sha", candidateSha,
+  ], { encoding: "utf8" });
+
+  writeFileSync(runPath, JSON.stringify(run));
+  assert.equal(validate().status, 0);
+
+  run.path = ".github/workflows/arbitrary-pr.yml";
+  writeFileSync(runPath, JSON.stringify(run));
+  assert.match(validate().stderr, /not trusted evidence producers/);
+
+  run.path = ".github/workflows/packaged-platform-pr.yml";
+  run.head_sha = "3".repeat(40);
+  writeFileSync(runPath, JSON.stringify(run));
+  assert.match(validate().stderr, /does not match the evidence SHA/);
+});
+
 test("checked-in candidate and report are deterministic and fully attested", () => {
   const dir = workspace();
   const out = path.join(dir, "report.json");

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -147,6 +147,12 @@ test("regression approval is bound to candidate hash, value, threshold, baseline
   writeFileSync(approvalPath, JSON.stringify(approval));
   result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--approval", approvalPath, "--out", reportPath]);
   assert.equal(result.status, 0, result.stderr);
+  approval.metrics.status_seconds.expires_at = "2026-07-12";
+  writeFileSync(approvalPath, JSON.stringify(approval));
+  result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--approval", approvalPath, "--out", reportPath]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /approval is expired/);
+  approval.metrics.status_seconds.expires_at = "2099-07-11";
   approval.metrics.status_seconds.measured_value = 1.9;
   writeFileSync(approvalPath, JSON.stringify(approval));
   result = run("evaluate", ["--candidate", path.join(dir, "candidate.json"), "--approval", approvalPath, "--out", reportPath]);


### PR DESCRIPTION
## Outcome

Wires the reusable protected release-evidence workflow into both release entry points after preflight and before packaged proof. Ordinary PRs remain unsigned: PR package proof sets `sign_macos: false`, cannot receive Apple secrets, and cannot reference `macos-release-signing`. Developer ID signing and notarization remain publication-only work in `release.yml`.

## Scope

- add the protected release-evidence job to manual and automatic release entry points
- allow exact rejected-run re-evaluation through an optional `source_run_id`
- validate reused runs against repository, exact SHA, producer workflow, event, and failed conclusion
- grant the main-triggered release caller read access to retained evidence runs
- enforce the PR/release signing boundary in workflow policy
- document the activated gate and recovery path

## Evidence

- protected baseline run `29313560991` passed full-sidecar stats and 9/9 publishable packet runs
- baseline approved by #1084 and pinned as `codestory-release-evidence-linux-arm64-v1@b09b8c44`
- independent exact-head review found no remaining source blocker

## Verification

- `node .github/scripts/check-workflow-policy.mjs`
- `node --test scripts/tests/codestory-release-evidence-gate.test.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `node scripts/lint-retrieval-generalization.mjs`
- `actionlint .github/workflows/release-candidate-evidence.yml .github/workflows/release.yml .github/workflows/auto-release.yml`
- `git diff --check`

Closes #958
Refs #922