### PR TITLE
Pin retrieval reads to one publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@
   remain at build, publication, readiness, and explicit health boundaries.
 - MCP resource reads now reject malformed or unknown URIs before selecting,
   refreshing, or repairing a project, leaving runtime and status state untouched.
+- Retrieval queries, numeric candidate resolution, file-role reads, and final
+  packet/search output now stay pinned to one core and sidecar publication.
+  Concurrent publication drift returns `cache_busy` and retries once instead of
+  resolving an older candidate ID against a newer graph.
 - Express, Fastify, and FastAPI route extraction now builds one ordered
   binding timeline per module. Route queries reuse that timeline instead of
   rescanning prior statements, and FastAPI imports are resolved from parsed

--- a/crates/codestory-retrieval/src/cache.rs
+++ b/crates/codestory-retrieval/src/cache.rs
@@ -8,6 +8,8 @@ use std::collections::{HashMap, VecDeque};
 /// reused after the manifest identity changes. The query fingerprint is not enough on its own.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RetrievalCacheKey {
+    pub core_generation_id: Option<String>,
+    pub core_run_id: Option<String>,
     pub project_id: String,
     pub lexical_version: String,
     pub qdrant_collection: String,
@@ -25,6 +27,8 @@ impl RetrievalCacheKey {
         query_fingerprint: impl Into<String>,
     ) -> Self {
         Self {
+            core_generation_id: None,
+            core_run_id: None,
             project_id: manifest.project_id.clone(),
             lexical_version: manifest.lexical_version.clone(),
             qdrant_collection: manifest.qdrant_collection.clone(),
@@ -50,6 +54,7 @@ pub struct RetrievalCache {
     entries: HashMap<RetrievalCacheKey, Vec<super::CandidateHit>>,
     order: VecDeque<RetrievalCacheKey>,
     capacity: usize,
+    publication_identity: Option<(String, String)>,
 }
 
 impl Default for RetrievalCache {
@@ -68,7 +73,32 @@ impl RetrievalCache {
             entries: HashMap::new(),
             order: VecDeque::new(),
             capacity: capacity.max(1),
+            publication_identity: None,
         }
+    }
+
+    pub fn scope_to_publication(&mut self, identity: &super::RetrievalPublicationIdentity) {
+        let publication = (
+            identity.core_generation_id.clone(),
+            identity.core_run_id.clone(),
+        );
+        if self.publication_identity.as_ref() != Some(&publication) {
+            self.clear();
+            self.publication_identity = Some(publication);
+        }
+    }
+
+    pub fn key_for_manifest(
+        &self,
+        manifest: &RetrievalIndexManifest,
+        query_fingerprint: impl Into<String>,
+    ) -> RetrievalCacheKey {
+        let mut key = RetrievalCacheKey::from_manifest(manifest, query_fingerprint);
+        if let Some((generation_id, run_id)) = &self.publication_identity {
+            key.core_generation_id = Some(generation_id.clone());
+            key.core_run_id = Some(run_id.clone());
+        }
+        key
     }
 
     pub fn get(&self, key: &RetrievalCacheKey) -> Option<&[super::CandidateHit]> {
@@ -95,7 +125,26 @@ impl RetrievalCache {
     }
 
     pub fn merge_delta_from(&mut self, baseline: &RetrievalCache, other: RetrievalCache) {
-        let RetrievalCache { entries, order, .. } = other;
+        let RetrievalCache {
+            entries,
+            order,
+            publication_identity,
+            ..
+        } = other;
+        if self.publication_identity != baseline.publication_identity
+            && self.publication_identity != publication_identity
+        {
+            return;
+        }
+        if self.publication_identity == baseline.publication_identity
+            && publication_identity != baseline.publication_identity
+        {
+            self.clear();
+            self.publication_identity = publication_identity.clone();
+        }
+        if self.publication_identity != publication_identity {
+            return;
+        }
         for key in order {
             let Some(hits) = entries.get(&key) else {
                 continue;
@@ -110,6 +159,7 @@ impl RetrievalCache {
     pub fn clear(&mut self) {
         self.entries.clear();
         self.order.clear();
+        self.publication_identity = None;
     }
 
     pub fn len(&self) -> usize {
@@ -129,6 +179,8 @@ mod tests {
     fn cache_round_trip() {
         let mut cache = RetrievalCache::new();
         let key = RetrievalCacheKey {
+            core_generation_id: None,
+            core_run_id: None,
             project_id: "abc".into(),
             lexical_version: "v1".into(),
             qdrant_collection: "codestory_abc".into(),
@@ -150,6 +202,8 @@ mod tests {
     fn cache_evicts_oldest_entry_when_capacity_is_reached() {
         let mut cache = RetrievalCache::with_capacity(1);
         let first = RetrievalCacheKey {
+            core_generation_id: None,
+            core_run_id: None,
             project_id: "abc".into(),
             lexical_version: "v1".into(),
             qdrant_collection: "codestory_abc".into(),
@@ -189,6 +243,8 @@ mod tests {
     #[test]
     fn merge_delta_from_does_not_replay_snapshot_entries() {
         let first = RetrievalCacheKey {
+            core_generation_id: None,
+            core_run_id: None,
             project_id: "abc".into(),
             lexical_version: "v1".into(),
             qdrant_collection: "codestory_abc".into(),
@@ -238,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn cache_key_tracks_sidecar_generation_contract() {
+    fn cache_key_tracks_core_and_sidecar_publications() {
         let base = RetrievalIndexManifest {
             project_id: "abc".into(),
             lexical_version: "v1".into(),
@@ -272,5 +328,39 @@ mod tests {
             RetrievalCacheKey::from_manifest(&base, "query"),
             RetrievalCacheKey::from_manifest(&changed, "query")
         );
+
+        let first = crate::executor::RetrievalPublicationIdentity {
+            core_generation_id: "core-a".into(),
+            core_run_id: "run-a".into(),
+            sidecar_generation: "abc-hash-a".into(),
+            sidecar_input_hash: "hash-a".into(),
+            qdrant_collection: base.qdrant_collection.clone(),
+        };
+        let second = crate::executor::RetrievalPublicationIdentity {
+            core_generation_id: "core-b".into(),
+            core_run_id: "run-b".into(),
+            ..first.clone()
+        };
+        let mut shared = RetrievalCache::new();
+        shared.scope_to_publication(&first);
+        let first_key = shared.key_for_manifest(&base, "query");
+        shared.insert(
+            first_key.clone(),
+            vec![super::super::CandidateHit::lexical_stub("src/old.rs", 1.0)],
+        );
+        let baseline = shared.clone();
+        let mut worker = baseline.clone();
+        worker.scope_to_publication(&second);
+        let second_key = worker.key_for_manifest(&base, "query");
+        worker.insert(
+            second_key.clone(),
+            vec![super::super::CandidateHit::lexical_stub("src/new.rs", 1.0)],
+        );
+        shared.merge_delta_from(&baseline, worker);
+
+        assert_ne!(first_key, second_key);
+        assert!(shared.get(&first_key).is_none());
+        assert_eq!(shared.key_for_manifest(&base, "query"), second_key);
+        assert!(shared.get(&second_key).is_some());
     }
 }

--- a/crates/codestory-retrieval/src/executor.rs
+++ b/crates/codestory-retrieval/src/executor.rs
@@ -1,4 +1,6 @@
-use crate::cache::{RetrievalCache, RetrievalCacheKey};
+use crate::cache::RetrievalCache;
+#[cfg(test)]
+use crate::cache::RetrievalCacheKey;
 use crate::candidate::CandidateHit;
 use crate::health::{
     probe_sidecar_health, probe_sidecar_health_for_runtime,
@@ -89,16 +91,37 @@ pub struct QueryTrace {
     pub stages: Vec<StageTrace>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetrievalPublicationIdentity {
+    pub core_generation_id: String,
+    pub core_run_id: String,
+    pub sidecar_generation: String,
+    pub sidecar_input_hash: String,
+    pub qdrant_collection: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 /// Result of executing one retrieval query against the sidecar stack.
 ///
 /// Hits may include lexical, graph, or dense-anchor candidates. Runtime packet code must still
 /// resolve candidates to indexed symbols before treating them as answer support.
 pub struct QueryResult {
+    #[serde(skip)]
+    pub publication_identity: Option<RetrievalPublicationIdentity>,
     pub query: String,
     pub features: QueryFeatures,
     pub hits: Vec<CandidateHit>,
     pub trace: QueryTrace,
+}
+
+impl QueryResult {
+    pub(crate) fn with_publication_identity(
+        mut self,
+        identity: &RetrievalPublicationIdentity,
+    ) -> Self {
+        self.publication_identity = Some(identity.clone());
+        self
+    }
 }
 
 /// Executes sidecar retrieval stages with manifest-scoped caching.
@@ -137,7 +160,7 @@ impl<'a> QueryExecutor<'a> {
         if !self.cancelled.load(Ordering::Acquire)
             && let Some(manifest) = self.manifest.as_ref()
         {
-            let key = RetrievalCacheKey::from_manifest(manifest, fingerprint.clone());
+            let key = self.cache.key_for_manifest(manifest, fingerprint.clone());
             if let Some(cached) = self.cache.get(&key) {
                 let cached = cached.to_vec();
                 if self.cancelled.load(Ordering::Acquire) {
@@ -149,6 +172,7 @@ impl<'a> QueryExecutor<'a> {
                     ));
                 }
                 return Ok(QueryResult {
+                    publication_identity: None,
                     query: features.raw_query.clone(),
                     features,
                     hits: cached,
@@ -209,7 +233,7 @@ impl<'a> QueryExecutor<'a> {
             && Instant::now() < deadline
             && let Some(manifest) = self.manifest.as_ref()
         {
-            let key = RetrievalCacheKey::from_manifest(manifest, fingerprint);
+            let key = self.cache.key_for_manifest(manifest, fingerprint);
             if !self.cancelled.load(Ordering::Acquire) {
                 self.cache.insert(key.clone(), hits.clone());
                 if self.cancelled.load(Ordering::Acquire) || Instant::now() >= deadline {
@@ -220,6 +244,7 @@ impl<'a> QueryExecutor<'a> {
         }
 
         Ok(QueryResult {
+            publication_identity: None,
             query: features.raw_query.clone(),
             features,
             hits,
@@ -541,6 +566,7 @@ fn cancelled_query_result(
     reason: &str,
 ) -> QueryResult {
     QueryResult {
+        publication_identity: None,
         query: features.raw_query.clone(),
         features,
         hits: Vec::new(),

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -873,7 +873,6 @@ fn persist_finalized_manifest(
     manifest.built_at_epoch_ms = Utc::now().timestamp_millis();
     manifest.degraded_modes_json =
         serde_json::to_string(&degraded_modes).unwrap_or_else(|_| "[]".into());
-    let lexical_source = lexical_source_input(project_root).context("hash lexical source input")?;
     let mut storage = Store::open(storage_path).context("open storage for retrieval manifest")?;
     let embedding_backend =
         crate::embeddings::embedding_runtime_id_for_runtime(retention_context.runtime);
@@ -884,6 +883,8 @@ fn persist_finalized_manifest(
         sidecar_input,
         &manifest,
         |storage| {
+            let lexical_source = lexical_source_input(project_root)
+                .context("rescan lexical source at publication fence")?;
             let current_input = compute_sidecar_input_fingerprint_with_lexical_source(
                 storage,
                 project_root,
@@ -2599,12 +2600,54 @@ mod tests {
                 .expect("marker exists"),
             marker_before
         );
-        let lexical_source = lexical_source_input(project.path()).expect("lexical source");
+
+        let source_path = project.path().join("lib.rs");
+        let drifted = promote_retrieval_manifest(
+            &mut storage,
+            &second,
+            &new_manifest,
+            |snapshot| {
+                let lexical_source =
+                    lexical_source_input(project.path()).expect("fresh lexical source");
+                compute_sidecar_input_fingerprint_with_lexical_source(
+                    snapshot,
+                    project.path(),
+                    "proj",
+                    crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+                    crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+                    &runtime.embedding,
+                    lexical_source,
+                )
+            },
+            || {
+                validate_candidate_generation_evidence(
+                    "proj",
+                    &second,
+                    &new_manifest,
+                    &runtime,
+                    &passing,
+                )?;
+                std::fs::write(&source_path, "pub fn changed_during_validation() {}\n")?;
+                Ok(())
+            },
+        )
+        .expect_err("source drift during validation must reject publication");
+        assert!(drifted.to_string().contains("input changed"));
+        assert_eq!(
+            storage
+                .get_retrieval_index_manifest("proj")
+                .expect("current manifest after source drift"),
+            Some(old_manifest.clone())
+        );
+        std::fs::write(&source_path, "pub fn do_work() {}\n").expect("restore source");
+
         promote_retrieval_manifest(
             &mut storage,
             &second,
             &new_manifest,
             |snapshot| {
+                let lexical_source =
+                    lexical_source_input(project.path()).expect("fresh lexical source");
                 compute_sidecar_input_fingerprint_with_lexical_source(
                     snapshot,
                     project.path(),

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -77,7 +77,8 @@ pub use embeddings::{
     qdrant_vector_dim,
 };
 pub use executor::{
-    QueryExecutor, QueryResult, QueryTrace, StageCompletionStatus, StageTrace, cancellation_flag,
+    QueryExecutor, QueryResult, QueryTrace, RetrievalPublicationIdentity, StageCompletionStatus,
+    StageTrace, cancellation_flag,
 };
 pub use generation::{SIDECAR_SCHEMA_VERSION, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED};
 pub use health::{
@@ -119,10 +120,14 @@ pub use query::{
     execute_retrieval_query_with_cache, execute_retrieval_query_with_cache_for_runtime,
     execute_strict_retrieval_query_batch_with_cache,
     execute_strict_retrieval_query_batch_with_cache_for_runtime,
+    retrieval_publication_identity_from_storage,
 };
 pub use query_features::{QueryFeatures, QueryShape, classify_query};
 pub use ranker::rank_candidates;
-pub use retention::{GenerationRetentionApplyReport, GenerationRetentionPlan};
+pub use retention::{
+    GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionApplyReport, GenerationRetentionLock,
+    GenerationRetentionPlan, global_generation_gc_state_file,
+};
 pub use scip_client::ScipClient;
 pub use sidecar::{
     EmbeddingLaunchOwnership, NativeEmbeddingLaunchIdentityStatus, SidecarStateFile,

--- a/crates/codestory-retrieval/src/query.rs
+++ b/crates/codestory-retrieval/src/query.rs
@@ -1,8 +1,11 @@
 use crate::cache::RetrievalCache;
+#[cfg(test)]
 use crate::cache::RetrievalCacheKey;
 use crate::config::{SidecarLayout, SidecarRuntimeConfig};
 use crate::embeddings::{EmbeddingDeviceReadiness, embedding_device_readiness_for_runtime};
-use crate::executor::{QueryExecutor, QueryResult, cancellation_flag};
+use crate::executor::{
+    QueryExecutor, QueryResult, RetrievalPublicationIdentity, cancellation_flag,
+};
 use crate::generation::manifest_unavailable_reason_for_runtime;
 use crate::health::probe_sidecar_health_for_runtime;
 use crate::index::{query_fingerprint, sidecar_project_id_for_runtime};
@@ -71,7 +74,9 @@ pub fn execute_retrieval_query_with_cache_for_runtime(
         manifest,
         file_roles,
         embedding_device,
+        publication_identity,
     } = load_query_context(request.project_root, request.storage_path, runtime)?;
+    cache.scope_to_publication(&publication_identity);
     let sidecars = Arc::new(LiveSidecarSearch::new_for_runtime_with_embedding_device(
         runtime,
         layout,
@@ -87,7 +92,9 @@ pub fn execute_retrieval_query_with_cache_for_runtime(
         cancelled,
         mode_override: None,
     };
-    executor.execute(request.query, request.budget_ms)
+    executor
+        .execute(request.query, request.budget_ms)
+        .map(|result| result.with_publication_identity(&publication_identity))
 }
 
 pub fn execute_strict_retrieval_query_batch_with_cache(
@@ -116,7 +123,9 @@ pub fn execute_strict_retrieval_query_batch_with_cache_for_runtime(
         manifest,
         file_roles,
         embedding_device,
+        publication_identity,
     } = load_query_context(request.project_root, request.storage_path, runtime)?;
+    cache.scope_to_publication(&publication_identity);
     let sidecars = Arc::new(LiveSidecarSearch::new_for_runtime_with_embedding_device(
         runtime,
         layout,
@@ -137,7 +146,7 @@ pub fn execute_strict_retrieval_query_batch_with_cache_for_runtime(
             degraded_reason.as_deref().unwrap_or("unknown")
         );
     }
-    execute_strict_retrieval_query_batch_against_sidecars(
+    let mut results = execute_strict_retrieval_query_batch_against_sidecars(
         sidecars,
         manifest,
         file_roles,
@@ -146,7 +155,11 @@ pub fn execute_strict_retrieval_query_batch_with_cache_for_runtime(
         request.queries,
         cache,
         strict_batch_worker_limit(request.queries.len()),
-    )
+    )?;
+    for result in &mut results {
+        result.publication_identity = Some(publication_identity.clone());
+    }
+    Ok(results)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -247,12 +260,13 @@ fn cached_batch_result(
     }
     let manifest = manifest?;
     let features = classify_query(query);
-    let key = RetrievalCacheKey::from_manifest(manifest, query_fingerprint(&features.raw_query));
+    let key = cache.key_for_manifest(manifest, query_fingerprint(&features.raw_query));
     let hits = cache.get(&key)?.to_vec();
     if cancelled.load(Ordering::Acquire) {
         return None;
     }
     Some(QueryResult {
+        publication_identity: None,
         query: features.raw_query.clone(),
         features,
         hits,
@@ -278,10 +292,7 @@ fn cache_completed_batch_result(
         return;
     }
     if let Some(manifest) = manifest {
-        let key = RetrievalCacheKey::from_manifest(
-            manifest,
-            query_fingerprint(&result.features.raw_query),
-        );
+        let key = cache.key_for_manifest(manifest, query_fingerprint(&result.features.raw_query));
         if !cancelled.load(Ordering::Acquire) {
             cache.insert(key.clone(), result.hits.clone());
             if cancelled.load(Ordering::Acquire) {
@@ -308,6 +319,36 @@ struct QueryContext {
     manifest: Option<RetrievalIndexManifest>,
     file_roles: Arc<HashMap<String, FileRole>>,
     embedding_device: EmbeddingDeviceReadiness,
+    publication_identity: RetrievalPublicationIdentity,
+}
+
+pub fn retrieval_publication_identity_from_storage(
+    storage: &Store,
+    project_id: &str,
+) -> Result<RetrievalPublicationIdentity> {
+    let publication = storage
+        .get_complete_index_publication()
+        .context("load complete core publication")?
+        .context("complete core publication is missing")?;
+    let manifest = storage
+        .get_retrieval_index_manifest(project_id)
+        .context("load retrieval manifest identity")?
+        .context("retrieval manifest is missing")?;
+    Ok(RetrievalPublicationIdentity {
+        core_generation_id: publication.generation_id,
+        core_run_id: publication.run_id,
+        sidecar_generation: manifest
+            .sidecar_generation
+            .filter(|value| !value.trim().is_empty())
+            .context("retrieval manifest sidecar generation is missing")?,
+        sidecar_input_hash: manifest
+            .sidecar_input_hash
+            .filter(|value| !value.trim().is_empty())
+            .context("retrieval manifest input hash is missing")?,
+        qdrant_collection: (!manifest.qdrant_collection.trim().is_empty())
+            .then_some(manifest.qdrant_collection)
+            .context("retrieval manifest Qdrant collection is missing")?,
+    })
 }
 
 fn load_query_context(
@@ -318,8 +359,12 @@ fn load_query_context(
     let embedding_device = embedding_device_readiness_for_runtime(runtime);
     let layout = runtime.layout.clone();
     let project_id = sidecar_project_id_for_runtime(project_root, runtime)?;
-    let (manifest, file_roles) = if storage_path.exists() {
-        let storage = Store::open(storage_path).context("open storage for query")?;
+    let (manifest, file_roles, publication_identity) = if storage_path.exists() {
+        let storage = Store::open_read_only(storage_path).context("open storage for query")?;
+        let snapshot = storage
+            .read_snapshot()
+            .context("pin core publication for retrieval query")?;
+        let storage = snapshot.storage();
         let manifest = storage
             .get_retrieval_index_manifest(&project_id)
             .context("load retrieval manifest")?;
@@ -327,7 +372,7 @@ fn load_query_context(
             if let Err(error) = validate_strict_sidecar_readiness_for_runtime(
                 project_root,
                 storage_path,
-                &storage,
+                storage,
                 runtime,
             ) {
                 bail!(
@@ -335,7 +380,7 @@ fn load_query_context(
                 );
             }
             if let Some(reason) =
-                manifest_unavailable_reason_for_runtime(&project_id, &storage, manifest, runtime)
+                manifest_unavailable_reason_for_runtime(&project_id, storage, manifest, runtime)
             {
                 bail!(
                     "retrieval sidecar manifest is unavailable ({reason}); run retrieval index for project {project_id}"
@@ -355,7 +400,12 @@ fn load_query_context(
                     .collect()
             })
             .unwrap_or_default();
-        (manifest, roles)
+        let publication_identity =
+            retrieval_publication_identity_from_storage(storage, &project_id)?;
+        snapshot
+            .finish()
+            .context("finish pinned retrieval query context")?;
+        (manifest, roles, publication_identity)
     } else {
         bail!("retrieval sidecar storage is missing; run retrieval index for project {project_id}");
     };
@@ -366,6 +416,7 @@ fn load_query_context(
         manifest,
         file_roles: Arc::new(file_roles),
         embedding_device,
+        publication_identity,
     })
 }
 

--- a/crates/codestory-runtime/src/agent/orchestrator.rs
+++ b/crates/codestory-runtime/src/agent/orchestrator.rs
@@ -3592,6 +3592,7 @@ fn execute_retrieval(
             ));
             return Err(sidecar_retrieval_unavailable_error(controller, reason));
         }
+        Some(SidecarPrimarySearchOutcome::Retryable { error }) => return Err(error),
         None => {
             return Err(sidecar_retrieval_unavailable_error(
                 controller,

--- a/crates/codestory-runtime/src/agent/retrieval_primary.rs
+++ b/crates/codestory-runtime/src/agent/retrieval_primary.rs
@@ -13,9 +13,11 @@ use codestory_contracts::graph::{NodeId as CoreNodeId, NodeKind};
 #[cfg(test)]
 use codestory_retrieval::SidecarRuntimeConfig;
 use codestory_retrieval::{
-    CandidateHit, CandidateSource, QueryBatchItem, QueryBatchRequest, QueryRequest, QueryResult,
-    QueryTrace, SidecarProfile, execute_retrieval_query_with_cache_for_runtime,
-    execute_strict_retrieval_query_batch_with_cache_for_runtime, is_phantom_sidecar_hit,
+    CandidateHit, CandidateSource, GLOBAL_GENERATION_GC_LOCK_SCOPE, GenerationRetentionLock,
+    QueryBatchItem, QueryBatchRequest, QueryRequest, QueryResult, QueryTrace,
+    RetrievalPublicationIdentity, SidecarProfile, execute_retrieval_query_with_cache_for_runtime,
+    execute_strict_retrieval_query_batch_with_cache_for_runtime, global_generation_gc_state_file,
+    is_phantom_sidecar_hit, retrieval_publication_identity_from_storage,
     sidecar_project_id_for_root, strict_sidecar_status_for_runtime,
 };
 use codestory_store::Store;
@@ -28,10 +30,169 @@ const DEFAULT_PACKET_BATCH_BUDGET_MS: u64 = 18_000;
 const MAX_PACKET_BATCH_BUDGET_MS: u64 = 120_000;
 const MAX_SHADOW_CANDIDATES: usize = 20;
 const MAX_SHADOW_WOULD_RANK: usize = 10;
+const RETRIEVAL_PUBLICATION_ATTEMPTS: usize = 2;
 pub(crate) const RETRIEVAL_VERSION_SIDECAR: &str = "sidecar";
 
 const RETRIEVAL_ENV: &str = "CODESTORY_RETRIEVAL";
 const RETRIEVAL_SHADOW_ENV: &str = "CODESTORY_RETRIEVAL_SHADOW";
+
+struct PinnedRetrievalRead {
+    storage: Store,
+    project_root: PathBuf,
+    storage_path: PathBuf,
+    project_id: String,
+    identity: RetrievalPublicationIdentity,
+    node_names: HashMap<CoreNodeId, String>,
+    _global_generation_lease: GenerationRetentionLock,
+    _project_generation_lease: GenerationRetentionLock,
+}
+
+impl PinnedRetrievalRead {
+    fn begin(controller: &AppController) -> Result<Self, ApiError> {
+        let project_root = controller.require_project_root()?;
+        let storage_path = controller.require_storage_path()?;
+        let project_id = sidecar_project_id_for_root(&project_root);
+        let global_generation_lease = GenerationRetentionLock::acquire_shared(
+            &global_generation_gc_state_file(&controller.runtime_config),
+            GLOBAL_GENERATION_GC_LOCK_SCOPE,
+        )
+        .map_err(|error| ApiError::new("cache_busy", format!("pin sidecar generation: {error}")))?;
+        let project_generation_lease = GenerationRetentionLock::acquire_shared(
+            &controller.runtime_config.layout.state_file,
+            &project_id,
+        )
+        .map_err(|error| {
+            ApiError::new(
+                "cache_busy",
+                format!("pin project sidecar generation: {error}"),
+            )
+        })?;
+        let storage = Store::open_read_only(&storage_path).map_err(|error| {
+            ApiError::internal(format!("open pinned retrieval storage: {error}"))
+        })?;
+        storage
+            .get_connection()
+            .execute_batch("BEGIN DEFERRED TRANSACTION")
+            .map_err(|error| {
+                ApiError::new(
+                    "cache_busy",
+                    format!("pin core retrieval snapshot: {error}"),
+                )
+            })?;
+        let identity = retrieval_publication_identity_from_storage(&storage, &project_id).map_err(
+            |error| ApiError::new("cache_busy", format!("pin retrieval publication: {error}")),
+        )?;
+        let node_names = crate::load_search_symbol_projection(&storage, 10_000)?.0;
+        Ok(Self {
+            storage,
+            project_root,
+            storage_path,
+            project_id,
+            identity,
+            node_names,
+            _global_generation_lease: global_generation_lease,
+            _project_generation_lease: project_generation_lease,
+        })
+    }
+
+    fn matches_query(&self, query: &QueryResult) -> bool {
+        query.publication_identity.as_ref() == Some(&self.identity)
+    }
+
+    fn revalidate(&self) -> Result<(), ApiError> {
+        let identity = read_retrieval_publication_identity(&self.storage_path, &self.project_id)?;
+        if identity != self.identity {
+            return Err(ApiError::new(
+                "cache_busy",
+                "retrieval publication changed while resolving candidates; retry",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for PinnedRetrievalRead {
+    fn drop(&mut self) {
+        let _ = self.storage.get_connection().execute_batch("ROLLBACK");
+    }
+}
+
+fn with_pinned_retrieval_read<T>(
+    controller: &AppController,
+    read: impl FnOnce(&PinnedRetrievalRead) -> Result<T, ApiError>,
+) -> Result<T, ApiError> {
+    let pinned = PinnedRetrievalRead::begin(controller)?;
+    let value = read(&pinned)?;
+    pinned.revalidate()?;
+    Ok(value)
+}
+
+fn read_retrieval_publication_identity(
+    storage_path: &Path,
+    project_id: &str,
+) -> Result<RetrievalPublicationIdentity, ApiError> {
+    let storage = Store::open_read_only(storage_path).map_err(|error| {
+        ApiError::new("cache_busy", format!("open retrieval publication: {error}"))
+    })?;
+    let snapshot = storage.read_snapshot().map_err(|error| {
+        ApiError::new(
+            "cache_busy",
+            format!("pin retrieval publication identity: {error}"),
+        )
+    })?;
+    let identity = retrieval_publication_identity_from_storage(snapshot.storage(), project_id)
+        .map_err(|error| {
+            ApiError::new(
+                "cache_busy",
+                format!("read retrieval publication identity: {error}"),
+            )
+        })?;
+    snapshot.finish().map_err(|error| {
+        ApiError::new(
+            "cache_busy",
+            format!("finish retrieval publication identity: {error}"),
+        )
+    })?;
+    Ok(identity)
+}
+
+pub(crate) fn current_retrieval_publication_identity(
+    controller: &AppController,
+) -> Result<RetrievalPublicationIdentity, ApiError> {
+    let project_root = controller.require_project_root()?;
+    let storage_path = controller.require_storage_path()?;
+    let project_id = sidecar_project_id_for_root(&project_root);
+    read_retrieval_publication_identity(&storage_path, &project_id)
+}
+
+pub(crate) fn with_stable_retrieval_publication<T>(
+    controller: &AppController,
+    operation: &str,
+    mut build: impl FnMut() -> Result<T, ApiError>,
+) -> Result<T, ApiError> {
+    if !sidecar_retrieval_primary_enabled(controller) {
+        return build();
+    }
+    for attempt in 0..RETRIEVAL_PUBLICATION_ATTEMPTS {
+        let result = (|| {
+            let before = current_retrieval_publication_identity(controller)?;
+            let output = build()?;
+            if before != current_retrieval_publication_identity(controller)? {
+                return Err(ApiError::new(
+                    "cache_busy",
+                    format!("retrieval publication changed while building {operation}; retry"),
+                ));
+            }
+            Ok(output)
+        })();
+        match result {
+            Err(error)
+                if error.code == "cache_busy" && attempt + 1 < RETRIEVAL_PUBLICATION_ATTEMPTS => {}
+            result => return result,
+        }
+    }
+    unreachable!("bounded retrieval attempts always return")
+}
 
 fn env_flag_enabled(value: &str) -> bool {
     matches!(
@@ -386,6 +547,32 @@ pub(crate) fn run_sidecar_query(
     })
 }
 
+pub(crate) fn run_and_resolve_sidecar_query(
+    controller: &AppController,
+    query: &str,
+    max_results: usize,
+    latency_budget_ms: Option<u32>,
+) -> Result<(QueryResult, SidecarCandidateResolutionOutcome), ApiError> {
+    with_pinned_retrieval_read(controller, |pinned| {
+        let query_result =
+            run_sidecar_query(controller, query, latency_budget_ms).map_err(|error| {
+                sidecar_retrieval_unavailable_error(
+                    controller,
+                    format!("sidecar retrieval query failed: {error}"),
+                )
+            })?;
+        if !pinned.matches_query(&query_result) {
+            return Err(ApiError::new(
+                "cache_busy",
+                "sidecar query and core publications differ",
+            ));
+        }
+        let resolution =
+            resolve_sidecar_candidates_in_read(pinned, &query_result.hits, max_results)?;
+        Ok((query_result, resolution))
+    })
+}
+
 pub(crate) fn run_sidecar_query_batch(
     controller: &AppController,
     queries: &[(String, u64)],
@@ -459,6 +646,9 @@ pub(crate) enum SidecarPrimarySearchOutcome {
     Unavailable {
         reason: String,
     },
+    Retryable {
+        error: ApiError,
+    },
     Served {
         hits: Vec<SearchHit>,
         scored_hits: Vec<HybridSearchScoredHit>,
@@ -472,50 +662,33 @@ pub(crate) fn try_sidecar_primary_search(
     max_results: usize,
     latency_budget_ms: Option<u32>,
 ) -> Option<SidecarPrimarySearchOutcome> {
-    try_sidecar_primary_search_inner_with_query(
-        controller,
-        prompt,
-        max_results,
-        latency_budget_ms,
-        run_sidecar_query,
-    )
-}
-
-fn try_sidecar_primary_search_inner_with_query(
-    controller: &AppController,
-    prompt: &str,
-    max_results: usize,
-    latency_budget_ms: Option<u32>,
-    mut run_query: impl FnMut(&AppController, &str, Option<u32>) -> Result<QueryResult, AnyhowError>,
-) -> Option<SidecarPrimarySearchOutcome> {
     if !sidecar_retrieval_primary_enabled(controller) {
         return sidecar_retrieval_unavailable_reason(controller)
             .map(|reason| SidecarPrimarySearchOutcome::Unavailable { reason });
     }
-
-    let query_result = match run_query(controller, prompt, latency_budget_ms) {
-        Ok(result) => result,
-        Err(error) => {
-            return Some(SidecarPrimarySearchOutcome::Unavailable {
-                reason: format!("sidecar retrieval primary unavailable: {error}"),
-            });
+    match run_and_resolve_sidecar_query(controller, prompt, max_results, latency_budget_ms) {
+        Ok((query_result, resolution)) => Some(sidecar_primary_search_outcome_from_resolution(
+            controller,
+            query_result,
+            resolution,
+        )),
+        Err(error) if error.code == "cache_busy" => {
+            Some(SidecarPrimarySearchOutcome::Retryable { error })
         }
-    };
-
-    Some(sidecar_primary_search_outcome_from_query_result(
-        controller,
-        query_result,
-        max_results,
-    ))
+        Err(error) => Some(SidecarPrimarySearchOutcome::Unavailable {
+            reason: format!("sidecar retrieval primary unavailable: {}", error.message),
+        }),
+    }
 }
 
+#[cfg(test)]
 fn sidecar_primary_search_outcome_from_query_result(
     controller: &AppController,
     query_result: QueryResult,
     max_results: usize,
 ) -> SidecarPrimarySearchOutcome {
     let resolution =
-        match resolve_sidecar_candidates_with_stats(controller, &query_result.hits, max_results) {
+        match resolve_sidecar_candidates_for_test(controller, &query_result.hits, max_results) {
             Ok(hits) => hits,
             Err(error) => {
                 return SidecarPrimarySearchOutcome::Unavailable {
@@ -526,6 +699,14 @@ fn sidecar_primary_search_outcome_from_query_result(
                 };
             }
         };
+    sidecar_primary_search_outcome_from_resolution(controller, query_result, resolution)
+}
+
+fn sidecar_primary_search_outcome_from_resolution(
+    controller: &AppController,
+    query_result: QueryResult,
+    resolution: SidecarCandidateResolutionOutcome,
+) -> SidecarPrimarySearchOutcome {
     let resolved_hits = resolution.resolved_hits.clone();
     let shadow = shadow_from_query_result_with_candidate_admission_diagnostics(
         controller,
@@ -640,14 +821,45 @@ fn search_sidecar_packet_batch_inner(
     queries: &[(String, usize)],
     latency_budget_ms: Option<u32>,
 ) -> Result<SidecarPacketBatchOutcome, ApiError> {
-    search_sidecar_packet_batch_inner_with_query_batch(
-        controller,
-        queries,
-        latency_budget_ms,
-        run_sidecar_query_batch,
-    )
+    let per_query_budget = sidecar_packet_batch_budget_ms(latency_budget_ms)
+        .checked_div(queries.len().max(1) as u64)
+        .unwrap_or(100)
+        .max(100);
+    let batch_queries = queries
+        .iter()
+        .map(|(query, _)| (query.clone(), per_query_budget))
+        .collect::<Vec<_>>();
+    with_pinned_retrieval_read(controller, |pinned| {
+        let batch_started_at = Instant::now();
+        let query_results =
+            run_sidecar_query_batch(controller, &batch_queries).map_err(|error| {
+                sidecar_retrieval_unavailable_error(
+                    controller,
+                    format!("sidecar retrieval batch query failed: {error}"),
+                )
+            })?;
+        if query_results
+            .iter()
+            .any(|result| !pinned.matches_query(result))
+        {
+            return Err(ApiError::new(
+                "cache_busy",
+                "sidecar retrieval batch and core publications differ",
+            ));
+        }
+        build_sidecar_packet_batch_outcome(
+            controller,
+            queries,
+            query_results,
+            clamp_elapsed_ms(batch_started_at),
+            |query_result, max_results| {
+                resolve_sidecar_candidates_in_read(pinned, &query_result.hits, max_results)
+            },
+        )
+    })
 }
 
+#[cfg(test)]
 fn search_sidecar_packet_batch_inner_with_query_batch(
     controller: &AppController,
     queries: &[(String, usize)],
@@ -673,6 +885,24 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
         )
     })?;
     let batch_query_wall_ms = clamp_elapsed_ms(batch_started_at);
+    build_sidecar_packet_batch_outcome(
+        controller,
+        queries,
+        query_results,
+        batch_query_wall_ms,
+        |query_result, max_results| {
+            resolve_sidecar_candidates_for_test(controller, &query_result.hits, max_results)
+        },
+    )
+}
+
+fn build_sidecar_packet_batch_outcome(
+    controller: &AppController,
+    queries: &[(String, usize)],
+    query_results: Vec<QueryResult>,
+    batch_query_wall_ms: u32,
+    mut resolve: impl FnMut(&QueryResult, usize) -> Result<SidecarCandidateResolutionOutcome, ApiError>,
+) -> Result<SidecarPacketBatchOutcome, ApiError> {
     if query_results.len() != queries.len() {
         return Err(sidecar_retrieval_unavailable_error(
             controller,
@@ -698,17 +928,15 @@ fn search_sidecar_packet_batch_inner_with_query_batch(
         let sidecar_query_ms = u32::try_from(query_result.trace.elapsed_ms).unwrap_or(u32::MAX);
         let max_results = (*max_results).clamp(1, 50);
         let resolution_started_at = Instant::now();
-        let resolution =
-            resolve_sidecar_candidates_with_stats(controller, &query_result.hits, max_results)
-                .map_err(|error| {
-                    sidecar_retrieval_unavailable_error(
-                        controller,
-                        format!(
-                            "sidecar retrieval rejected packet batch query `{query}`: candidate resolution failed: {}",
-                            error.message
-                        ),
-                    )
-                })?;
+        let resolution = resolve(&query_result, max_results).map_err(|error| {
+            sidecar_retrieval_unavailable_error(
+                controller,
+                format!(
+                    "sidecar retrieval rejected packet batch query `{query}`: candidate resolution failed: {}",
+                    error.message
+                ),
+            )
+        })?;
         let candidate_resolution_ms = clamp_elapsed_ms(resolution_started_at);
         diagnostics.push(packet_sidecar_query_diagnostic(
             &query_result,
@@ -1479,15 +1707,27 @@ fn resolve_candidate_node_id(
         .or(Some(file_node_id))
 }
 
-pub(crate) fn resolve_sidecar_candidates_with_stats(
-    controller: &AppController,
+fn resolve_sidecar_candidates_in_read(
+    pinned: &PinnedRetrievalRead,
     candidates: &[CandidateHit],
     max_results: usize,
 ) -> Result<SidecarCandidateResolutionOutcome, ApiError> {
-    controller.ensure_search_state()?;
-    let storage = controller.open_storage()?;
-    let project_root = controller.require_project_root()?;
-    let node_names = controller.state.lock().node_names.clone();
+    resolve_sidecar_candidates_in_storage(
+        &pinned.storage,
+        &pinned.node_names,
+        &pinned.project_root,
+        candidates,
+        max_results,
+    )
+}
+
+fn resolve_sidecar_candidates_in_storage(
+    storage: &Store,
+    node_names: &HashMap<CoreNodeId, String>,
+    project_root: &Path,
+    candidates: &[CandidateHit],
+    max_results: usize,
+) -> Result<SidecarCandidateResolutionOutcome, ApiError> {
     let mut hits = Vec::new();
     let mut unresolved_candidates = Vec::new();
     let mut attempted_candidate_indices = HashSet::new();
@@ -1498,8 +1738,8 @@ pub(crate) fn resolve_sidecar_candidates_with_stats(
         .filter(|(_, candidate)| !is_phantom_sidecar_hit(candidate))
         .collect();
     ordered.sort_by(|(_, left), (_, right)| {
-        let left_resolvable = candidate_path_resolvable(&project_root, &left.file_path);
-        let right_resolvable = candidate_path_resolvable(&project_root, &right.file_path);
+        let left_resolvable = candidate_path_resolvable(project_root, &left.file_path);
+        let right_resolvable = candidate_path_resolvable(project_root, &right.file_path);
         right_resolvable.cmp(&left_resolvable).then(
             right
                 .score
@@ -1513,11 +1753,11 @@ pub(crate) fn resolve_sidecar_candidates_with_stats(
             break;
         }
         attempted_candidate_indices.insert(candidate_index);
-        let rel_path = normalize_repo_relative_path(&project_root, &candidate.file_path);
+        let rel_path = normalize_repo_relative_path(project_root, &candidate.file_path);
         let Some(node_id) =
-            resolve_candidate_node_id(&storage, &node_names, &project_root, &rel_path, candidate)
+            resolve_candidate_node_id(storage, node_names, project_root, &rel_path, candidate)
         else {
-            let label = if candidate_path_resolvable(&project_root, &candidate.file_path) {
+            let label = if candidate_path_resolvable(project_root, &candidate.file_path) {
                 "node_unresolved"
             } else {
                 "path_unresolvable"
@@ -1530,7 +1770,7 @@ pub(crate) fn resolve_sidecar_candidates_with_stats(
             continue;
         }
         let Some(mut hit) =
-            AppController::build_search_hit(&storage, &node_names, node_id, candidate.score)
+            AppController::build_search_hit(storage, node_names, node_id, candidate.score)
         else {
             unresolved_candidates.push((candidate, "hit_build_failed"));
             continue;
@@ -1555,6 +1795,29 @@ pub(crate) fn resolve_sidecar_candidates_with_stats(
         blocking_unresolved_candidate_count,
         attempted_candidate_indices,
     })
+}
+
+#[cfg(test)]
+fn resolve_sidecar_candidates_for_test(
+    controller: &AppController,
+    candidates: &[CandidateHit],
+    max_results: usize,
+) -> Result<SidecarCandidateResolutionOutcome, ApiError> {
+    let storage = controller.open_storage()?;
+    let project_root = controller.require_project_root()?;
+    let node_names = storage
+        .get_nodes()
+        .map_err(|error| ApiError::internal(format!("load test nodes: {error}")))?
+        .into_iter()
+        .map(|node| (node.id, crate::node_display_name(&node)))
+        .collect();
+    resolve_sidecar_candidates_in_storage(
+        &storage,
+        &node_names,
+        &project_root,
+        candidates,
+        max_results,
+    )
 }
 
 fn score_breakdown_for_candidate(candidate: &CandidateHit) -> RetrievalScoreBreakdownDto {
@@ -1636,6 +1899,8 @@ mod tests {
 
     fn retrieval_cache_key_for_test(query_fingerprint: &str) -> RetrievalCacheKey {
         RetrievalCacheKey {
+            core_generation_id: None,
+            core_run_id: None,
             project_id: "abc".into(),
             lexical_version: "v1".into(),
             qdrant_collection: "codestory_abc".into(),
@@ -1877,6 +2142,7 @@ mod tests {
     #[test]
     fn unresolved_sidecar_candidates_are_diagnostic_only() {
         let result = QueryResult {
+            publication_identity: None,
             query: "application use".into(),
             features: classify_query("application use"),
             hits: vec![CandidateHit::with_source(
@@ -1914,6 +2180,7 @@ mod tests {
     #[test]
     fn shadow_maps_unavailable_trace() {
         let shadow = shadow_from_query_result(QueryResult {
+            publication_identity: None,
             query: "extension".into(),
             features: classify_query("extension"),
             hits: Vec::new(),
@@ -1938,6 +2205,7 @@ mod tests {
     #[test]
     fn shadow_maps_stage_timings_and_would_rank() {
         let shadow = shadow_from_query_result(QueryResult {
+            publication_identity: None,
             query: "extension".into(),
             features: classify_query("ExtensionService"),
             hits: vec![
@@ -2063,6 +2331,7 @@ mod tests {
         candidate.start_line = Some(42);
         let shadow = shadow_from_query_result_with_counts_and_resolution_labels(
             QueryResult {
+                publication_identity: None,
                 query: "handler".into(),
                 features: classify_query("handler"),
                 hits: vec![candidate],
@@ -2115,6 +2384,7 @@ mod tests {
     #[test]
     fn shadow_marks_only_bare_dense_anchors_as_diagnostic_only() {
         let dense_anchor = QueryResult {
+            publication_identity: None,
             query: "apii".into(),
             features: classify_query("apii"),
             hits: vec![CandidateHit::with_source(
@@ -2145,6 +2415,7 @@ mod tests {
         assert_eq!(value["diagnostic_only"], true);
 
         let missing_path = QueryResult {
+            publication_identity: None,
             query: "StringUtils".into(),
             features: classify_query("StringUtils"),
             hits: vec![CandidateHit::with_source(
@@ -2179,6 +2450,7 @@ mod tests {
     fn shadow_marks_non_parser_backed_file_candidates_diagnostic_only_with_source_hits() {
         let shadow = shadow_from_query_result_with_counts_and_resolution_labels(
             QueryResult {
+                publication_identity: None,
                 query: "form validation".into(),
                 features: classify_query("form validation"),
                 hits: vec![
@@ -2287,6 +2559,7 @@ mod tests {
     fn shadow_candidate_summaries_include_admission_diagnostics() {
         let shadow = shadow_from_query_result_with_counts_and_resolution_labels(
             QueryResult {
+                publication_identity: None,
                 query: "exec json flow".into(),
                 features: classify_query("exec json flow"),
                 hits: vec![
@@ -2574,6 +2847,122 @@ mod tests {
             .expect("manifest");
     }
 
+    #[test]
+    fn pinned_read_resolves_the_original_generation_and_rejects_publication_drift() {
+        use codestory_retrieval::CandidateSource;
+        use codestory_store::{FileInfo, FileRole, IndexPublicationMode, IndexPublicationRecord};
+
+        let project = tempfile::tempdir().expect("project");
+        let source_path = project.path().join("src/lib.rs");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("create source parent");
+        std::fs::write(&source_path, "fn original() {}\n").expect("write source");
+        let storage_path = project.path().join("cache/codestory.db");
+        std::fs::create_dir_all(storage_path.parent().expect("storage parent"))
+            .expect("create storage parent");
+        let project_id = sidecar_project_id_for_root(project.path());
+
+        let mut storage = Store::open(&storage_path).expect("open storage");
+        storage
+            .insert_file(&FileInfo {
+                id: 1,
+                path: source_path.clone(),
+                language: "rust".into(),
+                modification_time: 1,
+                indexed: true,
+                complete: true,
+                line_count: 1,
+                file_role: FileRole::Source,
+            })
+            .expect("insert file");
+        let original_node = codestory_contracts::graph::Node {
+            id: CoreNodeId(2),
+            kind: NodeKind::FUNCTION,
+            serialized_name: "original".into(),
+            file_node_id: Some(CoreNodeId(1)),
+            start_line: Some(1),
+            ..Default::default()
+        };
+        storage
+            .insert_nodes_batch(&[
+                codestory_contracts::graph::Node {
+                    id: CoreNodeId(1),
+                    kind: NodeKind::FILE,
+                    serialized_name: source_path.to_string_lossy().into_owned(),
+                    file_node_id: Some(CoreNodeId(1)),
+                    start_line: Some(1),
+                    ..Default::default()
+                },
+                original_node,
+            ])
+            .expect("insert nodes");
+        storage
+            .put_index_publication(&IndexPublicationRecord {
+                generation: 1,
+                generation_id: "11111111-1111-4111-8111-111111111111".into(),
+                run_id: "run-one".into(),
+                mode: IndexPublicationMode::Full,
+                published_at_epoch_ms: 1,
+            })
+            .expect("publish first identity");
+        let first_manifest = retrieval_manifest_fixture(&project_id, "first");
+        storage
+            .upsert_retrieval_index_manifest(&first_manifest)
+            .expect("publish first manifest");
+        drop(storage);
+
+        let controller = AppController::new();
+        {
+            let mut state = controller.state.lock();
+            state.project_root = Some(project.path().to_path_buf());
+            state.storage_path = Some(storage_path.clone());
+        }
+        let pinned = PinnedRetrievalRead::begin(&controller).expect("pin first publication");
+
+        let mut writer = Store::open(&storage_path).expect("open publication writer");
+        writer
+            .insert_nodes_batch(&[codestory_contracts::graph::Node {
+                id: CoreNodeId(2),
+                kind: NodeKind::FUNCTION,
+                serialized_name: "replacement".into(),
+                file_node_id: Some(CoreNodeId(1)),
+                start_line: Some(1),
+                ..Default::default()
+            }])
+            .expect("reuse numeric id in replacement generation");
+        writer
+            .put_index_publication(&IndexPublicationRecord {
+                generation: 2,
+                generation_id: "22222222-2222-4222-8222-222222222222".into(),
+                run_id: "run-two".into(),
+                mode: IndexPublicationMode::Full,
+                published_at_epoch_ms: 2,
+            })
+            .expect("publish replacement identity");
+        let replacement_manifest = retrieval_manifest_fixture(&project_id, "second");
+        writer
+            .upsert_retrieval_index_manifest(&replacement_manifest)
+            .expect("publish replacement manifest");
+        drop(writer);
+
+        let mut candidate = CandidateHit::with_source(
+            "src/lib.rs",
+            Some("original".into()),
+            1.0,
+            CandidateSource::Scip,
+        );
+        candidate.node_id = Some("2".into());
+        let resolution = resolve_sidecar_candidates_in_read(&pinned, &[candidate], 1)
+            .expect("resolve against pinned snapshot");
+        assert_eq!(resolution.resolved_hits.len(), 1);
+        assert_eq!(resolution.resolved_hits[0].display_name, "original");
+
+        let error = pinned
+            .revalidate()
+            .expect_err("publication drift must reject the result");
+        assert_eq!(error.code, "cache_busy");
+    }
+
     fn git_project() -> Option<tempfile::TempDir> {
         if std::process::Command::new("git")
             .arg("--version")
@@ -2624,6 +3013,7 @@ mod tests {
         use codestory_retrieval::{CandidateSource, classify_query};
 
         let empty_full = QueryResult {
+            publication_identity: None,
             query: "handler".into(),
             features: classify_query("handler"),
             hits: Vec::new(),
@@ -2643,6 +3033,7 @@ mod tests {
         );
 
         let unresolved = QueryResult {
+            publication_identity: None,
             query: "handler".into(),
             features: classify_query("handler"),
             hits: vec![CandidateHit::with_source(
@@ -2680,6 +3071,7 @@ mod tests {
             );
             let resolved_hit = search_hit_for_candidate(&candidate);
             let result = QueryResult {
+                publication_identity: None,
                 query: "handler".into(),
                 features: classify_query("handler"),
                 hits: vec![candidate],
@@ -2709,6 +3101,7 @@ mod tests {
 
         for mode in ["no_semantic", "no_scip", "lexical_only", "unavailable"] {
             let result = QueryResult {
+                publication_identity: None,
                 query: "handler".into(),
                 features: classify_query("handler"),
                 hits: Vec::new(),
@@ -2737,6 +3130,7 @@ mod tests {
         use codestory_retrieval::{CandidateSource, classify_query};
 
         let empty_full = QueryResult {
+            publication_identity: None,
             query: "unlikely symbol".into(),
             features: classify_query("unlikely symbol"),
             hits: Vec::new(),
@@ -2764,6 +3158,7 @@ mod tests {
         assert!(empty_diagnostic.diagnostic.is_none());
 
         let unresolved = QueryResult {
+            publication_identity: None,
             query: "handler".into(),
             features: classify_query("handler"),
             hits: vec![CandidateHit::with_source(
@@ -2801,6 +3196,7 @@ mod tests {
         );
 
         let cancelled = QueryResult {
+            publication_identity: None,
             query: "handler".into(),
             features: classify_query("handler"),
             hits: vec![CandidateHit::with_source(
@@ -2896,6 +3292,7 @@ mod tests {
         );
         resolved_candidate.node_id = Some("2".to_string());
         let query_result = QueryResult {
+            publication_identity: None,
             query: "alpha".into(),
             features: classify_query("alpha"),
             hits: vec![
@@ -2918,7 +3315,7 @@ mod tests {
             },
         };
 
-        let resolution = resolve_sidecar_candidates_with_stats(&controller, &query_result.hits, 1)
+        let resolution = resolve_sidecar_candidates_for_test(&controller, &query_result.hits, 1)
             .expect("resolve sidecar candidates");
         assert_eq!(resolution.attempted_candidate_indices.len(), 1);
         assert_eq!(resolution.resolved_hits.len(), 1);
@@ -2934,7 +3331,7 @@ mod tests {
         );
 
         let mixed_resolution =
-            resolve_sidecar_candidates_with_stats(&controller, &query_result.hits, 2)
+            resolve_sidecar_candidates_for_test(&controller, &query_result.hits, 2)
                 .expect("resolve mixed sidecar candidates");
         assert_eq!(mixed_resolution.attempted_candidate_indices.len(), 2);
         assert_eq!(mixed_resolution.resolved_hits.len(), 1);
@@ -2953,6 +3350,7 @@ mod tests {
         use codestory_retrieval::{CandidateSource, classify_query};
 
         let unavailable = QueryResult {
+            publication_identity: None,
             query: "handler".into(),
             features: classify_query("handler"),
             hits: Vec::new(),
@@ -2972,6 +3370,7 @@ mod tests {
         );
 
         let unresolved = QueryResult {
+            publication_identity: None,
             query: "handler".into(),
             features: classify_query("handler"),
             hits: vec![CandidateHit::with_source(
@@ -3018,6 +3417,7 @@ mod tests {
             |_, batch| {
                 assert_eq!(batch, &[("helpers".to_string(), 500)]);
                 Ok(vec![QueryResult {
+                    publication_identity: None,
                     query: "helpers".into(),
                     features: classify_query("helpers"),
                     hits: vec![CandidateHit::with_source(
@@ -3093,6 +3493,7 @@ mod tests {
                 Ok(batch
                     .iter()
                     .map(|(query, budget)| QueryResult {
+                        publication_identity: None,
                         query: query.to_string(),
                         features: classify_query(query),
                         hits: Vec::new(),
@@ -3137,6 +3538,7 @@ mod tests {
             |_, batch| {
                 assert_eq!(batch, &[("handler".to_string(), 500)]);
                 Ok(vec![QueryResult {
+                    publication_identity: None,
                     query: "handler".into(),
                     features: classify_query("handler"),
                     hits: vec![CandidateHit::with_source(
@@ -3185,6 +3587,7 @@ mod tests {
             .expect("remove storage parent");
 
         let query_result = QueryResult {
+            publication_identity: None,
             query: "handler".into(),
             features: classify_query("handler"),
             hits: vec![CandidateHit::with_source(
@@ -3278,6 +3681,7 @@ mod tests {
         );
         candidate.node_id = Some("2".to_string());
         let query_result = QueryResult {
+            publication_identity: None,
             query: "Explain how CodeStory validates packaged agent readiness.".into(),
             features: classify_query("Explain how CodeStory validates packaged agent readiness."),
             hits: vec![candidate],
@@ -3306,6 +3710,9 @@ mod tests {
             }
             SidecarPrimarySearchOutcome::Unavailable { reason } => {
                 panic!("resolved cancelled packet primary trace should stay available: {reason}")
+            }
+            SidecarPrimarySearchOutcome::Retryable { error } => {
+                panic!("resolved cancelled packet primary trace should not retry: {error:?}")
             }
         }
     }

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -9846,6 +9846,12 @@ impl AppController {
     /// The returned retrieval state distinguishes full sidecar evidence from degraded or
     /// diagnostic-only paths. Callers should not collapse those states into a generic success.
     pub fn search_results(&self, req: SearchRequest) -> Result<SearchResultsDto, ApiError> {
+        agent::retrieval_primary::with_stable_retrieval_publication(self, "search output", || {
+            self.search_results_once(req.clone())
+        })
+    }
+
+    fn search_results_once(&self, req: SearchRequest) -> Result<SearchResultsDto, ApiError> {
         self.ensure_consistent_read_state("Search")?;
         let original_query = req.query.clone();
         let intent_query = parse_search_intent_query(&original_query);
@@ -9884,27 +9890,12 @@ impl AppController {
         }
 
         let query = intent_query.effective_query.clone();
-        let query_result = agent::retrieval_primary::run_sidecar_query(self, &query, None)
-            .map_err(|error| {
-                agent::retrieval_primary::sidecar_retrieval_unavailable_error(
-                    self,
-                    format!("sidecar search failed: {error}"),
-                )
-            })?;
-        let resolution = agent::retrieval_primary::resolve_sidecar_candidates_with_stats(
+        let (query_result, resolution) = agent::retrieval_primary::run_and_resolve_sidecar_query(
             self,
-            &query_result.hits,
+            &query,
             limit_per_source,
-        )
-        .map_err(|error| {
-            agent::retrieval_primary::sidecar_retrieval_unavailable_error(
-                self,
-                format!(
-                    "sidecar search rejected query: candidate resolution failed: {}",
-                    error.message
-                ),
-            )
-        })?;
+            None,
+        )?;
         let mut indexed_symbol_hits = resolution.resolved_hits.clone();
         if let Some(reason) = agent::retrieval_primary::sidecar_primary_result_rejection_reason(
             &query_result,
@@ -11009,7 +11000,9 @@ impl AppController {
     /// Degraded sidecar state is reported through retrieval diagnostics or an error rather than
     /// silently substituting legacy search as answer-quality proof.
     pub fn agent_ask(&self, req: AgentAskRequest) -> Result<AgentAnswerDto, ApiError> {
-        agent::agent_ask(self, req)
+        agent::retrieval_primary::with_stable_retrieval_publication(self, "agent answer", || {
+            agent::agent_ask(self, req.clone())
+        })
     }
 
     pub fn begin_packet_retrieval(&self) {
@@ -11028,7 +11021,9 @@ impl AppController {
     /// candidates that fail symbol resolution remain diagnostics and do not become supported
     /// claims merely because retrieval returned them.
     pub fn agent_packet(&self, req: AgentPacketRequestDto) -> Result<AgentPacketDto, ApiError> {
-        agent::agent_packet(self, req)
+        agent::retrieval_primary::with_stable_retrieval_publication(self, "packet output", || {
+            agent::agent_packet(self, req.clone())
+        })
     }
 
     pub fn graph_neighborhood(&self, req: GraphRequest) -> Result<GraphResponse, ApiError> {

--- a/crates/codestory-runtime/tests/retrieval_primary_rejection.rs
+++ b/crates/codestory-runtime/tests/retrieval_primary_rejection.rs
@@ -24,6 +24,7 @@ fn phantom_only_candidates_are_detected() {
     ]));
 
     let _query = QueryResult {
+        publication_identity: None,
         query: "handler".into(),
         features: classify_query("handler"),
         hits,


### PR DESCRIPTION
Closes #1099
Refs #899

## Summary
- stamp retrieval results with the core and sidecar publication that produced them
- hold core SQLite snapshots plus global and project sidecar-generation leases through candidate resolution
- key and merge query caches by core publication, revalidate final search, packet, and ask output, and retry publication drift once
- rescan lexical source inside the publication fence before committing a sidecar manifest

## Verification
- `cargo test -p codestory-retrieval --lib --locked` (365 passed, 2 ignored)
- `cargo test -p codestory-runtime --lib --locked` (638 passed, 1 ignored)
- focused cache-publication, source-drift, and numeric-ID race tests after the final rebase
- retrieval and runtime clippy with `-D warnings`
- `cargo check -p codestory-runtime --locked`
- `cargo fmt --all -- --check`
- independent blocker review, then exact-head re-review: ready

## Line delta and simplification
- Rust source including inline tests: +727/-109
- standalone test surface: +1/-0
- changelog: +4/-0
- one numeric-ID publication race protects the credible failure boundary; no branch-by-branch test matrix was added
- retry ownership is consolidated at the public output surface, publication identity stays out of serialized query output, and the old current-storage candidate reopen path was removed
