### PR TITLE
fix coordinator evidence reuse

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -695,6 +695,8 @@ if (!fs.existsSync(releaseCandidateEvidence)) {
     "ref: ${{ inputs.ref }}",
     "validate-source-run",
     "actions/runs/$SOURCE_RUN_ID",
+    "actions/runs/$SOURCE_RUN_ID/artifacts",
+    "--artifacts target/release-evidence/source-run-artifacts.json",
     "--test-threads=1",
     "release-evidence-${{ inputs.ref }}",
   ], snippet => `release evidence workflow must include ${snippet}`);

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -138,8 +138,11 @@ jobs:
           mkdir -p target/release-evidence
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
             > target/release-evidence/source-run.json
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts" \
+            > target/release-evidence/source-run-artifacts.json
           node scripts/codestory-release-evidence-gate.mjs validate-source-run \
             --run target/release-evidence/source-run.json \
+            --artifacts target/release-evidence/source-run-artifacts.json \
             --repo "$GITHUB_REPOSITORY" \
             --expected-sha "$EVIDENCE_SHA"
           gh run download "$SOURCE_RUN_ID" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,9 @@
   focused source checks; exact-head, platform, protected hardware, signing, and
   installation proof run only at their explicit promotion boundaries. The
   evidence gate reconciles packet selectors with their recorded transport modes
-  before enforcing exact raw-row coverage.
+  before enforcing exact raw-row coverage, and coordinator re-evaluation binds
+  retained evidence to the selected candidate artifact even when the dispatch
+  workflow itself runs from a different branch.
 
 ### Release boundary
 

--- a/scripts/codestory-release-evidence-gate.mjs
+++ b/scripts/codestory-release-evidence-gate.mjs
@@ -28,6 +28,9 @@ const SOURCE_RUN_PRODUCERS = new Map([
   [".github/workflows/release.yml", new Set(["workflow_dispatch"])],
   [".github/workflows/auto-release.yml", new Set(["push"])],
 ]);
+const SELECTED_REF_PRODUCERS = new Set([
+  ".github/workflows/packaged-platform-pr.yml",
+]);
 
 function fail(message) { throw new Error(message); }
 function object(value, label) {
@@ -95,15 +98,12 @@ function machineFingerprint() {
   return `${process.platform}/${process.arch}/${os.cpus().length}/${cpu}/${memoryGiB}GiB`;
 }
 
-export function validateSourceRunMetadata({ run, expectedRepo, expectedSha }) {
+export function validateSourceRunMetadata({ run, artifacts, expectedRepo, expectedSha }) {
   object(run, "source run");
   const repo = text(expectedRepo, "expected repository");
   const sha = fullSha(expectedSha, "expected SHA");
   if (run.repository?.full_name !== repo || run.head_repository?.full_name !== repo) {
     fail("source run must come from the current repository");
-  }
-  if (fullSha(run.head_sha, "source run head SHA") !== sha) {
-    fail("source run head SHA does not match the evidence SHA");
   }
   if (run.conclusion !== "failure") {
     fail("source run must be a rejected failed evidence run");
@@ -111,6 +111,30 @@ export function validateSourceRunMetadata({ run, expectedRepo, expectedSha }) {
   const events = SOURCE_RUN_PRODUCERS.get(run.path);
   if (!events?.has(run.event)) {
     fail("source run workflow and event are not trusted evidence producers");
+  }
+  const runId = number(run.id, "source run id");
+  const artifactList = object(artifacts, "source run artifacts");
+  if (!Array.isArray(artifactList.artifacts)) {
+    fail("source run artifacts.artifacts must be an array");
+  }
+  const artifactName = `release-evidence-${sha}`;
+  const matches = artifactList.artifacts.filter((artifact) => artifact?.name === artifactName);
+  if (matches.length !== 1) {
+    fail(`source run must contain exactly one ${artifactName} artifact`);
+  }
+  const artifact = object(matches[0], "source run evidence artifact");
+  if (artifact.expired !== false) fail("source run evidence artifact must not be expired");
+  number(artifact.size_in_bytes, "source run evidence artifact size");
+  const artifactRun = object(artifact.workflow_run, "source run evidence artifact workflow_run");
+  if (number(artifactRun.id, "source run evidence artifact workflow_run id") !== runId) {
+    fail("source run evidence artifact belongs to a different workflow run");
+  }
+  const headSha = fullSha(run.head_sha, "source run head SHA");
+  if (fullSha(artifactRun.head_sha, "source run evidence artifact head SHA") !== headSha) {
+    fail("source run evidence artifact head SHA does not match its workflow run");
+  }
+  if (headSha !== sha && !SELECTED_REF_PRODUCERS.has(run.path)) {
+    fail("source run head SHA does not match the evidence SHA");
   }
 }
 function profileFrom(document, name, mode, baselineDir) {
@@ -384,6 +408,7 @@ function main() {
   if (command === "validate-source-run") {
     validateSourceRunMetadata({
       run: readJson(values.run, "source run"),
+      artifacts: readJson(values.artifacts, "source run artifacts"),
       expectedRepo: values.repo,
       expectedSha: values["expected-sha"],
     });

--- a/scripts/tests/codestory-release-evidence-gate.test.mjs
+++ b/scripts/tests/codestory-release-evidence-gate.test.mjs
@@ -65,10 +65,12 @@ test("fingerprint prefers a validated provisioned machine identity", () => {
   assert.match(result.stderr, /observed identity attestation changed/);
 });
 
-test("prior-run reuse requires an exact failed trusted producer", () => {
+test("prior-run reuse binds selected evidence to a failed trusted producer", () => {
   const dir = mkdtempSync(path.join(tmpdir(), "codestory-source-run-"));
   const runPath = path.join(dir, "run.json");
+  const artifactsPath = path.join(dir, "artifacts.json");
   const run = {
+    id: 42,
     path: ".github/workflows/packaged-platform-pr.yml",
     event: "workflow_dispatch",
     conclusion: "failure",
@@ -76,15 +78,25 @@ test("prior-run reuse requires an exact failed trusted producer", () => {
     repository: { full_name: "TheGreenCedar/CodeStory" },
     head_repository: { full_name: "TheGreenCedar/CodeStory" },
   };
+  const artifacts = {
+    artifacts: [{
+      name: `release-evidence-${candidateSha}`,
+      expired: false,
+      size_in_bytes: 1024,
+      workflow_run: { id: run.id, head_sha: run.head_sha },
+    }],
+  };
   const validate = () => spawnSync(process.execPath, [
     script,
     "validate-source-run",
     "--run", runPath,
+    "--artifacts", artifactsPath,
     "--repo", "TheGreenCedar/CodeStory",
     "--expected-sha", candidateSha,
   ], { encoding: "utf8" });
 
   writeFileSync(runPath, JSON.stringify(run));
+  writeFileSync(artifactsPath, JSON.stringify(artifacts));
   assert.equal(validate().status, 0);
 
   run.path = ".github/workflows/arbitrary-pr.yml";
@@ -93,8 +105,20 @@ test("prior-run reuse requires an exact failed trusted producer", () => {
 
   run.path = ".github/workflows/packaged-platform-pr.yml";
   run.head_sha = "3".repeat(40);
+  artifacts.artifacts[0].workflow_run.head_sha = run.head_sha;
+  writeFileSync(runPath, JSON.stringify(run));
+  writeFileSync(artifactsPath, JSON.stringify(artifacts));
+  assert.equal(validate().status, 0);
+
+  run.path = ".github/workflows/release.yml";
   writeFileSync(runPath, JSON.stringify(run));
   assert.match(validate().stderr, /does not match the evidence SHA/);
+
+  run.path = ".github/workflows/packaged-platform-pr.yml";
+  artifacts.artifacts[0].name = `release-evidence-${"4".repeat(40)}`;
+  writeFileSync(runPath, JSON.stringify(run));
+  writeFileSync(artifactsPath, JSON.stringify(artifacts));
+  assert.match(validate().stderr, /must contain exactly one release-evidence/);
 });
 
 test("checked-in candidate and report are deterministic and fully attested", () => {


### PR DESCRIPTION
## Summary

- validate retained evidence against the selected candidate artifact instead of assuming the coordinator dispatch branch is the candidate
- require one non-expired, non-empty artifact named for the exact 40-character candidate SHA and tied to the same failed trusted workflow run
- keep non-coordinator producers bound to their workflow head SHA
- cover the real coordinator mismatch and preserve fail-closed behavior for untrusted producers or wrong artifacts

## Tests

- `node --test scripts/tests/codestory-release-evidence-gate.test.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `git diff --check`
- live validation of rejected run `29315355952` against retained artifact `release-evidence-1d9b5c0dc4c22793cce3b2d3d5fdb468190b9b1a`

Broad release evidence and package matrices are intentionally deferred to the final integration candidate.

Closes #958
