### PR TITLE
[codex] centralize process start identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@
   still match the file. Failed, cancelled, or concurrent refreshes preserve the
   previous usable generation.
 - Native process reuse and cleanup now bind executable filesystem identity,
-  arguments, endpoint, and process start identity. Cleanup remains limited to
-  resources carrying CodeStory ownership proof.
+  arguments, endpoint, and one shared cross-platform process start identity.
+  macOS and Windows process inspection is bounded, dead, reused, or unverified
+  PIDs remain fail-closed, and cleanup stays limited to resources carrying
+  CodeStory ownership proof.
 - Managed installation and upgrade checks cover every shipped native platform,
   including upgrade from a verified older CLI with that version retained as the
   rollback. The Codex worktree setup dispatcher now provides equivalent native

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -424,7 +424,7 @@ pub(crate) fn wait_for_ready_repair_reservation_adoption(
                 match probe_process_start_identity(reservation.pid) {
                     ProcessStartProbe::NotRunning => return Ok(()),
                     ProcessStartProbe::Running {
-                        start_identity: Some(actual),
+                        start_identity: actual,
                     } if actual == expected_start_identity => return Ok(()),
                     ProcessStartProbe::Running { .. } | ProcessStartProbe::Unknown { .. } => {
                         anyhow::bail!(
@@ -1163,7 +1163,7 @@ pub(crate) fn process_owner_state(
 
 pub(crate) fn recorded_process_start_identity(pid: u32) -> Option<String> {
     match probe_process_start_identity(pid) {
-        ProcessStartProbe::Running { start_identity } => start_identity,
+        ProcessStartProbe::Running { start_identity } => Some(start_identity),
         ProcessStartProbe::NotRunning | ProcessStartProbe::Unknown { .. } => None,
     }
 }

--- a/crates/codestory-cli/src/ready_repair_status.rs
+++ b/crates/codestory-cli/src/ready_repair_status.rs
@@ -1,15 +1,16 @@
 use anyhow::Result;
 use codestory_contracts::api::{ApiError, ApiErrorDetails, CommandFailureEnvelope};
-use codestory_retrieval::{DEFAULT_AGENT_RUN_ID, SidecarProfile, SidecarRuntimeConfig};
+pub(crate) use codestory_retrieval::ProcessOwnerState;
+use codestory_retrieval::{
+    DEFAULT_AGENT_RUN_ID, ProcessStartProbe, SidecarProfile, SidecarRuntimeConfig,
+    probe_process_start_identity, process_owner_state as classify_process_owner_state,
+};
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs::{self, File, OpenOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
-use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -24,10 +25,6 @@ const READY_REPAIR_STATUS_TTL: Duration = Duration::from_secs(30);
 const READY_REPAIR_LOCK_STALE_TTL: Duration = Duration::from_secs(120);
 const READY_REPAIR_COORDINATION_TIMEOUT: Duration = Duration::from_secs(5);
 const READY_REPAIR_COORDINATION_POLL: Duration = Duration::from_millis(10);
-#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
-const READY_REPAIR_PROCESS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
-#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
-const READY_REPAIR_PROCESS_PROBE_REAP_TIMEOUT: Duration = Duration::from_millis(250);
 pub(crate) const READY_REPAIR_ATTEMPT_ENV: &str = "CODESTORY_READY_REPAIR_ATTEMPT_ID";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -185,20 +182,6 @@ pub(crate) struct ReadyRepairCleanup {
 pub(crate) enum ReadyRepairLockAttempt {
     Acquired(ReadyRepairLock),
     Busy(Box<ReadyRepairBusy>),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProcessOwnerState {
-    Matching,
-    GoneOrReused,
-    Unknown,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ProcessProbe {
-    Running { start_identity: Option<String> },
-    NotRunning,
-    Unknown,
 }
 
 #[derive(Debug)]
@@ -438,12 +421,12 @@ pub(crate) fn wait_for_ready_repair_reservation_adoption(
                             "ready repair reservation adopted without a worker start identity"
                         )
                     })?;
-                match probe_process(reservation.pid) {
-                    ProcessProbe::NotRunning => return Ok(()),
-                    ProcessProbe::Running {
+                match probe_process_start_identity(reservation.pid) {
+                    ProcessStartProbe::NotRunning => return Ok(()),
+                    ProcessStartProbe::Running {
                         start_identity: Some(actual),
                     } if actual == expected_start_identity => return Ok(()),
-                    ProcessProbe::Running { .. } | ProcessProbe::Unknown => {
+                    ProcessStartProbe::Running { .. } | ProcessStartProbe::Unknown { .. } => {
                         anyhow::bail!(
                             "ready repair reservation adopted an invalid worker identity"
                         );
@@ -1175,161 +1158,14 @@ pub(crate) fn process_owner_state(
     pid: u32,
     expected_start_identity: Option<&str>,
 ) -> ProcessOwnerState {
-    process_owner_state_with(pid, expected_start_identity, probe_process)
-}
-
-fn process_owner_state_with(
-    pid: u32,
-    expected_start_identity: Option<&str>,
-    probe: impl FnOnce(u32) -> ProcessProbe,
-) -> ProcessOwnerState {
-    match probe(pid) {
-        ProcessProbe::NotRunning => ProcessOwnerState::GoneOrReused,
-        ProcessProbe::Unknown => ProcessOwnerState::Unknown,
-        ProcessProbe::Running { start_identity } => match expected_start_identity {
-            None => ProcessOwnerState::Matching,
-            Some(expected) => match start_identity {
-                Some(actual) if actual == expected => ProcessOwnerState::Matching,
-                Some(_) => ProcessOwnerState::GoneOrReused,
-                None => ProcessOwnerState::Unknown,
-            },
-        },
-    }
+    classify_process_owner_state(&probe_process_start_identity(pid), expected_start_identity)
 }
 
 pub(crate) fn recorded_process_start_identity(pid: u32) -> Option<String> {
-    match probe_process(pid) {
-        ProcessProbe::Running { start_identity } => start_identity,
-        ProcessProbe::NotRunning | ProcessProbe::Unknown => None,
+    match probe_process_start_identity(pid) {
+        ProcessStartProbe::Running { start_identity } => start_identity,
+        ProcessStartProbe::NotRunning | ProcessStartProbe::Unknown { .. } => None,
     }
-}
-
-fn probe_process(pid: u32) -> ProcessProbe {
-    static CURRENT_PROCESS_START_IDENTITY: OnceLock<String> = OnceLock::new();
-
-    if pid == std::process::id()
-        && let Some(identity) = CURRENT_PROCESS_START_IDENTITY.get()
-    {
-        return ProcessProbe::Running {
-            start_identity: Some(identity.clone()),
-        };
-    }
-
-    let probe = probe_process_platform(pid);
-    if pid == std::process::id()
-        && let ProcessProbe::Running {
-            start_identity: Some(identity),
-        } = &probe
-    {
-        let _ = CURRENT_PROCESS_START_IDENTITY.set(identity.clone());
-    }
-    probe
-}
-
-#[cfg(any(windows, all(unix, not(target_os = "linux"))))]
-fn bounded_process_probe_output(command: &mut Command) -> Option<std::process::Output> {
-    let mut child = command
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-    let deadline = Instant::now() + READY_REPAIR_PROCESS_PROBE_TIMEOUT;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return child.wait_with_output().ok(),
-            Ok(None) if Instant::now() < deadline => {
-                thread::sleep(READY_REPAIR_COORDINATION_POLL);
-            }
-            Ok(None) | Err(_) => {
-                if child.kill().is_ok() {
-                    let reap_deadline = Instant::now() + READY_REPAIR_PROCESS_PROBE_REAP_TIMEOUT;
-                    while Instant::now() < reap_deadline {
-                        if child.try_wait().ok().flatten().is_some() {
-                            break;
-                        }
-                        thread::sleep(READY_REPAIR_COORDINATION_POLL);
-                    }
-                }
-                return None;
-            }
-        }
-    }
-}
-
-#[cfg(windows)]
-fn probe_process_platform(pid: u32) -> ProcessProbe {
-    let script = format!(
-        "$p=Get-CimInstance Win32_Process -Filter \"ProcessId = {pid}\" -ErrorAction Stop; if ($null -eq $p) {{ exit 2 }}; $p.CreationDate.ToUniversalTime().Ticks"
-    );
-    let mut command = Command::new("powershell");
-    command.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
-    let Some(output) = bounded_process_probe_output(&mut command) else {
-        return ProcessProbe::Unknown;
-    };
-    if output.status.code() == Some(2) {
-        return ProcessProbe::NotRunning;
-    }
-    if !output.status.success() {
-        return ProcessProbe::Unknown;
-    }
-    let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if identity.is_empty() {
-        return ProcessProbe::Unknown;
-    }
-    ProcessProbe::Running {
-        start_identity: Some(format!("windows:{identity}")),
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn probe_process_platform(pid: u32) -> ProcessProbe {
-    let path = Path::new("/proc").join(pid.to_string()).join("stat");
-    let stat = match fs::read_to_string(path) {
-        Ok(stat) => stat,
-        Err(error) if error.kind() == ErrorKind::NotFound => return ProcessProbe::NotRunning,
-        Err(_) => return ProcessProbe::Unknown,
-    };
-    let Some((_, fields)) = stat.rsplit_once(") ") else {
-        return ProcessProbe::Unknown;
-    };
-    let Some(start_ticks) = fields.split_whitespace().nth(19) else {
-        return ProcessProbe::Unknown;
-    };
-    ProcessProbe::Running {
-        start_identity: Some(format!("linux:{start_ticks}")),
-    }
-}
-
-#[cfg(all(unix, not(target_os = "linux")))]
-fn probe_process_platform(pid: u32) -> ProcessProbe {
-    let mut command = Command::new("ps");
-    command
-        .env("LC_ALL", "C")
-        .env("TZ", "UTC")
-        .args(["-o", "lstart=", "-p", &pid.to_string()]);
-    let Some(output) = bounded_process_probe_output(&mut command) else {
-        return ProcessProbe::Unknown;
-    };
-    if !output.status.success() {
-        return if output.status.code() == Some(1) {
-            ProcessProbe::NotRunning
-        } else {
-            ProcessProbe::Unknown
-        };
-    }
-    let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if identity.is_empty() {
-        return ProcessProbe::Unknown;
-    }
-    ProcessProbe::Running {
-        start_identity: Some(format!("unix:{identity}")),
-    }
-}
-
-#[cfg(not(any(windows, unix)))]
-fn probe_process_platform(_pid: u32) -> ProcessProbe {
-    ProcessProbe::Unknown
 }
 
 fn ready_repair_lock_paths_for_sidecar(sidecar: &SidecarRuntimeConfig) -> Vec<PathBuf> {
@@ -1469,47 +1305,6 @@ mod tests {
             labels: Default::default(),
             ..crate::sidecar_runtime::local()
         }
-    }
-
-    #[test]
-    fn process_owner_probe_matches_live_process_identity() {
-        let state = process_owner_state_with(42, Some("start-a"), |_| ProcessProbe::Running {
-            start_identity: Some("start-a".to_string()),
-        });
-
-        assert_eq!(state, ProcessOwnerState::Matching);
-    }
-
-    #[test]
-    fn process_owner_probe_detects_dead_process() {
-        let state = process_owner_state_with(42, Some("start-a"), |_| ProcessProbe::NotRunning);
-
-        assert_eq!(state, ProcessOwnerState::GoneOrReused);
-    }
-
-    #[test]
-    fn process_owner_probe_detects_pid_reuse() {
-        let state = process_owner_state_with(42, Some("start-a"), |_| ProcessProbe::Running {
-            start_identity: Some("start-b".to_string()),
-        });
-
-        assert_eq!(state, ProcessOwnerState::GoneOrReused);
-    }
-
-    #[test]
-    fn process_owner_probe_uncertainty_preserves_ownership() {
-        let failed_probe = process_owner_state_with(42, Some("start-a"), |_| ProcessProbe::Unknown);
-        let missing_identity =
-            process_owner_state_with(42, Some("start-a"), |_| ProcessProbe::Running {
-                start_identity: None,
-            });
-        let legacy_live = process_owner_state_with(42, None, |_| ProcessProbe::Running {
-            start_identity: Some("start-b".to_string()),
-        });
-
-        assert_eq!(failed_probe, ProcessOwnerState::Unknown);
-        assert_eq!(missing_identity, ProcessOwnerState::Unknown);
-        assert_eq!(legacy_live, ProcessOwnerState::Matching);
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -1229,7 +1229,7 @@ fn embedding_launch_metadata(
         pid: spawn.map(|spawn| spawn.pid),
         spawned_at_epoch_ms: spawn.map(|spawn| spawn.spawned_at_epoch_ms),
         process_start_identity: spawn.and_then(|spawn| {
-            crate::sidecar::native_embedding_process_start_identity(spawn.pid)
+            crate::native_embedding_process_start_identity(spawn.pid)
                 .ok()
                 .flatten()
         }),

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -25,6 +25,7 @@ mod lexical_index;
 mod mode;
 pub mod outbound_http;
 mod planner;
+mod process_identity;
 mod qdrant_client;
 mod qdrant_storage;
 mod query;
@@ -101,6 +102,10 @@ pub use lexical_index::LEXICAL_INDEX_VERSION;
 pub use mode::RetrievalDegradedMode;
 pub use mode::derive_degraded_mode;
 pub use planner::{PlannedStage, RetrievalPlan, RetrievalStageKind, plan_query};
+pub use process_identity::{
+    ProcessOwnerState, ProcessStartProbe, native_embedding_process_start_identity,
+    probe_process_start_identity, process_owner_state,
+};
 pub use qdrant_client::{
     QDRANT_INDEX_UPSERT_BATCH_SIZE, QDRANT_VECTOR_DIM, QdrantClient, QdrantUpsertPoint,
     diagnostic_query_vector,
@@ -122,8 +127,7 @@ pub use retention::{GenerationRetentionApplyReport, GenerationRetentionPlan};
 pub use scip_client::ScipClient;
 pub use sidecar::{
     EmbeddingLaunchOwnership, NativeEmbeddingLaunchIdentityStatus, SidecarStateFile,
-    ensure_native_embedding_launch_identity, native_embedding_launch_identity_status,
-    native_embedding_process_start_identity, sidecar_down,
+    ensure_native_embedding_launch_identity, native_embedding_launch_identity_status, sidecar_down,
     sidecar_down_after_failed_bootstrap_for_runtime, sidecar_down_for_project,
     sidecar_down_for_runtime, sidecar_state_matches_runtime, sidecar_status, sidecar_up,
     sidecar_up_with_runtime, sidecar_up_with_runtime_preserving_launch,

--- a/crates/codestory-retrieval/src/process_identity.rs
+++ b/crates/codestory-retrieval/src/process_identity.rs
@@ -1,0 +1,465 @@
+use anyhow::{Context, Result, bail};
+#[cfg(target_os = "linux")]
+use std::fs;
+#[cfg(windows)]
+use std::io;
+#[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+#[cfg(target_os = "linux")]
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+use std::sync::OnceLock;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const PROCESS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+const PROCESS_PROBE_REAP_TIMEOUT: Duration = Duration::from_millis(250);
+const PROCESS_PROBE_POLL: Duration = Duration::from_millis(10);
+
+#[cfg(windows)]
+const WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+#[cfg(windows)]
+const WINDOWS_ERROR_INVALID_PARAMETER: i32 = 87;
+#[cfg(windows)]
+const WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH: u64 = 504_911_232_000_000_000;
+#[cfg(windows)]
+const WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH: u64 = 116_444_736_000_000_000;
+
+/// Live-process evidence from the platform start-identity probe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessStartProbe {
+    Running { start_identity: Option<String> },
+    NotRunning,
+    Unknown { reason: String },
+}
+
+/// Whether a process probe still proves ownership of a recorded PID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessOwnerState {
+    Matching,
+    GoneOrReused,
+    Unknown,
+}
+
+/// Compare a live process probe with an optional persisted start identity.
+pub fn process_owner_state(
+    probe: &ProcessStartProbe,
+    expected_start_identity: Option<&str>,
+) -> ProcessOwnerState {
+    match probe {
+        ProcessStartProbe::NotRunning => ProcessOwnerState::GoneOrReused,
+        ProcessStartProbe::Unknown { .. } => ProcessOwnerState::Unknown,
+        ProcessStartProbe::Running { start_identity } => match expected_start_identity {
+            None => ProcessOwnerState::Matching,
+            Some(expected) => match start_identity {
+                Some(actual) if actual == expected => ProcessOwnerState::Matching,
+                Some(_) => ProcessOwnerState::GoneOrReused,
+                None => ProcessOwnerState::Unknown,
+            },
+        },
+    }
+}
+
+/// Probe the process start identity without collapsing unavailable evidence into death.
+pub fn probe_process_start_identity(pid: u32) -> ProcessStartProbe {
+    static CURRENT_PROCESS_START_IDENTITY: OnceLock<String> = OnceLock::new();
+
+    if pid == std::process::id()
+        && let Some(identity) = CURRENT_PROCESS_START_IDENTITY.get()
+    {
+        return ProcessStartProbe::Running {
+            start_identity: Some(identity.clone()),
+        };
+    }
+
+    let probe = probe_process_start_identity_platform(pid);
+    if pid == std::process::id()
+        && let ProcessStartProbe::Running {
+            start_identity: Some(identity),
+        } = &probe
+    {
+        let _ = CURRENT_PROCESS_START_IDENTITY.set(identity.clone());
+    }
+    probe
+}
+
+/// Return the persisted native embedding identity format used by sidecar state.
+pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String>> {
+    if pid == 0 {
+        bail!("native embedding process pid must be greater than zero");
+    }
+    match probe_process_start_identity(pid) {
+        ProcessStartProbe::Running {
+            start_identity: Some(identity),
+        } => Ok(Some(identity)),
+        ProcessStartProbe::Running {
+            start_identity: None,
+        } => bail!("native embedding process start identity is unavailable for pid {pid}"),
+        ProcessStartProbe::NotRunning => Ok(None),
+        ProcessStartProbe::Unknown { reason } => {
+            bail!("query native embedding start identity for pid {pid}: {reason}")
+        }
+    }
+}
+
+pub(crate) fn bounded_process_command_output(command: &mut Command) -> Result<Output> {
+    bounded_process_command_output_with_timeout(command, PROCESS_PROBE_TIMEOUT)
+}
+
+fn bounded_process_command_output_with_timeout(
+    command: &mut Command,
+    timeout: Duration,
+) -> Result<Output> {
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawn process identity probe")?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                return child
+                    .wait_with_output()
+                    .context("collect process identity probe output");
+            }
+            Ok(None) if Instant::now() < deadline => thread::sleep(PROCESS_PROBE_POLL),
+            Ok(None) => {
+                terminate_bounded_probe(&mut child);
+                bail!(
+                    "process identity probe timed out after {}ms",
+                    timeout.as_millis()
+                );
+            }
+            Err(error) => {
+                terminate_bounded_probe(&mut child);
+                return Err(error).context("wait for process identity probe");
+            }
+        }
+    }
+}
+
+fn terminate_bounded_probe(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let reap_deadline = Instant::now() + PROCESS_PROBE_REAP_TIMEOUT;
+    while Instant::now() < reap_deadline {
+        if child.try_wait().ok().flatten().is_some() {
+            break;
+        }
+        thread::sleep(PROCESS_PROBE_POLL);
+    }
+}
+
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Default)]
+struct WindowsFileTime {
+    low_date_time: u32,
+    high_date_time: u32,
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> RawHandle;
+    fn GetProcessTimes(
+        process: RawHandle,
+        creation_time: *mut WindowsFileTime,
+        exit_time: *mut WindowsFileTime,
+        kernel_time: *mut WindowsFileTime,
+        user_time: *mut WindowsFileTime,
+    ) -> i32;
+}
+
+#[cfg(windows)]
+fn windows_process_creation_time(pid: u32) -> Result<Option<WindowsFileTime>> {
+    if pid == 0 {
+        bail!("native embedding process pid must be greater than zero");
+    }
+    let raw_handle = unsafe { OpenProcess(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if raw_handle.is_null() {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(WINDOWS_ERROR_INVALID_PARAMETER) {
+            return Ok(None);
+        }
+        return Err(error).with_context(|| format!("open native embedding process {pid}"));
+    }
+    let process = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
+    let mut creation_time = WindowsFileTime::default();
+    let mut exit_time = WindowsFileTime::default();
+    let mut kernel_time = WindowsFileTime::default();
+    let mut user_time = WindowsFileTime::default();
+    if unsafe {
+        GetProcessTimes(
+            process.as_raw_handle(),
+            &mut creation_time,
+            &mut exit_time,
+            &mut kernel_time,
+            &mut user_time,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error())
+            .with_context(|| format!("query native embedding start identity for pid {pid}"));
+    }
+    Ok(Some(creation_time))
+}
+
+#[cfg(windows)]
+fn windows_filetime_ticks(filetime: &WindowsFileTime) -> u64 {
+    (u64::from(filetime.high_date_time) << 32) | u64::from(filetime.low_date_time)
+}
+
+#[cfg(windows)]
+fn windows_datetime_ticks_from_filetime(filetime: &WindowsFileTime) -> Result<u64> {
+    let filetime_ticks = windows_filetime_ticks(filetime);
+    // Win32_Process.CreationDate exposes microseconds, so discard sub-microsecond
+    // FILETIME ticks to preserve identities serialized by the previous CIM query.
+    let legacy_filetime_ticks = filetime_ticks / 10 * 10;
+    legacy_filetime_ticks
+        .checked_add(WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH)
+        .context("convert Windows process creation time to DateTime ticks")
+}
+
+#[cfg(windows)]
+fn windows_epoch_ms_from_filetime(filetime: &WindowsFileTime) -> Result<i64> {
+    let elapsed_ticks = windows_filetime_ticks(filetime)
+        .checked_sub(WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH)
+        .context("convert Windows process creation time to Unix epoch")?;
+    i64::try_from(elapsed_ticks / 10_000)
+        .context("convert Windows process creation time to epoch milliseconds")
+}
+
+#[cfg(windows)]
+pub(crate) fn process_started_at_epoch_ms(pid: u32) -> Result<Option<i64>> {
+    windows_process_creation_time(pid)?
+        .as_ref()
+        .map(windows_epoch_ms_from_filetime)
+        .transpose()
+}
+
+#[cfg(not(windows))]
+pub(crate) fn process_started_at_epoch_ms(pid: u32) -> Result<Option<i64>> {
+    let mut command = Command::new("ps");
+    command
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .args(["-p", &pid.to_string(), "-o", "lstart="]);
+    let output = bounded_process_command_output(&mut command)?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(process_started_at_epoch_ms_from_lstart(&output.stdout))
+}
+
+#[cfg(not(windows))]
+fn process_started_at_epoch_ms_from_lstart(output: &[u8]) -> Option<i64> {
+    use chrono::TimeZone;
+
+    let started = chrono::NaiveDateTime::parse_from_str(
+        String::from_utf8_lossy(output).trim(),
+        "%a %b %e %H:%M:%S %Y",
+    )
+    .ok()?;
+    Some(chrono::Utc.from_utc_datetime(&started).timestamp_millis())
+}
+
+#[cfg(windows)]
+fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
+    match windows_process_creation_time(pid) {
+        Ok(Some(creation_time)) => match windows_datetime_ticks_from_filetime(&creation_time) {
+            Ok(ticks) => ProcessStartProbe::Running {
+                start_identity: Some(format!("windows:{ticks}")),
+            },
+            Err(error) => ProcessStartProbe::Unknown {
+                reason: error.to_string(),
+            },
+        },
+        Ok(None) => ProcessStartProbe::NotRunning,
+        Err(error) => ProcessStartProbe::Unknown {
+            reason: error.to_string(),
+        },
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
+    let stat_path = Path::new("/proc").join(pid.to_string()).join("stat");
+    let stat = match fs::read_to_string(&stat_path) {
+        Ok(stat) => stat,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return ProcessStartProbe::NotRunning;
+        }
+        Err(error) => {
+            return ProcessStartProbe::Unknown {
+                reason: format!("read {}: {error}", stat_path.display()),
+            };
+        }
+    };
+    let Some(start_ticks) = stat
+        .rsplit_once(") ")
+        .and_then(|(_, fields)| fields.split_whitespace().nth(19))
+    else {
+        return ProcessStartProbe::Unknown {
+            reason: format!("parse process start identity from {}", stat_path.display()),
+        };
+    };
+    ProcessStartProbe::Running {
+        start_identity: Some(format!("linux:{start_ticks}")),
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
+    let mut command = Command::new("ps");
+    command
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .args(["-p", &pid.to_string(), "-o", "lstart="]);
+    let output = match bounded_process_command_output(&mut command) {
+        Ok(output) => output,
+        Err(error) => {
+            return ProcessStartProbe::Unknown {
+                reason: error.to_string(),
+            };
+        }
+    };
+    if !output.status.success() {
+        return if output.status.code() == Some(1) {
+            ProcessStartProbe::NotRunning
+        } else {
+            ProcessStartProbe::Unknown {
+                reason: format!(
+                    "ps exited with {}: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ),
+            }
+        };
+    }
+    let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if identity.is_empty() {
+        return ProcessStartProbe::Unknown {
+            reason: "ps returned an empty process start identity".to_string(),
+        };
+    }
+    ProcessStartProbe::Running {
+        start_identity: Some(format!("unix:{identity}")),
+    }
+}
+
+#[cfg(not(any(windows, unix)))]
+fn probe_process_start_identity_platform(_pid: u32) -> ProcessStartProbe {
+    ProcessStartProbe::Unknown {
+        reason: "process start identity is unsupported on this platform".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_owner_state_preserves_identity_and_probe_uncertainty() {
+        let running = ProcessStartProbe::Running {
+            start_identity: Some("start-a".to_string()),
+        };
+        assert_eq!(
+            process_owner_state(&running, Some("start-a")),
+            ProcessOwnerState::Matching
+        );
+        assert_eq!(
+            process_owner_state(&running, Some("start-b")),
+            ProcessOwnerState::GoneOrReused
+        );
+        assert_eq!(
+            process_owner_state(&ProcessStartProbe::NotRunning, Some("start-a")),
+            ProcessOwnerState::GoneOrReused
+        );
+        assert_eq!(
+            process_owner_state(
+                &ProcessStartProbe::Unknown {
+                    reason: "probe failed".to_string(),
+                },
+                Some("start-a")
+            ),
+            ProcessOwnerState::Unknown
+        );
+        assert_eq!(
+            process_owner_state(
+                &ProcessStartProbe::Running {
+                    start_identity: None,
+                },
+                Some("start-a")
+            ),
+            ProcessOwnerState::Unknown
+        );
+        assert_eq!(
+            process_owner_state(&running, None),
+            ProcessOwnerState::Matching
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_start_probe_tracks_live_child_and_exit() -> Result<()> {
+        let mut child = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .context("spawn process identity fixture")?;
+        let pid = child.id();
+        let expected_prefix = if cfg!(target_os = "linux") {
+            "linux:"
+        } else {
+            "unix:"
+        };
+
+        let first = probe_process_start_identity(pid);
+        let second = probe_process_start_identity(pid);
+        let result = (|| -> Result<()> {
+            let ProcessStartProbe::Running {
+                start_identity: Some(first),
+            } = first
+            else {
+                bail!("live child did not expose a process start identity")
+            };
+            let ProcessStartProbe::Running {
+                start_identity: Some(second),
+            } = second
+            else {
+                bail!("repeat live-child probe did not expose a process start identity")
+            };
+            assert!(first.starts_with(expected_prefix));
+            assert_eq!(first, second);
+            Ok(())
+        })();
+
+        let _ = child.kill();
+        let _ = child.wait();
+        result?;
+        assert_eq!(
+            probe_process_start_identity(pid),
+            ProcessStartProbe::NotRunning
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_identity_format_stays_compatible_with_legacy_cim_ticks() -> Result<()> {
+        const DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH: u64 = 621_355_968_000_000_000;
+
+        let unix_epoch_with_sub_microsecond_ticks = WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH + 8;
+        let unix_epoch = WindowsFileTime {
+            low_date_time: unix_epoch_with_sub_microsecond_ticks as u32,
+            high_date_time: (unix_epoch_with_sub_microsecond_ticks >> 32) as u32,
+        };
+        assert_eq!(
+            windows_datetime_ticks_from_filetime(&unix_epoch)?,
+            DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH
+        );
+        assert_eq!(windows_epoch_ms_from_filetime(&unix_epoch)?, 0);
+        Ok(())
+    }
+}

--- a/crates/codestory-retrieval/src/process_identity.rs
+++ b/crates/codestory-retrieval/src/process_identity.rs
@@ -28,7 +28,7 @@ const WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH: u64 = 116_444_736_000_000_000;
 /// Live-process evidence from the platform start-identity probe.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProcessStartProbe {
-    Running { start_identity: Option<String> },
+    Running { start_identity: String },
     NotRunning,
     Unknown { reason: String },
 }
@@ -51,11 +51,8 @@ pub fn process_owner_state(
         ProcessStartProbe::Unknown { .. } => ProcessOwnerState::Unknown,
         ProcessStartProbe::Running { start_identity } => match expected_start_identity {
             None => ProcessOwnerState::Matching,
-            Some(expected) => match start_identity {
-                Some(actual) if actual == expected => ProcessOwnerState::Matching,
-                Some(_) => ProcessOwnerState::GoneOrReused,
-                None => ProcessOwnerState::Unknown,
-            },
+            Some(expected) if start_identity == expected => ProcessOwnerState::Matching,
+            Some(_) => ProcessOwnerState::GoneOrReused,
         },
     }
 }
@@ -68,17 +65,15 @@ pub fn probe_process_start_identity(pid: u32) -> ProcessStartProbe {
         && let Some(identity) = CURRENT_PROCESS_START_IDENTITY.get()
     {
         return ProcessStartProbe::Running {
-            start_identity: Some(identity.clone()),
+            start_identity: identity.clone(),
         };
     }
 
     let probe = probe_process_start_identity_platform(pid);
     if pid == std::process::id()
-        && let ProcessStartProbe::Running {
-            start_identity: Some(identity),
-        } = &probe
+        && let ProcessStartProbe::Running { start_identity } = &probe
     {
-        let _ = CURRENT_PROCESS_START_IDENTITY.set(identity.clone());
+        let _ = CURRENT_PROCESS_START_IDENTITY.set(start_identity.clone());
     }
     probe
 }
@@ -89,12 +84,7 @@ pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String
         bail!("native embedding process pid must be greater than zero");
     }
     match probe_process_start_identity(pid) {
-        ProcessStartProbe::Running {
-            start_identity: Some(identity),
-        } => Ok(Some(identity)),
-        ProcessStartProbe::Running {
-            start_identity: None,
-        } => bail!("native embedding process start identity is unavailable for pid {pid}"),
+        ProcessStartProbe::Running { start_identity } => Ok(Some(start_identity)),
         ProcessStartProbe::NotRunning => Ok(None),
         ProcessStartProbe::Unknown { reason } => {
             bail!("query native embedding start identity for pid {pid}: {reason}")
@@ -104,6 +94,28 @@ pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String
 
 pub(crate) fn bounded_process_command_output(command: &mut Command) -> Result<Output> {
     bounded_process_command_output_with_timeout(command, PROCESS_PROBE_TIMEOUT)
+}
+
+#[cfg(not(windows))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PsProbeOutputStatus {
+    Success,
+    ProcessMissing,
+}
+
+#[cfg(not(windows))]
+pub(crate) fn classify_ps_probe_output(output: &Output) -> Result<PsProbeOutputStatus> {
+    if output.status.success() {
+        return Ok(PsProbeOutputStatus::Success);
+    }
+    if output.status.code() == Some(1) {
+        return Ok(PsProbeOutputStatus::ProcessMissing);
+    }
+    bail!(
+        "ps exited with {}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    )
 }
 
 fn bounded_process_command_output_with_timeout(
@@ -247,10 +259,10 @@ pub(crate) fn process_started_at_epoch_ms(pid: u32) -> Result<Option<i64>> {
         .env("TZ", "UTC")
         .args(["-p", &pid.to_string(), "-o", "lstart="]);
     let output = bounded_process_command_output(&mut command)?;
-    if !output.status.success() {
-        return Ok(None);
+    match classify_ps_probe_output(&output)? {
+        PsProbeOutputStatus::Success => Ok(process_started_at_epoch_ms_from_lstart(&output.stdout)),
+        PsProbeOutputStatus::ProcessMissing => Ok(None),
     }
-    Ok(process_started_at_epoch_ms_from_lstart(&output.stdout))
 }
 
 #[cfg(not(windows))]
@@ -270,7 +282,7 @@ fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
     match windows_process_creation_time(pid) {
         Ok(Some(creation_time)) => match windows_datetime_ticks_from_filetime(&creation_time) {
             Ok(ticks) => ProcessStartProbe::Running {
-                start_identity: Some(format!("windows:{ticks}")),
+                start_identity: format!("windows:{ticks}"),
             },
             Err(error) => ProcessStartProbe::Unknown {
                 reason: error.to_string(),
@@ -306,7 +318,7 @@ fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
         };
     };
     ProcessStartProbe::Running {
-        start_identity: Some(format!("linux:{start_ticks}")),
+        start_identity: format!("linux:{start_ticks}"),
     }
 }
 
@@ -325,18 +337,14 @@ fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
             };
         }
     };
-    if !output.status.success() {
-        return if output.status.code() == Some(1) {
-            ProcessStartProbe::NotRunning
-        } else {
-            ProcessStartProbe::Unknown {
-                reason: format!(
-                    "ps exited with {}: {}",
-                    output.status,
-                    String::from_utf8_lossy(&output.stderr).trim()
-                ),
-            }
-        };
+    match classify_ps_probe_output(&output) {
+        Ok(PsProbeOutputStatus::Success) => {}
+        Ok(PsProbeOutputStatus::ProcessMissing) => return ProcessStartProbe::NotRunning,
+        Err(error) => {
+            return ProcessStartProbe::Unknown {
+                reason: error.to_string(),
+            };
+        }
     }
     let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if identity.is_empty() {
@@ -345,7 +353,7 @@ fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
         };
     }
     ProcessStartProbe::Running {
-        start_identity: Some(format!("unix:{identity}")),
+        start_identity: format!("unix:{identity}"),
     }
 }
 
@@ -363,7 +371,7 @@ mod tests {
     #[test]
     fn process_owner_state_preserves_identity_and_probe_uncertainty() {
         let running = ProcessStartProbe::Running {
-            start_identity: Some("start-a".to_string()),
+            start_identity: "start-a".to_string(),
         };
         assert_eq!(
             process_owner_state(&running, Some("start-a")),
@@ -387,18 +395,33 @@ mod tests {
             ProcessOwnerState::Unknown
         );
         assert_eq!(
-            process_owner_state(
-                &ProcessStartProbe::Running {
-                    start_identity: None,
-                },
-                Some("start-a")
-            ),
-            ProcessOwnerState::Unknown
-        );
-        assert_eq!(
             process_owner_state(&running, None),
             ProcessOwnerState::Matching
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ps_status_distinguishes_missing_process_from_probe_failure() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let output = |code, stderr: &str| Output {
+            status: std::process::ExitStatus::from_raw(code << 8),
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        };
+
+        assert_eq!(
+            classify_ps_probe_output(&output(0, "")).expect("successful ps"),
+            PsProbeOutputStatus::Success
+        );
+        assert_eq!(
+            classify_ps_probe_output(&output(1, "")).expect("missing pid"),
+            PsProbeOutputStatus::ProcessMissing
+        );
+        let error = classify_ps_probe_output(&output(2, "invalid ps invocation"))
+            .expect_err("probe failure must not look like a dead process");
+        assert!(error.to_string().contains("invalid ps invocation"));
     }
 
     #[cfg(unix)]
@@ -419,13 +442,13 @@ mod tests {
         let second = probe_process_start_identity(pid);
         let result = (|| -> Result<()> {
             let ProcessStartProbe::Running {
-                start_identity: Some(first),
+                start_identity: first,
             } = first
             else {
                 bail!("live child did not expose a process start identity")
             };
             let ProcessStartProbe::Running {
-                start_identity: Some(second),
+                start_identity: second,
             } = second
             else {
                 bail!("repeat live-child probe did not expose a process start identity")

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -16,6 +16,8 @@ use crate::process_identity::{
     native_embedding_process_start_identity, probe_process_start_identity, process_owner_state,
     process_started_at_epoch_ms,
 };
+#[cfg(all(not(windows), not(target_os = "linux")))]
+use crate::process_identity::{PsProbeOutputStatus, classify_ps_probe_output};
 use anyhow::{Context, Result, bail};
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext,
@@ -592,7 +594,7 @@ pub fn native_embedding_launch_identity_status(
     let final_start_probe = probe_process_start_identity(pid);
     match &final_start_probe {
         ProcessStartProbe::Running {
-            start_identity: Some(actual),
+            start_identity: actual,
         } if start_identity_before != *actual => {
             return NativeEmbeddingLaunchIdentityStatus::Unverified {
                 pid: Some(pid),
@@ -601,12 +603,11 @@ pub fn native_embedding_launch_identity_status(
                 ),
             };
         }
+        ProcessStartProbe::Running { .. }
+            if process_owner_state(&final_start_probe, Some(expected_start_identity))
+                == ProcessOwnerState::Matching => {}
         ProcessStartProbe::Running {
-            start_identity: Some(_),
-        } if process_owner_state(&final_start_probe, Some(expected_start_identity))
-            == ProcessOwnerState::Matching => {}
-        ProcessStartProbe::Running {
-            start_identity: Some(actual),
+            start_identity: actual,
         } => {
             return NativeEmbeddingLaunchIdentityStatus::Mismatched {
                 pid,
@@ -615,10 +616,7 @@ pub fn native_embedding_launch_identity_status(
                 ),
             };
         }
-        ProcessStartProbe::Running {
-            start_identity: None,
-        }
-        | ProcessStartProbe::NotRunning => {
+        ProcessStartProbe::NotRunning => {
             return NativeEmbeddingLaunchIdentityStatus::Unverified {
                 pid: Some(pid),
                 reason: "live native embedding process start identity is unavailable".to_string(),
@@ -957,8 +955,9 @@ fn native_embedding_process_snapshot(pid: u32) -> Result<Option<NativeEmbeddingP
     command.args(["-p", &pid.to_string(), "-o", "state=", "-o", "command="]);
     let output = bounded_process_command_output(&mut command)
         .with_context(|| format!("query native embedding pid {pid}"))?;
-    if !output.status.success() {
-        return Ok(None);
+    match classify_ps_probe_output(&output)? {
+        PsProbeOutputStatus::Success => {}
+        PsProbeOutputStatus::ProcessMissing => return Ok(None),
     }
     let mut snapshot =
         native_embedding_non_linux_unix_process_snapshot_from_ps_output(&output.stdout);

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -11,10 +11,11 @@ use crate::health::{
     probe_sidecar_health_for_runtime, unavailable_status_report_with_embedding_device,
 };
 use crate::index::{compute_sidecar_input_fingerprint_for_runtime, sidecar_project_id_for_runtime};
+#[cfg(not(target_os = "linux"))]
+use crate::process_identity::bounded_process_command_output;
 use crate::process_identity::{
-    ProcessOwnerState, ProcessStartProbe, bounded_process_command_output,
-    native_embedding_process_start_identity, probe_process_start_identity, process_owner_state,
-    process_started_at_epoch_ms,
+    ProcessOwnerState, ProcessStartProbe, native_embedding_process_start_identity,
+    probe_process_start_identity, process_owner_state, process_started_at_epoch_ms,
 };
 #[cfg(all(not(windows), not(target_os = "linux")))]
 use crate::process_identity::{PsProbeOutputStatus, classify_ps_probe_output};

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -11,6 +11,11 @@ use crate::health::{
     probe_sidecar_health_for_runtime, unavailable_status_report_with_embedding_device,
 };
 use crate::index::{compute_sidecar_input_fingerprint_for_runtime, sidecar_project_id_for_runtime};
+use crate::process_identity::{
+    ProcessOwnerState, ProcessStartProbe, bounded_process_command_output,
+    native_embedding_process_start_identity, probe_process_start_identity, process_owner_state,
+    process_started_at_epoch_ms,
+};
 use anyhow::{Context, Result, bail};
 use codestory_contracts::language_support::{
     LanguageSupportMode, language_support_profile_for_ext,
@@ -20,10 +25,6 @@ use codestory_workspace::{RefreshInputs, WorkspaceManifest};
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "linux")]
 use std::fs;
-#[cfg(windows)]
-use std::io;
-#[cfg(windows)]
-use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
 use std::path::Path;
 use std::process::Command;
 #[cfg(not(windows))]
@@ -51,36 +52,7 @@ unsafe extern "C" {
     ) -> std::ffi::c_int;
 }
 
-#[cfg(windows)]
-#[repr(C)]
-#[derive(Default)]
-struct WindowsFileTime {
-    low_date_time: u32,
-    high_date_time: u32,
-}
-
-#[cfg(windows)]
-#[link(name = "kernel32")]
-unsafe extern "system" {
-    fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> RawHandle;
-    fn GetProcessTimes(
-        process: RawHandle,
-        creation_time: *mut WindowsFileTime,
-        exit_time: *mut WindowsFileTime,
-        kernel_time: *mut WindowsFileTime,
-        user_time: *mut WindowsFileTime,
-    ) -> i32;
-}
-
 const NATIVE_EMBEDDING_PROCESS_START_TOLERANCE_MS: i64 = 5 * 1000;
-#[cfg(windows)]
-const WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
-#[cfg(windows)]
-const WINDOWS_ERROR_INVALID_PARAMETER: i32 = 87;
-#[cfg(windows)]
-const WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH: u64 = 504_911_232_000_000_000;
-#[cfg(windows)]
-const WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH: u64 = 116_444_736_000_000_000;
 #[cfg(target_os = "macos")]
 const MACOS_CTL_KERN: std::ffi::c_int = 1;
 #[cfg(target_os = "macos")]
@@ -617,8 +589,11 @@ pub fn native_embedding_launch_identity_status(
             };
         }
     };
-    match native_embedding_process_start_identity(pid) {
-        Ok(Some(actual)) if start_identity_before != actual => {
+    let final_start_probe = probe_process_start_identity(pid);
+    match &final_start_probe {
+        ProcessStartProbe::Running {
+            start_identity: Some(actual),
+        } if start_identity_before != *actual => {
             return NativeEmbeddingLaunchIdentityStatus::Unverified {
                 pid: Some(pid),
                 reason: format!(
@@ -626,8 +601,13 @@ pub fn native_embedding_launch_identity_status(
                 ),
             };
         }
-        Ok(Some(actual)) if actual == expected_start_identity => {}
-        Ok(Some(actual)) => {
+        ProcessStartProbe::Running {
+            start_identity: Some(_),
+        } if process_owner_state(&final_start_probe, Some(expected_start_identity))
+            == ProcessOwnerState::Matching => {}
+        ProcessStartProbe::Running {
+            start_identity: Some(actual),
+        } => {
             return NativeEmbeddingLaunchIdentityStatus::Mismatched {
                 pid,
                 reason: format!(
@@ -635,16 +615,19 @@ pub fn native_embedding_launch_identity_status(
                 ),
             };
         }
-        Ok(None) => {
+        ProcessStartProbe::Running {
+            start_identity: None,
+        }
+        | ProcessStartProbe::NotRunning => {
             return NativeEmbeddingLaunchIdentityStatus::Unverified {
                 pid: Some(pid),
                 reason: "live native embedding process start identity is unavailable".to_string(),
             };
         }
-        Err(error) => {
+        ProcessStartProbe::Unknown { reason } => {
             return NativeEmbeddingLaunchIdentityStatus::Unverified {
                 pid: Some(pid),
-                reason: format!("query live native embedding process start identity: {error}"),
+                reason: format!("query live native embedding process start identity: {reason}"),
             };
         }
     }
@@ -882,104 +865,6 @@ fn normalized_identity_path(path: &str) -> String {
 }
 
 #[cfg(windows)]
-fn windows_process_creation_time(pid: u32) -> Result<Option<WindowsFileTime>> {
-    if pid == 0 {
-        bail!("native embedding process pid must be greater than zero");
-    }
-    let raw_handle = unsafe { OpenProcess(WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
-    if raw_handle.is_null() {
-        let error = io::Error::last_os_error();
-        if error.raw_os_error() == Some(WINDOWS_ERROR_INVALID_PARAMETER) {
-            return Ok(None);
-        }
-        return Err(error).with_context(|| format!("open native embedding process {pid}"));
-    }
-    let process = unsafe { OwnedHandle::from_raw_handle(raw_handle) };
-    let mut creation_time = WindowsFileTime::default();
-    let mut exit_time = WindowsFileTime::default();
-    let mut kernel_time = WindowsFileTime::default();
-    let mut user_time = WindowsFileTime::default();
-    if unsafe {
-        GetProcessTimes(
-            process.as_raw_handle(),
-            &mut creation_time,
-            &mut exit_time,
-            &mut kernel_time,
-            &mut user_time,
-        )
-    } == 0
-    {
-        return Err(io::Error::last_os_error())
-            .with_context(|| format!("query native embedding start identity for pid {pid}"));
-    }
-    Ok(Some(creation_time))
-}
-
-#[cfg(windows)]
-pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String>> {
-    let Some(creation_time) = windows_process_creation_time(pid)? else {
-        return Ok(None);
-    };
-    let ticks = windows_datetime_ticks_from_filetime(&creation_time)?;
-    Ok(Some(format!("windows:{ticks}")))
-}
-
-#[cfg(windows)]
-fn windows_filetime_ticks(filetime: &WindowsFileTime) -> u64 {
-    (u64::from(filetime.high_date_time) << 32) | u64::from(filetime.low_date_time)
-}
-
-#[cfg(windows)]
-fn windows_datetime_ticks_from_filetime(filetime: &WindowsFileTime) -> Result<u64> {
-    let filetime_ticks = windows_filetime_ticks(filetime);
-    // Win32_Process.CreationDate exposes microseconds, so discard sub-microsecond
-    // FILETIME ticks to preserve identities serialized by the previous CIM query.
-    let legacy_filetime_ticks = filetime_ticks / 10 * 10;
-    legacy_filetime_ticks
-        .checked_add(WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH)
-        .context("convert Windows process creation time to DateTime ticks")
-}
-
-#[cfg(windows)]
-fn windows_epoch_ms_from_filetime(filetime: &WindowsFileTime) -> Result<i64> {
-    let elapsed_ticks = windows_filetime_ticks(filetime)
-        .checked_sub(WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH)
-        .context("convert Windows process creation time to Unix epoch")?;
-    i64::try_from(elapsed_ticks / 10_000)
-        .context("convert Windows process creation time to epoch milliseconds")
-}
-
-#[cfg(target_os = "linux")]
-pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String>> {
-    let stat_path = Path::new("/proc").join(pid.to_string()).join("stat");
-    let stat = match fs::read_to_string(&stat_path) {
-        Ok(stat) => stat,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error).with_context(|| format!("read {}", stat_path.display())),
-    };
-    let start_ticks = stat
-        .rsplit_once(") ")
-        .and_then(|(_, fields)| fields.split_whitespace().nth(19))
-        .with_context(|| format!("parse process start identity from {}", stat_path.display()))?;
-    Ok(Some(format!("linux:{start_ticks}")))
-}
-
-#[cfg(all(not(windows), not(target_os = "linux")))]
-pub fn native_embedding_process_start_identity(pid: u32) -> Result<Option<String>> {
-    let output = Command::new("ps")
-        .env("LC_ALL", "C")
-        .env("TZ", "UTC")
-        .args(["-p", &pid.to_string(), "-o", "lstart="])
-        .output()
-        .with_context(|| format!("query native embedding start identity for pid {pid}"))?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-    let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok((!identity.is_empty()).then(|| format!("unix:{identity}")))
-}
-
-#[cfg(windows)]
 fn native_embedding_process_snapshot(pid: u32) -> Result<Option<NativeEmbeddingProcessSnapshot>> {
     #[derive(Deserialize)]
     struct WindowsProcessInfo {
@@ -989,15 +874,15 @@ fn native_embedding_process_snapshot(pid: u32) -> Result<Option<NativeEmbeddingP
         command_line: Option<String>,
     }
 
-    let Some(creation_time) = windows_process_creation_time(pid)? else {
+    let Some(started_at_epoch_ms) = process_started_at_epoch_ms(pid)? else {
         return Ok(None);
     };
     let script = format!(
         "$p=Get-CimInstance Win32_Process -Filter 'ProcessId = {pid}'; if ($null -eq $p) {{ exit 2 }}; [pscustomobject]@{{ExecutablePath=$p.ExecutablePath;CommandLine=$p.CommandLine}} | ConvertTo-Json -Compress"
     );
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-Command", &script])
-        .output()
+    let mut command = Command::new("powershell");
+    command.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+    let output = bounded_process_command_output(&mut command)
         .with_context(|| format!("query native embedding pid {pid}"))?;
     if output.status.code() == Some(2) {
         return Ok(None);
@@ -1014,7 +899,7 @@ fn native_embedding_process_snapshot(pid: u32) -> Result<Option<NativeEmbeddingP
         executable_path: info.executable_path,
         command_line: info.command_line,
         arguments: None,
-        started_at_epoch_ms: Some(windows_epoch_ms_from_filetime(&creation_time)?),
+        started_at_epoch_ms: Some(started_at_epoch_ms),
     }))
 }
 
@@ -1041,7 +926,7 @@ fn native_embedding_process_snapshot(pid: u32) -> Result<Option<NativeEmbeddingP
             .collect::<Vec<_>>()
             .join(" ")
     });
-    let started_at_epoch_ms = native_embedding_process_started_at_epoch_ms(pid);
+    let started_at_epoch_ms = process_started_at_epoch_ms(pid).ok().flatten();
     Ok(Some(NativeEmbeddingProcessSnapshot {
         executable_path,
         command_line,
@@ -1068,9 +953,9 @@ fn native_embedding_linux_process_state(process_dir: &Path) -> Result<Option<cha
 
 #[cfg(all(not(windows), not(target_os = "linux")))]
 fn native_embedding_process_snapshot(pid: u32) -> Result<Option<NativeEmbeddingProcessSnapshot>> {
-    let output = Command::new("ps")
-        .args(["-p", &pid.to_string(), "-o", "state=", "-o", "command="])
-        .output()
+    let mut command = Command::new("ps");
+    command.args(["-p", &pid.to_string(), "-o", "state=", "-o", "command="]);
+    let output = bounded_process_command_output(&mut command)
         .with_context(|| format!("query native embedding pid {pid}"))?;
     if !output.status.success() {
         return Ok(None);
@@ -1084,7 +969,7 @@ fn native_embedding_process_snapshot(pid: u32) -> Result<Option<NativeEmbeddingP
             snapshot.executable_path = Some(executable_path);
             snapshot.arguments = Some(arguments);
         }
-        snapshot.started_at_epoch_ms = native_embedding_process_started_at_epoch_ms(pid);
+        snapshot.started_at_epoch_ms = process_started_at_epoch_ms(pid).ok().flatten();
     }
     Ok(snapshot)
 }
@@ -1213,32 +1098,6 @@ fn native_embedding_non_linux_unix_process_snapshot_from_ps_output(
         arguments: None,
         started_at_epoch_ms: None,
     })
-}
-
-#[cfg(not(windows))]
-fn native_embedding_process_started_at_epoch_ms(pid: u32) -> Option<i64> {
-    let output = Command::new("ps")
-        .env("LC_ALL", "C")
-        .env("TZ", "UTC")
-        .args(["-p", &pid.to_string(), "-o", "lstart="])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    native_embedding_process_started_at_epoch_ms_from_lstart(&output.stdout)
-}
-
-#[cfg(any(test, not(windows)))]
-fn native_embedding_process_started_at_epoch_ms_from_lstart(output: &[u8]) -> Option<i64> {
-    use chrono::TimeZone;
-
-    let started = chrono::NaiveDateTime::parse_from_str(
-        String::from_utf8_lossy(output).trim(),
-        "%a %b %e %H:%M:%S %Y",
-    )
-    .ok()?;
-    Some(chrono::Utc.from_utc_datetime(&started).timestamp_millis())
 }
 
 /// Probe sidecar health and attach the latest retrieval manifest when storage is available.
@@ -2224,18 +2083,6 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_native_embedding_identity_and_snapshot_are_stable_and_compatible() -> Result<()> {
-        const DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH: u64 = 621_355_968_000_000_000;
-
-        let unix_epoch_with_sub_microsecond_ticks = WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH + 8;
-        let unix_epoch = WindowsFileTime {
-            low_date_time: unix_epoch_with_sub_microsecond_ticks as u32,
-            high_date_time: (unix_epoch_with_sub_microsecond_ticks >> 32) as u32,
-        };
-        assert_eq!(
-            windows_datetime_ticks_from_filetime(&unix_epoch)?,
-            DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH
-        );
-        assert_eq!(windows_epoch_ms_from_filetime(&unix_epoch)?, 0);
         assert!(native_embedding_process_start_identity(0).is_err());
 
         let before_spawn_epoch_ms = std::time::SystemTime::now()


### PR DESCRIPTION
## Context

Retrieval and CLI repair ownership independently probed and serialized process start identity. The implementations had already drifted: CLI probes were bounded and retained an explicit unknown state, while retrieval could wait indefinitely on Darwin `ps` and collapse some probe failures into a dead process.

Base: `dev/codestory-next` at `89d08263c9308532665c46433eaf9317016fb65b`
Head: `75d90483b1971d880fb7bf9e77959ab7bc04f438`

## What changed

- Added one retrieval-level process identity API for platform probing, `windows:` / `linux:` / `unix:` serialization, and owner comparison.
- Routed CLI repair reservations, locks, local refresh ownership, and broker/native-lease callers through that API without changing their dead/reused/unknown policies.
- Kept retrieval launch checks fail-closed while using the same shared comparison for exact start identity.
- Bounded macOS `ps` and Windows PowerShell snapshot probes, and centralized process start-time parsing alongside start identity.
- Treat only the known `ps` missing-PID exit as absent; other probe exits remain explicit unverified errors.
- Removed four duplicate CLI probe-state tests; three shared API tests now cover the comparison matrix, ps exit classification, and a real live-to-dead lifecycle.

Code-simplifier classification: `S3/R3`, profile `rust`, rule `rust-process-identity-extract-shared-api`, confidence `0.95`; risk drivers are `async_or_concurrency` and `semantic_coupling`.

## How to review

1. Start in `crates/codestory-retrieval/src/process_identity.rs`; verify platform wire formats and the bounded command helper.
2. Check `ready_repair_status.rs` to confirm caller policy still maps probe uncertainty to `Unknown` and exact mismatch to `GoneOrReused`.
3. Check `sidecar.rs` to confirm launch identity still distinguishes not-running, mismatched, and unverified states around the executable/argument snapshot.

## Verification

Passed locally on macOS ARM64:

- `cargo fmt --all`
- `cargo check --locked -p codestory-retrieval --lib`
- `cargo test --locked -p codestory-retrieval --lib process_identity::tests`
- `cargo test --locked -p codestory-retrieval --lib native_embedding_bsd_process_snapshot_includes_start_identity`
- `cargo test --locked -p codestory-retrieval --lib native_embedding_identity_rejects_exact_start_identity_mismatch`
- `cargo test --locked -p codestory-retrieval --lib native_embedding_identity_without_exact_start_distinguishes_live_from_dead`
- `cargo test --locked -p codestory-cli --bin codestory-cli reused_pid_repair_lock_is_reclaimable_immediately`
- `cargo test --locked -p codestory-cli --bin codestory-cli stale_live_repair_with_exact_identity_is_never_terminated_by_age`
- `git diff --check`

No broad workspace or packaged matrix was run on this draft head. Exact-head source proof remains the review gate; Windows runtime proof belongs to the Windows lane.

## Risk

The sensitive boundary is preserving the difference between a dead/reused PID and a live process whose identity cannot be proven. Focused tests cover that mapping and the macOS lifecycle. Windows formatting retains the prior .NET tick representation, but real Windows process behavior is intentionally left for the Windows orchestrator and CI.

Closes #1090
Refs #884
Refs #1046


