### PR TITLE
[codex] fix release evidence packet modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Release evidence now reconciles packet benchmark selector names with the
+  transport mode identifiers recorded by real packet rows.
 - Approved the first protected Linux ARM64 release-evidence baseline with
   pinned machine identity and explicit status, grounding, convergence, packet,
   search, indexing, and storage budgets.

--- a/benchmarks/release-evidence/fixtures/candidate-packet.json
+++ b/benchmarks/release-evidence/fixtures/candidate-packet.json
@@ -18,7 +18,7 @@
       {
         "repo": "fixture",
         "task_id": "quality-contract",
-        "mode": "cold-cli",
+        "mode": "cold_cli_packet",
         "repeat": 1,
         "status": "pass",
         "quality": { "pass": true },
@@ -43,7 +43,7 @@
       {
         "repo": "fixture",
         "task_id": "quality-contract",
-        "mode": "cold-cli",
+        "mode": "cold_cli_packet",
         "repeat": 2,
         "status": "pass",
         "quality": { "pass": true },
@@ -68,7 +68,7 @@
       {
         "repo": "fixture",
         "task_id": "quality-contract",
-        "mode": "cold-cli",
+        "mode": "cold_cli_packet",
         "repeat": 3,
         "status": "pass",
         "quality": { "pass": true },
@@ -93,7 +93,7 @@
     ]
   },
   "summary": [
-    { "task": "one", "median_e2e_wall_ms": 800 },
-    { "task": "two", "median_e2e_wall_ms": 900 }
+    { "task": "one", "mode": "cold_cli_packet", "median_e2e_wall_ms": 800 },
+    { "task": "two", "mode": "cold_cli_packet", "median_e2e_wall_ms": 900 }
   ]
 }

--- a/benchmarks/release-evidence/fixtures/candidate.json
+++ b/benchmarks/release-evidence/fixtures/candidate.json
@@ -18,8 +18,8 @@
     },
     "packet": {
       "path": "candidate-packet.json",
-      "sha256": "ff3bb834b3e473e2f099dbbf8a52651622039dddb60a2ce2b9b2e0bd40c21a0f",
-      "bytes": 4911
+      "sha256": "a541c576391fec8949a470c6de2920b8c9387fbdfcaad82cd42700dedae5956e",
+      "bytes": 4986
     }
   },
   "metrics": {

--- a/benchmarks/release-evidence/fixtures/report.json
+++ b/benchmarks/release-evidence/fixtures/report.json
@@ -7,7 +7,7 @@
   "baseline_id": "ci-contract-v1@1111111111111111111111111111111111111111",
   "baseline_sha256": "e7488c0625620ebeaf669fab3b9d4150a29b60d08398a3c6a005b2ee4c152642",
   "candidate_path": "benchmarks/release-evidence/fixtures/candidate.json",
-  "candidate_sha256": "6e34aa50106f6cac5ac66b9deb464575d285f2d110cd640336541b51e9f56937",
+  "candidate_sha256": "0bae343abdfbf71c9957e234e4df0406d01682a12b18e26ab0d4d7e8fedef126",
   "artifact_paths": [
     {
       "path": "candidate-stats.json",
@@ -16,8 +16,8 @@
     },
     {
       "path": "candidate-packet.json",
-      "sha256": "ff3bb834b3e473e2f099dbbf8a52651622039dddb60a2ce2b9b2e0bd40c21a0f",
-      "bytes": 4911
+      "sha256": "a541c576391fec8949a470c6de2920b8c9387fbdfcaad82cd42700dedae5956e",
+      "bytes": 4986
     }
   ],
   "metrics": [

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -19,6 +19,10 @@ const SHA = /^[0-9a-f]{40}$/;
 const SHA256 = /^[0-9a-f]{64}$/;
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const MACHINE_FINGERPRINT = /^[A-Za-z0-9][A-Za-z0-9._:/+-]{2,199}$/;
+const PACKET_RUNTIME_MODES = new Map([
+  ["cold-cli", "cold_cli_packet"],
+  ["warm-stdio", "warm_stdio_packet"],
+]);
 const SOURCE_RUN_PRODUCERS = new Map([
   [".github/workflows/packaged-platform-pr.yml", new Set(["workflow_dispatch"])],
   [".github/workflows/release.yml", new Set(["workflow_dispatch"])],
@@ -172,6 +176,15 @@ function metricsFrom(stats, packet, profile) {
   return values;
 }
 
+function packetRuntimeModes(modes) {
+  return [...new Set(modes.map((mode, index) => {
+    const selected = text(mode, `packet.modes[${index}]`);
+    const runtime = PACKET_RUNTIME_MODES.get(selected);
+    if (!runtime) fail(`packet.modes[${index}] is not a supported packet runtime mode`);
+    return runtime;
+  }))].sort();
+}
+
 function statsContractFrom(repoRoot) {
   const contract = readJson(path.join(repoRoot, "benchmarks/release-evidence/repo-stats-contract.json"), "stats contract");
   if (contract.schema_version !== 1) fail("stats contract schema_version must be 1");
@@ -242,8 +255,8 @@ function validateRawProvenance(stats, packet, commit, profileName, identity, sta
     repeats.set(key, values);
   }
   if ([...repeats.values()].some((values) => values.size !== packetProvenance.repeats)) fail("raw packet rows do not exactly cover the declared repeat count");
-  const rowModes = [...new Set(rows.map((row) => row.mode))].sort();
-  if (JSON.stringify(rowModes) !== JSON.stringify([...packet.modes].sort())) fail("raw packet row modes do not match top-level modes");
+  const rowModes = [...new Set(rows.map((row, index) => text(row.mode, `packet row ${index} mode`)))].sort();
+  if (JSON.stringify(rowModes) !== JSON.stringify(packetRuntimeModes(packet.modes))) fail("raw packet row modes do not match top-level modes");
 }
 
 export function produceCandidate({ baselineDocument, baselineDir, profileName, statsPath, packetPath, outPath, expectedSha, mode, repoRoot }) {

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -108,6 +108,20 @@ test("checked-in candidate and report are deterministic and fully attested", () 
   assert.ok(report.artifact_paths.every(({ sha256, bytes }) => /^[0-9a-f]{64}$/.test(sha256) && bytes > 0));
 });
 
+test("packet selectors normalize to production transport row modes", () => {
+  const dir = workspace();
+  const packet = JSON.parse(readFileSync(path.join(dir, "packet.json")));
+  assert.deepEqual(packet.modes, ["cold-cli"]);
+  assert.deepEqual([...new Set(packet.release_evidence.rows.map((row) => row.mode))], ["cold_cli_packet"]);
+  produce(dir);
+
+  for (const row of packet.release_evidence.rows) row.mode = "warm_stdio_packet";
+  writeFileSync(path.join(dir, "packet.json"), JSON.stringify(packet));
+  const result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "stats.json"), "--packet", path.join(dir, "packet.json"), "--out", path.join(dir, "candidate-2.json")]);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /row modes do not match top-level modes/);
+});
+
 test("missing and all-zero raw artifacts fail production", () => {
   const dir = workspace();
   let result = run("produce", ["--profile", "ci-contract-v1", "--stats", path.join(dir, "missing.json"), "--packet", path.join(dir, "packet.json"), "--out", path.join(dir, "candidate.json")]);


### PR DESCRIPTION
## Summary

- normalize packet benchmark selectors (`cold-cli`, `warm-stdio`) to the transport mode identifiers emitted by real packet rows
- make the checked-in release-evidence fixture use the production row and summary mode schema
- add a focused regression for valid selector normalization and mismatched rows

## Root cause

The benchmark summary records user-facing selectors in top-level `modes`, while packet rows record transport identifiers such as `cold_cli_packet`. The gate compared those two namespaces literally, so protected run 29315355952 rejected otherwise valid evidence.

## Verification

- `node --test scripts/tests/codestory-release-evidence-gate.test.mjs`
- `git diff --check`
- retained artifact 8303856397 produced and evaluated successfully with the fixed gate without remeasurement; all seven metrics passed their approved thresholds

Closes #958