### PR TITLE
Share managed retrieval assets across repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   bounded session contract. Status is observational and compact; tool text
   remains useful on hosts that do not render structured results, while large
   file, symbol, search, and impact payloads are capped with explicit counts.
+- The pinned search model and native backend are now verified and published in
+  one machine-wide cache. Repositories and worktrees reuse the same immutable
+  assets; concurrent first use is serialized, interrupted or corrupt payloads
+  are quarantined, and normal search preparation downloads missing assets
+  without a setup prompt.
 
 ## 0.15.0
 

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -740,6 +740,8 @@ pub(crate) struct RetrievalCommand {
 pub(crate) enum RetrievalAction {
     /// Start Docker Compose sidecars (when available), prepare cache dirs, and wait for health.
     Bootstrap(RetrievalBootstrapCommand),
+    #[command(name = "prewarm-assets", hide = true)]
+    PrewarmAssets(RetrievalPrewarmAssetsCommand),
     /// Prepare local sidecar data directories and write sidecar state (does not start Docker).
     Up(RetrievalSidecarStateCommand),
     /// Remove local sidecar state file (does not stop external processes).
@@ -752,6 +754,20 @@ pub(crate) enum RetrievalAction {
     Index(RetrievalIndexCommand),
     /// Execute a standalone sidecar retrieval query against indexed sidecar metadata.
     Query(RetrievalQueryCommand),
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct RetrievalPrewarmAssetsCommand {
+    #[arg(long, help = "Prewarm the pinned machine-wide embedding model.")]
+    pub(crate) model: bool,
+    #[arg(long, help = "Prewarm the managed native llama-server for this host.")]
+    pub(crate) native_backend: bool,
+    #[arg(
+        long,
+        value_name = "ID",
+        help = "Select a specific managed native llama-server backend."
+    )]
+    pub(crate) llama_backend: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -11,8 +11,9 @@ use codestory_retrieval::{
 
 use crate::args::{
     CliSidecarProfile, OutputFormat, RefreshMode, RetrievalAction, RetrievalBootstrapCommand,
-    RetrievalCommand, RetrievalIndexCommand, RetrievalInventoryCommand, RetrievalQueryCommand,
-    RetrievalSidecarStateCommand, RetrievalStatusCommand,
+    RetrievalCommand, RetrievalIndexCommand, RetrievalInventoryCommand,
+    RetrievalPrewarmAssetsCommand, RetrievalQueryCommand, RetrievalSidecarStateCommand,
+    RetrievalStatusCommand,
 };
 use crate::output::{emit, validate_output_file_parent};
 use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_refresh_request};
@@ -20,6 +21,7 @@ use crate::runtime::{RuntimeContext, ensure_index_ready, map_api_error, resolve_
 pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
     match cmd.action {
         RetrievalAction::Bootstrap(bootstrap_cmd) => run_retrieval_bootstrap(bootstrap_cmd),
+        RetrievalAction::PrewarmAssets(prewarm_cmd) => run_retrieval_prewarm_assets(prewarm_cmd),
         RetrievalAction::Up(up_cmd) => run_retrieval_up(up_cmd),
         RetrievalAction::Down(down_cmd) => run_retrieval_down(down_cmd),
         RetrievalAction::Status(status_cmd) => run_retrieval_status(status_cmd),
@@ -27,6 +29,16 @@ pub(crate) fn run_retrieval(cmd: RetrievalCommand) -> Result<()> {
         RetrievalAction::Index(index_cmd) => run_retrieval_index(index_cmd),
         RetrievalAction::Query(query_cmd) => run_retrieval_query(query_cmd),
     }
+}
+
+fn run_retrieval_prewarm_assets(cmd: RetrievalPrewarmAssetsCommand) -> Result<()> {
+    let report = codestory_retrieval::prewarm_managed_assets(
+        cmd.model,
+        cmd.native_backend,
+        cmd.llama_backend.as_deref(),
+    )?;
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
 }
 
 fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {

--- a/crates/codestory-retrieval/assets/embedding-models.json
+++ b/crates/codestory-retrieval/assets/embedding-models.json
@@ -1,0 +1,14 @@
+{
+  "models": [
+    {
+      "id": "bge-base-en-v1.5-q8_0",
+      "filename": "bge-base-en-v1.5.Q8_0.gguf",
+      "artifact_bytes": 117974304,
+      "sha256": "ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c",
+      "urls": [
+        "https://huggingface.co/BAAI/bge-base-en-v1.5-GGUF/resolve/main/bge-base-en-v1.5.Q8_0.gguf",
+        "https://huggingface.co/CompendiumLabs/bge-base-en-v1.5-gguf/resolve/main/bge-base-en-v1.5-q8_0.gguf"
+      ]
+    }
+  ]
+}

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -4,7 +4,6 @@ use crate::config::{
     retrieval_compose_profile, user_cache_root,
 };
 use crate::health::{InfrastructureHealth, probe_infrastructure_health};
-use crate::outbound_http::read_bytes;
 use crate::qdrant_storage::{
     BootstrapStorageScope, DEFAULT_QDRANT_COLLECTION_RETENTION, QdrantStorageRepairReport,
     repair_qdrant_storage,
@@ -303,6 +302,7 @@ struct NativeLlamaCandidate {
 #[derive(Debug, Deserialize)]
 struct NativeLlamaInstallManifest {
     artifact: String,
+    artifact_bytes: u64,
     artifact_sha256: String,
     executable_rel_path: String,
     executable_sha256: String,
@@ -1546,15 +1546,33 @@ fn ensure_selected_managed_native_llama_server(repo_root: Option<&Path>) -> Resu
 
 fn ensure_managed_native_llama_server(backend: &crate::config::LlamaSidecarBackend) -> Result<()> {
     let executable = user_cache_root().join(native_llama_backend_rel_path(backend));
+    let cache_root = user_cache_root();
+    let _asset_lock = crate::managed_assets::ManagedAssetLock::acquire(&cache_root)?;
     if executable.is_file() && validate_managed_native_llama_server(&executable, backend).is_ok() {
         return Ok(());
     }
+    if let Some(install_dir) = executable.parent()
+        && fs::symlink_metadata(install_dir).is_ok()
+    {
+        crate::managed_assets::quarantine_path(install_dir, "invalid")?;
+    }
+    let archive = cache_root
+        .join("managed-embeddings/blobs/sha256")
+        .join(&backend.sha256)
+        .join(&backend.artifact);
+    crate::managed_assets::ensure_cached_asset_locked(
+        &archive,
+        std::slice::from_ref(&backend.url),
+        backend.artifact_bytes,
+        &backend.sha256,
+    )?;
     let temp_root = managed_llama_temp_root()?;
-    let archive = temp_root.join(&backend.artifact);
-    let install_result = (|| {
-        download_managed_native_llama_server_archive(backend, &archive)?;
-        install_managed_native_llama_server_from_archive(backend, &archive, &executable)
-    })();
+    let install_result = install_managed_native_llama_server_from_archive(
+        backend,
+        &archive,
+        &temp_root.join("extract"),
+        &executable,
+    );
     let cleanup_result = fs::remove_dir_all(&temp_root);
     if let Err(error) = cleanup_result
         && install_result.is_ok()
@@ -1576,47 +1594,22 @@ fn managed_llama_temp_root() -> Result<PathBuf> {
     Ok(root)
 }
 
-fn download_managed_native_llama_server_archive(
-    backend: &crate::config::LlamaSidecarBackend,
-    archive: &Path,
-) -> Result<()> {
-    let response = read_bytes(
-        ureq::get(&backend.url)
-            .timeout(Duration::from_secs(120))
-            .call(),
-    )
-    .with_context(|| format!("download {}", backend.url))?;
-    if !(200..300).contains(&response.status) {
-        bail!(
-            "download managed native llama-server archive http {}",
-            response.status
-        );
-    }
-    fs::write(archive, &response.body).with_context(|| format!("write {}", archive.display()))?;
-    verify_sha256(archive, &backend.sha256)
-        .with_context(|| format!("verify {}", archive.display()))?;
-    Ok(())
-}
-
 fn install_managed_native_llama_server_from_archive(
     backend: &crate::config::LlamaSidecarBackend,
     archive: &Path,
+    extract_root: &Path,
     executable: &Path,
 ) -> Result<()> {
     verify_sha256(archive, &backend.sha256)
         .with_context(|| format!("verify {}", archive.display()))?;
-    let extract_root = archive
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("managed llama-server archive has no parent"))?
-        .join("extract");
-    fs::create_dir_all(&extract_root)
+    fs::create_dir_all(extract_root)
         .with_context(|| format!("create {}", extract_root.display()))?;
     let member_path = safe_archive_member_path(&backend.executable_archive_path)?;
     let output = Command::new("tar")
         .arg("-xzf")
         .arg(archive)
         .arg("-C")
-        .arg(&extract_root)
+        .arg(extract_root)
         .output()
         .with_context(|| format!("run tar for {}", archive.display()))?;
     if !output.status.success() {
@@ -1836,6 +1829,7 @@ fn write_managed_native_llama_install_manifest(
     let manifest = serde_json::json!({
         "backend": backend.id,
         "artifact": backend.artifact,
+        "artifact_bytes": backend.artifact_bytes,
         "artifact_sha256": backend.sha256,
         "executable_rel_path": backend.executable_rel_path,
         "executable_sha256": executable_sha,
@@ -1869,6 +1863,14 @@ fn validate_managed_native_llama_server(
             executable.display(),
             backend.artifact,
             manifest.artifact
+        );
+    }
+    if manifest.artifact_bytes != backend.artifact_bytes {
+        bail!(
+            "managed llama-server artifact size mismatch for {}: expected {}, got {}",
+            executable.display(),
+            backend.artifact_bytes,
+            manifest.artifact_bytes
         );
     }
     if !manifest
@@ -2468,25 +2470,19 @@ fn docker_bind_path(path: &Path) -> String {
     without_verbatim.replace('\\', "/")
 }
 
-fn embed_model_dir(repo_root: Option<&Path>, layout: &SidecarLayout) -> Result<PathBuf> {
-    let inventory = embed_model_inventory(repo_root, layout);
-    if let Some(model_dir) = inventory
-        .required_gguf_present
-        .then_some(inventory.model_dir.as_ref())
-        .flatten()
-    {
-        return Ok(PathBuf::from(model_dir));
-    }
-    if std::env::var("CODESTORY_EMBED_MODEL_DIR").is_ok() {
+fn embed_model_dir(_repo_root: Option<&Path>, _layout: &SidecarLayout) -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("CODESTORY_EMBED_MODEL_DIR") {
+        let path = PathBuf::from(path);
+        if embed_model_dir_ready(&path) {
+            return Ok(path);
+        }
         anyhow::bail!(
-            "CODESTORY_EMBED_MODEL_DIR does not contain {}; run `node scripts/setup-retrieval-env.mjs --fetch-embed-model` or set CODESTORY_EMBED_MODEL_DIR",
+            "CODESTORY_EMBED_MODEL_DIR does not contain {}",
             crate::embeddings::BGE_BASE_EN_V1_5_GGUF
         );
     }
-    anyhow::bail!(
-        "No llama.cpp embedding model directory contains {}; run `node scripts/setup-retrieval-env.mjs --fetch-embed-model` or set CODESTORY_EMBED_MODEL_DIR",
-        crate::embeddings::BGE_BASE_EN_V1_5_GGUF
-    )
+    crate::managed_assets::ensure_managed_embedding_model(&user_cache_root())
+        .context("prepare managed embedding model")
 }
 
 pub fn embed_model_inventory(
@@ -2499,9 +2495,14 @@ pub fn embed_model_inventory(
         .find(|candidate| embed_model_dir_ready(candidate))
         .or_else(|| candidates.first())
         .map(|path| path.display().to_string());
-    let required_gguf_present = model_dir
-        .as_ref()
-        .is_some_and(|path| embed_model_dir_ready(Path::new(path)));
+    let required_gguf_present = model_dir.as_ref().is_some_and(|path| {
+        let path = Path::new(path);
+        if path == crate::managed_assets::managed_embedding_model_dir(&user_cache_root()) {
+            crate::managed_assets::managed_embedding_model_is_published(&user_cache_root())
+        } else {
+            embed_model_dir_ready(path)
+        }
+    });
     EmbedModelInventory {
         model_dir,
         required_gguf: crate::embeddings::BGE_BASE_EN_V1_5_GGUF.to_string(),
@@ -2513,46 +2514,22 @@ pub fn embed_model_inventory(
     }
 }
 
-fn embed_model_candidates(repo_root: Option<&Path>, layout: &SidecarLayout) -> Vec<PathBuf> {
+fn embed_model_candidates(_repo_root: Option<&Path>, _layout: &SidecarLayout) -> Vec<PathBuf> {
     if let Ok(path) = std::env::var("CODESTORY_EMBED_MODEL_DIR") {
         return vec![PathBuf::from(path)];
     }
-    let workdir = repo_root
-        .or_else(|| Some(Path::new(".")))
-        .unwrap_or(Path::new("."));
-    let fallback = layout
-        .qdrant_data_dir
-        .parent()
-        .map(|parent| parent.join("embed-models"))
-        .unwrap_or_else(|| layout.qdrant_data_dir.join("embed-models"));
+    let cache_root = user_cache_root();
     let mut candidates = Vec::new();
     for candidate in [
-        workdir.join("target").join("retrieval-models"),
-        workdir.join("models").join("gguf").join("bge-base-en-v1.5"),
-        user_cache_root().join("retrieval-models"),
-        user_cache_root().join("embed-models"),
-        fallback,
+        crate::managed_assets::managed_embedding_model_dir(&cache_root),
+        cache_root.join("retrieval-models"),
+        cache_root.join("embed-models"),
     ] {
         if !candidates.contains(&candidate) {
             candidates.push(candidate);
         }
     }
     candidates
-}
-
-#[cfg(test)]
-fn embed_model_dir_from_candidates(
-    candidates: impl IntoIterator<Item = PathBuf>,
-) -> Result<PathBuf> {
-    for candidate in candidates {
-        if embed_model_dir_ready(&candidate) {
-            return Ok(candidate);
-        }
-    }
-    bail!(
-        "No llama.cpp embedding model directory contains {}; run `node scripts/setup-retrieval-env.mjs --fetch-embed-model` or set CODESTORY_EMBED_MODEL_DIR",
-        crate::embeddings::BGE_BASE_EN_V1_5_GGUF
-    )
 }
 
 fn embed_model_dir_ready(path: &Path) -> bool {
@@ -2921,7 +2898,8 @@ mod tests {
     }
 
     #[test]
-    fn embed_model_dir_discovers_repo_models_layout() {
+    fn embed_model_dir_uses_only_explicit_project_override() {
+        let _lock = crate::test_support::env_lock();
         let project = tempdir().expect("project");
         let model_dir = project
             .path()
@@ -2934,6 +2912,10 @@ mod tests {
             b"model placeholder",
         )
         .expect("model file");
+        let _override = EnvGuard::set(
+            "CODESTORY_EMBED_MODEL_DIR",
+            model_dir.to_str().expect("utf8 model dir"),
+        );
         let layout = SidecarLayout::from_env();
 
         assert_eq!(
@@ -2943,26 +2925,9 @@ mod tests {
     }
 
     #[test]
-    fn embed_model_dir_uses_first_candidate_with_model() {
-        let empty = tempdir().expect("empty");
-        let cache = tempdir().expect("cache");
-        let model_dir = cache.path().join("embed-models");
-        std::fs::create_dir_all(&model_dir).expect("model dir");
-        std::fs::write(
-            model_dir.join(crate::embeddings::BGE_BASE_EN_V1_5_GGUF),
-            b"model placeholder",
-        )
-        .expect("model file");
-
-        assert_eq!(
-            embed_model_dir_from_candidates([empty.path().to_path_buf(), model_dir.clone()])
-                .expect("fallback model dir"),
-            model_dir
-        );
-    }
-
-    #[test]
-    fn embed_model_dir_discovers_user_cache_retrieval_models() {
+    fn embed_model_inventory_reports_machine_cache_without_mutating_it() {
+        let _lock = crate::test_support::env_lock();
+        let _override = EnvGuard::remove("CODESTORY_EMBED_MODEL_DIR");
         let cache = tempdir().expect("cache");
         let project = tempdir().expect("project");
         let model_dir = cache.path().join("retrieval-models");
@@ -2973,26 +2938,15 @@ mod tests {
         )
         .expect("model file");
         let layout = compose_test_runtime(project.path()).layout;
-        let selected = crate::config::with_test_cache_root(cache.path(), || {
-            embed_model_dir(Some(project.path()), &layout)
-        })
-        .expect("model dir");
+        let inventory = crate::config::with_test_cache_root(cache.path(), || {
+            embed_model_inventory(Some(project.path()), &layout)
+        });
 
-        assert_eq!(selected, model_dir);
-    }
-
-    #[test]
-    fn embed_model_dir_fails_before_empty_fallback_container() {
-        let empty = tempdir().expect("empty");
-
-        let error = embed_model_dir_from_candidates([empty.path().to_path_buf()])
-            .expect_err("missing model must fail before docker compose");
-
-        assert!(
-            error
-                .to_string()
-                .contains(crate::embeddings::BGE_BASE_EN_V1_5_GGUF)
+        assert_eq!(
+            inventory.model_dir.as_deref(),
+            Some(model_dir.to_str().unwrap())
         );
+        assert!(inventory.required_gguf_present);
     }
 
     #[test]
@@ -3319,6 +3273,7 @@ mod tests {
         let manifest = serde_json::json!({
             "backend": legacy.id,
             "artifact": legacy.artifact,
+            "artifact_bytes": legacy.artifact_bytes,
             "artifact_sha256": legacy.sha256,
             "executable_rel_path": legacy.executable_rel_path,
             "executable_sha256": exe_sha,
@@ -3343,91 +3298,6 @@ mod tests {
     }
 
     #[test]
-    fn managed_native_candidate_requires_install_manifest() {
-        let _lock = crate::test_support::env_lock();
-        let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "macos/aarch64");
-        let backend =
-            crate::config::selected_llama_sidecar_backend("metal").expect("mac metal backend");
-        let temp = tempdir().expect("temp");
-        let exe = temp.path().join("llama-server");
-        std::fs::write(&exe, b"fake exe").expect("exe");
-
-        let error = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
-            path: exe,
-            backend: Some(backend),
-        }])
-        .expect_err("missing install manifest must fail closed");
-
-        assert!(error.to_string().contains("install-manifest.json"));
-    }
-
-    #[test]
-    fn managed_native_candidate_accepts_complete_extracted_install() {
-        let _lock = crate::test_support::env_lock();
-        let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "macos/aarch64");
-        let mut backend =
-            crate::config::selected_llama_sidecar_backend("metal").expect("mac metal backend");
-        let temp = tempdir().expect("temp");
-        let exe = temp.path().join("llama-server");
-        std::fs::write(&exe, b"fake exe").expect("exe");
-        let executable_sha = sha256_file(&exe).expect("sha");
-        backend.executable_sha256 = executable_sha.clone();
-        std::fs::write(
-            temp.path().join("install-manifest.json"),
-            serde_json::to_vec_pretty(&serde_json::json!({
-                "artifact": backend.artifact,
-                "artifact_sha256": backend.sha256,
-                "executable_rel_path": backend.executable_rel_path,
-                "executable_sha256": executable_sha,
-            }))
-            .expect("manifest"),
-        )
-        .expect("manifest write");
-        std::fs::write(temp.path().join(MANAGED_LLAMA_EXTRACTED_MARKER), b"1")
-            .expect("marker write");
-
-        let selected = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
-            path: exe.clone(),
-            backend: Some(backend),
-        }])
-        .expect("valid managed candidate");
-
-        assert_eq!(selected, exe);
-    }
-
-    #[test]
-    fn managed_native_candidate_rejects_single_file_install() {
-        let _lock = crate::test_support::env_lock();
-        let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "windows/x86_64");
-        let mut backend = crate::config::selected_llama_sidecar_backend("vulkan")
-            .expect("windows vulkan backend");
-        let temp = tempdir().expect("temp");
-        let exe = temp.path().join("llama-server.exe");
-        std::fs::write(&exe, b"fake exe").expect("exe");
-        let executable_sha = sha256_file(&exe).expect("sha");
-        backend.executable_sha256 = executable_sha.clone();
-        std::fs::write(
-            temp.path().join("install-manifest.json"),
-            serde_json::to_vec_pretty(&serde_json::json!({
-                "artifact": backend.artifact,
-                "artifact_sha256": backend.sha256,
-                "executable_rel_path": backend.executable_rel_path,
-                "executable_sha256": executable_sha,
-            }))
-            .expect("manifest"),
-        )
-        .expect("manifest write");
-
-        let error = native_llama_server_path_from_candidates(vec![NativeLlamaCandidate {
-            path: exe,
-            backend: Some(backend),
-        }])
-        .expect_err("single-file install must not validate");
-
-        assert!(error.to_string().contains("install is incomplete"));
-    }
-
-    #[test]
     fn managed_native_candidate_rejects_manifest_blessed_wrong_executable() {
         let _lock = crate::test_support::env_lock();
         let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "macos/aarch64");
@@ -3441,6 +3311,7 @@ mod tests {
             temp.path().join("install-manifest.json"),
             serde_json::to_vec_pretty(&serde_json::json!({
                 "artifact": backend.artifact,
+                "artifact_bytes": backend.artifact_bytes,
                 "artifact_sha256": backend.sha256,
                 "executable_rel_path": backend.executable_rel_path,
                 "executable_sha256": executable_sha,
@@ -3472,30 +3343,6 @@ mod tests {
         assert!(safe_archive_member_path("../llama-server").is_err());
         assert!(safe_archive_member_path("/tmp/llama-server").is_err());
         assert!(safe_archive_member_path("llama-b9902\\llama-server").is_err());
-    }
-
-    #[test]
-    fn managed_native_copy_materializes_safe_internal_symlink_target() {
-        let temp = tempdir().expect("temp");
-        let source_dir = temp.path().join("payload");
-        let target_dir = temp.path().join("install");
-        std::fs::create_dir_all(&source_dir).expect("payload dir");
-        std::fs::create_dir_all(&target_dir).expect("target dir");
-        let real = source_dir.join("libggml-rpc.dylib");
-        std::fs::write(&real, b"fake dylib").expect("real dylib");
-
-        copy_archive_symlinked_file_target(
-            &source_dir.join("libggml-rpc.0.dylib"),
-            &target_dir.join("libggml-rpc.0.dylib"),
-            &std::fs::canonicalize(&source_dir).expect("canonical source"),
-            Path::new("libggml-rpc.dylib"),
-        )
-        .expect("materialize symlink target");
-
-        assert_eq!(
-            std::fs::read(target_dir.join("libggml-rpc.0.dylib")).expect("copied dylib"),
-            b"fake dylib"
-        );
     }
 
     #[test]
@@ -3559,8 +3406,14 @@ mod tests {
             .join("b9902")
             .join("llama-b9902-bin-macos-arm64-metal")
             .join("llama-server");
-        install_managed_native_llama_server_from_archive(&backend, &archive, &executable)
-            .expect("install");
+        backend.artifact_bytes = std::fs::metadata(&archive).expect("archive metadata").len();
+        install_managed_native_llama_server_from_archive(
+            &backend,
+            &archive,
+            &temp.path().join("extract"),
+            &executable,
+        )
+        .expect("install");
 
         assert_eq!(
             std::fs::read(&executable).expect("installed exe"),
@@ -4108,20 +3961,6 @@ mod tests {
                 .expect("read state")
                 .is_none()
         );
-    }
-
-    #[test]
-    fn native_launch_missing_model_fails_before_spawn() {
-        let temp = tempdir().expect("temp");
-        let error = embed_model_dir_from_candidates([temp.path().join("embed-models")])
-            .expect_err("missing model should fail closed");
-
-        assert!(
-            error
-                .to_string()
-                .contains(crate::embeddings::BGE_BASE_EN_V1_5_GGUF)
-        );
-        assert!(error.to_string().contains("fetch-embed-model"));
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -16,7 +16,7 @@ use crate::sidecar::{
 };
 use anyhow::{Context, Result, bail};
 use fs4::fs_std::FileExt;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 #[cfg(windows)]
@@ -166,6 +166,15 @@ pub struct EmbedModelInventory {
     pub candidate_dirs: Vec<String>,
 }
 
+/// Machine-cache locations published while prewarming managed retrieval assets.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ManagedAssetPrewarmReport {
+    pub cache_root: String,
+    pub model_dir: Option<String>,
+    pub native_backend: Option<String>,
+    pub native_executable: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct BootstrapReport {
     pub state: SidecarStateFile,
@@ -302,7 +311,8 @@ struct NativeLlamaCandidate {
 #[derive(Debug, Deserialize)]
 struct NativeLlamaInstallManifest {
     artifact: String,
-    artifact_bytes: u64,
+    #[serde(default)]
+    artifact_bytes: Option<u64>,
     artifact_sha256: String,
     executable_rel_path: String,
     executable_sha256: String,
@@ -1582,6 +1592,59 @@ fn ensure_managed_native_llama_server(backend: &crate::config::LlamaSidecarBacke
     install_result
 }
 
+/// Publish the requested managed retrieval assets through the shared asset boundary.
+pub fn prewarm_managed_assets(
+    include_model: bool,
+    include_native_backend: bool,
+    backend_id: Option<&str>,
+) -> Result<ManagedAssetPrewarmReport> {
+    if !include_model && !include_native_backend {
+        bail!("select --model, --native-backend, or both");
+    }
+    if backend_id.is_some() && !include_native_backend {
+        bail!("--llama-backend requires --native-backend");
+    }
+
+    let cache_root = user_cache_root();
+    let model_dir = include_model
+        .then(|| crate::managed_assets::ensure_managed_embedding_model(&cache_root))
+        .transpose()?
+        .map(|path| path.display().to_string());
+
+    let backend = if include_native_backend {
+        let backend = match backend_id {
+            Some(id) => crate::config::llama_sidecar_backend_by_id(id)
+                .with_context(|| format!("unknown managed llama-server backend {id}"))?,
+            None => selected_native_llama_backend().context(
+                "no managed native llama-server backend is available for this host and accelerator",
+            )?,
+        };
+        if backend.launch_mode != EmbeddingServerLaunchMode::NativeSpawned.as_str() {
+            bail!(
+                "managed llama-server backend {} is not a native backend",
+                backend.id
+            );
+        }
+        ensure_managed_native_llama_server(&backend)?;
+        Some(backend)
+    } else {
+        None
+    };
+    let native_executable = backend.as_ref().map(|backend| {
+        cache_root
+            .join(native_llama_backend_rel_path(backend))
+            .display()
+            .to_string()
+    });
+
+    Ok(ManagedAssetPrewarmReport {
+        cache_root: cache_root.display().to_string(),
+        model_dir,
+        native_backend: backend.map(|backend| backend.id),
+        native_executable,
+    })
+}
+
 fn managed_llama_temp_root() -> Result<PathBuf> {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1865,12 +1928,14 @@ fn validate_managed_native_llama_server(
             manifest.artifact
         );
     }
-    if manifest.artifact_bytes != backend.artifact_bytes {
+    if let Some(artifact_bytes) = manifest.artifact_bytes
+        && artifact_bytes != backend.artifact_bytes
+    {
         bail!(
             "managed llama-server artifact size mismatch for {}: expected {}, got {}",
             executable.display(),
             backend.artifact_bytes,
-            manifest.artifact_bytes
+            artifact_bytes
         );
     }
     if !manifest
@@ -3246,7 +3311,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_windows_vulkan_cache_requires_matching_install_manifest() {
+    fn legacy_windows_vulkan_cache_accepts_the_original_install_manifest_shape() {
         let _lock = crate::test_support::env_lock();
         let _platform = EnvGuard::set("CODESTORY_TEST_HOST_PLATFORM", "windows/x86_64");
         let legacy = crate::config::llama_sidecar_backends("vulkan")
@@ -3273,7 +3338,6 @@ mod tests {
         let manifest = serde_json::json!({
             "backend": legacy.id,
             "artifact": legacy.artifact,
-            "artifact_bytes": legacy.artifact_bytes,
             "artifact_sha256": legacy.sha256,
             "executable_rel_path": legacy.executable_rel_path,
             "executable_sha256": exe_sha,

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -125,6 +125,8 @@ pub(crate) struct LlamaSidecarBackend {
     pub provider: String,
     pub launch_mode: String,
     pub artifact: String,
+    #[serde(default)]
+    pub artifact_bytes: u64,
     pub url: String,
     pub sha256: String,
     pub executable_archive_path: String,

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -162,6 +162,13 @@ pub(crate) fn selected_llama_sidecar_backend(provider: &str) -> Option<LlamaSide
     llama_sidecar_backends(provider).into_iter().next()
 }
 
+pub(crate) fn llama_sidecar_backend_by_id(id: &str) -> Option<LlamaSidecarBackend> {
+    llama_sidecar_backend_manifest()
+        .backends
+        .into_iter()
+        .find(|backend| backend.id == id)
+}
+
 pub(crate) fn llama_sidecar_backends(provider: &str) -> Vec<LlamaSidecarBackend> {
     let platform = embedding_host_platform();
     llama_sidecar_backend_manifest()

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -22,6 +22,7 @@ mod index;
 mod inventory;
 mod lexical_client;
 mod lexical_index;
+mod managed_assets;
 mod mode;
 pub mod outbound_http;
 mod planner;

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -48,13 +48,14 @@ pub use candidate::{is_phantom_sidecar_hit, phantom_sidecar_candidates_only};
 pub use capabilities::SidecarCapabilities;
 pub use compose::{
     BootstrapReport, BootstrapSidecarsOptions, DEFAULT_COMPOSE_REL_PATH, EmbedModelInventory,
-    NATIVE_EMBEDDING_DARWIN_EXEC_GATE_PROTOCOL, NATIVE_EMBEDDING_PORT_BIND_FAILED_REASON,
-    NativeEmbeddingStartupCleanupFailure, bootstrap_sidecars, bootstrap_sidecars_with_profile,
-    bootstrap_sidecars_with_runtime, bootstrap_sidecars_with_runtime_progress,
+    ManagedAssetPrewarmReport, NATIVE_EMBEDDING_DARWIN_EXEC_GATE_PROTOCOL,
+    NATIVE_EMBEDDING_PORT_BIND_FAILED_REASON, NativeEmbeddingStartupCleanupFailure,
+    bootstrap_sidecars, bootstrap_sidecars_with_profile, bootstrap_sidecars_with_runtime,
+    bootstrap_sidecars_with_runtime_progress,
     bootstrap_sidecars_with_runtime_progress_and_native_launch_observer, docker_available,
     embed_model_inventory, expected_native_embedding_launch_metadata,
     native_embedding_launch_contract_from_paths, native_embedding_launch_matches_runtime_for_reuse,
-    native_embedding_startup_cleanup_failure, resolve_compose_file,
+    native_embedding_startup_cleanup_failure, prewarm_managed_assets, resolve_compose_file,
 };
 pub use config::{
     DEFAULT_AGENT_RUN_ID, DEFAULT_EMBED_HTTP_PORT, DEFAULT_QDRANT_GRPC_PORT,

--- a/crates/codestory-retrieval/src/managed_assets.rs
+++ b/crates/codestory-retrieval/src/managed_assets.rs
@@ -1,0 +1,460 @@
+use anyhow::{Context, Result, bail};
+use fs4::fs_std::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const EMBEDDING_MODELS_JSON: &str = include_str!("../assets/embedding-models.json");
+const ASSET_LOCK_FILE: &str = "managed-embeddings/assets.lock";
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub(crate) struct ManagedModelAsset {
+    pub(crate) id: String,
+    pub(crate) filename: String,
+    pub(crate) artifact_bytes: u64,
+    pub(crate) sha256: String,
+    pub(crate) urls: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManagedModelManifest {
+    models: Vec<ManagedModelAsset>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ManagedModelInstallManifest {
+    id: String,
+    filename: String,
+    artifact_bytes: u64,
+    sha256: String,
+    source_url: String,
+}
+
+pub(crate) struct ManagedAssetLock {
+    _file: File,
+}
+
+impl ManagedAssetLock {
+    pub(crate) fn acquire(cache_root: &Path) -> Result<Self> {
+        let path = cache_root.join(ASSET_LOCK_FILE);
+        fs::create_dir_all(path.parent().expect("asset lock has a parent"))
+            .with_context(|| format!("create managed asset cache at {}", path.display()))?;
+        let file = open_regular_lock_file(&path)?;
+        FileExt::lock_exclusive(&file)
+            .with_context(|| format!("lock managed asset cache {}", path.display()))?;
+        Ok(Self { _file: file })
+    }
+}
+
+fn open_regular_lock_file(path: &Path) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).truncate(false);
+    let file = match options.create_new(true).open(path) {
+        Ok(file) => Ok(file),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            options.create_new(false).open(path)
+        }
+        Err(error) => Err(error),
+    }
+    .with_context(|| format!("open managed asset lock {}", path.display()))?;
+    let path_metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect managed asset lock {}", path.display()))?;
+    let file_metadata = file
+        .metadata()
+        .with_context(|| format!("inspect opened managed asset lock {}", path.display()))?;
+    if !path_metadata.file_type().is_file() || !file_metadata.file_type().is_file() {
+        bail!(
+            "managed asset lock is not a regular file: {}",
+            path.display()
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if path_metadata.dev() != file_metadata.dev() || path_metadata.ino() != file_metadata.ino()
+        {
+            bail!(
+                "managed asset lock changed while opening: {}",
+                path.display()
+            );
+        }
+    }
+    Ok(file)
+}
+
+pub(crate) fn pinned_embedding_model() -> ManagedModelAsset {
+    let manifest: ManagedModelManifest =
+        serde_json::from_str(EMBEDDING_MODELS_JSON).expect("embedded model manifest must be valid");
+    let [model] = manifest.models.as_slice() else {
+        panic!("embedded model manifest must contain exactly one product model");
+    };
+    assert_eq!(
+        model.filename,
+        crate::embeddings::BGE_BASE_EN_V1_5_GGUF,
+        "managed model filename must match the product embedding contract"
+    );
+    model.clone()
+}
+
+pub(crate) fn managed_embedding_model_dir(cache_root: &Path) -> PathBuf {
+    let model = pinned_embedding_model();
+    cache_root
+        .join("managed-embeddings/models/sha256")
+        .join(&model.sha256)
+}
+
+pub(crate) fn managed_embedding_model_is_published(cache_root: &Path) -> bool {
+    let model = pinned_embedding_model();
+    let dir = managed_embedding_model_dir(cache_root);
+    let path = dir.join(&model.filename);
+    let Ok(metadata) = fs::symlink_metadata(&path) else {
+        return false;
+    };
+    if metadata.file_type().is_symlink()
+        || !metadata.is_file()
+        || metadata.len() != model.artifact_bytes
+    {
+        return false;
+    }
+    let Ok(manifest) = fs::read(dir.join("install-manifest.json")) else {
+        return false;
+    };
+    serde_json::from_slice::<ManagedModelInstallManifest>(&manifest).is_ok_and(|manifest| {
+        manifest.id == model.id
+            && manifest.filename == model.filename
+            && manifest.artifact_bytes == model.artifact_bytes
+            && manifest.sha256.eq_ignore_ascii_case(&model.sha256)
+    })
+}
+
+pub(crate) fn ensure_managed_embedding_model(cache_root: &Path) -> Result<PathBuf> {
+    let model = pinned_embedding_model();
+    let _lock = ManagedAssetLock::acquire(cache_root)?;
+    let dir = managed_embedding_model_dir(cache_root);
+    let path = dir.join(&model.filename);
+    let source_url =
+        ensure_cached_asset_locked(&path, &model.urls, model.artifact_bytes, &model.sha256)?;
+    if source_url == "cache" && managed_embedding_model_is_published(cache_root) {
+        return Ok(dir);
+    }
+    let manifest = ManagedModelInstallManifest {
+        id: model.id,
+        filename: model.filename,
+        artifact_bytes: model.artifact_bytes,
+        sha256: model.sha256,
+        source_url,
+    };
+    codestory_workspace::atomic_file::write_bytes_atomic(
+        &dir.join("install-manifest.json"),
+        "managed-model-install-manifest",
+        &serde_json::to_vec_pretty(&manifest).expect("serialize managed model manifest"),
+    )?;
+    Ok(dir)
+}
+
+pub(crate) fn ensure_cached_asset_locked(
+    destination: &Path,
+    urls: &[String],
+    expected_bytes: u64,
+    expected_sha256: &str,
+) -> Result<String> {
+    validate_asset_metadata(urls, expected_bytes, expected_sha256)?;
+    fs::create_dir_all(
+        destination
+            .parent()
+            .context("managed asset has no parent")?,
+    )
+    .with_context(|| {
+        format!(
+            "create managed asset directory for {}",
+            destination.display()
+        )
+    })?;
+    quarantine_interrupted_partials(destination)?;
+    if destination.is_file() && file_matches(destination, expected_bytes, expected_sha256) {
+        return Ok("cache".to_string());
+    }
+    if fs::symlink_metadata(destination).is_ok() {
+        quarantine_path(destination, "invalid")?;
+    }
+
+    let mut errors = Vec::new();
+    for url in urls {
+        let partial = unique_partial_path(destination);
+        let downloaded = download_exact(url, &partial, expected_bytes)
+            .and_then(|()| verify_file(&partial, expected_bytes, expected_sha256));
+        match downloaded {
+            Ok(()) => {
+                codestory_workspace::atomic_file::publish_existing_file_atomic(
+                    &partial,
+                    destination,
+                )?;
+                return Ok(url.clone());
+            }
+            Err(error) => {
+                if partial.symlink_metadata().is_ok() {
+                    let _ = quarantine_path(&partial, "download");
+                }
+                errors.push(format!("{url}: {error:#}"));
+            }
+        }
+    }
+    bail!(
+        "managed asset download failed after {} source(s): {}",
+        urls.len(),
+        errors.join("; ")
+    )
+}
+
+pub(crate) fn quarantine_path(path: &Path, reason: &str) -> Result<PathBuf> {
+    let parent = path.parent().context("quarantine path has no parent")?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("quarantine path has no portable filename")?;
+    let quarantine = parent.join(format!(
+        ".quarantine-{name}-{reason}-{}-{}",
+        std::process::id(),
+        now_nanos()
+    ));
+    fs::rename(path, &quarantine).with_context(|| {
+        format!(
+            "quarantine managed asset {} as {}",
+            path.display(),
+            quarantine.display()
+        )
+    })?;
+    Ok(quarantine)
+}
+
+fn validate_asset_metadata(urls: &[String], expected_bytes: u64, sha256: &str) -> Result<()> {
+    if urls.is_empty() || expected_bytes == 0 || !is_sha256(sha256) {
+        bail!("managed asset metadata is incomplete");
+    }
+    if urls
+        .iter()
+        .any(|url| !url.starts_with("https://") && !cfg!(test))
+    {
+        bail!("managed asset URLs must use HTTPS");
+    }
+    Ok(())
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn quarantine_interrupted_partials(destination: &Path) -> Result<()> {
+    let parent = destination
+        .parent()
+        .context("managed asset has no parent")?;
+    let prefix = format!(
+        ".{}.partial-",
+        destination
+            .file_name()
+            .and_then(|name| name.to_str())
+            .context("managed asset has no portable filename")?
+    );
+    for entry in fs::read_dir(parent).with_context(|| format!("read {}", parent.display()))? {
+        let entry = entry.with_context(|| format!("read entry in {}", parent.display()))?;
+        if entry.file_name().to_string_lossy().starts_with(&prefix) {
+            quarantine_path(&entry.path(), "interrupted")?;
+        }
+    }
+    Ok(())
+}
+
+fn unique_partial_path(destination: &Path) -> PathBuf {
+    let parent = destination.parent().expect("managed asset has a parent");
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("managed asset has a portable filename");
+    parent.join(format!(
+        ".{name}.partial-{}-{}",
+        std::process::id(),
+        now_nanos()
+    ))
+}
+
+fn now_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+fn download_exact(url: &str, destination: &Path, expected_bytes: u64) -> Result<()> {
+    let response = ureq::get(url)
+        .timeout(DOWNLOAD_TIMEOUT)
+        .call()
+        .with_context(|| format!("download {url}"))?;
+    if let Some(content_length) = response.header("content-length") {
+        let announced = content_length
+            .parse::<u64>()
+            .with_context(|| format!("invalid content-length from {url}"))?;
+        if announced != expected_bytes {
+            bail!("download size mismatch from {url}: expected {expected_bytes}, got {announced}");
+        }
+    }
+    let mut source = response.into_reader();
+    let mut target = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+        .with_context(|| format!("create {}", destination.display()))?;
+    let mut received = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = source
+            .read(&mut buffer)
+            .with_context(|| format!("read {url}"))?;
+        if read == 0 {
+            break;
+        }
+        received = received.saturating_add(read as u64);
+        if received > expected_bytes {
+            bail!("download exceeds declared size from {url}");
+        }
+        target
+            .write_all(&buffer[..read])
+            .with_context(|| format!("write {}", destination.display()))?;
+    }
+    if received != expected_bytes {
+        bail!("download size mismatch from {url}: expected {expected_bytes}, got {received}");
+    }
+    target
+        .sync_all()
+        .with_context(|| format!("sync {}", destination.display()))?;
+    Ok(())
+}
+
+fn verify_file(path: &Path, expected_bytes: u64, expected_sha256: &str) -> Result<()> {
+    let metadata =
+        fs::symlink_metadata(path).with_context(|| format!("metadata {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!("managed asset is not a regular file: {}", path.display());
+    }
+    if metadata.len() != expected_bytes {
+        bail!(
+            "managed asset size mismatch for {}: expected {}, got {}",
+            path.display(),
+            expected_bytes,
+            metadata.len()
+        );
+    }
+    let actual = sha256_file(path)?;
+    if !actual.eq_ignore_ascii_case(expected_sha256) {
+        bail!(
+            "managed asset checksum mismatch for {}: expected {}, got {}",
+            path.display(),
+            expected_sha256,
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn file_matches(path: &Path, expected_bytes: u64, expected_sha256: &str) -> bool {
+    verify_file(path, expected_bytes, expected_sha256).is_ok()
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("read {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use tempfile::tempdir;
+
+    fn serve_once(body: Vec<u8>) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let url = format!(
+            "http://{}/asset",
+            listener.local_addr().expect("server addr")
+        );
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).expect("read request");
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .expect("write response headers");
+            stream.write_all(&body).expect("write response body");
+        });
+        (url, handle)
+    }
+
+    #[test]
+    fn product_model_metadata_resolves_to_one_machine_content_address() {
+        let first = tempdir().expect("cache");
+        let second_project = tempdir().expect("second project");
+        let model = pinned_embedding_model();
+        let path = managed_embedding_model_dir(first.path());
+
+        assert_eq!(model.filename, crate::embeddings::BGE_BASE_EN_V1_5_GGUF);
+        assert!(path.starts_with(first.path()));
+        assert!(path.ends_with(&model.sha256));
+        assert!(!path.starts_with(second_project.path()));
+    }
+
+    #[test]
+    fn corrupt_and_interrupted_assets_are_quarantined_before_atomic_publication() {
+        let cache = tempdir().expect("cache");
+        let destination = cache.path().join("sha256/test/asset.bin");
+        fs::create_dir_all(destination.parent().unwrap()).expect("asset dir");
+        fs::write(&destination, b"corrupt").expect("corrupt asset");
+        fs::write(
+            destination
+                .parent()
+                .unwrap()
+                .join(".asset.bin.partial-dead"),
+            b"partial",
+        )
+        .expect("partial asset");
+        let body = b"verified asset".to_vec();
+        let sha = format!("{:x}", Sha256::digest(&body));
+        let (url, server) = serve_once(body.clone());
+        let _lock = ManagedAssetLock::acquire(cache.path()).expect("asset lock");
+
+        ensure_cached_asset_locked(&destination, &[url], body.len() as u64, &sha)
+            .expect("publish asset");
+        server.join().expect("server thread");
+
+        assert_eq!(fs::read(&destination).expect("published asset"), body);
+        let quarantines = fs::read_dir(destination.parent().unwrap())
+            .expect("asset dir")
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".quarantine-")
+            })
+            .count();
+        assert_eq!(quarantines, 2);
+    }
+}

--- a/crates/codestory-retrieval/src/managed_assets.rs
+++ b/crates/codestory-retrieval/src/managed_assets.rs
@@ -111,13 +111,7 @@ pub(crate) fn managed_embedding_model_is_published(cache_root: &Path) -> bool {
     let model = pinned_embedding_model();
     let dir = managed_embedding_model_dir(cache_root);
     let path = dir.join(&model.filename);
-    let Ok(metadata) = fs::symlink_metadata(&path) else {
-        return false;
-    };
-    if metadata.file_type().is_symlink()
-        || !metadata.is_file()
-        || metadata.len() != model.artifact_bytes
-    {
+    if !file_matches(&path, model.artifact_bytes, &model.sha256) {
         return false;
     }
     let Ok(manifest) = fs::read(dir.join("install-manifest.json")) else {
@@ -384,7 +378,9 @@ mod tests {
     use super::*;
     use std::io::{Read, Write};
     use std::net::TcpListener;
+    use std::process::Command;
     use std::thread;
+    use std::time::Instant;
     use tempfile::tempdir;
 
     fn serve_once(body: Vec<u8>) -> (String, thread::JoinHandle<()>) {
@@ -425,8 +421,12 @@ mod tests {
     fn corrupt_and_interrupted_assets_are_quarantined_before_atomic_publication() {
         let cache = tempdir().expect("cache");
         let destination = cache.path().join("sha256/test/asset.bin");
+        let body = b"verified asset".to_vec();
+        let sha = format!("{:x}", Sha256::digest(&body));
         fs::create_dir_all(destination.parent().unwrap()).expect("asset dir");
-        fs::write(&destination, b"corrupt").expect("corrupt asset");
+        fs::write(&destination, b"corrupted data").expect("corrupt asset");
+        assert_eq!(fs::metadata(&destination).unwrap().len(), body.len() as u64);
+        assert!(!file_matches(&destination, body.len() as u64, &sha));
         fs::write(
             destination
                 .parent()
@@ -435,8 +435,6 @@ mod tests {
             b"partial",
         )
         .expect("partial asset");
-        let body = b"verified asset".to_vec();
-        let sha = format!("{:x}", Sha256::digest(&body));
         let (url, server) = serve_once(body.clone());
         let _lock = ManagedAssetLock::acquire(cache.path()).expect("asset lock");
 
@@ -456,5 +454,61 @@ mod tests {
             })
             .count();
         assert_eq!(quarantines, 2);
+    }
+
+    #[test]
+    fn managed_asset_lock_process_helper() {
+        let Ok(cache_root) = std::env::var("CODESTORY_TEST_ASSET_LOCK_CACHE") else {
+            return;
+        };
+        let cache_root = PathBuf::from(cache_root);
+        fs::write(cache_root.join("child-started"), b"1").expect("publish child start");
+        let _lock = ManagedAssetLock::acquire(&cache_root).expect("acquire child asset lock");
+        fs::write(cache_root.join("child-acquired"), b"1").expect("publish child acquisition");
+    }
+
+    #[test]
+    fn managed_asset_lock_serializes_processes() {
+        let cache = tempdir().expect("cache");
+        let lock = ManagedAssetLock::acquire(cache.path()).expect("acquire parent asset lock");
+        let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+            .arg("--exact")
+            .arg("managed_assets::tests::managed_asset_lock_process_helper")
+            .arg("--nocapture")
+            .env("CODESTORY_TEST_ASSET_LOCK_CACHE", cache.path())
+            .spawn()
+            .expect("spawn asset lock helper");
+
+        let started = cache.path().join("child-started");
+        let acquired = cache.path().join("child-acquired");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !started.is_file() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(started.is_file(), "child did not reach the asset lock");
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            !acquired.exists(),
+            "child crossed the machine asset lock while the parent held it"
+        );
+        assert!(
+            child.try_wait().expect("poll child").is_none(),
+            "child exited instead of waiting for the machine asset lock"
+        );
+
+        drop(lock);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(status) = child.try_wait().expect("poll child after release") {
+                assert!(status.success(), "asset lock helper failed: {status}");
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child did not acquire the released machine asset lock"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(acquired.is_file());
     }
 }

--- a/docs/contributors/debugging.md
+++ b/docs/contributors/debugging.md
@@ -93,9 +93,9 @@ Recovery order:
 
 1. Confirm whether the miss is in `indexed_symbol_hits`, `repo_text_hits`, or both.
 2. Confirm the reported retrieval mode and degraded-state reason before touching search ranking code.
-3. For product sidecar evidence, fetch the pinned GGUF when needed with
-   `node scripts/setup-retrieval-env.mjs --fetch-embed-model`, then run
-   `codestory-cli retrieval bootstrap --project .`. Set
+3. For product sidecar evidence, run
+   `codestory-cli retrieval bootstrap --project .`; it prepares the pinned
+   machine-wide assets when needed. Set
    `CODESTORY_EMBED_BACKEND=llamacpp` and `CODESTORY_EMBED_LLAMACPP_URL` only
    when your local sidecar endpoint differs from the default.
 4. Rebuild once with `codestory-cli index --project . --refresh full`, then

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -171,7 +171,7 @@ commands as product-quality proof.
 Use this lane only for packet/search, retrieval, ranking-quality, or sidecar
 work. Prepare the managed full-sidecar path before debugging ranking quality:
 
-- product sidecar setup: `node scripts/setup-retrieval-env.mjs --fetch-embed-model`, then `codestory-cli retrieval bootstrap --project .`
+- product sidecar setup: `codestory-cli retrieval bootstrap --project .` (the setup wrapper's fetch flags are optional offline prewarming)
 - default symbol-doc scope: durable symbols only; set `CODESTORY_SEMANTIC_DOC_SCOPE=all` when you intentionally need the broad all-symbol diagnostic symbol-doc set
 - default dense policy: `graph_first_v1` embeds only selected dense anchors; private trivial code remains searchable through symbol docs, lexical source, and graph expansion
 - default semantic alias mode: compact aliases; set `CODESTORY_SEMANTIC_DOC_ALIAS_MODE=no_alias` or `current_alias` only when reproducing benchmark rows

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -116,15 +116,15 @@ Attach these artifacts to issues or PRs that claim readiness repair:
 - Docker Desktop or Docker Engine for automated Qdrant and llama.cpp
   sidecars. On Apple Silicon the managed embedding server is native Metal, but
   Qdrant still requires Docker. Confirm the Docker daemon is running.
-- Node.js 18+ is also required by `scripts/setup-retrieval-env.mjs` to fetch or
-  verify the pinned GGUF and native `llama-server` payload.
+- Node.js 18+ is required only for the contributor setup wrapper. The CLI
+  downloads and verifies missing managed assets during normal preparation.
 - For manual Local profile only, the default localhost ports are Qdrant HTTP
   `6333`, Qdrant gRPC `6334`, and llama.cpp embeddings `8080`; lexical search
   has no service port.
   Managed Agent profiles allocate or reuse namespace-specific ports; read them
   from status rather than assuming the Local defaults.
-- GGUF embedding model available through `CODESTORY_EMBED_MODEL_DIR`, or fetched
-  with the setup wrapper.
+- `CODESTORY_EMBED_MODEL_DIR` is an explicit developer override. Without it,
+  CodeStory uses the pinned machine-wide model cache.
 
 Manual sidecar setup is allowed only when equivalent local Qdrant and
 llama.cpp services are already healthy. Agent-facing retrieval is invalid until
@@ -154,9 +154,10 @@ accelerated llama.cpp backend. On macOS arm64, bootstrap/repair installs and
 launches the managed native Metal `llama-server` with
 `launch_mode=native_spawned`; a Linux Docker/Colima embed service cannot satisfy
 a `vulkan:Vulkan0` request on Apple Silicon. Use
-`node scripts/setup-retrieval-env.mjs --fetch-llama-server --fetch-only` only to
-prewarm the managed Metal cache cell. Set `CODESTORY_EMBED_NATIVE_LLAMA_SERVER`
-only when overriding the managed binary with an absolute path.
+`node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-llama-server
+--fetch-only` only to prewarm the same machine cache. Set
+`CODESTORY_EMBED_NATIVE_LLAMA_SERVER` only when overriding the managed binary
+with an absolute path.
 
 On macOS x64, the CLI, managed plugin, local index, and grounding are supported,
 but there is no managed Metal cell. Packet/search requires an explicit degraded
@@ -213,10 +214,14 @@ opens. Prefer trusted user config, explicit CLI flags, or environment variables.
 From the CodeStory repository root:
 
 ```sh
-node scripts/setup-retrieval-env.mjs --fetch-embed-model
-# macOS arm64 Metal native sidecar only:
-node scripts/setup-retrieval-env.mjs --fetch-llama-server --fetch-only
 cargo run --locked -p codestory-cli -- retrieval bootstrap --project <repo> --format json
+```
+
+Bootstrap obtains missing pinned assets automatically. Contributors who need to
+prewarm a machine before going offline can run:
+
+```sh
+node scripts/setup-retrieval-env.mjs --fetch-embed-model --fetch-llama-server --fetch-only
 ```
 
 Use the environment variables from the minimum table only when the defaults do
@@ -400,15 +405,18 @@ Cache-root and profile layout:
 | Local profile | `<cache>/{lexical,qdrant,scip,retrieval-sidecars-v3.json}` in namespace `codestory-v3`, with configurable Qdrant/embed ports |
 | Managed Agent profile | `<cache>/sidecars/codestory-agent-v3-<workspace>-<run>/{lexical,qdrant,scip,retrieval-sidecars-v3.json}` with dynamic or persisted Qdrant/embed ports |
 | Agent port registry | Authoritative `<cache>/sidecars/port-allocations.sqlite3`; v0.15 also imports/projects locked legacy JSON records for compatibility |
+| Managed model | `<cache>/managed-embeddings/models/sha256/<digest>/bge-base-en-v1.5.Q8_0.gguf` |
+| Managed backend archives | `<cache>/managed-embeddings/blobs/sha256/<digest>/...` before verified native payload publication |
 
 Unversioned `retrieval-sidecars.json` files and pre-v3 Agent namespaces remain
 visible to inventory, but current runtimes never select, overwrite, or clean
 them automatically.
 
-Downloaded model artifacts under `CODESTORY_EMBED_MODEL_DIR` or
-`target/retrieval-models` are accepted only after pinned size and SHA-256
-verification by the setup wrapper. Remove that model directory to uninstall the
-downloaded GGUF.
+Managed assets use one machine lock, exact byte limits, SHA-256 verification,
+and atomic publication. Invalid canonical files and interrupted partials are
+renamed inside their asset directory for diagnosis instead of becoming active.
+Project-local models are considered only when `CODESTORY_EMBED_MODEL_DIR`
+explicitly selects them.
 
 ## Operator troubleshooting
 

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -157,7 +157,9 @@ Command table: [CLI reference - readiness and repair](cli-reference.md#readiness
 
 Apple Silicon uses managed Metal acceleration automatically. Retry the original
 broad-search tool while CodeStory reports `preparing`; local navigation remains
-available in the meantime.
+available in the meantime. The first broad search can take longer while
+CodeStory prepares its local search support once for the Mac; later repositories
+reuse it automatically.
 
 Intel Macs support local navigation by default. When broad search cannot use a
 supported local or trusted external backend, the tool returns `unavailable` and

--- a/scripts/setup-retrieval-env.mjs
+++ b/scripts/setup-retrieval-env.mjs
@@ -30,7 +30,7 @@ Options:
   --skip-compose            Pass --skip-compose to "retrieval bootstrap"
   --skip-status             Skip final "retrieval status"
   --with-holdout-clone      Clone holdout-retrieval OSS repos (network; large)
-  --fetch-embed-model       Download bge-base-en-v1.5.Q8_0.gguf into target/retrieval-models
+  --fetch-embed-model       Prewarm the machine-wide pinned embedding model cache
   --fetch-llama-server      Download the managed native llama-server for this host
   --llama-backend <id>      Select a llama-server backend from llama-sidecar-backends.json
   --fetch-only              With --fetch-embed-model/--fetch-llama-server, fetch/verify and exit
@@ -262,20 +262,29 @@ function printPrereqReport(opts) {
   return failed;
 }
 
-const BGE_GGUF = "bge-base-en-v1.5.Q8_0.gguf";
-const BGE_GGUF_SHA256 = "ad1afe72cd6654a558667a3db10878b049a75bfd72912e1dabb91310d671173c";
-const BGE_GGUF_BYTES = 117_974_304;
+const EMBED_MODELS_MANIFEST = path.join(
+  repoRoot,
+  "crates",
+  "codestory-retrieval",
+  "assets",
+  "embedding-models.json",
+);
 const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
-const BGE_URLS = [
-  "https://huggingface.co/BAAI/bge-base-en-v1.5-GGUF/resolve/main/bge-base-en-v1.5.Q8_0.gguf",
-  "https://huggingface.co/CompendiumLabs/bge-base-en-v1.5-gguf/resolve/main/bge-base-en-v1.5-q8_0.gguf",
-];
+
+function pinnedEmbedModel() {
+  const models = JSON.parse(fs.readFileSync(EMBED_MODELS_MANIFEST, "utf8")).models ?? [];
+  if (models.length !== 1) {
+    throw new Error(`${EMBED_MODELS_MANIFEST} must contain exactly one product model`);
+  }
+  return models[0];
+}
 
 function embedModelDir() {
   if (process.env.CODESTORY_EMBED_MODEL_DIR) {
     return path.resolve(process.env.CODESTORY_EMBED_MODEL_DIR);
   }
-  return path.join(repoRoot, "target", "retrieval-models");
+  const model = pinnedEmbedModel();
+  return path.join(codestoryCacheRoot(), "managed-embeddings", "models", "sha256", model.sha256);
 }
 
 function sha256File(file) {
@@ -289,19 +298,20 @@ function sha256File(file) {
 }
 
 async function verifyEmbedModel(file) {
+  const model = pinnedEmbedModel();
   const stat = fs.statSync(file);
   if (!stat.isFile()) {
     throw new Error(`Embed model path is not a file: ${file}`);
   }
-  if (stat.size !== BGE_GGUF_BYTES) {
+  if (stat.size !== model.artifact_bytes) {
     throw new Error(
-      `Embed model size mismatch for ${file}: got ${stat.size} bytes, expected ${BGE_GGUF_BYTES}`,
+      `Embed model size mismatch for ${file}: got ${stat.size} bytes, expected ${model.artifact_bytes}`,
     );
   }
   const actual = await sha256File(file);
-  if (actual !== BGE_GGUF_SHA256) {
+  if (actual !== model.sha256) {
     throw new Error(
-      `Embed model SHA-256 mismatch for ${file}: got ${actual}, expected ${BGE_GGUF_SHA256}`,
+      `Embed model SHA-256 mismatch for ${file}: got ${actual}, expected ${model.sha256}`,
     );
   }
   return actual;
@@ -376,32 +386,56 @@ async function downloadFile(
 }
 
 async function fetchEmbedModel() {
+  const model = pinnedEmbedModel();
   const dir = embedModelDir();
   fs.mkdirSync(dir, { recursive: true });
-  const dest = path.join(dir, BGE_GGUF);
+  const dest = path.join(dir, model.filename);
   if (fs.existsSync(dest) && fs.statSync(dest).size > 1_000_000) {
     let checksum;
     try {
       checksum = await verifyEmbedModel(dest);
     } catch (error) {
-      throw new Error(
-        `${error instanceof Error ? error.message : error}. Remove ${dest} and rerun --fetch-embed-model.`,
+      const quarantine = path.join(
+        dir,
+        `.quarantine-${model.filename}-invalid-${process.pid}-${Date.now()}`,
       );
+      fs.renameSync(dest, quarantine);
+      console.log(`Quarantined invalid managed model at ${quarantine}: ${error}`);
     }
-    console.log(`Embed model already present and verified: ${dest} sha256=${checksum}`);
-    return dest;
+    if (checksum) {
+      console.log(`Embed model already present and verified: ${dest} sha256=${checksum}`);
+      return dest;
+    }
   }
   let lastError = null;
-  for (const url of BGE_URLS) {
-    console.log(`Downloading ${BGE_GGUF} from ${url} to ${dest} ...`);
-    const tempDest = `${dest}.tmp-${process.pid}`;
+  for (const url of model.urls) {
+    console.log(`Downloading ${model.filename} from ${url} to ${dest} ...`);
+    const tempDest = path.join(dir, `.${model.filename}.partial-${process.pid}-${Date.now()}`);
     try {
       const downloadedBytes = await downloadFile(url, tempDest, {
-        expectedBytes: BGE_GGUF_BYTES,
-        maxBytes: BGE_GGUF_BYTES,
+        expectedBytes: model.artifact_bytes,
+        maxBytes: model.artifact_bytes,
       });
       const checksum = await verifyEmbedModel(tempDest);
-      fs.renameSync(tempDest, dest);
+      try {
+        fs.renameSync(tempDest, dest);
+      } catch (error) {
+        if (!fs.existsSync(dest)) throw error;
+        await verifyEmbedModel(dest);
+        fs.rmSync(tempDest, { force: true });
+        console.log(`Embed model was published concurrently and verified: ${dest}`);
+        return dest;
+      }
+      const manifestTemp = path.join(
+        dir,
+        `.install-manifest.json.partial-${process.pid}-${Date.now()}`,
+      );
+      fs.writeFileSync(
+        manifestTemp,
+        `${JSON.stringify({ ...model, source_url: url, urls: undefined }, null, 2)}\n`,
+        { flag: "wx" },
+      );
+      fs.renameSync(manifestTemp, path.join(dir, "install-manifest.json"));
       console.log(`Wrote ${dest} (${downloadedBytes} bytes, sha256=${checksum})`);
       return dest;
     } catch (error) {
@@ -667,6 +701,16 @@ async function fetchLlamaServer(opts) {
 }
 
 async function runSelfTest() {
+  const model = pinnedEmbedModel();
+  if (
+    model.filename !== "bge-base-en-v1.5.Q8_0.gguf" ||
+    !Number.isSafeInteger(model.artifact_bytes) ||
+    !/^[0-9a-f]{64}$/.test(model.sha256) ||
+    !Array.isArray(model.urls) ||
+    model.urls.length === 0
+  ) {
+    throw new Error("managed embedding model metadata is incomplete");
+  }
   const backends = readLlamaBackends();
   const macMetal = backends.find((backend) => backend.id === "macos-aarch64-metal");
   const winVulkan = backends.find((backend) => backend.id === "windows-x86_64-vulkan");

--- a/scripts/setup-retrieval-env.mjs
+++ b/scripts/setup-retrieval-env.mjs
@@ -9,12 +9,9 @@
  * SCIP language indexers are documented only — not installed by this script.
  */
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { Readable, Transform } from "node:stream";
-import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -199,7 +196,7 @@ function printPrereqReport(opts) {
     [
       "cargo",
       commandExists("cargo"),
-      opts.skipBuild || opts.fetchOnly ? "optional" : "required",
+      opts.skipBuild ? "optional" : "required",
     ],
     [
       "docker",
@@ -269,8 +266,6 @@ const EMBED_MODELS_MANIFEST = path.join(
   "assets",
   "embedding-models.json",
 );
-const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
-
 function pinnedEmbedModel() {
   const models = JSON.parse(fs.readFileSync(EMBED_MODELS_MANIFEST, "utf8")).models ?? [];
   if (models.length !== 1) {
@@ -280,170 +275,8 @@ function pinnedEmbedModel() {
 }
 
 function embedModelDir() {
-  if (process.env.CODESTORY_EMBED_MODEL_DIR) {
-    return path.resolve(process.env.CODESTORY_EMBED_MODEL_DIR);
-  }
   const model = pinnedEmbedModel();
   return path.join(codestoryCacheRoot(), "managed-embeddings", "models", "sha256", model.sha256);
-}
-
-function sha256File(file) {
-  return new Promise((resolve, reject) => {
-    const hash = createHash("sha256");
-    const stream = fs.createReadStream(file);
-    stream.on("data", (chunk) => hash.update(chunk));
-    stream.on("error", reject);
-    stream.on("end", () => resolve(hash.digest("hex")));
-  });
-}
-
-async function verifyEmbedModel(file) {
-  const model = pinnedEmbedModel();
-  const stat = fs.statSync(file);
-  if (!stat.isFile()) {
-    throw new Error(`Embed model path is not a file: ${file}`);
-  }
-  if (stat.size !== model.artifact_bytes) {
-    throw new Error(
-      `Embed model size mismatch for ${file}: got ${stat.size} bytes, expected ${model.artifact_bytes}`,
-    );
-  }
-  const actual = await sha256File(file);
-  if (actual !== model.sha256) {
-    throw new Error(
-      `Embed model SHA-256 mismatch for ${file}: got ${actual}, expected ${model.sha256}`,
-    );
-  }
-  return actual;
-}
-
-async function downloadFile(
-  url,
-  destination,
-  {
-    expectedBytes = null,
-    maxBytes = expectedBytes,
-    timeoutMs = DOWNLOAD_TIMEOUT_MS,
-    fetchImpl = fetch,
-  } = {},
-) {
-  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
-    throw new Error(`download_size_limit_invalid:${maxBytes}`);
-  }
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetchImpl(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} from ${url}`);
-    }
-    if (!response.body) {
-      throw new Error(`download_body_missing:${url}`);
-    }
-    const contentLength = response.headers.get("content-length");
-    if (contentLength !== null) {
-      const announcedBytes = Number(contentLength);
-      if (!Number.isSafeInteger(announcedBytes) || announcedBytes < 0) {
-        throw new Error(`download_content_length_invalid:${contentLength}`);
-      }
-      if (announcedBytes > maxBytes) {
-        throw new Error(`download_size_limit_exceeded:${announcedBytes}>${maxBytes}`);
-      }
-      if (expectedBytes !== null && announcedBytes !== expectedBytes) {
-        throw new Error(`download_size_mismatch:${announcedBytes}!=${expectedBytes}`);
-      }
-    }
-
-    let receivedBytes = 0;
-    const limiter = new Transform({
-      transform(chunk, _encoding, callback) {
-        receivedBytes += chunk.length;
-        if (receivedBytes > maxBytes) {
-          callback(new Error(`download_size_limit_exceeded:${receivedBytes}>${maxBytes}`));
-          return;
-        }
-        callback(null, chunk);
-      },
-    });
-    await pipeline(
-      Readable.fromWeb(response.body),
-      limiter,
-      fs.createWriteStream(destination, { flags: "wx" }),
-    );
-    if (expectedBytes !== null && receivedBytes !== expectedBytes) {
-      throw new Error(`download_size_mismatch:${receivedBytes}!=${expectedBytes}`);
-    }
-    return receivedBytes;
-  } catch (error) {
-    fs.rmSync(destination, { force: true });
-    if (error?.name === "AbortError") {
-      throw new Error(`download_deadline_exceeded:${timeoutMs}ms:${url}`);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-async function fetchEmbedModel() {
-  const model = pinnedEmbedModel();
-  const dir = embedModelDir();
-  fs.mkdirSync(dir, { recursive: true });
-  const dest = path.join(dir, model.filename);
-  if (fs.existsSync(dest) && fs.statSync(dest).size > 1_000_000) {
-    let checksum;
-    try {
-      checksum = await verifyEmbedModel(dest);
-    } catch (error) {
-      const quarantine = path.join(
-        dir,
-        `.quarantine-${model.filename}-invalid-${process.pid}-${Date.now()}`,
-      );
-      fs.renameSync(dest, quarantine);
-      console.log(`Quarantined invalid managed model at ${quarantine}: ${error}`);
-    }
-    if (checksum) {
-      console.log(`Embed model already present and verified: ${dest} sha256=${checksum}`);
-      return dest;
-    }
-  }
-  let lastError = null;
-  for (const url of model.urls) {
-    console.log(`Downloading ${model.filename} from ${url} to ${dest} ...`);
-    const tempDest = path.join(dir, `.${model.filename}.partial-${process.pid}-${Date.now()}`);
-    try {
-      const downloadedBytes = await downloadFile(url, tempDest, {
-        expectedBytes: model.artifact_bytes,
-        maxBytes: model.artifact_bytes,
-      });
-      const checksum = await verifyEmbedModel(tempDest);
-      try {
-        fs.renameSync(tempDest, dest);
-      } catch (error) {
-        if (!fs.existsSync(dest)) throw error;
-        await verifyEmbedModel(dest);
-        fs.rmSync(tempDest, { force: true });
-        console.log(`Embed model was published concurrently and verified: ${dest}`);
-        return dest;
-      }
-      const manifestTemp = path.join(
-        dir,
-        `.install-manifest.json.partial-${process.pid}-${Date.now()}`,
-      );
-      fs.writeFileSync(
-        manifestTemp,
-        `${JSON.stringify({ ...model, source_url: url, urls: undefined }, null, 2)}\n`,
-        { flag: "wx" },
-      );
-      fs.renameSync(manifestTemp, path.join(dir, "install-manifest.json"));
-      console.log(`Wrote ${dest} (${downloadedBytes} bytes, sha256=${checksum})`);
-      return dest;
-    } catch (error) {
-      fs.rmSync(tempDest, { force: true });
-      lastError = `${error instanceof Error ? error.message : error} from ${url}`;
-    }
-  }
-  throw new Error(`Failed to download embed model: ${lastError ?? "no URLs configured"}`);
 }
 
 const LLAMA_BACKENDS_MANIFEST = path.join(
@@ -453,9 +286,6 @@ const LLAMA_BACKENDS_MANIFEST = path.join(
   "assets",
   "llama-sidecar-backends.json",
 );
-const LLAMA_INSTALL_MANIFEST = "install-manifest.json";
-const LLAMA_EXTRACTED_MARKER = ".codestory-extracted";
-
 function readLlamaBackends() {
   return JSON.parse(fs.readFileSync(LLAMA_BACKENDS_MANIFEST, "utf8")).backends ?? [];
 }
@@ -512,120 +342,6 @@ function managedLlamaServerPath(backend) {
   return path.join(codestoryCacheRoot(), backend.managed_cache_rel_dir, backend.executable_rel_path);
 }
 
-async function verifySha256(file, expected, label) {
-  const actual = await sha256File(file);
-  if (actual !== expected.toLowerCase()) {
-    throw new Error(`${label} SHA-256 mismatch for ${file}: got ${actual}, expected ${expected}`);
-  }
-  return actual;
-}
-
-function safeArchiveMemberPath(member) {
-  if (!member || member.trim() === "" || member.includes("\\") || /^[A-Za-z]:/.test(member)) {
-    throw new Error(`Managed llama-server archive path is not portable: ${member}`);
-  }
-  const normalized = path.posix.normalize(member);
-  if (
-    normalized === "." ||
-    normalized.startsWith("../") ||
-    normalized.includes("/../") ||
-    path.posix.isAbsolute(normalized)
-  ) {
-    throw new Error(`Managed llama-server archive path must be relative and contained: ${member}`);
-  }
-  return normalized;
-}
-
-async function validateExtractedExecutable(file, backend) {
-  const stat = fs.lstatSync(file);
-  if (stat.isSymbolicLink() || !stat.isFile()) {
-    throw new Error(`Managed llama-server archive member is not a regular file: ${file}`);
-  }
-  const executableSha = await sha256File(file);
-  if (executableSha !== backend.executable_sha256.toLowerCase()) {
-    throw new Error(
-      `llama-server executable SHA-256 mismatch for ${file}: got ${executableSha}, expected ${backend.executable_sha256}`,
-    );
-  }
-  return executableSha;
-}
-
-function pathIsInside(root, candidate) {
-  const relative = path.relative(root, candidate);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
-function copyManagedPayloadSymlink(source, target, root) {
-  const linkTarget = fs.readlinkSync(source);
-  if (path.isAbsolute(linkTarget)) {
-    throw new Error(`Managed llama-server archive symlink must be relative: ${source} -> ${linkTarget}`);
-  }
-  const resolved = fs.realpathSync(path.resolve(path.dirname(source), linkTarget));
-  if (!pathIsInside(root, resolved)) {
-    throw new Error(`Managed llama-server archive symlink escapes payload: ${source} -> ${resolved}`);
-  }
-  if (!fs.statSync(resolved).isFile()) {
-    throw new Error(`Managed llama-server archive symlink target is not a regular file: ${source} -> ${resolved}`);
-  }
-  fs.copyFileSync(resolved, target);
-}
-
-function copyManagedPayload(source, target, root = fs.realpathSync(source)) {
-  fs.mkdirSync(target, { recursive: true });
-  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
-    const sourcePath = path.join(source, entry.name);
-    const targetPath = path.join(target, entry.name);
-    if (entry.isSymbolicLink()) {
-      copyManagedPayloadSymlink(sourcePath, targetPath, root);
-    } else if (entry.isDirectory()) {
-      copyManagedPayload(sourcePath, targetPath, root);
-    } else if (entry.isFile()) {
-      fs.copyFileSync(sourcePath, targetPath);
-    } else {
-      throw new Error(`Managed llama-server archive member is not a regular file or directory: ${sourcePath}`);
-    }
-  }
-}
-
-async function installExtractedLlamaServerPayload(backend, extracted, dest) {
-  await validateExtractedExecutable(extracted, backend);
-  const targetDir = path.dirname(dest);
-  const sourceDir = path.dirname(extracted);
-  const targetParent = path.dirname(targetDir);
-  fs.mkdirSync(targetParent, { recursive: true });
-  const stagingDir = `${targetDir}.download`;
-  fs.rmSync(stagingDir, { recursive: true, force: true });
-  copyManagedPayload(sourceDir, stagingDir);
-  const stagedExecutable = path.join(stagingDir, backend.executable_rel_path);
-  fs.chmodSync(stagedExecutable, 0o755);
-  const executableSha = await sha256File(stagedExecutable);
-  if (executableSha !== backend.executable_sha256.toLowerCase()) {
-    throw new Error(
-      `llama-server executable SHA-256 mismatch for ${stagedExecutable}: got ${executableSha}, expected ${backend.executable_sha256}`,
-    );
-  }
-  fs.writeFileSync(path.join(stagingDir, LLAMA_EXTRACTED_MARKER), "1");
-  fs.writeFileSync(
-    path.join(stagingDir, LLAMA_INSTALL_MANIFEST),
-    `${JSON.stringify(
-      {
-        backend: backend.id,
-        artifact: backend.artifact,
-        artifact_bytes: backend.artifact_bytes,
-        artifact_sha256: backend.sha256,
-        executable_rel_path: backend.executable_rel_path,
-        executable_sha256: backend.executable_sha256,
-        source_url: backend.url,
-      },
-      null,
-      2,
-    )}\n`,
-  );
-  fs.rmSync(targetDir, { recursive: true, force: true });
-  fs.renameSync(stagingDir, targetDir);
-  return dest;
-}
-
 function printLlamaServerPlan(backend) {
   console.log("\nManaged llama-server:");
   console.log(`  backend: ${backend.id}`);
@@ -638,69 +354,34 @@ function printLlamaServerPlan(backend) {
   console.log(`  target: ${managedLlamaServerPath(backend)}`);
 }
 
-async function fetchLlamaServer(opts) {
-  const backend = selectedLlamaBackend(opts);
-  if (!Number.isSafeInteger(backend.artifact_bytes) || backend.artifact_bytes <= 0) {
-    throw new Error(`Managed llama-server backend ${backend.id} is missing artifact_bytes`);
+function managedAssetPrewarmArgs(opts) {
+  const args = ["retrieval", "prewarm-assets"];
+  if (opts.fetchEmbedModel) args.push("--model");
+  if (opts.fetchLlamaServer) args.push("--native-backend");
+  if (opts.fetchLlamaServer && opts.llamaBackend) {
+    args.push("--llama-backend", opts.llamaBackend);
   }
-  const dest = managedLlamaServerPath(backend);
-  printLlamaServerPlan(backend);
-  if (opts.checkOnly) {
-    return dest;
-  }
-  if (!commandExists("tar")) {
-    throw new Error("tar is required to extract the managed llama-server archive");
-  }
-  const targetDir = path.dirname(dest);
-  fs.mkdirSync(targetDir, { recursive: true });
-  const existingManifest = path.join(targetDir, LLAMA_INSTALL_MANIFEST);
-  if (fs.existsSync(dest) && fs.existsSync(existingManifest)) {
-    const manifest = JSON.parse(fs.readFileSync(existingManifest, "utf8"));
-    const executableSha = await sha256File(dest);
-    if (
-      manifest.artifact === backend.artifact &&
-      manifest.artifact_bytes === backend.artifact_bytes &&
-      manifest.artifact_sha256?.toLowerCase() === backend.sha256.toLowerCase() &&
-      manifest.executable_rel_path === backend.executable_rel_path &&
-      manifest.executable_sha256?.toLowerCase() === backend.executable_sha256.toLowerCase() &&
-      executableSha === backend.executable_sha256.toLowerCase()
-    ) {
-      console.log(`llama-server already present and verified: ${dest} sha256=${executableSha}`);
-      return dest;
-    }
-    console.log(`Managed llama-server install manifest is stale for ${dest}; redownloading.`);
-  }
-
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-llama-server-"));
-  const archive = path.join(tempRoot, backend.artifact);
-  const extractDir = path.join(tempRoot, "extract");
-  fs.mkdirSync(extractDir);
-  try {
-    console.log(`Downloading ${backend.artifact} from ${backend.url} to ${archive} ...`);
-    await downloadFile(backend.url, archive, {
-      expectedBytes: backend.artifact_bytes,
-      maxBytes: backend.artifact_bytes,
-    });
-    await verifySha256(archive, backend.sha256, "llama-server artifact");
-    const member = safeArchiveMemberPath(backend.executable_archive_path);
-    const result = spawnSync(commandName("tar"), ["-xzf", archive, "-C", extractDir], {
-      encoding: "utf8",
-      shell: false,
-    });
-    if (result.status !== 0) {
-      throw new Error(`tar failed extracting ${archive}: ${result.stderr || result.stdout}`);
-    }
-    const extracted = path.join(extractDir, ...member.split("/"));
-    await installExtractedLlamaServerPayload(backend, extracted, dest);
-    const executableSha = await sha256File(dest);
-    console.log(`Wrote ${dest} (sha256=${executableSha})`);
-    return dest;
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
+  return args;
 }
 
-async function runSelfTest() {
+function runManagedAssetPrewarm(opts) {
+  const args = managedAssetPrewarmArgs(opts);
+  if (opts.skipBuild) {
+    const cli = cliPath(opts.release);
+    if (!fs.existsSync(cli)) {
+      throw new Error(`CLI not found at ${cli}; drop --skip-build to build it.`);
+    }
+    runChecked("Prewarm managed retrieval assets", cli, args);
+    return;
+  }
+  runChecked(
+    "Prewarm managed retrieval assets",
+    "cargo",
+    cargoRunArgs(...(opts.release ? ["--release"] : []), "-p", "codestory-cli", "--", ...args),
+  );
+}
+
+function runSelfTest() {
   const model = pinnedEmbedModel();
   if (
     model.filename !== "bge-base-en-v1.5.Q8_0.gguf" ||
@@ -740,13 +421,13 @@ async function runSelfTest() {
   if (!macMetal.managed_cache_rel_dir.includes("/llama/b9902/")) {
     throw new Error(`unexpected managed cache version path: ${macMetal.managed_cache_rel_dir}`);
   }
-  if (safeArchiveMemberPath(macMetal.executable_archive_path) !== "llama-b9902/llama-server") {
+  if (macMetal.executable_archive_path !== "llama-b9902/llama-server") {
     throw new Error(`unexpected executable archive path: ${macMetal.executable_archive_path}`);
   }
   if (!/^[0-9a-f]{64}$/.test(macMetal.executable_sha256)) {
     throw new Error(`unexpected executable sha256: ${macMetal.executable_sha256}`);
   }
-  if (safeArchiveMemberPath(winVulkan.executable_archive_path) !== "llama-server.exe") {
+  if (winVulkan.executable_archive_path !== "llama-server.exe") {
     throw new Error(`unexpected Windows executable archive path: ${winVulkan.executable_archive_path}`);
   }
   if (!winVulkan.managed_cache_rel_dir.includes("/llama/b9902/")) {
@@ -759,66 +440,23 @@ async function runSelfTest() {
   if (managedLlamaServerPath(selected).split(path.sep).join("/").endsWith("llama-server") !== true) {
     throw new Error("managed llama-server target path should end in llama-server");
   }
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codestory-llama-self-test-"));
-  try {
-    const payloadDir = path.join(tempRoot, "extract", "llama-b9902");
-    fs.mkdirSync(payloadDir, { recursive: true });
-    const executable = path.join(payloadDir, "llama-server");
-    fs.writeFileSync(executable, "fake exe");
-    fs.writeFileSync(path.join(payloadDir, "libllama-test.dylib"), "fake dylib");
-    const executableSha = await sha256File(executable);
-    const backend = {
-      id: "self-test",
-      artifact: "llama-test.tar.gz",
-      artifact_bytes: 8,
-      sha256: "0".repeat(64),
-      executable_archive_path: "llama-b9902/llama-server",
-      executable_rel_path: "llama-server",
-      executable_sha256: executableSha,
-      url: "https://example.invalid/llama-test.tar.gz",
-    };
-    const dest = path.join(tempRoot, "managed", "llama-server");
-    await installExtractedLlamaServerPayload(backend, executable, dest);
-    if (fs.readFileSync(dest, "utf8") !== "fake exe") {
-      throw new Error("managed install self-test did not copy executable");
-    }
-    if (fs.readFileSync(path.join(path.dirname(dest), "libllama-test.dylib"), "utf8") !== "fake dylib") {
-      throw new Error("managed install self-test did not copy sibling payload");
-    }
-    if (!fs.existsSync(path.join(path.dirname(dest), LLAMA_EXTRACTED_MARKER))) {
-      throw new Error("managed install self-test did not write extraction marker");
-    }
-    const manifest = JSON.parse(
-      fs.readFileSync(path.join(path.dirname(dest), LLAMA_INSTALL_MANIFEST), "utf8"),
-    );
-    if (manifest.artifact !== backend.artifact || manifest.executable_sha256 !== executableSha) {
-      throw new Error("managed install self-test wrote stale manifest metadata");
-    }
-
-    const partial = path.join(tempRoot, "oversized.partial");
-    const oversizedResponse = new Response(
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode("123"));
-          controller.enqueue(new TextEncoder().encode("456"));
-          controller.close();
-        },
-      }),
-    );
-    let rejectedOversize = false;
-    try {
-      await downloadFile("https://example.invalid/oversized", partial, {
-        maxBytes: 4,
-        fetchImpl: async () => oversizedResponse,
-      });
-    } catch (error) {
-      rejectedOversize = String(error).includes("download_size_limit_exceeded");
-    }
-    if (!rejectedOversize || fs.existsSync(partial)) {
-      throw new Error("bounded download self-test did not reject and clean an oversized stream");
-    }
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
+  const prewarmArgs = managedAssetPrewarmArgs({
+    fetchEmbedModel: true,
+    fetchLlamaServer: true,
+    llamaBackend: "macos-aarch64-metal",
+  });
+  if (
+    JSON.stringify(prewarmArgs) !==
+    JSON.stringify([
+      "retrieval",
+      "prewarm-assets",
+      "--model",
+      "--native-backend",
+      "--llama-backend",
+      "macos-aarch64-metal",
+    ])
+  ) {
+    throw new Error(`managed asset prewarm command drifted: ${prewarmArgs.join(" ")}`);
   }
   console.log("setup-retrieval-env self-test passed");
 }
@@ -840,11 +478,8 @@ async function main() {
     throw new Error("Fix missing prerequisites (or use --skip-compose / --skip-build where applicable).");
   }
 
-  if (opts.fetchEmbedModel) {
-    await fetchEmbedModel();
-  }
-  if (opts.fetchLlamaServer) {
-    await fetchLlamaServer(opts);
+  if (opts.fetchEmbedModel || opts.fetchLlamaServer) {
+    runManagedAssetPrewarm(opts);
   }
   if (opts.fetchOnly) {
     console.log("\nFetch-only setup complete.");


### PR DESCRIPTION
## Context

Managed retrieval assets were still partly repository-shaped: a fresh repository could discover or prewarm its own model copy, while the native backend used a separate publication path. That made first-run behavior expensive and ownership harder to reason about across concurrent projects.

This PR makes the pinned embedding model and native backend archives machine-owned, content-addressed assets. Normal runtime activation obtains them automatically; users do not need to know about or consent to a separate sidecar setup step.

Base: `930dcaf19b20f06323d8106b47cb6d5a0bc5e42f`
Head: `b62a35e7f8f700f17a0a6c22851ea8faca645b45`

## What changed

- Added one embedded model metadata source shared by Rust runtime provisioning and the maintainer prewarm path.
- Added a machine-wide managed-asset boundary with one cross-process lock, exact-size and SHA-256 verification, quarantine of partial or corrupt files, and atomic publication.
- Stored model and backend archives under content-addressed machine cache paths.
- Made normal model resolution automatically obtain the pinned machine asset unless an explicit `CODESTORY_EMBED_MODEL_DIR` override is present.
- Removed implicit repository-local `target/retrieval-models` and `models/gguf` discovery from the normal path.
- Kept inventory and status observational and documented the one-time first-repository cost and later reuse.
- Reduced managed-backend coverage to credible ownership and safety boundaries.

## Review remediation

- Routed the Node prewarm script through a hidden Rust/CLI asset command, so every canonical model and backend write crosses the same machine lock.
- Added one real child-process lock test instead of duplicating branch-level coverage.
- Preserved the original Windows b9058 install-manifest shape by accepting its absent archive-size field while still rejecting mismatched present values.
- Made model inventory checksum-truthful; a same-size corrupt canonical file is no longer reported as published.

## Review focus

The ownership boundary is in `managed_assets.rs`. Every canonical asset is content addressed, verified before publication, and serialized across processes without trusting a repository path. `compose.rs` consumes that boundary, and `setup-retrieval-env.mjs` delegates prewarming to it instead of maintaining a second downloader and publisher.

This does not release, version, sign, notarize, or publish CodeStory.

## Verification

Rebase proof on the current head:

- `git range-diff 80369f0..6d1b5e0 930dcaf..b62a35e` (the review-remediation commit is unchanged)
- `node .github/scripts/check-doc-links.mjs`
- conflict-marker scan across the affected documentation and asset surfaces
- `git diff --check origin/dev/codestory-next...HEAD`

The only manual conflict was the adjacent Unreleased changelog bullets from #1159 and this PR; both are retained. No Rust source conflicted, so the focused source proof below was not repeated after the rebase.

Focused source proof completed before the rebase:

- `cargo fmt --all -- --check`
- `cargo check --locked -p codestory-cli`
- `cargo test --locked -p codestory-retrieval --lib managed_assets::tests` (4/4, including the cross-process lock boundary)
- `cargo test --locked -p codestory-retrieval --lib managed_native_` (4/4)
- `cargo test --locked -p codestory-retrieval --lib legacy_windows_vulkan_cache_accepts_the_original_install_manifest_shape` (1/1)
- `cargo clippy --locked -p codestory-retrieval --lib -- -D warnings`
- `cargo clippy --locked -p codestory-cli --bin codestory-cli -- -D warnings -A clippy::collapsible_if`
- `node scripts/setup-retrieval-env.mjs --self-test`
- `node scripts/setup-retrieval-env.mjs --check-only --fetch-embed-model --fetch-only`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

The CLI-only clippy allowance isolates an unrelated pre-existing `collapsible_if` lint in `readiness_broker/native_lease.rs`; retrieval clippy is clean with all warnings denied.

On macOS, an isolated cold cache automatically downloaded one 117,974,304-byte model and one native backend archive. A second repository attached to the same Metal process and reused the same model, backend executable, PID, and cache. The borrower detached cleanly; owner shutdown stopped the process. Exactly one model and one backend archive remained in the isolated cache before cleanup.

The existing owner shutdown command still printed the generic `Error: retrieval down` after it had successfully stopped the PID. That lifecycle cleanup wrinkle is outside this asset-ownership lane and is referenced by #1150; no managed process or isolated cache was left behind.

## Simplification and line delta

The simplifier pass reused the existing atomic-file primitive, centralized model pins in one JSON source, removed redundant backend tests, and deleted the duplicate Node download, extraction, validation, and publication implementation.

- Total: +828 / -664 (net +164)

The review remediation alone removed 211 net lines. The remaining growth is the shared asset boundary, metadata, focused tests, and documentation.

Closes #1151
Refs #897
Refs #1150
