### PR TITLE
reuse managed search runtime across projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 - Cold and stale repositories now present `ground`, `files`, and `affected` as
   direct activation paths. One grounding call builds or refreshes the local map;
   agents no longer get sent through a status loop before repository navigation.
+- CodeStory now reuses a verified managed search runtime across projects and
+  worktrees without requiring a second project-local model copy. Borrower
+  handoff is serialized with owner shutdown, attached projects cannot stop the
+  shared process, and temporary contention is reported as background search
+  preparation without process or workspace details.
 
 ## 0.15.0
 

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -9467,6 +9467,7 @@ mod tests {
                 executable_source: Some("managed".into()),
                 executable_path: Some("C:/cache/llama-server.exe".into()),
                 model_path: Some("C:/cache/model.gguf".into()),
+                model_sha256: None,
                 log_path: Some("C:/cache/llama-server-native.log".into()),
                 requested_device: Some("Vulkan0".into()),
             }),

--- a/crates/codestory-cli/src/readiness_broker/machine_lock.rs
+++ b/crates/codestory-cli/src/readiness_broker/machine_lock.rs
@@ -393,23 +393,18 @@ fn replace_machine_resource_lock(temp_path: &Path, path: &Path) -> std::io::Resu
     fs::rename(temp_path, path)
 }
 
-pub(crate) fn release_machine_resource_lock_for_native_launch(
+pub(crate) fn release_machine_resource_lock_for_native_launch_with_guard(
     resource: &str,
     launch: &codestory_retrieval::EmbeddingLaunchMetadata,
+    guard: &BrokerMachineResourceReaperLock,
 ) -> Result<bool> {
-    let Some(pid) = launch.pid else {
+    if !guard.is_current() {
         return Ok(false);
-    };
+    }
     let path = machine_resource_lock_path(resource);
-    let Some(_release_guard) = try_acquire_machine_resource_reaper_lock(resource)? else {
-        return Ok(false);
-    };
     let Some(file_lock) = read_machine_resource_lock_file(&path) else {
         return Ok(false);
     };
-    if file_lock.pid != pid {
-        return Ok(false);
-    }
     if file_lock.native_embedding_launch.as_ref() != Some(launch) {
         return Ok(false);
     }

--- a/crates/codestory-cli/src/readiness_broker/mod.rs
+++ b/crates/codestory-cli/src/readiness_broker/mod.rs
@@ -19,14 +19,14 @@ pub(crate) use machine_lock::try_acquire_machine_resource_lock;
 #[allow(unused_imports)]
 pub(crate) use machine_lock::{
     BrokerMachineResourceBusy, BrokerMachineResourceLock, BrokerMachineResourceLockAttempt,
-    NATIVE_EMBEDDING_RESOURCE, release_machine_resource_lock_for_native_launch,
+    NATIVE_EMBEDDING_RESOURCE,
 };
 #[allow(unused_imports)]
 pub(crate) use native_lease::{
     BrokerNativeEmbeddingResourceLease, NativeEmbeddingLeaseLifecycleParams,
     cleanup_native_embedding_resource_lease_after_transfer_error,
-    native_embedding_launch_from_sidecar_state_file, native_embedding_owner_down_command,
-    reusable_native_embedding_resource_pid_for_snapshot, run_with_native_embedding_lease_lifecycle,
+    native_embedding_owner_down_command, reusable_native_embedding_resource_pid_for_snapshot,
+    run_with_native_embedding_lease_lifecycle, sidecar_down_with_native_embedding_handoff,
     transfer_native_embedding_resource_lease,
 };
 pub(crate) use paths::machine_resource_cache_fingerprint;

--- a/crates/codestory-cli/src/readiness_broker/native_lease.rs
+++ b/crates/codestory-cli/src/readiness_broker/native_lease.rs
@@ -5,12 +5,13 @@ use std::time::{Duration, Instant};
 
 use super::machine_lock::{
     BrokerMachineResourceBusy, BrokerMachineResourceLock, BrokerMachineResourceLockAttempt,
-    NATIVE_EMBEDDING_RESOURCE, machine_lock_owner_state,
-    quarantine_machine_resource_lock_for_native_launch, read_machine_resource_lock_file,
+    BrokerMachineResourceReaperLock, NATIVE_EMBEDDING_RESOURCE, machine_lock_owner_state,
+    machine_resource_snapshot, quarantine_machine_resource_lock_for_native_launch,
+    read_machine_resource_lock_file, release_machine_resource_lock_for_native_launch_with_guard,
     release_owned_quarantined_machine_resource_lock,
     release_quarantined_machine_resource_lock_for_native_launch,
     reset_owned_quarantined_machine_resource_lock, transfer_machine_resource_lock_to_native_launch,
-    try_acquire_native_embedding_machine_resource_lock,
+    try_acquire_machine_resource_reaper_lock, try_acquire_native_embedding_machine_resource_lock,
 };
 use super::paths::machine_resource_lock_path;
 use super::types::{BrokerResourceSnapshot, BrokerScope};
@@ -23,6 +24,7 @@ pub(crate) enum BrokerNativeEmbeddingResourceLease {
     Reused {
         pid: u32,
         launch: Box<codestory_retrieval::EmbeddingLaunchMetadata>,
+        _handoff_guard: BrokerMachineResourceReaperLock,
     },
 }
 
@@ -258,14 +260,6 @@ pub(crate) fn cleanup_native_embedding_resource_lease_after_transfer_error_with_
         None,
         false,
     )
-}
-
-pub(crate) fn native_embedding_launch_from_sidecar_state_file(
-    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
-) -> Result<Option<codestory_retrieval::EmbeddingLaunchMetadata>> {
-    Ok(read_sidecar_state_file(sidecar)?
-        .filter(codestory_retrieval::SidecarStateFile::owns_embedding_launch)
-        .and_then(|state| native_embedding_launch_from_sidecar_state(&state).cloned()))
 }
 
 fn native_embedding_launch_from_sidecar_state(
@@ -541,6 +535,19 @@ pub(super) fn acquire_native_embedding_resource_lease_if_needed_with_validator(
                 if cleanup_quarantined_native_embedding_resource(&busy)? {
                     continue;
                 }
+                let Some(handoff_guard) = try_acquire_machine_resource_reaper_lock(resource)?
+                else {
+                    if Instant::now() >= deadline {
+                        return bail_native_embedding_busy(&busy);
+                    }
+                    std::thread::sleep(
+                        poll.min(deadline.saturating_duration_since(Instant::now())),
+                    );
+                    continue;
+                };
+                let busy = BrokerMachineResourceBusy {
+                    snapshot: machine_resource_snapshot(resource),
+                };
                 if let Some(launch) = reusable_native_embedding_resource_launch(
                     scope,
                     sidecar,
@@ -553,6 +560,7 @@ pub(super) fn acquire_native_embedding_resource_lease_if_needed_with_validator(
                     return Ok(Some(BrokerNativeEmbeddingResourceLease::Reused {
                         pid,
                         launch: Box::new(launch),
+                        _handoff_guard: handoff_guard,
                     }));
                 }
                 if Instant::now() >= deadline {
@@ -562,6 +570,41 @@ pub(super) fn acquire_native_embedding_resource_lease_if_needed_with_validator(
             }
         }
     }
+}
+
+pub(crate) fn sidecar_down_with_native_embedding_handoff(
+    cache_root: &Path,
+    sidecar: &codestory_retrieval::SidecarRuntimeConfig,
+) -> Result<()> {
+    let Some(state) = read_sidecar_state_file(sidecar)? else {
+        return codestory_retrieval::sidecar_down_for_runtime(sidecar);
+    };
+    let Some(launch) = state.embedding_launch.as_ref() else {
+        return codestory_retrieval::sidecar_down_for_runtime(sidecar);
+    };
+    let guard = try_acquire_machine_resource_reaper_lock(NATIVE_EMBEDDING_RESOURCE)?
+        .context("CodeStory repository search setup is finishing; retry shortly")?;
+    if state.owns_embedding_launch() {
+        let attachments = codestory_retrieval::attached_native_embedding_state_paths(
+            cache_root,
+            &sidecar.layout.state_file,
+            launch,
+        )?;
+        if !attachments.is_empty() {
+            bail!("CodeStory repository search is still in use by another project");
+        }
+    }
+    codestory_retrieval::sidecar_down_for_runtime(sidecar)?;
+    if state.owns_embedding_launch() {
+        if !release_machine_resource_lock_for_native_launch_with_guard(
+            NATIVE_EMBEDDING_RESOURCE,
+            launch,
+            &guard,
+        )? {
+            bail!("CodeStory repository search ownership changed during shutdown; retry shortly");
+        }
+    }
+    Ok(())
 }
 
 fn cleanup_quarantined_native_embedding_resource(busy: &BrokerMachineResourceBusy) -> Result<bool> {
@@ -678,7 +721,6 @@ fn reusable_native_embedding_resource_launch(
         |owner_scope, requested_runtime, launch| {
             reused_launch_matches_owner_and_requested_runtime(
                 owner_scope,
-                scope,
                 requested_runtime,
                 launch,
             )
@@ -832,43 +874,18 @@ fn adopt_reused_native_launch_endpoint(
     Ok(true)
 }
 
-fn reused_launch_matches_owner_and_requested_runtime(
+pub(super) fn reused_launch_matches_owner_and_requested_runtime(
     owner_scope: &BrokerScope,
-    requested_scope: &BrokerScope,
     requested_runtime: &codestory_retrieval::SidecarRuntimeConfig,
     launch: &codestory_retrieval::EmbeddingLaunchMetadata,
 ) -> Result<bool> {
-    let owner_profile = match owner_scope.profile.as_str() {
-        "local" => codestory_retrieval::SidecarProfile::Local,
-        "agent" => codestory_retrieval::SidecarProfile::Agent,
-        _ => return Ok(false),
-    };
-    let owner_root = std::path::Path::new(&owner_scope.workspace_root);
-    let owner_runtime = requested_runtime.with_profile_and_run_id(
-        Some(owner_root),
-        owner_profile,
-        owner_scope.run_id.as_deref(),
-    );
-    let Some(expected_owner) =
-        codestory_retrieval::expected_native_embedding_launch_metadata(owner_root, &owner_runtime)?
-    else {
-        return Ok(false);
-    };
-    if !same_native_launch_configuration(&expected_owner, launch, true) {
+    if !matches!(owner_scope.profile.as_str(), "local" | "agent") {
         return Ok(false);
     }
-    let Some(expected_requested) = codestory_retrieval::expected_native_embedding_launch_metadata(
-        std::path::Path::new(&requested_scope.workspace_root),
+    codestory_retrieval::native_embedding_launch_matches_runtime_for_reuse(
         requested_runtime,
-    )?
-    else {
-        return Ok(false);
-    };
-    Ok(same_native_launch_configuration(
-        &expected_requested,
         launch,
-        false,
-    ))
+    )
 }
 
 pub(super) fn same_native_launch_configuration(
@@ -883,6 +900,10 @@ pub(super) fn same_native_launch_configuration(
         && expected.launch_fingerprint_sha256 == actual.launch_fingerprint_sha256
         && expected.executable_path == actual.executable_path
         && expected.model_path == actual.model_path
+        && actual
+            .model_sha256
+            .as_ref()
+            .is_none_or(|digest| expected.model_sha256.as_ref() == Some(digest))
         && expected.requested_device == actual.requested_device
         && (!require_log_path
             || actual.log_path.is_none()

--- a/crates/codestory-cli/src/readiness_broker/tests.rs
+++ b/crates/codestory-cli/src/readiness_broker/tests.rs
@@ -195,6 +195,7 @@ fn native_sidecar_state(spawned_at_epoch_ms: Option<i64>) -> codestory_retrieval
             executable_source: Some("test".to_string()),
             executable_path: Some("C:/cache/llama-server.exe".to_string()),
             model_path: Some("C:/cache/bge-base-en-v1.5.Q8_0.gguf".to_string()),
+            model_sha256: None,
             log_path: Some("C:/cache/llama-server-native.log".to_string()),
             requested_device: Some("Vulkan0".to_string()),
         }),
@@ -566,14 +567,50 @@ fn native_embedding_busy_lock_reuses_matching_cross_project_owner() {
         codestory_retrieval::SidecarProfile::Local,
         None,
     );
-    let requested_sidecar = test_sidecar_runtime(
+    let mut requested_sidecar = test_sidecar_runtime(
         requested_project.path(),
         codestory_retrieval::SidecarProfile::Agent,
         Some("shared-agent"),
     );
+    requested_sidecar
+        .use_broker_verified_native_embedding_endpoint(owner_sidecar.ownership().ports.embed_http)
+        .expect("select owner endpoint for borrower");
+    let owner_executable = owner_project.path().join("llama-server");
+    let owner_model = owner_project
+        .path()
+        .join(codestory_retrieval::BGE_BASE_EN_V1_5_GGUF);
+    fs::write(&owner_executable, b"owner executable").expect("owner executable");
+    fs::write(&owner_model, b"owner model").expect("owner model");
+    assert!(
+        !requested_project
+            .path()
+            .join(codestory_retrieval::BGE_BASE_EN_V1_5_GGUF)
+            .exists(),
+        "borrower must not have a model copy"
+    );
     let owner_pid = std::process::id();
     let lock_path = write_machine_lock(&resource, &owner_scope, owner_pid);
-    write_matching_native_sidecar_state(&owner_sidecar, owner_pid);
+    let mut owner_state = matching_native_sidecar_state(&owner_sidecar, owner_pid);
+    let mut owner_launch = codestory_retrieval::native_embedding_launch_contract_from_paths(
+        owner_executable,
+        owner_model,
+        &owner_sidecar,
+    );
+    owner_launch.pid = Some(owner_pid);
+    owner_state.embedding_launch = Some(owner_launch);
+    fs::create_dir_all(
+        owner_sidecar
+            .layout
+            .state_file
+            .parent()
+            .expect("owner state parent"),
+    )
+    .expect("owner state directory");
+    fs::write(
+        &owner_sidecar.layout.state_file,
+        serde_json::to_vec_pretty(&owner_state).expect("serialize owner state"),
+    )
+    .expect("write owner state");
     attach_native_launch_to_machine_lock(&lock_path, &owner_sidecar);
     let mut snapshot = machine_resource_snapshot(&resource);
     snapshot.status = "busy".to_string();
@@ -602,46 +639,11 @@ fn native_embedding_busy_lock_reuses_matching_cross_project_owner() {
                 validator_called.get(),
                 "process identity must be exact before runtime configuration matching"
             );
-            let lexical_log = owner_project.path().join("llama-server-native.log");
-            fs::write(&lexical_log, "native launch proof\n").expect("write native log fixture");
-            let mut lexical_log_launch = launch.clone();
-            lexical_log_launch.log_path = Some(lexical_log.display().to_string());
-            let mut canonical_log_launch = lexical_log_launch.clone();
-            canonical_log_launch.log_path = Some(
-                lexical_log
-                    .canonicalize()
-                    .expect("canonical native log fixture")
-                    .display()
-                    .to_string(),
-            );
-            assert!(same_native_launch_configuration(
-                &canonical_log_launch,
-                &lexical_log_launch,
-                true
-            ));
             assert_eq!(scope.operation_kind, "retrieval_bootstrap");
             assert_eq!(scope.profile, "local");
             assert_ne!(scope.project_id, requested_scope.project_id);
-            assert_ne!(
-                scope.canonical_root_hash,
-                requested_scope.canonical_root_hash
-            );
-            assert_ne!(
-                broker_operation_id(scope),
-                broker_operation_id(&requested_scope)
-            );
-            assert_eq!(
-                retargeted.project_identity,
-                requested_sidecar.project_identity
-            );
-            assert_eq!(
-                retargeted.profile,
-                codestory_retrieval::SidecarProfile::Agent
-            );
-            assert_eq!(retargeted.run_id.as_deref(), Some("shared-agent"));
-            assert_ne!(retargeted.embed_http_port, owner_sidecar.embed_http_port);
             assert_eq!(retargeted.embedding.endpoint, launch.endpoint);
-            Ok(true)
+            reused_launch_matches_owner_and_requested_runtime(scope, retargeted, launch)
         },
     )
     .expect("reuse check");
@@ -812,9 +814,9 @@ fn warm_reused_agent_state_binds_exact_broker_runtime_identity() {
 }
 
 #[test]
-fn borrower_down_leaves_owner_native_process_and_machine_lock_intact() {
+fn borrower_attachment_blocks_owner_down_until_borrower_detaches() {
     let project = tempdir().expect("project");
-    let resource = unique_resource("native-borrower-down");
+    let resource = NATIVE_EMBEDDING_RESOURCE.to_string();
     cleanup_machine_resource(&resource);
     let owner_scope = test_scope(project.path(), "owner-agent");
     let mut owner_runtime = test_sidecar_runtime(
@@ -888,14 +890,16 @@ fn borrower_down_leaves_owner_native_process_and_machine_lock_intact() {
         .expect("write state");
     }
 
-    let borrower_owned_launch = native_embedding_launch_from_sidecar_state_file(&borrower_runtime)
-        .expect("read borrower state");
-    codestory_retrieval::sidecar_down_for_runtime(&borrower_runtime)
-        .expect("borrower down must not stop owner pid");
-    if let Some(launch) = borrower_owned_launch.as_ref() {
-        release_machine_resource_lock_for_native_launch(&resource, launch)
-            .expect("release borrower-owned launch");
-    }
+    let error = sidecar_down_with_native_embedding_handoff(&broker_cache_root(), &owner_runtime)
+        .expect_err("owner down must not stop a launch while a borrower is attached");
+    assert!(
+        error
+            .to_string()
+            .contains("repository search is still in use"),
+        "unexpected owner-down error: {error:#}"
+    );
+    sidecar_down_with_native_embedding_handoff(&broker_cache_root(), &borrower_runtime)
+        .expect("borrower detaches without stopping owner");
 
     assert_eq!(
         std::process::id(),

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use codestory_retrieval::{
     BootstrapStorageScope, FinalizeIndexOutcome, ProjectQdrantRepairOutcome, QueryRequest,
     RetrievalIndexManifest, RetrievalStatusReport, SIDECAR_SEMANTIC_DOC_CONTRACT_CHANGED,
-    SidecarProfile, SidecarRuntimeConfig, sidecar_down_for_runtime,
-    sidecar_up_with_runtime_preserving_launch, strict_sidecar_status_for_runtime,
+    SidecarProfile, SidecarRuntimeConfig, sidecar_up_with_runtime_preserving_launch,
+    strict_sidecar_status_for_runtime,
 };
 
 use crate::args::{
@@ -138,16 +138,11 @@ fn run_retrieval_down(cmd: RetrievalSidecarStateCommand) -> Result<()> {
         cmd.profile.into(),
         cmd.run_id.as_deref(),
     );
-    let native_embedding_launch =
-        crate::readiness_broker::native_embedding_launch_from_sidecar_state_file(&sidecar)?;
-    sidecar_down_for_runtime(&sidecar).context("retrieval down")?;
-    if let Some(launch) = native_embedding_launch.as_ref() {
-        crate::readiness_broker::release_machine_resource_lock_for_native_launch(
-            crate::readiness_broker::NATIVE_EMBEDDING_RESOURCE,
-            launch,
-        )
-        .context("release native embedding broker lock")?;
-    }
+    crate::readiness_broker::sidecar_down_with_native_embedding_handoff(
+        &runtime.cache_root,
+        &sidecar,
+    )
+    .context("retrieval down")?;
     println!("retrieval sidecar state cleared");
     Ok(())
 }

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -4792,33 +4792,13 @@ fn stdio_native_embedding_resource_hard_busy_with_classifier<'a>(
 }
 
 fn stdio_status_native_embedding_busy_next_calls(
-    busy: &crate::readiness_broker::BrokerResourceSnapshot,
-    project: &serde_json::Value,
+    _busy: &crate::readiness_broker::BrokerResourceSnapshot,
+    _project: &serde_json::Value,
 ) -> serde_json::Value {
-    let owner_workspace = busy.owner_workspace_root.as_deref().unwrap_or("unknown");
-    let owner_project = busy.owner_project_id.as_deref().unwrap_or("unknown");
-    let instruction = crate::readiness_broker::native_embedding_owner_down_command(busy)
-        .map(|command| {
-            format!(
-                "CodeStory could not reuse the full native embedding runtime owned by another operation. Stop the incompatible owner with `{command}`, then retry MCP repair. owner_project={owner_project} owner_workspace={owner_workspace} owner_pid={:?}",
-                busy.owner_pid
-            )
-        })
-        .unwrap_or_else(|| {
-            format!(
-                "CodeStory could not yet reuse the native embedding runtime owned by another operation. Wait for its active repair to finish, then retry MCP repair. owner_project={owner_project} owner_workspace={owner_workspace} owner_pid={:?}",
-                busy.owner_pid
-            )
-        });
     serde_json::json!([
         {
             "method": "host/instruction",
-            "instruction": instruction
-        },
-        {
-            "method": "tools/call",
-            "tool": "status",
-            "arguments": {"project": project}
+            "instruction": "CodeStory is preparing repository search. Retry the original CodeStory request shortly."
         }
     ])
 }
@@ -5712,12 +5692,9 @@ fn stdio_sidecar_repair_machine_busy_result(
     let project = &sidecar_setup["project"];
     serde_json::json!({
         "result": {
-            "status": "native_embedding_runtime_busy",
+            "status": "preparing",
             "mode": "background",
-            "message": "CodeStory native embedding runtime is already owned by another operation.",
-            "owner_pid": busy.owner_pid,
-            "owner_project_id": busy.owner_project_id,
-            "owner_workspace_root": busy.owner_workspace_root,
+            "message": "CodeStory is preparing repository search. Retry the original request shortly.",
             "sidecar_setup": sidecar_setup,
             "recommended_next_calls": stdio_status_native_embedding_busy_next_calls(busy, project)
         }
@@ -6003,16 +5980,13 @@ fn stdio_sidecar_setup_surface(
             "canonical_arguments": {"action": "status"},
         });
     }
-    if let Some(busy) = native_embedding_hard_busy {
+    if let Some(_busy) = native_embedding_hard_busy {
         return serde_json::json!({
             "allowed": true,
             "readiness_goal": "agent_packet_search",
-            "status": "busy",
+            "status": "preparing",
             "failed_layer": "native_embedding_runtime",
-            "summary": "sidecar_setup status is available; repair is blocked because CodeStory native embedding runtime is already owned by another operation.",
-            "owner_pid": busy.owner_pid,
-            "owner_project_id": busy.owner_project_id,
-            "owner_workspace_root": busy.owner_workspace_root,
+            "summary": "CodeStory is preparing repository search.",
             "allowed_actions": ["status"],
             "canonical_arguments": {"action": "status"},
         });
@@ -6061,18 +6035,15 @@ fn stdio_repair_all_surface(
             "full_repair": [],
         });
     }
-    if let Some(busy) = native_embedding_hard_busy {
+    if let Some(_busy) = native_embedding_hard_busy {
         return serde_json::json!({
             "allowed": false,
             "readiness_goal": "agent_packet_search",
-            "status": "busy",
+            "status": "preparing",
             "failed_layer": "native_embedding_runtime",
-            "summary": "CodeStory native embedding runtime is already owned by another operation.",
-            "repair_reason": "native_embedding_runtime_busy",
-            "blocked_reason": "native_embedding_runtime_busy",
-            "owner_pid": busy.owner_pid,
-            "owner_project_id": busy.owner_project_id,
-            "owner_workspace_root": busy.owner_workspace_root,
+            "summary": "CodeStory is preparing repository search.",
+            "repair_reason": "preparing",
+            "blocked_reason": "preparing",
             "minimum_next": [],
             "full_repair": [],
         });
@@ -7320,8 +7291,11 @@ mod tests {
 
         assert!(hard_busy.is_some());
         assert_eq!(calls[0]["method"], json!("host/instruction"));
+        assert_eq!(calls.as_array().map(Vec::len), Some(1));
+        assert!(!calls.to_string().contains("owner_"));
+        assert!(!calls.to_string().contains("pid"));
         assert_eq!(surfaces["sidecar_setup"]["allowed"], json!(true));
-        assert_eq!(surfaces["sidecar_setup"]["status"], json!("busy"));
+        assert_eq!(surfaces["sidecar_setup"]["status"], json!("preparing"));
         assert_eq!(
             surfaces["sidecar_setup"]["allowed_actions"],
             json!(["status"])
@@ -7330,11 +7304,10 @@ mod tests {
             surfaces["sidecar_setup"]["canonical_arguments"]["action"],
             json!("status")
         );
-        assert_eq!(surfaces["repair_all"]["status"], json!("busy"));
-        assert_eq!(
-            surfaces["repair_all"]["repair_reason"],
-            json!("native_embedding_runtime_busy")
-        );
+        assert_eq!(surfaces["repair_all"]["status"], json!("preparing"));
+        assert_eq!(surfaces["repair_all"]["repair_reason"], json!("preparing"));
+        assert!(!surfaces.to_string().contains("owner_"));
+        assert!(!surfaces.to_string().contains("pid"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -282,6 +282,7 @@ pub fn native_embedding_startup_cleanup_failure(
 struct NativeEmbeddingServerLaunch {
     executable: PathBuf,
     model_path: PathBuf,
+    model_sha256: Option<String>,
     args: Vec<String>,
     log_path: PathBuf,
 }
@@ -406,7 +407,13 @@ pub fn bootstrap_sidecars_with_runtime_progress_and_native_launch_observer(
         repair_qdrant_storage(&layout, &storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?;
     let launch_mode = crate::config::embedding_server_launch_mode_for_runtime(runtime)?;
     let native_embedding = (launch_mode == EmbeddingServerLaunchMode::NativeSpawned)
-        .then(|| native_embedding_server_launch(repo_root, runtime))
+        .then(|| {
+            native_embedding_server_launch_for_bootstrap(
+                repo_root,
+                runtime,
+                reusable_native_embedding_launch.as_ref(),
+            )
+        })
         .transpose()?;
 
     let resolved_compose = if skip_compose {
@@ -1111,6 +1118,93 @@ fn native_embedding_server_launch(
     ))
 }
 
+fn native_embedding_server_launch_for_bootstrap(
+    repo_root: Option<&Path>,
+    runtime: &SidecarRuntimeConfig,
+    reusable_launch: Option<&crate::health::EmbeddingLaunchMetadata>,
+) -> Result<NativeEmbeddingServerLaunch> {
+    if let Some(reusable_launch) = reusable_launch {
+        return native_embedding_server_launch_from_verified_metadata(runtime, reusable_launch)
+            .context("restore verified native embedding launch contract for reuse");
+    }
+    native_embedding_server_launch(repo_root, runtime)
+}
+
+fn native_embedding_server_launch_from_verified_metadata(
+    runtime: &SidecarRuntimeConfig,
+    metadata: &crate::health::EmbeddingLaunchMetadata,
+) -> Result<NativeEmbeddingServerLaunch> {
+    let executable = metadata
+        .executable_path
+        .as_deref()
+        .map(PathBuf::from)
+        .context("verified native embedding launch is missing executable_path")?;
+    let model_path = metadata
+        .model_path
+        .as_deref()
+        .map(PathBuf::from)
+        .context("verified native embedding launch is missing model_path")?;
+    let mut launch = native_embedding_server_launch_from_paths(executable, model_path, runtime);
+    launch.model_sha256.clone_from(&metadata.model_sha256);
+    if !native_embedding_launch_matches_runtime_contract(runtime, metadata, &launch) {
+        bail!("verified native embedding launch does not match the requested runtime contract");
+    }
+    Ok(launch)
+}
+
+#[doc(hidden)]
+pub fn native_embedding_launch_matches_runtime_for_reuse(
+    runtime: &SidecarRuntimeConfig,
+    metadata: &crate::health::EmbeddingLaunchMetadata,
+) -> Result<bool> {
+    if crate::config::embedding_server_launch_mode_for_runtime(runtime)?
+        != EmbeddingServerLaunchMode::NativeSpawned
+    {
+        return Ok(false);
+    }
+    let Some(executable) = metadata.executable_path.as_deref().map(PathBuf::from) else {
+        return Ok(false);
+    };
+    let Some(model_path) = metadata.model_path.as_deref().map(PathBuf::from) else {
+        return Ok(false);
+    };
+    let mut launch = native_embedding_server_launch_from_paths(executable, model_path, runtime);
+    if metadata.model_sha256.is_none() {
+        launch.model_sha256 = None;
+    }
+    Ok(native_embedding_launch_matches_runtime_contract(
+        runtime, metadata, &launch,
+    ))
+}
+
+#[doc(hidden)]
+pub fn native_embedding_launch_contract_from_paths(
+    executable: PathBuf,
+    model_path: PathBuf,
+    runtime: &SidecarRuntimeConfig,
+) -> crate::health::EmbeddingLaunchMetadata {
+    let launch = native_embedding_server_launch_from_paths(executable, model_path, runtime);
+    embedding_launch_metadata(&launch, runtime, None, None)
+}
+
+fn native_embedding_launch_matches_runtime_contract(
+    runtime: &SidecarRuntimeConfig,
+    metadata: &crate::health::EmbeddingLaunchMetadata,
+    launch: &NativeEmbeddingServerLaunch,
+) -> bool {
+    metadata.provider == "llamacpp"
+        && metadata.launch_mode == EmbeddingServerLaunchMode::NativeSpawned.as_str()
+        && metadata.endpoint == runtime.embedding.endpoint
+        && metadata.launch_args == launch.args
+        && metadata.launch_fingerprint_sha256.as_deref()
+            == Some(native_embedding_launch_fingerprint(launch).as_str())
+        && metadata.executable_path.as_deref() == Some(launch.executable.to_string_lossy().as_ref())
+        && metadata.model_path.as_deref() == Some(launch.model_path.to_string_lossy().as_ref())
+        && metadata.model_sha256 == launch.model_sha256
+        && metadata.requested_device
+            == crate::embeddings::embedding_accelerator_request().and_then(|request| request.device)
+}
+
 pub fn expected_native_embedding_launch_metadata(
     repo_root: &Path,
     runtime: &SidecarRuntimeConfig,
@@ -1147,6 +1241,7 @@ fn native_embedding_server_launch_from_paths(
     }
     NativeEmbeddingServerLaunch {
         executable,
+        model_sha256: sha256_file(&model_path).ok(),
         model_path,
         args,
         log_path: crate::embeddings::native_embedding_log_path(runtime),
@@ -1234,6 +1329,7 @@ fn embedding_launch_metadata(
         )),
         executable_path: Some(native_launch.executable.display().to_string()),
         model_path: Some(native_launch.model_path.display().to_string()),
+        model_sha256: native_launch.model_sha256.clone(),
         log_path: Some(native_launch.log_path.display().to_string()),
         requested_device: crate::embeddings::embedding_accelerator_request()
             .and_then(|request| request.device),
@@ -2235,6 +2331,10 @@ fn reusable_native_embedding_spawn_from_metadata_with_identity(
     if metadata.launch_mode != EmbeddingServerLaunchMode::NativeSpawned.as_str()
         || metadata.endpoint != runtime.embedding.endpoint
         || metadata.launch_fingerprint_sha256.as_deref() != Some(launch_fingerprint.as_str())
+        || metadata
+            .model_sha256
+            .as_ref()
+            .is_some_and(|digest| launch.model_sha256.as_ref() != Some(digest))
     {
         return Ok(None);
     }
@@ -3850,6 +3950,51 @@ mod tests {
         assert_eq!(spawn.pid, 4321);
         assert_eq!(spawn.spawned_at_epoch_ms, 123);
         assert!(validator_called);
+    }
+
+    #[test]
+    fn native_embedding_reuse_bootstraps_from_owner_contract_without_borrower_model() {
+        let _lock = crate::test_support::env_lock();
+        let _device = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_DEVICE");
+        let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
+
+        let owner = tempdir().expect("owner");
+        let borrower = tempdir().expect("borrower");
+        let executable = owner.path().join("llama-server");
+        let model = owner.path().join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF);
+        std::fs::write(&executable, b"owner executable").expect("owner executable");
+        std::fs::write(&model, b"owner model").expect("owner model");
+        let owner_runtime = compose_test_runtime(owner.path());
+        let mut borrower_runtime = compose_test_runtime(borrower.path());
+        borrower_runtime
+            .use_broker_verified_native_embedding_endpoint(
+                owner_runtime.ownership().ports.embed_http,
+            )
+            .expect("reuse owner endpoint");
+        let owner_contract = native_embedding_launch_contract_from_paths(
+            executable.clone(),
+            model.clone(),
+            &owner_runtime,
+        );
+        assert!(owner_contract.model_sha256.is_some());
+
+        let selected = native_embedding_server_launch_for_bootstrap(
+            Some(borrower.path()),
+            &borrower_runtime,
+            Some(&owner_contract),
+        )
+        .expect("select verified owner launch");
+
+        assert_eq!(selected.executable, executable);
+        assert_eq!(selected.model_path, model);
+        assert_eq!(selected.model_sha256, owner_contract.model_sha256);
+        assert!(
+            !borrower
+                .path()
+                .join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF)
+                .exists(),
+            "bootstrap must not require a borrower model copy"
+        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -2767,6 +2767,7 @@ offloaded 13/13 layers to GPU\n";
             executable_source: Some("test".into()),
             executable_path: Some("/tmp/llama-server".into()),
             model_path: Some("/tmp/model.gguf".into()),
+            model_sha256: None,
             log_path: Some(owner_log.display().to_string()),
             requested_device: Some("Metal0".into()),
         };

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -93,6 +93,8 @@ pub struct EmbeddingLaunchMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requested_device: Option<String>,

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -2445,6 +2445,7 @@ mod tests {
             executable_source: None,
             executable_path: Some("llama-server".into()),
             model_path: Some("bge-base-en-v1.5.gguf".into()),
+            model_sha256: None,
             log_path: Some("llama-server-native.log".into()),
             requested_device: None,
         };

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -52,6 +52,7 @@ pub use compose::{
     bootstrap_sidecars_with_runtime, bootstrap_sidecars_with_runtime_progress,
     bootstrap_sidecars_with_runtime_progress_and_native_launch_observer, docker_available,
     embed_model_inventory, expected_native_embedding_launch_metadata,
+    native_embedding_launch_contract_from_paths, native_embedding_launch_matches_runtime_for_reuse,
     native_embedding_startup_cleanup_failure, resolve_compose_file,
 };
 pub use config::{
@@ -132,7 +133,8 @@ pub use retention::{
 pub use scip_client::ScipClient;
 pub use sidecar::{
     EmbeddingLaunchOwnership, NativeEmbeddingLaunchIdentityStatus, SidecarStateFile,
-    ensure_native_embedding_launch_identity, native_embedding_launch_identity_status, sidecar_down,
+    attached_native_embedding_state_paths, ensure_native_embedding_launch_identity,
+    native_embedding_launch_identity_status, sidecar_down,
     sidecar_down_after_failed_bootstrap_for_runtime, sidecar_down_for_project,
     sidecar_down_for_runtime, sidecar_state_matches_runtime, sidecar_status, sidecar_up,
     sidecar_up_with_runtime, sidecar_up_with_runtime_preserving_launch,

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -28,7 +28,7 @@ use codestory_workspace::{RefreshInputs, WorkspaceManifest};
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "linux")]
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 #[cfg(not(windows))]
 use std::time::{Duration, Instant};
@@ -159,6 +159,56 @@ impl SidecarStateFile {
         self.embedding_launch.is_some()
             && self.embedding_launch_ownership == EmbeddingLaunchOwnership::Owner
     }
+}
+
+pub fn attached_native_embedding_state_paths(
+    cache_root: &Path,
+    owner_state_file: &Path,
+    launch: &EmbeddingLaunchMetadata,
+) -> Result<Vec<PathBuf>> {
+    let mut candidates = vec![cache_root.join(crate::config::SIDECAR_STATE_FILE_V3)];
+    let agent_root = cache_root.join("sidecars");
+    match std::fs::read_dir(&agent_root) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry =
+                    entry.with_context(|| format!("read {} entry", agent_root.display()))?;
+                if entry
+                    .file_type()
+                    .with_context(|| format!("inspect {}", entry.path().display()))?
+                    .is_dir()
+                {
+                    candidates.push(entry.path().join(crate::config::SIDECAR_STATE_FILE_V3));
+                }
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("read {}", agent_root.display()));
+        }
+    }
+    let mut attachments = Vec::new();
+    for path in candidates {
+        if codestory_workspace::same_workspace_path(&path, owner_state_file) {
+            continue;
+        }
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error).with_context(|| format!("read {}", path.display()));
+            }
+        };
+        let state = serde_json::from_str::<SidecarStateFile>(&raw)
+            .with_context(|| format!("parse {}", path.display()))?;
+        if state.owner == "codestory"
+            && state.embedding_launch_ownership == EmbeddingLaunchOwnership::Attached
+            && state.embedding_launch.as_ref() == Some(launch)
+        {
+            attachments.push(path);
+        }
+    }
+    Ok(attachments)
 }
 
 pub fn sidecar_up() -> Result<SidecarStateFile> {
@@ -1722,6 +1772,7 @@ mod tests {
             executable_source: Some("managed_cache".to_string()),
             executable_path: Some("C:/cache/llama-server".to_string()),
             model_path: Some("C:/cache/bge-base-en-v1.5.Q8_0.gguf".to_string()),
+            model_sha256: None,
             log_path: Some("C:/cache/llama-server-native.log".to_string()),
             requested_device: None,
         };
@@ -2078,6 +2129,7 @@ mod tests {
             executable_source: Some("managed_cache".to_string()),
             executable_path: Some(executable),
             model_path: Some("C:/cache/bge-base-en-v1.5.Q8_0.gguf".to_string()),
+            model_sha256: None,
             log_path: Some("C:/cache/llama-server-native.log".to_string()),
             requested_device: None,
         }


### PR DESCRIPTION
## Context

Opening a second project could reject the machine's already verified managed search runtime because the borrower tried to discover its own model before reuse. The normal MCP response then exposed process and workspace ownership details and asked the agent to manage that internal runtime.

## What changed

- Reuse the owner's verified executable, arguments, endpoint, model digest, device, GPU proof, PID, and process-start identity before borrower model discovery.
- Serialize borrower attachment with owner shutdown. Borrowers detach without stopping the shared process, and owners cannot stop it while an exact borrower attachment remains.
- Report temporary contention as background repository-search preparation without PID, workspace, or stop-owner instructions.
- Persist the model digest in new native launch metadata while retaining compatibility with legacy metadata.
- Replace redundant matcher assertions with one real A to B lifecycle test where B has no model, plus one attachment/owner-liveness boundary.

## Review

Start with `crates/codestory-cli/src/readiness_broker/native_lease.rs` for handoff ownership, then `crates/codestory-retrieval/src/compose.rs` for reuse-before-discovery. The user-facing response change is in `crates/codestory-cli/src/stdio_transport.rs`.

## Verification

- `cargo test -p codestory-retrieval --lib native_embedding_reuse_ --locked` (5 passed)
- `cargo test -p codestory-cli --bin codestory-cli native_embedding_busy_lock_reuses_matching_cross_project_owner --locked` (1 passed)
- `cargo test -p codestory-cli --bin codestory-cli borrower_attachment_blocks_owner_down_until_borrower_detaches --locked` (1 passed)
- `cargo test -p codestory-cli --bin codestory-cli stdio_native_embedding_ --locked` (3 passed)
- `cargo fmt --all -- --check`
- `git diff --check origin/dev/codestory-next...HEAD`

Exact base: `43cec0fe31cb3d27b9ee25c3d6fd85722c36e285`

Exact head: `7ee40c8bbfb3aaaad565b3e2e4ca1ac32a69b5f8`

Line delta: production +246/-110, tests +110/-54, changelog +5/-0. The net growth is the serialized attachment/shutdown boundary and persisted model identity; the previous borrower-side model reconstruction and redundant tests were removed.

## Risk and proof boundary

The focused source tests cover contract matching, a borrower without a model, process identity rejection, attachment ownership, and user-facing output. Packaged Metal lifecycle proof remains an integration-head gate; this PR makes no packaged or installed-runtime claim.

Closes #1150

Refs #897
