### PR TITLE
Make managed retrieval automatic and invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   handoff is serialized with owner shutdown, attached projects cannot stop the
   shared process, and temporary contention is reported as background search
   preparation without process or workspace details.
+- Managed search is now automatic and invisible in normal plugin use. Public
+  setup, repair, enable, disable, and consent controls are gone; broad tools
+  prepare their dependencies and return one same-tool retry while work is in
+  progress. Diagnostics remain available when automatic recovery cannot
+  converge.
 
 ## 0.15.0
 

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -8,67 +8,47 @@
 use anyhow::Result;
 use serde_json::{Map, Value, json};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-/// Side-effect class advertised for a stdio tool.
-///
-/// Adding a new effect requires updating both safety metadata and tool annotations.
-pub(crate) enum ToolEffect {
-    Read,
-    LocalConfigWrite,
-}
-
 #[derive(Debug, Clone, Copy)]
 /// Safety metadata emitted in both legacy and annotation-style catalog fields.
 pub(crate) struct SafetyMetadata {
-    effect: ToolEffect,
+    activates_managed_state: bool,
 }
 
 impl SafetyMetadata {
-    pub(crate) const fn read_only() -> Self {
+    pub(crate) const fn observational() -> Self {
         Self {
-            effect: ToolEffect::Read,
+            activates_managed_state: false,
         }
     }
 
-    pub(crate) const fn local_config_write() -> Self {
+    pub(crate) const fn managed_activation() -> Self {
         Self {
-            effect: ToolEffect::LocalConfigWrite,
+            activates_managed_state: true,
         }
     }
 
     fn to_json(self) -> Value {
-        match self.effect {
-            ToolEffect::Read => json!({
-                "readOnly": true,
-                "sideEffects": false,
-                "localOnly": true,
-                "openWorld": false
-            }),
-            ToolEffect::LocalConfigWrite => json!({
-                "readOnly": false,
-                "sideEffects": true,
-                "localOnly": true,
-                "openWorld": false,
-                "mutation": "local_plugin_configuration"
-            }),
-        }
+        json!({
+            "effect": if self.activates_managed_state { "managed_activation" } else { "read_only" },
+            "readOnly": !self.activates_managed_state,
+            "sideEffects": self.activates_managed_state,
+            "activatesProject": self.activates_managed_state,
+            "writesRepository": false,
+            "destructive": false,
+            "idempotent": true,
+            "requiresConfirmation": false,
+            "localOnly": true,
+            "openWorld": false
+        })
     }
 
     fn annotations_json(self) -> Value {
-        match self.effect {
-            ToolEffect::Read => json!({
-                "readOnlyHint": true,
-                "destructiveHint": false,
-                "idempotentHint": true,
-                "openWorldHint": false
-            }),
-            ToolEffect::LocalConfigWrite => json!({
-                "readOnlyHint": false,
-                "destructiveHint": false,
-                "idempotentHint": true,
-                "openWorldHint": false
-            }),
-        }
+        json!({
+            "readOnlyHint": !self.activates_managed_state,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false
+        })
     }
 }
 
@@ -1307,174 +1287,149 @@ static PACKET_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
     &["question"],
 );
 
-static SIDECAR_SETUP_INPUT_SCHEMA: SchemaObject = SchemaObject::object(
-    "Configure the plugin-local sidecar setup policy.",
-    &[SchemaProperty::string("action", "Policy action.")
-        .with_enum(&["status", "enable", "disable", "ask", "repair"])
-        .with_default(ValueLiteral::String("status"))],
-    &[],
-);
-
-static REPAIR_ALL_INPUT_SCHEMA: SchemaObject =
-    SchemaObject::object("Compatibility alias for sidecar_setup repair.", &[], &[]);
-
 static STATUS_INPUT_SCHEMA: SchemaObject =
     SchemaObject::object("Read readiness for one explicit repository.", &[], &[]);
 
 static TOOLS: &[ToolSpec] = &[
     ToolSpec {
         name: "status",
-        description: "Read CodeStory readiness for the requested repository before using other tools.",
+        description: "Inspect CodeStory readiness for the requested repository when diagnostics are needed.",
         input_schema: STATUS_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GENERIC_OBJECT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
-    },
-    ToolSpec {
-        name: "repair_all",
-        description: "Deprecated compatibility alias for sidecar_setup action=repair; agents should follow codestory://status recommended_next_calls.",
-        input_schema: REPAIR_ALL_INPUT_SCHEMA,
-        output_schema: Some(SchemaSpec::Object(GENERIC_OBJECT_SCHEMA)),
-        safety: SafetyMetadata::local_config_write(),
-    },
-    ToolSpec {
-        name: "sidecar_setup",
-        description: "Read or change the plugin-local sidecar setup policy through MCP; use this instead of asking the user to run shell commands.",
-        input_schema: SIDECAR_SETUP_INPUT_SCHEMA,
-        output_schema: Some(SchemaSpec::Object(GENERIC_OBJECT_SCHEMA)),
-        safety: SafetyMetadata::local_config_write(),
+        safety: SafetyMetadata::observational(),
     },
     ToolSpec {
         name: "packet",
-        description: "Answer broad structural questions with graph/sidecar evidence, sufficiency, truncation, and follow-up commands before source snippets.",
+        description: "Answer broad structural questions with repository evidence, sufficiency, truncation, and follow-up commands before source snippets. CodeStory prepares managed retrieval automatically.",
         input_schema: PACKET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(AGENT_PACKET_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "search",
-        description: "Discover candidate symbols and sidecar hits; for broad structural questions call packet before snippet/source reads.",
+        description: "Discover candidate symbols and retrieval hits; for broad structural questions call packet before snippet/source reads. CodeStory prepares managed retrieval automatically.",
         input_schema: SEARCH_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(SEARCH_RESULTS_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "ground",
-        description: "Return a compact repository map for orientation before packet/search, activating one bounded local refresh first when the repository is cold or stale; equivalent to codestory://grounding.",
+        description: "Return a compact repository map for orientation before packet/search; equivalent to codestory://grounding. The first call may refresh the local map and begin managed retrieval preparation.",
         input_schema: GROUND_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GROUNDING_SNAPSHOT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "files",
-        description: "List indexed files and coverage from a locally fresh index; refreshes local graph before dispatch and never bootstraps sidecars.",
+        description: "List indexed files and coverage from a locally fresh index; refreshes the repository map before dispatch and does not wait for broad search.",
         input_schema: FILES_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(INDEXED_FILES_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "affected",
-        description: "Analyze explicit changed paths against a locally fresh index; uses provided paths only, refreshes local graph before dispatch, never discovers git changes, and never bootstraps sidecars.",
+        description: "Analyze explicit changed paths against a locally fresh index; uses provided paths only, refreshes the repository map before dispatch, never discovers git changes, and does not wait for broad search.",
         input_schema: AFFECTED_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(AFFECTED_ANALYSIS_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "symbol",
         description: "Resolve a symbol id or query and return details.",
         input_schema: TARGET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(SYMBOL_CONTEXT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "trail",
         description: "Return a graph trail around a symbol.",
         input_schema: TRAIL_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(TRAIL_CONTEXT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "callers",
         description: "Return a bounded incoming caller graph around a symbol.",
         input_schema: LOCAL_GRAPH_ALIAS_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GRAPH_TOOL_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "callees",
         description: "Return a bounded outgoing callee graph around a symbol.",
         input_schema: LOCAL_GRAPH_ALIAS_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GRAPH_TOOL_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "trace",
         description: "Return a readable trace around a symbol.",
         input_schema: TRACE_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(TRAIL_CONTEXT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "get_node",
         description: "Return one stable graph node with file refs before requesting a packet.",
         input_schema: GRAPH_TARGET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GRAPH_TOOL_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "neighbors",
         description: "Return a bounded graph neighborhood around one node.",
         input_schema: GRAPH_NEIGHBORS_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GRAPH_TOOL_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "shortest_path",
         description: "Return a bounded forward path graph between two node ids.",
         input_schema: SHORTEST_PATH_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GRAPH_TOOL_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "query_subgraph",
         description: "Return a bounded subgraph around one resolved node; packet remains the broad task tool.",
         input_schema: QUERY_SUBGRAPH_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(GRAPH_TOOL_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "definition",
         description: "Return definition metadata for a symbol id or query.",
         input_schema: TARGET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(DEFINITION_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "references",
         description: "Return incoming references for a symbol id or query.",
         input_schema: TARGET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(TRAIL_CONTEXT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "symbols",
         description: "Browse root symbols or children for a parent id.",
         input_schema: SYMBOLS_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(SYMBOLS_OUTPUT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "snippet",
         description: "Return a focused source snippet after packet, search, or graph evidence selects a concrete target.",
         input_schema: TARGET_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(SNIPPET_CONTEXT_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
     ToolSpec {
         name: "context",
         description: "Build proof-bearing source/graph evidence for one concrete target; not broad question answering.",
         input_schema: CONTEXT_INPUT_SCHEMA,
         output_schema: Some(SchemaSpec::Object(CONTEXT_PACKET_SCHEMA)),
-        safety: SafetyMetadata::read_only(),
+        safety: SafetyMetadata::managed_activation(),
     },
 ];
 

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -31,7 +31,7 @@ use std::sync::{
     mpsc,
 };
 use std::thread;
-use std::time::{Duration as StdDuration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration as StdDuration, SystemTime};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
 use crate::args;
@@ -866,6 +866,39 @@ fn stdio_tool_blocked_error(
     {
         return Ok(None);
     }
+    if matches!(name, "packet" | "search" | "context") {
+        let has_active_repair = status
+            .pointer("/managed_retrieval/active_repair")
+            .is_some_and(serde_json::Value::is_object);
+        let terminal_worker_outcome = (!has_active_repair)
+            .then(|| {
+                status
+                    .pointer("/managed_retrieval/last_worker_result/outcome")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|outcome| matches!(*outcome, "failed" | "abandoned"))
+            })
+            .flatten();
+        if terminal_worker_outcome.is_some() {
+            return Ok(Some(serde_json::json!({
+                "code": "codestory_unavailable",
+                "message": "CodeStory could not prepare broad repository search automatically. Continue with local navigation or inspect diagnostics.",
+                "tool": name,
+                "state": "unavailable",
+                "project": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+                "diagnostics_uri": "codestory://status"
+            })));
+        }
+        return Ok(Some(serde_json::json!({
+            "code": "codestory_preparing",
+            "message": "CodeStory is preparing broad repository search. Retry the same tool shortly.",
+            "tool": name,
+            "state": "preparing",
+            "retry_tool": name,
+            "retry_after_ms": 1500,
+            "project": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+            "diagnostics_uri": "codestory://status"
+        })));
+    }
     let readiness_goal = surface
         .get("readiness_goal")
         .and_then(serde_json::Value::as_str);
@@ -926,7 +959,8 @@ fn activate_stdio_project(runtime: &RuntimeContext, state: &mut StdioServerState
 
     state.status_cache = None;
     let status = read_stdio_status_resource_cached(runtime, state)?;
-    if stdio_agent_activation_needs_repair(&status) {
+    if stdio_managed_retrieval_preparation_enabled() && stdio_agent_activation_needs_repair(&status)
+    {
         let fingerprint = stdio_agent_repair_input_fingerprint(&status);
         if stdio_auto_repair_retry_blocked(
             &agent_sidecar,
@@ -948,6 +982,17 @@ fn activate_stdio_project(runtime: &RuntimeContext, state: &mut StdioServerState
     Ok(())
 }
 
+fn stdio_managed_retrieval_preparation_enabled() -> bool {
+    #[cfg(debug_assertions)]
+    if std::env::var("CODESTORY_TEST_MANAGED_RETRIEVAL_PREPARATION")
+        .ok()
+        .is_some_and(|value| value.trim() == "0")
+    {
+        return false;
+    }
+    true
+}
+
 fn stdio_agent_repair_input_fingerprint(status: &serde_json::Value) -> String {
     let input = serde_json::json!({
         "server_version": status.get("server_version"),
@@ -960,13 +1005,13 @@ fn stdio_agent_repair_input_fingerprint(status: &serde_json::Value) -> String {
             "removed_file_count": status.pointer("/effective_index_freshness/removed_file_count"),
             "indexed_file_count": status.pointer("/effective_index_freshness/indexed_file_count")
         },
-        "sidecar_retrieval": {
-            "retrieval_mode": status.pointer("/sidecar_retrieval/retrieval_mode"),
-            "degraded_reason": status.pointer("/sidecar_retrieval/degraded_reason"),
-            "manifest_generation": status.pointer("/sidecar_retrieval/manifest_generation"),
-            "manifest_input_hash": status.pointer("/sidecar_retrieval/manifest_input_hash")
+        "retrieval_diagnostics": {
+            "retrieval_mode": status.pointer("/retrieval_diagnostics/retrieval_mode"),
+            "degraded_reason": status.pointer("/retrieval_diagnostics/degraded_reason"),
+            "manifest_generation": status.pointer("/retrieval_diagnostics/manifest_generation"),
+            "manifest_input_hash": status.pointer("/retrieval_diagnostics/manifest_input_hash")
         },
-        "sidecar_policy": status.pointer("/sidecar_setup/state"),
+        "managed_retrieval": status.pointer("/managed_retrieval/state"),
         "embedding_device_policy": status.get("embedding_device_policy")
     });
     format!(
@@ -1007,11 +1052,7 @@ fn stdio_auto_repair_retry_cooldown() -> Duration {
 }
 
 fn stdio_agent_activation_needs_repair(status: &serde_json::Value) -> bool {
-    status
-        .pointer("/sidecar_setup/state")
-        .and_then(serde_json::Value::as_str)
-        == Some("enabled")
-        && !stdio_sidecar_setup_has_active_repair(&status["sidecar_setup"])
+    !stdio_sidecar_setup_has_active_repair(&status["managed_retrieval"])
         && status
             .get("readiness")
             .and_then(serde_json::Value::as_array)
@@ -1078,7 +1119,7 @@ fn stdio_jsonrpc_tool_call_from_legacy(
 }
 
 fn stdio_tool_reads_publication(name: &str) -> bool {
-    !matches!(name, "status" | "repair_all" | "sidecar_setup")
+    name != "status"
 }
 
 fn stdio_served_publication_meta(
@@ -1496,40 +1537,8 @@ fn handle_stdio_tool_call(
         "symbols" => handle_stdio_symbols(runtime, request),
         "snippet" => handle_stdio_snippet(runtime, request),
         "context" => handle_stdio_context(runtime, request),
-        "repair_all" => {
-            state.status_cache = None;
-            stdio_deprecated_repair_all_response(
-                handle_stdio_sidecar_repair(runtime, state, None),
-                &runtime.project_root,
-            )
-        }
-        "sidecar_setup" => handle_stdio_sidecar_setup(runtime, state, request),
         _ => serde_json::json!({"error": "unknown tool"}),
     }
-}
-
-fn stdio_deprecated_repair_all_response(
-    mut response: serde_json::Value,
-    project_root: &Path,
-) -> serde_json::Value {
-    if let Some(result) = response
-        .get_mut("result")
-        .and_then(serde_json::Value::as_object_mut)
-    {
-        result.insert("deprecated".to_string(), serde_json::json!(true));
-        result.insert(
-            "canonical_tool".to_string(),
-            serde_json::json!("sidecar_setup"),
-        );
-        result.insert(
-            "canonical_arguments".to_string(),
-            serde_json::json!({
-                "project": crate::display::clean_path_string(&project_root.to_string_lossy()),
-                "action": "repair"
-            }),
-        );
-    }
-    response
 }
 
 fn handle_stdio_ground(runtime: &RuntimeContext, request: &serde_json::Value) -> serde_json::Value {
@@ -3089,21 +3098,21 @@ fn stdio_status_with_recent_sidecar_repair_for_sidecar(
         "updated_at_epoch_ms": repair.started_at_epoch_ms
     });
     let live_active_repair = status
-        .pointer("/sidecar_setup/active_repair")
+        .pointer("/managed_retrieval/active_repair")
         .filter(|value| !value.is_null())
         .cloned();
     let active_repair = live_active_repair
         .clone()
         .unwrap_or_else(|| fallback_active_repair.clone());
     let active_repair_empty = status
-        .pointer("/sidecar_setup/active_repair")
+        .pointer("/managed_retrieval/active_repair")
         .is_none_or(serde_json::Value::is_null);
     if active_repair_empty
-        && let Some(sidecar_setup) = status
-            .get_mut("sidecar_setup")
+        && let Some(managed_retrieval) = status
+            .get_mut("managed_retrieval")
             .and_then(serde_json::Value::as_object_mut)
     {
-        sidecar_setup.insert("active_repair".to_string(), active_repair.clone());
+        managed_retrieval.insert("active_repair".to_string(), active_repair.clone());
     }
 
     if let Some(operations) = status
@@ -3618,32 +3627,6 @@ fn stdio_workspace_mismatch_diagnostic(
     })
 }
 
-fn stdio_workspace_mismatch_sidecar_setup(mismatch: &StdioWorkspaceMismatch) -> serde_json::Value {
-    let policy = stdio_sidecar_policy_file();
-    let state = stdio_sidecar_policy_state_from_file(policy.as_ref());
-    serde_json::json!({
-        "state": state,
-        "auto_repair": false,
-        "prompt_required": false,
-        "prompt": null,
-        "status": "workspace_mismatch",
-        "blocked_reason": "CodeStory MCP is serving a stale workspace; sidecar repair commands are hidden until the host relaunches MCP for the active workspace.",
-        "workspace_mismatch": stdio_workspace_mismatch_diagnostic(
-            mismatch,
-            &stdio_plugin_runtime_status(),
-        ),
-        "mcp_control": stdio_sidecar_setup_mcp_control(&mismatch.served_root),
-        "enable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND"),
-        "disable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND"),
-        "next_repair_command": null,
-        "policy_path": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH"),
-        "policy_updated_at": stdio_sidecar_policy_updated_at(policy.as_ref()),
-        "last_repair": null,
-        "active_repair": null,
-        "abandoned_repair": null
-    })
-}
-
 fn stdio_workspace_mismatch_allowed_surfaces() -> serde_json::Value {
     let mut surfaces = serde_json::Map::new();
     for surface in [
@@ -3669,37 +3652,6 @@ fn stdio_workspace_mismatch_allowed_surfaces() -> serde_json::Value {
     ] {
         surfaces.insert(surface.to_string(), stdio_workspace_mismatch_surface());
     }
-    surfaces.insert(
-        "repair_all".to_string(),
-        serde_json::json!({
-            "allowed": false,
-            "readiness_goal": "workspace",
-            "status": "workspace_mismatch",
-            "failed_layer": "workspace_binding",
-            "summary": "repair_all is blocked until the host relaunches MCP for the active workspace.",
-            "blocked_reason": "workspace_mismatch_repair_blocked",
-            "repair_reason": "workspace_mismatch",
-            "canonical_tool": "sidecar_setup",
-            "canonical_arguments": {"action": "status"},
-            "deprecated": true,
-            "minimum_next": [],
-            "full_repair": [],
-        }),
-    );
-    surfaces.insert(
-        "sidecar_setup".to_string(),
-        serde_json::json!({
-            "allowed": true,
-            "readiness_goal": "agent_packet_search",
-            "status": "workspace_mismatch",
-            "summary": "sidecar_setup status and policy actions are available; repair is blocked until the host relaunches MCP for the active workspace.",
-            "blocked_reason": "workspace_mismatch_repair_blocked",
-            "allowed_actions": ["status", "enable", "disable", "ask"],
-            "canonical_arguments": {"action": "status"},
-            "minimum_next": [],
-            "full_repair": [],
-        }),
-    );
     serde_json::Value::Object(surfaces)
 }
 
@@ -3849,7 +3801,7 @@ fn read_stdio_status_resource(
         "server_executable_sha256": server_executable_sha256,
         "source_checkout_version": source_checkout_version,
         "runtime_update": runtime_update,
-        "sidecar_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
+        "retrieval_contract_version": codestory_retrieval::SIDECAR_SCHEMA_VERSION,
         "plugin_runtime": plugin_runtime,
         "runtime_truth": surfaces.runtime_truth,
         "runtime_boundary": {
@@ -3871,8 +3823,8 @@ fn read_stdio_status_resource(
         "embedding_accelerator_request_provider": sidecar.embedding_accelerator_request_provider,
         "embedding_accelerator_request_device": sidecar.embedding_accelerator_request_device,
         "embedding_cpu_allowed": sidecar.embedding_cpu_allowed,
-        "sidecar_retrieval": sidecar.sidecar_retrieval,
-        "sidecar_setup": readiness.sidecar_setup,
+        "retrieval_diagnostics": sidecar.sidecar_retrieval,
+        "managed_retrieval": readiness.sidecar_setup,
         "dirty_marker": stdio_dirty_marker_json(&readiness.dirty_marker),
         "legacy_semantic_diagnostics": {
             "mode": retrieval.map(|state| state.mode),
@@ -4186,7 +4138,7 @@ fn build_stdio_status_surfaces(
 
 fn stdio_runtime_truth_status(
     plugin_runtime: &serde_json::Value,
-    sidecar_setup: &serde_json::Value,
+    _managed_retrieval: &serde_json::Value,
 ) -> serde_json::Value {
     serde_json::json!({
         "runtime_source": plugin_runtime
@@ -4202,11 +4154,8 @@ fn stdio_runtime_truth_status(
             .get("cli_source")
             .cloned()
             .unwrap_or_else(|| serde_json::json!("unavailable")),
-        "sidecar_policy": sidecar_setup
-            .get("state")
-            .cloned()
-            .unwrap_or_else(|| serde_json::json!("unavailable")),
-        "sidecar_status_ref": "readiness_lanes.agent_packet_search",
+        "managed_retrieval": "automatic",
+        "retrieval_status_ref": "readiness_lanes.agent_packet_search",
         "readiness_refs": {
             "local_graph": "readiness[goal=local_navigation]",
             "local_refresh": "local_refresh",
@@ -4623,7 +4572,7 @@ fn semver_triplet(version: &str) -> Option<(u64, u64, u64)> {
 fn stdio_status_recommended_next_calls(
     readiness: &[ReadinessVerdictDto],
     sidecar_setup: &serde_json::Value,
-    native_embedding_hard_busy: Option<&crate::readiness_broker::BrokerResourceSnapshot>,
+    _native_embedding_hard_busy: Option<&crate::readiness_broker::BrokerResourceSnapshot>,
 ) -> serde_json::Value {
     let project = sidecar_setup["project"].clone();
     if let Some(non_ready) = crate::readiness::primary_non_ready(readiness) {
@@ -4641,35 +4590,7 @@ fn stdio_status_recommended_next_calls(
             }]);
         }
         if non_ready.goal == ReadinessGoalDto::AgentPacketSearch {
-            if stdio_sidecar_setup_has_active_repair(sidecar_setup) {
-                return stdio_status_repair_in_progress_next_calls(&project);
-            }
-            if let Some(busy) = native_embedding_hard_busy {
-                return stdio_status_native_embedding_busy_next_calls(busy, &project);
-            }
-            match sidecar_setup
-                .get("state")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("ask")
-            {
-                "ask" | "disabled" | "unmanaged" => {
-                    return stdio_repair_policy_next_calls(sidecar_setup);
-                }
-                _ => {}
-            }
-            return serde_json::json!([
-                {
-                    "method": "tools/call",
-                    "tool": "sidecar_setup",
-                    "arguments": {"project": project, "action": "repair"},
-                    "debug_commands": non_ready.full_repair
-                },
-                {
-                    "method": "tools/call",
-                    "tool": "status",
-                    "arguments": {"project": project}
-                }
-            ]);
+            return serde_json::json!([]);
         }
         if let Some(host_action) = non_ready
             .minimum_next
@@ -4693,7 +4614,7 @@ fn stdio_status_recommended_next_calls(
                     .first()
                     .or_else(|| non_ready.minimum_next.first())
                     .map(String::as_str)
-                    .unwrap_or("Call project-scoped status and follow sidecar_setup guidance."),
+                    .unwrap_or("Retry the requested CodeStory tool."),
                 &project
             ),
             {
@@ -4803,51 +4724,10 @@ fn stdio_status_native_embedding_busy_next_calls(
     ])
 }
 
-fn stdio_status_repair_in_progress_next_calls(project: &serde_json::Value) -> serde_json::Value {
-    serde_json::json!([
-        {
-            "method": "tools/call",
-            "tool": "status",
-            "arguments": {"project": project}
-        }
-    ])
-}
-
 fn stdio_sidecar_setup_has_active_repair(sidecar_setup: &serde_json::Value) -> bool {
     sidecar_setup
         .get("active_repair")
         .is_some_and(|value| !value.is_null())
-}
-
-fn stdio_sidecar_policy_state(sidecar_setup: &serde_json::Value) -> &str {
-    sidecar_setup
-        .get("state")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("ask")
-}
-
-fn stdio_repair_blocked_by_policy(
-    sidecar_setup: &serde_json::Value,
-) -> Option<(&'static str, &'static str)> {
-    match stdio_sidecar_policy_state(sidecar_setup) {
-        "enabled" => None,
-        "ask" => Some((
-            "confirm_required",
-            "MCP sidecar repair requires explicit confirmation before it can start.",
-        )),
-        "disabled" => Some((
-            "repair_disabled",
-            "MCP sidecar repair is disabled for this plugin install.",
-        )),
-        "unmanaged" => Some((
-            "repair_unmanaged",
-            "MCP sidecar repair policy is not persisted for this host.",
-        )),
-        _ => Some((
-            "confirm_required",
-            "MCP sidecar repair requires explicit confirmation before it can start.",
-        )),
-    }
 }
 
 fn stdio_recommended_next_call(command: &str, project: &serde_json::Value) -> serde_json::Value {
@@ -4855,14 +4735,6 @@ fn stdio_recommended_next_call(command: &str, project: &serde_json::Value) -> se
         return serde_json::json!({
             "method": "host/restart",
             "instruction": command
-        });
-    }
-    if command.contains("ready --goal agent --repair") {
-        return serde_json::json!({
-            "method": "tools/call",
-            "tool": "sidecar_setup",
-            "arguments": {"project": project, "action": "repair"},
-            "debug_commands": [command]
         });
     }
     if command.contains("ready --goal local") || command.contains("codestory-cli doctor") {
@@ -4939,39 +4811,6 @@ fn stdio_plugin_runtime_status() -> serde_json::Value {
     })
 }
 
-fn stdio_sidecar_setup_mcp_control(project_root: &Path) -> serde_json::Value {
-    let project = crate::display::clean_path_string(&project_root.to_string_lossy());
-    serde_json::json!({
-        "status": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"project": project, "action": "status"}},
-        "enable": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"project": project, "action": "enable"}},
-        "disable": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"project": project, "action": "disable"}},
-        "ask": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"project": project, "action": "ask"}},
-        "repair": {"method": "tools/call", "tool": "sidecar_setup", "arguments": {"project": project, "action": "repair"}}
-    })
-}
-
-fn stdio_sidecar_policy_state_from_file(policy: Option<&serde_json::Value>) -> &'static str {
-    let env_state = env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE");
-    match policy
-        .and_then(|policy| policy.get("state"))
-        .and_then(serde_json::Value::as_str)
-        .or(env_state.as_deref())
-    {
-        Some("enabled") => "enabled",
-        Some("disabled") => "disabled",
-        Some(_) => "ask",
-        None => "unmanaged",
-    }
-}
-
-fn stdio_sidecar_policy_updated_at(policy: Option<&serde_json::Value>) -> Option<String> {
-    policy
-        .and_then(|policy| policy.get("updated_at"))
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
-        .or_else(|| env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT"))
-}
-
 pub(crate) fn stdio_sidecar_setup_status(project_root: &Path) -> serde_json::Value {
     let sidecar = crate::sidecar_runtime::for_project_with_run_id(
         project_root,
@@ -5000,16 +4839,6 @@ fn stdio_sidecar_setup_status_with_sidecar(
     project_root: &Path,
     sidecar: &codestory_retrieval::SidecarRuntimeConfig,
 ) -> serde_json::Value {
-    let policy = stdio_sidecar_policy_file();
-    let state = stdio_sidecar_policy_state_from_file(policy.as_ref());
-    let prompt_required = matches!(state, "ask");
-    let explicit_repair_enabled = matches!(state, "enabled");
-    let repair_mode = match state {
-        "enabled" => "activation_or_explicit_mcp",
-        "unmanaged" => "explicit_mcp_unmanaged",
-        "disabled" => "disabled",
-        _ => "consent_required",
-    };
     let project = crate::display::clean_path_string(&project_root.to_string_lossy());
     let default_repair = format!(
         "codestory-cli ready --goal agent --repair --project \"{project}\" --format json --run-id {}",
@@ -5052,20 +4881,12 @@ fn stdio_sidecar_setup_status_with_sidecar(
     );
     serde_json::json!({
         "project": project,
-        "state": state,
-        "auto_repair": explicit_repair_enabled,
+        "state": "managed",
+        "auto_repair": true,
         "status_triggered_repair": false,
-        "activation_triggered_repair": explicit_repair_enabled,
-        "explicit_repair_enabled": explicit_repair_enabled,
-        "repair_mode": repair_mode,
-        "prompt_required": prompt_required,
-        "prompt": if prompt_required { Some("CodeStory packet/search needs retrieval sidecars. MCP repair may start or download retrieval sidecars for this project. Enable MCP sidecar repair for this plugin install?") } else { None },
-        "mcp_control": stdio_sidecar_setup_mcp_control(project_root),
-        "enable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND"),
-        "disable_command": env_nonempty("CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND"),
+        "activation_triggered_repair": true,
+        "repair_mode": "automatic",
         "next_repair_command": next_repair_command,
-        "policy_path": env_nonempty("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH"),
-        "policy_updated_at": stdio_sidecar_policy_updated_at(policy.as_ref()),
         "last_repair": {
             "state": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE"),
             "updated_at": env_nonempty("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT"),
@@ -5174,97 +4995,6 @@ fn stdio_agent_retrieval_down_command(project_root: &Path, run_id: &str) -> Stri
     )
 }
 
-fn stdio_sidecar_policy_file() -> Option<serde_json::Value> {
-    let policy_path =
-        std::env::var_os("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH").map(PathBuf::from)?;
-    fs::read_to_string(policy_path)
-        .ok()
-        .and_then(|text| serde_json::from_str(&text).ok())
-}
-
-fn handle_stdio_sidecar_setup(
-    runtime: &RuntimeContext,
-    state: &mut StdioServerState,
-    request: &serde_json::Value,
-) -> serde_json::Value {
-    let action = request
-        .pointer("/params/arguments/action")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("status");
-    let mismatch = stdio_workspace_mismatch(runtime);
-    match action {
-        "status" => {
-            if let Some(mismatch) = mismatch.as_ref() {
-                return serde_json::json!({"result": stdio_workspace_mismatch_sidecar_setup(mismatch)});
-            }
-            serde_json::json!({"result": stdio_sidecar_setup_status_for_runtime(runtime)})
-        }
-        "enable" | "disable" | "ask" => match stdio_write_sidecar_policy(action) {
-            Ok(()) => {
-                state.status_cache = None;
-                if let Some(mismatch) = mismatch.as_ref() {
-                    return serde_json::json!({"result": stdio_workspace_mismatch_sidecar_setup(mismatch)});
-                }
-                serde_json::json!({"result": stdio_sidecar_setup_status_for_runtime(runtime)})
-            }
-            Err(error) => serde_json::json!({"error": error.to_string()}),
-        },
-        "repair" => {
-            if let Some(mismatch) = mismatch.as_ref() {
-                return serde_json::json!({"error": {
-                    "code": "workspace_mismatch",
-                    "message": "CodeStory MCP is serving a stale workspace; repair is blocked until the host relaunches MCP for the active workspace.",
-                    "workspace_mismatch": stdio_workspace_mismatch_diagnostic(
-                        mismatch,
-                        &stdio_plugin_runtime_status(),
-                    ),
-                    "minimum_next": [],
-                    "full_repair": [],
-                }});
-            }
-            state.status_cache = None;
-            handle_stdio_sidecar_repair(runtime, state, None)
-        }
-        _ => {
-            serde_json::json!({"error": "sidecar_setup.action must be status, enable, disable, ask, or repair"})
-        }
-    }
-}
-
-fn stdio_write_sidecar_policy(action: &str) -> Result<()> {
-    let state = match action {
-        "enable" => "enabled",
-        "disable" => "disabled",
-        "ask" => "ask",
-        _ => bail!("unsupported sidecar setup action: {action}"),
-    };
-    let policy_path = std::env::var_os("CODESTORY_PLUGIN_SIDECAR_POLICY_PATH")
-        .map(PathBuf::from)
-        .context("CodeStory plugin data is unavailable; restart from an installed plugin before changing sidecar setup policy")?;
-    if let Some(parent) = policy_path.parent() {
-        fs::create_dir_all(parent).with_context(|| {
-            format!("create sidecar setup policy directory {}", parent.display())
-        })?;
-    }
-    let current = fs::read_to_string(&policy_path)
-        .ok()
-        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
-        .unwrap_or_else(|| serde_json::json!({}));
-    let mut next = current.as_object().cloned().unwrap_or_default();
-    next.insert("state".to_string(), serde_json::json!(state));
-    let updated_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| format!("unix:{}", duration.as_secs()))
-        .unwrap_or_else(|_| "unix:0".to_string());
-    next.insert("updated_at".to_string(), serde_json::json!(updated_at));
-    fs::write(
-        &policy_path,
-        serde_json::to_string_pretty(&serde_json::Value::Object(next))?,
-    )
-    .with_context(|| format!("write sidecar setup policy {}", policy_path.display()))?;
-    Ok(())
-}
-
 fn handle_stdio_sidecar_repair(
     runtime: &RuntimeContext,
     state: &mut StdioServerState,
@@ -5313,9 +5043,6 @@ fn handle_stdio_sidecar_repair(
         });
     }
     let sidecar_setup = stdio_sidecar_setup_status_for_runtime(runtime);
-    if let Some(result) = stdio_sidecar_repair_policy_block_result(&sidecar_setup) {
-        return result;
-    }
     if let Some(stale) = crate::ready_repair_status::stale_live_ready_repair_status_for_sidecar(
         &runtime.project_root,
         &repair_sidecar,
@@ -5670,21 +5397,6 @@ fn join_stdio_ready_repair_tail(
     }
 }
 
-fn stdio_sidecar_repair_policy_block_result(
-    sidecar_setup: &serde_json::Value,
-) -> Option<serde_json::Value> {
-    let (status, message) = stdio_repair_blocked_by_policy(sidecar_setup)?;
-    Some(serde_json::json!({
-        "result": {
-            "status": status,
-            "mode": "background",
-            "message": message,
-            "sidecar_setup": sidecar_setup,
-            "recommended_next_calls": stdio_repair_policy_next_calls(sidecar_setup)
-        }
-    }))
-}
-
 fn stdio_sidecar_repair_machine_busy_result(
     busy: &crate::readiness_broker::BrokerResourceSnapshot,
     sidecar_setup: &serde_json::Value,
@@ -5781,87 +5493,6 @@ fn stdio_sidecar_repair_reconciliation_block_result(
     }))
 }
 
-fn stdio_repair_policy_next_calls(sidecar_setup: &serde_json::Value) -> serde_json::Value {
-    let project = sidecar_setup["project"].clone();
-    match stdio_sidecar_policy_state(sidecar_setup) {
-        "ask" => serde_json::json!([
-            {
-                "method": "host/confirm",
-                "instruction": sidecar_setup["prompt"],
-                "confirm_next": [
-                    {
-                        "method": "tools/call",
-                        "tool": "sidecar_setup",
-                        "arguments": {"project": project, "action": "enable"},
-                        "debug_command": sidecar_setup["enable_command"]
-                    },
-                    {
-                        "method": "tools/call",
-                        "tool": "sidecar_setup",
-                        "arguments": {"project": project, "action": "repair"},
-                        "debug_command": sidecar_setup["next_repair_command"]
-                    },
-                    {
-                        "method": "tools/call",
-                        "tool": "status",
-                        "arguments": {"project": project}
-                    }
-                ],
-                "decline_next": [
-                    {
-                        "method": "tools/call",
-                        "tool": "sidecar_setup",
-                        "arguments": {"project": project, "action": "disable"},
-                        "debug_command": sidecar_setup["disable_command"]
-                    },
-                    {
-                        "method": "tools/call",
-                        "tool": "status",
-                        "arguments": {"project": project}
-                    }
-                ]
-            }
-        ]),
-        "disabled" => serde_json::json!([
-            {
-                "method": "host/confirm",
-                "instruction": "CodeStory packet/search repair is disabled for this plugin install. Enable MCP sidecar repair for this plugin install?",
-                "confirm_next": [
-                    {
-                        "method": "tools/call",
-                        "tool": "sidecar_setup",
-                        "arguments": {"project": project, "action": "enable"},
-                        "debug_command": sidecar_setup["enable_command"]
-                    },
-                    {
-                        "method": "tools/call",
-                        "tool": "status",
-                        "arguments": {"project": project}
-                    }
-                ]
-            }
-        ]),
-        "unmanaged" => serde_json::json!([
-            {
-                "method": "host/instruction",
-                "instruction": "Sidecar setup policy is not persisted for this host, so MCP repair is blocked until the host/plugin provides CODESTORY_PLUGIN_SIDECAR_POLICY_PATH. Use project-scoped status for current state or run CLI repair outside MCP."
-            },
-            {
-                "method": "tools/call",
-                "tool": "status",
-                "arguments": {"project": project}
-            }
-        ]),
-        _ => serde_json::json!([
-            {
-                "method": "tools/call",
-                "tool": "status",
-                "arguments": {"project": project}
-            }
-        ]),
-    }
-}
-
 fn stdio_parse_trailing_json_object(text: &str) -> Option<serde_json::Value> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
@@ -5899,8 +5530,8 @@ fn stdio_allowed_surfaces(readiness: &[ReadinessVerdictDto]) -> serde_json::Valu
 
 fn stdio_allowed_surfaces_with_policy(
     readiness: &[ReadinessVerdictDto],
-    sidecar_setup: Option<&serde_json::Value>,
-    native_embedding_hard_busy: Option<&crate::readiness_broker::BrokerResourceSnapshot>,
+    _sidecar_setup: Option<&serde_json::Value>,
+    _native_embedding_hard_busy: Option<&crate::readiness_broker::BrokerResourceSnapshot>,
 ) -> serde_json::Value {
     let local = readiness
         .iter()
@@ -5933,14 +5564,6 @@ fn stdio_allowed_surfaces_with_policy(
     for surface in ["packet", "search", "context"] {
         surfaces.insert(surface.to_string(), stdio_allowed_surface(agent));
     }
-    surfaces.insert(
-        "sidecar_setup".to_string(),
-        stdio_sidecar_setup_surface(readiness, sidecar_setup, native_embedding_hard_busy),
-    );
-    surfaces.insert(
-        "repair_all".to_string(),
-        stdio_repair_all_surface(readiness, sidecar_setup, native_embedding_hard_busy),
-    );
     serde_json::Value::Object(surfaces)
 }
 
@@ -5953,116 +5576,6 @@ fn stdio_local_surface(surface: &str, verdict: Option<&ReadinessVerdictDto>) -> 
         status["activation_required"] = serde_json::json!(true);
     }
     status
-}
-
-fn stdio_sidecar_setup_surface(
-    readiness: &[ReadinessVerdictDto],
-    sidecar_setup: Option<&serde_json::Value>,
-    native_embedding_hard_busy: Option<&crate::readiness_broker::BrokerResourceSnapshot>,
-) -> serde_json::Value {
-    let Some(non_ready) = crate::readiness::primary_non_ready(readiness) else {
-        return serde_json::json!({
-            "allowed": true,
-            "readiness_goal": "agent_packet_search",
-            "status": "ready",
-            "summary": "sidecar_setup status is available; repair is not currently required.",
-            "allowed_actions": ["status"],
-            "canonical_arguments": {"action": "status"},
-        });
-    };
-    if non_ready.goal != ReadinessGoalDto::AgentPacketSearch {
-        return serde_json::json!({
-            "allowed": true,
-            "readiness_goal": crate::readiness::goal_label(non_ready.goal),
-            "status": crate::readiness::status_label(non_ready.status),
-            "summary": "sidecar_setup status is available; repair actions are for agent packet/search sidecars.",
-            "allowed_actions": ["status"],
-            "canonical_arguments": {"action": "status"},
-        });
-    }
-    if let Some(_busy) = native_embedding_hard_busy {
-        return serde_json::json!({
-            "allowed": true,
-            "readiness_goal": "agent_packet_search",
-            "status": "preparing",
-            "failed_layer": "native_embedding_runtime",
-            "summary": "CodeStory is preparing repository search.",
-            "allowed_actions": ["status"],
-            "canonical_arguments": {"action": "status"},
-        });
-    }
-    let (allowed_actions, canonical_action) = match sidecar_setup.map(stdio_sidecar_policy_state) {
-        Some("enabled") => (serde_json::json!(["status", "repair"]), "repair"),
-        Some("ask") => (serde_json::json!(["status", "enable", "disable"]), "status"),
-        Some("disabled") => (serde_json::json!(["status", "enable"]), "status"),
-        Some("unmanaged") => (serde_json::json!(["status"]), "status"),
-        _ => (serde_json::json!(["status"]), "status"),
-    };
-    serde_json::json!({
-        "allowed": true,
-        "readiness_goal": "agent_packet_search",
-        "status": crate::readiness::status_label(non_ready.status),
-        "failed_layer": crate::readiness::failed_layer(non_ready),
-        "summary": "Use sidecar_setup for the MCP-managed agent packet/search repair path.",
-        "allowed_actions": allowed_actions,
-        "canonical_arguments": {"action": canonical_action},
-        "minimum_next": non_ready.minimum_next,
-        "full_repair": non_ready.full_repair,
-    })
-}
-
-fn stdio_repair_all_surface(
-    readiness: &[ReadinessVerdictDto],
-    sidecar_setup: Option<&serde_json::Value>,
-    native_embedding_hard_busy: Option<&crate::readiness_broker::BrokerResourceSnapshot>,
-) -> serde_json::Value {
-    if let Some(setup) = readiness
-        .iter()
-        .find(|verdict| verdict.status == ReadinessStatusDto::RepairSetup)
-    {
-        return stdio_allowed_surface(Some(setup));
-    }
-    if let Some((status, blocked_reason)) = sidecar_setup.and_then(stdio_repair_blocked_by_policy) {
-        return serde_json::json!({
-            "allowed": false,
-            "readiness_goal": "agent_packet_search",
-            "status": status,
-            "failed_layer": "mcp_sidecar_policy",
-            "summary": blocked_reason,
-            "repair_reason": blocked_reason,
-            "blocked_reason": blocked_reason,
-            "minimum_next": [],
-            "full_repair": [],
-        });
-    }
-    if let Some(_busy) = native_embedding_hard_busy {
-        return serde_json::json!({
-            "allowed": false,
-            "readiness_goal": "agent_packet_search",
-            "status": "preparing",
-            "failed_layer": "native_embedding_runtime",
-            "summary": "CodeStory is preparing repository search.",
-            "repair_reason": "preparing",
-            "blocked_reason": "preparing",
-            "minimum_next": [],
-            "full_repair": [],
-        });
-    }
-
-    serde_json::json!({
-        "allowed": false,
-        "readiness_goal": "agent_packet_search",
-        "status": "compatibility_alias",
-        "failed_layer": null,
-        "summary": "repair_all is a deprecated compatibility alias. Follow recommended_next_calls and call sidecar_setup with action=repair.",
-        "canonical_tool": "sidecar_setup",
-        "canonical_arguments": {"action": "repair"},
-        "deprecated": true,
-        "repair_reason": null,
-        "blocked_reason": null,
-        "minimum_next": [],
-        "full_repair": [],
-    })
 }
 
 fn stdio_allowed_surface(verdict: Option<&ReadinessVerdictDto>) -> serde_json::Value {
@@ -6105,18 +5618,18 @@ fn stdio_repair_reason(verdict: &ReadinessVerdictDto) -> Option<String> {
 fn read_stdio_agent_guide_resource(project_root: &Path) -> serde_json::Value {
     let project = crate::display::clean_path_string(&project_root.to_string_lossy());
     serde_json::json!({
-        "purpose": "Default read-only CodeStory browser loop for local codebase grounding.",
+        "purpose": "Direct CodeStory tools for repository orientation, navigation, and broad search.",
         "recommended_call_sequence": [
             {
                 "method": "tools/call",
-                "tool": "status",
-                "arguments": {"project": project}
+                "tool": "ground",
+                "arguments": {"project": project, "budget": "balanced"}
             }
         ],
         "readiness_lanes": [
             {
                 "readiness_goal": "local_navigation",
-                "condition": "Use only surfaces whose project-scoped status allowed_surfaces.<surface>.allowed value is true.",
+                "condition": "Call the intended tool directly. CodeStory refreshes the repository map when needed.",
                 "surfaces": ["ground", "files", "symbol", "definition", "get_node", "callers", "callees", "neighbors", "shortest_path", "query_subgraph", "symbols", "snippet", "references", "trace", "trail", "affected"],
                 "calls": [
                     {
@@ -6187,7 +5700,7 @@ fn read_stdio_agent_guide_resource(project_root: &Path) -> serde_json::Value {
             },
             {
                 "readiness_goal": "agent_packet_search",
-                "condition": "Use packet/search/context only when their project-scoped status allowed_surfaces entries are true.",
+                "condition": "Call packet, search, or context directly. If CodeStory is preparing broad search, retry the same tool after retry_after_ms.",
                 "surfaces": ["packet", "search", "context"],
                 "calls": [
                     {
@@ -6223,27 +5736,27 @@ fn read_stdio_agent_guide_resource(project_root: &Path) -> serde_json::Value {
             {
                 "surface": "ground",
                 "kind": "tool and codestory://grounding resource",
-                "when": "Use after status when allowed_surfaces.ground.allowed is true."
+                "when": "Use first for compact repository orientation."
             },
             {
                 "surface": "packet",
                 "kind": "tool",
-                "when": "Use for broad structural questions only when allowed_surfaces.packet.allowed is true and strict retrieval is full."
+                "when": "Use for broad structural questions. Retry the same call when CodeStory reports preparing."
             },
             {
                 "surface": "search",
                 "kind": "tool",
-                "when": "Use for bounded candidate discovery only when allowed_surfaces.search.allowed is true."
+                "when": "Use for bounded candidate discovery. Retry the same call when CodeStory reports preparing."
             },
             {
                 "surface": "context",
                 "kind": "tool",
-                "when": "Use after selecting one concrete target only when allowed_surfaces.context.allowed is true."
+                "when": "Use after selecting one concrete target. Retry the same call when CodeStory reports preparing."
             },
             {
                 "surface": "direct_source_reads",
                 "kind": "fallback",
-                "when": "Use when status reports missing, stale, or degraded index/sidecar state."
+                "when": "Use only when CodeStory reports unavailable or when exact source inspection is needed."
             },
             {
                 "surface": "cache identity, retrieval status",
@@ -6252,14 +5765,15 @@ fn read_stdio_agent_guide_resource(project_root: &Path) -> serde_json::Value {
             }
         ],
         "safety_notes": [
-            "Browser stdio tools are read-only, non-destructive, idempotent, local-only, and closed-world; sidecar_setup is the local plugin-configuration exception.",
-            "Call status with this exact project first, then pass the same project to every tool call.",
-            "Use ground for compact repository orientation after status when local_navigation is ready.",
-            "Use packet for broad task questions only when packet/search status is allowed; use context only when allowed_surfaces.context.allowed is true.",
+            "CodeStory tools never edit repository source. Some calls refresh the local map or prepare managed search automatically; all are non-destructive, idempotent, local-only, and closed-world.",
+            "Pass the same absolute project path to every tool call.",
+            "Use ground first for compact repository orientation.",
+            "Use packet for broad task questions and context after selecting a concrete target.",
+            "When a tool reports preparing, wait retry_after_ms and retry that same tool. Do not ask the user to repair CodeStory.",
             "Treat packet status other than sufficient as unsafe to claim until gaps, open_next, and follow_up_commands are resolved.",
             "Use continuation links from search or definition results before broadening retrieval.",
             "Keep search limits bounded; stdio search clamps limit to 1..50.",
-            "Treat repo-text hits as navigation clues and search hits as discovery clues until backed by proof-bearing sidecar, graph, or source evidence."
+            "Treat repo-text hits as navigation clues and search hits as discovery clues until backed by graph or source evidence."
         ]
     })
 }
@@ -6535,19 +6049,6 @@ mod tests {
         );
     }
 
-    fn agent_packet_search_not_ready() -> ReadinessVerdictDto {
-        ReadinessVerdictDto {
-            goal: ReadinessGoalDto::AgentPacketSearch,
-            status: ReadinessStatusDto::RepairRetrieval,
-            summary: "agent packet/search sidecars need repair".to_string(),
-            minimum_next: vec!["codestory-cli ready --goal agent --repair".to_string()],
-            full_repair: vec!["codestory-cli ready --goal agent --repair".to_string()],
-            setup: None,
-            index: None,
-            sidecar: None,
-        }
-    }
-
     #[test]
     fn stdio_gpu_proof_blocks_manual_assertion_and_allows_runtime_smoke() {
         let sidecar = args::DoctorSidecarStatusOutput {
@@ -6643,67 +6144,6 @@ mod tests {
         assert_eq!(degraded.embedding_device_state, "cpu");
     }
 
-    fn broker_snapshot_with_native_resource(
-        project_root: &Path,
-        resource: crate::readiness_broker::BrokerResourceSnapshot,
-    ) -> crate::readiness_broker::ReadinessBrokerSnapshot {
-        let scope = crate::readiness_broker::agent_repair_scope(
-            project_root,
-            Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-            env!("CARGO_PKG_VERSION"),
-        );
-        let mut resources = std::collections::BTreeMap::new();
-        resources.insert(
-            crate::readiness_broker::NATIVE_EMBEDDING_RESOURCE.to_string(),
-            resource,
-        );
-        crate::readiness_broker::ReadinessBrokerSnapshot {
-            schema_version: crate::readiness_broker::BROKER_SCHEMA_VERSION,
-            identity: scope.identity.clone(),
-            install_id: "test-install".to_string(),
-            project_id: scope.project_id,
-            canonical_root_hash: "test-root-hash".to_string(),
-            workspace_root: scope.workspace_root,
-            cli_version: env!("CARGO_PKG_VERSION").to_string(),
-            updated_at_epoch_ms: crate::ready_repair_status::now_epoch_ms(),
-            snapshot_path: None,
-            persistence_status: "pending".to_string(),
-            persistence_error: None,
-            operations: Vec::new(),
-            resources,
-            reconciliation: crate::readiness_broker::BrokerReconciliationSnapshot {
-                status: "observed".to_string(),
-                cleanup_performed: false,
-                stale_status_paths_removed: Vec::new(),
-                stale_lock_paths_removed: Vec::new(),
-                abandoned_repairs: Vec::new(),
-                local_refresh_cleanups: Vec::new(),
-                active_repair: None,
-                unresolved_orphan_reason: None,
-            },
-            gpu_proof: None,
-        }
-    }
-
-    fn native_resource_snapshot_for_scope(
-        scope: &crate::readiness_broker::BrokerScope,
-        status: &str,
-        owner_pid: u32,
-    ) -> crate::readiness_broker::BrokerResourceSnapshot {
-        crate::readiness_broker::BrokerResourceSnapshot {
-            resource: crate::readiness_broker::NATIVE_EMBEDDING_RESOURCE.to_string(),
-            scope: "machine".to_string(),
-            status: status.to_string(),
-            owner_pid: Some(owner_pid),
-            owner_operation_id: None,
-            owner_project_id: Some(scope.project_id.clone()),
-            owner_workspace_root: Some(scope.workspace_root.clone()),
-            started_at_epoch_ms: Some(crate::ready_repair_status::now_epoch_ms()),
-            lock_path: "C:/cache/readiness-broker/machine/native.lock".to_string(),
-            queued_reason: (status == "busy").then(|| "machine_resource_busy".to_string()),
-        }
-    }
-
     #[test]
     fn stdio_status_recent_repair_keeps_live_status_phase() {
         let project = tempfile::tempdir().expect("project");
@@ -6718,7 +6158,7 @@ mod tests {
             observed_at: Instant::now(),
         });
         let status = json!({
-            "sidecar_setup": {
+            "managed_retrieval": {
                 "active_repair": {
                     "status": "repairing",
                     "project_root": project.path().display().to_string(),
@@ -6738,7 +6178,7 @@ mod tests {
         let updated = stdio_status_with_recent_sidecar_repair(status, &mut recent, project.path());
 
         assert_eq!(
-            updated["sidecar_setup"]["active_repair"]["phase"],
+            updated["managed_retrieval"]["active_repair"]["phase"],
             json!("Qdrant finalize")
         );
         assert_eq!(
@@ -6770,7 +6210,7 @@ mod tests {
             observed_at: Instant::now(),
         });
         let status = json!({
-            "sidecar_setup": {
+            "managed_retrieval": {
                 "active_repair": null
             },
             "readiness_broker": {
@@ -6781,7 +6221,7 @@ mod tests {
         let updated = stdio_status_with_recent_sidecar_repair(status, &mut recent, project.path());
 
         assert_eq!(
-            updated["sidecar_setup"]["active_repair"]["phase"],
+            updated["managed_retrieval"]["active_repair"]["phase"],
             json!("starting")
         );
         assert_eq!(
@@ -6808,7 +6248,7 @@ mod tests {
 
     fn empty_recent_repair_status() -> serde_json::Value {
         json!({
-            "sidecar_setup": {
+            "managed_retrieval": {
                 "active_repair": null
             },
             "readiness_broker": {
@@ -6874,7 +6314,7 @@ mod tests {
             recent.is_none(),
             "dead pid without durable status must clear overlay"
         );
-        assert!(updated["sidecar_setup"]["active_repair"].is_null());
+        assert!(updated["managed_retrieval"]["active_repair"].is_null());
         assert_eq!(updated["readiness_broker"]["operations"], json!([]));
     }
 
@@ -6906,7 +6346,7 @@ mod tests {
             "durable active repair must retain overlay even when overlay pid is dead"
         );
         assert_eq!(
-            updated["sidecar_setup"]["active_repair"]["phase"],
+            updated["managed_retrieval"]["active_repair"]["phase"],
             json!("starting")
         );
         assert_eq!(
@@ -6946,7 +6386,7 @@ mod tests {
             recent.is_none(),
             "aged overlay must clear even when durable repair is still active"
         );
-        assert!(updated["sidecar_setup"]["active_repair"].is_null());
+        assert!(updated["managed_retrieval"]["active_repair"].is_null());
     }
 
     #[test]
@@ -6971,7 +6411,7 @@ mod tests {
         );
 
         assert!(recent.is_none(), "project_root mismatch must clear overlay");
-        assert!(updated["sidecar_setup"]["active_repair"].is_null());
+        assert!(updated["managed_retrieval"]["active_repair"].is_null());
     }
 
     #[test]
@@ -7145,23 +6585,10 @@ mod tests {
         assert_eq!(status["degraded_reason"], json!("workspace_mismatch"));
         assert_eq!(status["readiness"][0]["minimum_next"], json!([]));
         assert_eq!(status["readiness"][0]["full_repair"], json!([]));
-        assert_eq!(
-            status["allowed_surfaces"]["sidecar_setup"]["allowed_actions"],
-            json!(["status", "enable", "disable", "ask"])
-        );
-        assert_eq!(
-            status["allowed_surfaces"]["repair_all"]["status"],
-            json!("workspace_mismatch")
-        );
-
-        let setup = stdio_workspace_mismatch_sidecar_setup(&mismatch);
-        assert_eq!(setup["status"], json!("workspace_mismatch"));
-        assert!(setup["next_repair_command"].is_null());
-        assert!(setup["last_repair"].is_null());
-        assert!(setup["active_repair"].is_null());
         assert!(
-            !setup.to_string().contains("ready --goal agent --repair"),
-            "workspace mismatch must not advertise CLI agent repair: {setup}"
+            status["allowed_surfaces"].get("sidecar_setup").is_none()
+                && status["allowed_surfaces"].get("repair_all").is_none(),
+            "workspace mismatch must not expose infrastructure controls: {status}"
         );
     }
 
@@ -7192,157 +6619,6 @@ mod tests {
             calls[0].get("command").is_none(),
             "restart boundary should not be exposed as a CLI command: {calls}"
         );
-    }
-
-    #[test]
-    fn stdio_native_embedding_cross_project_reusable_lock_does_not_block_repair() {
-        let project = tempfile::tempdir().expect("requested project");
-        let owner_project = tempfile::tempdir().expect("owner project");
-        let sidecar = crate::sidecar_runtime::for_project_with_run_id(
-            project.path(),
-            codestory_retrieval::SidecarProfile::Agent,
-            Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-        );
-        let scope = crate::readiness_broker::agent_repair_scope(
-            project.path(),
-            sidecar.run_id.as_deref(),
-            env!("CARGO_PKG_VERSION"),
-        );
-        let owner_scope = crate::readiness_broker::agent_repair_scope(
-            owner_project.path(),
-            Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-            env!("CARGO_PKG_VERSION"),
-        );
-        let resource = native_resource_snapshot_for_scope(&owner_scope, "busy", 44);
-        let snapshot = broker_snapshot_with_native_resource(project.path(), resource);
-        let mut classifier_called = false;
-
-        let hard_busy = stdio_native_embedding_resource_hard_busy_with_classifier(
-            project.path(),
-            &sidecar,
-            Some(&snapshot),
-            |classifier_scope, classifier_sidecar, classifier_resource| {
-                classifier_called = true;
-                assert_eq!(classifier_scope.project_id, scope.project_id);
-                assert_ne!(
-                    classifier_scope.project_id,
-                    classifier_resource.owner_project_id.as_deref().unwrap()
-                );
-                assert_eq!(classifier_sidecar.run_id, sidecar.run_id);
-                assert_eq!(classifier_resource.owner_pid, Some(44));
-                Ok(Some(44))
-            },
-        );
-        let calls = stdio_status_recommended_next_calls(
-            &[agent_packet_search_not_ready()],
-            &json!({"state": "enabled"}),
-            hard_busy,
-        );
-        let surfaces = stdio_allowed_surfaces_with_policy(
-            &[agent_packet_search_not_ready()],
-            Some(&json!({"state": "enabled"})),
-            hard_busy,
-        );
-
-        assert!(classifier_called);
-        assert!(hard_busy.is_none());
-        assert_eq!(calls[0]["tool"], json!("sidecar_setup"));
-        assert_eq!(calls[0]["arguments"]["action"], json!("repair"));
-        assert_eq!(surfaces["sidecar_setup"]["allowed"], json!(true));
-        assert_eq!(
-            surfaces["sidecar_setup"]["canonical_arguments"]["action"],
-            json!("repair")
-        );
-    }
-
-    #[test]
-    fn stdio_native_embedding_foreign_lock_blocks_repair() {
-        let project = tempfile::tempdir().expect("project");
-        let sidecar = crate::sidecar_runtime::for_project_with_run_id(
-            project.path(),
-            codestory_retrieval::SidecarProfile::Agent,
-            Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-        );
-        let scope = crate::readiness_broker::agent_repair_scope(
-            project.path(),
-            sidecar.run_id.as_deref(),
-            env!("CARGO_PKG_VERSION"),
-        );
-        let mut resource = native_resource_snapshot_for_scope(&scope, "busy", 45);
-        resource.owner_project_id = Some("foreign-project".to_string());
-        let snapshot = broker_snapshot_with_native_resource(project.path(), resource);
-
-        let hard_busy = stdio_native_embedding_resource_hard_busy_with_classifier(
-            project.path(),
-            &sidecar,
-            Some(&snapshot),
-            |_classifier_scope, _classifier_sidecar, _classifier_resource| Ok(None),
-        );
-        let calls = stdio_status_recommended_next_calls(
-            &[agent_packet_search_not_ready()],
-            &json!({"state": "enabled"}),
-            hard_busy,
-        );
-        let surfaces = stdio_allowed_surfaces_with_policy(
-            &[agent_packet_search_not_ready()],
-            Some(&json!({"state": "enabled"})),
-            hard_busy,
-        );
-
-        assert!(hard_busy.is_some());
-        assert_eq!(calls[0]["method"], json!("host/instruction"));
-        assert_eq!(calls.as_array().map(Vec::len), Some(1));
-        assert!(!calls.to_string().contains("owner_"));
-        assert!(!calls.to_string().contains("pid"));
-        assert_eq!(surfaces["sidecar_setup"]["allowed"], json!(true));
-        assert_eq!(surfaces["sidecar_setup"]["status"], json!("preparing"));
-        assert_eq!(
-            surfaces["sidecar_setup"]["allowed_actions"],
-            json!(["status"])
-        );
-        assert_eq!(
-            surfaces["sidecar_setup"]["canonical_arguments"]["action"],
-            json!("status")
-        );
-        assert_eq!(surfaces["repair_all"]["status"], json!("preparing"));
-        assert_eq!(surfaces["repair_all"]["repair_reason"], json!("preparing"));
-        assert!(!surfaces.to_string().contains("owner_"));
-        assert!(!surfaces.to_string().contains("pid"));
-    }
-
-    #[test]
-    fn stdio_native_embedding_stale_snapshot_does_not_block_repair() {
-        let project = tempfile::tempdir().expect("project");
-        let sidecar = crate::sidecar_runtime::for_project_with_run_id(
-            project.path(),
-            codestory_retrieval::SidecarProfile::Agent,
-            Some(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-        );
-        let scope = crate::readiness_broker::agent_repair_scope(
-            project.path(),
-            sidecar.run_id.as_deref(),
-            env!("CARGO_PKG_VERSION"),
-        );
-        let resource = native_resource_snapshot_for_scope(&scope, "stale", 46);
-        let snapshot = broker_snapshot_with_native_resource(project.path(), resource);
-
-        let hard_busy = stdio_native_embedding_resource_hard_busy_with_classifier(
-            project.path(),
-            &sidecar,
-            Some(&snapshot),
-            |_classifier_scope, _classifier_sidecar, _classifier_resource| {
-                panic!("stale native lock snapshots must not reach busy classification")
-            },
-        );
-        let calls = stdio_status_recommended_next_calls(
-            &[agent_packet_search_not_ready()],
-            &json!({"state": "enabled"}),
-            hard_busy,
-        );
-
-        assert!(hard_busy.is_none());
-        assert_eq!(calls[0]["tool"], json!("sidecar_setup"));
-        assert_eq!(calls[0]["arguments"]["action"], json!("repair"));
     }
 
     #[test]
@@ -8142,10 +7418,10 @@ starting sidecar setup
     }
 
     #[test]
-    fn project_activation_respects_agent_repair_policy_and_readiness() {
-        let status = |state: &str, readiness: &str| {
+    fn project_activation_follows_readiness_without_user_policy() {
+        let status = |readiness: &str| {
             json!({
-                "sidecar_setup": {"state": state, "active_repair": null},
+                "managed_retrieval": {"state": "managed", "active_repair": null},
                 "readiness": [{"goal": "agent_packet_search", "status": readiness}]
             })
         };
@@ -8162,15 +7438,8 @@ starting sidecar setup
                 .expect("grounding resource")
                 .activates_project()
         );
-        assert!(stdio_agent_activation_needs_repair(&status(
-            "enabled", "blocked"
-        )));
-        assert!(!stdio_agent_activation_needs_repair(&status(
-            "ask", "blocked"
-        )));
-        assert!(!stdio_agent_activation_needs_repair(&status(
-            "enabled", "ready"
-        )));
+        assert!(stdio_agent_activation_needs_repair(&status("blocked")));
+        assert!(!stdio_agent_activation_needs_repair(&status("ready")));
 
         let failed: crate::ready_repair_status::ReadyRepairWorkerResult =
             serde_json::from_value(json!({

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -21,12 +21,11 @@ struct StdioFixture {
     disable_installed_cli_probe: bool,
     plugin_data_dir: Option<PathBuf>,
     plugin_cli_source: Option<String>,
-    sidecar_policy_state: Option<String>,
-    sidecar_last_repair_command: Option<String>,
     dirty_marker_path: Option<PathBuf>,
     dirty_marker_project_root: Option<PathBuf>,
     local_refresh_timeout_ms: Option<u64>,
     ready_repair_worker_probe_exit_code: Option<i32>,
+    managed_retrieval_preparation: bool,
 }
 
 struct StdioServer {
@@ -577,12 +576,11 @@ fn indexed_fixture_with_embedding_mode(hash_embeddings: bool) -> StdioFixture {
         disable_installed_cli_probe: false,
         plugin_data_dir: None,
         plugin_cli_source: None,
-        sidecar_policy_state: None,
-        sidecar_last_repair_command: None,
         dirty_marker_path: None,
         dirty_marker_project_root: None,
         local_refresh_timeout_ms: None,
         ready_repair_worker_probe_exit_code: None,
+        managed_retrieval_preparation: false,
     }
 }
 
@@ -607,12 +605,11 @@ fn unindexed_fixture() -> StdioFixture {
         disable_installed_cli_probe: false,
         plugin_data_dir: None,
         plugin_cli_source: None,
-        sidecar_policy_state: None,
-        sidecar_last_repair_command: None,
         dirty_marker_path: None,
         dirty_marker_project_root: None,
         local_refresh_timeout_ms: None,
         ready_repair_worker_probe_exit_code: None,
+        managed_retrieval_preparation: false,
     }
 }
 
@@ -726,7 +723,15 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
         .stderr(Stdio::piped())
         .env("CODESTORY_CACHE_ROOT", state_root.join("cache"))
         .env("CODESTORY_STDIO_CACHE_ROOT", state_root.join("stdio-cache"))
-        .env("CODESTORY_PLUGIN_DATA", state_root.join("plugin-data"));
+        .env("CODESTORY_PLUGIN_DATA", state_root.join("plugin-data"))
+        .env(
+            "CODESTORY_TEST_MANAGED_RETRIEVAL_PREPARATION",
+            if fixture.managed_retrieval_preparation {
+                "1"
+            } else {
+                "0"
+            },
+        );
     apply_fixture_embedding_env(&mut command, fixture.hash_embeddings);
     if let Some(version) = &fixture.latest_release_version {
         command.env("CODESTORY_LATEST_RELEASE_VERSION", version);
@@ -742,25 +747,6 @@ fn spawn_stdio_server(fixture: &StdioFixture) -> StdioServer {
     }
     if let Some(source) = &fixture.plugin_cli_source {
         command.env("CODESTORY_PLUGIN_CLI_SOURCE", source);
-    }
-    if let Some(state) = &fixture.sidecar_policy_state {
-        command.env("CODESTORY_PLUGIN_SIDECAR_POLICY_STATE", state);
-        command.env(
-            "CODESTORY_PLUGIN_SIDECAR_POLICY_PATH",
-            fixture.cache_dir.path().join("plugin-sidecar-policy.json"),
-        );
-        command.env(
-            "CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND",
-            "node codestory-mcp.cjs sidecar-policy enable",
-        );
-        command.env(
-            "CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND",
-            "node codestory-mcp.cjs sidecar-policy disable",
-        );
-    }
-    if let Some(command_text) = &fixture.sidecar_last_repair_command {
-        command.env("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE", "completed");
-        command.env("CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND", command_text);
     }
     if let Some(path) = &fixture.dirty_marker_path {
         command.env("CODESTORY_PLUGIN_DIRTY_MARKER_PATH", path);
@@ -806,6 +792,7 @@ fn spawn_multi_project_stdio_server(cache_root: &Path) -> StdioServer {
         .env("CODESTORY_EMBED_RUNTIME_MODE", "hash")
         .env("CODESTORY_STDIO_CACHE_ROOT", cache_root)
         .env("CODESTORY_PLUGIN_MULTI_PROJECT", "1")
+        .env("CODESTORY_TEST_MANAGED_RETRIEVAL_PREPARATION", "0")
         .spawn()
         .expect("spawn multi-project stdio server");
     let stdin = child.stdin.take().expect("multi-project stdio stdin");
@@ -833,6 +820,7 @@ fn spawn_multi_project_stdio_server_with_project_network_config(cache_root: &Pat
         .env("CODESTORY_EMBED_ALLOW_CPU", "1")
         .env("CODESTORY_STDIO_CACHE_ROOT", cache_root)
         .env("CODESTORY_PLUGIN_MULTI_PROJECT", "1")
+        .env("CODESTORY_TEST_MANAGED_RETRIEVAL_PREPARATION", "0")
         .spawn()
         .expect("spawn multi-project network-config stdio server");
     let stdin = child.stdin.take().expect("multi-project stdio stdin");
@@ -886,36 +874,6 @@ fn assert_tool_success(response: &Value, id: Value) -> &Value {
     result
         .get("structuredContent")
         .expect("tools/call success should include structuredContent")
-}
-
-#[cfg(debug_assertions)]
-fn wait_for_sidecar_worker_result(server: &mut StdioServer, attempt_id: &str) -> Value {
-    let deadline = Instant::now() + Duration::from_secs(15);
-    loop {
-        let response = send_json(
-            server,
-            json!({
-                "jsonrpc": "2.0",
-                "id": "sidecar-setup-terminal-status",
-                "method": "tools/call",
-                "params": {
-                    "name": "sidecar_setup",
-                    "arguments": {"action": "status"}
-                }
-            }),
-        );
-        let setup = assert_tool_success(&response, json!("sidecar-setup-terminal-status"));
-        if setup["last_worker_result"]["attempt_id"] == json!(attempt_id)
-            && setup["active_repair"].is_null()
-        {
-            return setup.clone();
-        }
-        assert!(
-            Instant::now() < deadline,
-            "repair worker did not reach a durable terminal state: {setup}"
-        );
-        thread::sleep(Duration::from_millis(25));
-    }
 }
 
 fn assert_structured_citations_have_no_evidence(value: &Value) {
@@ -1444,21 +1402,9 @@ fn assert_continuation_links(value: &Value, node_id: &str, context: &str) {
     }
 }
 
-fn has_safety_metadata(tool: &Value) -> bool {
-    let Some(metadata) = tool.get("annotations").or_else(|| tool.get("metadata")) else {
-        return false;
-    };
-    let text = metadata.to_string().to_ascii_lowercase();
-    text.contains("write")
-        || text.contains("system")
-        || text.contains("destructive")
-        || text.contains("danger")
-        || text.contains("mutation")
-        || text.contains("safety")
-}
-
-fn assert_read_only_tool_metadata(tool: &Value) {
+fn assert_tool_safety_metadata(tool: &Value) {
     let name = tool["name"].as_str().expect("tool name");
+    let observational = name == "status";
     let annotations = tool
         .get("annotations")
         .unwrap_or_else(|| panic!("{name} should include MCP-style annotations: {tool}"));
@@ -1468,9 +1414,33 @@ fn assert_read_only_tool_metadata(tool: &Value) {
         .unwrap_or_else(|| panic!("{name} should include safety metadata: {tool}"));
 
     assert!(
-        annotations.get("readOnlyHint").and_then(Value::as_bool) == Some(true)
-            || contains_bool_recursive(safety, &["readOnly", "read_only"], true),
-        "{name} should declare read-only behavior: {tool}"
+        annotations.get("readOnlyHint").and_then(Value::as_bool) == Some(observational)
+            && safety.get("readOnly").and_then(Value::as_bool) == Some(observational),
+        "{name} should distinguish observation from managed activation: {tool}"
+    );
+    assert_eq!(
+        safety.get("effect").and_then(Value::as_str),
+        Some(if observational {
+            "read_only"
+        } else {
+            "managed_activation"
+        }),
+        "{name} should label its effect truthfully: {tool}"
+    );
+    assert_eq!(
+        safety.get("activatesProject").and_then(Value::as_bool),
+        Some(!observational),
+        "{name} should declare whether it activates managed local state: {tool}"
+    );
+    assert_eq!(
+        safety.get("writesRepository").and_then(Value::as_bool),
+        Some(false),
+        "{name} must not edit repository source: {tool}"
+    );
+    assert_eq!(
+        safety.get("requiresConfirmation").and_then(Value::as_bool),
+        Some(false),
+        "{name} should not ask the user to confirm managed local preparation: {tool}"
     );
     assert!(
         annotations.get("destructiveHint").and_then(Value::as_bool) == Some(false)
@@ -1486,43 +1456,6 @@ fn assert_read_only_tool_metadata(tool: &Value) {
         contains_bool_recursive(tool, &["localOnly", "local_only"], true)
             || contains_bool_recursive(tool, &["openWorld", "open_world"], false),
         "{name} should declare local-only or open-world=false behavior: {tool}"
-    );
-}
-
-fn assert_local_plugin_mutation_tool_metadata(tool: &Value) {
-    let name = tool["name"].as_str().expect("tool name");
-    let annotations = tool
-        .get("annotations")
-        .unwrap_or_else(|| panic!("{name} should include MCP-style annotations: {tool}"));
-    let safety = tool
-        .get("safety")
-        .or_else(|| tool.get("metadata"))
-        .unwrap_or_else(|| panic!("{name} should include safety metadata: {tool}"));
-
-    assert_eq!(
-        annotations.get("readOnlyHint").and_then(Value::as_bool),
-        Some(false),
-        "{name} should declare local config writes: {tool}"
-    );
-    assert_eq!(
-        annotations.get("destructiveHint").and_then(Value::as_bool),
-        Some(false),
-        "{name} should declare non-destructive behavior: {tool}"
-    );
-    assert_eq!(
-        annotations.get("idempotentHint").and_then(Value::as_bool),
-        Some(true),
-        "{name} should declare idempotent behavior: {tool}"
-    );
-    assert!(
-        contains_bool_recursive(safety, &["localOnly", "local_only"], true)
-            && contains_bool_recursive(safety, &["openWorld", "open_world"], false),
-        "{name} should declare local-only closed-world behavior: {tool}"
-    );
-    assert_eq!(
-        safety.get("mutation").and_then(Value::as_str),
-        Some("local_plugin_configuration"),
-        "{name} should label the plugin-local mutation: {tool}"
     );
 }
 
@@ -1865,12 +1798,12 @@ fn multi_project_stdio_routes_interleaved_requests_by_explicit_project() {
         second_status["readiness_broker"]["identity"]["workspace_id"]
     );
     assert_ne!(
-        first_status["sidecar_retrieval"]["ownership"]["labels"]["dev.codestory.workspace_id"],
-        second_status["sidecar_retrieval"]["ownership"]["labels"]["dev.codestory.workspace_id"]
+        first_status["retrieval_diagnostics"]["ownership"]["labels"]["dev.codestory.workspace_id"],
+        second_status["retrieval_diagnostics"]["ownership"]["labels"]["dev.codestory.workspace_id"]
     );
     assert_eq!(
-        first_status["sidecar_retrieval"]["ownership"]["profile"],
-        second_status["sidecar_retrieval"]["ownership"]["profile"],
+        first_status["retrieval_diagnostics"]["ownership"]["profile"],
+        second_status["retrieval_diagnostics"]["ownership"]["profile"],
         "multi-project routing changed sidecar profile"
     );
     for pointer in [
@@ -1878,8 +1811,8 @@ fn multi_project_stdio_routes_interleaved_requests_by_explicit_project() {
         "/storage_path",
         "/readiness_broker/identity/project_id",
         "/readiness_broker/identity/workspace_id",
-        "/sidecar_retrieval/ownership/labels/dev.codestory.workspace_id",
-        "/sidecar_retrieval/ownership/profile",
+        "/retrieval_diagnostics/ownership/labels/dev.codestory.workspace_id",
+        "/retrieval_diagnostics/ownership/profile",
     ] {
         assert_eq!(
             first_status.pointer(pointer),
@@ -2042,7 +1975,7 @@ fn multi_project_stdio_startup_snapshot_keeps_embedding_endpoints_isolated_acros
 }
 
 #[test]
-fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
+fn tool_catalog_keeps_stable_product_tool_names() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);
 
@@ -2071,10 +2004,8 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
             "packet",
             "query_subgraph",
             "references",
-            "repair_all",
             "search",
             "shortest_path",
-            "sidecar_setup",
             "snippet",
             "status",
             "symbol",
@@ -2082,7 +2013,7 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
             "trace",
             "trail",
         ],
-        "stdio browser/setup tool names should stay stable: {tools}"
+        "stdio product tool names should stay stable: {tools}"
     );
     assert!(
         !tool_names.iter().any(|name| name.starts_with("codestory_")),
@@ -2093,7 +2024,7 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
         .expect("packet description");
     assert!(
         packet_description.contains("broad structural questions")
-            && packet_description.contains("graph/sidecar evidence")
+            && packet_description.contains("repository evidence")
             && packet_description.contains("truncation")
             && packet_description.contains("follow-up commands")
             && packet_description.contains("before source snippets"),
@@ -2112,9 +2043,9 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
         .expect("ground description");
     assert!(
         ground_description.contains("compact repository map")
-            && ground_description.contains("before packet/search")
-            && ground_description.contains("codestory://grounding"),
-        "ground description should connect the tool to orientation and the grounding resource: {ground_description}"
+            && ground_description.contains("orientation")
+            && ground_description.contains("managed retrieval preparation"),
+        "ground description should connect the tool to orientation and automatic preparation: {ground_description}"
     );
     let files_description = tool_by_name(&tools, "files")["description"]
         .as_str()
@@ -2122,8 +2053,8 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
     assert!(
         files_description.contains("indexed files")
             && files_description.contains("locally fresh index")
-            && files_description.contains("refreshes local graph")
-            && files_description.contains("never bootstraps sidecars"),
+            && files_description.contains("refreshes the repository map")
+            && files_description.contains("does not wait for broad search"),
         "files description should make the local-refresh boundary explicit: {files_description}"
     );
     let affected_description = tool_by_name(&tools, "affected")["description"]
@@ -2133,8 +2064,8 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
         affected_description.contains("changed paths")
             && affected_description.contains("locally fresh index")
             && affected_description.contains("never discovers git changes")
-            && affected_description.contains("refreshes local graph")
-            && affected_description.contains("never bootstraps sidecars"),
+            && affected_description.contains("refreshes the repository map")
+            && affected_description.contains("does not wait for broad search"),
         "affected description should make the explicit-path local-refresh boundary clear: {affected_description}"
     );
     let snippet_description = tool_by_name(&tools, "snippet")["description"]
@@ -2146,22 +2077,7 @@ fn tool_catalog_keeps_stable_browser_and_setup_tool_names() {
     );
 
     for tool in tools["tools"].as_array().expect("tools array") {
-        let name = tool["name"].as_str().expect("tool name");
-        if matches!(name, "repair_all" | "sidecar_setup") {
-            assert_local_plugin_mutation_tool_metadata(tool);
-        } else {
-            assert_read_only_tool_metadata(tool);
-        }
-        let looks_like_write_or_system_tool = [
-            "write", "edit", "delete", "remove", "create", "update", "patch", "open_", "launch",
-            "shell", "exec", "system", "fs.",
-        ]
-        .iter()
-        .any(|needle| name.contains(needle));
-        assert!(
-            !looks_like_write_or_system_tool || has_safety_metadata(tool),
-            "write/system-looking tool {name} must include explicit safety metadata before it can appear in the read-only catalog: {tool}"
-        );
+        assert_tool_safety_metadata(tool);
     }
 }
 
@@ -2262,18 +2178,6 @@ fn tool_catalog_input_schemas_capture_stable_arguments() {
         schema_property(packet, "include_evidence").get("default"),
         Some(&json!(true)),
         "packet.include_evidence should document the stdio default: {packet}"
-    );
-
-    let sidecar_setup = tool_input_schema(&tools, "sidecar_setup");
-    assert_schema_enum_values(
-        sidecar_setup,
-        "/properties/action/enum",
-        &["status", "enable", "disable", "ask", "repair"],
-    );
-    assert_eq!(
-        schema_property(sidecar_setup, "action").get("default"),
-        Some(&json!("status")),
-        "sidecar_setup.action should default to the cheap status probe: {sidecar_setup}"
     );
 
     let ground = tool_input_schema(&tools, "ground");
@@ -3279,12 +3183,12 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         "status should distinguish source checkout version from active runtime version: {status}"
     );
     assert!(
-        status["sidecar_contract_version"].is_number(),
-        "status should expose the sidecar contract version: {status}"
+        status["retrieval_contract_version"].is_number(),
+        "status should expose the retrieval contract version: {status}"
     );
     assert!(
-        status["sidecar_retrieval"]["sidecar_contract_version"].is_number(),
-        "sidecar status should expose the sidecar contract version: {status}"
+        status["retrieval_diagnostics"]["sidecar_contract_version"].is_number(),
+        "retrieval diagnostics should expose the internal contract version: {status}"
     );
     assert!(
         status["server_executable"]
@@ -3321,12 +3225,12 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         "runtime truth should reuse plugin runtime launch evidence: {status}"
     );
     assert_eq!(
-        status["runtime_truth"]["sidecar_policy"],
-        json!("unmanaged"),
-        "direct stdio status should make unmanaged sidecar policy explicit: {status}"
+        status["runtime_truth"]["managed_retrieval"],
+        json!("automatic"),
+        "runtime truth should make managed retrieval automatic: {status}"
     );
     assert_eq!(
-        status["runtime_truth"]["sidecar_status_ref"],
+        status["runtime_truth"]["retrieval_status_ref"],
         json!("readiness_lanes.agent_packet_search"),
         "runtime truth should reference the canonical agent readiness lane: {status}"
     );
@@ -3374,8 +3278,8 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
         "fresh local graph state should not block local graph surfaces: {status}"
     );
     assert!(
-        status["sidecar_retrieval"]["retrieval_mode"].is_string(),
-        "status should expose sidecar retrieval diagnostics: {status}"
+        status["retrieval_diagnostics"]["retrieval_mode"].is_string(),
+        "status should expose retrieval diagnostics: {status}"
     );
     assert_eq!(
         status["legacy_semantic_diagnostics"]["diagnostic_only"],
@@ -3509,28 +3413,10 @@ fn resources_read_status_reports_browser_readiness_and_next_calls() {
             && !next_call_text.contains("\"tool\":\"search\""),
         "status should recommend repair, not packet/search calls, when mode is not full: {status}"
     );
-    assert!(
-        !next_call_text.contains("codestory-cli index --project")
-            && !next_call_text.contains("retrieval bootstrap")
-            && !next_call_text.contains("retrieval index")
-            && !next_call_text.contains("\"tool\":\"repair_all\"")
-            && next_call_text.contains("\"tool\":\"status\"")
-            && next_call_text.contains("\"project\":")
-            && next_call_text.contains("not persisted for this host"),
-        "status should block MCP sidecar repair without repeating a fresh core index when mode is not full and policy is unmanaged: {status}"
-    );
-    assert!(
-        !next_call_text.contains("\"method\":\"cli\""),
-        "status should not expose CLI as the normal user-facing repair method: {status}"
-    );
-    assert!(
-        status
-            .get("recommended_next_calls")
-            .or_else(|| status.get("recommended_calls"))
-            .or_else(|| status.get("next_calls"))
-            .and_then(Value::as_array)
-            .is_some_and(|calls| !calls.is_empty()),
-        "status should include recommended next calls: {status}"
+    assert_eq!(
+        status["recommended_next_calls"],
+        json!([]),
+        "diagnostics should not send agents through a repair loop; direct tools own preparation: {status}"
     );
 }
 
@@ -3579,7 +3465,7 @@ fn resources_read_status_reports_active_agent_repair_phase() {
         "repairing status should include the active namespace: {status}"
     );
     assert_eq!(
-        status["runtime_truth"]["sidecar_status_ref"],
+        status["runtime_truth"]["retrieval_status_ref"],
         json!("readiness_lanes.agent_packet_search"),
         "{status}"
     );
@@ -3613,19 +3499,19 @@ fn resources_read_status_reports_abandoned_agent_repair_actions() {
     );
     let result = assert_success_envelope(&response, json!("status-abandoned-repair"));
     let status = json_resource_content(result, "codestory://status");
-    assert_eq!(status["sidecar_setup"]["active_repair"], Value::Null);
+    assert_eq!(status["managed_retrieval"]["active_repair"], Value::Null);
     assert_eq!(
-        status["sidecar_setup"]["abandoned_repair"]["status"],
+        status["managed_retrieval"]["abandoned_repair"]["status"],
         json!("abandoned"),
         "{status}"
     );
     assert_eq!(
-        status["sidecar_setup"]["abandoned_repair"]["run_id"],
+        status["managed_retrieval"]["abandoned_repair"]["run_id"],
         json!("aborted-run"),
         "{status}"
     );
     assert!(
-        status["sidecar_setup"]["abandoned_repair"]["inspect_command"]
+        status["managed_retrieval"]["abandoned_repair"]["inspect_command"]
             .as_str()
             .is_some_and(|command| command.contains("retrieval status")
                 && command.contains("--run-id")
@@ -3633,7 +3519,7 @@ fn resources_read_status_reports_abandoned_agent_repair_actions() {
         "abandoned repair should include a bounded inspect command: {status}"
     );
     assert!(
-        status["sidecar_setup"]["abandoned_repair"]["cleanup_command"]
+        status["managed_retrieval"]["abandoned_repair"]["cleanup_command"]
             .as_str()
             .is_some_and(|command| command.contains("retrieval down")
                 && command.contains("--run-id")
@@ -3647,217 +3533,11 @@ fn resources_read_status_reports_abandoned_agent_repair_actions() {
     // status-shape suite.
 }
 
-#[test]
-fn resources_read_status_prompts_before_sidecar_repair_when_policy_is_ask() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("ask".to_string());
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "status-sidecar-ask",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let result = assert_success_envelope(&response, json!("status-sidecar-ask"));
-    let status = json_resource_content(result, "codestory://status");
-
-    assert_eq!(status["sidecar_setup"]["state"], json!("ask"));
-    assert_eq!(status["sidecar_setup"]["prompt_required"], json!(true));
-    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
-    assert_eq!(
-        status["sidecar_setup"]["repair_mode"],
-        json!("consent_required")
-    );
-    assert_eq!(
-        status["allowed_surfaces"]["sidecar_setup"]["allowed_actions"],
-        json!(["status", "enable", "disable"]),
-        "{status}"
-    );
-    assert_eq!(
-        status["allowed_surfaces"]["sidecar_setup"]["canonical_arguments"]["action"],
-        json!("status"),
-        "{status}"
-    );
-    assert!(
-        status["sidecar_setup"]["prompt"]
-            .as_str()
-            .is_some_and(|prompt| prompt.contains("may start or download retrieval sidecars")),
-        "{status}"
-    );
-    let next_call_text = status["recommended_next_calls"].to_string();
-    assert!(next_call_text.contains("host/confirm"), "{status}");
-    assert!(
-        next_call_text.contains("\"tool\":\"sidecar_setup\""),
-        "{status}"
-    );
-    assert!(next_call_text.contains("\"action\":\"enable\""), "{status}");
-    assert!(
-        next_call_text.contains("\"action\":\"disable\""),
-        "{status}"
-    );
-    assert!(
-        next_call_text.contains("confirm_next")
-            && next_call_text.contains("\"tool\":\"sidecar_setup\"")
-            && next_call_text.contains("\"action\":\"repair\""),
-        "ask policy should include sidecar_setup repair only after consent: {status}"
-    );
-    assert!(
-        next_call_text.contains("decline_next"),
-        "ask policy should include a decline path: {status}"
-    );
-    assert!(
-        !next_call_text.contains("\"tool\":\"repair_all\""),
-        "ask policy should not recommend raw repair_all before consent: {status}"
-    );
-    assert!(
-        !next_call_text.contains("\"method\":\"cli\""),
-        "ask policy should not expose CLI as the normal consent path: {status}"
-    );
-}
-
-#[test]
-fn resources_read_status_blocks_unmanaged_session_repair_without_persisted_policy() {
-    let fixture = indexed_fixture();
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "status-sidecar-unmanaged",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let result = assert_success_envelope(&response, json!("status-sidecar-unmanaged"));
-    let status = json_resource_content(result, "codestory://status");
-
-    assert_eq!(status["sidecar_setup"]["state"], json!("unmanaged"));
-    assert_eq!(
-        status["sidecar_setup"]["repair_mode"],
-        json!("explicit_mcp_unmanaged")
-    );
-    assert_eq!(
-        status["allowed_surfaces"]["sidecar_setup"]["allowed_actions"],
-        json!(["status"]),
-        "{status}"
-    );
-    assert_eq!(
-        status["allowed_surfaces"]["sidecar_setup"]["canonical_arguments"]["action"],
-        json!("status"),
-        "{status}"
-    );
-    let next_call_text = status["recommended_next_calls"].to_string();
-    assert!(
-        next_call_text.contains("not persisted for this host"),
-        "{status}"
-    );
-    assert!(
-        !next_call_text.contains("\"tool\":\"repair_all\""),
-        "unmanaged policy should block MCP repair until policy is persisted: {status}"
-    );
-    assert_eq!(
-        status["allowed_surfaces"]["repair_all"]["status"],
-        json!("repair_unmanaged"),
-        "{status}"
-    );
-    assert!(
-        next_call_text.contains("\"tool\":\"status\"") && next_call_text.contains("\"project\":"),
-        "{status}"
-    );
-}
-
-#[test]
-fn resources_read_status_recommends_explicit_repair_when_policy_enabled() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "status-sidecar-enabled",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let result = assert_success_envelope(&response, json!("status-sidecar-enabled"));
-    let status = json_resource_content(result, "codestory://status");
-
-    assert_eq!(status["sidecar_setup"]["state"], json!("enabled"));
-    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(true));
-    assert_eq!(
-        status["sidecar_setup"]["status_triggered_repair"],
-        json!(false)
-    );
-    assert_eq!(
-        status["sidecar_setup"]["activation_triggered_repair"],
-        json!(true)
-    );
-    assert_eq!(
-        status["sidecar_setup"]["explicit_repair_enabled"],
-        json!(true)
-    );
-    assert_eq!(
-        status["sidecar_setup"]["repair_mode"],
-        json!("activation_or_explicit_mcp")
-    );
-    let sidecar_repair_command = status["sidecar_setup"]["next_repair_command"]
-        .as_str()
-        .expect("sidecar setup next repair command");
-    assert!(
-        sidecar_repair_command.contains("--run-id")
-            && sidecar_repair_command.contains("shared-agent"),
-        "sidecar setup should point at the shared agent run id: {status}"
-    );
-    let next_call_text = status["recommended_next_calls"].to_string();
-    assert_eq!(
-        status["status_resource_auto_repair"],
-        Value::Null,
-        "status reads must not spawn sidecar repair: {status}"
-    );
-    assert!(
-        next_call_text.contains("\"tool\":\"sidecar_setup\"")
-            && next_call_text.contains("\"action\":\"repair\"")
-            && !next_call_text.contains("\"tool\":\"repair_all\""),
-        "enabled policy should recommend explicit sidecar_setup repair: {status}"
-    );
-    assert_eq!(
-        status["readiness_broker"]["project_id"],
-        status["readiness_broker"]["identity"]["project_id"],
-        "status should expose the durable readiness broker identity: {status}"
-    );
-    assert!(
-        status["readiness_broker"]["identity"]["workspace_id"]
-            .as_str()
-            .is_some_and(|workspace_id| !workspace_id.is_empty()),
-        "status should expose workspace ownership separately: {status}"
-    );
-    assert_eq!(
-        status["readiness_broker"]["resources"]["native_embedding_runtime"]["scope"],
-        json!("machine"),
-        "{status}"
-    );
-    assert!(
-        next_call_text.contains("\"tool\":\"status\"") && next_call_text.contains("\"project\":"),
-        "enabled policy should include status readback after explicit repair: {status}"
-    );
-    assert!(
-        !next_call_text.contains("\"method\":\"cli\""),
-        "enabled policy should not expose CLI as the normal repair path: {status}"
-    );
-}
-
 #[cfg(debug_assertions)]
 #[test]
-fn ground_activation_enqueues_enabled_agent_repair() {
+fn ground_activation_enqueues_managed_retrieval_preparation() {
     let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
+    fixture.managed_retrieval_preparation = true;
     fixture.ready_repair_worker_probe_exit_code = Some(0);
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
@@ -3905,7 +3585,7 @@ fn ground_activation_enqueues_enabled_agent_repair() {
 #[test]
 fn repeated_grounding_cools_down_identical_failed_agent_repair_across_servers() {
     let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
+    fixture.managed_retrieval_preparation = true;
     fixture.ready_repair_worker_probe_exit_code = Some(17);
     let canonical_root =
         fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
@@ -3957,490 +3637,62 @@ fn repeated_grounding_cools_down_identical_failed_agent_repair_across_servers() 
     )
     .expect("cooled-down automatic repair result json");
     assert_eq!(second["attempt_id"], first_attempt, "{second}");
-}
 
-#[test]
-fn resources_read_status_reports_abandoned_repair_without_starting_when_policy_enabled() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
-    let status_path = write_abandoned_repair_status_fixture(
+    let unavailable = send_json(
+        &mut second_server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "search-after-terminal-preparation-failure",
+            "method": "tools/call",
+            "params": {
+                "name": "search",
+                "arguments": {"query": "AppController"}
+            }
+        }),
+    );
+    let error = assert_tool_error(
+        &unavailable,
+        json!("search-after-terminal-preparation-failure"),
+    );
+    assert_eq!(error["code"], json!("codestory_unavailable"), "{error}");
+    assert_eq!(error["state"], json!("unavailable"), "{error}");
+    assert!(error.get("retry_tool").is_none(), "{error}");
+    assert!(error.get("retry_after_ms").is_none(), "{error}");
+
+    write_active_repair_status_fixture(
         &fixture,
         codestory_retrieval::DEFAULT_AGENT_RUN_ID,
-        "graph artifact",
+        "retrying",
     );
-    assert!(status_path.exists(), "repair status fixture should exist");
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
+    let mut retrying_server = spawn_stdio_server(&fixture);
+    let retrying = send_json(
+        &mut retrying_server,
         json!({
             "jsonrpc": "2.0",
-            "id": "status-sidecar-enabled-abandoned",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let result = assert_success_envelope(&response, json!("status-sidecar-enabled-abandoned"));
-    let status = json_resource_content(result, "codestory://status");
-
-    assert_eq!(status["sidecar_setup"]["state"], json!("enabled"));
-    assert_eq!(
-        status["sidecar_setup"]["abandoned_repair"]["status"],
-        json!("abandoned"),
-        "{status}"
-    );
-    assert_eq!(
-        status["status_resource_auto_repair"],
-        Value::Null,
-        "status reads must not spawn repair while abandoned state is present: {status}"
-    );
-    assert!(
-        status["recommended_next_calls"]
-            .to_string()
-            .contains("\"tool\":\"sidecar_setup\""),
-        "enabled policy should leave repair as an explicit MCP action: {status}"
-    );
-    assert_eq!(
-        status["readiness_broker"]["reconciliation"]["status"],
-        json!("observed"),
-        "{status}"
-    );
-    if let Some(gpu_proof) = status["readiness_broker"]["gpu_proof"].as_object() {
-        assert!(
-            gpu_proof.contains_key("proof_status"),
-            "gpu_proof should expose proof_status when present: {status}"
-        );
-        // embed_smoke_* are optional and may be omitted when None; when present they
-        // must be typed smoke evidence fields on the gpu_proof object.
-        if let Some(ok) = gpu_proof.get("embed_smoke_ok") {
-            assert!(
-                ok.is_boolean() || ok.is_null(),
-                "embed_smoke_ok must be bool|null when present: {status}"
-            );
-        }
-        if let Some(ms) = gpu_proof.get("embed_smoke_ms") {
-            assert!(
-                ms.is_u64() || ms.is_null(),
-                "embed_smoke_ms must be u64|null when present: {status}"
-            );
-        }
-    }
-}
-
-#[test]
-fn resources_read_status_suppresses_auto_repair_when_policy_disabled() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("disabled".to_string());
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "status-sidecar-disabled",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let result = assert_success_envelope(&response, json!("status-sidecar-disabled"));
-    let status = json_resource_content(result, "codestory://status");
-
-    assert_eq!(status["sidecar_setup"]["state"], json!("disabled"));
-    assert_eq!(status["sidecar_setup"]["auto_repair"], json!(false));
-    assert_eq!(status["sidecar_setup"]["repair_mode"], json!("disabled"));
-    assert_eq!(
-        status["allowed_surfaces"]["sidecar_setup"]["allowed_actions"],
-        json!(["status", "enable"]),
-        "{status}"
-    );
-    assert_eq!(
-        status["allowed_surfaces"]["sidecar_setup"]["canonical_arguments"]["action"],
-        json!("status"),
-        "{status}"
-    );
-    let next_call_text = status["recommended_next_calls"].to_string();
-    assert!(
-        next_call_text.contains("CodeStory packet/search repair is disabled"),
-        "{status}"
-    );
-    assert!(
-        next_call_text.contains("\"tool\":\"sidecar_setup\""),
-        "{status}"
-    );
-    assert!(next_call_text.contains("\"action\":\"enable\""), "{status}");
-    assert!(
-        !next_call_text.contains("ready --goal agent --repair"),
-        "disabled policy should not recommend sidecar repair: {status}"
-    );
-    assert!(
-        !next_call_text.contains("\"method\":\"cli\""),
-        "disabled policy should not expose CLI as the normal recovery path: {status}"
-    );
-
-    let repair_all_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "repair-all-disabled",
+            "id": "search-during-retry-after-terminal-failure",
             "method": "tools/call",
-            "params": {"name": "repair_all", "arguments": {}}
+            "params": {
+                "name": "search",
+                "arguments": {"query": "AppController"}
+            }
         }),
     );
-    let repair_all = assert_tool_error(&repair_all_response, json!("repair-all-disabled"));
+    let retrying_error = assert_tool_error(
+        &retrying,
+        json!("search-during-retry-after-terminal-failure"),
+    );
     assert_eq!(
-        repair_all["status"],
-        json!("repair_disabled"),
-        "{repair_all}"
+        retrying_error["code"],
+        json!("codestory_preparing"),
+        "{retrying_error}"
     );
-    assert_eq!(repair_all["minimum_next"], json!([]), "{repair_all}");
-    assert_eq!(repair_all["full_repair"], json!([]), "{repair_all}");
-    assert!(
-        !repair_all
-            .to_string()
-            .contains("ready --goal agent --repair"),
-        "disabled repair_all must not recover commands from the canonical verdict: {repair_all}"
-    );
-}
-
-#[test]
-fn sidecar_setup_status_marks_old_last_repair_as_stale() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
-    fixture.sidecar_last_repair_command = Some(
-        r#""C:\\Users\\alber\\.codex\\plugins\\data\\codestory-TheGreenCedar\\codestory-cli\\0.12.3\\bin\\codestory-cli.exe" ready --goal agent --repair"#
-            .to_string(),
-    );
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "status-stale-last-repair",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let result = assert_success_envelope(&response, json!("status-stale-last-repair"));
-    let status = json_resource_content(result, "codestory://status");
-    assert_eq!(
-        status["sidecar_setup"]["last_repair"]["current"],
-        json!(false)
-    );
-    assert!(
-        status["sidecar_setup"]["last_repair"]["stale_reason"]
-            .as_str()
-            .is_some_and(|reason| reason.contains("last_repair_cli_version_mismatch")),
-        "old last_repair command should be marked stale: {status}"
-    );
+    assert_eq!(retrying_error["state"], json!("preparing"));
 }
 
 #[cfg(debug_assertions)]
-#[test]
-fn tools_call_sidecar_setup_updates_plugin_policy_without_cli_user_steps() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("ask".to_string());
-    fixture.ready_repair_worker_probe_exit_code = Some(17);
-    let policy_path = fixture.cache_dir.path().join("plugin-sidecar-policy.json");
-    let canonical_root =
-        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let repair_sidecar = test_sidecar_runtime(
-        &fixture,
-        &canonical_root,
-        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
-    );
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-enable",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "enable"}
-            }
-        }),
-    );
-    let setup = assert_tool_success(&response, json!("sidecar-setup-enable"));
-    assert_eq!(
-        setup["state"],
-        json!("enabled"),
-        "sidecar_setup enable should report the updated policy state immediately: {setup}"
-    );
-    assert_eq!(
-        setup["mcp_control"]["repair"],
-        json!({"method": "tools/call", "tool": "sidecar_setup", "arguments": {"project": setup["project"], "action": "repair"}}),
-        "sidecar_setup should expose the MCP repair call, not a user CLI step: {setup}"
-    );
-
-    let policy: Value = serde_json::from_str(
-        &fs::read_to_string(&policy_path)
-            .unwrap_or_else(|error| panic!("read sidecar policy {policy_path:?}: {error}")),
-    )
-    .unwrap_or_else(|error| panic!("sidecar policy should be json: {error}"));
-    assert_eq!(policy["state"], json!("enabled"), "{policy}");
-    assert!(
-        policy["updated_at"]
-            .as_str()
-            .is_some_and(|value| value.starts_with("unix:")),
-        "sidecar policy should record an update timestamp: {policy}"
-    );
-
-    let repair_all_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "repair-all-compat",
-            "method": "tools/call",
-            "params": {
-                "name": "repair_all",
-                "arguments": {}
-            }
-        }),
-    );
-    let repair_all = assert_tool_error(&repair_all_response, json!("repair-all-compat"));
-    assert_eq!(repair_all["code"], json!("codestory_tool_blocked"));
-    assert_eq!(repair_all["tool"], json!("repair_all"));
-    assert_eq!(
-        repair_all["canonical_arguments"],
-        json!({"project": setup["project"], "action": "repair"})
-    );
-    assert_eq!(
-        repair_all["canonical_tool"],
-        json!("sidecar_setup"),
-        "repair_all should be blocked and point at canonical sidecar_setup repair: {repair_all}"
-    );
-
-    let repair_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-repair",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "repair"}
-            }
-        }),
-    );
-    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair"));
-    assert_eq!(
-        repair["status"],
-        json!("started"),
-        "a unique fixture must start exactly one repair worker: {repair}"
-    );
-    let attempt_id = repair["attempt_id"]
-        .as_str()
-        .expect("started repair attempt id")
-        .to_string();
-    assert_eq!(
-        repair["mode"],
-        json!("background"),
-        "sidecar_setup repair should not wait for full repair inside the MCP request: {repair}"
-    );
-    assert_eq!(repair["reservation_published"], json!(true), "{repair}");
-    assert!(
-        repair["debug_status_command"]
-            .as_str()
-            .is_some_and(|command| command.contains("retrieval status")
-                && command.contains("--profile agent")
-                && command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)),
-        "sidecar_setup repair should keep CLI status as debug evidence: {repair}"
-    );
-    assert!(
-        repair["recommended_next_calls"]
-            .as_array()
-            .is_some_and(|calls| calls.iter().any(|call| {
-                call.get("method").and_then(Value::as_str) == Some("tools/call")
-                    && call.get("tool").and_then(Value::as_str) == Some("status")
-                    && call.pointer("/arguments/project") == Some(&setup["project"])
-            })),
-        "sidecar_setup repair should point agents back to project-scoped status: {repair}"
-    );
-    assert!(
-        repair["broker_reconciliation"]["status"]
-            .as_str()
-            .is_some_and(|status| matches!(status, "clean" | "abandoned_cleaned")),
-        "sidecar_setup repair should reconcile broker state before spawning: {repair}"
-    );
-
-    let terminal_setup = wait_for_sidecar_worker_result(&mut server, &attempt_id);
-    let terminal = &terminal_setup["last_worker_result"];
-    assert_eq!(terminal["outcome"], json!("failed"), "{terminal_setup}");
-    assert_eq!(terminal["exit_code"], json!(17), "{terminal_setup}");
-    assert!(terminal["wait_error"].is_null(), "{terminal_setup}");
-    assert_eq!(
-        terminal["terminal_envelope"]["error"]["code"],
-        json!("background_repair_failed"),
-        "{terminal_setup}"
-    );
-    assert_eq!(
-        terminal["terminal_envelope"]["error"]["details"]["failed_layer"],
-        json!("background_repair"),
-        "{terminal_setup}"
-    );
-    assert_eq!(terminal["stdout_truncated"], json!(true));
-    assert_eq!(terminal["stderr_truncated"], json!(true));
-    assert_eq!(
-        terminal_setup["state"],
-        json!("enabled"),
-        "{terminal_setup}"
-    );
-    assert!(
-        terminal["stdout_tail"]
-            .as_str()
-            .is_some_and(|tail| tail.contains("worker probe stdout") && tail.contains(&attempt_id)),
-        "{terminal_setup}"
-    );
-    assert!(
-        terminal["stderr_tail"]
-            .as_str()
-            .is_some_and(|tail| tail.contains("worker probe stderr") && tail.contains(&attempt_id)),
-        "{terminal_setup}"
-    );
-
-    let result_path = repair_sidecar
-        .layout
-        .state_file
-        .with_file_name("ready-repair-result.json");
-    let durable: Value = serde_json::from_str(
-        &fs::read_to_string(&result_path).expect("durable repair worker result"),
-    )
-    .expect("repair worker result json");
-    assert_eq!(durable["attempt_id"], json!(attempt_id));
-    assert_eq!(durable["exit_code"], json!(17));
-    assert_eq!(durable["outcome"], json!("failed"));
-    assert_eq!(
-        durable["terminal_envelope"]["error"]["code"],
-        json!("background_repair_failed")
-    );
-    assert!(
-        !repair_sidecar
-            .layout
-            .state_file
-            .with_file_name("ready-repair-enqueue.lock")
-            .exists(),
-        "terminal monitor should compare-and-clear the adopted reservation"
-    );
-    assert!(
-        !repair_sidecar
-            .layout
-            .state_file
-            .with_file_name("ready-repair-status.json")
-            .exists(),
-        "terminal monitor should leave no active repair marker"
-    );
-}
-
-#[cfg(debug_assertions)]
-#[test]
-fn tools_call_sidecar_setup_records_successful_worker_terminal_state() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
-    fixture.ready_repair_worker_probe_exit_code = Some(0);
-    let canonical_root =
-        fs::canonicalize(fixture.workspace.path()).expect("canonical fixture root");
-    let repair_sidecar = test_sidecar_runtime(
-        &fixture,
-        &canonical_root,
-        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
-    );
-    let mutable_cache_sidecar = test_sidecar_runtime_in_cache(
-        &canonical_root,
-        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
-        &fixture.cache_dir.path().join("test-state").join("cache"),
-    );
-    assert_ne!(
-        repair_sidecar.layout.state_file, mutable_cache_sidecar.layout.state_file,
-        "the regression contract requires distinct retained and mutable cache roots"
-    );
-    let mut server = spawn_stdio_server(&fixture);
-
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-success-repair",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "repair"}
-            }
-        }),
-    );
-    let repair = assert_tool_success(&response, json!("sidecar-setup-success-repair"));
-    assert_eq!(repair["status"], json!("started"), "{repair}");
-    let attempt_id = repair["attempt_id"]
-        .as_str()
-        .expect("repair attempt id")
-        .to_string();
-
-    let setup = wait_for_sidecar_worker_result(&mut server, &attempt_id);
-    let terminal = &setup["last_worker_result"];
-
-    assert_eq!(terminal["outcome"], json!("succeeded"), "{setup}");
-    assert_eq!(terminal["exit_code"], json!(0), "{setup}");
-    assert!(terminal["wait_error"].is_null(), "{setup}");
-    assert_eq!(terminal["stdout_truncated"], json!(true));
-    assert_eq!(terminal["stderr_truncated"], json!(true));
-    assert!(
-        terminal["stdout_tail"]
-            .as_str()
-            .is_some_and(|tail| tail.contains(&attempt_id)),
-        "{setup}"
-    );
-    assert!(
-        terminal["stderr_tail"]
-            .as_str()
-            .is_some_and(|tail| tail.contains(&attempt_id)),
-        "{setup}"
-    );
-    let retained_result_path = repair_sidecar
-        .layout
-        .state_file
-        .with_file_name("ready-repair-result.json");
-    let retained_result: Value = serde_json::from_str(
-        &fs::read_to_string(&retained_result_path).expect("retained repair worker result"),
-    )
-    .expect("retained repair worker result json");
-    assert_eq!(retained_result["attempt_id"], json!(attempt_id));
-    assert_eq!(retained_result["outcome"], json!("succeeded"));
-    assert!(
-        !repair_sidecar
-            .layout
-            .state_file
-            .with_file_name("ready-repair-enqueue.lock")
-            .exists()
-    );
-    assert!(
-        !repair_sidecar
-            .layout
-            .state_file
-            .with_file_name("ready-repair-status.json")
-            .exists()
-    );
-    for file_name in [
-        "ready-repair-result.json",
-        "ready-repair-status.json",
-        "ready-repair-enqueue.lock",
-    ] {
-        assert!(
-            !mutable_cache_sidecar
-                .layout
-                .state_file
-                .with_file_name(file_name)
-                .exists(),
-            "stdio repair state must not leak into the mutable cache root: {file_name}"
-        );
-    }
-}
-
 #[test]
 fn resources_read_status_surfaces_stale_live_repair_without_mutation() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
+    let fixture = indexed_fixture();
     let status_path = write_stale_live_repair_status_fixture(
         &fixture,
         codestory_retrieval::DEFAULT_AGENT_RUN_ID,
@@ -4467,28 +3719,28 @@ fn resources_read_status_surfaces_stale_live_repair_without_mutation() {
     );
 
     assert_eq!(
-        status["sidecar_setup"]["stale_live_repair"]["status"],
+        status["managed_retrieval"]["stale_live_repair"]["status"],
         json!("stale_live"),
         "{status}"
     );
     assert_eq!(
-        status["sidecar_setup"]["stale_live_repair"]["pid"],
+        status["managed_retrieval"]["stale_live_repair"]["pid"],
         json!(std::process::id()),
         "{status}"
     );
     assert_eq!(
-        status["sidecar_setup"]["stale_live_repair"]["phase"],
+        status["managed_retrieval"]["stale_live_repair"]["phase"],
         json!("Embedding documents"),
         "{status}"
     );
     assert!(
-        status["sidecar_setup"]["stale_live_repair"]
+        status["managed_retrieval"]["stale_live_repair"]
             .get("cleanup_command")
             .is_none(),
         "live ownership must not expose destructive cleanup guidance: {status}"
     );
     assert!(
-        status["sidecar_setup"]["stale_live_repair"]["inspect_command"].is_string(),
+        status["managed_retrieval"]["stale_live_repair"]["inspect_command"].is_string(),
         "stale-live evidence should retain read-only inspection guidance: {status}"
     );
     assert_eq!(
@@ -4503,258 +3755,6 @@ fn resources_read_status_surfaces_stale_live_repair_without_mutation() {
     assert!(
         !result_path.exists(),
         "status read must not record a worker result"
-    );
-}
-
-#[test]
-fn tools_call_sidecar_setup_reports_active_shared_agent_repair_without_waiting() {
-    let fixture = indexed_fixture();
-    let status_path = write_active_repair_status_fixture(
-        &fixture,
-        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
-        "Qdrant finalize",
-    );
-    assert!(status_path.exists(), "repair status fixture should exist");
-    thread::sleep(Duration::from_millis(25));
-    fs::write(
-        fixture.workspace.path().join("src").join("runtime.rs"),
-        r#"pub fn normalize_project(project_name: &str) -> String {
-    format!("active-repair:{project_name}")
-}
-"#,
-    )
-    .expect("make local graph stale while active repair is running");
-    let mut server = spawn_stdio_server(&fixture);
-
-    let status_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-status-active",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "status"}
-            }
-        }),
-    );
-    let setup = assert_tool_success(&status_response, json!("sidecar-setup-status-active"));
-    assert_eq!(
-        setup["active_repair"]["status"],
-        json!("repairing"),
-        "sidecar_setup status should surface the active shared-agent repair: {setup}"
-    );
-    assert_eq!(
-        setup["active_repair"]["run_id"],
-        json!(codestory_retrieval::DEFAULT_AGENT_RUN_ID),
-        "{setup}"
-    );
-    let status_resource = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-status-active-resource",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let status_result = assert_success_envelope(
-        &status_resource,
-        json!("sidecar-setup-status-active-resource"),
-    );
-    let status = json_resource_content(status_result, "codestory://status");
-    assert_eq!(
-        status["local_refresh"]["state"],
-        json!("refreshing"),
-        "active repair should compact stale local refresh chatter into a refreshing lane: {status}"
-    );
-    assert_eq!(
-        status["local_refresh"]["reason"],
-        json!("active_ready_repair:Qdrant finalize"),
-        "{status}"
-    );
-    assert_eq!(
-        status["effective_index_freshness"]["status"],
-        json!("stale"),
-        "maintainer JSON should still expose stale freshness detail while agent status stays compact: {status}"
-    );
-
-    let repair_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-repair-active",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "repair"}
-            }
-        }),
-    );
-    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair-active"));
-    assert_eq!(
-        repair["status"],
-        json!("already_running"),
-        "sidecar_setup repair should not spawn or wait when shared-agent repair is active: {repair}"
-    );
-    assert_eq!(
-        repair["phase"],
-        json!("Qdrant finalize"),
-        "already-running response should preserve current repair phase: {repair}"
-    );
-    assert!(
-        repair["next_status_command"]
-            .as_str()
-            .is_some_and(|command| command.contains("retrieval status")
-                && command.contains("--profile agent")
-                && command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)),
-        "already-running response should point to cheap status inspection: {repair}"
-    );
-}
-
-#[test]
-fn tools_call_sidecar_setup_preserves_stale_live_repair_ownership() {
-    let mut fixture = indexed_fixture();
-    fixture.sidecar_policy_state = Some("enabled".to_string());
-    let status_path = write_stale_live_repair_status_fixture(
-        &fixture,
-        codestory_retrieval::DEFAULT_AGENT_RUN_ID,
-        "Embedding documents",
-    );
-    let status_before = fs::read_to_string(&status_path).expect("read stale live status fixture");
-    let mut server = spawn_stdio_server(&fixture);
-
-    let repair_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-repair-stale-live",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "repair"}
-            }
-        }),
-    );
-    let repair = assert_tool_success(&repair_response, json!("sidecar-setup-repair-stale-live"));
-    assert_eq!(repair["status"], json!("already_running"), "{repair}");
-    assert!(
-        repair["reason"]
-            .as_str()
-            .is_some_and(|reason| reason.starts_with("live_ready_repair_heartbeat_stale")),
-        "stale heartbeat should be reported without reclaiming the live owner: {repair}"
-    );
-    assert_eq!(repair["pid"], Value::Null, "{repair}");
-    assert_eq!(
-        fs::read_to_string(&status_path).expect("stale live status should remain"),
-        status_before,
-        "repair enqueue must not rewrite or delete stale status owned by a live PID"
-    );
-}
-
-#[test]
-fn tools_call_sidecar_setup_reports_active_agent_repair_non_default_without_spawning_default() {
-    let fixture = indexed_fixture();
-    let run_id = "non-default-active";
-    let status_path = write_active_repair_status_fixture(&fixture, run_id, "Embedding documents");
-    assert!(status_path.exists(), "repair status fixture should exist");
-    thread::sleep(Duration::from_millis(25));
-    fs::write(
-        fixture.workspace.path().join("src").join("runtime.rs"),
-        r#"pub fn normalize_project(project_name: &str) -> String {
-    format!("non-default-active-repair:{project_name}")
-}
-"#,
-    )
-    .expect("make local graph stale while non-default active repair is running");
-    let mut server = spawn_stdio_server(&fixture);
-
-    let status_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-status-non-default-active",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "status"}
-            }
-        }),
-    );
-    let setup = assert_tool_success(
-        &status_response,
-        json!("sidecar-setup-status-non-default-active"),
-    );
-    assert_eq!(
-        setup["active_repair"]["run_id"],
-        json!(run_id),
-        "sidecar_setup status should surface non-default active repair lanes: {setup}"
-    );
-    assert!(
-        setup["next_repair_command"]
-            .as_str()
-            .is_some_and(|command| command.contains("ready --goal agent --repair")
-                && command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)
-                && !command.contains(run_id)),
-        "normal repair command should remain shared-agent when no user action is taken: {setup}"
-    );
-
-    let status_resource = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-status-non-default-resource",
-            "method": "resources/read",
-            "params": {"uri": "codestory://status"}
-        }),
-    );
-    let status_result = assert_success_envelope(
-        &status_resource,
-        json!("sidecar-setup-status-non-default-resource"),
-    );
-    let status = json_resource_content(status_result, "codestory://status");
-    assert_eq!(
-        status["local_refresh"]["reason"],
-        json!("active_ready_repair:Embedding documents"),
-        "status should not start local refresh while any project agent repair is active: {status}"
-    );
-    assert_eq!(
-        status["sidecar_setup"]["active_repair"]["run_id"],
-        json!(run_id),
-        "runtime truth should expose the non-default active repair: {status}"
-    );
-
-    let repair_response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "sidecar-setup-repair-non-default-active",
-            "method": "tools/call",
-            "params": {
-                "name": "sidecar_setup",
-                "arguments": {"action": "repair"}
-            }
-        }),
-    );
-    let repair = assert_tool_success(
-        &repair_response,
-        json!("sidecar-setup-repair-non-default-active"),
-    );
-    assert_eq!(
-        repair["status"],
-        json!("already_running"),
-        "sidecar_setup repair should not spawn shared-agent while another run_id is active: {repair}"
-    );
-    assert_eq!(repair["run_id"], json!(run_id), "{repair}");
-    assert!(
-        repair["next_status_command"]
-            .as_str()
-            .is_some_and(|command| command.contains("retrieval status")
-                && command.contains("--profile agent")
-                && command.contains("--run-id")
-                && command.contains(run_id)
-                && !command.contains(codestory_retrieval::DEFAULT_AGENT_RUN_ID)),
-        "already-running response should inspect the active non-default run: {repair}"
     );
 }
 
@@ -5965,8 +4965,8 @@ fn tools_call_local_graph_refreshes_long_lived_index_after_source_mutation() {
         assert_tool_error(&search_response, json!("tool-refresh-search-still-blocked"));
     assert_eq!(
         search_error.pointer("/code").and_then(Value::as_str),
-        Some("codestory_tool_blocked"),
-        "packet/search readiness should remain separately gated after local graph refresh: {search_response}"
+        Some("codestory_preparing"),
+        "broad search should prepare automatically after local graph refresh: {search_response}"
     );
 }
 
@@ -5995,7 +4995,7 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
             .and_then(Value::as_array)
             .is_some_and(|calls| {
                 calls.iter().any(|call| {
-                    call["tool"] == json!("status") && call.pointer("/arguments/project").is_some()
+                    call["tool"] == json!("ground") && call.pointer("/arguments/project").is_some()
                 })
             })
             && guide
@@ -6086,10 +5086,10 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
         "packet/search should not be unconditional normal next steps: {guide}"
     );
     assert!(
-        guide_text.contains("allowed_surfaces.packet.allowed")
-            && guide_text.contains("allowed_surfaces.search.allowed")
-            && guide_text.contains("allowed_surfaces.context.allowed"),
-        "agent guide should make packet/search/context conditional on status allowed_surfaces: {guide}"
+        guide_text.contains("preparing")
+            && guide_text.contains("retry")
+            && guide_text.contains("same tool"),
+        "agent guide should tell agents to retry the intended tool while CodeStory prepares: {guide}"
     );
     assert!(
         guide_text.contains("repo-text hits as navigation clues"),
@@ -6097,8 +5097,8 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
     );
     assert!(
         guide_text.contains("search hits as discovery clues")
-            && guide_text.contains("proof-bearing sidecar, graph, or source evidence"),
-        "agent guide should distinguish discovery clues from proof-bearing evidence: {guide}"
+            && guide_text.contains("graph or source evidence"),
+        "agent guide should distinguish discovery clues from evidence: {guide}"
     );
     assert!(
         guide_text.contains("unsafe to claim") && guide_text.contains("follow_up_commands"),
@@ -6106,7 +5106,8 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
     );
     assert!(
         guide_text.contains("direct_source_reads")
-            && guide_text.contains("missing, stale, or degraded index/sidecar state"),
+            && guide_text.contains("unavailable")
+            && guide_text.contains("exact source inspection"),
         "agent guide should name the direct source-read fallback: {guide}"
     );
     assert!(
@@ -6321,7 +5322,7 @@ fn transcript_calls_search_tool() {
 }
 
 #[test]
-fn search_tool_fails_closed_without_full_retrieval_sidecars() {
+fn search_tool_starts_managed_preparation_and_returns_same_tool_retry() {
     let fixture = indexed_fixture();
     let mut server = spawn_stdio_server(&fixture);
 
@@ -6341,71 +5342,34 @@ fn search_tool_fails_closed_without_full_retrieval_sidecars() {
     let error = assert_tool_error(&response, json!("search-requires-full-retrieval"));
     assert_eq!(
         error.pointer("/code").and_then(Value::as_str),
-        Some("codestory_tool_blocked"),
-        "stdio search should be blocked by readiness before dispatch: {response}"
+        Some("codestory_preparing"),
+        "stdio search should start managed preparation and return a retry: {response}"
     );
-    assert_eq!(
-        error.pointer("/readiness_goal").and_then(Value::as_str),
-        Some("agent_packet_search")
-    );
-    assert_eq!(
-        error.pointer("/status").and_then(Value::as_str),
-        Some("blocked")
-    );
-    assert_eq!(
-        error.pointer("/failed_layer").and_then(Value::as_str),
-        Some("retrieval_sidecar")
-    );
-    assert_eq!(
-        error.pointer("/repair_reason").and_then(Value::as_str),
-        Some("retrieval_manifest_missing")
-    );
-    assert_eq!(
-        error
-            .pointer("/sidecar/degraded_reason")
-            .and_then(Value::as_str),
-        Some("retrieval_manifest_missing")
-    );
-    let minimum_next = error["minimum_next"]
-        .as_array()
-        .unwrap_or_else(|| panic!("stdio search error should include minimum_next: {response}"));
-    assert_eq!(
-        minimum_next.len(),
-        1,
-        "stdio search readiness error should expose exactly one canonical minimum repair: {response}"
-    );
+    assert_eq!(error["state"], json!("preparing"));
+    assert_eq!(error["tool"], json!("search"));
+    assert_eq!(error["retry_tool"], json!("search"));
     assert!(
-        minimum_next.iter().any(|call| call
-            .get("tool")
-            .and_then(Value::as_str)
-            .is_some_and(|tool| tool == "sidecar_setup")
-            && call.pointer("/arguments/action").and_then(Value::as_str) == Some("repair")
-            && call
-                .get("debug_commands")
-                .and_then(Value::as_array)
-                .is_some_and(|commands| !commands.is_empty())),
-        "stdio search readiness error should point at MCP-managed agent repair: {response}"
+        error["retry_after_ms"]
+            .as_u64()
+            .is_some_and(|delay| delay > 0)
     );
-    let full_repair = error["full_repair"]
-        .as_array()
-        .unwrap_or_else(|| panic!("stdio search error should include full_repair: {response}"));
-    assert!(
-        full_repair
-            .iter()
-            .all(|call| !call.to_string().contains("\"method\":\"cli\"")
-                && call
-                    .get("debug_command")
-                    .and_then(Value::as_str)
-                    .is_none_or(|text| !text.contains("codestory-cli index"))),
-        "stdio search sidecar errors should not repeat core index repair commands: {response}"
-    );
-    assert!(
-        full_repair.iter().any(
-            |call| call.to_string().contains("codestory-cli retrieval status")
-                && call.to_string().contains("--format json")
-        ),
-        "stdio search error should include sidecar status proof debug command: {response}"
-    );
+    assert_eq!(error["diagnostics_uri"], json!("codestory://status"));
+    let serialized = error.to_string();
+    for hidden_detail in [
+        "sidecar",
+        "minimum_next",
+        "full_repair",
+        "repair_reason",
+        "failed_layer",
+        "pid",
+        "port",
+        "model",
+    ] {
+        assert!(
+            !serialized.contains(hidden_detail),
+            "preparing response should hide infrastructure detail `{hidden_detail}`: {response}"
+        );
+    }
 }
 
 #[test]

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -10,7 +10,7 @@ the agent back to live MCP; they do not inject substitute grounding context.
 | --- | --- |
 | Install the plugin once from `/plugins` | MCP starts via `scripts/codestory-mcp.cjs` |
 | Open your repo and start a fresh thread | Passes that repo's absolute path on every live CodeStory MCP tool call |
-| Ask repo questions with concrete terms | Calls project-scoped `status`, uses allowed surfaces, cites sources |
+| Ask repo questions with concrete terms | Calls the matching project-scoped tool, lets CodeStory prepare what it needs, and cites sources |
 
 Codex is the reference host for the managed MCP plugin path. See
 [capability matrix](README.md#capability-matrix).
@@ -22,16 +22,14 @@ Surfaces and readiness: [Glossary](../glossary.md).
 CodeStory supports macOS 15 and later on Apple Silicon and Intel Macs. Install
 the Xcode Command Line Tools and Node.js before using the managed plugin or
 source-worktree setup. Docker Desktop or another compatible Docker engine is
-required for managed Qdrant; make sure it is running before repairing
-packet/search retrieval.
+currently required for broad search.
 
-- Apple Silicon uses the checksum-pinned native `llama-server` and managed
-  Metal path. A healthy agent lane reports `launch_mode=native_spawned`, live
-  native-process identity, and verified GPU proof.
-- Intel Macs support the native CLI, plugin provisioning, local index, and
-  grounding. Packet/search requires either explicit CPU allowance or a trusted
-  external embedding endpoint under an explicit operator policy. Intel never
-  reports or implies managed Metal support.
+Apple Silicon uses managed Metal acceleration automatically. Intel Macs keep
+local navigation available and report one plain environment requirement when
+broad search needs an explicit CPU or trusted external configuration. Backend,
+process, and model details live in the
+[maintainer operations guide](../ops/retrieval-sidecars.md), not the normal user
+flow.
 
 The plugin downloads the matching signed and notarized CLI. Contributors who
 build the CLI locally also need the Rust toolchain; normal plugin users do not.
@@ -90,21 +88,19 @@ Run these three checks before your first real task:
 1. **Adapter present** — Open `/plugins` and confirm **TheGreenCedar -> codestory**
    is listed as installed.
 2. **MCP live** — Start a **new** Codex thread in the grounded repo. CodeStory
-   MCP should be registered by the plugin and start when Codex reads its status
-   or tools.
-3. **First status read succeeds** — Use a normal repository question or the
-   readiness probe in [First session](#first-session). The agent should answer
-   in plain English whether your repo map is ready and whether broad search is
-   available.
+   MCP should be registered by the plugin and start with the first repository
+   tool call.
+3. **First repository question succeeds** — Ask a normal repository question.
+   CodeStory prepares the local map and broad search automatically.
 
 ## First session
 
 1. Start a **new** Codex thread in the grounded repository (not an old thread
    from before install).
-2. Ask a normal repository question. For an explicit readiness probe, ask:
+2. Ask a normal repository question. For example:
 
 ```text
-Call CodeStory status with this repository's absolute path, ground the same project if allowed, and tell me which surfaces are ready before I edit.
+Use CodeStory to map this repository and show me the files and symbols that own [feature].
 ```
 
 **Expected wait:** On a large repository, the first index build can take several
@@ -113,14 +109,17 @@ minutes. Let the agent finish grounding before you ask it to edit files.
 **Success looks like:** The agent confirms your repo map is ready, says whether
 broad search is available, and does not report a missing CLI or broken plugin.
 
-The agent reports `allowed_surfaces`, [local navigation](../glossary.md#local-navigation-readiness) vs [packet/search](../glossary.md#agent-packetsearch-readiness) readiness, and any repair steps. You do not tag the plugin, install a CLI, or run the CLI yourself for normal setup.
+The agent uses [local navigation](../glossary.md#local-navigation-readiness) while
+[packet/search](../glossary.md#agent-packetsearch-readiness) prepares. You do
+not approve an internal service, tag the plugin, install a CLI, or run repair
+commands for normal setup.
 
 ## Example prompts
 
-**Readiness before editing**
+**Orient before editing**
 
 ```text
-Call CodeStory status for this repository and check allowed_surfaces before I change [path/to/file].
+Use CodeStory to orient around [path/to/file] before I change it.
 ```
 
 **Find ownership**
@@ -162,64 +161,34 @@ More pairs, anti-patterns, and language-flavored examples:
 
 | Symptom | What to try |
 | --- | --- |
-| No CodeStory `status` tool is visible | Reload only after plugin install or config changes, then start a fresh thread from the target repo |
+| No CodeStory tools are visible | Reload only after plugin install or config changes, then start a fresh thread from the target repo |
 | CodeStory resources are visible but `mcp__codestory` tools are hidden | Report the host blocker. Unscoped resources cannot safely select a repository in multi-project mode |
 | Status names the wrong repository | Retry the call with the target repository's absolute `project` path. Hook active-state files do not route MCP requests; a schema-3 project/workspace identity mismatch is rejected instead of reusing another repository's readiness. |
 | Status shows `runtime_update.state=available` | Current compatible surfaces keep working; reload when convenient if `restart_recommended=true` |
 | Status shows `repair_setup` | The active runtime could not start or prove compatibility; follow `recommended_next_calls` |
 | Windows terminal refresh says `Access is denied` | Quit stale Codex windows running the old plugin, then refresh from `/plugins` or rerun `codex.cmd plugin add codestory@TheGreenCedar` |
-| Packet/search blocked | Follow `recommended_next_calls`. Status reads are observational. A grounding/project tool activation starts or attaches local refresh and automatically enqueues agent repair only when the installed sidecar policy is already enabled; otherwise explicit MCP confirmation/repair remains required. See [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
-| Status/grounding call times out | If status remains visible, reread it and follow its bounded blocker/next call; do not kill or restart managed MCP for index or sidecar readiness. Reload only for host transport/registration failure, plugin/config replacement, or a runtime update whose status says `restart_recommended=true` |
+| Broad search is preparing | Retry the same `packet`, `search`, or `context` call after its reported delay. CodeStory prepares the managed runtime automatically. See [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
+| A CodeStory call times out | Retry the same tool once. Read status only if it still does not converge; do not kill managed processes. Reload only for host transport/registration failure, plugin replacement, or a runtime update whose status says `restart_recommended=true` |
 
 ### Managed platform matrix
 
-| Host | Managed CLI | Managed accelerated embeddings |
+| Host | Managed CLI | Managed broad search |
 | --- | --- | --- |
 | Windows x64 | Yes | Native Vulkan |
-| Windows arm64 | Yes | No managed accelerated sidecar cell; use a proven external endpoint or explicit degraded CPU opt-in |
+| Windows arm64 | Yes | Managed CPU or a trusted external endpoint |
 | Linux x64 / arm64 | Yes | Docker Vulkan with a verified `/dev/dri` render node |
 | macOS arm64 (macOS 15+) | Yes | Managed native Metal |
-| macOS x64 (macOS 15+) | Yes | No managed Metal cell; use a trusted external endpoint under explicit policy or explicit degraded CPU opt-in |
+| macOS x64 (macOS 15+) | Yes | Managed CPU or a trusted external endpoint; never claims Metal |
 
 Linux CUDA, HIP/ROCm, SYCL, and OpenVINO remain contract-only until packaging,
 launch, and live GPU evidence exist. A compatible version difference is
 advisory; an already-running MCP changes binaries only after an actual runtime
 replacement and host reload.
 
-### Native embedding busy decision tree
-
-1. `native_embedding_runtime.status=stale` → call `sidecar_setup repair` (or follow `recommended_next_calls`) so the broker can reclaim.
-2. `status=busy` and owner is same-project / reusable → continue; do not treat as a hard block.
-3. `status=busy` and owner is foreign or unverifiable → wait and reread status; do not start a competing repair.
-4. `status=available` → repair is free to proceed when policy allows.
-
-### Readiness broker fields
-
-Broker schema 3 scopes processes, operations, locks, snapshots, and verified
-GPU runtime evidence with the lossless workspace identity. On case-sensitive
-filesystems, roots that differ only by case remain separate; Windows aliases
-for the same existing path remain one workspace. Schema 1/2 state is consulted
-only when its recorded root and repository provenance map unambiguously to the
-requested workspace. Otherwise CodeStory leaves that state isolated and
-publishes a fresh schema-3 snapshot.
-
-| Field | Healthy value | Action value |
-| --- | --- | --- |
-| `readiness_broker.reconciliation.status` | `clean` or `observed` | `active_repair` means wait and reread status; `stale_state_cleaned` means retry repair once |
-| `readiness_broker.resources.native_embedding_runtime.status` | `available` | `busy` blocks repair only when the owner is foreign or unverifiable; same-project reusable owners should continue through `recommended_next_calls`; `stale` means retry repair so the broker can reclaim it |
-| `readiness_broker.gpu_proof.proof_status` | `verified` when accelerator is required and live embed smoke succeeded | `gpu_unverified` means repair should stop before a long semantic rebuild; inspect `embed_smoke_ok` / `embed_smoke_ms` |
-| `readiness_broker.persistence_status` | `persisted` | `failed` means inspect `persistence_error`; status may be live but not durable across processes |
-| `sidecar_setup.last_worker_result` | `outcome=succeeded` for the matching repair `attempt_id` | `failed` or `abandoned` means branch on `terminal_envelope.error.code` when present. Legacy persisted results can omit the envelope; use `wait_error` and bounded tails as compatibility diagnostics. It is terminal evidence, not an active lock |
-| `recommended_next_calls` | Start with `agent-guide`, then use allowed tools | For packet/search blockers, follow the listed `sidecar_setup repair` and status read sequence; if tools are hidden, stop and report host visibility |
-
-Shared repair lanes: [Troubleshooting](troubleshooting.md).
-
-`retrieval_mode=full` describes the persisted retrieval manifest; it does not
-override live infrastructure. When acceleration is required, packet/search is
-allowed only while the selected endpoint is reachable, the native executable,
-arguments, and process-start identity still match, and GPU proof is `verified`.
-If the endpoint dies, status changes the agent lane to `repair_retrieval` and
-keeps local navigation available with actionable repair guidance.
+CodeStory verifies process identity, publication freshness, and acceleration
+before returning broad-search evidence. Those implementation diagnostics live
+in the [retrieval operations guide](../ops/retrieval-sidecars.md); normal users
+only need the tool state and retry guidance.
 
 Optional Git dirty-marker hooks (local graph freshness after checkout/merge):
 

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -6,53 +6,32 @@ work through the steps in order.
 Trust boundaries: [Trust and readiness](trust-and-readiness.md). Terms:
 [Glossary](../glossary.md).
 
-**Need JSON field names?** Common status keys: `allowed_surfaces`,
-`retrieval_mode`, and `recommended_next_calls`. Full agent contract:
+**Need JSON field names?** Normal tools report their capability state and a
+retry delay when preparation is still running. Full agent contract:
 [status-contract](../../plugins/codestory/skills/codestory-grounding/references/status-contract.md).
 CLI commands are maintainer/debug transcripts: [CLI reference](cli-reference.md#readiness-and-repair).
 
-## Repair quick reference
+## Quick reference
 
-| Symptom | Supported action | Check in output |
+| Symptom | Supported action | Healthy result |
 | --- | --- | --- |
-| Repo map stale or blocked | Agent reads `codestory://status`, follows `recommended_next_calls`, then rereads status | Local graph surfaces are allowed after the reread |
-| Broad search blocked | Same MCP `sidecar_setup repair` loop | `packet`, `search`, or `context` allowed, `retrieval_mode` is `full`, and any required live accelerator proof is verified |
+| Repo map stale | Retry `ground`; CodeStory refreshes the map automatically | `ground` returns current files and symbols |
+| Broad search preparing | Retry the same `packet`, `search`, or `context` call after `retry_after_ms` | The requested tool returns cited evidence |
 | MCP down, need handoff | Reload/fix host MCP; CLI can collect a debug transcript only | `codestory://status` becomes visible in the agent host |
-| Sidecar health | MCP status first; CLI `retrieval status` only for maintainer evidence | `retrieval_mode` is `full` before trusting packet/search |
+| Managed runtime failed | Use `codestory://status` or CLI diagnostics only after automatic retries stop converging | The requested tool returns `ready` instead of `needs_environment` or `unavailable` |
 
 ## Decision tree
 
 ```mermaid
 flowchart TD
-  start([Session feels wrong]) --> q1{Can the agent read<br/>CodeStory status?}
-  q1 -->|No| mcp[MCP not connected]
-  q1 -->|Yes| qTools{Are mcp__codestory<br/>tools visible?}
-  qTools -->|No| toolsHidden[Resources only]
-  qTools -->|Yes| q2{Is the repo map ready?}
-  q2 -->|No| local[Local navigation lane]
-  q2 -->|Yes| q3{Need packet or search?}
-  q3 -->|No| ok[Local tools should work]
-  q3 -->|Yes| q4{Is broad search ready?}
-  q4 -->|No| sidecar[Packet/search lane]
-  q4 -->|Yes| ok2[Broad search should work]
-  mcp --> fix_mcp[MCP registration]
-  toolsHidden --> hostBlocker[Report host tool visibility]
-  local --> fix_local[Refresh or repair local index]
-  sidecar --> nativeBusy{Native embedding busy?}
-  nativeBusy -->|stale| fix_sidecar[Sidecar setup or repair]
-  nativeBusy -->|same project reusable| fix_sidecar
-  nativeBusy -->|foreign or unverifiable| waitBusy[Wait and reread status]
-  nativeBusy -->|no| fix_sidecar
-  fix_mcp --> host[Host guide]
-  hostBlocker --> host
-  fix_local --> reread
-  fix_sidecar --> mcp_repair
-  waitBusy --> reread
-  mcp_repair --> reread["Reread codestory://status"]
-  host --> codex[Codex guide]
-  host --> cursor[Cursor guide]
-  host --> claude[Claude Code guide]
-  host --> copilot[Copilot guide]
+  start([Call the intended CodeStory tool]) --> result{Result state}
+  result -->|ready| done[Use the cited evidence]
+  result -->|preparing or updating| retry[Wait for retry_after_ms]
+  retry --> start
+  result -->|working_locally| local[Use local navigation and retry broad search later]
+  result -->|needs_environment| host[Follow the one plain-language host requirement]
+  result -->|unavailable| fallback[Use source inspection and report the gap]
+  start -->|tool missing| mcp[Reload the plugin host]
 ```
 
 ## Host x symptom
@@ -60,8 +39,8 @@ flowchart TD
 | Symptom | Codex | Cursor | Claude Code | Copilot |
 | --- | --- | --- | --- | --- |
 | MCP missing | Fresh thread after `/plugins` install | Check `.cursor/mcp.json`; reload MCP server | MCP configured separately from hooks | MCP not auto-started; configure or use CLI |
-| Stale index / wrong symbols | Follow status repair guidance in the current thread | Run local repair; reload MCP only for transport or registration changes | Run local repair in the current session | Run [local repair](cli-reference.md#readiness-and-repair) |
-| Packet/search blocked | Agent calls MCP `sidecar_setup repair` when status says so | Same; verify retrieval mode | Same | Use CLI [retrieval status](cli-reference.md#readiness-and-repair) only as a debug transcript |
+| Stale index / wrong symbols | Retry `ground`; CodeStory refreshes automatically | Retry `ground` | Retry `ground` | Run [local repair](cli-reference.md#readiness-and-repair) |
+| Broad search preparing | Retry the same tool after its delay | Same | Same | Use CLI [retrieval status](cli-reference.md#readiness-and-repair) only as a debug transcript |
 | Version drift after update | Refresh marketplace, refresh plugin package, restart host, fresh status read | Reload MCP server | Restart session | Reinstall or point to current binary |
 
 Host-specific steps: [Codex](codex.md#troubleshooting), [Cursor](cursor.md#troubleshooting), [Claude Code](claude-code.md#troubleshooting), [Copilot](copilot.md).
@@ -82,8 +61,8 @@ discovery to SQLite?" The agent says broad search is ready, returns a compact
 answer with multiple cited files, and each path exists.
 
 **Blocked (broad search).** The agent gives a long essay with no file citations,
-or says packet/search is unavailable. Do not treat the answer as proof; repair
-sidecars or ask narrower local questions.
+or says packet/search is unavailable. Do not treat the answer as proof; let
+CodeStory finish preparing or ask narrower local questions.
 
 ## Step 1 -- Is my repo map ready?
 
@@ -100,11 +79,11 @@ If yes, local navigation is likely good. If no, go to [Local navigation stale or
 Ask the agent:
 
 ```text
-Read codestory://status, report allowed_surfaces, and tell me what is blocked and the next repair action.
+Call the CodeStory tool needed for this task. If it does not converge, read codestory://status and report the capability state in plain language.
 ```
 
-The agent uses MCP status, `codestory://agent-guide`, and `sidecar_setup repair`
-when status recommends repair. Re-read status after any repair.
+The agent retries the intended tool while CodeStory prepares. It reads status
+only when that automatic path stops converging.
 
 </details>
 
@@ -130,8 +109,8 @@ source-built binary.
 
 Symptoms: missing symbols, old file list, `ground` or `files` not allowed.
 
-**Agent (MCP live):** Use allowed local graph tools only; request index refresh
-through status guidance.
+**Agent (MCP live):** Retry `ground`, `files`, or the requested local graph
+tool. CodeStory refreshes the repository map as part of the call.
 
 **You (CLI debug transcript):**
 
@@ -156,16 +135,14 @@ node plugins/codestory/hooks/codestory-dirty-hook.cjs install --project <repo> -
 Symptoms: `packet`, `search`, or `context` not allowed; retrieval mode not
 `full`.
 
-**Agent:** Call MCP `sidecar_setup repair` when status says so, then reread
-`codestory://status`. Before repairing, classify
-`readiness_broker.resources.native_embedding_runtime`: `stale` or same-project
-reusable `busy` can proceed; foreign/unverifiable `busy` means wait. If status
-resources are visible but tools are hidden, do not loop on `tools/call`
-recommendations. Do not treat degraded output as proof. See
-[Trust and readiness](trust-and-readiness.md#proof-vs-hint).
+**Agent:** Retry the same `packet`, `search`, or `context` request after the
+returned delay. Use local graph tools while the state is `working_locally`.
+If the result becomes `needs_environment`, report its single host requirement
+without exposing internal processes or services. Do not treat an unavailable
+or partial result as proof. See [Trust and readiness](trust-and-readiness.md#proof-vs-hint).
 
-**You:** Sidecar model download and lifecycle:
-[Retrieval sidecars ops](../ops/retrieval-sidecars.md).
+**Maintainer:** Runtime lifecycle details are kept in
+[retrieval operations](../ops/retrieval-sidecars.md).
 
 CLI check:
 
@@ -174,77 +151,22 @@ codestory-cli retrieval status --project <repo> --format json
 codestory-cli fix --project <repo> --format json
 ```
 
-Require `retrieval_mode: "full"` before trusting packet/search evidence. Under
-`accelerator_required`, also require a reachable selected embedding endpoint,
-matching native-process identity, and
-`readiness_broker.gpu_proof.proof_status=verified`; the persisted manifest does
-not override a dead or unverifiable runtime.
+Require `retrieval_mode: "full"` before trusting packet/search evidence.
 Command table: [CLI reference - readiness and repair](cli-reference.md#readiness-and-repair).
 
-### Apple Silicon acceleration
+### macOS broad search
 
-On macOS arm64, the supported accelerated embedding path is the native Metal
-sidecar. A healthy repaired status should report the embedding launch as
-`native_spawned`, request provider `metal`, runtime observation from native
-sidecar logs, and a successful live timed embed smoke. Request fields, device
-inventory, and operator assertions are diagnostic only. Require
-`readiness_broker.gpu_proof.proof_status=verified`,
-`meaningful_accelerator_work_proven=true`, allowed packet/search surfaces, and
-`retrieval_mode=full` before trusting acceleration-backed readiness.
+Apple Silicon uses managed Metal acceleration automatically. Retry the original
+broad-search tool while CodeStory reports `preparing`; local navigation remains
+available in the meantime.
 
-Agent repair now runs that proof before long semantic indexing. The timed smoke
-uses the same embedding endpoint and runtime configuration as the rebuild, and
-the current runtime log must show positive offload for the requested provider
-and device. A reachable endpoint or device inventory without both pieces stops
-with `gpu_unverified` instead of remaining in a long `repairing` state.
-Accelerator-required external endpoints intentionally remain unverified because
-CodeStory does not own their runtime log or process identity.
+Intel Macs support local navigation by default. If broad search needs an
+explicit CPU or trusted external configuration, CodeStory reports that as one
+plain `needs_environment` requirement. The agent should relay that requirement
+without process, service, model, or port details.
 
-If a previously healthy Metal endpoint exits, status retains
-`retrieval_mode=full` as the persisted-manifest classification but changes the
-agent lane to `repair_retrieval`, removes packet/search from allowed surfaces,
-and reports `gpu_unverified`. Follow the recommended repair call; do not delete
-the manifest or cache just to make the status field change.
-
-The old failure pattern is `accelerator_request_provider=vulkan`,
-`accelerator_request_device=Vulkan0`, Docker/Colima embed launch, and
-`accelerator_request_unobserved`. That is a stale or pre-release runtime for
-Apple Silicon, not a Colima tuning problem: the Linux Docker sidecar cannot
-observe macOS Metal and normally has no usable `/dev/dri`.
-
-**Agent:** Read `codestory://status`, follow `recommended_next_calls`, call MCP
-`sidecar_setup repair` when recommended, and reread status. Keep local navigation separate
-from packet/search: a ready local graph can answer source-navigation questions
-while packet/search remains blocked until `retrieval_mode` is `full`.
-
-**You:** For a maintainer transcript, prewarm the managed Metal binary and then
-rerun bootstrap/status:
-
-```sh
-node scripts/setup-retrieval-env.mjs --fetch-llama-server --fetch-only
-codestory-cli retrieval bootstrap --project <repo> --format json
-codestory-cli retrieval status --project <repo> --format json
-```
-
-CPU-backed embeddings are degraded and explicit. Use
-`CODESTORY_EMBED_ALLOW_CPU=1` or `CODESTORY_EMBED_DEVICE_POLICY=allow_cpu` only
-when CPU retrieval is acceptable for that machine; CPU opt-in is not the default
-Apple Silicon success path.
-
-### Intel macOS retrieval
-
-Intel macOS supports the signed native CLI, managed plugin provisioning, local
-index/ground, and cleanup, but has no managed Metal backend. Without a prepared
-embedding backend, agent status should fail with actionable acceleration
-guidance while local navigation remains available.
-
-For packet/search, either opt into degraded CPU execution explicitly or point
-`CODESTORY_EMBED_LLAMACPP_URL` at a trusted external llama.cpp-compatible
-endpoint and select an explicit CPU/external operator policy. Because CodeStory
-cannot bind provider-owned logs and PID identity to an external request, that
-endpoint cannot satisfy `accelerator_required`; use the explicit CPU allowance
-when accepting it. Status and evidence must label the path CPU/external and
-must never claim Metal on Intel.
+Maintainer-only acceleration evidence and recovery commands are in
+[retrieval operations](../ops/retrieval-sidecars.md).
 
 ## MCP visibility failure
 
@@ -252,7 +174,7 @@ Symptoms: skill or rule loads but no `codestory://status` or `mcp__codestory` to
 
 | Host | Check |
 | --- | --- |
-| Codex | Read `codestory://status` through live MCP resources. Inspect `readiness_broker` and follow `recommended_next_calls`; status reads do not start repair. If resources are visible but `mcp__codestory` tools are hidden, report the host tool-visibility blocker; reload only after plugin install/config changes; see [Codex guide](codex.md#troubleshooting) |
+| Codex | If resources are visible but `mcp__codestory` tools are hidden, report the host tool-visibility blocker; reload only after plugin install/config changes; see [Codex guide](codex.md#troubleshooting) |
 | Cursor | MCP config path to `plugins/codestory/scripts/codestory-mcp.cjs`; reload server |
 | Claude Code | MCP configured separately; hooks alone do not expose tools |
 | Copilot | MCP not auto-started; configure manually or use CLI |
@@ -304,4 +226,4 @@ active runtime through `codestory://status`, not only `codex.cmd plugin list`.
 - [Trust and readiness](trust-and-readiness.md) -- when to trust output
 - [CLI reference - command by situation](cli-reference.md#command-by-situation) for command-by-situation table
 - [Contributor debugging](../contributors/debugging.md) for crate-level investigation
-- [Retrieval sidecars ops](../ops/retrieval-sidecars.md) for embedding backend repair
+- [Managed search operations](../ops/retrieval-sidecars.md) for maintainer-only backend diagnostics

--- a/plugins/codestory/README.md
+++ b/plugins/codestory/README.md
@@ -72,11 +72,13 @@ refreshes the catalog snapshot. Refresh the installed package from `/plugins` or
 the matching terminal plugin add command, then start a fresh Codex host session
 before trusting the active MCP runtime.
 
-## Repair and CLI
+## Diagnostics and CLI
 
-Normal users repair through the agent and MCP (`status` and `sidecar_setup`,
-both with an explicit `project`). Power-user CLI transcripts:
-[CLI reference](../../docs/users/cli-reference.md).
+CodeStory prepares its local repository map and broad-search runtime
+automatically. Agents call the intended tool with an explicit `project`; users
+do not need to configure or repair a background service. `status` and the
+[CLI reference](../../docs/users/cli-reference.md) are diagnostics for
+maintainers when automatic preparation cannot converge.
 
 Blocked session steps: [Troubleshooting](../../docs/users/troubleshooting.md).
 

--- a/plugins/codestory/hooks/codestory-activate.cjs
+++ b/plugins/codestory/hooks/codestory-activate.cjs
@@ -27,16 +27,15 @@ function contextFor(input, event) {
   const mcpInstructions = event === 'UserPromptSubmit'
     ? [
       'Use the codestory-grounding skill. Set project to this hook event\'s absolute repository cwd and pass that exact absolute path to every CodeStory call.',
-      'If status is not current, call it once for that project.',
-      'Reuse status until repository/runtime/index state changes or a tool reports stale evidence.',
+      'Call the CodeStory tool that matches the request directly; status is optional diagnostics.',
+      'If CodeStory is preparing, retry that same tool after its reported delay.',
       MCP_RESOURCE_TEXT,
-      'If deep retrieval is blocked, use routed local graph surfaces before source. Repair only when packet/search is required.',
+      'Use routed local graph surfaces while broad search prepares, then focused source for remaining evidence gaps.',
       'Hook text routes; only live MCP or verified source is evidence.',
     ].join('\n')
     : [
       'Set project to this hook event\'s absolute repository cwd and pass that exact absolute path to every CodeStory call. The MCP is multi-project and request-scoped.',
-      'Reuse status until repository/runtime/index state changes or a tool reports freshness failure.',
-      'If packet/search is blocked, use allowed local graph surfaces before source; do not repair unless broad retrieval is required.',
+      'Call the intended CodeStory tool directly. If it is preparing, retry that same tool after its reported delay.',
       MCP_RESOURCE_TEXT,
     ].join('\n');
 

--- a/plugins/codestory/hooks/codestory-instructions.cjs
+++ b/plugins/codestory/hooks/codestory-instructions.cjs
@@ -1,4 +1,4 @@
-const MCP_RESOURCE_TEXT = 'If CodeStory MCP tools are hidden and tool_search is available, query "codestory mcp ground status packet search", then use the loaded tools.';
+const MCP_RESOURCE_TEXT = 'If CodeStory MCP tools are hidden and tool_search is available, query "codestory mcp ground packet search symbol", then use the loaded tools.';
 
 function normalizePrompt(prompt) {
   return String(prompt || '').replace(/\s+/g, ' ').trim();
@@ -37,7 +37,7 @@ function routeForPrompt(prompt) {
     return 'Symbol ownership: use symbol, then definition; add callers/callees only when the question asks for flow.';
   }
   if (/\b(?:whole|entire|broad|architecture|subsystem|data flow|how does|how do|explain|codebase review)\b/u.test(text)) {
-    return 'Broad question: use packet only when status allows it and retrieval_mode=full; otherwise use ground, then focused symbol/trace evidence before source.';
+    return 'Broad question: call packet directly; if it is still preparing, use ground plus focused symbol/trace evidence and retry packet after its reported delay.';
   }
   return 'Repository orientation: use ground; use files only for language, role, path, or coverage questions.';
 }
@@ -76,8 +76,8 @@ function eventHeader(event, input = {}) {
   return [
     'CODESTORY SESSION ROUTING ACTIVE',
     '',
-    'For repository work, use the codestory-grounding skill and call status once for the explicit project.',
-    'Task router: orientation -> ground/files; symbol -> symbol/definition; flow -> callers/callees/trace; review/change -> affected with explicit paths plus focused graph evidence; broad -> packet only when allowed/full.',
+    'For repository work, use the codestory-grounding skill and call the intended tool with the explicit project.',
+    'Task router: orientation -> ground/files; symbol -> symbol/definition; flow -> callers/callees/trace; review/change -> affected with explicit paths plus focused graph evidence; broad -> packet.',
     '',
   ].join('\n');
 }

--- a/plugins/codestory/scripts/codestory-mcp.cjs
+++ b/plugins/codestory/scripts/codestory-mcp.cjs
@@ -134,10 +134,6 @@ function pluginDataDir() {
     || inferredCodexPluginDataDir();
 }
 
-function sidecarPolicyPath(dataDir = pluginDataDir()) {
-  return dataDir ? path.join(dataDir, 'sidecar-setup-policy.json') : null;
-}
-
 function activeStatePath(dataDir = pluginDataDir()) {
   return dataDir ? path.join(dataDir, activeStateFile) : null;
 }
@@ -236,102 +232,6 @@ function resolveProjectRoot(options = {}) {
   };
 }
 
-function sidecarPolicyCommand(action, policyFile = sidecarPolicyPath()) {
-  const policyArg = policyFile ? ` --policy-file ${JSON.stringify(policyFile)}` : '';
-  return `node ${JSON.stringify(__filename)} sidecar-policy ${action}${policyArg}`;
-}
-
-function normalizeSidecarPolicyState(value) {
-  const state = String(value || '').trim().toLowerCase();
-  if (state === 'enabled' || state === 'disabled' || state === 'ask' || state === 'unknown') {
-    return state === 'unknown' ? 'ask' : state;
-  }
-  return 'ask';
-}
-
-function sidecarPolicyStateForAction(action) {
-  if (action === 'enable' || action === 'repair') return 'enabled';
-  if (action === 'disable') return 'disabled';
-  return 'ask';
-}
-
-function readSidecarPolicy(file = sidecarPolicyPath()) {
-  const policy = file ? readJson(file) : null;
-  const state = normalizeSidecarPolicyState(process.env.CODESTORY_PLUGIN_SIDECAR_POLICY || policy?.state);
-  return {
-    state,
-    path: file,
-    updatedAt: policy?.updated_at || null,
-    lastRepair: policy?.last_repair || null,
-  };
-}
-
-function firstSemverToken(value) {
-  const match = String(value || '').match(/\b\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?\b/u);
-  return match ? match[0] : null;
-}
-
-function sidecarLastRepairStaleReason(lastRepair, activeVersion = pluginVersion(), activePath = null) {
-  const command = lastRepair?.command;
-  if (!command) return null;
-  const version = firstSemverToken(command);
-  if (version && activeVersion && version !== activeVersion) {
-    return `last_repair_cli_version_mismatch:${version}!=${activeVersion}`;
-  }
-  if (activePath && command.includes('codestory-cli') && !command.includes(activePath)) {
-    return 'last_repair_cli_path_mismatch';
-  }
-  return null;
-}
-
-function normalizedSidecarLastRepair(lastRepair, activeVersion = pluginVersion(), activePath = null) {
-  if (!lastRepair) return null;
-  const staleReason = sidecarLastRepairStaleReason(lastRepair, activeVersion, activePath);
-  return {
-    ...lastRepair,
-    current: Boolean(lastRepair.command) && !staleReason,
-    stale_reason: staleReason,
-  };
-}
-
-function writeSidecarPolicy(state, patch = {}, file = sidecarPolicyPath()) {
-  if (!file) return null;
-  const current = readJson(file) || {};
-  const next = {
-    ...current,
-    ...patch,
-    state: normalizeSidecarPolicyState(state),
-    updated_at: new Date().toISOString(),
-  };
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(next, null, 2));
-  return next;
-}
-
-function handleSidecarPolicyCommand(argv) {
-  if (argv[2] !== 'sidecar-policy') return;
-  const action = argv[3] || 'status';
-  const policyFileFlag = argv.indexOf('--policy-file');
-  const policyFile = policyFileFlag >= 0 ? argv[policyFileFlag + 1] : sidecarPolicyPath();
-  if (!['enable', 'disable', 'ask', 'repair', 'status'].includes(action)) {
-    process.stderr.write('usage: codestory-mcp.cjs sidecar-policy [enable|disable|ask|repair|status] [--policy-file PATH]\n');
-    process.exit(2);
-  }
-  if (policyFileFlag >= 0 && !policyFile) {
-    process.stderr.write('sidecar-policy --policy-file requires a path\n');
-    process.exit(2);
-  }
-  if (action !== 'status') {
-    if (!policyFile) {
-      process.stderr.write('sidecar-policy needs PLUGIN_DATA, COPILOT_PLUGIN_DATA, CODESTORY_PLUGIN_DATA, or --policy-file to remember the setting\n');
-      process.exit(2);
-    }
-    writeSidecarPolicy(sidecarPolicyStateForAction(action), {}, policyFile);
-  }
-  process.stdout.write(`${JSON.stringify(readSidecarPolicy(policyFile), null, 2)}\n`);
-  process.exit(0);
-}
-
 function repairCommandForProject(projectRoot = launchCwd) {
   return `codestory-cli ready --goal agent --repair --project ${JSON.stringify(projectRoot)} --format json --run-id ${sharedAgentRunId}`;
 }
@@ -380,7 +280,7 @@ function runtimeTruthStatus(plugin, options = {}) {
   if (readinessLanes?.agent_packet_search) {
     readinessRefs.agent_packet_search = 'readiness_lanes.agent_packet_search';
   }
-  const sidecarStatusRef = readinessLanes?.agent_packet_search
+  const retrievalStatusRef = readinessLanes?.agent_packet_search
     ? 'readiness_lanes.agent_packet_search'
     : readinessGoals.has('agent_packet_search')
       ? 'readiness[goal=agent_packet_search]'
@@ -390,8 +290,8 @@ function runtimeTruthStatus(plugin, options = {}) {
     plugin_root: plugin.plugin_root || null,
     managed_cli_path: plugin.managed_binary_path || null,
     launcher_source: plugin.cli_source || 'unavailable',
-    sidecar_policy: options.sidecarPolicy || 'unavailable',
-    sidecar_status_ref: sidecarStatusRef,
+    managed_retrieval: 'automatic',
+    retrieval_status_ref: retrievalStatusRef,
     readiness_refs: readinessRefs,
     readiness_broker_ref: options.hasReadinessBroker ? 'readiness_broker' : null,
   };
@@ -2432,8 +2332,6 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   ]);
   const fullRepair = options.fullRepair || minimumNext;
   const recommendedNext = options.recommendedNext || fullRepair;
-  const sidecarPolicy = readSidecarPolicy();
-  const lastRepair = normalizedSidecarLastRepair(sidecarPolicy.lastRepair, resolved.version, resolved.path);
   const plugin = pluginRuntimeForResolved({ ...resolved, warnings: [...resolved.warnings, reason] });
   const repair = {
     goal: options.goal || 'local_navigation',
@@ -2472,7 +2370,7 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     'shortest_path',
     'query_subgraph',
   ];
-  const sidecarSurfaces = ['packet', 'search', 'context'];
+  const retrievalSurfaces = ['packet', 'search', 'context'];
   const blockedSurface = () => ({
     allowed: false,
     readiness_goal: repair.goal,
@@ -2481,38 +2379,8 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
   });
   const allowedSurfaces = Object.fromEntries([
     ...localSurfaces.map((surface) => [surface, blockedSurface()]),
-    ...sidecarSurfaces.map((surface) => [surface, blockedSurface()]),
+    ...retrievalSurfaces.map((surface) => [surface, blockedSurface()]),
   ]);
-  allowedSurfaces.repair_all = {
-    ...blockedSurface('repair_all', 'agent_packet_search'),
-    blocked_reason: 'diagnostic_fail_open',
-  };
-  const sidecarSetup = {
-    state: sidecarPolicy.state || 'unavailable',
-    auto_repair: false,
-    status_triggered_repair: false,
-    explicit_repair_enabled: sidecarPolicy.state === 'enabled',
-    repair_mode: 'diagnostic_fail_open',
-    prompt_required: sidecarPolicy.state === 'ask',
-    prompt: sidecarPolicy.state === 'ask'
-      ? 'CodeStory packet/search needs retrieval sidecars. MCP repair may start or download retrieval sidecars for this project. Enable MCP sidecar repair for this plugin install?'
-      : null,
-    last_repair: lastRepair,
-    active_repair: null,
-    abandoned_repair: null,
-  };
-  allowedSurfaces.sidecar_setup = {
-    allowed: true,
-    readiness_goal: repair.goal,
-    status: repair.status,
-    repair_reason: reason,
-    blocked_reason: 'diagnostic_fail_open_repair_unavailable',
-    summary: 'sidecar_setup status and policy actions are available in diagnostic fail-open mode; repair requires the real stdio runtime.',
-    allowed_actions: ['status', 'enable', 'disable', 'ask'],
-    canonical_arguments: { action: 'status' },
-    minimum_next: minimumNext,
-    full_repair: fullRepair,
-  };
   const readinessBroker = {
     schema_version: 2,
     identity: null,
@@ -2560,10 +2428,9 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     server_executable: null,
     server_executable_sha256: null,
     source_checkout_version: sourceCheckoutVersion(projectRoot),
-    sidecar_contract_version: null,
+    retrieval_contract_version: null,
     plugin_runtime: plugin,
     runtime_truth: runtimeTruthStatus(plugin, {
-      sidecarPolicy: sidecarPolicy.state || 'unavailable',
       localRefresh: options.localRefresh || null,
       readinessGoals: [repair.goal],
       hasReadinessBroker: true,
@@ -2581,7 +2448,10 @@ function fallbackDiagnostic(resolved, probe, reason, options = {}) {
     degraded_reason: reason,
     local_refresh: options.localRefresh || null,
     readiness: [repair],
-    sidecar_setup: sidecarSetup,
+    managed_retrieval: {
+      state: managedProvisioning ? 'preparing' : 'unavailable',
+      automatic: true,
+    },
     readiness_broker: readinessBroker,
     allowed_surfaces: allowedSurfaces,
     recommended_next_calls: singleRepairNextCalls(recommendedNext),
@@ -2659,7 +2529,6 @@ async function bootstrapStatus(projectRoot = launchCwd) {
     };
   }
 
-  const sidecarPolicy = readSidecarPolicy();
   const plugin = pluginRuntimeForResolved(resolved);
   const agentReadiness = probeAgentReadiness(resolved, projectRoot);
   const identityMismatch = projectIdentityMismatch(projectIdentity.identity, agentReadiness);
@@ -2712,7 +2581,6 @@ async function bootstrapStatus(projectRoot = launchCwd) {
     plugin_runtime: plugin,
     project_root_source: 'argument',
     runtime_truth: runtimeTruthStatus(plugin, {
-      sidecarPolicy: sidecarPolicy.state || 'unavailable',
       localRefresh,
       readinessGoals: readiness.map((verdict) => verdict.goal),
       readinessLanes: agentReadiness.parsed?.readiness_lanes || null,
@@ -2889,51 +2757,6 @@ function resourceContents(uri, value) {
   };
 }
 
-function failOpenSidecarSetupResult(request, status = null) {
-  const action = request.params?.arguments?.action || 'status';
-  if (action === 'repair') {
-    return {
-      isError: true,
-      content: [{ type: 'text', text: 'sidecar_setup repair is unavailable while CodeStory is in diagnostic fail-open mode; reload the host or restore the stdio runtime first.' }],
-      structuredContent: {
-        code: 'repair_unavailable_diagnostic_fail_open',
-        action,
-        recommended_next_calls: [{
-          method: 'resources/read',
-          uri: 'codestory://status',
-          instruction: 'Read status again after restoring the compatible stdio runtime.',
-        }],
-      },
-    };
-  }
-  if (!['status', 'enable', 'disable', 'ask'].includes(action)) {
-    return {
-      isError: true,
-      content: [{ type: 'text', text: 'sidecar_setup.action must be status, enable, disable, or ask while the runtime is in diagnostic mode.' }],
-      structuredContent: { code: 'invalid_sidecar_setup_action', action },
-    };
-  }
-  if (action !== 'status') {
-    writeSidecarPolicy(sidecarPolicyStateForAction(action));
-  }
-  const policy = readSidecarPolicy();
-  const lastRepair = normalizedSidecarLastRepair(
-    policy.lastRepair,
-    status?.plugin_runtime?.plugin_version,
-    status?.plugin_runtime?.cli_path,
-  );
-  const statusPolicy = { ...policy, lastRepair };
-  return {
-    content: [{ type: 'text', text: JSON.stringify(statusPolicy) }],
-    structuredContent: {
-      state: policy.state,
-      path: policy.path,
-      updated_at: policy.updatedAt,
-      last_repair: lastRepair,
-    },
-  };
-}
-
 function runFailOpenMcp(status, options = {}) {
   const currentStatus = () => (typeof status === 'function' ? status() : status);
   let handoff = null;
@@ -3027,31 +2850,7 @@ function runFailOpenMcp(status, options = {}) {
     if (stdinEnded) handoff.stdin.end();
     return handoff;
   };
-  const tools = [{
-    name: 'sidecar_setup',
-    description: 'Read or change plugin-local sidecar setup policy while CodeStory is in diagnostic fail-open mode. Repair requires the real stdio runtime.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        action: { type: 'string', enum: ['status', 'enable', 'disable', 'ask'], default: 'status' },
-      },
-      additionalProperties: false,
-    },
-    outputSchema: { type: 'object', additionalProperties: true },
-    safety: {
-      readOnly: false,
-      sideEffects: true,
-      localOnly: true,
-      openWorld: false,
-      mutation: 'local_plugin_configuration',
-    },
-    annotations: {
-      readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: true,
-      openWorldHint: false,
-    },
-  }];
+  const tools = [];
   const resources = [
     { uri: 'codestory://status', name: 'CodeStory runtime status', mimeType: 'application/json' },
     { uri: 'codestory://agent-guide', name: 'CodeStory agent guide', mimeType: 'application/json' },
@@ -3126,11 +2925,7 @@ function runFailOpenMcp(status, options = {}) {
           response = jsonrpcError(request.id, -32602, `unknown resource: ${uri || '<missing>'}`);
         }
       } else if (request.method === 'tools/call') {
-        if (request.params?.name === 'sidecar_setup') {
-          response = jsonrpcResult(request.id, failOpenSidecarSetupResult(request, currentStatus()));
-        } else {
-          response = jsonrpcError(request.id, -32602, 'CodeStory grounding tools are unavailable in diagnostic fail-open mode; read codestory://status and restore a compatible stdio runtime.');
-        }
+        response = jsonrpcError(request.id, -32602, 'CodeStory grounding tools are temporarily unavailable while the managed runtime starts. Retry after the host reports that CodeStory is ready.');
       } else {
         response = jsonrpcError(request.id, -32601, `method not found: ${request.method || '<missing>'}`);
       }
@@ -3178,7 +2973,6 @@ function rememberLaunch(resolved, runtimeCwd = process.cwd()) {
 }
 
 function stdioRuntimeEnv(resolved, runtimeCwd) {
-  const sidecarStatus = readSidecarPolicy();
   return {
     ...process.env,
     CODESTORY_PLUGIN_VERSION: resolved.version || '',
@@ -3200,15 +2994,6 @@ function stdioRuntimeEnv(resolved, runtimeCwd) {
     CODESTORY_PLUGIN_CLI_WARNINGS: resolved.warnings.join(';'),
     CODESTORY_PLUGIN_MULTI_PROJECT: '1',
     CODESTORY_PLUGIN_DATA: pluginDataDir() || '',
-    CODESTORY_PLUGIN_SIDECAR_POLICY_STATE: sidecarStatus.state,
-    CODESTORY_PLUGIN_SIDECAR_POLICY_PATH: sidecarStatus.path || '',
-    CODESTORY_PLUGIN_SIDECAR_POLICY_UPDATED_AT: sidecarStatus.updatedAt || '',
-    CODESTORY_PLUGIN_SIDECAR_ENABLE_COMMAND: sidecarPolicyCommand('enable'),
-    CODESTORY_PLUGIN_SIDECAR_DISABLE_COMMAND: sidecarPolicyCommand('disable'),
-    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_STATE: sidecarStatus.lastRepair?.state || '',
-    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_AT: sidecarStatus.lastRepair?.updated_at || '',
-    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_PROJECT: sidecarStatus.lastRepair?.project_root || '',
-    CODESTORY_PLUGIN_SIDECAR_LAST_REPAIR_COMMAND: sidecarStatus.lastRepair?.command || '',
   };
 }
 
@@ -3223,7 +3008,6 @@ function spawnStdioRuntime(resolved, runtimeCwd, stdio) {
 
 async function main() {
   if (await handleBootstrapStatusCommand(process.argv)) return;
-  handleSidecarPolicyCommand(process.argv);
   const runtimeCwd = releasePluginCacheCwd();
   const installed = await resolveCli({ provision: false });
   if (

--- a/plugins/codestory/skills/codestory-grounding/SKILL.md
+++ b/plugins/codestory/skills/codestory-grounding/SKILL.md
@@ -1,134 +1,87 @@
 ---
 name: codestory-grounding
-description: Use when an agent should ground a local repository with CodeStory before making source claims, planning edits, choosing tests, reviewing changes, or using packet/search evidence through the CodeStory plugin MCP.
+description: Use when an agent should ground a local repository with CodeStory before making source claims, planning edits, choosing tests, reviewing changes, or using broad retrieval evidence through the CodeStory plugin MCP.
 ---
 
 # CodeStory Grounding
 
-CodeStory indexes a repository once and serves read-only local evidence so an
-agent can stop rediscovering the same files, symbols, and call paths every turn.
+CodeStory keeps a local repository map and broad-search index so agents can
+reach useful evidence without rediscovering the same code every turn.
 
-The target is always the repository workspace being grounded. The CodeStory
-checkout is only tool source unless the user is editing CodeStory itself.
+The target is always the repository being grounded. Pass its exact absolute
+root as `project` on every CodeStory call. Never rely on a global active
+workspace.
 
-## When To Use
+## Direct Tool Loop
 
-Use CodeStory before making source claims, planning edits, choosing tests, or
-reviewing changes in a repository. Do not wait for the user to mention it by name.
+Call the tool that matches the task. Do not call `status` first.
 
-Before opening source files, call the CodeStory `status` tool with
-`project=<target-workspace>` when MCP is live. The MCP server is multi-project;
-every tool call must carry the caller's absolute repository root and must not
-rely on a mutable global or thread workspace binding. In
-Codex hosts where the server-specific `mcp__codestory__*` tool namespace is not
-initially visible, use host deferred discovery/tool_search with
-`codestory mcp ground status packet search`, then use the loaded CodeStory MCP
-tools. Treat this as MCP activation, not source fallback.
+1. Resolve the target repository root.
+2. Call the intended tool with `project=<absolute-root>`.
+3. If the result says `state=preparing`, wait for `retry_after_ms` and retry the
+   same tool with the same arguments. Do not poll status or ask the user to set
+   up CodeStory.
+4. Preserve cited anchors in source claims. Read focused source only for the
+   remaining evidence gaps.
 
-If `status`, `ready`, or `ground` reports no repo, no supported files, or zero
-indexed files, stop the CodeStory path. Do not paste empty ground output as
-context. Fall back to ordinary source inspection or ask for the intended repo
-path when ambiguous.
+CodeStory prepares its managed local runtime automatically. `status` and
+`codestory://status` are optional diagnostics for a failed or unexpectedly slow
+request, not prerequisites for normal grounding.
 
-## Quick Loop (MCP)
-
-When the plugin MCP server is available:
-
-1. Resolve `<target-workspace>` explicitly.
-2. Call `status` with `project=<target-workspace>` — field meanings in [status-contract](references/status-contract.md). If `mcp__codestory__*` tools are not initially visible and tool_search is available, query `codestory mcp ground status packet search`, then use the loaded CodeStory MCP tools.
-3. Reuse that status result until repository, runtime, or index state changes, or
-   a tool reports stale/freshness failure.
-4. Obey `allowed_surfaces` and `retrieval_mode`.
-5. Call the allowed surface that fits the task; preserve cited anchors in answers.
-6. Follow project-scoped `recommended_next_calls` only when the task requires a
-   blocked surface or setup is otherwise necessary.
-
-If the skill is visible but no `mcp__codestory` tools are exposed, call it a
-plugin MCP visibility failure. Unscoped resources cannot identify the caller's
-repository in multi-project mode. Do not use CLI as CodeStory grounding unless
-the user explicitly asks; use ordinary source inspection and report that live
-MCP tools were not visible.
+If the server-specific tools are hidden and deferred discovery is available,
+query `codestory mcp ground packet search symbol`, then call the discovered tool
+directly. If the plugin MCP is unavailable, use ordinary source inspection and
+report the visibility gap. Do not substitute CLI diagnostics for a live plugin
+result unless the user explicitly asks.
 
 ## Task Router
 
 | Situation | Route |
 | --- | --- |
-| Orientation: "What is in this checkout?" | `ground` / `codestory://grounding`; use `files` for language mix or gaps. |
-| Find symbol: "Where is X defined?" | `symbol`, then `definition` or `snippet`. |
-| Trace: "Who calls this?" | `callers`, `callees`, `trace`, or `trail --story --hide-speculative`. |
-| Impact: "What might this change touch?" | `affected` with changed files from git; planning hints only, not proof. |
-| Broad question | `packet`, `search`, or `context` only when allowed and `retrieval_mode=full`. |
-| Blocked packet/search/context, local route available | Do not repair. Route by task through allowed `ground`, `files`, `symbol`, `definition`, `callers`, `callees`, `trace`, `trail`, `references`, `snippet`, `affected`, `symbols`, `get_node`, `neighbors`, `shortest_path`, or `query_subgraph`, then use focused source only for remaining evidence gaps. |
-| Blocked surface required by the task | Follow `recommended_next_calls`; normally call MCP `sidecar_setup` with the same `project` and `action=repair`, then call project-scoped `status` again. |
+| Repository orientation | `ground`; use `files` for language mix or coverage gaps. |
+| Find a symbol | `symbol`, then `definition` or `snippet`. |
+| Follow a call path | `callers`, `callees`, `trace`, or `trail`. |
+| Review change impact | `affected` with explicit Git-changed paths, then focused symbol or trace evidence. |
+| Broad structural question | `packet`; use `search` or `context` for bounded follow-up. |
 
 ## Evidence Rules
 
 - Treat CodeStory output as evidence, not omniscience.
-- Preserve cited file, symbol, trail, and snippet anchors in user-facing claims.
-- Local graph output is navigation evidence. It does not prove full
-  packet/search readiness or substitute for sidecar-backed evidence claims.
-- When `packet` reports `sufficient` with no `follow_up_commands`, answer from the packet.
-- When `packet` reports `partial`, run named follow-up commands before proof claims.
-- `retrieval_mode=full` is infrastructure eligibility, not answer-quality proof;
-  anything weaker is navigation hints only.
-- On macOS arm64, expected accelerated sidecar intent is
-  `launch_mode=native_spawned` with request provider `metal`. Requested provider
-  and device are intent; observed device state and source are proof inputs, not
-  sufficient proof. When acceleration is required, require
-  `gpu_proof.proof_status=verified`, `meaningful_accelerator_work_proven=true`,
-  and `embed_smoke_ok=true`; manual assertions and device inventory remain
-  diagnostic. If status still reports `vulkan`/`Vulkan0` or
-  `accelerator_request_unobserved` on Apple Silicon, report a stale/pre-release
-  runtime or failed repair and follow the MCP repair loop.
-- CPU-backed retrieval is an explicit degraded policy. It does not make
-  packet/search evidence full unless refreshed status also allows those
-  surfaces and reports `retrieval_mode=full`.
+- Local repository-map output is navigation evidence. Broad packet/search
+  output is stronger only when the response reports full retrieval readiness.
+- When `packet` reports `sufficient`, answer from the packet and cited anchors.
+  When it reports `partial`, run the named follow-up before making proof claims.
+- `affected` is planning evidence, not a guarantee that every runtime effect was
+  found.
+- Do not paste empty grounding output as context. If a repository truly has no
+  supported files, fall back to ordinary inspection or resolve the intended
+  root when it is ambiguous.
 
-## Repair Loop
+## Failure Handling
 
-Supported agent repair is MCP-only:
+- `preparing`: retry the same tool after its delay.
+- `updating`: the last complete repository map remains usable; retry the same
+  tool when current publication evidence is required.
+- `working_locally`: use local navigation while broad search prepares.
+- `needs_environment`: report the single plain-language host requirement from
+  the result. Do not expose internal process, port, model, or service details.
+- `unavailable`: use ordinary source inspection and report that CodeStory was
+  unavailable for this task.
 
-1. Call `status` with `project=<target-workspace>`.
-2. Inspect `readiness_broker` and `sidecar_setup`; status reads report state
-   but do not start repairs.
-3. If the task requires the blocked surface, `recommended_next_calls` says so,
-   and the `mcp__codestory__sidecar_setup` tool is visible, call MCP `sidecar_setup` with
-   `project=<target-workspace>, action=repair`.
-4. Call `status` again with the same project.
-5. Use only the surfaces allowed by the refreshed status.
-
-If Codex exposes CodeStory resources but hides server-specific tools, report the
-host tool-visibility blocker; unscoped resources are not a safe multi-project
-fallback. Do not synthesize repair context or run CLI repair in the agent path.
-
-CLI commands such as `fix`, `doctor`, `ready`, and `retrieval status` are
-maintainer/debug transcript tools. They do not prove plugin MCP is live in the
-agent host and are not the supported repair path for agent grounding.
-
-Repair details: [serve](references/serve.md), [doctor](references/doctor.md).
+Maintainer commands such as `doctor`, `ready`, and retrieval status are debug
+transcript tools. They do not prove that the installed plugin is live in the
+agent host.
 
 `setup.ps1` and `setup.sh` under this skill are build-from-source paths for
-contributors only, not the normal user install path.
+contributors, not normal installation steps.
 
-## References (load on demand)
+## References
 
-- [status-contract](references/status-contract.md)
-- [index](references/index.md)
-- [cache](references/cache.md)
-- [ground](references/ground.md)
-- [doctor](references/doctor.md)
+- [status contract](references/status-contract.md)
+- [repository map](references/ground.md)
 - [packet](references/packet.md)
 - [search](references/search.md)
 - [context](references/context.md)
-- [symbol](references/symbol.md)
-- [trail](references/trail.md)
-- [snippet](references/snippet.md)
-- [drill](references/drill.md)
-- [drill-suite](references/drill-suite.md)
-- [query](references/query.md)
-- [explore](references/explore.md)
-- [files](references/files.md)
-- [affected](references/affected.md)
-- [bookmark](references/bookmark.md)
-- [retrieval-rollout](references/retrieval-rollout.md)
-- [serve](references/serve.md)
+- [symbols](references/symbol.md)
+- [trails](references/trail.md)
+- [snippets](references/snippet.md)

--- a/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
+++ b/plugins/codestory/skills/codestory-grounding/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "CodeStory Grounding"
   short_description: "Ground local repositories through CodeStory MCP before source claims, edits, reviews, or test planning."
-  default_prompt: "Call CodeStory status with the active repository's absolute path first; pass that same project to every tool call, repair only when recommended, then answer from allowed evidence."
+  default_prompt: "Call the CodeStory tool that matches the repository task with the active repository's absolute path. If CodeStory reports preparing, retry that same tool after its delay, then answer from returned evidence."
 dependencies:
   tools:
     - type: "mcp"

--- a/plugins/codestory/skills/codestory-grounding/references/doctor.md
+++ b/plugins/codestory/skills/codestory-grounding/references/doctor.md
@@ -22,11 +22,11 @@ Reads project/cache/index/retrieval health without mutating the index. Use it fo
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> doctor --project <target-workspace>` | Reports project root, cache path, indexed stats, retrieval state, sidecar embedding setup, environment hints, and next commands. |
-| Failure path | In MCP, follow project-scoped `status` `recommended_next_calls`, normally `sidecar_setup` with the same project and `action=repair`, then another status call for that project. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific setup/index command surfaced by `doctor`; use explicit `index --refresh full` only when the reported failure calls for a rebuild. If symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, repair before trusting broad packet/search evidence. | Separates missing index, stale symbol docs, partial dense anchors, and mandatory retrieval setup failures. |
+| Failure path | In MCP, retry the intended tool after its reported delay; read project-scoped status only if automatic preparation stops converging. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific setup/index command surfaced by `doctor`; use explicit `index --refresh full` only when the reported failure calls for a rebuild. If symbol docs, dense anchors, policy version, Qdrant counts, or semantic health report partial/stale/failed state, do not trust broad evidence until the managed path recovers. | Separates user-facing capability state from maintainer diagnostics. |
 | Integration edge | Use doctor before `ground`, `search --why`, `explore`, `context`, or `serve`; its next commands are the safe follow-up loop. | Prevents read commands from silently querying the wrong or empty cache. |
 
 For MCP/runtime drift, collect binary evidence only after status is missing or
-suspect (see [status-contract.md](status-contract.md#runtime-repair)). Installed
+suspect (see [status-contract.md](status-contract.md#maintainer-recovery)). Installed
 plugin MCP runtime changes require managed status/reinstall/reload, or an
 explicit `CODESTORY_CLI` override for local development, before starting a fresh
 Codex host/app session.

--- a/plugins/codestory/skills/codestory-grounding/references/serve.md
+++ b/plugins/codestory/skills/codestory-grounding/references/serve.md
@@ -8,7 +8,10 @@ For direct MCP-style clients:
 codestory-cli serve --stdio --multi-project --refresh none
 ```
 
-The installed plugin starts `scripts/codestory-mcp.cjs` (managed CLI bootstrap and `repair_setup` diagnostics when spawn fails). Once MCP is live, call `status` with the target repository's absolute path before any grounding, packet, or search call. Pass the same `project` to every tool.
+The installed plugin starts `scripts/codestory-mcp.cjs`, provisions the managed
+CLI when needed, and keeps diagnostic MCP available if startup fails. Once MCP
+is live, call the intended repository tool directly and pass the same absolute
+`project` path to every call.
 
 ## Usage
 
@@ -45,7 +48,7 @@ The installed plugin starts `scripts/codestory-mcp.cjs` (managed CLI bootstrap a
 | Path | Command | Expected result |
 |------|---------|-----------------|
 | Normal path | `<codestory-cli> serve --project <target-workspace> --addr 127.0.0.1:3917` then `GET /health` | Local JSON service returns `{"ok": true}` and browser routes use the existing index. |
-| Failure path | If MCP status reports missing index, follow `recommended_next_calls`, normally `sidecar_setup repair` then a status reread. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific command surfaced by `doctor`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes cache readiness from port conflicts. |
+| Failure path | If a tool reports `preparing`, retry that same tool after `retry_after_ms`. Read status only if the managed path stops converging. In CLI/debug transcripts, use `fix --project <target-workspace> --format json` or the specific command surfaced by `doctor`; use explicit `index --refresh full` only when the health output calls for a rebuild. If bind fails, choose a free `--addr`. | Distinguishes managed preparation from cache or port failures. |
 | Integration edge | Use `serve --stdio --multi-project` for MCP-style clients; it exposes project-scoped `status`, `ground`, `files`, `affected`, `packet`, `search`, `symbol`, and graph/source tools. | One server safely routes interleaved requests from different repositories without mutable workspace state. |
 
 Stdio MCP status fields and allowed-surface rules: [status-contract.md](status-contract.md).

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -1,67 +1,71 @@
-# Status Contract
+# CodeStory Tool State
 
-When plugin MCP is live, the `status` tool with an explicit absolute `project`
-is the first and canonical runtime truth. Call it before `ground`, `files`,
-`packet`, or `search`, and pass the same project to every tool. The server has no
-global workspace binding.
+Call the tool that matches the repository question and pass the same absolute
+`project` path to every call. Do not read status first. CodeStory owns local
+map refresh, managed search preparation, retry cooldowns, and runtime reuse
+across repositories.
 
-Status is observational: it reports freshness, active ownership, policy, and
-proof without starting work. Calling a project tool such as `ground` activates
-the selected project, starts or attaches its local refresh, and may enqueue the
-existing broker-backed agent repair when sidecar policy is already enabled.
-Failed automatic repairs are cooldown-gated until the relevant project or
-sidecar state changes. A stale heartbeat from a still-live owner remains
-fail-closed because suspension or starvation is not proof of abandonment;
-CodeStory never terminates a repair process based only on heartbeat age.
+## Normal tool loop
 
-Reuse a status result until repository, runtime, or index state changes, or a
-tool reports stale evidence or a freshness failure. A blocked sidecar-backed
-surface does not invalidate an allowed local graph route.
-
-## Status Fields
-
-| Status field | Meaning | Agent action |
+| State | Meaning | Agent action |
 | --- | --- | --- |
-| `server_version` | Version of the active MCP server binary. | Use as active runtime evidence once MCP is live. |
-| `cli_version` | Version reported by the active CLI runtime. | Use as the active CLI version, not the source checkout version. |
-| `server_executable` | Executable path serving this MCP session. | Use as active runtime evidence; do not guess from source paths. |
-| `server_executable_sha256` | Checksum of the active MCP server binary when available. | Use to confirm the exact runtime binary after install, repair, or reload. |
-| `runtime_update` | Non-blocking release and managed-install advisory. `state=available` reports an optional update; `restart_recommended=true` means a newer checksum-valid managed CLI is already installed. Release metadata is cached and refreshed outside the status request path. | Do not treat update availability as a readiness failure. Continue using each compatible surface according to `allowed_surfaces`; reload the host when convenient if restart is recommended. |
-| `sidecar_contract_version` | Sidecar schema contract compiled into the active CLI. | Use to diagnose sidecar/runtime contract drift. |
-| `plugin_runtime` | Plugin launch source and managed CLI metadata, including `plugin_runtime.plugin_root`, `plugin_cache_version`, `build_source`, and `repo_ref` when provisioned. | Treat `managed` as installed plugin runtime, `local_dev_override` as source/dev override, and `managed_unavailable` as blocked managed setup. |
-| `runtime_truth` | Grouped runtime source, plugin root, managed CLI path, launcher source, and references to canonical readiness fields. | Use as the concise bounded runtime identity summary. Follow its `*_ref` fields into top-level status instead of expecting cloned readiness payloads. |
-| `sidecar_setup` | Plugin sidecar setup policy and last repair state. | Diagnostic sidecar policy detail. For agent repair, follow `recommended_next_calls` and prefer MCP `sidecar_setup` with `action=repair`. |
-| `sidecar_setup.stale_live_repair` | Read-only evidence for a repair whose heartbeat is stale while its recorded process is still live. | Treat it as unresolved ownership. Do not infer abandonment from age, start another repair, or terminate the owner. |
-| `readiness_broker` | Durable repair, local refresh, native embedding resource ownership, stale-lock reconciliation, persistence status, and GPU proof (`proof_status`, `embed_smoke_ok`, `embed_smoke_ms`). | Inspect before retrying repair. A foreign or unverifiable `native_embedding_runtime` busy state blocks repair; a same-project reusable native owner should be followed through `recommended_next_calls`. `gpu_proof.proof_status == "verified"` and `gpu_proof.meaningful_accelerator_work_proven == true` require observed acceleration plus a live timed embed smoke when accelerator is required. |
-| `index_publication` | Durable identity of the complete core database generation currently served at the live path. It is null when the live database is fenced by an incomplete legacy run. | Use its generation, generation ID, run ID, mode, and publication time to distinguish old-or-new complete reads during refresh. |
-| `local_refresh` | Single-flight local refresh state and owner metadata. While `state=refreshing`, `serving_publication` identifies the last complete generation that remains readable. | Continue using local surfaces whose allowed bit is true. Do not treat staged work as live. Read tool-call `_meta.codestory_publication` identifies the exact complete response generation; `served_from=last_complete_publication` means a writer was refreshing concurrently. |
-| `embedding_launch_metadata.launch_mode` | Embedding sidecar launch mode when available, such as `native_spawned` or Docker Compose embed. | On macOS arm64, expect `native_spawned` for accelerated Metal; Docker/Vulkan on Apple Silicon is stale or unrepaired. |
-| `embedding_accelerator_request_provider` / `embedding_accelerator_request_device` | Requested accelerator provider/device. These fields are intent, not proof. | Use them to diagnose mismatched requests, for example `metal` with no device on Apple Silicon versus `vulkan`/`Vulkan0` on Windows or Linux Vulkan paths. |
-| `embedding_device_state` / `embedding_device_observation_source` | Observed embedding device state and where the observation came from. | Treat these as proof inputs. `manual_env` and device-inventory observations remain diagnostic; complete accelerator proof requires the verified broker GPU proof above. Treat `accelerator_request_unobserved` as blocked unless CPU mode is explicitly allowed. |
-| `allowed_surfaces.<surface>.allowed` | A concrete MCP surface is callable. Ordinary surface entries stay compact and name their canonical verdict with `readiness_goal`; failure summaries are not cloned into every entry. On a cold or stale repository, `ground`, `files`, and `affected` remain callable while local readiness stays `repair_index`. | Use local graph entries only when their surface is allowed. Follow `readiness_goal` into top-level `readiness` for publication state and full diagnostics. |
-| `allowed_surfaces.<surface>.activation_required` | The callable surface must first build or refresh the bounded local graph. This marker appears on `ground`, `files`, and `affected` while local readiness is `repair_index`. | Call the intended tool once with the same project. Do not poll status first or repair packet/search infrastructure for local activation. Other graph evidence surfaces remain blocked until a complete publication exists. |
-| `allowed_surfaces.packet.allowed` / `allowed_surfaces.search.allowed` / `allowed_surfaces.context.allowed` | Sidecar-backed agent surfaces are allowed. | Use `packet`, `search`, and `context` confidently when their own allowed bit is true and `retrieval_mode=full`. |
+| `ready` | The requested capability is available. | Use the result. |
+| `preparing` | CodeStory is starting or updating managed search. | Wait `retry_after_ms`, then retry the same tool with the same arguments. |
+| `updating` | The repository map is moving to a new complete publication. | Retry the same tool after the reported delay; do not start another refresh. |
+| `working_locally` | Local graph navigation is available while broad search prepares. | Continue with local tools and retry the original broad tool later. |
+| `needs_environment` | Automatic preparation found one host requirement it cannot satisfy. | Report that single requirement in plain language. |
+| `unavailable` | CodeStory could not converge within the managed path. | Use focused source inspection and state the evidence gap. |
 
-New background repair failures record one shared `terminal_envelope`. Treat
-that structured envelope as the primary failure contract. A persisted result
-created by an older runtime can omit it; in that compatibility case, use
-`wait_error`, then the bounded stderr/stdout tails. Do not mistake either form
-of terminal evidence for an active repair lock.
+`packet`, `search`, and `context` return `codestory_preparing` with
+`retry_tool` and `retry_after_ms` while their managed dependencies are coming
+up. Retry that same tool. Do not ask the user to enable, repair, approve, or
+configure an internal service.
 
-## Runtime Repair
+`ground`, `files`, and `affected` can build or refresh the bounded local map as
+part of the call. Other local graph tools use the last complete publication and
+never read a half-published generation.
 
-Use managed project-scoped `status`, release install records, or source-build
-checks only for maintainer/debug transcripts when MCP is missing or suspect.
-They are not the supported agent repair path. `CODESTORY_CLI` is an explicit
-local-dev override; installed `.mcp.json` launches the managed adapter first,
-provisions from `github_release` when needed, and records the launch source in
-`plugin_runtime`. If the managed runtime cannot spawn or be provisioned, the
-adapter stays up with `repair_setup` diagnostics instead of closing transport.
+## Diagnostic status
 
-If project-scoped `status` reports a repairable state and the task requires the
-blocked surface, run the MCP `recommended_next_calls` loop: call
-`sidecar_setup` with the same `project` and `action=repair` when recommended,
-then call `status` again before using that surface. When an allowed local graph
-surface satisfies the task, use it without repairing packet/search/context and
-do not represent local navigation as full retrieval proof. Do not ask the human to install the binary unless network,
-permissions, host reload, or release assets block the repair.
+`codestory://status` is an observational diagnostic surface. Read it only when
+the direct tool loop stops converging, the tool reports stale evidence, or the
+task explicitly asks for runtime diagnostics. A status read never starts work.
+
+The most useful fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `server_version`, `server_executable`, `server_executable_sha256` | Exact live MCP runtime identity. |
+| `plugin_runtime` | Installed plugin and managed CLI source. |
+| `runtime_truth` | Compact references to the canonical readiness and runtime fields. |
+| `index_publication` | Complete core database generation currently being served. |
+| `local_refresh` | Local map state and the complete publication retained during refresh. |
+| `managed_retrieval` | Automatic broad-search lifecycle state. This is diagnostic, not a user control. |
+| `retrieval_mode` | Persisted broad-search classification; `full` is required for trustworthy broad results. |
+| `readiness_lanes.agent_packet_search` | Current broad-search capability state. |
+| `readiness_broker` | Maintainer evidence for ownership, liveness, and accelerator proof. |
+| `retrieval_diagnostics` | Detailed managed-runtime evidence for debugging. |
+| `runtime_update` | Non-blocking installed-runtime update advisory. |
+
+Reuse a status result until repository, runtime, or index state changes. Follow
+its references instead of treating duplicated nested payloads as separate
+truths.
+
+## Evidence boundary
+
+Local navigation is useful while broad search prepares, but it is not full
+retrieval proof. Trust a broad result only when the requested tool succeeds
+against a current complete publication. Under accelerator-required policy,
+maintainer proof additionally requires a live selected endpoint, matching
+process identity, and verified accelerator work.
+
+Stale ownership remains fail-closed. Heartbeat age alone does not prove that a
+process is abandoned, and CodeStory does not terminate an owner on that basis.
+
+## Maintainer recovery
+
+CLI status, doctor, install records, process IDs, ports, model paths, and backend
+logs are maintainer diagnostics. They are not the normal agent or user repair
+path. Use them only after automatic retries stop converging or when collecting
+an explicit proof transcript. `CODESTORY_CLI` remains a local-development
+override; installed plugin sessions use the managed launcher.

--- a/plugins/codestory/tests/plugin-static.test.mjs
+++ b/plugins/codestory/tests/plugin-static.test.mjs
@@ -623,28 +623,13 @@ test("mcp launcher prefers a checksummed managed cli without PATH", async () => 
     assert.equal(observed.pluginRoot, pluginRoot);
     assert.equal(observed.pluginCacheVersion, "");
     assert.equal(observed.activeStatePath, undefined);
-    assert.equal(observed.sidecarPolicy, "ask");
-    assert.match(observed.sidecarEnable, /sidecar-policy enable/u);
-    assert.match(observed.sidecarEnable, /--policy-file/u);
+    assert.equal(observed.sidecarPolicy, undefined);
+    assert.equal(observed.sidecarEnable, undefined);
     assert.equal(observed.sidecarRepair, undefined);
     assert.equal(observed.dirtyMarkerRoot, undefined);
     assert.equal(observed.dirtyMarkerPath, undefined);
     assert.deepEqual(observed.args, ["serve", "--stdio", "--multi-project", "--refresh", "none"]);
-
-    const enable = spawnSync(observed.sidecarEnable, {
-      shell: true,
-      env: {
-        ...process.env,
-        PLUGIN_DATA: "",
-        COPILOT_PLUGIN_DATA: "",
-      },
-      encoding: "utf8",
-    });
-    assert.equal(enable.status, 0, enable.stderr);
-    const policy = JSON.parse(
-      await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
-    );
-    assert.equal(policy.state, "enabled");
+    await assert.rejects(access(join(dataDir, "sidecar-setup-policy.json")), /ENOENT/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -1536,20 +1521,12 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
   const binDir = await mkdtemp(join(tmpdir(), "codestory-delegated-stdio-bin-"));
   const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
   const realRepoRoot = await realpath(repoRoot);
-  const input = [
-    JSON.stringify({
-      jsonrpc: "2.0",
-      id: "status",
-      method: "resources/read",
-      params: { uri: "codestory://status" },
-    }),
-    JSON.stringify({
-      jsonrpc: "2.0",
-      id: "sidecar-status",
-      method: "tools/call",
-      params: { name: "sidecar_setup", arguments: { action: "status" } },
-    }),
-  ].join("\n") + "\n";
+  const input = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "status",
+    method: "resources/read",
+    params: { uri: "codestory://status" },
+  }) + "\n";
   const cliPath = await writeNodeCli(
     binDir,
     [
@@ -1570,26 +1547,6 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
       }),
       "utf8",
     );
-    const staleCliPath = join(
-      binDir,
-      version,
-      process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
-    );
-    await writeFile(
-      join(dataDir, "sidecar-setup-policy.json"),
-      JSON.stringify({
-        state: "ask",
-        updated_at: "2026-07-09T00:00:00.000Z",
-        last_repair: {
-          state: "completed",
-          updated_at: "2026-07-09T00:00:00.000Z",
-          project_root: realRepoRoot,
-          command: `${JSON.stringify(staleCliPath)} ready --goal agent --repair`,
-        },
-      }),
-      "utf8",
-    );
-
     const result = spawnSync(process.execPath, [launcher], {
       cwd: pluginRoot,
       env: {
@@ -1606,7 +1563,7 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
 
     assert.equal(result.status, 0, result.stderr);
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 2, result.stdout);
+    assert.equal(responses.length, 1, result.stdout);
     const status = JSON.parse(responses[0].result.contents[0].text);
     assert.equal(status.degraded_reason, "runtime_stdio_child_exit");
     assert.equal(status.project_root, null);
@@ -1616,13 +1573,7 @@ test("mcp launcher fails open when delegated stdio runtime exits", async () => {
       status.readiness[0].setup.probe_error,
       /codestory-cli serve --stdio exited with status 17/u,
     );
-    assert.equal(status.sidecar_setup.last_repair.current, false);
-    assert.equal(status.sidecar_setup.last_repair.stale_reason, "last_repair_cli_path_mismatch");
-    assert.equal(responses[1].result.structuredContent.last_repair.current, false);
-    assert.equal(
-      responses[1].result.structuredContent.last_repair.stale_reason,
-      "last_repair_cli_path_mismatch",
-    );
+    assert.equal(status.managed_retrieval.automatic, true);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
     await rm(binDir, { recursive: true, force: true });
@@ -2165,8 +2116,8 @@ test("projectless mcp hands off to stdio without active project state", async ()
       "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { serverInfo: { name: 'codestory' } } }) + '\\n');",
       "      } else if (request.method === 'tools/list') {",
       "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { tools: [{ name: 'ground' }] } }) + '\\n');",
-      "      } else if (request.method === 'tools/call' && request.params && request.params.name === 'sidecar_setup') {",
-      "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { structuredContent: { state: 'runtime-sidecar-setup' } } }) + '\\n');",
+      "      } else if (request.method === 'tools/call' && request.params && request.params.name === 'ground') {",
+      "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { structuredContent: { state: 'ready' } } }) + '\\n');",
       "      } else if (request.method === 'resources/read') {",
       "        process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: { contents: [{ uri: request.params.uri, mimeType: 'application/json', text: JSON.stringify({ project_root: process.env.CODESTORY_PLUGIN_PROJECT_ROOT, project_root_source: process.env.CODESTORY_PLUGIN_PROJECT_ROOT_SOURCE }) }] } }) + '\\n');",
       "      }",
@@ -2237,13 +2188,13 @@ test("projectless mcp hands off to stdio without active project state", async ()
     });
     assert.equal(init.result.serverInfo.name, "codestory");
 
-    const repaired = await sendRequest({
+    const grounded = await sendRequest({
       jsonrpc: "2.0",
-      id: "repair",
+      id: "ground",
       method: "tools/call",
-      params: { name: "sidecar_setup", arguments: { project: realRepoRoot, action: "repair" } },
+      params: { name: "ground", arguments: { project: realRepoRoot } },
     });
-    assert.equal(repaired.result.structuredContent.state, "runtime-sidecar-setup");
+    assert.equal(grounded.result.structuredContent.state, "ready");
 
     const tools = await sendRequest({ jsonrpc: "2.0", id: "tools", method: "tools/list" });
     assert.deepEqual(tools.result.tools.map((tool) => tool.name), ["ground"]);
@@ -2405,10 +2356,10 @@ test("bootstrap-status binds Rust readiness to request-scoped project identity",
     assert.equal(result.status, 0, result.stderr);
     const status = JSON.parse(result.stdout.trim());
     assert.equal(status.ready, true);
-    assert.equal(status.runtime_truth.sidecar_status_ref, "readiness_lanes.agent_packet_search");
+    assert.equal(status.runtime_truth.retrieval_status_ref, "readiness_lanes.agent_packet_search");
     assert.equal(status.runtime_truth.readiness_refs.local_graph, "readiness[goal=local_navigation]");
     assert.equal(status.runtime_truth.readiness_broker_ref, "readiness_broker");
-    assert.equal(Object.hasOwn(status.runtime_truth, "sidecar_status"), false);
+    assert.equal(Object.hasOwn(status.runtime_truth, "retrieval_status"), false);
     assert.equal(Object.hasOwn(status.runtime_truth, "readiness_lanes"), false);
     assert.equal(status.readiness_lanes.agent_packet_search.status, "ready");
     assert.equal(status.project_identity.project_identity_schema_version, 3);
@@ -2551,26 +2502,10 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
     JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 2, method: "resources/read", params: { uri: "codestory://status" } }),
     JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
-    JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "sidecar_setup", arguments: { action: "status" } } }),
-    JSON.stringify({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "sidecar_setup", arguments: { action: "repair" } } }),
-    JSON.stringify({ jsonrpc: "2.0", id: 6, method: "tools/call", params: { name: "ground", arguments: {} } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "ground", arguments: {} } }),
   ].join("\n") + "\n";
 
   try {
-    await writeFile(
-      join(dataDir, "sidecar-setup-policy.json"),
-      JSON.stringify({
-        state: "ask",
-        updated_at: "2026-07-09T00:00:00.000Z",
-        last_repair: {
-          state: "completed",
-          updated_at: "2026-07-09T00:00:00.000Z",
-          project_root: repoRoot,
-          command: '"C:\\Users\\alber\\.codex\\plugins\\data\\codestory-TheGreenCedar\\codestory-cli\\0.12.3\\bin\\codestory-cli.exe" ready --goal agent --repair',
-        },
-      }),
-      "utf8",
-    );
     const result = spawnSync(process.execPath, [launcher], {
       env: {
         PLUGIN_DATA: "",
@@ -2588,7 +2523,7 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
 
     assert.equal(result.status, 0, result.stderr);
     const responses = result.stdout.trim().split(/\r?\n/u).map((line) => JSON.parse(line));
-    assert.equal(responses.length, 6, result.stdout);
+    assert.equal(responses.length, 4, result.stdout);
     const status = JSON.parse(responses[1].result.contents[0].text);
     assert.equal(status.plugin_runtime.plugin_version, version);
     assert.equal(status.source_checkout_version, null);
@@ -2597,13 +2532,15 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
     assert.equal(status.plugin_runtime.cli_path, null);
     assert.equal(status.runtime_truth.runtime_source, "managed_unavailable");
     assert.equal(status.runtime_truth.plugin_root, pluginRoot);
-    assert.equal(status.runtime_truth.sidecar_policy, "ask");
-    assert.equal(status.runtime_truth.sidecar_status_ref, null);
+    assert.equal(status.runtime_truth.managed_retrieval, "automatic");
+    assert.equal(status.retrieval_contract_version, null);
+    assert.equal(Object.hasOwn(status, "sidecar_contract_version"), false);
+    assert.equal(status.runtime_truth.retrieval_status_ref, null);
     assert.equal(status.runtime_truth.readiness_refs.local_graph, "readiness[goal=local_navigation]");
     assert.equal(status.runtime_truth.readiness_broker_ref, "readiness_broker");
     assert.equal(Object.hasOwn(status.runtime_truth.readiness_refs, "local_default"), false);
     assert.equal(Object.hasOwn(status.runtime_truth.readiness_refs, "agent_packet_search"), false);
-    assert.equal(Object.hasOwn(status.runtime_truth, "sidecar_status"), false);
+    assert.equal(Object.hasOwn(status.runtime_truth, "retrieval_status"), false);
     assert.equal(Object.hasOwn(status.runtime_truth, "readiness_lanes"), false);
     assert.equal(status.readiness[0].status, "repair_setup");
     assert.equal(status.readiness[0].repair_reason, "managed_cli_unavailable");
@@ -2652,34 +2589,12 @@ test("mcp launcher blocks when managed runtime is unavailable", async () => {
     assert.equal(status.readiness_broker.gpu_proof.embed_smoke_ok, null);
     assert.equal(status.readiness_broker.gpu_proof.embed_smoke_ms, null);
     assert.equal(status.allowed_surfaces.ground.allowed, false);
-    assert.equal(status.allowed_surfaces.sidecar_setup.allowed, true);
-    assert.deepEqual(status.allowed_surfaces.sidecar_setup.allowed_actions, ["status", "enable", "disable", "ask"]);
-    assert.deepEqual(status.allowed_surfaces.sidecar_setup.canonical_arguments, { action: "status" });
-    assert.equal(status.sidecar_setup.last_repair.current, false);
-    assert.match(
-      status.sidecar_setup.last_repair.stale_reason,
-      /last_repair_cli_version_mismatch:0\.12\.3!=/,
-    );
-    assert.doesNotMatch(JSON.stringify(status.recommended_next_calls), /"tool":"repair_all"/u);
+    assert.equal(status.managed_retrieval.automatic, true);
     assert.match(status.readiness[0].minimum_next[0], /Refresh or reinstall the CodeStory plugin/u);
-    assert.deepEqual(responses[2].result.tools.map((tool) => tool.name), ["sidecar_setup"]);
-    assert.deepEqual(
-      responses[2].result.tools[0].inputSchema.properties.action.enum,
-      ["status", "enable", "disable", "ask"],
-    );
-    assert.equal(responses[3].result.structuredContent.last_repair.current, false);
-    assert.match(
-      responses[3].result.structuredContent.last_repair.stale_reason,
-      /last_repair_cli_version_mismatch:0\.12\.3!=/,
-    );
-    assert.equal(responses[4].result.isError, true);
-    assert.equal(
-      responses[4].result.structuredContent.code,
-      "repair_unavailable_diagnostic_fail_open",
-    );
-    assert.equal(responses[5].error.code, -32602);
-    assert.match(responses[5].error.message, /grounding tools are unavailable/u);
-    assert.match(responses[5].error.message, /restore a compatible stdio runtime/u);
+    assert.deepEqual(responses[2].result.tools, []);
+    assert.equal(responses[3].error.code, -32602);
+    assert.match(responses[3].error.message, /grounding tools are temporarily unavailable/u);
+    assert.match(responses[3].error.message, /Retry after the host reports that CodeStory is ready/u);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -2797,9 +2712,7 @@ test("mcp launcher fails open when CODESTORY_CLI override cannot spawn", async (
     assert.equal(status.plugin_runtime.cli_source, "local_dev_override");
     assert.equal(status.readiness[0].repair_reason, "local_dev_override_cli_unspawnable");
     assert.equal(status.allowed_surfaces.ground.allowed, false);
-    assert.equal(status.allowed_surfaces.sidecar_setup.allowed, true);
-    assert.deepEqual(status.allowed_surfaces.sidecar_setup.allowed_actions, ["status", "enable", "disable", "ask"]);
-    assert.doesNotMatch(JSON.stringify(status.recommended_next_calls), /"tool":"repair_all"/u);
+    assert.equal(status.managed_retrieval.automatic, true);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -2891,110 +2804,6 @@ test("mcp launcher fails open when managed cli probe fails", async () => {
       version,
     );
     assert.doesNotMatch(JSON.stringify(status.recommended_next_calls), /"tool":"repair_all"/u);
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-  }
-});
-
-test("mcp launcher persists sidecar setup policy in plugin data", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-policy-"));
-  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
-
-  try {
-    const enable = spawnSync(process.execPath, [launcher, "sidecar-policy", "enable"], {
-      env: { PLUGIN_DATA: dataDir },
-      encoding: "utf8",
-    });
-    assert.equal(enable.status, 0, enable.stderr);
-    assert.equal(JSON.parse(enable.stdout).state, "enabled");
-
-    const disable = spawnSync(process.execPath, [launcher, "sidecar-policy", "disable"], {
-      env: { PLUGIN_DATA: dataDir },
-      encoding: "utf8",
-    });
-    assert.equal(disable.status, 0, disable.stderr);
-    assert.equal(JSON.parse(disable.stdout).state, "disabled");
-
-    const repair = spawnSync(process.execPath, [launcher, "sidecar-policy", "repair"], {
-      env: { PLUGIN_DATA: dataDir },
-      encoding: "utf8",
-    });
-    assert.equal(repair.status, 0, repair.stderr);
-    assert.equal(JSON.parse(repair.stdout).state, "enabled");
-
-    const policy = JSON.parse(
-      await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"),
-    );
-    assert.equal(policy.state, "enabled");
-  } finally {
-    await rm(dataDir, { recursive: true, force: true });
-  }
-});
-
-test("enabled sidecar policy defers repair until after MCP startup", async () => {
-  const { spawnSync } = await import("node:child_process");
-  const version = await readPluginVersion();
-  const dataDir = await mkdtemp(join(tmpdir(), "codestory-sidecar-enabled-"));
-  const logFile = join(dataDir, "calls.jsonl");
-  const cliDir = join(dataDir, "codestory-cli", version);
-  const cliPath = join(
-    cliDir,
-    process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
-  );
-  const launcher = join(pluginRoot, "scripts", "codestory-mcp.cjs");
-
-  try {
-    await mkdir(cliDir, { recursive: true });
-    await writeRecordingCli(cliPath);
-    const sha256 = createHash("sha256")
-      .update(await readFile(cliPath))
-      .digest("hex");
-    await writeFile(
-      join(cliDir, "manifest.json"),
-      JSON.stringify(managedReleaseManifest(
-        version,
-        process.platform === "win32" ? "codestory-cli.cmd" : "codestory-cli",
-        sha256,
-      )),
-      "utf8",
-    );
-    await writeFile(
-      join(dataDir, "sidecar-setup-policy.json"),
-      JSON.stringify({ state: "enabled" }),
-      "utf8",
-    );
-
-    const result = spawnSync(process.execPath, [launcher], {
-      env: {
-        PLUGIN_DATA: dataDir,
-        TEST_LOG: logFile,
-        TEST_CODESTORY_VERSION: version,
-        PATH: "",
-        ComSpec: process.env.ComSpec || process.env.COMSPEC || "",
-      },
-      encoding: "utf8",
-    });
-    assert.equal(result.status, 0, result.stderr);
-
-    const text = await readFile(logFile, "utf8");
-    const calls = text.trim().split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
-    const repairCalls = calls.filter((call) => call.repair);
-    assert.equal(repairCalls.length, 0, text);
-    const serveCall = calls.find((call) => {
-      return JSON.stringify(call.args) === JSON.stringify([
-        "serve",
-        "--stdio",
-        "--multi-project",
-        "--refresh",
-        "none",
-      ]);
-    });
-    assert.ok(serveCall, text);
-    assert.equal(serveCall.policy, "enabled");
-    const policy = JSON.parse(await readFile(join(dataDir, "sidecar-setup-policy.json"), "utf8"));
-    assert.equal(policy.state, "enabled");
-    assert.equal(policy.last_repair, undefined);
   } finally {
     await rm(dataDir, { recursive: true, force: true });
   }
@@ -4018,10 +3827,10 @@ test("hook emits MCP activation guidance without running CLI", async () => {
     assert.equal(output.systemMessage, "CODESTORY:BACKGROUND");
     assert.match(context, /CODESTORY REQUEST ROUTING ACTIVE/u);
     assert.match(context, /Route: Symbol ownership/u);
-    assert.match(context, /codestory mcp ground status packet search/u);
+    assert.match(context, /codestory mcp ground packet search symbol/u);
     assert.match(context, /absolute repository cwd/u);
-    assert.match(context, /local graph surfaces before source/u);
-    assert.match(context, /Repair only when packet\/search is required/u);
+    assert.match(context, /Call the CodeStory tool that matches the request directly/u);
+    assert.match(context, /If CodeStory is preparing, retry that same tool/u);
     assert.match(context, /Hook text routes; only live MCP or verified source is evidence/u);
     assert.doesNotMatch(context, /CodeStory hook output truncated/u);
     assert.doesNotMatch(context, /HOOK MCP BRIDGE/u);
@@ -4071,7 +3880,7 @@ test("hook qualification compares executable policies with sourced MCP observati
   const dataDir = await mkdtemp(join(tmpdir(), "codestory-hook-qualification-"));
   const toolVocabulary = new Set([
     "affected", "callees", "callers", "definition", "files", "ground", "packet",
-    "search", "sidecar_setup", "snippet", "status", "symbol", "trace", "trail",
+    "search", "snippet", "status", "symbol", "trace", "trail",
   ]);
   const record = (output) => {
     const context = output.hookSpecificOutput?.additionalContext || "";
@@ -4239,7 +4048,7 @@ test("compact and resume session starts re-inject complete bounded routing", asy
       const context = output.hookSpecificOutput.additionalContext;
       assert.ok(context.length <= 900, `hook output was ${context.length} characters`);
       assert.match(context, /absolute repository cwd/u);
-      assert.match(context, /codestory mcp ground status packet search/u);
+      assert.match(context, /codestory mcp ground packet search symbol/u);
       assert.doesNotMatch(context, /truncated/u);
       assert.equal(context.endsWith("tools."), true);
     }


### PR DESCRIPTION
## Context

The plugin exposed its internal retrieval service as a user choice and taught agents to inspect status and ask people for setup help. That made first use noisy and failure recovery confusing.

Closes #1148
Refs #897

## What changed

- managed broad search prepares automatically from ordinary activating tools
- packet, search, and context return a compact same-tool retry while work is active
- terminal preparation failures return unavailable instead of looping forever
- removed public setup, repair-all, consent, policy, enable, and disable surfaces
- kept status observational and made activating-tool safety metadata truthful
- rewrote hooks, skill guidance, and user docs around intent-first tool use
- removed redundant branch-level tests and retired setup-policy machinery

## Review

Start with stdio_tool_blocked_error and the catalog safety split, then read the hook and skill changes. The diff is net -2,362 lines:

- production +177/-1,170
- tests +223/-1,450
- docs and instructions +214/-356

## Verification

- cargo test --locked -p codestory-cli --bin codestory-cli: 270 passed
- cargo test --locked -p codestory-cli --test stdio_protocol_contracts: 43 passed, 9 ignored live proofs
- node --test plugins/codestory/tests/plugin-static.test.mjs: 71 passed, 1 Windows skip
- cargo check --locked -p codestory-cli
- cargo fmt --all -- --check
- node .github/scripts/check-doc-links.mjs
- git diff --check

Exact head: 56067b3
Base: 3061235