### PR TITLE
isolate runtime test config

### DIFF
--- a/crates/codestory-runtime/src/agent/packet_search.rs
+++ b/crates/codestory-runtime/src/agent/packet_search.rs
@@ -198,7 +198,7 @@ mod tests {
     fn packet_subquery_warmup_fails_closed_without_sidecar_primary() {
         let _lock = crate::process_env_test_lock();
         let _retrieval_env = EnvVarGuard::cleared("CODESTORY_RETRIEVAL");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(crate::test_sidecar_runtime_from_env());
 
         let error = controller
             .warm_packet_subquery_embeddings(&["run_exec_session".to_string()])

--- a/crates/codestory-runtime/src/lib.rs
+++ b/crates/codestory-runtime/src/lib.rs
@@ -104,7 +104,24 @@ static PROCESS_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 pub(crate) fn process_env_test_lock() -> std::sync::MutexGuard<'static, ()> {
-    PROCESS_ENV_TEST_LOCK.lock().expect("process env test lock")
+    PROCESS_ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+pub(crate) fn test_sidecar_runtime_from_env() -> codestory_retrieval::SidecarRuntimeConfig {
+    let process_defaults = codestory_retrieval::SidecarProcessDefaults::new(
+        std::env::temp_dir().join(format!("codestory-runtime-tests-{}", std::process::id())),
+        codestory_retrieval::SidecarRuntimeDefaults::from_process_env(),
+    );
+    codestory_retrieval::SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        None,
+        codestory_retrieval::SidecarProfile::Local,
+        None,
+        &process_defaults,
+        &codestory_retrieval::SidecarRuntimeOverrides::default(),
+    )
 }
 pub use search_runtime::*;
 use semantic_doc_text::{
@@ -3405,7 +3422,7 @@ fn build_search_state(
         llm_refresh_file_scope,
         semantic_projection_mode,
         hydrate_semantic_docs,
-        &codestory_retrieval::SidecarRuntimeConfig::local(),
+        &test_sidecar_runtime_from_env(),
     )
 }
 
@@ -4563,11 +4580,7 @@ fn load_persisted_search_state(
     storage: &mut Storage,
     storage_path: &Path,
 ) -> Result<LoadedSearchState, ApiError> {
-    load_persisted_search_state_for_runtime(
-        storage,
-        storage_path,
-        &codestory_retrieval::SidecarRuntimeConfig::local(),
-    )
+    load_persisted_search_state_for_runtime(storage, storage_path, &test_sidecar_runtime_from_env())
 }
 
 fn load_persisted_search_state_for_runtime(
@@ -4836,10 +4849,7 @@ fn retrieval_state_from_engine_with_storage_contract(
 
 #[cfg(test)]
 fn retrieval_state_from_storage(storage: &Storage) -> Result<RetrievalStateDto, ApiError> {
-    retrieval_state_from_storage_for_runtime(
-        storage,
-        &codestory_retrieval::SidecarRuntimeConfig::local(),
-    )
+    retrieval_state_from_storage_for_runtime(storage, &test_sidecar_runtime_from_env())
 }
 
 fn retrieval_state_from_storage_for_runtime(
@@ -6925,7 +6935,7 @@ fn finalize_staged_semantic_docs(
         llm_refresh_file_scope,
         component_report_refresh,
         cancel_token,
-        &codestory_retrieval::SidecarRuntimeConfig::local(),
+        &test_sidecar_runtime_from_env(),
     )
 }
 
@@ -12071,7 +12081,7 @@ fn index_incremental(
         storage_path,
         events_tx,
         cancel_token,
-        &codestory_retrieval::SidecarRuntimeConfig::local(),
+        &test_sidecar_runtime_from_env(),
     )
 }
 
@@ -12650,7 +12660,7 @@ fn rebuild_search_state_from_storage(
         storage_path,
         llm_refresh_scope,
         hydrate_semantic_docs,
-        &codestory_retrieval::SidecarRuntimeConfig::local(),
+        &test_sidecar_runtime_from_env(),
         None,
     )
 }
@@ -12821,10 +12831,8 @@ mod tests {
     use crossbeam_channel::unbounded;
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard};
+    use std::sync::MutexGuard as StdMutexGuard;
     use tempfile::tempdir;
-
-    static ENV_TEST_LOCK: StdMutex<()> = StdMutex::new(());
 
     struct EnvGuard {
         key: &'static str,
@@ -13021,9 +13029,7 @@ mod tests {
     }
 
     fn hybrid_test_env() -> HybridTestEnv {
-        let lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let lock = process_env_test_lock();
         HybridTestEnv {
             guards: vec![
                 EnvGuard::set(HYBRID_RETRIEVAL_ENABLED_ENV, "true"),
@@ -13227,9 +13233,7 @@ mod tests {
 
     #[test]
     fn llm_doc_embed_batch_size_uses_throughput_default() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::remove(LLM_DOC_EMBED_BATCH_SIZE_ENV);
 
         assert_eq!(llm_doc_embed_batch_size(), 128);
@@ -13341,9 +13345,7 @@ mod tests {
 
     #[test]
     fn llm_doc_embed_batch_size_allows_wider_managed_batches() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::set(LLM_DOC_EMBED_BATCH_SIZE_ENV, "1024");
 
         assert_eq!(llm_doc_embed_batch_size(), 1024);
@@ -13351,9 +13353,7 @@ mod tests {
 
     #[test]
     fn stream_pending_llm_symbol_docs_defaults_to_enabled() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::remove(SEMANTIC_STREAM_PENDING_DOCS_ENV);
         assert!(stream_pending_llm_symbol_docs_from_env());
 
@@ -13363,9 +13363,7 @@ mod tests {
 
     #[test]
     fn semantic_stream_sort_window_defaults_to_one_batch() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::remove(SEMANTIC_STREAM_SORT_WINDOW_BATCHES_ENV);
         assert_eq!(semantic_stream_sort_window_batches_from_env(), 1);
 
@@ -13378,9 +13376,7 @@ mod tests {
 
     #[test]
     fn semantic_doc_scope_defaults_to_durable_symbols_and_all_scope_is_opt_in() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::remove(SEMANTIC_DOC_SCOPE_ENV);
         assert_eq!(
             semantic_doc_scope_from_env(),
@@ -13431,9 +13427,7 @@ mod tests {
 
     #[test]
     fn semantic_doc_alias_mode_defaults_to_alias_variant() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::remove(SEMANTIC_DOC_ALIAS_MODE_ENV);
         assert_eq!(
             semantic_doc_alias_mode_from_env(),
@@ -13455,9 +13449,7 @@ mod tests {
 
     #[test]
     fn semantic_doc_token_budget_defaults_to_safe_window() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::remove(SEMANTIC_DOC_MAX_TOKENS_ENV);
 
         assert_eq!(
@@ -14009,9 +14001,7 @@ mod tests {
 
     #[test]
     fn semantic_doc_text_adds_symbol_aliases_for_supported_language_naming_styles() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::set(SEMANTIC_DOC_ALIAS_MODE_ENV, "current_alias");
         let _budget = EnvGuard::set(SEMANTIC_DOC_MAX_TOKENS_ENV, "512");
         let cases = [
@@ -14098,9 +14088,7 @@ mod tests {
 
     #[test]
     fn semantic_doc_text_adds_kind_role_owner_and_path_alias_context() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::set(SEMANTIC_DOC_ALIAS_MODE_ENV, "current_alias");
         let _budget = EnvGuard::set(SEMANTIC_DOC_MAX_TOKENS_ENV, "512");
         let doc = semantic_doc_text_for_test(
@@ -14132,9 +14120,7 @@ mod tests {
 
     #[test]
     fn semantic_doc_text_keeps_comments_before_long_file_path() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::set(SEMANTIC_DOC_ALIAS_MODE_ENV, "current_alias");
         let _budget = EnvGuard::set(SEMANTIC_DOC_MAX_TOKENS_ENV, "128");
         let file_path = r"\\?\C:\Users\alber\AppData\Local\Temp\codestory-search-quality-fixture-with-a-long-path\src\architecture.ts";
@@ -14174,9 +14160,7 @@ export class SourceGroupCxxCdb {
 
     #[test]
     fn semantic_doc_text_alias_modes_are_switchable_for_research() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _budget = EnvGuard::set(SEMANTIC_DOC_MAX_TOKENS_ENV, "512");
         let no_alias = EnvGuard::set(SEMANTIC_DOC_ALIAS_MODE_ENV, "no_alias");
         let no_alias_doc = semantic_doc_text_for_test(
@@ -14221,9 +14205,7 @@ export class SourceGroupCxxCdb {
 
     #[test]
     fn semantic_doc_text_token_budget_respects_configured_limit() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _alias = EnvGuard::set(SEMANTIC_DOC_ALIAS_MODE_ENV, "current_alias");
         let _budget = EnvGuard::set(SEMANTIC_DOC_MAX_TOKENS_ENV, "48");
         let doc = semantic_doc_text_for_test(
@@ -16607,12 +16589,10 @@ fn build_llm_symbol_doc_text() -> String {
 
     #[test]
     fn search_prefers_full_sidecars_for_tictactoe_queries() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::set(HYBRID_RETRIEVAL_ENABLED_ENV, "false");
         let workspace = copy_tictactoe_workspace();
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         controller
             .open_project(OpenProjectRequest {
                 path: workspace.path().to_string_lossy().to_string(),
@@ -16639,12 +16619,10 @@ fn build_llm_symbol_doc_text() -> String {
 
     #[test]
     fn repo_explanation_search_requires_full_sidecar_retrieval() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = process_env_test_lock();
         let _env = EnvGuard::set(HYBRID_RETRIEVAL_ENABLED_ENV, "false");
         let workspace = copy_tictactoe_workspace();
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         controller
             .open_project(OpenProjectRequest {
                 path: workspace.path().to_string_lossy().to_string(),
@@ -16821,7 +16799,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -16854,7 +16832,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -16910,7 +16888,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -17010,7 +16988,7 @@ fn build_llm_symbol_doc_text() -> String {
         let mut env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -17049,7 +17027,7 @@ fn build_llm_symbol_doc_text() -> String {
             EMBEDDING_BACKEND_ENV,
             "unavailable-test-backend",
         ));
-        let reopened = AppController::new();
+        let reopened = AppController::new_with_config(test_sidecar_runtime_from_env());
         reopened
             .open_project_summary_with_storage_path(
                 workspace.path().to_path_buf(),
@@ -17096,7 +17074,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -17154,7 +17132,7 @@ fn build_llm_symbol_doc_text() -> String {
         env.push(EnvGuard::set(EMBEDDING_EXPECTED_DIM_ENV, "128"));
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -17178,8 +17156,7 @@ fn build_llm_symbol_doc_text() -> String {
         );
 
         env.push(EnvGuard::set(EMBEDDING_EXPECTED_DIM_ENV, "384"));
-        let repair_controller =
-            AppController::new_with_config(codestory_retrieval::SidecarRuntimeConfig::local());
+        let repair_controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         repair_controller
             .open_project_summary_with_storage_path(
                 workspace.path().to_path_buf(),
@@ -17211,7 +17188,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -17296,7 +17273,7 @@ fn build_llm_symbol_doc_text() -> String {
             .expect("write component source");
         }
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         controller
             .open_project_summary_with_storage_path(
                 workspace.path().to_path_buf(),
@@ -17404,7 +17381,7 @@ fn build_llm_symbol_doc_text() -> String {
         )
         .expect("write alpha source");
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         controller
             .open_project_summary_with_storage_path(
                 workspace.path().to_path_buf(),
@@ -17448,7 +17425,7 @@ fn build_llm_symbol_doc_text() -> String {
         env.push(EnvGuard::set(EMBEDDING_EXPECTED_DIM_ENV, "128"));
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -17481,8 +17458,7 @@ fn build_llm_symbol_doc_text() -> String {
         source.push_str("\nfn codestory_contract_drift_added_hint() -> i32 { 7 }\n");
         fs::write(&rust_fixture, source).expect("write changed rust fixture");
 
-        let repair_controller =
-            AppController::new_with_config(codestory_retrieval::SidecarRuntimeConfig::local());
+        let repair_controller = AppController::new_with_config(test_sidecar_runtime_from_env());
         repair_controller
             .open_project_summary_with_storage_path(
                 workspace.path().to_path_buf(),
@@ -17525,7 +17501,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -17573,7 +17549,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(workspace.path().to_path_buf(), storage_path)
@@ -18086,7 +18062,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = copy_tictactoe_workspace();
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         controller
             .open_project_summary_with_storage_path(
@@ -19174,7 +19150,7 @@ fn build_llm_symbol_doc_text() -> String {
         let _env = hybrid_test_env();
         let workspace = tempdir().expect("workspace dir");
         let storage_path = workspace.path().join(".cache").join("codestory.db");
-        let controller = AppController::new();
+        let controller = AppController::new_with_config(test_sidecar_runtime_from_env());
 
         write_reindex_semantic_fixture(workspace.path(), "initial compressed digest");
         controller

--- a/crates/codestory-runtime/src/search/engine.rs
+++ b/crates/codestory-runtime/src/search/engine.rs
@@ -119,7 +119,7 @@ impl EmbeddingBackendSelection {
                 "{EMBEDDING_RUNTIME_MODE_ENV}={runtime_mode} is no longer supported; CodeStory retrieval requires the llama.cpp sidecar"
             );
         }
-        Self::from_config(&codestory_retrieval::SidecarRuntimeConfig::local().embedding)
+        Self::from_config(&crate::test_sidecar_runtime_from_env().embedding)
     }
 
     fn from_config(config: &codestory_retrieval::EmbeddingRuntimeConfig) -> Result<Self> {
@@ -190,7 +190,7 @@ struct EmbeddingProfile {
 impl EmbeddingProfile {
     #[cfg(test)]
     fn from_env() -> Result<Self> {
-        Self::from_config(&codestory_retrieval::SidecarRuntimeConfig::local().embedding)
+        Self::from_config(&crate::test_sidecar_runtime_from_env().embedding)
     }
 
     fn from_config(config: &codestory_retrieval::EmbeddingRuntimeConfig) -> Result<Self> {
@@ -2047,11 +2047,8 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
-    use std::sync::Mutex as StdMutex;
     use std::thread;
     use tempfile::tempdir;
-
-    static ENV_TEST_LOCK: StdMutex<()> = StdMutex::new(());
 
     fn test_axis_embedding(axis: usize) -> Vec<f32> {
         let mut embedding = vec![0.0; EMBEDDING_DIM];
@@ -2096,9 +2093,7 @@ mod tests {
 
     #[test]
     fn embedding_profile_defaults_to_bge_base() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _guard = EnvGuard::remove(EMBEDDING_PROFILE_ENV);
 
         let profile = EmbeddingProfile::from_env()?;
@@ -2111,9 +2106,7 @@ mod tests {
 
     #[test]
     fn mandatory_sidecar_defaults_to_llamacpp_backend_when_backend_is_unset() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _mode = EnvGuard::remove(EMBEDDING_RUNTIME_MODE_ENV);
         let _backend = EnvGuard::remove(EMBEDDING_BACKEND_ENV);
         let _url = EnvGuard::remove(LLAMACPP_EMBEDDINGS_URL_ENV);
@@ -2129,9 +2122,7 @@ mod tests {
 
     #[test]
     fn removed_onnx_configuration_fails_explicitly() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _mode = EnvGuard::remove(EMBEDDING_RUNTIME_MODE_ENV);
         let _backend = EnvGuard::set(EMBEDDING_BACKEND_ENV, "onnx");
 
@@ -2143,9 +2134,7 @@ mod tests {
 
     #[test]
     fn removed_onnx_runtime_mode_fails_even_with_llamacpp_backend() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _backend = EnvGuard::set(EMBEDDING_BACKEND_ENV, "llamacpp");
 
         for alias in ["onnx", "ort", "onnxruntime", "onnx-runtime"] {
@@ -2161,9 +2150,7 @@ mod tests {
 
     #[test]
     fn removed_onnx_environment_fails_even_with_llamacpp_selected() {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _backend = EnvGuard::set(EMBEDDING_BACKEND_ENV, "llamacpp");
         let _legacy = EnvGuard::set("CODESTORY_EMBED_ONNX_MODEL", "legacy.onnx");
 
@@ -2254,7 +2241,7 @@ mod tests {
             truncate_dim: None,
             expected_dim: Some(3),
         };
-        let mut client_config = codestory_retrieval::SidecarRuntimeConfig::local().embedding;
+        let mut client_config = crate::test_sidecar_runtime_from_env().embedding;
         client_config.endpoint = url.clone();
         client_config.endpoint_origin =
             codestory_retrieval::EmbeddingEndpointOrigin::TrustedProjectConfig;
@@ -2288,9 +2275,7 @@ mod tests {
     #[test]
     #[ignore]
     fn embedding_identity_probe_from_env() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let query = std::env::var("CODESTORY_EMBED_IDENTITY_PROBE_QUERY").unwrap_or_else(|_| {
             "Where is the retrieval sidecar embedding contract enforced?".into()
         });
@@ -2449,9 +2434,7 @@ mod tests {
 
     #[test]
     fn symbol_full_text_index_can_be_disabled_for_projection_only_search() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _guard = EnvGuard::set(SYMBOL_FULL_TEXT_INDEX_ENV, "false");
         let mut engine = SearchEngine::new(None)?;
 
@@ -2759,9 +2742,7 @@ mod tests {
 
     #[test]
     fn test_hybrid_search_quantized_prefilter_rescores_full_precision() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _guard = EnvGuard::set(STORED_VECTOR_ENCODING_ENV, "int8");
 
         let mut engine = SearchEngine::new(None)?;
@@ -2872,9 +2853,7 @@ mod tests {
 
     #[test]
     fn test_quantized_semantic_prefilter_prefers_primary_docs() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _guard = EnvGuard::set(STORED_VECTOR_ENCODING_ENV, "int8");
 
         let mut engine = SearchEngine::new(None)?;
@@ -2903,9 +2882,7 @@ mod tests {
 
     #[test]
     fn test_float32_semantic_scores_return_bounded_top_candidates() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _guard = EnvGuard::set(STORED_VECTOR_ENCODING_ENV, "float32");
 
         fn axis_embedding(axis: usize) -> Vec<f32> {
@@ -2935,9 +2912,7 @@ mod tests {
 
     #[test]
     fn test_quantized_semantic_scores_return_bounded_top_candidates() -> Result<()> {
-        let _lock = ENV_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _lock = crate::process_env_test_lock();
         let _guard = EnvGuard::set(STORED_VECTOR_ENCODING_ENV, "int8");
 
         fn axis_embedding(axis: usize) -> Vec<f32> {


### PR DESCRIPTION
## Summary

Environment-sensitive runtime tests now construct explicit fresh sidecar configs instead of relying on the production process-wide defaults snapshot. The production `OnceLock` contract is unchanged.

- share one process-environment lock across runtime test modules
- inject fresh runtime defaults into the cfg(test) search/index wrappers and affected controllers
- remove duplicate locks and repeated poison-recovery blocks
- keep the exact-head runtime suite safe at default concurrency

## Delta

- production: 0 lines
- tests: +74 / -123 (net -49)
- documentation: 0 lines

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p codestory-runtime --lib --locked` twice at default concurrency: 651 passed, 1 ignored each run
- `cargo clippy -p codestory-runtime --lib --locked -- -D warnings`
- `git diff --check`
- code-simplifier review: removed duplicate locks and kept production config paths untouched

Closes #1124
Refs #899