### PR TITLE
Remove Docker from default local retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- Managed retrieval now stores generation-bound dense vectors in embedded
+  SQLite by default, so macOS packet/search no longer starts or requires
+  Qdrant or Docker. Apple Silicon keeps managed Metal; Intel now installs a
+  checksum-pinned native CPU runtime automatically and never claims Metal.
+  Search traces describe this lane as semantic instead of exposing the storage
+  engine. External Qdrant remains an explicit advanced compatibility override.
 - Delegated worktree setup now prepares and reports the local repository map
   without attempting full retrieval or printing backend repair instructions.
   Maintainers can request that separate proof explicitly with

--- a/crates/codestory-cli/src/args.rs
+++ b/crates/codestory-cli/src/args.rs
@@ -738,7 +738,7 @@ pub(crate) struct RetrievalCommand {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum RetrievalAction {
-    /// Start Docker Compose sidecars (when available), prepare cache dirs, and wait for health.
+    /// Prepare managed retrieval services and wait for health.
     Bootstrap(RetrievalBootstrapCommand),
     #[command(name = "prewarm-assets", hide = true)]
     PrewarmAssets(RetrievalPrewarmAssetsCommand),
@@ -746,7 +746,7 @@ pub(crate) enum RetrievalAction {
     Up(RetrievalSidecarStateCommand),
     /// Remove local sidecar state file (does not stop external processes).
     Down(RetrievalSidecarStateCommand),
-    /// Validate the lexical shard plus Qdrant and SCIP availability for the project.
+    /// Validate lexical, semantic, and graph retrieval for the project.
     Status(RetrievalStatusCommand),
     /// List owned sidecar namespaces and dry-run cleanup eligibility.
     Inventory(RetrievalInventoryCommand),
@@ -838,7 +838,7 @@ pub(crate) struct RetrievalBootstrapCommand {
         long,
         value_name = "SECS",
         default_value_t = 90,
-        help = "Seconds to wait for Qdrant and embedding HTTP probes (0 = no wait)."
+        help = "Seconds to wait for managed retrieval health (0 = no wait)."
     )]
     pub(crate) wait_secs: u64,
     #[arg(

--- a/crates/codestory-cli/src/main.rs
+++ b/crates/codestory-cli/src/main.rs
@@ -3275,13 +3275,17 @@ fn run_ready_repair_with_native_embedding_lease(
                     gpu_proof: Some(gpu_proof.clone()),
                     reconciliation: None,
                 });
-            progress.set_phase("Qdrant finalize");
-            codestory_retrieval::repair_project_qdrant_collection_for_runtime(
-                &runtime.project_root,
-                &runtime.storage_path,
-                selected_sidecar,
-            )
-            .context("ready repair project qdrant repair")?;
+            progress.set_phase("semantic finalize");
+            if selected_sidecar.vector_backend()
+                == codestory_retrieval::VectorBackend::ExternalQdrant
+            {
+                codestory_retrieval::repair_project_qdrant_collection_for_runtime(
+                    &runtime.project_root,
+                    &runtime.storage_path,
+                    selected_sidecar,
+                )
+                .context("ready repair external vector collection")?;
+            }
             progress.set_phase("graph artifact");
             runtime
                 .index
@@ -3353,7 +3357,7 @@ fn ensure_ready_repair_embed_liveness_with_probe(
     let smoke = probe();
     if !smoke.reachable {
         bail!(
-            "ready repair embedding sidecar liveness failed before mandatory Qdrant semantic smoke: {}; lexical_ready={} ({}); qdrant_reachable={} ({})",
+            "ready repair embedding liveness failed before semantic readiness validation: {}; lexical_ready={} ({}); semantic_ready={} ({})",
             smoke.detail,
             infrastructure.lexical_ready,
             infrastructure.lexical_detail,

--- a/crates/codestory-cli/src/retrieval.rs
+++ b/crates/codestory-cli/src/retrieval.rs
@@ -94,13 +94,18 @@ fn run_retrieval_bootstrap(cmd: RetrievalBootstrapCommand) -> Result<()> {
             },
             |report| &report.state,
             |report, selected_sidecar| {
-                let project_qdrant_repair =
-                    codestory_retrieval::repair_project_qdrant_collection_for_runtime(
-                        &runtime.project_root,
-                        &runtime.storage_path,
-                        selected_sidecar,
-                    )
-                    .context("retrieval project qdrant repair")?;
+                let project_qdrant_repair = (selected_sidecar.vector_backend()
+                    == codestory_retrieval::VectorBackend::ExternalQdrant)
+                    .then(|| {
+                        codestory_retrieval::repair_project_qdrant_collection_for_runtime(
+                            &runtime.project_root,
+                            &runtime.storage_path,
+                            selected_sidecar,
+                        )
+                    })
+                    .transpose()
+                    .context("retrieval external vector repair")?
+                    .flatten();
                 let status = strict_sidecar_status_for_runtime(
                     &runtime.project_root,
                     Some(&runtime.storage_path),
@@ -439,7 +444,7 @@ fn emit_retrieval_index(
         generation_retention: &outcome.generation_retention,
     };
     let markdown = format!(
-        "# Retrieval index\n\n- project_id: `{}`\n- lexical_version: `{}`\n- qdrant_collection: `{}`\n- scip_revision: {:?}\n- degraded_modes: {:?}\n- retention_retained_bytes: {}\n- retention_reclaimable_bytes: {}\n- retention_removed_bytes: {}\n- retention_remaining_reclaimable_bytes: {}\n- retention_pruning_suppressed: {}\n",
+        "# Retrieval index\n\n- project_id: `{}`\n- lexical_version: `{}`\n- semantic_generation: `{}`\n- scip_revision: {:?}\n- degraded_modes: {:?}\n- retention_retained_bytes: {}\n- retention_reclaimable_bytes: {}\n- retention_removed_bytes: {}\n- retention_remaining_reclaimable_bytes: {}\n- retention_pruning_suppressed: {}\n",
         payload.manifest.project_id,
         payload.manifest.lexical_version,
         payload.manifest.qdrant_collection,
@@ -478,6 +483,7 @@ fn emit_retrieval_query(
 
 #[derive(serde::Serialize)]
 struct RetrievalBootstrapOutput<'a> {
+    semantic_backend: &'static str,
     compose_started: bool,
     compose_file: Option<&'a str>,
     lexical_ready: bool,
@@ -507,6 +513,11 @@ fn emit_retrieval_bootstrap(
         .as_ref()
         .map(|path| path.display().to_string());
     let payload = RetrievalBootstrapOutput {
+        semantic_backend: if report.state.qdrant_http_port == 0 {
+            "embedded"
+        } else {
+            "external_qdrant"
+        },
         compose_started: report.compose_started,
         compose_file: compose_path.as_deref(),
         lexical_ready: report.infrastructure.lexical_ready,
@@ -562,15 +573,23 @@ fn emit_retrieval_bootstrap(
             )
         })
         .unwrap_or_default();
-    let sidecar_images_note = format!(
-        "\n- sidecar_images: qdrant=`{}` embed=`{}`",
-        payload.sidecar_state.sidecar_images.qdrant, payload.sidecar_state.sidecar_images.embed
-    );
+    let sidecar_images_note = if payload.semantic_backend == "external_qdrant" {
+        format!(
+            "\n- sidecar_images: qdrant=`{}` embed=`{}`",
+            payload.sidecar_state.sidecar_images.qdrant, payload.sidecar_state.sidecar_images.embed
+        )
+    } else {
+        format!(
+            "\n- embedding_image: `{}`",
+            payload.sidecar_state.sidecar_images.embed
+        )
+    };
     let markdown = format!(
-        "# Retrieval bootstrap\n\n- compose_started: {}\n- lexical_ready: {} ({})\n- qdrant_reachable: {} ({})\n- embed_reachable: {} ({})\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- retrieval_mode: `{}`\n- storage_repair: protected={} pruned={} invalid_dirs_removed={} stub_markers_migrated={} collections_seen={} overflow_protected={}{overflow_note}{scan_warning}{prune_suppressed_note}",
+        "# Retrieval bootstrap\n\n- compose_started: {}\n- lexical_ready: {} ({})\n- semantic_backend: `{}`\n- semantic_ready: {} ({})\n- embed_reachable: {} ({})\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- retrieval_mode: `{}`\n- storage_repair: protected={} pruned={} invalid_dirs_removed={} stub_markers_migrated={} collections_seen={} overflow_protected={}{overflow_note}{scan_warning}{prune_suppressed_note}",
         payload.compose_started,
         payload.lexical_ready,
         payload.lexical_detail,
+        payload.semantic_backend,
         payload.qdrant_reachable,
         payload.qdrant_detail,
         payload.embed_reachable,
@@ -657,22 +676,37 @@ fn emit_retrieval_status(
         .ownership
         .as_ref()
         .map(|ownership| {
+            let ports = if ownership.ports.qdrant_http == 0 {
+                format!("embed:{}", ownership.ports.embed_http)
+            } else {
+                format!(
+                    "qdrant:{} grpc:{} embed:{}",
+                    ownership.ports.qdrant_http,
+                    ownership.ports.qdrant_grpc,
+                    ownership.ports.embed_http,
+                )
+            };
             format!(
-                "- ownership: owner=`{}` profile=`{}` namespace=`{}` cleanup=`{}` ports=qdrant:{} grpc:{} embed:{}\n",
+                "- ownership: owner=`{}` profile=`{}` namespace=`{}` cleanup=`{}` ports={}\n",
                 ownership.owner,
                 ownership.profile,
                 ownership.namespace,
                 ownership.cleanup_command,
-                ownership.ports.qdrant_http,
-                ownership.ports.qdrant_grpc,
-                ownership.ports.embed_http,
+                ports,
             )
         })
         .unwrap_or_default();
-    let sidecar_images_note = format!(
-        "- sidecar_images: qdrant=`{}` embed=`{}`\n",
-        report.sidecar_images.qdrant, report.sidecar_images.embed
-    );
+    let sidecar_images_note = report
+        .ownership
+        .as_ref()
+        .filter(|ownership| ownership.ports.qdrant_http != 0)
+        .map(|_| {
+            format!(
+                "- sidecar_images: qdrant=`{}` embed=`{}`\n",
+                report.sidecar_images.qdrant, report.sidecar_images.embed
+            )
+        })
+        .unwrap_or_else(|| format!("- embedding_image: `{}`\n", report.sidecar_images.embed));
     let broker_note = format!(
         "- readiness_broker: project_id={} persistence={} operations={} gpu_proof={}\n",
         readiness_broker.project_id,
@@ -685,7 +719,7 @@ fn emit_retrieval_status(
             .unwrap_or("unknown")
     );
     let markdown = format!(
-        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}{}{}- lexical: {:?} ({:?}) capabilities: lexical={}\n- qdrant: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
+        "# Retrieval status\n\n- retrieval_mode: `{}`\n- degraded_reason: {:?}\n- query_embedding_backend: `{}`\n- embedding_device_policy: `{}` observed_device=`{}` observation_source=`{}` detected_provider={:?} detected_gpu={:?} accelerator_requested={} accelerator_request_provider={:?} accelerator_request_device={:?} cpu_allowed={}\n- manifest_vector_backend: `{}` dim={:?}\n- stored_doc_vector_producer: `{}` dim={:?} mixed_backends={:?}\n{}{}{}{}{}- lexical: {:?} ({:?}) capabilities: lexical={}\n- semantic: {:?} ({:?}) capabilities: semantic={}\n- scip: {:?} ({:?}) capabilities: graph={}\n",
         report.retrieval_mode,
         report.degraded_reason,
         report.query_embedding_backend,

--- a/crates/codestory-retrieval/assets/llama-sidecar-backends.json
+++ b/crates/codestory-retrieval/assets/llama-sidecar-backends.json
@@ -31,6 +31,36 @@
       "log_markers": ["metal", "offloaded"]
     },
     {
+      "id": "macos-x86_64-cpu",
+      "os": "macos",
+      "arch": "x86_64",
+      "provider": "cpu",
+      "launch_mode": "native_spawned",
+      "artifact": "llama-b9902-bin-macos-x64.tar.gz",
+      "artifact_bytes": 11452449,
+      "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9902/llama-b9902-bin-macos-x64.tar.gz",
+      "sha256": "df5d74c1d7046829f109a2f7e80d79c1398a86dcff2cfacfc9b44633c8b96abe",
+      "executable_archive_path": "llama-b9902/llama-server",
+      "executable_rel_path": "llama-server",
+      "executable_sha256": "7c1502821385a4fcdf1355b6fcb58729befdb6d199fc3b1fb54b5c838dbe7f5d",
+      "managed_cache_rel_dir": "managed-embeddings/llama/b9902/llama-b9902-bin-macos-x64-cpu",
+      "launch_args": [
+        "--embedding",
+        "--model",
+        "{model}",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "{port}",
+        "--n-gpu-layers",
+        "0",
+        "--log-verbosity",
+        "4"
+      ],
+      "device_arg_policy": "none_by_default",
+      "log_markers": ["cpu"]
+    },
+    {
       "id": "windows-x86_64-vulkan",
       "os": "windows",
       "arch": "x86_64",

--- a/crates/codestory-retrieval/src/candidate.rs
+++ b/crates/codestory-retrieval/src/candidate.rs
@@ -42,6 +42,7 @@ pub struct CandidateHit {
 /// Sidecar lane that produced a retrieval candidate.
 pub enum CandidateSource {
     Lexical,
+    #[serde(rename = "semantic", alias = "qdrant")]
     Qdrant,
     Scip,
     Legacy,

--- a/crates/codestory-retrieval/src/compose.rs
+++ b/crates/codestory-retrieval/src/compose.rs
@@ -399,8 +399,26 @@ pub fn bootstrap_sidecars_with_runtime_progress_and_native_launch_observer(
     runtime: &SidecarRuntimeConfig,
     repo_root: Option<&Path>,
     options: BootstrapSidecarsOptions,
+    progress: impl FnMut(&'static str),
+    observe_new_native_launch: impl FnMut(&crate::health::EmbeddingLaunchMetadata) -> Result<()>,
+) -> Result<BootstrapReport> {
+    bootstrap_sidecars_with_transition_down(
+        runtime,
+        repo_root,
+        options,
+        progress,
+        observe_new_native_launch,
+        docker_compose_down_for_transition_state,
+    )
+}
+
+fn bootstrap_sidecars_with_transition_down(
+    runtime: &SidecarRuntimeConfig,
+    repo_root: Option<&Path>,
+    options: BootstrapSidecarsOptions,
     mut progress: impl FnMut(&'static str),
     mut observe_new_native_launch: impl FnMut(&crate::health::EmbeddingLaunchMetadata) -> Result<()>,
+    mut transition_down: impl FnMut(&SidecarStateFile) -> Result<()>,
 ) -> Result<BootstrapReport> {
     let port_lease_heartbeat = runtime.start_port_lease_heartbeat()?;
     let BootstrapSidecarsOptions {
@@ -413,8 +431,12 @@ pub fn bootstrap_sidecars_with_runtime_progress_and_native_launch_observer(
     } = options;
     let layout = runtime.layout.clone();
     layout.ensure_data_dirs()?;
-    let storage_repair =
-        repair_qdrant_storage(&layout, &storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?;
+    let vector_backend = runtime.ensure_vector_backend_configured()?;
+    let storage_repair = if vector_backend == crate::config::VectorBackend::ExternalQdrant {
+        repair_qdrant_storage(&layout, &storage_scope, DEFAULT_QDRANT_COLLECTION_RETENTION)?
+    } else {
+        QdrantStorageRepairReport::default()
+    };
     let launch_mode = crate::config::embedding_server_launch_mode_for_runtime(runtime)?;
     let native_embedding = (launch_mode == EmbeddingServerLaunchMode::NativeSpawned)
         .then(|| {
@@ -426,19 +448,30 @@ pub fn bootstrap_sidecars_with_runtime_progress_and_native_launch_observer(
         })
         .transpose()?;
 
-    let resolved_compose = if skip_compose {
+    let compose_required = launch_mode == EmbeddingServerLaunchMode::DockerComposeEmbed
+        || vector_backend == crate::config::VectorBackend::ExternalQdrant;
+    let resolved_compose = if skip_compose || !compose_required {
         None
     } else {
         Some(resolve_compose_file(repo_root, compose_file.as_deref())?)
     };
+    let embedded_transition_pending = vector_backend == crate::config::VectorBackend::Embedded
+        && embedded_qdrant_transition_state(runtime)?.is_some();
     // Docker Compose project names are daemon-global. Keep the exact ownership probe, startup,
     // and any caller-side failure cleanup serialized for this project.
-    let mut compose_bootstrap_lock = resolved_compose
-        .as_ref()
-        .map(|_| acquire_compose_bootstrap_lock(&runtime.compose_project))
+    let mut compose_bootstrap_lock = (resolved_compose.is_some() || embedded_transition_pending)
+        .then(|| acquire_compose_bootstrap_lock(&runtime.compose_project))
         .transpose()?;
     let mut hold_compose_lock =
         |error| hold_compose_bootstrap_lock_on_error(error, &mut compose_bootstrap_lock);
+    if embedded_transition_pending && let Some(state) = embedded_qdrant_transition_state(runtime)? {
+        if state.compose_file.is_none() {
+            return Err(hold_compose_lock(anyhow::anyhow!(
+                "recorded Qdrant transition state has no exact Compose file; preserving it for repair"
+            )));
+        }
+        transition_down(&state).map_err(&mut hold_compose_lock)?;
+    }
 
     let (compose_started, compose_owned_for_rollback) =
         if let Some(path) = resolved_compose.as_ref() {
@@ -734,11 +767,9 @@ fn docker_compose_up(
     let layout = &runtime.layout;
     if !docker_available() {
         bail!(
-            "docker is not available on PATH. Install Docker Desktop (Windows) or Docker Engine, \
-             then re-run bootstrap. Manual Qdrant: docker run -p 6333:6333 -p 6334:6334 \
-             -v \"{}:/qdrant/storage\" {}",
-            layout.qdrant_data_dir.display(),
-            crate::config::QDRANT_IMAGE_PIN
+            "docker is not available on PATH for the selected managed embedding backend. \
+             Install Docker Desktop or Docker Engine, configure a supported native embedding \
+             backend, or use a trusted external embedding endpoint, then retry"
         );
     }
 
@@ -880,7 +911,7 @@ fn append_docker_compose_up_args(
     if force_recreate {
         command.arg("--force-recreate");
     }
-    command.args(docker_compose_services_for_launch_mode(launch_mode));
+    command.args(docker_compose_services_for_runtime(runtime, launch_mode));
 }
 
 fn maybe_write_vulkan_compose_override(
@@ -952,6 +983,19 @@ pub fn docker_compose_down_for_state(state: &SidecarStateFile) -> Result<()> {
     if state.owner != "codestory" || state.profile != SidecarProfile::Agent.as_str() {
         return Ok(());
     }
+    docker_compose_down_for_exact_state(state)
+}
+
+fn docker_compose_down_for_transition_state(state: &SidecarStateFile) -> Result<()> {
+    let known_profile = state.profile == SidecarProfile::Local.as_str()
+        || state.profile == SidecarProfile::Agent.as_str();
+    if state.owner != "codestory" || !known_profile {
+        bail!("refusing to stop an unowned retrieval transition state");
+    }
+    docker_compose_down_for_exact_state(state)
+}
+
+fn docker_compose_down_for_exact_state(state: &SidecarStateFile) -> Result<()> {
     let Some(compose_file) = state.compose_file.as_ref().map(PathBuf::from) else {
         // Legacy state may predate exact Compose-path publication. There is no owned path to
         // retry, so retain the historical no-op behavior for that schema shape only.
@@ -992,6 +1036,50 @@ pub fn docker_compose_down_for_state(state: &SidecarStateFile) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn embedded_qdrant_transition_state(
+    runtime: &SidecarRuntimeConfig,
+) -> Result<Option<SidecarStateFile>> {
+    let contents = match std::fs::read_to_string(&runtime.layout.state_file) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "read embedded backend transition state {}",
+                    runtime.layout.state_file.display()
+                )
+            });
+        }
+    };
+    let state: SidecarStateFile = serde_json::from_str(&contents).with_context(|| {
+        format!(
+            "parse embedded backend transition state {}",
+            runtime.layout.state_file.display()
+        )
+    })?;
+    if state.qdrant_http_port == 0 && state.qdrant_grpc_port == 0 {
+        return Ok(None);
+    }
+    if state.owner != "codestory"
+        || state.profile != runtime.profile.as_str()
+        || state.namespace != runtime.namespace
+        || state.compose_project != runtime.compose_project
+        || state.project_identity != runtime.project_identity
+        || state.run_id != runtime.run_id
+        || state.qdrant_http_port == 0
+        || state.qdrant_grpc_port == 0
+        || runtime.layout.qdrant_http_port != 0
+        || runtime.layout.qdrant_grpc_port != 0
+        || state.embed_http_port != runtime.embed_http_port
+    {
+        bail!(
+            "recorded Qdrant transition state does not exactly match embedded sidecar namespace {}; preserving it for repair",
+            runtime.namespace
+        );
+    }
+    Ok(Some(state))
 }
 
 fn docker_compose_down_for_runtime(
@@ -1089,14 +1177,24 @@ fn docker_compose_command() -> Result<Command> {
     Ok(Command::new("docker"))
 }
 
-fn docker_compose_services_for_launch_mode(
+fn docker_compose_services_for_runtime(
+    runtime: &SidecarRuntimeConfig,
     mode: EmbeddingServerLaunchMode,
 ) -> &'static [&'static str] {
-    match mode {
-        EmbeddingServerLaunchMode::DockerComposeEmbed => &[],
-        EmbeddingServerLaunchMode::NativeSpawned | EmbeddingServerLaunchMode::ExternalEndpoint => {
-            &["qdrant"]
-        }
+    match (runtime.vector_backend(), mode) {
+        (
+            crate::config::VectorBackend::ExternalQdrant,
+            EmbeddingServerLaunchMode::DockerComposeEmbed,
+        ) => &[],
+        (
+            crate::config::VectorBackend::ExternalQdrant,
+            EmbeddingServerLaunchMode::NativeSpawned | EmbeddingServerLaunchMode::ExternalEndpoint,
+        ) => &["qdrant"],
+        (_, EmbeddingServerLaunchMode::DockerComposeEmbed) => &["embed"],
+        (
+            _,
+            EmbeddingServerLaunchMode::NativeSpawned | EmbeddingServerLaunchMode::ExternalEndpoint,
+        ) => &[],
     }
 }
 
@@ -1487,11 +1585,10 @@ fn native_llama_server_candidates(repo_root: Option<&Path>) -> Vec<NativeLlamaCa
 }
 
 fn selected_native_llama_backend() -> Option<crate::config::LlamaSidecarBackend> {
-    crate::embeddings::embedding_accelerator_request().and_then(|request| {
-        matching_native_llama_backends(&request.provider)
-            .into_iter()
-            .next()
-    })
+    let provider = crate::embeddings::embedding_accelerator_request()
+        .map(|request| request.provider)
+        .unwrap_or_else(|| "cpu".to_string());
+    matching_native_llama_backends(&provider).into_iter().next()
 }
 
 fn matching_native_llama_backends(provider: &str) -> Vec<crate::config::LlamaSidecarBackend> {
@@ -2765,6 +2862,93 @@ mod tests {
         );
     }
 
+    #[test]
+    fn local_qdrant_transition_preserves_state_on_failure_then_publishes_embedded_state() {
+        let root = tempdir().expect("root");
+        let compose_file = root.path().join("retrieval-compose.yml");
+        std::fs::write(&compose_file, "services: {}\n").expect("compose file");
+        let mut runtime = compose_test_runtime(root.path());
+        runtime.layout.qdrant_http_port = 0;
+        runtime.layout.qdrant_grpc_port = 0;
+        runtime.embedding.endpoint_origin =
+            crate::config::EmbeddingEndpointOrigin::ProcessEnvironment;
+        runtime.embedding.endpoint = SidecarLayout::embed_base_url(runtime.embed_http_port);
+        runtime
+            .labels
+            .insert("dev.codestory.vector_backend".into(), "embedded".into());
+
+        let old_state: SidecarStateFile = serde_json::from_value(serde_json::json!({
+            "owner": "codestory",
+            "profile": "local",
+            "namespace": runtime.namespace,
+            "compose_project": runtime.compose_project,
+            "qdrant_http_port": 16333,
+            "qdrant_grpc_port": 16334,
+            "embed_http_port": runtime.embed_http_port,
+            "embed_url": SidecarLayout::embed_base_url(runtime.embed_http_port),
+            "lexical_data_dir": runtime.layout.lexical_data_dir,
+            "qdrant_data_dir": runtime.layout.qdrant_data_dir,
+            "scip_artifacts_root": runtime.layout.scip_artifacts_root,
+            "compose_file": compose_file,
+            "cleanup_command": "codestory-cli retrieval down",
+            "started_at_epoch_ms": 1
+        }))
+        .expect("old state");
+        let old_bytes = serde_json::to_vec_pretty(&old_state).expect("serialize old state");
+        std::fs::write(&runtime.layout.state_file, &old_bytes).expect("write old state");
+        let options = BootstrapSidecarsOptions {
+            storage_scope: BootstrapStorageScope {
+                repo_root: None,
+                active_storage_path: None,
+                active_cache_root: None,
+                global_cache_root: root.path().to_path_buf(),
+            },
+            compose_file: None,
+            skip_compose: true,
+            wait_timeout: Duration::ZERO,
+            allow_native_embedding_spawn: false,
+            reusable_native_embedding_launch: None,
+        };
+
+        let error = bootstrap_sidecars_with_transition_down(
+            &runtime,
+            None,
+            options.clone(),
+            |_| {},
+            |_| Ok(()),
+            |state| {
+                assert_eq!(state.qdrant_http_port, 16333);
+                assert_eq!(state.qdrant_grpc_port, 16334);
+                bail!("injected transition down failure")
+            },
+        )
+        .expect_err("transition failure");
+        assert!(format!("{error:#}").contains("injected transition down failure"));
+        assert_eq!(
+            std::fs::read(&runtime.layout.state_file).expect("preserved state"),
+            old_bytes
+        );
+        drop(error);
+
+        let report = bootstrap_sidecars_with_transition_down(
+            &runtime,
+            None,
+            options,
+            |_| {},
+            |_| Ok(()),
+            |state| {
+                assert_eq!(state.qdrant_http_port, 16333);
+                assert_eq!(state.qdrant_grpc_port, 16334);
+                assert_eq!(state.embed_http_port, runtime.embed_http_port);
+                Ok(())
+            },
+        )
+        .expect("retry transition");
+        assert_eq!(report.state.qdrant_http_port, 0);
+        assert_eq!(report.state.qdrant_grpc_port, 0);
+        assert_eq!(report.state.embed_http_port, runtime.embed_http_port);
+    }
+
     fn one_shot_json_server(body: serde_json::Value) -> (SocketAddr, thread::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test HTTP server");
         let address = listener.local_addr().expect("test HTTP server address");
@@ -2813,16 +2997,10 @@ mod tests {
     #[test]
     fn infrastructure_wait_uses_selected_runtime_embedding_endpoint() {
         let root = tempdir().expect("root");
-        let (qdrant_address, qdrant_server) = one_shot_json_server(serde_json::json!({
-            "result": { "collections": [] },
-            "status": "ok",
-            "time": 0.0
-        }));
         let (embedding_address, embedding_server) = one_shot_json_server(serde_json::json!({
             "data": [{ "index": 0, "embedding": [0.1, 0.2, 0.3] }]
         }));
         let mut runtime = compose_test_runtime(root.path());
-        runtime.layout.qdrant_http_port = qdrant_address.port();
         runtime.embed_http_port = embedding_address.port();
         runtime.embedding.configuration_error = None;
         runtime.embedding.backend = "llamacpp".to_string();
@@ -2841,7 +3019,6 @@ mod tests {
         assert!(health.lexical_ready);
         assert!(health.qdrant_reachable, "{}", health.qdrant_detail);
         assert!(health.embed_reachable, "{}", health.embed_detail);
-        qdrant_server.join().expect("qdrant test server");
         embedding_server.join().expect("embedding test server");
     }
 
@@ -3119,57 +3296,6 @@ mod tests {
         let written = written.expect("override path");
         let contents = std::fs::read_to_string(written).expect("override contents");
         assert!(contents.contains("/dev/dri:/dev/dri"));
-    }
-
-    #[test]
-    fn native_launch_mode_limits_compose_to_qdrant() {
-        assert_eq!(
-            docker_compose_services_for_launch_mode(EmbeddingServerLaunchMode::NativeSpawned),
-            &["qdrant"]
-        );
-        assert_eq!(
-            docker_compose_services_for_launch_mode(EmbeddingServerLaunchMode::ExternalEndpoint),
-            &["qdrant"]
-        );
-        assert!(
-            docker_compose_services_for_launch_mode(EmbeddingServerLaunchMode::DockerComposeEmbed)
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn compose_up_removes_services_deleted_from_the_compose_file() {
-        let root = tempdir().expect("root");
-        let runtime = compose_test_runtime(root.path());
-        let mut command = Command::new("docker");
-
-        append_docker_compose_up_args(
-            &mut command,
-            &runtime,
-            Path::new("retrieval-compose.yml"),
-            None,
-            EmbeddingServerLaunchMode::NativeSpawned,
-            false,
-        );
-
-        let args = command
-            .get_args()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            args,
-            [
-                "compose",
-                "-p",
-                "test",
-                "-f",
-                "retrieval-compose.yml",
-                "up",
-                "-d",
-                "--remove-orphans",
-                "qdrant",
-            ]
-        );
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/config.rs
+++ b/crates/codestory-retrieval/src/config.rs
@@ -1,5 +1,5 @@
 use crate::port_registry::{
-    AGENT_PORT_LEASE_TTL, AgentPortAllocation, allocate_agent_ports, free_local_port,
+    AGENT_PORT_LEASE_TTL, AgentPortAllocation, allocate_agent_ports_for_backend, free_local_port,
     renew_agent_port_lease, revalidate_agent_embedding_port,
 };
 use anyhow::{Context, Result, bail};
@@ -67,6 +67,7 @@ const RUNTIME_ENV_KEYS: &[&str] = &[
     "GITHUB_ACTIONS",
     "CODESTORY_QDRANT_HTTP_PORT",
     "CODESTORY_QDRANT_GRPC_PORT",
+    "CODESTORY_VECTOR_BACKEND",
     "CODESTORY_EMBED_PORT",
     "CODESTORY_EMBED_BACKEND",
     "CODESTORY_EMBED_RUNTIME_MODE",
@@ -219,6 +220,23 @@ pub enum EmbeddingServerLaunchMode {
     DockerComposeEmbed,
     NativeSpawned,
     ExternalEndpoint,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VectorBackend {
+    #[default]
+    Embedded,
+    ExternalQdrant,
+}
+
+impl VectorBackend {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Embedded => "embedded",
+            Self::ExternalQdrant => "external_qdrant",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -570,17 +588,27 @@ impl SidecarRuntimeConfig {
             && stored_value
                 .as_ref()
                 .is_some_and(sidecar_state_uses_native_embedding);
+        let (vector_backend, vector_backend_error) = vector_backend_from_defaults(defaults);
+        let qdrant_required = vector_backend == VectorBackend::ExternalQdrant;
         let configured_ports = [
-            env_port(
-                defaults,
-                "CODESTORY_QDRANT_HTTP_PORT",
-                DEFAULT_QDRANT_HTTP_PORT,
-            ),
-            env_port(
-                defaults,
-                "CODESTORY_QDRANT_GRPC_PORT",
-                DEFAULT_QDRANT_GRPC_PORT,
-            ),
+            qdrant_required
+                .then(|| {
+                    env_port(
+                        defaults,
+                        "CODESTORY_QDRANT_HTTP_PORT",
+                        DEFAULT_QDRANT_HTTP_PORT,
+                    )
+                })
+                .flatten(),
+            qdrant_required
+                .then(|| {
+                    env_port(
+                        defaults,
+                        "CODESTORY_QDRANT_GRPC_PORT",
+                        DEFAULT_QDRANT_GRPC_PORT,
+                    )
+                })
+                .flatten(),
             env_port(defaults, "CODESTORY_EMBED_PORT", DEFAULT_EMBED_HTTP_PORT),
         ];
         let requested_ports = std::array::from_fn(|index| {
@@ -596,7 +624,7 @@ impl SidecarRuntimeConfig {
             })
         });
         let agent_allocation = (profile == SidecarProfile::Agent)
-            .then(|| dynamic_agent_ports(&base, &namespace, requested_ports));
+            .then(|| dynamic_agent_ports(&base, &namespace, requested_ports, qdrant_required));
         let dynamic_failed = agent_allocation
             .as_ref()
             .is_some_and(AgentPortAllocation::failed);
@@ -608,22 +636,30 @@ impl SidecarRuntimeConfig {
                     configured.or(stored).or(dynamic).unwrap_or(default)
                 }
             };
-        let qdrant_http_port = selected_port(
-            configured_ports[0],
-            stored.as_ref().map(|ports| ports.qdrant_http),
-            agent_allocation
-                .as_ref()
-                .map(|allocation| allocation.ports.qdrant_http),
-            DEFAULT_QDRANT_HTTP_PORT,
-        );
-        let qdrant_grpc_port = selected_port(
-            configured_ports[1],
-            stored.as_ref().map(|ports| ports.qdrant_grpc),
-            agent_allocation
-                .as_ref()
-                .map(|allocation| allocation.ports.qdrant_grpc),
-            DEFAULT_QDRANT_GRPC_PORT,
-        );
+        let qdrant_http_port = if qdrant_required {
+            selected_port(
+                configured_ports[0],
+                stored.as_ref().map(|ports| ports.qdrant_http),
+                agent_allocation
+                    .as_ref()
+                    .map(|allocation| allocation.ports.qdrant_http),
+                DEFAULT_QDRANT_HTTP_PORT,
+            )
+        } else {
+            0
+        };
+        let qdrant_grpc_port = if qdrant_required {
+            selected_port(
+                configured_ports[1],
+                stored.as_ref().map(|ports| ports.qdrant_grpc),
+                agent_allocation
+                    .as_ref()
+                    .map(|allocation| allocation.ports.qdrant_grpc),
+                DEFAULT_QDRANT_GRPC_PORT,
+            )
+        } else {
+            0
+        };
         let embed_http_port = selected_port(
             configured_ports[2],
             (!stored_native_embedding)
@@ -653,6 +689,13 @@ impl SidecarRuntimeConfig {
         labels.insert("dev.codestory.owner".into(), "codestory".into());
         labels.insert("dev.codestory.profile".into(), profile.as_str().into());
         labels.insert("dev.codestory.namespace".into(), namespace.clone());
+        labels.insert(
+            "dev.codestory.vector_backend".into(),
+            vector_backend.as_str().into(),
+        );
+        if let Some(error) = vector_backend_error {
+            labels.insert("dev.codestory.vector_backend_error".into(), error);
+        }
         if let Some(project_root) = project_root {
             if let Some(identity) = project_identity.as_ref() {
                 labels.insert(
@@ -744,6 +787,24 @@ impl SidecarRuntimeConfig {
         }
     }
 
+    pub fn vector_backend(&self) -> VectorBackend {
+        match self
+            .labels
+            .get("dev.codestory.vector_backend")
+            .map(String::as_str)
+        {
+            Some("external_qdrant") => VectorBackend::ExternalQdrant,
+            _ => VectorBackend::Embedded,
+        }
+    }
+
+    pub fn ensure_vector_backend_configured(&self) -> Result<VectorBackend> {
+        if let Some(error) = self.labels.get("dev.codestory.vector_backend_error") {
+            bail!("{error}");
+        }
+        Ok(self.vector_backend())
+    }
+
     #[doc(hidden)]
     pub fn legacy_state_path_for_compatibility(&self) -> Option<PathBuf> {
         legacy_state_path_for_runtime(self)
@@ -785,12 +846,9 @@ impl SidecarRuntimeConfig {
 
     pub(crate) fn ensure_ports_allocated(&self) -> Result<()> {
         if self.profile == SidecarProfile::Agent
-            && [
-                self.layout.qdrant_http_port,
-                self.layout.qdrant_grpc_port,
-                self.embed_http_port,
-            ]
-            .contains(&0)
+            && (self.embed_http_port == 0
+                || (self.vector_backend() == VectorBackend::ExternalQdrant
+                    && [self.layout.qdrant_http_port, self.layout.qdrant_grpc_port].contains(&0)))
         {
             anyhow::bail!(
                 "agent sidecar port allocation is unavailable; inspect sidecars/port-allocations.sqlite3 and retry"
@@ -1104,6 +1162,15 @@ fn embedding_runtime_config(
             server_launch = Some("external_endpoint".to_string());
         }
     }
+    let device_policy = if default_flag(defaults, "CODESTORY_EMBED_ALLOW_CPU", false) {
+        "allow_cpu".to_string()
+    } else if let Some(policy) = default_nonempty(defaults, "CODESTORY_EMBED_DEVICE_POLICY") {
+        policy
+    } else if managed_cpu_is_default_for_host() {
+        "allow_cpu".to_string()
+    } else {
+        "accelerator_required".to_string()
+    };
     EmbeddingRuntimeConfig {
         configuration_error,
         backend: configured_backend,
@@ -1148,14 +1215,14 @@ fn embedding_runtime_config(
                 .unwrap_or(1)
         }),
         allow_remote: default_flag(defaults, "CODESTORY_ALLOW_REMOTE_EMBEDDINGS", false),
-        device_policy: if default_flag(defaults, "CODESTORY_EMBED_ALLOW_CPU", false) {
-            "allow_cpu".to_string()
-        } else {
-            default_nonempty(defaults, "CODESTORY_EMBED_DEVICE_POLICY")
-                .unwrap_or_else(|| "accelerator_required".to_string())
-        },
+        device_policy,
         server_launch,
     }
+}
+
+fn managed_cpu_is_default_for_host() -> bool {
+    let host = embedding_host_platform();
+    host.os == "macos" && host.arch == "x86_64"
 }
 
 fn retrieval_runtime_config(
@@ -1267,6 +1334,28 @@ fn env_profile(defaults: &SidecarRuntimeDefaults) -> Option<SidecarProfile> {
             "local" | "dev" => Some(SidecarProfile::Local),
             _ => None,
         })
+}
+
+fn vector_backend_from_defaults(
+    defaults: &SidecarRuntimeDefaults,
+) -> (VectorBackend, Option<String>) {
+    let Some(raw) = defaults
+        .get("CODESTORY_VECTOR_BACKEND")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return (VectorBackend::Embedded, None);
+    };
+    match raw.to_ascii_lowercase().as_str() {
+        "embedded" | "sqlite" | "local" => (VectorBackend::Embedded, None),
+        "qdrant" | "external_qdrant" | "external-qdrant" => (VectorBackend::ExternalQdrant, None),
+        _ => (
+            VectorBackend::Embedded,
+            Some(format!(
+                "CODESTORY_VECTOR_BACKEND must be embedded or external_qdrant, found {raw:?}"
+            )),
+        ),
+    }
 }
 
 fn env_agent_run_id(defaults: &SidecarRuntimeDefaults) -> Option<String> {
@@ -1785,8 +1874,10 @@ fn dynamic_agent_ports(
     base: &Path,
     namespace: &str,
     configured: [Option<u16>; 3],
+    qdrant_required: bool,
 ) -> AgentPortAllocation {
-    allocate_agent_ports(base, namespace, configured).unwrap_or_else(|error| {
+    allocate_agent_ports_for_backend(base, namespace, configured, qdrant_required).unwrap_or_else(
+        |error| {
         eprintln!(
             "CodeStory sidecar port allocation failed closed: namespace={namespace} error={error:#}"
         );
@@ -1799,7 +1890,8 @@ fn dynamic_agent_ports(
             },
             owner_id: String::new(),
         }
-    })
+    },
+    )
 }
 
 pub(crate) fn fnv1a_hex(bytes: &[u8]) -> String {
@@ -2041,10 +2133,8 @@ pub fn embedding_server_launch_mode_for_runtime(
     if runtime.embedding.endpoint_origin != EmbeddingEndpointOrigin::ManagedSidecar {
         return Ok(EmbeddingServerLaunchMode::ExternalEndpoint);
     }
-    let request = crate::embeddings::embedding_accelerator_request();
     let host = embedding_host_platform();
-    if request.is_some() && ((host.os == "macos" && host.arch == "aarch64") || host.os == "windows")
-    {
+    if host.os == "macos" || host.os == "windows" {
         Ok(EmbeddingServerLaunchMode::NativeSpawned)
     } else {
         Ok(EmbeddingServerLaunchMode::DockerComposeEmbed)
@@ -2532,6 +2622,7 @@ mod tests {
         let poison_cache = tempdir().expect("poison cache");
         let _cache = EnvGuard::remove("CODESTORY_CACHE_ROOT");
         let _qdrant = EnvGuard::remove("CODESTORY_QDRANT_HTTP_PORT");
+        let _vector = EnvGuard::remove("CODESTORY_VECTOR_BACKEND");
         let _endpoint = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
         let retained =
             test_sidecar_runtime_in_cache(None, SidecarProfile::Local, None, cache.path());
@@ -2540,6 +2631,7 @@ mod tests {
             poison_cache.path().to_str().expect("utf8 poison cache"),
         );
         let _qdrant = EnvGuard::set("CODESTORY_QDRANT_HTTP_PORT", "39999");
+        let _vector = EnvGuard::set("CODESTORY_VECTOR_BACKEND", "external_qdrant");
         let _endpoint = EnvGuard::set(
             "CODESTORY_EMBED_LLAMACPP_URL",
             "http://127.0.0.1:39998/v1/embeddings",
@@ -2549,7 +2641,9 @@ mod tests {
         let selected = retained.with_profile_and_run_id(None, SidecarProfile::Local, None);
         let selected_agent = retained.with_profile_and_run_id(None, SidecarProfile::Agent, None);
 
-        assert_eq!(selected.layout.qdrant_http_port, DEFAULT_QDRANT_HTTP_PORT);
+        assert_eq!(selected.vector_backend(), VectorBackend::Embedded);
+        assert_eq!(selected.layout.qdrant_http_port, 0);
+        assert_eq!(selected_agent.layout.qdrant_http_port, 0);
         assert_eq!(
             selected.layout.state_file,
             cache.path().join(SIDECAR_STATE_FILE_V3)
@@ -2558,6 +2652,36 @@ mod tests {
         assert!(!selected.layout.state_file.starts_with(poison_cache.path()));
         assert_eq!(selected_agent.run_id.as_deref(), Some(DEFAULT_AGENT_RUN_ID));
         assert!(!selected_agent.namespace.contains("poison-run-id"));
+    }
+
+    #[test]
+    fn vector_backend_selection_controls_qdrant_ports_and_fails_closed() {
+        let _lock = crate::test_support::env_lock();
+        let cache = tempdir().expect("cache");
+        let _cache = EnvGuard::set(
+            "CODESTORY_CACHE_ROOT",
+            cache.path().to_str().expect("cache path"),
+        );
+        {
+            let _backend = EnvGuard::remove("CODESTORY_VECTOR_BACKEND");
+            let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
+            assert_eq!(runtime.vector_backend(), VectorBackend::Embedded);
+            assert_eq!(runtime.layout.qdrant_http_port, 0);
+            assert_eq!(runtime.layout.qdrant_grpc_port, 0);
+        }
+        {
+            let _backend = EnvGuard::set("CODESTORY_VECTOR_BACKEND", "external_qdrant");
+            let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
+            assert_eq!(runtime.vector_backend(), VectorBackend::ExternalQdrant);
+            assert_eq!(runtime.layout.qdrant_http_port, DEFAULT_QDRANT_HTTP_PORT);
+            assert_eq!(runtime.layout.qdrant_grpc_port, DEFAULT_QDRANT_GRPC_PORT);
+        }
+        {
+            let _backend = EnvGuard::set("CODESTORY_VECTOR_BACKEND", "unknown");
+            let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Local, None);
+            assert!(runtime.ensure_vector_backend_configured().is_err());
+            assert_eq!(runtime.layout.qdrant_http_port, 0);
+        }
     }
 
     #[test]
@@ -2768,6 +2892,27 @@ mod tests {
             embedding_server_launch_mode_from_env().expect("launch mode"),
             EmbeddingServerLaunchMode::NativeSpawned
         );
+    }
+
+    #[test]
+    fn simulated_macos_x64_defaults_to_managed_native_cpu() {
+        let _lock = crate::test_support::env_lock();
+        let _host = EnvGuard::set(TEST_HOST_PLATFORM_ENV, "macos/x86_64");
+        let _mode = EnvGuard::remove("CODESTORY_EMBED_SERVER_LAUNCH");
+        let _url = EnvGuard::remove("CODESTORY_EMBED_LLAMACPP_URL");
+        let _allow_cpu = EnvGuard::remove("CODESTORY_EMBED_ALLOW_CPU");
+        let _policy = EnvGuard::remove("CODESTORY_EMBED_DEVICE_POLICY");
+
+        let runtime = test_sidecar_runtime_from_env(None, SidecarProfile::Agent, None);
+        assert_eq!(runtime.embedding.device_policy, "allow_cpu");
+        assert_eq!(
+            embedding_server_launch_mode_for_runtime(&runtime).expect("launch mode"),
+            EmbeddingServerLaunchMode::NativeSpawned
+        );
+        let backend = selected_llama_sidecar_backend("cpu").expect("macOS Intel CPU backend");
+        assert_eq!(backend.id, "macos-x86_64-cpu");
+        assert_eq!(backend.launch_mode, "native_spawned");
+        assert_eq!(backend.executable_archive_path, "llama-b9902/llama-server");
     }
 
     #[test]

--- a/crates/codestory-retrieval/src/embedded_vector.rs
+++ b/crates/codestory-retrieval/src/embedded_vector.rs
@@ -1,0 +1,564 @@
+use crate::candidate::{CandidateHit, CandidateSource};
+use crate::config::SidecarLayout;
+use crate::embeddings::LlamaCppEmbeddingClient;
+use crate::qdrant_client::QdrantUpsertPoint;
+use crate::sidecar_search::SearchExecutionContext;
+use anyhow::{Context, Result, bail};
+use rusqlite::{Connection, OpenFlags, TransactionBehavior, params};
+use std::cmp::Ordering;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+const VECTOR_INDEX_SCHEMA_VERSION: i64 = 1;
+const VECTOR_INDEX_FILE: &str = "vectors.sqlite3";
+type ScoredHit = (
+    f32,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EmbeddedVectorHealth {
+    pub ready: bool,
+    pub point_count: u64,
+    pub latency_ms: u64,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EmbeddedVectorIndex {
+    path: PathBuf,
+    generation: String,
+    input_hash: String,
+    embedding: LlamaCppEmbeddingClient,
+}
+
+impl EmbeddedVectorIndex {
+    pub(crate) fn open(
+        layout: &SidecarLayout,
+        collection: &str,
+        generation: &str,
+        input_hash: &str,
+        embedding: LlamaCppEmbeddingClient,
+    ) -> Self {
+        Self {
+            path: index_path(layout, collection),
+            generation: generation.to_string(),
+            input_hash: input_hash.to_string(),
+            embedding,
+        }
+    }
+
+    pub(crate) fn build_with_points(
+        layout: &SidecarLayout,
+        collection: &str,
+        generation: &str,
+        input_hash: &str,
+        embedding_backend: &str,
+        embedding_dim: usize,
+        produce: impl FnOnce(&mut dyn FnMut(QdrantUpsertPoint) -> Result<()>) -> Result<()>,
+    ) -> Result<u64> {
+        let path = index_path(layout, collection);
+        let parent = path
+            .parent()
+            .context("embedded vector index has no parent")?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create embedded vector directory {}", parent.display()))?;
+        let (temp_path, reserved) =
+            codestory_workspace::atomic_file::create_unique_temp_file(&path, "vector-index")?;
+        drop(reserved);
+        let result = (|| {
+            let point_count = write_database(
+                &temp_path,
+                generation,
+                input_hash,
+                embedding_backend,
+                embedding_dim,
+                produce,
+            )?;
+            validate_database(
+                &temp_path,
+                generation,
+                input_hash,
+                point_count,
+                embedding_backend,
+                embedding_dim,
+            )?;
+            codestory_workspace::atomic_file::publish_existing_file_atomic(&temp_path, &path)?;
+            Ok(point_count)
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temp_path);
+        }
+        result
+    }
+
+    pub(crate) fn health(
+        layout: &SidecarLayout,
+        collection: &str,
+        generation: &str,
+        input_hash: &str,
+        expected_points: u64,
+        embedding_backend: &str,
+        embedding_dim: usize,
+    ) -> EmbeddedVectorHealth {
+        let started = Instant::now();
+        let result = validate_database(
+            &index_path(layout, collection),
+            generation,
+            input_hash,
+            expected_points,
+            embedding_backend,
+            embedding_dim,
+        );
+        EmbeddedVectorHealth {
+            ready: result.is_ok(),
+            point_count: result.as_ref().map_or(0, |count| *count),
+            latency_ms: started.elapsed().as_millis() as u64,
+            detail: result.map_or_else(
+                |error| format!("embedded vector index unavailable: {error:#}"),
+                |count| format!("embedded SQLite vectors ready points_count={count}"),
+            ),
+        }
+    }
+
+    pub(crate) fn search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
+        let vector = self.embedding.embed_query(query)?;
+        search_database(
+            &self.path,
+            &self.generation,
+            &self.input_hash,
+            &vector,
+            limit,
+            || false,
+        )
+    }
+
+    pub(crate) fn search_with_context(
+        &self,
+        query: &str,
+        limit: usize,
+        context: &SearchExecutionContext,
+    ) -> Result<Vec<CandidateHit>> {
+        let vector = self
+            .embedding
+            .embed_query_with_timeout(query, context.timeout(std::time::Duration::from_secs(2))?)?;
+        context.check_cancelled()?;
+        let context = context.clone();
+        search_database(
+            &self.path,
+            &self.generation,
+            &self.input_hash,
+            &vector,
+            limit,
+            move || context.is_cancelled(),
+        )
+    }
+}
+
+pub(crate) fn index_path(layout: &SidecarLayout, collection: &str) -> PathBuf {
+    layout
+        .qdrant_data_dir
+        .join("collections")
+        .join(collection)
+        .join(VECTOR_INDEX_FILE)
+}
+
+fn write_database(
+    path: &Path,
+    generation: &str,
+    input_hash: &str,
+    embedding_backend: &str,
+    embedding_dim: usize,
+    produce: impl FnOnce(&mut dyn FnMut(QdrantUpsertPoint) -> Result<()>) -> Result<()>,
+) -> Result<u64> {
+    let mut connection = Connection::open(path)
+        .with_context(|| format!("create embedded vector index {}", path.display()))?;
+    connection.execute_batch(
+        "PRAGMA journal_mode=DELETE;
+         PRAGMA synchronous=FULL;
+         CREATE TABLE metadata (
+             schema_version INTEGER NOT NULL,
+             generation TEXT NOT NULL,
+             input_hash TEXT NOT NULL,
+             embedding_backend TEXT NOT NULL,
+             embedding_dim INTEGER NOT NULL,
+             point_count INTEGER NOT NULL
+         );
+         CREATE TABLE vectors (
+             node_id TEXT PRIMARY KEY NOT NULL,
+             display_name TEXT NOT NULL,
+             file_path TEXT,
+             file_role TEXT,
+             dense_reason TEXT,
+             vector BLOB NOT NULL
+         ) WITHOUT ROWID;",
+    )?;
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let mut point_count = 0_u64;
+    {
+        let mut insert = transaction.prepare(
+            "INSERT INTO vectors (
+                 node_id, display_name, file_path, file_role, dense_reason, vector
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )?;
+        let mut visit = |point: QdrantUpsertPoint| -> Result<()> {
+            let vector = point
+                .vector
+                .as_deref()
+                .context("embedded vector point is missing")?;
+            if vector.len() != embedding_dim {
+                bail!(
+                    "embedded vector dimension mismatch for node {}: expected {embedding_dim}, found {}",
+                    point.node_id,
+                    vector.len()
+                );
+            }
+            insert.execute(params![
+                point.node_id,
+                point.display_name,
+                point.file_path,
+                point.file_role.map(|role| role.as_str()),
+                point.dense_reason,
+                vector_bytes(vector),
+            ])?;
+            point_count = point_count.saturating_add(1);
+            Ok(())
+        };
+        produce(&mut visit)?;
+    }
+    transaction.execute(
+        "INSERT INTO metadata VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            VECTOR_INDEX_SCHEMA_VERSION,
+            generation,
+            input_hash,
+            embedding_backend,
+            embedding_dim as i64,
+            point_count as i64,
+        ],
+    )?;
+    transaction.commit()?;
+    connection.execute_batch("PRAGMA optimize;")?;
+    drop(connection);
+    std::fs::File::open(path)?.sync_all()?;
+    Ok(point_count)
+}
+
+fn validate_database(
+    path: &Path,
+    generation: &str,
+    input_hash: &str,
+    expected_points: u64,
+    embedding_backend: &str,
+    embedding_dim: usize,
+) -> Result<u64> {
+    let connection = open_read_only(path)?;
+    let metadata = connection.query_row(
+        "SELECT schema_version, generation, input_hash, embedding_backend,
+                embedding_dim, point_count
+         FROM metadata",
+        [],
+        |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+            ))
+        },
+    )?;
+    if metadata.0 != VECTOR_INDEX_SCHEMA_VERSION
+        || metadata.1 != generation
+        || metadata.2 != input_hash
+        || metadata.3 != embedding_backend
+        || metadata.4 != embedding_dim as i64
+        || metadata.5 < 0
+        || metadata.5 as u64 != expected_points
+    {
+        bail!("embedded vector metadata does not match the published generation");
+    }
+    let actual: i64 = connection.query_row("SELECT COUNT(*) FROM vectors", [], |row| row.get(0))?;
+    if actual < 0 || actual as u64 != expected_points {
+        bail!(
+            "embedded vector count mismatch: expected {expected_points}, found {}",
+            actual.max(0)
+        );
+    }
+    Ok(actual as u64)
+}
+
+fn search_database(
+    path: &Path,
+    generation: &str,
+    input_hash: &str,
+    query: &[f32],
+    limit: usize,
+    cancelled: impl Fn() -> bool,
+) -> Result<Vec<CandidateHit>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let connection = open_read_only(path)?;
+    let (stored_generation, stored_hash, stored_dim): (String, String, i64) = connection
+        .query_row(
+            "SELECT generation, input_hash, embedding_dim FROM metadata",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+    if stored_generation != generation
+        || stored_hash != input_hash
+        || stored_dim != query.len() as i64
+    {
+        bail!("embedded vector index publication identity changed");
+    }
+    let mut statement = connection.prepare(
+        "SELECT node_id, display_name, file_path, file_role, dense_reason, vector FROM vectors",
+    )?;
+    let mut rows = statement.query([])?;
+    let mut scored = Vec::with_capacity(limit);
+    let query_norm = query.iter().map(|value| value * value).sum::<f32>().sqrt();
+    while let Some(row) = rows.next()? {
+        if cancelled() {
+            bail!("embedded vector search cancelled");
+        }
+        let bytes: Vec<u8> = row.get(5)?;
+        let score = cosine_similarity_bytes(query, query_norm, &bytes)?;
+        let candidate = (
+            score,
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, Option<String>>(3)?,
+            row.get::<_, Option<String>>(4)?,
+        );
+        if scored.len() < limit {
+            scored.push(candidate);
+            continue;
+        }
+        let (worst_index, worst) = scored
+            .iter()
+            .enumerate()
+            .max_by(|(_, left), (_, right)| compare_scored_hits(left, right))
+            .expect("non-empty bounded score set");
+        if compare_scored_hits(&candidate, worst) == Ordering::Less {
+            scored[worst_index] = candidate;
+        }
+    }
+    scored.sort_unstable_by(compare_scored_hits);
+    Ok(scored
+        .into_iter()
+        .map(
+            |(score, node_id, display_name, file_path, file_role, dense_reason)| {
+                let file_path = file_path.unwrap_or_else(|| display_name.clone());
+                let mut hit = CandidateHit::with_source(
+                    file_path,
+                    Some(display_name),
+                    score,
+                    CandidateSource::Qdrant,
+                );
+                hit.node_id = Some(node_id);
+                hit.file_role = file_role
+                    .as_deref()
+                    .map(codestory_store::FileRole::from_db_value);
+                hit.add_provenance(if dense_reason.as_deref() == Some("component_report") {
+                    "component_report"
+                } else {
+                    "dense_anchor"
+                });
+                hit
+            },
+        )
+        .collect())
+}
+
+fn compare_scored_hits(left: &ScoredHit, right: &ScoredHit) -> Ordering {
+    right
+        .0
+        .total_cmp(&left.0)
+        .then_with(|| left.1.cmp(&right.1))
+}
+
+fn open_read_only(path: &Path) -> Result<Connection> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("open embedded vector index {}", path.display()))
+}
+
+fn vector_bytes(vector: &[f32]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(std::mem::size_of_val(vector));
+    for value in vector {
+        bytes.extend_from_slice(&value.to_bits().to_le_bytes());
+    }
+    bytes
+}
+
+fn cosine_similarity_bytes(query: &[f32], query_norm: f32, bytes: &[u8]) -> Result<f32> {
+    if bytes.len() != std::mem::size_of_val(query) {
+        bail!("embedded vector blob has an invalid width");
+    }
+    let mut dot = 0.0_f32;
+    let mut vector_norm = 0.0_f32;
+    for (query_value, chunk) in query.iter().zip(bytes.chunks_exact(4)) {
+        let value = f32::from_bits(u32::from_le_bytes(chunk.try_into().expect("four bytes")));
+        dot += query_value * value;
+        vector_norm += value * value;
+    }
+    let denominator = query_norm * vector_norm.sqrt();
+    Ok(if denominator > f32::EPSILON {
+        dot / denominator
+    } else {
+        0.0
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SidecarLayout;
+    use codestory_store::FileRole;
+    use tempfile::tempdir;
+
+    fn layout(root: &Path) -> SidecarLayout {
+        SidecarLayout {
+            qdrant_http_port: 0,
+            qdrant_grpc_port: 0,
+            lexical_data_dir: root.join("lexical"),
+            qdrant_data_dir: root.join("semantic"),
+            scip_artifacts_root: root.join("scip"),
+            state_file: root.join("state.json"),
+        }
+    }
+
+    fn point(node_id: &str, vector: Vec<f32>) -> QdrantUpsertPoint {
+        QdrantUpsertPoint {
+            id: 1,
+            display_name: format!("symbol_{node_id}"),
+            node_id: node_id.into(),
+            file_path: Some(format!("src/{node_id}.rs")),
+            file_role: Some(FileRole::Source),
+            dense_reason: Some("public_api".into()),
+            vector: Some(vector),
+        }
+    }
+
+    #[test]
+    fn immutable_index_is_generation_bound_and_ranks_cosine_similarity() {
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let points = [point("1", vec![1.0, 0.0]), point("2", vec![0.0, 1.0])];
+        EmbeddedVectorIndex::build_with_points(
+            &layout,
+            "codestory_test_deadbeefdeadbeef",
+            "test-deadbeefdeadbeef",
+            "input",
+            "backend",
+            2,
+            |visit| {
+                for point in points {
+                    visit(point)?;
+                }
+                Ok(())
+            },
+        )
+        .expect("build");
+
+        let path = index_path(&layout, "codestory_test_deadbeefdeadbeef");
+        let hits = search_database(
+            &path,
+            "test-deadbeefdeadbeef",
+            "input",
+            &[0.9, 0.1],
+            1,
+            || false,
+        )
+        .expect("search");
+        assert_eq!(hits[0].node_id.as_deref(), Some("1"));
+        assert!(
+            !EmbeddedVectorIndex::health(
+                &layout,
+                "codestory_test_deadbeefdeadbeef",
+                "other-generation",
+                "input",
+                2,
+                "backend",
+                2,
+            )
+            .ready
+        );
+    }
+
+    #[test]
+    #[ignore = "measurement lane; run with --release --ignored --nocapture"]
+    fn embedded_vector_scan_measurement() {
+        const DIMENSION: usize = 768;
+        const SEARCH_RUNS: usize = 10;
+
+        let root = tempdir().expect("tempdir");
+        let layout = layout(root.path());
+        let mut measurements = Vec::new();
+        for point_count in [1_000_usize, 10_000, 25_000] {
+            let collection = format!("codestory_measurement_{point_count}");
+            let build_started = Instant::now();
+            EmbeddedVectorIndex::build_with_points(
+                &layout,
+                &collection,
+                "measurement-generation",
+                "measurement-input",
+                "llamacpp:bge-base-en-v1.5",
+                DIMENSION,
+                |visit| {
+                    for index in 0..point_count {
+                        let mut vector = vec![0.0_f32; DIMENSION];
+                        vector[index % DIMENSION] = 1.0;
+                        vector[(index.wrapping_mul(31) + 7) % DIMENSION] = 0.5;
+                        visit(point(&index.to_string(), vector))?;
+                    }
+                    Ok(())
+                },
+            )
+            .expect("build measurement index");
+            let build_ms = build_started.elapsed().as_millis();
+
+            let mut query = vec![0.0_f32; DIMENSION];
+            query[0] = 1.0;
+            query[7] = 0.5;
+            let path = index_path(&layout, &collection);
+            let mut search_us = Vec::with_capacity(SEARCH_RUNS);
+            for _ in 0..SEARCH_RUNS {
+                let started = Instant::now();
+                let hits = search_database(
+                    &path,
+                    "measurement-generation",
+                    "measurement-input",
+                    &query,
+                    20,
+                    || false,
+                )
+                .expect("measure search");
+                assert_eq!(hits.len(), 20);
+                search_us.push(started.elapsed().as_micros());
+            }
+            search_us.sort_unstable();
+            measurements.push(serde_json::json!({
+                "points": point_count,
+                "dimension": DIMENSION,
+                "database_bytes": std::fs::metadata(&path).expect("index metadata").len(),
+                "build_ms": build_ms,
+                "warm_search_p50_us": search_us[SEARCH_RUNS / 2],
+                "warm_search_p95_us": search_us[SEARCH_RUNS - 1],
+            }));
+        }
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&measurements).expect("serialize measurements")
+        );
+    }
+}

--- a/crates/codestory-retrieval/src/embeddings.rs
+++ b/crates/codestory-retrieval/src/embeddings.rs
@@ -925,10 +925,21 @@ fn runtime_log_proves_requested_accelerator(
 }
 
 pub fn embedding_accelerator_request() -> Option<EmbeddingAcceleratorRequest> {
-    if explicit_cpu_allowed() {
+    if explicit_cpu_allowed() || default_cpu_allowed_for_host() {
         return None;
     }
     Some(default_embedding_accelerator_request())
+}
+
+fn default_cpu_allowed_for_host() -> bool {
+    if std::env::var(DEVICE_POLICY_ENV)
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return false;
+    }
+    let host = crate::config::embedding_host_platform();
+    host.os == "macos" && host.arch == "x86_64"
 }
 
 fn default_embedding_accelerator_request() -> EmbeddingAcceleratorRequest {

--- a/crates/codestory-retrieval/src/health.rs
+++ b/crates/codestory-retrieval/src/health.rs
@@ -1,8 +1,9 @@
 use crate::capabilities::SidecarCapabilities;
 use crate::config::{
     QDRANT_HEALTH_BUDGET, SidecarImagePins, SidecarLayout, SidecarOwnership, SidecarProfile,
-    SidecarRuntimeConfig, default_sidecar_image_pins, retrieval_command,
+    SidecarRuntimeConfig, VectorBackend, default_sidecar_image_pins, retrieval_command,
 };
+use crate::embedded_vector::EmbeddedVectorIndex;
 use crate::embeddings::{EmbeddingDeviceReadiness, manifest_embedding_backend_is_product};
 use crate::generation::{manifest_has_current_sidecar_contract, manifest_sidecar_generation};
 use crate::qdrant_client::QdrantClient;
@@ -455,12 +456,12 @@ pub fn probe_infrastructure_health_with_embedding_device(
     embedding_device: &EmbeddingDeviceReadiness,
 ) -> InfrastructureHealth {
     let layout = &runtime.layout;
-    let qdrant_client = QdrantClient::new(layout);
-    let qdrant_probe = qdrant_client.list_collections_probe();
+    let qdrant_probe = (runtime.vector_backend() == VectorBackend::ExternalQdrant)
+        .then(|| QdrantClient::new(layout).list_collections_probe());
     let embed_probe = crate::embeddings::probe_product_embedding_runtime_for_runtime(runtime);
     InfrastructureHealth {
         lexical_ready: layout.lexical_data_dir.is_dir(),
-        qdrant_reachable: qdrant_probe.reachable,
+        qdrant_reachable: qdrant_probe.as_ref().is_none_or(|probe| probe.reachable),
         embed_reachable: embed_probe.reachable,
         embedding_device_policy: embedding_device.requested_policy.into(),
         embedding_device_state: embedding_device.observed_state.into(),
@@ -477,7 +478,10 @@ pub fn probe_infrastructure_health_with_embedding_device(
             "project-local SQLite FTS root {}",
             layout.lexical_data_dir.display()
         ),
-        qdrant_detail: qdrant_probe.detail,
+        qdrant_detail: qdrant_probe.map_or_else(
+            || "embedded SQLite vectors require no external service".into(),
+            |probe| probe.detail,
+        ),
         embed_detail: embed_probe.detail,
     }
 }
@@ -732,8 +736,71 @@ pub fn probe_sidecar_health_for_runtime(
         .dense_projection_count
         .or(manifest.projection_count)
         .unwrap_or(0);
-    let qdrant = if dense_anchor_count == 0 {
+    let vector_backend = runtime.ensure_vector_backend_configured();
+    let qdrant = if let Err(error) = vector_backend {
+        ComponentHealth {
+            name: "semantic".into(),
+            status: ComponentStatus::Unavailable,
+            latency_ms: None,
+            detail: error.to_string(),
+            degraded_reason: Some("vector_backend_configuration_invalid".into()),
+            capabilities: SidecarCapabilities::NONE,
+        }
+    } else if dense_anchor_count == 0 {
         zero_dense_qdrant_health(embedding_device)
+    } else if runtime.vector_backend() == VectorBackend::Embedded {
+        let collection = manifest.qdrant_collection.clone();
+        let expected_points = u64::try_from(dense_anchor_count).unwrap_or(u64::MAX);
+        let embedded = EmbeddedVectorIndex::health(
+            layout,
+            &collection,
+            sidecar_generation,
+            sidecar_input_hash,
+            expected_points,
+            manifest.embedding_backend.as_deref().unwrap_or_default(),
+            usize::try_from(manifest.embedding_dim.unwrap_or_default()).unwrap_or_default(),
+        );
+        let embedding = crate::embeddings::probe_product_embedding_runtime_for_runtime(runtime);
+        let product_embedding_backend =
+            manifest_embedding_backend_is_product(manifest.embedding_backend.as_deref())
+                && manifest_embedding_backend_is_product(Some(current_embedding_backend.as_str()));
+        let degraded_reason = if !embedded.ready {
+            Some("embedded_vector_index_unavailable".into())
+        } else if !product_embedding_backend {
+            Some("semantic_embedding_contract_mismatch".into())
+        } else if !embedding.reachable {
+            Some("embedding_runtime_unavailable".into())
+        } else if !embedding_device.full_retrieval_allowed {
+            embedding_device.degraded_reason.clone()
+        } else {
+            None
+        };
+        ComponentHealth {
+            name: "semantic".into(),
+            status: if degraded_reason.is_none() {
+                ComponentStatus::Healthy
+            } else if embedded.ready {
+                ComponentStatus::Degraded
+            } else {
+                ComponentStatus::Unavailable
+            },
+            latency_ms: Some(embedded.latency_ms),
+            detail: format!("{}; {}", embedded.detail, embedding.detail),
+            degraded_reason,
+            capabilities: if embedded.ready
+                && product_embedding_backend
+                && embedding.reachable
+                && embedding_device.full_retrieval_allowed
+            {
+                SidecarCapabilities {
+                    lexical: false,
+                    semantic: true,
+                    graph: false,
+                }
+            } else {
+                SidecarCapabilities::NONE
+            },
+        }
     } else {
         let collection = manifest.qdrant_collection.clone();
         let qdrant_probe = QdrantClient::new(layout).health_probe(&collection);
@@ -762,7 +829,7 @@ pub fn probe_sidecar_health_for_runtime(
             && current_product_embedding_backend
             && !embedding_device.full_retrieval_allowed;
         ComponentHealth {
-            name: "qdrant".into(),
+            name: "semantic".into(),
             status: if !qdrant_probe.reachable {
                 ComponentStatus::Unavailable
             } else if !qdrant_probe.collection_exists
@@ -869,7 +936,7 @@ fn zero_dense_qdrant_health(
 ) -> ComponentHealth {
     if !embedding_device.full_retrieval_allowed {
         return ComponentHealth {
-            name: "qdrant".into(),
+            name: "semantic".into(),
             status: ComponentStatus::Degraded,
             latency_ms: None,
             detail: "graph_first_v1 selected zero dense anchors, but embedding device policy is not verified".into(),
@@ -879,7 +946,7 @@ fn zero_dense_qdrant_health(
     }
 
     ComponentHealth {
-        name: "qdrant".into(),
+        name: "semantic".into(),
         status: ComponentStatus::Healthy,
         latency_ms: None,
         detail: "graph_first_v1 selected zero dense anchors; semantic retrieval skipped by policy"

--- a/crates/codestory-retrieval/src/index.rs
+++ b/crates/codestory-retrieval/src/index.rs
@@ -1,4 +1,5 @@
-use crate::config::{SidecarLayout, SidecarRuntimeConfig, dir_size_bytes};
+use crate::config::{SidecarLayout, SidecarRuntimeConfig, VectorBackend, dir_size_bytes};
+use crate::embedded_vector::EmbeddedVectorIndex;
 #[cfg(test)]
 use crate::generation::manifest_unavailable_reason;
 use crate::generation::{
@@ -64,6 +65,25 @@ pub(crate) struct SidecarInputFingerprint {
     pub(crate) lexical_file_count: u32,
     pub(crate) lexical_hash: String,
     pub(crate) lexical_coverage: crate::lexical_index::LexicalCoverage,
+}
+
+struct SidecarEmbeddingContract<'a> {
+    backend: &'a str,
+    dimension: i32,
+    config: &'a crate::config::EmbeddingRuntimeConfig,
+    vector_backend: &'a str,
+}
+
+struct SemanticGeneration<'a> {
+    runtime: &'a SidecarRuntimeConfig,
+    qdrant_client: &'a Option<QdrantClient>,
+    layout: &'a SidecarLayout,
+    collection: &'a str,
+    generation: &'a str,
+    input_hash: &'a str,
+    embedding_backend: &'a str,
+    embedding_dim: i32,
+    expected_points: i64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -146,6 +166,17 @@ pub fn repair_project_qdrant_collection_for_runtime(
 
     let layout = &runtime.layout;
     layout.ensure_data_dirs()?;
+    let vector_backend = runtime.ensure_vector_backend_configured()?;
+    if vector_backend == VectorBackend::Embedded {
+        return Ok(Some(ProjectQdrantRepairOutcome {
+            project_id,
+            qdrant_collection: manifest.qdrant_collection,
+            collection_existed: false,
+            repaired: false,
+            points_upserted: 0,
+            skipped_reason: Some("embedded_vector_backend".into()),
+        }));
+    }
     let qdrant_client = QdrantClient::for_runtime(runtime)?;
     let probe = qdrant_client.health_probe(&manifest.qdrant_collection);
     if !probe.reachable {
@@ -243,7 +274,10 @@ pub fn finalize_index_for_runtime_with_progress(
     let qdrant_stubbed = false;
     let scip_stubbed = false;
 
-    let qdrant_client = QdrantClient::for_runtime(runtime)?;
+    let vector_backend = runtime.ensure_vector_backend_configured()?;
+    let qdrant_client = (vector_backend == VectorBackend::ExternalQdrant)
+        .then(|| QdrantClient::for_runtime(runtime))
+        .transpose()?;
     let embedding_backend = crate::embeddings::embedding_runtime_id_for_runtime(runtime);
     let embedding_dim = i32::try_from(crate::embeddings::qdrant_vector_dim())
         .unwrap_or(crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32);
@@ -257,13 +291,17 @@ pub fn finalize_index_for_runtime_with_progress(
     let input_snapshot = storage
         .read_snapshot()
         .context("open coherent sidecar input snapshot")?;
+    let embedding_contract = SidecarEmbeddingContract {
+        backend: &embedding_backend,
+        dimension: embedding_dim,
+        config: &runtime.embedding,
+        vector_backend: vector_backend.as_str(),
+    };
     let sidecar_input = compute_sidecar_input_fingerprint_with_lexical_source(
         input_snapshot.storage(),
         project_root,
         &project_id,
-        &embedding_backend,
-        embedding_dim,
-        &runtime.embedding,
+        &embedding_contract,
         lexical_source,
     )?;
     input_snapshot
@@ -304,11 +342,18 @@ pub fn finalize_index_for_runtime_with_progress(
                 &embedding_device,
                 runtime,
             );
-            let qdrant_point_count = qdrant_ready_point_count(
-                &qdrant_client,
-                &previous.qdrant_collection,
-                sidecar_input.projection_count,
-            );
+            let previous_semantic = SemanticGeneration {
+                runtime,
+                qdrant_client: &qdrant_client,
+                layout: &layout,
+                collection: &previous.qdrant_collection,
+                generation: previous.sidecar_generation.as_deref().unwrap_or_default(),
+                input_hash: previous.sidecar_input_hash.as_deref().unwrap_or_default(),
+                embedding_backend: &embedding_backend,
+                embedding_dim,
+                expected_points: sidecar_input.projection_count,
+            };
+            let qdrant_point_count = semantic_ready_point_count(&previous_semantic);
             if status.retrieval_mode == "full" && qdrant_point_count.is_some() {
                 let mut manifest = previous.clone();
                 if let Some(generation) = manifest.sidecar_generation.as_deref() {
@@ -364,6 +409,17 @@ pub fn finalize_index_for_runtime_with_progress(
     let generation = sidecar_generation_id(&project_id, &sidecar_input.hash);
     let collection = QdrantClient::collection_name_for_generation(&project_id, &sidecar_input.hash);
     let scip_dir = layout.scip_project_dir(&generation);
+    let semantic_generation = SemanticGeneration {
+        runtime,
+        qdrant_client: &qdrant_client,
+        layout: &layout,
+        collection: &collection,
+        generation: &generation,
+        input_hash: &sidecar_input.hash,
+        embedding_backend: &embedding_backend,
+        embedding_dim,
+        expected_points: sidecar_input.projection_count,
+    };
     let mut manifest = retrieval_manifest_for_sidecar(
         &project_id,
         &generation,
@@ -390,7 +446,7 @@ pub fn finalize_index_for_runtime_with_progress(
             &sidecar_input.hash,
         );
     let qdrant_ready_points = if existing_status.qdrant.capabilities.semantic {
-        qdrant_ready_point_count(&qdrant_client, &collection, sidecar_input.projection_count)
+        semantic_ready_point_count(&semantic_generation)
     } else {
         None
     };
@@ -445,13 +501,11 @@ pub fn finalize_index_for_runtime_with_progress(
         )
     })?;
 
-    let _qdrant_point_count = ensure_qdrant_collection(
+    let _qdrant_point_count = ensure_semantic_index(
         storage_path,
         project_root,
-        &qdrant_client,
         &project_id,
-        &collection,
-        sidecar_input.projection_count,
+        &semantic_generation,
         qdrant_ready_points,
         &mut progress,
     )?;
@@ -543,26 +597,63 @@ fn ensure_lexical_generation(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
-fn ensure_qdrant_collection(
+fn ensure_semantic_index(
     storage_path: &Path,
     project_root: &Path,
-    qdrant_client: &QdrantClient,
     project_id: &str,
-    collection: &str,
-    projection_count: i64,
+    semantic: &SemanticGeneration<'_>,
     mut qdrant_ready_points: Option<u64>,
     progress: &mut impl FnMut(&'static str),
 ) -> Result<u64> {
-    if projection_count == 0 {
+    if semantic.expected_points == 0 {
         info!(
             project_id = %project_id,
-            collection = %collection,
-            "Qdrant collection skipped because graph_first_v1 selected zero dense anchors"
+            collection = %semantic.collection,
+            "dense vector index skipped because graph_first_v1 selected zero dense anchors"
         );
         return Ok(0);
     }
-    let qdrant_probe = qdrant_client.health_probe(collection);
+    if semantic.runtime.vector_backend() == VectorBackend::Embedded {
+        if let Some(point_count) = qdrant_ready_points {
+            info!(
+                project_id = %project_id,
+                sidecar_generation = %semantic.generation,
+                point_count,
+                "embedded vector generation reused"
+            );
+            return Ok(point_count);
+        }
+        let point_count = with_finalize_progress(progress, "embedded vectors", || {
+            EmbeddedVectorIndex::build_with_points(
+                semantic.layout,
+                semantic.collection,
+                semantic.generation,
+                semantic.input_hash,
+                semantic.embedding_backend,
+                usize::try_from(semantic.embedding_dim).context("negative embedding dimension")?,
+                |visit| visit_semantic_points_from_store(storage_path, project_root, visit),
+            )
+        })?;
+        if point_count != u64::try_from(semantic.expected_points).unwrap_or(u64::MAX) {
+            bail!(
+                "embedded vector generation incomplete for {project_id}: expected {} points, found {point_count}",
+                semantic.expected_points
+            );
+        }
+        info!(
+            project_id = %project_id,
+            sidecar_generation = %semantic.generation,
+            point_count,
+            "embedded SQLite vector generation published"
+        );
+        return Ok(point_count);
+    }
+
+    let qdrant_client = semantic
+        .qdrant_client
+        .as_ref()
+        .context("external Qdrant backend selected without a client")?;
+    let qdrant_probe = qdrant_client.health_probe(semantic.collection);
     if !qdrant_probe.reachable {
         bail!(
             "qdrant sidecar is mandatory but unreachable while finalizing retrieval index for {project_id}: {}",
@@ -572,32 +663,38 @@ fn ensure_qdrant_collection(
     if let Some(point_count) = qdrant_ready_points {
         info!(
             project_id = %project_id,
-            collection = %collection,
+            collection = %semantic.collection,
             qdrant_point_count = point_count,
             "Qdrant generated collection reused"
         );
     } else {
         let count = with_finalize_progress(progress, "embeddings", || {
-            upsert_qdrant_points_from_store(storage_path, project_root, qdrant_client, collection)
+            upsert_qdrant_points_from_store(
+                storage_path,
+                project_root,
+                qdrant_client,
+                semantic.collection,
+            )
         })?;
         if count == 0 {
             bail!(
                 "mandatory Qdrant semantic collection has no indexed symbol points for {project_id}"
             );
         }
-        qdrant_ready_points = qdrant_ready_point_count(qdrant_client, collection, projection_count);
+        qdrant_ready_points =
+            qdrant_ready_point_count(qdrant_client, semantic.collection, semantic.expected_points);
         if qdrant_ready_points.is_none() {
             let actual = qdrant_client
-                .count_points_exact(collection)
+                .count_points_exact(semantic.collection)
                 .unwrap_or_default();
             bail!(
                 "mandatory Qdrant semantic collection incomplete for {project_id}: expected at least {} points, found {actual}",
-                projection_count
+                semantic.expected_points
             );
         }
         info!(
             project_id = %project_id,
-            collection = %collection,
+            collection = %semantic.collection,
             points = count,
             qdrant_point_count = qdrant_ready_points.unwrap_or_default(),
             real_embeddings = true,
@@ -605,7 +702,7 @@ fn ensure_qdrant_collection(
         );
     }
     with_finalize_progress(progress, "Qdrant finalize", || {
-        ensure_qdrant_semantic_smoke(project_id, collection, qdrant_client)
+        ensure_qdrant_semantic_smoke(project_id, semantic.collection, qdrant_client)
     })?;
     Ok(qdrant_ready_points.unwrap_or_default())
 }
@@ -814,21 +911,28 @@ fn qdrant_ready_point_count(
     })
 }
 
-fn qdrant_candidate_point_count(
-    qdrant_client: &QdrantClient,
-    collection: &str,
-    expected_points: i64,
-) -> Option<u64> {
-    qdrant_candidate_point_count_with(expected_points, || {
-        qdrant_ready_point_count(qdrant_client, collection, expected_points)
-    })
-}
-
-fn qdrant_candidate_point_count_with(
-    expected_points: i64,
-    count_points: impl FnOnce() -> Option<u64>,
-) -> Option<u64> {
-    (expected_points > 0).then(count_points).flatten()
+fn semantic_ready_point_count(semantic: &SemanticGeneration<'_>) -> Option<u64> {
+    let expected = u64::try_from(semantic.expected_points).ok()?;
+    if expected == 0 {
+        return Some(0);
+    }
+    match semantic.runtime.vector_backend() {
+        VectorBackend::Embedded => {
+            let health = EmbeddedVectorIndex::health(
+                semantic.layout,
+                semantic.collection,
+                semantic.generation,
+                semantic.input_hash,
+                expected,
+                semantic.embedding_backend,
+                usize::try_from(semantic.embedding_dim).ok()?,
+            );
+            health.ready.then_some(health.point_count)
+        }
+        VectorBackend::ExternalQdrant => semantic.qdrant_client.as_ref().and_then(|client| {
+            qdrant_ready_point_count(client, semantic.collection, semantic.expected_points)
+        }),
+    }
 }
 
 fn qdrant_ready_point_count_with(
@@ -885,13 +989,17 @@ fn persist_finalized_manifest(
         |storage| {
             let lexical_source = lexical_source_input(project_root)
                 .context("rescan lexical source at publication fence")?;
+            let embedding_contract = SidecarEmbeddingContract {
+                backend: &embedding_backend,
+                dimension: embedding_dim,
+                config: &retention_context.runtime.embedding,
+                vector_backend: retention_context.runtime.vector_backend().as_str(),
+            };
             let current_input = compute_sidecar_input_fingerprint_with_lexical_source(
                 storage,
                 project_root,
                 &project_id,
-                &embedding_backend,
-                embedding_dim,
-                &retention_context.runtime.embedding,
+                &embedding_contract,
                 lexical_source,
             )?;
             if let Some(reason) = manifest_unavailable_reason_for_runtime(
@@ -1173,14 +1281,25 @@ fn validate_candidate_generation(
         })
         .transpose()
         .context("validate candidate embedding container identity before final probes")?;
-    let qdrant_client = QdrantClient::for_runtime(context.runtime)?;
-    let qdrant_points = qdrant_candidate_point_count(
-        &qdrant_client,
-        &manifest.qdrant_collection,
-        sidecar_input.projection_count,
-    );
-    if sidecar_input.projection_count > 0 {
-        ensure_qdrant_semantic_smoke(project_id, &manifest.qdrant_collection, &qdrant_client)?;
+    let qdrant_client = (context.runtime.vector_backend() == VectorBackend::ExternalQdrant)
+        .then(|| QdrantClient::for_runtime(context.runtime))
+        .transpose()?;
+    let semantic_generation = SemanticGeneration {
+        runtime: context.runtime,
+        qdrant_client: &qdrant_client,
+        layout: context.layout,
+        collection: &manifest.qdrant_collection,
+        generation,
+        input_hash: &sidecar_input.hash,
+        embedding_backend: manifest.embedding_backend.as_deref().unwrap_or_default(),
+        embedding_dim: manifest.embedding_dim.unwrap_or_default(),
+        expected_points: sidecar_input.projection_count,
+    };
+    let qdrant_points = semantic_ready_point_count(&semantic_generation);
+    if sidecar_input.projection_count > 0
+        && let Some(qdrant_client) = qdrant_client.as_ref()
+    {
+        ensure_qdrant_semantic_smoke(project_id, &manifest.qdrant_collection, qdrant_client)?;
     }
     let embedding_accelerator_smoke =
         crate::embeddings::ensure_embedding_accelerator_smoke_for_runtime(context.runtime)
@@ -1325,13 +1444,18 @@ fn retain_published_generations(
         protection.rollback.push(rollback.manifest);
     }
     protection.errors.extend(errors);
-    let live_qdrant_collections = match QdrantClient::new(context.layout).list_collection_names() {
-        Ok(collections) => collections,
-        Err(error) => {
-            protection.errors.push(format!(
-                "list live Qdrant collections for retention: {error:#}"
-            ));
-            Vec::new()
+    let live_qdrant_collections = match context.runtime.vector_backend() {
+        VectorBackend::Embedded => Vec::new(),
+        VectorBackend::ExternalQdrant => {
+            match QdrantClient::new(context.layout).list_collection_names() {
+                Ok(collections) => collections,
+                Err(error) => {
+                    protection.errors.push(format!(
+                        "list live Qdrant collections for retention: {error:#}"
+                    ));
+                    Vec::new()
+                }
+            }
         }
     };
     let plan = plan_generation_retention_with_qdrant_collections(
@@ -1340,7 +1464,7 @@ fn retain_published_generations(
         &protection,
         &live_qdrant_collections,
     );
-    let mut remover = FsQdrantGenerationRemover::new(context.layout)?;
+    let mut remover = FsQdrantGenerationRemover::new_for_runtime(context.layout, context.runtime)?;
     let apply = apply_generation_retention(&plan, &mut remover);
     Ok((plan, apply))
 }
@@ -1361,7 +1485,7 @@ pub(crate) fn compute_sidecar_input_fingerprint(
         project_id,
         embedding_backend,
         embedding_dim,
-        &crate::config::SidecarRuntimeConfig::local().embedding,
+        &crate::config::SidecarRuntimeConfig::local(),
     )
 }
 
@@ -1372,16 +1496,20 @@ pub(crate) fn compute_sidecar_input_fingerprint_for_runtime(
     project_id: &str,
     embedding_backend: &str,
     embedding_dim: i32,
-    embedding: &crate::config::EmbeddingRuntimeConfig,
+    runtime: &SidecarRuntimeConfig,
 ) -> Result<SidecarInputFingerprint> {
     let lexical_source = lexical_source_input(project_root).context("hash lexical source input")?;
+    let embedding_contract = SidecarEmbeddingContract {
+        backend: embedding_backend,
+        dimension: embedding_dim,
+        config: &runtime.embedding,
+        vector_backend: runtime.vector_backend().as_str(),
+    };
     compute_sidecar_input_fingerprint_with_lexical_source(
         storage,
         project_root,
         project_id,
-        embedding_backend,
-        embedding_dim,
-        embedding,
+        &embedding_contract,
         lexical_source,
     )
 }
@@ -1390,9 +1518,7 @@ fn compute_sidecar_input_fingerprint_with_lexical_source(
     storage: &Store,
     project_root: &Path,
     project_id: &str,
-    embedding_backend: &str,
-    embedding_dim: i32,
-    embedding: &crate::config::EmbeddingRuntimeConfig,
+    embedding: &SidecarEmbeddingContract<'_>,
     lexical_source: crate::lexical_index::LexicalSourceInput,
 ) -> Result<SidecarInputFingerprint> {
     let lexical = finish_lexical_input_for_store(lexical_source, project_root, storage)
@@ -1406,14 +1532,21 @@ fn compute_sidecar_input_fingerprint_with_lexical_source(
     hash_part(&mut hasher, LEXICAL_INDEX_VERSION);
     hash_part(&mut hasher, &lexical.file_count.to_string());
     hash_part(&mut hasher, &lexical.hash);
-    hash_part(&mut hasher, embedding_backend);
-    hash_part(&mut hasher, &embedding_dim.to_string());
-    hash_part(&mut hasher, &embedding.profile);
-    hash_part(&mut hasher, embedding.model_id.as_deref().unwrap_or(""));
-    hash_part(&mut hasher, embedding.pooling.as_deref().unwrap_or(""));
+    hash_part(&mut hasher, embedding.backend);
+    hash_part(&mut hasher, &embedding.dimension.to_string());
+    hash_part(&mut hasher, &embedding.config.profile);
+    hash_part(
+        &mut hasher,
+        embedding.config.model_id.as_deref().unwrap_or(""),
+    );
+    hash_part(
+        &mut hasher,
+        embedding.config.pooling.as_deref().unwrap_or(""),
+    );
     hash_part(
         &mut hasher,
         &embedding
+            .config
             .layer_norm
             .map(|value| value.to_string())
             .unwrap_or_default(),
@@ -1421,6 +1554,7 @@ fn compute_sidecar_input_fingerprint_with_lexical_source(
     hash_part(
         &mut hasher,
         &embedding
+            .config
             .truncate_dim
             .map(|value| value.to_string())
             .unwrap_or_default(),
@@ -1428,20 +1562,25 @@ fn compute_sidecar_input_fingerprint_with_lexical_source(
     hash_part(
         &mut hasher,
         &embedding
+            .config
             .expected_dim
             .map(|value| value.to_string())
             .unwrap_or_default(),
     );
     hash_part(
         &mut hasher,
-        embedding.server_launch.as_deref().unwrap_or(""),
+        embedding.config.server_launch.as_deref().unwrap_or(""),
     );
-    hash_part(&mut hasher, embedding.query_prefix.as_deref().unwrap_or(""));
     hash_part(
         &mut hasher,
-        embedding.document_prefix.as_deref().unwrap_or(""),
+        embedding.config.query_prefix.as_deref().unwrap_or(""),
     );
-    hash_part(&mut hasher, "qdrant-semantic-vectors");
+    hash_part(
+        &mut hasher,
+        embedding.config.document_prefix.as_deref().unwrap_or(""),
+    );
+    hash_part(&mut hasher, embedding.vector_backend);
+    hash_part(&mut hasher, "semantic-vectors-v2");
     hash_part(&mut hasher, "scip-symbols-json-v1");
 
     let mut symbol_doc_count = 0_i64;
@@ -1632,13 +1771,37 @@ fn upsert_qdrant_points_from_store(
     qdrant_client: &QdrantClient,
     collection: &str,
 ) -> Result<usize> {
+    let mut total = 0usize;
+    let mut points = Vec::with_capacity(QDRANT_INDEX_UPSERT_BATCH_SIZE);
+    visit_semantic_points_from_store(storage_path, project_root, &mut |point| {
+        points.push(point);
+        if points.len() == QDRANT_INDEX_UPSERT_BATCH_SIZE {
+            total += qdrant_client
+                .upsert_points(collection, &points)
+                .context("qdrant collection upsert")?;
+            points.clear();
+        }
+        Ok(())
+    })?;
+    if !points.is_empty() {
+        total += qdrant_client
+            .upsert_points(collection, &points)
+            .context("qdrant collection upsert")?;
+    }
+    Ok(total)
+}
+
+fn visit_semantic_points_from_store(
+    storage_path: &Path,
+    project_root: &Path,
+    visit: &mut dyn FnMut(QdrantUpsertPoint) -> Result<()>,
+) -> Result<()> {
     let mut storage = Store::open(storage_path).context("open storage for qdrant upsert")?;
     ensure_search_symbol_projection(&mut storage)?;
     let file_roles = storage
         .get_files()
         .map(|files| sidecar_file_role_map(files, project_root))
         .unwrap_or_default();
-    let mut total = 0usize;
     let mut after = None;
     loop {
         let batch = storage
@@ -1648,43 +1811,33 @@ fn upsert_qdrant_points_from_store(
             break;
         }
         after = batch.last().map(|doc| doc.node_id);
-        let points = batch
-            .into_iter()
-            .filter(qdrant_semantic_doc_row)
-            .map(|doc| {
-                let id = qdrant_point_id_for_node_id(doc.node_id.0);
-                let display_name = doc.qualified_name.clone().unwrap_or(doc.display_name);
-                let file_path = doc
-                    .file_path
-                    .as_deref()
-                    .and_then(|path| normalize_sidecar_file_path(path, project_root).ok());
-                let file_role = file_path
-                    .as_deref()
-                    .and_then(|path| file_roles.get(path).copied())
-                    .or_else(|| {
-                        file_path
-                            .as_deref()
-                            .map(|path| FileRole::classify_path(Path::new(path)))
-                    });
-                QdrantUpsertPoint {
-                    id,
-                    display_name,
-                    node_id: doc.node_id.0.to_string(),
-                    file_path,
-                    file_role,
-                    dense_reason: doc.dense_reason.clone(),
-                    vector: Some(doc.embedding),
-                }
-            })
-            .collect::<Vec<_>>();
-        if points.is_empty() {
-            continue;
+        for doc in batch.into_iter().filter(qdrant_semantic_doc_row) {
+            let id = qdrant_point_id_for_node_id(doc.node_id.0);
+            let display_name = doc.qualified_name.clone().unwrap_or(doc.display_name);
+            let file_path = doc
+                .file_path
+                .as_deref()
+                .and_then(|path| normalize_sidecar_file_path(path, project_root).ok());
+            let file_role = file_path
+                .as_deref()
+                .and_then(|path| file_roles.get(path).copied())
+                .or_else(|| {
+                    file_path
+                        .as_deref()
+                        .map(|path| FileRole::classify_path(Path::new(path)))
+                });
+            visit(QdrantUpsertPoint {
+                id,
+                display_name,
+                node_id: doc.node_id.0.to_string(),
+                file_path,
+                file_role,
+                dense_reason: doc.dense_reason.clone(),
+                vector: Some(doc.embedding),
+            })?;
         }
-        total += qdrant_client
-            .upsert_points(collection, &points)
-            .context("qdrant collection upsert")?;
     }
-    Ok(total)
+    Ok(())
 }
 
 fn sidecar_file_role_map(
@@ -1841,34 +1994,6 @@ mod tests {
     }
 
     #[test]
-    fn qdrant_candidate_point_count_requires_an_exact_verified_collection() {
-        let mut zero_count_calls = 0usize;
-        assert_eq!(
-            qdrant_candidate_point_count_with(0, || {
-                zero_count_calls += 1;
-                Some(0)
-            }),
-            None
-        );
-        assert_eq!(
-            zero_count_calls, 0,
-            "zero-dense candidates must not query an intentionally absent collection"
-        );
-        assert_eq!(
-            qdrant_candidate_point_count_with(2, || {
-                qdrant_ready_point_count_with("exact", 2, || Ok(2))
-            }),
-            Some(2)
-        );
-        assert_eq!(
-            qdrant_candidate_point_count_with(2, || {
-                qdrant_ready_point_count_with("missing", 2, || anyhow::bail!("collection missing"))
-            }),
-            None
-        );
-    }
-
-    #[test]
     fn project_qdrant_repair_noops_without_manifest() {
         let project = TempDir::new().expect("project dir");
         let storage_dir = TempDir::new().expect("storage dir");
@@ -1923,7 +2048,7 @@ mod tests {
             );
         }
 
-        let runtime = SidecarRuntimeConfig {
+        let mut runtime = SidecarRuntimeConfig {
             project_identity: None,
             layout: SidecarLayout {
                 qdrant_http_port: 9,
@@ -1942,6 +2067,10 @@ mod tests {
             labels: BTreeMap::new(),
             ..SidecarRuntimeConfig::local()
         };
+        runtime.labels.insert(
+            "dev.codestory.vector_backend".into(),
+            "external_qdrant".into(),
+        );
 
         let repair =
             repair_project_qdrant_collection_for_runtime(project.path(), &storage_path, &runtime)
@@ -2150,6 +2279,12 @@ mod tests {
         let mut runtime = SidecarRuntimeConfig::local();
         runtime.embedding.server_launch = None;
         runtime.embedding.device_policy = "accelerator_required".into();
+        let embedding_contract = SidecarEmbeddingContract {
+            backend: crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            dimension: crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            config: &runtime.embedding,
+            vector_backend: runtime.vector_backend().as_str(),
+        };
         storage
             .insert_nodes_batch(&[Node {
                 id: NodeId(1),
@@ -2189,9 +2324,25 @@ mod tests {
             "proj",
             crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
             crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-            &runtime.embedding,
+            &runtime,
         )
         .expect("first fingerprint");
+        let mut external_runtime = runtime.clone();
+        external_runtime.labels.insert(
+            "dev.codestory.vector_backend".into(),
+            "external_qdrant".into(),
+        );
+        let external = compute_sidecar_input_fingerprint_for_runtime(
+            &storage,
+            &storage_path,
+            project.path(),
+            "proj",
+            crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
+            crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
+            &external_runtime,
+        )
+        .expect("external fingerprint");
+        assert_ne!(first.hash, external.hash);
         let old_manifest = retrieval_manifest_for_sidecar(
             "proj",
             &sidecar_generation_id("proj", &first.hash),
@@ -2216,7 +2367,7 @@ mod tests {
             "proj",
             crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
             crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-            &runtime.embedding,
+            &runtime,
         )
         .expect("second fingerprint");
 
@@ -2245,9 +2396,7 @@ mod tests {
                     snapshot,
                     project.path(),
                     "proj",
-                    crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
-                    crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-                    &runtime.embedding,
+                    &embedding_contract,
                     lexical_source,
                 )
             },
@@ -2347,7 +2496,7 @@ mod tests {
             "proj",
             crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
             crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-            &cpu_runtime.embedding,
+            &cpu_runtime,
         )
         .expect("cpu-policy fingerprint");
         let mut cpu_manifest = retrieval_manifest_for_sidecar(
@@ -2418,7 +2567,7 @@ mod tests {
             "proj",
             crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
             crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-            &native_runtime.embedding,
+            &native_runtime,
         )
         .expect("native fingerprint");
         let mut native_manifest = retrieval_manifest_for_sidecar(
@@ -2526,7 +2675,7 @@ mod tests {
                         "proj",
                         crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
                         crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-                        &candidate_runtime.embedding,
+                        &candidate_runtime,
                     )
                     .expect("mismatched model fingerprint");
                     assert_ne!(candidate_input.hash, second.hash);
@@ -2614,9 +2763,7 @@ mod tests {
                     snapshot,
                     project.path(),
                     "proj",
-                    crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
-                    crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-                    &runtime.embedding,
+                    &embedding_contract,
                     lexical_source,
                 )
             },
@@ -2653,9 +2800,7 @@ mod tests {
                     snapshot,
                     project.path(),
                     "proj",
-                    crate::embeddings::PRODUCT_EMBEDDING_RUNTIME_ID,
-                    crate::embeddings::RETRIEVAL_EMBEDDING_DIM as i32,
-                    &runtime.embedding,
+                    &embedding_contract,
                     lexical_source,
                 )
             },

--- a/crates/codestory-retrieval/src/lib.rs
+++ b/crates/codestory-retrieval/src/lib.rs
@@ -14,6 +14,7 @@ mod candidate;
 mod capabilities;
 mod compose;
 mod config;
+mod embedded_vector;
 mod embeddings;
 mod executor;
 mod generation;
@@ -63,7 +64,7 @@ pub use config::{
     EmbeddingServerLaunchMode, QDRANT_IMAGE_PIN, RetrievalRuntimeConfig, SidecarImagePins,
     SidecarLayout, SidecarOwnership, SidecarPorts, SidecarProcessDefaults, SidecarProfile,
     SidecarRuntimeConfig, SidecarRuntimeDefaults, SidecarRuntimeOverrides, SummaryRuntimeConfig,
-    default_sidecar_image_pins, embedding_server_launch_mode,
+    VectorBackend, default_sidecar_image_pins, embedding_server_launch_mode,
     embedding_server_launch_mode_for_runtime, sidecar_process_defaults, user_cache_root,
 };
 #[cfg(feature = "test-support")]

--- a/crates/codestory-retrieval/src/planner.rs
+++ b/crates/codestory-retrieval/src/planner.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 pub enum RetrievalStageKind {
     Stage0ScipAnchor,
     Stage1Lexical,
+    #[serde(rename = "stage1b_semantic", alias = "stage1b_qdrant_semantic")]
     Stage1bQdrantSemantic,
     Stage2ScipExpand,
     Stage3RepoTextFallback,
@@ -22,7 +23,7 @@ impl RetrievalStageKind {
         match self {
             RetrievalStageKind::Stage0ScipAnchor => "stage0_scip_anchor",
             RetrievalStageKind::Stage1Lexical => "stage1_lexical",
-            RetrievalStageKind::Stage1bQdrantSemantic => "stage1b_qdrant_semantic",
+            RetrievalStageKind::Stage1bQdrantSemantic => "stage1b_semantic",
             RetrievalStageKind::Stage2ScipExpand => "stage2_scip_expand",
             RetrievalStageKind::Stage3RepoTextFallback => "stage3_repo_text_fallback",
         }

--- a/crates/codestory-retrieval/src/port_registry.rs
+++ b/crates/codestory-retrieval/src/port_registry.rs
@@ -59,12 +59,8 @@ pub(crate) struct AgentPortAllocation {
 impl AgentPortAllocation {
     pub(crate) fn failed(&self) -> bool {
         self.owner_id.is_empty()
-            || [
-                self.ports.qdrant_http,
-                self.ports.qdrant_grpc,
-                self.ports.embed_http,
-            ]
-            .contains(&0)
+            || self.ports.embed_http == 0
+            || (self.ports.qdrant_http == 0) != (self.ports.qdrant_grpc == 0)
     }
 }
 
@@ -84,18 +80,20 @@ impl RegistryCleanup {
     }
 }
 
-pub(crate) fn allocate_agent_ports(
+pub(crate) fn allocate_agent_ports_for_backend(
     base: &Path,
     namespace: &str,
     configured: [Option<u16>; 3],
+    qdrant_required: bool,
 ) -> Result<AgentPortAllocation> {
-    allocate_agent_ports_at(base, namespace, configured, now_epoch_ms())
+    allocate_agent_ports_at(base, namespace, configured, qdrant_required, now_epoch_ms())
 }
 
 fn allocate_agent_ports_at(
     base: &Path,
     namespace: &str,
     configured: [Option<u16>; 3],
+    qdrant_required: bool,
     now: i64,
 ) -> Result<AgentPortAllocation> {
     if !is_agent_namespace_path_component(namespace) {
@@ -111,26 +109,34 @@ fn allocate_agent_ports_at(
             None
         };
         let mut reserved = reserved_ports_excluding(&registry, namespace);
-        let qdrant_http = select_port(
-            configured[0],
-            existing.as_ref().map(|lease| lease.ports.qdrant_http),
-            namespace,
-            "qdrant-http",
-            &mut reserved,
-            state_ports
-                .as_ref()
-                .is_some_and(|ports| Some(ports.qdrant_http) == configured[0]),
-        )?;
-        let qdrant_grpc = select_port(
-            configured[1],
-            existing.as_ref().map(|lease| lease.ports.qdrant_grpc),
-            namespace,
-            "qdrant-grpc",
-            &mut reserved,
-            state_ports
-                .as_ref()
-                .is_some_and(|ports| Some(ports.qdrant_grpc) == configured[1]),
-        )?;
+        let qdrant_http = if qdrant_required {
+            select_port(
+                configured[0],
+                existing.as_ref().map(|lease| lease.ports.qdrant_http),
+                namespace,
+                "qdrant-http",
+                &mut reserved,
+                state_ports
+                    .as_ref()
+                    .is_some_and(|ports| Some(ports.qdrant_http) == configured[0]),
+            )?
+        } else {
+            0
+        };
+        let qdrant_grpc = if qdrant_required {
+            select_port(
+                configured[1],
+                existing.as_ref().map(|lease| lease.ports.qdrant_grpc),
+                namespace,
+                "qdrant-grpc",
+                &mut reserved,
+                state_ports
+                    .as_ref()
+                    .is_some_and(|ports| Some(ports.qdrant_grpc) == configured[1]),
+            )?
+        } else {
+            0
+        };
         let embed_http = select_port(
             configured[2],
             existing.as_ref().map(|lease| lease.ports.embed_http),
@@ -147,7 +153,41 @@ fn allocate_agent_ports_at(
             embed_http,
             embed_url: SidecarLayout::embed_base_url(embed_http),
         };
-        let owner = select_owner(root, namespace, existing.as_ref(), &ports, now)?;
+        let embedded_transition = match existing.as_ref() {
+            Some(lease)
+                if !qdrant_required
+                    && lease.ports.qdrant_http != 0
+                    && lease.ports.qdrant_grpc != 0
+                    && ports.qdrant_http == 0
+                    && ports.qdrant_grpc == 0
+                    && ports.embed_http == lease.ports.embed_http =>
+            {
+                lease_is_live(root, lease, now)?
+            }
+            Some(_) | None => false,
+        };
+        if embedded_transition {
+            let lease = existing
+                .as_ref()
+                .context("embedded transition lost its live lease")?;
+            let owner = read_agent_port_owner(root, namespace)?
+                .context("embedded transition requires the current port owner")?;
+            if owner != lease.owner
+                || !sidecar_state_proves_qdrant_transition(root, namespace, &lease.ports)?
+            {
+                anyhow::bail!(
+                    "agent sidecar namespace {namespace} cannot rotate a live Qdrant lease without exact owner and sidecar-state proof"
+                );
+            }
+        }
+        let owner = select_owner(
+            root,
+            namespace,
+            existing.as_ref(),
+            &ports,
+            now,
+            embedded_transition,
+        )?;
         let continued = existing
             .as_ref()
             .filter(|lease| lease.owner.id == owner.id && lease.ports == ports);
@@ -398,6 +438,9 @@ fn put_lease(transaction: &Transaction<'_>, lease: &AgentPortLease) -> Result<()
         ("qdrant_grpc", lease.ports.qdrant_grpc),
         ("embed_http", lease.ports.embed_http),
     ] {
+        if port == 0 {
+            continue;
+        }
         transaction
             .execute(
                 "INSERT INTO lease_ports (namespace, role, port) VALUES (?1, ?2, ?3)",
@@ -628,13 +671,18 @@ fn select_owner(
     existing: Option<&AgentPortLease>,
     ports: &SidecarPorts,
     now: i64,
+    allow_proven_embedded_transition: bool,
 ) -> Result<AgentPortOwner> {
     match existing {
         Some(lease) if lease.ports != *ports => {
-            if lease_is_live(root, lease, now)? {
+            if lease_is_live(root, lease, now)? && !allow_proven_embedded_transition {
                 anyhow::bail!("agent sidecar namespace {namespace} already has a live port lease");
             }
-            Ok(new_agent_port_owner(now))
+            if allow_proven_embedded_transition {
+                Ok(lease.owner.clone())
+            } else {
+                Ok(new_agent_port_owner(now))
+            }
         }
         Some(lease) => match read_agent_port_owner(root, namespace)? {
             Some(owner) if owner.id == lease.owner.id => Ok(owner),
@@ -684,12 +732,20 @@ fn validate_registry(registry: &BTreeMap<String, AgentPortLease>) -> Result<()> 
         {
             anyhow::bail!("sidecar port lease timestamps are invalid");
         }
+        if lease.ports.embed_http == 0
+            || (lease.ports.qdrant_http == 0) != (lease.ports.qdrant_grpc == 0)
+        {
+            anyhow::bail!("sidecar port registry contains an incomplete port set");
+        }
         for port in [
             lease.ports.qdrant_http,
             lease.ports.qdrant_grpc,
             lease.ports.embed_http,
-        ] {
-            if port == 0 || !ports.insert(port) {
+        ]
+        .into_iter()
+        .filter(|port| *port != 0)
+        {
+            if !ports.insert(port) {
                 anyhow::bail!("sidecar port registry contains invalid or duplicate ports");
             }
         }
@@ -735,6 +791,33 @@ fn sidecar_state_owns_ports(root: &Path, namespace: &str, ports: &SidecarPorts) 
     Ok(owned_sidecar_state_ports(root, namespace)?
         .as_ref()
         .is_some_and(|state_ports| same_port_numbers(state_ports, ports)))
+}
+
+fn sidecar_state_proves_qdrant_transition(
+    root: &Path,
+    namespace: &str,
+    ports: &SidecarPorts,
+) -> Result<bool> {
+    let path = root.join(namespace).join(SIDECAR_STATE_FILE_V3);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    let value: serde_json::Value =
+        serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))?;
+    Ok(
+        value.get("owner").and_then(serde_json::Value::as_str) == Some("codestory")
+            && value.get("profile").and_then(serde_json::Value::as_str) == Some("agent")
+            && value.get("namespace").and_then(serde_json::Value::as_str) == Some(namespace)
+            && value
+                .get("compose_project")
+                .and_then(serde_json::Value::as_str)
+                == Some(namespace)
+            && sidecar_ports_from_value(&value)
+                .as_ref()
+                .is_some_and(|state_ports| same_port_numbers(state_ports, ports)),
+    )
 }
 
 fn read_agent_port_owner(root: &Path, namespace: &str) -> Result<Option<AgentPortOwner>> {
@@ -845,6 +928,7 @@ fn is_agent_namespace_path_component(namespace: &str) -> bool {
 fn sidecar_ports_are_bound(ports: &SidecarPorts) -> bool {
     [ports.qdrant_http, ports.qdrant_grpc, ports.embed_http]
         .into_iter()
+        .filter(|port| *port != 0)
         .any(|port| !local_port_available(port))
 }
 
@@ -868,6 +952,7 @@ fn reserved_ports_excluding(
                 lease.ports.embed_http,
             ]
         })
+        .filter(|port| *port != 0)
         .collect()
 }
 
@@ -991,7 +1076,9 @@ mod tests {
             root.join(namespace).join(SIDECAR_STATE_FILE_V3),
             serde_json::to_vec(&serde_json::json!({
                 "owner": "codestory",
+                "profile": "agent",
                 "namespace": namespace,
+                "compose_project": namespace,
                 "qdrant_http_port": ports.qdrant_http,
                 "qdrant_grpc_port": ports.qdrant_grpc,
                 "embed_http_port": ports.embed_http,
@@ -1013,7 +1100,7 @@ mod tests {
                 let barrier = barrier.clone();
                 std::thread::spawn(move || {
                     barrier.wait();
-                    allocate_agent_ports_at(&base, &format!("worker-{index}"), [None; 3], 100)
+                    allocate_agent_ports_at(&base, &format!("worker-{index}"), [None; 3], true, 100)
                         .expect("allocation")
                         .ports
                 })
@@ -1038,12 +1125,35 @@ mod tests {
     }
 
     #[test]
+    fn embedded_backend_leases_only_the_embedding_port() {
+        let cache = tempdir().expect("cache");
+        let allocation =
+            allocate_agent_ports_for_backend(cache.path(), "embedded", [None; 3], false)
+                .expect("embedded allocation");
+        assert_eq!(allocation.ports.qdrant_http, 0);
+        assert_eq!(allocation.ports.qdrant_grpc, 0);
+        assert_ne!(allocation.ports.embed_http, 0);
+
+        let connection = Connection::open(cache.path().join("sidecars").join(SQLITE_REGISTRY_FILE))
+            .expect("registry");
+        let roles: Vec<String> = connection
+            .prepare("SELECT role FROM lease_ports WHERE namespace = 'embedded' ORDER BY role")
+            .expect("role query")
+            .query_map([], |row| row.get(0))
+            .expect("roles")
+            .collect::<rusqlite::Result<_>>()
+            .expect("collect roles");
+        assert_eq!(roles, ["embed_http"]);
+    }
+
+    #[test]
     fn crashed_owner_is_reclaimed() {
         let cache = tempdir().expect("cache");
         let root = cache.path().join("sidecars");
         let first =
-            allocate_agent_ports_at(cache.path(), "crashed", [None; 3], 100).expect("first");
-        let live = allocate_agent_ports_at(cache.path(), "live", [None; 3], 100).expect("live");
+            allocate_agent_ports_at(cache.path(), "crashed", [None; 3], true, 100).expect("first");
+        let live =
+            allocate_agent_ports_at(cache.path(), "live", [None; 3], true, 100).expect("live");
         std::fs::remove_file(agent_port_owner_path(&root, "crashed")).expect("remove owner");
         renew_agent_port_lease(cache.path(), "live", &live.owner_id, &live.ports)
             .expect("renew unrelated lease");
@@ -1051,6 +1161,7 @@ mod tests {
             cache.path(),
             "replacement",
             configured_ports(&first.ports),
+            true,
             101,
         )
         .expect("replacement");
@@ -1063,12 +1174,13 @@ mod tests {
         let root = cache.path().join("sidecars");
         let (listeners, ports) = bound_ports();
         write_owned_state(&root, "live", &ports);
-        allocate_agent_ports_at(cache.path(), "live", configured_ports(&ports), 100)
+        allocate_agent_ports_at(cache.path(), "live", configured_ports(&ports), true, 100)
             .expect("owned allocation");
         let error = allocate_agent_ports_at(
             cache.path(),
             "other",
             configured_ports(&ports),
+            true,
             lease_expiry(100) + 1,
         )
         .expect_err("bound ports remain reserved");
@@ -1076,9 +1188,14 @@ mod tests {
         assert!(format!("{error:#}").contains("already reserved"));
 
         let unowned = tempdir().expect("unowned cache");
-        let error =
-            allocate_agent_ports_at(unowned.path(), "unowned", configured_ports(&ports), 100)
-                .expect_err("bound ports require matching state");
+        let error = allocate_agent_ports_at(
+            unowned.path(),
+            "unowned",
+            configured_ports(&ports),
+            true,
+            100,
+        )
+        .expect_err("bound ports require matching state");
         assert!(format!("{error:#}").contains("bound without matching ownership"));
     }
 
@@ -1086,10 +1203,11 @@ mod tests {
     fn stale_owner_token_cannot_renew_successor() {
         let cache = tempdir().expect("cache");
         let root = cache.path().join("sidecars");
-        let first = allocate_agent_ports_at(cache.path(), "same", [None; 3], 100).expect("first");
+        let first =
+            allocate_agent_ports_at(cache.path(), "same", [None; 3], true, 100).expect("first");
         std::fs::remove_file(agent_port_owner_path(&root, "same")).expect("remove owner");
         let successor =
-            allocate_agent_ports_at(cache.path(), "same", [None; 3], 101).expect("successor");
+            allocate_agent_ports_at(cache.path(), "same", [None; 3], true, 101).expect("successor");
         assert_ne!(first.owner_id, successor.owner_id);
         let error = renew_agent_port_lease(cache.path(), "same", &first.owner_id, &first.ports)
             .expect_err("stale token");
@@ -1110,7 +1228,7 @@ mod tests {
         )
         .expect("legacy registry");
         let migrated =
-            allocate_agent_ports_at(cache.path(), "legacy", configured_ports(&ports), 100)
+            allocate_agent_ports_at(cache.path(), "legacy", configured_ports(&ports), true, 100)
                 .expect("migration");
         assert_eq!(migrated.ports, ports);
         assert!(root.join(SQLITE_REGISTRY_FILE).is_file());
@@ -1126,7 +1244,7 @@ mod tests {
         std::fs::create_dir_all(&corrupt_root).expect("corrupt root");
         let corrupt_path = corrupt_root.join(LEGACY_REGISTRY_FILE);
         std::fs::write(&corrupt_path, b"{").expect("corrupt registry");
-        let error = allocate_agent_ports_at(corrupt.path(), "current", [None; 3], 100)
+        let error = allocate_agent_ports_at(corrupt.path(), "current", [None; 3], true, 100)
             .expect_err("corruption must fail closed");
         assert!(error.to_string().contains("malformed legacy"));
         assert_eq!(std::fs::read(&corrupt_path).expect("preserved"), b"{");

--- a/crates/codestory-retrieval/src/qdrant_storage.rs
+++ b/crates/codestory-retrieval/src/qdrant_storage.rs
@@ -50,7 +50,7 @@ struct ProtectionScanResult {
     sources_scanned: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
 pub struct QdrantStorageRepairReport {
     pub qdrant_reachable: bool,
     pub removed_invalid_dirs: usize,

--- a/crates/codestory-retrieval/src/retention.rs
+++ b/crates/codestory-retrieval/src/retention.rs
@@ -521,7 +521,7 @@ pub trait GenerationRemover {
 }
 
 pub struct FsQdrantGenerationRemover {
-    qdrant: QdrantClient,
+    qdrant: Option<QdrantClient>,
     root: PathBuf,
     deletion: OwnedDeletionRoot,
     collections_dir: PathBuf,
@@ -529,6 +529,19 @@ pub struct FsQdrantGenerationRemover {
 
 impl FsQdrantGenerationRemover {
     pub fn new(layout: &SidecarLayout) -> Result<Self> {
+        Self::new_with_qdrant(layout, Some(QdrantClient::new(layout)))
+    }
+
+    pub fn new_for_runtime(
+        layout: &SidecarLayout,
+        runtime: &crate::config::SidecarRuntimeConfig,
+    ) -> Result<Self> {
+        let qdrant = (runtime.vector_backend() == crate::config::VectorBackend::ExternalQdrant)
+            .then(|| QdrantClient::new(layout));
+        Self::new_with_qdrant(layout, qdrant)
+    }
+
+    fn new_with_qdrant(layout: &SidecarLayout, qdrant: Option<QdrantClient>) -> Result<Self> {
         let root = layout
             .lexical_data_dir
             .parent()
@@ -541,7 +554,7 @@ impl FsQdrantGenerationRemover {
         let deletion = OwnedDeletionRoot::open(root)
             .with_context(|| format!("open owned sidecar root {}", root.display()))?;
         Ok(Self {
-            qdrant: QdrantClient::new(layout),
+            qdrant,
             root: root.to_path_buf(),
             deletion,
             collections_dir: layout.qdrant_data_dir.join("collections"),
@@ -575,8 +588,12 @@ impl GenerationRemover for FsQdrantGenerationRemover {
     }
 
     fn delete_qdrant_collection(&mut self, collection: &str) -> Result<bool> {
-        let outcome = self.qdrant.delete_collection_with_outcome(collection)?;
         let path = self.collections_dir.join(collection);
+        let Some(qdrant) = self.qdrant.as_ref() else {
+            self.remove_owned_path(&path)?;
+            return Ok(true);
+        };
+        let outcome = qdrant.delete_collection_with_outcome(collection)?;
         if outcome == QdrantDeleteOutcome::NotFound {
             self.remove_owned_path(&path)?;
             return Ok(true);

--- a/crates/codestory-retrieval/src/sidecar.rs
+++ b/crates/codestory-retrieval/src/sidecar.rs
@@ -1495,7 +1495,7 @@ fn strict_readiness_unavailable_reason_for_runtime(
         project_id,
         &embedding_backend,
         embedding_dim,
-        &runtime.embedding,
+        runtime,
     )
     .context("compute strict sidecar input fingerprint")?;
     let stored_files = storage

--- a/crates/codestory-retrieval/src/sidecar_search.rs
+++ b/crates/codestory-retrieval/src/sidecar_search.rs
@@ -1,5 +1,6 @@
 use crate::candidate::CandidateHit;
 use crate::config::{SidecarLayout, SidecarRuntimeConfig};
+use crate::embedded_vector::EmbeddedVectorIndex;
 use crate::embeddings::EmbeddingDeviceReadiness;
 use crate::lexical_client::LexicalClient;
 use crate::qdrant_client::QdrantClient;
@@ -130,7 +131,13 @@ pub struct LiveSidecarSearch {
     qdrant_collection: String,
     embedding_device: Option<EmbeddingDeviceReadiness>,
     lexical: LexicalClient,
-    qdrant: QdrantClient,
+    semantic: SemanticSearch,
+}
+
+#[derive(Debug, Clone)]
+enum SemanticSearch {
+    Embedded(EmbeddedVectorIndex),
+    ExternalQdrant(QdrantClient),
 }
 
 impl LiveSidecarSearch {
@@ -170,7 +177,6 @@ impl LiveSidecarSearch {
         embedding_device: Option<EmbeddingDeviceReadiness>,
     ) -> Result<Self> {
         let lexical = LexicalClient::new(&layout);
-        let qdrant = QdrantClient::for_runtime(runtime)?;
         let sidecar_generation = manifest
             .and_then(|manifest| manifest.sidecar_generation.clone())
             .unwrap_or_else(|| format!("{project_id}-missing-manifest"));
@@ -180,6 +186,20 @@ impl LiveSidecarSearch {
         let qdrant_collection = manifest
             .map(|manifest| manifest.qdrant_collection.clone())
             .unwrap_or_else(|| format!("codestory_{project_id}_missing_manifest"));
+        let semantic = match runtime.ensure_vector_backend_configured()? {
+            crate::config::VectorBackend::Embedded => {
+                SemanticSearch::Embedded(EmbeddedVectorIndex::open(
+                    &layout,
+                    &qdrant_collection,
+                    &sidecar_generation,
+                    &sidecar_input_hash,
+                    crate::embeddings::LlamaCppEmbeddingClient::new(&runtime.embedding)?,
+                ))
+            }
+            crate::config::VectorBackend::ExternalQdrant => {
+                SemanticSearch::ExternalQdrant(QdrantClient::for_runtime(runtime)?)
+            }
+        };
         Ok(Self {
             runtime: runtime.clone(),
             layout,
@@ -189,7 +209,7 @@ impl LiveSidecarSearch {
             qdrant_collection,
             embedding_device,
             lexical,
-            qdrant,
+            semantic,
         })
     }
 
@@ -247,7 +267,12 @@ impl SidecarSearch for LiveSidecarSearch {
     }
 
     fn qdrant_search(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {
-        self.qdrant.search(&self.qdrant_collection, query, limit)
+        match &self.semantic {
+            SemanticSearch::Embedded(index) => index.search(query, limit),
+            SemanticSearch::ExternalQdrant(client) => {
+                client.search(&self.qdrant_collection, query, limit)
+            }
+        }
     }
 
     fn qdrant_search_with_context(
@@ -256,8 +281,12 @@ impl SidecarSearch for LiveSidecarSearch {
         limit: usize,
         context: &SearchExecutionContext,
     ) -> Result<Vec<CandidateHit>> {
-        self.qdrant
-            .search_with_context(&self.qdrant_collection, query, limit, context)
+        match &self.semantic {
+            SemanticSearch::Embedded(index) => index.search_with_context(query, limit, context),
+            SemanticSearch::ExternalQdrant(client) => {
+                client.search_with_context(&self.qdrant_collection, query, limit, context)
+            }
+        }
     }
 
     fn scip_anchor(&self, query: &str, limit: usize) -> Result<Vec<CandidateHit>> {

--- a/crates/codestory-retrieval/tests/full_stack_integration.rs
+++ b/crates/codestory-retrieval/tests/full_stack_integration.rs
@@ -1,24 +1,132 @@
-//! Phase 2 exit: fixture index → `full` mode → SQLite-resolvable hits.
+//! A supported local project reaches full retrieval without Docker or Qdrant.
 
 use codestory_contracts::graph::{Node, NodeId, NodeKind};
 use codestory_retrieval::{
-    QdrantClient, QueryRequest, SidecarLayout, execute_retrieval_query, finalize_index,
-    probe_sidecar_health, project_id_for_root,
+    CandidateSource, EmbeddingEndpointOrigin, QueryRequest, RETRIEVAL_EMBEDDING_DIM,
+    RetrievalCache, SidecarProcessDefaults, SidecarProfile, SidecarRuntimeConfig,
+    SidecarRuntimeDefaults, SidecarRuntimeOverrides,
+    execute_retrieval_query_with_cache_for_runtime, finalize_index_for_runtime,
 };
-use codestory_store::{FileInfo, FileRole, SearchSymbolProjection, Store};
+use codestory_store::{
+    FileInfo, FileRole, IndexPublicationMode, IndexPublicationRecord, LlmSymbolDoc,
+    SearchSymbolProjection, Store,
+};
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
 use tempfile::TempDir;
 
-fn seed_fixture_graph(
-    storage: &mut Store,
-    project_root: &Path,
-) -> codestory_contracts::graph::NodeId {
-    let file_path = project_root.join("lib.rs");
+struct EmbeddingServer {
+    endpoint: String,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl EmbeddingServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind embedding server");
+        listener
+            .set_nonblocking(true)
+            .expect("make embedding listener nonblocking");
+        let address = listener.local_addr().expect("embedding server address");
+        let stop = Arc::new(AtomicBool::new(false));
+        let server_stop = Arc::clone(&stop);
+        let thread = thread::spawn(move || {
+            while !server_stop.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => serve_embedding(&mut stream),
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(error) => panic!("accept embedding request: {error}"),
+                }
+            }
+        });
+        Self {
+            endpoint: format!("http://{address}/v1/embeddings"),
+            stop,
+            thread: Some(thread),
+        }
+    }
+}
+
+impl Drop for EmbeddingServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            thread.join().expect("join embedding server");
+        }
+    }
+}
+
+fn serve_embedding(stream: &mut TcpStream) {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    loop {
+        let read = stream.read(&mut buffer).expect("read embedding request");
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..read]);
+        let Some(header_end) = request
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|index| index + 4)
+        else {
+            continue;
+        };
+        let header = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = header
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        if request.len().saturating_sub(header_end) >= content_length {
+            break;
+        }
+    }
+    let mut embedding = vec![0.0_f32; RETRIEVAL_EMBEDDING_DIM];
+    embedding[0] = 1.0;
+    let body = serde_json::json!({"data": [{"index": 0, "embedding": embedding}]}).to_string();
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )
+    .expect("write embedding response");
+}
+
+fn runtime(project_root: &Path, cache_root: &Path, endpoint: String) -> SidecarRuntimeConfig {
+    let defaults =
+        SidecarProcessDefaults::new(cache_root.to_path_buf(), SidecarRuntimeDefaults::default());
+    let mut runtime = SidecarRuntimeConfig::for_project_profile_with_process_defaults(
+        Some(project_root),
+        SidecarProfile::Local,
+        None,
+        &defaults,
+        &SidecarRuntimeOverrides::default(),
+    );
+    runtime.embedding.endpoint = endpoint;
+    runtime.embedding.endpoint_origin = EmbeddingEndpointOrigin::ProcessEnvironment;
+    runtime.embedding.device_policy = "allow_cpu".into();
+    runtime.embedding.server_launch = Some("external_endpoint".into());
+    runtime
+}
+
+fn seed_fixture_graph(storage: &mut Store, project_root: &Path) -> NodeId {
     let file_node_id = 1_001_i64;
     storage
         .insert_file(&FileInfo {
             id: file_node_id,
-            path: file_path.clone(),
+            path: project_root.join("lib.rs"),
             language: "rust".to_string(),
             modification_time: 1,
             indexed: true,
@@ -27,130 +135,122 @@ fn seed_fixture_graph(
             file_role: FileRole::Entrypoint,
         })
         .expect("insert file");
-    let file_node = Node {
-        id: NodeId(file_node_id),
-        kind: NodeKind::FILE,
-        serialized_name: "lib.rs".to_string(),
-        qualified_name: None,
-        canonical_id: None,
-        file_node_id: None,
-        start_line: Some(1),
-        start_col: Some(0),
-        end_line: Some(3),
-        end_col: Some(0),
-    };
-    storage.insert_nodes_batch(&[file_node]).expect("file node");
-    let func_node = Node {
+    storage
+        .insert_nodes_batch(&[Node {
+            id: NodeId(file_node_id),
+            kind: NodeKind::FILE,
+            serialized_name: "lib.rs".to_string(),
+            start_line: Some(1),
+            start_col: Some(0),
+            end_line: Some(3),
+            end_col: Some(0),
+            ..Default::default()
+        }])
+        .expect("file node");
+    let function = Node {
         id: NodeId(2_001),
         kind: NodeKind::FUNCTION,
         serialized_name: "extension_service".to_string(),
         qualified_name: Some("extension_service".to_string()),
-        canonical_id: None,
         file_node_id: Some(NodeId(file_node_id)),
         start_line: Some(1),
         start_col: Some(0),
         end_line: Some(1),
         end_col: Some(30),
+        ..Default::default()
     };
     storage
-        .insert_nodes_batch(std::slice::from_ref(&func_node))
-        .expect("func node");
+        .insert_nodes_batch(std::slice::from_ref(&function))
+        .expect("function node");
     storage
         .upsert_search_symbol_projection_batch(&[SearchSymbolProjection {
-            node_id: func_node.id,
-            display_name: "extension_service".to_string(),
+            node_id: function.id,
+            display_name: function.serialized_name.clone(),
         }])
-        .expect("projection");
-    func_node.id
+        .expect("search projection");
+    let mut vector = vec![0.0; RETRIEVAL_EMBEDDING_DIM];
+    vector[0] = 1.0;
+    storage
+        .upsert_llm_symbol_docs_batch(&[LlmSymbolDoc {
+            node_id: function.id,
+            file_node_id: Some(NodeId(file_node_id)),
+            kind: NodeKind::FUNCTION,
+            display_name: function.serialized_name.clone(),
+            qualified_name: function.qualified_name.clone(),
+            file_path: Some("lib.rs".into()),
+            start_line: Some(1),
+            doc_text: "semantic_doc_version: 4\nsymbol_kind: FUNCTION\nname: extension_service"
+                .into(),
+            doc_version: 4,
+            doc_hash: "extension-service-doc".into(),
+            embedding_profile: Some("bge-base-en-v1.5".into()),
+            embedding_model: "llamacpp:bge-base-en-v1.5".into(),
+            embedding_backend: Some("llamacpp".into()),
+            embedding_dim: RETRIEVAL_EMBEDDING_DIM as u32,
+            doc_shape: Some("semantic_doc_version=4;scope=durable_symbols".into()),
+            semantic_policy_version: Some("graph_first_v1".into()),
+            dense_reason: Some("public_api".into()),
+            embedding: vector,
+            updated_at_epoch_ms: 1,
+        }])
+        .expect("semantic document");
+    storage
+        .put_index_publication(&IndexPublicationRecord {
+            generation: 1,
+            generation_id: "core-generation-1".into(),
+            run_id: "core-run-1".into(),
+            mode: IndexPublicationMode::Full,
+            published_at_epoch_ms: 1,
+        })
+        .expect("core publication");
+    function.id
 }
 
 #[test]
-#[ignore = "requires live mandatory retrieval sidecars"]
-fn full_mode_fixture_produces_resolvable_hits() {
-    // SAFETY: serialized env mutation for this test only.
-    unsafe {
-        std::env::set_var("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS", "1");
-        std::env::set_var("CODESTORY_EMBED_BACKEND", "llamacpp");
-    }
-
+fn embedded_default_reaches_full_mode_and_returns_dense_hits() {
+    let embedding = EmbeddingServer::start();
     let project = TempDir::new().expect("project");
     std::fs::write(
         project.path().join("lib.rs"),
         "pub fn extension_service() {}\n",
     )
-    .expect("write lib.rs");
-
-    let storage_dir = TempDir::new().expect("storage");
-    let storage_path = storage_dir.path().join("codestory.db");
+    .expect("write source");
+    let cache = TempDir::new().expect("cache");
+    let database = TempDir::new().expect("database");
+    let storage_path = database.path().join("codestory.db");
     {
-        let mut storage = Store::open(&storage_path).expect("open db");
+        let mut storage = Store::open(&storage_path).expect("open store");
         seed_fixture_graph(&mut storage, project.path());
     }
+    let runtime = runtime(project.path(), cache.path(), embedding.endpoint.clone());
 
-    finalize_index(project.path(), &storage_path).expect("finalize index");
+    let finalized = finalize_index_for_runtime(project.path(), &storage_path, &runtime)
+        .expect("finalize embedded retrieval");
+    assert_eq!(runtime.vector_backend().as_str(), "embedded");
+    assert!(!finalized.qdrant_stubbed);
 
-    let layout = SidecarLayout::from_env();
-    let project_id = project_id_for_root(project.path());
-    let qdrant = QdrantClient::new(&layout);
-    if qdrant.list_collections_probe().reachable {
-        let collection = QdrantClient::collection_name(&project_id);
-        let _ = qdrant.ensure_collection(&collection);
-        let storage = Store::open(&storage_path).expect("reopen for qdrant");
-        if storage.get_search_symbol_projection_count().unwrap_or(0) > 0 {
-            let points = vec![codestory_retrieval::QdrantUpsertPoint {
-                id: 2_001,
-                display_name: "extension_service".to_string(),
-                node_id: "2001".to_string(),
-                file_path: Some("lib.rs".to_string()),
-                file_role: Some(FileRole::Entrypoint),
-                dense_reason: Some("entrypoint".to_string()),
-                vector: None,
-            }];
-            if qdrant.upsert_points(&collection, &points).is_ok() {
-                let stub = QdrantClient::stub_marker_path(&layout.qdrant_data_dir, &collection);
-                if stub.is_file() {
-                    let _ = std::fs::remove_file(stub);
-                }
-            }
-        }
-    }
+    let result = execute_retrieval_query_with_cache_for_runtime(
+        QueryRequest {
+            project_root: project.path(),
+            storage_path: &storage_path,
+            query: "how the extension service is implemented",
+            budget_ms: Some(2_000),
+            cancelled: None,
+        },
+        &mut RetrievalCache::new(),
+        &runtime,
+    )
+    .expect("query embedded retrieval");
 
-    let manifest = Store::open(&storage_path)
-        .expect("reopen")
-        .get_retrieval_index_manifest(&project_id)
-        .expect("load manifest")
-        .expect("manifest row");
-    let status = probe_sidecar_health(&layout, &project_id, Some(manifest));
-    assert_eq!(
-        status.retrieval_mode, "full",
-        "expected full mode, got {} ({:?})",
-        status.retrieval_mode, status.degraded_reason
-    );
-    assert!(status.lexical.capabilities.lexical);
-    assert!(status.qdrant.capabilities.semantic);
-    assert!(status.scip.capabilities.graph);
-
-    let result = execute_retrieval_query(QueryRequest {
-        project_root: project.path(),
-        storage_path: &storage_path,
-        query: "extension_service",
-        budget_ms: Some(1_000),
-        cancelled: None,
-    })
-    .expect("query");
-    assert!(!result.hits.is_empty(), "expected sidecar hits");
+    assert_eq!(result.trace.retrieval_mode, "full");
     assert!(
-        result
-            .hits
-            .iter()
-            .any(|hit| hit.file_path.contains("lib.rs") && !hit.file_path.starts_with("lexical:")),
-        "expected repo-relative lexical/scip hit, got {:?}",
+        result.hits.iter().any(|hit| {
+            hit.node_id.as_deref() == Some("2001")
+                && hit.file_path == "lib.rs"
+                && (hit.source == CandidateSource::Qdrant
+                    || hit.provenance.iter().any(|source| source == "dense_anchor"))
+        }),
+        "expected embedded dense hit, got {:?}",
         result.hits
     );
-
-    // SAFETY: test env cleanup.
-    unsafe {
-        std::env::remove_var("CODESTORY_RETRIEVAL_REAL_EMBEDDINGS");
-        std::env::remove_var("CODESTORY_EMBED_BACKEND");
-    }
 }

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -65,7 +65,7 @@ flowchart LR
 - `codestory-workspace` discovers files, loads `codestory_project.json`, and computes full or incremental refresh plans.
 - `codestory-store` owns SQLite schema, graph persistence, snapshot lifecycle, trail queries, bookmark rows, and stored search documents.
 - `codestory-indexer` parses files, extracts symbols and edges, flushes batches to the store, and runs semantic resolution.
-- `codestory-retrieval` owns the project-local SQLite lexical shard, Qdrant/SCIP health, sidecar manifests, product embedding backend checks, and fail-closed query execution.
+- `codestory-retrieval` owns the project-local SQLite lexical and embedded-vector generations, optional external Qdrant, SCIP health, retrieval manifests, product embedding checks, and fail-closed query execution.
 - `codestory-runtime` orchestrates indexing, search, grounding, trail building, project summaries, and agent flows.
 - `codestory-cli` is the thin command adapter that parses args, calls runtime or retrieval services, and renders text or JSON.
 - `codestory-bench` measures indexing, grounding, resolution, and cleanup-sensitive paths without owning product behavior.

--- a/docs/architecture/retrieval-design.md
+++ b/docs/architecture/retrieval-design.md
@@ -1,4 +1,4 @@
-# Mandatory Sidecar Retrieval Design
+# Managed Retrieval Design
 
 CodeStory packet/search evidence is sidecar-primary. A product response may be
 served only when the current project has a manifest-backed sidecar generation
@@ -9,18 +9,22 @@ with `retrieval_mode=full`.
 - The project-local SQLite FTS lexical shard exists, matches the current lexical input hash, and
   answers smoke queries against source files plus generated graph-native symbol
   docs and component-report virtual docs.
-- Qdrant collection exists, has at least the manifest dense-anchor projection
-  count, matches the product-compatible BGE-base embedding contract, and answers
-  semantic smoke queries from the live llama.cpp sidecar when the active
-  semantic policy selects one or more dense anchors. If the active policy
-  selects zero dense anchors, Qdrant is explicitly not required for that
-  generation.
+- The immutable embedded SQLite vector generation exists, has the exact
+  manifest dense-anchor projection count, and matches the product-compatible
+  BGE-base embedding contract when the active semantic policy selects dense
+  anchors. A trusted operator may explicitly select external Qdrant instead;
+  it must satisfy the same generation and semantic-smoke contract. If the
+  policy selects zero dense anchors, no vector index is required.
 - SCIP graph artifacts exist and are not stub markers.
 - The SQLite `retrieval_index_manifest` has the current schema version and
-  canonical `lexical_version`, sidecar input hash, sidecar generation, Qdrant
-  collection, embedding backend, embedding dimension, symbol-doc count,
+  canonical `lexical_version`, sidecar input hash, sidecar generation, semantic
+  generation key, embedding backend, embedding dimension, symbol-doc count,
   dense-anchor count, semantic policy version, graph artifact hash, and dense
   reason counts.
+
+The persisted field is still named `qdrant_collection` for wire and database
+compatibility. Under the default embedded backend it names the immutable vector
+generation; it does not imply a Qdrant process, port, or container.
 
 Everything else is diagnostic only. `no_scip`, `no_semantic`, `lexical_only`,
 `unavailable`, stale manifests, stub markers, disabled sidecars, hash vectors,
@@ -43,7 +47,7 @@ databases. Current code reads and writes only `lexical_version`.
 
 ## Mode Matrix
 
-| SQLite lexical | Qdrant | SCIP | Dense anchors | Mode | Product behavior |
+| SQLite lexical | Semantic vectors | SCIP | Dense anchors | Mode | Product behavior |
 |-------|--------|------|---------------|------|------------------|
 | up | up | up | >0 | `full` | Serve packet/search evidence |
 | up | skipped by policy | up | 0 | `full` | Serve graph/lexical packet/search evidence; dense stage is explicitly skipped |
@@ -62,7 +66,9 @@ Runtime rules:
   explicitly labeled diagnostics.
 - Each opened project owns one immutable `SidecarRuntimeConfig`. Retrieval
   indexing, query embedding, readiness/status, runtime search, and summary
-  generation consume that retained value. Managed sidecar endpoints are
+  generation consume that retained value. Embedded vectors are the default;
+  `CODESTORY_VECTOR_BACKEND=external_qdrant` is an explicit maintainer override.
+  Managed embedding endpoints are
   derived from the selected profile/run ports; external endpoints retain their
   trusted origin. Persisted state records that origin plus an install-keyed
   HMAC-SHA256 fingerprint of the full endpoint while exposing only the redacted
@@ -104,8 +110,8 @@ also aborts if re-observation changes its workspace or artifact scope.
 The hash includes local lexical input, graph-native `symbol_search_doc` rows,
 dense-anchor rows, semantic file-role metadata, sidecar schema version, lexical
 version pin, embedding backend, configured profile/model/pooling/normalization
-contract, embedding dimension, semantic policy version, dense reason counts,
-and SCIP artifact contract inputs. Endpoint ports are deliberately excluded:
+contract, embedding dimension, vector engine, semantic policy version, dense
+reason counts, and SCIP artifact contract inputs. Endpoint ports are deliberately excluded:
 they route the retained runtime but do not identify the model or its vectors.
 
 `retrieval index --refresh auto` should reuse an unchanged healthy generation.
@@ -120,9 +126,10 @@ during workspace discovery.
 
 The publication path has one mandatory validation gate immediately before its
 short input/pointer transaction. The candidate manifest must bind the expected
-SQLite lexical shard, SCIP revision and graph artifacts, Qdrant generation
-collection with an exact point count and semantic smoke, llama.cpp runtime
-identity and dimension, and the configured model/profile contract. Native
+SQLite lexical shard, SCIP revision and graph artifacts, embedded vector
+generation (or explicitly selected external Qdrant collection) with an exact
+point count, llama.cpp runtime identity and dimension, and the configured
+model/profile contract. Native
 managed launches must also expose a matching model path and launch fingerprint;
 Docker launches must retain the same persisted running-container identity
 across the final probes. Accelerator-required policy reruns a bounded embedding

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -30,19 +30,17 @@ Replace `[TARGET_FEATURE]` and `[OWNING_CRATE]` with the specific feature and cr
 ## Host prerequisites
 
 Supported Mac development starts at macOS 15 on Apple Silicon or Intel. Install
-the Xcode Command Line Tools, Node.js 18+, and the Rust toolchain. Start Docker
-Desktop or another compatible Docker engine before running packet/search lanes;
-Qdrant uses Docker on both Mac architectures even though Apple Silicon runs the
-managed embedding server natively with Metal.
+the Xcode Command Line Tools, Node.js 18+, and the Rust toolchain. Docker is not
+part of the default Mac packet/search path: vectors are embedded in SQLite,
+Apple Silicon runs managed Metal, and Intel runs the managed native CPU backend.
 
 The protected packaged-hardware proof also requires `python3`; use that
 versioned command in Mac automation because Command Line Tools does not promise
 an unversioned `python` shim.
 
-Apple Silicon is the managed accelerated Mac cell. Intel supports the native
-CLI/plugin and local graph; retrieval must use explicit degraded CPU allowance
-or a trusted external embedding endpoint under explicit operator policy, and
-must never be described as Metal.
+Apple Silicon is the managed accelerated Mac cell. Intel is a managed CPU cell
+and must never be described as Metal. Both paths prepare automatically; trusted
+external endpoints remain explicit advanced overrides.
 
 ## Choose The Verification Lane First
 
@@ -171,7 +169,7 @@ commands as product-quality proof.
 Use this lane only for packet/search, retrieval, ranking-quality, or sidecar
 work. Prepare the managed full-sidecar path before debugging ranking quality:
 
-- product sidecar setup: `codestory-cli retrieval bootstrap --project .` (the setup wrapper's fetch flags are optional offline prewarming)
+- product retrieval setup: normal plugin tools prepare it automatically; for a maintainer transcript use `codestory-cli retrieval bootstrap --project .` (the setup wrapper's fetch flags are optional offline prewarming)
 - default symbol-doc scope: durable symbols only; set `CODESTORY_SEMANTIC_DOC_SCOPE=all` when you intentionally need the broad all-symbol diagnostic symbol-doc set
 - default dense policy: `graph_first_v1` embeds only selected dense anchors; private trivial code remains searchable through symbol docs, lexical source, and graph expansion
 - default semantic alias mode: compact aliases; set `CODESTORY_SEMANTIC_DOC_ALIAS_MODE=no_alias` or `current_alias` only when reproducing benchmark rows

--- a/docs/contributors/testing-matrix.md
+++ b/docs/contributors/testing-matrix.md
@@ -188,7 +188,7 @@ SHA.
 | Linux arm64 | `ubuntu-24.04-arm` | Version, help, stdio shape, managed provisioning, stale-local grounding convergence, terminal shared-agent evidence, and cleanup |
 | Windows x64 | `windows-latest` | Version, help, stdio shape, installer ownership self-test, managed provisioning, stale-local grounding convergence, terminal shared-agent evidence, and cleanup |
 | Windows arm64 | `windows-11-arm` | Version, help, stdio shape, managed provisioning, stale-local grounding convergence, terminal shared-agent evidence, and cleanup |
-| macOS x64 | `macos-15-intel` | Unsigned in PR/integration cells; Developer ID signed and notarized only in release/post-publish cells. Version, help, stdio shape, managed provisioning, stale-local grounding convergence, terminal shared-agent evidence, cleanup, actionable failure without a backend, and explicitly labelled CPU/external operation when configured; never Metal |
+| macOS x64 | `macos-15-intel` | Unsigned in PR/integration cells; Developer ID signed and notarized only in release/post-publish cells. Version, help, stdio shape, managed provisioning, stale-local grounding convergence, checksum-pinned native CPU retrieval without Docker/Qdrant or configuration, terminal shared-agent evidence, and cleanup; never Metal |
 | macOS arm64 | `macos-15` | Unsigned in PR/integration cells; Developer ID signed and notarized only in release/post-publish cells. Version, help, stdio shape, managed provisioning, stale-local grounding convergence, terminal shared-agent evidence, and cleanup |
 
 The managed convergence proof on every native runner uses an isolated project

--- a/docs/ops/retrieval-sidecars.md
+++ b/docs/ops/retrieval-sidecars.md
@@ -1,9 +1,12 @@
 # Retrieval sidecars operations
 
-Project-local SQLite FTS, Qdrant, SCIP, and llama.cpp back agent `packet`, `search`,
-and `context`. They are required for `agent_packet_search` infrastructure
+Project-local SQLite FTS and embedded vectors, SCIP, and a managed llama.cpp
+embedding runtime back agent `packet`, `search`, and `context`. They are required for `agent_packet_search` infrastructure
 readiness: `retrieval status` must report `retrieval_mode: "full"` before those
 surfaces can claim full sidecar retrieval.
+
+Normal Mac operation does not run Docker or Qdrant. External Qdrant remains an
+explicit maintainer override for comparison and migration work.
 
 A healthy SQLite cache alone is not enough. A persisted full manifest also
 cannot override dead live infrastructure: under `accelerator_required`, agent
@@ -33,7 +36,7 @@ Promotion checks: [`retrieval-architecture.md`](../testing/retrieval-architectur
 ```mermaid
 flowchart LR
     cli[codestory-cli] --> lexical["Project-local SQLite FTS shard"]
-    cli --> qdrant["Qdrant at profile-selected localhost ports"]
+    cli --> vectors["Immutable embedded SQLite vectors"]
     cli --> scip[SCIP artifacts in user cache]
     cli --> embed[llama.cpp embedding endpoint]
 ```
@@ -79,7 +82,7 @@ Layer repair should follow the first failing layer, not a broad rebuild:
 | Active runtime or plugin adapter | `codestory://status` fields, `server_executable`, `cli_version`, `plugin_runtime`, `allowed_surfaces` | Reload or reinstall the active CLI/plugin runtime, then reread status |
 | Core SQLite graph | `doctor` cache/index checks and indexed file counts | Follow status `recommended_next_calls`; CLI transcript: `codestory-cli ready --goal local --repair --project <repo> --format json` |
 | SQLite lexical shard | `retrieval status` lexical coverage, generation/input binding, and shard health | Rerun `retrieval index --refresh full`; old JSONL shards are rebuilt, not queried |
-| Qdrant dense sidecar | Qdrant health, collection name, point count, dense-anchor count, backend/dimension fields | Fix Qdrant/model/backend state; move the Qdrant cache aside only if repeated health checks fail |
+| Semantic vector generation | Generation identity, point count, dense-anchor count, backend/dimension fields | Rerun retrieval indexing; inspect external Qdrant only when that override is explicitly selected |
 | SCIP graph artifacts | `scip_unavailable`, graph artifact hash/path, manifest contract | Rerun `retrieval index --refresh full`; inspect SCIP cache paths if it repeats |
 | Embedding endpoint | `CODESTORY_EMBED_LLAMACPP_URL`, sidecar health, model/backend/dimension fields | Start or reconfigure llama.cpp, then rerun retrieval index/status |
 | Manifest contract | `manifest_contract`, source root, input hash, generation, schema, graph hash, counts, lane provenance | Rerun `retrieval index --project <repo> --refresh full` |
@@ -113,21 +116,22 @@ Attach these artifacts to issues or PRs that claim readiness repair:
 - macOS 15 or later for supported Mac operation. Install the Xcode Command Line
   Tools and Node.js 18+; contributors building from source also need Rust.
 - Rust toolchain with `cargo`, or an already-built `codestory-cli` binary.
-- Docker Desktop or Docker Engine for automated Qdrant and llama.cpp
-  sidecars. On Apple Silicon the managed embedding server is native Metal, but
-  Qdrant still requires Docker. Confirm the Docker daemon is running.
+- Docker is not required on macOS. Apple Silicon uses the managed native Metal
+  runtime; Intel uses the checksum-pinned managed native CPU runtime. Linux
+  managed embedding and an explicit external-Qdrant comparison lane may still
+  require Docker.
 - Node.js 18+ is required only for the contributor setup wrapper. The CLI
   downloads and verifies missing managed assets during normal preparation.
-- For manual Local profile only, the default localhost ports are Qdrant HTTP
-  `6333`, Qdrant gRPC `6334`, and llama.cpp embeddings `8080`; lexical search
-  has no service port.
+- For manual Local profile only, llama.cpp embeddings default to localhost port
+  `8080`; lexical and embedded-vector search have no service ports. External
+  Qdrant uses HTTP `6333` and gRPC `6334` only when explicitly selected.
   Managed Agent profiles allocate or reuse namespace-specific ports; read them
   from status rather than assuming the Local defaults.
 - `CODESTORY_EMBED_MODEL_DIR` is an explicit developer override. Without it,
   CodeStory uses the pinned machine-wide model cache.
 
-Manual sidecar setup is allowed only when equivalent local Qdrant and
-llama.cpp services are already healthy. Agent-facing retrieval is invalid until
+Manual runtime setup is allowed only when an equivalent local llama.cpp
+endpoint, and external Qdrant when selected, are already healthy. Agent-facing retrieval is invalid until
 the CLI status proof below reports `full`.
 
 ### Minimum environment
@@ -146,8 +150,9 @@ explicit override or persisted Agent state selects a port.
 | `CODESTORY_EMBED_DEVICE_STATE` | Optional diagnostic assertion for observed device state: `accelerated`, `cpu`, or unset/unknown; it does not satisfy broker GPU proof |
 | `CODESTORY_EMBED_ALLOW_CPU` | Set to `1` only when intentional CPU-backed retrieval is acceptable on this machine |
 | `CODESTORY_EMBED_DEVICE_POLICY` | Optional policy alias; set `allow_cpu` instead of `CODESTORY_EMBED_ALLOW_CPU=1` when CPU mode is intentional |
-| `CODESTORY_QDRANT_HTTP_PORT` | Override Qdrant HTTP port when `6333` is unavailable |
-| `CODESTORY_QDRANT_GRPC_PORT` | Override Qdrant gRPC port when `6334` is unavailable |
+| `CODESTORY_VECTOR_BACKEND` | Leave unset for embedded vectors; `external_qdrant` enables the advanced compatibility lane |
+| `CODESTORY_QDRANT_HTTP_PORT` | External-Qdrant-only HTTP port override |
+| `CODESTORY_QDRANT_GRPC_PORT` | External-Qdrant-only gRPC port override |
 
 If CPU is not explicitly allowed, CodeStory asks the platform resolver for an
 accelerated llama.cpp backend. On macOS arm64, bootstrap/repair installs and
@@ -159,13 +164,11 @@ a `vulkan:Vulkan0` request on Apple Silicon. Use
 `CODESTORY_EMBED_NATIVE_LLAMA_SERVER` only when overriding the managed binary
 with an absolute path.
 
-On macOS x64, the CLI, managed plugin, local index, and grounding are supported,
-but there is no managed Metal cell. Packet/search requires an explicit degraded
-CPU opt-in or a trusted external llama.cpp-compatible endpoint under explicit
-operator policy. External endpoints cannot satisfy `accelerator_required`
-because CodeStory cannot bind their provider-owned logs and PID identity to the
-request; opt into CPU/external operation explicitly. Intel status and release
-evidence must never claim Metal.
+On macOS x64, CodeStory installs the checksum-pinned b9902 native x64 runtime
+and selects its CPU policy automatically. Packet/search therefore needs no
+Docker, Qdrant, or user configuration. Status labels the path `cpu_allowed` and
+Intel status and release evidence never claim Metal. A trusted external
+llama.cpp-compatible endpoint remains an advanced override.
 
 On Windows x64, the native llama.cpp resolver selects the manifest-backed b9902
 Vulkan cell by default and launches it with `Vulkan0`, `99` GPU layers, and
@@ -229,8 +232,10 @@ not match your machine. On Windows PowerShell, set them with `$env:NAME =
 "value"` and use `.\target\release\codestory-cli.exe` if you are running a
 built binary.
 
-`retrieval bootstrap` may start Docker Compose, create sidecar cache dirs, write
-`retrieval-sidecars-v3.json`, and repair CodeStory-owned local sidecar state. For a
+`retrieval bootstrap` creates retrieval cache dirs, prepares the managed native
+runtime on macOS, writes `retrieval-sidecars-v3.json`, and repairs
+CodeStory-owned local state. Linux or explicit compatibility overrides may
+start Docker Compose. For a
 no-change prerequisite check, run:
 
 ```sh
@@ -281,8 +286,8 @@ The proof is the final status JSON:
   count, and lane provenance.
 
 Under `graph_first_v1`, a generation can be full with zero dense anchors. In
-that case Qdrant is reported as policy-skipped instead of probing a missing
-collection. That is still full mode only when SQLite lexical, SCIP, and the manifest
+that case semantic vectors are policy-skipped. That is still full mode only
+when SQLite lexical, SCIP, and the manifest
 contract are complete.
 
 ### Non-full status actions
@@ -296,10 +301,10 @@ closed and must not claim sidecar-backed evidence.
 | `unavailable` or lexical shard invalid | SQLite lexical shard is missing, malformed, or stale | Rerun retrieval index, then inspect lexical coverage and generation/input binding in status |
 | `lexical_source_coverage_incomplete` | The indexed lexical subset remains usable, while oversized or unreadable paths are named diagnostically | Inspect the bounded path samples; fix file access or size only when the omitted paths matter |
 | `lexical_source_coverage_empty` | Files were discovered but every source was oversized or unreadable, so lexical retrieval is unavailable | Fix at least one relevant source input, then rerun retrieval index/status |
-| `no_semantic`, `lexical_only`, or Qdrant down when dense anchors are expected | Semantic sidecar is unavailable or stale | Fix Qdrant/model/backend, rerun bootstrap and retrieval index, then rerun status |
+| `no_semantic` or `lexical_only` when dense anchors are expected | Semantic vectors or the embedding runtime are unavailable or stale | Retry managed preparation and retrieval indexing; inspect external Qdrant only when explicitly selected |
 | `no_scip` | Graph artifacts are missing or stale | Rerun retrieval index; inspect SCIP artifact paths if it repeats |
 | Obsolete, stale, or partial manifest | Source, schema, graph, symbol-doc, dense-anchor, or backend contract drifted | Rerun `retrieval index --project <repo> --refresh full` |
-| `full` with dense anchors `0` | Valid graph-first policy skip | No Qdrant repair needed; verify SQLite lexical, SCIP, and manifest contract fields |
+| `full` with dense anchors `0` | Valid graph-first policy skip | No vector repair needed; verify SQLite lexical, SCIP, and manifest contract fields |
 
 Traces must include `retrieval_mode` and `degraded_reason`. A non-`full` mode is
 not an answer-quality claim and not a product packet/search success.
@@ -430,8 +435,8 @@ sidecar-layer symptoms during ops work:
 | SQLite lexical shard unavailable | Shard missing, malformed, or stale | Rerun retrieval index and inspect the lexical readiness detail |
 | `lexical_source_coverage_incomplete` with lexical capability present | Partial source coverage; indexed files remain queryable | Inspect the omitted/unreadable path samples and repair only relevant inputs |
 | `lexical_source_coverage_empty` | Every discovered source was omitted; the empty shard is diagnostic only | Fix source size/access and rebuild before claiming retrieval readiness |
-| Qdrant unhealthy | Wrong image tag, stale collection, volume permissions, or model/backend mismatch | Rerun bootstrap; if repeated, move the Qdrant cache aside and rebuild |
-| Qdrant unavailable while dense-anchor count is `0` | Expected graph-first policy skip | Verify SQLite lexical, SCIP, and manifest contract fields |
+| External Qdrant unhealthy | Wrong image tag, stale collection, volume permissions, or model/backend mismatch | Verify the explicit external-Qdrant configuration, then rerun bootstrap |
+| External Qdrant unavailable while dense-anchor count is `0` | Expected graph-first policy skip | Verify SQLite lexical, SCIP, and manifest contract fields |
 | SCIP `scip_unavailable` | Graph artifacts missing | Rerun retrieval index and inspect the SCIP cache path |
 | Smoke latency is high | Cold cache or oversized fixture | Retry once; then inspect tier envelope evidence |
 
@@ -445,14 +450,14 @@ sidecar implementation, CI policy, retention behavior, or promotion gates.
 | Dependency | Pin policy | Pinned identity | Notes |
 |------------|------------|-----------------|-------|
 | SQLite lexical | Bundled `rusqlite`/SQLite FTS5 | `sqlite-fts5-v1` | One immutable `lexical-index.sqlite3` per sidecar generation; no daemon |
-| Qdrant | Digest-pinned container image | `qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae` | HTTP `6333`, gRPC `6334` |
+| External Qdrant compatibility path | Digest-pinned container image | `qdrant/qdrant:v1.12.5@sha256:05fecce7dce45d1254e0468bc037e8210e187fd56fa847688b012293d5f08aae` | Used only when `CODESTORY_VECTOR_BACKEND=external_qdrant`; HTTP `6333`, gRPC `6334` |
 | llama.cpp embed | Digest-pinned container image | `ghcr.io/ggml-org/llama.cpp:server@sha256:f16ca66f3ba316b7a7a16003ddfa88d29c3404fbe86550da086736864c11574c` | Used only when the embedding launch mode is Docker Compose |
 | SCIP | CodeStory graph artifact emitter | `graph-<hash>` | Generated local graph artifacts under the sidecar generation |
 
 CI `retrieval-sidecar-smoke` should use the same pins as local development.
 `retrieval bootstrap --format json`, `retrieval status --format json`, and the
-sidecar state file expose `sidecar_images` so smoke artifacts record the exact
-image identities used for packet/search readiness.
+sidecar state file expose `sidecar_images` so container-backed smoke artifacts
+record the exact image identities used for packet/search readiness.
 
 To refresh an image pin safely:
 

--- a/docs/testing/embedding-backend-benchmarks.md
+++ b/docs/testing/embedding-backend-benchmarks.md
@@ -40,6 +40,7 @@ promoted on quality and cross-repo evidence.
 
 | Candidate or lane | Best relevant evidence | Quality signal | Speed and footprint signal | Decision |
 | --- | --- | --- | --- | --- |
+| Generation-bound embedded SQLite exact scan | Apple M5 release-mode synthetic scan at 768 dimensions over 1k, 10k, and 25k dense anchors | Exact cosine ranking preserves the existing BGE vectors and provenance; the end-to-end full-mode boundary returns the expected dense hit | Warm p95 was 2.928 ms, 14.442 ms, and 37.300 ms; database sizes were 4.68 MB, 46.64 MB, and 116.60 MB | Select as the default local vector engine. It stays inside the accepted historical 84.7 ms cross-repo search p95 without a service, port, or container. Keep external Qdrant only as an explicit compatibility lane. |
 | Managed BGE-base ONNX Runtime, CLS-pooled graph, DirectML, doc batch 2048, token budget 32768, stored int8 | Large C++ workspace fresh-cache timing on 26,010 semantic docs after batch-fast tokenizer switch and pooled-output graph derivation | Quality gate not run yet; direct CPU ORT check showed pooled graph output exactly matched source `last_hidden_state[:, 0, :]` on sampled inputs; semantic contract and search smoke passed | `semantic_embedding_ms=128.438s`; previous 32k unpooled row was `135.762s`; pooled 65k was slower at `131.807s`; prior managed ONNX 65k first pass was `152.500s`, batch-fast 65k was `138.118s`, 16k was `137.776s`; unpooled 131k was aborted as slower and memory-heavy after sampled peak working set around `3.37 GB` | Historical diagnostic lane after mandatory-sidecar reset. Do not treat as promoted product evidence without a fresh sidecar contract and quality gate. |
 | BGE-base llama.cpp, b512/Q8/r6, server batch 1024, microbatch 1024, stored int8, full-text enabled | Segment 2 baseline `909369.110274`; repeat `909844.215726`; earlier fixed-wrapper holdout `910504.353332`; cross-repo `851670.370370` | Local MRR@10 `0.982432`, Hit@10 `1.0`, Hit@1 `0.972973`; cross-repo Hit@10 `1.0`, adversarial Hit@10 `1.0`, MRR@10 `0.826831` across 225 queries | Segment 2 baseline `368.01` docs/sec, cache `74.40 MB`, sampled peak descendant working set `828.73 MB`; repeat `371.89` docs/sec, sampled peak `1019.79 MB`; cross-repo search p95 `84.7 ms` | Historical externally validated baseline and closest prior evidence to the current mandatory sidecar backend. Re-run the same gates under the generation-bound sidecar contract before promotion. |
 | BGE-base llama.cpp, b512/r5, microbatch 1024, stored int8 | Earlier local `pipeline_score=918957.022351`; confirmation `918697.617312`; corrected segment-2 scout `901789.644032` | Earlier perfect local scores triggered the overfit review; corrected segment-2 quality matched q8/r6, but did not improve it | Corrected segment-2 r5 slowed to `327.58` docs/sec and sampled peak rose to `1074.43 MB` | Historical/discarded. Do not treat r5 as the current promoted answer after the corrected broad-holdout pass. |
@@ -63,6 +64,11 @@ promoted on quality and cross-repo evidence.
 
 The measured work covered these families:
 
+- Embedded SQLite exact cosine scans with bounded top-k selection. The measured
+  25k-vector row is deliberately larger than CodeStory's recent roughly 1k
+  dense-anchor repo-scale publication, while 10k covers a substantially denser
+  policy. Measurements exclude query embedding time so vector-engine cost stays
+  visible; no wall-clock threshold is asserted in unit tests.
 - ONNX Runtime provider and batch geometry, plus external llama.cpp request geometry for historical comparison.
 - Stored-vector footprint: compact scaled int8 persisted vectors.
 - Quality metric repair: explicit gates, continuous penalties, denominator metrics, and query-rank reporting.

--- a/docs/users/troubleshooting.md
+++ b/docs/users/troubleshooting.md
@@ -161,9 +161,10 @@ available in the meantime. The first broad search can take longer while
 CodeStory prepares its local search support once for the Mac; later repositories
 reuse it automatically.
 
-Intel Macs support local navigation by default. When broad search cannot use a
-supported local or trusted external backend, the tool returns `unavailable` and
-the agent continues with focused source inspection.
+Intel Macs use the managed native CPU path automatically. Broad search should
+move through `preparing` to ready without Docker, Qdrant, or user configuration,
+and must report CPU operation rather than Metal. A `needs_environment` result
+means automatic preparation failed; relay only the plain host requirement.
 
 Maintainer-only acceleration evidence and recovery commands are in
 [retrieval operations](../ops/retrieval-sidecars.md).

--- a/scripts/setup-retrieval-env.mjs
+++ b/scripts/setup-retrieval-env.mjs
@@ -5,7 +5,8 @@
  * Primary documented path: `cargo retrieval-setup` from repo root.
  * This script adds prerequisite reporting and optional holdout repo clones.
  *
- * Prerequisites: Node 18+, cargo, Docker Desktop (unless --skip-compose).
+ * Prerequisites: Node 18+ and cargo. Docker is needed only for the managed
+ * Linux embedding service or an explicitly selected external-Qdrant compose path.
  * SCIP language indexers are documented only — not installed by this script.
  */
 import { spawnSync } from "node:child_process";
@@ -191,6 +192,10 @@ function cargoRunArgs(...args) {
 function printPrereqReport(opts) {
   const composeFile = path.join(repoRoot, "docker", "retrieval-compose.yml");
   const cacheRoot = codestoryCacheRoot();
+  const externalQdrant =
+    process.env.CODESTORY_VECTOR_BACKEND?.trim().toLowerCase() === "external_qdrant";
+  const composeRequired =
+    !opts.skipCompose && !opts.fetchOnly && (process.platform === "linux" || externalQdrant);
   const checks = [
     ["node", commandExists("node"), "required"],
     [
@@ -201,7 +206,9 @@ function printPrereqReport(opts) {
     [
       "docker",
       commandExists("docker"),
-      opts.skipCompose || opts.fetchOnly ? "optional" : "required for live Qdrant",
+      composeRequired
+        ? "required for the selected container-backed service"
+        : "optional; unused by the default managed path on this host",
     ],
     [
       "tar",
@@ -213,9 +220,9 @@ function printPrereqReport(opts) {
     [
       `compose file (${composeFile})`,
       fs.existsSync(composeFile),
-      opts.fetchOnly
-        ? "optional"
-        : "required unless CODESTORY_RETRIEVAL_COMPOSE_FILE points elsewhere",
+      composeRequired
+        ? "required unless CODESTORY_RETRIEVAL_COMPOSE_FILE points elsewhere"
+        : "optional for the selected managed path",
     ],
   ];
 
@@ -234,7 +241,16 @@ function printPrereqReport(opts) {
   }
 
   console.log("\nAutomated:");
-  console.log("  - Docker Compose: Qdrant + llama.cpp embed service");
+  if (externalQdrant) {
+    console.log("  - External-Qdrant compatibility path selected explicitly");
+  } else {
+    console.log("  - Embedded SQLite vector generation (no Qdrant service)");
+  }
+  console.log(
+    process.platform === "linux"
+      ? "  - Managed llama.cpp embedding service through Docker Compose"
+      : "  - Managed native llama.cpp embedding service",
+  );
   console.log("  - codestory retrieval bootstrap (cache dirs, sidecar state, health wait)");
   console.log("  - codestory retrieval status --project <path>");
   if (opts.withHoldoutClone) {
@@ -245,9 +261,9 @@ function printPrereqReport(opts) {
   console.log("  - SCIP indexers per language (rust-analyzer scip, scip-typescript, etc.)");
   console.log("  - retrieval index --project <repo> after sidecars are healthy");
 
-  if (!opts.skipCompose && !commandExists("docker")) {
-    console.log("\nDocker install (Windows):");
-    console.log("  https://docs.docker.com/desktop/setup/install/windows-install/");
+  if (composeRequired && !commandExists("docker")) {
+    console.log("\nDocker install:");
+    console.log("  https://docs.docker.com/desktop/");
     console.log("\nManual Qdrant without compose:");
     console.log(
       `  docker run -d --name codestory-qdrant -p 127.0.0.1:6333:6333 -p 127.0.0.1:6334:6334 ` +
@@ -325,6 +341,8 @@ function selectedLlamaBackend(opts) {
     process.env.CODESTORY_EMBED_DEVICE_PROVIDER?.trim().toLowerCase() ||
     (osName === "macos" && arch === "aarch64"
       ? "metal"
+      : osName === "macos" && arch === "x86_64"
+        ? "cpu"
       : osName === "windows" && arch === "x86_64"
         ? "vulkan"
         : "");
@@ -394,12 +412,21 @@ function runSelfTest() {
   }
   const backends = readLlamaBackends();
   const macMetal = backends.find((backend) => backend.id === "macos-aarch64-metal");
+  const macCpu = backends.find((backend) => backend.id === "macos-x86_64-cpu");
   const winVulkan = backends.find((backend) => backend.id === "windows-x86_64-vulkan");
   const winLegacy = backends.find(
     (backend) => backend.id === "windows-x86_64-vulkan-b9058-legacy",
   );
   if (!macMetal) {
     throw new Error("missing macos-aarch64-metal backend");
+  }
+  if (
+    !macCpu ||
+    macCpu.launch_mode !== "native_spawned" ||
+    !macCpu.sha256 ||
+    !macCpu.executable_sha256
+  ) {
+    throw new Error("missing checksum-backed macOS Intel native CPU backend");
   }
   if (!winVulkan) {
     throw new Error("missing windows-x86_64-vulkan backend");
@@ -414,9 +441,6 @@ function runSelfTest() {
     )
   ) {
     throw new Error("downloadable llama-server backends must declare artifact_bytes");
-  }
-  if (backends.some((backend) => backend.os === "macos" && backend.arch !== "aarch64")) {
-    throw new Error("macOS Intel llama-server backend must not be present");
   }
   if (!macMetal.managed_cache_rel_dir.includes("/llama/b9902/")) {
     throw new Error(`unexpected managed cache version path: ${macMetal.managed_cache_rel_dir}`);


### PR DESCRIPTION
## Context

The default plugin still depended on a Qdrant container for dense retrieval, even though CodeStory already persists the selected embeddings in its publication. That made Docker part of the normal Mac experience and left Intel Macs without a managed broad-search path.

Base: `e00244f796ef46bc133a1f3f8128c87493db8ad7`
Head: `5d774d0cc9bdcc259385e052c68063603538b642`

Closes #1153
Refs #897

## What changed

- Publishes immutable generation-bound dense vectors in embedded SQLite and performs bounded exact cosine top-k search through the existing pinned retrieval read path.
- Makes embedded vectors the default. Default Agent runtimes lease only the embedding port; bootstrap, health, retention, and search no longer start or probe Qdrant.
- Keeps `CODESTORY_VECTOR_BACKEND=external_qdrant` as the explicit compatibility/comparison path, including its prior Compose lifecycle.
- Adds a checksum-pinned b9902 macOS x64 native CPU backend. Intel Macs select it automatically and never claim Metal; Apple Silicon keeps managed Metal.
- Keeps persisted manifest/status compatibility fields while exposing the product lane as `semantic`, not the underlying engine.
- Updates setup output, operator docs, troubleshooting, testing guidance, and the changelog.

## How to review

1. Start with `embedded_vector.rs`: immutable publication, generation/input validation, cancellation, and bounded top-k selection.
2. Review runtime dispatch in `index.rs`, `health.rs`, and `sidecar_search.rs`.
3. Check `config.rs`, `port_registry.rs`, and `compose.rs` for the default embedded/one-port path and the explicit external-Qdrant branch.
4. Confirm the Intel backend metadata and setup self-test.

## Verification

- `cargo check -p codestory-cli --locked`
- `cargo test -p codestory-retrieval --lib --locked` — 349 passed, 3 ignored before the narrow upgrade fix
- `cargo test -p codestory-retrieval --test full_stack_integration --locked` — passed after the combined-head rebase
- Exact-head upgrade rerun: port-registry boundary suite — 6 passed; Local transition failure/retry bootstrap regression — passed
- `cargo clippy -p codestory-retrieval --lib --locked -- -D warnings`
- `node scripts/setup-retrieval-env.mjs --self-test`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`

Fresh isolated Apple Silicon proof used the real managed b9902 runtime and model: Metal offload and `gpu_proof=verified`, qdrant ports `0/0`, embedded vectors healthy, `retrieval_mode=full`, and successful live search and packet calls. No Qdrant process existed. The proof-owned llama process and temporary cache were removed afterward.

Release-mode exact-scan measurements on this Apple M5:

| Dense anchors | DB size | Build | Warm p50 | Warm p95 |
| ---: | ---: | ---: | ---: | ---: |
| 1,000 | 4.7 MB | 29 ms | 2.22 ms | 2.93 ms |
| 10,000 | 46.6 MB | 103 ms | 13.08 ms | 14.44 ms |
| 25,000 | 116.6 MB | 221 ms | 32.62 ms | 37.30 ms |

## Size and risk

Delta: production `+1,293/-382` (net `+911`), tests `+348/-105` (net `+243`), docs net `+23`, scripts/assets net `+54`; total net `+1,201`.

The material growth is the embedded vector engine itself (421 production lines) plus dispatch that replaces network-service assumptions across publication, health, search, retention, ports, and Mac architecture selection. Test growth is limited to one generation/ranking unit boundary, one ignored measurement lane, and one real full-stack test replacing the old ignored Qdrant fixture. The simplifier pass removed forwarding APIs, bundled repeated semantic-generation arguments, bounded top-k memory, and hoisted query normalization out of the corpus loop.

The main remaining cross-platform risk is Intel and Windows hardware execution. The checked-in Intel artifact is checksum-pinned and its selection contract is covered here; native Intel/Windows proof remains part of the coordinated platform validation before release. This PR does not release or sign anything.




