### PR TITLE
Preserve lossless affected paths and native workspace identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@
 - Sidecar cache roots and runtime environment defaults are captured once per
   process and passed explicitly through test construction. Windows process
   probes also reject completed processes using both exit time and exit code.
+- `affected` now reads Git name-status and untracked paths through NUL-delimited
+  byte protocols, preserves valid UTF-8 pathname whitespace, and returns
+  `unsupported_non_utf8_path` instead of lossy DTO text. Workspace-relative
+  path stripping now follows native filesystem identity and case rules.
 - Managed installation and upgrade checks cover every shipped native platform,
   including upgrade from a verified older CLI with that version retained as the
   rollback. The Codex worktree setup dispatcher now provides equivalent native

--- a/crates/codestory-cli/src/display.rs
+++ b/crates/codestory-cli/src/display.rs
@@ -45,31 +45,10 @@ fn quote_shell_single_quoted_value(value: &str) -> String {
 }
 
 pub(crate) fn relative_path(project_root: &Path, raw: &str) -> String {
-    let normalized_root = clean_path_string(&project_root.to_string_lossy());
     let normalized_raw = clean_path_string(raw);
-    let normalized_root = normalized_root.trim_end_matches('/');
-    let normalized_raw_lower = normalized_raw.to_ascii_lowercase();
-    let normalized_root_lower = normalized_root.to_ascii_lowercase();
-
-    if normalized_raw_lower == normalized_root_lower {
-        return String::new();
-    }
-    if let Some(remainder) = normalized_raw_lower.strip_prefix(&format!("{normalized_root_lower}/"))
-    {
-        let start = normalized_raw.len() - remainder.len();
-        return normalized_raw[start..].to_string();
-    }
-
-    let path = Path::new(raw);
-    if !path.is_absolute() {
-        return normalized_raw;
-    }
-
-    if let Ok(relative) = path.strip_prefix(project_root) {
-        return clean_path_string(&relative.to_string_lossy());
-    }
-
-    normalized_raw
+    codestory_workspace::workspace_relative_path(project_root, Path::new(&normalized_raw))
+        .map(|relative| clean_path_string(&relative.to_string_lossy()))
+        .unwrap_or(normalized_raw)
 }
 
 pub(crate) fn format_search_hit_target(project_root: &Path, hit: &SearchHit) -> String {

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -5976,15 +5976,9 @@ fn symbol_workflow_seed_path(project_root: &Path, path: &str) -> String {
         .strip_prefix(r"\\?\")
         .unwrap_or(path)
         .replace('\\', "/");
-    let root_lossy = project_root.to_string_lossy();
-    let root = root_lossy
-        .strip_prefix(r"\\?\")
-        .unwrap_or(&root_lossy)
-        .replace('\\', "/");
-    clean_path
-        .strip_prefix(&format!("{root}/"))
-        .unwrap_or(&clean_path)
-        .to_string()
+    codestory_workspace::workspace_relative_path(project_root, Path::new(&clean_path))
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .unwrap_or(clean_path)
 }
 
 fn symbol_workflow_impacted_files(
@@ -6523,7 +6517,8 @@ fn run_affected(cmd: AffectedCommand) -> Result<()> {
     let runtime = RuntimeContext::new(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
     ensure_index_ready(&opened, "affected")?;
-    let change_records = affected_change_records(&cmd)?;
+    let change_records =
+        affected_change_records(&cmd).map_err(|error| affected_discovery_error(&cmd, error))?;
     let changed_paths = change_records
         .iter()
         .map(|record| record.path.clone())
@@ -6548,20 +6543,17 @@ fn affected_change_records(cmd: &AffectedCommand) -> Result<Vec<AffectedChangeRe
         .map(|path| affected_path_record(path, AffectedChangeKindDto::Unknown, "path"))
         .collect::<Vec<_>>();
     if cmd.stdin {
-        let mut input = String::new();
+        let mut input = Vec::new();
         std::io::stdin()
-            .read_to_string(&mut input)
+            .read_to_end(&mut input)
             .context("Failed to read changed paths from stdin")?;
+        let input = path_text_from_bytes(&input, "stdin")?;
         match cmd.stdin_format {
-            AffectedStdinFormat::Path => records.extend(
-                input
-                    .lines()
-                    .map(str::trim)
-                    .filter(|line| !line.is_empty())
-                    .map(|path| {
-                        affected_path_record(path, AffectedChangeKindDto::Unknown, "stdin")
-                    }),
-            ),
+            AffectedStdinFormat::Path => {
+                records.extend(input.lines().filter(|line| !line.is_empty()).map(|path| {
+                    affected_path_record(path, AffectedChangeKindDto::Unknown, "stdin")
+                }))
+            }
             AffectedStdinFormat::NameStatus => {
                 records.extend(parse_git_name_status_records(&input)?);
             }
@@ -6578,17 +6570,16 @@ fn affected_change_records(cmd: &AffectedCommand) -> Result<Vec<AffectedChangeRe
             String::from_utf8_lossy(&output.stderr).trim()
         );
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
     let mut records = match cmd.changes {
-        AffectedChangeSource::Untracked => stdout
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty())
-            .map(|path| affected_path_record(path, AffectedChangeKindDto::Untracked, "??"))
-            .collect::<Vec<_>>(),
+        AffectedChangeSource::Untracked => parse_git_nul_path_records(
+            &output.stdout,
+            AffectedChangeKindDto::Untracked,
+            "??",
+            "git_ls_files",
+        )?,
         AffectedChangeSource::Head
         | AffectedChangeSource::Staged
-        | AffectedChangeSource::Unstaged => parse_git_name_status_records(&stdout)?,
+        | AffectedChangeSource::Unstaged => parse_git_name_status_records_z(&output.stdout)?,
     };
     dedupe_affected_change_records(&mut records);
     Ok(records)
@@ -6599,17 +6590,26 @@ fn affected_git_change_output(cmd: &AffectedCommand) -> Result<std::process::Out
     command.arg("-C").arg(&cmd.project.project);
     match cmd.changes {
         AffectedChangeSource::Head => {
-            command.arg("diff").arg("--name-status").arg("HEAD");
+            command
+                .arg("diff")
+                .arg("--name-status")
+                .arg("-z")
+                .arg("HEAD");
         }
         AffectedChangeSource::Staged => {
-            command.arg("diff").arg("--cached").arg("--name-status");
+            command
+                .arg("diff")
+                .arg("--cached")
+                .arg("--name-status")
+                .arg("-z");
         }
         AffectedChangeSource::Unstaged => {
-            command.arg("diff").arg("--name-status");
+            command.arg("diff").arg("--name-status").arg("-z");
         }
         AffectedChangeSource::Untracked => {
             command
                 .arg("ls-files")
+                .arg("-z")
                 .arg("--others")
                 .arg("--exclude-standard");
         }
@@ -6619,10 +6619,119 @@ fn affected_git_change_output(cmd: &AffectedCommand) -> Result<std::process::Out
         .context("Failed to run git change discovery")
 }
 
+#[derive(Debug)]
+struct UnsupportedNonUtf8Path {
+    source: &'static str,
+}
+
+impl std::fmt::Display for UnsupportedNonUtf8Path {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "unsupported_non_utf8_path: {} returned a path that cannot be represented in UTF-8",
+            self.source
+        )
+    }
+}
+
+impl std::error::Error for UnsupportedNonUtf8Path {}
+
+fn affected_discovery_error(cmd: &AffectedCommand, error: anyhow::Error) -> anyhow::Error {
+    let Some(unsupported) = error.downcast_ref::<UnsupportedNonUtf8Path>() else {
+        return error;
+    };
+    StructuredCommandFailure {
+        envelope: unsupported_non_utf8_path_envelope(unsupported),
+        output_file: cmd.output_file.clone(),
+        markdown: None,
+    }
+    .into()
+}
+
+fn unsupported_non_utf8_path_envelope(error: &UnsupportedNonUtf8Path) -> CommandFailureEnvelope {
+    command_failure_envelope(
+        "unsupported_non_utf8_path",
+        "git_change_discovery",
+        error.to_string(),
+        serde_json::json!({"source": error.source}),
+    )
+}
+
+fn nul_delimited_git_fields(input: &[u8]) -> Result<Vec<&[u8]>> {
+    if input.is_empty() {
+        return Ok(Vec::new());
+    }
+    if input.last() != Some(&0) {
+        bail!("git NUL-delimited path output is missing its terminator");
+    }
+    let fields = input[..input.len() - 1]
+        .split(|byte| *byte == 0)
+        .collect::<Vec<_>>();
+    if fields.iter().any(|field| field.is_empty()) {
+        bail!("git NUL-delimited path output contains an empty field");
+    }
+    Ok(fields)
+}
+
+fn path_text_from_bytes(bytes: &[u8], source: &'static str) -> Result<String> {
+    std::str::from_utf8(bytes)
+        .map(str::to_string)
+        .map_err(|_| anyhow::Error::new(UnsupportedNonUtf8Path { source }))
+}
+
+fn parse_git_nul_path_records(
+    input: &[u8],
+    kind: AffectedChangeKindDto,
+    status: &str,
+    source: &'static str,
+) -> Result<Vec<AffectedChangeRecordDto>> {
+    nul_delimited_git_fields(input)?
+        .into_iter()
+        .map(|field| {
+            path_text_from_bytes(field, source)
+                .map(|path| affected_path_record(&path, kind.clone(), status))
+        })
+        .collect()
+}
+
+fn parse_git_name_status_records_z(input: &[u8]) -> Result<Vec<AffectedChangeRecordDto>> {
+    let fields = nul_delimited_git_fields(input)?;
+    let mut records = Vec::new();
+    let mut index = 0;
+    while index < fields.len() {
+        let status = std::str::from_utf8(fields[index])
+            .context("git name-status status is not valid UTF-8")?;
+        index += 1;
+        let kind = affected_change_kind_from_status(status);
+        let previous_path = if matches!(
+            kind,
+            AffectedChangeKindDto::Renamed | AffectedChangeKindDto::Copied
+        ) {
+            let field = fields
+                .get(index)
+                .context("git name-status rename/copy record is missing the previous path")?;
+            index += 1;
+            Some(path_text_from_bytes(field, "git_name_status")?)
+        } else {
+            None
+        };
+        let field = fields
+            .get(index)
+            .context("git name-status record is missing the path")?;
+        index += 1;
+        records.push(AffectedChangeRecordDto {
+            path: path_text_from_bytes(field, "git_name_status")?,
+            kind,
+            status: status.to_string(),
+            previous_path,
+        });
+    }
+    Ok(records)
+}
+
 fn parse_git_name_status_records(input: &str) -> Result<Vec<AffectedChangeRecordDto>> {
     input
         .lines()
-        .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(parse_git_name_status_record)
         .collect()
@@ -6637,7 +6746,7 @@ fn parse_git_name_status_record(line: &str) -> Result<AffectedChangeRecordDto> {
             "path",
         ));
     }
-    let status = parts[0].trim();
+    let status = parts[0];
     let kind = affected_change_kind_from_status(status);
     let (previous_path, path) = if matches!(
         kind,
@@ -6645,19 +6754,19 @@ fn parse_git_name_status_record(line: &str) -> Result<AffectedChangeRecordDto> {
     ) {
         let previous = parts
             .get(1)
-            .map(|path| path.trim())
+            .copied()
             .filter(|path| !path.is_empty())
             .context("git name-status rename/copy row is missing the previous path")?;
         let current = parts
             .get(2)
-            .map(|path| path.trim())
+            .copied()
             .filter(|path| !path.is_empty())
             .context("git name-status rename/copy row is missing the current path")?;
         (Some(previous.to_string()), current)
     } else {
         let path = parts
             .get(1)
-            .map(|path| path.trim())
+            .copied()
             .filter(|path| !path.is_empty())
             .context("git name-status row is missing the path")?;
         (None, path)
@@ -6676,7 +6785,7 @@ fn affected_path_record(
     status: &str,
 ) -> AffectedChangeRecordDto {
     AffectedChangeRecordDto {
-        path: path.trim().to_string(),
+        path: path.to_string(),
         kind,
         status: status.to_string(),
         previous_path: None,
@@ -6696,7 +6805,7 @@ fn affected_change_kind_from_status(status: &str) -> AffectedChangeKindDto {
 }
 
 fn dedupe_affected_change_records(records: &mut Vec<AffectedChangeRecordDto>) {
-    records.retain(|record| !record.path.trim().is_empty());
+    records.retain(|record| !record.path.is_empty());
     records.sort_by(|left, right| {
         left.path
             .cmp(&right.path)
@@ -10620,20 +10729,42 @@ mod tests {
     }
 
     #[test]
-    fn affected_name_status_parser_preserves_status_and_renames() {
-        let records = parse_git_name_status_records(
-            "M\tcrates/codestory-cli/src/main.rs\nD\tsrc/old.ts\nR100\tsrc/before.ts\tsrc/after.ts\nC75\tsrc/base.ts\tsrc/copy.ts\n",
+    fn affected_name_status_parser_preserves_nul_delimited_special_paths() {
+        let records = parse_git_name_status_records_z(
+            b"M\0 leading and trailing \t\n \0D\0src/old.ts\0R100\0 before.ts \0after\nname.ts\0C75\0src/base.ts\0src/copy.ts\0",
         )
-        .expect("parse name-status");
+        .expect("parse NUL-delimited name-status");
 
         assert_eq!(records[0].kind, AffectedChangeKindDto::Modified);
         assert_eq!(records[0].status, "M");
+        assert_eq!(records[0].path, " leading and trailing \t\n ");
         assert_eq!(records[1].kind, AffectedChangeKindDto::Deleted);
         assert_eq!(records[2].kind, AffectedChangeKindDto::Renamed);
-        assert_eq!(records[2].previous_path.as_deref(), Some("src/before.ts"));
-        assert_eq!(records[2].path, "src/after.ts");
+        assert_eq!(records[2].previous_path.as_deref(), Some(" before.ts "));
+        assert_eq!(records[2].path, "after\nname.ts");
         assert_eq!(records[3].kind, AffectedChangeKindDto::Copied);
         assert_eq!(records[3].previous_path.as_deref(), Some("src/base.ts"));
+    }
+
+    #[test]
+    fn affected_non_utf8_git_path_has_a_typed_failure_envelope() {
+        let error = parse_git_name_status_records_z(b"M\0src/invalid-\xff.rs\0")
+            .expect_err("non-UTF-8 Git paths cannot enter string DTOs");
+        let unsupported = error
+            .downcast_ref::<UnsupportedNonUtf8Path>()
+            .expect("typed non-UTF-8 path error");
+        let envelope = unsupported_non_utf8_path_envelope(unsupported);
+
+        assert_eq!(envelope.error.code, "unsupported_non_utf8_path");
+        assert_eq!(
+            envelope
+                .error
+                .details
+                .as_deref()
+                .and_then(|details| details.failed_layer.as_deref()),
+            Some("git_change_discovery")
+        );
+        assert!(!unsupported.to_string().contains('\u{fffd}'));
     }
 
     fn sample_retrieval() -> RetrievalStateDto {

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -1325,50 +1325,10 @@ fn candidate_path_text_is_path_like(path: &str) -> bool {
 }
 
 fn normalize_repo_relative_path(project_root: &Path, file_path: &str) -> String {
-    if let Some(rel) = strip_project_prefix_from_normalized_path(project_root, file_path) {
-        return rel;
-    }
-    let path = PathBuf::from(file_path);
-    if path.is_absolute() {
-        path.strip_prefix(project_root)
-            .map(|p| p.to_string_lossy().replace('\\', "/"))
-            .unwrap_or_else(|_| file_path.replace('\\', "/"))
-    } else {
-        file_path.replace('\\', "/")
-    }
-}
-
-fn strip_project_prefix_from_normalized_path(
-    project_root: &Path,
-    file_path: &str,
-) -> Option<String> {
-    let candidate = normalize_storage_path_text(file_path);
-    let roots = [
-        normalize_storage_path_text(&project_root.to_string_lossy()),
-        std::fs::canonicalize(project_root)
-            .ok()
-            .map(|path| normalize_storage_path_text(&path.to_string_lossy()))
-            .unwrap_or_default(),
-    ];
-    roots
-        .into_iter()
-        .filter(|root| !root.is_empty())
-        .find_map(|root| {
-            if candidate.eq_ignore_ascii_case(&root) {
-                return Some(String::new());
-            }
-            let prefix = format!("{root}/");
-            candidate
-                .strip_prefix(&prefix)
-                .or_else(|| {
-                    let candidate_lower = candidate.to_ascii_lowercase();
-                    let prefix_lower = prefix.to_ascii_lowercase();
-                    candidate_lower
-                        .strip_prefix(&prefix_lower)
-                        .map(|_| &candidate[prefix.len()..])
-                })
-                .map(str::to_string)
-        })
+    let normalized = normalize_storage_path_text(file_path);
+    codestory_workspace::workspace_relative_path(project_root, Path::new(&normalized))
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .unwrap_or(normalized)
 }
 
 fn normalize_storage_path_text(path: &str) -> String {
@@ -1786,6 +1746,7 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
     #[test]
     fn normalize_repo_relative_path_strips_forward_slash_verbatim_prefix() {
         let project = Path::new("C:/workspaces/example");

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -1070,6 +1070,30 @@ fn normalized_compare_key(root: &Path, path: &Path) -> String {
     normalize_path_key(&stable)
 }
 
+/// Return `path` relative to `workspace_root` using native path identity.
+///
+/// Exact lexical prefixes are preferred. Alias spellings then compare each
+/// candidate ancestor with the workspace root using filesystem identity for
+/// existing paths and platform lexical rules only for missing paths.
+pub fn workspace_relative_path(workspace_root: &Path, path: &Path) -> Option<PathBuf> {
+    let root = normalize_lexical_path(workspace_root);
+    let candidate = normalize_lexical_path(path);
+    if let Ok(relative) = candidate.strip_prefix(&root) {
+        return Some(relative.to_path_buf());
+    }
+    if !candidate.is_absolute() {
+        return Some(candidate);
+    }
+
+    let matching_root = candidate
+        .ancestors()
+        .find(|ancestor| same_workspace_path(&root, ancestor))?;
+    candidate
+        .strip_prefix(matching_root)
+        .ok()
+        .map(Path::to_path_buf)
+}
+
 fn normalize_path_key(path: &Path) -> String {
     #[cfg(windows)]
     {

--- a/crates/codestory-workspace/src/repository_identity.rs
+++ b/crates/codestory-workspace/src/repository_identity.rs
@@ -1222,6 +1222,11 @@ mod tests {
         match fs::create_dir(&lower) {
             Ok(()) => {
                 assert!(!same_workspace_path(&upper, &lower));
+                assert_eq!(
+                    crate::workspace_relative_path(&upper, &lower.join("src/lib.rs")),
+                    None,
+                    "case-distinct Unix roots must not be stripped as aliases"
+                );
                 assert_ne!(
                     workspace_id_v3_for_root(&upper),
                     workspace_id_v3_for_root(&lower)
@@ -1231,6 +1236,10 @@ mod tests {
                 assert!(
                     same_workspace_path(&upper, &lower),
                     "case-insensitive filesystems must identify case aliases as the same path"
+                );
+                assert_eq!(
+                    crate::workspace_relative_path(&upper, &lower.join("src/lib.rs")),
+                    Some(PathBuf::from("src/lib.rs"))
                 );
             }
             Err(error) => panic!("lower-case path: {error}"),
@@ -1266,6 +1275,10 @@ mod tests {
         fs::create_dir(&existing).expect("mixed-case path");
         let existing_alias = project.path().join("codestory");
         assert!(same_workspace_path(&existing, &existing_alias));
+        assert_eq!(
+            crate::workspace_relative_path(&existing, &existing_alias.join("src/lib.rs")),
+            Some(PathBuf::from("src/lib.rs"))
+        );
 
         let missing = project.path().join("Missing");
         let missing_alias = project.path().join("missing");


### PR DESCRIPTION
## Context

`affected` decoded line-delimited Git output with `from_utf8_lossy` and trimmed pathname whitespace. Runtime and CLI path rendering also carried separate case-insensitive prefix strippers, so Unix case-distinct roots could be treated as the same workspace.

This closes the two path-identity findings without broadening the path model or adding speculative tests.

## What changed

- request `git diff --name-status -z` and `git ls-files -z`, parse the byte records before UTF-8 conversion, and preserve valid pathname whitespace exactly
- return a structured `unsupported_non_utf8_path` failure before raw non-UTF-8 bytes can enter string DTOs
- add `codestory_workspace::workspace_relative_path` as the shared owner of native filesystem identity and case rules
- route runtime retrieval, CLI display, and symbol workflow path stripping through the shared helper
- cover NUL-delimited special names, the typed non-UTF-8 boundary, Unix case-distinct roots, and Windows native aliases using existing platform test boundaries

## How to review

Start with `workspace_relative_path` and its repository-identity assertions, then follow the three callers. The affected parser is deliberately byte-oriented only at the Git boundary; DTOs remain UTF-8 strings.

Base: `6bd8eb553ea3a777a0c2b6dbbf4aeea1a856e49f`

Head: `e19ccccc2619baa490a4bc3a287da91c1bf21547`

## Verification

- `cargo fmt --all --check`
- `cargo test -p codestory-workspace --locked` — 46 passed
- `cargo test -p codestory-cli --locked affected_` — 4 relevant tests passed
- `cargo test -p codestory-cli --locked relative_path_` — 3 passed
- direct Rustfmt check on the five changed Rust files
- `git diff --check`
- `node .github/scripts/check-doc-links.mjs`
- code-simplifier changed-scope scan plus manual Rust review; its remaining long-function/deep-nesting flags are pre-existing outside these hunks

## Risk and follow-up

The behavior change is limited to pathname discovery and workspace-prefix removal. Explicit line-delimited stdin remains supported; automatic Git discovery now uses the unambiguous NUL protocol. Windows alias behavior is covered in the Windows-only identity test and still needs normal PR CI on that runner.

Closes #1105
Refs #899
