### PR TITLE
journal snapshot promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@
   binding timeline per module. Route queries reuse that timeline instead of
   rescanning prior statements, and FastAPI imports are resolved from parsed
   nodes so multiline aliases, comments, and later shadowing remain accurate.
+- Core snapshot promotion now records durable prepared and committed identities.
+  A committed generation cannot be rolled back by a retained cleanup backup,
+  while interrupted and legacy recovery validates complete database identities
+  before replacing the live store.
 - Native process reuse and cleanup now bind executable filesystem identity,
   arguments, endpoint, and one shared cross-platform process start identity.
   macOS and Windows process inspection is bounded, dead, reused, or unverified

--- a/crates/codestory-store/src/snapshot_store.rs
+++ b/crates/codestory-store/src/snapshot_store.rs
@@ -279,12 +279,22 @@ mod tests {
     fn snapshot_store_can_prepare_and_promote_staged_publish() {
         let temp = fresh_temp_root("promote");
         let live_path = temp.join("live.sqlite");
-        let staged = SnapshotStore::open_staged(&live_path).expect("open staged");
+        let mut staged = SnapshotStore::open_staged(&live_path).expect("open staged");
 
         staged
             .snapshots()
             .finalize_staged()
             .expect("prepare staged publish");
+        staged
+            .store_mut()
+            .put_index_publication(&crate::IndexPublicationRecord {
+                generation: 1,
+                generation_id: "prepared-generation".to_string(),
+                run_id: "prepared-run".to_string(),
+                mode: crate::IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            })
+            .expect("identify staged publication");
         staged.publish(&live_path).expect("promote staged snapshot");
 
         let live = Store::open(&live_path).expect("open live store");

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::{self, File, OpenOptions};
-#[cfg(test)]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -56,6 +55,10 @@ const OCCURRENCE_LOOKUP_BATCH_SIZE: usize = 200;
 const PROMOTION_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_SENTINEL";
 #[cfg(test)]
 const PROMOTION_ABORT_SENTINEL: &[u8] = b"after-live-restore-step\n";
+const PROMOTION_JOURNAL_VERSION: u32 = 1;
+#[cfg(test)]
+const PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV: &str =
+    "CODESTORY_TEST_PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE";
 
 fn clamp_i64_to_u32(value: i64) -> u32 {
     if value <= 0 {
@@ -178,8 +181,170 @@ struct PromotionLock {
     file: File,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PromotionJournalPhase {
+    Prepared,
+    Committed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PromotionDatabaseIdentity {
+    schema_version: u32,
+    publication: Option<IndexPublicationRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PromotionJournal {
+    version: u32,
+    phase: PromotionJournalPhase,
+    previous: Option<PromotionDatabaseIdentity>,
+    candidate: PromotionDatabaseIdentity,
+}
+
 fn promotion_lock_path(path: &Path) -> PathBuf {
     PathBuf::from(format!("{}.promotion.lock", path.display()))
+}
+
+fn promotion_prepared_journal_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.promotion.prepared.json", path.display()))
+}
+
+fn promotion_committed_journal_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.promotion.committed.json", path.display()))
+}
+
+fn promotion_artifacts_exist(path: &Path) -> bool {
+    path.with_extension("sqlite.backup").exists()
+        || promotion_prepared_journal_path(path).exists()
+        || promotion_committed_journal_path(path).exists()
+}
+
+fn promotion_error(message: impl Into<String>) -> StorageError {
+    StorageError::Other(message.into())
+}
+
+fn read_promotion_database_identity(
+    path: &Path,
+) -> Result<Option<PromotionDatabaseIdentity>, StorageError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    let _ = conn.busy_timeout(Duration::from_millis(2_500));
+    let quick_check: String = conn.query_row("PRAGMA quick_check", [], |row| row.get(0))?;
+    if quick_check != "ok" {
+        return Err(promotion_error(format!(
+            "SQLite promotion artifact {} failed quick_check: {quick_check}",
+            path.display()
+        )));
+    }
+    let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    let schema_version = version.max(0) as u32;
+    if schema_version != SCHEMA_VERSION {
+        return Err(promotion_error(format!(
+            "SQLite promotion artifact {} has schema version {schema_version}, expected {SCHEMA_VERSION}",
+            path.display()
+        )));
+    }
+    let publication = read_complete_index_publication(&conn)?;
+    Ok(Some(PromotionDatabaseIdentity {
+        schema_version,
+        publication,
+    }))
+}
+
+fn read_promotion_journal(
+    path: &Path,
+    expected_phase: PromotionJournalPhase,
+) -> Result<PromotionJournal, StorageError> {
+    let bytes = fs::read(path).map_err(|error| {
+        promotion_error(format!(
+            "Failed to read promotion journal {}: {error}",
+            path.display()
+        ))
+    })?;
+    let journal: PromotionJournal = serde_json::from_slice(&bytes).map_err(|error| {
+        promotion_error(format!(
+            "Failed to parse promotion journal {}: {error}",
+            path.display()
+        ))
+    })?;
+    if journal.version != PROMOTION_JOURNAL_VERSION || journal.phase != expected_phase {
+        return Err(promotion_error(format!(
+            "Unsupported promotion journal {}: version={} phase={:?}",
+            path.display(),
+            journal.version,
+            journal.phase
+        )));
+    }
+    Ok(journal)
+}
+
+fn sync_promotion_parent(path: &Path) -> Result<(), StorageError> {
+    #[cfg(not(windows))]
+    if let Some(parent) = path.parent() {
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| {
+                promotion_error(format!(
+                    "Failed to sync promotion journal directory {}: {error}",
+                    parent.display()
+                ))
+            })?;
+    }
+    #[cfg(windows)]
+    let _ = path;
+    Ok(())
+}
+
+fn write_promotion_journal(path: &Path, journal: &PromotionJournal) -> Result<(), StorageError> {
+    let bytes = serde_json::to_vec(journal).map_err(|error| {
+        promotion_error(format!(
+            "Failed to serialize promotion journal {}: {error}",
+            path.display()
+        ))
+    })?;
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| {
+            promotion_error(format!(
+                "Failed to create promotion journal {}: {error}",
+                path.display()
+            ))
+        })?;
+    let write_result = file.write_all(&bytes).and_then(|()| file.sync_all());
+    drop(file);
+    if let Err(error) = write_result {
+        let cleanup = fs::remove_file(path);
+        let _ = sync_promotion_parent(path);
+        return Err(promotion_error(format!(
+            "Failed to persist promotion journal {}: {error}; cleanup={cleanup:?}",
+            path.display()
+        )));
+    }
+    if let Err(error) = sync_promotion_parent(path) {
+        let cleanup = fs::remove_file(path);
+        let _ = sync_promotion_parent(path);
+        return Err(promotion_error(format!(
+            "Failed to publish promotion journal {}: {error}; cleanup={cleanup:?}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn remove_promotion_file(path: &Path) -> Result<(), StorageError> {
+    match fs::remove_file(path) {
+        Ok(()) => sync_promotion_parent(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(promotion_error(format!(
+            "Failed to remove promotion artifact {}: {error}",
+            path.display()
+        ))),
+    }
 }
 
 impl PromotionLock {
@@ -238,7 +403,7 @@ impl Drop for PromotionLock {
 }
 
 fn recover_interrupted_promotion(path: &Path) -> Result<(), StorageError> {
-    if !path.with_extension("sqlite.backup").exists() {
+    if !promotion_artifacts_exist(path) {
         return Ok(());
     }
     let Some(_lock) = PromotionLock::try_acquire(path)? else {
@@ -251,18 +416,188 @@ fn recover_interrupted_promotion(path: &Path) -> Result<(), StorageError> {
 
 fn recover_interrupted_promotion_locked(path: &Path) -> Result<(), StorageError> {
     let backup_path = path.with_extension("sqlite.backup");
-    if !backup_path.exists() {
+    let prepared_path = promotion_prepared_journal_path(path);
+    let committed_path = promotion_committed_journal_path(path);
+
+    if committed_path.exists() {
+        let committed = read_promotion_journal(&committed_path, PromotionJournalPhase::Committed)?;
+        if prepared_path.exists() {
+            let prepared = read_promotion_journal(&prepared_path, PromotionJournalPhase::Prepared)?;
+            if prepared.previous != committed.previous || prepared.candidate != committed.candidate
+            {
+                return Err(promotion_error(format!(
+                    "Promotion journals disagree for {}",
+                    path.display()
+                )));
+            }
+        }
+        let live_identity = read_promotion_database_identity(path)?.ok_or_else(|| {
+            promotion_error(format!(
+                "Committed promotion for {} has no live database",
+                path.display()
+            ))
+        })?;
+        if live_identity != committed.candidate {
+            return Err(promotion_error(format!(
+                "Committed promotion identity does not match live database {}",
+                path.display()
+            )));
+        }
+        cleanup_committed_promotion_artifacts(path);
         return Ok(());
     }
-    let mut live = Connection::open(path)?;
+
+    if prepared_path.exists() {
+        let prepared = read_promotion_journal(&prepared_path, PromotionJournalPhase::Prepared)?;
+        return rollback_prepared_promotion(path, &prepared);
+    }
+
+    if backup_path.exists() {
+        return recover_legacy_promotion_backup(path, &backup_path);
+    }
+    Ok(())
+}
+
+fn restore_promotion_database(source_path: &Path, live_path: &Path) -> Result<(), StorageError> {
+    let mut live = Connection::open(live_path)?;
     let _ = live.busy_timeout(Duration::from_millis(2_500));
-    live.restore(
-        MAIN_DB,
-        &backup_path,
-        None::<fn(rusqlite::backup::Progress)>,
-    )?;
-    drop(live);
-    cleanup_sqlite_sidecars(&backup_path)
+    live.restore(MAIN_DB, source_path, None::<fn(rusqlite::backup::Progress)>)?;
+    Ok(())
+}
+
+fn rollback_prepared_promotion(
+    live_path: &Path,
+    prepared: &PromotionJournal,
+) -> Result<(), StorageError> {
+    let backup_path = live_path.with_extension("sqlite.backup");
+    let prepared_path = promotion_prepared_journal_path(live_path);
+    match prepared.previous.as_ref() {
+        Some(expected_previous) => {
+            let backup_identity =
+                read_promotion_database_identity(&backup_path)?.ok_or_else(|| {
+                    promotion_error(format!(
+                        "Prepared promotion for {} has no recovery backup",
+                        live_path.display()
+                    ))
+                })?;
+            if &backup_identity != expected_previous {
+                return Err(promotion_error(format!(
+                    "Prepared promotion backup identity does not match {}",
+                    live_path.display()
+                )));
+            }
+            restore_promotion_database(&backup_path, live_path)?;
+            let restored = read_promotion_database_identity(live_path)?.ok_or_else(|| {
+                promotion_error(format!(
+                    "Prepared promotion rollback removed live database {}",
+                    live_path.display()
+                ))
+            })?;
+            if &restored != expected_previous {
+                return Err(promotion_error(format!(
+                    "Prepared promotion rollback did not restore the recorded identity for {}",
+                    live_path.display()
+                )));
+            }
+            remove_promotion_file(&prepared_path)?;
+            cleanup_sqlite_sidecars(&backup_path)
+        }
+        None => {
+            if backup_path.exists() {
+                return Err(promotion_error(format!(
+                    "Prepared first publication for {} unexpectedly has a backup",
+                    live_path.display()
+                )));
+            }
+            cleanup_sqlite_sidecars(live_path)?;
+            remove_promotion_file(&prepared_path)
+        }
+    }
+}
+
+fn recover_legacy_promotion_backup(
+    live_path: &Path,
+    backup_path: &Path,
+) -> Result<(), StorageError> {
+    let backup_identity = read_promotion_database_identity(backup_path)?.ok_or_else(|| {
+        promotion_error(format!(
+            "Legacy promotion backup {} disappeared during validation",
+            backup_path.display()
+        ))
+    })?;
+    let live_identity = read_promotion_database_identity(live_path);
+    let restore_backup = match live_identity {
+        Ok(None) => true,
+        Err(error) => {
+            return Err(promotion_error(format!(
+                "Cannot validate live database {} while a legacy promotion backup exists: {error}",
+                live_path.display()
+            )));
+        }
+        Ok(Some(ref live)) if live == &backup_identity => false,
+        Ok(Some(ref live)) => match (&live.publication, &backup_identity.publication) {
+            (Some(current), Some(previous)) if current.generation > previous.generation => false,
+            (None, Some(_)) => true,
+            _ => {
+                return Err(promotion_error(format!(
+                    "Ambiguous legacy promotion backup for {}; refusing to overwrite the live database",
+                    live_path.display()
+                )));
+            }
+        },
+    };
+    if restore_backup {
+        restore_promotion_database(backup_path, live_path)?;
+        let restored = read_promotion_database_identity(live_path)?.ok_or_else(|| {
+            promotion_error(format!(
+                "Legacy promotion recovery removed live database {}",
+                live_path.display()
+            ))
+        })?;
+        if restored != backup_identity {
+            return Err(promotion_error(format!(
+                "Legacy promotion recovery produced an unexpected identity for {}",
+                live_path.display()
+            )));
+        }
+    }
+    cleanup_sqlite_sidecars(backup_path)
+}
+
+fn cleanup_committed_promotion_artifacts(live_path: &Path) {
+    #[cfg(test)]
+    if std::env::var_os(PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV).as_deref()
+        == Some(live_path.as_os_str())
+    {
+        return;
+    }
+
+    let backup_path = live_path.with_extension("sqlite.backup");
+    if let Err(error) = cleanup_sqlite_sidecars(&backup_path) {
+        tracing::warn!(
+            live_path = %live_path.display(),
+            error = %error,
+            "committed promotion retained its journal because backup cleanup failed"
+        );
+        return;
+    }
+    let prepared_path = promotion_prepared_journal_path(live_path);
+    if let Err(error) = remove_promotion_file(&prepared_path) {
+        tracing::warn!(
+            live_path = %live_path.display(),
+            error = %error,
+            "committed promotion retained its commit journal because prepared cleanup failed"
+        );
+        return;
+    }
+    let committed_path = promotion_committed_journal_path(live_path);
+    if let Err(error) = remove_promotion_file(&committed_path) {
+        tracing::warn!(
+            live_path = %live_path.display(),
+            error = %error,
+            "committed promotion journal cleanup failed"
+        );
+    }
 }
 
 fn grounding_display_name_expr(alias: &str) -> String {
@@ -2373,6 +2708,15 @@ impl Storage {
         let _promotion_lock = PromotionLock::acquire(live_path)?;
         recover_interrupted_promotion_locked(live_path)?;
         let backup_path = live_path.with_extension("sqlite.backup");
+        let prepared_path = promotion_prepared_journal_path(live_path);
+        let committed_path = promotion_committed_journal_path(live_path);
+        let candidate = read_promotion_database_identity(staged_path)?.ok_or_else(|| {
+            promotion_error(format!(
+                "Staged promotion candidate {} does not exist",
+                staged_path.display()
+            ))
+        })?;
+        let previous = read_promotion_database_identity(live_path)?;
         let live_exists = live_path.exists();
         cleanup_sqlite_sidecars(&backup_path)?;
         let mut live_conn = Connection::open(live_path)?;
@@ -2384,6 +2728,33 @@ impl Storage {
                 &backup_path,
                 None::<fn(rusqlite::backup::Progress)>,
             )?;
+            let backup_identity =
+                read_promotion_database_identity(&backup_path)?.ok_or_else(|| {
+                    promotion_error(format!(
+                        "Promotion backup {} disappeared after creation",
+                        backup_path.display()
+                    ))
+                })?;
+            if Some(&backup_identity) != previous.as_ref() {
+                return Err(promotion_error(format!(
+                    "Promotion backup identity does not match live database {}",
+                    live_path.display()
+                )));
+            }
+        }
+
+        let prepared = PromotionJournal {
+            version: PROMOTION_JOURNAL_VERSION,
+            phase: PromotionJournalPhase::Prepared,
+            previous: previous.clone(),
+            candidate: candidate.clone(),
+        };
+        if let Err(error) = write_promotion_journal(&prepared_path, &prepared) {
+            drop(live_conn);
+            if !prepared_path.exists() {
+                let _ = cleanup_sqlite_sidecars(&backup_path);
+            }
+            return Err(error);
         }
 
         #[cfg(test)]
@@ -2411,15 +2782,8 @@ impl Storage {
             live_conn.restore(MAIN_DB, staged_path, None::<fn(rusqlite::backup::Progress)>);
 
         if let Err(err) = restore_result {
-            if live_exists && backup_path.exists() {
-                let _ = live_conn.restore(
-                    MAIN_DB,
-                    &backup_path,
-                    None::<fn(rusqlite::backup::Progress)>,
-                );
-            } else {
-                let _ = cleanup_sqlite_sidecars(live_path);
-            }
+            drop(live_conn);
+            let _ = rollback_prepared_promotion(live_path, &prepared);
             return Err(StorageError::Other(format!(
                 "Failed to promote staged snapshot {} -> {}: {err}",
                 staged_path.display(),
@@ -2427,10 +2791,40 @@ impl Storage {
             )));
         }
         drop(live_conn);
-        cleanup_sqlite_sidecars(staged_path)?;
-        if backup_path.exists() {
-            let _ = cleanup_sqlite_sidecars(&backup_path);
+
+        let published = read_promotion_database_identity(live_path)?.ok_or_else(|| {
+            promotion_error(format!(
+                "Promoted live database {} disappeared during validation",
+                live_path.display()
+            ))
+        })?;
+        if published != candidate {
+            let _ = rollback_prepared_promotion(live_path, &prepared);
+            return Err(promotion_error(format!(
+                "Promoted live database identity does not match staged candidate {}",
+                staged_path.display()
+            )));
         }
+
+        let committed = PromotionJournal {
+            phase: PromotionJournalPhase::Committed,
+            ..prepared.clone()
+        };
+        if let Err(error) = write_promotion_journal(&committed_path, &committed) {
+            if !committed_path.exists() {
+                let _ = rollback_prepared_promotion(live_path, &prepared);
+            }
+            return Err(error);
+        }
+
+        if let Err(error) = cleanup_sqlite_sidecars(staged_path) {
+            tracing::warn!(
+                staged_path = %staged_path.display(),
+                error = %error,
+                "committed promotion left a staged cleanup artifact"
+            );
+        }
+        cleanup_committed_promotion_artifacts(live_path);
         Ok(())
     }
 

--- a/crates/codestory-store/src/storage_impl/mod.rs
+++ b/crates/codestory-store/src/storage_impl/mod.rs
@@ -56,9 +56,6 @@ const PROMOTION_ABORT_SENTINEL_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_SENTI
 #[cfg(test)]
 const PROMOTION_ABORT_SENTINEL: &[u8] = b"after-live-restore-step\n";
 const PROMOTION_JOURNAL_VERSION: u32 = 1;
-#[cfg(test)]
-const PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV: &str =
-    "CODESTORY_TEST_PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE";
 
 fn clamp_i64_to_u32(value: i64) -> u32 {
     if value <= 0 {
@@ -181,25 +178,11 @@ struct PromotionLock {
     file: File,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum PromotionJournalPhase {
-    Prepared,
-    Committed,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct PromotionDatabaseIdentity {
-    schema_version: u32,
-    publication: Option<IndexPublicationRecord>,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct PromotionJournal {
     version: u32,
-    phase: PromotionJournalPhase,
-    previous: Option<PromotionDatabaseIdentity>,
-    candidate: PromotionDatabaseIdentity,
+    previous: Option<IndexPublicationRecord>,
+    candidate: IndexPublicationRecord,
 }
 
 fn promotion_lock_path(path: &Path) -> PathBuf {
@@ -214,6 +197,11 @@ fn promotion_committed_journal_path(path: &Path) -> PathBuf {
     PathBuf::from(format!("{}.promotion.committed.json", path.display()))
 }
 
+#[cfg(test)]
+fn promotion_cleanup_failure_path(path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}.promotion.cleanup-blocked", path.display()))
+}
+
 fn promotion_artifacts_exist(path: &Path) -> bool {
     path.with_extension("sqlite.backup").exists()
         || promotion_prepared_journal_path(path).exists()
@@ -224,9 +212,13 @@ fn promotion_error(message: impl Into<String>) -> StorageError {
     StorageError::Other(message.into())
 }
 
+fn promotion_path_error(action: &str, path: &Path, error: impl std::fmt::Display) -> StorageError {
+    promotion_error(format!("Failed to {action} {}: {error}", path.display()))
+}
+
 fn read_promotion_database_identity(
     path: &Path,
-) -> Result<Option<PromotionDatabaseIdentity>, StorageError> {
+) -> Result<Option<IndexPublicationRecord>, StorageError> {
     if !path.exists() {
         return Ok(None);
     }
@@ -241,41 +233,39 @@ fn read_promotion_database_identity(
     }
     let version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
     let schema_version = version.max(0) as u32;
+    if schema_version == 0 {
+        return Ok(None);
+    }
     if schema_version != SCHEMA_VERSION {
         return Err(promotion_error(format!(
             "SQLite promotion artifact {} has schema version {schema_version}, expected {SCHEMA_VERSION}",
             path.display()
         )));
     }
-    let publication = read_complete_index_publication(&conn)?;
-    Ok(Some(PromotionDatabaseIdentity {
-        schema_version,
-        publication,
-    }))
+    read_complete_index_publication(&conn)
 }
 
-fn read_promotion_journal(
+fn require_promotion_database_identity(
     path: &Path,
-    expected_phase: PromotionJournalPhase,
-) -> Result<PromotionJournal, StorageError> {
-    let bytes = fs::read(path).map_err(|error| {
+    role: &str,
+) -> Result<IndexPublicationRecord, StorageError> {
+    read_promotion_database_identity(path)?.ok_or_else(|| {
         promotion_error(format!(
-            "Failed to read promotion journal {}: {error}",
+            "{role} {} has no complete publication identity",
             path.display()
         ))
-    })?;
-    let journal: PromotionJournal = serde_json::from_slice(&bytes).map_err(|error| {
-        promotion_error(format!(
-            "Failed to parse promotion journal {}: {error}",
-            path.display()
-        ))
-    })?;
-    if journal.version != PROMOTION_JOURNAL_VERSION || journal.phase != expected_phase {
+    })
+}
+
+fn read_promotion_journal(path: &Path) -> Result<PromotionJournal, StorageError> {
+    let bytes = fs::read(path).map_err(|error| promotion_path_error("read", path, error))?;
+    let journal: PromotionJournal = serde_json::from_slice(&bytes)
+        .map_err(|error| promotion_path_error("parse", path, error))?;
+    if journal.version != PROMOTION_JOURNAL_VERSION {
         return Err(promotion_error(format!(
-            "Unsupported promotion journal {}: version={} phase={:?}",
+            "Unsupported promotion journal {}: version={}",
             path.display(),
-            journal.version,
-            journal.phase
+            journal.version
         )));
     }
     Ok(journal)
@@ -286,12 +276,7 @@ fn sync_promotion_parent(path: &Path) -> Result<(), StorageError> {
     if let Some(parent) = path.parent() {
         File::open(parent)
             .and_then(|directory| directory.sync_all())
-            .map_err(|error| {
-                promotion_error(format!(
-                    "Failed to sync promotion journal directory {}: {error}",
-                    parent.display()
-                ))
-            })?;
+            .map_err(|error| promotion_path_error("sync directory", parent, error))?;
     }
     #[cfg(windows)]
     let _ = path;
@@ -299,51 +284,48 @@ fn sync_promotion_parent(path: &Path) -> Result<(), StorageError> {
 }
 
 fn write_promotion_journal(path: &Path, journal: &PromotionJournal) -> Result<(), StorageError> {
-    let bytes = serde_json::to_vec(journal).map_err(|error| {
-        promotion_error(format!(
-            "Failed to serialize promotion journal {}: {error}",
-            path.display()
-        ))
-    })?;
+    let bytes = serde_json::to_vec(journal)
+        .map_err(|error| promotion_path_error("serialize", path, error))?;
     let mut file = OpenOptions::new()
         .create_new(true)
         .write(true)
         .open(path)
-        .map_err(|error| {
-            promotion_error(format!(
-                "Failed to create promotion journal {}: {error}",
-                path.display()
-            ))
-        })?;
+        .map_err(|error| promotion_path_error("create", path, error))?;
     let write_result = file.write_all(&bytes).and_then(|()| file.sync_all());
     drop(file);
     if let Err(error) = write_result {
-        let cleanup = fs::remove_file(path);
+        let _ = fs::remove_file(path);
         let _ = sync_promotion_parent(path);
-        return Err(promotion_error(format!(
-            "Failed to persist promotion journal {}: {error}; cleanup={cleanup:?}",
-            path.display()
-        )));
+        return Err(promotion_path_error("persist", path, error));
     }
     if let Err(error) = sync_promotion_parent(path) {
-        let cleanup = fs::remove_file(path);
+        let _ = fs::remove_file(path);
         let _ = sync_promotion_parent(path);
-        return Err(promotion_error(format!(
-            "Failed to publish promotion journal {}: {error}; cleanup={cleanup:?}",
-            path.display()
-        )));
+        return Err(error);
     }
     Ok(())
+}
+
+fn commit_promotion_journal(
+    prepared_path: &Path,
+    committed_path: &Path,
+) -> Result<(), StorageError> {
+    if committed_path.exists() {
+        return Err(promotion_error(format!(
+            "Cannot commit promotion while prior journal {} remains",
+            committed_path.display()
+        )));
+    }
+    fs::rename(prepared_path, committed_path)
+        .map_err(|error| promotion_path_error("commit journal as", committed_path, error))?;
+    sync_promotion_parent(committed_path)
 }
 
 fn remove_promotion_file(path: &Path) -> Result<(), StorageError> {
     match fs::remove_file(path) {
         Ok(()) => sync_promotion_parent(path),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(promotion_error(format!(
-            "Failed to remove promotion artifact {}: {error}",
-            path.display()
-        ))),
+        Err(error) => Err(promotion_path_error("remove", path, error)),
     }
 }
 
@@ -419,36 +401,34 @@ fn recover_interrupted_promotion_locked(path: &Path) -> Result<(), StorageError>
     let prepared_path = promotion_prepared_journal_path(path);
     let committed_path = promotion_committed_journal_path(path);
 
+    if committed_path.exists() && prepared_path.exists() {
+        return Err(promotion_error(format!(
+            "Promotion has both prepared and committed journals for {}",
+            path.display()
+        )));
+    }
+
     if committed_path.exists() {
-        let committed = read_promotion_journal(&committed_path, PromotionJournalPhase::Committed)?;
-        if prepared_path.exists() {
-            let prepared = read_promotion_journal(&prepared_path, PromotionJournalPhase::Prepared)?;
-            if prepared.previous != committed.previous || prepared.candidate != committed.candidate
-            {
-                return Err(promotion_error(format!(
-                    "Promotion journals disagree for {}",
-                    path.display()
-                )));
-            }
-        }
-        let live_identity = read_promotion_database_identity(path)?.ok_or_else(|| {
-            promotion_error(format!(
-                "Committed promotion for {} has no live database",
-                path.display()
-            ))
-        })?;
+        let committed = read_promotion_journal(&committed_path)?;
+        let live_identity = require_promotion_database_identity(path, "Committed live database")?;
         if live_identity != committed.candidate {
             return Err(promotion_error(format!(
                 "Committed promotion identity does not match live database {}",
                 path.display()
             )));
         }
-        cleanup_committed_promotion_artifacts(path);
+        if let Err(error) = cleanup_committed_promotion_artifacts(path) {
+            tracing::warn!(
+                live_path = %path.display(),
+                error = %error,
+                "committed promotion retained recovery artifacts"
+            );
+        }
         return Ok(());
     }
 
     if prepared_path.exists() {
-        let prepared = read_promotion_journal(&prepared_path, PromotionJournalPhase::Prepared)?;
+        let prepared = read_promotion_journal(&prepared_path)?;
         return rollback_prepared_promotion(path, &prepared);
     }
 
@@ -471,28 +451,32 @@ fn rollback_prepared_promotion(
 ) -> Result<(), StorageError> {
     let backup_path = live_path.with_extension("sqlite.backup");
     let prepared_path = promotion_prepared_journal_path(live_path);
+    let live_identity = read_promotion_database_identity(live_path)?;
+    if live_identity
+        .as_ref()
+        .is_some_and(|live| live != &prepared.candidate && Some(live) != prepared.previous.as_ref())
+    {
+        return Err(promotion_error(format!(
+            "Prepared promotion for {} found an unrelated live publication",
+            live_path.display()
+        )));
+    }
+
     match prepared.previous.as_ref() {
         Some(expected_previous) => {
             let backup_identity =
-                read_promotion_database_identity(&backup_path)?.ok_or_else(|| {
-                    promotion_error(format!(
-                        "Prepared promotion for {} has no recovery backup",
-                        live_path.display()
-                    ))
-                })?;
+                require_promotion_database_identity(&backup_path, "Prepared recovery backup")?;
             if &backup_identity != expected_previous {
                 return Err(promotion_error(format!(
                     "Prepared promotion backup identity does not match {}",
                     live_path.display()
                 )));
             }
-            restore_promotion_database(&backup_path, live_path)?;
-            let restored = read_promotion_database_identity(live_path)?.ok_or_else(|| {
-                promotion_error(format!(
-                    "Prepared promotion rollback removed live database {}",
-                    live_path.display()
-                ))
-            })?;
+            if live_identity.as_ref() != Some(expected_previous) {
+                restore_promotion_database(&backup_path, live_path)?;
+            }
+            let restored =
+                require_promotion_database_identity(live_path, "Restored live database")?;
             if &restored != expected_previous {
                 return Err(promotion_error(format!(
                     "Prepared promotion rollback did not restore the recorded identity for {}",
@@ -509,7 +493,9 @@ fn rollback_prepared_promotion(
                     live_path.display()
                 )));
             }
-            cleanup_sqlite_sidecars(live_path)?;
+            if live_identity.is_some() || live_path.exists() {
+                cleanup_sqlite_sidecars(live_path)?;
+            }
             remove_promotion_file(&prepared_path)
         }
     }
@@ -519,12 +505,8 @@ fn recover_legacy_promotion_backup(
     live_path: &Path,
     backup_path: &Path,
 ) -> Result<(), StorageError> {
-    let backup_identity = read_promotion_database_identity(backup_path)?.ok_or_else(|| {
-        promotion_error(format!(
-            "Legacy promotion backup {} disappeared during validation",
-            backup_path.display()
-        ))
-    })?;
+    let backup_identity =
+        require_promotion_database_identity(backup_path, "Legacy promotion backup")?;
     let live_identity = read_promotion_database_identity(live_path);
     let restore_backup = match live_identity {
         Ok(None) => true,
@@ -535,25 +517,17 @@ fn recover_legacy_promotion_backup(
             )));
         }
         Ok(Some(ref live)) if live == &backup_identity => false,
-        Ok(Some(ref live)) => match (&live.publication, &backup_identity.publication) {
-            (Some(current), Some(previous)) if current.generation > previous.generation => false,
-            (None, Some(_)) => true,
-            _ => {
-                return Err(promotion_error(format!(
-                    "Ambiguous legacy promotion backup for {}; refusing to overwrite the live database",
-                    live_path.display()
-                )));
-            }
-        },
+        Ok(Some(ref live)) if live.generation > backup_identity.generation => false,
+        Ok(Some(_)) => {
+            return Err(promotion_error(format!(
+                "Ambiguous legacy promotion backup for {}; refusing to overwrite the live database",
+                live_path.display()
+            )));
+        }
     };
     if restore_backup {
         restore_promotion_database(backup_path, live_path)?;
-        let restored = read_promotion_database_identity(live_path)?.ok_or_else(|| {
-            promotion_error(format!(
-                "Legacy promotion recovery removed live database {}",
-                live_path.display()
-            ))
-        })?;
+        let restored = require_promotion_database_identity(live_path, "Recovered live database")?;
         if restored != backup_identity {
             return Err(promotion_error(format!(
                 "Legacy promotion recovery produced an unexpected identity for {}",
@@ -564,40 +538,18 @@ fn recover_legacy_promotion_backup(
     cleanup_sqlite_sidecars(backup_path)
 }
 
-fn cleanup_committed_promotion_artifacts(live_path: &Path) {
+fn cleanup_committed_promotion_artifacts(live_path: &Path) -> Result<(), StorageError> {
     #[cfg(test)]
-    if std::env::var_os(PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV).as_deref()
-        == Some(live_path.as_os_str())
-    {
-        return;
+    if promotion_cleanup_failure_path(live_path).exists() {
+        return Err(promotion_error(
+            "injected committed promotion cleanup failure",
+        ));
     }
 
     let backup_path = live_path.with_extension("sqlite.backup");
-    if let Err(error) = cleanup_sqlite_sidecars(&backup_path) {
-        tracing::warn!(
-            live_path = %live_path.display(),
-            error = %error,
-            "committed promotion retained its journal because backup cleanup failed"
-        );
-        return;
-    }
-    let prepared_path = promotion_prepared_journal_path(live_path);
-    if let Err(error) = remove_promotion_file(&prepared_path) {
-        tracing::warn!(
-            live_path = %live_path.display(),
-            error = %error,
-            "committed promotion retained its commit journal because prepared cleanup failed"
-        );
-        return;
-    }
+    cleanup_sqlite_sidecars(&backup_path)?;
     let committed_path = promotion_committed_journal_path(live_path);
-    if let Err(error) = remove_promotion_file(&committed_path) {
-        tracing::warn!(
-            live_path = %live_path.display(),
-            error = %error,
-            "committed promotion journal cleanup failed"
-        );
-    }
+    remove_promotion_file(&committed_path)
 }
 
 fn grounding_display_name_expr(alias: &str) -> String {
@@ -2707,34 +2659,31 @@ impl Storage {
     ) -> Result<(), StorageError> {
         let _promotion_lock = PromotionLock::acquire(live_path)?;
         recover_interrupted_promotion_locked(live_path)?;
+        if promotion_artifacts_exist(live_path) {
+            return Err(promotion_error(format!(
+                "Cannot start a new promotion while prior artifacts remain for {}",
+                live_path.display()
+            )));
+        }
         let backup_path = live_path.with_extension("sqlite.backup");
         let prepared_path = promotion_prepared_journal_path(live_path);
         let committed_path = promotion_committed_journal_path(live_path);
-        let candidate = read_promotion_database_identity(staged_path)?.ok_or_else(|| {
-            promotion_error(format!(
-                "Staged promotion candidate {} does not exist",
-                staged_path.display()
-            ))
-        })?;
+        let candidate =
+            require_promotion_database_identity(staged_path, "Staged promotion candidate")?;
         let previous = read_promotion_database_identity(live_path)?;
-        let live_exists = live_path.exists();
         cleanup_sqlite_sidecars(&backup_path)?;
-        let mut live_conn = Connection::open(live_path)?;
-        let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
 
-        if live_exists {
+        if previous.is_some() {
+            let live_conn = Connection::open(live_path)?;
+            let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
             live_conn.backup(
                 MAIN_DB,
                 &backup_path,
                 None::<fn(rusqlite::backup::Progress)>,
             )?;
+            drop(live_conn);
             let backup_identity =
-                read_promotion_database_identity(&backup_path)?.ok_or_else(|| {
-                    promotion_error(format!(
-                        "Promotion backup {} disappeared after creation",
-                        backup_path.display()
-                    ))
-                })?;
+                require_promotion_database_identity(&backup_path, "Promotion backup")?;
             if Some(&backup_identity) != previous.as_ref() {
                 return Err(promotion_error(format!(
                     "Promotion backup identity does not match live database {}",
@@ -2745,17 +2694,18 @@ impl Storage {
 
         let prepared = PromotionJournal {
             version: PROMOTION_JOURNAL_VERSION,
-            phase: PromotionJournalPhase::Prepared,
             previous: previous.clone(),
             candidate: candidate.clone(),
         };
         if let Err(error) = write_promotion_journal(&prepared_path, &prepared) {
-            drop(live_conn);
             if !prepared_path.exists() {
                 let _ = cleanup_sqlite_sidecars(&backup_path);
             }
             return Err(error);
         }
+
+        let mut live_conn = Connection::open(live_path)?;
+        let _ = live_conn.busy_timeout(Duration::from_millis(2_500));
 
         #[cfg(test)]
         let restore_result = if let Some(sentinel_path) =
@@ -2792,12 +2742,7 @@ impl Storage {
         }
         drop(live_conn);
 
-        let published = read_promotion_database_identity(live_path)?.ok_or_else(|| {
-            promotion_error(format!(
-                "Promoted live database {} disappeared during validation",
-                live_path.display()
-            ))
-        })?;
+        let published = require_promotion_database_identity(live_path, "Promoted live database")?;
         if published != candidate {
             let _ = rollback_prepared_promotion(live_path, &prepared);
             return Err(promotion_error(format!(
@@ -2806,11 +2751,7 @@ impl Storage {
             )));
         }
 
-        let committed = PromotionJournal {
-            phase: PromotionJournalPhase::Committed,
-            ..prepared.clone()
-        };
-        if let Err(error) = write_promotion_journal(&committed_path, &committed) {
+        if let Err(error) = commit_promotion_journal(&prepared_path, &committed_path) {
             if !committed_path.exists() {
                 let _ = rollback_prepared_promotion(live_path, &prepared);
             }
@@ -2824,7 +2765,13 @@ impl Storage {
                 "committed promotion left a staged cleanup artifact"
             );
         }
-        cleanup_committed_promotion_artifacts(live_path);
+        if let Err(error) = cleanup_committed_promotion_artifacts(live_path) {
+            tracing::warn!(
+                live_path = %live_path.display(),
+                error = %error,
+                "committed promotion retained recovery artifacts"
+            );
+        }
         Ok(())
     }
 

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -2103,6 +2103,17 @@ fn reader_open_during_healthy_promotion_does_not_recover_active_backup() -> Resu
 
     seed_promotion_file(&live_path, 2, "new.rs")?;
     seed_promotion_file(&backup_path, 1, "old.rs")?;
+    let prepared_path = promotion_prepared_journal_path(&live_path);
+    write_promotion_journal(
+        &prepared_path,
+        &PromotionJournal {
+            version: PROMOTION_JOURNAL_VERSION,
+            phase: PromotionJournalPhase::Prepared,
+            previous: read_promotion_database_identity(&backup_path)?,
+            candidate: read_promotion_database_identity(&live_path)?
+                .expect("live promotion identity"),
+        },
+    )?;
     let promotion_lock = PromotionLock::acquire(&live_path)?;
 
     let during_promotion = Storage::open(&live_path)?;
@@ -2124,6 +2135,7 @@ fn reader_open_during_healthy_promotion_does_not_recover_active_backup() -> Resu
         !backup_path.exists(),
         "recovery consumes the abandoned backup"
     );
+    assert!(!prepared_path.exists(), "recovery consumes its journal");
 
     let _ = cleanup_sqlite_sidecars(&live_path);
     let _ = cleanup_sqlite_sidecars(&backup_path);
@@ -2146,6 +2158,13 @@ fn seed_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageEr
         line_count: 1,
         file_role: FileRole::Source,
     }])?;
+    storage.put_index_publication(&IndexPublicationRecord {
+        generation: id.max(0) as u64,
+        generation_id: format!("generation-{id}"),
+        run_id: format!("run-{id}"),
+        mode: IndexPublicationMode::Full,
+        published_at_epoch_ms: id.max(0),
+    })?;
     storage.finalize_staged_snapshot()
 }
 
@@ -2166,6 +2185,8 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
     let staged_path = unique_temp_db_path("promotion-abort-staged");
     let sentinel_path = unique_temp_db_path("promotion-abort-sentinel");
     let backup_path = live_path.with_extension("sqlite.backup");
+    let prepared_path = promotion_prepared_journal_path(&live_path);
+    let committed_path = promotion_committed_journal_path(&live_path);
     seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
     seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged generation");
 
@@ -2216,6 +2237,8 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
         !backup_path.exists(),
         "opening live storage must consume the recovery backup"
     );
+    assert!(!prepared_path.exists(), "rollback must consume its journal");
+    assert!(!committed_path.exists(), "aborted promotion cannot commit");
 
     Storage::promote_staged_snapshot(&staged_path, &live_path)
         .expect("retry promotion after abort");
@@ -2239,7 +2262,111 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
     let _ = cleanup_sqlite_sidecars(&live_path);
     let _ = cleanup_sqlite_sidecars(&staged_path);
     let _ = cleanup_sqlite_sidecars(&backup_path);
+    let _ = std::fs::remove_file(prepared_path);
+    let _ = std::fs::remove_file(committed_path);
     let _ = std::fs::remove_file(&sentinel_path);
+}
+
+#[test]
+fn staged_promotion_cleanup_failure_child() {
+    let Some(live_path) =
+        std::env::var_os(PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV).map(PathBuf::from)
+    else {
+        return;
+    };
+    let staged_path =
+        PathBuf::from(std::env::var_os(PROMOTION_ABORT_STAGED_ENV).expect("child staged path"));
+    Storage::promote_staged_snapshot(&staged_path, &live_path)
+        .expect("committed promotion must not fail when backup cleanup is deferred");
+}
+
+#[test]
+fn committed_promotion_never_rolls_back_when_backup_cleanup_fails() {
+    let live_path = unique_temp_db_path("promotion-cleanup-failure-live");
+    let staged_path = unique_temp_db_path("promotion-cleanup-failure-staged");
+    let backup_path = live_path.with_extension("sqlite.backup");
+    let prepared_path = promotion_prepared_journal_path(&live_path);
+    let committed_path = promotion_committed_journal_path(&live_path);
+    seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
+    seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged generation");
+
+    let status =
+        std::process::Command::new(std::env::current_exe().expect("resolve store test executable"))
+            .arg("--exact")
+            .arg("storage_impl::tests::staged_promotion_cleanup_failure_child")
+            .arg("--nocapture")
+            .env(PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV, &live_path)
+            .env(PROMOTION_ABORT_STAGED_ENV, &staged_path)
+            .status()
+            .expect("run cleanup-failure child");
+    assert!(status.success(), "committed cleanup-failure child failed");
+    assert!(
+        backup_path.exists(),
+        "fault injection must retain the backup"
+    );
+    assert!(
+        committed_path.exists(),
+        "a retained backup must keep its commit marker"
+    );
+
+    let reopened = Storage::open(&live_path).expect("reopen committed live generation");
+    assert_eq!(
+        reopened.get_files().expect("read committed generation")[0].path,
+        PathBuf::from("new.rs")
+    );
+    drop(reopened);
+    assert!(!backup_path.exists(), "reopen cleans the retained backup");
+    assert!(!prepared_path.exists(), "reopen cleans the prepare marker");
+    assert!(!committed_path.exists(), "reopen cleans the commit marker");
+
+    let _ = cleanup_sqlite_sidecars(&live_path);
+    let _ = cleanup_sqlite_sidecars(&staged_path);
+    let _ = cleanup_sqlite_sidecars(&backup_path);
+}
+
+#[test]
+fn legacy_backup_never_overwrites_a_newer_complete_publication() {
+    let live_path = unique_temp_db_path("newer-legacy-live");
+    let backup_path = live_path.with_extension("sqlite.backup");
+    seed_promotion_file(&live_path, 2, "new.rs").expect("seed newer live generation");
+    seed_promotion_file(&backup_path, 1, "old.rs").expect("seed older backup generation");
+
+    let live = Storage::open(&live_path).expect("open newer live generation");
+    assert_eq!(
+        live.get_files().expect("read newer live generation")[0].path,
+        PathBuf::from("new.rs")
+    );
+    drop(live);
+    assert!(!backup_path.exists(), "older backup should be cleaned");
+
+    let _ = cleanup_sqlite_sidecars(&live_path);
+    let _ = cleanup_sqlite_sidecars(&backup_path);
+}
+
+#[test]
+fn invalid_legacy_backup_fails_closed_without_overwriting_live() {
+    let live_path = unique_temp_db_path("invalid-legacy-backup-live");
+    let backup_path = live_path.with_extension("sqlite.backup");
+    seed_promotion_file(&live_path, 2, "new.rs").expect("seed live generation");
+    std::fs::write(&backup_path, b"not a sqlite database").expect("write invalid backup");
+
+    let error = match Storage::open(&live_path) {
+        Ok(_) => panic!("invalid backup must fail closed"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("database") || error.to_string().contains("SQLite"),
+        "unexpected recovery error: {error}"
+    );
+    std::fs::remove_file(&backup_path).expect("remove invalid backup");
+    let live = Storage::open(&live_path).expect("reopen untouched live generation");
+    assert_eq!(
+        live.get_files().expect("read untouched live generation")[0].path,
+        PathBuf::from("new.rs")
+    );
+
+    drop(live);
+    let _ = cleanup_sqlite_sidecars(&live_path);
 }
 
 #[test]

--- a/crates/codestory-store/src/storage_impl/tests/mod.rs
+++ b/crates/codestory-store/src/storage_impl/tests/mod.rs
@@ -2051,6 +2051,13 @@ fn test_promote_staged_snapshot_replaces_live_db_while_live_reader_is_open()
             line_count: 10,
             file_role: FileRole::Source,
         }])?;
+        seed.put_index_publication(&IndexPublicationRecord {
+            generation: 1,
+            generation_id: "live-generation".to_string(),
+            run_id: "live-run".to_string(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        })?;
         drop(seed);
         let live = Storage::open_read_only(&live_path)?;
 
@@ -2066,6 +2073,13 @@ fn test_promote_staged_snapshot_replaces_live_db_while_live_reader_is_open()
                 line_count: 20,
                 file_role: FileRole::Source,
             }])?;
+            staged.put_index_publication(&IndexPublicationRecord {
+                generation: 2,
+                generation_id: "staged-generation".to_string(),
+                run_id: "staged-run".to_string(),
+                mode: IndexPublicationMode::Full,
+                published_at_epoch_ms: 2,
+            })?;
             staged.finalize_staged_snapshot()?;
         }
 
@@ -2106,13 +2120,7 @@ fn reader_open_during_healthy_promotion_does_not_recover_active_backup() -> Resu
     let prepared_path = promotion_prepared_journal_path(&live_path);
     write_promotion_journal(
         &prepared_path,
-        &PromotionJournal {
-            version: PROMOTION_JOURNAL_VERSION,
-            phase: PromotionJournalPhase::Prepared,
-            previous: read_promotion_database_identity(&backup_path)?,
-            candidate: read_promotion_database_identity(&live_path)?
-                .expect("live promotion identity"),
-        },
+        &promotion_journal(&backup_path, &live_path)?,
     )?;
     let promotion_lock = PromotionLock::acquire(&live_path)?;
 
@@ -2146,7 +2154,12 @@ fn reader_open_during_healthy_promotion_does_not_recover_active_backup() -> Resu
 const PROMOTION_ABORT_LIVE_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_LIVE";
 const PROMOTION_ABORT_STAGED_ENV: &str = "CODESTORY_TEST_PROMOTION_ABORT_STAGED";
 
-fn seed_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
+fn seed_promotion_file_with_identity(
+    path: &Path,
+    id: i64,
+    name: &str,
+    publish: bool,
+) -> Result<(), StorageError> {
     let mut storage = Storage::open(path)?;
     storage.insert_files_batch(&[FileInfo {
         id,
@@ -2158,14 +2171,35 @@ fn seed_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageEr
         line_count: 1,
         file_role: FileRole::Source,
     }])?;
-    storage.put_index_publication(&IndexPublicationRecord {
-        generation: id.max(0) as u64,
-        generation_id: format!("generation-{id}"),
-        run_id: format!("run-{id}"),
-        mode: IndexPublicationMode::Full,
-        published_at_epoch_ms: id.max(0),
-    })?;
+    if publish {
+        storage.put_index_publication(&IndexPublicationRecord {
+            generation: id.max(0) as u64,
+            generation_id: format!("generation-{id}"),
+            run_id: format!("run-{id}"),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: id.max(0),
+        })?;
+    }
     storage.finalize_staged_snapshot()
+}
+
+fn seed_promotion_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
+    seed_promotion_file_with_identity(path, id, name, true)
+}
+
+fn seed_unpublished_file(path: &Path, id: i64, name: &str) -> Result<(), StorageError> {
+    seed_promotion_file_with_identity(path, id, name, false)
+}
+
+fn promotion_journal(
+    previous_path: &Path,
+    candidate_path: &Path,
+) -> Result<PromotionJournal, StorageError> {
+    Ok(PromotionJournal {
+        version: PROMOTION_JOURNAL_VERSION,
+        previous: read_promotion_database_identity(previous_path)?,
+        candidate: require_promotion_database_identity(candidate_path, "Test candidate")?,
+    })
 }
 
 #[test]
@@ -2268,60 +2302,122 @@ fn staged_promotion_abort_recovers_old_or_complete_new_and_cleans_artifacts() {
 }
 
 #[test]
-fn staged_promotion_cleanup_failure_child() {
-    let Some(live_path) =
-        std::env::var_os(PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV).map(PathBuf::from)
-    else {
-        return;
-    };
-    let staged_path =
-        PathBuf::from(std::env::var_os(PROMOTION_ABORT_STAGED_ENV).expect("child staged path"));
-    Storage::promote_staged_snapshot(&staged_path, &live_path)
-        .expect("committed promotion must not fail when backup cleanup is deferred");
-}
-
-#[test]
-fn committed_promotion_never_rolls_back_when_backup_cleanup_fails() {
+fn retained_committed_promotion_stays_live_and_blocks_the_next_writer() {
     let live_path = unique_temp_db_path("promotion-cleanup-failure-live");
     let staged_path = unique_temp_db_path("promotion-cleanup-failure-staged");
+    let second_staged_path = unique_temp_db_path("promotion-cleanup-failure-second-staged");
     let backup_path = live_path.with_extension("sqlite.backup");
-    let prepared_path = promotion_prepared_journal_path(&live_path);
     let committed_path = promotion_committed_journal_path(&live_path);
+    let cleanup_failure_path = promotion_cleanup_failure_path(&live_path);
     seed_promotion_file(&live_path, 1, "old.rs").expect("seed live generation");
     seed_promotion_file(&staged_path, 2, "new.rs").expect("seed staged generation");
+    seed_promotion_file(&second_staged_path, 3, "newer.rs").expect("seed second staged generation");
+    std::fs::write(&cleanup_failure_path, b"blocked").expect("inject cleanup failure");
 
-    let status =
-        std::process::Command::new(std::env::current_exe().expect("resolve store test executable"))
-            .arg("--exact")
-            .arg("storage_impl::tests::staged_promotion_cleanup_failure_child")
-            .arg("--nocapture")
-            .env(PROMOTION_BACKUP_CLEANUP_FAILURE_LIVE_ENV, &live_path)
-            .env(PROMOTION_ABORT_STAGED_ENV, &staged_path)
-            .status()
-            .expect("run cleanup-failure child");
-    assert!(status.success(), "committed cleanup-failure child failed");
-    assert!(
-        backup_path.exists(),
-        "fault injection must retain the backup"
-    );
-    assert!(
-        committed_path.exists(),
-        "a retained backup must keep its commit marker"
-    );
+    Storage::promote_staged_snapshot(&staged_path, &live_path)
+        .expect("committed promotion tolerates deferred cleanup");
+    let error = Storage::promote_staged_snapshot(&second_staged_path, &live_path)
+        .expect_err("retained committed artifacts must block the next promotion");
+    assert!(error.to_string().contains("prior artifacts remain"));
+    assert!(backup_path.exists() && committed_path.exists());
+    assert!(second_staged_path.exists());
 
+    std::fs::remove_file(&cleanup_failure_path).expect("restore cleanup");
     let reopened = Storage::open(&live_path).expect("reopen committed live generation");
     assert_eq!(
         reopened.get_files().expect("read committed generation")[0].path,
         PathBuf::from("new.rs")
     );
     drop(reopened);
-    assert!(!backup_path.exists(), "reopen cleans the retained backup");
-    assert!(!prepared_path.exists(), "reopen cleans the prepare marker");
-    assert!(!committed_path.exists(), "reopen cleans the commit marker");
+    assert!(!backup_path.exists() && !committed_path.exists());
 
     let _ = cleanup_sqlite_sidecars(&live_path);
     let _ = cleanup_sqlite_sidecars(&staged_path);
+    let _ = cleanup_sqlite_sidecars(&second_staged_path);
     let _ = cleanup_sqlite_sidecars(&backup_path);
+}
+
+#[test]
+fn prepared_promotion_refuses_to_overwrite_an_unrelated_newer_live_publication() {
+    let live_path = unique_temp_db_path("prepared-newer-live");
+    let candidate_path = unique_temp_db_path("prepared-newer-candidate");
+    let backup_path = live_path.with_extension("sqlite.backup");
+    let prepared_path = promotion_prepared_journal_path(&live_path);
+    seed_promotion_file(&live_path, 3, "newer.rs").expect("seed unrelated newer live");
+    seed_promotion_file(&backup_path, 1, "old.rs").expect("seed previous backup");
+    seed_promotion_file(&candidate_path, 2, "candidate.rs").expect("seed candidate");
+    let journal = promotion_journal(&backup_path, &candidate_path).expect("build journal");
+    write_promotion_journal(&prepared_path, &journal).expect("write prepared journal");
+
+    let error = match Storage::open(&live_path) {
+        Ok(_) => panic!("prepared recovery must reject an unrelated live publication"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("unrelated live publication"),
+        "unexpected prepared recovery error: {error}"
+    );
+    assert!(
+        prepared_path.exists(),
+        "failed-closed recovery keeps its journal"
+    );
+    assert!(
+        backup_path.exists(),
+        "failed-closed recovery keeps its backup"
+    );
+
+    std::fs::remove_file(&prepared_path).expect("remove prepared journal");
+    cleanup_sqlite_sidecars(&backup_path).expect("remove previous backup");
+    let live = Storage::open(&live_path).expect("reopen untouched newer live");
+    assert_eq!(
+        live.get_files().expect("read newer live")[0].path,
+        PathBuf::from("newer.rs")
+    );
+    drop(live);
+
+    let _ = cleanup_sqlite_sidecars(&live_path);
+    let _ = cleanup_sqlite_sidecars(&candidate_path);
+}
+
+#[test]
+fn publicationless_promotion_state_is_ambiguous_and_fails_closed() {
+    let live_path = unique_temp_db_path("publicationless-live");
+    let backup_path = live_path.with_extension("sqlite.backup");
+    let staged_path = unique_temp_db_path("publicationless-staged");
+    seed_unpublished_file(&live_path, 1, "live.rs").expect("seed unpublished live");
+    seed_unpublished_file(&backup_path, 2, "backup.rs").expect("seed unpublished backup");
+
+    let error = match Storage::open(&live_path) {
+        Ok(_) => panic!("publicationless legacy backup cannot prove recovery identity"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("no complete publication identity"),
+        "unexpected publicationless recovery error: {error}"
+    );
+    assert!(backup_path.exists(), "ambiguous backup must be retained");
+
+    cleanup_sqlite_sidecars(&backup_path).expect("remove ambiguous backup");
+    seed_unpublished_file(&staged_path, 3, "staged.rs").expect("seed unpublished candidate");
+    let error = Storage::promote_staged_snapshot(&staged_path, &live_path)
+        .expect_err("promotion requires a complete candidate publication");
+    assert!(
+        error
+            .to_string()
+            .contains("no complete publication identity"),
+        "unexpected unpublished candidate error: {error}"
+    );
+    let live = Storage::open(&live_path).expect("reopen untouched unpublished live");
+    assert_eq!(
+        live.get_files().expect("read untouched live")[0].path,
+        PathBuf::from("live.rs")
+    );
+    drop(live);
+
+    let _ = cleanup_sqlite_sidecars(&live_path);
+    let _ = cleanup_sqlite_sidecars(&staged_path);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- write one durable promotion journal at prepare time, then atomically rename that same payload to the committed path after validating the candidate
- require complete publication identities for candidates and recovery artifacts
- validate prepared recovery against absent, previous, or candidate live state and fail closed on an unrelated publication
- keep a committed generation readable when cleanup is deferred, but refuse a second writer until retained artifacts are gone
- preserve bounded legacy-backup recovery without treating publication-less databases as equal

## Why

A successful staged publication could leave `live.sqlite.backup` behind when Windows denied deletion. The next open treated that file as crash evidence and silently restored the older generation over the published database.

The initial journal implementation fixed that case but left three gaps: a retained committed marker could strand the next promotion after it had already replaced live state, prepared rollback could overwrite an unrelated newer live generation, and publication-less databases compared equal by schema alone.

## Review guide

Start with the journal helpers and `recover_interrupted_promotion_locked` in `storage_impl/mod.rs`. The prepared and committed paths now encode the only two durable states; there is no duplicated phase payload. Then review `rollback_prepared_promotion` and the preflight in `promote_staged_snapshot`.

Focused tests cover:

- process abort during the prepared restore window
- retained committed cleanup followed by a blocked second writer
- prepared recovery facing an unrelated newer live publication
- publication-less legacy and candidate ambiguity
- invalid and older legacy backups

## Verification

Exact head: `8eca2b8b4961f7d72c1fc7bfa57d2cb50c6c2b48`

- `cargo test -p codestory-store --lib --locked` — 91 passed
- `cargo clippy -p codestory-store --lib --tests --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Diff

- production state machine: +368/-27, net +341
- focused tests and publication fixtures: +235/-2
- changelog: +4

The production state machine is 76 net lines smaller than the prior PR head despite the added recovery checks. The prior subprocess-only cleanup test was removed; the final store suite has one additional test versus that head.

Closes #1098
Refs #899
