### PR TITLE
reuse managed native embedding across projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@
   trusted external embedding endpoint; Intel status and evidence never claim
   Metal acceleration.
 - Managed macOS readiness follows the selected dynamic Agent endpoint instead
-  of assuming port 8080, reuses only a matching live native process, and blocks
-  packet and search with repair guidance if that endpoint or its verified
-  accelerator identity disappears.
+  of assuming port 8080, reuses one matching live native process across project
+  workspaces, and blocks packet and search with repair guidance if that endpoint
+  or its verified accelerator identity disappears.
 - Direct-download Mac artifacts are release-ready only after the exact arm64 and
   x64 binaries pass Developer ID signing, notarization, quarantined extraction,
   Gatekeeper, and native execution checks. Source or unsigned package checks do

--- a/crates/codestory-cli/src/output.rs
+++ b/crates/codestory-cli/src/output.rs
@@ -239,7 +239,7 @@ fn append_readiness_broker(
     {
         let next = match resource.status.as_str() {
             "stale" => "retry repair to reclaim stale native embedding lock",
-            "busy" => "wait for owner or retry after current repair completes",
+            "busy" => "wait for active owner repair, or stop an incompatible full owner runtime",
             _ => "inspect broker snapshot",
         };
         let _ = writeln!(

--- a/crates/codestory-cli/src/readiness_broker/mod.rs
+++ b/crates/codestory-cli/src/readiness_broker/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use machine_lock::{
 pub(crate) use native_lease::{
     BrokerNativeEmbeddingResourceLease, NativeEmbeddingLeaseLifecycleParams,
     cleanup_native_embedding_resource_lease_after_transfer_error,
-    native_embedding_launch_from_sidecar_state_file,
+    native_embedding_launch_from_sidecar_state_file, native_embedding_owner_down_command,
     reusable_native_embedding_resource_pid_for_snapshot, run_with_native_embedding_lease_lifecycle,
     transfer_native_embedding_resource_lease,
 };

--- a/crates/codestory-cli/src/readiness_broker/native_lease.rs
+++ b/crates/codestory-cli/src/readiness_broker/native_lease.rs
@@ -631,17 +631,37 @@ pub(crate) fn reusable_native_embedding_resource_pid_for_snapshot(
     )
 }
 
-#[cfg(test)]
-pub(crate) fn reusable_native_embedding_resource_pid(
-    scope: &BrokerScope,
-    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
-    busy: &BrokerMachineResourceBusy,
-    validate_launch: &mut impl FnMut(&codestory_retrieval::EmbeddingLaunchMetadata) -> Result<u32>,
-) -> Result<Option<u32>> {
-    Ok(
-        reusable_native_embedding_resource_launch(scope, sidecar, busy, validate_launch)?
-            .and_then(|launch| launch.pid),
-    )
+pub(crate) fn native_embedding_owner_down_command(
+    snapshot: &BrokerResourceSnapshot,
+) -> Option<String> {
+    let lock_path = machine_resource_lock_path(&snapshot.resource);
+    if super::paths::clean_path(&lock_path) != snapshot.lock_path {
+        return None;
+    }
+    let lock = read_machine_resource_lock_file(&lock_path)?;
+    if lock.resource != snapshot.resource
+        || Some(lock.pid) != snapshot.owner_pid
+        || Some(lock.scope.project_id.as_str()) != snapshot.owner_project_id.as_deref()
+        || Some(lock.scope.workspace_root.as_str()) != snapshot.owner_workspace_root.as_deref()
+        || lock.native_embedding_launch.is_none()
+        || lock.native_embedding_quarantine_reason.is_some()
+    {
+        return None;
+    }
+    let project = crate::display::quote_command_argument_value(&lock.scope.workspace_root);
+    match lock.scope.profile.as_str() {
+        "local" => Some(format!(
+            "codestory-cli retrieval down --project {project} --profile local"
+        )),
+        "agent" => {
+            let run_id = lock.scope.run_id.as_deref()?;
+            Some(format!(
+                "codestory-cli retrieval down --project {project} --profile agent --run-id {}",
+                crate::display::quote_command_argument_value(run_id)
+            ))
+        }
+        _ => None,
+    }
 }
 
 fn reusable_native_embedding_resource_launch(
@@ -655,7 +675,14 @@ fn reusable_native_embedding_resource_launch(
         sidecar,
         busy,
         validate_launch,
-        reused_launch_matches_owner_and_requested_runtime,
+        |owner_scope, requested_runtime, launch| {
+            reused_launch_matches_owner_and_requested_runtime(
+                owner_scope,
+                scope,
+                requested_runtime,
+                launch,
+            )
+        },
     )?
     else {
         return Ok(None);
@@ -710,6 +737,9 @@ pub(crate) fn reusable_native_embedding_resource_launch_with_matcher(
     let Some(scope_identity) = super::scope::effective_scope_identity(scope) else {
         return Ok(None);
     };
+    if sidecar.project_identity.as_ref() != Some(&scope_identity) {
+        return Ok(None);
+    }
     let Some(owner_workspace_root) = busy.snapshot.owner_workspace_root.as_deref() else {
         return Ok(None);
     };
@@ -717,14 +747,6 @@ pub(crate) fn reusable_native_embedding_resource_launch_with_matcher(
     else {
         return Ok(None);
     };
-    if owner_identity.workspace_id != scope_identity.workspace_id
-        || !codestory_workspace::same_workspace_path(
-            Path::new(owner_workspace_root),
-            Path::new(&scope.workspace_root),
-        )
-    {
-        return Ok(None);
-    }
     let lock_path = machine_resource_lock_path(&busy.snapshot.resource);
     if super::paths::clean_path(&lock_path) != busy.snapshot.lock_path {
         return Ok(None);
@@ -741,7 +763,6 @@ pub(crate) fn reusable_native_embedding_resource_launch_with_matcher(
     if lock.resource != busy.snapshot.resource
         || lock.pid != owner_pid
         || busy.snapshot.owner_project_id.as_deref() != Some(lock.scope.project_id.as_str())
-        || lock_identity.workspace_id != scope_identity.workspace_id
         || lock_identity.workspace_id != owner_identity.workspace_id
         || !codestory_workspace::same_workspace_path(
             Path::new(&lock.scope.workspace_root),
@@ -813,6 +834,7 @@ fn adopt_reused_native_launch_endpoint(
 
 fn reused_launch_matches_owner_and_requested_runtime(
     owner_scope: &BrokerScope,
+    requested_scope: &BrokerScope,
     requested_runtime: &codestory_retrieval::SidecarRuntimeConfig,
     launch: &codestory_retrieval::EmbeddingLaunchMetadata,
 ) -> Result<bool> {
@@ -836,7 +858,7 @@ fn reused_launch_matches_owner_and_requested_runtime(
         return Ok(false);
     }
     let Some(expected_requested) = codestory_retrieval::expected_native_embedding_launch_metadata(
-        std::path::Path::new(&owner_scope.workspace_root),
+        std::path::Path::new(&requested_scope.workspace_root),
         requested_runtime,
     )?
     else {
@@ -849,7 +871,7 @@ fn reused_launch_matches_owner_and_requested_runtime(
     ))
 }
 
-fn same_native_launch_configuration(
+pub(super) fn same_native_launch_configuration(
     expected: &codestory_retrieval::EmbeddingLaunchMetadata,
     actual: &codestory_retrieval::EmbeddingLaunchMetadata,
     require_log_path: bool,
@@ -862,7 +884,13 @@ fn same_native_launch_configuration(
         && expected.executable_path == actual.executable_path
         && expected.model_path == actual.model_path
         && expected.requested_device == actual.requested_device
-        && (!require_log_path || actual.log_path.is_none() || expected.log_path == actual.log_path)
+        && (!require_log_path
+            || actual.log_path.is_none()
+            || expected.log_path.as_deref().is_some_and(|expected| {
+                actual.log_path.as_deref().is_some_and(|actual| {
+                    codestory_workspace::same_workspace_path(Path::new(expected), Path::new(actual))
+                })
+            }))
 }
 
 pub(super) fn enrich_legacy_native_launch_log_path(
@@ -884,14 +912,20 @@ fn bail_native_embedding_busy<T>(busy: &BrokerMachineResourceBusy) -> Result<T> 
         .owner_workspace_root
         .as_deref()
         .unwrap_or("unknown");
+    let next = native_embedding_owner_down_command(&busy.snapshot)
+        .map(|command| format!("the full owner runtime has an incompatible native launch contract; stop it with `{command}`, then retry"))
+        .unwrap_or_else(|| {
+            "the owner is still active after the bounded wait; retry after its current repair completes"
+                .to_string()
+        });
     bail!(
-        "native embedding runtime is busy for another CodeStory operation: resource={} owner_project={} owner_workspace={} owner_pid={:?}; retry after the current repair reaches full retrieval",
+        "native embedding runtime is busy for another CodeStory operation: resource={} owner_project={} owner_workspace={} owner_pid={:?}; {next}",
         busy.snapshot.resource,
         busy.snapshot
             .owner_project_id
             .as_deref()
             .unwrap_or("unknown"),
         owner,
-        busy.snapshot.owner_pid
+        busy.snapshot.owner_pid,
     );
 }

--- a/crates/codestory-cli/src/readiness_broker/tests.rs
+++ b/crates/codestory-cli/src/readiness_broker/tests.rs
@@ -548,60 +548,26 @@ fn broker_scope_treats_windows_case_alias_as_one_workspace() {
 }
 
 #[test]
-fn native_embedding_reuse_does_not_cross_workspace_roots() {
-    let project = tempdir().expect("project");
-    let other_worktree = tempdir().expect("other worktree");
-    let scope = test_scope(project.path(), "shared-agent");
-    let sidecar = test_sidecar_runtime(
-        project.path(),
-        codestory_retrieval::SidecarProfile::Agent,
-        Some("shared-agent"),
-    );
-    let busy = BrokerMachineResourceBusy {
-        snapshot: BrokerResourceSnapshot {
-            resource: NATIVE_EMBEDDING_RESOURCE.to_string(),
-            scope: "machine".to_string(),
-            status: "busy".to_string(),
-            owner_pid: Some(std::process::id()),
-            owner_operation_id: Some("other-worktree".to_string()),
-            owner_project_id: Some(scope.project_id.clone()),
-            owner_workspace_root: Some(clean_path(other_worktree.path())),
-            started_at_epoch_ms: Some(now_epoch_ms()),
-            lock_path: "other-worktree.lock".to_string(),
-            queued_reason: Some("machine_resource_busy".to_string()),
-        },
-    };
-    let mut validate = |_launch: &codestory_retrieval::EmbeddingLaunchMetadata| {
-        panic!("different workspace must not reach launch validation")
-    };
-
-    assert_eq!(
-        reusable_native_embedding_resource_pid(&scope, &sidecar, &busy, &mut validate)
-            .expect("workspace comparison"),
-        None
-    );
-}
-
-#[test]
-fn native_embedding_busy_lock_reuses_matching_sidecar_owner() {
-    let project = tempdir().expect("temp project");
+fn native_embedding_busy_lock_reuses_matching_cross_project_owner() {
+    let owner_project = tempdir().expect("owner project");
+    let requested_project = tempdir().expect("requested project");
     let resource = unique_resource("native-reuse");
     cleanup_machine_resource(&resource);
     let owner_scope = operation_scope(
-        project.path(),
+        owner_project.path(),
         "local",
         None,
         "retrieval_bootstrap",
         "9.9.9",
     );
-    let requested_scope = test_scope(project.path(), "shared-agent");
+    let requested_scope = test_scope(requested_project.path(), "shared-agent");
     let owner_sidecar = test_sidecar_runtime(
-        project.path(),
+        owner_project.path(),
         codestory_retrieval::SidecarProfile::Local,
         None,
     );
     let requested_sidecar = test_sidecar_runtime(
-        project.path(),
+        requested_project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
     );
@@ -613,6 +579,14 @@ fn native_embedding_busy_lock_reuses_matching_sidecar_owner() {
     snapshot.status = "busy".to_string();
     let busy = BrokerMachineResourceBusy { snapshot };
     let validator_called = std::cell::Cell::new(false);
+
+    let owner_down = native_embedding_owner_down_command(&busy.snapshot)
+        .expect("full owner exposes exact cleanup command");
+    assert!(owner_down.contains("--profile local"), "{owner_down}");
+    assert!(
+        owner_down.contains(&clean_path(owner_project.path())),
+        "{owner_down}"
+    );
 
     let reused = reusable_native_embedding_resource_launch_with_matcher(
         &requested_scope,
@@ -628,11 +602,37 @@ fn native_embedding_busy_lock_reuses_matching_sidecar_owner() {
                 validator_called.get(),
                 "process identity must be exact before runtime configuration matching"
             );
+            let lexical_log = owner_project.path().join("llama-server-native.log");
+            fs::write(&lexical_log, "native launch proof\n").expect("write native log fixture");
+            let mut lexical_log_launch = launch.clone();
+            lexical_log_launch.log_path = Some(lexical_log.display().to_string());
+            let mut canonical_log_launch = lexical_log_launch.clone();
+            canonical_log_launch.log_path = Some(
+                lexical_log
+                    .canonicalize()
+                    .expect("canonical native log fixture")
+                    .display()
+                    .to_string(),
+            );
+            assert!(same_native_launch_configuration(
+                &canonical_log_launch,
+                &lexical_log_launch,
+                true
+            ));
             assert_eq!(scope.operation_kind, "retrieval_bootstrap");
             assert_eq!(scope.profile, "local");
+            assert_ne!(scope.project_id, requested_scope.project_id);
+            assert_ne!(
+                scope.canonical_root_hash,
+                requested_scope.canonical_root_hash
+            );
             assert_ne!(
                 broker_operation_id(scope),
                 broker_operation_id(&requested_scope)
+            );
+            assert_eq!(
+                retargeted.project_identity,
+                requested_sidecar.project_identity
             );
             assert_eq!(
                 retargeted.profile,

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -4722,13 +4722,23 @@ fn stdio_status_native_embedding_busy_next_calls(
 ) -> serde_json::Value {
     let owner_workspace = busy.owner_workspace_root.as_deref().unwrap_or("unknown");
     let owner_project = busy.owner_project_id.as_deref().unwrap_or("unknown");
+    let instruction = crate::readiness_broker::native_embedding_owner_down_command(busy)
+        .map(|command| {
+            format!(
+                "CodeStory could not reuse the full native embedding runtime owned by another operation. Stop the incompatible owner with `{command}`, then retry MCP repair. owner_project={owner_project} owner_workspace={owner_workspace} owner_pid={:?}",
+                busy.owner_pid
+            )
+        })
+        .unwrap_or_else(|| {
+            format!(
+                "CodeStory could not yet reuse the native embedding runtime owned by another operation. Wait for its active repair to finish, then retry MCP repair. owner_project={owner_project} owner_workspace={owner_workspace} owner_pid={:?}",
+                busy.owner_pid
+            )
+        });
     serde_json::json!([
         {
             "method": "host/instruction",
-            "instruction": format!(
-                "CodeStory native embedding runtime is already owned by another operation; wait for it to finish before starting MCP repair. owner_project={owner_project} owner_workspace={owner_workspace} owner_pid={:?}",
-                busy.owner_pid
-            )
+            "instruction": instruction
         },
         {
             "method": "tools/call",
@@ -7132,8 +7142,9 @@ mod tests {
     }
 
     #[test]
-    fn stdio_native_embedding_same_project_reusable_lock_does_not_block_repair() {
-        let project = tempfile::tempdir().expect("project");
+    fn stdio_native_embedding_cross_project_reusable_lock_does_not_block_repair() {
+        let project = tempfile::tempdir().expect("requested project");
+        let owner_project = tempfile::tempdir().expect("owner project");
         let sidecar = crate::sidecar_runtime::for_project_with_run_id(
             project.path(),
             codestory_retrieval::SidecarProfile::Agent,
@@ -7144,7 +7155,12 @@ mod tests {
             sidecar.run_id.as_deref(),
             env!("CARGO_PKG_VERSION"),
         );
-        let resource = native_resource_snapshot_for_scope(&scope, "busy", 44);
+        let owner_scope = crate::readiness_broker::agent_repair_scope(
+            owner_project.path(),
+            Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
+            env!("CARGO_PKG_VERSION"),
+        );
+        let resource = native_resource_snapshot_for_scope(&owner_scope, "busy", 44);
         let snapshot = broker_snapshot_with_native_resource(project.path(), resource);
         let mut classifier_called = false;
 
@@ -7155,6 +7171,10 @@ mod tests {
             |classifier_scope, classifier_sidecar, classifier_resource| {
                 classifier_called = true;
                 assert_eq!(classifier_scope.project_id, scope.project_id);
+                assert_ne!(
+                    classifier_scope.project_id,
+                    classifier_resource.owner_project_id.as_deref().unwrap()
+                );
                 assert_eq!(classifier_sidecar.run_id, sidecar.run_id);
                 assert_eq!(classifier_resource.owner_pid, Some(44));
                 Ok(Some(44))

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -1115,17 +1115,9 @@ pub fn expected_native_embedding_launch_metadata(
     repo_root: &Path,
     runtime: &SidecarRuntimeConfig,
 ) -> Result<Option<crate::health::EmbeddingLaunchMetadata>> {
-    let native = runtime
-        .embedding
-        .server_launch
-        .as_deref()
-        .is_some_and(|mode| {
-            matches!(
-                mode.trim().to_ascii_lowercase().as_str(),
-                "native" | "native_spawned"
-            )
-        });
-    if !native {
+    if crate::config::embedding_server_launch_mode_for_runtime(runtime)?
+        != EmbeddingServerLaunchMode::NativeSpawned
+    {
         return Ok(None);
     }
     let launch = native_embedding_server_launch(Some(repo_root), runtime)?;


### PR DESCRIPTION
## Context

A completed managed native embedding launch keeps the machine-wide broker lock for the life of `llama-server`. The reuse path previously rejected every different workspace before validating the launch, so switching from project A to project B could wait on a healthy persistent process that B was forbidden to attach to.

Base: `89d08263c9308532665c46433eaf9317016fb65b` (`dev/codestory-next`)
Head: `2e3d21b1bccaff04bed16afe53c5c32754decfad`

## What changed

- Allow a requested project runtime to attach to a matching machine-owned native embedding process after validating its own project identity.
- Validate the owner and requested launch contracts independently, including executable, arguments, endpoint, model, device, launch fingerprint, and exact process-start identity.
- Compare persisted native log paths by native filesystem identity, so Darwin's `/tmp` and `/private/tmp` spellings cannot reject the same launch.
- Resolve the effective native launch mode before producing expected metadata, including the default Apple Metal selection.
- Retarget only the requested runtime's embedding endpoint; its project identity, state layout, Qdrant/SCIP namespace, and publication remain project-scoped.
- Keep incompatible or in-progress owners fail-closed, with an exact `retrieval down` command when a completed incompatible owner can be stopped safely.
- Replace the old cross-workspace rejection test with the cross-project reuse contract and update MCP repair routing coverage. This removes one test overall.

## How to review

Start in `readiness_broker/native_lease.rs`. The key change removes workspace equality as a process-compatibility condition while retaining requested-runtime identity validation and all owner lock/launch checks. `compose.rs` now applies the effective launch-mode resolver consistently. `stdio_transport.rs` only changes busy classification coverage and operator guidance.

## Verification

Focused source checks on the exact head:

- `cargo test -p codestory-cli readiness_broker::tests::native_embedding_busy_lock_reuses_matching_cross_project_owner -- --exact --nocapture`
- `cargo test -p codestory-cli stdio_transport::tests::stdio_native_embedding_cross_project_reusable_lock_does_not_block_repair -- --exact --nocapture`
- `cargo test -p codestory-cli readiness_broker::tests::native_embedding_busy_lock_rejects_mismatched_state_pid -- --exact --nocapture`
- `cargo build -p codestory-cli`
- `cargo fmt --all -- --check`
- `git diff --check`

All passed locally on macOS arm64.

Local Apple Silicon lifecycle proof used one isolated cache and two fresh Rust projects:

- Project A reached full retrieval in 15.09s with managed Metal, `gpu_proof=verified`, meaningful accelerator work, endpoint `127.0.0.1:44061`, and PID `32627`.
- Project B then reached full retrieval in 7.14s without stopping A or starting another server. It attached to the same endpoint and exact process-start identity with `gpu_proof=verified`.
- Project IDs, broker namespaces, SQLite retrieval generations, input hashes, and Qdrant collection names remained distinct. A reacquired its original full publication in 1.19s after B completed.
- Process inspection found exactly one proof-owned `llama-server`. The model and backend artifacts matched their pinned checksums.
- Cleanup detached B first, confirmed A still owned the process, stopped A through its exact project command, and verified PID `32627`, port `44061`, containers, networks, and the isolated proof root were gone.

## Risk

The change broadens reuse from one workspace to any project in the same trusted machine broker scope. Reuse still fails closed unless the live PID and start identity match the broker launch and both owner/requested native launch configurations are identical. No process ownership, cleanup, publication, package, signing, or release behavior is broadened.

Closes #1091
Refs #884
Refs #1046
