### PR TITLE
Keep installed-host retrieval migration retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
   indexing. While the first complete publication is still being built, ground
   and broad-search tools return a short same-tool retry instead of an empty
   success or terminal unavailable result.
+- Installed-host semantic migrations now keep packet, search, and context in a
+  same-tool preparing state while a refresh owns publication. Successful MCP
+  search reports only that retrieval is ready, and grounding no longer exposes
+  obsolete server-era semantic counters or backend details.
 
 ## 0.15.0
 

--- a/crates/codestory-cli/src/stdio_catalog.rs
+++ b/crates/codestory-cli/src/stdio_catalog.rs
@@ -617,7 +617,7 @@ static SEARCH_RESULTS_SCHEMA: SchemaObject = SchemaObject::object(
     "CodeStory discovery results DTO. Treat broad structural questions as packet-first; search rows select candidates for proof-bearing graph/source follow-up.",
     &[
         SchemaProperty::string("query", "Search query."),
-        SchemaProperty::object("retrieval", "Retrieval state DTO."),
+        SchemaProperty::object("retrieval", "Retrieval readiness."),
         SchemaProperty::integer("limit_per_source", "Per-source result limit."),
         SchemaProperty::string("repo_text_mode", "Repo text search mode.")
             .with_enum(SEARCH_REPO_TEXT_MODES),
@@ -822,7 +822,6 @@ static GROUNDING_SNAPSHOT_SCHEMA: SchemaObject = SchemaObject::object(
         SchemaProperty::string("budget", "Grounding output budget.").with_enum(GROUNDING_BUDGETS),
         SchemaProperty::integer("generated_at_epoch_ms", "Snapshot generation time."),
         SchemaProperty::object("stats", "Indexed project stats."),
-        SchemaProperty::object("retrieval", "Optional retrieval state DTO.").nullable(),
         SchemaProperty::object("coverage", "Grounding coverage summary."),
         SchemaProperty::array(
             "root_symbols",

--- a/crates/codestory-cli/src/stdio_transport.rs
+++ b/crates/codestory-cli/src/stdio_transport.rs
@@ -371,6 +371,12 @@ struct StdioServerState {
     recent_local_refresh: Option<crate::readiness::LocalRefreshOutput>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StdioActivationOutcome {
+    CheckReadiness,
+    RetrievalPreparing,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum StdioResource {
     Status,
@@ -684,18 +690,29 @@ fn handle_stdio_message(session: &mut StdioServerSession, line: &str) -> Option<
                 return Some(stdio_jsonrpc_success(id, stdio_tool_call_error(&error)));
             }
             let runtime = session.runtime.as_ref().expect("stdio project selected");
-            if stdio_tool_reads_publication(name)
-                && let Err(error) = activate_stdio_project(
+            let activation = if stdio_tool_reads_publication(name) {
+                match activate_stdio_project(
                     runtime,
                     &mut session.state,
                     matches!(name, "ground" | "packet" | "search" | "context"),
-                )
+                ) {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        let error = serde_json::json!({
+                            "code": "project_activation_failed",
+                            "message": format!("Unable to activate CodeStory before running `{name}`: {error}"),
+                            "tool": name
+                        });
+                        return Some(stdio_jsonrpc_success(id, stdio_tool_call_error(&error)));
+                    }
+                }
+            } else {
+                StdioActivationOutcome::CheckReadiness
+            };
+            if activation == StdioActivationOutcome::RetrievalPreparing
+                && matches!(name, "packet" | "search" | "context")
             {
-                let error = serde_json::json!({
-                    "code": "project_activation_failed",
-                    "message": format!("Unable to activate CodeStory before running `{name}`: {error}"),
-                    "tool": name
-                });
+                let error = stdio_tool_preparing_error(runtime, name);
                 return Some(stdio_jsonrpc_success(id, stdio_tool_call_error(&error)));
             }
             if name != "status" {
@@ -980,9 +997,9 @@ fn activate_stdio_project(
     runtime: &RuntimeContext,
     state: &mut StdioServerState,
     requires_retrieval: bool,
-) -> Result<()> {
+) -> Result<StdioActivationOutcome> {
     if stdio_workspace_mismatch(runtime).is_some() {
-        return Ok(());
+        return Ok(StdioActivationOutcome::CheckReadiness);
     }
     let project = stdio_project_args(runtime);
     let inspect_runtime = RuntimeContext::new_inspect_only(&project)?;
@@ -999,12 +1016,16 @@ fn activate_stdio_project(
         state.recent_local_refresh = refresh;
         state.status_cache = None;
         if refresh_is_live {
-            return Ok(());
+            return Ok(if requires_retrieval {
+                StdioActivationOutcome::RetrievalPreparing
+            } else {
+                StdioActivationOutcome::CheckReadiness
+            });
         }
     }
 
     if !requires_retrieval || !embedding_ready {
-        return Ok(());
+        return Ok(StdioActivationOutcome::CheckReadiness);
     }
     let ready = codestory_retrieval::strict_sidecar_status_for_runtime(
         &runtime.project_root,
@@ -1013,39 +1034,71 @@ fn activate_stdio_project(
     )
     .is_ok_and(|status| status.is_live_ready());
     if !ready {
-        if crate::retrieval::finalize_retrieval_index_for_sidecar_runtime(runtime, &agent_sidecar)
-            .is_err()
-        {
-            if runtime
-                .index
-                .run_indexing_blocking(IndexMode::Full)
-                .map_err(map_api_error)
-                .is_err()
+        match crate::retrieval::finalize_retrieval_index_for_sidecar_runtime(
+            runtime,
+            &agent_sidecar,
+        ) {
+            Ok(_) => {}
+            Err(error)
+                if stdio_activation_outcome_for_error(&error)
+                    == StdioActivationOutcome::RetrievalPreparing =>
             {
-                return Ok(());
+                return Ok(StdioActivationOutcome::RetrievalPreparing);
             }
-            if crate::retrieval::finalize_retrieval_index_for_sidecar_runtime(
-                runtime,
-                &agent_sidecar,
-            )
-            .is_err()
-            {
-                return Ok(());
+            Err(_) => {
+                if let Err(error) = runtime
+                    .index
+                    .run_indexing_blocking(IndexMode::Full)
+                    .map_err(map_api_error)
+                {
+                    return Ok(stdio_activation_outcome_for_error(&error));
+                }
+                if let Err(error) = crate::retrieval::finalize_retrieval_index_for_sidecar_runtime(
+                    runtime,
+                    &agent_sidecar,
+                ) {
+                    return Ok(stdio_activation_outcome_for_error(&error));
+                }
             }
         }
-        let Ok(status) = codestory_retrieval::strict_sidecar_status_for_runtime(
+        let status = match codestory_retrieval::strict_sidecar_status_for_runtime(
             &runtime.project_root,
             Some(&runtime.storage_path),
             agent_sidecar,
-        ) else {
-            return Ok(());
+        ) {
+            Ok(status) => status,
+            Err(error) => return Ok(stdio_activation_outcome_for_error(&error)),
         };
         if !status.is_live_ready() {
-            return Ok(());
+            return Ok(StdioActivationOutcome::CheckReadiness);
         }
     }
     state.status_cache = None;
-    Ok(())
+    Ok(StdioActivationOutcome::CheckReadiness)
+}
+
+fn stdio_activation_outcome_for_error(error: &anyhow::Error) -> StdioActivationOutcome {
+    const RETRYABLE_MARKERS: &[&str] = &[
+        "cache_busy",
+        "database is locked",
+        "database table is locked",
+        "another indexing run owns the writer lock",
+        "sidecar generation input changed before manifest publication",
+        "publication changed",
+    ];
+    if error
+        .chain()
+        .map(|cause| cause.to_string().to_ascii_lowercase())
+        .any(|message| {
+            RETRYABLE_MARKERS
+                .iter()
+                .any(|marker| message.contains(marker))
+        })
+    {
+        StdioActivationOutcome::RetrievalPreparing
+    } else {
+        StdioActivationOutcome::CheckReadiness
+    }
 }
 
 fn stdio_jsonrpc_tool_call_from_legacy(
@@ -1677,7 +1730,9 @@ fn handle_stdio_ground(runtime: &RuntimeContext, request: &serde_json::Value) ->
     runtime
         .grounding
         .grounding_snapshot(budget)
-        .map(|snapshot| serde_json::json!({"result": snapshot}))
+        .map(|snapshot| {
+            serde_json::json!({"result": compact_stdio_ground_result(serde_json::json!(snapshot))})
+        })
         .unwrap_or_else(|error| serde_json::json!({"error": stdio_api_error_value(error)}))
 }
 
@@ -4769,6 +4824,33 @@ fn enrich_stdio_search_result(
         }
         object.insert("counts".to_string(), counts);
     }
+    compact_stdio_ready_search_retrieval(&mut value);
+    value
+}
+
+fn compact_stdio_ready_search_retrieval(value: &mut serde_json::Value) {
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "retrieval".to_string(),
+            serde_json::json!({"state": "ready"}),
+        );
+    }
+}
+
+fn compact_stdio_ground_result(mut value: serde_json::Value) -> serde_json::Value {
+    if let Some(object) = value.as_object_mut() {
+        object.remove("retrieval");
+        if let Some(notes) = object
+            .get_mut("notes")
+            .and_then(serde_json::Value::as_array_mut)
+        {
+            notes.retain(|note| {
+                !note
+                    .as_str()
+                    .is_some_and(|note| note.starts_with("Retrieval mode:"))
+            });
+        }
+    }
     value
 }
 
@@ -5328,6 +5410,35 @@ version = "0.11.20"
             hit.get("links").is_none(),
             "non-resolvable repo-text hits should stay link-free: {hit}"
         );
+    }
+
+    #[test]
+    fn stdio_installed_host_migration_contracts_stay_retryable_and_compact() {
+        for message in [
+            "cache_busy: publication changed",
+            "sidecar generation input changed before manifest publication",
+            "database is locked",
+        ] {
+            assert_eq!(
+                stdio_activation_outcome_for_error(&anyhow::anyhow!(message)),
+                StdioActivationOutcome::RetrievalPreparing
+            );
+        }
+        assert_eq!(
+            stdio_activation_outcome_for_error(&anyhow::anyhow!("accelerator unavailable")),
+            StdioActivationOutcome::CheckReadiness
+        );
+
+        let mut search = json!({"retrieval": {"fallback_reason": "missing_semantic_docs"}});
+        compact_stdio_ready_search_retrieval(&mut search);
+        assert_eq!(search["retrieval"], json!({"state": "ready"}));
+
+        let snapshot = json!({
+            "retrieval": {"mode": "symbolic"},
+            "notes": ["keep", "Retrieval mode: symbolic"]
+        });
+        let ground = compact_stdio_ground_result(snapshot);
+        assert_eq!(ground, json!({"notes": ["keep"]}));
     }
 
     #[test]

--- a/crates/codestory-cli/tests/stdio_protocol_contracts.rs
+++ b/crates/codestory-cli/tests/stdio_protocol_contracts.rs
@@ -3933,4 +3933,23 @@ fn cold_ground_and_search_retry_while_first_publication_is_owned() {
             );
         }
     }
+
+    let fixture = indexed_fixture();
+    write_live_local_refresh(&fixture);
+    let mut server = spawn_stdio_server(&fixture);
+    let response = send_json(
+        &mut server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "migration-search-preparing",
+            "method": "tools/call",
+            "params": {
+                "name": "search",
+                "arguments": {"query": "AppController"}
+            }
+        }),
+    );
+    let error = assert_tool_error(&response, json!("migration-search-preparing"));
+    assert_eq!(error["code"], json!("codestory_preparing"));
+    assert_eq!(error["retry_tool"], json!("search"));
 }


### PR DESCRIPTION
## Context

A real Codex restart with the installed CodeStoryDev plugin exposed one last migration race. The full in-process retrieval generation eventually became ready across three repositories, but a broad request could briefly become terminal `codestory_unavailable`, and successful ground/search responses still repeated obsolete core semantic counters.

## What changed

- Carries retrieval preparation ownership from activation into broad-tool admission instead of reconstructing it from a later status snapshot.
- Treats cache contention, SQLite locks, another index writer, commit-fence input drift, and publication changes as same-tool `codestory_preparing` outcomes.
- Keeps nonretryable accelerator or policy failures on the normal terminal readiness path.
- Compacts successful MCP search retrieval metadata to `{ "state": "ready" }` after the full gate admits it.
- Removes obsolete retrieval counters and backend-era notes from MCP grounding output; maintainer diagnostics retain detailed runtime evidence.
- Updates the stdio output schemas and changelog.

## Review guide

The behavior change is confined to `stdio_transport.rs`. Review the activation outcome propagation first, then the two output compactors. No runtime, retrieval engine, plugin launcher, package, signing, or release path changed.

## Verification

Exact head: `42a8c0a`

- `cargo test -p codestory-cli --bin codestory-cli --locked` — 164 passed
- `cargo test -p codestory-cli --test stdio_protocol_contracts --locked` — 29 passed
- `cargo check -p codestory-cli --locked`
- `cargo clippy -p codestory-cli --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `node .github/scripts/check-doc-links.mjs`
- `git diff --check`
- Independent exact-diff review — no blockers

The pre-fix installed plugin also proved sufficient full-retrieval packets in CodeStory, rootandruntime, and codex-autoresearch; this PR corrects the contradictory adapter contract found by that proof. A rebuilt installed-plugin readback remains the post-merge acceptance step.

## Line delta

- Production Rust: +117 / -36 (net +81)
- Tests: +48 / -0
- Documentation: +4 / -0

The production growth is the explicit activation outcome and narrow retryable-error classification that replaces timing-dependent status inference. The code-simplifier pass found no safe reduction that preserved the same testable boundary; a one-call setter remains separate so the compact public contract can be tested without constructing the full search DTO.

## Risk

The retryable classifier is deliberately narrow. Unknown failures still use the existing readiness verdict and remain terminal rather than looping. Successful search compaction changes only the MCP adapter; direct CLI/runtime DTOs and maintainer diagnostics are unchanged.

Closes #1168
Refs #897
