### PR TITLE
Centralize agent surface readiness

### DIFF
--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -365,6 +365,31 @@ fn new_agent_surface_runtime(
     RuntimeContext::new_agent_sidecar_with_selection(project, profile, run_id)
 }
 
+struct OpenedAgentSurface {
+    runtime: RuntimeContext,
+    before: ProjectSummary,
+    opened: runtime::OpenedProject,
+}
+
+fn open_agent_surface(
+    project: &ProjectArgs,
+    profile: Option<args::CliSidecarProfile>,
+    run_id: Option<&str>,
+    refresh: args::RefreshMode,
+    surface: &'static str,
+) -> Result<OpenedAgentSurface> {
+    let runtime = new_agent_surface_runtime(project, profile, run_id)?;
+    let before = runtime.open_project_summary()?;
+    let opened = runtime.ensure_open_from_summary(refresh, before.clone())?;
+    ensure_index_ready(&opened, surface)?;
+    ensure_agent_surface_gpu_proof(&runtime, surface)?;
+    Ok(OpenedAgentSurface {
+        runtime,
+        before,
+        opened,
+    })
+}
+
 fn run_cache(cmd: CacheCommand) -> Result<()> {
     match cmd.action {
         CacheAction::Identity(cmd) => run_cache_identity(cmd),
@@ -1342,10 +1367,8 @@ struct ResolvedContextTarget {
 fn run_context(cmd: ContextCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "context")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = new_agent_surface_runtime(&cmd.project, None, None)?;
-    let opened = runtime.ensure_open(cmd.refresh)?;
-    ensure_index_ready(&opened, "context")?;
-    ensure_agent_surface_gpu_proof(&runtime, "context")?;
+    let OpenedAgentSurface { runtime, .. } =
+        open_agent_surface(&cmd.project, None, None, cmd.refresh, "context")?;
 
     let resolved = resolve_context_target(&runtime, &cmd, cmd.format, cmd.output_file.as_deref())?;
     let target_prompt = context_target_prompt(&resolved);
@@ -1390,10 +1413,13 @@ fn run_context(cmd: ContextCommand) -> Result<()> {
 fn run_packet(cmd: PacketCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "packet")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = new_agent_surface_runtime(&cmd.project, cmd.profile, cmd.run_id.as_deref())?;
-    let opened = runtime.ensure_open(cmd.refresh)?;
-    ensure_index_ready(&opened, "packet")?;
-    ensure_agent_surface_gpu_proof(&runtime, "packet")?;
+    let OpenedAgentSurface { runtime, .. } = open_agent_surface(
+        &cmd.project,
+        cmd.profile,
+        cmd.run_id.as_deref(),
+        cmd.refresh,
+        "packet",
+    )?;
 
     let packet = runtime
         .browser
@@ -1423,10 +1449,8 @@ fn run_task(cmd: TaskCommand) -> Result<()> {
 fn run_task_brief(cmd: TaskBriefCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "task brief")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = new_agent_surface_runtime(&cmd.project, None, None)?;
-    let opened = runtime.ensure_open(cmd.refresh)?;
-    ensure_index_ready(&opened, "task brief")?;
-    ensure_agent_surface_gpu_proof(&runtime, "task brief")?;
+    let OpenedAgentSurface { runtime, .. } =
+        open_agent_surface(&cmd.project, None, None, cmd.refresh, "task brief")?;
 
     let packet = runtime
         .browser
@@ -2477,10 +2501,7 @@ fn ensure_agent_surface_gpu_proof(runtime: &RuntimeContext, surface: &str) -> Re
     );
     let live_degraded_reason = status.degraded_reason.clone();
     if live_degraded_reason.is_none()
-        && broker
-            .gpu_proof
-            .as_ref()
-            .is_some_and(|proof| gpu_proof_matches_selected_runtime(proof, &sidecar))
+        && agent_surface_gpu_proof_is_valid(&status, &sidecar, broker.gpu_proof.as_ref())
     {
         return Ok(());
     }
@@ -2550,6 +2571,15 @@ fn gpu_proof_matches_selected_runtime(
             .project_identity
             .as_ref()
             .is_none_or(|expected| identity.workspace_id == expected.workspace_id)
+}
+
+fn agent_surface_gpu_proof_is_valid(
+    status: &DoctorSidecarStatusOutput,
+    runtime: &codestory_retrieval::SidecarRuntimeConfig,
+    proof: Option<&readiness_broker::BrokerGpuProofSnapshot>,
+) -> bool {
+    !agent_surface_requires_identity_bound_gpu_proof(status)
+        || proof.is_some_and(|proof| gpu_proof_matches_selected_runtime(proof, runtime))
 }
 
 fn agent_surface_requires_identity_bound_gpu_proof(status: &DoctorSidecarStatusOutput) -> bool {
@@ -3682,10 +3712,13 @@ fn render_agent_preflight_markdown(output: &args::AgentPreflightOutput) -> Strin
 fn run_search(cmd: SearchCommand) -> Result<()> {
     ensure_dot_only_for_trail(cmd.format, "search")?;
     preflight_output_file(cmd.output_file.as_deref())?;
-    let runtime = new_agent_surface_runtime(&cmd.project, cmd.profile, cmd.run_id.as_deref())?;
-    let opened = runtime.ensure_open(cmd.refresh)?;
-    ensure_index_ready(&opened, "search")?;
-    ensure_agent_surface_gpu_proof(&runtime, "search")?;
+    let OpenedAgentSurface { runtime, .. } = open_agent_surface(
+        &cmd.project,
+        cmd.profile,
+        cmd.run_id.as_deref(),
+        cmd.refresh,
+        "search",
+    )?;
     let search_results = runtime
         .browser
         .search_results(search_request_from_command(&cmd))
@@ -3719,11 +3752,17 @@ fn execute_drill(cmd: &DrillCommand) -> Result<DrillOutput> {
     let total_timer = Instant::now();
     let setup_timer = Instant::now();
     validate_drill_output_dir(&cmd.output_dir)?;
-    let runtime = new_agent_surface_runtime(&cmd.project, cmd.profile, cmd.run_id.as_deref())?;
-    let before = runtime.open_project_summary()?;
-    let opened = runtime.ensure_open_from_summary(cmd.refresh, before.clone())?;
-    ensure_index_ready(&opened, "drill")?;
-    ensure_agent_surface_gpu_proof(&runtime, "drill")?;
+    let OpenedAgentSurface {
+        runtime,
+        before,
+        opened,
+    } = open_agent_surface(
+        &cmd.project,
+        cmd.profile,
+        cmd.run_id.as_deref(),
+        cmd.refresh,
+        "drill",
+    )?;
     if cmd.refresh != args::RefreshMode::None {
         retrieval::finalize_retrieval_index_for_runtime(&runtime)
             .context("drill retrieval index finalize")?;
@@ -9655,6 +9694,20 @@ mod tests {
                 requested_device: Some("Vulkan0".into()),
             }),
         });
+        let surface_status = doctor_sidecar_status_from_report(
+            ready_repair_test_report("full", None),
+            Some(&sidecar),
+        );
+        assert!(!agent_surface_gpu_proof_is_valid(
+            &surface_status,
+            &sidecar,
+            None,
+        ));
+        assert!(agent_surface_gpu_proof_is_valid(
+            &surface_status,
+            &sidecar,
+            Some(&verified),
+        ));
         assert!(ready_repair_existing_sidecar_is_reusable(
             &full_accelerated,
             Some(&verified),

--- a/crates/codestory-cli/tests/architecture_contracts.rs
+++ b/crates/codestory-cli/tests/architecture_contracts.rs
@@ -75,63 +75,6 @@ fn source_between<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
 }
 
 #[test]
-fn direct_cli_and_stdio_agent_surfaces_share_runtime_constructor() {
-    let main = read("crates/codestory-cli/src/main.rs");
-    let helper = source_between(&main, "fn new_agent_surface_runtime", "fn run_cache");
-    assert!(
-        helper
-            .contains("RuntimeContext::new_agent_sidecar_with_selection(project, profile, run_id)"),
-        "shared agent surface runtime must retain the selected profile and run id"
-    );
-
-    for (start, end, surface) in [
-        ("fn run_context", "fn run_packet", "context"),
-        ("fn run_packet", "fn run_task", "packet"),
-        (
-            "fn run_task_brief",
-            "fn render_packet_markdown",
-            "task brief",
-        ),
-        ("fn run_search", "fn search_request_from_command", "search"),
-        ("fn run_serve", "fn run_generate_completions", "stdio/serve"),
-    ] {
-        let body = source_between(&main, start, end);
-        assert!(
-            body.contains("new_agent_surface_runtime(&cmd.project,"),
-            "{surface} must use the same agent-sidecar runtime constructor as stdio status/ready"
-        );
-    }
-
-    let ready = source_between(&main, "fn run_ready", "fn run_agent");
-    assert!(
-        ready.contains("new_agent_surface_runtime(&cmd.project,"),
-        "ready --goal agent --repair must stay on the shared agent-sidecar runtime constructor"
-    );
-}
-
-#[test]
-fn direct_full_retrieval_surfaces_require_identity_bound_gpu_proof() {
-    let main = read("crates/codestory-cli/src/main.rs");
-    for (start, end, surface) in [
-        ("fn run_context", "fn run_packet", "context"),
-        ("fn run_packet", "fn run_task", "packet"),
-        (
-            "fn run_task_brief",
-            "fn render_packet_markdown",
-            "task brief",
-        ),
-        ("fn run_search", "fn search_request_from_command", "search"),
-        ("fn execute_drill", "fn execute_drill_packet", "drill"),
-    ] {
-        let body = source_between(&main, start, end);
-        assert!(
-            body.contains("ensure_agent_surface_gpu_proof(&runtime,"),
-            "{surface} must reject full accelerator-required retrieval without identity-bound broker proof"
-        );
-    }
-}
-
-#[test]
 fn cli_sidecar_construction_stays_behind_test_safe_gateway() {
     let source_root = repo_root().join("crates/codestory-cli/src");
     let gateway_path = source_root.join("sidecar_runtime.rs");


### PR DESCRIPTION
## Context

Direct context, packet, task-brief, search, and drill handlers repeated the same runtime construction, index-readiness, and identity-bound GPU-proof sequence. A source-order architecture test tried to enforce the invariant by slicing `main.rs` between function names and checking exact call text. That test was brittle under harmless refactors and could not protect a newly added surface by construction.

Base: `dev/codestory-next@89d08263c9308532665c46433eaf9317016fb65b`
Head: `a606e815abbb297de0d9530dfb1e758e6df4f6fa`

## What changed

- Add one `open_agent_surface` entrypoint that selects the agent runtime, captures the pre-refresh summary, opens or refreshes the index, requires indexed graph data, and verifies the selected runtime's GPU proof.
- Route context, packet, task brief, search, and drill through that entrypoint.
- Preserve drill's before/after mechanical statistics by returning both its pre-refresh summary and opened project state.
- Extract the proof-validity decision so the existing identity-bound lifecycle test covers missing proof rejection and matching proof acceptance.
- Delete both source-order/source-call architecture tests instead of replacing them with another source-shape assertion.

The result removes two tests and is four lines smaller overall (`78` added, `82` removed). CLI syntax, output, refresh behavior, and readiness errors are unchanged.

## How to review

Start with `open_agent_surface` and confirm the operation order matches each deleted handler sequence. Then inspect the five call sites; task brief remains a packet surface, and drill still reports the original pre-refresh summary. Finally, check `agent_surface_gpu_proof_is_valid` and its assertions in the existing lifecycle test.

Code-simplifier classification: `rust` / `rust-test-replace-source-contract-with-api-invariant`, `S2/R2`, confidence `0.91`; risk drivers are `semantic_coupling` and `api_contract_sensitivity`.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p codestory-cli --bin codestory-cli ready_repair_reuses_only_accelerated_sidecar_with_identity_bound_proof` — 1 passed
- `cargo test --locked -p codestory-cli --test architecture_contracts` — 12 passed
- `git diff --check`

The default-concurrency CLI suite remains assigned to the independently accepted merge-ready head. This draft does not claim that broader proof.

## Risk

The helper changes no readiness policy. Its main risk is accidentally dropping command-specific runtime selection or drill's pre-refresh metrics; the call sites preserve profile/run-id selection, and the returned pre-open summary keeps the drill contract intact.

Closes #1088
Refs #1046
Refs #884
