### PR TITLE
Keep worktree setup local by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Delegated worktree setup now prepares and reports the local repository map
+  without attempting full retrieval or printing backend repair instructions.
+  Maintainers can request that separate proof explicitly with
+  `--full-retrieval-proof` (or `-FullRetrievalProof` in PowerShell).
+
 ## 0.15.0
 
 ### Highlights

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -194,7 +194,7 @@ After bootstrap, run a target-repo sidecar index before using packet/search:
 ## Delegated Worktree Proof Target
 
 Before a delegated CodeStory lane spends time on cache repair, readiness, or
-sidecar proof, verify the Git target. The tracked Codex environment runs:
+full-retrieval proof, verify the Git target. The tracked Codex environment runs:
 
 ```sh
 node scripts/codex-worktree-setup.mjs
@@ -226,13 +226,23 @@ by itself.
 
 The setup reports stale `main`, stale local `dev/codestory-next`, stale PR
 heads, unresolved refs, and the exact `git ls-remote origin ...` result before
-it runs index, retrieval, or doctor handoff work. It then resolves a
+it prepares the worktree. It then resolves a
 version-matched CLI through `CODESTORY_CLI`, PATH, the CodeStory install
 directory, this worktree, and sibling worktrees; tries the matching release;
 and falls back to a locked release Cargo build with optional `sccache`. It best-effort
-rehydrates a compatible sibling cache, refreshes the local index, and reports
-agent sidecar readiness. Treat Git-target warnings as proof-target blockers,
-not packet/search readiness blockers.
+rehydrates a compatible sibling cache, refreshes the local repository map, and
+reports a compact setup state. The default does not prepare or wait for full
+retrieval, so it works without a model, Docker, or another local service.
+
+Maintainers can opt into the full retrieval preparation lane when that evidence
+is part of the verification target:
+
+```sh
+node scripts/codex-worktree-setup.mjs --full-retrieval-proof
+```
+
+The PowerShell adapter accepts `-FullRetrievalProof`. Treat Git-target warnings
+as proof-target blockers, not broad-search readiness blockers.
 
 Exercise the shared dispatcher behavior and the current platform adapter without
 changing your real workspace state:

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -99,6 +99,11 @@ node scripts/setup-retrieval-env.mjs --self-test
 node --test scripts/tests/codex-worktree-setup.test.mjs
 ```
 
+The shared worktree suite proves that normal setup stops after the local
+repository map and that only `--full-retrieval-proof` enters the full retrieval
+lane. The adapter smoke verifies forwarding only; platform scripts do not own a
+second setup implementation.
+
 ## Release And Version Bumps
 
 `crates/codestory-cli/Cargo.toml` is the release version source. When bumping a

--- a/scripts/codex-worktree-setup.mjs
+++ b/scripts/codex-worktree-setup.mjs
@@ -37,6 +37,7 @@ const usage = `Usage: node scripts/codex-worktree-setup.mjs [options]
   --pr-head-ref <ref>          Optional PR head used in the proof summary
   --branch-head-proof          Prove only the PR branch head
   --resolve-cli-only           Resolve/install the CLI without indexing
+  --full-retrieval-proof       Prepare and verify full retrieval (maintainers only)
   --self-test                  Run the shared Node setup test suite
   --help                       Show this help`;
 
@@ -51,6 +52,7 @@ export function parseArguments(argv, env = process.env) {
     prHeadRef: env.CODESTORY_PR_HEAD_REF || "",
     branchHeadProof: truthy(env.CODESTORY_BRANCH_HEAD_PROOF),
     resolveCliOnly: false,
+    fullRetrievalProof: false,
     selfTest: false,
     help: false,
   };
@@ -60,6 +62,7 @@ export function parseArguments(argv, env = process.env) {
     ["-PrHeadRef", "--pr-head-ref"],
     ["-BranchHeadProof", "--branch-head-proof"],
     ["-ResolveCliOnly", "--resolve-cli-only"],
+    ["-FullRetrievalProof", "--full-retrieval-proof"],
     ["-SelfTest", "--self-test"],
     ["-Help", "--help"],
   ]);
@@ -81,6 +84,7 @@ export function parseArguments(argv, env = process.env) {
     }
     if (argument === "--branch-head-proof") options.branchHeadProof = true;
     else if (argument === "--resolve-cli-only") options.resolveCliOnly = true;
+    else if (argument === "--full-retrieval-proof") options.fullRetrievalProof = true;
     else if (argument === "--self-test") options.selfTest = true;
     else if (["--help", "-h"].includes(argument)) options.help = true;
     else {
@@ -566,7 +570,7 @@ function findRehydrateSource(context, projectPath) {
     .find(candidate => existsSync(join(candidate, "Cargo.toml"))) || null;
 }
 
-export function agentRepairArguments(projectPath) {
+function fullRetrievalProofArguments(projectPath) {
   return [
     "ready",
     "--goal",
@@ -581,36 +585,29 @@ export function agentRepairArguments(projectPath) {
   ];
 }
 
-export function doctorSummaryLines(doctor) {
+export function setupSummaryLines(doctor, cliVersion, fullRetrievalProof) {
   const verdict = goal => (doctor.readiness || []).find(item => item.goal === goal);
   const local = verdict("local_navigation");
   const agent = verdict("agent_packet_search");
-  const ready = item => item?.status === "ready";
-  const minimumNext = [local, agent]
-    .filter(item => !ready(item))
-    .flatMap(item => item?.minimum_next || [])
-    .concat(doctor.next_commands || [])
-    .find(Boolean);
+  const repositoryMap = local?.status === "ready" ? "ready" : "needs_attention";
+  const activePreparation = (doctor.readiness_broker?.operations || []).length > 0;
+  const backgroundPreparation = agent?.status === "ready" && doctor.retrieval_mode === "full"
+    ? "ready"
+    : activePreparation
+      ? "in_progress"
+      : fullRetrievalProof
+        ? "needs_attention"
+        : "not_requested";
   const lines = [
-    "CodeStory worktree readiness",
-    `  local_navigation: ${local?.status || "unknown"}`,
+    "CodeStory worktree setup complete",
+    `  cli_version: ${cliVersion}`,
+    `  repository_map: ${repositoryMap}`,
+    `  background_preparation: ${backgroundPreparation}`,
   ];
-  if (local?.summary) lines.push(`    reason: ${local.summary}`);
-  lines.push(`  agent_packet_search: ${agent?.status || "unknown"}`);
-  if (agent?.summary) lines.push(`    reason: ${agent.summary}`);
-  lines.push(`  retrieval_mode: ${doctor.retrieval_mode || "unknown"}`);
-  lines.push(`  degraded_reason: ${doctor.degraded_reason || "none"}`);
-  if (minimumNext) lines.push(`  minimum_next: ${minimumNext}`);
-  if (!ready(agent)) {
-    lines.push([
-      "  handoff: CodeStory packet/search is unavailable; use direct source reads until",
-      "the minimum_next command repairs readiness.",
-    ].join(" "));
-  }
   return lines;
 }
 
-function doctorSummary(context, cli, projectPath) {
+function setupSummary(context, cli, cliVersion, projectPath, fullRetrievalProof) {
   const result = invoke(context, cli, ["doctor", "--project", projectPath, "--format", "json"], {
     cwd: projectPath,
     capture: true,
@@ -619,7 +616,11 @@ function doctorSummary(context, cli, projectPath) {
     throw new Error(commandFailure(cli, ["doctor", "--project", projectPath, "--format", "json"], result));
   }
   const doctor = JSON.parse(outputText(result.stdout));
-  for (const line of doctorSummaryLines(doctor)) context.log(line);
+  const agent = (doctor.readiness || []).find(item => item.goal === "agent_packet_search");
+  if (fullRetrievalProof && (agent?.status !== "ready" || doctor.retrieval_mode !== "full")) {
+    throw new Error("Full retrieval proof did not reach the ready state.");
+  }
+  for (const line of setupSummaryLines(doctor, cliVersion, fullRetrievalProof)) context.log(line);
 }
 
 export function runSetup(options, contextOverrides = {}) {
@@ -635,41 +636,42 @@ export function runSetup(options, contextOverrides = {}) {
   }
 
   const cli = resolveCli(context, projectPath, expectedVersion, options.resolveCliOnly);
-  context.log(`CODESTORY_CLI=${cli}`);
   if (options.resolveCliOnly) return { cli, projectPath };
 
   const source = findRehydrateSource(context, projectPath);
   if (source) {
     step(
       context,
-      `Rehydrate CodeStory cache from ${source}`,
+      `Reuse repository map from ${source}`,
       () => runRequired(context, cli, ["cache", "rehydrate", "--from-project", source, "--project", projectPath], {
         cwd: projectPath,
+        capture: true,
       }),
       true,
     );
   } else {
     context.log("");
-    context.log("==> Rehydrate CodeStory cache");
-    context.log("No sibling source worktree found; refreshing this worktree directly.");
+    context.log("==> Reuse repository map");
+    context.log("No sibling repository map found; preparing this worktree directly.");
   }
-  step(context, "Refresh SQLite graph/search/doc cache", () => runRequired(
+  step(context, "Prepare repository map", () => runRequired(
     context,
     cli,
     ["index", "--project", projectPath, "--refresh", "auto"],
-    { cwd: projectPath },
+    { cwd: projectPath, capture: true },
   ));
+  if (options.fullRetrievalProof) {
+    step(context, "Prepare full retrieval proof", () => runRequired(
+      context,
+      cli,
+      fullRetrievalProofArguments(projectPath),
+      { cwd: projectPath, capture: true },
+    ));
+  }
   step(
     context,
-    "Repair agent sidecar readiness",
-    () => runRequired(context, cli, agentRepairArguments(projectPath), { cwd: projectPath }),
-    true,
-  );
-  step(
-    context,
-    "Doctor readiness handoff",
-    () => doctorSummary(context, cli, projectPath),
-    true,
+    "Check setup state",
+    () => setupSummary(context, cli, expectedVersion, projectPath, options.fullRetrievalProof),
   );
   return { cli, projectPath };
 }

--- a/scripts/codex-worktree-setup.ps1
+++ b/scripts/codex-worktree-setup.ps1
@@ -5,6 +5,7 @@ param(
     [string]$PrHeadRef = $env:CODESTORY_PR_HEAD_REF,
     [switch]$BranchHeadProof,
     [switch]$ResolveCliOnly,
+    [switch]$FullRetrievalProof,
     [switch]$SelfTest,
     [switch]$Help
 )
@@ -20,6 +21,7 @@ $arguments = @("--project", $Project, "--intended-base-ref", $IntendedBaseRef)
 if ($PrHeadRef) { $arguments += @("--pr-head-ref", $PrHeadRef) }
 if ($BranchHeadProof) { $arguments += "--branch-head-proof" }
 if ($ResolveCliOnly) { $arguments += "--resolve-cli-only" }
+if ($FullRetrievalProof) { $arguments += "--full-retrieval-proof" }
 if ($SelfTest) { $arguments += "--self-test" }
 if ($Help) { $arguments += "--help" }
 

--- a/scripts/tests/codex-worktree-setup.test.mjs
+++ b/scripts/tests/codex-worktree-setup.test.mjs
@@ -14,15 +14,14 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
-  agentRepairArguments,
   cliCandidates,
-  doctorSummaryLines,
   findCli,
   parseArguments,
   proofTarget,
   remoteHeadName,
   resolveSccache,
   runSetup,
+  setupSummaryLines,
 } from "../codex-worktree-setup.mjs";
 
 const scriptsDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
@@ -75,11 +74,13 @@ test("portable and PowerShell argument spellings share one parser", () => {
       prHeadRef: "origin/topic",
       branchHeadProof: true,
       resolveCliOnly: true,
+      fullRetrievalProof: false,
       selfTest: false,
       help: false,
     },
   );
   assert.equal(parseArguments([], { CODESTORY_BRANCH_HEAD_PROOF: "yes" }).branchHeadProof, true);
+  assert.equal(parseArguments(["-FullRetrievalProof"], {}).fullRetrievalProof, true);
 });
 
 test("only a hexadecimal 40-character ref is detached", () => {
@@ -153,7 +154,7 @@ test("sccache prefers the user Cargo installation", () => {
   assert.equal(resolveSccache({ env: { HOME: home, USERPROFILE: home, PATH: "" } }), expected);
 });
 
-test("shared orchestration rehydrates, indexes, repairs, and reports status in order", () => {
+test("default setup rehydrates, indexes, and reports a local result without full retrieval work", () => {
   const project = createProject();
   const source = temporaryRoot();
   writeFileSync(join(source, "Cargo.toml"), "[workspace]\n");
@@ -187,7 +188,7 @@ test("shared orchestration rehydrates, indexes, repairs, and reports status in o
       return result(1);
     },
   });
-  assert.deepEqual(calls.map(args => args[0]), ["cache", "index", "ready", "doctor"]);
+  assert.deepEqual(calls.map(args => args[0]), ["cache", "index", "doctor"]);
   assert.deepEqual(calls[0], [
     "cache",
     "rehydrate",
@@ -196,8 +197,10 @@ test("shared orchestration rehydrates, indexes, repairs, and reports status in o
     "--project",
     realpathSync(project),
   ]);
-  assert.ok(logs.includes("  agent_packet_search: ready"));
-  assert.ok(logs.includes("  retrieval_mode: full"));
+  assert.ok(logs.includes("CodeStory worktree setup complete"));
+  assert.ok(logs.includes("  cli_version: 0.15.0"));
+  assert.ok(logs.includes("  repository_map: ready"));
+  assert.ok(logs.includes("  background_preparation: ready"));
 });
 
 test("Cargo fallback is locked and still feeds the shared setup path", () => {
@@ -237,35 +240,55 @@ test("Cargo fallback is locked and still feeds the shared setup path", () => {
   assert.deepEqual(cargoArguments, ["build", "--release", "--locked", "-p", "codestory-cli"]);
 });
 
-test("readiness helpers preserve the agent repair and degraded handoff contracts", () => {
-  assert.deepEqual(agentRepairArguments("/repo"), [
+test("maintainer proof flag is the only setup path that prepares full retrieval", () => {
+  const project = createProject();
+  const cli = writeExecutable(join(temporaryRoot(), "codestory-cli"));
+  const calls = [];
+  const logs = [];
+  const doctor = {
+    retrieval_mode: "full",
+    readiness: [
+      { goal: "local_navigation", status: "ready" },
+      { goal: "agent_packet_search", status: "ready" },
+    ],
+  };
+  runSetup(parseArguments(["--project", project, "--full-retrieval-proof"]), {
+    env: { CODESTORY_CLI: cli, HOME: temporaryRoot(), PATH: "" },
+    log: line => logs.push(line),
+    warn: line => logs.push(`warning: ${line}`),
+    spawnSync(command, args) {
+      if (command === "git") return result(1);
+      if (command === cli && args[0] === "--version") return result(0, "codestory-cli 0.15.0\n");
+      if (command === cli) {
+        calls.push(args);
+        return args[0] === "doctor" ? result(0, JSON.stringify(doctor)) : result();
+      }
+      return result(1);
+    },
+  });
+  assert.deepEqual(calls.map(args => args[0]), ["index", "ready", "doctor"]);
+  assert.deepEqual(calls[1], [
     "ready",
     "--goal",
     "agent",
     "--repair",
     "--project",
-    "/repo",
+    realpathSync(project),
     "--format",
     "json",
     "--run-id",
     "shared-agent",
   ]);
-  const summary = doctorSummaryLines({
-    retrieval_mode: "lexical",
-    degraded_reason: "embedding unavailable",
-    readiness: [
-      { goal: "local_navigation", status: "ready" },
-      {
-        goal: "agent_packet_search",
-        status: "repair_retrieval",
-        minimum_next: ["codestory-cli ready --goal agent --repair"],
-      },
+  assert.ok(logs.includes("  background_preparation: ready"));
+  assert.deepEqual(
+    setupSummaryLines({ readiness: [{ goal: "local_navigation", status: "ready" }] }, "0.15.0", false),
+    [
+      "CodeStory worktree setup complete",
+      "  cli_version: 0.15.0",
+      "  repository_map: ready",
+      "  background_preparation: not_requested",
     ],
-  });
-  assert.ok(summary.includes("  agent_packet_search: repair_retrieval"));
-  assert.ok(summary.includes("  degraded_reason: embedding unavailable"));
-  assert.ok(summary.some(line => line.startsWith("  minimum_next:")));
-  assert.ok(summary.some(line => line.startsWith("  handoff:")));
+  );
 });
 
 test(`${process.platform === "win32" ? "PowerShell" : "POSIX"} adapter forwards to the Node help surface`, () => {


### PR DESCRIPTION
## Context

`node scripts/codex-worktree-setup.mjs` always ran `ready --goal agent --repair` after refreshing the repository map. On a normal delegated worktree that added an unnecessary full-retrieval wait, exposed backend repair output, and could fail when no model or runtime was installed even though local navigation was ready.

Base: `85a877e1f0bc9986d203b09efe70f2956fb5b32e`
Head: `0b55994d55860cfc7175d11dd3833e0a1c88c91d`

## What changed

- Default setup now rehydrates and refreshes only the local repository map, then reads status and prints a compact result.
- Index/rehydrate command output is captured so normal setup does not print backend guidance.
- Full retrieval preparation remains available to maintainers through `--full-retrieval-proof` and PowerShell `-FullRetrievalProof`.
- The Node dispatcher remains the single implementation; shell and PowerShell stay thin adapters.
- Existing journey tests were replaced in place: 10 tests before, 10 tests after.
- Contributor guidance and the Unreleased changelog describe the new boundary.

Line delta: production scripts +43/-39, tests +47/-24, docs/changelog +29/-5; total +119/-68. Most growth is the explicit proof journey and contributor-facing contract; the normal setup implementation is effectively flat.

## Review

The key boundary is `runSetup`: no `ready` call occurs unless `fullRetrievalProof` is true. `setupSummaryLines` intentionally maps detailed doctor state to `repository_map` and `background_preparation` without forwarding repair commands or backend details.

## Verification

- `node --test scripts/tests/codex-worktree-setup.test.mjs` — 10/10 passed
- Real default setup against this worktree — passed in 8.3s; repository map ready; background preparation not requested; no full-retrieval repair attempted
- `node --check scripts/codex-worktree-setup.mjs`
- `bash -n scripts/codex-worktree-setup.sh`
- `node scripts/lint-retrieval-generalization.mjs`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

PowerShell itself was not available on this Mac; the shared parser covers `-FullRetrievalProof`, and the existing platform adapter smoke remains the Windows proof.

## Risk

Low and isolated to contributor setup. The explicit proof path preserves the previous `ready --goal agent --repair --run-id shared-agent` arguments and now fails if the resulting doctor state is not actually full/ready.

Closes #1152
Refs #897
