### PR TITLE
[codex] fix macos cli release proof

### DIFF
--- a/.github/scripts/check-workflow-policy.mjs
+++ b/.github/scripts/check-workflow-policy.mjs
@@ -101,6 +101,23 @@ function requireJob(violations, file, workflow, name) {
 
 export const releaseEvidenceWorkflowRef = "./.github/workflows/release-candidate-evidence.yml";
 
+export function macosCliDistributionViolations(assessmentStep, executionStep, quarantinedPath) {
+  const violations = [];
+  const assessment = executableRunText(String(assessmentStep?.run ?? ""));
+  const execution = executableRunText(String(executionStep?.run ?? ""));
+  const assessmentLines = assessment.split("\n");
+  const executionLines = execution.split("\n");
+  const lineHas = (lines, ...fragments) => lines.some(line => fragments.every(fragment => line.includes(fragment)));
+  add(violations, lineHas(assessmentLines, "xattr -w com.apple.quarantine", quarantinedPath), "macOS CLI proof must quarantine the assessed executable");
+  add(violations, lineHas(assessmentLines, "xattr -p com.apple.quarantine", quarantinedPath), "macOS CLI proof must record the executable quarantine");
+  add(violations, lineHas(assessmentLines, "spctl --assess --type execute --verbose=4", quarantinedPath), "macOS CLI proof must retain the spctl diagnostic for that executable");
+  add(violations, assessment.includes("spctl_status=$?"), "macOS CLI proof must record the spctl diagnostic status");
+  add(violations, assessment.includes("does not seem to be an app"), "macOS CLI proof must recognize the bare-executable spctl result");
+  add(violations, !/(^|\n)\s*accepted=false\s*($|\n)/u.test(assessment), "macOS CLI proof must not require spctl application acceptance");
+  add(violations, lineHas(executionLines, quarantinedPath, "--version") && lineHas(executionLines, quarantinedPath, "--help"), "macOS CLI proof must execute that quarantined binary's version and help");
+  return violations;
+}
+
 export function releaseEvidenceApprovalViolations(callerJobs, calledWorkflow) {
   const violations = [];
   const file = releaseEvidenceWorkflowRef.slice(releaseEvidenceWorkflowRef.lastIndexOf("/") + 1);
@@ -615,6 +632,11 @@ function validatePackagedProof(workflows, violations) {
   ]) {
     add(violations, signingRun.includes(fragment), `${file} signing step must include ${fragment}`);
   }
+  violations.push(...macosCliDistributionViolations(
+    signing,
+    namedStep(job, "Execute quarantined notarized macOS CLI without signing credentials"),
+    '"$work_dir/codestory-cli-quarantined"',
+  ).map(message => `${file} ${message}`));
   requireStepRun(violations, file, job, "Run Windows installer ownership self-test", ["scripts/install-codestory.ps1 -SelfTest"]);
   requireStepRun(violations, file, job, "Prove Linux x64 glibc 2.31 baseline", ["bash .github/scripts/check-linux-glibc-baseline.sh"]);
   violations.push(...managedPluginViolations(
@@ -640,14 +662,15 @@ function validatePostPublish(workflows, violations) {
     job,
     '--archive "${{ steps.asset.outputs.archive }}"',
   ).map(message => `${file} ${message}`));
-  requireStepRun(violations, file, job, "Prove published macOS signature, notarization, and Gatekeeper acceptance", [
+  const macProof = namedStep(job, "Prove published macOS signature, notarization, and quarantined execution");
+  requireStepRun(violations, file, job, "Prove published macOS signature, notarization, and quarantined execution", [
     "archive-quarantine.txt",
     "extracted-binary-quarantine.txt",
     "Authority=Developer ID Application:",
-    "source=Notarized Developer ID",
     "TeamIdentifier=${APPLE_DEVELOPER_TEAM_ID}",
     "certificate leaf",
   ]);
+  violations.push(...macosCliDistributionViolations(macProof, macProof, '"$bin"').map(message => `${file} ${message}`));
   requireStepRun(violations, file, job, "Run Windows installer ownership self-test", ["scripts/install-codestory.ps1 -SelfTest"]);
   requireStepRun(violations, file, job, "Prove published Intel macOS backend policy and explicit CPU/external operation", ["--intel-runtime-policy"]);
   add(violations, !scalarStrings(workflow).some(value => value.includes("sha256sum")), `${file} must use the portable Python checksum gate`);

--- a/.github/scripts/check-workflow-policy.test.mjs
+++ b/.github/scripts/check-workflow-policy.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   basicWorkflowViolations,
+  macosCliDistributionViolations,
   managedPluginViolations,
   notaryStepViolations,
   packagedPrSigningViolations,
@@ -204,4 +205,29 @@ test("notarization must use explicit polling", () => {
     notaryStepViolations({ run: "xcrun notarytool submit bundle.zip \\\n  --wait" }).join("\n"),
     /poll explicitly/u,
   );
+});
+
+test("bare macOS CLI proof uses quarantine execution instead of app assessment", () => {
+  const assessment = {
+    run: [
+      "xattr -w com.apple.quarantine quarantine codestory-cli",
+      "xattr -p com.apple.quarantine codestory-cli > quarantine.txt",
+      "spctl --assess --type execute --verbose=4 codestory-cli > spctl-diagnostic.txt 2>&1",
+      "spctl_status=$?",
+      "grep -F 'does not seem to be an app' spctl-diagnostic.txt",
+    ].join("\n"),
+  };
+  const execution = { run: "codestory-cli --version\ncodestory-cli --help" };
+  assert.deepEqual(macosCliDistributionViolations(assessment, execution, "codestory-cli"), []);
+
+  for (const mutate of [
+    candidate => { candidate.assessment.run = candidate.assessment.run.replace("xattr -w com.apple.quarantine quarantine codestory-cli", "true"); },
+    candidate => { candidate.assessment.run += "\naccepted=false"; },
+    candidate => { candidate.assessment.run = candidate.assessment.run.replace("spctl_status=$?", "true"); },
+    candidate => { candidate.execution.run = "original-cli --version\noriginal-cli --help"; },
+  ]) {
+    const candidate = { assessment: structuredClone(assessment), execution: structuredClone(execution) };
+    mutate(candidate);
+    assert.notDeepEqual(macosCliDistributionViolations(candidate.assessment, candidate.execution, "codestory-cli"), []);
+  }
 });

--- a/.github/workflows/packaged-platform-proof.yml
+++ b/.github/workflows/packaged-platform-proof.yml
@@ -283,24 +283,23 @@ jobs:
 
           cp "$bin" "$work_dir/codestory-cli-quarantined"
           xattr -w com.apple.quarantine "0083;$(date +%s);CodeStory;" "$work_dir/codestory-cli-quarantined"
-          accepted=false
-          for _attempt in $(seq 1 12); do
-            if spctl --assess --type execute --verbose=4 "$work_dir/codestory-cli-quarantined" \
-              > "$proof_dir/spctl.txt" 2>&1
-            then
-              accepted=true
-              break
-            fi
-            sleep 5
-          done
-          if [ "$accepted" != true ]; then
-            cat "$proof_dir/spctl.txt"
-            echo "::error::Gatekeeper did not accept the signed and notarized CLI"
-            exit 1
+          xattr -p com.apple.quarantine "$work_dir/codestory-cli-quarantined" \
+            > "$proof_dir/executable-quarantine.txt"
+          set +e
+          spctl --assess --type execute --verbose=4 "$work_dir/codestory-cli-quarantined" \
+            > "$proof_dir/spctl-diagnostic.txt" 2>&1
+          spctl_status=$?
+          set -e
+          printf '%s\n' "$spctl_status" > "$proof_dir/spctl-status.txt"
+          if [ "$spctl_status" -eq 0 ]; then
+            grep -F "source=Notarized Developer ID" "$proof_dir/spctl-diagnostic.txt"
+          else
+            # spctl does not assess bare Mach-O tools as applications. Keep its
+            # diagnostic, then prove the quarantined executable in the next step.
+            grep -F "does not seem to be an app" "$proof_dir/spctl-diagnostic.txt"
           fi
-          grep -F "source=Notarized Developer ID" "$proof_dir/spctl.txt"
 
-      - name: Execute notarized macOS CLI without signing credentials
+      - name: Execute quarantined notarized macOS CLI without signing credentials
         if: runner.os == 'macOS' && inputs.sign_macos
         shell: bash
         run: |

--- a/.github/workflows/post-publish-release-smoke.yml
+++ b/.github/workflows/post-publish-release-smoke.yml
@@ -100,7 +100,7 @@ jobs:
           --version-only
           --out-dir "target/post-publish-version-proof/${{ matrix.asset_target }}"
 
-      - name: Prove published macOS signature, notarization, and Gatekeeper acceptance
+      - name: Prove published macOS signature, notarization, and quarantined execution
         if: runner.os == 'macOS'
         shell: bash
         run: |
@@ -134,19 +134,16 @@ jobs:
           # quarantine event to the extracted executable before assessment.
           xattr -w com.apple.quarantine "$quarantine" "$bin"
           xattr -p com.apple.quarantine "$bin" > "$proof_dir/extracted-binary-quarantine.txt"
-          accepted=false
-          for _attempt in $(seq 1 12); do
-            if spctl --assess --type execute --verbose=4 "$bin" > "$proof_dir/spctl.txt" 2>&1; then
-              accepted=true
-              break
-            fi
-            sleep 5
-          done
-          if [ "$accepted" != true ]; then
-            cat "$proof_dir/spctl.txt"
-            exit 1
+          set +e
+          spctl --assess --type execute --verbose=4 "$bin" > "$proof_dir/spctl-diagnostic.txt" 2>&1
+          spctl_status=$?
+          set -e
+          printf '%s\n' "$spctl_status" > "$proof_dir/spctl-status.txt"
+          if [ "$spctl_status" -eq 0 ]; then
+            grep -F "source=Notarized Developer ID" "$proof_dir/spctl-diagnostic.txt"
+          else
+            grep -F "does not seem to be an app" "$proof_dir/spctl-diagnostic.txt"
           fi
-          grep -F "source=Notarized Developer ID" "$proof_dir/spctl.txt"
           "$bin" --version
           "$bin" --help >/dev/null
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@
   disappears or changes.
 - Direct-download Mac artifacts are release-ready only after the exact arm64 and
   x64 binaries pass Developer ID signing, notarization, quarantined extraction,
-  Gatekeeper, and native execution checks. Source or unsigned package checks do
-  not make that claim.
+  and native execution checks. Release proof retains `spctl` diagnostics but no
+  longer mistakes its bare-CLI "not an app" result for notarization failure.
+  Source or unsigned package checks do not make that claim.
 
 ### Reliability and operations
 
@@ -90,7 +91,7 @@
 - The repository version and release notes describe the candidate source.
   Publication is complete only when the matching archives and checksums are
   available and the required platform checks pass.
-- Marketplace availability, Gatekeeper acceptance, installed runtime/version
+- Marketplace availability, quarantined native execution, installed runtime/version
   readback, and live full-retrieval behavior are separate post-publication
   claims and require their own evidence.
 

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -252,10 +252,13 @@ blocks the release before any Mac asset is published.
 After publication, both Mac tarballs receive a download quarantine before
 extraction. Because command-line tar does not propagate that xattr, the proof
 records the archive quarantine and transfers the same event to the extracted
-binary before `codesign --verify`, online Gatekeeper `spctl` assessment,
-version, and help execution on each native architecture. Preserve the
+binary before `codesign --verify`, an `spctl` diagnostic, and native version
+and help execution on each architecture. `spctl` treats a bare Mach-O CLI as
+"not an app" even when Apple notarization is accepted, so quarantined native
+execution is the release gate; the diagnostic is retained without requiring
+application-bundle acceptance. Preserve the
 release-time `notarytool` result and post-publish quarantine,
-codesign/Gatekeeper artifacts. Signing/notary material is scoped to the
+codesign/execution artifacts. Signing/notary material is scoped to the
 protected `macos-release-signing` environment and written with owner-only
 permissions. Release-time and post-publish proof require both the reported
 `TeamIdentifier` and the designated-requirement certificate OU to match Apple


### PR DESCRIPTION
## Summary

- keep Developer ID, hardened runtime, timestamp, team identity, and Apple `notarytool` `Accepted` checks fail-closed
- retain `spctl` as a diagnostic for bare Mach-O executables instead of requiring application-bundle acceptance
- gate both release-time and post-publish proof on the same quarantined CLI executing `--version` and `--help`
- structurally bind quarantine write/read, diagnostic, and execution to the same path

## Verification

- `node --test .github/scripts/check-workflow-policy.test.mjs`
- `node .github/scripts/check-workflow-policy.mjs`
- `actionlint .github/workflows/packaged-platform-proof.yml .github/workflows/post-publish-release-smoke.yml .github/workflows/release.yml`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- independent blocker-only review approved the exact diff

No Rust or product-runtime code changed. Automation is net -4 lines; the net growth is the structural policy boundary, one focused mutation test, and release documentation.

Closes #1144
Refs #1046
