### PR TITLE
freeze sidecar process defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@
   macOS and Windows process inspection is bounded, dead, reused, or unverified
   PIDs remain fail-closed, and cleanup stays limited to resources carrying
   CodeStory ownership proof.
+- Sidecar cache roots and runtime environment defaults are captured once per
+  process and passed explicitly through test construction. Windows process
+  probes also reject completed processes using both exit time and exit code.
 - Managed installation and upgrade checks cover every shipped native platform,
   including upgrade from a verified older CLI with that version retained as the
   rollback. The Codex worktree setup dispatcher now provides equivalent native

--- a/crates/codestory-cli/src/config.rs
+++ b/crates/codestory-cli/src/config.rs
@@ -10,9 +10,8 @@ const PROJECT_NETWORK_CONFIG_OPT_IN_ENV: &str = "CODESTORY_ALLOW_PROJECT_NETWORK
 pub(crate) struct CliStartupConfig {
     pub(crate) user_home: Option<PathBuf>,
     pub(crate) project_network_config_allowed: bool,
-    pub(crate) user_cache_root: PathBuf,
     pub(crate) stdio_cache_root: Option<PathBuf>,
-    pub(crate) runtime_defaults: codestory_retrieval::SidecarRuntimeDefaults,
+    pub(crate) sidecar_defaults: codestory_retrieval::SidecarProcessDefaults,
 }
 
 impl CliStartupConfig {
@@ -26,8 +25,7 @@ impl CliStartupConfig {
                 .map(|value| matches!(value.trim(), "1" | "true" | "TRUE" | "yes" | "YES"))
                 .unwrap_or(false),
             stdio_cache_root: std::env::var_os("CODESTORY_STDIO_CACHE_ROOT").map(PathBuf::from),
-            user_cache_root: crate::sidecar_runtime::user_cache_root(),
-            runtime_defaults: codestory_retrieval::SidecarRuntimeDefaults::from_process_env(),
+            sidecar_defaults: crate::sidecar_runtime::process_defaults(),
         }
     }
 }

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -168,17 +168,19 @@ impl RuntimeContext {
         let process_cache_root = startup
             .stdio_cache_root
             .as_deref()
-            .unwrap_or(&startup.user_cache_root);
+            .unwrap_or_else(|| startup.sidecar_defaults.cache_root());
         let cache_root = cache_root_for_project_in(
             &project_root,
             cache_override.as_deref(),
             process_cache_root,
         )?;
         let storage_path = cache_root.join("codestory.db");
-        let sidecar = crate::sidecar_runtime::for_project_auto_with_defaults_in_cache(
+        let sidecar_defaults = startup
+            .sidecar_defaults
+            .with_cache_root(process_cache_root.to_path_buf());
+        let sidecar = crate::sidecar_runtime::for_project_auto_with_process_defaults(
             &project_root,
-            process_cache_root,
-            &startup.runtime_defaults,
+            &sidecar_defaults,
             &config.runtime_overrides(),
         );
         let runtime = Runtime::new_with_config(sidecar.clone());
@@ -1003,9 +1005,11 @@ mod tests {
         let startup = |cache_root: &Path| crate::config::CliStartupConfig {
             user_home: None,
             project_network_config_allowed: true,
-            user_cache_root: cache_root.to_path_buf(),
             stdio_cache_root: Some(cache_root.to_path_buf()),
-            runtime_defaults: codestory_retrieval::SidecarRuntimeDefaults::default(),
+            sidecar_defaults: codestory_retrieval::SidecarProcessDefaults::new(
+                cache_root.to_path_buf(),
+                codestory_retrieval::SidecarRuntimeDefaults::default(),
+            ),
         };
         let first_startup = startup(&first_cache);
         let second_startup = startup(&second_cache);

--- a/crates/codestory-cli/src/sidecar_runtime.rs
+++ b/crates/codestory-cli/src/sidecar_runtime.rs
@@ -5,10 +5,14 @@
 //! isolation before the constructor (or startup configuration) can fall back
 //! to the platform `ProjectDirs` cache.
 
+#[cfg(test)]
+use codestory_retrieval::SidecarRuntimeDefaults;
 use codestory_retrieval::{
-    SidecarProfile, SidecarRuntimeConfig, SidecarRuntimeDefaults, SidecarRuntimeOverrides,
+    SidecarProcessDefaults, SidecarProfile, SidecarRuntimeConfig, SidecarRuntimeOverrides,
 };
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 #[cfg(test)]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -41,20 +45,33 @@ fn with_default_test_cache_root<T>(task: impl FnOnce() -> T) -> T {
     codestory_retrieval::with_test_cache_root(&root, task)
 }
 
-pub(crate) fn user_cache_root() -> PathBuf {
+pub(crate) fn process_defaults() -> SidecarProcessDefaults {
     prepare_cache_access();
     #[cfg(test)]
-    return with_default_test_cache_root(codestory_retrieval::user_cache_root);
+    return with_default_test_cache_root(|| {
+        SidecarProcessDefaults::new(
+            codestory_retrieval::user_cache_root(),
+            SidecarRuntimeDefaults::from_process_env(),
+        )
+    });
     #[cfg(not(test))]
-    codestory_retrieval::user_cache_root()
+    codestory_retrieval::sidecar_process_defaults()
+}
+
+#[cfg(test)]
+pub(crate) fn user_cache_root() -> PathBuf {
+    process_defaults().cache_root().to_path_buf()
 }
 
 pub(crate) fn local() -> SidecarRuntimeConfig {
-    prepare_cache_access();
-    #[cfg(test)]
-    return with_default_test_cache_root(SidecarRuntimeConfig::local);
-    #[cfg(not(test))]
-    SidecarRuntimeConfig::local()
+    let defaults = process_defaults();
+    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        None,
+        SidecarProfile::Local,
+        None,
+        &defaults,
+        &SidecarRuntimeOverrides::default(),
+    )
 }
 
 #[cfg(test)]
@@ -63,13 +80,14 @@ pub(crate) fn embedding_runtime_id() -> String {
 }
 
 pub(crate) fn for_project(project_root: &Path, profile: SidecarProfile) -> SidecarRuntimeConfig {
-    prepare_cache_access();
-    #[cfg(test)]
-    return with_default_test_cache_root(|| {
-        codestory_retrieval::sidecar_runtime_for_project(project_root, profile)
-    });
-    #[cfg(not(test))]
-    codestory_retrieval::sidecar_runtime_for_project(project_root, profile)
+    let defaults = process_defaults();
+    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        Some(project_root),
+        profile,
+        None,
+        &defaults,
+        &SidecarRuntimeOverrides::default(),
+    )
 }
 
 pub(crate) fn for_project_with_run_id(
@@ -77,28 +95,23 @@ pub(crate) fn for_project_with_run_id(
     profile: SidecarProfile,
     run_id: Option<&str>,
 ) -> SidecarRuntimeConfig {
-    prepare_cache_access();
-    #[cfg(test)]
-    return with_default_test_cache_root(|| {
-        codestory_retrieval::sidecar_runtime_for_project_with_run_id(project_root, profile, run_id)
-    });
-    #[cfg(not(test))]
-    codestory_retrieval::sidecar_runtime_for_project_with_run_id(project_root, profile, run_id)
+    let defaults = process_defaults();
+    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        Some(project_root),
+        profile,
+        run_id,
+        &defaults,
+        &SidecarRuntimeOverrides::default(),
+    )
 }
 
-pub(crate) fn for_project_auto_with_defaults_in_cache(
+pub(crate) fn for_project_auto_with_process_defaults(
     project_root: &Path,
-    cache_root: &Path,
-    defaults: &SidecarRuntimeDefaults,
+    defaults: &SidecarProcessDefaults,
     overrides: &SidecarRuntimeOverrides,
 ) -> SidecarRuntimeConfig {
     prepare_cache_access();
-    SidecarRuntimeConfig::for_project_auto_with_defaults_in_cache(
-        project_root,
-        cache_root,
-        defaults,
-        overrides,
-    )
+    SidecarRuntimeConfig::for_project_auto_with_process_defaults(project_root, defaults, overrides)
 }
 
 #[cfg(test)]
@@ -117,11 +130,16 @@ pub(crate) fn for_project_with_run_id_in_cache(
     cache_root: &Path,
 ) -> SidecarRuntimeConfig {
     prepare_cache_access();
-    SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+    let defaults = SidecarProcessDefaults::new(
+        cache_root.to_path_buf(),
+        SidecarRuntimeDefaults::from_process_env(),
+    );
+    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
         project_root,
         profile,
         run_id,
-        cache_root,
+        &defaults,
+        &SidecarRuntimeOverrides::default(),
     )
 }
 
@@ -135,10 +153,7 @@ mod tests {
         let active_root = codestory_retrieval::active_test_cache_root()
             .expect("gateway should activate a process-unique test cache root");
 
-        let explicit_root = std::env::var_os("CODESTORY_CACHE_ROOT")
-            .filter(|value| !value.is_empty())
-            .map(PathBuf::from);
-        assert_eq!(cache_root, explicit_root.unwrap_or(active_root));
+        assert_eq!(cache_root, active_root);
         assert!(local().layout.state_file.starts_with(&cache_root));
     }
 

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -1366,15 +1366,32 @@ fn test_sidecar_runtime(
     project: &Path,
     run_id: &str,
 ) -> codestory_retrieval::SidecarRuntimeConfig {
-    codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
-        Some(project),
-        codestory_retrieval::SidecarProfile::Agent,
-        Some(run_id),
+    test_sidecar_runtime_in_cache(
+        project,
+        run_id,
         &fixture
             .cache_dir
             .path()
             .join("test-state")
             .join("stdio-cache"),
+    )
+}
+
+fn test_sidecar_runtime_in_cache(
+    project: &Path,
+    run_id: &str,
+    cache_root: &Path,
+) -> codestory_retrieval::SidecarRuntimeConfig {
+    let defaults = codestory_retrieval::SidecarProcessDefaults::new(
+        cache_root.to_path_buf(),
+        codestory_retrieval::SidecarRuntimeDefaults::from_process_env(),
+    );
+    codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        Some(project),
+        codestory_retrieval::SidecarProfile::Agent,
+        Some(run_id),
+        &defaults,
+        &codestory_retrieval::SidecarRuntimeOverrides::default(),
     )
 }
 
@@ -4284,13 +4301,11 @@ fn tools_call_sidecar_setup_records_successful_worker_terminal_state() {
         &canonical_root,
         codestory_retrieval::DEFAULT_AGENT_RUN_ID,
     );
-    let mutable_cache_sidecar =
-        codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
-            Some(&canonical_root),
-            codestory_retrieval::SidecarProfile::Agent,
-            Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-            &fixture.cache_dir.path().join("test-state").join("cache"),
-        );
+    let mutable_cache_sidecar = test_sidecar_runtime_in_cache(
+        &canonical_root,
+        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
+        &fixture.cache_dir.path().join("test-state").join("cache"),
+    );
     assert_ne!(
         repair_sidecar.layout.state_file, mutable_cache_sidecar.layout.state_file,
         "the regression contract requires distinct retained and mutable cache roots"

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -2586,7 +2586,7 @@ mod tests {
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".to_string(),
             labels: std::collections::BTreeMap::new(),
-            ..SidecarRuntimeConfig::local()
+            ..crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None)
         }
     }
 
@@ -2863,12 +2863,7 @@ mod tests {
 
     #[test]
     fn embed_model_dir_discovers_user_cache_retrieval_models() {
-        let _lock = crate::test_support::env_lock();
         let cache = tempdir().expect("cache");
-        let _cache_root = EnvGuard::set(
-            "CODESTORY_CACHE_ROOT",
-            cache.path().to_str().expect("cache path"),
-        );
         let project = tempdir().expect("project");
         let model_dir = cache.path().join("retrieval-models");
         std::fs::create_dir_all(&model_dir).expect("model dir");
@@ -2878,11 +2873,12 @@ mod tests {
         )
         .expect("model file");
         let layout = compose_test_runtime(project.path()).layout;
+        let selected = crate::config::with_test_cache_root(cache.path(), || {
+            embed_model_dir(Some(project.path()), &layout)
+        })
+        .expect("model dir");
 
-        assert_eq!(
-            embed_model_dir(Some(project.path()), &layout).expect("model dir"),
-            model_dir
-        );
+        assert_eq!(selected, model_dir);
     }
 
     #[test]
@@ -3181,7 +3177,8 @@ mod tests {
         let _provider = EnvGuard::set("CODESTORY_EMBED_DEVICE_PROVIDER", "vulkan");
         let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
         let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
-        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Local);
+        let runtime =
+            crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
 
         let error = native_embedding_server_launch(None, &runtime)
             .expect_err("linux compose-only backend must not satisfy native_spawned");
@@ -3499,7 +3496,8 @@ mod tests {
         let model = temp.path().join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF);
         std::fs::write(&exe, b"fake exe").expect("exe");
         std::fs::write(&model, b"fake model").expect("model");
-        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Local);
+        let runtime =
+            crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
 
         let launch =
             native_embedding_server_launch_from_paths(exe.clone(), model.clone(), &runtime);
@@ -3577,7 +3575,8 @@ mod tests {
         let model = temp.path().join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF);
         std::fs::write(&exe, b"fake exe").expect("exe");
         std::fs::write(&model, b"fake model").expect("model");
-        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Local);
+        let runtime =
+            crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
 
         let launch =
             native_embedding_server_launch_from_paths(exe.clone(), model.clone(), &runtime);

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -12,6 +12,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Qdrant container image pin for local dev and CI smoke.
@@ -270,6 +271,37 @@ impl SidecarRuntimeDefaults {
     }
 }
 
+/// Immutable process-scoped inputs used to construct sidecar runtimes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SidecarProcessDefaults {
+    cache_root: PathBuf,
+    runtime: SidecarRuntimeDefaults,
+}
+
+impl SidecarProcessDefaults {
+    pub fn new(cache_root: PathBuf, runtime: SidecarRuntimeDefaults) -> Self {
+        Self {
+            cache_root,
+            runtime,
+        }
+    }
+
+    pub fn cache_root(&self) -> &Path {
+        &self.cache_root
+    }
+
+    pub fn runtime(&self) -> &SidecarRuntimeDefaults {
+        &self.runtime
+    }
+
+    pub fn with_cache_root(&self, cache_root: PathBuf) -> Self {
+        Self {
+            cache_root,
+            runtime: self.runtime.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetrievalRuntimeConfig {
     pub hybrid_enabled: bool,
@@ -437,40 +469,21 @@ impl SidecarRuntimeConfig {
     }
 
     pub fn for_project_auto(project_root: &Path) -> Self {
-        Self::for_project_auto_with_overrides(project_root, &SidecarRuntimeOverrides::default())
-    }
-
-    pub fn for_project_auto_with_overrides(
-        project_root: &Path,
-        overrides: &SidecarRuntimeOverrides,
-    ) -> Self {
-        Self::for_project_auto_with_defaults(
+        Self::for_project_auto_with_process_defaults(
             project_root,
-            &SidecarRuntimeDefaults::from_process_env(),
-            overrides,
-        )
-    }
-
-    pub fn for_project_auto_with_defaults(
-        project_root: &Path,
-        defaults: &SidecarRuntimeDefaults,
-        overrides: &SidecarRuntimeOverrides,
-    ) -> Self {
-        Self::for_project_auto_with_defaults_in_cache(
-            project_root,
-            &user_cache_root(),
-            defaults,
-            overrides,
+            &sidecar_process_defaults(),
+            &SidecarRuntimeOverrides::default(),
         )
     }
 
     #[doc(hidden)]
-    pub fn for_project_auto_with_defaults_in_cache(
+    pub fn for_project_auto_with_process_defaults(
         project_root: &Path,
-        cache_root: &Path,
-        defaults: &SidecarRuntimeDefaults,
+        process_defaults: &SidecarProcessDefaults,
         overrides: &SidecarRuntimeOverrides,
     ) -> Self {
+        let cache_root = process_defaults.cache_root();
+        let defaults = process_defaults.runtime();
         let explicit_profile = env_profile(defaults);
         let env_run_id = env_agent_run_id(defaults);
         let latest_run_id = if explicit_profile.is_none() && env_run_id.is_none() {
@@ -484,12 +497,11 @@ impl SidecarRuntimeConfig {
             latest_run_id,
             running_in_ci_agent(defaults),
         );
-        Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
+        Self::for_project_profile_with_process_defaults(
             Some(project_root),
             profile,
             run_id.as_deref(),
-            cache_root,
-            defaults,
+            process_defaults,
             overrides,
         )
     }
@@ -503,89 +515,25 @@ impl SidecarRuntimeConfig {
         profile: SidecarProfile,
         run_id: Option<&str>,
     ) -> Self {
-        Self::for_project_profile_with_run_id_and_overrides(
+        Self::for_project_profile_with_process_defaults(
             project_root,
             profile,
             run_id,
-            &SidecarRuntimeOverrides::default(),
-        )
-    }
-
-    pub fn for_project_profile_with_run_id_and_overrides(
-        project_root: Option<&Path>,
-        profile: SidecarProfile,
-        run_id: Option<&str>,
-        overrides: &SidecarRuntimeOverrides,
-    ) -> Self {
-        Self::for_project_profile_with_run_id_defaults_and_overrides(
-            project_root,
-            profile,
-            run_id,
-            &SidecarRuntimeDefaults::from_process_env(),
-            overrides,
-        )
-    }
-
-    fn for_project_profile_with_run_id_defaults_and_overrides(
-        project_root: Option<&Path>,
-        profile: SidecarProfile,
-        run_id: Option<&str>,
-        defaults: &SidecarRuntimeDefaults,
-        overrides: &SidecarRuntimeOverrides,
-    ) -> Self {
-        Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
-            project_root,
-            profile,
-            run_id,
-            &user_cache_root(),
-            defaults,
-            overrides,
-        )
-    }
-
-    #[doc(hidden)]
-    pub fn for_project_profile_with_run_id_in_cache(
-        project_root: Option<&Path>,
-        profile: SidecarProfile,
-        run_id: Option<&str>,
-        cache_root: &Path,
-    ) -> Self {
-        Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
-            project_root,
-            profile,
-            run_id,
-            cache_root,
-            &SidecarRuntimeDefaults::from_process_env(),
+            &sidecar_process_defaults(),
             &SidecarRuntimeOverrides::default(),
         )
     }
 
     #[doc(hidden)]
-    pub fn for_project_profile_with_run_id_in_cache_and_overrides(
+    pub fn for_project_profile_with_process_defaults(
         project_root: Option<&Path>,
         profile: SidecarProfile,
         run_id: Option<&str>,
-        cache_root: &Path,
+        process_defaults: &SidecarProcessDefaults,
         overrides: &SidecarRuntimeOverrides,
     ) -> Self {
-        Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
-            project_root,
-            profile,
-            run_id,
-            cache_root,
-            &SidecarRuntimeDefaults::from_process_env(),
-            overrides,
-        )
-    }
-
-    fn for_project_profile_with_run_id_in_cache_defaults_and_overrides(
-        project_root: Option<&Path>,
-        profile: SidecarProfile,
-        run_id: Option<&str>,
-        cache_root: &Path,
-        defaults: &SidecarRuntimeDefaults,
-        overrides: &SidecarRuntimeOverrides,
-    ) -> Self {
+        let cache_root = process_defaults.cache_root();
+        let defaults = process_defaults.runtime();
         let base = cache_root.to_path_buf();
         let run_id = (profile == SidecarProfile::Agent).then(|| agent_run_id(run_id, defaults));
         let project_identity = project_root.map(codestory_workspace::project_identity_v3);
@@ -942,12 +890,15 @@ impl SidecarRuntimeConfig {
                 .and_then(Path::parent),
         }
         .unwrap_or_else(|| Path::new("."));
-        let mut selected = Self::for_project_profile_with_run_id_in_cache_defaults_and_overrides(
+        let process_defaults = SidecarProcessDefaults::new(
+            cache_root.to_path_buf(),
+            SidecarRuntimeDefaults::default(),
+        );
+        let mut selected = Self::for_project_profile_with_process_defaults(
             project_root,
             profile,
             run_id,
-            cache_root,
-            &SidecarRuntimeDefaults::default(),
+            &process_defaults,
             &SidecarRuntimeOverrides::default(),
         );
         let selected_managed_endpoint = selected.embedding.endpoint.clone();
@@ -1080,25 +1031,6 @@ impl SidecarLayout {
         }
         Ok(())
     }
-}
-
-pub fn sidecar_runtime_for_project(
-    project_root: &Path,
-    profile: SidecarProfile,
-) -> SidecarRuntimeConfig {
-    SidecarRuntimeConfig::for_project_profile(Some(project_root), profile)
-}
-
-pub fn sidecar_runtime_for_project_with_run_id(
-    project_root: &Path,
-    profile: SidecarProfile,
-    run_id: Option<&str>,
-) -> SidecarRuntimeConfig {
-    SidecarRuntimeConfig::for_project_profile_with_run_id(Some(project_root), profile, run_id)
-}
-
-pub fn sidecar_runtime_auto(project_root: &Path) -> SidecarRuntimeConfig {
-    SidecarRuntimeConfig::for_project_auto(project_root)
 }
 
 fn embedding_runtime_config(
@@ -2686,24 +2618,87 @@ pub fn retrieval_command(
     command
 }
 
-pub fn user_cache_root() -> PathBuf {
+fn uncached_user_cache_root() -> PathBuf {
     if let Ok(path) = std::env::var("CODESTORY_CACHE_ROOT") {
         let path = path.trim();
         if !path.is_empty() {
             return PathBuf::from(path);
         }
     }
-    #[cfg(feature = "test-support")]
-    if let Some(path) = active_test_cache_root() {
-        return path;
-    }
-    #[cfg(test)]
-    if let Some(path) = automatic_unit_test_cache_root() {
-        return path;
-    }
     ProjectDirs::from("dev", "codestory", "codestory")
         .map(|dirs| dirs.cache_dir().to_path_buf())
         .unwrap_or_else(|| std::env::temp_dir().join("codestory").join("cache"))
+}
+
+fn frozen_process_defaults(cell: &OnceLock<SidecarProcessDefaults>) -> &SidecarProcessDefaults {
+    cell.get_or_init(|| {
+        SidecarProcessDefaults::new(
+            uncached_user_cache_root(),
+            SidecarRuntimeDefaults::from_process_env(),
+        )
+    })
+}
+
+pub fn sidecar_process_defaults() -> SidecarProcessDefaults {
+    #[cfg(test)]
+    let defaults = SidecarProcessDefaults::new(
+        uncached_user_cache_root(),
+        SidecarRuntimeDefaults::default(),
+    );
+    #[cfg(not(test))]
+    let defaults = {
+        static PROCESS_DEFAULTS: OnceLock<SidecarProcessDefaults> = OnceLock::new();
+        frozen_process_defaults(&PROCESS_DEFAULTS).clone()
+    };
+
+    #[cfg(any(test, feature = "test-support"))]
+    if let Some(cache_root) = test_cache_root_override() {
+        return defaults.with_cache_root(cache_root);
+    }
+    defaults
+}
+
+pub fn user_cache_root() -> PathBuf {
+    sidecar_process_defaults().cache_root
+}
+
+#[cfg(test)]
+pub(crate) fn test_sidecar_runtime_from_env(
+    project_root: Option<&Path>,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+) -> SidecarRuntimeConfig {
+    let defaults = SidecarProcessDefaults::new(
+        uncached_user_cache_root(),
+        SidecarRuntimeDefaults::from_process_env(),
+    );
+    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        project_root,
+        profile,
+        run_id,
+        &defaults,
+        &SidecarRuntimeOverrides::default(),
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn test_sidecar_runtime_in_cache(
+    project_root: Option<&Path>,
+    profile: SidecarProfile,
+    run_id: Option<&str>,
+    cache_root: &Path,
+) -> SidecarRuntimeConfig {
+    let defaults = SidecarProcessDefaults::new(
+        cache_root.to_path_buf(),
+        SidecarRuntimeDefaults::from_process_env(),
+    );
+    SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        project_root,
+        profile,
+        run_id,
+        &defaults,
+        &SidecarRuntimeOverrides::default(),
+    )
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -2714,14 +2709,20 @@ thread_local! {
 #[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub fn active_test_cache_root() -> Option<PathBuf> {
-    TEST_CACHE_ROOT_OVERRIDE
-        .with(|root| root.borrow().clone())
-        .or_else(|| {
-            AUTOMATIC_TEST_CACHE_ROOT_ENABLED
-                .load(std::sync::atomic::Ordering::Acquire)
-                .then(automatic_unit_test_cache_root)
-                .flatten()
-        })
+    test_cache_root_override()
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn test_cache_root_override() -> Option<PathBuf> {
+    let explicit = TEST_CACHE_ROOT_OVERRIDE.with(|root| root.borrow().clone());
+    if explicit.is_some() {
+        return explicit;
+    }
+    #[cfg(feature = "test-support")]
+    if !AUTOMATIC_TEST_CACHE_ROOT_ENABLED.load(std::sync::atomic::Ordering::Acquire) {
+        return None;
+    }
+    automatic_unit_test_cache_root()
 }
 
 #[cfg(feature = "test-support")]
@@ -2760,7 +2761,7 @@ fn automatic_unit_test_cache_root() -> Option<PathBuf> {
     Some(root)
 }
 
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]
 pub fn with_test_cache_root<T>(root: &Path, task: impl FnOnce() -> T) -> T {
     struct Reset(Option<PathBuf>);
@@ -2860,6 +2861,11 @@ mod tests {
     use sha2::{Digest, Sha256};
     use tempfile::tempdir;
 
+    fn embedding_server_launch_mode_from_env() -> Result<EmbeddingServerLaunchMode> {
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
+        embedding_server_launch_mode_for_runtime(&runtime)
+    }
+
     #[test]
     fn test_support_isolates_named_threads_after_explicit_activation() {
         #[cfg(feature = "test-support")]
@@ -2868,6 +2874,34 @@ mod tests {
         assert!(root.starts_with(std::env::temp_dir().join("codestory-unit-tests")));
         #[cfg(feature = "test-support")]
         assert_eq!(active_test_cache_root(), Some(root));
+    }
+
+    #[test]
+    fn process_defaults_are_frozen_after_first_capture() {
+        let _lock = crate::test_support::env_lock();
+        let cache = tempdir().expect("cache");
+        let poison = tempdir().expect("poison cache");
+        let _cache = EnvGuard::set(
+            "CODESTORY_CACHE_ROOT",
+            cache.path().to_str().expect("cache path"),
+        );
+        let _port = EnvGuard::set("CODESTORY_QDRANT_HTTP_PORT", "32101");
+        let cell = OnceLock::new();
+        let first = frozen_process_defaults(&cell).clone();
+
+        let _poison_cache = EnvGuard::set(
+            "CODESTORY_CACHE_ROOT",
+            poison.path().to_str().expect("poison cache path"),
+        );
+        let _poison_port = EnvGuard::set("CODESTORY_QDRANT_HTTP_PORT", "32102");
+        let second = frozen_process_defaults(&cell);
+
+        assert_eq!(first.cache_root(), cache.path());
+        assert_eq!(second, &first);
+        assert_eq!(
+            second.runtime().get("CODESTORY_QDRANT_HTTP_PORT"),
+            Some("32101")
+        );
     }
 
     #[test]
@@ -2880,9 +2914,9 @@ mod tests {
         );
 
         let first =
-            SidecarRuntimeConfig::for_project_profile(Some(project.path()), SidecarProfile::Agent);
+            test_sidecar_runtime_from_env(Some(project.path()), SidecarProfile::Agent, None);
         let second =
-            SidecarRuntimeConfig::for_project_profile(Some(project.path()), SidecarProfile::Agent);
+            test_sidecar_runtime_from_env(Some(project.path()), SidecarProfile::Agent, None);
 
         assert_eq!(first.run_id.as_deref(), Some(DEFAULT_AGENT_RUN_ID));
         assert_eq!(first.run_id, second.run_id);
@@ -2909,7 +2943,7 @@ mod tests {
             project.path().join("cache").to_str().expect("utf8 cache"),
         );
         let runtime =
-            SidecarRuntimeConfig::for_project_profile(Some(project.path()), SidecarProfile::Agent);
+            test_sidecar_runtime_from_env(Some(project.path()), SidecarProfile::Agent, None);
         let identity = runtime.project_identity.as_ref().expect("project identity");
 
         assert_eq!(
@@ -2950,12 +2984,12 @@ mod tests {
             project.path().join("cache").to_str().expect("utf8 cache"),
         );
 
-        let first = SidecarRuntimeConfig::for_project_profile_with_run_id(
+        let first = test_sidecar_runtime_from_env(
             Some(project.path()),
             SidecarProfile::Agent,
             Some("review-fix"),
         );
-        let second = SidecarRuntimeConfig::for_project_profile_with_run_id(
+        let second = test_sidecar_runtime_from_env(
             Some(project.path()),
             SidecarProfile::Agent,
             Some("review-fix"),
@@ -2980,7 +3014,7 @@ mod tests {
             "CODESTORY_CACHE_ROOT",
             project.path().join("cache").to_str().expect("utf8 cache"),
         );
-        let first = SidecarRuntimeConfig::for_project_profile_with_run_id(
+        let first = test_sidecar_runtime_from_env(
             Some(project.path()),
             SidecarProfile::Agent,
             Some("persisted"),
@@ -3008,7 +3042,7 @@ mod tests {
         )
         .expect("state file");
 
-        let second = SidecarRuntimeConfig::for_project_profile_with_run_id(
+        let second = test_sidecar_runtime_from_env(
             Some(project.path()),
             SidecarProfile::Agent,
             Some("persisted"),
@@ -3048,7 +3082,7 @@ mod tests {
     #[test]
     fn retained_runtime_identity_fails_closed_after_reobservation_drift() {
         let project = tempdir().expect("project");
-        let mut runtime = SidecarRuntimeConfig::for_project_profile_with_run_id(
+        let mut runtime = test_sidecar_runtime_from_env(
             Some(project.path()),
             SidecarProfile::Agent,
             Some("identity-drift"),
@@ -3093,7 +3127,7 @@ mod tests {
             .expect("legacy state directory");
         std::fs::write(&legacy_state_file, b"{}\n").expect("legacy state file");
 
-        let runtime = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let runtime = test_sidecar_runtime_in_cache(
             Some(&noncanonical_project),
             SidecarProfile::Agent,
             Some(run_id),
@@ -3127,7 +3161,7 @@ mod tests {
         );
 
         let v3_run_id = "current-run";
-        let v3_runtime = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let v3_runtime = test_sidecar_runtime_in_cache(
             Some(&noncanonical_project),
             SidecarProfile::Agent,
             Some(v3_run_id),
@@ -3239,7 +3273,7 @@ mod tests {
     #[test]
     fn stale_runtime_cannot_renew_successor_owner_lease() {
         let cache = tempdir().expect("cache");
-        let first = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let first = test_sidecar_runtime_in_cache(
             None,
             SidecarProfile::Agent,
             Some("successor"),
@@ -3248,7 +3282,7 @@ mod tests {
         let root = cache.path().join("sidecars");
         std::fs::remove_file(agent_port_owner_path(&root, &first.namespace))
             .expect("remove first owner");
-        let successor = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let successor = test_sidecar_runtime_in_cache(
             None,
             SidecarProfile::Agent,
             Some("successor"),
@@ -3267,7 +3301,7 @@ mod tests {
     #[test]
     fn heartbeat_keeps_unbound_ports_past_original_ttl_under_contention() {
         let cache = tempdir().expect("cache");
-        let runtime = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let runtime = test_sidecar_runtime_in_cache(
             None,
             SidecarProfile::Agent,
             Some("heartbeat"),
@@ -3808,11 +3842,7 @@ mod tests {
         let _qdrant_grpc = EnvGuard::set("CODESTORY_QDRANT_GRPC_PORT", "invalid");
         let _embed = EnvGuard::set("CODESTORY_EMBED_PORT", "invalid");
 
-        let runtime = SidecarRuntimeConfig::for_project_profile_with_run_id(
-            None,
-            SidecarProfile::Agent,
-            Some("current"),
-        );
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Agent, Some("current"));
 
         assert_eq!(runtime.layout.qdrant_http_port, 0);
         assert_eq!(runtime.layout.qdrant_grpc_port, 0);
@@ -3855,7 +3885,7 @@ mod tests {
         let _url = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
 
         assert_eq!(
-            embedding_server_launch_mode().expect("launch mode"),
+            embedding_server_launch_mode_from_env().expect("launch mode"),
             EmbeddingServerLaunchMode::NativeSpawned
         );
     }
@@ -3870,7 +3900,7 @@ mod tests {
         );
 
         assert_eq!(
-            embedding_server_launch_mode().expect("launch mode"),
+            embedding_server_launch_mode_from_env().expect("launch mode"),
             EmbeddingServerLaunchMode::ExternalEndpoint
         );
     }
@@ -3885,7 +3915,7 @@ mod tests {
         let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
 
         assert_eq!(
-            embedding_server_launch_mode().expect("launch mode"),
+            embedding_server_launch_mode_from_env().expect("launch mode"),
             EmbeddingServerLaunchMode::DockerComposeEmbed
         );
     }
@@ -3896,7 +3926,7 @@ mod tests {
         let _mode = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "external_endpoint");
         let _url = EnvGuard::set("CODESTORY_EMBED_LLAMACPP_URL", " ");
 
-        let error = embedding_server_launch_mode().expect_err("blank external url");
+        let error = embedding_server_launch_mode_from_env().expect_err("blank external url");
 
         assert!(
             error
@@ -3914,7 +3944,7 @@ mod tests {
         let _host = EnvGuard::set(TEST_HOST_PLATFORM_ENV, "windows/x86_64");
         let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
         let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
-        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Agent, None);
 
         assert_eq!(
             embedding_server_launch_mode_for_runtime(&runtime).expect("launch mode"),
@@ -3931,7 +3961,7 @@ mod tests {
         let _lock = crate::test_support::env_lock();
         let _mode = EnvGuard::remove("CODESTORY_EMBED_SERVER_LAUNCH");
         let _url = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
-        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Agent, None);
 
         assert_eq!(
             runtime.embedding.endpoint,
@@ -3948,12 +3978,8 @@ mod tests {
         let _cache = EnvGuard::remove("CODESTORY_CACHE_ROOT");
         let _qdrant = EnvGuard::remove("CODESTORY_QDRANT_HTTP_PORT");
         let _endpoint = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
-        let retained = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
-            None,
-            SidecarProfile::Local,
-            None,
-            cache.path(),
-        );
+        let retained =
+            test_sidecar_runtime_in_cache(None, SidecarProfile::Local, None, cache.path());
         let _cache = EnvGuard::set(
             "CODESTORY_CACHE_ROOT",
             poison_cache.path().to_str().expect("utf8 poison cache"),
@@ -3984,7 +4010,7 @@ mod tests {
         let _lock = crate::test_support::env_lock();
         let _legacy = EnvGuard::set("CODESTORY_EMBED_ONNX_MODEL", "legacy.onnx");
 
-        let runtime = SidecarRuntimeConfig::local();
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
 
         let error = runtime
             .embedding
@@ -3998,12 +4024,8 @@ mod tests {
     #[test]
     fn ownership_redacts_external_embedding_endpoint_secrets() {
         let cache = tempdir().expect("cache");
-        let mut runtime = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
-            None,
-            SidecarProfile::Local,
-            None,
-            cache.path(),
-        );
+        let mut runtime =
+            test_sidecar_runtime_in_cache(None, SidecarProfile::Local, None, cache.path());
         runtime.embedding.endpoint =
             "http://username-secret:password-secret@127.0.0.1:8080/v1/embeddings?token=query-secret#fragment-secret"
                 .into();
@@ -4041,12 +4063,8 @@ mod tests {
                 Sha256::digest(runtime.embedding.endpoint.as_bytes())
             )
         );
-        let mut restarted = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
-            None,
-            SidecarProfile::Local,
-            None,
-            cache.path(),
-        );
+        let mut restarted =
+            test_sidecar_runtime_in_cache(None, SidecarProfile::Local, None, cache.path());
         restarted.embedding.endpoint = runtime.embedding.endpoint.clone();
         restarted.embedding.endpoint_origin = runtime.embedding.endpoint_origin;
         let retained = restarted.ownership();
@@ -4128,7 +4146,7 @@ mod tests {
             "CODESTORY_EMBED_LLAMACPP_URL",
             "http://127.0.0.1:37040/v1/embeddings",
         );
-        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Agent, None);
 
         assert_eq!(
             runtime.embedding.endpoint_origin,
@@ -4150,7 +4168,7 @@ mod tests {
         let _mode = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "docker_compose_embed");
         let endpoint = "http://127.0.0.1:37040/v1/embeddings";
         let _url = EnvGuard::set("CODESTORY_EMBED_LLAMACPP_URL", endpoint);
-        let runtime = SidecarRuntimeConfig::for_project_profile(None, SidecarProfile::Agent);
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Agent, None);
 
         assert_eq!(runtime.embedding.endpoint, endpoint);
         assert_eq!(
@@ -4173,7 +4191,7 @@ mod tests {
         let _mode = EnvGuard::set("CODESTORY_EMBED_SERVER_LAUNCH", "llama-server.exe");
         let _url = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
 
-        let error = embedding_server_launch_mode().expect_err("invalid mode");
+        let error = embedding_server_launch_mode_from_env().expect_err("invalid mode");
 
         assert!(
             error
@@ -4192,7 +4210,7 @@ mod tests {
         let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
 
         assert_eq!(
-            embedding_server_launch_mode().expect("launch mode"),
+            embedding_server_launch_mode_from_env().expect("launch mode"),
             EmbeddingServerLaunchMode::NativeSpawned
         );
     }
@@ -4207,7 +4225,7 @@ mod tests {
         let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
 
         assert_eq!(
-            embedding_server_launch_mode().expect("launch mode"),
+            embedding_server_launch_mode_from_env().expect("launch mode"),
             EmbeddingServerLaunchMode::DockerComposeEmbed
         );
     }

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -1303,8 +1303,12 @@ pub fn embedding_backend_label_for_runtime(
 
 #[cfg(test)]
 pub fn embed_documents(texts: &[String]) -> Result<Vec<Vec<f32>>> {
-    LlamaCppEmbeddingClient::new(&crate::config::SidecarRuntimeConfig::local().embedding)?
-        .embed_documents(texts)
+    let runtime = crate::config::test_sidecar_runtime_from_env(
+        None,
+        crate::config::SidecarProfile::Local,
+        None,
+    );
+    LlamaCppEmbeddingClient::new(&runtime.embedding)?.embed_documents(texts)
 }
 
 pub fn embed_documents_for_runtime(
@@ -1603,6 +1607,10 @@ mod tests {
     use std::collections::BTreeMap;
     use std::io::Write;
     use std::net::TcpListener;
+
+    fn runtime_from_env() -> SidecarRuntimeConfig {
+        crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None)
+    }
 
     fn llama_client_config(endpoint: String) -> crate::config::EmbeddingRuntimeConfig {
         crate::config::EmbeddingRuntimeConfig {
@@ -1925,7 +1933,11 @@ mod tests {
         let _lock = crate::test_support::env_lock();
         let _guard = EnvGuard::remove("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS");
         let _guard2 = EnvGuard::remove(EMBEDDING_BACKEND_ENV);
-        assert_eq!(embedding_runtime_id(), PRODUCT_EMBEDDING_RUNTIME_ID);
+        let runtime = runtime_from_env();
+        assert_eq!(
+            embedding_runtime_id_for_runtime(&runtime),
+            PRODUCT_EMBEDDING_RUNTIME_ID
+        );
         assert_eq!(qdrant_vector_dim(), RETRIEVAL_EMBEDDING_DIM);
     }
 
@@ -1934,7 +1946,11 @@ mod tests {
         let _lock = crate::test_support::env_lock();
         let _guard = EnvGuard::set(EMBEDDING_BACKEND_ENV, "llamacpp");
         let _guard2 = EnvGuard::set("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
-        assert_eq!(embedding_runtime_id(), "llamacpp:bge-base-en-v1.5");
+        let runtime = runtime_from_env();
+        assert_eq!(
+            embedding_runtime_id_for_runtime(&runtime),
+            "llamacpp:bge-base-en-v1.5"
+        );
     }
 
     #[test]
@@ -1943,9 +1959,11 @@ mod tests {
         let _guard = EnvGuard::set(EMBEDDING_BACKEND_ENV, "onnx");
         let _guard2 = EnvGuard::set("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
 
-        assert_eq!(embedding_runtime_id(), "hash-projection:768");
+        let runtime = runtime_from_env();
+        let runtime_id = embedding_runtime_id_for_runtime(&runtime);
+        assert_eq!(runtime_id, "hash-projection:768");
         assert!(!manifest_embedding_backend_is_product(Some(
-            embedding_runtime_id().as_str()
+            runtime_id.as_str()
         )));
         let error = ensure_product_embedding_backend()
             .expect_err("explicit ONNX should not satisfy product sidecar indexing");

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -2719,7 +2719,7 @@ offloaded 13/13 layers to GPU\n";
             "starting native llama.cpp embedding server: current\noffloaded 13/13 layers to GPU\n",
         )
         .expect("owner log");
-        let mut runtime = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let mut runtime = crate::config::test_sidecar_runtime_in_cache(
             Some(project.path()),
             SidecarProfile::Agent,
             Some("shared-agent"),
@@ -2770,7 +2770,7 @@ offloaded 13/13 layers to GPU\n";
         );
         assert_eq!(runtime.ownership().ports.embed_http, reused_embed_port);
 
-        let warm = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let warm = crate::config::test_sidecar_runtime_in_cache(
             Some(project.path()),
             SidecarProfile::Agent,
             Some("shared-agent"),
@@ -2781,7 +2781,7 @@ offloaded 13/13 layers to GPU\n";
         assert!(crate::sidecar::sidecar_state_matches_runtime(&state, &warm));
         warm.ensure_ports_allocated()
             .expect("warm runtime renews the original isolated lease tuple");
-        let local = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let local = crate::config::test_sidecar_runtime_in_cache(
             Some(project.path()),
             SidecarProfile::Local,
             None,
@@ -2917,7 +2917,7 @@ offloaded 13/13 layers to GPU\n";
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".into(),
             labels: BTreeMap::new(),
-            ..SidecarRuntimeConfig::local()
+            ..crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None)
         };
         std::fs::create_dir_all(runtime.layout.state_file.parent().expect("state parent"))
             .expect("create state dir");
@@ -2967,7 +2967,7 @@ offloaded 13/13 layers to GPU\n";
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".into(),
             labels: BTreeMap::new(),
-            ..SidecarRuntimeConfig::local()
+            ..crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None)
         };
         std::fs::create_dir_all(runtime.layout.state_file.parent().expect("state parent"))
             .expect("create state dir");

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -208,7 +208,7 @@ pub fn repair_project_qdrant_collection_for_runtime(
 }
 
 pub fn finalize_index(project_root: &Path, storage_path: &Path) -> Result<FinalizeIndexOutcome> {
-    let runtime = crate::config::sidecar_runtime_auto(project_root);
+    let runtime = crate::config::SidecarRuntimeConfig::for_project_auto(project_root);
     finalize_index_for_runtime(project_root, storage_path, &runtime)
 }
 

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -57,11 +57,10 @@ pub use config::{
     DEFAULT_AGENT_RUN_ID, DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT,
     DEFAULT_QDRANT_HTTP_PORT, EmbeddingEndpointOrigin, EmbeddingRuntimeConfig,
     EmbeddingServerLaunchMode, QDRANT_IMAGE_PIN, RetrievalRuntimeConfig, SidecarImagePins,
-    SidecarLayout, SidecarOwnership, SidecarPorts, SidecarProfile, SidecarRuntimeConfig,
-    SidecarRuntimeDefaults, SidecarRuntimeOverrides, SummaryRuntimeConfig,
+    SidecarLayout, SidecarOwnership, SidecarPorts, SidecarProcessDefaults, SidecarProfile,
+    SidecarRuntimeConfig, SidecarRuntimeDefaults, SidecarRuntimeOverrides, SummaryRuntimeConfig,
     default_sidecar_image_pins, embedding_server_launch_mode,
-    embedding_server_launch_mode_for_runtime, sidecar_runtime_auto, sidecar_runtime_for_project,
-    sidecar_runtime_for_project_with_run_id, user_cache_root,
+    embedding_server_launch_mode_for_runtime, sidecar_process_defaults, user_cache_root,
 };
 #[cfg(feature = "test-support")]
 pub use config::{

--- a/crates/codestory-retrieval/src/process_identity.rs
+++ b/crates/codestory-retrieval/src/process_identity.rs
@@ -21,6 +21,8 @@ const WINDOWS_PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
 #[cfg(windows)]
 const WINDOWS_ERROR_INVALID_PARAMETER: i32 = 87;
 #[cfg(windows)]
+const WINDOWS_STILL_ACTIVE: u32 = 259;
+#[cfg(windows)]
 const WINDOWS_DATETIME_TICKS_AT_FILETIME_EPOCH: u64 = 504_911_232_000_000_000;
 #[cfg(windows)]
 const WINDOWS_FILETIME_TICKS_AT_UNIX_EPOCH: u64 = 116_444_736_000_000_000;
@@ -182,10 +184,11 @@ unsafe extern "system" {
         kernel_time: *mut WindowsFileTime,
         user_time: *mut WindowsFileTime,
     ) -> i32;
+    fn GetExitCodeProcess(process: RawHandle, exit_code: *mut u32) -> i32;
 }
 
 #[cfg(windows)]
-fn windows_process_creation_time(pid: u32) -> Result<Option<WindowsFileTime>> {
+fn windows_running_process_creation_time(pid: u32) -> Result<Option<WindowsFileTime>> {
     if pid == 0 {
         bail!("native embedding process pid must be greater than zero");
     }
@@ -215,12 +218,25 @@ fn windows_process_creation_time(pid: u32) -> Result<Option<WindowsFileTime>> {
         return Err(io::Error::last_os_error())
             .with_context(|| format!("query native embedding start identity for pid {pid}"));
     }
+    let mut exit_code = 0_u32;
+    if unsafe { GetExitCodeProcess(process.as_raw_handle(), &mut exit_code) } == 0 {
+        return Err(io::Error::last_os_error())
+            .with_context(|| format!("query native embedding exit code for pid {pid}"));
+    }
+    if !windows_process_is_running(&exit_time, exit_code) {
+        return Ok(None);
+    }
     Ok(Some(creation_time))
 }
 
 #[cfg(windows)]
 fn windows_filetime_ticks(filetime: &WindowsFileTime) -> u64 {
     (u64::from(filetime.high_date_time) << 32) | u64::from(filetime.low_date_time)
+}
+
+#[cfg(windows)]
+fn windows_process_is_running(exit_time: &WindowsFileTime, exit_code: u32) -> bool {
+    windows_filetime_ticks(exit_time) == 0 && exit_code == WINDOWS_STILL_ACTIVE
 }
 
 #[cfg(windows)]
@@ -245,7 +261,7 @@ fn windows_epoch_ms_from_filetime(filetime: &WindowsFileTime) -> Result<i64> {
 
 #[cfg(windows)]
 pub(crate) fn process_started_at_epoch_ms(pid: u32) -> Result<Option<i64>> {
-    windows_process_creation_time(pid)?
+    windows_running_process_creation_time(pid)?
         .as_ref()
         .map(windows_epoch_ms_from_filetime)
         .transpose()
@@ -279,7 +295,7 @@ fn process_started_at_epoch_ms_from_lstart(output: &[u8]) -> Option<i64> {
 
 #[cfg(windows)]
 fn probe_process_start_identity_platform(pid: u32) -> ProcessStartProbe {
-    match windows_process_creation_time(pid) {
+    match windows_running_process_creation_time(pid) {
         Ok(Some(creation_time)) => match windows_datetime_ticks_from_filetime(&creation_time) {
             Ok(ticks) => ProcessStartProbe::Running {
                 start_identity: format!("windows:{ticks}"),
@@ -483,6 +499,48 @@ mod tests {
             DOTNET_DATETIME_TICKS_AT_UNIX_EPOCH
         );
         assert_eq!(windows_epoch_ms_from_filetime(&unix_epoch)?, 0);
+        assert!(windows_process_is_running(
+            &WindowsFileTime::default(),
+            WINDOWS_STILL_ACTIVE
+        ));
+        assert!(!windows_process_is_running(
+            &WindowsFileTime {
+                low_date_time: 1,
+                high_date_time: 0,
+            },
+            WINDOWS_STILL_ACTIVE
+        ));
+        assert!(!windows_process_is_running(&WindowsFileTime::default(), 0));
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_process_start_probe_rejects_exited_child() -> Result<()> {
+        let mut child = Command::new("ping")
+            .args(["-n", "30", "127.0.0.1"])
+            .stdout(Stdio::null())
+            .spawn()
+            .context("spawn Windows process identity fixture")?;
+        let pid = child.id();
+        let result = match probe_process_start_identity(pid) {
+            ProcessStartProbe::Running { start_identity }
+                if start_identity.starts_with("windows:") =>
+            {
+                Ok(())
+            }
+            probe => Err(anyhow::anyhow!(
+                "live Windows child did not expose a process start identity: {probe:?}"
+            )),
+        };
+
+        let _ = child.kill();
+        let _ = child.wait();
+        result?;
+        assert_eq!(
+            probe_process_start_identity(pid),
+            ProcessStartProbe::NotRunning
+        );
         Ok(())
     }
 }

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1,6 +1,6 @@
 use crate::config::{
     SidecarImagePins, SidecarLayout, SidecarProfile, SidecarRuntimeConfig,
-    default_sidecar_image_pins, sidecar_runtime_auto, sidecar_runtime_for_project,
+    default_sidecar_image_pins,
 };
 use crate::generation::{
     SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED, manifest_has_current_sidecar_contract,
@@ -442,7 +442,10 @@ pub fn sidecar_down() -> Result<()> {
 }
 
 pub fn sidecar_down_for_project(project_root: &Path, profile: SidecarProfile) -> Result<()> {
-    sidecar_down_for_runtime(&sidecar_runtime_for_project(project_root, profile))
+    sidecar_down_for_runtime(&SidecarRuntimeConfig::for_project_profile(
+        Some(project_root),
+        profile,
+    ))
 }
 
 pub fn sidecar_down_for_runtime(runtime: &SidecarRuntimeConfig) -> Result<()> {
@@ -1129,7 +1132,7 @@ pub fn strict_sidecar_status_for_profile(
     strict_sidecar_status_for_runtime(
         project_root,
         storage_path,
-        sidecar_runtime_for_project(project_root, profile),
+        SidecarRuntimeConfig::for_project_profile(Some(project_root), profile),
     )
 }
 
@@ -1146,7 +1149,7 @@ fn sidecar_status_inner(
     storage_path: Option<&Path>,
     strict: bool,
 ) -> Result<RetrievalStatusReport> {
-    let runtime = sidecar_runtime_auto(project_root);
+    let runtime = SidecarRuntimeConfig::for_project_auto(project_root);
     sidecar_status_inner_with_runtime(project_root, storage_path, strict, runtime)
 }
 
@@ -1601,7 +1604,7 @@ mod tests {
             embed_http_port: 18080,
             cleanup_command: "codestory-cli retrieval down".to_string(),
             labels: BTreeMap::new(),
-            ..SidecarRuntimeConfig::local()
+            ..crate::config::test_sidecar_runtime_from_env(None, SidecarProfile::Local, None)
         };
         runtime.embedding.endpoint = SidecarLayout::embed_base_url(runtime.embed_http_port);
         runtime.embedding.endpoint_origin = crate::config::EmbeddingEndpointOrigin::ManagedSidecar;
@@ -1857,7 +1860,7 @@ mod tests {
     fn sidecar_down_preserves_recorded_compose_state_when_docker_is_unavailable() {
         let _lock = crate::test_support::env_lock();
         let root = TempDir::new().expect("root");
-        let runtime = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let runtime = crate::config::test_sidecar_runtime_in_cache(
             Some(root.path()),
             SidecarProfile::Agent,
             Some("docker-retry"),
@@ -1887,7 +1890,7 @@ mod tests {
     fn failed_bootstrap_cleanup_preserves_preexisting_compose_after_state_publication() {
         let _lock = crate::test_support::env_lock();
         let root = TempDir::new().expect("root");
-        let runtime = SidecarRuntimeConfig::for_project_profile_with_run_id_in_cache(
+        let runtime = crate::config::test_sidecar_runtime_in_cache(
             Some(root.path()),
             SidecarProfile::Agent,
             Some("preexisting-compose"),

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -11,7 +11,7 @@ use codestory_contracts::api::{
 };
 use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
 #[cfg(test)]
-use codestory_retrieval::sidecar_runtime_auto;
+use codestory_retrieval::SidecarRuntimeConfig;
 use codestory_retrieval::{
     CandidateHit, CandidateSource, QueryBatchItem, QueryBatchRequest, QueryRequest, QueryResult,
     QueryTrace, SidecarProfile, execute_retrieval_query_with_cache_for_runtime,
@@ -2552,7 +2552,7 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve dead port");
         let dead_port = listener.local_addr().expect("dead port address").port();
         drop(listener);
-        let mut runtime = sidecar_runtime_auto(project.path());
+        let mut runtime = SidecarRuntimeConfig::for_project_auto(project.path());
         runtime.embed_http_port = dead_port;
         runtime.embedding.endpoint = format!("http://127.0.0.1:{dead_port}/v1/embeddings");
         runtime.embedding.endpoint_origin =


### PR DESCRIPTION
## Context

Sidecar configuration was being recaptured through a broad chain of constructors, which made process behavior depend on later environment mutations. On Windows, a completed process could also be treated as live while its process object remained queryable.

Base: 2e9352beb5051907580b28443342adcca84ac476
Head: 569f656

## What changed

- freeze the production cache root and sidecar runtime defaults in one process snapshot
- keep test defaults explicit and preserve the CLI construction gateway and cache isolation
- reject Windows processes whose exit time is set or whose exit code is not STILL_ACTIVE
- migrate callers to the explicit process-defaults boundary and remove redundant retrieval constructor forwarders
- add focused environment-freezing and Windows lifecycle regressions
- document the reliability change under Unreleased

## How to review

Start with crates/codestory-retrieval/src/config.rs for the new snapshot boundary, then crates/codestory-cli/src/sidecar_runtime.rs for the preserved gateway. The Windows liveness check is isolated in crates/codestory-retrieval/src/process_identity.rs.

## Verification

- cargo fmt --all -- --check
- cargo test -p codestory-retrieval --locked config::tests
- cargo test -p codestory-retrieval --locked process_identity::tests
- cargo check -p codestory-cli --locked
- cargo test -p codestory-cli --test architecture_contracts --locked
- cargo test -p codestory-cli --bin codestory-cli --locked sidecar_runtime::tests
- cargo clippy -p codestory-retrieval --locked --all-targets --all-features -- -D warnings
- git diff --check

All listed checks passed on macOS. The Windows live-child/exited-child regression is included but cannot run locally; Windows CI remains the required platform proof.

## Risk

The constructor cleanup changes internal call paths but not CLI syntax or wire contracts. Production values are now intentionally immutable for the process lifetime; tests that exercise environment changes inject their own defaults.

Closes #1103
Refs #899