### PR TITLE
Make generation cleanup handle-relative

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -130,6 +130,44 @@ def remove_tree_with_retry(path: Path, timeout_secs: float = 10.0, platform: str
             time.sleep(0.2)
 
 
+def remove_owned_tree_with_retry(
+    cli: Path,
+    root: Path,
+    relative: Path,
+    timeout_secs: float = 10.0,
+    platform: str = os.name,
+) -> None:
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise ValueError(f"owned cleanup requires a plain relative path: {relative}")
+    command = [
+        str(cli),
+        "internal-owned-delete",
+        "--root",
+        str(root),
+        "--relative",
+        str(relative),
+    ]
+    deadline = time.monotonic() + timeout_secs
+    while True:
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        if platform != "nt" or time.monotonic() >= deadline:
+            detail = result.stderr.strip() or result.stdout.strip() or "no command output"
+            raise RuntimeError(f"owned cleanup exited {result.returncode}: {detail}")
+        time.sleep(0.2)
+
+
 @contextlib.contextmanager
 def temporary_directory_with_retry(prefix: str, directory: Path):
     path = Path(tempfile.mkdtemp(prefix=prefix, dir=directory))
@@ -1083,8 +1121,12 @@ def cleanup_proof_cache(
     *,
     registered_sidecars: list[dict] | None = None,
     direct_only: bool = False,
+    owned_delete: Callable[[Path, Path], None] | None = None,
 ) -> None:
-    del cli
+    if owned_delete is None:
+        if cli is None:
+            raise RuntimeError("proof cache cleanup requires the packaged CLI owned-deletion boundary")
+        owned_delete = lambda root, relative: remove_owned_tree_with_retry(cli, root, relative)
     env = {**os.environ, "CODESTORY_CACHE_ROOT": str(cache_root)}
     results = []
     errors = []
@@ -1211,8 +1253,8 @@ def cleanup_proof_cache(
             + "; ".join(errors)
         )
     try:
-        remove_tree_with_retry(cache_root)
-    except OSError as exc:
+        owned_delete(canonical_cache.parent, Path(canonical_cache.name))
+    except (OSError, RuntimeError, ValueError) as exc:
         write_json(
             artifact,
             {"cache_root": str(cache_root), "commands": results, "removed": False, "error": str(exc)},
@@ -1728,6 +1770,18 @@ def cleanup_registered_proof_temp_root(args: argparse.Namespace) -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     if out_dir.is_relative_to(root):
         raise RuntimeError("proof cleanup artifacts must be outside the removable proof root")
+    owned_delete = getattr(args, "owned_delete", None)
+    cleanup_cli = None
+    if owned_delete is None:
+        cleanup_cli_dir = out_dir / "owned-delete-cli"
+        if cleanup_cli_dir.exists():
+            remove_tree_with_retry(cleanup_cli_dir)
+        cleanup_cli_dir.mkdir()
+        unpack_archive(owned_archive, cleanup_cli_dir)
+        cleanup_cli = find_cli(cleanup_cli_dir)
+        owned_delete = lambda boundary, relative: remove_owned_tree_with_retry(
+            cleanup_cli, boundary, relative
+        )
     project_value = ownership.get("project")
     project = (
         Path(project_value).resolve(strict=False)
@@ -1824,14 +1878,18 @@ def cleanup_registered_proof_temp_root(args: argparse.Namespace) -> None:
         artifact = out_dir / f"registered-cache-cleanup-{index}.json"
         try:
             preserve_native_embedding_evidence(cache, out_dir, f"registered-cache-{index}")
+            owned_relative = canonical.relative_to(root.parent)
             cleanup_proof_cache(
-                None,
+                cleanup_cli,
                 project,
                 cache,
                 artifact,
                 run=cleanup_run,
                 registered_sidecars=registered_sidecars,
                 direct_only=True,
+                owned_delete=lambda _cache_parent, _relative: owned_delete(
+                    root.parent, owned_relative
+                ),
             )
             results["cache_cleanup"].append({"cache_root": str(cache), "status": "removed"})
         except Exception as exc:
@@ -1849,7 +1907,7 @@ def cleanup_registered_proof_temp_root(args: argparse.Namespace) -> None:
             {"kind": "ports", "error": f"proof-owned ports remained reachable: {remaining_ports}"}
         )
     if not results["errors"]:
-        remove_tree_with_retry(root)
+        owned_delete(root.parent, Path(root.name))
         results["root_removed"] = not root.exists()
     else:
         results["root_removed"] = False
@@ -3873,6 +3931,9 @@ def self_test() -> None:
         runner_temp = os.environ.get("RUNNER_TEMP", "").strip()
         proof_root_parent = Path(runner_temp).resolve(strict=True) if runner_temp else root
 
+        def fake_owned_delete(boundary: Path, relative: Path) -> None:
+            remove_tree_with_retry(boundary / relative)
+
         assert docker_created_epoch_ms(
             "2026-07-13T14:08:36.245344828Z"
         ) == docker_created_epoch_ms("2026-07-13T14:08:36.245344Z")
@@ -4085,6 +4146,7 @@ def self_test() -> None:
             cleanup_artifact,
             fake_docker,
             registered_sidecars=[identity],
+            owned_delete=fake_owned_delete,
         )
         assert not compose_cache.exists()
         assert [command[1] for command in compose_calls if "rm" in command] == [
@@ -4098,7 +4160,11 @@ def self_test() -> None:
             write_json(global_cache / state_file_name, {"owner": "codestory"})
             try:
                 cleanup_proof_cache(
-                    None, root, global_cache, root / "global-local-cleanup.json"
+                    None,
+                    root,
+                    global_cache,
+                    root / "global-local-cleanup.json",
+                    owned_delete=fake_owned_delete,
                 )
             except RuntimeError as exc:
                 assert "global local-sidecar namespace" in str(exc)
@@ -4141,6 +4207,7 @@ def self_test() -> None:
                 project=str(project),
                 out_dir=str(cleanup_out),
                 cleanup_proof_temp_root=str(registered_root),
+                owned_delete=fake_owned_delete,
             )
         )
         assert not registered_root.exists()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@
   byte protocols, preserves valid UTF-8 pathname whitespace, and returns
   `unsupported_non_utf8_path` instead of lossy DTO text. Workspace-relative
   path stripping now follows native filesystem identity and case rules.
+- Generation and packaged-proof deletion now stays relative to one pinned,
+  trusted directory handle. Unix cleanup uses no-follow descriptor traversal;
+  Windows rejects reparse traversal and deletes through the opened handle, so
+  an ancestor rename cannot redirect cleanup outside CodeStory-owned storage.
 - Managed installation and upgrade checks cover every shipped native platform,
   including upgrade from a verified older CLI with that version retained as the
   rollback. The Codex worktree setup dispatcher now owns one version-checked,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -594,13 +612,17 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "codestory-contracts",
+ "fs_at",
  "glob",
  "ignore",
+ "libc",
+ "remove_dir_all",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -804,6 +826,15 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "cvt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1265,6 +1296,20 @@ checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fs_at"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14af6c9694ea25db25baa2a1788703b9e7c6648dcaeeebeb98f7561b5384c036"
+dependencies = [
+ "aligned",
+ "cfg-if",
+ "cvt",
+ "libc",
+ "nix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2266,6 +2311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,6 +3075,20 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "remove_dir_all"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cc0b475acf76adf36f08ca49429b12aad9f678cb56143d5b3cb49b9a1dd08"
+dependencies = [
+ "cfg-if",
+ "cvt",
+ "fs_at",
+ "libc",
+ "normpath",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ crossbeam-channel = "0.5"
 crossterm = "0.28"
 parking_lot = "0.12"
 ratatui = "0.30"
+fs_at = "0.2.1"
+libc = "0.2"
+remove_dir_all = "1.0.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6.0.0"
@@ -80,6 +83,7 @@ sha2 = "0.10"
 ring = "0.17.14"
 ureq = "2.12"
 turbovec = "0.9.0"
+windows-sys = { version = "0.59", features = ["Win32_Storage_FileSystem"] }
 
 criterion = "0.8.2"
 proptest = "1.5"

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -120,6 +120,16 @@ pub(crate) enum Command {
     Retrieval(RetrievalCommand),
     #[command(about = "Show retrieval sidecar status.")]
     Sidecar(SidecarCommand),
+    #[command(name = "internal-owned-delete", hide = true)]
+    InternalOwnedDelete(InternalOwnedDeleteCommand),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct InternalOwnedDeleteCommand {
+    #[arg(long, value_name = "DIR")]
+    pub(crate) root: PathBuf,
+    #[arg(long, value_name = "RELATIVE_PATH")]
+    pub(crate) relative: PathBuf,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -82,12 +82,13 @@ use args::{
     DrillSummaryOpenGapsOutput, DrillSummaryOutput, DrillSummarySourceTruthOutput,
     DrillSummarySourceTruthTargetOutput, DrillSummaryStatsOutput, DrillSummaryVerdictOutput,
     FilesCommand, FixCommand, FixOutput, GenerateCompletionsCommand, GroundCommand, IndexCommand,
-    IndexDryRunOutput, IndexOutput, PacketCommand, ProjectArgs, QueryCommand, QueryOutput,
-    QueryResolutionOutput, QuerySelectorOutput, ReadinessLaneOutput, ReadyCommand, ReadyOutput,
-    RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput, ServeCommand, SidecarAction,
-    SidecarCommand, SmokeCommand, SmokeProfile, SnippetCommand, SnippetJsonOutput, SymbolCommand,
-    SymbolJsonOutput, SymbolWorkflowCommand, TaskAction, TaskBriefCommand, TaskCommand,
-    TrailCommand, TrailJsonOutput, VerificationTargetOutput, build_trail_request,
+    IndexDryRunOutput, IndexOutput, InternalOwnedDeleteCommand, PacketCommand, ProjectArgs,
+    QueryCommand, QueryOutput, QueryResolutionOutput, QuerySelectorOutput, ReadinessLaneOutput,
+    ReadyCommand, ReadyOutput, RepoTextMode, SearchCommand, SearchHitOutput, SearchOutput,
+    ServeCommand, SidecarAction, SidecarCommand, SmokeCommand, SmokeProfile, SnippetCommand,
+    SnippetJsonOutput, SymbolCommand, SymbolJsonOutput, SymbolWorkflowCommand, TaskAction,
+    TaskBriefCommand, TaskCommand, TrailCommand, TrailJsonOutput, VerificationTargetOutput,
+    build_trail_request,
 };
 #[cfg(test)]
 use explore::{ExploreTuiAction, ExploreTuiState, explore_tui_action};
@@ -258,7 +259,21 @@ async fn run_cli(cli: Cli) -> Result<()> {
         Command::GenerateCompletions(cmd) => run_generate_completions(cmd),
         Command::Retrieval(cmd) => retrieval::run_retrieval(cmd),
         Command::Sidecar(cmd) => run_sidecar(cmd),
+        Command::InternalOwnedDelete(cmd) => run_internal_owned_delete(cmd),
     }
+}
+
+fn run_internal_owned_delete(cmd: InternalOwnedDeleteCommand) -> Result<()> {
+    let deletion = codestory_workspace::owned_deletion::OwnedDeletionRoot::open(&cmd.root)
+        .with_context(|| format!("open owned deletion root {}", cmd.root.display()))?;
+    deletion.remove(&cmd.relative).with_context(|| {
+        format!(
+            "remove owned relative path {} below {}",
+            cmd.relative.display(),
+            cmd.root.display()
+        )
+    })?;
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -917,7 +917,7 @@ fn persist_finalized_manifest(
     )?;
 
     let (generation_retention_plan, generation_retention) =
-        retain_published_generations(storage_path, retention_context, &project_id, &manifest);
+        retain_published_generations(storage_path, retention_context, &project_id, &manifest)?;
 
     info!(
         project_id = %project_id,
@@ -1254,7 +1254,7 @@ fn retain_published_generations(
     context: &GenerationRetentionContext<'_>,
     project_id: &str,
     active: &RetrievalIndexManifest,
-) -> (GenerationRetentionPlan, GenerationRetentionApplyReport) {
+) -> Result<(GenerationRetentionPlan, GenerationRetentionApplyReport)> {
     let now = Utc::now().timestamp_millis();
     let mut errors = Vec::new();
     let existing_marker =
@@ -1339,9 +1339,9 @@ fn retain_published_generations(
         &protection,
         &live_qdrant_collections,
     );
-    let mut remover = FsQdrantGenerationRemover::new(context.layout);
+    let mut remover = FsQdrantGenerationRemover::new(context.layout)?;
     let apply = apply_generation_retention(&plan, &mut remover);
-    (plan, apply)
+    Ok((plan, apply))
 }
 
 #[cfg(test)]

--- a/crates/codestory-retrieval/src/inventory.rs
+++ b/crates/codestory-retrieval/src/inventory.rs
@@ -437,7 +437,7 @@ fn apply_generation_retention_for_storage(
         &project_id,
         GenerationRetentionState::Reclaimable,
     );
-    let mut remover = FsQdrantGenerationRemover::new(&runtime.layout);
+    let mut remover = FsQdrantGenerationRemover::new(&runtime.layout)?;
     Ok(apply_generation_retention(&plan, &mut remover))
 }
 

--- a/crates/codestory-retrieval/src/qdrant_storage.rs
+++ b/crates/codestory-retrieval/src/qdrant_storage.rs
@@ -4,6 +4,7 @@ use crate::config::{SidecarLayout, user_cache_root};
 use crate::qdrant_client::QdrantClient;
 use anyhow::{Context, Result};
 use codestory_store::Store;
+use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -283,6 +284,15 @@ fn collection_has_config(collection_dir: &Path) -> bool {
 }
 
 fn remove_invalid_collection_dirs(qdrant_data_dir: &Path) -> Result<usize> {
+    let deletion = match OwnedDeletionRoot::open(qdrant_data_dir) {
+        Ok(deletion) => deletion,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("open owned Qdrant data root {}", qdrant_data_dir.display())
+            });
+        }
+    };
     let collections_dir = qdrant_data_dir.join("collections");
     let Ok(entries) = std::fs::read_dir(&collections_dir) else {
         return Ok(0);
@@ -297,13 +307,16 @@ fn remove_invalid_collection_dirs(qdrant_data_dir: &Path) -> Result<usize> {
         if !name.starts_with("codestory_") {
             continue;
         }
-        if !collection_has_config(&collection_dir) {
-            std::fs::remove_dir_all(&collection_dir).with_context(|| {
-                format!(
-                    "remove invalid qdrant collection dir without config {}",
-                    collection_dir.display()
-                )
-            })?;
+        if !collection_has_config(&collection_dir)
+            && deletion
+                .remove(Path::new("collections").join(&name).as_path())
+                .with_context(|| {
+                    format!(
+                        "remove invalid qdrant collection dir without config {}",
+                        collection_dir.display()
+                    )
+                })?
+        {
             removed += 1;
         }
     }
@@ -480,29 +493,39 @@ fn execute_retention_on_disk(
     max_keep: usize,
     repair_errors: &mut Vec<String>,
 ) -> Result<(usize, usize, usize, bool)> {
+    let deletion = match OwnedDeletionRoot::open(qdrant_data_dir) {
+        Ok(deletion) => deletion,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((0, 0, 0, false));
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("open owned Qdrant data root {}", qdrant_data_dir.display())
+            });
+        }
+    };
     let all = list_on_disk_codestory_collections(qdrant_data_dir, recency_by_collection)?;
     let collections_seen = all.len();
     let plan = plan_retention(&all, protected, max_keep);
     let prune_candidates = plan.to_prune.len();
     let mut removed = 0usize;
     for name in plan.to_prune {
-        let path = qdrant_data_dir.join("collections").join(&name);
-        if path.is_dir() {
-            match std::fs::remove_dir_all(&path) {
-                Ok(()) => {
+        match deletion.remove(Path::new("collections").join(&name).as_path()) {
+            Ok(was_removed) => {
+                if was_removed {
                     QdrantClient::clear_stub_marker_files(qdrant_data_dir, &name);
                     removed += 1;
                 }
-                Err(error) => {
-                    warn!(
-                        collection = %name,
-                        %error,
-                        "failed to prune stale Qdrant collection dir; continuing bootstrap repair"
-                    );
-                    repair_errors.push(format!(
-                        "remove stale qdrant collection dir {name}: {error}"
-                    ));
-                }
+            }
+            Err(error) => {
+                warn!(
+                    collection = %name,
+                    %error,
+                    "failed to prune stale Qdrant collection dir; continuing bootstrap repair"
+                );
+                repair_errors.push(format!(
+                    "remove stale qdrant collection dir {name}: {error}"
+                ));
             }
         }
     }

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -4,6 +4,7 @@ use crate::config::{SidecarLayout, SidecarProfile, SidecarRuntimeConfig};
 use crate::qdrant_client::{QdrantClient, QdrantDeleteOutcome};
 use anyhow::{Context, Result, bail};
 use codestory_store::{RetrievalIndexManifest, Store};
+use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -521,46 +522,64 @@ pub trait GenerationRemover {
 
 pub struct FsQdrantGenerationRemover {
     qdrant: QdrantClient,
+    root: PathBuf,
+    deletion: OwnedDeletionRoot,
     collections_dir: PathBuf,
 }
 
 impl FsQdrantGenerationRemover {
-    pub fn new(layout: &SidecarLayout) -> Self {
-        Self {
-            qdrant: QdrantClient::new(layout),
-            collections_dir: layout.qdrant_data_dir.join("collections"),
+    pub fn new(layout: &SidecarLayout) -> Result<Self> {
+        let root = layout
+            .lexical_data_dir
+            .parent()
+            .context("lexical data directory has no sidecar root")?;
+        if layout.qdrant_data_dir.parent() != Some(root)
+            || layout.scip_artifacts_root.parent() != Some(root)
+        {
+            bail!("retrieval generation roots do not share one owned sidecar root");
         }
+        let deletion = OwnedDeletionRoot::open(root)
+            .with_context(|| format!("open owned sidecar root {}", root.display()))?;
+        Ok(Self {
+            qdrant: QdrantClient::new(layout),
+            root: root.to_path_buf(),
+            deletion,
+            collections_dir: layout.qdrant_data_dir.join("collections"),
+        })
+    }
+
+    fn remove_owned_path(&self, path: &Path) -> Result<bool> {
+        let relative = path.strip_prefix(&self.root).with_context(|| {
+            format!(
+                "generation path {} is outside owned sidecar root {}",
+                path.display(),
+                self.root.display()
+            )
+        })?;
+        self.deletion
+            .remove(relative)
+            .with_context(|| format!("remove owned generation path {}", path.display()))
     }
 }
 
 impl GenerationRemover for FsQdrantGenerationRemover {
     fn remove_generation_dir(&mut self, path: &Path) -> Result<()> {
-        let metadata = std::fs::symlink_metadata(path)
-            .with_context(|| format!("inspect generation directory {}", path.display()))?;
-        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        if self.remove_owned_path(path)? {
+            Ok(())
+        } else {
             bail!(
-                "refuse to remove non-direct generation directory {}",
+                "generation directory disappeared before removal: {}",
                 path.display()
-            );
+            )
         }
-        std::fs::remove_dir_all(path)
-            .with_context(|| format!("remove generation directory {}", path.display()))
     }
 
     fn delete_qdrant_collection(&mut self, collection: &str) -> Result<bool> {
         let outcome = self.qdrant.delete_collection_with_outcome(collection)?;
         let path = self.collections_dir.join(collection);
-        if outcome == QdrantDeleteOutcome::NotFound && path.exists() {
-            let metadata = std::fs::symlink_metadata(&path)
-                .with_context(|| format!("inspect orphan Qdrant collection {}", path.display()))?;
-            if metadata.file_type().is_symlink() || !metadata.is_dir() {
-                bail!(
-                    "refuse to remove non-direct orphan Qdrant collection {}",
-                    path.display()
-                );
-            }
-            std::fs::remove_dir_all(&path)
-                .with_context(|| format!("remove orphan Qdrant collection {}", path.display()))?;
+        if outcome == QdrantDeleteOutcome::NotFound {
+            self.remove_owned_path(&path)?;
+            return Ok(true);
         }
         Ok(!path.exists())
     }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -49,6 +49,7 @@ use codestory_store::{
     LlmSymbolDocStats, SearchSymbolProjection, SnapshotStore, Store, SymbolSearchDoc,
     SymbolSummaryRecord,
 };
+use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 use codestory_workspace::{
     RefreshExecutionPlan, RefreshInputs, WorkspaceInventoryOutcome, WorkspaceManifest,
 };
@@ -4378,7 +4379,11 @@ fn inspect_search_generation(path: &Path) -> Result<Option<bool>, ApiError> {
     Ok(Some(valid))
 }
 
-fn try_remove_search_generation(path: &Path) -> Result<bool, ApiError> {
+fn try_remove_search_generation(
+    deletion: &OwnedDeletionRoot,
+    relative: &Path,
+    path: &Path,
+) -> Result<bool, ApiError> {
     let lock_path = crate::search::engine::persisted_search_index_lock_path(path);
     let lock = std::fs::OpenOptions::new()
         .read(true)
@@ -4400,21 +4405,15 @@ fn try_remove_search_generation(path: &Path) -> Result<bool, ApiError> {
     })? {
         return Ok(false);
     }
-    let removal = if path.is_dir() {
-        std::fs::remove_dir_all(path)
-    } else if path.exists() {
-        std::fs::remove_file(path)
-    } else {
-        Ok(())
-    };
+    let removal = deletion.remove(relative);
     let _ = FileExt::unlock(&lock);
-    removal.map_err(|error| {
+    let removed = removal.map_err(|error| {
         ApiError::internal(format!(
             "Failed to remove persisted search generation {}: {error}",
             path.display()
         ))
     })?;
-    Ok(true)
+    Ok(removed)
 }
 
 fn prune_search_generations(
@@ -4425,6 +4424,19 @@ fn prune_search_generations(
     if !root.is_dir() {
         return Ok(());
     }
+    let parent = root.parent().unwrap_or_else(|| Path::new("."));
+    let deletion = OwnedDeletionRoot::open(parent).map_err(|error| {
+        ApiError::internal(format!(
+            "Failed to open persisted search generation deletion root {}: {error}",
+            parent.display()
+        ))
+    })?;
+    let relative_root = root.file_name().ok_or_else(|| {
+        ApiError::internal(format!(
+            "Persisted search generation root has no owned relative name: {}",
+            root.display()
+        ))
+    })?;
     let mut generations = std::fs::read_dir(&root)
         .map_err(|error| {
             ApiError::internal(format!(
@@ -4460,7 +4472,8 @@ fn prune_search_generations(
         match inspection {
             Some(true) if !rollback_retained => rollback_retained = true,
             Some(_) => {
-                let _ = try_remove_search_generation(&path)?;
+                let relative = Path::new(relative_root).join(&name);
+                let _ = try_remove_search_generation(&deletion, &relative, &path)?;
             }
             None => {
                 tracing::debug!(
@@ -4484,7 +4497,16 @@ fn discard_unpublished_search_generation(
         return;
     }
     if let Ok(path) = search_index_path_for_publication(storage_path, Some(publication)) {
-        let _ = try_remove_search_generation(&path);
+        let root = search_index_generation_root(storage_path);
+        let parent = root.parent().unwrap_or_else(|| Path::new("."));
+        if let (Ok(deletion), Some(relative_root), Some(generation_name)) = (
+            OwnedDeletionRoot::open(parent),
+            root.file_name(),
+            path.file_name(),
+        ) {
+            let relative = Path::new(relative_root).join(generation_name);
+            let _ = try_remove_search_generation(&deletion, &relative, &path);
+        }
     }
 }
 

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -3,6 +3,7 @@ use crate::symbol_query::RetrievalFileRole;
 use crate::symbol_query::query_mentions_non_primary_source;
 use anyhow::{Context, Result, anyhow, bail};
 use codestory_contracts::graph::NodeId;
+use codestory_workspace::owned_deletion::OwnedDeletionRoot;
 use fs4::fs_std::FileExt;
 use nucleo_matcher::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config as NucleoConfig, Matcher, Utf32String};
@@ -1525,16 +1526,28 @@ fn symbol_candidate_rank(query: &str, name: &Utf32String, score: u32) -> SymbolC
 }
 
 fn recreate_search_storage_dir(path: &Path) -> Result<()> {
-    if path.exists() {
-        if path.is_dir() {
-            std::fs::remove_dir_all(path)
-                .with_context(|| format!("Failed to clear search index dir {}", path.display()))?;
-        } else {
-            std::fs::remove_file(path).with_context(|| {
-                format!("Failed to clear search index artifact {}", path.display())
-            })?;
-        }
-    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "Failed to create search index parent directory {}",
+            parent.display()
+        )
+    })?;
+    let name = path.file_name().ok_or_else(|| {
+        anyhow!(
+            "Search index path has no owned relative name: {}",
+            path.display()
+        )
+    })?;
+    let deletion = OwnedDeletionRoot::open(parent).with_context(|| {
+        format!(
+            "Failed to open search index deletion root {}",
+            parent.display()
+        )
+    })?;
+    deletion
+        .remove(Path::new(name))
+        .with_context(|| format!("Failed to clear search index artifact {}", path.display()))?;
     std::fs::create_dir_all(path)
         .with_context(|| format!("Failed to create search index dir {}", path.display()))?;
     Ok(())

--- a/crates/codestory-workspace/Cargo.toml
+++ b/crates/codestory-workspace/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2024"
 [dependencies]
 anyhow = { workspace = true }
 codestory-contracts = { workspace = true }
+fs_at = { workspace = true }
 glob = { workspace = true }
 ignore = { workspace = true }
+remove_dir_all = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -15,3 +17,9 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }

--- a/crates/codestory-workspace/src/lib.rs
+++ b/crates/codestory-workspace/src/lib.rs
@@ -25,6 +25,7 @@ use std::path::{Component, Path, PathBuf};
 use uuid::Uuid;
 
 pub mod atomic_file;
+pub mod owned_deletion;
 mod repository_identity;
 pub use repository_identity::{
     PROJECT_IDENTITY_SCHEMA_VERSION, PROJECT_IDENTITY_V3_SCHEMA_VERSION, ProjectIdentityV2,

--- a/crates/codestory-workspace/src/owned_deletion.rs
+++ b/crates/codestory-workspace/src/owned_deletion.rs
@@ -1,0 +1,262 @@
+//! Handle-relative deletion for resources below an already trusted directory.
+
+use fs_at::{OpenOptions as AtOpenOptions, OpenOptionsWriteMode};
+use remove_dir_all::RemoveDir as _;
+use std::{
+    ffi::{OsStr, OsString},
+    fs::{self, File},
+    io,
+    path::{Component, Path},
+};
+
+/// A deletion boundary pinned to one open directory handle.
+///
+/// Callers establish ownership of `root` before opening this boundary, then
+/// pass only owned relative names. Traversal and removal stay relative to the
+/// open handle even if the ambient pathname is renamed or replaced.
+#[derive(Debug)]
+pub struct OwnedDeletionRoot {
+    root: File,
+}
+
+impl OwnedDeletionRoot {
+    /// Pin a directory that the caller has already established as trusted.
+    pub fn open(root: &Path) -> io::Result<Self> {
+        open_root(root).map(|root| Self { root })
+    }
+
+    /// Remove one owned file or directory below this boundary.
+    ///
+    /// Missing entries are already removed and return `false`. Absolute paths,
+    /// parent traversal, and an empty/root path are always rejected.
+    pub fn remove(&self, relative: &Path) -> io::Result<bool> {
+        let parts = relative_owned_parts(relative)?;
+        let (leaf, ancestors) = parts
+            .split_last()
+            .expect("relative_owned_parts rejects an empty path");
+        let mut parent = self.root.try_clone()?;
+        for ancestor in ancestors {
+            parent = open_child_dir(&parent, ancestor)?;
+        }
+
+        match open_child_dir(&parent, leaf) {
+            Ok(mut target) => {
+                target.remove_dir_contents(Some(relative))?;
+                remove_open_directory(&parent, leaf, target)?;
+                Ok(true)
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(_) => remove_file_entry(&parent, leaf),
+        }
+    }
+}
+
+fn relative_owned_parts(path: &Path) -> io::Result<Vec<OsString>> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_owned()),
+            _ => return Err(invalid_relative_path(path)),
+        }
+    }
+    if parts.is_empty() {
+        return Err(invalid_relative_path(path));
+    }
+    Ok(parts)
+}
+
+fn invalid_relative_path(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!(
+            "owned deletion requires a non-empty relative path without traversal: {}",
+            path.display()
+        ),
+    )
+}
+
+fn open_child_dir(parent: &File, name: &OsStr) -> io::Result<File> {
+    let mut options = AtOpenOptions::default();
+    options
+        .read(true)
+        .write(OpenOptionsWriteMode::Write)
+        .follow(false);
+    let child = options.open_dir_at(parent, Path::new(name))?;
+    let metadata = child.metadata()?;
+    if !metadata.is_dir() {
+        return Err(io::Error::other("owned deletion target is not a directory"));
+    }
+    reject_windows_reparse(&metadata)?;
+    Ok(child)
+}
+
+#[cfg(unix)]
+fn open_root(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn open_root(path: &Path) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+    let root = options.open(path)?;
+    let metadata = root.metadata()?;
+    if !metadata.is_dir() {
+        return Err(io::Error::other("owned deletion root is not a directory"));
+    }
+    reject_windows_reparse(&metadata)?;
+    Ok(root)
+}
+
+#[cfg(unix)]
+fn reject_windows_reparse(_: &fs::Metadata) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn reject_windows_reparse(metadata: &fs::Metadata) -> io::Result<()> {
+    use std::os::windows::fs::MetadataExt as _;
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        Err(io::Error::other("owned deletion refuses reparse points"))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn remove_open_directory(parent: &File, leaf: &OsStr, target: File) -> io::Result<()> {
+    drop(target);
+    AtOpenOptions::default().rmdir_at(parent, Path::new(leaf))
+}
+
+#[cfg(windows)]
+fn remove_open_directory(_: &File, _: &OsStr, target: File) -> io::Result<()> {
+    use fs_at::os::windows::FileExt as _;
+
+    target.delete_by_handle().map_err(|(_, error)| error)
+}
+
+#[cfg(unix)]
+fn remove_file_entry(parent: &File, leaf: &OsStr) -> io::Result<bool> {
+    match AtOpenOptions::default().unlink_at(parent, Path::new(leaf)) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(windows)]
+fn remove_file_entry(parent: &File, leaf: &OsStr) -> io::Result<bool> {
+    use fs_at::os::windows::{FileExt as _, OpenOptionsExt as _};
+    use windows_sys::Win32::Storage::FileSystem::{DELETE, FILE_READ_ATTRIBUTES};
+
+    let mut options = AtOpenOptions::default();
+    options
+        .desired_access(DELETE | FILE_READ_ATTRIBUTES)
+        .follow(false);
+    let target = match options.open_at(parent, Path::new(leaf)) {
+        Ok(target) => target,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let metadata = target.metadata()?;
+    reject_windows_reparse(&metadata)?;
+    if metadata.is_dir() {
+        return Err(io::Error::other(
+            "owned deletion target directory could not be opened safely",
+        ));
+    }
+    target
+        .delete_by_handle()
+        .map(|()| true)
+        .map_err(|(_, error)| error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OwnedDeletionRoot;
+    use std::fs;
+    #[cfg(windows)]
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_root_swap_cannot_redirect_deletion() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("create temp root");
+        let owned = temp.path().join("owned");
+        let pinned = temp.path().join("pinned-owned");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(owned.join("generation")).expect("create owned generation");
+        fs::create_dir_all(&outside).expect("create outside directory");
+        let sentinel = outside.join("sentinel");
+        fs::write(&sentinel, b"outside").expect("write outside sentinel");
+
+        let deletion = OwnedDeletionRoot::open(&owned).expect("pin owned root");
+        fs::rename(&owned, &pinned).expect("move ambient owned root");
+        symlink(&outside, &owned).expect("replace ambient root with outside symlink");
+
+        assert!(
+            deletion
+                .remove("generation".as_ref())
+                .expect("remove owned generation")
+        );
+        assert!(
+            sentinel.is_file(),
+            "pinned deletion must not follow the replacement root"
+        );
+        assert!(!pinned.join("generation").exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_root_swap_cannot_redirect_deletion() {
+        let temp = tempdir().expect("create temp root");
+        let owned = temp.path().join("owned");
+        let pinned = temp.path().join("pinned-owned");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(owned.join("generation")).expect("create owned generation");
+        fs::create_dir_all(&outside).expect("create outside directory");
+        let sentinel = outside.join("sentinel");
+        fs::write(&sentinel, b"outside").expect("write outside sentinel");
+
+        let deletion = OwnedDeletionRoot::open(&owned).expect("pin owned root");
+        fs::rename(&owned, &pinned).expect("move ambient owned root");
+        let junction = Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&owned)
+            .arg(&outside)
+            .status()
+            .expect("create replacement junction");
+        assert!(junction.success(), "create replacement junction");
+
+        assert!(
+            deletion
+                .remove("generation".as_ref())
+                .expect("remove owned generation")
+        );
+        assert!(
+            sentinel.is_file(),
+            "pinned deletion must not follow the replacement root"
+        );
+        assert!(!pinned.join("generation").exists());
+    }
+}

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -219,6 +219,13 @@ the following run also cleans a marker-owned prior attempt if cancellation
 prevented the prior `always()` step. Contract tests or hosted package smoke
 cannot replace this hardware evidence.
 
+Proof cleanup validates the marker and archive before invoking the packaged
+CLI's internal owned-deletion boundary. Cache and proof-root names are removed
+relative to a pinned runner-temp handle; Unix traversal is descriptor-relative
+and no-follow, while Windows rejects reparse ancestors and deletes by handle.
+The platform boundary test swaps the ambient ancestor after the trusted handle
+opens and must preserve an outside sentinel.
+
 An actual Mac host reboot remains a separate two-phase operator proof because a
 GitHub job cannot safely reboot its own self-hosted runner and resume the same
 job. Preserve the pre-reboot PID/launch/status bundle, reboot the protected host,

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -522,6 +522,10 @@ Before Compose starts, bootstrap may repair Qdrant storage:
    diagnostics.
 
 Non-`codestory_*` collection dirs are never deleted by this repair path.
+Deletion is resolved below an already open Qdrant data-directory handle. Each
+relative component is opened without following links or reparse points, and
+recursive removal remains handle-relative, so replacing an ambient ancestor
+cannot redirect retention into another directory tree.
 
 ### Query and embedding contracts
 


### PR DESCRIPTION
Closes #1100
Refs #899
Refs #1046

## Context

Generation retention and packaged-proof cleanup validated ambient paths and then recursively deleted through them. An ancestor symlink, junction, or reparse swap could redirect that cleanup after validation.

## What changed

- Added one `OwnedDeletionRoot` boundary in `codestory-workspace`: callers open a trusted root once and pass only plain relative names.
- Unix traversal uses `openat` with no-follow handles and `unlinkat`; Windows rejects reparse traversal and deletes the exact opened handle.
- Routed retrieval generation retention, Qdrant disk pruning, runtime search-generation pruning/recreation, and packaged proof-root/cache cleanup through that boundary.
- Added one deterministic ancestor-swap sentinel test per platform. The packaged proof extracts its marker-bound CLI outside the removable root and uses the same internal deletion path.
- Updated cleanup proof documentation and `CHANGELOG.md`.

## Review

Start with `crates/codestory-workspace/src/owned_deletion.rs`, then verify that each consumer supplies a trusted root plus a derived relative path. The Python proof cleanup deliberately keeps marker/archive validation ahead of CLI extraction and deletion.

A code-simplifier pass found no justified broad refactor in the touched large files. I kept the OS branches explicit, removed redundant error plumbing, and applied the one clippy simplification in Qdrant cleanup.

## Verification

Exact head: `c7519139de78dcc4dd6630c486a408afef97c701`

- `cargo test -p codestory-workspace owned_deletion`
- `cargo check -p codestory-workspace --target x86_64-pc-windows-msvc --locked`
- `cargo test -p codestory-retrieval active_and_rollback_are_retained_while_stale_bundle_is_removed --locked`
- `cargo test -p codestory-runtime search_generation_retention_keeps_active_and_one_verified_rollback --locked`
- `cargo check -p codestory-cli --locked` after rebasing onto `origin/dev/codestory-next@6bd8eb5`
- `cargo clippy -p codestory-cli --locked -- -D warnings`
- `python3 .github/scripts/check-packaged-agent-proof.py --self-test`
- `node .github/scripts/check-doc-links.mjs`
- `python3 -m py_compile .github/scripts/check-packaged-agent-proof.py`
- `git diff --check`

## Risk and remaining proof

This is a deletion boundary, so the PR stays draft until the Windows-hosted test executes the junction swap and the normal draft CI is green. The Windows implementation and test compile locally, but this Mac cannot execute the Windows test binary. No full workspace or packaged matrix was run for this draft head.