### PR TITLE
[codex] fix release approval handoff

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -104,7 +104,7 @@ export const releaseEvidenceWorkflowRef = "./.github/workflows/release-candidate
 export function releaseEvidenceApprovalViolations(callerJobs, calledWorkflow) {
   const violations = [];
   const file = releaseEvidenceWorkflowRef.slice(releaseEvidenceWorkflowRef.lastIndexOf("/") + 1);
-  for (const [callerFile, callerJob] of callerJobs) {
+  for (const [callerFile, callerJob, passesApproval] of callerJobs) {
     const job = object(callerJob);
     add(
       violations,
@@ -121,36 +121,40 @@ export function releaseEvidenceApprovalViolations(callerJobs, calledWorkflow) {
       object(job.with).source_run_id === "${{ inputs.source_run_id }}",
       `${callerFile} release-evidence must forward source_run_id`,
     );
+    const secrets = object(job.secrets);
+    const secret = secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON;
     add(
       violations,
-      job.secrets === undefined,
-      `${callerFile} release-evidence must not receive caller secrets`,
+      passesApproval
+        ? secret === "${{ secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON }}"
+          && Object.keys(secrets).length === 1
+        : job.secrets === undefined,
+      passesApproval
+        ? `${callerFile} release-evidence must pass only the named approval secret`
+        : `${callerFile} release-evidence must not receive caller secrets`,
     );
   }
   add(
     violations,
-    at(
-      calledWorkflow,
-      "on",
-      "workflow_call",
-      "secrets",
+    object(at(
+      calledWorkflow, "on", "workflow_call", "secrets",
       "CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON",
-    ) === undefined,
-    `${file} approval must not be declared as a caller secret`,
+    )).required === false,
+    `${file} approval must be an optional caller secret`,
   );
 
   const job = object(at(calledWorkflow, "jobs", "measure"));
   add(
     violations,
     job.environment === "release-evidence",
-    `${file} approval must use the release-evidence environment`,
+    `${file} approval must remain gated by the release-evidence environment`,
   );
   const evaluation = namedStep(job, "Produce and evaluate same-SHA candidate");
   add(
     violations,
     object(evaluation?.env).APPROVAL_JSON
       === "${{ secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON }}",
-    `${file} approval must come from the protected environment secret`,
+    `${file} approval must use the explicitly passed release secret`,
   );
   requireStepRun(violations, file, job, "Produce and evaluate same-SHA candidate", [
     'if [ -n "$SOURCE_RUN_ID" ] && [ -z "$APPROVAL_JSON" ]; then',
@@ -714,8 +718,8 @@ function validateRemainingWorkflows(workflows, violations) {
     add(violations, JSON.stringify(job["runs-on"]) === JSON.stringify(["self-hosted", "Linux", "ARM64", "codestory-release-evidence"]), `${evidenceFile} must use the protected evidence runner`);
     violations.push(...releaseEvidenceApprovalViolations(
       [
-        ["release.yml", at(workflows.get("release.yml"), "jobs", "release-evidence")],
-        ["packaged-platform-pr.yml", at(workflows.get("packaged-platform-pr.yml"), "jobs", "release-evidence")],
+        ["release.yml", at(workflows.get("release.yml"), "jobs", "release-evidence"), true],
+        ["packaged-platform-pr.yml", at(workflows.get("packaged-platform-pr.yml"), "jobs", "release-evidence"), false],
       ],
       evidence,
     ));

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -34,14 +34,24 @@ function releaseEvidenceApprovalBoundary() {
       ["release.yml", {
         uses: releaseEvidenceWorkflowRef,
         with: { source_run_id: "${{ inputs.source_run_id }}" },
-      }],
+        secrets: {
+          CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON:
+            "${{ secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON }}",
+        },
+      }, true],
       ["packaged-platform-pr.yml", {
         uses: releaseEvidenceWorkflowRef,
         with: { source_run_id: "${{ inputs.source_run_id }}" },
-      }],
+      }, false],
     ],
     called: {
-      on: { workflow_call: {} },
+      on: {
+        workflow_call: {
+          secrets: {
+            CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON: { required: false },
+          },
+        },
+      },
       jobs: {
         measure: {
           environment: "release-evidence",
@@ -154,7 +164,7 @@ test("PR package proof cannot opt into signing credentials", () => {
   }
 });
 
-test("release approval remains inside the protected evidence environment", () => {
+test("release approval crosses only the protected release boundary", () => {
   const boundary = releaseEvidenceApprovalBoundary();
   assert.deepEqual(releaseEvidenceApprovalViolations(boundary.callers, boundary.called), []);
 
@@ -162,12 +172,18 @@ test("release approval remains inside the protected evidence environment", () =>
     candidate => { candidate.callers[0][1] = undefined; },
     candidate => { candidate.callers[1][1].uses = "./.github/workflows/release.yml"; },
     candidate => { delete candidate.callers[1][1].with.source_run_id; },
+    candidate => { delete candidate.callers[0][1].secrets; },
+    candidate => {
+      candidate.callers[0][1].secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON
+        = "${{ secrets.WRONG_SECRET }}";
+    },
+    candidate => { candidate.callers[0][1].secrets.EXTRA_SECRET = "${{ secrets.EXTRA }}"; },
     candidate => { candidate.callers[0][1].secrets = "inherit"; },
     candidate => { candidate.callers[1][1].secrets = "inherit"; },
+    candidate => { delete candidate.called.on.workflow_call.secrets; },
     candidate => {
-      candidate.called.on.workflow_call.secrets = {
-        CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON: { required: false },
-      };
+      candidate.called.on.workflow_call.secrets
+        .CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON.required = true;
     },
     candidate => { candidate.called.jobs.measure.environment = "release"; },
     candidate => {

--- a/.github/workflows/release-candidate-evidence.yml
+++ b/.github/workflows/release-candidate-evidence.yml
@@ -24,6 +24,9 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON:
+        required: false
 
 permissions:
   actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,8 @@ jobs:
       drill_manifest: /srv/codestory-release-evidence/drills/real-repo-drill-cases.json
       embedding_model_dir: /srv/codestory-release-evidence/models
       source_run_id: ${{ inputs.source_run_id }}
+    secrets:
+      CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON: ${{ secrets.CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON }}
 
   packaged-proof:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,9 +67,10 @@
   verified CodeStory ownership. Dead or reused processes, conflicting legacy
   state, unsafe paths, oversized downloads, and ambiguous cleanup all fail
   closed instead of being guessed through.
-- Release-evidence re-evaluation reads exception approvals only from its
-  protected environment and fails before evaluation when that approval is
-  missing.
+- Release-evidence re-evaluation stays behind its protected environment gate,
+  accepts only the named secret explicitly passed by the release coordinator,
+  and fails before evaluation when that approval is missing. PR packaging never
+  receives the approval secret.
 - The packaged plugin launches the native CodeStory CLI without a shell. On
   Windows, `CODESTORY_CLI` must name a native `.exe`; the supported `codex.cmd`
   host shim is unchanged. Cross-platform worktree setup uses one

--- a/docs/contributors/release-evidence-runner.md
+++ b/docs/contributors/release-evidence-runner.md
@@ -153,9 +153,12 @@ artifact and evaluates it again without producing new measurements. Before the
 download, it requires a failed trusted evidence workflow from this repository
 whose head is the exact evidence SHA.
 
-The approval secret belongs only to the protected `release-evidence`
-environment used by the reusable workflow's measurement job. Release callers
-must not pass or inherit it. A re-evaluation with no nonempty protected approval
+GitHub does not expose environment-only secrets across a reusable-workflow
+call. Store the short-lived approval as the repository Actions secret
+`CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON`; `release.yml` passes only that named
+secret into the called job, which remains behind the protected
+`release-evidence` environment gate. PR packaging passes no secrets. Delete the
+repository secret after publication. A re-evaluation with no nonempty approval
 fails before the evaluator runs.
 
 The workflow uploads `release-evidence-<full SHA>` from

--- a/docs/testing/performance-review-playbook.md
+++ b/docs/testing/performance-review-playbook.md
@@ -159,10 +159,11 @@ artifact can become release-eligible.
 
 On rejection, the workflow uploads provisioning, raw, candidate, approval (when
 provided), and report files with `if: always()`. Author an exception against the
-reported hashes and values in the
-protected `release-evidence` environment's
-`CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON` secret, then dispatch the Release
-workflow on the same SHA and version with
+reported hashes and values in the short-lived repository Actions secret
+`CODESTORY_RELEASE_EVIDENCE_APPROVAL_JSON`. The release coordinator passes only
+that named secret into the reusable job behind the protected
+`release-evidence` environment gate; PR packaging receives none. Dispatch the
+Release workflow on the same SHA and version with
 `source_run_id=<rejected-run-id>`. That path downloads and re-evaluates the
 exact candidate without re-running measurements; any SHA, hash, value, profile,
 baseline, threshold, date, or expiry drift still fails.


### PR DESCRIPTION
## Summary

- pass the short-lived approval repository secret explicitly from `release.yml`
- keep the called evidence job behind the protected `release-evidence` environment
- forbid approval secrets in PR/package callers
- document deletion of the temporary repository secret after publication

## Local proof

- workflow-policy tests 7/7
- structural workflow policy
- actionlint
- retrieval generalization lint
- docs links
- release version sync
- git diff check

No Rust or product runtime code changed. Per release-coordinator direction, merge without waiting for hosted PR checks.

Closes #1141
Refs #1136
Refs #899