### PR TITLE
Make cold grounding converge retrieval

### DIFF
--- a/.github/scripts/check-packaged-agent-proof.py
+++ b/.github/scripts/check-packaged-agent-proof.py
@@ -299,6 +299,26 @@ class McpProcess:
         require("error" not in response, f"MCP {name} failed: {response.get('error')}")
         return response
 
+    def tool_until_ready(self, name: str, arguments: dict, request_id: str) -> tuple[dict, int]:
+        deadline = time.monotonic() + self.timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            response = self.tool(name, arguments, f"{request_id}-{attempt}")
+            result = response.get("result", {})
+            if result.get("isError") is not True:
+                return response, attempt
+            state = result.get("structuredContent", {})
+            require(
+                state.get("code") in {"codestory_preparing", "codestory_updating"},
+                f"MCP {name} did not converge: {state}",
+            )
+            require(state.get("retry_tool") == name, f"MCP {name} returned the wrong retry tool: {state}")
+            remaining = deadline - time.monotonic()
+            require(remaining > 0, f"MCP {name} did not become ready")
+            delay = max(1, int(state.get("retry_after_ms", 1))) / 1000
+            time.sleep(min(delay, remaining))
+
     def close(self) -> None:
         if self.process.stdin:
             self.process.stdin.close()
@@ -364,21 +384,19 @@ def create_second_repository(root: Path) -> Path:
 
 def prove_runtime(args: argparse.Namespace, cli: Path, env: dict[str, str], root: Path, out_dir: Path) -> dict:
     project = args.project.resolve()
-    second = create_second_repository(root)
-    commands = {}
+    if args.additional_project:
+        require(
+            len(args.additional_project) == len(args.additional_query),
+            "each --additional-project requires one --additional-query",
+        )
+        additional_projects = [
+            (path.resolve(), query)
+            for path, query in zip(args.additional_project, args.additional_query)
+        ]
+    else:
+        additional_projects = [(create_second_repository(root), "shared_engine_probe")]
     embedded_models = Path(env["CODESTORY_CACHE_ROOT"]) / "embedded-models"
     require(not embedded_models.exists(), "isolated proof cache was not empty before first use")
-    commands["index"], _ = json_command([str(cli), "index", "--project", str(project), "--refresh", "full", "--format", "json"], env=env, cwd=project, timeout=args.timeout_secs)
-    cold_models = list(embedded_models.rglob("*.gguf"))
-    require(len(cold_models) == 1, "first use did not materialize exactly one embedded model")
-    cold_materialization = {
-        "path": str(cold_models[0]),
-        "sha256": sha256(cold_models[0]),
-        "first_command_wall_ms": commands["index"]["wall_ms"],
-    }
-    commands["retrieval_index"], _ = json_command([str(cli), "retrieval", "index", "--project", str(project), "--refresh", "full", "--format", "json"], env=env, cwd=project, timeout=args.timeout_secs)
-    commands["status"], status = json_command([str(cli), "retrieval", "status", "--project", str(project), "--format", "json"], env=env, cwd=project, timeout=args.timeout_secs)
-    require(find_value(status, "retrieval_mode") == "full", "retrieval status is not full")
 
     command = [str(cli), "serve", "--stdio", "--multi-project", "--refresh", "none"]
     if args.plugin_handoff:
@@ -390,17 +408,50 @@ def prove_runtime(args: argparse.Namespace, cli: Path, env: dict[str, str], root
     mcp = McpProcess(command, env=env, cwd=project, timeout=args.timeout_secs)
     try:
         mcp.initialize()
-        mcp.tool("search", {"project": str(project), "query": args.query, "why": True}, "search-one")
+        cold_started = time.perf_counter()
+        _, cold_attempts = mcp.tool_until_ready(
+            "ground", {"project": str(project), "budget": "strict"}, "cold-ground"
+        )
+        cold_ground_wall_ms = round((time.perf_counter() - cold_started) * 1000, 3)
+        cold_models = list(embedded_models.rglob("*.gguf"))
+        require(len(cold_models) == 1, "first use did not materialize exactly one embedded model")
+        cold_materialization = {
+            "path": str(cold_models[0]),
+            "sha256": sha256(cold_models[0]),
+            "first_command_wall_ms": cold_ground_wall_ms,
+            "ground_attempts": cold_attempts,
+        }
+        mcp.tool_until_ready(
+            "search", {"project": str(project), "query": args.query, "why": True}, "search-one"
+        )
         public_status = mcp.status(project, "status-one")
         assert_public_status(public_status)
         first = mcp.engine_diagnostics(project, "diagnostics-one")
-        mcp.tool("search", {"project": str(second), "query": "shared_engine_probe", "why": True}, "search-two")
-        second_status = mcp.engine_diagnostics(second, "diagnostics-two")
         first_identity = engine_identity(first, args.engine_policy, args.expected_backend)
-        second_identity = engine_identity(second_status, args.engine_policy, args.expected_backend)
-        require(first_identity["embedding_engine_instance_id"] == second_identity["embedding_engine_instance_id"], "repositories did not share one process engine")
-        require(second_identity["embedding_model_load_count"] == 1, "second repository reloaded the model")
-        mcp.tool("packet", {"project": str(project), "question": args.question, "budget": "compact"}, "packet")
+        for index, (additional_project, query) in enumerate(additional_projects, start=1):
+            mcp.tool_until_ready(
+                "search",
+                {"project": str(additional_project), "query": query, "why": True},
+                f"search-additional-{index}",
+            )
+            additional_status = mcp.engine_diagnostics(
+                additional_project, f"diagnostics-additional-{index}"
+            )
+            additional_identity = engine_identity(
+                additional_status, args.engine_policy, args.expected_backend
+            )
+            require(
+                first_identity["embedding_engine_instance_id"]
+                == additional_identity["embedding_engine_instance_id"],
+                "repositories did not share one process engine",
+            )
+            require(
+                additional_identity["embedding_model_load_count"] == 1,
+                "an additional repository reloaded the model",
+            )
+        mcp.tool_until_ready(
+            "packet", {"project": str(project), "question": args.question, "budget": "compact"}, "packet"
+        )
         transcript = mcp.transcript
     finally:
         mcp.close()
@@ -426,7 +477,6 @@ def prove_runtime(args: argparse.Namespace, cli: Path, env: dict[str, str], root
     require(materialized.stat().st_mtime_ns == before_mtime, "restart rewrote the materialized model")
     assert_no_legacy_state(Path(env["CODESTORY_CACHE_ROOT"]))
     return {
-        "commands": commands,
         "cold_materialization": cold_materialization,
         "identity": identity,
         "restart_identity": restart_identity,
@@ -489,6 +539,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--out-dir", type=Path, default=Path("target/packaged-agent-proof"))
     parser.add_argument("--query", default=DEFAULT_QUERY)
     parser.add_argument("--question", default=DEFAULT_QUESTION)
+    parser.add_argument("--additional-project", type=Path, action="append", default=[])
+    parser.add_argument("--additional-query", action="append", default=[])
     parser.add_argument("--timeout-secs", type=int, default=900)
     parser.add_argument("--version-only", action="store_true")
     parser.add_argument("--plugin-handoff", action="store_true")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
   acceleration claim; Linux x64 proof retains the glibc 2.31 baseline.
 - Delegated worktree setup uses `retrieval index` for its optional full proof
   and no longer enters an embedding repair lifecycle.
+- A first `ground` request now initializes the in-process engine before
+  indexing. While the first complete publication is still being built, ground
+  and broad-search tools return a short same-tool retry instead of an empty
+  success or terminal unavailable result.
 
 ## 0.15.0
 

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -64,6 +64,7 @@ const STDIO_TEXT_MAX_BYTES: usize = 4 * 1024;
 const STDIO_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
 const STDIO_STATUS_PUBLICATION_ATTEMPTS: usize = 3;
 const STDIO_LOCAL_REFRESH_FOREGROUND_BUDGET: Duration = Duration::from_secs(5);
+const STDIO_PREPARING_RETRY_AFTER_MS: u64 = 1_500;
 const STDIO_SOURCE_FINGERPRINT_FILE_CAP: usize = 25_000;
 const STDIO_MAX_FRAME_BYTES: usize = 1024 * 1024;
 const DIRTY_MARKER_SCHEMA_VERSION: u32 = 1;
@@ -422,7 +423,7 @@ impl StdioResource {
     }
 
     fn requires_retrieval(&self) -> bool {
-        false
+        matches!(self, Self::Grounding)
     }
 
     fn uri(&self) -> String {
@@ -687,7 +688,7 @@ fn handle_stdio_message(session: &mut StdioServerSession, line: &str) -> Option<
                 && let Err(error) = activate_stdio_project(
                     runtime,
                     &mut session.state,
-                    matches!(name, "packet" | "search" | "context"),
+                    matches!(name, "ground" | "packet" | "search" | "context"),
                 )
             {
                 let error = serde_json::json!({
@@ -854,6 +855,16 @@ fn stdio_tool_blocked_error(
     let Some(surface) = status.pointer(&format!("/allowed_surfaces/{name}")) else {
         return Ok(None);
     };
+    let updating = status
+        .pointer("/local_refresh/state")
+        .and_then(serde_json::Value::as_str)
+        == Some("refreshing");
+    let has_complete_publication = status
+        .get("index_publication")
+        .is_some_and(|publication| !publication.is_null());
+    if updating && !has_complete_publication && stdio_tool_reads_publication(name) {
+        return Ok(Some(stdio_tool_preparing_error(runtime, name)));
+    }
     if surface
         .get("allowed")
         .and_then(serde_json::Value::as_bool)
@@ -862,6 +873,9 @@ fn stdio_tool_blocked_error(
         return Ok(None);
     }
     if matches!(name, "packet" | "search" | "context") {
+        if updating {
+            return Ok(Some(stdio_tool_preparing_error(runtime, name)));
+        }
         return Ok(Some(serde_json::json!({
             "code": "codestory_unavailable",
             "message": "CodeStory could not prepare broad repository search automatically. Continue with local navigation or inspect diagnostics.",
@@ -871,10 +885,6 @@ fn stdio_tool_blocked_error(
             "diagnostics_uri": "codestory://status"
         })));
     }
-    let updating = status
-        .pointer("/local_refresh/state")
-        .and_then(serde_json::Value::as_str)
-        == Some("refreshing");
     let (code, message, state_name, retry_after_ms) = if updating {
         (
             "codestory_updating",
@@ -900,6 +910,19 @@ fn stdio_tool_blocked_error(
         "project": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
         "diagnostics_uri": "codestory://status"
     })))
+}
+
+fn stdio_tool_preparing_error(runtime: &RuntimeContext, name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "code": "codestory_preparing",
+        "message": "CodeStory is preparing this repository. Retry the same tool shortly.",
+        "tool": name,
+        "state": "preparing",
+        "retry_tool": name,
+        "retry_after_ms": STDIO_PREPARING_RETRY_AFTER_MS,
+        "project": crate::display::clean_path_string(&runtime.project_root.to_string_lossy()),
+        "diagnostics_uri": "codestory://status"
+    })
 }
 
 fn compact_stdio_status(status: &serde_json::Value) -> serde_json::Value {
@@ -965,15 +988,22 @@ fn activate_stdio_project(
     let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
     let summary = inspect_runtime.open_project_summary()?;
     let agent_sidecar = stdio_agent_sidecar_for_runtime(runtime);
+    let embedding_ready = !requires_retrieval
+        || codestory_retrieval::ensure_product_embedding_backend_for_runtime(&agent_sidecar)
+            .is_ok();
     if crate::local_freshness_needs_refresh(&summary) {
         let (_, refresh) = wait_for_stdio_local_freshness(&project, &summary)?;
+        let refresh_is_live = refresh.as_ref().is_some_and(|refresh| {
+            refresh.state == crate::readiness::LocalRefreshState::Refreshing
+        });
         state.recent_local_refresh = refresh;
+        state.status_cache = None;
+        if refresh_is_live {
+            return Ok(());
+        }
     }
 
-    if !requires_retrieval {
-        return Ok(());
-    }
-    if codestory_retrieval::ensure_product_embedding_backend_for_runtime(&agent_sidecar).is_err() {
+    if !requires_retrieval || !embedding_ready {
         return Ok(());
     }
     let ready = codestory_retrieval::strict_sidecar_status_for_runtime(
@@ -983,18 +1013,25 @@ fn activate_stdio_project(
     )
     .is_ok_and(|status| status.is_live_ready());
     if !ready {
-        if runtime
-            .index
-            .run_indexing_blocking(IndexMode::Full)
-            .map_err(map_api_error)
-            .is_err()
-        {
-            return Ok(());
-        }
         if crate::retrieval::finalize_retrieval_index_for_sidecar_runtime(runtime, &agent_sidecar)
             .is_err()
         {
-            return Ok(());
+            if runtime
+                .index
+                .run_indexing_blocking(IndexMode::Full)
+                .map_err(map_api_error)
+                .is_err()
+            {
+                return Ok(());
+            }
+            if crate::retrieval::finalize_retrieval_index_for_sidecar_runtime(
+                runtime,
+                &agent_sidecar,
+            )
+            .is_err()
+            {
+                return Ok(());
+            }
         }
         let Ok(status) = codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -153,6 +153,49 @@ fn write_dirty_marker_fixture(fixture: &StdioFixture, name: &str, marker: Value)
     marker_path
 }
 
+fn write_live_local_refresh(fixture: &StdioFixture) -> u32 {
+    let project_root = fs::canonicalize(fixture.workspace.path())
+        .expect("canonical workspace")
+        .to_string_lossy()
+        .trim_start_matches(r"\\?\")
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_millis() as i64;
+    let pid = std::process::id();
+    fs::write(
+        fixture.cache_dir.path().join("local-refresh.lock"),
+        serde_json::to_vec_pretty(&json!({
+            "schema_version": 1,
+            "project_root": project_root,
+            "pid": pid,
+            "started_at_epoch_ms": now,
+            "token": format!("test:{pid}:{now}")
+        }))
+        .expect("serialize refresh lock"),
+    )
+    .expect("write refresh lock");
+    fs::write(
+        fixture.cache_dir.path().join("local-refresh-status.json"),
+        serde_json::to_vec_pretty(&json!({
+            "schema_version": 1,
+            "status": "refreshing",
+            "project_root": project_root,
+            "phase": "incremental_index",
+            "pid": pid,
+            "started_at_epoch_ms": now,
+            "updated_at_epoch_ms": now,
+            "last_failure_reason": null
+        }))
+        .expect("serialize refresh status"),
+    )
+    .expect("write refresh status");
+    pid
+}
+
 fn refresh_fixture_index(fixture: &StdioFixture) {
     let mut command = test_support::cli_command();
     command
@@ -3209,45 +3252,7 @@ fn independent_clients_serve_one_complete_generation_while_refresh_is_owned() {
     )
     .expect("make the published index stale");
 
-    let project_root = fs::canonicalize(fixture.workspace.path())
-        .expect("canonical workspace")
-        .to_string_lossy()
-        .trim_start_matches(r"\\?\")
-        .replace('\\', "/")
-        .trim_end_matches('/')
-        .to_string();
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock")
-        .as_millis() as i64;
-    let pid = std::process::id();
-    fs::write(
-        fixture.cache_dir.path().join("local-refresh.lock"),
-        serde_json::to_vec_pretty(&json!({
-            "schema_version": 1,
-            "project_root": project_root,
-            "pid": pid,
-            "started_at_epoch_ms": now,
-            "token": format!("test:{pid}:{now}")
-        }))
-        .expect("serialize refresh lock"),
-    )
-    .expect("write refresh lock");
-    fs::write(
-        fixture.cache_dir.path().join("local-refresh-status.json"),
-        serde_json::to_vec_pretty(&json!({
-            "schema_version": 1,
-            "status": "refreshing",
-            "project_root": project_root,
-            "phase": "incremental_index",
-            "pid": pid,
-            "started_at_epoch_ms": now,
-            "updated_at_epoch_ms": now,
-            "last_failure_reason": null
-        }))
-        .expect("serialize refresh status"),
-    )
-    .expect("write refresh status");
+    let pid = write_live_local_refresh(&fixture);
 
     let mut status_client = spawn_stdio_server(&fixture);
     let status_response = send_json(
@@ -3438,8 +3443,8 @@ fn two_stdio_processes_observe_only_complete_generations_during_real_refresh() {
             .as_u64()
             .expect("reader complete generation");
         assert!(
-            generation == old_generation || generation == old_generation + 1,
-            "reader observed an unexpected publication generation: {status}"
+            generation >= old_generation,
+            "reader observed publication generation rollback: {status}"
         );
         let expected_status_file_count = if generation == old_generation { 5 } else { 101 };
         assert_eq!(
@@ -3462,12 +3467,14 @@ fn two_stdio_processes_observe_only_complete_generations_during_real_refresh() {
             ground_result["_meta"]["codestory_publication"]["publication"]["generation"]
                 .as_u64()
                 .expect("ground response publication generation");
+        assert!(
+            ground_generation >= old_generation,
+            "ground response identified publication generation rollback: {ground_result}"
+        );
         let expected_file_count = if ground_generation == old_generation {
             5
-        } else if ground_generation == old_generation + 1 {
-            101
         } else {
-            panic!("ground response identified an unexpected publication: {ground_result}");
+            101
         };
         assert!(
             ground["stats"]["file_count"]
@@ -3476,9 +3483,7 @@ fn two_stdio_processes_observe_only_complete_generations_during_real_refresh() {
             "reader ground mixed publication metadata and file contents: {ground_result}"
         );
 
-        if generation == old_generation + 1
-            && status["local_refresh"]["state"] != json!("refreshing")
-        {
+        if generation > old_generation && status["local_refresh"]["state"] != json!("refreshing") {
             break generation;
         }
         assert!(
@@ -3890,63 +3895,42 @@ fn resources_read_agent_guide_describes_default_browser_loop_and_safety() {
 }
 
 #[test]
-fn search_tool_retries_only_while_managed_preparation_is_live() {
-    let fixture = indexed_fixture();
+fn cold_ground_and_search_retry_while_first_publication_is_owned() {
+    let fixture = unindexed_fixture();
+    write_live_local_refresh(&fixture);
     let mut server = spawn_stdio_server(&fixture);
 
-    let response = send_json(
-        &mut server,
-        json!({
-            "jsonrpc": "2.0",
-            "id": "search-requires-full-retrieval",
-            "method": "tools/call",
-            "params": {
-                "name": "search",
-                "arguments": {"query": "AppController"}
-            }
-        }),
-    );
-
-    let error = assert_tool_error(&response, json!("search-requires-full-retrieval"));
-    assert_eq!(error["tool"], json!("search"));
-    match error.pointer("/code").and_then(Value::as_str) {
-        Some("codestory_preparing") => {
-            assert_eq!(error["state"], json!("preparing"));
-            assert_eq!(error["retry_tool"], json!("search"));
-            assert!(
-                error["retry_after_ms"]
-                    .as_u64()
-                    .is_some_and(|delay| delay > 0)
-            );
-            assert!(
-                error["operation"]["id"]
-                    .as_str()
-                    .is_some_and(|id| !id.is_empty()),
-                "retryable preparation must name the live operation: {response}"
-            );
-        }
-        Some("codestory_unavailable") => {
-            assert_eq!(error["state"], json!("unavailable"));
-            assert!(error.get("retry_tool").is_none(), "{response}");
-            assert!(error.get("retry_after_ms").is_none(), "{response}");
-        }
-        code => panic!("unexpected search preparation result {code:?}: {response}"),
-    }
-    assert_eq!(error["diagnostics_uri"], json!("codestory://status"));
-    let serialized = error.to_string();
-    for hidden_detail in [
-        "sidecar",
-        "minimum_next",
-        "full_repair",
-        "repair_reason",
-        "failed_layer",
-        "pid",
-        "port",
-        "model",
+    for (name, arguments) in [
+        ("ground", json!({"budget": "strict"})),
+        ("search", json!({"query": "AppController"})),
     ] {
-        assert!(
-            !serialized.contains(hidden_detail),
-            "managed response should hide infrastructure detail `{hidden_detail}`: {response}"
+        let request_id = format!("cold-{name}-preparing");
+        let response = send_json(
+            &mut server,
+            json!({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments}
+            }),
         );
+        let error = assert_tool_error(&response, json!(request_id));
+        assert_eq!(error["code"], json!("codestory_preparing"));
+        assert_eq!(error["tool"], json!(name));
+        assert_eq!(error["state"], json!("preparing"));
+        assert_eq!(error["retry_tool"], json!(name));
+        assert!(
+            error["retry_after_ms"]
+                .as_u64()
+                .is_some_and(|delay| delay > 0)
+        );
+        assert_eq!(error["diagnostics_uri"], json!("codestory://status"));
+        let serialized = error.to_string();
+        for hidden_detail in ["sidecar", "repair", "pid", "port", "model", "operation"] {
+            assert!(
+                !serialized.contains(hidden_detail),
+                "preparation response should hide lifecycle detail `{hidden_detail}`: {response}"
+            );
+        }
     }
 }

--- a/docs/users/codex.md
+++ b/docs/users/codex.md
@@ -167,7 +167,7 @@ More pairs, anti-patterns, and language-flavored examples:
 | Status shows `runtime_update.state=available` | Current compatible surfaces keep working; reload when convenient if `restart_recommended=true` |
 | Status shows `repair_setup` | The active runtime could not start or prove compatibility; follow `recommended_next_calls` |
 | Windows terminal refresh says `Access is denied` | Quit stale Codex windows running the old plugin, then refresh from `/plugins` or rerun `codex.cmd plugin add codestory@TheGreenCedar` |
-| Broad search is preparing | Retry the same `packet`, `search`, or `context` call after its reported delay. CodeStory initializes retrieval automatically. See [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
+| First ground or broad search is preparing | Retry the same `ground`, `packet`, `search`, or `context` call after its reported delay. CodeStory initializes retrieval automatically. See [Troubleshooting](troubleshooting.md#packetsearch-degraded-or-blocked) |
 | A CodeStory call times out | Retry the same tool once. Read status only if it still does not converge. Reload only for host transport/registration failure, plugin replacement, or a runtime update whose status says `restart_recommended=true` |
 
 ### Managed platform matrix

--- a/plugins/codestory/skills/codestory-grounding/references/status-contract.md
+++ b/plugins/codestory/skills/codestory-grounding/references/status-contract.md
@@ -15,14 +15,15 @@ across repositories.
 | `working_locally` | Local graph navigation is available while broad search prepares. | Continue with local tools and retry the original broad tool later. |
 | `unavailable` | CodeStory could not converge within the managed path. | Use focused source inspection and state the evidence gap. |
 
-`packet`, `search`, and `context` return `codestory_preparing` with
-`retry_tool` and `retry_after_ms` while their managed dependencies are coming
-up. Retry that same tool. Do not ask the user to enable, repair, approve, or
-configure an internal service.
+When no complete publication exists yet, `ground`, `packet`, `search`, and
+`context` return `codestory_preparing` with `retry_tool` and
+`retry_after_ms`. Broad tools use the same response while managed search is
+coming up. Retry that same tool. Do not ask the user to enable, repair,
+approve, or configure an internal service.
 
 `ground`, `files`, and `affected` can build or refresh the bounded local map as
-part of the call. Other local graph tools use the last complete publication and
-never read a half-published generation.
+part of the call. Once a complete publication exists, local graph tools keep
+using it during refresh and never read a half-published generation.
 
 ## Diagnostic status
 


### PR DESCRIPTION
## Context

The packaged embedding proof pre-indexed repositories before launching MCP, so it missed the actual first-session path. Against an empty cache, `ground` could return a successful empty map while refresh was still running; the following `search` then returned terminal unavailable even though the in-process Metal engine was healthy.

Closes #1166
Refs #897

Base: `e33bee8112122dbbf75a82a6002ad075411c40a4`
Head: `1494094ffc4bdaf421d809b4aa7d77b2208a90fc`

## What changed

- Initialize the shared in-process embedding engine before the first grounding refresh.
- Keep a live refresh single-owner and return retryable `codestory_preparing` instead of an empty publication or terminal broad-search failure.
- Try retrieval finalization against the completed index before paying for a fallback full rebuild.
- Preserve the last complete publication throughout refresh and relax the concurrency regression to test old-or-new coherence instead of assuming exactly one generation increment.
- Make the packaged proof start through the plugin launcher from an empty offline cache, follow only same-tool retry guidance, and optionally verify any number of real repositories in one process.
- Document that first `ground` can prepare automatically; users are never asked to configure, approve, or repair an internal service.

No Docker/Compose retrieval runtime, helper server, endpoint, port, PID, repair worker, download, or consent path is retained. Remaining Docker references are the unrelated Docker Compose source collector and isolated Linux glibc package builder.

## Review

The important path is `activate_stdio_project` plus `stdio_tool_blocked_error`. A first publication must prepare until committed; an existing complete publication must remain usable while a new refresh is owned elsewhere. The proof harness now exercises the path that exposed the bug instead of constructing readiness beforehand.

## Verification

- `cargo test -p codestory-cli --test stdio_protocol_contracts --locked` — 29 passed
- `cargo clippy -p codestory-cli --bin codestory-cli --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `node --test plugins/codestory/tests/plugin-static.test.mjs` — 65 passed, 1 Windows-only skip
- `node .github/scripts/check-workflow-policy.mjs`
- `node .github/scripts/check-doc-links.mjs`
- packaged proof self-test and Python syntax check
- exact release build with the checksum-pinned embedded model
- offline packaged plugin-launcher proof across `/Users/albert/Developer/CodeStory`, `/Users/albert/Developer/rootandruntime`, and `/Users/albert/Developer/codex-autoresearch`

Exact packaged Mac evidence:

- executable SHA-256: `6912d5f3bd490836a829f4318e60480bbee08ea8a5925d33e288e23b56c3ba98`
- archive SHA-256: `b143e16184c1951c690d8bc7a10fa28d1ad4e4d9f3c6688da0138aad8c39153f`
- cold CodeStory ground: 7 attempts over 19.9s; every interim result was `codestory_preparing` with `retry_tool=ground`
- Metal: `MTL0`, 13/13 layers, 16ms smoke, one model load shared across all three repositories
- real searches: 10 hits in each repository; packet result sufficient
- restart: content-addressed model reused, 269ms initialization, 15ms smoke
- offline cache contained no legacy process state

## Size and risk

- production: `+56/-19` (net `+37`)
- tests and proof: `+157/-121` (net `+36`)
- documentation: `+12/-7` (net `+5`)
- total: `+225/-147` (net `+78`)

The behavior change is deliberately limited to automatic MCP activation and retry precedence. It does not change CLI syntax, public status fields, model/backend policy, signing, publishing, or release state.
