### PR TITLE
[codex] move symbol workflows into runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
   byte protocols, preserves valid UTF-8 pathname whitespace, and returns
   `unsupported_non_utf8_path` instead of lossy DTO text. Workspace-relative
   path stripping now follows native filesystem identity and case rules.
+- `impact` and `test-map` now use one typed runtime workflow for symbol
+  resolution, caller traversal, affected projections, caps, unknowns, and next
+  actions. The CLI keeps the existing syntax and output while limiting itself
+  to request parsing and rendering.
 - Generation and packaged-proof deletion now stays relative to one pinned,
   trusted directory handle. Unix cleanup uses no-follow descriptor traversal;
   Windows rejects reparse traversal and deletes through the opened handle, so

--- a/crates/codestory-cli/src/display.rs
+++ b/crates/codestory-cli/src/display.rs
@@ -1,4 +1,4 @@
-use codestory_contracts::api::{GroundingBudgetDto, SearchHit, TrailDirection};
+use codestory_contracts::api::{GroundingBudgetDto, TrailDirection};
 use std::path::Path;
 
 use crate::args::CliTrailMode;
@@ -49,19 +49,6 @@ pub(crate) fn relative_path(project_root: &Path, raw: &str) -> String {
     codestory_workspace::workspace_relative_path(project_root, Path::new(&normalized_raw))
         .map(|relative| clean_path_string(&relative.to_string_lossy()))
         .unwrap_or(normalized_raw)
-}
-
-pub(crate) fn format_search_hit_target(project_root: &Path, hit: &SearchHit) -> String {
-    let mut out = format!("{} [{}]", hit.display_name, format_kind(hit.kind));
-    if let Some(path) = hit.file_path.as_deref() {
-        out.push(' ');
-        out.push_str(&relative_path(project_root, path));
-    }
-    if let Some(line) = hit.line {
-        out.push(':');
-        out.push_str(&line.to_string());
-    }
-    out
 }
 
 pub(crate) fn format_kind(kind: codestory_contracts::api::NodeKind) -> String {

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -25,7 +25,7 @@ use codestory_contracts::api::{
     ReadinessGoalDto, ReadinessStatusDto, RepoTextScanStatsDto, RetrievalFallbackReasonDto,
     RetrievalScoreBreakdownDto, RetrievalShadowDto, SearchHit, SearchMatchQualityDto,
     SearchQueryAssessmentDto, SearchRepoTextMode, SearchRequest, SourceOccurrenceDto,
-    TrailCallerScope, TrailConfigDto, TrailContextDto, TrailDirection, TrailMode,
+    TrailContextDto,
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -55,7 +55,6 @@ mod file_state;
 mod http_transport;
 mod local_refresh_status;
 mod output;
-mod query_resolution;
 mod readiness;
 mod readiness_broker;
 mod ready_repair_status;
@@ -243,8 +242,12 @@ async fn run_cli(cli: Cli) -> Result<()> {
         Command::Drill(cmd) => run_drill(cmd),
         Command::DrillSuite(cmd) => run_drill_suite(cmd),
         Command::Symbol(cmd) => run_symbol(cmd),
-        Command::Impact(cmd) => run_symbol_workflow(SymbolWorkflowKind::Impact, cmd),
-        Command::TestMap(cmd) => run_symbol_workflow(SymbolWorkflowKind::TestMap, cmd),
+        Command::Impact(cmd) => {
+            run_symbol_workflow(codestory_runtime::SymbolWorkflowMode::Impact, cmd)
+        }
+        Command::TestMap(cmd) => {
+            run_symbol_workflow(codestory_runtime::SymbolWorkflowMode::TestMap, cmd)
+        }
         Command::Trail(cmd) => run_trail(cmd),
         Command::Callers(cmd) => run_callers(cmd),
         Command::Callees(cmd) => run_callees(cmd),
@@ -5681,472 +5684,102 @@ fn run_symbol(cmd: SymbolCommand) -> Result<()> {
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
 
-#[derive(Debug, Clone, Copy)]
-enum SymbolWorkflowKind {
-    Impact,
-    TestMap,
-}
-
-impl SymbolWorkflowKind {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Impact => "impact",
-            Self::TestMap => "test_map",
-        }
-    }
-
-    fn title(self) -> &'static str {
-        match self {
-            Self::Impact => "Symbol Impact",
-            Self::TestMap => "Symbol Test Map",
-        }
-    }
-}
-
-#[derive(serde::Serialize)]
-struct SymbolWorkflowNodeOutput {
-    node_id: NodeId,
-    display_name: String,
-    kind: String,
-    file_path: Option<String>,
-    depth: u32,
-}
-
-#[derive(serde::Serialize)]
-struct SymbolWorkflowRouteOutput {
-    display_name: String,
-    method: String,
-    path: String,
-    file_path: Option<String>,
-    line: Option<u32>,
-    confidence: String,
-    reason: String,
-}
-
-#[derive(serde::Serialize)]
-struct SymbolWorkflowTestOutput {
-    path: String,
-    reason: String,
-    confidence: String,
-    graph_depth: u32,
-    impacted_symbol_count: u32,
-}
-
-#[derive(serde::Serialize)]
-struct SymbolWorkflowCapsOutput {
-    caller_depth: u32,
-    caller_max_nodes: u32,
-    affected_depth: u32,
-    impacted_symbols_cap: u32,
-    impacted_routes_cap: u32,
-    affected_seed: String,
-}
-
 #[derive(serde::Serialize)]
 struct SymbolWorkflowOutput<'a> {
     workflow: &'static str,
-    project_root: String,
+    project_root: &'a str,
     resolution: QueryResolutionOutput,
     symbol: &'a codestory_contracts::api::SymbolContextDto,
-    direct_callers: Vec<SymbolWorkflowNodeOutput>,
-    transitive_callers: Vec<SymbolWorkflowNodeOutput>,
-    impacted_files: Vec<String>,
-    impacted_routes: Vec<SymbolWorkflowRouteOutput>,
-    likely_tests: Vec<SymbolWorkflowTestOutput>,
-    caps: SymbolWorkflowCapsOutput,
-    unknowns: Vec<String>,
-    next_commands: Vec<String>,
+    direct_callers: &'a [codestory_runtime::SymbolWorkflowNode],
+    transitive_callers: &'a [codestory_runtime::SymbolWorkflowNode],
+    impacted_files: &'a [String],
+    impacted_routes: &'a [codestory_runtime::SymbolWorkflowRoute],
+    likely_tests: &'a [codestory_runtime::SymbolWorkflowTest],
+    caps: &'a codestory_runtime::SymbolWorkflowCaps,
+    unknowns: &'a [String],
+    next_commands: &'a [String],
     #[serde(default, skip_serializing_if = "Option::is_none")]
     affected: Option<&'a codestory_contracts::api::AffectedAnalysisDto>,
     trail: &'a TrailContextDto,
 }
 
-fn run_symbol_workflow(kind: SymbolWorkflowKind, cmd: SymbolWorkflowCommand) -> Result<()> {
-    ensure_dot_only_for_trail(cmd.format, kind.label())?;
+fn run_symbol_workflow(
+    mode: codestory_runtime::SymbolWorkflowMode,
+    cmd: SymbolWorkflowCommand,
+) -> Result<()> {
+    ensure_dot_only_for_trail(cmd.format, mode.label())?;
     preflight_output_file(cmd.output_file.as_deref())?;
     let runtime = RuntimeContext::new(&cmd.project)?;
     let opened = runtime.ensure_open(cmd.refresh)?;
-    ensure_index_ready(&opened, kind.label())?;
+    ensure_index_ready(&opened, mode.label())?;
 
     let file_filter = cmd.target.file_filter();
-    let target = resolve_target_or_emit_ambiguity(
-        &runtime,
-        cmd.target.selection()?,
-        file_filter.as_deref(),
-        cmd.format,
-        cmd.output_file.as_deref(),
-    )?;
-    let symbol = runtime
-        .browser
-        .symbol_context(target.selected.node_id.clone())
-        .map_err(map_api_error)?;
-
-    let depth = cmd.depth.clamp(1, 8);
-    let max_nodes = cmd.max_nodes.clamp(1, 200);
-    let include_tests = cmd.include_tests || matches!(kind, SymbolWorkflowKind::TestMap);
-    let trail = runtime
-        .browser
-        .trail_context(TrailConfigDto {
-            root_id: target.selected.node_id.clone(),
-            mode: TrailMode::AllReferencing,
-            target_id: None,
-            depth,
-            direction: TrailDirection::Incoming,
-            caller_scope: if include_tests {
-                TrailCallerScope::IncludeTestsAndBenches
-            } else {
-                TrailCallerScope::ProductionOnly
-            },
-            edge_filter: Vec::new(),
-            show_utility_calls: false,
-            hide_speculative: true,
-            story: false,
-            node_filter: Vec::new(),
-            max_nodes,
-            layout_direction: codestory_contracts::api::LayoutDirection::Horizontal,
-        })
-        .map_err(map_api_error)?;
-
-    let affected_seed = target
-        .selected
-        .file_path
-        .clone()
-        .or_else(|| symbol.node.file_path.clone())
-        .map(|path| symbol_workflow_seed_path(&runtime.project_root, &path));
-    let affected = if let Some(path) = affected_seed.as_ref() {
-        Some(
-            runtime
-                .browser
-                .affected_analysis(AffectedAnalysisRequest {
-                    changed_paths: vec![path.clone()],
-                    change_records: vec![AffectedChangeRecordDto {
-                        path: path.clone(),
-                        kind: AffectedChangeKindDto::Unknown,
-                        status: "symbol_file".to_string(),
-                        previous_path: None,
-                    }],
-                    depth: Some(depth),
-                    filter: None,
-                })
-                .map_err(map_api_error)?,
-        )
-    } else {
-        None
+    let target = match cmd.target.selection()? {
+        args::TargetSelection::Id(id) => codestory_runtime::TargetSelection::Id(id),
+        args::TargetSelection::Query { query, choose } => {
+            codestory_runtime::TargetSelection::Query { query, choose }
+        }
     };
-
-    let direct_callers = symbol_workflow_direct_callers(&trail);
-    let transitive_callers = symbol_workflow_transitive_callers(&trail, &direct_callers);
-    let impacted_files = symbol_workflow_impacted_files(affected.as_ref());
-    let impacted_routes = symbol_workflow_routes(affected.as_ref());
-    let likely_tests = symbol_workflow_tests(affected.as_ref());
-    let unknowns = symbol_workflow_unknowns(
-        affected.as_ref(),
-        &trail,
-        &direct_callers,
-        &transitive_callers,
-        &likely_tests,
-        affected_seed.as_deref(),
-        max_nodes,
-    );
-    let next_commands = symbol_workflow_next_commands(
+    let response = match runtime
+        .browser
+        .symbol_workflow(codestory_runtime::SymbolWorkflowRequest {
+            mode,
+            target,
+            file_filter,
+            depth: cmd.depth,
+            max_nodes: cmd.max_nodes,
+            include_tests: cmd.include_tests,
+        }) {
+        Ok(codestory_runtime::SymbolWorkflowOutcome::Complete(response)) => *response,
+        Ok(codestory_runtime::SymbolWorkflowOutcome::Ambiguous(ambiguous)) => {
+            return structured_ambiguous_target_failure(
+                &runtime,
+                AmbiguousTargetError {
+                    query: ambiguous.query,
+                    file_filter: ambiguous.file_filter,
+                    alternatives: ambiguous.alternatives,
+                    message: ambiguous.message,
+                },
+                cmd.format,
+                cmd.output_file.as_deref(),
+            );
+        }
+        Ok(codestory_runtime::SymbolWorkflowOutcome::Rejected(message)) => bail!(message),
+        Err(error) => return Err(map_api_error(error)),
+    };
+    let resolution_target =
+        runtime::ResolvedTarget::from_runtime(response.resolution.target.clone());
+    let resolution = build_query_resolution_output_from_occurrences(
         &runtime.project_root,
-        &target.selected.node_id,
-        affected_seed.as_deref(),
-        depth,
-        max_nodes,
-        kind,
-        include_tests,
+        &resolution_target,
+        &response.resolution.occurrences,
     );
-    let resolution = build_query_resolution_output_with_runtime(&runtime, &target);
-    let caps = SymbolWorkflowCapsOutput {
-        caller_depth: depth,
-        caller_max_nodes: max_nodes,
-        affected_depth: depth,
-        impacted_symbols_cap: 200,
-        impacted_routes_cap: 100,
-        affected_seed: affected_seed
-            .clone()
-            .unwrap_or_else(|| "none: selected symbol has no indexed file path".to_string()),
-    };
     let output = SymbolWorkflowOutput {
-        workflow: kind.label(),
-        project_root: runtime.project_root.to_string_lossy().to_string(),
+        workflow: response.workflow,
+        project_root: &response.project_root,
         resolution,
-        symbol: &symbol,
-        direct_callers,
-        transitive_callers,
-        impacted_files,
-        impacted_routes,
-        likely_tests,
-        caps,
-        unknowns,
-        next_commands,
-        affected: affected.as_ref(),
-        trail: &trail,
+        symbol: &response.symbol,
+        direct_callers: &response.direct_callers,
+        transitive_callers: &response.transitive_callers,
+        impacted_files: &response.impacted_files,
+        impacted_routes: &response.impacted_routes,
+        likely_tests: &response.likely_tests,
+        caps: &response.caps,
+        unknowns: &response.unknowns,
+        next_commands: &response.next_commands,
+        affected: response.affected.as_ref(),
+        trail: &response.trail,
     };
-    let markdown = render_symbol_workflow_markdown(kind, &output);
+    let markdown = render_symbol_workflow_markdown(mode, &output);
     emit(cmd.format, &output, markdown, cmd.output_file.as_deref())
 }
 
-fn symbol_workflow_direct_callers(trail: &TrailContextDto) -> Vec<SymbolWorkflowNodeOutput> {
-    let nodes = trail
-        .trail
-        .nodes
-        .iter()
-        .map(|node| (node.id.0.clone(), node))
-        .collect::<HashMap<_, _>>();
-    let mut seen = HashSet::new();
-    let mut callers = trail
-        .trail
-        .edges
-        .iter()
-        .filter(|edge| {
-            edge.kind == codestory_contracts::api::EdgeKind::CALL
-                && edge.target == trail.focus.id
-                && edge.source != trail.focus.id
-        })
-        .filter_map(|edge| {
-            if !seen.insert(edge.source.0.clone()) {
-                return None;
-            }
-            nodes
-                .get(&edge.source.0)
-                .map(|node| symbol_workflow_node_output(node))
-        })
-        .collect::<Vec<_>>();
-    callers.sort_by(|left, right| {
-        left.file_path
-            .cmp(&right.file_path)
-            .then(left.display_name.cmp(&right.display_name))
-    });
-    callers
-}
-
-fn symbol_workflow_transitive_callers(
-    trail: &TrailContextDto,
-    direct_callers: &[SymbolWorkflowNodeOutput],
-) -> Vec<SymbolWorkflowNodeOutput> {
-    let direct_ids = direct_callers
-        .iter()
-        .map(|caller| caller.node_id.0.clone())
-        .collect::<HashSet<_>>();
-    let mut callers = trail
-        .trail
-        .nodes
-        .iter()
-        .filter(|node| {
-            node.id != trail.focus.id
-                && node.depth > 1
-                && !direct_ids.contains(&node.id.0)
-                && symbol_workflow_has_call_path_to_focus(trail, &node.id)
-        })
-        .map(symbol_workflow_node_output)
-        .collect::<Vec<_>>();
-    callers.sort_by(|left, right| {
-        left.depth
-            .cmp(&right.depth)
-            .then(left.file_path.cmp(&right.file_path))
-            .then(left.display_name.cmp(&right.display_name))
-    });
-    callers.truncate(50);
-    callers
-}
-
-fn symbol_workflow_has_call_path_to_focus(trail: &TrailContextDto, start: &NodeId) -> bool {
-    let mut seen = HashSet::new();
-    let mut stack = vec![start.clone()];
-    while let Some(current) = stack.pop() {
-        if !seen.insert(current.0.clone()) {
-            continue;
-        }
-        for edge in trail.trail.edges.iter().filter(|edge| {
-            edge.kind == codestory_contracts::api::EdgeKind::CALL && edge.source == current
-        }) {
-            if edge.target == trail.focus.id {
-                return true;
-            }
-            stack.push(edge.target.clone());
-        }
-    }
-    false
-}
-
-fn symbol_workflow_node_output(
-    node: &codestory_contracts::api::GraphNodeDto,
-) -> SymbolWorkflowNodeOutput {
-    SymbolWorkflowNodeOutput {
-        node_id: node.id.clone(),
-        display_name: node
-            .qualified_name
-            .clone()
-            .unwrap_or_else(|| node.label.clone()),
-        kind: format!("{:?}", node.kind).to_ascii_lowercase(),
-        file_path: node.file_path.clone(),
-        depth: node.depth,
-    }
-}
-
-fn symbol_workflow_seed_path(project_root: &Path, path: &str) -> String {
-    let clean_path = path
-        .strip_prefix(r"\\?\")
-        .unwrap_or(path)
-        .replace('\\', "/");
-    codestory_workspace::workspace_relative_path(project_root, Path::new(&clean_path))
-        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
-        .unwrap_or(clean_path)
-}
-
-fn symbol_workflow_impacted_files(
-    affected: Option<&codestory_contracts::api::AffectedAnalysisDto>,
-) -> Vec<String> {
-    let mut files = BTreeSet::new();
-    if let Some(affected) = affected {
-        files.extend(affected.matched_files.iter().map(|file| file.path.clone()));
-        files.extend(
-            affected
-                .impacted_symbols
-                .iter()
-                .filter_map(|symbol| symbol.file_path.clone()),
-        );
-        files.extend(
-            affected
-                .impacted_routes
-                .iter()
-                .filter_map(|route| route.file_path.clone()),
-        );
-        files.extend(
-            affected
-                .impacted_routes
-                .iter()
-                .filter_map(|route| route.route.source_file.clone()),
-        );
-        files.extend(affected.impacted_tests.iter().map(|test| test.path.clone()));
-    }
-    files.into_iter().collect()
-}
-
-fn symbol_workflow_routes(
-    affected: Option<&codestory_contracts::api::AffectedAnalysisDto>,
-) -> Vec<SymbolWorkflowRouteOutput> {
-    affected
-        .into_iter()
-        .flat_map(|affected| affected.impacted_routes.iter())
-        .map(|route| SymbolWorkflowRouteOutput {
-            display_name: route.display_name.clone(),
-            method: route.route.method.clone(),
-            path: route.route.path.clone(),
-            file_path: route
-                .file_path
-                .clone()
-                .or_else(|| route.route.source_file.clone()),
-            line: route.line.or(route.route.line),
-            confidence: route.confidence.clone(),
-            reason: route.reason.clone(),
-        })
-        .collect()
-}
-
-fn symbol_workflow_tests(
-    affected: Option<&codestory_contracts::api::AffectedAnalysisDto>,
-) -> Vec<SymbolWorkflowTestOutput> {
-    affected
-        .into_iter()
-        .flat_map(|affected| affected.impacted_tests.iter())
-        .map(|test| SymbolWorkflowTestOutput {
-            path: test.path.clone(),
-            reason: test.reason.clone(),
-            confidence: test.confidence.clone(),
-            graph_depth: test.graph_depth,
-            impacted_symbol_count: test.impacted_symbol_count,
-        })
-        .collect()
-}
-
-fn symbol_workflow_unknowns(
-    affected: Option<&codestory_contracts::api::AffectedAnalysisDto>,
-    trail: &TrailContextDto,
-    direct_callers: &[SymbolWorkflowNodeOutput],
-    transitive_callers: &[SymbolWorkflowNodeOutput],
-    likely_tests: &[SymbolWorkflowTestOutput],
-    affected_seed: Option<&str>,
-    max_nodes: u32,
-) -> Vec<String> {
-    let mut unknowns = Vec::new();
-    unknowns.push(
-        "affected files/routes/tests are seeded from the selected symbol's file, not a symbol-level change slice"
-            .to_string(),
-    );
-    if affected_seed.is_none() {
-        unknowns.push(
-            "selected symbol has no indexed file path; affected analysis was skipped".to_string(),
-        );
-    }
-    if direct_callers.is_empty() {
-        unknowns.push("no direct callers found in the incoming trail".to_string());
-    }
-    if transitive_callers.is_empty() {
-        unknowns.push("no transitive callers found inside the caller depth cap".to_string());
-    }
-    if likely_tests.is_empty() {
-        unknowns.push("no test-like file reached by the affected graph walk".to_string());
-    }
-    if trail.trail.truncated {
-        unknowns.push(format!(
-            "caller trail truncated at max_nodes={max_nodes}; rerun with a narrower symbol or higher cap"
-        ));
-    }
-    if let Some(affected) = affected {
-        unknowns.extend(affected.blind_spots.iter().cloned());
-    }
-    unknowns.sort();
-    unknowns.dedup();
-    unknowns
-}
-
-fn symbol_workflow_next_commands(
-    project_root: &Path,
-    node_id: &NodeId,
-    affected_seed: Option<&str>,
-    depth: u32,
-    max_nodes: u32,
-    kind: SymbolWorkflowKind,
-    include_tests: bool,
-) -> Vec<String> {
-    let project = quote_command_path(project_root);
-    let id = quote_command_value(&node_id.0);
-    let caller_scope_flag = if include_tests {
-        " --include-tests"
-    } else {
-        ""
-    };
-    let mut commands = vec![
-        format!("codestory-cli symbol --project {project} --id {id}"),
-        format!(
-            "codestory-cli callers --project {project} --id {id} --depth {depth} --max-nodes {max_nodes}{caller_scope_flag}"
-        ),
-    ];
-    if let Some(path) = affected_seed {
-        commands.push(format!(
-            "codestory-cli affected --project {project} {} --depth {depth}",
-            quote_command_value(path)
-        ));
-    }
-    let paired = match kind {
-        SymbolWorkflowKind::Impact => "test-map",
-        SymbolWorkflowKind::TestMap => "impact",
-    };
-    commands.push(format!(
-        "codestory-cli {paired} --project {project} --id {id} --depth {depth} --max-nodes {max_nodes}{caller_scope_flag}"
-    ));
-    commands
-}
-
 fn render_symbol_workflow_markdown(
-    kind: SymbolWorkflowKind,
+    mode: codestory_runtime::SymbolWorkflowMode,
     output: &SymbolWorkflowOutput<'_>,
 ) -> String {
     let mut markdown = String::new();
-    let _ = writeln!(markdown, "# {}", kind.title());
+    let _ = writeln!(markdown, "# {}", mode.title());
     let _ = writeln!(
         markdown,
         "symbol: {} [{}]",
@@ -6167,19 +5800,19 @@ fn render_symbol_workflow_markdown(
         output.caps.caller_depth, output.caps.caller_max_nodes, output.caps.affected_depth
     );
 
-    append_symbol_workflow_nodes(&mut markdown, "direct_callers", &output.direct_callers);
+    append_symbol_workflow_nodes(&mut markdown, "direct_callers", output.direct_callers);
     append_symbol_workflow_nodes(
         &mut markdown,
         "transitive_callers",
-        &output.transitive_callers,
+        output.transitive_callers,
     );
-    append_symbol_workflow_strings(&mut markdown, "impacted_files", &output.impacted_files);
+    append_symbol_workflow_strings(&mut markdown, "impacted_files", output.impacted_files);
 
     let _ = writeln!(markdown, "impacted_routes:");
     if output.impacted_routes.is_empty() {
         let _ = writeln!(markdown, "- none");
     } else {
-        for route in &output.impacted_routes {
+        for route in output.impacted_routes {
             let location = route
                 .file_path
                 .as_deref()
@@ -6203,7 +5836,7 @@ fn render_symbol_workflow_markdown(
     if output.likely_tests.is_empty() {
         let _ = writeln!(markdown, "- none");
     } else {
-        for test in &output.likely_tests {
+        for test in output.likely_tests {
             let _ = writeln!(
                 markdown,
                 "- {} confidence={} graph_depth={} impacted_symbols={}",
@@ -6213,15 +5846,15 @@ fn render_symbol_workflow_markdown(
         }
     }
 
-    append_symbol_workflow_strings(&mut markdown, "unknowns", &output.unknowns);
-    append_symbol_workflow_strings(&mut markdown, "next_commands", &output.next_commands);
+    append_symbol_workflow_strings(&mut markdown, "unknowns", output.unknowns);
+    append_symbol_workflow_strings(&mut markdown, "next_commands", output.next_commands);
     markdown
 }
 
 fn append_symbol_workflow_nodes(
     markdown: &mut String,
     label: &str,
-    nodes: &[SymbolWorkflowNodeOutput],
+    nodes: &[codestory_runtime::SymbolWorkflowNode],
 ) {
     let _ = writeln!(markdown, "{label}:");
     if nodes.is_empty() {
@@ -7270,19 +6903,32 @@ fn resolve_target_or_emit_ambiguity(
         Ok(target) => Ok(target),
         Err(error) => {
             if let Some(ambiguous) = error.downcast_ref::<AmbiguousTargetError>() {
-                let output = build_ambiguous_target_error_output(&runtime.project_root, ambiguous);
-                let markdown = (format != args::OutputFormat::Json)
-                    .then(|| render_cli_error_markdown(&output));
-                return Err(StructuredCommandFailure {
-                    envelope: ambiguous_command_failure(&output, &runtime.project_root),
-                    output_file: output_file.map(Path::to_path_buf),
-                    markdown,
-                }
-                .into());
+                return structured_ambiguous_target_failure(
+                    runtime,
+                    ambiguous.clone(),
+                    format,
+                    output_file,
+                );
             }
             Err(error)
         }
     }
+}
+
+fn structured_ambiguous_target_failure<T>(
+    runtime: &RuntimeContext,
+    ambiguous: AmbiguousTargetError,
+    format: args::OutputFormat,
+    output_file: Option<&Path>,
+) -> Result<T> {
+    let output = build_ambiguous_target_error_output(&runtime.project_root, &ambiguous);
+    let markdown = (format != args::OutputFormat::Json).then(|| render_cli_error_markdown(&output));
+    Err(StructuredCommandFailure {
+        envelope: ambiguous_command_failure(&output, &runtime.project_root),
+        output_file: output_file.map(Path::to_path_buf),
+        markdown,
+    }
+    .into())
 }
 
 fn ambiguous_command_failure(
@@ -8765,6 +8411,14 @@ fn build_query_resolution_output_with_runtime(
         runtime,
         std::iter::once(&target.selected).chain(target.alternatives.iter()),
     );
+    build_query_resolution_output_from_occurrences(&runtime.project_root, target, &occurrences)
+}
+
+fn build_query_resolution_output_from_occurrences(
+    project_root: &Path,
+    target: &runtime::ResolvedTarget,
+    occurrences: &HashMap<NodeId, Vec<SourceOccurrenceDto>>,
+) -> QueryResolutionOutput {
     QueryResolutionOutput {
         selector: target.selector,
         requested: target.requested.clone(),
@@ -8773,11 +8427,11 @@ fn build_query_resolution_output_with_runtime(
             .as_deref()
             .map(crate::display::clean_path_string),
         resolved: build_search_hit_output(
-            &runtime.project_root,
+            project_root,
             &target.selected,
             Some(&target.requested),
             false,
-            occurrences_for_hit(&occurrences, &target.selected),
+            occurrences_for_hit(occurrences, &target.selected),
         ),
         alternatives: target
             .alternatives
@@ -8785,11 +8439,11 @@ fn build_query_resolution_output_with_runtime(
             .skip(1)
             .map(|hit| {
                 build_search_hit_output(
-                    &runtime.project_root,
+                    project_root,
                     hit,
                     Some(&target.requested),
                     false,
-                    occurrences_for_hit(&occurrences, hit),
+                    occurrences_for_hit(occurrences, hit),
                 )
             })
             .collect(),
@@ -9497,7 +9151,6 @@ mod tests {
     use super::*;
     use crate::args::RefreshMode;
     use crate::display::{clean_path_string, relative_path};
-    use crate::query_resolution::compare_resolution_hits;
     use crate::runtime::{cache_root_for_project, fnv1a_hex, resolve_refresh_request};
     use codestory_contracts::api::{
         AgentAnswerDto, AgentCitationDto, AgentRetrievalPolicyModeDto, AgentRetrievalPresetDto,
@@ -11124,134 +10777,24 @@ mod tests {
         }
     }
 
-    fn sample_search_hit_output(id: &str, name: &str) -> SearchHitOutput {
-        SearchHitOutput {
-            number: None,
-            node_id: id.to_string(),
-            node_ref: Some(format!("src/lib.rs:1:{name}")),
-            display_name: name.to_string(),
-            kind: NodeKind::FUNCTION,
-            file_path: Some("src/lib.rs".to_string()),
-            line: Some(1),
-            score: 1.0,
-            origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-            match_quality: SearchMatchQualityDto::Exact,
-            resolvable: true,
-            score_breakdown: None,
-            duplicate_of: None,
-            excerpt: None,
-            primary_occurrence_kind: None,
-            symbol_role: None,
-            paired_refs: Vec::new(),
-            verification_targets: Vec::new(),
-            resolution_hints: Vec::new(),
-            why: Vec::new(),
-        }
-    }
-
     #[test]
-    fn symbol_workflow_transitive_callers_render_only_call_paths() {
-        let focus = sample_graph_node("focus", "Focus");
-        let mut direct = sample_graph_node("direct", "DirectCaller");
-        let mut transitive = sample_graph_node("transitive", "TransitiveCaller");
-        let mut reference = sample_graph_node("reference", "ReferenceOnly");
-        direct.depth = 1;
-        transitive.depth = 2;
-        reference.depth = 2;
-        let trail = TrailContextDto {
-            focus: sample_node_details("focus", "Focus"),
-            trail: GraphResponse {
-                center_id: NodeId("focus".to_string()),
-                nodes: vec![focus, direct, transitive, reference],
-                edges: vec![
-                    sample_graph_edge("direct-focus", "direct", "focus", Some("certain")),
-                    sample_graph_edge("transitive-direct", "transitive", "direct", Some("certain")),
-                    sample_graph_edge_with_kind(
-                        "reference-direct",
-                        "reference",
-                        "direct",
-                        EdgeKind::USAGE,
-                        Some("certain"),
-                    ),
-                ],
-                truncated: false,
-                omitted_edge_count: 0,
-                canonical_layout: None,
-            },
-            story: None,
-        };
-        let symbol = codestory_contracts::api::SymbolContextDto {
-            node: sample_node_details("focus", "Focus"),
-            summary: None,
-            children: Vec::new(),
-            related_hits: Vec::new(),
-            edge_digest: Vec::new(),
-        };
-        let direct_callers = symbol_workflow_direct_callers(&trail);
-        let transitive_callers = symbol_workflow_transitive_callers(&trail, &direct_callers);
-        let output = SymbolWorkflowOutput {
-            workflow: SymbolWorkflowKind::Impact.label(),
-            project_root: "C:/repo".to_string(),
-            resolution: QueryResolutionOutput {
-                selector: QuerySelectorOutput::Id,
-                requested: "focus".to_string(),
-                file_filter: None,
-                resolved: sample_search_hit_output("focus", "Focus"),
-                alternatives: Vec::new(),
-            },
-            symbol: &symbol,
-            direct_callers,
-            transitive_callers,
-            impacted_files: Vec::new(),
-            impacted_routes: Vec::new(),
-            likely_tests: Vec::new(),
-            caps: SymbolWorkflowCapsOutput {
-                caller_depth: 3,
-                caller_max_nodes: 20,
-                affected_depth: 3,
-                impacted_symbols_cap: 200,
-                impacted_routes_cap: 100,
-                affected_seed: "none".to_string(),
-            },
-            unknowns: Vec::new(),
-            next_commands: Vec::new(),
-            affected: None,
-            trail: &trail,
-        };
-
-        let markdown = render_symbol_workflow_markdown(SymbolWorkflowKind::Impact, &output);
-
-        assert!(markdown.contains("transitive_callers:"));
-        assert!(markdown.contains("TransitiveCaller"));
-        assert!(
-            !markdown.contains("ReferenceOnly"),
-            "non-CALL depth-2 nodes must not render as transitive callers:\n{markdown}"
-        );
-    }
-
-    #[test]
-    fn symbol_workflow_next_commands_preserve_include_tests_scope() {
-        let commands = symbol_workflow_next_commands(
-            Path::new("C:/repo"),
-            &NodeId("focus".to_string()),
-            None,
-            3,
-            20,
-            SymbolWorkflowKind::Impact,
-            true,
+    fn symbol_workflow_renderer_keeps_caller_shape() {
+        let mut markdown = String::new();
+        append_symbol_workflow_nodes(
+            &mut markdown,
+            "direct_callers",
+            &[codestory_runtime::SymbolWorkflowNode {
+                node_id: NodeId("caller".to_string()),
+                display_name: "Caller".to_string(),
+                kind: "function".to_string(),
+                file_path: Some("src/lib.rs".to_string()),
+                depth: 1,
+            }],
         );
 
-        assert!(
-            commands
-                .iter()
-                .any(|command| command.contains("callers") && command.contains("--include-tests")),
-            "callers next command should preserve include-tests scope: {commands:#?}"
-        );
-        assert!(
-            commands
-                .iter()
-                .any(|command| command.contains("test-map") && command.contains("--include-tests")),
-            "paired workflow next command should preserve include-tests scope: {commands:#?}"
+        assert_eq!(
+            markdown,
+            "direct_callers:\n- [caller] Caller (function) depth=1 src/lib.rs\n"
         );
     }
 
@@ -12572,265 +12115,6 @@ mod tests {
             cache_root.ends_with(&fnv1a_hex(b"C:/repo")),
             "default cache root should end with the project hash"
         );
-    }
-
-    #[test]
-    fn resolution_prefers_exact_type_name_over_member_hits() {
-        let query = "AppController";
-        let mut hits = [
-            SearchHit {
-                node_id: NodeId("2".to_string()),
-                display_name: "AppController::open_project".to_string(),
-                kind: codestory_contracts::api::NodeKind::FUNCTION,
-                file_path: None,
-                line: None,
-                score: 0.9,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-            SearchHit {
-                node_id: NodeId("1".to_string()),
-                display_name: "AppController".to_string(),
-                kind: codestory_contracts::api::NodeKind::CLASS,
-                file_path: None,
-                line: None,
-                score: 0.9,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-        ];
-
-        hits.sort_by(|left, right| compare_resolution_hits(query, left, right));
-        assert_eq!(hits[0].display_name, "AppController");
-    }
-
-    #[test]
-    fn resolution_prefers_declaration_anchor_over_impl_anchor() {
-        let temp = tempdir().expect("create temp dir");
-        let file_path = temp.path().join("lib.rs");
-        fs::write(
-            &file_path,
-            "pub struct AppController;\nimpl AppController {\n    fn open_project(&self) {}\n}\n",
-        )
-        .expect("write file");
-
-        let query = "AppController";
-        let mut hits = [
-            SearchHit {
-                node_id: NodeId("2".to_string()),
-                display_name: "AppController".to_string(),
-                kind: codestory_contracts::api::NodeKind::CLASS,
-                file_path: Some(file_path.to_string_lossy().to_string()),
-                line: Some(2),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-            SearchHit {
-                node_id: NodeId("1".to_string()),
-                display_name: "AppController".to_string(),
-                kind: codestory_contracts::api::NodeKind::STRUCT,
-                file_path: Some(file_path.to_string_lossy().to_string()),
-                line: Some(1),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-        ];
-
-        hits.sort_by(|left, right| compare_resolution_hits(query, left, right));
-        assert_eq!(hits[0].line, Some(1));
-        assert_eq!(hits[0].kind, codestory_contracts::api::NodeKind::STRUCT);
-    }
-
-    #[test]
-    fn resolution_prefers_callable_definitions_over_unknown_hits() {
-        let query = "check_winner";
-        let mut hits = [
-            SearchHit {
-                node_id: NodeId("2".to_string()),
-                display_name: "check_winner".to_string(),
-                kind: codestory_contracts::api::NodeKind::UNKNOWN,
-                file_path: Some("src/callsite.rs".to_string()),
-                line: Some(20),
-                score: 0.9,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-            SearchHit {
-                node_id: NodeId("1".to_string()),
-                display_name: "check_winner".to_string(),
-                kind: codestory_contracts::api::NodeKind::FUNCTION,
-                file_path: Some("src/game.rs".to_string()),
-                line: Some(10),
-                score: 0.8,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-        ];
-
-        hits.sort_by(|left, right| compare_resolution_hits(query, left, right));
-        assert_eq!(hits[0].kind, codestory_contracts::api::NodeKind::FUNCTION);
-    }
-
-    #[test]
-    fn resolution_prefers_callable_implementation_over_declaration() {
-        let temp = tempdir().expect("create temp dir");
-        let declaration_path = temp.path().join("Project.h");
-        let implementation_path = temp.path().join("Project.cpp");
-        fs::write(&declaration_path, "void buildIndex() const;\n").expect("write declaration");
-        fs::write(
-            &implementation_path,
-            "void Project::buildIndex() const\n{\n    runIndexer();\n}\n",
-        )
-        .expect("write implementation");
-
-        let query = "Project::buildIndex";
-        let mut hits = [
-            SearchHit {
-                node_id: NodeId("declaration".to_string()),
-                display_name: "Project::buildIndex".to_string(),
-                kind: codestory_contracts::api::NodeKind::METHOD,
-                file_path: Some(declaration_path.to_string_lossy().to_string()),
-                line: Some(1),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-            SearchHit {
-                node_id: NodeId("implementation".to_string()),
-                display_name: "Project::buildIndex".to_string(),
-                kind: codestory_contracts::api::NodeKind::FUNCTION,
-                file_path: Some(implementation_path.to_string_lossy().to_string()),
-                line: Some(1),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-        ];
-
-        hits.sort_by(|left, right| compare_resolution_hits(query, left, right));
-        assert_eq!(hits[0].node_id.0, "implementation");
-    }
-
-    #[test]
-    fn resolution_prefers_multiline_callable_implementation_over_declaration() {
-        let temp = tempdir().expect("create temp dir");
-        let declaration_path = temp.path().join("IndexerJava.h");
-        let implementation_path = temp.path().join("IndexerJava.cpp");
-        fs::write(
-            &declaration_path,
-            "void doIndex(\n    Command command,\n    State state) override;\n",
-        )
-        .expect("write declaration");
-        fs::write(
-            &implementation_path,
-            "void IndexerJava::doIndex(\n    Command command,\n    State state)\n{\n    parse(command);\n}\n",
-        )
-        .expect("write implementation");
-
-        let query = "IndexerJava::doIndex";
-        let mut hits = [
-            SearchHit {
-                node_id: NodeId("declaration".to_string()),
-                display_name: "IndexerJava::doIndex".to_string(),
-                kind: codestory_contracts::api::NodeKind::METHOD,
-                file_path: Some(declaration_path.to_string_lossy().to_string()),
-                line: Some(1),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-            SearchHit {
-                node_id: NodeId("implementation".to_string()),
-                display_name: "IndexerJava::doIndex".to_string(),
-                kind: codestory_contracts::api::NodeKind::FUNCTION,
-                file_path: Some(implementation_path.to_string_lossy().to_string()),
-                line: Some(1),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-        ];
-
-        hits.sort_by(|left, right| compare_resolution_hits(query, left, right));
-        assert_eq!(hits[0].node_id.0, "implementation");
-    }
-
-    #[test]
-    fn resolution_keeps_callable_implementation_when_body_contains_assignment() {
-        let temp = tempdir().expect("create temp dir");
-        let declaration_path = temp.path().join("Foo.h");
-        let implementation_path = temp.path().join("Foo.cpp");
-        fs::write(&declaration_path, "void bar();\n").expect("write declaration");
-        fs::write(
-            &implementation_path,
-            "void Foo::bar()\n{\n    int status = 0;\n    use(status);\n}\n",
-        )
-        .expect("write implementation");
-
-        let query = "Foo::bar";
-        let mut hits = [
-            SearchHit {
-                node_id: NodeId("declaration".to_string()),
-                display_name: "Foo::bar".to_string(),
-                kind: codestory_contracts::api::NodeKind::METHOD,
-                file_path: Some(declaration_path.to_string_lossy().to_string()),
-                line: Some(1),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-            SearchHit {
-                node_id: NodeId("implementation".to_string()),
-                display_name: "Foo::bar".to_string(),
-                kind: codestory_contracts::api::NodeKind::FUNCTION,
-                file_path: Some(implementation_path.to_string_lossy().to_string()),
-                line: Some(1),
-                score: 1.0,
-                origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-                match_quality: None,
-                resolvable: true,
-                score_breakdown: None,
-                ..test_search_hit_defaults()
-            },
-        ];
-
-        hits.sort_by(|left, right| compare_resolution_hits(query, left, right));
-        assert_eq!(hits[0].node_id.0, "implementation");
     }
 
     fn sample_runtime_hit(

--- a/crates/codestory-cli/src/runtime.rs
+++ b/crates/codestory-cli/src/runtime.rs
@@ -7,25 +7,17 @@
 
 use anyhow::{Context, Result, anyhow, bail};
 use codestory_contracts::api::{
-    ApiError, AppEventPayload, IndexMode, IndexingPhaseTimings, NodeDetailsDto, NodeDetailsRequest,
-    ProjectSummary, SearchHit,
+    ApiError, AppEventPayload, IndexMode, IndexingPhaseTimings, ProjectSummary, SearchHit,
 };
 use codestory_runtime::{
     BookmarkService, GroundingService, IndexService, ProjectService, ReadOnlyBrowserService,
-    Runtime,
+    Runtime, TargetResolution,
 };
 use std::path::{Path, PathBuf};
 
 use crate::args::{ProjectArgs, QuerySelectorOutput, RefreshMode, TargetSelection};
-use crate::display::{
-    clean_path_string, format_search_hit_target, quote_command_path, relative_path,
-};
-use crate::query_resolution::{
-    ResolutionRank, compare_resolution_hits, file_filter_match_bucket, is_resolvable_graph_target,
-    resolution_rank_with_project_root, search_hit_matches_file_filter,
-};
+use crate::display::{clean_path_string, quote_command_path};
 
-const HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT: usize = 10;
 const INCOMPLETE_INDEX_RECOVERY_REASON: &str =
     "previous_incremental_run_incomplete_full_refresh_required";
 
@@ -58,23 +50,28 @@ pub(crate) struct RuntimeContext {
     pub(crate) sidecar: codestory_retrieval::SidecarRuntimeConfig,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct ResolutionCandidateRank {
-    file_filter_match: u8,
-    resolution: ResolutionRank,
-}
-
 #[derive(Debug, Clone)]
-/// A query or id after CLI target resolution has selected one graph-backed hit.
-///
-/// `alternatives` is ordered for reviewer/operator display and may be truncated
-/// by the search layer; it is not a complete search result set.
 pub(crate) struct ResolvedTarget {
     pub(crate) selector: QuerySelectorOutput,
     pub(crate) requested: String,
     pub(crate) file_filter: Option<String>,
     pub(crate) selected: SearchHit,
     pub(crate) alternatives: Vec<SearchHit>,
+}
+
+impl ResolvedTarget {
+    pub(crate) fn from_runtime(target: codestory_runtime::ResolvedTarget) -> Self {
+        Self {
+            selector: match target.selector {
+                codestory_runtime::TargetSelector::Id => QuerySelectorOutput::Id,
+                codestory_runtime::TargetSelector::Query => QuerySelectorOutput::Query,
+            },
+            requested: target.requested,
+            file_filter: target.file_filter,
+            selected: target.selected,
+            alternatives: target.alternatives,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -260,216 +257,24 @@ pub(crate) fn resolve_target(
     target: TargetSelection,
     file_filter: Option<&str>,
 ) -> Result<ResolvedTarget> {
-    match target {
-        TargetSelection::Id(id) => {
-            let details = runtime
-                .browser
-                .node_details(NodeDetailsRequest { id: id.clone() })
-                .map_err(map_api_error)?;
-            Ok(ResolvedTarget {
-                selector: QuerySelectorOutput::Id,
-                requested: id.0,
-                file_filter: None,
-                selected: search_hit_from_node(&details),
-                alternatives: Vec::new(),
-            })
-        }
+    let target = match target {
+        TargetSelection::Id(id) => codestory_runtime::TargetSelection::Id(id),
         TargetSelection::Query { query, choose } => {
-            resolve_query_target(runtime, query, choose, file_filter)
+            codestory_runtime::TargetSelection::Query { query, choose }
         }
-    }
-}
-
-fn resolve_query_target(
-    runtime: &RuntimeContext,
-    query: String,
-    choose: Option<usize>,
-    file_filter: Option<&str>,
-) -> Result<ResolvedTarget> {
-    let alternatives = query_resolution_alternatives(runtime, &query, file_filter)?;
-    let tied_alternatives =
-        tied_top_alternatives(&runtime.project_root, &query, file_filter, &alternatives);
-
-    if let Some(choice) = choose {
-        return resolve_chosen_query_target(
-            query,
-            file_filter,
-            alternatives,
-            tied_alternatives,
-            choice,
-        );
-    }
-
-    reject_ambiguous_query_target(
-        &runtime.project_root,
-        &query,
-        file_filter,
-        tied_alternatives,
-    )?;
-    debug_assert_unique_top_candidate(&runtime.project_root, &query, file_filter, &alternatives);
-
-    let selected = alternatives
-        .first()
-        .cloned()
-        .ok_or_else(|| no_query_match_error(&runtime.project_root, &query, file_filter))?;
-    Ok(query_resolved_target(
-        query,
-        file_filter,
-        selected,
-        alternatives,
-    ))
-}
-
-fn query_resolution_alternatives(
-    runtime: &RuntimeContext,
-    query: &str,
-    file_filter: Option<&str>,
-) -> Result<Vec<SearchHit>> {
-    let mut alternatives = query_resolution_search_hits(runtime, query)?;
-    alternatives.retain(|hit| is_resolvable_graph_target(query, hit));
-    if alternatives.is_empty()
-        && let Some(stem) = command_query_resolution_stem(query)
-    {
-        alternatives = query_resolution_search_hits(runtime, &stem)?;
-        alternatives.retain(|hit| is_resolvable_graph_target(query, hit));
-    }
-    if let Some(file_filter) = file_filter {
-        alternatives
-            .retain(|hit| search_hit_matches_file_filter(&runtime.project_root, hit, file_filter));
-    }
-    if alternatives.is_empty() {
-        return Err(no_query_match_error(
-            &runtime.project_root,
-            query,
-            file_filter,
-        ));
-    }
-
-    alternatives.sort_by(|left, right| {
-        compare_resolution_candidates(&runtime.project_root, query, file_filter, left, right)
-    });
-    Ok(alternatives)
-}
-
-fn query_resolution_search_hits(runtime: &RuntimeContext, query: &str) -> Result<Vec<SearchHit>> {
-    runtime
-        .browser
-        .resolve_indexed_symbol_candidates(query, 50)
-        .map_err(map_api_error)
-}
-
-fn command_query_resolution_stem(query: &str) -> Option<String> {
-    for suffix in ["_command", "_cmd", "_handler"] {
-        if let Some(stem) = query.strip_suffix(suffix)
-            && stem.len() >= 4
-        {
-            return Some(stem.to_string());
-        }
-    }
-    None
-}
-
-fn resolve_chosen_query_target(
-    query: String,
-    file_filter: Option<&str>,
-    mut alternatives: Vec<SearchHit>,
-    tied_alternatives: Vec<SearchHit>,
-    choice: usize,
-) -> Result<ResolvedTarget> {
-    if choice == 0 || choice > tied_alternatives.len() {
-        bail!(
-            "`--choose {choice}` is outside the displayed alternative range 1..={}. Re-run without `--choose` to inspect the current alternatives.",
-            tied_alternatives.len()
-        );
-    }
-
-    let selected = tied_alternatives[choice - 1].clone();
-    promote_selected_alternative(&mut alternatives, &selected);
-    Ok(query_resolved_target(
-        query,
-        file_filter,
-        selected,
-        alternatives,
-    ))
-}
-
-fn promote_selected_alternative(alternatives: &mut Vec<SearchHit>, selected: &SearchHit) {
-    if let Some(position) = alternatives
-        .iter()
-        .position(|hit| hit.node_id == selected.node_id)
-    {
-        let chosen = alternatives.remove(position);
-        alternatives.insert(0, chosen);
-    }
-}
-
-fn reject_ambiguous_query_target(
-    project_root: &Path,
-    query: &str,
-    file_filter: Option<&str>,
-    tied_alternatives: Vec<SearchHit>,
-) -> Result<()> {
-    if tied_alternatives.len() <= 1 {
-        return Ok(());
-    }
-
-    let message = ambiguous_query_error(project_root, query, file_filter, &tied_alternatives);
-    Err(AmbiguousTargetError {
-        query: query.to_owned(),
-        file_filter: file_filter.map(ToOwned::to_owned),
-        alternatives: tied_alternatives,
-        message,
-    }
-    .into())
-}
-
-fn debug_assert_unique_top_candidate(
-    project_root: &Path,
-    query: &str,
-    file_filter: Option<&str>,
-    alternatives: &[SearchHit],
-) {
-    if alternatives.len() > 1 {
-        let rank1 = resolution_candidate_rank(project_root, query, file_filter, &alternatives[1]);
-        debug_assert_ne!(
-            resolution_candidate_rank(project_root, query, file_filter, &alternatives[0]),
-            rank1
-        );
-    }
-}
-
-fn query_resolved_target(
-    query: String,
-    file_filter: Option<&str>,
-    selected: SearchHit,
-    alternatives: Vec<SearchHit>,
-) -> ResolvedTarget {
-    ResolvedTarget {
-        selector: QuerySelectorOutput::Query,
-        requested: query,
-        file_filter: file_filter.map(ToOwned::to_owned),
-        selected,
-        alternatives,
-    }
-}
-
-fn tied_top_alternatives(
-    project_root: &Path,
-    query: &str,
-    file_filter: Option<&str>,
-    alternatives: &[SearchHit],
-) -> Vec<SearchHit> {
-    let Some(first) = alternatives.first() else {
-        return Vec::new();
     };
-    let top_rank = resolution_candidate_rank(project_root, query, file_filter, first);
-    alternatives
-        .iter()
-        .take_while(|hit| {
-            resolution_candidate_rank(project_root, query, file_filter, hit) == top_rank
-        })
-        .cloned()
-        .collect()
+    match runtime.browser.resolve_target(target, file_filter) {
+        Ok(TargetResolution::Resolved(target)) => Ok(ResolvedTarget::from_runtime(*target)),
+        Ok(TargetResolution::Ambiguous(ambiguous)) => Err(AmbiguousTargetError {
+            query: ambiguous.query,
+            file_filter: ambiguous.file_filter,
+            alternatives: ambiguous.alternatives,
+            message: ambiguous.message,
+        }
+        .into()),
+        Ok(TargetResolution::Rejected(message)) => Err(anyhow!(message)),
+        Err(error) => Err(map_api_error(error)),
+    }
 }
 
 /// Canonicalize a project argument before deriving cache identity.
@@ -662,185 +467,6 @@ fn cache_busy_message(project: Option<&Path>) -> String {
     format!(
         "cache_busy: CodeStory cache is busy or locked. Wait for the active indexing/search process to release the SQLite cache, then retry.\n\nMinimum next:\n  codestory-cli ready --project {project} --goal agent\n\nFull repair:\n  codestory-cli ready --project {project} --goal agent\n  codestory-cli doctor --project {project}"
     )
-}
-
-pub(crate) fn search_hit_from_node(node: &NodeDetailsDto) -> SearchHit {
-    SearchHit {
-        node_id: node.id.clone(),
-        display_name: node.display_name.clone(),
-        kind: node.kind,
-        file_path: node.file_path.clone(),
-        line: node.start_line,
-        score: 0.0,
-        origin: codestory_contracts::api::SearchHitOrigin::IndexedSymbol,
-        match_quality: None,
-        resolvable: true,
-        evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::ResolvedGraph),
-        evidence_producer: Some("node_details".to_string()),
-        resolution_status: Some(codestory_contracts::api::PacketEvidenceResolutionDto::Resolved),
-        loss_reason: None,
-        coverage_role: None,
-        eligible_for_sufficiency: Some(true),
-        score_breakdown: None,
-    }
-}
-
-fn resolution_candidate_rank(
-    project_root: &Path,
-    query: &str,
-    file_filter: Option<&str>,
-    hit: &SearchHit,
-) -> ResolutionCandidateRank {
-    let rank = resolution_rank_with_project_root(Some(project_root), query, hit);
-    ResolutionCandidateRank {
-        file_filter_match: file_filter
-            .map(|filter| file_filter_match_bucket(project_root, hit, filter))
-            .unwrap_or(0),
-        resolution: rank,
-    }
-}
-
-fn compare_resolution_candidates(
-    project_root: &Path,
-    query: &str,
-    file_filter: Option<&str>,
-    left: &SearchHit,
-    right: &SearchHit,
-) -> std::cmp::Ordering {
-    resolution_candidate_rank(project_root, query, file_filter, right)
-        .cmp(&resolution_candidate_rank(
-            project_root,
-            query,
-            file_filter,
-            left,
-        ))
-        .then_with(|| compare_resolution_hits(query, left, right))
-        .then_with(|| left.node_id.0.cmp(&right.node_id.0))
-}
-
-fn no_query_match_error(
-    project_root: &Path,
-    query: &str,
-    file_filter: Option<&str>,
-) -> anyhow::Error {
-    let search_command = format!(
-        "codestory-cli search --project {} --query {} --limit 10",
-        quote_cli_path(project_root),
-        quote_cli_value(query)
-    );
-    match file_filter {
-        Some(file_filter) => anyhow!(
-            "query_resolution: No symbol matched query `{query}` within files matching `{}`. Run `{search_command}` to inspect candidates, or relax `--file`.",
-            clean_path_string(file_filter)
-        ),
-        None => anyhow!(
-            "query_resolution: No symbol matched query `{query}`. Run `{search_command}` to inspect candidates."
-        ),
-    }
-}
-
-fn ambiguous_query_error(
-    project_root: &Path,
-    query: &str,
-    file_filter: Option<&str>,
-    alternatives: &[SearchHit],
-) -> String {
-    let mut message = String::new();
-    let scope = file_filter
-        .map(|value| format!(" even after applying `--file {}`", clean_path_string(value)))
-        .unwrap_or_default();
-    message.push_str(&format!(
-        "Query `{query}` is ambiguous{scope}; choose a match or pass a stable id.\n"
-    ));
-    message.push_str("\nNext commands:\n");
-    message.push_str(&format!(
-        "  codestory-cli symbol --project {} --query {}{} --choose 1\n",
-        quote_cli_path(project_root),
-        quote_cli_value(query),
-        file_filter
-            .map(|value| format!(" --file {}", quote_cli_value(&clean_path_string(value))))
-            .unwrap_or_default()
-    ));
-    if let Some(first) = alternatives.first() {
-        message.push_str(&format!(
-            "  codestory-cli symbol --project {} --id {}\n",
-            quote_cli_path(project_root),
-            first.node_id.0
-        ));
-        if let Some(path) = first.file_path.as_deref() {
-            message.push_str(&format!(
-                "  codestory-cli symbol --project {} --query {} --file {}\n",
-                quote_cli_path(project_root),
-                quote_cli_value(query),
-                quote_cli_value(&relative_path(project_root, path))
-            ));
-        }
-    }
-    if file_filter.is_some() {
-        message.push_str(
-            "\nPass a more qualified symbol name, a stable `--id`, or a narrower `--file` fragment.",
-        );
-    } else {
-        message.push_str(
-            "\nPass a more qualified symbol name, add `--file <path-fragment>`, or resolve the exact `--id` from `search` output.",
-        );
-    }
-    let displayed = alternatives.len().min(HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT);
-    message.push_str(&format!(
-        "\n\nTop equally ranked matches (showing {displayed} of {}):\n",
-        alternatives.len()
-    ));
-    for (index, hit) in alternatives
-        .iter()
-        .take(HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT)
-        .enumerate()
-    {
-        let number = index + 1;
-        message.push_str("  ");
-        message.push_str(&number.to_string());
-        message.push_str(". ");
-        message.push_str(&format_search_hit_target(project_root, hit));
-        message.push_str(" id=`");
-        message.push_str(&hit.node_id.0);
-        message.push('`');
-        if let Some(node_ref) = node_ref(project_root, hit) {
-            message.push_str(" ref=`");
-            message.push_str(&node_ref);
-            message.push('`');
-        }
-        message.push('\n');
-    }
-    message
-}
-
-fn node_ref(project_root: &Path, hit: &SearchHit) -> Option<String> {
-    let file_path = hit.file_path.as_deref()?;
-    let line = hit.line?;
-    Some(format!(
-        "{}:{line}:{}",
-        relative_path(project_root, file_path),
-        hit.display_name
-    ))
-}
-
-fn quote_cli_path(path: &Path) -> String {
-    quote_cli_value(&clean_path_string(&path.to_string_lossy()))
-}
-
-fn quote_cli_value(value: &str) -> String {
-    if cli_value_needs_single_quotes(value) {
-        quote_cli_single_quoted_value(value)
-    } else {
-        format!("\"{}\"", value.replace('"', "\\\""))
-    }
-}
-
-fn cli_value_needs_single_quotes(value: &str) -> bool {
-    value.chars().any(|ch| matches!(ch, '$' | '`' | '\'' | '"'))
-}
-
-fn quote_cli_single_quoted_value(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
 }
 
 #[cfg(test)]

--- a/crates/codestory-runtime/src/browser.rs
+++ b/crates/codestory-runtime/src/browser.rs
@@ -12,7 +12,10 @@ use codestory_contracts::query::{
     SymbolQuery, TrailQuery,
 };
 
-use crate::{AppController, compare_ranked_hits, symbol_name_match_rank};
+use crate::{
+    AppController, SymbolWorkflowOutcome, SymbolWorkflowRequest, TargetResolution, TargetSelection,
+    compare_ranked_hits, symbol_name_match_rank,
+};
 
 #[derive(Debug, Clone)]
 pub struct BrowserQueryItem {
@@ -116,6 +119,21 @@ impl ReadOnlyBrowserService {
     ) -> Result<Vec<SearchHit>, ApiError> {
         self.controller
             .resolve_indexed_symbol_candidates(query, max_results)
+    }
+
+    pub fn resolve_target(
+        &self,
+        target: TargetSelection,
+        file_filter: Option<&str>,
+    ) -> Result<TargetResolution, ApiError> {
+        self.controller.resolve_target(target, file_filter)
+    }
+
+    pub fn symbol_workflow(
+        &self,
+        request: SymbolWorkflowRequest,
+    ) -> Result<SymbolWorkflowOutcome, ApiError> {
+        self.controller.symbol_workflow(request)
     }
 
     pub fn indexed_files(&self, req: IndexedFilesRequest) -> Result<IndexedFilesDto, ApiError> {

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -84,7 +84,9 @@ mod semantic_doc_text;
 mod services;
 mod support;
 mod symbol_query;
+mod symbol_workflow;
 mod system_actions;
+mod target_resolution;
 mod trail_story;
 
 pub use browser::{BrowserQueryItem, ReadOnlyBrowserService};
@@ -112,6 +114,14 @@ use semantic_doc_text::{
 pub use services::{
     AgentService, BookmarkService, GroundingService, IndexService, ProjectService, SearchService,
     TrailService,
+};
+pub use symbol_workflow::{
+    SymbolWorkflowCaps, SymbolWorkflowMode, SymbolWorkflowNode, SymbolWorkflowOutcome,
+    SymbolWorkflowRequest, SymbolWorkflowResolution, SymbolWorkflowResponse, SymbolWorkflowRoute,
+    SymbolWorkflowTest,
+};
+pub use target_resolution::{
+    AmbiguousTarget, ResolvedTarget, TargetResolution, TargetSelection, TargetSelector,
 };
 
 #[cfg(feature = "test-support")]

--- a/crates/codestory-runtime/src/symbol_workflow.rs
+++ b/crates/codestory-runtime/src/symbol_workflow.rs
@@ -1,0 +1,660 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::Path;
+
+use codestory_contracts::api::{
+    AffectedAnalysisDto, AffectedAnalysisRequest, AffectedChangeKindDto, AffectedChangeRecordDto,
+    ApiError, EdgeKind, GraphNodeDto, LayoutDirection, NodeId, NodeOccurrencesRequest,
+    SourceOccurrenceDto, SymbolContextDto, TrailCallerScope, TrailConfigDto, TrailContextDto,
+    TrailDirection, TrailMode,
+};
+use serde::Serialize;
+
+use crate::{AmbiguousTarget, AppController, ResolvedTarget, TargetResolution, TargetSelection};
+
+const IMPACTED_SYMBOLS_CAP: u32 = 200;
+const IMPACTED_ROUTES_CAP: u32 = 100;
+const TRANSITIVE_CALLERS_CAP: usize = 50;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolWorkflowMode {
+    Impact,
+    TestMap,
+}
+
+impl SymbolWorkflowMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Impact => "impact",
+            Self::TestMap => "test_map",
+        }
+    }
+
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::Impact => "Symbol Impact",
+            Self::TestMap => "Symbol Test Map",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SymbolWorkflowRequest {
+    pub mode: SymbolWorkflowMode,
+    pub target: TargetSelection,
+    pub file_filter: Option<String>,
+    pub depth: u32,
+    pub max_nodes: u32,
+    pub include_tests: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum SymbolWorkflowOutcome {
+    Complete(Box<SymbolWorkflowResponse>),
+    Ambiguous(AmbiguousTarget),
+    Rejected(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolWorkflowResolution {
+    #[serde(flatten)]
+    pub target: ResolvedTarget,
+    #[serde(skip)]
+    pub occurrences: HashMap<NodeId, Vec<SourceOccurrenceDto>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolWorkflowNode {
+    pub node_id: NodeId,
+    pub display_name: String,
+    pub kind: String,
+    pub file_path: Option<String>,
+    pub depth: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolWorkflowRoute {
+    pub display_name: String,
+    pub method: String,
+    pub path: String,
+    pub file_path: Option<String>,
+    pub line: Option<u32>,
+    pub confidence: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolWorkflowTest {
+    pub path: String,
+    pub reason: String,
+    pub confidence: String,
+    pub graph_depth: u32,
+    pub impacted_symbol_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolWorkflowCaps {
+    pub caller_depth: u32,
+    pub caller_max_nodes: u32,
+    pub affected_depth: u32,
+    pub impacted_symbols_cap: u32,
+    pub impacted_routes_cap: u32,
+    pub affected_seed: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolWorkflowResponse {
+    pub workflow: &'static str,
+    pub project_root: String,
+    pub resolution: SymbolWorkflowResolution,
+    pub symbol: SymbolContextDto,
+    pub direct_callers: Vec<SymbolWorkflowNode>,
+    pub transitive_callers: Vec<SymbolWorkflowNode>,
+    pub impacted_files: Vec<String>,
+    pub impacted_routes: Vec<SymbolWorkflowRoute>,
+    pub likely_tests: Vec<SymbolWorkflowTest>,
+    pub caps: SymbolWorkflowCaps,
+    pub unknowns: Vec<String>,
+    pub next_commands: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub affected: Option<AffectedAnalysisDto>,
+    pub trail: TrailContextDto,
+}
+
+impl AppController {
+    pub fn symbol_workflow(
+        &self,
+        request: SymbolWorkflowRequest,
+    ) -> Result<SymbolWorkflowOutcome, ApiError> {
+        let project_root = self.require_project_root()?;
+        let target = match self.resolve_target(request.target, request.file_filter.as_deref())? {
+            TargetResolution::Resolved(target) => *target,
+            TargetResolution::Ambiguous(ambiguous) => {
+                return Ok(SymbolWorkflowOutcome::Ambiguous(ambiguous));
+            }
+            TargetResolution::Rejected(message) => {
+                return Ok(SymbolWorkflowOutcome::Rejected(message));
+            }
+        };
+
+        let depth = request.depth.clamp(1, 8);
+        let max_nodes = request.max_nodes.clamp(1, 200);
+        let include_tests = request.include_tests || request.mode == SymbolWorkflowMode::TestMap;
+        let symbol = self.symbol_context(target.selected.node_id.clone())?;
+        let trail = self.trail_context(TrailConfigDto {
+            root_id: target.selected.node_id.clone(),
+            mode: TrailMode::AllReferencing,
+            target_id: None,
+            depth,
+            direction: TrailDirection::Incoming,
+            caller_scope: if include_tests {
+                TrailCallerScope::IncludeTestsAndBenches
+            } else {
+                TrailCallerScope::ProductionOnly
+            },
+            edge_filter: Vec::new(),
+            show_utility_calls: false,
+            hide_speculative: true,
+            story: false,
+            node_filter: Vec::new(),
+            max_nodes,
+            layout_direction: LayoutDirection::Horizontal,
+        })?;
+
+        let affected_seed = target
+            .selected
+            .file_path
+            .clone()
+            .or_else(|| symbol.node.file_path.clone())
+            .map(|path| workflow_seed_path(&project_root, &path));
+        let affected = affected_seed
+            .as_ref()
+            .map(|path| {
+                self.affected_analysis(AffectedAnalysisRequest {
+                    changed_paths: vec![path.clone()],
+                    change_records: vec![AffectedChangeRecordDto {
+                        path: path.clone(),
+                        kind: AffectedChangeKindDto::Unknown,
+                        status: "symbol_file".to_string(),
+                        previous_path: None,
+                    }],
+                    depth: Some(depth),
+                    filter: None,
+                })
+            })
+            .transpose()?;
+        let (direct_callers, transitive_callers) = workflow_callers(&trail);
+        let likely_tests = workflow_tests(affected.as_ref());
+        let unknowns = workflow_unknowns(
+            affected.as_ref(),
+            &trail,
+            &direct_callers,
+            &transitive_callers,
+            &likely_tests,
+            affected_seed.as_deref(),
+            max_nodes,
+        );
+        let next_commands = workflow_next_commands(
+            &project_root,
+            &target.selected.node_id,
+            affected_seed.as_deref(),
+            depth,
+            max_nodes,
+            request.mode,
+            include_tests,
+        );
+        let occurrences = workflow_occurrences(self, &target);
+
+        Ok(SymbolWorkflowOutcome::Complete(Box::new(
+            SymbolWorkflowResponse {
+                workflow: request.mode.label(),
+                project_root: project_root.to_string_lossy().to_string(),
+                resolution: SymbolWorkflowResolution {
+                    target,
+                    occurrences,
+                },
+                symbol,
+                direct_callers,
+                transitive_callers,
+                impacted_files: workflow_impacted_files(affected.as_ref()),
+                impacted_routes: workflow_routes(affected.as_ref()),
+                likely_tests,
+                caps: SymbolWorkflowCaps {
+                    caller_depth: depth,
+                    caller_max_nodes: max_nodes,
+                    affected_depth: depth,
+                    impacted_symbols_cap: IMPACTED_SYMBOLS_CAP,
+                    impacted_routes_cap: IMPACTED_ROUTES_CAP,
+                    affected_seed: affected_seed.unwrap_or_else(|| {
+                        "none: selected symbol has no indexed file path".to_string()
+                    }),
+                },
+                unknowns,
+                next_commands,
+                affected,
+                trail,
+            },
+        )))
+    }
+}
+
+fn workflow_occurrences(
+    controller: &AppController,
+    target: &ResolvedTarget,
+) -> HashMap<NodeId, Vec<SourceOccurrenceDto>> {
+    let mut seen = HashSet::new();
+    let mut by_node = HashMap::new();
+    for hit in std::iter::once(&target.selected).chain(target.alternatives.iter()) {
+        if hit.is_text_match() || !hit.resolvable || !seen.insert(hit.node_id.clone()) {
+            continue;
+        }
+        if let Ok(occurrences) = controller.node_occurrences(NodeOccurrencesRequest {
+            id: hit.node_id.clone(),
+        }) {
+            by_node.insert(hit.node_id.clone(), occurrences);
+        }
+    }
+    by_node
+}
+
+fn workflow_callers(trail: &TrailContextDto) -> (Vec<SymbolWorkflowNode>, Vec<SymbolWorkflowNode>) {
+    let nodes = trail
+        .trail
+        .nodes
+        .iter()
+        .map(|node| (node.id.clone(), node))
+        .collect::<HashMap<_, _>>();
+    let mut incoming = HashMap::<NodeId, Vec<NodeId>>::new();
+    for edge in &trail.trail.edges {
+        if edge.kind == EdgeKind::CALL && edge.source != edge.target {
+            incoming
+                .entry(edge.target.clone())
+                .or_default()
+                .push(edge.source.clone());
+        }
+    }
+    let mut direct_order = incoming.get(&trail.focus.id).cloned().unwrap_or_default();
+    let mut seen_direct = HashSet::new();
+    direct_order.retain(|id| seen_direct.insert(id.clone()));
+    let direct_ids = direct_order.iter().cloned().collect::<HashSet<_>>();
+    let mut direct = direct_order
+        .iter()
+        .filter_map(|id| nodes.get(id).map(|node| workflow_node(node)))
+        .collect::<Vec<_>>();
+    direct.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then(left.display_name.cmp(&right.display_name))
+    });
+
+    let mut call_ancestors = HashSet::new();
+    let mut stack = vec![trail.focus.id.clone()];
+    while let Some(target) = stack.pop() {
+        for source in incoming.get(&target).into_iter().flatten() {
+            if call_ancestors.insert(source.clone()) {
+                stack.push(source.clone());
+            }
+        }
+    }
+    let mut transitive = trail
+        .trail
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.id != trail.focus.id
+                && node.depth > 1
+                && !direct_ids.contains(&node.id)
+                && call_ancestors.contains(&node.id)
+        })
+        .map(workflow_node)
+        .collect::<Vec<_>>();
+    transitive.sort_by(|left, right| {
+        left.depth
+            .cmp(&right.depth)
+            .then(left.file_path.cmp(&right.file_path))
+            .then(left.display_name.cmp(&right.display_name))
+    });
+    transitive.truncate(TRANSITIVE_CALLERS_CAP);
+    (direct, transitive)
+}
+
+fn workflow_node(node: &GraphNodeDto) -> SymbolWorkflowNode {
+    SymbolWorkflowNode {
+        node_id: node.id.clone(),
+        display_name: node
+            .qualified_name
+            .clone()
+            .unwrap_or_else(|| node.label.clone()),
+        kind: format!("{:?}", node.kind).to_ascii_lowercase(),
+        file_path: node.file_path.clone(),
+        depth: node.depth,
+    }
+}
+
+fn workflow_seed_path(project_root: &Path, path: &str) -> String {
+    let clean_path = path
+        .strip_prefix(r"\\?\")
+        .unwrap_or(path)
+        .replace('\\', "/");
+    codestory_workspace::workspace_relative_path(project_root, Path::new(&clean_path))
+        .map(|relative| relative.to_string_lossy().replace('\\', "/"))
+        .unwrap_or(clean_path)
+}
+
+fn workflow_impacted_files(affected: Option<&AffectedAnalysisDto>) -> Vec<String> {
+    let mut files = BTreeSet::new();
+    if let Some(affected) = affected {
+        files.extend(affected.matched_files.iter().map(|file| file.path.clone()));
+        files.extend(
+            affected
+                .impacted_symbols
+                .iter()
+                .filter_map(|symbol| symbol.file_path.clone()),
+        );
+        files.extend(
+            affected
+                .impacted_routes
+                .iter()
+                .filter_map(|route| route.file_path.clone()),
+        );
+        files.extend(
+            affected
+                .impacted_routes
+                .iter()
+                .filter_map(|route| route.route.source_file.clone()),
+        );
+        files.extend(affected.impacted_tests.iter().map(|test| test.path.clone()));
+    }
+    files.into_iter().collect()
+}
+
+fn workflow_routes(affected: Option<&AffectedAnalysisDto>) -> Vec<SymbolWorkflowRoute> {
+    affected
+        .into_iter()
+        .flat_map(|affected| affected.impacted_routes.iter())
+        .map(|route| SymbolWorkflowRoute {
+            display_name: route.display_name.clone(),
+            method: route.route.method.clone(),
+            path: route.route.path.clone(),
+            file_path: route
+                .file_path
+                .clone()
+                .or_else(|| route.route.source_file.clone()),
+            line: route.line.or(route.route.line),
+            confidence: route.confidence.clone(),
+            reason: route.reason.clone(),
+        })
+        .collect()
+}
+
+fn workflow_tests(affected: Option<&AffectedAnalysisDto>) -> Vec<SymbolWorkflowTest> {
+    affected
+        .into_iter()
+        .flat_map(|affected| affected.impacted_tests.iter())
+        .map(|test| SymbolWorkflowTest {
+            path: test.path.clone(),
+            reason: test.reason.clone(),
+            confidence: test.confidence.clone(),
+            graph_depth: test.graph_depth,
+            impacted_symbol_count: test.impacted_symbol_count,
+        })
+        .collect()
+}
+
+fn workflow_unknowns(
+    affected: Option<&AffectedAnalysisDto>,
+    trail: &TrailContextDto,
+    direct_callers: &[SymbolWorkflowNode],
+    transitive_callers: &[SymbolWorkflowNode],
+    likely_tests: &[SymbolWorkflowTest],
+    affected_seed: Option<&str>,
+    max_nodes: u32,
+) -> Vec<String> {
+    let mut unknowns = vec![
+        "affected files/routes/tests are seeded from the selected symbol's file, not a symbol-level change slice"
+            .to_string(),
+    ];
+    if affected_seed.is_none() {
+        unknowns.push(
+            "selected symbol has no indexed file path; affected analysis was skipped".to_string(),
+        );
+    }
+    if direct_callers.is_empty() {
+        unknowns.push("no direct callers found in the incoming trail".to_string());
+    }
+    if transitive_callers.is_empty() {
+        unknowns.push("no transitive callers found inside the caller depth cap".to_string());
+    }
+    if likely_tests.is_empty() {
+        unknowns.push("no test-like file reached by the affected graph walk".to_string());
+    }
+    if trail.trail.truncated {
+        unknowns.push(format!(
+            "caller trail truncated at max_nodes={max_nodes}; rerun with a narrower symbol or higher cap"
+        ));
+    }
+    if let Some(affected) = affected {
+        unknowns.extend(affected.blind_spots.iter().cloned());
+    }
+    unknowns.sort();
+    unknowns.dedup();
+    unknowns
+}
+
+fn workflow_next_commands(
+    project_root: &Path,
+    node_id: &NodeId,
+    affected_seed: Option<&str>,
+    depth: u32,
+    max_nodes: u32,
+    mode: SymbolWorkflowMode,
+    include_tests: bool,
+) -> Vec<String> {
+    let project = quote_command_path(project_root);
+    let id = quote_command_value(&node_id.0);
+    let caller_scope_flag = if include_tests {
+        " --include-tests"
+    } else {
+        ""
+    };
+    let mut commands = vec![
+        format!("codestory-cli symbol --project {project} --id {id}"),
+        format!(
+            "codestory-cli callers --project {project} --id {id} --depth {depth} --max-nodes {max_nodes}{caller_scope_flag}"
+        ),
+    ];
+    if let Some(path) = affected_seed {
+        commands.push(format!(
+            "codestory-cli affected --project {project} {} --depth {depth}",
+            quote_command_value(path)
+        ));
+    }
+    let paired = match mode {
+        SymbolWorkflowMode::Impact => "test-map",
+        SymbolWorkflowMode::TestMap => "impact",
+    };
+    commands.push(format!(
+        "codestory-cli {paired} --project {project} --id {id} --depth {depth} --max-nodes {max_nodes}{caller_scope_flag}"
+    ));
+    commands
+}
+
+fn quote_command_path(path: &Path) -> String {
+    quote_command_argument_value(&clean_path_string(&path.to_string_lossy()))
+}
+
+fn quote_command_value(value: &str) -> String {
+    shell_single_quoted_value(value)
+}
+
+fn quote_command_argument_value(value: &str) -> String {
+    if value.chars().any(|ch| matches!(ch, '$' | '`' | '\'' | '"')) {
+        quote_command_value(value)
+    } else {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    }
+}
+
+#[cfg(windows)]
+fn shell_single_quoted_value(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+#[cfg(not(windows))]
+fn shell_single_quoted_value(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn clean_path_string(path: &str) -> String {
+    let mut normalized = path.replace('\\', "/");
+    if let Some(stripped) = normalized.strip_prefix("//?/UNC/") {
+        normalized = format!("//{stripped}");
+    } else if normalized.starts_with("//?/") {
+        normalized = normalized[4..].to_string();
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codestory_contracts::api::{EdgeId, GraphEdgeDto, GraphResponse, NodeDetailsDto, NodeKind};
+
+    fn node(id: &str, label: &str, depth: u32) -> GraphNodeDto {
+        GraphNodeDto {
+            id: NodeId(id.to_string()),
+            label: label.to_string(),
+            kind: NodeKind::FUNCTION,
+            depth,
+            label_policy: None,
+            badge_visible_members: None,
+            badge_total_members: None,
+            merged_symbol_examples: Vec::new(),
+            file_path: Some(format!("src/{label}.rs")),
+            qualified_name: None,
+            member_access: None,
+        }
+    }
+
+    #[test]
+    fn callers_follow_only_call_paths_in_one_traversal() {
+        let trail = TrailContextDto {
+            focus: NodeDetailsDto {
+                id: NodeId("focus".to_string()),
+                kind: NodeKind::FUNCTION,
+                display_name: "Focus".to_string(),
+                serialized_name: "Focus".to_string(),
+                qualified_name: None,
+                canonical_id: None,
+                file_path: Some("src/Focus.rs".to_string()),
+                start_line: Some(1),
+                start_col: Some(0),
+                end_line: Some(1),
+                end_col: Some(5),
+                member_access: None,
+                route_endpoint: None,
+            },
+            trail: GraphResponse {
+                center_id: NodeId("focus".to_string()),
+                nodes: vec![
+                    node("focus", "Focus", 0),
+                    node("direct-b", "Direct", 1),
+                    node("direct-a", "Direct", 1),
+                    node("transitive-b", "Transitive", 2),
+                    node("transitive-a", "Transitive", 2),
+                    node("reference", "Reference", 2),
+                ],
+                edges: vec![
+                    GraphEdgeDto {
+                        id: EdgeId("direct-b-focus".to_string()),
+                        source: NodeId("direct-b".to_string()),
+                        target: NodeId("focus".to_string()),
+                        kind: EdgeKind::CALL,
+                        confidence: None,
+                        certainty: None,
+                        callsite_identity: None,
+                        candidate_targets: Vec::new(),
+                    },
+                    GraphEdgeDto {
+                        id: EdgeId("direct-a-focus".to_string()),
+                        source: NodeId("direct-a".to_string()),
+                        target: NodeId("focus".to_string()),
+                        kind: EdgeKind::CALL,
+                        confidence: None,
+                        certainty: None,
+                        callsite_identity: None,
+                        candidate_targets: Vec::new(),
+                    },
+                    GraphEdgeDto {
+                        id: EdgeId("transitive-b-direct".to_string()),
+                        source: NodeId("transitive-b".to_string()),
+                        target: NodeId("direct-b".to_string()),
+                        kind: EdgeKind::CALL,
+                        confidence: None,
+                        certainty: None,
+                        callsite_identity: None,
+                        candidate_targets: Vec::new(),
+                    },
+                    GraphEdgeDto {
+                        id: EdgeId("transitive-a-direct".to_string()),
+                        source: NodeId("transitive-a".to_string()),
+                        target: NodeId("direct-a".to_string()),
+                        kind: EdgeKind::CALL,
+                        confidence: None,
+                        certainty: None,
+                        callsite_identity: None,
+                        candidate_targets: Vec::new(),
+                    },
+                    GraphEdgeDto {
+                        id: EdgeId("reference-direct".to_string()),
+                        source: NodeId("reference".to_string()),
+                        target: NodeId("direct-b".to_string()),
+                        kind: EdgeKind::USAGE,
+                        confidence: None,
+                        certainty: None,
+                        callsite_identity: None,
+                        candidate_targets: Vec::new(),
+                    },
+                ],
+                truncated: false,
+                omitted_edge_count: 0,
+                canonical_layout: None,
+            },
+            story: None,
+        };
+
+        let (direct, transitive) = workflow_callers(&trail);
+
+        assert_eq!(
+            direct
+                .iter()
+                .map(|node| node.node_id.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["direct-b", "direct-a"]
+        );
+        assert_eq!(
+            transitive
+                .iter()
+                .map(|node| node.node_id.0.as_str())
+                .collect::<Vec<_>>(),
+            vec!["transitive-b", "transitive-a"]
+        );
+    }
+
+    #[test]
+    fn test_map_next_action_keeps_test_scope() {
+        let commands = workflow_next_commands(
+            Path::new("C:/repo"),
+            &NodeId("focus".to_string()),
+            None,
+            3,
+            20,
+            SymbolWorkflowMode::Impact,
+            true,
+        );
+        assert!(commands.iter().all(|command| {
+            !command.contains(" callers ") && !command.contains(" test-map ")
+                || command.contains("--include-tests")
+        }));
+    }
+}

--- a/crates/codestory-runtime/src/target_resolution.rs
+++ b/crates/codestory-runtime/src/target_resolution.rs
@@ -1,8 +1,63 @@
 use anyhow::{Context, Result};
-use codestory_contracts::api::{NodeKind, SearchHit, SearchMatchQualityDto};
-use codestory_runtime::{compare_ranked_hits, retrieval_file_role_for_hit, symbol_name_match_rank};
+use codestory_contracts::api::{
+    ApiError, NodeDetailsDto, NodeDetailsRequest, NodeId, NodeKind, SearchHit, SearchHitOrigin,
+    SearchMatchQualityDto,
+};
+use serde::Serialize;
 use std::fs;
 use std::path::Path;
+
+use crate::{
+    AppController, compare_ranked_hits, retrieval_file_role_for_hit, symbol_name_match_rank,
+};
+
+const HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetSelector {
+    Id,
+    Query,
+}
+
+#[derive(Debug, Clone)]
+pub enum TargetSelection {
+    Id(NodeId),
+    Query {
+        query: String,
+        choose: Option<usize>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ResolvedTarget {
+    pub selector: TargetSelector,
+    pub requested: String,
+    pub file_filter: Option<String>,
+    pub selected: SearchHit,
+    pub alternatives: Vec<SearchHit>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AmbiguousTarget {
+    pub query: String,
+    pub file_filter: Option<String>,
+    pub alternatives: Vec<SearchHit>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum TargetResolution {
+    Resolved(Box<ResolvedTarget>),
+    Ambiguous(AmbiguousTarget),
+    Rejected(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct ResolutionCandidateRank {
+    file_filter_match: u8,
+    resolution: ResolutionRank,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ResolutionRank {
@@ -78,16 +133,16 @@ pub(crate) fn is_name_resolvable_graph_target(query: &str, hit: &SearchHit) -> b
         return true;
     }
 
-    let query = codestory_runtime::normalize_symbol_query(query);
+    let query = crate::normalize_symbol_query(query);
     if query.is_empty() {
         return false;
     }
-    let display = codestory_runtime::normalize_symbol_query(&hit.display_name);
+    let display = crate::normalize_symbol_query(&hit.display_name);
     if query.contains('/') && display.contains(&query) {
         return true;
     }
-    let terminal = codestory_runtime::terminal_symbol_segment(&hit.display_name);
-    let leading = codestory_runtime::leading_symbol_segment(&hit.display_name);
+    let terminal = crate::terminal_symbol_segment(&hit.display_name);
+    let leading = crate::leading_symbol_segment(&hit.display_name);
     display.starts_with(&query) || terminal.starts_with(&query) || leading.starts_with(&query)
 }
 
@@ -100,8 +155,8 @@ fn inexact_query_prefix_match_bucket(query: &str, hit: &SearchHit) -> u8 {
     if rank.exact_display != 0 || rank.exact_terminal != 0 || rank.exact_leading != 0 {
         return 0;
     }
-    let query = codestory_runtime::normalize_symbol_query(query);
-    let terminal = codestory_runtime::terminal_symbol_segment(&hit.display_name);
+    let query = crate::normalize_symbol_query(query);
+    let terminal = crate::terminal_symbol_segment(&hit.display_name);
     if terminal.len() < 4 || query == terminal {
         return 0;
     }
@@ -219,7 +274,7 @@ pub(crate) fn file_filter_match_bucket(project_root: &Path, hit: &SearchHit, fra
     };
 
     let absolute = normalize_path_fragment(file_path);
-    let relative = normalize_path_fragment(&crate::display::relative_path(project_root, file_path));
+    let relative = normalize_path_fragment(&relative_path(project_root, file_path));
     let fragment = normalize_path_fragment(fragment);
     let fragment = fragment.trim_matches('/').to_string();
     if fragment.is_empty() {
@@ -283,7 +338,24 @@ fn resolution_kind_bucket(kind: NodeKind) -> u8 {
 }
 
 fn normalize_path_fragment(value: &str) -> String {
-    crate::display::clean_path_string(value).to_ascii_lowercase()
+    clean_path_string(value).to_ascii_lowercase()
+}
+
+fn clean_path_string(path: &str) -> String {
+    let mut normalized = path.replace('\\', "/");
+    if let Some(stripped) = normalized.strip_prefix("//?/UNC/") {
+        normalized = format!("//{stripped}");
+    } else if normalized.starts_with("//?/") {
+        normalized = normalized[4..].to_string();
+    }
+    normalized
+}
+
+fn relative_path(project_root: &Path, raw: &str) -> String {
+    let normalized = clean_path_string(raw);
+    codestory_workspace::workspace_relative_path(project_root, Path::new(&normalized))
+        .map(|path| clean_path_string(&path.to_string_lossy()))
+        .unwrap_or(normalized)
 }
 
 fn declaration_anchor_bucket(hit: &SearchHit) -> u8 {
@@ -334,7 +406,7 @@ fn type_definition_line_bucket(project_root: Option<&Path>, query: &str, hit: &S
         return 0;
     };
     let trimmed = source_line.split("//").next().unwrap_or(source_line).trim();
-    let expected = codestory_runtime::terminal_symbol_segment(query);
+    let expected = crate::terminal_symbol_segment(query);
     let tokens = trimmed
         .split(|ch: char| ch.is_whitespace() || ch == ':' || ch == ';' || ch == '{')
         .map(|token| token.trim_matches(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_')))
@@ -390,7 +462,7 @@ fn callable_definition_line_bucket(
         return 0;
     };
     let trimmed = source_line.split("//").next().unwrap_or(source_line).trim();
-    let expected = codestory_runtime::terminal_symbol_segment(query);
+    let expected = crate::terminal_symbol_segment(query);
     if expected.is_empty() || !line_contains_symbol_name(trimmed, &expected) {
         return 0;
     }
@@ -478,10 +550,348 @@ fn read_file_contents_for_resolution(project_root: Option<&Path>, path: &str) ->
     fs::read_to_string(path).with_context(|| format!("Failed to read file `{path}`"))
 }
 
+impl AppController {
+    pub fn resolve_target(
+        &self,
+        target: TargetSelection,
+        file_filter: Option<&str>,
+    ) -> Result<TargetResolution, ApiError> {
+        match target {
+            TargetSelection::Id(id) => {
+                let details = self.node_details(NodeDetailsRequest { id: id.clone() })?;
+                Ok(TargetResolution::Resolved(Box::new(ResolvedTarget {
+                    selector: TargetSelector::Id,
+                    requested: id.0,
+                    file_filter: None,
+                    selected: search_hit_from_node(&details),
+                    alternatives: Vec::new(),
+                })))
+            }
+            TargetSelection::Query { query, choose } => {
+                self.resolve_query_target(query, choose, file_filter)
+            }
+        }
+    }
+
+    fn resolve_query_target(
+        &self,
+        query: String,
+        choose: Option<usize>,
+        file_filter: Option<&str>,
+    ) -> Result<TargetResolution, ApiError> {
+        let project_root = self.require_project_root()?;
+        let mut alternatives = self.query_resolution_alternatives(&query)?;
+        if alternatives.is_empty()
+            && let Some(stem) = command_query_resolution_stem(&query)
+        {
+            alternatives = self.query_resolution_alternatives(&stem)?;
+        }
+        alternatives.retain(|hit| is_resolvable_graph_target(&query, hit));
+        if let Some(file_filter) = file_filter {
+            alternatives
+                .retain(|hit| search_hit_matches_file_filter(&project_root, hit, file_filter));
+        }
+        if alternatives.is_empty() {
+            return Ok(TargetResolution::Rejected(no_query_match_error(
+                &project_root,
+                &query,
+                file_filter,
+            )));
+        }
+        alternatives.sort_by(|left, right| {
+            compare_resolution_candidates(&project_root, &query, file_filter, left, right)
+        });
+        let tied = tied_top_alternatives(&project_root, &query, file_filter, &alternatives);
+        if let Some(choice) = choose {
+            if choice == 0 || choice > tied.len() {
+                return Ok(TargetResolution::Rejected(format!(
+                    "`--choose {choice}` is outside the displayed alternative range 1..={}. Re-run without `--choose` to inspect the current alternatives.",
+                    tied.len()
+                )));
+            }
+            let selected = tied[choice - 1].clone();
+            promote_selected_alternative(&mut alternatives, &selected);
+            return Ok(TargetResolution::Resolved(Box::new(query_resolved_target(
+                query,
+                file_filter,
+                selected,
+                alternatives,
+            ))));
+        }
+        if tied.len() > 1 {
+            return Ok(TargetResolution::Ambiguous(AmbiguousTarget {
+                query: query.clone(),
+                file_filter: file_filter.map(ToOwned::to_owned),
+                message: ambiguous_query_error(&project_root, &query, file_filter, &tied),
+                alternatives: tied,
+            }));
+        }
+        debug_assert_unique_top_candidate(&project_root, &query, file_filter, &alternatives);
+        let selected = alternatives
+            .first()
+            .cloned()
+            .expect("non-empty alternatives checked above");
+        Ok(TargetResolution::Resolved(Box::new(query_resolved_target(
+            query,
+            file_filter,
+            selected,
+            alternatives,
+        ))))
+    }
+
+    fn query_resolution_alternatives(&self, query: &str) -> Result<Vec<SearchHit>, ApiError> {
+        let mut alternatives = self.resolve_indexed_symbol_candidates(query, 50)?;
+        alternatives.retain(|hit| is_resolvable_graph_target(query, hit));
+        Ok(alternatives)
+    }
+}
+
+fn command_query_resolution_stem(query: &str) -> Option<String> {
+    ["_command", "_cmd", "_handler"]
+        .into_iter()
+        .find_map(|suffix| {
+            query
+                .strip_suffix(suffix)
+                .filter(|stem| stem.len() >= 4)
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn query_resolved_target(
+    query: String,
+    file_filter: Option<&str>,
+    selected: SearchHit,
+    alternatives: Vec<SearchHit>,
+) -> ResolvedTarget {
+    ResolvedTarget {
+        selector: TargetSelector::Query,
+        requested: query,
+        file_filter: file_filter.map(ToOwned::to_owned),
+        selected,
+        alternatives,
+    }
+}
+
+fn promote_selected_alternative(alternatives: &mut Vec<SearchHit>, selected: &SearchHit) {
+    if let Some(position) = alternatives
+        .iter()
+        .position(|hit| hit.node_id == selected.node_id)
+    {
+        let selected = alternatives.remove(position);
+        alternatives.insert(0, selected);
+    }
+}
+
+fn tied_top_alternatives(
+    project_root: &Path,
+    query: &str,
+    file_filter: Option<&str>,
+    alternatives: &[SearchHit],
+) -> Vec<SearchHit> {
+    let Some(first) = alternatives.first() else {
+        return Vec::new();
+    };
+    let top_rank = resolution_candidate_rank(project_root, query, file_filter, first);
+    alternatives
+        .iter()
+        .take_while(|hit| {
+            resolution_candidate_rank(project_root, query, file_filter, hit) == top_rank
+        })
+        .cloned()
+        .collect()
+}
+
+fn debug_assert_unique_top_candidate(
+    project_root: &Path,
+    query: &str,
+    file_filter: Option<&str>,
+    alternatives: &[SearchHit],
+) {
+    if alternatives.len() > 1 {
+        debug_assert_ne!(
+            resolution_candidate_rank(project_root, query, file_filter, &alternatives[0]),
+            resolution_candidate_rank(project_root, query, file_filter, &alternatives[1])
+        );
+    }
+}
+
+fn resolution_candidate_rank(
+    project_root: &Path,
+    query: &str,
+    file_filter: Option<&str>,
+    hit: &SearchHit,
+) -> ResolutionCandidateRank {
+    ResolutionCandidateRank {
+        file_filter_match: file_filter
+            .map(|filter| file_filter_match_bucket(project_root, hit, filter))
+            .unwrap_or(0),
+        resolution: resolution_rank_with_project_root(Some(project_root), query, hit),
+    }
+}
+
+fn compare_resolution_candidates(
+    project_root: &Path,
+    query: &str,
+    file_filter: Option<&str>,
+    left: &SearchHit,
+    right: &SearchHit,
+) -> std::cmp::Ordering {
+    resolution_candidate_rank(project_root, query, file_filter, right)
+        .cmp(&resolution_candidate_rank(
+            project_root,
+            query,
+            file_filter,
+            left,
+        ))
+        .then_with(|| compare_resolution_hits(query, left, right))
+        .then_with(|| left.node_id.0.cmp(&right.node_id.0))
+}
+
+fn search_hit_from_node(node: &NodeDetailsDto) -> SearchHit {
+    SearchHit {
+        node_id: node.id.clone(),
+        display_name: node.display_name.clone(),
+        kind: node.kind,
+        file_path: node.file_path.clone(),
+        line: node.start_line,
+        score: 0.0,
+        origin: SearchHitOrigin::IndexedSymbol,
+        match_quality: None,
+        resolvable: true,
+        evidence_tier: Some(codestory_contracts::api::PacketEvidenceTierDto::ResolvedGraph),
+        evidence_producer: Some("node_details".to_string()),
+        resolution_status: Some(codestory_contracts::api::PacketEvidenceResolutionDto::Resolved),
+        loss_reason: None,
+        coverage_role: None,
+        eligible_for_sufficiency: Some(true),
+        score_breakdown: None,
+    }
+}
+
+fn no_query_match_error(project_root: &Path, query: &str, file_filter: Option<&str>) -> String {
+    let search_command = format!(
+        "codestory-cli search --project {} --query {} --limit 10",
+        quote_cli_path(project_root),
+        quote_cli_value(query)
+    );
+    match file_filter {
+        Some(file_filter) => format!(
+            "query_resolution: No symbol matched query `{query}` within files matching `{}`. Run `{search_command}` to inspect candidates, or relax `--file`.",
+            clean_path_string(file_filter)
+        ),
+        None => format!(
+            "query_resolution: No symbol matched query `{query}`. Run `{search_command}` to inspect candidates."
+        ),
+    }
+}
+
+fn ambiguous_query_error(
+    project_root: &Path,
+    query: &str,
+    file_filter: Option<&str>,
+    alternatives: &[SearchHit],
+) -> String {
+    let scope = file_filter
+        .map(|value| format!(" even after applying `--file {}`", clean_path_string(value)))
+        .unwrap_or_default();
+    let mut message = format!(
+        "Query `{query}` is ambiguous{scope}; choose a match or pass a stable id.\n\nNext commands:\n"
+    );
+    let filter_arg = file_filter
+        .map(|value| format!(" --file {}", quote_cli_value(&clean_path_string(value))))
+        .unwrap_or_default();
+    message.push_str(&format!(
+        "  codestory-cli symbol --project {} --query {}{filter_arg} --choose 1\n",
+        quote_cli_path(project_root),
+        quote_cli_value(query)
+    ));
+    if let Some(first) = alternatives.first() {
+        message.push_str(&format!(
+            "  codestory-cli symbol --project {} --id {}\n",
+            quote_cli_path(project_root),
+            first.node_id.0
+        ));
+        if let Some(path) = first.file_path.as_deref() {
+            message.push_str(&format!(
+                "  codestory-cli symbol --project {} --query {} --file {}\n",
+                quote_cli_path(project_root),
+                quote_cli_value(query),
+                quote_cli_value(&relative_path(project_root, path))
+            ));
+        }
+    }
+    message.push_str(if file_filter.is_some() {
+        "\nPass a more qualified symbol name, a stable `--id`, or a narrower `--file` fragment."
+    } else {
+        "\nPass a more qualified symbol name, add `--file <path-fragment>`, or resolve the exact `--id` from `search` output."
+    });
+    let displayed = alternatives.len().min(HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT);
+    message.push_str(&format!(
+        "\n\nTop equally ranked matches (showing {displayed} of {}):\n",
+        alternatives.len()
+    ));
+    for (index, hit) in alternatives
+        .iter()
+        .take(HUMAN_AMBIGUOUS_ALTERNATIVE_LIMIT)
+        .enumerate()
+    {
+        message.push_str(&format!(
+            "  {}. {} id=`{}`",
+            index + 1,
+            format_search_hit_target(project_root, hit),
+            hit.node_id.0
+        ));
+        if let Some(reference) = node_ref(project_root, hit) {
+            message.push_str(&format!(" ref=`{reference}`"));
+        }
+        message.push('\n');
+    }
+    message
+}
+
+fn format_search_hit_target(project_root: &Path, hit: &SearchHit) -> String {
+    let mut output = format!(
+        "{} [{}]",
+        hit.display_name,
+        format!("{:?}", hit.kind).to_ascii_lowercase()
+    );
+    if let Some(path) = hit.file_path.as_deref() {
+        output.push(' ');
+        output.push_str(&relative_path(project_root, path));
+    }
+    if let Some(line) = hit.line {
+        output.push(':');
+        output.push_str(&line.to_string());
+    }
+    output
+}
+
+fn node_ref(project_root: &Path, hit: &SearchHit) -> Option<String> {
+    Some(format!(
+        "{}:{}:{}",
+        relative_path(project_root, hit.file_path.as_deref()?),
+        hit.line?,
+        hit.display_name
+    ))
+}
+
+fn quote_cli_path(path: &Path) -> String {
+    quote_cli_value(&clean_path_string(&path.to_string_lossy()))
+}
+
+fn quote_cli_value(value: &str) -> String {
+    if value.chars().any(|ch| matches!(ch, '$' | '`' | '\'' | '"')) {
+        format!("'{}'", value.replace('\'', "''"))
+    } else {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use codestory_contracts::api::{NodeId, SearchHitOrigin};
+    use tempfile::tempdir;
 
     fn test_search_hit_defaults() -> SearchHit {
         SearchHit {
@@ -820,5 +1230,77 @@ mod tests {
             hits.first().map(|hit| &hit.node_id),
             Some(&implementation.node_id)
         );
+    }
+
+    #[test]
+    fn exact_type_query_prefers_declaration_over_impl_and_member() {
+        let temp = tempdir().expect("create temp dir");
+        let source = temp.path().join("lib.rs");
+        fs::write(
+            &source,
+            "pub struct AppController;\nimpl AppController {\n    fn open_project(&self) {}\n}\n",
+        )
+        .expect("write source");
+        let path = source.to_string_lossy();
+        let declaration = hit("declaration", "AppController", NodeKind::STRUCT, 1.0, &path);
+        let mut implementation = hit(
+            "implementation",
+            "AppController",
+            NodeKind::CLASS,
+            1.0,
+            &path,
+        );
+        implementation.line = Some(2);
+        let mut member = hit(
+            "member",
+            "AppController::open_project",
+            NodeKind::FUNCTION,
+            1.0,
+            &path,
+        );
+        member.line = Some(3);
+        let mut hits = [implementation, member, declaration.clone()];
+
+        hits.sort_by(|left, right| compare_resolution_hits("AppController", left, right));
+
+        assert_eq!(hits[0].node_id, declaration.node_id);
+    }
+
+    #[test]
+    fn callable_query_prefers_multiline_definition_with_assignment() {
+        let temp = tempdir().expect("create temp dir");
+        let declaration_path = temp.path().join("Indexer.h");
+        let implementation_path = temp.path().join("Indexer.cpp");
+        fs::write(
+            &declaration_path,
+            "void doIndex(\n    Command command,\n    State state) override;\n",
+        )
+        .expect("write declaration");
+        fs::write(
+            &implementation_path,
+            "void Indexer::doIndex(\n    Command command,\n    State state)\n{\n    int status = 0;\n    parse(command, status);\n}\n",
+        )
+        .expect("write implementation");
+        let declaration_path = declaration_path.to_string_lossy();
+        let implementation_path = implementation_path.to_string_lossy();
+        let declaration = hit(
+            "declaration",
+            "Indexer::doIndex",
+            NodeKind::METHOD,
+            1.0,
+            &declaration_path,
+        );
+        let implementation = hit(
+            "implementation",
+            "Indexer::doIndex",
+            NodeKind::FUNCTION,
+            1.0,
+            &implementation_path,
+        );
+        let mut hits = [declaration, implementation.clone()];
+
+        hits.sort_by(|left, right| compare_resolution_hits("Indexer::doIndex", left, right));
+
+        assert_eq!(hits[0].node_id, implementation.node_id);
     }
 }


### PR DESCRIPTION
## Context

`impact` and `test-map` were shipped CLI commands whose symbol resolution, caller traversal, affected projections, caps, unknowns, and next-action policy lived in the adapter. That duplicated the product-orchestration boundary and made the behavior unavailable to other runtime clients.

Base: `c210b4f033dc41d4c6b6e318fd1736c2dff417d2`

Head: `663fe88`

## What changed

- adds typed runtime target selection/resolution and symbol-workflow request, mode, outcome, and response DTOs
- moves target ranking, ambiguity handling, caller traversal, affected projection, caps, unknowns, and next actions into `codestory-runtime`
- keeps `impact` and `test-map` syntax plus JSON/Markdown output stable while reducing the CLI to parse, call, and render
- replaces repeated per-node CALL-path searches with one ordered ancestor walk and preserves deterministic tied output
- removes six adapter-owned ranking tests and the two old CLI workflow semantic tests; keeps two target-resolution boundaries, two workflow boundaries, and one renderer smoke
- records the ownership change in the changelog

No MCP surface is added.

## Review

The main boundary is `crates/codestory-runtime/src/symbol_workflow.rs`. The CLI adapter in `main.rs` should contain no graph traversal, affected projection, cap, unknown, or next-action policy.

Target resolution moved from `codestory-cli` to `codestory-runtime`; ranking and filter helpers remain crate-private. The only public surface is the typed target/workflow boundary.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p codestory-runtime -p codestory-cli --locked`
- `cargo test -p codestory-runtime --lib target_resolution::tests --locked` — 12 passed
- `cargo test -p codestory-runtime --lib symbol_workflow::tests --locked` — 2 passed
- `cargo test -p codestory-cli --bin codestory-cli symbol_workflow_renderer_keeps_caller_shape --locked` — 1 passed
- `cargo clippy -p codestory-runtime -p codestory-cli --locked -- -D warnings`
- `git diff --check`

This is focused source proof only. It does not claim the exact-head workspace, packaged-platform, installed-runtime, or live-sidecar release gates.

## Line delta

- production source: `+222`
- test code: `-155`
- documentation: `+4`
- total: `+1,351 / -1,280` (`+71` net)

The production growth is the typed runtime API and owned response DTOs. It replaces adapter orchestration rather than adding a second implementation; test pruning offsets most of the move.

Closes #1108

Refs #899
