### PR TITLE
[codex] parse workflow policy structurally

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -1,839 +1,746 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { LineCounter, parseDocument } from "yaml";
 
 const workflowRoot = path.join(".github", "workflows");
-const trustedOwners = new Set(["actions", "github"]);
-const shaPattern = /^[0-9a-f]{40}$/i;
-const violations = [];
-const sagaIssueLinkGuard = path.join(workflowRoot, "saga-issue-link-guard.yml");
-const closeDevIssues = path.join(workflowRoot, "close-dev-issues.yml");
-const pluginStatic = path.join(workflowRoot, "plugin-static.yml");
-const rustCi = path.join(workflowRoot, "rust-ci.yml");
-const autoRelease = path.join(workflowRoot, "auto-release.yml");
-const releaseWorkflow = path.join(workflowRoot, "release.yml");
-const releaseCandidateEvidence = path.join(workflowRoot, "release-candidate-evidence.yml");
-const releaseNotesExtractor = path.join(".github", "scripts", "extract-codestory-release-notes.mjs");
-const postPublishReleaseSmoke = path.join(workflowRoot, "post-publish-release-smoke.yml");
-const packagedPlatformPr = path.join(workflowRoot, "packaged-platform-pr.yml");
-const packagedPlatformProof = path.join(workflowRoot, "packaged-platform-proof.yml");
-const macosMetalProof = path.join(workflowRoot, "macos-metal-proof.yml");
-const mainBranchSourceGuard = path.join(workflowRoot, "main-branch-source-guard.yml");
-const sourceProof = path.join(workflowRoot, "source-proof.yml");
-const repoScaleStats = path.join(workflowRoot, "repo-scale-stats.yml");
-const retrievalSidecarSmoke = path.join(workflowRoot, "retrieval-sidecar-smoke.yml");
+const trustedActionOwners = new Set(["actions", "github"]);
+const fullSha = /^[0-9a-f]{40}$/iu;
 
-function yamlMapping(content, name, indent) {
-  const lines = content.split(/\r?\n/u);
-  const padding = " ".repeat(indent);
-  const start = lines.indexOf(`${padding}${name}:`);
-  if (start < 0) return [];
-  const sibling = new RegExp(`^${padding}\\S`, "u");
-  const end = lines.findIndex((line, index) => index > start && sibling.test(line));
-  return lines.slice(start, end < 0 ? undefined : end);
+function object(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : {};
 }
 
-function yamlJob(content, name) {
-  return yamlMapping(content, name, 2);
+function list(value) {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
 }
 
-function namedStep(job, name) {
-  const start = job.indexOf(`      - name: ${name}`);
-  if (start < 0) return [];
-  const relativeEnd = job.slice(start + 1).findIndex((line) => /^      - /u.test(line));
-  return job.slice(start, relativeEnd < 0 ? undefined : start + 1 + relativeEnd);
-}
-
-function yamlJobWithValue(job, key) {
-  const withStart = job.indexOf("    with:");
-  if (withStart < 0) return undefined;
-  const relativeEnd = job.slice(withStart + 1).findIndex((line) => /^    \S/u.test(line));
-  const withLines = job.slice(
-    withStart + 1,
-    relativeEnd < 0 ? undefined : withStart + 1 + relativeEnd,
-  );
-  const prefix = `      ${key}:`;
-  const values = withLines
-    .filter((line) => line.startsWith(prefix))
-    .map((line) => line.slice(prefix.length).trim());
-  return values.length === 1 ? values[0] : undefined;
-}
-
-function packagedPrSigningPolicyViolations(content) {
-  const found = [];
-  const packagedProofJob = yamlJob(content, "packaged-proof");
-  if (yamlJobWithValue(packagedProofJob, "sign_macos") !== "false") {
-    found.push("named packaged-proof job must set with.sign_macos to false");
+function at(value, ...keys) {
+  let current = value;
+  for (const key of keys) {
+    if (current === null || typeof current !== "object") return undefined;
+    current = current[key];
   }
-  if (packagedProofJob.some((line) => /^    secrets:/u.test(line))) {
-    found.push("named packaged-proof job must not receive caller secrets");
-  }
-  if (/\bAPPLE_[A-Z0-9_]+\b/u.test(content)) {
-    found.push("must not reference Apple secret identifiers");
-  }
-  if (content.includes("macos-release-signing")) {
-    found.push("must not reference the release signing environment");
+  return current;
+}
+
+function scalarStrings(value, found = []) {
+  if (typeof value === "string") {
+    found.push(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) scalarStrings(item, found);
+  } else if (value !== null && typeof value === "object") {
+    for (const item of Object.values(value)) scalarStrings(item, found);
   }
   return found;
 }
 
-function requireContent(content, requirements, violationFor) {
-  for (const requirement of requirements) {
-    if (!content.includes(requirement)) {
-      violations.push(violationFor(requirement));
-    }
-  }
+function includesAll(values, expected) {
+  const present = new Set(list(values));
+  return expected.every(value => present.has(value));
 }
 
-function unlockedCargoCommandLines(content) {
-  return content
+function sameMembers(actual, expected) {
+  const left = [...new Set(list(actual))].sort();
+  const right = [...new Set(expected)].sort();
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function needs(job) {
+  return list(job?.needs);
+}
+
+function namedStep(job, name) {
+  const matches = list(job?.steps).filter(step => object(step).name === name);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function stepRun(job, name) {
+  const run = namedStep(job, name)?.run;
+  return typeof run === "string" ? run : "";
+}
+
+function executableRunText(run) {
+  return run
     .split(/\r?\n/u)
-    .map((line, index) => ({ line, number: index + 1 }))
-    .filter(({ line }) => /\bcargo\s+(?:build|check|test|clippy|doc|run)\b/u.test(line))
-    .filter(({ line }) => !/\s--locked(?:\s|$)/u.test(line));
+    .filter(line => !/^\s*#/u.test(line))
+    .join("\n");
 }
 
-const cargoLockPolicyFixture = [
-  "run: cargo test --workspace",
-  "run: cargo test --workspace --locked",
-].join("\n");
-if (
-  unlockedCargoCommandLines(cargoLockPolicyFixture).map(({ number }) => number).join(",") !== "1"
-) {
-  violations.push("Cargo lock policy self-test must reject only the unlocked fixture");
+function add(violations, condition, message) {
+  if (!condition) violations.push(message);
 }
 
-function managedPluginMatrixIsRequired(content, jobName, archiveLine) {
-  const job = yamlJob(content, jobName);
-  const step = namedStep(job, "Prove managed plugin handoff");
-  const required = [
-    "        run: >-",
-    "          python .github/scripts/check-packaged-agent-proof.py",
-    archiveLine,
-    "          --managed-plugin-handoff",
-  ];
-  return !(
-    job.length === 0 ||
-    job.some((line) => /^    (?:if|continue-on-error):/u.test(line)) ||
-    !job.includes("      fail-fast: false") ||
-    job.some(
-      (line) =>
-        /^\s+exclude:/u.test(line) &&
-        !line.includes("fromJSON(inputs.scope == 'macos'"),
-    ) ||
-    step.length === 0 ||
-    step.some((line) => /^        (?:if|continue-on-error):/u.test(line)) ||
-    required.some((line) => !step.includes(line))
-  );
-}
-
-function requireManagedPluginStep(content, jobName, workflowName, archiveLine) {
-  if (!managedPluginMatrixIsRequired(content, jobName, archiveLine)) {
-    violations.push(`${workflowName} must run the managed plugin handoff unconditionally in every matrix cell`);
-  }
-  const matrixBypass = content.includes("      matrix: ${{ fromJSON")
-    ? content.replace(
-        /^      matrix: \$\{\{ fromJSON.*$/mu,
-        "      matrix:\n        exclude:\n          - os: never",
-      )
-    : content.replace("      matrix:\n", "      matrix:\n        exclude:\n          - os: never\n");
-  const policyBypasses = [
-    ["fail-fast", content.replace("      fail-fast: false\n", "")],
-    ["matrix exclude", matrixBypass],
-    ["job if", content.replace(`  ${jobName}:\n`, `  ${jobName}:\n    if: always()\n`)],
-    [
-      "job continue-on-error",
-      content.replace(`  ${jobName}:\n`, `  ${jobName}:\n    continue-on-error: true\n`),
-    ],
-    [
-      "step if",
-      content.replace(
-        "      - name: Prove managed plugin handoff\n",
-        "      - name: Prove managed plugin handoff\n        if: always()\n",
-      ),
-    ],
-    [
-      "step continue-on-error",
-      content.replace(
-        "      - name: Prove managed plugin handoff\n",
-        "      - name: Prove managed plugin handoff\n        continue-on-error: true\n",
-      ),
-    ],
-  ];
-  const acceptedBypasses = policyBypasses
-    .filter(([, candidate]) => managedPluginMatrixIsRequired(candidate, jobName, archiveLine))
-    .map(([name]) => name);
-  if (acceptedBypasses.length > 0) {
-    violations.push(`${workflowName} managed matrix policy accepted bypasses: ${acceptedBypasses.join(", ")}`);
-  }
-}
-
-for (const file of fs
-  .readdirSync(workflowRoot)
-  .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))) {
-  const workflowPath = path.join(workflowRoot, file);
-  const content = fs.readFileSync(workflowPath, "utf8");
-
-  if (/^  pull_request(?:_target)?:/mu.test(content)) {
-    if (!/^concurrency:/mu.test(content) || !/^  cancel-in-progress: true$/mu.test(content)) {
-      violations.push(`${file} pull-request runs must cancel stale work`);
-    }
-  }
-
-  content.split(/\r?\n/).forEach((line, index) => {
-    if (/^\s+key:/u.test(line) && line.includes("github.sha")) {
-      violations.push(`${file}:${index + 1} Cargo cache keys must not include commit SHA`);
-    }
-    const match = line.match(/\buses:\s*['"]?([^'"\s#]+)['"]?/);
-    if (!match) return;
-
-    const spec = match[1];
-    if (spec.startsWith("./")) return;
-
-    const at = spec.lastIndexOf("@");
-    if (at === -1) {
-      violations.push(`${file}:${index + 1} ${spec} is missing a ref`);
-      return;
-    }
-
-    const action = spec.slice(0, at);
-    const ref = spec.slice(at + 1);
-    const owner = action.split("/")[0];
-
-    if (!trustedOwners.has(owner) && !shaPattern.test(ref)) {
-      violations.push(
-        `${file}:${index + 1} ${spec} must pin third-party actions to a full-length SHA`,
-      );
-    }
-  });
-  for (const { number } of unlockedCargoCommandLines(content)) {
-    violations.push(`${file}:${number} dependency-resolving Cargo commands must use --locked`);
-  }
-}
-
-const lockedSetupSurfaces = [
-  [
-    path.join(".cargo", "config.toml"),
-    [
-      'retrieval-setup = "run --locked -p codestory-cli',
-      'retrieval-status = "run --locked -p codestory-cli',
-    ],
-  ],
-  [
-    path.join("scripts", "codex-worktree-setup.mjs"),
-    ['["build", "--release", "--locked", "-p", "codestory-cli"]'],
-  ],
-  [
-    path.join("plugins", "codestory", "skills", "codestory-grounding", "scripts", "setup.sh"),
-    ["cargo build --release --locked -p codestory-cli"],
-  ],
-  [
-    path.join("plugins", "codestory", "skills", "codestory-grounding", "scripts", "setup.ps1"),
-    ['@("build", "--release", "--locked", "-p", "codestory-cli"'],
-  ],
-  [
-    path.join("scripts", "setup-retrieval-env.mjs"),
-    ['return ["run", "--locked", ...args]'],
-  ],
-];
-for (const [surface, requirements] of lockedSetupSurfaces) {
-  const content = fs.readFileSync(surface, "utf8");
-  requireContent(
-    content,
-    requirements,
-    requirement => `${surface} must preserve locked Cargo setup contract ${requirement}`,
-  );
-}
-
-if (fs.existsSync(sagaIssueLinkGuard)) {
-  const content = fs.readFileSync(sagaIssueLinkGuard, "utf8");
-  const closingRef =
-    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:#\d+|https:\/\/github\.com\/TheGreenCedar\/CodeStory\/issues\/\d+)\b/im;
-
-  if (!content.includes("review/codestory-saga-")) {
-    violations.push("saga-issue-link-guard.yml must guard review/codestory-saga-* branches");
-  }
-
-  if (
-    !content.includes(
-      'r"(?:#\\d+|https://github\\.com/TheGreenCedar/CodeStory/issues/\\d+)\\b"',
-    )
-  ) {
-    violations.push("saga-issue-link-guard.yml closing refs must require # or a full issue URL");
-  }
-
-  if (
-    closingRef.test("Closes 123") ||
-    !closingRef.test("Closes #123") ||
-    !closingRef.test("Closes https://github.com/TheGreenCedar/CodeStory/issues/123")
-  ) {
-    violations.push("saga-issue-link-guard.yml closing ref policy must reject bare numbers and accept # or full issue URLs");
-  }
-}
-
-if (!fs.existsSync(closeDevIssues)) {
-  violations.push("close-dev-issues.yml must close linked issues for merged dev PRs");
-} else {
-  const content = fs.readFileSync(closeDevIssues, "utf8");
-  const requiredSnippets = [
-    "push:",
-    "dev/codestory-next",
-    'commit = event["after"]',
-    'pull_request.get("merged_at")',
-    'pull_request.get("merge_commit_sha") == commit',
-    "issues: write",
-    'if "pull_request" in issue:',
-    '"state_reason=completed"',
-  ];
-
-  requireContent(content, requiredSnippets, snippet => `close-dev-issues.yml must include ${snippet}`);
-
-  if (
-    !content.includes(
-      'r"(?:#(\\d+)|https://github\\.com/TheGreenCedar/CodeStory/issues/(\\d+))\\b"',
-    )
-  ) {
-    violations.push("close-dev-issues.yml must accept only # or same-repository issue URLs");
-  }
-}
-
-if (!fs.existsSync(pluginStatic)) {
-  violations.push("plugin-static.yml must run plugin static tests for plugin changes");
-} else {
-  const content = fs.readFileSync(pluginStatic, "utf8");
-  const requiredSnippets = [
-    "plugins/codestory/**",
-    "dev/codestory-next",
-    "node --test plugins/codestory/tests/plugin-static.test.mjs",
-    "node .github/scripts/check-workflow-policy.mjs",
-    "node .github/scripts/route-ci-proof.mjs --self-test",
-    "python .github/scripts/check-packaged-agent-proof.py --self-test",
-    "python .github/scripts/package-codestory-release.py --self-test",
-    "python .github/scripts/check-codestory-release.py --version",
-    ".github/scripts/check-packaged-agent-proof.py",
-    ".github/scripts/package-codestory-release.py",
-    ".github/scripts/route-ci-proof.mjs",
-    ".github/workflows/release.yml",
-    ".github/workflows/post-publish-release-smoke.yml",
-    ".github/workflows/packaged-platform-pr.yml",
-    ".github/workflows/packaged-platform-proof.yml",
-    ".github/workflows/macos-metal-proof.yml",
-    ".github/workflows/source-proof.yml",
-    ".github/workflows/repo-scale-stats.yml",
-    "scripts/codex-worktree-setup.*",
-    "scripts/tests/codex-worktree-setup.test.mjs",
-    "scripts/setup-retrieval-env.*",
-    "scripts/install-codestory.ps1",
-  ];
-
-  requireContent(content, requiredSnippets, snippet => `plugin-static.yml must include ${snippet}`);
-}
-
-if (!fs.existsSync(rustCi)) {
-  violations.push("rust-ci.yml must run default Rust workspace checks for routine code changes");
-} else {
-  const content = fs.readFileSync(rustCi, "utf8");
-  const requiredSnippets = [
-    "Cargo.lock",
-    "Cargo.toml",
-    "crates/**",
-    "cargo fmt --check",
-    "cargo check --workspace --locked",
-    "cargo clippy --workspace --lib --locked -- -D warnings",
-    "Prove focused publication contracts",
-    "workspace-default-features",
-    "cancel-in-progress: true",
-  ];
-
-  requireContent(content, requiredSnippets, snippet => `rust-ci.yml must include ${snippet}`);
-  if (content.includes("macos-") || content.includes("windows-") || content.includes("push:")) {
-    violations.push("rust-ci.yml draft pushes must use one Ubuntu-only lane");
-  }
-}
-
-if (!fs.existsSync(sourceProof)) {
-  violations.push("source-proof.yml must own exact-head full source proof");
-} else {
-  const content = fs.readFileSync(sourceProof, "utf8");
-  requireContent(content, [
-    "types: [labeled, synchronize]",
-    "review-accepted",
-    'test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY"',
-    'test "$current_head" = "$EVENT_HEAD_SHA"',
-    "name: full-source-gate",
-    "cargo test --workspace --locked",
-    "cargo clippy --workspace --all-targets --all-features --locked -- -D warnings",
-    "cancel-in-progress: true",
-  ], snippet => `source-proof.yml must include ${snippet}`);
-  if (content.includes("pull_request_target:")) {
-    violations.push("source-proof.yml must not execute pull-request code through pull_request_target");
-  }
-}
-
-if (!fs.existsSync(releaseWorkflow)) {
-  violations.push("release.yml must exist for release automation");
-} else {
-  const content = fs.readFileSync(releaseWorkflow, "utf8");
-  if (content.includes("rustup toolchain install stable")) {
-    violations.push("release.yml release builds must not install floating stable Rust");
-  }
-  requireContent(content, [
-    "actions: read",
-    "uses: ./.github/workflows/packaged-platform-proof.yml",
-    "sign_macos: true",
-    "APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}",
-    "APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}",
-    "APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}",
-    "APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}",
-    "APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}",
-    "APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}",
-    "uses: ./.github/workflows/macos-metal-proof.yml",
-    "use_packaged_cli_artifact: true",
-    "version: ${{ needs.preflight.outputs.version }}",
-    "uses: ./.github/workflows/post-publish-release-smoke.yml",
-    "Validate versioned changelog notes",
-    "Compose versioned GitHub release notes",
-    "node .github/scripts/extract-codestory-release-notes.mjs",
-    "--notes-file target/release-assets/release-notes.md",
-    'if [ "${#assets[@]}" -ne 7 ]; then',
-    "Expected six binary archives plus SHA256SUMS.txt",
-    "macOS x64/arm64",
-    "gated on packaged managed-Metal cold/warm reuse, dead-endpoint blocking, recovery, packet, and search proof",
-    "Linux x64 is packaged and executed at the glibc 2.31 baseline; this does not claim musl support or Linux arm64 baseline parity.",
-  ], snippet => `release.yml must include ${snippet}`);
-  const releaseEvidenceJob = yamlJob(content, "release-evidence");
-  requireContent(releaseEvidenceJob.join("\n"), [
-    "needs: preflight",
-    "ref: ${{ github.sha }}",
-    "proof_key: release-${{ needs.preflight.outputs.version }}",
-    "profile: codestory-release-evidence-linux-arm64-v1",
-    "drill_manifest: /srv/codestory-release-evidence/drills/real-repo-drill-cases.json",
-    "embedding_model_dir: /srv/codestory-release-evidence/models",
-    "source_run_id: ${{ inputs.source_run_id }}",
-  ], snippet => `release.yml release-evidence job must include ${snippet}`);
-  const packagedProofJob = yamlJob(content, "packaged-proof");
-  if (!packagedProofJob.includes("      - release-evidence")) {
-    violations.push("release.yml packaged-proof must wait for release-evidence");
-  }
-  for (const trigger of ["workflow_call", "workflow_dispatch"]) {
-    const triggerBlock = yamlMapping(content, trigger, 2).join("\n");
-    const inputsBlock = yamlMapping(triggerBlock, "inputs", 4).join("\n");
-    const sourceRunInput = yamlMapping(inputsBlock, "source_run_id", 6).join("\n");
-    requireContent(
-      sourceRunInput,
-      ["required: false", "type: string", 'default: ""'],
-      field => `release.yml ${trigger} source_run_id input must include ${field}`,
+function requireStepRun(violations, file, job, name, fragments) {
+  const run = executableRunText(stepRun(job, name));
+  add(violations, run.length > 0, `${file} must contain named step ${name}`);
+  for (const fragment of fragments) {
+    add(
+      violations,
+      run.includes(fragment),
+      `${file} step ${name} must run ${fragment}`,
     );
   }
-  if (!fs.existsSync(releaseNotesExtractor)) {
-    violations.push("release.yml must use the checked-in versioned changelog extractor");
-  }
-  const preflightNotesStep = namedStep(
-    yamlJob(content, "preflight"),
-    "Validate versioned changelog notes",
-  ).join("\n");
-  const publishNotesStep = namedStep(
-    yamlJob(content, "publish"),
-    "Compose versioned GitHub release notes",
-  ).join("\n");
-  if (
-    !preflightNotesStep.includes("node .github/scripts/extract-codestory-release-notes.mjs") ||
-    !preflightNotesStep.includes('--version "$VERSION"')
-  ) {
-    violations.push("release.yml preflight must validate the exact versioned changelog section");
-  }
-  if (
-    !publishNotesStep.includes("node .github/scripts/extract-codestory-release-notes.mjs") ||
-    !publishNotesStep.includes("--output target/release-assets/release-notes.md") ||
-    !publishNotesStep.includes("## Platform proof boundaries")
-  ) {
-    violations.push("release.yml publish must compose changelog notes before the proof-boundary appendix");
-  }
-  if (content.includes("--generate-notes")) {
-    violations.push("release.yml must not replace curated changelog notes with generated pull-request notes");
-  }
-  requireContent(content, [
-    "macos-metal-proof:\n    needs:\n      - preflight\n      - packaged-proof\n    uses: ./.github/workflows/macos-metal-proof.yml",
-    "needs:\n      - preflight\n      - packaged-proof\n      - macos-metal-proof\n    runs-on: ubuntu-latest",
-    "needs:\n      - preflight\n      - publish\n    uses: ./.github/workflows/post-publish-release-smoke.yml",
-  ], row => `release.yml must preserve release proof block ${row.split("\n")[0]}`);
 }
 
-if (!fs.existsSync(autoRelease)) {
-  violations.push("auto-release.yml must exist for main release detection");
-} else {
-  const content = fs.readFileSync(autoRelease, "utf8");
-  const releaseJob = yamlJob(content, "release");
-  if (!releaseJob.includes("      actions: read")) {
-    violations.push("auto-release.yml release job must allow prior-run evidence download");
+function requireStepUses(violations, file, job, name, expected) {
+  add(
+    violations,
+    namedStep(job, name)?.uses === expected,
+    `${file} step ${name} must use ${expected}`,
+  );
+}
+
+function requireJob(violations, file, workflow, name) {
+  const found = object(workflow.jobs)[name];
+  add(violations, found !== undefined, `${file} must contain job ${name}`);
+  return object(found);
+}
+
+export function parseWorkflow(source, file = "workflow") {
+  const document = parseDocument(source, {
+    lineCounter: new LineCounter(),
+    prettyErrors: true,
+    schema: "core",
+    strict: true,
+    uniqueKeys: true,
+  });
+  if (document.errors.length > 0) {
+    throw new Error(document.errors.map(error => error.message).join("\n"));
+  }
+  const parsed = document.toJS({ maxAliasCount: 50 });
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${file} must contain one YAML mapping`);
+  }
+  return parsed;
+}
+
+function loadWorkflows(root = workflowRoot) {
+  const loaded = new Map();
+  for (const file of fs.readdirSync(root).filter(name => /\.ya?ml$/u.test(name)).sort()) {
+    const source = fs.readFileSync(path.join(root, file), "utf8");
+    loaded.set(file, parseWorkflow(source, file));
+  }
+  return loaded;
+}
+
+function trigger(workflow, name) {
+  return object(workflow.on)[name];
+}
+
+function concurrencyCancels(workflow) {
+  return object(workflow.concurrency)["cancel-in-progress"] === true;
+}
+
+function executableCargoLines(run) {
+  return run
+    .split(/\r?\n/u)
+    .map((line, index) => ({ line, number: index + 1 }))
+    .filter(({ line }) =>
+      /^\s*(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?:sudo\s+)?cargo\s+(?:build|check|test|clippy|doc|run)\b/u.test(line),
+    );
+}
+
+function walk(value, visit, trail = []) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => walk(item, visit, [...trail, index]));
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    visit(key, child, [...trail, key]);
+    walk(child, visit, [...trail, key]);
   }
 }
 
-if (!fs.existsSync(packagedPlatformProof)) {
-  violations.push("packaged-platform-proof.yml must own the reusable native package matrix");
-} else {
-  const content = fs.readFileSync(packagedPlatformProof, "utf8");
-  requireContent(content, [
-    "workflow_call:",
-    "contents: read",
-    'RELEASE_RUST_TOOLCHAIN: "1.95.0"',
-    'LINUX_GLIBC_BUILD_IMAGE: "rust:1.95.0-bullseye@sha256:28afaeb8445f2a2e7d878bd34ed39ba02bb517efb29986188cbd59b7cf4f2fdf"',
-    'LINUX_GLIBC_BASELINE_IMAGE: "ubuntu:20.04@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214"',
-    'APPLE_DEVELOPER_TEAM_ID: "PKUJNR8D6F"',
-    "Build Linux x64 at the glibc 2.31 baseline",
-    'cargo build --release --locked -p codestory-cli --target "${{ matrix.rust_target }}"',
-    "CARGO_TARGET_DIR=/workspace/target/glibc-2.31",
-    'cp "target/glibc-2.31/${{ matrix.rust_target }}/release/codestory-cli"',
-    "bash .github/scripts/check-linux-glibc-baseline.sh",
-    '"glibc 2.31"',
-    "linux-glibc-2.31-baseline-proof",
-    "packaged-version-proof-${{ matrix.asset_target }}",
-    "packaged-managed-proof-${{ matrix.asset_target }}",
-    "- name: Prove managed plugin handoff",
-    "--archive \"target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}\"",
+export function basicWorkflowViolations(file, workflow) {
+  const violations = [];
+  const triggers = object(workflow.on);
+  if (triggers.pull_request !== undefined || triggers.pull_request_target !== undefined) {
+    add(
+      violations,
+      concurrencyCancels(workflow),
+      `${file} pull-request runs must cancel stale work`,
+    );
+  }
+
+  walk(workflow, (key, value, trail) => {
+    if (key === "key" && typeof value === "string" && value.includes("github.sha")) {
+      violations.push(`${file} ${trail.join(".")} Cargo cache key must not include commit SHA`);
+    }
+    if (key !== "uses" || typeof value !== "string" || value.startsWith("./")) return;
+    const separator = value.lastIndexOf("@");
+    if (separator < 0) {
+      violations.push(`${file} ${value} is missing an action ref`);
+      return;
+    }
+    const owner = value.slice(0, separator).split("/")[0];
+    const ref = value.slice(separator + 1);
+    if (!trustedActionOwners.has(owner) && !fullSha.test(ref)) {
+      violations.push(`${file} ${value} must pin third-party actions to a full-length SHA`);
+    }
+  });
+
+  for (const [jobName, job] of Object.entries(object(workflow.jobs))) {
+    for (const [stepIndex, step] of list(object(job).steps).entries()) {
+      if (typeof step?.run !== "string") continue;
+      for (const { line, number } of executableCargoLines(step.run)) {
+        if (!/(?:^|\s)--locked(?:\s|$)/u.test(line)) {
+          violations.push(
+            `${file} jobs.${jobName}.steps.${stepIndex}.run:${number} dependency-resolving Cargo command must use --locked`,
+          );
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+export function managedPluginViolations(job, archiveFragment) {
+  const violations = [];
+  const strategy = object(job.strategy);
+  const matrix = strategy.matrix;
+  const step = namedStep(job, "Prove managed plugin handoff");
+  add(violations, strategy["fail-fast"] === false, "managed plugin matrix must set fail-fast to false");
+  add(violations, job.if === undefined, "managed plugin job must not be conditional");
+  add(violations, job["continue-on-error"] === undefined, "managed plugin job must not continue on error");
+  add(
+    violations,
+    typeof matrix === "string" || object(matrix).exclude === undefined,
+    "managed plugin matrix must not exclude cells",
+  );
+  add(violations, step !== undefined, "managed plugin proof step is missing");
+  add(violations, step?.if === undefined, "managed plugin proof step must not be conditional");
+  add(
+    violations,
+    step?.["continue-on-error"] === undefined,
+    "managed plugin proof step must not continue on error",
+  );
+  const run = executableRunText(typeof step?.run === "string" ? step.run : "");
+  for (const fragment of [
+    "python .github/scripts/check-packaged-agent-proof.py",
+    archiveFragment,
     "--managed-plugin-handoff",
-    "sign_macos:",
-    "environment: ${{ inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 'macos-release-signing' || null }}",
-    "timeout-minutes: ${{ inputs.sign_macos && startsWith(matrix.asset_target, 'macos-') && 90 || 60 }}",
+  ]) {
+    add(violations, run.includes(fragment), `managed plugin proof step must run ${fragment}`);
+  }
+  return violations;
+}
+
+export function packagedPrSigningViolations(workflow) {
+  const violations = [];
+  const job = object(object(workflow.jobs)["packaged-proof"]);
+  add(
+    violations,
+    object(job.with).sign_macos === false,
+    "packaged-platform-pr.yml packaged-proof must set sign_macos to false",
+  );
+  add(
+    violations,
+    job.secrets === undefined,
+    "packaged-platform-pr.yml packaged-proof must not receive caller secrets",
+  );
+  const scalars = scalarStrings(workflow);
+  let referencesAppleSecret = false;
+  walk(workflow, (key, value) => {
+    if (/^APPLE_[A-Z0-9_]+$/u.test(key)) referencesAppleSecret = true;
+    if (typeof value === "string" && /\bAPPLE_[A-Z0-9_]+\b/u.test(value)) {
+      referencesAppleSecret = true;
+    }
+  });
+  add(
+    violations,
+    !referencesAppleSecret,
+    "packaged-platform-pr.yml must not reference Apple secret identifiers",
+  );
+  add(
+    violations,
+    !scalars.some(value => value.includes("macos-release-signing")),
+    "packaged-platform-pr.yml must not reference the release signing environment",
+  );
+  return violations;
+}
+
+export function notaryStepViolations(step) {
+  const run = typeof step?.run === "string" ? step.run : "";
+  return run
+    .split(/\r?\n/u)
+    .some(line => /^\s*--wait(?:\s|\\|$)/u.test(line) || /notarytool\s+submit.*\s--wait(?:\s|$)/u.test(line))
+    ? ["notarization must poll explicitly instead of using notarytool --wait"]
+    : [];
+}
+
+function validateLockedSetupSurfaces(violations) {
+  const contracts = new Map([
+    [
+      path.join(".cargo", "config.toml"),
+      [
+        'retrieval-setup = "run --locked -p codestory-cli',
+        'retrieval-status = "run --locked -p codestory-cli',
+      ],
+    ],
+    [path.join("scripts", "codex-worktree-setup.mjs"), ['["build", "--release", "--locked", "-p", "codestory-cli"]']],
+    [path.join("plugins", "codestory", "skills", "codestory-grounding", "scripts", "setup.sh"), ["cargo build --release --locked -p codestory-cli"]],
+    [path.join("plugins", "codestory", "skills", "codestory-grounding", "scripts", "setup.ps1"), ['@("build", "--release", "--locked", "-p", "codestory-cli"']],
+    [path.join("scripts", "setup-retrieval-env.mjs"), ['return ["run", "--locked", ...args]']],
+  ]);
+  for (const [file, fragments] of contracts) {
+    const source = fs.readFileSync(file, "utf8");
+    for (const fragment of fragments) {
+      add(violations, source.includes(fragment), `${file} must preserve locked Cargo contract ${fragment}`);
+    }
+  }
+}
+
+function validateIssueWorkflows(workflows, violations) {
+  const sagaFile = "saga-issue-link-guard.yml";
+  const saga = workflows.get(sagaFile);
+  if (!saga) {
+    violations.push(`${sagaFile} must exist`);
+  } else {
+    add(violations, trigger(saga, "pull_request_target") !== undefined, `${sagaFile} must use pull_request_target`);
+    add(violations, object(saga.permissions)["pull-requests"] === "read", `${sagaFile} must read pull requests`);
+    const job = requireJob(violations, sagaFile, saga, "require-closing-issue-link");
+    for (const fragment of ["codex/", "review/codestory-saga-", "[codex]", "saga:codestory-intelligence"]) {
+      add(violations, String(job.if ?? "").includes(fragment), `${sagaFile} guarded condition must include ${fragment}`);
+    }
+    requireStepRun(violations, sagaFile, job, "Check PR issue relationship", [
+      "close[sd]?|fix(?:e[sd])?|resolve[sd]?",
+      "#\\d+|https://github\\.com/TheGreenCedar/CodeStory/issues/\\d+",
+    ]);
+  }
+
+  const closeFile = "close-dev-issues.yml";
+  const close = workflows.get(closeFile);
+  if (!close) {
+    violations.push(`${closeFile} must exist`);
+  } else {
+    add(violations, includesAll(at(close, "on", "push", "branches"), ["dev/codestory-next"]), `${closeFile} must run on dev/codestory-next pushes`);
+    add(violations, object(close.permissions).issues === "write", `${closeFile} must write issues`);
+    add(violations, object(close.permissions)["pull-requests"] === "read", `${closeFile} must read pull requests`);
+    const job = requireJob(violations, closeFile, close, "close-linked-issues");
+    requireStepRun(violations, closeFile, job, "Close issues referenced by the merged PR", [
+      'commit = event["after"]',
+      'pull_request.get("merged_at")',
+      'pull_request.get("merge_commit_sha") == commit',
+      'if "pull_request" in issue:',
+      '"state_reason=completed"',
+      "https://github\\.com/TheGreenCedar/CodeStory/issues/(\\d+)",
+    ]);
+  }
+}
+
+function validatePluginAndDraftWorkflows(workflows, violations) {
+  const pluginFile = "plugin-static.yml";
+  const plugin = workflows.get(pluginFile);
+  if (!plugin) {
+    violations.push(`${pluginFile} must exist`);
+  } else {
+    const requiredPaths = [
+      "plugins/codestory/**",
+      ".github/scripts/check-workflow-policy.mjs",
+      ".github/scripts/check-workflow-policy.test.mjs",
+      ".github/workflows/release.yml",
+      ".github/workflows/packaged-platform-pr.yml",
+      ".github/workflows/packaged-platform-proof.yml",
+      ".github/workflows/macos-metal-proof.yml",
+      ".github/workflows/source-proof.yml",
+      ".github/workflows/repo-scale-stats.yml",
+      "package.json",
+      "package-lock.json",
+      "scripts/codex-worktree-setup.*",
+      "scripts/setup-retrieval-env.*",
+      "scripts/install-codestory.ps1",
+    ];
+    for (const event of ["pull_request", "push"]) {
+      add(violations, includesAll(at(plugin, "on", event, "paths"), requiredPaths), `${pluginFile} ${event} paths must cover policy and release surfaces`);
+    }
+    add(violations, includesAll(at(plugin, "on", "push", "branches"), ["dev/codestory-next"]), `${pluginFile} must run on dev pushes`);
+    const job = requireJob(violations, pluginFile, plugin, "plugin-static");
+    requireStepRun(violations, pluginFile, job, "Install workflow policy dependencies", ["npm ci --ignore-scripts"]);
+    requireStepRun(violations, pluginFile, job, "Check workflow policy", [
+      "node .github/scripts/check-workflow-policy.mjs",
+      "node --test .github/scripts/check-workflow-policy.test.mjs",
+    ]);
+    requireStepRun(violations, pluginFile, job, "Check plugin static wiring", ["node --test plugins/codestory/tests/plugin-static.test.mjs"]);
+    requireStepRun(violations, pluginFile, job, "Check CI proof routing fixtures", ["node .github/scripts/route-ci-proof.mjs --self-test"]);
+    requireStepRun(violations, pluginFile, job, "Check packaged proof harness", ["python .github/scripts/check-packaged-agent-proof.py --self-test"]);
+  }
+
+  const rustFile = "rust-ci.yml";
+  const rust = workflows.get(rustFile);
+  if (!rust) {
+    violations.push(`${rustFile} must exist`);
+  } else {
+    add(violations, trigger(rust, "push") === undefined, `${rustFile} draft checks must not run on push`);
+    add(violations, includesAll(at(rust, "on", "pull_request", "paths"), ["Cargo.lock", "Cargo.toml", "crates/**"]), `${rustFile} must cover workspace source changes`);
+    const job = requireJob(violations, rustFile, rust, "linux-draft");
+    add(violations, job["runs-on"] === "ubuntu-latest", `${rustFile} must use one Ubuntu lane`);
+    requireStepRun(violations, rustFile, job, "Check formatting", ["cargo fmt --check"]);
+    requireStepRun(violations, rustFile, job, "Check the workspace", ["cargo check --workspace --locked"]);
+    requireStepRun(violations, rustFile, job, "Lint workspace libraries", ["cargo clippy --workspace --lib --locked -- -D warnings"]);
+    requireStepRun(violations, rustFile, job, "Prove focused publication contracts", ["cargo test --locked"]);
+  }
+
+  const sourceFile = "source-proof.yml";
+  const source = workflows.get(sourceFile);
+  if (!source) {
+    violations.push(`${sourceFile} must exist`);
+  } else {
+    add(violations, sameMembers(at(source, "on", "pull_request", "types"), ["labeled", "synchronize"]), `${sourceFile} pull request types must be labeled and synchronize`);
+    add(violations, trigger(source, "pull_request_target") === undefined, `${sourceFile} must not execute pull-request code through pull_request_target`);
+    const resolve = requireJob(violations, sourceFile, source, "resolve");
+    add(violations, String(resolve.if ?? "").includes("review-accepted"), `${sourceFile} resolve job must require review-accepted`);
+    requireStepRun(violations, sourceFile, resolve, "Resolve trusted exact head", [
+      'test "$EVENT_HEAD_REPO" = "$GITHUB_REPOSITORY"',
+      'test "$current_head" = "$EVENT_HEAD_SHA"',
+    ]);
+    const full = requireJob(violations, sourceFile, source, "full-source-gate");
+    add(violations, sameMembers(needs(full), ["resolve"]), `${sourceFile} full source gate must need resolve`);
+    requireStepRun(violations, sourceFile, full, "Test the complete workspace once", ["cargo test --workspace --locked"]);
+    requireStepRun(violations, sourceFile, full, "Lint every workspace target and feature once", ["cargo clippy --workspace --all-targets --all-features --locked -- -D warnings"]);
+  }
+}
+
+function validateReleaseCoordinator(workflows, violations) {
+  const releaseFile = "release.yml";
+  const release = workflows.get(releaseFile);
+  if (!release) {
+    violations.push(`${releaseFile} must exist`);
+    return;
+  }
+  add(violations, object(release.permissions).actions === "read", `${releaseFile} must read prior-run evidence`);
+  for (const event of ["workflow_call", "workflow_dispatch"]) {
+    const input = object(at(release, "on", event, "inputs", "source_run_id"));
+    add(violations, input.required === false && input.type === "string" && input.default === "", `${releaseFile} ${event} source_run_id must be an optional empty string`);
+  }
+  const policy = requireJob(violations, releaseFile, release, "workflow-policy");
+  requireStepRun(violations, releaseFile, policy, "Install workflow policy dependencies", ["npm ci --ignore-scripts"]);
+  requireStepRun(violations, releaseFile, policy, "Enforce workflow policy", ["node .github/scripts/check-workflow-policy.mjs"]);
+
+  const preflight = requireJob(violations, releaseFile, release, "preflight");
+  add(violations, sameMembers(needs(preflight), ["workflow-policy"]), `${releaseFile} preflight must need workflow-policy`);
+  requireStepRun(violations, releaseFile, preflight, "Validate versioned changelog notes", [
+    "node .github/scripts/extract-codestory-release-notes.mjs",
+    '--version "$VERSION"',
+  ]);
+
+  const evidence = requireJob(violations, releaseFile, release, "release-evidence");
+  add(violations, evidence.uses === "./.github/workflows/release-candidate-evidence.yml", `${releaseFile} release-evidence must call the evidence workflow`);
+  add(violations, sameMembers(needs(evidence), ["preflight"]), `${releaseFile} release-evidence must need preflight`);
+  for (const [key, value] of Object.entries({
+    ref: "${{ github.sha }}",
+    proof_key: "release-${{ needs.preflight.outputs.version }}",
+    profile: "codestory-release-evidence-linux-arm64-v1",
+    drill_manifest: "/srv/codestory-release-evidence/drills/real-repo-drill-cases.json",
+    embedding_model_dir: "/srv/codestory-release-evidence/models",
+    source_run_id: "${{ inputs.source_run_id }}",
+  })) {
+    add(violations, object(evidence.with)[key] === value, `${releaseFile} release-evidence with.${key} must equal ${value}`);
+  }
+
+  const packaged = requireJob(violations, releaseFile, release, "packaged-proof");
+  add(violations, packaged.uses === "./.github/workflows/packaged-platform-proof.yml", `${releaseFile} packaged-proof must call the package workflow`);
+  add(violations, sameMembers(needs(packaged), ["preflight", "release-evidence"]), `${releaseFile} packaged-proof must wait for preflight and release evidence`);
+  add(violations, object(packaged.with).sign_macos === true, `${releaseFile} packaged-proof must sign Mac assets`);
+  const expectedSecrets = [
     "APPLE_DEVELOPER_ID_P12_BASE64",
+    "APPLE_DEVELOPER_ID_P12_PASSWORD",
+    "APPLE_SIGNING_IDENTITY",
     "APPLE_NOTARY_KEY_P8_BASE64",
+    "APPLE_NOTARY_KEY_ID",
+    "APPLE_NOTARY_ISSUER_ID",
+  ];
+  add(violations, sameMembers(Object.keys(object(packaged.secrets)), expectedSecrets), `${releaseFile} packaged-proof must pass exactly the Apple signing secrets`);
+
+  const metal = requireJob(violations, releaseFile, release, "macos-metal-proof");
+  add(violations, metal.uses === "./.github/workflows/macos-metal-proof.yml", `${releaseFile} must call protected Metal proof`);
+  add(violations, sameMembers(needs(metal), ["preflight", "packaged-proof"]), `${releaseFile} Metal proof must wait for packaged proof`);
+  add(violations, object(metal.with).use_packaged_cli_artifact === true, `${releaseFile} Metal proof must use the packaged CLI`);
+
+  const publish = requireJob(violations, releaseFile, release, "publish");
+  add(violations, sameMembers(needs(publish), ["preflight", "packaged-proof", "macos-metal-proof"]), `${releaseFile} publish must wait for all release proofs`);
+  requireStepRun(violations, releaseFile, publish, "Compose versioned GitHub release notes", [
+    "node .github/scripts/extract-codestory-release-notes.mjs",
+    "--output target/release-assets/release-notes.md",
+  ]);
+  requireStepRun(violations, releaseFile, publish, "Create GitHub release", [
+    "--notes-file target/release-assets/release-notes.md",
+    'if [ "${#assets[@]}" -ne 7 ]; then',
+  ]);
+  add(violations, !scalarStrings(release).some(value => value.includes("--generate-notes")), `${releaseFile} must use curated release notes`);
+
+  const post = requireJob(violations, releaseFile, release, "post-publish-smoke");
+  add(violations, post.uses === "./.github/workflows/post-publish-release-smoke.yml", `${releaseFile} must call post-publish smoke`);
+  add(violations, sameMembers(needs(post), ["preflight", "publish"]), `${releaseFile} post-publish smoke must wait for publish`);
+}
+
+function expectedPackageRows() {
+  return [
+    { os: "ubuntu-latest", rust_target: "x86_64-unknown-linux-gnu", asset_target: "linux-x64", exe_suffix: "", extension: "tar.gz" },
+    { os: "ubuntu-24.04-arm", rust_target: "aarch64-unknown-linux-gnu", asset_target: "linux-arm64", exe_suffix: "", extension: "tar.gz" },
+    { os: "windows-latest", rust_target: "x86_64-pc-windows-msvc", asset_target: "windows-x64", exe_suffix: ".exe", extension: "zip" },
+    { os: "windows-11-arm", rust_target: "aarch64-pc-windows-msvc", asset_target: "windows-arm64", exe_suffix: ".exe", extension: "zip" },
+    { os: "macos-15-intel", rust_target: "x86_64-apple-darwin", asset_target: "macos-x64", exe_suffix: "", extension: "tar.gz" },
+    { os: "macos-15", rust_target: "aarch64-apple-darwin", asset_target: "macos-arm64", exe_suffix: "", extension: "tar.gz" },
+  ];
+}
+
+function validatePackageMatrixExpression(violations, expression) {
+  const match = typeof expression === "string" && expression.match(
+    /fromJSON\(inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\)/u,
+  );
+  if (!match) {
+    violations.push("packaged-platform-proof.yml matrix must select structural JSON by scope");
+    return;
+  }
+  const full = expectedPackageRows();
+  const expected = [
+    { include: full.filter(row => row.asset_target === "windows-x64") },
+    { include: full.filter(row => row.asset_target.startsWith("macos-")) },
+    { include: full },
+  ];
+  try {
+    match.slice(1).forEach((json, index) => {
+      add(violations, JSON.stringify(JSON.parse(json)) === JSON.stringify(expected[index]), "packaged-platform-proof.yml package matrix scope changed");
+    });
+  } catch {
+    violations.push("packaged-platform-proof.yml package matrix must contain valid JSON");
+  }
+}
+
+function validatePackagedProof(workflows, violations) {
+  const file = "packaged-platform-proof.yml";
+  const workflow = workflows.get(file);
+  if (!workflow) {
+    violations.push(`${file} must exist`);
+    return;
+  }
+  add(violations, trigger(workflow, "workflow_call") !== undefined, `${file} must be reusable`);
+  add(violations, object(workflow.permissions).contents === "read", `${file} must use read-only contents permission`);
+  add(
+    violations,
+    object(workflow.env).LINUX_GLIBC_BUILD_IMAGE ===
+      "rust:1.95.0-bullseye@sha256:28afaeb8445f2a2e7d878bd34ed39ba02bb517efb29986188cbd59b7cf4f2fdf",
+    `${file} must pin the glibc build image`,
+  );
+  const job = requireJob(violations, file, workflow, "build");
+  validatePackageMatrixExpression(violations, at(job, "strategy", "matrix"));
+  add(violations, String(job.environment ?? "").includes("macos-release-signing"), `${file} signed Mac cells must use the protected signing environment`);
+  requireStepRun(violations, file, job, "Build Linux x64 at the glibc 2.31 baseline", [
+    "cargo build --release --locked -p codestory-cli",
+    "CARGO_TARGET_DIR=/workspace/target/glibc-2.31",
+  ]);
+  const signing = namedStep(job, "Sign and notarize macOS CLI");
+  add(violations, signing !== undefined, `${file} must sign and notarize Mac binaries`);
+  violations.push(...notaryStepViolations(signing).map(message => `${file} ${message}`));
+  const signingRun = executableRunText(String(signing?.run ?? ""));
+  for (const fragment of [
     "umask 077",
-    "chmod 600 \"$work_dir/developer-id.p12\" \"$work_dir/notary-key.p8\"",
-    "security list-keychains -d user -s \"$keychain\"",
-    "--sign \"$signing_hash\"",
+    "chmod 600",
     "--options runtime",
     "--timestamp",
     "xcrun notarytool submit",
     "--no-wait",
-    "notarytool-submission-id.txt",
-    'xcrun notarytool info "$submission_id"',
-    "max_notary_attempts=120",
-    "notary_poll_seconds=30",
-    "Invalid|Rejected)",
-    'xcrun notarytool log "$submission_id"',
-    "Notarization timed out after",
-    "jq -e '.status == \"Accepted\"'",
-    "source=Notarized Developer ID",
+    "xcrun notarytool info",
+    "xcrun notarytool log",
+    'jq -e \'.status == "Accepted"\'',
     "TeamIdentifier=${APPLE_DEVELOPER_TEAM_ID}",
-    '> "$proof_dir/designated-requirement.txt" 2>&1',
-    "subject\\\\.OU",
-    "macos-notarization-proof-${{ matrix.asset_target }}",
-    "--intel-runtime-policy",
-    "packaged-intel-policy-proof-${{ matrix.asset_target }}",
-    "if: matrix.asset_target == 'macos-x64'",
-    "scripts/install-codestory.ps1 -SelfTest",
-    "--checksum-file target/release-dist/SHA256SUMS.txt",
-    "scope:",
-    "proof_key:",
-    "ref:",
-    "cancel-in-progress: true",
-    "codestory-cli-default-features",
-    "matrix: ${{ fromJSON(inputs.scope == 'windows'",
-  ], snippet => `packaged-platform-proof.yml must include ${snippet}`);
-  const macosSigningStep = namedStep(yamlJob(content, "build"), "Sign and notarize macOS CLI").join("\n");
-  const blockingNotaryWait = /^\s+--wait(?:\s|\\|$)/mu;
-  if (blockingNotaryWait.test(macosSigningStep)) {
-    violations.push("packaged-platform-proof.yml must poll notarization explicitly instead of using notarytool --wait");
+    "certificate leaf",
+  ]) {
+    add(violations, signingRun.includes(fragment), `${file} signing step must include ${fragment}`);
   }
-  const blockingWaitBypass = namedStep(
-    yamlJob(content.replace("--no-wait", "--wait"), "build"),
-    "Sign and notarize macOS CLI",
-  ).join("\n");
-  if (!blockingNotaryWait.test(blockingWaitBypass)) {
-    violations.push("packaged-platform-proof.yml blocking notary wait policy did not detect its bypass fixture");
-  }
-  const releaseAssetStart = content.indexOf("- name: Upload release asset");
-  const notarizationProofStart = content.indexOf("- name: Upload macOS notarization proof");
-  const releaseAssetBlock = releaseAssetStart >= 0
-    ? content.slice(releaseAssetStart, notarizationProofStart >= 0 ? notarizationProofStart : undefined)
-    : "";
-  if (releaseAssetBlock.includes("target/notarization-proof")) {
-    violations.push("packaged-platform-proof.yml must keep notarization evidence out of the flat binary release artifact");
-  }
-  if (!releaseAssetBlock.includes("target/release-dist/SHA256SUMS.txt")) {
-    violations.push("packaged-platform-proof.yml must include SHA256SUMS.txt in each reusable package artifact");
-  }
-  const matrixMatch = content.match(
-    /^      matrix: \$\{\{ fromJSON\(inputs\.scope == 'windows' && '([^']+)' \|\| inputs\.scope == 'macos' && '([^']+)' \|\| '([^']+)'\) \}\}$/mu,
-  );
-  const expectedFullMatrix = {
-    include: [
-      { os: "ubuntu-latest", rust_target: "x86_64-unknown-linux-gnu", asset_target: "linux-x64", exe_suffix: "", extension: "tar.gz" },
-      { os: "ubuntu-24.04-arm", rust_target: "aarch64-unknown-linux-gnu", asset_target: "linux-arm64", exe_suffix: "", extension: "tar.gz" },
-      { os: "windows-latest", rust_target: "x86_64-pc-windows-msvc", asset_target: "windows-x64", exe_suffix: ".exe", extension: "zip" },
-      { os: "windows-11-arm", rust_target: "aarch64-pc-windows-msvc", asset_target: "windows-arm64", exe_suffix: ".exe", extension: "zip" },
-      { os: "macos-15-intel", rust_target: "x86_64-apple-darwin", asset_target: "macos-x64", exe_suffix: "", extension: "tar.gz" },
-      { os: "macos-15", rust_target: "aarch64-apple-darwin", asset_target: "macos-arm64", exe_suffix: "", extension: "tar.gz" },
-    ],
-  };
-  const expectedMacMatrix = {
-    include: expectedFullMatrix.include.filter(row => row.asset_target.startsWith("macos-")),
-  };
-  const expectedWindowsMatrix = {
-    include: expectedFullMatrix.include.filter(row => row.asset_target === "windows-x64"),
-  };
-  try {
-    const windowsMatrix = matrixMatch && JSON.parse(matrixMatch[1]);
-    const macMatrix = matrixMatch && JSON.parse(matrixMatch[2]);
-    const fullMatrix = matrixMatch && JSON.parse(matrixMatch[3]);
-    if (JSON.stringify(windowsMatrix) !== JSON.stringify(expectedWindowsMatrix)) {
-      violations.push("packaged-platform-proof.yml windows scope must contain exactly the Windows x64 package row");
-    }
-    if (JSON.stringify(macMatrix) !== JSON.stringify(expectedMacMatrix)) {
-      violations.push("packaged-platform-proof.yml macos scope must contain exactly the two Mac package rows");
-    }
-    if (JSON.stringify(fullMatrix) !== JSON.stringify(expectedFullMatrix)) {
-      violations.push("packaged-platform-proof.yml full scope must contain exactly all six native package rows");
-    }
-  } catch {
-    violations.push("packaged-platform-proof.yml package matrices must be valid JSON objects");
-  }
-  requireContent(content, [
-    "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: pwsh -File scripts/install-codestory.ps1 -SelfTest",
-  ], row => `packaged-platform-proof.yml must preserve native proof block ${row.split("\n")[0]}`);
-  requireManagedPluginStep(
-    content,
-    "build",
-    "packaged-platform-proof.yml",
-    '          --archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}"',
-  );
+  requireStepRun(violations, file, job, "Run Windows installer ownership self-test", ["scripts/install-codestory.ps1 -SelfTest"]);
+  requireStepRun(violations, file, job, "Prove Linux x64 glibc 2.31 baseline", ["bash .github/scripts/check-linux-glibc-baseline.sh"]);
+  violations.push(...managedPluginViolations(
+    job,
+    '--archive "target/release-dist/codestory-cli-v${{ inputs.version }}-${{ matrix.asset_target }}.${{ matrix.extension }}"',
+  ).map(message => `${file} ${message}`));
+  requireStepUses(violations, file, job, "Upload release asset", "actions/upload-artifact@v7.0.1");
+  requireStepUses(violations, file, job, "Upload macOS notarization proof", "actions/upload-artifact@v7.0.1");
 }
 
-if (!fs.existsSync(postPublishReleaseSmoke)) {
-  violations.push("post-publish-release-smoke.yml must exist for native published-asset proof");
-} else {
-  const content = fs.readFileSync(postPublishReleaseSmoke, "utf8");
-  requireContent(content, [
-    "workflow_call:",
-    "ubuntu-latest",
-    "ubuntu-24.04-arm",
-    "windows-latest",
-    "windows-11-arm",
-    "macos-15",
-    "linux-x64",
-    "linux-arm64",
-    "windows-x64",
-    "windows-arm64",
-    "macos-x64",
-    "macos-arm64",
-    "--version-only",
-    "- name: Prove managed plugin handoff",
-    "--managed-plugin-handoff",
-    "Prove published macOS signature, notarization, and Gatekeeper acceptance",
+function validatePostPublish(workflows, violations) {
+  const file = "post-publish-release-smoke.yml";
+  const workflow = workflows.get(file);
+  if (!workflow) {
+    violations.push(`${file} must exist`);
+    return;
+  }
+  add(violations, trigger(workflow, "workflow_call") !== undefined, `${file} must be reusable`);
+  const job = requireJob(violations, file, workflow, "smoke");
+  const expected = expectedPackageRows().map(({ os, asset_target, extension }) => ({ os, asset_target, extension }));
+  add(violations, JSON.stringify(at(job, "strategy", "matrix", "include")) === JSON.stringify(expected), `${file} must smoke all six native assets`);
+  violations.push(...managedPluginViolations(
+    job,
+    '--archive "${{ steps.asset.outputs.archive }}"',
+  ).map(message => `${file} ${message}`));
+  requireStepRun(violations, file, job, "Prove published macOS signature, notarization, and Gatekeeper acceptance", [
     "archive-quarantine.txt",
     "extracted-binary-quarantine.txt",
     "Authority=Developer ID Application:",
     "source=Notarized Developer ID",
-    'APPLE_DEVELOPER_TEAM_ID: "PKUJNR8D6F"',
     "TeamIdentifier=${APPLE_DEVELOPER_TEAM_ID}",
-    '> "$proof_dir/designated-requirement.txt" 2>&1',
-    "subject\\\\.OU",
-    "--intel-runtime-policy",
-    "target/post-publish-intel-policy-proof",
-    "if: matrix.asset_target == 'macos-x64'",
-    "scripts/install-codestory.ps1 -SelfTest",
-    "--checksum-file \"${{ steps.asset.outputs.checksum }}\"",
-  ], snippet => `post-publish-release-smoke.yml must include ${snippet}`);
-  requireContent(content, [
-    "- os: ubuntu-latest\n            asset_target: linux-x64\n            extension: tar.gz",
-    "- os: ubuntu-24.04-arm\n            asset_target: linux-arm64\n            extension: tar.gz",
-    "- os: windows-latest\n            asset_target: windows-x64\n            extension: zip",
-    "- os: windows-11-arm\n            asset_target: windows-arm64\n            extension: zip",
-    "- os: macos-15-intel\n            asset_target: macos-x64\n            extension: tar.gz",
-    "- os: macos-15\n            asset_target: macos-arm64\n            extension: tar.gz",
-    "if: matrix.asset_target == 'windows-x64'\n        shell: pwsh\n        run: pwsh -File scripts/install-codestory.ps1 -SelfTest",
-  ], row => `post-publish-release-smoke.yml must preserve native proof block ${row.split("\n")[0]}`);
-  if (content.includes("sha256sum")) {
-    violations.push("post-publish-release-smoke.yml must use the portable Python checksum gate");
-  }
-  requireManagedPluginStep(
-    content,
-    "smoke",
-    "post-publish-release-smoke.yml",
-    '          --archive "${{ steps.asset.outputs.archive }}"',
-  );
+    "certificate leaf",
+  ]);
+  requireStepRun(violations, file, job, "Run Windows installer ownership self-test", ["scripts/install-codestory.ps1 -SelfTest"]);
+  requireStepRun(violations, file, job, "Prove published Intel macOS backend policy and explicit CPU/external operation", ["--intel-runtime-policy"]);
+  add(violations, !scalarStrings(workflow).some(value => value.includes("sha256sum")), `${file} must use the portable Python checksum gate`);
 }
 
-if (!fs.existsSync(packagedPlatformPr)) {
-  violations.push("packaged-platform-pr.yml must orchestrate explicitly promoted platform proof");
-} else {
-  const content = fs.readFileSync(packagedPlatformPr, "utf8");
-  requireContent(content, [
-    "types: [labeled, synchronize]",
-    "platform-proof",
-    "workflow_dispatch:",
-    "options: [platform, release-evidence, integration]",
-    "options: [auto, windows, macos, full]",
-    "expected_head_sha:",
-    "actions: read",
+function validatePackagedCoordinator(workflows, violations) {
+  const file = "packaged-platform-pr.yml";
+  const workflow = workflows.get(file);
+  if (!workflow) {
+    violations.push(`${file} must exist`);
+    return;
+  }
+  add(violations, sameMembers(at(workflow, "on", "pull_request", "types"), ["labeled", "synchronize"]), `${file} pull request types must be labeled and synchronize`);
+  add(violations, includesAll(at(workflow, "on", "workflow_dispatch", "inputs", "mode", "options"), ["platform", "release-evidence", "integration"]), `${file} dispatch modes changed`);
+  add(violations, includesAll(at(workflow, "on", "workflow_dispatch", "inputs", "scope", "options"), ["auto", "windows", "macos", "full"]), `${file} dispatch scopes changed`);
+  add(violations, trigger(workflow, "pull_request_target") === undefined, `${file} must not use pull_request_target`);
+  add(violations, object(workflow.permissions).actions === "read", `${file} must read source-proof runs`);
+  add(violations, object(workflow.permissions).contents === "read", `${file} must use read-only contents permission`);
+  const route = requireJob(violations, file, workflow, "route");
+  requireStepRun(violations, file, route, "Resolve trusted exact head", [
     'test "$head_repo" = "$GITHUB_REPOSITORY"',
     'test "$current_head" = "$expected_head"',
     'test "$base_ref" = "dev/codestory-next"',
-    'any(.labels[]; .name == "review-accepted")',
+  ]);
+  requireStepRun(violations, file, route, "Require successful exact-head source proof", [
     "actions/runs?head_sha=$HEAD_SHA",
     '.path == ".github/workflows/source-proof.yml"',
-    ".head_repository.full_name == $repo",
     '.name == "full-source-gate" and .conclusion == "success"',
-    'test "$INPUT_HEAD_SHA" = "$dev_head"',
-    "node .github/scripts/route-ci-proof.mjs --stdin",
-    "scope=full",
-    "uses: ./.github/workflows/source-proof.yml",
-    "uses: ./.github/workflows/repo-scale-stats.yml",
-    "uses: ./.github/workflows/release-candidate-evidence.yml",
-    "uses: ./.github/workflows/packaged-platform-proof.yml",
-    "profile: codestory-release-evidence-linux-arm64-v1",
-    "source_run_id: ${{ inputs.source_run_id }}",
-    "scope: ${{ needs.route.outputs.scope }}",
-    "always() &&\n      needs.route.result == 'success' &&\n      needs.packaged-proof.result == 'success' &&",
-    "uses: ./.github/workflows/macos-metal-proof.yml",
-    "use_packaged_cli_artifact: true",
-    "dev/codestory-next moved from proved head",
-  ], snippet => `packaged-platform-pr.yml must include ${snippet}`);
-  for (const violation of packagedPrSigningPolicyViolations(content)) {
-    violations.push(`packaged-platform-pr.yml ${violation}`);
-  }
-  const signingPolicyMutations = [
-    [
-      "sign_macos true",
-      content.replace("      sign_macos: false", "      sign_macos: true"),
-    ],
-    [
-      "explicit secrets mapping",
-      content.replace(
-        "      sign_macos: false",
-        "      sign_macos: false\n    secrets:\n      PACKAGE_PROOF_TOKEN: ${{ secrets.PACKAGE_PROOF_TOKEN }}",
-      ),
-    ],
-    [
-      "inherited secrets",
-      content.replace("      sign_macos: false", "      sign_macos: false\n    secrets: inherit"),
-    ],
-    [
-      "Apple secret identifier",
-      content.replace("      sign_macos: false", "      sign_macos: false\n    # APPLE_NOTARY_KEY_ID"),
-    ],
-    [
-      "release signing environment",
-      content.replace(
-        "  packaged-proof:\n",
-        "  packaged-proof:\n    environment: macos-release-signing\n",
-      ),
-    ],
-  ];
-  for (const [name, candidate] of signingPolicyMutations) {
-    if (candidate === content) {
-      violations.push(`packaged-platform-pr.yml could not apply ${name} policy mutation`);
-    } else if (packagedPrSigningPolicyViolations(candidate).length === 0) {
-      violations.push(`packaged-platform-pr.yml signing policy accepted ${name} mutation`);
-    }
-  }
-  if ((content.match(/branches\/dev\/codestory-next/gu) ?? []).length < 2) {
-    violations.push("packaged-platform-pr.yml must verify the dev head before and after integration proof");
-  }
-  if (
-    content.includes("contents: write") ||
-    content.includes("uses: ./.github/workflows/release.yml") ||
-    content.includes("pull_request_target:")
-  ) {
-    violations.push("packaged-platform-pr.yml must not request release permissions or call the publishing workflow");
-  }
+  ]);
+  requireStepRun(violations, file, route, "Select change-aware proof scope", ["node .github/scripts/route-ci-proof.mjs --stdin"]);
+  const packaged = requireJob(violations, file, workflow, "packaged-proof");
+  add(violations, packaged.uses === "./.github/workflows/packaged-platform-proof.yml", `${file} must call packaged proof`);
+  violations.push(...packagedPrSigningViolations(workflow));
+  const metal = requireJob(violations, file, workflow, "macos-metal-proof");
+  add(violations, sameMembers(needs(metal), ["route", "packaged-proof"]), `${file} Metal proof must wait for package proof`);
+  add(violations, object(metal.with).use_packaged_cli_artifact === true, `${file} Metal proof must use the packaged CLI`);
+  const closeout = requireJob(violations, file, workflow, "closeout");
+  requireStepRun(violations, file, closeout, "Require one coherent accepted proof", ["dev/codestory-next moved from proved head"]);
+  add(violations, !scalarStrings(workflow).some(value => value === "./.github/workflows/release.yml"), `${file} must not publish releases`);
 }
 
-if (!fs.existsSync(releaseCandidateEvidence)) {
-  violations.push("release evidence workflow must own protected live evidence");
-} else {
-  const content = fs.readFileSync(releaseCandidateEvidence, "utf8");
-  requireContent(content, [
-    "workflow_call:",
-    "proof_key:",
-    "environment: release-evidence",
-    "runs-on: [self-hosted, Linux, ARM64, codestory-release-evidence]",
-    "ref: ${{ inputs.ref }}",
-    "validate-source-run",
-    "actions/runs/$SOURCE_RUN_ID",
-    "actions/runs/$SOURCE_RUN_ID/artifacts",
-    "--artifacts target/release-evidence/source-run-artifacts.json",
-    "--test-threads=1",
-    "release-evidence-${{ inputs.ref }}",
-  ], snippet => `release evidence workflow must include ${snippet}`);
-  if (content.includes("workflow_dispatch:")) {
-    violations.push("release evidence workflow must be callable only through the coordinator workflow");
+function validateRemainingWorkflows(workflows, violations) {
+  const autoFile = "auto-release.yml";
+  const auto = workflows.get(autoFile);
+  if (!auto) {
+    violations.push(`${autoFile} must exist`);
+  } else {
+    add(violations, includesAll(at(auto, "on", "push", "branches"), ["main"]), `${autoFile} must run on main`);
+    add(violations, includesAll(at(auto, "on", "push", "paths"), ["package.json", "package-lock.json"]), `${autoFile} must observe policy dependency changes`);
+    const policy = requireJob(violations, autoFile, auto, "workflow-policy");
+    requireStepRun(violations, autoFile, policy, "Install workflow policy dependencies", ["npm ci --ignore-scripts"]);
+    requireStepRun(violations, autoFile, policy, "Enforce workflow policy", ["node .github/scripts/check-workflow-policy.mjs"]);
+    const release = requireJob(violations, autoFile, auto, "release");
+    add(violations, release.uses === "./.github/workflows/release.yml", `${autoFile} must call the release workflow`);
+    add(violations, sameMembers(needs(release), ["detect-version"]), `${autoFile} release must need version detection`);
+    add(violations, object(release.permissions).contents === "write", `${autoFile} release caller must grant contents write`);
+    add(violations, object(release.permissions).actions === "read", `${autoFile} release caller must grant actions read`);
   }
-}
 
-if (!fs.existsSync(macosMetalProof)) {
-  violations.push("macos-metal-proof.yml must gate release assets on protected Apple Silicon hardware");
-} else {
-  const content = fs.readFileSync(macosMetalProof, "utf8");
-  requireContent(content, [
-    "workflow_call:",
-    "workflow_dispatch:",
-    "use_packaged_cli_artifact:",
-    "runs-on: [self-hosted, macOS, ARM64, codestory-metal]",
-    "environment: macos-metal-release",
-    "actions/download-artifact@v8.0.1",
-    "name: codestory-cli-macos-arm64",
-    "node scripts/setup-retrieval-env.mjs --self-test",
-    "python3 --version",
-    "test \"$macos_major\" -ge 15",
-    "--native-accelerator-lifecycle",
-    "--managed-plugin-grounding-convergence",
-    "CODESTORY_PROOF_TEMP_ROOT:",
-    "Clean and assert proof-owned hardware state",
-    "--cleanup-proof-temp-root",
-    "CODESTORY_EMBED_DEVICE_PROVIDER: metal",
-    "CODESTORY_EMBED_ALLOW_CPU: \"0\"",
-    "macos-arm64-metal-proof-${{ inputs.version }}",
-    "proof_key:",
-    "cancel-in-progress: true",
-  ], snippet => `macos-metal-proof.yml must include ${snippet}`);
-}
+  const evidenceFile = "release-candidate-evidence.yml";
+  const evidence = workflows.get(evidenceFile);
+  if (!evidence) {
+    violations.push(`${evidenceFile} must exist`);
+  } else {
+    add(violations, trigger(evidence, "workflow_call") !== undefined, `${evidenceFile} must be reusable`);
+    add(violations, trigger(evidence, "workflow_dispatch") === undefined, `${evidenceFile} must be coordinator-only`);
+    const job = requireJob(violations, evidenceFile, evidence, "measure");
+    add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Linux", "ARM64", "codestory-release-evidence"]), `${evidenceFile} must use the protected evidence runner`);
+    add(violations, job.environment === "release-evidence", `${evidenceFile} must use the release-evidence environment`);
+    requireStepRun(violations, evidenceFile, job, "Produce full-sidecar repo evidence", ["--test-threads=1"]);
+    requireStepRun(violations, evidenceFile, job, "Download prior rejected evidence for approval re-evaluation", ["actions/runs/$SOURCE_RUN_ID", "actions/runs/$SOURCE_RUN_ID/artifacts"]);
+  }
 
-if (!fs.existsSync(repoScaleStats)) {
-  violations.push("repo-scale-stats.yml must own promoted-head stats proof");
-} else {
-  const content = fs.readFileSync(repoScaleStats, "utf8");
-  requireContent(content, [
-    "workflow_call:",
-    "cargo build --release --locked -p codestory-cli",
-    "cargo test --locked -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture",
-    "repo-scale-stats-${{ inputs.proof_key }}",
-    "actions/upload-artifact@v7.0.1",
-    "codestory-cli-default-features",
-    "cancel-in-progress: true",
-  ], snippet => `repo-scale-stats.yml must include ${snippet}`);
-}
+  const metalFile = "macos-metal-proof.yml";
+  const metal = workflows.get(metalFile);
+  if (!metal) {
+    violations.push(`${metalFile} must exist`);
+  } else {
+    add(violations, trigger(metal, "workflow_call") !== undefined && trigger(metal, "workflow_dispatch") !== undefined, `${metalFile} must support reusable and manual proof`);
+    const job = requireJob(violations, metalFile, metal, "packaged-metal-lifecycle");
+    add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "macOS", "ARM64", "codestory-metal"]), `${metalFile} must use the protected Apple Silicon runner`);
+    add(violations, job.environment === "macos-metal-release", `${metalFile} must use the protected Metal environment`);
+    requireStepRun(violations, metalFile, job, "Capture host evidence", ["python3 --version", 'test "$macos_major" -ge 15']);
+    const lifecycle = namedStep(job, "Prove cold, warm, dead-endpoint, recovery, packet, and plugin lifecycle");
+    requireStepRun(violations, metalFile, job, "Prove cold, warm, dead-endpoint, recovery, packet, and plugin lifecycle", ["--native-accelerator-lifecycle", "--managed-plugin-grounding-convergence"]);
+    add(violations, object(lifecycle?.env).CODESTORY_EMBED_DEVICE_PROVIDER === "metal", `${metalFile} lifecycle must require Metal`);
+    add(violations, object(lifecycle?.env).CODESTORY_EMBED_ALLOW_CPU === "0", `${metalFile} lifecycle must reject CPU fallback`);
+    requireStepRun(violations, metalFile, job, "Clean and assert proof-owned hardware state", ["--cleanup-proof-temp-root"]);
+  }
 
-if (!fs.existsSync(retrievalSidecarSmoke)) {
-  violations.push("retrieval-sidecar-smoke.yml must exist");
-} else {
-  const windowsJob = yamlJob(fs.readFileSync(retrievalSidecarSmoke, "utf8"), "windows-manifest-missing");
-  if (
-    !windowsJob.includes("    if: github.event_name == 'workflow_dispatch'") ||
-    windowsJob.some(line => line.includes("labels"))
-  ) {
-    violations.push("retrieval-sidecar-smoke.yml Windows proof must be workflow_dispatch-only");
+  const statsFile = "repo-scale-stats.yml";
+  const stats = workflows.get(statsFile);
+  if (!stats) {
+    violations.push(`${statsFile} must exist`);
+  } else {
+    const job = requireJob(violations, statsFile, stats, "stats");
+    requireStepRun(violations, statsFile, job, "Build the release CLI", ["cargo build --release --locked -p codestory-cli"]);
+    requireStepRun(violations, statsFile, job, "Run mandatory repo-scale stats once", ["cargo test --locked -p codestory-cli --test codestory_repo_e2e_stats -- --ignored --nocapture"]);
+    requireStepUses(violations, statsFile, job, "Upload repo-scale stats output", "actions/upload-artifact@v7.0.1");
+  }
+
+  const retrievalFile = "retrieval-sidecar-smoke.yml";
+  const retrieval = workflows.get(retrievalFile);
+  if (!retrieval) {
+    violations.push(`${retrievalFile} must exist`);
+  } else {
+    const windows = requireJob(violations, retrievalFile, retrieval, "windows-manifest-missing");
+    add(violations, windows.if === "github.event_name == 'workflow_dispatch'", `${retrievalFile} Windows proof must be workflow-dispatch only`);
+    add(violations, !scalarStrings(windows).some(value => value.includes("labels")), `${retrievalFile} Windows proof must not be label-triggered`);
+  }
+
+  const guardFile = "main-branch-source-guard.yml";
+  const guard = workflows.get(guardFile);
+  if (!guard) {
+    violations.push(`${guardFile} must exist`);
+  } else {
+    add(violations, includesAll(at(guard, "on", "pull_request", "branches"), ["main"]), `${guardFile} must guard main`);
+    const job = requireJob(violations, guardFile, guard, "enforce-source-branch");
+    const step = namedStep(job, "Require dev/codestory-next source branch");
+    add(violations, object(step?.env).HEAD_REPO !== undefined && object(step?.env).BASE_REPO !== undefined, `${guardFile} must compare source and base repository identity`);
+    add(violations, String(step?.run ?? "").includes("dev/codestory-next"), `${guardFile} must require the dev source branch`);
   }
 }
 
-if (!fs.existsSync(mainBranchSourceGuard)) {
-  violations.push("main-branch-source-guard.yml must guard PRs into main");
-} else {
-  const content = fs.readFileSync(mainBranchSourceGuard, "utf8");
-  const requiredSnippets = [
-    "pull_request:",
-    "- main",
-    "dev/codestory-next",
-    "HEAD_REPO",
-    "BASE_REPO",
-  ];
-
-  requireContent(content, requiredSnippets, snippet => `main-branch-source-guard.yml must include ${snippet}`);
+export function validateWorkflows(workflows) {
+  const violations = [];
+  for (const [file, workflow] of workflows) {
+    violations.push(...basicWorkflowViolations(file, workflow));
+  }
+  validateLockedSetupSurfaces(violations);
+  validateIssueWorkflows(workflows, violations);
+  validatePluginAndDraftWorkflows(workflows, violations);
+  validateReleaseCoordinator(workflows, violations);
+  validatePackagedProof(workflows, violations);
+  validatePostPublish(workflows, violations);
+  validatePackagedCoordinator(workflows, violations);
+  validateRemainingWorkflows(workflows, violations);
+  return violations;
 }
 
-if (violations.length > 0) {
-  console.error(violations.join("\n"));
-  process.exit(1);
+function main() {
+  let workflows;
+  try {
+    workflows = loadWorkflows();
+  } catch (error) {
+    console.error(`Workflow YAML parse failed: ${error.message}`);
+    process.exit(1);
+  }
+  const violations = validateWorkflows(workflows);
+  if (violations.length > 0) {
+    console.error(violations.join("\n"));
+    process.exit(1);
+  }
+  console.log("Workflow policy passed: parsed workflow structure satisfies repository contracts.");
 }
 
-console.log("Workflow policy passed: third-party actions and saga issue-link guard are valid.");
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  basicWorkflowViolations,
+  managedPluginViolations,
+  notaryStepViolations,
+  packagedPrSigningViolations,
+  parseWorkflow,
+} from "./check-workflow-policy.mjs";
+
+const fullSha = "0123456789abcdef0123456789abcdef01234567";
+
+function managedJob() {
+  return {
+    strategy: { "fail-fast": false, matrix: { include: [{ os: "ubuntu-latest" }] } },
+    steps: [
+      {
+        name: "Prove managed plugin handoff",
+        run: [
+          "python .github/scripts/check-packaged-agent-proof.py",
+          "--archive package.tar.gz",
+          "--managed-plugin-handoff",
+        ].join("\n"),
+      },
+    ],
+  };
+}
+
+test("parser ignores YAML comments and harmless formatting", () => {
+  const block = parseWorkflow(`
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vendor/action@${fullSha}
+# uses: vendor/action@main
+`);
+  const flow = parseWorkflow(`
+"on": { pull_request: null }
+permissions: { contents: read }
+jobs: { check: { runs-on: ubuntu-latest, steps: [ { uses: vendor/action@${fullSha} } ] } }
+`);
+  assert.deepEqual(block, flow);
+});
+
+test("third-party action policy reads only parsed uses values", () => {
+  const valid = parseWorkflow(`
+on: { workflow_dispatch: null }
+jobs:
+  check:
+    steps:
+      - uses: vendor/action@${fullSha}
+# uses: vendor/action@main
+`);
+  assert.deepEqual(basicWorkflowViolations("fixture.yml", valid), []);
+
+  const invalid = structuredClone(valid);
+  invalid.jobs.check.steps[0].uses = "vendor/action@main";
+  assert.match(basicWorkflowViolations("fixture.yml", invalid).join("\n"), /full-length SHA/u);
+});
+
+test("Cargo lock policy reads executable step commands", () => {
+  const workflow = parseWorkflow(`
+on: { workflow_dispatch: null }
+jobs:
+  check:
+    steps:
+      - run: |
+          # cargo test --workspace
+          cargo test --workspace --locked
+`);
+  assert.deepEqual(basicWorkflowViolations("fixture.yml", workflow), []);
+
+  workflow.jobs.check.steps[0].run += "\ncargo check --workspace\n";
+  assert.match(basicWorkflowViolations("fixture.yml", workflow).join("\n"), /must use --locked/u);
+});
+
+test("managed proof rejects structural bypasses and decoy commands", () => {
+  assert.deepEqual(managedPluginViolations(managedJob(), "--archive package.tar.gz"), []);
+
+  const mutations = [
+    job => { job.strategy["fail-fast"] = true; },
+    job => { job.strategy.matrix.exclude = [{ os: "ubuntu-latest" }]; },
+    job => { job.if = "always()"; },
+    job => { job.steps[0]["continue-on-error"] = true; },
+    job => {
+      job.steps[0].run = "python .github/scripts/check-packaged-agent-proof.py\n--archive package.tar.gz\n# --managed-plugin-handoff";
+      job.steps.push({ name: "Decoy", run: "--managed-plugin-handoff" });
+    },
+  ];
+  for (const mutate of mutations) {
+    const candidate = managedJob();
+    mutate(candidate);
+    assert.notDeepEqual(managedPluginViolations(candidate, "--archive package.tar.gz"), []);
+  }
+});
+
+test("PR package proof cannot opt into signing credentials", () => {
+  const workflow = { jobs: { "packaged-proof": { with: { sign_macos: false } } } };
+  assert.deepEqual(packagedPrSigningViolations(workflow), []);
+
+  for (const mutate of [
+    candidate => { candidate.jobs["packaged-proof"].with.sign_macos = true; },
+    candidate => { candidate.jobs["packaged-proof"].secrets = "inherit"; },
+    candidate => { candidate.jobs["packaged-proof"].environment = "macos-release-signing"; },
+    candidate => { candidate.env = { APPLE_NOTARY_KEY_ID: "forbidden" }; },
+  ]) {
+    const candidate = structuredClone(workflow);
+    mutate(candidate);
+    assert.notDeepEqual(packagedPrSigningViolations(candidate), []);
+  }
+});
+
+test("notarization must use explicit polling", () => {
+  assert.deepEqual(notaryStepViolations({ run: "xcrun notarytool submit bundle.zip \\\n  --no-wait" }), []);
+  assert.match(
+    notaryStepViolations({ run: "xcrun notarytool submit bundle.zip \\\n  --wait" }).join("\n"),
+    /poll explicitly/u,
+  );
+});

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,6 +13,8 @@ on:
       - .github/workflows/auto-release.yml
       - .github/workflows/release.yml
       - .github/scripts/**
+      - package.json
+      - package-lock.json
       - plugins/codestory/**
 
 permissions:
@@ -31,7 +33,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Enforce third-party action pinning
+      - name: Install workflow policy dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Enforce workflow policy
         run: node .github/scripts/check-workflow-policy.mjs
 
   detect-version:

--- a/.github/workflows/plugin-static.yml
+++ b/.github/workflows/plugin-static.yml
@@ -10,6 +10,9 @@ on:
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/check-workflow-policy.test.mjs
+      - package.json
+      - package-lock.json
       - .github/scripts/route-ci-proof.mjs
       - .github/workflows/auto-release.yml
       - .github/workflows/main-branch-source-guard.yml
@@ -39,6 +42,9 @@ on:
       - .github/scripts/check-packaged-agent-proof.py
       - .github/scripts/package-codestory-release.py
       - .github/scripts/check-workflow-policy.mjs
+      - .github/scripts/check-workflow-policy.test.mjs
+      - package.json
+      - package-lock.json
       - .github/scripts/route-ci-proof.mjs
       - .github/workflows/auto-release.yml
       - .github/workflows/main-branch-source-guard.yml
@@ -73,11 +79,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Install workflow policy dependencies
+        run: npm ci --ignore-scripts
+
       - name: Check plugin static wiring
         run: node --test plugins/codestory/tests/plugin-static.test.mjs
 
       - name: Check workflow policy
-        run: node .github/scripts/check-workflow-policy.mjs
+        run: |
+          node .github/scripts/check-workflow-policy.mjs
+          node --test .github/scripts/check-workflow-policy.test.mjs
 
       - name: Check CI proof routing fixtures
         run: node .github/scripts/route-ci-proof.mjs --self-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Enforce third-party action pinning
+      - name: Install workflow policy dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Enforce workflow policy
         run: node .github/scripts/check-workflow-policy.mjs
 
   preflight:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@
   and workflow policy rejects unlocked Cargo commands. Project-controlled
   network endpoints remain disabled unless a trusted operator enables the
   process-wide project-network opt-in.
+- Workflow policy now parses YAML structure with one exact-pinned dependency.
+  Trigger, permission, job, matrix, secret, dependency, condition, and named
+  step checks no longer accept comments or unrelated command text as evidence.
 - Release proof is staged by maturity and changed surface. Draft changes use
   focused source checks; exact-head, platform, protected hardware, signing, and
   installation proof run only at their explicit promotion boundaries. The

--- a/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
+++ b/crates/codestory-runtime/tests/retrieval_generalization_guard.rs
@@ -598,7 +598,7 @@ fn linter_binds_policy_allowances_to_the_exact_approved_use() {
         ),
         (
             ".github/scripts/check-workflow-policy.mjs",
-            "const retrievalSidecarSmoke = path.join(workflowRoot, \"retrieval-sidecar-smoke.yml\");\nviolations.push(\"retrieval-sidecar-smoke.yml must exist\");\nviolations.push(\"retrieval-sidecar-smoke.yml Windows proof must be workflow_dispatch-only\");\n",
+            "const retrievalFile = \"retrieval-sidecar-smoke.yml\";\n",
         ),
     ]);
     let allowed_stderr = String::from_utf8_lossy(&allowed.stderr);
@@ -614,7 +614,7 @@ fn linter_binds_policy_allowances_to_the_exact_approved_use() {
         ),
         (
             ".github/scripts/check-workflow-policy.mjs",
-            "const retrievalSidecarSmoke = path.join(workflowRoot, \"retrieval-sidecar-smoke.yml\");\nconst hostile = \".github/workflows/retrieval-\" + \"sidecar-smoke.yml\";\n",
+            "const retrievalFile = \"retrieval-sidecar-smoke.yml\";\nconst hostile = \".github/workflows/retrieval-\" + \"sidecar-smoke.yml\";\n",
         ),
     ]);
     let rejected_stderr = String::from_utf8_lossy(&rejected.stderr).to_ascii_lowercase();

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -106,9 +106,16 @@ release version, update every `codestory-*` workspace crate version and
 `Cargo.lock` in the same change.
 
 ```sh
+npm ci --ignore-scripts
 node .github/scripts/check-workflow-policy.mjs
+node --test .github/scripts/check-workflow-policy.test.mjs
 python .github/scripts/check-codestory-release.py --version <version>
 ```
+
+The workflow policy checker parses YAML before inspecting triggers,
+permissions, jobs, matrices, secrets, dependencies, conditions, and named step
+commands. Keep its single exact-pinned parser dependency in `package-lock.json`;
+comments and unrelated steps are not policy evidence.
 
 After a `main` release, run the release version check on `dev/codestory-next`
 with the released version before starting the next release lane.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "issue-1110-workflow-policy",
+  "name": "codestory-workflow-policy",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "codestory-workflow-policy",
       "devDependencies": {
         "yaml": "2.9.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "issue-1110-workflow-policy",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "yaml": "2.9.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "codestory-workflow-policy",
   "private": true,
   "devDependencies": {
     "yaml": "2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "yaml": "2.9.0"
+  }
+}

--- a/scripts/lint-retrieval-generalization.mjs
+++ b/scripts/lint-retrieval-generalization.mjs
@@ -103,27 +103,17 @@ const allowedHarnessReferences = [
   [
     path.join(".github", "scripts", "check-workflow-policy.mjs"),
     "retrieval-sidecar-smoke.yml",
-    "const retrievalSidecarSmoke = path.join(workflowRoot, \"retrieval-sidecar-smoke.yml\");",
-  ],
-  [
-    path.join(".github", "scripts", "check-workflow-policy.mjs"),
-    "retrieval-sidecar-smoke.yml",
-    "violations.push(\"retrieval-sidecar-smoke.yml must exist\");",
-  ],
-  [
-    path.join(".github", "scripts", "check-workflow-policy.mjs"),
-    "retrieval-sidecar-smoke.yml",
-    "violations.push(\"retrieval-sidecar-smoke.yml Windows proof must be workflow_dispatch-only\");",
+    'const retrievalFile = "retrieval-sidecar-smoke.yml";',
   ],
   [
     path.join(".github", "scripts", "check-workflow-policy.mjs"),
     ".github/workflows/release-candidate-evidence.yml",
-    "const releaseCandidateEvidence = path.join(workflowRoot, \"release-candidate-evidence.yml\");",
+    'const evidenceFile = "release-candidate-evidence.yml";',
   ],
   [
     path.join(".github", "scripts", "check-workflow-policy.mjs"),
     ".github/workflows/release-candidate-evidence.yml",
-    "\"uses: ./.github/workflows/release-candidate-evidence.yml\",",
+    'add(violations, evidence.uses === "./.github/workflows/release-candidate-evidence.yml", `${releaseFile} release-evidence must call the evidence workflow`);',
   ],
   [
     path.join(".github", "workflows", "packaged-platform-pr.yml"),


### PR DESCRIPTION
## Context

The workflow-policy gate was parsing YAML as indented text. Comments, harmless quoting changes, and formatting could satisfy or break checks without changing the workflow GitHub executes. This replaces that parser while preserving the current policy surface, including the centralized Node worktree setup added on the integration branch.

Base: `1ee918119e004cccf220bfab05085152172b3b34`
Head: `d3df927a06044afdb2eceb3de195b08fdc17f4d1`

Closes #1110
Refs #899

## What changed

- exact-pinned `yaml@2.9.0` in the root package and lockfile, installed with `npm ci --ignore-scripts` in every workflow that runs the policy gate
- structural checks for triggers, permissions, jobs, dependencies, conditions, matrices, secrets, action refs, cache keys, and named step commands
- six focused mutation tests covering formatting immunity and credible policy bypasses
- updated generalization-lint fixtures, contributor guidance, and changelog

The production checker shrinks from 839 lines on the base to 746. Tests live in a separate 124-line file instead of being embedded in formatting-sensitive parsing helpers.

## Review

Start with `.github/scripts/check-workflow-policy.mjs` and its six mutation tests. The one intentionally scalar-specific parser is the dynamic `fromJSON(...)` package matrix expression; the surrounding workflow and matrix field are still selected structurally.

Risk: S4/R2. This changes a release-policy gate, but not runtime behavior. The main risk is dropping an existing invariant during the parser replacement; the full live workflow set and focused bypass mutations both pass.

## Verification

- `npm ci --ignore-scripts`
- `node --test .github/scripts/check-workflow-policy.test.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` (73 passed, 1 Windows-only skip)
- `node scripts/codex-worktree-setup.mjs --self-test`
- `node .github/scripts/route-ci-proof.mjs --self-test`
- `python .github/scripts/check-packaged-agent-proof.py --self-test`
- `python .github/scripts/package-codestory-release.py --self-test`
- `python .github/scripts/test-detect-codestory-release.py`
- `python .github/scripts/check-codestory-release.py --version 0.15.0`
- `node scripts/lint-retrieval-generalization.mjs`
- `node .github/scripts/check-doc-links.mjs`
- direct `rustfmt` on the adjusted Rust fixture
- changed-scope code-simplifier scan and `git diff --check`

No Cargo lane was run; this change does not alter Rust behavior, and broad Cargo proof belongs on the accepted exact head.
